### PR TITLE
Console foreign IOPub refactor + tests

### DIFF
--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -30,10 +30,11 @@ class CellCompleterHandler implements IDisposable {
   /**
    * Construct a new completer handler for a widget.
    */
-  constructor(completer: CompleterWidget) {
-    this._completer = completer;
+  constructor(options: CellCompleterHandler.IOptions) {
+    this._completer = options.completer;
     this._completer.selected.connect(this.onCompletionSelected, this);
     this._completer.visibilityChanged.connect(this.onVisibilityChanged, this);
+    this._kernel = options.kernel || null;
   }
 
   /**
@@ -193,4 +194,26 @@ class CellCompleterHandler implements IDisposable {
   private _completer: CompleterWidget = null;
   private _kernel: Kernel.IKernel = null;
   private _pending = 0;
+}
+
+/**
+ * A namespace for cell completer handler statics.
+ */
+export
+namespace CellCompleterHandler {
+  /**
+   * The instantiation options for cell completer handlers.
+   */
+  export
+  interface IOptions {
+    /**
+     * The completer widget the handler will connect to.
+     */
+    completer: CompleterWidget;
+
+    /**
+     * The kernel for the completer handler.
+     */
+    kernel?: Kernel.IKernel;
+  }
 }

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -533,11 +533,6 @@ namespace CompleterWidget {
   export
   interface IOptions {
     /**
-     * The model for the completer widget.
-     */
-    model?: ICompleterModel;
-
-    /**
      * The semantic parent of the completer widget, its anchor element. An
      * event listener will peg the position of the completer widget to the
      * anchor element's scroll position. Other event listeners will guarantee
@@ -545,6 +540,11 @@ namespace CompleterWidget {
      * if it does not appear as a descendant in the DOM.
      */
     anchor?: HTMLElement;
+
+    /**
+     * The model for the completer widget.
+     */
+    model?: ICompleterModel;
 
     /**
      * The renderer for the completer widget nodes.

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -224,7 +224,7 @@ class CompleterWidget extends Widget {
   }
 
   /**
-   * Handle `update_request` messages.
+   * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {
     let model = this._model;

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -259,7 +259,7 @@ class ConsoleContent extends Widget {
    * should wait for the API to determine whether code being submitted is
    * incomplete before attempting submission anyway. The default value is `250`.
    */
-  execute(force = false, timeout?: number): Promise<void> {
+  execute(force = false, timeout = EXECUTION_TIMEOUT): Promise<void> {
     this._completer.reset();
 
     if (this._session.status === 'dead') {
@@ -276,7 +276,7 @@ class ConsoleContent extends Widget {
     }
 
     // Check whether we should execute.
-    return this._shouldExecute(timeout || EXECUTION_TIMEOUT).then(should => {
+    return this._shouldExecute(timeout).then(should => {
       if (should) {
         // Create a new prompt before kernel execution to allow typeahead.
         this.newPrompt();

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -182,11 +182,17 @@ class ConsoleContent extends Widget {
     });
   }
 
+  /*
+   * The console content panel that holds the banner and executed cells.
+   */
+  get content(): Panel {
+    return this._content;
+  }
+
   /**
    * A signal emitted when the console executes its prompt.
    */
   readonly executed: ISignal<this, Date>;
-
 
   /**
    * Get the inspection handler used by the console.

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -2,8 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Session, KernelMessage
+  KernelMessage, Session
 } from '@jupyterlab/services';
+
+import {
+  Message
+} from 'phosphor/lib/core/messaging';
 
 import {
   clearSignalData, defineSignal, ISignal
@@ -14,10 +18,6 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
-  Message
-} from 'phosphor/lib/core/messaging';
-
-import {
   Panel, PanelLayout
 } from 'phosphor/lib/ui/panel';
 
@@ -26,12 +26,12 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
-  InspectionHandler
-} from '../inspector';
+  CellCompleterHandler, CompleterModel, CompleterWidget
+} from '../completer';
 
 import {
-  nbformat
-} from '../notebook/notebook/nbformat';
+  InspectionHandler
+} from '../inspector';
 
 import {
   CodeCellWidget, RawCellWidget
@@ -42,8 +42,8 @@ import {
 } from '../notebook/cells/editor';
 
 import {
-  CompleterWidget, CompleterModel, CellCompleterHandler
-} from '../completer';
+  nbformat
+} from '../notebook/notebook/nbformat';
 
 import {
   IRenderMime

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -400,7 +400,7 @@ class ConsoleContent extends Widget {
   }
 
   /**
-   * Handle `update_request` messages.
+   * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {
     super.onUpdateRequest(msg);

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -142,8 +142,10 @@ class ConsoleContent extends Widget {
     this._initialize();
 
     // Set up the inspection handler.
-    this._inspectionHandler = new InspectionHandler(this._rendermime);
-    this._inspectionHandler.kernel = this._session.kernel;
+    this._inspectionHandler = new InspectionHandler({
+      kernel: this._session.kernel,
+      rendermime: this._rendermime
+    });
 
     // Set up the foreign iopub handler.
     this._foreignHandler = new ForeignHandler({

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -156,8 +156,6 @@ class ConsoleContent extends Widget {
 
     // Instantiate the completer.
     this._newCompleter(options.completer);
-
-    this._addSessionListeners();
   }
 
   /*
@@ -356,6 +354,8 @@ class ConsoleContent extends Widget {
     if (!this.prompt) {
       this.newPrompt();
     }
+    // Listen for kernel change events.
+    this._addSessionListeners();
   }
 
   /**
@@ -407,9 +407,14 @@ class ConsoleContent extends Widget {
     Private.scrollToBottom(this._content.node);
   }
 
+  /**
+   * Handle kernel change events on the session.
+   */
   private _addSessionListeners(): void {
-    // Handle changes to the kernel.
-    this._session.kernelChanged.connect((sender, kernel) => {
+    if (this._listening) {
+      return;
+    }
+    this._listening = this._session.kernelChanged.connect((sender, kernel) => {
       this.clear();
       this.newPrompt();
       this._initialize();
@@ -543,6 +548,7 @@ class ConsoleContent extends Widget {
   private _history: IConsoleHistory = null;
   private _input: Panel = null;
   private _inspectionHandler: InspectionHandler = null;
+  private _listening = false;
   private _mimetype = 'text/x-ipython';
   private _renderer: ConsoleContent.IRenderer = null;
   private _rendermime: IRenderMime = null;

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -287,15 +287,19 @@ class ConsoleContent extends Widget {
 
   /**
    * Inject arbitrary code for the console to execute immediately.
+   *
+   * @param code - The code contents of the cell being injected.
+   *
+   * @returns A promise that indicates when the injected cell's execution ends.
    */
-  inject(code: string): void {
+  inject(code: string): Promise<void> {
     // Create a new cell using the prompt renderer.
     let cell = this._renderer.createPrompt(this._rendermime);
     cell.model.source = code;
     cell.mimetype = this._mimetype;
     cell.readOnly = true;
     this._content.addWidget(cell);
-    this._execute(cell);
+    return this._execute(cell);
   }
 
   /**

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -121,7 +121,9 @@ class ConsoleContent extends Widget {
     this._renderer = options.renderer;
     this._rendermime = options.rendermime;
     this._session = options.session;
-    this._history = new ConsoleHistory({ kernel: this._session.kernel });
+    this._history = options.history || new ConsoleHistory({
+      kernel: this._session.kernel
+    });
 
     // Add top-level CSS classes.
     this._content.addClass(CONTENT_CLASS);
@@ -418,8 +420,7 @@ class ConsoleContent extends Widget {
       this.clear();
       this.newPrompt();
       this._initialize();
-      this._history.dispose();
-      this._history = new ConsoleHistory(kernel);
+      this._history.kernel = kernel;
       this._completerHandler.kernel = kernel;
       this._foreignHandler.kernel = kernel;
       this._inspectionHandler.kernel = kernel;
@@ -482,7 +483,9 @@ class ConsoleContent extends Widget {
     banner.model.source = info.banner;
     let lang = info.language_info as nbformat.ILanguageInfoMetadata;
     this._mimetype = this._renderer.getCodeMimetype(lang);
-    this.prompt.mimetype = this._mimetype;
+    if (this.prompt) {
+      this.prompt.mimetype = this._mimetype;
+    }
   }
 
   /**
@@ -575,6 +578,11 @@ namespace ConsoleContent {
      * The completer widget for a console content widget.
      */
     completer?: CompleterWidget;
+
+    /**
+     * The history manager for a console content widget.
+     */
+    history?: IConsoleHistory;
 
     /**
      * The renderer for a console content widget.

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -108,7 +108,7 @@ const EXECUTION_TIMEOUT = 250;
 export
 class ConsoleContent extends Widget {
   /**
-   * Construct a console widget.
+   * Construct a console content widget.
    */
   constructor(options: ConsoleContent.IOptions) {
     super();
@@ -498,8 +498,10 @@ class ConsoleContent extends Widget {
     }
 
     // Set up the completer handler.
-    this._completerHandler = new CellCompleterHandler(this._completer);
-    this._completerHandler.kernel = this._session.kernel;
+    this._completerHandler = new CellCompleterHandler({
+      completer: this._completer,
+      kernel: this._session.kernel
+    });
   }
 
   /**

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -213,19 +213,19 @@ class ConsoleContent extends Widget {
     if (this.isDisposed) {
       return;
     }
-    this._history.dispose();
-    this._history = null;
+    super.dispose();
     this._completerHandler.dispose();
     this._completerHandler = null;
     this._completer.dispose();
     this._completer = null;
     this._foreignHandler.dispose();
     this._foreignHandler = null;
+    this._history.dispose();
+    this._history = null;
     this._inspectionHandler.dispose();
     this._inspectionHandler = null;
     this._session.dispose();
     this._session = null;
-    super.dispose();
   }
 
   /**

--- a/src/console/foreign.ts
+++ b/src/console/foreign.ts
@@ -1,0 +1,140 @@
+import {
+  Kernel, KernelMessage
+} from '@jupyterlab/services';
+
+import {
+  IDisposable
+} from 'phosphor/lib/core/disposable';
+
+import {
+  Panel
+} from 'phosphor/lib/ui/panel';
+
+import {
+  CodeCellWidget
+} from '../notebook/cells';
+
+import {
+  nbformat
+} from '../notebook/notebook/nbformat';
+
+
+export
+class ForeignHandler implements IDisposable {
+  constructor(options: ForeignHandler.IOptions) {
+    this._cellRenderer = options.renderer.createCell;
+    this._kernel = options.kernel;
+    this._parent = options.parent;
+  }
+
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * The kernel used by the foreign handler.
+   */
+  get kernel(): Kernel.IKernel {
+    return this._kernel;
+  }
+  set kernel(value: Kernel.IKernel) {
+    if (this._kernel === value) {
+      return;
+    }
+    // Disconnect previously connected kernel.
+    if (this._kernel) {
+      this._kernel.iopubMessage.disconnect(this.onIOPubMessage, this);
+    }
+
+    this._kernel = value;
+    if (this._kernel) {
+      this._kernel.iopubMessage.connect(this.onIOPubMessage, this);
+    }
+  }
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this.kernel = null;
+    this._cells = null;
+  }
+
+  /**
+   * Make a new code cell for an input originated from a foreign session.
+   */
+  protected newCell(parentMsgId: string): CodeCellWidget {
+    let cell = this._cellRenderer();
+    this._cells[parentMsgId] = cell;
+    this._parent.addWidget(cell);
+    return;
+  }
+
+  protected onIOPubMessage(sender: Kernel.IKernel, msg: KernelMessage.IIOPubMessage) {
+    // Check whether this message came from an external session.
+    let parent = this._parent;
+    let session = (msg.parent_header as KernelMessage.IHeader).session;
+    if (session === this._kernel.clientId) {
+      return;
+    }
+    let msgType = msg.header.msg_type;
+    let parentHeader = msg.parent_header as KernelMessage.IHeader;
+    let parentMsgId = parentHeader.msg_id as string;
+    let cell: CodeCellWidget;
+    switch (msgType) {
+    case 'execute_input':
+      let inputMsg = msg as KernelMessage.IExecuteInputMsg;
+      cell = this.newCell(parentMsgId);
+      cell.model.executionCount = inputMsg.content.execution_count;
+      cell.model.source = inputMsg.content.code;
+      cell.trusted = true;
+      parent.update();
+      break;
+    case 'execute_result':
+    case 'display_data':
+    case 'stream':
+    case 'error':
+      if (!(parentMsgId in this._cells)) {
+        // This is an output from an input that was broadcast before our
+        // session started listening. We will ignore it.
+        console.warn('Ignoring output with no associated input cell.');
+        break;
+      }
+      cell = this._cells[parentMsgId];
+      let output = msg.content as nbformat.IOutput;
+      output.output_type = msgType as nbformat.OutputType;
+      cell.model.outputs.add(output);
+      parent.update();
+      break;
+    case 'clear_output':
+      let wait = (msg as KernelMessage.IClearOutputMsg).content.wait;
+      cell.model.outputs.clear(wait);
+      break;
+    default:
+      break;
+    }
+  }
+
+  private _cells: { [key: string]: CodeCellWidget } = Object.create(null);
+  private _cellRenderer: () => CodeCellWidget = null;
+  private _isDisposed = false;
+  private _kernel: Kernel.IKernel = null;
+  private _parent: Panel = null;
+}
+
+
+export
+namespace ForeignHandler {
+  export
+  interface IOptions {
+    kernel: Kernel.IKernel;
+    parent: Panel;
+    renderer: IRenderer;
+  }
+
+  export
+  interface IRenderer {
+    createCell: () => CodeCellWidget;
+  }
+}

--- a/src/console/foreign.ts
+++ b/src/console/foreign.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 import {
   Kernel, KernelMessage
 } from '@jupyterlab/services';
@@ -78,16 +81,6 @@ class ForeignHandler implements IDisposable {
   }
 
   /**
-   * Make a new code cell for an input originated from a foreign session.
-   */
-  protected newCell(parentMsgId: string): CodeCellWidget {
-    let cell = this._renderer();
-    this._cells.set(parentMsgId, cell);
-    this._parent.addWidget(cell);
-    return;
-  }
-
-  /**
    * Handler IOPub messages.
    */
   protected onIOPubMessage(sender: Kernel.IKernel, msg: KernelMessage.IIOPubMessage) {
@@ -104,7 +97,7 @@ class ForeignHandler implements IDisposable {
     switch (msgType) {
     case 'execute_input':
       let inputMsg = msg as KernelMessage.IExecuteInputMsg;
-      cell = this.newCell(parentMsgId);
+      cell = this._newCell(parentMsgId);
       cell.model.executionCount = inputMsg.content.execution_count;
       cell.model.source = inputMsg.content.code;
       cell.trusted = true;
@@ -133,6 +126,16 @@ class ForeignHandler implements IDisposable {
     default:
       break;
     }
+  }
+
+  /**
+   * Create a new code cell for an input originated from a foreign session.
+   */
+  private _newCell(parentMsgId: string): CodeCellWidget {
+    let cell = this._renderer();
+    this._cells.set(parentMsgId, cell);
+    this._parent.addWidget(cell);
+    return cell;
   }
 
   private _cells = new Map<string, CodeCellWidget>();

--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -38,24 +38,25 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
   /**
    * Construct a new inspection handler for a widget.
    */
-  constructor(rendermime: RenderMime) {
-    this._rendermime = rendermime;
+  constructor(options: InspectionHandler.IOptions) {
+    this._kernel = options.kernel || null;
+    this._rendermime = options.rendermime;
   }
 
   /**
    * A signal emitted when the handler is disposed.
    */
-  disposed: ISignal<InspectionHandler, void>;
+  readonly disposed: ISignal<InspectionHandler, void>;
 
   /**
    * A signal emitted when inspector should clear all items with no history.
    */
-  ephemeralCleared: ISignal<InspectionHandler, void>;
+  readonly ephemeralCleared: ISignal<InspectionHandler, void>;
 
   /**
    * A signal emitted when an inspector value is generated.
    */
-  inspected: ISignal<InspectionHandler, Inspector.IInspectorUpdate>;
+  readonly inspected: ISignal<InspectionHandler, Inspector.IInspectorUpdate>;
 
   /**
    * The cell widget used by the inspection handler.
@@ -180,3 +181,26 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
 defineSignal(InspectionHandler.prototype, 'ephemeralCleared');
 defineSignal(InspectionHandler.prototype, 'disposed');
 defineSignal(InspectionHandler.prototype, 'inspected');
+
+
+/**
+ * A namespace for inspection handler statics.
+ */
+export
+namespace InspectionHandler {
+  /**
+   * The instantiation options for an inspection handler.
+   */
+  export
+  interface IOptions {
+    /**
+     * The kernel for the inspection handler.
+     */
+    kernel?: Kernel.IKernel;
+
+    /**
+     * The mime renderer for the inspection handler.
+     */
+    rendermime: RenderMime;
+  }
+}

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -260,7 +260,7 @@ class BaseCellWidget extends Widget {
   }
 
   /**
-   * Handle `update_request` messages.
+   * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {
     if (!this._model) {
@@ -456,7 +456,7 @@ class CodeCellWidget extends BaseCellWidget {
   }
 
   /**
-   * Handle `update_request` messages.
+   * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {
     if (this._collapsedCursor) {
@@ -630,7 +630,7 @@ class MarkdownCellWidget extends BaseCellWidget {
   }
 
   /**
-   * Handle `update_request` messages.
+   * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {
     let model = this.model;

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -104,7 +104,9 @@ class NotebookPanel extends Widget {
     Widget.attach(this._completer, document.body);
 
     // Set up the completer handler.
-    this._completerHandler = new CellCompleterHandler(this._completer);
+    this._completerHandler = new CellCompleterHandler({
+      completer: this._completer
+    });
     this._completerHandler.activeCell = this._content.activeCell;
     this._content.activeCellChanged.connect((s, cell) => {
       this._completerHandler.activeCell = cell;

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -540,7 +540,9 @@ class Notebook extends StaticNotebook {
     super(options);
     this.node.tabIndex = -1;  // Allow the widget to take focus.
     // Set up the inspection handler.
-    this._inspectionHandler = new InspectionHandler(this.rendermime);
+    this._inspectionHandler = new InspectionHandler({
+      rendermime: this.rendermime
+    });
     this.activeCellChanged.connect((s, cell) => {
       this._inspectionHandler.activeCell = cell;
     });

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -296,7 +296,7 @@ class OutputAreaWidget extends Widget {
   }
 
   /**
-   * Handle `update_request` messages.
+   * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {
     if (this.collapsed) {

--- a/test/src/completer/handler.spec.ts
+++ b/test/src/completer/handler.spec.ts
@@ -92,7 +92,9 @@ describe('completer/handler', () => {
     describe('#constructor()', () => {
 
       it('should create a completer handler', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget()
+        });
         expect(handler).to.be.a(CellCompleterHandler);
       });
 
@@ -101,12 +103,16 @@ describe('completer/handler', () => {
     describe('#kernel', () => {
 
       it('should default to null', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget()
+        });
         expect(handler.kernel).to.be(null);
       });
 
       it('should be settable', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget()
+        });
         expect(handler.kernel).to.be(null);
         handler.kernel = kernel;
         expect(handler.kernel).to.be(kernel);
@@ -118,12 +124,16 @@ describe('completer/handler', () => {
     describe('#activeCell', () => {
 
       it('should default to null', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget()
+        });
         expect(handler.activeCell).to.be(null);
       });
 
       it('should be settable', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget()
+        });
         let cell = new BaseCellWidget({
           renderer: CodeMirrorCodeCellWidgetRenderer.defaultRenderer
         });
@@ -134,7 +144,9 @@ describe('completer/handler', () => {
       });
 
       it('should be resettable', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget()
+        });
         let one = new BaseCellWidget({
           renderer: CodeMirrorCodeCellWidgetRenderer.defaultRenderer
         });
@@ -155,7 +167,9 @@ describe('completer/handler', () => {
     describe('#isDisposed', () => {
 
       it('should be true if handler has been disposed', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget()
+        });
         expect(handler.isDisposed).to.be(false);
         handler.dispose();
         expect(handler.isDisposed).to.be(true);
@@ -166,8 +180,10 @@ describe('completer/handler', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the handler resources', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
-        handler.kernel = kernel;
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget(),
+          kernel: kernel
+        });
         expect(handler.isDisposed).to.be(false);
         expect(handler.kernel).to.be.ok();
         handler.dispose();
@@ -176,7 +192,9 @@ describe('completer/handler', () => {
       });
 
       it('should be safe to call multiple times', () => {
-        let handler = new CellCompleterHandler(new CompleterWidget());
+        let handler = new CellCompleterHandler({
+          completer: new CompleterWidget()
+        });
         expect(handler.isDisposed).to.be(false);
         handler.dispose();
         handler.dispose();
@@ -188,7 +206,9 @@ describe('completer/handler', () => {
     describe('#makeRequest()', () => {
 
       it('should reject if handler has no kernel', (done) => {
-        let handler = new TestCompleterHandler(new CompleterWidget());
+        let handler = new TestCompleterHandler({
+          completer: new CompleterWidget()
+        });
         let request: ICompletionRequest = {
           ch: 0,
           chHeight: 0,
@@ -207,7 +227,9 @@ describe('completer/handler', () => {
       // TODO: This test needs to be updated to use a python kernel.
       it('should resolve if handler has a kernel', () => {
         console.warn('This test needs to be updated to use a python kernel.');
-        let handler = new TestCompleterHandler(new CompleterWidget());
+        let handler = new TestCompleterHandler({
+          completer: new CompleterWidget()
+        });
         let request: ICompletionRequest = {
           ch: 0,
           chHeight: 0,
@@ -227,7 +249,7 @@ describe('completer/handler', () => {
 
       it('should do nothing if handler has been disposed', () => {
         let completer = new CompleterWidget();
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
         completer.model = new CompleterModel();
         completer.model.options = ['foo', 'bar', 'baz'];
         handler.dispose();
@@ -237,7 +259,7 @@ describe('completer/handler', () => {
 
       it('should do nothing if pending request ID does not match', () => {
         let completer = new CompleterWidget();
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
         completer.model = new CompleterModel();
         completer.model.options = ['foo', 'bar', 'baz'];
         handler.onReply(2, null, null);
@@ -246,7 +268,7 @@ describe('completer/handler', () => {
 
       it('should reset model if status is not ok', () => {
         let completer = new CompleterWidget();
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
         let options = ['a', 'b', 'c'];
         let request: ICompletionRequest = {
           ch: 0,
@@ -280,7 +302,7 @@ describe('completer/handler', () => {
 
       it('should update model if status is ok', () => {
         let completer = new CompleterWidget();
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
         let options = ['a', 'b', 'c'];
         let request: ICompletionRequest = {
           ch: 0,
@@ -317,7 +339,9 @@ describe('completer/handler', () => {
     describe('#onTextChanged()', () => {
 
       it('should fire when the active editor emits a text change', () => {
-        let handler = new TestCompleterHandler(new CompleterWidget());
+        let handler = new TestCompleterHandler({
+          completer: new CompleterWidget()
+        });
         let change: ITextChange = {
           ch: 0,
           chHeight: 0,
@@ -342,7 +366,7 @@ describe('completer/handler', () => {
         let completer = new CompleterWidget({
           model: new TestCompleterModel()
         });
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
         let change: ITextChange = {
           ch: 0,
           chHeight: 0,
@@ -369,7 +393,9 @@ describe('completer/handler', () => {
     describe('#onCompletionRequested()', () => {
 
       it('should fire when the active editor emits a request', () => {
-        let handler = new TestCompleterHandler(new CompleterWidget());
+        let handler = new TestCompleterHandler({
+          completer: new CompleterWidget()
+        });
         let request: ICompletionRequest = {
           ch: 0,
           chHeight: 0,
@@ -393,7 +419,7 @@ describe('completer/handler', () => {
         let completer = new CompleterWidget({
           model: new TestCompleterModel()
         });
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
         let request: ICompletionRequest = {
           ch: 0,
           chHeight: 0,
@@ -420,7 +446,7 @@ describe('completer/handler', () => {
 
       it('should fire when the completer widget emits a signal', () => {
         let completer = new CompleterWidget();
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
 
         expect(handler.methods).to.not.contain('onCompletionSelected');
         completer.selected.emit('foo');
@@ -431,7 +457,7 @@ describe('completer/handler', () => {
         let completer = new CompleterWidget({
           model: new TestCompleterModel()
         });
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
         let model = completer.model as TestCompleterModel;
         let renderer = CodeMirrorCodeCellWidgetRenderer.defaultRenderer;
 
@@ -445,7 +471,7 @@ describe('completer/handler', () => {
         let model = new CompleterModel();
         let patch = 'foobar';
         let completer = new CompleterWidget({ model });
-        let handler = new TestCompleterHandler(completer);
+        let handler = new TestCompleterHandler({ completer });
         let renderer = CodeMirrorCodeCellWidgetRenderer.defaultRenderer;
         let cell = new BaseCellWidget({ renderer });
         let request: ICompletionRequest = {

--- a/test/src/console/content.spec.ts
+++ b/test/src/console/content.spec.ts
@@ -8,6 +8,10 @@ import {
 } from '@jupyterlab/services';
 
 import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
   CodeMirrorConsoleRenderer
 } from '../../../lib/console/codemirror/widget';
 
@@ -42,6 +46,7 @@ describe('console/content', () => {
       it('should create a new console content widget', done => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
+          Widget.attach(widget, document.body);
           expect(widget).to.be.a(ConsoleContent);
           expect(widget.node.classList.contains(CONSOLE_CLASS)).to.be(true);
           widget.dispose();
@@ -58,6 +63,7 @@ describe('console/content', () => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
           let called: Date = null;
           let force = true;
+          Widget.attach(widget, document.body);
           widget.executed.connect((sender, time) => { called = time; });
           widget.execute(force).then(() => {
             expect(called).to.be.a(Date);
@@ -74,6 +80,7 @@ describe('console/content', () => {
       it('should exist after instantiation', done => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
+          Widget.attach(widget, document.body);
           expect(widget.inspectionHandler).to.be.an(InspectionHandler);
           widget.dispose();
           done();
@@ -87,18 +94,22 @@ describe('console/content', () => {
       it('should be a code cell widget', done => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
+          Widget.attach(widget, document.body);
           expect(widget.prompt).to.be.a(CodeCellWidget);
           widget.dispose();
           done();
         }).catch(done);
       });
 
-      it('should be be replaced after execution', done => {
+      it('should be replaced after execution', done => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
-          let old = widget.prompt;
           let force = true;
+          Widget.attach(widget, document.body);
+
+          let old = widget.prompt;
           expect(old).to.be.a(CodeCellWidget);
+
           widget.execute(force).then(() => {
             expect(widget.prompt).to.be.a(CodeCellWidget);
             expect(widget.prompt).to.not.be(old);
@@ -115,6 +126,7 @@ describe('console/content', () => {
       it('should return the session passed in at instantiation', done => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
+          Widget.attach(widget, document.body);
           expect(widget.session).to.be(session);
           widget.dispose();
           done();
@@ -129,6 +141,7 @@ describe('console/content', () => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
           let force = true;
+          Widget.attach(widget, document.body);
           widget.execute(force).then(() => {
             expect(widget.content.widgets.length).to.be.greaterThan(1);
             widget.clear();
@@ -146,6 +159,7 @@ describe('console/content', () => {
       it('should dispose the content widget', done => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
+          Widget.attach(widget, document.body);
           expect(widget.isDisposed).to.be(false);
           widget.dispose();
           expect(widget.isDisposed).to.be(true);
@@ -156,6 +170,7 @@ describe('console/content', () => {
       it('should be safe to dispose multiple times', done => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
+          Widget.attach(widget, document.body);
           expect(widget.isDisposed).to.be(false);
           widget.dispose();
           widget.dispose();
@@ -172,6 +187,7 @@ describe('console/content', () => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
           let force = true;
+          Widget.attach(widget, document.body);
           expect(widget.content.widgets.length).to.be(1);
           widget.execute(force).then(() => {
             expect(widget.content.widgets.length).to.be.greaterThan(1);
@@ -186,6 +202,7 @@ describe('console/content', () => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
           let force = false;
           let timeout = 5000;
+          Widget.attach(widget, document.body);
           widget.prompt.model.source = 'for x in range(5):';
           expect(widget.content.widgets.length).to.be(1);
           widget.execute(force, timeout).then(() => {
@@ -204,6 +221,7 @@ describe('console/content', () => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
           let code = 'print("Hello.")';
+          Widget.attach(widget, document.body);
           expect(widget.content.widgets.length).to.be(1);
           widget.inject(code).then(() => {
             expect(widget.content.widgets.length).to.be.greaterThan(1);
@@ -221,6 +239,7 @@ describe('console/content', () => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
           let model = widget.prompt.model;
+          Widget.attach(widget, document.body);
           expect(model.source).to.be.empty();
           widget.insertLinebreak();
           expect(model.source).to.be('\n');

--- a/test/src/console/content.spec.ts
+++ b/test/src/console/content.spec.ts
@@ -46,7 +46,7 @@ describe('console/content', () => {
           expect(widget.node.classList.contains(CONSOLE_CLASS)).to.be(true);
           widget.dispose();
           done();
-        });
+        }).catch(done);
       });
 
     });
@@ -64,7 +64,7 @@ describe('console/content', () => {
             widget.dispose();
             done();
           });
-        });
+        }).catch(done);
       });
 
     });
@@ -77,7 +77,7 @@ describe('console/content', () => {
           expect(widget.inspectionHandler).to.be.an(InspectionHandler);
           widget.dispose();
           done();
-        });
+        }).catch(done);
       });
 
     });
@@ -90,7 +90,7 @@ describe('console/content', () => {
           expect(widget.prompt).to.be.a(CodeCellWidget);
           widget.dispose();
           done();
-        });
+        }).catch(done);
       });
 
       it('should be be replaced after execution', done => {
@@ -104,7 +104,7 @@ describe('console/content', () => {
             expect(widget.prompt).to.not.be(old);
             widget.dispose();
             done();
-          });
+          }).catch(done);
         });
       });
 
@@ -118,7 +118,7 @@ describe('console/content', () => {
           expect(widget.session).to.be(session);
           widget.dispose();
           done();
-        });
+        }).catch(done);
       });
 
     });
@@ -136,7 +136,7 @@ describe('console/content', () => {
             widget.dispose();
             done();
           });
-        });
+        }).catch(done);
       });
 
     });
@@ -150,7 +150,7 @@ describe('console/content', () => {
           widget.dispose();
           expect(widget.isDisposed).to.be(true);
           done();
-        });
+        }).catch(done);
       });
 
       it('should be safe to dispose multiple times', done => {
@@ -161,6 +161,38 @@ describe('console/content', () => {
           widget.dispose();
           expect(widget.isDisposed).to.be(true);
           done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('#execute()', () => {
+
+      it('should execute contents of the prompt if forced', done => {
+        Session.startNew({ path: utils.uuid() }).then(session => {
+          let widget = new ConsoleContent({ renderer, rendermime, session });
+          let force = true;
+          expect(widget.content.widgets.length).to.be(1);
+          widget.execute(force).then(() => {
+            expect(widget.content.widgets.length).to.be.greaterThan(1);
+            widget.dispose();
+            done();
+          }).catch(done);
+        });
+      });
+
+      it('should check if code is multiline and allow amending', done => {
+        Session.startNew({ path: utils.uuid() }).then(session => {
+          let widget = new ConsoleContent({ renderer, rendermime, session });
+          let force = false;
+          let timeout = 5000;
+          widget.prompt.model.source = 'for x in range(5):';
+          expect(widget.content.widgets.length).to.be(1);
+          widget.execute(force, timeout).then(() => {
+            expect(widget.content.widgets.length).to.be(1);
+            widget.dispose();
+            done();
+          }).catch(done);
         });
       });
 

--- a/test/src/console/content.spec.ts
+++ b/test/src/console/content.spec.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  utils, Session
+} from '@jupyterlab/services';
+
+import {
+  CodeMirrorConsoleRenderer
+} from '../../../lib/console/codemirror/widget';
+
+import {
+  ConsoleContent
+} from '../../../lib/console/content';
+
+import {
+  defaultRenderMime
+} from '../utils';
+
+
+const rendermime = defaultRenderMime();
+const renderer = CodeMirrorConsoleRenderer.defaultRenderer;
+
+
+describe('console/content', () => {
+
+  describe('ConsoleContent', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create a new console content widget', done => {
+        Session.startNew({ path: utils.uuid() }).then(session => {
+          let content = new ConsoleContent({ renderer, rendermime, session });
+          expect(content).to.be.a(ConsoleContent);
+          done();
+        });
+      });
+
+    });
+
+    // describe('#isDisposed', () => {
+
+    //   it('should get whether the object is disposed', () => {
+    //     let history = new ConsoleHistory();
+    //     expect(history.isDisposed).to.be(false);
+    //     history.dispose();
+    //     expect(history.isDisposed).to.be(true);
+    //   });
+
+    // });
+
+    // describe('#dispose()', () => {
+
+    //   it('should dispose the history object', () => {
+    //     let history = new ConsoleHistory();
+    //     expect(history.isDisposed).to.be(false);
+    //     history.dispose();
+    //     expect(history.isDisposed).to.be(true);
+    //   });
+
+    //   it('should be safe to dispose multiple times', () => {
+    //     let history = new ConsoleHistory();
+    //     expect(history.isDisposed).to.be(false);
+    //     history.dispose();
+    //     history.dispose();
+    //     expect(history.isDisposed).to.be(true);
+    //   });
+
+    // });
+
+  });
+
+});

--- a/test/src/console/content.spec.ts
+++ b/test/src/console/content.spec.ts
@@ -198,6 +198,23 @@ describe('console/content', () => {
 
     });
 
+    describe('#inject()', () => {
+
+      it('should add a code cell and execute it', done => {
+        Session.startNew({ path: utils.uuid() }).then(session => {
+          let widget = new ConsoleContent({ renderer, rendermime, session });
+          let code = 'print("Hello.")';
+          expect(widget.content.widgets.length).to.be(1);
+          widget.inject(code).then(() => {
+            expect(widget.content.widgets.length).to.be.greaterThan(1);
+            widget.dispose();
+            done();
+          }).catch(done);
+        });
+      });
+
+    });
+
   });
 
 });

--- a/test/src/console/content.spec.ts
+++ b/test/src/console/content.spec.ts
@@ -8,6 +8,10 @@ import {
 } from '@jupyterlab/services';
 
 import {
+  Message
+} from 'phosphor/lib/core/messaging';
+
+import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
@@ -38,6 +42,16 @@ class TestContent extends ConsoleContent {
   protected newPrompt(): void {
     super.newPrompt();
     this.methods.push('newPrompt');
+  }
+
+  protected onActivateRequest(msg: Message): void {
+    super.onActivateRequest(msg);
+    this.methods.push('onActivateRequest');
+  }
+
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    this.methods.push('onAfterAttach');
   }
 }
 
@@ -316,6 +330,45 @@ describe('console/content', () => {
             done();
           }).catch(done);
 
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('#onActivateRequest()', () => {
+
+      it('should focus the prompt editor', done => {
+        Session.startNew({ path: utils.uuid() }).then(session => {
+          let widget = new TestContent({ renderer, rendermime, session });
+          expect(widget.prompt).to.not.be.ok();
+          expect(widget.methods).to.not.contain('onActivateRequest');
+          Widget.attach(widget, document.body);
+          requestAnimationFrame(() => {
+            widget.activate();
+            requestAnimationFrame(() => {
+              expect(widget.methods).to.contain('onActivateRequest');
+              expect(widget.prompt.editor.hasFocus()).to.be(true);
+              widget.dispose();
+              done();
+            });
+          });
+        }).catch(done);
+      });
+
+    });
+
+    describe('#onAfterAttach()', () => {
+
+      it('should be called after attach, creating a prompt', done => {
+        Session.startNew({ path: utils.uuid() }).then(session => {
+          let widget = new TestContent({ renderer, rendermime, session });
+          expect(widget.prompt).to.not.be.ok();
+          expect(widget.methods).to.not.contain('onAfterAttach');
+          Widget.attach(widget, document.body);
+          expect(widget.methods).to.contain('onAfterAttach');
+          expect(widget.prompt).to.be.ok();
+          widget.dispose();
           done();
         }).catch(done);
       });

--- a/test/src/console/content.spec.ts
+++ b/test/src/console/content.spec.ts
@@ -235,15 +235,34 @@ describe('console/content', () => {
 
     describe('#insertLinebreak()', () => {
 
-      it('should insert a line break into the prompt', () => {
+      it('should insert a line break into the prompt', done => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
-          let model = widget.prompt.model;
           Widget.attach(widget, document.body);
+
+          let model = widget.prompt.model;
           expect(model.source).to.be.empty();
           widget.insertLinebreak();
           expect(model.source).to.be('\n');
-        });
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('#serialize()', () => {
+
+      it('should serialize the contents of a console', done => {
+        Session.startNew({ path: utils.uuid() }).then(session => {
+          let widget = new ConsoleContent({ renderer, rendermime, session });
+          Widget.attach(widget, document.body);
+          widget.prompt.model.source = 'foo';
+
+          let serialized = widget.serialize();
+          expect(serialized).to.have.length(2);
+          expect(serialized[1].source).to.be('foo');
+          done();
+        }).catch(done);
       });
 
     });

--- a/test/src/console/content.spec.ts
+++ b/test/src/console/content.spec.ts
@@ -215,6 +215,20 @@ describe('console/content', () => {
 
     });
 
+    describe('#insertLinebreak()', () => {
+
+      it('should insert a line break into the prompt', () => {
+        Session.startNew({ path: utils.uuid() }).then(session => {
+          let widget = new ConsoleContent({ renderer, rendermime, session });
+          let model = widget.prompt.model;
+          expect(model.source).to.be.empty();
+          widget.insertLinebreak();
+          expect(model.source).to.be('\n');
+        });
+      });
+
+    });
+
   });
 
 });

--- a/test/src/console/content.spec.ts
+++ b/test/src/console/content.spec.ts
@@ -201,7 +201,7 @@ describe('console/content', () => {
         Session.startNew({ path: utils.uuid() }).then(session => {
           let widget = new ConsoleContent({ renderer, rendermime, session });
           let force = false;
-          let timeout = 5000;
+          let timeout = 9000;
           Widget.attach(widget, document.body);
           widget.prompt.model.source = 'for x in range(5):';
           expect(widget.content.widgets.length).to.be(1);

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -10,6 +10,7 @@ import './completer/handler.spec';
 import './completer/model.spec';
 import './completer/widget.spec';
 
+import './console/content.spec';
 import './console/history.spec';
 
 import './dialog/dialog.spec';

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -4,7 +4,7 @@
 import expect = require('expect.js');
 
 import {
-  utils, Session
+  Session, utils
 } from '@jupyterlab/services';
 
 import {
@@ -16,6 +16,10 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
+  Context
+} from '../../../../lib/docregistry/context';
+
+import {
  CodeCellWidget, MarkdownCellWidget
 } from '../../../../lib/notebook/cells/widget';
 
@@ -24,11 +28,8 @@ import {
 } from '../../../../lib/notebook/notebook/actions';
 
 import {
- createInterruptButton,
- createKernelNameItem,
- createKernelStatusItem,
- createRestartButton
-} from '../../../../lib/toolbar/kernel';
+  CodeMirrorNotebookPanelRenderer
+} from '../../../../lib/notebook/codemirror/notebook/panel';
 
 import {
  ToolbarItems
@@ -43,8 +44,11 @@ import {
 } from '../../../../lib/notebook/notebook/panel';
 
 import {
-  Context
-} from '../../../../lib/docregistry/context';
+ createInterruptButton,
+ createKernelNameItem,
+ createKernelStatusItem,
+ createRestartButton
+} from '../../../../lib/toolbar/kernel';
 
 import {
   createNotebookContext, defaultRenderMime
@@ -53,10 +57,6 @@ import {
 import {
   DEFAULT_CONTENT
 } from '../utils';
-
-import {
-  CodeMirrorNotebookPanelRenderer
-} from '../../../../lib/notebook/codemirror/notebook/panel';
 
 
 /**


### PR DESCRIPTION
- [x] Create a new `ForeignHandler` class to deal with foreign messages that should result in cells being injected into a console.
- [x] Create `CellCompleterHandler.IOptions` for instantiation.
- [x] Create `InspectionHandler.IOptions` for instantiation.
- [x] Bugfix: Update `ConsoleContent` constructor to not call any `protected` methods.
- [x] Write `ConsoleContent` unit tests