### PR TITLE
Bugfix: closing consoles generates an error.

### DIFF
--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -59,10 +59,10 @@ class InspectorManager implements IInspector {
   set source(source: Inspector.IInspectable) {
     if (this._source !== source) {
       if (this._source) {
-        this._source.disposed.disconnect(this._onSourceDisposed);
+        this._source.disposed.disconnect(this._onSourceDisposed, this);
       }
       this._source = source;
-      this._source.disposed.connect(this._onSourceDisposed);
+      this._source.disposed.connect(this._onSourceDisposed, this);
     }
     if (this._inspector && !this._inspector.isDisposed) {
       this._inspector.source = this._source;


### PR DESCRIPTION
Closing consoles generated an error because signal scope was incorrect.

Fixes https://github.com/jupyterlab/jupyterlab/issues/1106