### PR TITLE
Clean up typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/marked": "0.0.28",
     "@types/mathjax": "0.0.31",
     "@types/mocha": "^2.2.32",
-    "@types/node": "^6.0.45",
+    "@types/requirejs": "^2.1.28",
     "@types/sanitize-html": "^1.13.31",
     "awesome-typescript-loader": "^2.2.4",
     "concurrently": "^2.0.0",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,5 +10,6 @@
     "target": "ES5",
     "outDir": "../lib",
     "sourceMap": true
-  }
+  },
+  "exclude": ["typedoc.d.ts"]
 }

--- a/src/typedoc.d.ts
+++ b/src/typedoc.d.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+/*
+ * TODO: remove this file and the excludes entry in tsconfig.json
+ * after typedoc understands the lib compiler option and @types packages.
+ */
+/// <reference path="../node_modules/@types/mathjax/index.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.dom.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.es5.d.ts"/>
+/// <reference path="../node_modules/typescript/lib/lib.es2015.collection.d.ts"/>

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,13 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 /// <reference path="../typings/ansi_up/ansi_up.d.ts"/>
 /// <reference path="../typings/codemirror/codemirror.d.ts"/>
 /// <reference path="../typings/xterm/xterm.d.ts"/>
-
-/*
- * TODO: remove the below typings after typedoc understands the lib compiler option
- * and the @types typing resolution.
- */
-/// <reference path="../node_modules/@types/mathjax/index.d.ts"/>
-/// <reference path="../node_modules/typescript/lib/lib.es2015.promise.d.ts"/>
-/// <reference path="../node_modules/typescript/lib/lib.dom.d.ts"/>
-/// <reference path="../node_modules/typescript/lib/lib.es5.d.ts"/>
-/// <reference path="../node_modules/typescript/lib/lib.es2015.collection.d.ts"/>

--- a/test/src/tsconfig.json
+++ b/test/src/tsconfig.json
@@ -3,7 +3,7 @@
     "noImplicitAny": true,
     "noEmitOnError": true,
     "lib": ["dom", "es5", "es2015.promise"],
-    "types": ["mocha", "expect.js", "node"],
+    "types": ["mocha", "expect.js", "requirejs"],
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES5",


### PR DESCRIPTION
Moves typedoc typings to a separate file and replaces the node typings with requirejs typings.