### PR TITLE
Focus tracker fixes

### DIFF
--- a/examples/console/src/typings.d.ts
+++ b/examples/console/src/typings.d.ts
@@ -1,4 +1,1 @@
 /// <reference path="../../../typings/codemirror/codemirror.d.ts"/>
-
-// For a Thenable reference in jupyter-js-services
-type Thenable<T> = Promise<T>

--- a/examples/console/src/typings.d.ts
+++ b/examples/console/src/typings.d.ts
@@ -1,4 +1,10 @@
 /// <reference path="../../../typings/codemirror/codemirror.d.ts"/>
+/// <reference path="../../../node_modules/@types/mathjax/index.d.ts"/>
+/// <reference path="../../../node_modules/@types/node/index.d.ts"/>
+/// <reference path="../../../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>
+/// <reference path="../../../node_modules/typescript/lib/lib.dom.d.ts"/>
+/// <reference path="../../../node_modules/typescript/lib/lib.es5.d.ts"/>
+/// <reference path="../../../node_modules/typescript/lib/lib.es2015.collection.d.ts"/>
 
 // For a Thenable reference in jupyter-js-services
 type Thenable<T> = Promise<T>

--- a/examples/console/src/typings.d.ts
+++ b/examples/console/src/typings.d.ts
@@ -1,10 +1,4 @@
 /// <reference path="../../../typings/codemirror/codemirror.d.ts"/>
-/// <reference path="../../../node_modules/@types/mathjax/index.d.ts"/>
-/// <reference path="../../../node_modules/@types/node/index.d.ts"/>
-/// <reference path="../../../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>
-/// <reference path="../../../node_modules/typescript/lib/lib.dom.d.ts"/>
-/// <reference path="../../../node_modules/typescript/lib/lib.es5.d.ts"/>
-/// <reference path="../../../node_modules/typescript/lib/lib.es2015.collection.d.ts"/>
 
 // For a Thenable reference in jupyter-js-services
 type Thenable<T> = Promise<T>

--- a/examples/filebrowser/src/typings.d.ts
+++ b/examples/filebrowser/src/typings.d.ts
@@ -1,4 +1,1 @@
 /// <reference path="../../../typings/codemirror/codemirror.d.ts"/>
-
-// For a Thenable reference in jupyter-js-services
-type Thenable<T> = Promise<T>

--- a/examples/notebook/src/typings.d.ts
+++ b/examples/notebook/src/typings.d.ts
@@ -1,4 +1,1 @@
 /// <reference path="../../../typings/codemirror/codemirror.d.ts"/>
-
-// For a Thenable reference in jupyter-js-services
-type Thenable<T> = Promise<T>

--- a/examples/notebook/src/typings.d.ts
+++ b/examples/notebook/src/typings.d.ts
@@ -1,4 +1,10 @@
 /// <reference path="../../../typings/codemirror/codemirror.d.ts"/>
+/// <reference path="../../../node_modules/@types/mathjax/index.d.ts"/>
+/// <reference path="../../../node_modules/@types/node/index.d.ts"/>
+/// <reference path="../../../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>
+/// <reference path="../../../node_modules/typescript/lib/lib.dom.d.ts"/>
+/// <reference path="../../../node_modules/typescript/lib/lib.es5.d.ts"/>
+/// <reference path="../../../node_modules/typescript/lib/lib.es2015.collection.d.ts"/>
 
 // For a Thenable reference in jupyter-js-services
 type Thenable<T> = Promise<T>

--- a/examples/notebook/src/typings.d.ts
+++ b/examples/notebook/src/typings.d.ts
@@ -1,10 +1,4 @@
 /// <reference path="../../../typings/codemirror/codemirror.d.ts"/>
-/// <reference path="../../../node_modules/@types/mathjax/index.d.ts"/>
-/// <reference path="../../../node_modules/@types/node/index.d.ts"/>
-/// <reference path="../../../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>
-/// <reference path="../../../node_modules/typescript/lib/lib.dom.d.ts"/>
-/// <reference path="../../../node_modules/typescript/lib/lib.es5.d.ts"/>
-/// <reference path="../../../node_modules/typescript/lib/lib.es2015.collection.d.ts"/>
 
 // For a Thenable reference in jupyter-js-services
 type Thenable<T> = Promise<T>

--- a/examples/terminal/src/typings.d.ts
+++ b/examples/terminal/src/typings.d.ts
@@ -1,4 +1,1 @@
 /// <reference path="../../../typings/codemirror/codemirror.d.ts"/>
-
-// For a Thenable reference in jupyter-js-services
-type Thenable<T> = Promise<T>

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -17,10 +17,6 @@ import {
 } from 'phosphor/lib/ui/dockpanel';
 
 import {
-  FocusTracker
-} from 'phosphor/lib/ui/focustracker';
-
-import {
   each
 } from 'phosphor/lib/algorithm/iteration';
 
