### PR TITLE
Fix alignment of Folder and current working directory text

### DIFF
--- a/src/landing/index.css
+++ b/src/landing/index.css
@@ -111,7 +111,6 @@
 
 .jp-Landing-folder {
   margin-right: 0;
-  float: left;
   display: inline-block;
   background-origin: content-box;
   background-repeat: no-repeat;
@@ -132,5 +131,3 @@
     padding-left: 14px;
     margin-right: auto;
 }
-
-

--- a/src/launcher/index.css
+++ b/src/launcher/index.css
@@ -104,7 +104,6 @@
 
 .jp-LauncherWidget-folder {
   margin-right: 0;
-  float: left;
   display: inline-block;
   background-origin: content-box;
   background-repeat: no-repeat;
@@ -125,5 +124,3 @@
     padding-top: 14px;
     margin-right: auto;
 }
-
-


### PR DESCRIPTION
Removed `float:left` CSS rule for the folder since its parent container already has that rule.

Before:
![screen shot 2016-10-21 at 3 07 41 pm](https://cloud.githubusercontent.com/assets/16314651/19613415/42e747a4-97a1-11e6-97d3-35a8a848ac26.png)
![screen shot 2016-10-21 at 3 07 47 pm](https://cloud.githubusercontent.com/assets/16314651/19613416/457c3c5e-97a1-11e6-8145-073dfee7730f.png)

After:
![screen shot 2016-10-21 at 3 08 06 pm](https://cloud.githubusercontent.com/assets/16314651/19613418/4b514f2a-97a1-11e6-9bf3-7198b7636e03.png)
![screen shot 2016-10-21 at 3 08 37 pm](https://cloud.githubusercontent.com/assets/16314651/19613420/4d6d5164-97a1-11e6-9599-526865083c6a.png)


