### PR TITLE
DocumentWidgetManager cleanup and tests

### DIFF
--- a/src/csvwidget/widget.ts
+++ b/src/csvwidget/widget.ts
@@ -240,9 +240,7 @@ class CSVWidgetFactory extends ABCWidgetFactory<CSVWidget, DocumentRegistry.IMod
   /**
    * Create a new widget given a context.
    */
-  createNew(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, kernel?: Kernel.IModel): CSVWidget {
-    let widget = new CSVWidget(context);
-    this.widgetCreated.emit(widget);
-    return widget;
+  protected createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): CSVWidget {
+    return new CSVWidget(context);
   }
 }

--- a/src/docmanager/index.ts
+++ b/src/docmanager/index.ts
@@ -3,3 +3,4 @@
 
 export * from './manager';
 export * from './savehandler';
+export * from './widgetmanager';

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -99,7 +99,6 @@ class DocumentManager implements IDisposable {
       context.dispose();
     });
     this._contexts.clear();
-    this._widgetManager.dispose();
     this._widgetManager = null;
   }
 
@@ -223,8 +222,8 @@ class DocumentManager implements IDisposable {
    * This will create a new widget with the same model and context
    * as this widget.
    */
-  clone(widget: Widget): Widget {
-    return this._widgetManager.clone(widget);
+  cloneWidget(widget: Widget): Widget {
+    return this._widgetManager.cloneWidget(widget);
   }
 
   /**
@@ -232,7 +231,7 @@ class DocumentManager implements IDisposable {
    */
   closeFile(path: string): void {
     let context = this._contextForPath(path);
-    this._widgetManager.close(context);
+    this._widgetManager.closeWidgets(context);
   }
 
   /**
@@ -240,7 +239,7 @@ class DocumentManager implements IDisposable {
    */
   closeAll(): void {
     each(this._contexts, context => {
-      this._widgetManager.close(context);
+      this._widgetManager.closeWidgets(context);
     });
   }
 

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -127,7 +127,10 @@ class DocumentManager implements IDisposable {
       // Load the contents from disk.
       context.revert();
     }
-    let widget = this._widgetManager.createWidget(widgetFactory.name, context, kernel);
+    if (kernel) {
+      context.changeKernel(kernel);
+    }
+    let widget = this._widgetManager.createWidget(widgetFactory.name, context);
     this._opener.open(widget);
     return widget;
   }
@@ -153,7 +156,10 @@ class DocumentManager implements IDisposable {
     let context = this._createContext(path, factory);
     // Immediately save the contents to disk.
     context.save();
-    let widget = this._widgetManager.createWidget(widgetFactory.name, context, kernel);
+    if (kernel) {
+      context.changeKernel(kernel);
+    }
+    let widget = this._widgetManager.createWidget(widgetFactory.name, context);
     this._opener.open(widget);
     return widget;
   }

--- a/src/docmanager/widgetmanager.ts
+++ b/src/docmanager/widgetmanager.ts
@@ -72,7 +72,7 @@ class DocumentWidgetManager implements IDisposable {
   }
 
   /**
-   * Dispose of the resources used by the widget.
+   * Dispose of the resources used by the widget manager.
    */
   dispose(): void {
     if (this.isDisposed) {
@@ -84,6 +84,14 @@ class DocumentWidgetManager implements IDisposable {
 
   /**
    * Create a widget for a document and handle its lifecycle.
+   *
+   * @param name - The name of the widget factory.
+   *
+   * @param context - The document context object.
+   *
+   * @returns A widget created by the factory.
+   *
+   * @throws If the factory is not registered.
    */
   createWidget(name: string, context: DocumentRegistry.IContext<DocumentRegistry.IModel>): Widget {
     let factory = this._registry.getWidgetFactory(name);
@@ -115,6 +123,10 @@ class DocumentWidgetManager implements IDisposable {
   /**
    * Install the message hook for the widget and add to list
    * of known widgets.
+   *
+   * @param context - The document context object.
+   *
+   * @param widget - The widget to adopt.
    */
   adoptWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, widget: Widget): void {
     let widgets = Private.widgetsProperty.get(context);
@@ -138,6 +150,10 @@ class DocumentWidgetManager implements IDisposable {
   /**
    * See if a widget already exists for the given context and widget name.
    *
+   * @param context - The document context object.
+   *
+   * @returns The found widget, or `undefined`.
+   *
    * #### Notes
    * This can be used to use an existing widget instead of opening
    * a new widget.
@@ -154,6 +170,10 @@ class DocumentWidgetManager implements IDisposable {
 
   /**
    * Get the document context for a widget.
+   *
+   * @param widget - The widget of interest.
+   *
+   * @returns The context associated with the widget, or `undefined`.
    */
   contextForWidget(widget: Widget): DocumentRegistry.IContext<DocumentRegistry.IModel> {
     return Private.contextProperty.get(widget);
@@ -162,12 +182,19 @@ class DocumentWidgetManager implements IDisposable {
   /**
    * Clone a widget.
    *
+   * @param widget - The source widget.
+   *
+   * @returns A new widget or `undefined`.
+   *
    * #### Notes
-   * This will create a new widget with the same context as this widget using
-   * the same widget factory.
+   *  Uses the same widget factory and context as the source, or returns
+   *  `undefined` if the source widget is not managed by this manager.
    */
   cloneWidget(widget: Widget): Widget {
     let context = Private.contextProperty.get(widget);
+    if (!context) {
+      return;
+    }
     let name = Private.nameProperty.get(widget);
     let newWidget = this.createWidget(name, context);
     this.adoptWidget(context, newWidget);
@@ -176,6 +203,8 @@ class DocumentWidgetManager implements IDisposable {
 
   /**
    * Close the widgets associated with a given context.
+   *
+   * @param context - The document context object.
    */
   closeWidgets(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): void {
     let widgets = Private.widgetsProperty.get(context);
@@ -207,6 +236,8 @@ class DocumentWidgetManager implements IDisposable {
 
   /**
    * Set the caption for widget title.
+   *
+   * @param widget - The target widget.
    */
   protected setCaption(widget: Widget): void {
     let context = Private.contextProperty.get(widget);
@@ -229,6 +260,10 @@ class DocumentWidgetManager implements IDisposable {
 
   /**
    * Handle `'close-request'` messages.
+   *
+   * @param widget - The target widget.
+   *
+   * @returns A promise that resolves with whether the widget was closed.
    */
   protected onClose(widget: Widget): Promise<boolean> {
     // Handle dirty state.

--- a/src/docmanager/widgetmanager.ts
+++ b/src/docmanager/widgetmanager.ts
@@ -163,8 +163,8 @@ class DocumentWidgetManager implements IDisposable {
    * Clone a widget.
    *
    * #### Notes
-   * This will create a new widget with the same model and context
-   * as this widget.
+   * This will create a new widget with the same context as this widget using
+   * the same widget factory.
    */
   cloneWidget(widget: Widget): Widget {
     let context = Private.contextProperty.get(widget);

--- a/src/docmanager/widgetmanager.ts
+++ b/src/docmanager/widgetmanager.ts
@@ -60,30 +60,12 @@ const DOCUMENT_CLASS = 'jp-Document';
  * A class that maintains the lifecyle of file-backed widgets.
  */
 export
-class DocumentWidgetManager implements IDisposable {
+class DocumentWidgetManager {
   /**
    * Construct a new document widget manager.
    */
   constructor(options: DocumentWidgetManager.IOptions) {
     this._registry = options.registry;
-  }
-
-  /**
-   * Test whether the context has been disposed (read-only).
-   */
-  get isDisposed(): boolean {
-    return this._registry === null;
-  }
-
-  /**
-   * Dispose of the resources used by the widget manager.
-   */
-  dispose(): void {
-    if (this.isDisposed) {
-      return;
-    }
-    this._registry = null;
-    clearSignalData(this);
   }
 
   /**
@@ -167,7 +149,7 @@ class DocumentWidgetManager implements IDisposable {
    * This will create a new widget with the same model and context
    * as this widget.
    */
-  clone(widget: Widget): Widget {
+  cloneWidget(widget: Widget): Widget {
     let context = Private.contextProperty.get(widget);
     let name = Private.nameProperty.get(widget);
     let newWidget = this.createWidget(name, context);
@@ -178,7 +160,7 @@ class DocumentWidgetManager implements IDisposable {
   /**
    * Close the widgets associated with a given context.
    */
-  close(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): void {
+  closeWidgets(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): void {
     let widgets = Private.widgetsProperty.get(context);
     each(widgets, widget => {
       widget.close();

--- a/src/docmanager/widgetmanager.ts
+++ b/src/docmanager/widgetmanager.ts
@@ -30,7 +30,7 @@ import {
 } from 'phosphor/lib/core/properties';
 
 import {
-  clearSignalData
+  disconnectReceiver
 } from 'phosphor/lib/core/signaling';
 
 import {
@@ -60,12 +60,30 @@ const DOCUMENT_CLASS = 'jp-Document';
  * A class that maintains the lifecyle of file-backed widgets.
  */
 export
-class DocumentWidgetManager {
+class DocumentWidgetManager implements IDisposable {
   /**
    * Construct a new document widget manager.
    */
   constructor(options: DocumentWidgetManager.IOptions) {
     this._registry = options.registry;
+  }
+
+  /**
+   * Test whether the document widget manager is disposed.
+   */
+  get IDisposed(): boolean {
+    return this._registry === null;
+  }
+
+  /**
+   * Dispose of the resources used by the widget.
+   */
+  dispose(): void {
+    if (this.IDisposed) {
+      return;
+    }
+    disconnectReceiver(this);
+    this._registry = null;
   }
 
   /**

--- a/src/docregistry/default.ts
+++ b/src/docregistry/default.ts
@@ -357,7 +357,16 @@ abstract class ABCWidgetFactory<T extends Widget, U extends DocumentRegistry.IMo
    * #### Notes
    * It should emit the [widgetCreated] signal with the new widget.
    */
-  abstract createNew(context: DocumentRegistry.IContext<U>, kernel?: Kernel.IModel): T;
+  createNew(context: DocumentRegistry.IContext<U>): T {
+    let widget = this.createNewWidget(context);
+    this.widgetCreated.emit(widget);
+    return widget;
+  }
+
+  /**
+   * Create a widget for a context.
+   */
+  protected abstract createNewWidget(context: DocumentRegistry.IContext<U>): T;
 
   private _isDisposed = false;
   private _name: string;

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -780,12 +780,12 @@ namespace DocumentRegistry {
     widgetCreated: ISignal<IWidgetFactory<T, U>, T>;
 
     /**
-     * Create a new widget.
+     * Create a new widget given a context.
      *
      * #### Notes
      * It should emit the [widgetCreated] signal with the new widget.
      */
-    createNew(context: IContext<U>, kernel?: Kernel.IModel): T;
+    createNew(context: IContext<U>): T;
   }
 
   /**

--- a/src/editorwidget/widget.ts
+++ b/src/editorwidget/widget.ts
@@ -131,12 +131,7 @@ class EditorWidgetFactory extends ABCWidgetFactory<EditorWidget, DocumentRegistr
   /**
    * Create a new widget given a context.
    */
-  createNew(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, kernel?: Kernel.IModel): EditorWidget {
-    if (kernel) {
-      context.changeKernel(kernel);
-    }
-    let widget = new EditorWidget(context);
-    this.widgetCreated.emit(widget);
-    return widget;
+  protected createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): EditorWidget {
+    return new EditorWidget(context);
   }
 }

--- a/src/imagewidget/widget.ts
+++ b/src/imagewidget/widget.ts
@@ -108,10 +108,8 @@ class ImageWidgetFactory extends ABCWidgetFactory<ImageWidget, DocumentRegistry.
   /**
    * Create a new widget given a context.
    */
-  createNew(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, kernel?: Kernel.IModel): ImageWidget {
-    let widget = new ImageWidget(context);
-    this.widgetCreated.emit(widget);
-    return widget;
+  protected createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): ImageWidget {
+    return new ImageWidget(context);
   }
 }
 

--- a/src/markdownwidget/widget.ts
+++ b/src/markdownwidget/widget.ts
@@ -122,10 +122,8 @@ class MarkdownWidgetFactory extends ABCWidgetFactory<MarkdownWidget, DocumentReg
   /**
    * Create a new widget given a context.
    */
-  createNew(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, kernel?: Kernel.IModel): MarkdownWidget {
-    let widget = new MarkdownWidget(context, this._rendermime.clone());
-    this.widgetCreated.emit(widget);
-    return widget;
+  protected createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): MarkdownWidget {
+    return new MarkdownWidget(context, this._rendermime.clone());
   }
 
   private _rendermime: RenderMime = null;

--- a/src/notebook/notebook/widgetfactory.ts
+++ b/src/notebook/notebook/widgetfactory.ts
@@ -66,11 +66,8 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
    * The factory will start the appropriate kernel and populate
    * the default toolbar items using `ToolbarItems.populateDefaults`.
    */
-  createNew(context: DocumentRegistry.IContext<INotebookModel>, kernel?: Kernel.IModel): NotebookPanel {
+  protected createNewWidget(context: DocumentRegistry.IContext<INotebookModel>): NotebookPanel {
     let rendermime = this._rendermime.clone();
-    if (kernel) {
-      context.changeKernel(kernel);
-    }
     let panel = new NotebookPanel({
       rendermime,
       clipboard: this._clipboard,
@@ -78,7 +75,6 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
     });
     panel.context = context;
     ToolbarItems.populateDefaults(panel);
-    this.widgetCreated.emit(panel);
     return panel;
   }
 

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  DocumentRegistry
+} from '../../../lib/docregistry';
+
+import {
+  DocumentWidgetManager
+} from '../../../lib/docmanager';
+
+
+describe('docmanager/widgetmanager', () => {
+
+  let manager: DocumentWidgetManager;
+
+  beforeEach(() => {
+    manager = new DocumentWidgetManager({ registry: new DocumentRegistry() });
+  });
+
+  describe('DocumentWidgetManager', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create a new document widget manager', () => {
+        expect(manager).to.be.a(DocumentWidgetManager);
+      });
+
+    });
+
+    describe('#createWidget()', () => {
+
+    });
+
+    describe('#adoptWidget()', () => {
+
+    });
+
+    describe('#findWidget()', () => {
+
+    });
+
+    describe('#contextForWidget()', () => {
+
+    });
+
+    describe('#cloneWidget()', () => {
+
+    });
+
+    describe('#closeWidgets()', () => {
+
+    });
+
+    describe('#filterMessage()', () => {
+
+    });
+
+    describe('#setCaption()', () => {
+
+    });
+
+    describe('#onClose()', () => {
+
+    });
+
+  });
+
+});

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -16,12 +16,12 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
-  DocumentRegistry, TextModelFactory, ABCWidgetFactory, Context
-} from '../../../lib/docregistry';
-
-import {
   DocumentWidgetManager
 } from '../../../lib/docmanager';
+
+import {
+  DocumentRegistry, TextModelFactory, ABCWidgetFactory, Context
+} from '../../../lib/docregistry';
 
 import {
   acceptDialog, dismissDialog
@@ -207,6 +207,10 @@ describe('docmanager/widgetmanager', () => {
         expect(clone.hasClass('WidgetFactory')).to.be(true);
         expect(clone.hasClass('jp-Document')).to.be(true);
         expect(manager.contextForWidget(clone)).to.be(context);
+      });
+
+      it('should return undefined if the source widget is not managed', () => {
+        expect(manager.cloneWidget(new Widget()).to.be(void 0);
       });
 
     });

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -20,6 +20,10 @@ describe('docmanager/widgetmanager', () => {
     manager = new DocumentWidgetManager({ registry: new DocumentRegistry() });
   });
 
+  afterEach(() => {
+    manager.dispose();
+  });
+
   describe('DocumentWidgetManager', () => {
 
     describe('#constructor()', () => {
@@ -27,6 +31,14 @@ describe('docmanager/widgetmanager', () => {
       it('should create a new document widget manager', () => {
         expect(manager).to.be.a(DocumentWidgetManager);
       });
+
+    });
+
+    describe('#isDisposed', () => {
+
+    });
+
+    describe('#dispose()', () => {
 
     });
 

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -4,7 +4,19 @@
 import expect = require('expect.js');
 
 import {
-  DocumentRegistry
+  ServiceManager, utils
+} from '@jupyterlab/services';
+
+import {
+  IMessageHandler, Message, sendMessage
+} from 'phosphor/lib/core/messaging';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
+  DocumentRegistry, TextModelFactory, ABCWidgetFactory, Context
 } from '../../../lib/docregistry';
 
 import {
@@ -12,16 +24,68 @@ import {
 } from '../../../lib/docmanager';
 
 
+class WidgetFactory extends ABCWidgetFactory<Widget, DocumentRegistry.IModel> {
+
+  protected createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): Widget {
+    return new Widget();
+  }
+}
+
+
+class LoggingManager extends DocumentWidgetManager {
+
+  methods: string[] = [];
+
+  protected filterMessage(handler: IMessageHandler, msg: Message): boolean {
+    this.methods.push('filterMessage');
+    return super.filterMessage(handler, msg);
+  }
+
+  protected setCaption(widget: Widget): void {
+    this.methods.push('setCaption');
+    super.setCaption(widget);
+  }
+
+  protected onClose(widget: Widget): Promise<boolean> {
+    this.methods.push('onClose');
+    return super.onClose(widget);
+  }
+}
+
+
 describe('docmanager/widgetmanager', () => {
 
-  let manager: DocumentWidgetManager;
+  let manager: LoggingManager;
+  let services: ServiceManager.IManager;
+  let modelFactory = new TextModelFactory();
+  let context: Context<DocumentRegistry.IModel>;
+  let widgetFactory = new WidgetFactory({
+    name: 'test',
+    fileExtensions: ['.txt']
+  });
+
+  before((done) => {
+    ServiceManager.create().then(m => {
+      services = m;
+      done();
+    }).catch(done);
+  });
 
   beforeEach(() => {
-    manager = new DocumentWidgetManager({ registry: new DocumentRegistry() });
+    let registry = new DocumentRegistry();
+    registry.addModelFactory(modelFactory);
+    registry.addWidgetFactory(widgetFactory);
+    manager = new LoggingManager({ registry });
+    context = new Context({
+      manager: services,
+      factory: modelFactory,
+      path: utils.uuid()
+    });
   });
 
   afterEach(() => {
     manager.dispose();
+    context.dispose();
   });
 
   describe('DocumentWidgetManager', () => {
@@ -36,17 +100,70 @@ describe('docmanager/widgetmanager', () => {
 
     describe('#isDisposed', () => {
 
+      it('should test whether the manager is disposed', () => {
+        expect(manager.isDisposed).to.be(false);
+        manager.dispose();
+        expect(manager.isDisposed).to.be(true);
+      });
+
     });
 
     describe('#dispose()', () => {
+
+      it('should dispose of the resources used by the manager', () => {
+        expect(manager.isDisposed).to.be(false);
+        manager.dispose();
+        expect(manager.isDisposed).to.be(true);
+        manager.dispose();
+        expect(manager.isDisposed).to.be(true);
+      });
 
     });
 
     describe('#createWidget()', () => {
 
+      it('should create a widget', () => {
+        let widget = manager.createWidget('test', context);
+        expect(widget).to.be.a(Widget);
+      });
+
+      it('should throw an error if the name is not registered', () => {
+        expect(() => {
+          manager.createWidget('foo', context);
+        }).to.throwError();
+      });
+
+      it('should emit the widgetCreated signal', () => {
+        let called = false;
+        widgetFactory.widgetCreated.connect(() => {
+          called = true;
+        });
+        manager.createWidget('test', context);
+        expect(called).to.be(true);
+      });
+
     });
 
     describe('#adoptWidget()', () => {
+
+      it('should install a message hook', () => {
+        let widget = new Widget();
+        manager.adoptWidget(context, widget);
+        sendMessage(widget, new Message('foo'));
+        expect(manager.methods).to.contain('filterMessage');
+      });
+
+      it('should add the document class', () => {
+        let widget = new Widget();
+        manager.adoptWidget(context, widget);
+        expect(widget.hasClass('jp-Document')).to.be(true);
+      });
+
+      it('should be retrievable', () => {
+        let widget = new Widget();
+        manager.adoptWidget(context, widget);
+        expect(manager.contextForWidget(widget)).to.be(context);
+      });
 
     });
 

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -210,7 +210,7 @@ describe('docmanager/widgetmanager', () => {
       });
 
       it('should return undefined if the source widget is not managed', () => {
-        expect(manager.cloneWidget(new Widget()).to.be(void 0);
+        expect(manager.cloneWidget(new Widget())).to.be(void 0);
       });
 
     });

--- a/test/src/docregistry/default.spec.ts
+++ b/test/src/docregistry/default.spec.ts
@@ -4,10 +4,6 @@
 import expect = require('expect.js');
 
 import {
-  Kernel
-} from '@jupyterlab/services';
-
-import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
@@ -23,7 +19,7 @@ import {
 
 class WidgetFactory extends ABCWidgetFactory<Widget, DocumentRegistry.IModel> {
 
-  createNew(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, kernel?: Kernel.IModel): Widget {
+  createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): Widget {
     return new Widget();
   }
 }

--- a/test/src/docregistry/registry.spec.ts
+++ b/test/src/docregistry/registry.spec.ts
@@ -4,7 +4,7 @@
 import expect = require('expect.js');
 
 import {
-  Kernel, utils
+  utils
 } from '@jupyterlab/services';
 
 import {
@@ -26,7 +26,7 @@ import {
 
 class WidgetFactory extends ABCWidgetFactory<Widget, DocumentRegistry.IModel> {
 
-  createNew(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, kernel?: Kernel.IModel): Widget {
+  createNewWidget(context: DocumentRegistry.IContext<DocumentRegistry.IModel>): Widget {
     return new Widget();
   }
 }

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -16,6 +16,7 @@ import './console/history.spec';
 import './dialog/dialog.spec';
 
 import './docmanager/savehandler.spec';
+import './docmanager/widgetmanager.spec';
 
 import './docregistry/context.spec';
 import './docregistry/default.spec';

--- a/test/src/notebook/notebook/widgetfactory.spec.ts
+++ b/test/src/notebook/notebook/widgetfactory.spec.ts
@@ -61,10 +61,6 @@ describe('notebook/notebook/widgetfactory', () => {
     });
   });
 
-  after(() => {
-    context.kernel.shutdown();
-  });
-
   describe('NotebookWidgetFactory', () => {
 
     describe('#constructor()', () => {
@@ -117,36 +113,6 @@ describe('notebook/notebook/widgetfactory', () => {
         let panel = factory.createNew(context);
         expect(panel.rendermime).to.not.be(rendermime);
       });
-
-      it('should start a kernel if one is given', (done) => {
-        let factory = createFactory();
-        context.kernelChanged.connect((sender, kernel) => {
-          expect(kernel.name).to.be(context.kernelspecs.default);
-          done();
-        });
-        factory.createNew(context, { name: context.kernelspecs.default });
-      });
-
-      it('should start a kernel given the default kernel language', (done) => {
-        let factory = createFactory();
-        createNotebookContext().then(ctx => {
-          ctx.kernelChanged.connect((sender, kernel) => {
-            expect(kernel.name).to.be(ctx.kernelspecs.default);
-            done();
-          });
-          factory.createNew(ctx);
-          ctx.save();
-        });
-      });
-
-      // it('should start a kernel based on default language of the model', () => {
-      //   // TODO: inject other kernelspecs
-      //   let cursor = context.model.getMetadata('language_info');
-      //   cursor.setValue({ name: 'shell' });
-      //   let factory = createFactory();
-      //   let panel = factory.createNew(context);
-      //   expect(panel.context.kernel.name).to.be('shell');
-      // });
 
       it('should populate the default toolbar items', () => {
         let factory = createFactory();


### PR DESCRIPTION
Also simplifies the API of widget factories and moves the handling of starting a kernel to the document manager.