@@ -145,8 +141,7 @@ class ApplicationShell extends Widget {
 
     this.layout = rootLayout;
 
-    this._tracker = new FocusTracker<Widget>();
-    this._tracker.currentChanged.connect((sender, args) => {
+    this._dockPanel.currentChanged.connect((sender, args) => {
       if (args.newValue) {
         args.newValue.title.className += ` ${CURRENT_CLASS}`;
       }
@@ -216,7 +211,6 @@ class ApplicationShell extends Widget {
       return;
     }
     this._dockPanel.addWidget(widget, { mode: 'tab-after' });
-    this._tracker.add(widget);
   }
 
   /**
@@ -262,9 +256,7 @@ class ApplicationShell extends Widget {
    * Close all tracked widgets.
    */
   closeAll(): void {
-    each(this._tracker.widgets, widget => {
-      widget.close();
-    });
+    each(this._dockPanel.widgets, widget => { widget.close(); });
   }
 
   private _topPanel: Panel;
@@ -273,7 +265,6 @@ class ApplicationShell extends Widget {
   private _hsplitPanel: SplitPanel;
   private _leftHandler: SideBarHandler;
   private _rightHandler: SideBarHandler;
-  private _tracker: FocusTracker<Widget>;
 }
 
 
@@ -321,6 +312,7 @@ class SideBarHandler {
     let widget = this._findWidgetByID(id);
     if (widget) {
       this._sideBar.currentTitle = widget.title;
+      widget.activate();
     }
   }
 

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -165,7 +165,17 @@ class ApplicationShell extends Widget {
   /**
    * A signal emitted when main area's current focus changes.
    */
-  currentChanged: ISignal<this, FocusTracker.ICurrentChangedArgs<Widget>>;
+  readonly currentChanged: ISignal<this, FocusTracker.ICurrentChangedArgs<Widget>>;
+
+  /**
+   * The current widget in the shell's main area.
+   *
+   * #### Notes
+   * This property is read-only.
+   */
+  get currentWidget(): Widget {
+    return this._dockPanel.currentWidget;
+  }
 
   /**
    * Add a widget to the top content area.

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -9,6 +9,10 @@ import {
 } from 'phosphor/lib/collections/vector';
 
 import {
+  defineSignal, ISignal
+} from 'phosphor/lib/core/signaling';
+
+import {
   BoxLayout, BoxPanel
 } from 'phosphor/lib/ui/boxpanel';
 
@@ -19,6 +23,10 @@ import {
 import {
   each
 } from 'phosphor/lib/algorithm/iteration';
+
+import {
+  FocusTracker
+} from 'phosphor/lib/ui/focustracker';
 
 import {
   Panel
@@ -142,6 +150,7 @@ class ApplicationShell extends Widget {
     this.layout = rootLayout;
 
     this._dockPanel.currentChanged.connect((sender, args) => {
+      this.currentChanged.emit(args);
       if (args.newValue) {
         args.newValue.title.className += ` ${CURRENT_CLASS}`;
       }
@@ -152,6 +161,11 @@ class ApplicationShell extends Widget {
       }
     });
   }
+
+  /**
+   * A signal emitted when main area's current focus changes.
+   */
+  currentChanged: ISignal<this, FocusTracker.ICurrentChangedArgs<Widget>>;
 
   /**
    * Add a widget to the top content area.
@@ -266,6 +280,10 @@ class ApplicationShell extends Widget {
   private _leftHandler: SideBarHandler;
   private _rightHandler: SideBarHandler;
 }
+
+
+// Define the signals for the `ApplicationShell` class.
+defineSignal(ApplicationShell.prototype, 'currentChanged');
 
 
 /**

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -1,5 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
+
+import {
+  each
+} from 'phosphor/lib/algorithm/iteration';
+
 import {
   find, findIndex, upperBound
 } from 'phosphor/lib/algorithm/searching';
@@ -19,10 +24,6 @@ import {
 import {
   DockPanel
 } from 'phosphor/lib/ui/dockpanel';
-
-import {
-  each
-} from 'phosphor/lib/algorithm/iteration';
 
 import {
   FocusTracker

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -2,7 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  defineSignal, ISignal
+  IDisposable
+} from 'phosphor/lib/core/disposable';
+
+import {
+  clearSignalData, defineSignal, ISignal
 } from 'phosphor/lib/core/signaling';
 
 import {
@@ -34,7 +38,7 @@ interface IInstanceTracker<T extends Widget> {
 
 
 export
-class InstanceTracker<T extends Widget> implements IInstanceTracker<T> {
+class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposable {
   /**
    * A signal emitted when the current widget changes.
    *
@@ -54,6 +58,13 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T> {
   }
 
   /**
+   * Test whether the model is disposed.
+   */
+  get isDisposed(): boolean {
+    return this._widgets === null;
+  }
+
+  /**
    * Add a new widget to the tracker.
    */
   add(widget: T): void {
@@ -66,6 +77,19 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T> {
     }
     this._widgets.set(widget.id, widget);
     widget.disposed.connect(() => { this._widgets.delete(widget.id); });
+  }
+
+  /**
+   * Dispose of the resources held by the tracker.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    clearSignalData(this);
+    this._currentWidget = null;
+    this._widgets.clear();
+    this._widgets = null;
   }
 
   /**

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -69,6 +69,24 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T> {
   }
 
   /**
+   * Find the first widget in the tracker that satisfies a filter function.
+   *
+   * @param fn The filter function to call on each widget.
+   */
+  find(fn: (widget: T) => boolean): T {
+    let result: T = null;
+    this._widgets.forEach(widget => {
+      if (!result) {
+        return;
+      }
+      if (fn(widget)) {
+        result = widget;
+      }
+    });
+    return result;
+  }
+
+  /**
    * Iterate through each widget in the tracker.
    *
    * @param fn The function to call on each widget.

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  defineSignal, ISignal
+} from 'phosphor/lib/core/signaling';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+
+/**
+ * An object that tracks widget instances.
+ */
+export
+interface IInstanceTracker<T extends Widget> {
+  /**
+   * A signal emitted when the current widget changes.
+   *
+   * #### Notes
+   * If there is no widget with the focus, then `null` will be emitted.
+   */
+  currentChanged: ISignal<this, T>;
+
+  /**
+   * The current widget.
+   *
+   * #### Notes
+   * If there is no widget with the focus, then this value is `null`.
+   */
+  currentWidget: T;
+}
+
+
+export
+class InstanceTracker<T extends Widget> implements IInstanceTracker<T> {
+  /**
+   * A signal emitted when the current widget changes.
+   *
+   * #### Notes
+   * If there is no widget with the focus, then `null` will be emitted.
+   */
+  currentChanged: ISignal<this, T>;
+
+  /**
+   * The current widget.
+   *
+   * #### Notes
+   * If there is no widget with the focus, then this value is `null`.
+   */
+  get currentWidget(): T {
+    return this._currentWidget;
+  }
+
+  /**
+   * Add a new widget to the tracker.
+   */
+  add(widget: T): void {
+    if (!widget.id) {
+      throw new Error('All tracked widgets must have IDs.');
+    }
+    if (this._widgets.has(widget.id)) {
+      console.warn(`${widget.id} has already been added to the tracker.`);
+      return;
+    }
+    this._widgets.set(widget.id, widget);
+    widget.disposed.connect(() => { this._widgets.delete(widget.id); });
+  }
+
+  /**
+   * Iterate through each widget in the tracker.
+   *
+   * @param fn The function to call on each widget.
+   */
+  forEach(fn: (widget: T) => void): void {
+    this._widgets.forEach(widget => { fn(widget); });
+  }
+
+  /**
+   * Check if this tracker has the specified widget.
+   */
+  has(widget: Widget): boolean {
+    return this._widgets.has(widget.id);
+  }
+
+  /**
+   * Syncs the state of the tracker with a widget known to have focus.
+   *
+   * @param current The currently focused widget.
+   *
+   * @returns The current widget or `null` if there is none.
+   *
+   * #### Notes
+   * Syncing acts as a gate returning the widget that's passed in any time it is
+   * held by the tracker and not already the current widget. It returns `null`
+   * at all other times.
+   */
+  sync(current: Widget): T {
+    if (current && this.has(current) && this._currentWidget !== current) {
+      this._currentWidget = current as T;
+      this.currentChanged.emit(this._currentWidget);
+      this.onSync();
+      return current as T;
+    }
+    if (this._currentWidget) {
+      this._currentWidget = null;
+      this.currentChanged.emit(null);
+    }
+    this.onSync();
+    return null;
+  }
+
+  /**
+   * Handle the sync event.
+   *
+   * #### Notes
+   * The default implementation is a no-op. This may be reimplemented by
+   * subclasses to customize the behavior.
+   */
+  protected onSync(): void {
+    /* This is a no-op. */
+  }
+
+  private _currentWidget: T = null;
+  private _widgets = new Map<string, T>();
+}
+
+// Define the signals for the `InstanceTracker` class.
+defineSignal(InstanceTracker.prototype, 'currentChanged');

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -58,7 +58,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   }
 
   /**
-   * Test whether the model is disposed.
+   * Test whether the tracker is disposed.
    */
   get isDisposed(): boolean {
     return this._widgets === null;

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -174,5 +174,6 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   private _widgets = new Map<string, T>();
 }
 
+
 // Define the signals for the `InstanceTracker` class.
 defineSignal(InstanceTracker.prototype, 'currentChanged');

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -48,7 +48,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * #### Notes
    * If the last widget being tracked is disposed, `null` will be emitted.
    */
-  currentChanged: ISignal<this, T>;
+  readonly currentChanged: ISignal<this, T>;
 
   /**
    * The current widget is the most recently focused widget.
@@ -139,23 +139,21 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * @returns The current widget or `null` if there is none.
    *
    * #### Notes
-   * Syncing acts as a gate returning the widget that's passed in any time it is
-   * held by the tracker and not already the current widget. It returns `null`
-   * at all other times.
+   * Syncing acts as a gate returning a widget only if it is the current widget.
    */
   sync(current: Widget): T {
     if (this.isDisposed) {
       return;
     }
-    if (current && this.has(current)) {
+    if (current && this._widgets.has(current as any)) {
       // If no state change needs to occur, just bail.
       if (this._currentWidget === current) {
-        return null;
+        return this._currentWidget;
       }
       this._currentWidget = current as T;
       this.onCurrentChanged();
       this.currentChanged.emit(this._currentWidget);
-      return current as T;
+      return this._currentWidget;
     }
     return null;
   }

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -23,15 +23,12 @@ interface IInstanceTracker<T extends Widget> {
    * A signal emitted when the current widget changes.
    *
    * #### Notes
-   * If there is no widget with the focus, then `null` will be emitted.
+   * If the last widget being tracked is disposed, `null` will be emitted.
    */
   currentChanged: ISignal<this, T>;
 
   /**
-   * The current widget.
-   *
-   * #### Notes
-   * If there is no widget with the focus, then this value is `null`.
+   * The current widget is the most recently focused widget.
    */
   currentWidget: T;
 }
@@ -151,7 +148,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
       return;
     }
     if (current && this.has(current)) {
-      // If not state change needs to occur, just bail.
+      // If no state change needs to occur, just bail.
       if (this._currentWidget === current) {
         return null;
       }

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -140,7 +140,12 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * at all other times.
    */
   sync(current: Widget): T {
-    if (current && this.has(current) && this._currentWidget !== current) {
+    if (current && this.has(current)) {
+      // If not state change needs to occur, just bail.
+      if (this._currentWidget === current) {
+        this.onSync();
+        return null;
+      }
       this._currentWidget = current as T;
       this.currentChanged.emit(this._currentWidget);
       this.onSync();

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -76,7 +76,8 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T> {
   find(fn: (widget: T) => boolean): T {
     let result: T = null;
     this._widgets.forEach(widget => {
-      if (!result) {
+      // If a result has already been found, short circuit.
+      if (result) {
         return;
       }
       if (fn(widget)) {

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -71,16 +71,13 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * Add a new widget to the tracker.
    */
   add(widget: T): void {
-    if (!widget.id) {
-      throw new Error('All tracked widgets must have IDs.');
-    }
-    if (this._widgets.has(widget.id)) {
+    if (this._widgets.has(widget)) {
       console.warn(`${widget.id} has already been added to the tracker.`);
       return;
     }
-    this._widgets.set(widget.id, widget);
+    this._widgets.add(widget);
     widget.disposed.connect(() => {
-      this._widgets.delete(widget.id);
+      this._widgets.delete(widget);
       if (!this._widgets.size) {
         this._currentWidget = null;
         this.onCurrentChanged();
@@ -134,7 +131,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * Check if this tracker has the specified widget.
    */
   has(widget: Widget): boolean {
-    return this._widgets.has(widget.id);
+    return this._widgets.has(widget as any);
   }
 
   /**
@@ -178,7 +175,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   }
 
   private _currentWidget: T = null;
-  private _widgets = new Map<string, T>();
+  private _widgets = new Set<T>();
 }
 
 

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -10,10 +10,6 @@ import {
 } from 'phosphor/lib/core/messaging';
 
 import {
-  defineSignal, ISignal
-} from 'phosphor/lib/core/signaling';
-
-import {
   Panel
 } from 'phosphor/lib/ui/panel';
 
@@ -58,11 +54,6 @@ class ConsolePanel extends Panel {
   }
 
   /**
-   * A signal emitted when the console panel has been activated.
-   */
-  activated: ISignal<ConsolePanel, void>;
-
-  /**
    * The console widget used by the panel.
    *
    * #### Notes
@@ -92,7 +83,6 @@ class ConsolePanel extends Panel {
    */
   protected onActivateRequest(msg: Message): void {
     this.content.activate();
-    this.activated.emit(void 0);
   }
 
   /**
@@ -123,10 +113,6 @@ class ConsolePanel extends Panel {
 
   private _content: ConsoleContent = null;
 }
-
-
-// Define the signals for the `ConsolePanel` class.
-defineSignal(ConsolePanel.prototype, 'activated');
 
 
 /**

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -115,8 +115,13 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   let command: string;
 
   // Set the source of the code inspector to the current console.
-  app.shell.currentChanged.connect((shell, args) => {
+  app.shell.currentChanged.connect((sender, args) => {
     let widget = args.newValue;
+    if (!widget) {
+      // Reset the current reference.
+      current = null;
+      return;
+    }
     // Type information can be safely discarded here as `.has()` relies on
     // referential identity.
     if (instances.has(widget.id || '')) {

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -89,6 +89,11 @@ const LANDSCAPE_ICON_CLASS = 'jp-MainAreaLandscapeIcon';
  */
 const CONSOLE_ICON_CLASS = 'jp-ImageConsole';
 
+/**
+ * The console panel instance tracker.
+ */
+const tracker = new InstanceTracker<ConsolePanel>();
+
 
 /**
  * The interface for a start console.
@@ -105,7 +110,6 @@ interface ICreateConsoleArgs extends JSONObject {
  * Activate the console extension.
  */
 function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, inspector: IInspector, palette: ICommandPalette, pathTracker: IPathTracker, renderer: ConsoleContent.IRenderer): IConsoleTracker {
-  let tracker = new InstanceTracker<ConsolePanel>();
   let manager = services.sessions;
   let specs = services.kernelspecs;
 

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -109,7 +109,7 @@ interface ICreateConsoleArgs extends JSONObject {
  * Activate the console extension.
  */
 function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, inspector: IInspector, palette: ICommandPalette, pathTracker: IPathTracker, renderer: ConsoleContent.IRenderer): IConsoleTracker {
-  let tracker = new FocusTracker<Widget>();
+  let tracker = new FocusTracker<ConsolePanel>();
   let manager = services.sessions;
   let specs = services.kernelspecs;
 
@@ -123,9 +123,9 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
 
   // Set the source of the code inspector to the current console.
   app.shell.currentChanged.connect((shell, args) => {
-    let widget = args.newValue;
+    let widget = args.newValue as ConsolePanel;
     if (tracker.has(widget)) {
-      inspector.source = (widget as ConsolePanel).content.inspectionHandler;
+      inspector.source = widget.content.inspectionHandler;
     }
   });
 
@@ -147,8 +147,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     label: 'Clear Cells',
     execute: () => {
       if (tracker.currentWidget) {
-        let content = (tracker.currentWidget as ConsolePanel).content;
-        content.clear();
+        tracker.currentWidget.content.clear();
       }
     }
   });
@@ -159,8 +158,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   commands.addCommand(command, {
     execute: () => {
       if (tracker.currentWidget) {
-        let content = (tracker.currentWidget as ConsolePanel).content;
-        content.dismissCompleter();
+        tracker.currentWidget.content.dismissCompleter();
       }
     }
   });
@@ -170,8 +168,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     label: 'Run Cell',
     execute: () => {
       if (tracker.currentWidget) {
-        let content = (tracker.currentWidget as ConsolePanel).content;
-        content.execute();
+        tracker.currentWidget.content.execute();
       }
     }
   });
@@ -184,8 +181,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     label: 'Run Cell (forced)',
     execute: () => {
       if (tracker.currentWidget) {
-        let content = (tracker.currentWidget as ConsolePanel).content;
-        content.execute(true);
+        tracker.currentWidget.content.execute(true);
       }
     }
   });
@@ -197,8 +193,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     label: 'Insert Line Break',
     execute: () => {
       if (tracker.currentWidget) {
-        let content = (tracker.currentWidget as ConsolePanel).content;
-        content.insertLinebreak();
+        tracker.currentWidget.content.insertLinebreak();
       }
     }
   });
@@ -210,8 +205,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     label: 'Interrupt Kernel',
     execute: () => {
       if (tracker.currentWidget) {
-        let content = (tracker.currentWidget as ConsolePanel).content;
-        let kernel = content.session.kernel;
+        let kernel = tracker.currentWidget.content.session.kernel;
         if (kernel) {
           kernel.interrupt();
         }
@@ -270,7 +264,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     execute: (args: JSONObject) => {
       let id = args['id'];
       for (let i = 0; i < tracker.widgets.length; i++) {
-        let widget = tracker.widgets.at(i) as ConsolePanel;
+        let widget = tracker.widgets.at(i);
         if (widget.content.session.id === id) {
           widget.content.inject(args['code'] as string);
         }
@@ -352,7 +346,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       if (!tracker.currentWidget) {
         return;
       }
-      let widget = (tracker.currentWidget as ConsolePanel).content;
+      let widget = tracker.currentWidget.content;
       let session = widget.session;
       let lang = '';
       if (session.kernel) {

--- a/src/console/tracker.ts
+++ b/src/console/tracker.ts
@@ -6,10 +6,6 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
-  FocusTracker
-} from 'phosphor/lib/ui/focustracker';
-
-import {
   ConsolePanel
 } from './';
 
@@ -27,4 +23,4 @@ const IConsoleTracker = new Token<IConsoleTracker>('jupyter.services.consoles');
  * A class that tracks console widgets.
  */
 export
-interface IConsoleTracker extends FocusTracker<ConsolePanel> {}
+interface IConsoleTracker extends Map<string, ConsolePanel> {}

--- a/src/console/tracker.ts
+++ b/src/console/tracker.ts
@@ -6,6 +6,10 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
+  IInstanceTracker
+} from '../common/instancetracker';
+
+import {
   ConsolePanel
 } from './';
 
@@ -23,4 +27,4 @@ const IConsoleTracker = new Token<IConsoleTracker>('jupyter.services.consoles');
  * A class that tracks console widgets.
  */
 export
-interface IConsoleTracker extends Map<string, ConsolePanel> {}
+interface IConsoleTracker extends IInstanceTracker<ConsolePanel> {}

--- a/src/console/tracker.ts
+++ b/src/console/tracker.ts
@@ -10,8 +10,8 @@ import {
 } from 'phosphor/lib/ui/focustracker';
 
 import {
-  ConsolePanel
-} from './';
+  Widget
+} from 'phosphor/lib/ui/widget';
 
 
 /* tslint:disable */
@@ -19,7 +19,7 @@ import {
  * The console tracker token.
  */
 export
-const IConsoleTracker = new Token<IConsoleTracker>('jupyter.services.console-handler');
+const IConsoleTracker = new Token<IConsoleTracker>('jupyter.services.consoles');
 /* tslint:enable */
 
 
@@ -27,4 +27,4 @@ const IConsoleTracker = new Token<IConsoleTracker>('jupyter.services.console-han
  * A class that tracks console widgets.
  */
 export
-interface IConsoleTracker extends FocusTracker<ConsolePanel> {}
+interface IConsoleTracker extends FocusTracker<Widget> {}

--- a/src/console/tracker.ts
+++ b/src/console/tracker.ts
@@ -10,8 +10,8 @@ import {
 } from 'phosphor/lib/ui/focustracker';
 
 import {
-  Widget
-} from 'phosphor/lib/ui/widget';
+  ConsolePanel
+} from './';
 
 
 /* tslint:disable */
@@ -27,4 +27,4 @@ const IConsoleTracker = new Token<IConsoleTracker>('jupyter.services.consoles');
  * A class that tracks console widgets.
  */
 export
-interface IConsoleTracker extends FocusTracker<Widget> {}
+interface IConsoleTracker extends FocusTracker<ConsolePanel> {}

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -62,18 +62,6 @@ const PORTRAIT_ICON_CLASS = 'jp-MainAreaPortraitIcon';
 const EDITOR_ICON_CLASS = 'jp-ImageTextEditor';
 
 /**
- * The editor handler extension.
- */
-export
-const editorHandlerProvider: JupyterLabPlugin<IEditorTracker> = {
-  id: 'jupyter.services.editor-handler',
-  requires: [IDocumentRegistry, IMainMenu, ICommandPalette],
-  provides: IEditorTracker,
-  activate: activateEditorHandler,
-  autoStart: true
-};
-
-/**
  * The map of command ids used by the editor.
  */
 const cmdIds = {
@@ -91,6 +79,19 @@ const cmdIds = {
  * The editor widget instance tracker.
  */
 const tracker = new InstanceTracker<EditorWidget>();
+
+
+/**
+ * The editor handler extension.
+ */
+export
+const editorHandlerProvider: JupyterLabPlugin<IEditorTracker> = {
+  id: 'jupyter.services.editor-handler',
+  requires: [IDocumentRegistry, IMainMenu, ICommandPalette],
+  provides: IEditorTracker,
+  activate: activateEditorHandler,
+  autoStart: true
+};
 
 
 /**

--- a/src/editorwidget/widget.ts
+++ b/src/editorwidget/widget.ts
@@ -15,12 +15,12 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
-  FocusTracker
-} from 'phosphor/lib/ui/focustracker';
-
-import {
   loadModeByFileName
 } from '../codemirror';
+
+import {
+  IInstanceTracker
+} from '../common/instancetracker';
 
 import {
   CodeMirrorWidget, DEFAULT_CODEMIRROR_THEME
@@ -46,7 +46,7 @@ const EDITOR_CLASS = 'jp-EditorWidget';
  * A class that tracks editor widgets.
  */
 export
-interface IEditorTracker extends FocusTracker<EditorWidget> {}
+interface IEditorTracker extends IInstanceTracker<EditorWidget> {}
 
 
 /* tslint:disable */

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  each
+} from 'phosphor/lib/algorithm/iteration';
+
+import {
   DisposableSet
 } from 'phosphor/lib/core/disposable';
 
@@ -129,9 +133,9 @@ function activateFileBrowser(app: JupyterLab, manager: IServiceManager, registry
     tracker.sync(args.newValue);
   });
 
-  for (let creator of creators) {
+  each(creators, creator => {
     addCreator(creator.name);
-  }
+  });
 
   // Add a context menu to the dir listing.
   let node = fbWidget.node.getElementsByClassName('jp-DirListing-content')[0];

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -44,24 +44,40 @@ class InspectorManager implements IInspector {
       return;
     }
     this._inspector = inspector;
+    // If an inspector was added and it has no source
+    if (inspector && !inspector.source) {
+      inspector.source = this._source;
+    }
   }
 
   /**
    * The source of events the inspector panel listens for.
    */
   get source(): Inspector.IInspectable {
-    if (this._inspector && !this._inspector.isDisposed) {
-      return this._inspector.source;
-    }
-    return null;
+    return this._source;
   }
   set source(source: Inspector.IInspectable) {
+    if (this._source !== source) {
+      if (this._source) {
+        this._source.disposed.disconnect(this._onSourceDisposed);
+      }
+      this._source = source;
+      this._source.disposed.connect(this._onSourceDisposed);
+    }
     if (this._inspector && !this._inspector.isDisposed) {
-      this._inspector.source = source;
+      this._inspector.source = this._source;
     }
   }
 
+  /**
+   * Handle the source disposed signal.
+   */
+  private _onSourceDisposed() {
+    this._source = null;
+  }
+
   private _inspector: Inspector = null;
+  private _source: Inspector.IInspectable = null;
 }
 
 

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -149,8 +149,8 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
   // Set the source of the code inspector to the current notebook.
   app.shell.currentChanged.connect((shell, args) => {
     let widget = args.newValue;
-    if (tracker.has(widget)) {
-      inspector.source = (widget as NotebookPanel).content.inspectionHandler;
+    if (tracker.has(widget as NotebookPanel)) {
+      inspector.source = tracker.currentWidget.content.inspectionHandler;
     }
   });
 
@@ -196,7 +196,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Run Cell(s) and Advance',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         let content = nbWidget.content;
         NotebookActions.runAndAdvance(content, nbWidget.context.kernel);
       }
@@ -206,7 +206,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Run Cell(s)',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.run(nbWidget.content, nbWidget.context.kernel);
       }
     }
@@ -215,7 +215,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Run Cell(s) and Insert',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.runAndInsert(nbWidget.content, nbWidget.context.kernel);
       }
     }
@@ -224,7 +224,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Run All Cells',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.runAll(nbWidget.content, nbWidget.context.kernel);
       }
     }
@@ -233,7 +233,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Restart Kernel',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         restartKernel(nbWidget.kernel, nbWidget.node);
       }
     }
@@ -242,7 +242,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Restart Kernel & Clear Outputs',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         let promise = restartKernel(nbWidget.kernel, nbWidget.node);
         promise.then(result => {
           if (result) {
@@ -256,7 +256,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Restart Kernel & Run All',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         let promise = restartKernel(nbWidget.kernel, nbWidget.node);
         promise.then(result => {
           NotebookActions.runAll(nbWidget.content, nbWidget.context.kernel);
@@ -268,7 +268,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Clear All Outputs',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.clearAllOutputs(nbWidget.content);
       }
     }
@@ -277,7 +277,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Clear Output(s)',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.clearOutputs(nbWidget.content);
       }
     }
@@ -286,8 +286,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Interrupt Kernel',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        let kernel = nbWidget.context.kernel;
+        let kernel = tracker.currentWidget.context.kernel;
         if (kernel) {
           kernel.interrupt();
         }
@@ -298,7 +297,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Convert to Code',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.changeCellType(nbWidget.content, 'code');
       }
     }
@@ -307,7 +306,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Convert to Markdown',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.changeCellType(nbWidget.content, 'markdown');
       }
     }
@@ -316,7 +315,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Convert to Raw',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.changeCellType(nbWidget.content, 'raw');
       }
     }
