### PR TITLE
Rendered codemirror widget

### DIFF
--- a/src/codemirror/widget.ts
+++ b/src/codemirror/widget.ts
@@ -234,7 +234,7 @@ class StaticCodeMirror extends Widget {
    * Construct a new static code mirror widget.
    */
   constructor(editor: CodeMirror.Editor) {
-    super();
+    super({ node: document.createElement('pre') });
     this._editor = editor;
     this.addClass(`cm-s-${editor.getOption('theme')}`);
     this.addClass('CodeMirror');

--- a/src/codemirror/widget.ts
+++ b/src/codemirror/widget.ts
@@ -84,6 +84,8 @@ class CodeMirrorWidget extends Widget {
    * Handle `'activate-request'` messages.
    */
   protected onActivateRequest(msg: Message): void {
+    this._static.hide();
+    this._live.show();
     this.editor.focus();
   }
 
@@ -130,6 +132,9 @@ class CodeMirrorWidget extends Widget {
    * Handle `focus` events for the widget.
    */
   private _evtFocus(event: MouseEvent): void {
+    if (this.editor.getOption('readOnly') !== false) {
+      return;
+    }
     this._static.hide();
     this._live.show();
   }

--- a/src/codemirror/widget.ts
+++ b/src/codemirror/widget.ts
@@ -103,10 +103,10 @@ class CodeMirrorWidget extends Widget {
       this._evtMouseDown(event as MouseEvent);
       break;
     case 'focus':
-      this._evtFocus(event as MouseEvent);
+      this._evtFocus(event as FocusEvent);
       break;
     case 'blur':
-      this._evtBlur(event as MouseEvent);
+      this._evtBlur(event as FocusEvent);
       break;
     default:
       break;
@@ -144,14 +144,14 @@ class CodeMirrorWidget extends Widget {
   /**
    * Handle `focus` events for the widget.
    */
-  private _evtFocus(event: MouseEvent): void {
+  private _evtFocus(event: FocusEvent): void {
     this._activate();
   }
 
   /**
    * Handle `blur` events for the widget.
    */
-  private _evtBlur(event: MouseEvent): void {
+  private _evtBlur(event: FocusEvent): void {
     this._lastMouseDown = null;
     if (this.node.contains(event.relatedTarget as HTMLElement)) {
       return;

--- a/src/codemirror/widget.ts
+++ b/src/codemirror/widget.ts
@@ -164,22 +164,20 @@ class CodeMirrorWidget extends Widget {
    * Handle an activation message or a focus event.
    */
   private _activate(): void {
-    if (this.editor.getOption('readOnly') !== false) {
+    let editor = this.editor;
+    if (editor.getOption('readOnly') !== false) {
       this._lastMouseDown = null;
       return;
     }
     this._static.hide();
     this._live.show();
     if (this._lastMouseDown) {
-      let node = this._live.node;
-      let evt = document.createEvent();
-      let evt = generate('mousedown', this._lastMouseDown);
-      evt.target = node;
-      simulate(node, 'mousedown', this._lastMouseDown);
-      this._lastMouseDown = null;
-    } else {
-      this.editor.focus();
+      let x = this._lastMouseDown.clientX;
+      let y = this._lastMouseDown.clientY;
+      let pos = editor.coordsChar({ left: x, top: y });
+      editor.getDoc().setCursor(pos);
     }
+    editor.focus();
   }
 
   private _live: LiveCodeMirror;
@@ -264,6 +262,13 @@ class StaticCodeMirror extends Widget {
   dispose(): void {
     this._editor = null;
     super.dispose();
+  }
+
+  /**
+   * A message handler invoked on an `'after-attach'` message.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this._render();
   }
 
   /**

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -113,6 +113,8 @@ class ConsoleContent extends Widget {
     // Create the panels that hold the content and input.
     let layout = this.layout = new PanelLayout();
     this._content = new Panel();
+    this._content.node.tabIndex = -1;
+    this._content.node.style.outline = 'none';
     this._input = new Panel();
     this._content.addClass(CONTENT_CLASS);
     this._input.addClass(INPUT_CLASS);

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -79,41 +79,6 @@ class ConsolePanel extends Panel {
   }
 
   /**
-   * Handle the DOM events for the widget.
-   *
-   * @param event - The DOM event sent to the widget.
-   *
-   * #### Notes
-   * This method implements the DOM `EventListener` interface and is
-   * called in response to events on the console panel's node. It should
-   * not be called directly by user code.
-   */
-  handleEvent(event: Event): void {
-    switch (event.type) {
-    case 'mousedown':
-      this._evtMouseDown(event as MouseEvent);
-      break;
-    default:
-      break;
-    }
-  }
-
-  /**
-   * Handle `after_attach` messages for the widget.
-   */
-  protected onAfterAttach(msg: Message): void {
-    super.onAfterAttach(msg);
-    this.node.addEventListener('mousedown', this);
-  }
-
-  /**
-   * Handle `before_detach` messages for the widget.
-   */
-  protected onBeforeDetach(msg: Message): void {
-    this.node.removeEventListener('mousedown', this);
-  }
-
-  /**
    * Handle `'activate-request'` messages.
    */
   protected onActivateRequest(msg: Message): void {
@@ -144,13 +109,6 @@ class ConsolePanel extends Panel {
       super.onCloseRequest(msg);
       this.dispose();
     });
-  }
-
-  /**
-   * Handle `mousedown` events for the widget.
-   */
-  private _evtMouseDown(event: MouseEvent): void {
-    this.activate();
   }
 
   private _content: ConsoleContent = null;

--- a/src/notebook/codemirror/index.css
+++ b/src/notebook/codemirror/index.css
@@ -33,3 +33,7 @@
   padding: 0 4px 0 4px;
 }
 
+
+.p-Widget.CodeMirror {
+  margin: var(--jp-code-padding);
+}

--- a/src/notebook/codemirror/index.css
+++ b/src/notebook/codemirror/index.css
@@ -39,6 +39,6 @@
 }
 
 
-.jp-CodeMirrorWidget {
+.jp-CodeMirrorWidget, .jp-CodeMirrorWidget-static {
   cursor: text;
 }

--- a/src/notebook/codemirror/index.css
+++ b/src/notebook/codemirror/index.css
@@ -37,3 +37,8 @@
 .jp-CodeMirrorWidget-static {
   margin: var(--jp-code-padding);
 }
+
+
+.jp-CodeMirrorWidget {
+  cursor: text;
+}

--- a/src/notebook/codemirror/index.css
+++ b/src/notebook/codemirror/index.css
@@ -34,6 +34,6 @@
 }
 
 
-.p-Widget.CodeMirror {
+.jp-CodeMirrorWidget-static {
   margin: var(--jp-code-padding);
 }


### PR DESCRIPTION
Makes the codemirror widget render itself statically when not focused.
Maintains cursor position on click behavior.

Fixes #25. Fixes #816.  Fixes #958.  Fixes #679.


![single-codemirror](https://cloud.githubusercontent.com/assets/2096628/19561207/43b342dc-969d-11e6-9d51-9a1b4de3d6fb.gif)

![single-codemirror-perf](https://cloud.githubusercontent.com/assets/2096628/19561367/105e6870-969e-11e6-9662-b5283fa42407.gif)

