### PR TITLE
Static CodeMirror Widget Fixes

### DIFF
--- a/src/codemirror/widget.ts
+++ b/src/codemirror/widget.ts
@@ -319,11 +319,15 @@ class StaticCodeMirror extends Widget {
     let child = wrapper.cloneNode(true) as HTMLElement;
     let node = this.node;
     node.innerHTML = '';
-    node.appendChild(child);
-    let cursor = child.getElementsByClassName('CodeMirror-cursor')[0];
-    if (cursor) {
-      (cursor as HTMLElement).style.borderLeft = 'none';
+    let cursors = child.getElementsByClassName('CodeMirror-cursors')[0];
+    if (cursors) {
+      cursors.parentElement.removeChild(cursors);
     }
+    let textarea = child.getElementsByTagName('textarea')[0];
+    if (textarea) {
+      textarea.parentElement.removeChild(textarea);
+    }
+    node.appendChild(child);
   }
 
   private _editor: CodeMirror.Editor = null;

--- a/src/codemirror/widget.ts
+++ b/src/codemirror/widget.ts
@@ -95,13 +95,6 @@ class CodeMirrorWidget extends Widget {
   }
 
   /**
-   * Handle `'activate-request'` messages.
-   */
-  protected onActivateRequest(msg: Message): void {
-    this._activate();
-  }
-
-  /**
    * Handle the DOM events for the widget.
    *
    * @param event - The DOM event sent to the widget.
@@ -125,6 +118,13 @@ class CodeMirrorWidget extends Widget {
     default:
       break;
     }
+  }
+
+  /**
+   * Handle `'activate-request'` messages.
+   */
+  protected onActivateRequest(msg: Message): void {
+    this._activate();
   }
 
   /**

--- a/src/codemirror/widget.ts
+++ b/src/codemirror/widget.ts
@@ -276,10 +276,9 @@ class StaticCodeMirror extends Widget {
    * Construct a new static code mirror widget.
    */
   constructor(editor: CodeMirror.Editor) {
-    super({ node: document.createElement('div') });
+    super();
     this._editor = editor;
     this.addClass(STATIC_CLASS);
-    this.addClass('CodeMirror');
     CodeMirror.on(this._editor.getDoc(), 'change', (instance, change) => {
       if (this.isVisible) {
         this._render();

--- a/src/codemirror/widget.ts
+++ b/src/codemirror/widget.ts
@@ -187,45 +187,22 @@ class CodeMirrorWidget extends Widget {
 
     this._static.hide();
     this._live.show();
-    if (this._lastMouseDown) {
-      this._handleMouseDown();
+
+    let prev = this._lastMouseDown;
+    if (prev) {
+      // Clone and dispatch the mouse event
+      // so we can handle appropriate selection behavior.
+      let evt = document.createEvent('MouseEvent') as MouseEvent;
+      let node = editor.getScrollerElement();
+      evt.initMouseEvent('mousedown', true, true,
+                         window, prev.detail, prev.screenX, prev.screenY,
+                         prev.clientX, prev.clientY,
+                         prev.ctrlKey, prev.altKey, prev.shiftKey,
+                         prev.metaKey, prev.button, null);
+      node.dispatchEvent(evt);
       this._lastMouseDown = null;
     }
     editor.focus();
-  }
-
-  /**
-   * Handle a mousedown event when we activate.
-   */
-  private _handleMouseDown(): void {
-    let editor = this.editor;
-    let prev = this._lastMouseDown;
-    let doc = editor.getDoc();
-    let pos = editor.coordsChar({ left: prev.clientX, top: prev.clientY });
-    let offset = doc.indexFromPos(pos);
-
-    // If we have clicked in the middle of a selection, bail.
-    if (doc.somethingSelected()) {
-      for (let selection of doc.listSelections()) {
-        let { anchor, head } = selection;
-        let start = doc.indexFromPos(anchor);
-        let end = doc.indexFromPos(head);
-        if (start <= offset && end >= offset) {
-          return;
-        }
-      }
-    }
-
-    // Otherwise, clone and dispatch the mouse event
-    // so we can handle a new selection.
-    let evt = document.createEvent('MouseEvent') as MouseEvent;
-    let node = editor.getScrollerElement();
-    evt.initMouseEvent('mousedown', true, true,
-                       window, prev.detail, prev.screenX, prev.screenY,
-                       prev.clientX, prev.clientY,
-                       prev.ctrlKey, prev.altKey, prev.shiftKey,
-                       prev.metaKey, prev.button, null);
-    node.dispatchEvent(evt);
   }
 
   private _live: LiveCodeMirror;
@@ -273,7 +250,6 @@ class LiveCodeMirror extends Widget {
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
-    console.log('refresh live');
     this._editor.refresh();
   }
 

--- a/src/editorwidget/index.css
+++ b/src/editorwidget/index.css
@@ -7,4 +7,5 @@
 .jp-EditorWidget {
     border-top: var(--jp-border-width) solid var(--jp-border-color1);
     margin-top: 4px;
+    overflow: auto;
 }

--- a/src/notebook/codemirror/cells/editor.ts
+++ b/src/notebook/codemirror/cells/editor.ts
@@ -122,7 +122,6 @@ class CodeMirrorCellEditorWidget extends CodeMirrorWidget implements ICellEditor
     return this.editor.getOption('lineNumbers');
   }
   set lineNumbers(value: boolean) {
-    console.log('line numbers', value);
     this.editor.setOption('lineNumbers', value);
     this.refresh();
   }

--- a/src/notebook/codemirror/cells/editor.ts
+++ b/src/notebook/codemirror/cells/editor.ts
@@ -122,7 +122,9 @@ class CodeMirrorCellEditorWidget extends CodeMirrorWidget implements ICellEditor
     return this.editor.getOption('lineNumbers');
   }
   set lineNumbers(value: boolean) {
+    console.log('line numbers', value);
     this.editor.setOption('lineNumbers', value);
+    this.refresh();
   }
 
   /**

--- a/src/notebook/codemirror/index.css
+++ b/src/notebook/codemirror/index.css
@@ -32,13 +32,3 @@
 .CodeMirror-linenumbers {
   padding: 0 4px 0 4px;
 }
-
-
-.jp-CodeMirrorWidget-static {
-  margin: var(--jp-code-padding);
-}
-
-
-.jp-CodeMirrorWidget, .jp-CodeMirrorWidget-static {
-  cursor: text;
-}

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -139,7 +139,7 @@ class StaticNotebook extends Widget {
     super();
     this.addClass(NB_CLASS);
     this._rendermime = options.rendermime;
-    this.layout = new PanelLayout();
+    this.layout = new Private.NotebookPanelLayout();
     this._renderer = options.renderer;
   }
 
@@ -1029,4 +1029,21 @@ namespace Private {
     name: 'selected',
     value: false
   });
+
+  /**
+   * A custom panel layout for the notebook.
+   */
+  export
+  class NotebookPanelLayout extends PanelLayout {
+    /**
+     * A message handler invoked on an `'update-request'` message.
+     *
+     * #### Notes
+     * This is a reimplementation of the base class method,
+     * and is a no-op.
+     */
+    protected onUpdateRequest(msg: Message): void {
+      // This is a no-op.
+    }
+  }
 }

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -139,7 +139,7 @@ class StaticNotebook extends Widget {
     super();
     this.addClass(NB_CLASS);
     this._rendermime = options.rendermime;
-    this.layout = new Private.NotebookPanelLayout();
+    this.layout = new PanelLayout();
     this._renderer = options.renderer;
   }
 
@@ -1029,21 +1029,4 @@ namespace Private {
     name: 'selected',
     value: false
   });
-
-  /**
-   * A custom panel layout for the notebook.
-   */
-  export
-  class NotebookPanelLayout extends PanelLayout {
-    /**
-     * A message handler invoked on an `'update-request'` message.
-     *
-     * #### Notes
-     * This is a reimplementation of the base class method,
-     * and is a no-op.
-     */
-    protected onUpdateRequest(msg: Message): void {
-      // This is a no-op.
-    }
-  }
 }

--- a/typings/codemirror/codemirror.d.ts
+++ b/typings/codemirror/codemirror.d.ts
@@ -43,6 +43,7 @@ declare module CodeMirror {
     var modeInfo: modeinfo[];
 
     function runMode(code: string, mode: modespec | string, el: HTMLElement): void;
+    function runMode(code: string, mode: modespec | string, callback: (text: string, style: string) => void): void;
 
     var version: string;
 


### PR DESCRIPTION
Fixes #1128. Follow-up to #1123.

Uses `node.cloneNode()` to clone the node rather than `runMode` because we want to preserve the DOM structure of the CodeMirror instance (scroll position, line numbers, etc.).  This operation does *not* clone event listeners.

Preserves the the selection behavior by cloning and dispatching the `mousedown` event.