@@ -325,7 +324,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Cut Cell(s)',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.cut(nbWidget.content, nbWidget.clipboard);
       }
     }
@@ -334,7 +333,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Copy Cell(s)',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.copy(nbWidget.content, nbWidget.clipboard);
       }
     }
@@ -343,7 +342,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Paste Cell(s)',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.paste(nbWidget.content, nbWidget.clipboard);
       }
     }
@@ -352,7 +351,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Delete Cell(s)',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.deleteCells(nbWidget.content);
       }
     }
@@ -361,7 +360,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Split Cell',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.splitCell(nbWidget.content);
       }
     }
@@ -370,7 +369,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Merge Selected Cell(s)',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.mergeCells(nbWidget.content);
       }
     }
@@ -379,7 +378,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Insert Cell Above',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.insertAbove(nbWidget.content);
       }
     }
@@ -388,7 +387,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Insert Cell Below',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.insertBelow(nbWidget.content);
       }
     }
@@ -397,7 +396,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Select Cell Above',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.selectAbove(nbWidget.content);
       }
     }
@@ -406,7 +405,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Select Cell Below',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.selectBelow(nbWidget.content);
       }
     }
@@ -415,7 +414,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Extend Selection Above',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.extendSelectionAbove(nbWidget.content);
       }
     }
