### PR TITLE
Minor Clean up of CSS Classes

### DIFF
--- a/src/default-theme/images.css
+++ b/src/default-theme/images.css
@@ -49,13 +49,10 @@
 }
 
 
-.jp-Landing-folder {
+.jp-FolderIcon {
   background-image: url(images/landingfolder.svg);
 }
 
-.jp-LauncherWidget-folder {
-  background-image: url(images/landingfolder.svg);
-}
 
 .jp-MainAreaLandscapeIcon {
   background-repeat: no-repeat;

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -113,7 +113,7 @@ function activateLanding(app: JupyterLab, services: IServiceManager, pathTracker
 
 
   let folderImage = document.createElement('span');
-  folderImage.className = 'jp-Landing-folder';
+  folderImage.className = 'jp-Landing-folder jp-FolderIcon';
 
 
   let path = document.createElement('span');

--- a/src/launcher/index.ts
+++ b/src/launcher/index.ts
@@ -76,6 +76,7 @@ const FOLDER_CLASS = 'jp-LauncherWidget-folder';
  * The class name added for the folder icon from default-theme.
  */
 const FOLDER_ICON_CLASS = 'jp-FolderIcon';
+
 /**
  * The class name added to LauncherWidget path nodes.
  */

--- a/src/launcher/index.ts
+++ b/src/launcher/index.ts
@@ -73,6 +73,10 @@ const ITEM_CLASS = 'jp-LauncherWidget-item';
 const FOLDER_CLASS = 'jp-LauncherWidget-folder';
 
 /**
+ * The class name added for the folder icon from default-theme.
+ */
+const FOLDER_ICON_CLASS = 'jp-FolderIcon';
+/**
  * The class name added to LauncherWidget path nodes.
  */
 const PATH_CLASS = 'jp-LauncherWidget-path';
@@ -308,7 +312,7 @@ class LauncherWidget extends VDomWidget<LauncherModel> {
       return h.div({ className: ITEM_CLASS, dataset: { index } }, [img, text]);
     });
 
-    let folderImage = h.span({ className: FOLDER_CLASS });
+    let folderImage = h.span({ className: FOLDER_CLASS + ' ' + FOLDER_ICON_CLASS});
     let p = this.model.path;
     let pathName = p.length ? `home > ${p.replace(/\//g, ' > ')}` : 'home';
     let path = h.span({ className: PATH_CLASS }, pathName );


### PR DESCRIPTION
I noticed multiple classes were referencing the same folder image in `default-theme` and moved it to one class, similar to how the FAQ page references the question icon from default theme but uses another class to further stye it.