### PR TITLE
Bump xterm version

### DIFF
--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -29,6 +29,9 @@ buildExtension({
   config: {
     output: {
       publicPath: 'lab/'
+    },
+    module: {
+      noParse: [/xterm/]  // Xterm ships a UMD module
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sanitize-html": "^1.12.0",
     "semver": "^5.3.0",
     "simulate-event": "^1.2.0",
-    "xterm": "^1.1.3"
+    "xterm": "^2.0.1"
   },
   "devDependencies": {
     "@types/d3-dsv": "^1.0.29",

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -138,42 +138,42 @@ class TerminalWidget extends Widget {
    * Get whether the bell is shown.
    */
   get visualBell(): boolean {
-    return this._term.visualBell;
+    return this._term.getOption('visualBell');
   }
 
   /**
    * Set whether the bell is shown.
    */
   set visualBell(value: boolean) {
-    this._term.visualBell = value;
+    this._term.setOption('visualBell', value);
   }
 
   /**
    * Get whether to focus on a bell event.
    */
   get popOnBell(): boolean {
-    return this._term.popOnBell;
+    return this._term.getOption('popOnBell');
   }
 
   /**
    * Set whether to focus on a bell event.
    */
   set popOnBell(value: boolean) {
-    this._term.popOnBell = value;
+    this._term.setOption('popOnBell', value);
   }
 
   /**
    * Get the size of the scrollback buffer in the terminal.
    */
   get scrollback(): number {
-    return this._term.scrollback;
+    return this._term.getOption('scrollback');
   }
 
   /**
    * Set the size of the scrollback buffer in the terminal.
    */
   set scrollback(value: number) {
-    this._term.scrollback = value;
+    this._term.setOption('scrollback', value);
   }
 
   /**
@@ -303,10 +303,6 @@ class TerminalWidget extends Widget {
           content: [data]
         });
       }
-    });
-
-    this._term.on('title', (title: string) => {
-        this.title.label = title;
     });
   }
 

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -20,7 +20,6 @@ import {
 import * as Xterm
   from 'xterm';
 
-
 /**
  * The class name added to a terminal widget.
  */
@@ -69,7 +68,6 @@ class TerminalWidget extends Widget {
     this.color = options.color || 'white';
     this.id = `jp-TerminalWidget-${Private.id++}`;
     this.title.label = 'Terminal';
-    (Xterm as any).brokenBold = true;
   }
 
   /**
@@ -303,6 +301,10 @@ class TerminalWidget extends Widget {
           content: [data]
         });
       }
+    });
+
+    this._term.on('title', (title: string) => {
+        this.title.label = title;
     });
   }
 

--- a/typings/xterm/xterm.d.ts
+++ b/typings/xterm/xterm.d.ts
@@ -51,7 +51,6 @@ interface Xterm {
 interface XtermConstructor {
   new (options?: Xterm.IOptions): Xterm;
   (options?: Xterm.IOptions): Xterm;
-  brokenBold: boolean;
 }
 
 

--- a/typings/xterm/xterm.d.ts
+++ b/typings/xterm/xterm.d.ts
@@ -12,29 +12,39 @@ interface Xterm {
 
   element: HTMLElement;
 
-  colors: string[];
+  textarea: HTMLElement;
 
-  rows: number;
+  attachCustomKeydownHandler(callback: (event: KeyboardEvent) => boolean): void;
 
-  cols: number;
+  blur(): void;
 
-  visualBell: boolean;
-
-  popOnBell: boolean;
-
-  scrollback: number;
-
-  on(event: string, callback: (arg: any) => void): void;
-
-  open(el: HTMLElement): void;
-
-  write(msg: string): void;
-
-  resize(width: number, height: number): void;
+  clear(): void;
 
   destroy(): void;
 
   focus(): void;
+
+  getOption(key: string): any;
+
+  on(event: string, callback: (arg: any) => void): void;
+
+  off(event: string, callback: (arg: any) => void): void;
+
+  open(parent: HTMLElement): void;
+
+  refresh(start: number, end: number, queue?: boolean): void;
+
+  reset(): void;
+
+  resize(x: number, y: number): void;
+
+  scrollDisp(n: number): void;
+
+  setOption(key: string, value: any): void;
+
+  write(text: string): void;
+
+  writeln(text: string): void;
 }
 
 


### PR DESCRIPTION
cf https://github.com/jupyter/notebook/pull/1838

Xterm now has a public [API](http://xtermjs.org/docs/api/Terminal/), but there are still a few things missing (documenting the options, the `title` event).  Once those are resolved, we can update our typings again.

https://github.com/sourcelair/xterm.js/issues/313
https://github.com/sourcelair/xterm.js/issues/315