@@ -424,7 +423,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Extend Selection Below',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.extendSelectionBelow(nbWidget.content);
       }
     }
@@ -433,7 +432,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Move Cell(s) Up',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.moveUp(nbWidget.content);
       }
     }
@@ -442,7 +441,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Move Cell(s) Down',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.moveDown(nbWidget.content);
       }
     }
@@ -451,7 +450,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Toggle Line Numbers',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.toggleLineNumbers(nbWidget.content);
       }
     }
@@ -460,7 +459,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Toggle All Line Numbers',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
+        let nbWidget = tracker.currentWidget;
         NotebookActions.toggleAllLineNumbers(nbWidget.content);
       }
     }
@@ -469,8 +468,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'To Command Mode',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        nbWidget.content.mode = 'command';
+        tracker.currentWidget.content.mode = 'command';
       }
     }
   });
@@ -478,8 +476,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'To Edit Mode',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        nbWidget.content.mode = 'edit';
+        tracker.currentWidget.content.mode = 'edit';
       }
     }
   });
@@ -487,8 +484,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Undo Cell Operation',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        NotebookActions.undo(nbWidget.content);
+        NotebookActions.undo(tracker.currentWidget.content);
       }
     }
   });
@@ -496,8 +492,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Redo Cell Operation',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        NotebookActions.redo(nbWidget.content);
+        NotebookActions.redo(tracker.currentWidget.content);
       }
     }
   });
@@ -505,7 +500,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Switch Kernel',
     execute: () => {
       if (tracker.currentWidget) {
-        let { context, node } = tracker.currentWidget as NotebookPanel;
+        let { context, node } = tracker.currentWidget;
         selectKernelForContext(context, node);
       }
     }
@@ -514,8 +509,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Markdown Header 1',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        NotebookActions.setMarkdownHeader(nbWidget.content, 1);
+        NotebookActions.setMarkdownHeader(tracker.currentWidget.content, 1);
       }
     }
   });
@@ -523,8 +517,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Markdown Header 2',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        NotebookActions.setMarkdownHeader(nbWidget.content, 2);
+        NotebookActions.setMarkdownHeader(tracker.currentWidget.content, 2);
       }
     }
   });
@@ -532,8 +525,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Markdown Header 3',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        NotebookActions.setMarkdownHeader(nbWidget.content, 3);
+        NotebookActions.setMarkdownHeader(tracker.currentWidget.content, 3);
       }
     }
   });
@@ -541,8 +533,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Markdown Header 4',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        NotebookActions.setMarkdownHeader(nbWidget.content, 4);
+        NotebookActions.setMarkdownHeader(tracker.currentWidget.content, 4);
       }
     }
   });
@@ -550,8 +541,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Markdown Header 5',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        NotebookActions.setMarkdownHeader(nbWidget.content, 5);
+        NotebookActions.setMarkdownHeader(tracker.currentWidget.content, 5);
       }
     }
   });
@@ -559,8 +549,7 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
     label: 'Markdown Header 6',
     execute: () => {
       if (tracker.currentWidget) {
-        let nbWidget = tracker.currentWidget as NotebookPanel;
-        NotebookActions.setMarkdownHeader(nbWidget.content, 6);
+        NotebookActions.setMarkdownHeader(tracker.currentWidget.content, 6);
       }
     }
   });

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -55,6 +55,11 @@ const PORTRAIT_ICON_CLASS = 'jp-MainAreaPortraitIcon';
 const NOTEBOOK_ICON_CLASS = 'jp-ImageNotebook';
 
 /**
+ * The notebook instance tracker.
+ */
+const tracker = new NotebookTracker();
+
+/**
  * The map of command ids used by the notebook.
  */
 const cmdIds = {
@@ -100,7 +105,6 @@ const cmdIds = {
   markdown6: 'notebook-cells:markdown-header6',
 };
 
-
 /**
  * The notebook widget tracker provider.
  */
@@ -128,7 +132,6 @@ const notebookTrackerProvider: JupyterLabPlugin<INotebookTracker> = {
  */
 function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, clipboard: IClipboard, mainMenu: IMainMenu, palette: ICommandPalette, inspector: IInspector, renderer: NotebookPanel.IRenderer): INotebookTracker {
   let widgetFactory = new NotebookWidgetFactory(rendermime, clipboard, renderer);
-  let tracker = new NotebookTracker();
   let options: DocumentRegistry.IWidgetFactoryOptions = {
     fileExtensions: ['.ipynb'],
     displayName: 'Notebook',
@@ -161,7 +164,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     widgetName: 'Notebook'
   });
 
-  addCommands(app, tracker);
+  addCommands(app);
   populatePalette(palette);
 
   let id = 0; // The ID counter for notebook panels.
@@ -185,7 +188,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
 /**
  * Add the notebook commands to the application's command registry.
  */
-function addCommands(app: JupyterLab, tracker: NotebookTracker): void {
+function addCommands(app: JupyterLab): void {
   let commands = app.commands;
 
   commands.addCommand(cmdIds.runAndAdvance, {
@@ -550,17 +553,17 @@ function addCommands(app: JupyterLab, tracker: NotebookTracker): void {
       if (current) {
         NotebookActions.setMarkdownHeader(current.content, 5);
       }
+    }
+  });
+  commands.addCommand(cmdIds.markdown6, {
+    label: 'Markdown Header 6',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.setMarkdownHeader(current.content, 6);
       }
-    });
-    commands.addCommand(cmdIds.markdown6, {
-      label: 'Markdown Header 6',
-      execute: () => {
-        let current = tracker.currentWidget;
-        if (current) {
-          NotebookActions.setMarkdownHeader(current.content, 6);
-        }
-      }
-    });
+    }
+  });
   }
 
 /**

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -39,7 +39,7 @@ import {
 } from '../services';
 
 import {
-  INotebookTracker, NotebookPanel, NotebookModelFactory,
+  INotebookTracker, NotebookModelFactory, NotebookPanel, NotebookTracker,
   NotebookWidgetFactory, NotebookActions
 } from './index';
 
@@ -128,8 +128,7 @@ const notebookTrackerProvider: JupyterLabPlugin<INotebookTracker> = {
  */
 function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, clipboard: IClipboard, mainMenu: IMainMenu, palette: ICommandPalette, inspector: IInspector, renderer: NotebookPanel.IRenderer): INotebookTracker {
   let widgetFactory = new NotebookWidgetFactory(rendermime, clipboard, renderer);
-  let instances = new Map<string, NotebookPanel>();
-  let current: NotebookPanel = null;
+  let tracker = new NotebookTracker();
   let options: DocumentRegistry.IWidgetFactoryOptions = {
     fileExtensions: ['.ipynb'],
     displayName: 'Notebook',
@@ -139,23 +138,11 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     canStartKernel: true
   };
 
-  // Set the source of the code inspector to the current notebook.
+  // Sync tracker and set the source of the code inspector.
   app.shell.currentChanged.connect((sender, args) => {
-    let widget = args.newValue;
-    if (!widget) {
-      // Reset the current reference.
-      current = null;
-      return;
-    }
-    // Type information can be safely discarded here as `.has()` relies on
-    // referential identity.
-    if (instances.has(widget.id || '')) {
-      // Set the current reference to the current widget.
-      current = widget as NotebookPanel;
-      inspector.source = current.content.inspectionHandler;
-    } else {
-      // Reset the current reference.
-      current = null;
+    let widget = tracker.sync(args.newValue);
+    if (widget) {
+      inspector.source = widget.content.inspectionHandler;
     }
   });
 
@@ -174,7 +161,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     widgetName: 'Notebook'
   });
 
