### PR TITLE
Clear signals to avoid accessing disposed-of members.

### DIFF
--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -207,6 +207,7 @@ class NotebookPanel extends Widget {
       return;
     }
     this._context = null;
+    this._content.dispose();
     this._content = null;
     this._rendermime = null;
     this._clipboard = null;


### PR DESCRIPTION
Disposing of a notebook results in access of the already-disposed `CompleterHandler` through a signal. This clears the signals beforehand.