### PR TITLE
Clean up Console Focus Behavior

### DIFF
--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -238,8 +238,10 @@ class CompleterWidget extends Widget {
     // If there are no items, reset and bail.
     if (!items || !items.length) {
       this._reset();
-      this.hide();
-      this.visibilityChanged.emit(void 0);
+      if (!this.isHidden) {
+        this.hide();
+        this.visibilityChanged.emit(void 0);
+      }
       return;
     }
 

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -471,7 +471,7 @@ class ConsoleContent extends Widget {
    */
   private _evtKeyDown(event: KeyboardEvent): void {
     if (event.keyCode === 13 && !this.prompt.editor.hasFocus()) {
-      sendMessage(this.prompt.editor, WidgetMessage.ActivateRequest);
+      this.prompt.editor.activate();
     }
   }
 

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
-  Message
+  Message, sendMessage
 } from 'phosphor/lib/core/messaging';
 
 import {
@@ -26,7 +26,7 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  Widget
+  Widget, WidgetMessage
 } from 'phosphor/lib/ui/widget';
 
 import {
@@ -333,6 +333,57 @@ class ConsoleContent extends Widget {
     return toArray(output).concat(prompt.model.toJSON() as nbformat.ICodeCell);
   }
 
+
+  /**
+   * Handle the DOM events for the widget.
+   *
+   * @param event - The DOM event sent to the widget.
+   *
+   * #### Notes
+   * This method implements the DOM `EventListener` interface and is
+   * called in response to events on the notebook panel's node. It should
+   * not be called directly by user code.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+    case 'keydown':
+      this._evtKeyDown(event as KeyboardEvent);
+      break;
+    default:
+      break;
+    }
+  }
+
+  /**
+   * Handle `after_attach` messages for the widget.
+   */
+  protected onAfterAttach(msg: Message): void {
+    let node = this.node;
+    node.addEventListener('keydown', this, true);
+    // Create a prompt if necessary.
+    if (!this.prompt) {
+      this.newPrompt();
+    }
+    // Listen for kernel change events.
+    this._addSessionListeners();
+  }
+
+  /**
+   * Handle `before_detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    let node = this.node;
+    node.removeEventListener('keydown', this, true);
+  }
+
+  /**
+   * Handle `'activate-request'` messages.
+   */
+  protected onActivateRequest(msg: Message): void {
+    sendMessage(this.prompt.editor, WidgetMessage.ActivateRequest);
+    this.update();
+  }
+
   /**
    * Make a new prompt.
    */
@@ -364,28 +415,8 @@ class ConsoleContent extends Widget {
     this._completerHandler.activeCell = prompt;
     this._inspectionHandler.activeCell = prompt;
 
-    prompt.activate();
+    sendMessage(prompt.editor, WidgetMessage.ActivateRequest);
     this.update();
-  }
-
-  /**
-   * Handle `'activate-request'` messages.
-   */
-  protected onActivateRequest(msg: Message): void {
-    this.prompt.activate();
-    this.update();
-  }
-
-  /**
-   * Handle `'after-attach'` messages.
-   */
-  protected onAfterAttach(msg: Message): void {
-    // Create a prompt if necessary.
-    if (!this.prompt) {
-      this.newPrompt();
-    }
-    // Listen for kernel change events.
-    this._addSessionListeners();
   }
 
   /**
@@ -432,8 +463,16 @@ class ConsoleContent extends Widget {
    * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {
-    super.onUpdateRequest(msg);
     Private.scrollToBottom(this._content.node);
+  }
+
+  /**
+   * Handle the `'keydown'` event for the widget.
+   */
+  private _evtKeyDown(event: KeyboardEvent): void {
+    if (event.keyCode === 13 && !this.prompt.editor.hasFocus()) {
+      sendMessage(this.prompt.editor, WidgetMessage.ActivateRequest);
+    }
   }
 
   /**

--- a/src/notebook/codemirror/cells/editor.ts
+++ b/src/notebook/codemirror/cells/editor.ts
@@ -49,6 +49,11 @@ const TAB = 9;
  */
 const CELL_EDITOR_CLASS = 'jp-CellEditor';
 
+/**
+ * The class name added to read only cell editor widgets.
+ */
+const READ_ONLY_CLASS = 'jp-mod-readOnly';
+
 
 /**
  * A code mirror widget for a cell editor.
@@ -144,8 +149,9 @@ class CodeMirrorCellEditorWidget extends CodeMirrorWidget implements ICellEditor
    * Set whether the editor is read only.
    */
   setReadOnly(readOnly: boolean): void {
-    let option = readOnly ? 'nocursor' : false;
+    let option = readOnly ? true : false;
     this.editor.setOption('readOnly', option);
+    this.toggleClass(READ_ONLY_CLASS, option);
   }
 
   /**

--- a/src/notebook/codemirror/index.css
+++ b/src/notebook/codemirror/index.css
@@ -42,3 +42,8 @@
 .jp-CodeMirrorWidget, .jp-CodeMirrorWidget-static {
   cursor: text;
 }
+
+
+.jp-CodeMirrorWidget.jp-mod-readOnly .CodeMirror-cursor {
+  display: none;
+}

--- a/src/shortcuts/plugin.ts
+++ b/src/shortcuts/plugin.ts
@@ -257,22 +257,22 @@ const SHORTCUTS = [
   },
   {
     command: 'console:run',
-    selector: '.jp-ConsolePanel',
+    selector: '.jp-ConsoleContent-prompt',
     keys: ['Enter']
   },
   {
     command: 'console:run-forced',
-    selector: '.jp-ConsolePanel',
+    selector: '.jp-ConsoleContent-prompt',
     keys: ['Shift Enter']
   },
   {
     command: 'console:linebreak',
-    selector: '.jp-ConsolePanel',
+    selector: '.jp-ConsoleContent-prompt',
     keys: ['Ctrl Enter']
   },
   {
     command: 'console:toggle-inspectors',
-    selector: '.jp-ConsolePanel',
+    selector: '.jp-ConsoleContent-promptt',
     keys: ['Accel I']
   },
   {

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -108,7 +108,6 @@ describe('console/panel', () => {
         expect(panel.methods).to.not.contain('onActivateRequest');
         Widget.attach(panel, document.body);
         requestAnimationFrame(() => {
-          expect(panel.content.prompt.editor.hasFocus()).to.be(false);
           panel.activate();
           requestAnimationFrame(() => {
             expect(panel.methods).to.contain('onActivateRequest');

--- a/test/src/notebook/cells/widget.spec.ts
+++ b/test/src/notebook/cells/widget.spec.ts
@@ -340,7 +340,6 @@ describe('notebook/cells/widget', () => {
       it('should focus the cell editor', (done) => {
         let widget = new LogBaseCell();
         Widget.attach(widget, document.body);
-        expect(widget.editor.hasFocus()).to.be(false);
         widget.activate();
         requestAnimationFrame(() => {
           expect(widget.methods).to.contain('onActivateRequest');


### PR DESCRIPTION
Fixes #644.

- Allows text selection in read-only CodeMirror cells.
- "Enter" now gives focus to the cell.
