### PR TITLE
Test cleanup

### DIFF
--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -15,8 +15,8 @@ jupyter serverextension enable --py jupyterlab
 
 npm run clean
 npm run build
-npm test || npm test
-npm run test:coverage || npm run test:coverage
+npm test || npm test || npm test
+npm run test:coverage || npm run test:coverage || npm run test:coverage
 
 
 # Run the python tests

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,48 +1,10 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import './common/activitymonitor.spec';
-import './common/observablelist.spec';
-import './common/vdom.spec';
-
-import './completer/handler.spec';
-import './completer/model.spec';
-import './completer/widget.spec';
-
-import './console/history.spec';
-
-import './dialog/dialog.spec';
-
-import './docregistry/default.spec';
-import './docregistry/registry.spec';
-
-import './filebrowser/model.spec';
-
-import './inspector/inspector.spec';
-
-import './markdownwidget/widget.spec';
-
-import './renderers/renderers.spec';
-import './renderers/latex.spec';
-
-import './rendermime/rendermime.spec';
-
-import './notebook/cells/editor.spec';
-import './notebook/cells/model.spec';
-import './notebook/cells/widget.spec';
-
-import './notebook/notebook/actions.spec';
-import './notebook/notebook/default-toolbar.spec';
-import './notebook/notebook/model.spec';
-import './notebook/notebook/modelfactory.spec';
-import './notebook/notebook/panel.spec';
-import './notebook/notebook/trust.spec';
-import './notebook/notebook/widget.spec';
-import './notebook/notebook/widgetfactory.spec';
-
-import './notebook/output-area/model.spec';
-import './notebook/output-area/widget.spec';
-
-import './toolbar/toolbar.spec';
-
 import 'phosphor/styles/base.css';
+
+
+// Require all spec files
+// From https://webpack.github.io/docs/context.html#context-module-api
+let context = (require as any).context('./', true, /^.*?\.spec\.ts$/);
+context.keys.map(context);


### PR DESCRIPTION
Import all test files automatically - avoids the common mistake of making a test file without enabling it.
Allow tests to run three times to match what the main notebook repo does.