### PR TITLE
Clean up handling of code mimetype

### DIFF
--- a/src/codemirror/index.ts
+++ b/src/codemirror/index.ts
@@ -4,6 +4,8 @@
 import * as CodeMirror
   from 'codemirror';
 
+import 'codemirror/mode/meta';
+
 import './codemirror-ipython';
 import './codemirror-ipythongfm';
 
@@ -47,26 +49,31 @@ function loadModeByName(editor: CodeMirror.Editor, mode: string): void {
 
 
 /**
+ * Find a codemirror mode by name or CodeMirror spec.
+ */
+export
+function findMode(mode: string | CodeMirror.modespec): CodeMirror.modespec {
+  let modename = (typeof mode === 'string') ? mode :
+      mode.mode || mode.name;
+  let mimetype = (typeof mode !== 'string') ? mode.mime : '';
+
+  return (
+    CodeMirror.findModeByName(modename) ||
+    CodeMirror.findModeByMIME(mimetype) ||
+    CodeMirror.modes['null']
+  );
+}
+
+
+/**
  * Require a codemirror mode by name or Codemirror spec.
  */
 export
 function requireMode(mode: string | CodeMirror.modespec): Promise<CodeMirror.modespec> {
-  let modename = (typeof mode === 'string') ? mode :
-      mode.mode || mode.name;
-  let mimetype = (typeof mode !== 'string') ? mode.mime : '';
-  let ext = modename.split('.').pop();
-
-  // Get a modespec object by whatever means necessary.
-  let info: CodeMirror.modespec = (
-      (modename && mimetype && mode as CodeMirror.modespec) ||
-      CodeMirror.findModeByName(modename) ||
-      CodeMirror.findModeByExtension(ext) ||
-      CodeMirror.findModeByMIME(modename) ||
-      {mode: modename, mime: modename}
-  );
+  let info = findMode(mode);
 
   // Simplest, cheapest check by mode name.
-  if (CodeMirror.modes.hasOwnProperty(modename)) {
+  if (CodeMirror.modes.hasOwnProperty(info.mode)) {
     return Promise.resolve(info);
   }
 

--- a/src/console/codemirror/widget.ts
+++ b/src/console/codemirror/widget.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+
 import {
   CodeCellModel, RawCellModel
 } from '../../notebook/cells/model';
@@ -16,6 +17,14 @@ import {
 import {
   CodeMirrorNotebookRenderer
 } from '../../notebook/codemirror/notebook/widget';
+
+import {
+  mimetypeForLanguage
+} from '../../notebook/common/mimetype';
+
+import {
+  nbformat
+} from '../../notebook/notebook/nbformat';
 
 import {
   RenderMime
@@ -64,6 +73,13 @@ class CodeMirrorConsoleRenderer implements ConsoleContent.IRenderer {
     });
     widget.model = new CodeCellModel();
     return widget;
+  }
+
+  /**
+   * Get the preferred mimetype given language info.
+   */
+  getCodeMimetype(info: nbformat.ILanguageInfoMetadata): string {
+    return mimetypeForLanguage(info);
   }
 }
 

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -42,10 +42,6 @@ import {
 } from '../notebook/cells/editor';
 
 import {
-  mimetypeForLanguage
-} from '../notebook/common/mimetype';
-
-import {
   CompleterWidget, CompleterModel, CellCompleterHandler
 } from '../completer';
 
@@ -547,7 +543,8 @@ class ConsoleContent extends Widget {
     let layout = this._content.layout as PanelLayout;
     let banner = layout.widgets.at(0) as RawCellWidget;
     banner.model.source = info.banner;
-    this._mimetype = mimetypeForLanguage(info.language_info);
+    let lang = info.language_info as nbformat.ILanguageInfoMetadata;
+    this._mimetype = this._renderer.getCodeMimetype(lang);
     this.prompt.mimetype = this._mimetype;
   }
 
@@ -620,6 +617,11 @@ namespace ConsoleContent {
      * Create a code cell whose input originated from a foreign session.
      */
     createForeignCell(rendermine: IRenderMime): CodeCellWidget;
+
+    /**
+     * Get the preferred mimetype given language info.
+     */
+    getCodeMimetype(info: nbformat.ILanguageInfoMetadata): string;
   }
 
   /* tslint:disable */

--- a/src/notebook/codemirror/notebook/widget.ts
+++ b/src/notebook/codemirror/notebook/widget.ts
@@ -14,6 +14,14 @@ import {
 } from '../../cells/widget';
 
 import {
+  mimetypeForLanguage
+  } from '../../common/mimetype';
+
+import {
+  nbformat
+} from '../../notebook/nbformat';
+
+import {
   Notebook
 } from '../../notebook/widget';
 
@@ -60,6 +68,13 @@ class CodeMirrorNotebookRenderer extends Notebook.Renderer {
     });
     widget.model = model;
     return widget;
+  }
+
+  /**
+   * Get the preferred mimetype given language info.
+   */
+  getCodeMimetype(info: nbformat.ILanguageInfoMetadata): string {
+    return mimetypeForLanguage(info);
   }
 }
 

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  KernelMessage
-} from '@jupyterlab/services';
-
-import {
   each
 } from 'phosphor/lib/algorithm/iteration';
 
