### PR TITLE
Ignore temporary dotfiles created by some editors when watching.

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,9 +82,9 @@
     "test:debug": "npm run build:test && cd test && python run-test.py  --browsers=Chrome --singleRun=false --debug=true karma.conf.js",
     "test:firefox": "npm run build:test && cd test && python run-test.py --browsers=Firefox karma.conf.js",
     "test:ie": "npm run build:test && cd test && python run-test.py  --browsers=IE karma.conf.js",
-    "watch": "watch \"npm run build:all\" src --wait 10",
-    "watch:src": "watch \"npm run build\" src --wait 10",
-    "watch:test": "watch \"npm run build && npm test\" src test/src --wait 10"
+    "watch": "watch \"npm run build:all\" src --wait 10 --ignoreDotFiles",
+    "watch:src": "watch \"npm run build\" src --wait 10 --ignoreDotFiles",
+    "watch:test": "watch \"npm run build && npm test\" src test/src --wait 10 --ignoreDotFiles"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some text editors (such as vim) create temporary backup files that trigger unwanted rebuilding of the js bundles when using `npm run watch`. This flag ignores those.