-  addCommands(app);
+  addCommands(app, tracker);
   populatePalette(palette);
 
   let id = 0; // The ID counter for notebook panels.
@@ -185,358 +172,396 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     widget.title.icon = `${PORTRAIT_ICON_CLASS} ${NOTEBOOK_ICON_CLASS}`;
     // Immediately set the inspector source to the current notebook.
     inspector.source = widget.content.inspectionHandler;
-    // Add the notebook panel to the instances map.
-    instances.set(widget.id, widget);
-    // Remove from the instances map upon disposal.
-    widget.disposed.connect(() => { instances.delete(widget.id); });
+    // Add the notebook panel to the tracker.
+    tracker.add(widget);
   });
 
   // Add main menu notebook menu.
   mainMenu.addMenu(createMenu(app), { rank: 20 });
 
-  /**
-   * Add the notebook commands to the application's command registry.
-   */
-  function addCommands(app: JupyterLab): void {
-    let commands = app.commands;
+  return tracker;
+}
 
-    commands.addCommand(cmdIds.runAndAdvance, {
-      label: 'Run Cell(s) and Advance',
-      execute: () => {
-        if (current) {
-          let content = current.content;
-          NotebookActions.runAndAdvance(content, current.context.kernel);
-        }
+/**
+ * Add the notebook commands to the application's command registry.
+ */
+function addCommands(app: JupyterLab, tracker: NotebookTracker): void {
+  let commands = app.commands;
+
+  commands.addCommand(cmdIds.runAndAdvance, {
+    label: 'Run Cell(s) and Advance',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        let content = current.content;
+        NotebookActions.runAndAdvance(content, current.context.kernel);
       }
-    });
-    commands.addCommand(cmdIds.run, {
-      label: 'Run Cell(s)',
-      execute: () => {
-        if (current) {
-          NotebookActions.run(current.content, current.context.kernel);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.run, {
+    label: 'Run Cell(s)',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.run(current.content, current.context.kernel);
       }
-    });
-    commands.addCommand(cmdIds.runAndInsert, {
-      label: 'Run Cell(s) and Insert',
-      execute: () => {
-        if (current) {
-          NotebookActions.runAndInsert(current.content, current.context.kernel);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.runAndInsert, {
+    label: 'Run Cell(s) and Insert',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.runAndInsert(current.content, current.context.kernel);
       }
-    });
-    commands.addCommand(cmdIds.runAll, {
-      label: 'Run All Cells',
-      execute: () => {
-        if (current) {
-          NotebookActions.runAll(current.content, current.context.kernel);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.runAll, {
+    label: 'Run All Cells',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.runAll(current.content, current.context.kernel);
       }
-    });
-    commands.addCommand(cmdIds.restart, {
-      label: 'Restart Kernel',
-      execute: () => {
-        if (current) {
-          restartKernel(current.kernel, current.node);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.restart, {
+    label: 'Restart Kernel',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        restartKernel(current.kernel, current.node);
       }
-    });
-    commands.addCommand(cmdIds.restartClear, {
-      label: 'Restart Kernel & Clear Outputs',
-      execute: () => {
-        if (current) {
-          let promise = restartKernel(current.kernel, current.node);
-          promise.then(result => {
-            if (result) {
-              NotebookActions.clearAllOutputs(current.content);
-            }
-          });
-        }
-      }
-    });
-    commands.addCommand(cmdIds.restartRunAll, {
-      label: 'Restart Kernel & Run All',
-      execute: () => {
-        if (current) {
-          let promise = restartKernel(current.kernel, current.node);
-          promise.then(result => {
-            NotebookActions.runAll(current.content, current.context.kernel);
-          });
-        }
-      }
-    });
-    commands.addCommand(cmdIds.clearAllOutputs, {
-      label: 'Clear All Outputs',
-      execute: () => {
-        if (current) {
-          NotebookActions.clearAllOutputs(current.content);
-        }
-      }
-    });
-    commands.addCommand(cmdIds.clearOutputs, {
-      label: 'Clear Output(s)',
-      execute: () => {
-        if (current) {
-          NotebookActions.clearOutputs(current.content);
-        }
-      }
-    });
-    commands.addCommand(cmdIds.interrupt, {
-      label: 'Interrupt Kernel',
-      execute: () => {
-        if (current) {
-          let kernel = current.context.kernel;
-          if (kernel) {
-            kernel.interrupt();
+    }
+  });
+  commands.addCommand(cmdIds.restartClear, {
+    label: 'Restart Kernel & Clear Outputs',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        let promise = restartKernel(current.kernel, current.node);
+        promise.then(result => {
+          if (result) {
+            NotebookActions.clearAllOutputs(current.content);
           }
+        });
+      }
+    }
+  });
+  commands.addCommand(cmdIds.restartRunAll, {
+    label: 'Restart Kernel & Run All',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        let promise = restartKernel(current.kernel, current.node);
+        promise.then(result => {
+          NotebookActions.runAll(current.content, current.context.kernel);
+        });
+      }
+    }
+  });
+  commands.addCommand(cmdIds.clearAllOutputs, {
+    label: 'Clear All Outputs',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.clearAllOutputs(current.content);
+      }
+    }
+  });
+  commands.addCommand(cmdIds.clearOutputs, {
+    label: 'Clear Output(s)',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.clearOutputs(current.content);
+      }
+    }
+  });
+  commands.addCommand(cmdIds.interrupt, {
+    label: 'Interrupt Kernel',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        let kernel = current.context.kernel;
+        if (kernel) {
+          kernel.interrupt();
         }
       }
-    });
-    commands.addCommand(cmdIds.toCode, {
-      label: 'Convert to Code',
-      execute: () => {
-        if (current) {
-          NotebookActions.changeCellType(current.content, 'code');
-        }
+    }
+  });
+  commands.addCommand(cmdIds.toCode, {
+    label: 'Convert to Code',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.changeCellType(current.content, 'code');
       }
-    });
-    commands.addCommand(cmdIds.toMarkdown, {
-      label: 'Convert to Markdown',
-      execute: () => {
-        if (current) {
-          NotebookActions.changeCellType(current.content, 'markdown');
-        }
+    }
+  });
+  commands.addCommand(cmdIds.toMarkdown, {
+    label: 'Convert to Markdown',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.changeCellType(current.content, 'markdown');
       }
-    });
-    commands.addCommand(cmdIds.toRaw, {
-      label: 'Convert to Raw',
-      execute: () => {
-        if (current) {
-          NotebookActions.changeCellType(current.content, 'raw');
-        }
+    }
+  });
+  commands.addCommand(cmdIds.toRaw, {
+    label: 'Convert to Raw',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.changeCellType(current.content, 'raw');
       }
-    });
-    commands.addCommand(cmdIds.cut, {
-      label: 'Cut Cell(s)',
-      execute: () => {
-        if (current) {
-          NotebookActions.cut(current.content, current.clipboard);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.cut, {
+    label: 'Cut Cell(s)',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.cut(current.content, current.clipboard);
       }
-    });
-    commands.addCommand(cmdIds.copy, {
-      label: 'Copy Cell(s)',
-      execute: () => {
-        if (current) {
-          NotebookActions.copy(current.content, current.clipboard);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.copy, {
+    label: 'Copy Cell(s)',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.copy(current.content, current.clipboard);
       }
-    });
-    commands.addCommand(cmdIds.paste, {
-      label: 'Paste Cell(s)',
-      execute: () => {
-        if (current) {
-          NotebookActions.paste(current.content, current.clipboard);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.paste, {
+    label: 'Paste Cell(s)',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.paste(current.content, current.clipboard);
       }
-    });
-    commands.addCommand(cmdIds.deleteCell, {
-      label: 'Delete Cell(s)',
-      execute: () => {
-        if (current) {
-          NotebookActions.deleteCells(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.deleteCell, {
+    label: 'Delete Cell(s)',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.deleteCells(current.content);
       }
-    });
-    commands.addCommand(cmdIds.split, {
-      label: 'Split Cell',
-      execute: () => {
-        if (current) {
-          NotebookActions.splitCell(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.split, {
+    label: 'Split Cell',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.splitCell(current.content);
       }
-    });
-    commands.addCommand(cmdIds.merge, {
-      label: 'Merge Selected Cell(s)',
-      execute: () => {
-        if (current) {
-          NotebookActions.mergeCells(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.merge, {
+    label: 'Merge Selected Cell(s)',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.mergeCells(current.content);
       }
-    });
-    commands.addCommand(cmdIds.insertAbove, {
-      label: 'Insert Cell Above',
-      execute: () => {
-        if (current) {
-          NotebookActions.insertAbove(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.insertAbove, {
+    label: 'Insert Cell Above',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.insertAbove(current.content);
       }
-    });
-    commands.addCommand(cmdIds.insertBelow, {
-      label: 'Insert Cell Below',
-      execute: () => {
-        if (current) {
-          NotebookActions.insertBelow(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.insertBelow, {
+    label: 'Insert Cell Below',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.insertBelow(current.content);
       }
-    });
-    commands.addCommand(cmdIds.selectAbove, {
-      label: 'Select Cell Above',
-      execute: () => {
-        if (current) {
-          NotebookActions.selectAbove(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.selectAbove, {
+    label: 'Select Cell Above',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.selectAbove(current.content);
       }
-    });
-    commands.addCommand(cmdIds.selectBelow, {
-      label: 'Select Cell Below',
-      execute: () => {
-        if (current) {
-          NotebookActions.selectBelow(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.selectBelow, {
+    label: 'Select Cell Below',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.selectBelow(current.content);
       }
-    });
-    commands.addCommand(cmdIds.extendAbove, {
-      label: 'Extend Selection Above',
-      execute: () => {
-        if (current) {
-          NotebookActions.extendSelectionAbove(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.extendAbove, {
+    label: 'Extend Selection Above',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.extendSelectionAbove(current.content);
       }
-    });
-    commands.addCommand(cmdIds.extendBelow, {
-      label: 'Extend Selection Below',
-      execute: () => {
-        if (current) {
-          NotebookActions.extendSelectionBelow(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.extendBelow, {
+    label: 'Extend Selection Below',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.extendSelectionBelow(current.content);
       }
-    });
-    commands.addCommand(cmdIds.moveUp, {
-      label: 'Move Cell(s) Up',
-      execute: () => {
-        if (current) {
-          NotebookActions.moveUp(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.moveUp, {
+    label: 'Move Cell(s) Up',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.moveUp(current.content);
       }
-    });
-    commands.addCommand(cmdIds.moveDown, {
-      label: 'Move Cell(s) Down',
-      execute: () => {
-        if (current) {
-          NotebookActions.moveDown(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.moveDown, {
+    label: 'Move Cell(s) Down',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.moveDown(current.content);
       }
-    });
-    commands.addCommand(cmdIds.toggleLines, {
-      label: 'Toggle Line Numbers',
-      execute: () => {
-        if (current) {
-          NotebookActions.toggleLineNumbers(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.toggleLines, {
+    label: 'Toggle Line Numbers',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.toggleLineNumbers(current.content);
       }
-    });
-    commands.addCommand(cmdIds.toggleAllLines, {
-      label: 'Toggle All Line Numbers',
-      execute: () => {
-        if (current) {
-          NotebookActions.toggleAllLineNumbers(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.toggleAllLines, {
+    label: 'Toggle All Line Numbers',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.toggleAllLineNumbers(current.content);
       }
-    });
-    commands.addCommand(cmdIds.commandMode, {
-      label: 'To Command Mode',
-      execute: () => {
-        if (current) {
-          current.content.mode = 'command';
-        }
+    }
+  });
+  commands.addCommand(cmdIds.commandMode, {
+    label: 'To Command Mode',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        current.content.mode = 'command';
       }
-    });
-    commands.addCommand(cmdIds.editMode, {
-      label: 'To Edit Mode',
-      execute: () => {
-        if (current) {
-          current.content.mode = 'edit';
-        }
+    }
+  });
+  commands.addCommand(cmdIds.editMode, {
+    label: 'To Edit Mode',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        current.content.mode = 'edit';
       }
-    });
-    commands.addCommand(cmdIds.undo, {
-      label: 'Undo Cell Operation',
-      execute: () => {
-        if (current) {
-          NotebookActions.undo(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.undo, {
+    label: 'Undo Cell Operation',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.undo(current.content);
       }
-    });
-    commands.addCommand(cmdIds.redo, {
-      label: 'Redo Cell Operation',
-      execute: () => {
-        if (current) {
-          NotebookActions.redo(current.content);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.redo, {
+    label: 'Redo Cell Operation',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.redo(current.content);
       }
-    });
-    commands.addCommand(cmdIds.switchKernel, {
-      label: 'Switch Kernel',
-      execute: () => {
-        if (current) {
-          let { context, node } = current;
-          selectKernelForContext(context, node);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.switchKernel, {
+    label: 'Switch Kernel',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        let { context, node } = current;
+        selectKernelForContext(context, node);
       }
-    });
-    commands.addCommand(cmdIds.markdown1, {
-      label: 'Markdown Header 1',
-      execute: () => {
-        if (current) {
-          NotebookActions.setMarkdownHeader(current.content, 1);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.markdown1, {
+    label: 'Markdown Header 1',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.setMarkdownHeader(current.content, 1);
       }
-    });
-    commands.addCommand(cmdIds.markdown2, {
-      label: 'Markdown Header 2',
-      execute: () => {
-        if (current) {
-          NotebookActions.setMarkdownHeader(current.content, 2);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.markdown2, {
+    label: 'Markdown Header 2',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.setMarkdownHeader(current.content, 2);
       }
-    });
-    commands.addCommand(cmdIds.markdown3, {
-      label: 'Markdown Header 3',
-      execute: () => {
-        if (current) {
-          NotebookActions.setMarkdownHeader(current.content, 3);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.markdown3, {
+    label: 'Markdown Header 3',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.setMarkdownHeader(current.content, 3);
       }
-    });
-    commands.addCommand(cmdIds.markdown4, {
-      label: 'Markdown Header 4',
-      execute: () => {
-        if (current) {
-          NotebookActions.setMarkdownHeader(current.content, 4);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.markdown4, {
+    label: 'Markdown Header 4',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.setMarkdownHeader(current.content, 4);
       }
-    });
-    commands.addCommand(cmdIds.markdown5, {
-      label: 'Markdown Header 5',
-      execute: () => {
-        if (current) {
-          NotebookActions.setMarkdownHeader(current.content, 5);
-        }
+    }
+  });
+  commands.addCommand(cmdIds.markdown5, {
+    label: 'Markdown Header 5',
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        NotebookActions.setMarkdownHeader(current.content, 5);
+      }
       }
     });
     commands.addCommand(cmdIds.markdown6, {
       label: 'Markdown Header 6',
       execute: () => {
+        let current = tracker.currentWidget;
         if (current) {
           NotebookActions.setMarkdownHeader(current.content, 6);
         }
       }
     });
   }
-
-  return instances;
-}
 
 /**
  * Populate the application's command palette with notebook commands.

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -140,8 +140,13 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
   };
 
   // Set the source of the code inspector to the current notebook.
-  app.shell.currentChanged.connect((shell, args) => {
+  app.shell.currentChanged.connect((sender, args) => {
     let widget = args.newValue;
+    if (!widget) {
+      // Reset the current reference.
+      current = null;
+      return;
+    }
     // Type information can be safely discarded here as `.has()` relies on
     // referential identity.
     if (instances.has(widget.id || '')) {

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -105,6 +105,7 @@ const cmdIds = {
   markdown6: 'notebook-cells:markdown-header6',
 };
 
+
 /**
  * The notebook widget tracker provider.
  */

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -10,8 +10,8 @@ import {
 } from 'phosphor/lib/ui/focustracker';
 
 import {
-  NotebookPanel
-} from './';
+  Widget
+} from 'phosphor/lib/ui/widget';
 
 
 /* tslint:disable */
@@ -19,7 +19,7 @@ import {
  * The notebook tracker token.
  */
 export
-const INotebookTracker = new Token<INotebookTracker>('jupyter.services.notebook-handler');
+const INotebookTracker = new Token<INotebookTracker>('jupyter.services.notebooks');
 /* tslint:enable */
 
 
@@ -27,4 +27,4 @@ const INotebookTracker = new Token<INotebookTracker>('jupyter.services.notebook-
  * A class that tracks notebook widgets.
  */
 export
-interface INotebookTracker extends FocusTracker<NotebookPanel> {}
+interface INotebookTracker extends FocusTracker<Widget> {}

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -6,10 +6,6 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
-  FocusTracker
-} from 'phosphor/lib/ui/focustracker';
-
-import {
   NotebookPanel
 } from './';
 
@@ -27,4 +23,4 @@ const INotebookTracker = new Token<INotebookTracker>('jupyter.services.notebooks
  * A class that tracks notebook widgets.
  */
 export
-interface INotebookTracker extends FocusTracker<NotebookPanel> {}
+interface INotebookTracker extends Map<string, NotebookPanel> {}

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -84,6 +84,20 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
   activeCellChanged: ISignal<this, BaseCellWidget>;
 
   /**
+   * Dispose of the resources held by the tracker.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    super.dispose();
+    if (this._handler) {
+      this._handler.dispose();
+      this._handler = null;
+    }
+  }
+
+  /**
    * Handle the sync event.
    */
   protected onSync(): void {

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -98,9 +98,9 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
   }
 
   /**
-   * Handle the sync event.
+   * Handle the current change event.
    */
-  protected onSync(): void {
+  protected onCurrentChanged(): void {
     if (this._handler) {
       this._handler.dispose();
     }

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -10,8 +10,8 @@ import {
 } from 'phosphor/lib/ui/focustracker';
 
 import {
-  Widget
-} from 'phosphor/lib/ui/widget';
+  NotebookPanel
+} from './';
 
 
 /* tslint:disable */
@@ -27,4 +27,4 @@ const INotebookTracker = new Token<INotebookTracker>('jupyter.services.notebooks
  * A class that tracks notebook widgets.
  */
 export
-interface INotebookTracker extends FocusTracker<Widget> {}
+interface INotebookTracker extends FocusTracker<NotebookPanel> {}

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -2,12 +2,51 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  DisposableDelegate
+} from 'phosphor/lib/core/disposable';
+
+import {
+  defineSignal, ISignal
+} from 'phosphor/lib/core/signaling';
+
+import {
   Token
 } from 'phosphor/lib/core/token';
 
 import {
+  IInstanceTracker, InstanceTracker
+} from '../common/instancetracker';
+
+import {
   NotebookPanel
 } from './';
+
+import {
+  BaseCellWidget
+} from './cells';
+
+
+/**
+ * An object that tracks notebook widgets.
+ */
+export
+interface INotebookTracker extends IInstanceTracker<NotebookPanel> {
+  /**
+   * The currently focused cell.
+   *
+   * #### Notes
+   * If there is no cell with the focus, then this value is `null`.
+   */
+  activeCell: BaseCellWidget;
+
+  /**
+   * A signal emitted when the current active cell changes.
+   *
+   * #### Notes
+   * If there is no cell with the focus, then `null` will be emitted.
+   */
+  activeCellChanged: ISignal<this, BaseCellWidget>;
+}
 
 
 /* tslint:disable */
@@ -19,8 +58,55 @@ const INotebookTracker = new Token<INotebookTracker>('jupyter.services.notebooks
 /* tslint:enable */
 
 
-/**
- * A class that tracks notebook widgets.
- */
 export
-interface INotebookTracker extends Map<string, NotebookPanel> {}
+class NotebookTracker extends InstanceTracker<NotebookPanel> implements INotebookTracker {
+  /**
+   * The currently focused cell.
+   *
+   * #### Notes
+   * This is a read-only property. If there is no cell with the focus, then this
+   * value is `null`.
+   */
+  get activeCell(): BaseCellWidget {
+    let widget = this.currentWidget;
+    if (!widget) {
+      return null;
+    }
+    return widget.content.activeCell || null;
+  }
+
+  /**
+   * A signal emitted when the current active cell changes.
+   *
+   * #### Notes
+   * If there is no cell with the focus, then `null` will be emitted.
+   */
+  activeCellChanged: ISignal<this, BaseCellWidget>;
+
+  /**
+   * Handle the sync event.
+   */
+  protected onSync(): void {
+    if (this._handler) {
+      this._handler.dispose();
+    }
+
+    let widget = this.currentWidget;
+    if (!widget) {
+      return;
+    }
+
+    let changeHandler = (sender: any, cell: BaseCellWidget) => {
+      this.activeCellChanged.emit(cell || null);
+    };
+    widget.content.activeCellChanged.connect(changeHandler);
+    this._handler = new DisposableDelegate(() => {
+      widget.content.activeCellChanged.disconnect(changeHandler);
+    });
+  }
+
+  private _handler: DisposableDelegate = null;
+}
+
+// Define the signals for the `NotebookTracker` class.
+defineSignal(InstanceTracker.prototype, 'activeCellChanged');

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -51,17 +51,19 @@ const LANDSCAPE_ICON_CLASS = 'jp-MainAreaLandscapeIcon';
  */
 const TERMINAL_ICON_CLASS = 'jp-ImageTerminal';
 
+/**
+ * The terminal widget instance tracker.
+ */
+const tracker = new InstanceTracker<TerminalWidget>();
+
 
 function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: IMainMenu, palette: ICommandPalette): void {
-
   let { commands, keymap } = app;
   let newTerminalId = 'terminal:create-new';
   let increaseTerminalFontSize = 'terminal:increase-font';
   let decreaseTerminalFontSize = 'terminal:decrease-font';
   let toggleTerminalTheme = 'terminal:toggle-theme';
   let openTerminalId = 'terminal:open';
-
-  let tracker = new InstanceTracker<TerminalWidget>();
   let options = {
     background: 'black',
     color: 'white',

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -31,17 +31,6 @@ import {
 
 
 /**
- * The default terminal extension.
- */
-export
-const terminalExtension: JupyterLabPlugin<void> = {
-  id: 'jupyter.extensions.terminal',
-  requires: [IServiceManager, IMainMenu, ICommandPalette],
-  activate: activateTerminal,
-  autoStart: true
-};
-
-/**
  * The class name for all main area landscape tab icons.
  */
 const LANDSCAPE_ICON_CLASS = 'jp-MainAreaLandscapeIcon';
@@ -55,6 +44,18 @@ const TERMINAL_ICON_CLASS = 'jp-ImageTerminal';
  * The terminal widget instance tracker.
  */
 const tracker = new InstanceTracker<TerminalWidget>();
+
+
+/**
+ * The default terminal extension.
+ */
+export
+const terminalExtension: JupyterLabPlugin<void> = {
+  id: 'jupyter.extensions.terminal',
+  requires: [IServiceManager, IMainMenu, ICommandPalette],
+  activate: activateTerminal,
+  autoStart: true
+};
 
 
 function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: IMainMenu, palette: ICommandPalette): void {

--- a/test/src/common/instancetracker.spec.ts
+++ b/test/src/common/instancetracker.spec.ts
@@ -4,6 +4,10 @@
 import expect = require('expect.js');
 
 import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
   InstanceTracker
 } from '../../../lib/common/instancetracker';
 
@@ -15,8 +19,43 @@ describe('common/instancetracker', () => {
     describe('#constructor()', () => {
 
       it('should create an InstanceTracker', () => {
-        let tracker = new InstanceTracker();
+        let tracker = new InstanceTracker<Widget>();
         expect(tracker).to.be.an(InstanceTracker);
+      });
+
+    });
+
+    describe('#currentChanged', () => {
+
+      it('should emit when the current widget has been updated', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widget = new Widget();
+        let called = false;
+        widget.id = 'test';
+        tracker.currentChanged.connect(() => { called = true; });
+        tracker.add(widget);
+        expect(called).to.be(false);
+        tracker.sync(widget);
+        expect(called).to.be(true);
+      });
+
+    });
+
+    describe('#currentWidget', () => {
+
+      it('should default to null', () => {
+        let tracker = new InstanceTracker<Widget>();
+        expect(tracker.currentWidget).to.be(null);
+      });
+
+      it('should be updated by sync if the tracker has the widget', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widget = new Widget();
+        widget.id = 'test';
+        tracker.add(widget);
+        expect(tracker.currentWidget).to.be(null);
+        tracker.sync(widget);
+        expect(tracker.currentWidget).to.be(widget);
       });
 
     });

--- a/test/src/common/instancetracker.spec.ts
+++ b/test/src/common/instancetracker.spec.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  InstanceTracker
+} from '../../../lib/common/instancetracker';
+
+
+describe('common/instancetracker', () => {
+
+  describe('InstanceTracker', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create an InstanceTracker', () => {
+        let tracker = new InstanceTracker();
+        expect(tracker).to.be.an(InstanceTracker);
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/common/instancetracker.spec.ts
+++ b/test/src/common/instancetracker.spec.ts
@@ -12,6 +12,16 @@ import {
 } from '../../../lib/common/instancetracker';
 
 
+class TestTracker<T extends Widget> extends InstanceTracker<T> {
+  methods: string[] = [];
+
+  protected onCurrentChanged(): void {
+    super.onCurrentChanged();
+    this.methods.push('onCurrentChanged');
+  }
+}
+
+
 describe('common/instancetracker', () => {
 
   describe('InstanceTracker', () => {
@@ -31,7 +41,6 @@ describe('common/instancetracker', () => {
         let tracker = new InstanceTracker<Widget>();
         let widget = new Widget();
         let called = false;
-        widget.id = 'test';
         tracker.currentChanged.connect(() => { called = true; });
         tracker.add(widget);
         expect(called).to.be(false);
@@ -51,11 +60,152 @@ describe('common/instancetracker', () => {
       it('should be updated by sync if the tracker has the widget', () => {
         let tracker = new InstanceTracker<Widget>();
         let widget = new Widget();
-        widget.id = 'test';
         tracker.add(widget);
         expect(tracker.currentWidget).to.be(null);
         tracker.sync(widget);
         expect(tracker.currentWidget).to.be(widget);
+      });
+
+    });
+
+    describe('#isDisposed', () => {
+
+      it('should test whether the tracker is disposed', () => {
+        let tracker = new InstanceTracker<Widget>();
+        expect(tracker.isDisposed).to.be(false);
+        tracker.dispose();
+        expect(tracker.isDisposed).to.be(true);
+      });
+
+    });
+
+    describe('#add()', () => {
+
+      it('should add a widget to the tracker', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widget = new Widget();
+        expect(tracker.has(widget)).to.be(false);
+        tracker.add(widget);
+        expect(tracker.has(widget)).to.be(true);
+      });
+
+      it('should remove an added widget if it is disposed', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widget = new Widget();
+        tracker.add(widget);
+        expect(tracker.has(widget)).to.be(true);
+        widget.dispose();
+        expect(tracker.has(widget)).to.be(false);
+      });
+
+    });
+
+    describe('#dispose()', () => {
+
+      it('should dispose of the resources used by the tracker', () => {
+        let tracker = new InstanceTracker<Widget>();
+        expect(tracker.isDisposed).to.be(false);
+        tracker.dispose();
+        expect(tracker.isDisposed).to.be(true);
+      });
+
+      it('should be safe to call multiple times', () => {
+        let tracker = new InstanceTracker<Widget>();
+        expect(tracker.isDisposed).to.be(false);
+        tracker.dispose();
+        tracker.dispose();
+        expect(tracker.isDisposed).to.be(true);
+      });
+
+    });
+
+    describe('#find()', () => {
+
+      it('should find a tracked item that matches a filter function', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widgetA = new Widget();
+        let widgetB = new Widget();
+        let widgetC = new Widget();
+        widgetA.id = 'A';
+        widgetB.id = 'B';
+        widgetC.id = 'C';
+        tracker.add(widgetA);
+        tracker.add(widgetB);
+        tracker.add(widgetC);
+        expect(tracker.find(widget => widget.id === 'B')).to.be(widgetB);
+      });
+
+      it('should return `null` if no item is found', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widgetA = new Widget();
+        let widgetB = new Widget();
+        let widgetC = new Widget();
+        widgetA.id = 'A';
+        widgetB.id = 'B';
+        widgetC.id = 'C';
+        tracker.add(widgetA);
+        tracker.add(widgetB);
+        tracker.add(widgetC);
+        expect(tracker.find(widget => widget.id === 'D')).to.be(null);
+      });
+
+    });
+
+    describe('#forEach()', () => {
+
+      it('should iterate through all the tracked items', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widgetA = new Widget();
+        let widgetB = new Widget();
+        let widgetC = new Widget();
+        let visited = '';
+        widgetA.id = 'A';
+        widgetB.id = 'B';
+        widgetC.id = 'C';
+        tracker.add(widgetA);
+        tracker.add(widgetB);
+        tracker.add(widgetC);
+        tracker.forEach(widget => { visited += widget.id; });
+        expect(visited).to.be('ABC');
+      });
+
+    });
+
+    describe('#has()', () => {
+
+      it('should return `true` if an item exists in the tracker', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widget = new Widget();
+        expect(tracker.has(widget)).to.be(false);
+        tracker.add(widget);
+        expect(tracker.has(widget)).to.be(true);
+      });
+
+    });
+
+    describe('#sync()', () => {
+
+      it('should emit a signal when the current widget is updated', () => {
+        let tracker = new InstanceTracker<Widget>();
+        let widget = new Widget();
+        let called = false;
+        tracker.currentChanged.connect(() => { called = true; });
+        tracker.add(widget);
+        expect(called).to.be(false);
+        tracker.sync(widget);
+        expect(called).to.be(true);
+      });
+
+    });
+
+    describe('#onCurrentChanged()', () => {
+
+      it('should be called when the current widget is changed', () => {
+        let tracker = new TestTracker<Widget>();
+        let widget = new Widget();
+        tracker.add(widget);
+        tracker.sync(widget);
+        expect(tracker.methods).to.contain('onCurrentChanged');
       });
 
     });

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,51 +1,50 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import './common/activitymonitor.spec';
+// import './common/activitymonitor.spec';
 import './common/instancetracker.spec';
-import './common/observablelist.spec';
-import './common/vdom.spec';
+// import './common/observablelist.spec';
+// import './common/vdom.spec';
 
-import './completer/handler.spec';
-import './completer/model.spec';
-import './completer/widget.spec';
+// import './completer/handler.spec';
+// import './completer/model.spec';
+// import './completer/widget.spec';
 
-import './console/history.spec';
+// import './console/history.spec';
 
-import './dialog/dialog.spec';
+// import './dialog/dialog.spec';
 
 import './docregistry/context.spec';
-
 import './docregistry/default.spec';
 import './docregistry/registry.spec';
 
-import './filebrowser/model.spec';
+// import './filebrowser/model.spec';
 
-import './inspector/inspector.spec';
+// import './inspector/inspector.spec';
 
-import './markdownwidget/widget.spec';
+// import './markdownwidget/widget.spec';
 
-import './renderers/renderers.spec';
-import './renderers/latex.spec';
+// import './renderers/renderers.spec';
+// import './renderers/latex.spec';
 
-import './rendermime/rendermime.spec';
+// import './rendermime/rendermime.spec';
 
-import './notebook/cells/editor.spec';
-import './notebook/cells/model.spec';
-import './notebook/cells/widget.spec';
+// import './notebook/cells/editor.spec';
+// import './notebook/cells/model.spec';
+// import './notebook/cells/widget.spec';
 
-import './notebook/notebook/actions.spec';
-import './notebook/notebook/default-toolbar.spec';
-import './notebook/notebook/model.spec';
-import './notebook/notebook/modelfactory.spec';
-import './notebook/notebook/panel.spec';
-import './notebook/notebook/trust.spec';
-import './notebook/notebook/widget.spec';
-import './notebook/notebook/widgetfactory.spec';
+// import './notebook/notebook/actions.spec';
+// import './notebook/notebook/default-toolbar.spec';
+// import './notebook/notebook/model.spec';
+// import './notebook/notebook/modelfactory.spec';
+// import './notebook/notebook/panel.spec';
+// import './notebook/notebook/trust.spec';
+// import './notebook/notebook/widget.spec';
+// import './notebook/notebook/widgetfactory.spec';
 
-import './notebook/output-area/model.spec';
-import './notebook/output-area/widget.spec';
+// import './notebook/output-area/model.spec';
+// import './notebook/output-area/widget.spec';
 
-import './toolbar/toolbar.spec';
+// import './toolbar/toolbar.spec';
 
 import 'phosphor/styles/base.css';

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,50 +1,50 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// import './common/activitymonitor.spec';
+import './common/activitymonitor.spec';
 import './common/instancetracker.spec';
-// import './common/observablelist.spec';
-// import './common/vdom.spec';
+import './common/observablelist.spec';
+import './common/vdom.spec';
 
-// import './completer/handler.spec';
-// import './completer/model.spec';
-// import './completer/widget.spec';
+import './completer/handler.spec';
+import './completer/model.spec';
+import './completer/widget.spec';
 
-// import './console/history.spec';
+import './console/history.spec';
 
-// import './dialog/dialog.spec';
+import './dialog/dialog.spec';
 
 import './docregistry/context.spec';
 import './docregistry/default.spec';
 import './docregistry/registry.spec';
 
-// import './filebrowser/model.spec';
+import './filebrowser/model.spec';
 
-// import './inspector/inspector.spec';
+import './inspector/inspector.spec';
 
-// import './markdownwidget/widget.spec';
+import './markdownwidget/widget.spec';
 
-// import './renderers/renderers.spec';
-// import './renderers/latex.spec';
+import './renderers/renderers.spec';
+import './renderers/latex.spec';
 
-// import './rendermime/rendermime.spec';
+import './rendermime/rendermime.spec';
 
-// import './notebook/cells/editor.spec';
-// import './notebook/cells/model.spec';
-// import './notebook/cells/widget.spec';
+import './notebook/cells/editor.spec';
+import './notebook/cells/model.spec';
+import './notebook/cells/widget.spec';
 
-// import './notebook/notebook/actions.spec';
-// import './notebook/notebook/default-toolbar.spec';
-// import './notebook/notebook/model.spec';
-// import './notebook/notebook/modelfactory.spec';
-// import './notebook/notebook/panel.spec';
-// import './notebook/notebook/trust.spec';
-// import './notebook/notebook/widget.spec';
-// import './notebook/notebook/widgetfactory.spec';
+import './notebook/notebook/actions.spec';
+import './notebook/notebook/default-toolbar.spec';
+import './notebook/notebook/model.spec';
+import './notebook/notebook/modelfactory.spec';
+import './notebook/notebook/panel.spec';
+import './notebook/notebook/trust.spec';
+import './notebook/notebook/widget.spec';
+import './notebook/notebook/widgetfactory.spec';
 
-// import './notebook/output-area/model.spec';
-// import './notebook/output-area/widget.spec';
+import './notebook/output-area/model.spec';
+import './notebook/output-area/widget.spec';
 
-// import './toolbar/toolbar.spec';
+import './toolbar/toolbar.spec';
 
 import 'phosphor/styles/base.css';

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,50 +1,51 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// import './common/activitymonitor.spec';
-// import './common/observablelist.spec';
-// import './common/vdom.spec';
+import './common/activitymonitor.spec';
+import './common/instancetracker.spec';
+import './common/observablelist.spec';
+import './common/vdom.spec';
 
-// import './completer/handler.spec';
-// import './completer/model.spec';
-// import './completer/widget.spec';
+import './completer/handler.spec';
+import './completer/model.spec';
+import './completer/widget.spec';
 
-// import './console/history.spec';
+import './console/history.spec';
 
-// import './dialog/dialog.spec';
+import './dialog/dialog.spec';
 
-// import './docregistry/context.spec';
+import './docregistry/context.spec';
 
-// import './docregistry/default.spec';
+import './docregistry/default.spec';
 import './docregistry/registry.spec';
 
-// import './filebrowser/model.spec';
+import './filebrowser/model.spec';
 
-// import './inspector/inspector.spec';
+import './inspector/inspector.spec';
 
-// import './markdownwidget/widget.spec';
+import './markdownwidget/widget.spec';
 
-// import './renderers/renderers.spec';
-// import './renderers/latex.spec';
+import './renderers/renderers.spec';
+import './renderers/latex.spec';
 
-// import './rendermime/rendermime.spec';
+import './rendermime/rendermime.spec';
 
-// import './notebook/cells/editor.spec';
-// import './notebook/cells/model.spec';
-// import './notebook/cells/widget.spec';
+import './notebook/cells/editor.spec';
+import './notebook/cells/model.spec';
+import './notebook/cells/widget.spec';
 
-// import './notebook/notebook/actions.spec';
-// import './notebook/notebook/default-toolbar.spec';
-// import './notebook/notebook/model.spec';
-// import './notebook/notebook/modelfactory.spec';
-// import './notebook/notebook/panel.spec';
-// import './notebook/notebook/trust.spec';
-// import './notebook/notebook/widget.spec';
-// import './notebook/notebook/widgetfactory.spec';
+import './notebook/notebook/actions.spec';
+import './notebook/notebook/default-toolbar.spec';
+import './notebook/notebook/model.spec';
+import './notebook/notebook/modelfactory.spec';
+import './notebook/notebook/panel.spec';
+import './notebook/notebook/trust.spec';
+import './notebook/notebook/widget.spec';
+import './notebook/notebook/widgetfactory.spec';
 
-// import './notebook/output-area/model.spec';
-// import './notebook/output-area/widget.spec';
+import './notebook/output-area/model.spec';
+import './notebook/output-area/widget.spec';
 
-// import './toolbar/toolbar.spec';
+import './toolbar/toolbar.spec';
 
 import 'phosphor/styles/base.css';


### PR DESCRIPTION
- [x] Create an `InstanceTracker` class to replace almost all uses of `FocusTracker`, as what we *really* want is something to keep track of individual widget types and shared by their plugins.
- [x] Expose `currentWidget` and `currentChanged` in the application shell to give plugins access to the internal focus tracking of the main area. Allow focus changes to sync with individual instance trackers.
- [x] Stop using separate focus trackers for consoles and notebooks in order to rationalize connecting to the inspector. Fixes https://github.com/jupyter/jupyterlab/issues/1062
- [x] Create a subclass of `InstanceTracker` (*i.e.*, `NotebookTracker`) for notebooks. Fixes https://github.com/jupyter/jupyterlab/issues/1063