@@ -63,10 +59,6 @@ import {
   CodeCellModel, RawCellWidget, RawCellModel,
   ICodeCellModel, IMarkdownCellModel, IRawCellModel
 } from '../cells';
-
-import {
-  mimetypeForLanguage
-} from '../common/mimetype';
 
 import {
   EdgeLocation
@@ -257,7 +249,7 @@ class StaticNotebook extends Widget {
   protected onMetadataChanged(model: INotebookModel, args: IChangedArgs<any>): void {
     switch (args.name) {
     case 'language_info':
-      this._mimetype = this._renderer.getCodeMimetype(model);
+      this._updateMimetype();
       this._updateCells();
       break;
     default:
@@ -310,7 +302,7 @@ class StaticNotebook extends Widget {
       this._mimetype = 'text/plain';
       return;
     }
-    this._mimetype = this._renderer.getCodeMimetype(newValue);
+    this._updateMimetype();
     let cells = newValue.cells;
     for (let i = 0; i < cells.length; i++) {
       this._insertCell(i, cells.at(i));
@@ -418,6 +410,15 @@ class StaticNotebook extends Widget {
     this._renderer.updateCell(child);
   }
 
+  /**
+   * Update the mimetype of the notebook.
+   */
+  private _updateMimetype(): void {
+    let cursor = this._model.getMetadata('language_info');
+    let info = cursor.getValue() as nbformat.ILanguageInfoMetadata;
+    this._mimetype = this._renderer.getCodeMimetype(info);
+  }
+
   private _mimetype = 'text/plain';
   private _model: INotebookModel = null;
   private _rendermime: RenderMime = null;
@@ -484,12 +485,9 @@ namespace StaticNotebook {
     updateCell(cell: BaseCellWidget): void;
 
     /**
-     * Get the preferred mime type for code cells in the notebook.
-     *
-     * #### Notes
-     * The model is guaranteed to be non-null.
+     * Get the preferred mimetype given language info.
      */
-    getCodeMimetype(model: INotebookModel): string;
+    getCodeMimetype(info: nbformat.ILanguageInfoMetadata): string;
   }
 
   /**
@@ -523,16 +521,9 @@ namespace StaticNotebook {
     }
 
     /**
-     * Get the preferred mimetype for code cells in the notebook.
-     *
-     * #### Notes
-     * The model is guaranteed to be non-null.
+     * Get the preferred mimetype given language info.
      */
-    getCodeMimetype(model: INotebookModel): string {
-      let cursor = model.getMetadata('language_info');
-      let info = cursor.getValue() as nbformat.ILanguageInfoMetadata;
-      return mimetypeForLanguage(info as KernelMessage.ILanguageInfo);
-    }
+    abstract getCodeMimetype(info: nbformat.ILanguageInfoMetadata): string;
   }
 }
 

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -29,6 +29,10 @@ import {
 } from '../../../../lib/notebook/notebook/model';
 
 import {
+  nbformat
+} from '../../../../lib/notebook/notebook/nbformat';
+
+import {
   Notebook, StaticNotebook
 } from '../../../../lib/notebook/notebook/widget';
 
@@ -531,7 +535,8 @@ describe('notebook/notebook/widget', () => {
           let model = new NotebookModel();
           let cursor = model.getMetadata('language_info');
           cursor.setValue({ name: 'python', mimetype: 'text/x-python' });
-          expect(renderer.getCodeMimetype(model)).to.be('text/x-python');
+          let info = cursor.getValue() as nbformat.ILanguageInfoMetadata;
+          expect(renderer.getCodeMimetype(info)).to.be('text/x-python');
         });
 
       });


### PR DESCRIPTION
Make better use of the `nbformat` data.

Fixes #894.

<img width="507" alt="screen shot 2016-10-21 at 12 05 29 pm" src="https://cloud.githubusercontent.com/assets/2096628/19606260/c03e5186-9786-11e6-81f5-36c778066744.png">
