### PR TITLE
Update Services and Improve handling of Kernel specs

### DIFF
--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -9,7 +9,7 @@
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.25.0",
+    "@jupyterlab/services": "^0.30.2",
     "jupyterlab": "file:../..",
     "phosphor": "^0.7.0"
   },

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -9,7 +9,7 @@
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.25.0",
+    "@jupyterlab/services": "^0.30.2",
     "jupyterlab": "file:../..",
     "phosphor": "^0.7.0"
   },

--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -54,7 +54,8 @@ import '../index.css';
 
 
 function main(): void {
-  ServiceManager.create().then(manager => {
+  let manager = new ServiceManager();
+  manager.ready().then(() => {
     createApp(manager);
   });
 }

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -9,7 +9,7 @@
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.25.0",
+    "@jupyterlab/services": "^0.30.2",
     "jupyterlab": "file:../..",
     "phosphor": "^0.7.0"
   },

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -90,7 +90,8 @@ const cmdIds = {
 
 
 function main(): void {
-  ServiceManager.create().then(manager => {
+  let manager = new ServiceManager();
+  manager.ready().then(() => {
     createApp(manager);
   });
 }
@@ -187,7 +188,7 @@ function createApp(manager: ServiceManager.IManager): void {
   });
   commands.addCommand(cmdIds.switchKernel, {
     label: 'Switch Kernel',
-    execute: () => selectKernelForContext(nbWidget.context, nbWidget.node)
+    execute: () => selectKernelForContext(nbWidget.context, manager.sessions, nbWidget.node)
   });
   commands.addCommand(cmdIds.runAndAdvance, {
     label: 'Run and Advance',

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -9,7 +9,7 @@
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.25.0",
+    "@jupyterlab/services": "^0.30.2",
     "jupyterlab": "file:../..",
     "phosphor": "^0.7.0",
     "xterm": "^1.1.3"

--- a/examples/terminal/src/index.ts
+++ b/examples/terminal/src/index.ts
@@ -31,8 +31,8 @@ function main(): void {
     color: 'black'
   });
 
-  TerminalSession.startNew().then(session => term1.session = session);
-  TerminalSession.startNew().then(session => term2.session = session);
+  TerminalSession.startNew().then(session => { term1.session = session; });
+  TerminalSession.startNew().then(session => { term2.session = session; });
 
   term1.title.closable = true;
   term2.title.closable = true;

--- a/examples/terminal/src/index.ts
+++ b/examples/terminal/src/index.ts
@@ -31,8 +31,8 @@ function main(): void {
     color: 'black'
   });
 
-  TerminalSession.open().then(session => term1.session = session);
-  TerminalSession.open().then(session => term2.session = session);
+  TerminalSession.startNew().then(session => term1.session = session);
+  TerminalSession.startNew().then(session => term2.session = session);
 
   term1.title.closable = true;
   term2.title.closable = true;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@jupyterlab/services": "^0.30.0",
+    "@jupyterlab/services": "^0.30.1",
     "ansi_up": "^1.3.0",
     "backbone": "^1.2.0",
     "codemirror": "^5.20.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@jupyterlab/services": "^0.30.1",
+    "@jupyterlab/services": "^0.30.2",
     "ansi_up": "^1.3.0",
     "backbone": "^1.2.0",
     "codemirror": "^5.20.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@jupyterlab/services": "^0.25.0",
+    "@jupyterlab/services": "^0.27.0",
     "ansi_up": "^1.3.0",
     "backbone": "^1.2.0",
     "codemirror": "^5.20.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@jupyterlab/services": "^0.27.0",
+    "@jupyterlab/services": "^0.29.0",
     "ansi_up": "^1.3.0",
     "backbone": "^1.2.0",
     "codemirror": "^5.20.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@jupyterlab/services": "^0.29.0",
+    "@jupyterlab/services": "^0.30.0",
     "ansi_up": "^1.3.0",
     "backbone": "^1.2.0",
     "codemirror": "^5.20.2",

--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -107,7 +107,7 @@ class CellCompleterHandler implements IDisposable {
     };
     let pending = ++this._pending;
 
-    return this._kernel.complete(content).then(msg => {
+    return this._kernel.requestComplete(content).then(msg => {
       this.onReply(pending, request, msg);
     });
   }

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -497,7 +497,10 @@ class ConsoleContent extends Widget {
    * Initialize the banner and mimetype.
    */
   private _initialize(): void {
-    this._session.kernel.info().then(info => this._handleInfo(info));
+    let kernel = this._session.kernel;
+    kernel.ready().then(() => {
+      this._handleInfo(kernel.info);
+    });
   }
 
   /**

--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -497,12 +497,7 @@ class ConsoleContent extends Widget {
    * Initialize the banner and mimetype.
    */
   private _initialize(): void {
-    let session = this._session;
-    if (session.kernel.info) {
-      this._handleInfo(this._session.kernel.info);
-      return;
-    }
-    session.kernel.kernelInfo().then(msg => this._handleInfo(msg.content));
+    this._session.kernel.info().then(info => this._handleInfo(info));
   }
 
   /**
@@ -606,7 +601,7 @@ class ConsoleContent extends Widget {
     let code = prompt.model.source + '\n';
     return new Promise<boolean>((resolve, reject) => {
       let timer = setTimeout(() => { resolve(true); }, timeout);
-      this._session.kernel.isComplete({ code }).then(isComplete => {
+      this._session.kernel.requestIsComplete({ code }).then(isComplete => {
         clearTimeout(timer);
         if (isComplete.content.status !== 'incomplete') {
           resolve(true);

--- a/src/console/history.ts
+++ b/src/console/history.ts
@@ -114,7 +114,9 @@ class ConsoleHistory implements IConsoleHistory {
       return;
     }
 
-    this._kernel.history(Private.initialRequest).then(v => this.onHistory(v));
+    this._kernel.requestHistory(Private.initialRequest).then(v => {
+      this.onHistory(v);
+    });
   }
 
   /**

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -301,9 +301,6 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
 
   /**
    * Get the kernel given the create args.
-   *
-   * #### Notes
-   * The manager must be ready before calling this function.
    */
   function getKernel(args: ICreateConsoleArgs, name: string): Promise<Kernel.IModel> {
     if (args.kernel) {

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -369,7 +369,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       let widget = current.content;
       let session = widget.session;
       let lang = '';
-      // Make sure we have the latest kernel specs
+      // Make sure we have the latest kernel specs.
       manager.fetchSpecs().then(specs => {
         if (session.kernel) {
           lang = manager.specs.kernelspecs[session.kernel.name].language;

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -369,18 +369,21 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       let widget = current.content;
       let session = widget.session;
       let lang = '';
-      if (session.kernel && manager.specs) {
-        lang = manager.specs.kernelspecs[session.kernel.name].language;
-      }
-      let options = {
-        name: widget.parent.title.label,
-        specs: manager.specs,
-        sessions: manager.running(),
-        preferredLanguage: lang,
-        kernel: session.kernel.model,
-        host: widget.parent.node
-      };
-      return selectKernel(options).then(kernelId => {
+      // Make sure we have the latest kernel specs
+      manager.fetchSpecs().then(specs => {
+        if (session.kernel) {
+          lang = manager.specs.kernelspecs[session.kernel.name].language;
+        }
+        let options = {
+          name: widget.parent.title.label,
+          specs,
+          sessions: manager.running(),
+          preferredLanguage: lang,
+          kernel: session.kernel.model,
+          host: widget.parent.node
+        };
+        return selectKernel(options);
+      }).then(kernelId => {
         // If the user cancels, kernelId will be void and should be ignored.
         if (kernelId) {
           session.changeKernel(kernelId);

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -74,6 +74,13 @@ class DocumentManager implements IDisposable {
   }
 
   /**
+   * The the service manager used by the manager.
+   */
+  get services(): ServiceManager.IManager {
+    return this._serviceManager;
+  }
+
+  /**
    * Get whether the document manager has been disposed.
    */
   get isDisposed(): boolean {
@@ -93,13 +100,6 @@ class DocumentManager implements IDisposable {
     });
     this._contexts.clear();
     this._widgetManager = null;
-  }
-
-  /**
-   * Get the kernel spec models.
-   */
-  get specs(): Kernel.ISpecModels | null {
-    return this._serviceManager.sessions.specs;
   }
 
   /**
@@ -162,15 +162,6 @@ class DocumentManager implements IDisposable {
     let widget = this._widgetManager.createWidget(widgetFactory.name, context);
     this._opener.open(widget);
     return widget;
-  }
-
-  /**
-   * Create an iterator over the running sessions.
-   *
-   * @returns A new iterator over the running sessions.
-   */
-  sessions(): IIterable<Session.IModel> {
-    return this._serviceManager.sessions.running();
   }
 
   /**

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -6,7 +6,7 @@ import {
 } from '@jupyterlab/services';
 
 import {
-  each
+  IIterable, each
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
@@ -165,32 +165,12 @@ class DocumentManager implements IDisposable {
   }
 
   /**
-   * List the running notebook sessions.
-   */
-  listSessions(): Promise<Session.IModel[]> {
-    return this._serviceManager.sessions.listRunning();
-  }
-
-  /**
-   * Handle the renaming of an open document.
+   * Create an iterator over the running sessions.
    *
-   * @param oldPath - The previous path.
-   *
-   * @param newPath - The new path.
+   * @returns A new iterator over the running sessions.
    */
-  handleRename(oldPath: string, newPath: string): void {
-    each(this._contexts, context => {
-      if (context.path === oldPath) {
-        context.setPath(newPath);
-      }
-    });
-  }
-
-  /**
-   * Handle a file deletion.
-   */
-  handleDelete(path: string): void {
-    // TODO: Leave all of the widgets open and flag them as orphaned?
+  sessions(): IIterable<Session.IModel> {
+    return this._serviceManager.sessions.running();
   }
 
   /**

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -258,7 +258,7 @@ class DocumentManager implements IDisposable {
       manager: this._serviceManager
     });
     Private.saveHandlerProperty.set(context, handler);
-    context.populated.connect(() => {
+    context.ready().then(() => {
       handler.start();
     });
     context.disposed.connect(() => {

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -127,8 +127,11 @@ class DocumentManager implements IDisposable {
       // Load the contents from disk.
       context.revert();
     }
-    if (kernel) {
+    // Handle the kernel for the context.
+    if (kernel && widgetFactory.canStartKernel) {
       context.changeKernel(kernel);
+    } else if (widgetFactory.preferKernel && !context.kernel) {
+      context.startDefaultKernel();
     }
     let widget = this._widgetManager.createWidget(widgetFactory.name, context);
     this._opener.open(widget);
@@ -156,8 +159,11 @@ class DocumentManager implements IDisposable {
     let context = this._createContext(path, factory);
     // Immediately save the contents to disk.
     context.save();
-    if (kernel) {
+    // Handle the kernel for the context.
+    if (kernel && widgetFactory.canStartKernel) {
       context.changeKernel(kernel);
+    } else if (widgetFactory.preferKernel && !context.kernel) {
+      context.startDefaultKernel();
     }
     let widget = this._widgetManager.createWidget(widgetFactory.name, context);
     this._opener.open(widget);

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -67,13 +67,6 @@ class DocumentManager implements IDisposable {
   }
 
   /**
-   * Get the kernel spec models for the manager.
-   */
-  get kernelspecs(): Kernel.ISpecModels {
-    return this._serviceManager.kernelspecs;
-  }
-
-  /**
    * Get the registry used by the manager.
    */
   get registry(): DocumentRegistry {
@@ -100,6 +93,13 @@ class DocumentManager implements IDisposable {
     });
     this._contexts.clear();
     this._widgetManager = null;
+  }
+
+  /**
+   * Get the kernel spec models.
+   */
+  get specs(): Kernel.ISpecModels | null {
+    return this._serviceManager.sessions.specs;
   }
 
   /**

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -74,7 +74,7 @@ class DocumentManager implements IDisposable {
   }
 
   /**
-   * The the service manager used by the manager.
+   * Get the service manager used by the manager.
    */
   get services(): ServiceManager.IManager {
     return this._serviceManager;

--- a/src/docmanager/widgetmanager.ts
+++ b/src/docmanager/widgetmanager.ts
@@ -110,11 +110,10 @@ class DocumentWidgetManager implements IDisposable {
       disposables.dispose();
     });
     this.adoptWidget(context, widget);
-    this.setCaption(widget);
     context.fileChanged.connect(() => {
       this.setCaption(widget);
     });
-    context.populated.connect(() => {
+    context.ready().then(() => {
       this.setCaption(widget);
     });
     return widget;

--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -79,11 +79,6 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   fileChanged: ISignal<this, Contents.IModel>;
 
   /**
-   * A signal emitted when the context is fully populated for the first time.
-   */
-  populated: ISignal<this, void>;
-
-  /**
    * A signal emitted when the context is disposed.
    */
   disposed: ISignal<this, void>;

--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -158,6 +158,13 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     return this._manager.specs;
   }
 
+  /**
+   * Whether the context is ready.
+   */
+  get isReady(): boolean {
+    return this._isReady;
+  }
+
  /**
   * A promise that is fulfilled when the context is ready.
   */
@@ -459,6 +466,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
         return this.createCheckpoint();
       }
     }).then(() => {
+      this._isReady = true;
       this._populatedPromise.resolve(void 0);
     });
   }
@@ -473,6 +481,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   private _readyPromise: Promise<void>;
   private _populatedPromise = new utils.PromiseDelegate<void>();
   private _isPopulated = false;
+  private _isReady = false;
 }
 
 

--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -117,13 +117,6 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   }
 
   /**
-   * Get the kernel spec information.
-   */
-  get kernelspecs(): Kernel.ISpecModels {
-    return this._manager.kernelspecs;
-  }
-
-  /**
    * Test whether the context is fully populated.
    */
   get isPopulated(): boolean {
@@ -165,6 +158,13 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
         this._session = null;
       });
     }
+  }
+
+  /**
+   * Get the kernel spec models.
+   */
+  get specs(): Kernel.ISpecModels | null {
+    return this._manager.sessions.specs;
   }
 
   /**

--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -161,10 +161,10 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   }
 
   /**
-   * Get the kernel spec models.
+   * The service manager used by the context.
    */
-  get specs(): Kernel.ISpecModels | null {
-    return this._manager.sessions.specs;
+  get services(): ServiceManager.IManager {
+    return this._manager;
   }
 
   /**
@@ -329,15 +329,6 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
    */
   listCheckpoints(): Promise<Contents.ICheckpointModel[]> {
     return this._manager.contents.listCheckpoints(this._path);
-  }
-
-  /**
-   * Create an iterator over the running sessions.
-   *
-   * @returns A new iterator over the running sessions.
-   */
-  sessions(): IIterable<Session.IModel> {
-    return this._manager.sessions.running();
   }
 
   /**

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -129,22 +129,18 @@ function selectKernel(options: IKernelSelection): Promise<Kernel.IModel> {
  */
 export
 function selectKernelForContext(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, host?: HTMLElement): Promise<void> {
-  if (!context.specs) {
-    return showDialog({
-      title: 'No Kernel Information',
-      body: 'Kernel Information Is Not Ready',
-      buttons: [okButton]
-    });
-  }
-  let options: IKernelSelection = {
-    name: context.path.split('/').pop(),
-    specs: context.specs,
-    sessions: context.sessions(),
-    preferredLanguage: context.model.defaultKernelLanguage,
-    kernel: context.kernel.model,
-    host
-  };
-  return selectKernel(options).then(kernel => {
+  // Make sure we have the latest specs.
+  return context.services.sessions.fetchSpecs().then(specs => {
+    let options: IKernelSelection = {
+      name: context.path.split('/').pop(),
+      specs,
+      sessions: context.services.sessions.running(),
+      preferredLanguage: context.model.defaultKernelLanguage,
+      kernel: context.kernel.model,
+      host
+    };
+    return selectKernel(options);
+  }).then(kernel => {
     if (kernel) {
       context.changeKernel(kernel);
     }

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
-  showDialog
+  okButton, showDialog
 } from '../dialog';
 
 import {
@@ -129,9 +129,16 @@ function selectKernel(options: IKernelSelection): Promise<Kernel.IModel> {
  */
 export
 function selectKernelForContext(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, host?: HTMLElement): Promise<void> {
+  if (!context.specs) {
+    return showDialog({
+      title: 'No Kernel Information',
+      body: 'Kernel Information Is Not Ready',
+      buttons: [okButton]
+    });
+  }
   let options: IKernelSelection = {
     name: context.path.split('/').pop(),
-    specs: context.kernelspecs,
+    specs: context.specs,
     sessions: context.sessions(),
     preferredLanguage: context.model.defaultKernelLanguage,
     kernel: context.kernel.model,

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
-  okButton, showDialog
+  showDialog
 } from '../dialog';
 
 import {
@@ -128,13 +128,12 @@ function selectKernel(options: IKernelSelection): Promise<Kernel.IModel> {
  * Change the kernel on a context.
  */
 export
-function selectKernelForContext(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, host?: HTMLElement): Promise<void> {
-  // Make sure we have the latest specs.
-  return context.services.sessions.fetchSpecs().then(specs => {
+function selectKernelForContext(context: DocumentRegistry.IContext<DocumentRegistry.IModel>, manager: Session.IManager, host?: HTMLElement): Promise<void> {
+  return manager.ready().then(() => {
     let options: IKernelSelection = {
       name: context.path.split('/').pop(),
-      specs,
-      sessions: context.services.sessions.running(),
+      specs: manager.specs,
+      sessions: manager.running(),
       preferredLanguage: context.model.defaultKernelLanguage,
       kernel: context.kernel.model,
       host
@@ -232,7 +231,7 @@ function populateKernels(node: HTMLSelectElement, options: IPopulateOptions): vo
   }
 
   // Handle a preferred kernel language in order of display name.
-  if (preferredLanguage) {
+  if (preferredLanguage && specs) {
     for (let name in specs.kernelspecs) {
       if (languages[name] === preferredLanguage) {
         names.push(name);
@@ -297,7 +296,7 @@ function populateKernels(node: HTMLSelectElement, options: IPopulateOptions): vo
       return a.notebook.path.localeCompare(b.notebook.path);
     });
     for (let session of otherSessions) {
-      let name = displayNames[session.kernel.name];
+      let name = displayNames[session.kernel.name] || session.kernel.name;
       node.appendChild(optionForSession(session, name, maxLength));
     }
   }

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -135,7 +135,7 @@ function selectKernelForContext(context: DocumentRegistry.IContext<DocumentRegis
       specs: manager.specs,
       sessions: manager.running(),
       preferredLanguage: context.model.defaultKernelLanguage,
-      kernel: context.kernel.model,
+      kernel: context.kernel ? context.kernel.model : null,
       host
     };
     return selectKernel(options);

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -284,10 +284,10 @@ function populateKernels(node: HTMLSelectElement, options: IPopulateOptions): vo
     matchingSessions.sort((a, b) => {
       return a.notebook.path.localeCompare(b.notebook.path);
     });
-    for (let session of matchingSessions) {
+    each(matchingSessions, session => {
       let name = displayNames[session.kernel.name];
       node.appendChild(optionForSession(session, name, maxLength));
-    }
+    });
     node.appendChild(createSeparatorOption(maxLength));
   }
 
@@ -295,10 +295,10 @@ function populateKernels(node: HTMLSelectElement, options: IPopulateOptions): vo
     otherSessions.sort((a, b) => {
       return a.notebook.path.localeCompare(b.notebook.path);
     });
-    for (let session of otherSessions) {
+    each(otherSessions, session => {
       let name = displayNames[session.kernel.name] || session.kernel.name;
       node.appendChild(optionForSession(session, name, maxLength));
-    }
+    });
   }
   node.selectedIndex = 0;
 }

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -596,11 +596,6 @@ namespace DocumentRegistry {
     fileChanged: ISignal<this, Contents.IModel>;
 
     /**
-     * A signal emitted when the context is fully populated for the first time.
-     */
-    populated: ISignal<this, void>;
-
-    /**
      * A signal emitted when the context is disposed.
      */
     disposed: ISignal<this, void>;
@@ -625,19 +620,21 @@ namespace DocumentRegistry {
      *
      * #### Notes
      * The model will have an empty `contents` field.
-     * It will be `null` until the context is populated.
+     * It will be `null` until the context is ready.
      */
     readonly contentsModel: Contents.IModel;
 
     /**
-     * Test whether the context is fully populated.
+     * A promise that is fulfilled when the context is ready.
      */
-    readonly isPopulated: boolean;
+    ready(): Promise<void>;
 
     /**
-     * The service manager used by the context.
+     * Start the default kernel for the context.
+     *
+     * @returns A promise that resolves with the new kernel.
      */
-    readonly services: ServiceManager.IManager;
+    startDefaultKernel(): Promise<Kernel.IKernel>;
 
     /**
      * Change the current kernel associated with the document.

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Contents, Kernel, Session
+  Contents, Kernel, ServiceManager
 } from '@jupyterlab/services';
 
 import {
@@ -635,9 +635,9 @@ namespace DocumentRegistry {
     readonly isPopulated: boolean;
 
     /**
-     * Get the kernel spec models.
+     * The service manager used by the context.
      */
-    readonly specs: Kernel.ISpecModels | null;
+    readonly services: ServiceManager.IManager;
 
     /**
      * Change the current kernel associated with the document.
@@ -696,13 +696,6 @@ namespace DocumentRegistry {
      *    the file.
      */
     listCheckpoints(): Promise<Contents.ICheckpointModel[]>;
-
-    /**
-     * Create an iterator over the running sessions.
-     *
-     * @returns A new iterator over the running sessions.
-     */
-    sessions(): IIterable<Session.IModel>;
 
     /**
      * Resolve a url to a correct server path.

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Contents, Kernel, ServiceManager
+  Contents, Kernel
 } from '@jupyterlab/services';
 
 import {
-  IIterator, IIterable, each, map
+  IIterator, each, empty, map
 } from 'phosphor/lib/algorithm/iteration';
 
 import {

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -625,6 +625,11 @@ namespace DocumentRegistry {
     readonly contentsModel: Contents.IModel;
 
     /**
+     * Whether the context is ready.
+     */
+    readonly isReady: boolean;
+
+    /**
      * A promise that is fulfilled when the context is ready.
      */
     ready(): Promise<void>;

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -630,14 +630,14 @@ namespace DocumentRegistry {
     readonly contentsModel: Contents.IModel;
 
     /**
-     * Get the kernel spec information.
-     */
-    readonly kernelspecs: Kernel.ISpecModels;
-
-    /**
      * Test whether the context is fully populated.
      */
     readonly isPopulated: boolean;
+
+    /**
+     * Get the kernel spec models.
+     */
+    readonly specs: Kernel.ISpecModels | null;
 
     /**
      * Change the current kernel associated with the document.

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -6,7 +6,7 @@ import {
 } from '@jupyterlab/services';
 
 import {
-  IIterator, each, empty, map
+  IIterator, IIterable, each, map
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
@@ -698,9 +698,11 @@ namespace DocumentRegistry {
     listCheckpoints(): Promise<Contents.ICheckpointModel[]>;
 
     /**
-     * Get the list of running sessions.
+     * Create an iterator over the running sessions.
+     *
+     * @returns A new iterator over the running sessions.
      */
-    listSessions(): Promise<Session.IModel[]>;
+    sessions(): IIterable<Session.IModel>;
 
     /**
      * Resolve a url to a correct server path.

--- a/src/filebrowser/browser.ts
+++ b/src/filebrowser/browser.ts
@@ -105,15 +105,6 @@ class FileBrowser extends Widget {
     });
     this._listing = new DirListing({ manager, model, renderer });
 
-    model.fileChanged.connect((fbModel, args) => {
-      let oldPath = args.oldValue && args.oldValue.path || null;
-      if (args.newValue) {
-        manager.handleRename(oldPath, args.newValue.path);
-      } else {
-        manager.handleDelete(oldPath);
-      }
-    });
-
     this._crumbs.addClass(CRUMBS_CLASS);
     this._buttons.addClass(BUTTON_CLASS);
     this._listing.addClass(LISTING_CLASS);

--- a/src/filebrowser/buttons.ts
+++ b/src/filebrowser/buttons.ts
@@ -158,9 +158,7 @@ class FileButtons extends Widget {
    * @returns A promise that resolves with the created widget.
    */
   createFrom(creatorName: string): Promise<Widget> {
-    return createFromDialog(this.model, this.manager, creatorName).then(widget => {
-      return widget ? this._open(widget) : null;
-    });
+    return createFromDialog(this.model, this.manager, creatorName);
   }
 
   /**
@@ -179,7 +177,7 @@ class FileButtons extends Widget {
     if (!widget) {
       widget = this._manager.open(path, widgetName, kernel);
     }
-    return this._open(widget);
+    return widget;
   }
 
   /**
@@ -194,18 +192,7 @@ class FileButtons extends Widget {
    * @return The widget for the path.
    */
   createNew(path: string, widgetName='default', kernel?: Kernel.IModel): Widget {
-    let widget = this._manager.createNew(path, widgetName, kernel);
-    return this._open(widget);
-  }
-
-  /**
-   * Open a widget and attach listeners.
-   */
-  private _open(widget: Widget): Widget {
-    let context = this._manager.contextForWidget(widget);
-    context.populated.connect(() => this.model.refresh() );
-    context.kernelChanged.connect(() => this.model.refresh() );
-    return widget;
+    return this._manager.createNew(path, widgetName, kernel);
   }
 
   /**

--- a/src/filebrowser/dialogs.ts
+++ b/src/filebrowser/dialogs.ts
@@ -47,7 +47,7 @@ const FILE_CONFLICT_CLASS = 'jp-mod-conflict';
 export
 function createFromDialog(model: FileBrowserModel, manager: DocumentManager, creatorName: string): Promise<Widget> {
   let handler = new CreateFromHandler(model, manager, creatorName);
-  return manager.services.sessions.fetchSpecs().then(() => {
+  return manager.services.ready().then(() => {
     return handler.populate();
   }).then(() => {
     return handler.showDialog();
@@ -61,7 +61,7 @@ function createFromDialog(model: FileBrowserModel, manager: DocumentManager, cre
 export
 function openWithDialog(path: string, manager: DocumentManager, host?: HTMLElement): Promise<Widget> {
   let handler: OpenWithHandler;
-  return manager.services.sessions.fetchSpecs().then(() => {
+  return manager.services.ready().then(() => {
     handler = new OpenWithHandler(path, manager);
     return showDialog({
       title: 'Open File',
@@ -82,7 +82,7 @@ function openWithDialog(path: string, manager: DocumentManager, host?: HTMLEleme
 export
 function createNewDialog(model: FileBrowserModel, manager: DocumentManager, host?: HTMLElement): Promise<Widget> {
   let handler: CreateNewHandler;
-  return manager.services.sessions.fetchSpecs().then(() => {
+  return manager.services.ready().then(() => {
     handler = new CreateNewHandler(model, manager);
     return showDialog({
       title: 'Create New File',
@@ -210,7 +210,7 @@ class OpenWithHandler extends Widget {
     let preference = this._manager.registry.getKernelPreference(
       this._ext, widgetName
     );
-    let specs = this._manager.services.sessions.specs;
+    let specs = this._manager.services.specs;
     let sessions = this._manager.services.sessions.running();
     Private.updateKernels(this.kernelDropdownNode,
       { preference, specs, sessions }
@@ -319,7 +319,7 @@ class CreateFromHandler extends Widget {
     // Handle the kernel preferences.
     let preference = registry.getKernelPreference(ext, widgetName);
     if (preference.canStartKernel) {
-      let specs = this._manager.services.sessions.specs;
+      let specs = this._manager.services.specs;
       let sessions = this._manager.services.sessions.running();
       let preferredKernel = kernelName;
       Private.updateKernels(this.kernelDropdownNode,
@@ -548,7 +548,7 @@ class CreateNewHandler extends Widget {
     let widgetName = this.widgetDropdown.value;
     let manager = this._manager;
     let preference = manager.registry.getKernelPreference(ext, widgetName);
-    let specs = manager.services.sessions.specs;
+    let specs = manager.services.specs;
     let sessions = manager.services.sessions.running();
     Private.updateKernels(this.kernelDropdownNode,
       { preference, sessions, specs }
@@ -637,7 +637,7 @@ namespace Private {
     );
 
     // Select the "null" valued kernel if we do not prefer a kernel.
-    if (!preference.preferKernel && !specs) {
+    if (!preference.preferKernel) {
       node.value = 'null';
     }
   }

--- a/src/filebrowser/dialogs.ts
+++ b/src/filebrowser/dialogs.ts
@@ -479,7 +479,7 @@ class CreateNewHandler extends Widget {
     }
     // Update the file type dropdown and the factories.
     if (this._extensions.indexOf(ext) === -1) {
-      this.fileTypeDropdown.value = this._sentinal;
+      this.fileTypeDropdown.value = this._sentinel;
     } else {
       this.fileTypeDropdown.value = ext;
     }
@@ -493,7 +493,7 @@ class CreateNewHandler extends Widget {
     let dropdown = this.fileTypeDropdown;
     let option = document.createElement('option');
     option.text = 'File';
-    option.value = this._sentinal;
+    option.value = this._sentinel;
 
     each(this._manager.registry.fileTypes(), ft => {
       option = document.createElement('option');
@@ -505,7 +505,7 @@ class CreateNewHandler extends Widget {
     if (this.ext in this._extensions) {
       dropdown.value = this.ext;
     } else {
-      dropdown.value = this._sentinal;
+      dropdown.value = this._sentinel;
     }
   }
 
@@ -557,7 +557,7 @@ class CreateNewHandler extends Widget {
 
   private _model: FileBrowserModel = null;
   private _manager: DocumentManager = null;
-  private _sentinal = 'UNKNOWN_EXTENSION';
+  private _sentinel = 'UNKNOWN_EXTENSION';
   private _prevExt = '';
   private _extensions: string[] = [];
 }

--- a/src/filebrowser/dialogs.ts
+++ b/src/filebrowser/dialogs.ts
@@ -204,7 +204,7 @@ class OpenWithHandler extends Widget {
     let preference = this._manager.registry.getKernelPreference(
       this._ext, widgetName
     );
-    let specs = this._manager.kernelspecs;
+    let specs = this._manager.specs;
     let sessions = this._manager.sessions();
     Private.updateKernels(this.kernelDropdownNode,
       { preference, specs, sessions }
@@ -313,7 +313,7 @@ class CreateFromHandler extends Widget {
     // Handle the kernel preferences.
     let preference = registry.getKernelPreference(ext, widgetName);
     if (preference.canStartKernel) {
-      let specs = this._manager.kernelspecs;
+      let specs = this._manager.specs;
       let sessions = this._manager.sessions();
       let preferredKernel = kernelName;
       Private.updateKernels(this.kernelDropdownNode,
@@ -542,7 +542,7 @@ class CreateNewHandler extends Widget {
     let widgetName = this.widgetDropdown.value;
     let manager = this._manager;
     let preference = manager.registry.getKernelPreference(ext, widgetName);
-    let specs = manager.kernelspecs;
+    let specs = manager.specs;
     let sessions = manager.sessions();
     Private.updateKernels(this.kernelDropdownNode,
       { preference, sessions, specs }
@@ -619,13 +619,19 @@ namespace Private {
       node.disabled = true;
       return;
     }
+    // Bail if there are no kernel specs.
+    if (!specs) {
+      return;
+    }
     let preferredLanguage = preference.language;
     node.disabled = false;
+
     populateKernels(node,
       { specs, sessions, preferredLanguage, preferredKernel }
     );
+
     // Select the "null" valued kernel if we do not prefer a kernel.
-    if (!preference.preferKernel) {
+    if (!preference.preferKernel && !specs) {
       node.value = 'null';
     }
   }

--- a/src/filebrowser/dialogs.ts
+++ b/src/filebrowser/dialogs.ts
@@ -47,7 +47,9 @@ const FILE_CONFLICT_CLASS = 'jp-mod-conflict';
 export
 function createFromDialog(model: FileBrowserModel, manager: DocumentManager, creatorName: string): Promise<Widget> {
   let handler = new CreateFromHandler(model, manager, creatorName);
-  return handler.populate().then(() => {
+  return manager.services.sessions.fetchSpecs().then(() => {
+    return handler.populate();
+  }).then(() => {
     return handler.showDialog();
   });
 }
@@ -59,11 +61,13 @@ function createFromDialog(model: FileBrowserModel, manager: DocumentManager, cre
 export
 function openWithDialog(path: string, manager: DocumentManager, host?: HTMLElement): Promise<Widget> {
   let handler: OpenWithHandler;
-  handler = new OpenWithHandler(path, manager);
-  return showDialog({
-    title: 'Open File',
-    body: handler.node,
-    okText: 'OPEN'
+  return manager.services.sessions.fetchSpecs().then(() => {
+    handler = new OpenWithHandler(path, manager);
+    return showDialog({
+      title: 'Open File',
+      body: handler.node,
+      okText: 'OPEN'
+    });
   }).then(result => {
     if (result.text === 'OPEN') {
       return handler.open();
@@ -78,12 +82,14 @@ function openWithDialog(path: string, manager: DocumentManager, host?: HTMLEleme
 export
 function createNewDialog(model: FileBrowserModel, manager: DocumentManager, host?: HTMLElement): Promise<Widget> {
   let handler: CreateNewHandler;
-  handler = new CreateNewHandler(model, manager);
-  return showDialog({
-    title: 'Create New File',
-    host,
-    body: handler.node,
-    okText: 'CREATE'
+  return manager.services.sessions.fetchSpecs().then(() => {
+    handler = new CreateNewHandler(model, manager);
+    return showDialog({
+      title: 'Create New File',
+      host,
+      body: handler.node,
+      okText: 'CREATE'
+    });
   }).then(result => {
     if (result.text === 'CREATE') {
       return handler.open();
@@ -204,8 +210,8 @@ class OpenWithHandler extends Widget {
     let preference = this._manager.registry.getKernelPreference(
       this._ext, widgetName
     );
-    let specs = this._manager.specs;
-    let sessions = this._manager.sessions();
+    let specs = this._manager.services.sessions.specs;
+    let sessions = this._manager.services.sessions.running();
     Private.updateKernels(this.kernelDropdownNode,
       { preference, specs, sessions }
     );
@@ -313,8 +319,8 @@ class CreateFromHandler extends Widget {
     // Handle the kernel preferences.
     let preference = registry.getKernelPreference(ext, widgetName);
     if (preference.canStartKernel) {
-      let specs = this._manager.specs;
-      let sessions = this._manager.sessions();
+      let specs = this._manager.services.sessions.specs;
+      let sessions = this._manager.services.sessions.running();
       let preferredKernel = kernelName;
       Private.updateKernels(this.kernelDropdownNode,
         { specs, sessions, preferredKernel, preference }
@@ -542,8 +548,8 @@ class CreateNewHandler extends Widget {
     let widgetName = this.widgetDropdown.value;
     let manager = this._manager;
     let preference = manager.registry.getKernelPreference(ext, widgetName);
-    let specs = manager.specs;
-    let sessions = manager.sessions();
+    let specs = manager.services.sessions.specs;
+    let sessions = manager.services.sessions.running();
     Private.updateKernels(this.kernelDropdownNode,
       { preference, sessions, specs }
     );

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Contents
+  Contents, Kernel
 } from '@jupyterlab/services';
 
 import {
@@ -669,12 +669,16 @@ class DirListing extends Widget {
 
     // Handle notebook session statuses.
     let paths = toArray(map(items, item => item.path));
-    let specs = this._model.kernelspecs;
     each(this._model.sessions(), session => {
       let index = indexOf(paths, session.notebook.path);
       let node = nodes.at(index);
       node.classList.add(RUNNING_CLASS);
-      node.title = specs.kernelspecs[session.kernel.name].display_name;
+      let name = session.kernel.name;
+      let specs = this._model.specs;
+      if (specs) {
+        name = specs.kernelspecs[name].display_name;
+      }
+      node.title = name;
     });
 
     this._prevPath = this._model.path;

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -872,9 +872,6 @@ class DirListing extends Widget {
       let widget = this._manager.findWidget(path);
       if (!widget) {
         widget = this._manager.open(item.path);
-        let context = this._manager.contextForWidget(widget);
-        context.populated.connect(() => model.refresh() );
-        context.kernelChanged.connect(() => model.refresh() );
       }
     }
   }
@@ -1006,9 +1003,6 @@ class DirListing extends Widget {
         let widget = this._manager.findWidget(path);
         if (!widget) {
           widget = this._manager.open(item.path);
-          let context = this._manager.contextForWidget(widget);
-          context.populated.connect(() => model.refresh() );
-          context.kernelChanged.connect(() => model.refresh() );
         }
         return widget;
       });

--- a/src/filebrowser/model.ts
+++ b/src/filebrowser/model.ts
@@ -384,7 +384,7 @@ class FileBrowserModel implements IDisposable, IPathTracker {
    * Handle a change on the contents manager.
    */
   private _onFileChanged(sender: Contents.IManager, change: Contents.IChangedArgs): void {
-    let path = this._model.path;
+    let path = this._model.path || '.';
     let value = change.oldValue;
     if (value && value.path && ContentsManager.dirname(value.path) === path) {
       this.fileChanged.emit(change);

--- a/src/filebrowser/model.ts
+++ b/src/filebrowser/model.ts
@@ -85,10 +85,10 @@ class FileBrowserModel implements IDisposable, IPathTracker {
   }
 
   /**
-   * Get the kernel specs.
+   * Get the kernel spec models.
    */
-  get kernelspecs(): Kernel.ISpecModels {
-    return this._manager.kernelspecs;
+  get specs(): Kernel.ISpecModels | null {
+    return this._manager.sessions.specs;
   }
 
   /**

--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -140,7 +140,7 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
     };
     let pending = ++this._pending;
 
-    this._kernel.inspect(contents).then(msg => {
+    this._kernel.requestInspect(contents).then(msg => {
       let value = msg.content;
 
       // If handler has been disposed, bail.

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -320,15 +320,11 @@ class NotebookPanel extends Widget {
     if (!this.model || !kernel) {
       return;
     }
-    if (kernel.info) {
-      this._updateLanguage(kernel.info.language_info);
-    } else {
-      kernel.kernelInfo().then(msg => {
-        if (this.model) {
-          this._updateLanguage(msg.content.language_info);
-        }
-      });
-    }
+    kernel.info().then(msg => {
+      if (this.model) {
+        this._updateLanguage(msg.language_info);
+      }
+    });
     this._updateSpec(kernel);
   }
 

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -257,28 +257,6 @@ class NotebookPanel extends Widget {
   }
 
   /**
-   * Handle a context population.
-   */
-  protected onPopulated(context: DocumentRegistry.IContext<INotebookModel>, args: void): void {
-    let model = context.model;
-    // Clear the undo state of the cells.
-    if (model) {
-      model.cells.clearUndo();
-    }
-    if (!context.kernel && model) {
-      // context.startDefaultKernel();
-      // let name = findKernel(
-      //   model.defaultKernelName,
-      //   model.defaultKernelLanguage,
-      //   context.specs
-      // );
-      // if (name) {
-      //   context.changeKernel({ name });
-      // }
-    }
-  }
-
-  /**
    * Handle a change in the context.
    */
   private _onContextChanged(oldValue: DocumentRegistry.IContext<INotebookModel>, newValue: DocumentRegistry.IContext<INotebookModel>): void {
@@ -303,13 +281,7 @@ class NotebookPanel extends Widget {
     this._handleDirtyState();
     newValue.model.stateChanged.connect(this.onModelStateChanged, this);
 
-    // Handle context initialization.
-    newValue.ready().then(() => {
-      if (!newValue.kernel) {
-        newValue.startDefaultKernel();
-      }
-    });
-
+    // Clear the cells when the context is initially populated.
     if (!newValue.isReady) {
       newValue.ready().then(() => {
         let model = newValue.model;

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -305,15 +305,20 @@ class NotebookPanel extends Widget {
 
     // Handle context initialization.
     newValue.ready().then(() => {
-      let model = newValue.model;
-      // Clear the undo state of the cells.
-      if (model) {
-        model.cells.clearUndo();
-      }
       if (!newValue.kernel) {
         newValue.startDefaultKernel();
       }
     });
+
+    if (!newValue.isReady) {
+      newValue.ready().then(() => {
+        let model = newValue.model;
+        // Clear the undo state of the cells.
+        if (model) {
+          model.cells.clearUndo();
+        }
+      });
+    }
 
     // Handle the document title.
     this.onPathChanged(context, context.path);

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -265,11 +265,11 @@ class NotebookPanel extends Widget {
     if (model) {
       model.cells.clearUndo();
     }
-    if (!sender.kernel && model) {
+    if (!sender.kernel && model && sender.specs) {
       let name = findKernel(
         model.defaultKernelName,
         model.defaultKernelLanguage,
-        sender.kernelspecs
+        sender.specs
       );
       sender.changeKernel({ name });
     }
@@ -340,13 +340,13 @@ class NotebookPanel extends Widget {
    * Update the kernel spec.
    */
   private _updateSpec(kernel: Kernel.IKernel): void {
-    let specs = this.context.kernelspecs;
-    let spec = specs.kernelspecs[kernel.name];
-    let specCursor = this.model.getMetadata('kernelspec');
-    specCursor.setValue({
-      name: kernel.name,
-      display_name: spec.display_name,
-      language: spec.language
+    kernel.spec().then(spec => {
+      let specCursor = this.model.getMetadata('kernelspec');
+      specCursor.setValue({
+        name: kernel.name,
+        display_name: spec.display_name,
+        language: spec.language
+      });
     });
   }
 

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -34,7 +34,7 @@ import {
 } from '../../common/interfaces';
 
 import {
-  DocumentRegistry, findKernel
+  DocumentRegistry, findKernel, selectKernelForContext
 } from '../../docregistry';
 
 import {
@@ -259,19 +259,26 @@ class NotebookPanel extends Widget {
   /**
    * Handle a context population.
    */
-  protected onPopulated(sender: DocumentRegistry.IContext<INotebookModel>, args: void): void {
-    let model = sender.model;
+  protected onPopulated(context: DocumentRegistry.IContext<INotebookModel>, args: void): void {
+    let model = context.model;
     // Clear the undo state of the cells.
     if (model) {
       model.cells.clearUndo();
     }
-    if (!sender.kernel && model && sender.specs) {
-      let name = findKernel(
-        model.defaultKernelName,
-        model.defaultKernelLanguage,
-        sender.specs
-      );
-      sender.changeKernel({ name });
+    if (!context.kernel && model) {
+      if (context.services.sessions.specs) {
+        let name = findKernel(
+          model.defaultKernelName,
+          model.defaultKernelLanguage,
+          context.services.sessions.specs
+        );
+        if (name) {
+          context.changeKernel({ name });
+          return;
+        }
+      }
+      // Fall back on using a kernel selection.
+      selectKernelForContext(context);
     }
   }
 

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -191,7 +191,7 @@ class OutputAreaModel implements IDisposable {
     };
     this.clear();
     return new Promise<KernelMessage.IExecuteReplyMsg>((resolve, reject) => {
-      let future = kernel.execute(content);
+      let future = kernel.requestExecute(content);
       // Handle published messages.
       future.onIOPub = (msg: KernelMessage.IIOPubMessage) => {
         let msgType = msg.header.msg_type;

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -509,7 +509,7 @@ function addCommands(app: JupyterLab, services: IServiceManager): void {
       let current = tracker.currentWidget;
       if (current) {
         let { context, node } = current;
-        selectKernelForContext(context, node);
+        selectKernelForContext(context, services.sessions, node);
       }
     }
   });

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -167,7 +167,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     widgetName: 'Notebook'
   });
 
-  addCommands(app);
+  addCommands(app, services);
   populatePalette(palette);
 
   let id = 0; // The ID counter for notebook panels.
@@ -191,7 +191,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
 /**
  * Add the notebook commands to the application's command registry.
  */
-function addCommands(app: JupyterLab): void {
+function addCommands(app: JupyterLab, services: IServiceManager): void {
   let commands = app.commands;
 
   commands.addCommand(cmdIds.runAndAdvance, {

--- a/src/running/index.css
+++ b/src/running/index.css
@@ -29,10 +29,37 @@
 }
 
 
+.jp-RunningSessions-headerRefresh {
+  flex: 1 1 auto;
+  max-width: 100px;
+  padding: 4px 6px;
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
+  border: none;
+  font-size: var(--jp-ui-font-size1);
+  outline: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+
 .jp-RunningSessions-section {
   display: flex;
   flex: 0 1 auto;
   flex-direction: column;
+}
+
+
+.jp-RunningSessions-headerRefresh:before {
+  font-family: FontAwesome;
+  content: '\f021'; /* refresh */
+  font-size: var(--jp-ui-icon-font-size);
+}
+
+
+.jp-RunningSessions-headerRefresh:hover {
+  background: var(--jp-layout-color2);
+  z-index: 1; /* raise overlapping border */
 }
 
 

--- a/src/running/index.css
+++ b/src/running/index.css
@@ -29,37 +29,10 @@
 }
 
 
-.jp-RunningSessions-headerRefresh {
-  flex: 1 1 auto;
-  max-width: 100px;
-  padding: 4px 6px;
-  background: var(--jp-layout-color1);
-  color: var(--jp-ui-font-color1);
-  border: none;
-  font-size: var(--jp-ui-font-size1);
-  outline: 0;
-  padding-top: 8px;
-  padding-bottom: 8px;
-}
-
-
 .jp-RunningSessions-section {
   display: flex;
   flex: 0 1 auto;
   flex-direction: column;
-}
-
-
-.jp-RunningSessions-headerRefresh:before {
-  font-family: FontAwesome;
-  content: '\f021'; /* refresh */
-  font-size: var(--jp-ui-icon-font-size);
-}
-
-
-.jp-RunningSessions-headerRefresh:hover {
-  background: var(--jp-layout-color2);
-  z-index: 1; /* raise overlapping border */
 }
 
 

--- a/src/running/index.ts
+++ b/src/running/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  ServiceManager, Session, TerminalSession
+  Kernel, ServiceManager, Session, TerminalSession
 } from '@jupyterlab/services';
 
 import {
@@ -166,6 +166,7 @@ class RunningSessions extends Widget {
 
     terminals.runningChanged.connect(this._onTerminalsChanged, this);
     sessions.runningChanged.connect(this._onSessionsChanged, this);
+    sessions.specsChanged.connect(this.update, this);
 
     this._onTerminalsChanged(terminals, terminals.running());
     this._onSessionsChanged(sessions, sessions.running());
@@ -254,7 +255,6 @@ class RunningSessions extends Widget {
     let sessionSection = findElement(this.node, SESSIONS_CLASS);
     let sessionList = findElement(sessionSection, LIST_CLASS);
     let renderer = this._renderer;
-    let kernelspecs = this._manager.kernelspecs.kernelspecs;
 
     // Remove any excess item nodes.
     while (termList.children.length > this._runningTerminals.length) {
@@ -283,7 +283,11 @@ class RunningSessions extends Widget {
     });
     each(enumerate(this._runningSessions), ([index, value]) => {
       let node = sessionList.children[index] as HTMLLIElement;
-      let kernelName = kernelspecs[value.kernel.name].display_name;
+      let kernelName = value.kernel.name;
+      let specs = this._manager.sessions.specs;
+      if (specs) {
+        kernelName = specs.kernelspecs[kernelName].display_name;
+      }
       renderer.updateSessionNode(node, value, kernelName);
     });
   }
@@ -359,6 +363,7 @@ class RunningSessions extends Widget {
 
   private _manager: ServiceManager.IManager = null;
   private _renderer: RunningSessions.IRenderer = null;
+  private _specs: Kernel.ISpecModels = null;
   private _runningSessions = new Vector<Session.IModel>();
   private _runningTerminals = new Vector<TerminalSession.IModel>();
 }

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -21,7 +21,7 @@ export
 const servicesProvider: JupyterLabPlugin<IServiceManager> = {
   id: 'jupyter.services.services',
   provides: IServiceManager,
-  activate: (): Promise<IServiceManager> => {
-    return ServiceManager.create() as Promise<IServiceManager>;
+  activate: (): IServiceManager => {
+    return new ServiceManager();
   }
 };

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -80,10 +80,17 @@ class TerminalWidget extends Widget {
     if (this._session && !this._session.isDisposed) {
       this._session.messageReceived.disconnect(this._onMessage, this);
     }
-    this._session = value;
-    this._session.messageReceived.connect(this._onMessage, this);
-    this.title.label = `Terminal ${this._session.name}`;
-    this._resizeTerminal(-1, -1);
+    this._session = null;
+    if (!value) {
+      return;
+    }
+
+    value.ready().then(() => {
+      this._session = value;
+      this._session.messageReceived.connect(this._onMessage, this);
+      this.title.label = `Terminal ${this._session.name}`;
+      this._resizeTerminal(-1, -1);
+    });
   }
 
   /**

--- a/src/toolbar/kernel.ts
+++ b/src/toolbar/kernel.ts
@@ -123,15 +123,11 @@ function updateKernelNameItem(widget: Widget, kernel: Kernel.IKernel): void {
   if (!kernel) {
     return;
   }
-  if (kernel.spec) {
-    widget.node.textContent = kernel.spec.display_name;
-  } else {
-    kernel.getSpec().then(spec => {
-      if (!widget.isDisposed) {
-        widget.node.textContent = kernel.spec.display_name;
-      }
-    });
-  }
+  kernel.spec().then(spec => {
+    if (!widget.isDisposed) {
+      widget.node.textContent = spec.display_name;
+    }
+  });
 }
 
 

--- a/src/toolbar/kernel.ts
+++ b/src/toolbar/kernel.ts
@@ -123,9 +123,9 @@ function updateKernelNameItem(widget: Widget, kernel: Kernel.IKernel): void {
   if (!kernel) {
     return;
   }
-  kernel.spec().then(spec => {
+  kernel.ready().then(() => {
     if (!widget.isDisposed) {
-      widget.node.textContent = spec.display_name;
+      widget.node.textContent = kernel.spec.display_name;
     }
   });
 }

--- a/src/toolbar/kernel.ts
+++ b/src/toolbar/kernel.ts
@@ -123,6 +123,9 @@ function updateKernelNameItem(widget: Widget, kernel: Kernel.IKernel): void {
   if (!kernel) {
     return;
   }
+  if (kernel.spec) {
+    widget.node.textContent = kernel.spec.display_name;
+  }
   kernel.ready().then(() => {
     if (!widget.isDisposed) {
       widget.node.textContent = kernel.spec.display_name;

--- a/test/src/console/foreign.spec.ts
+++ b/test/src/console/foreign.spec.ts
@@ -150,14 +150,14 @@ describe('console/foreign', () => {
       it('should allow foreign cells to be injected if `true`', done => {
         let code = 'print("#enabled:true")';
         handler.injected.connect(() => { done(); });
-        foreign.kernel.execute({ code, stop_on_error: true });
+        foreign.kernel.requestExecute({ code, stop_on_error: true });
       });
 
       it('should reject foreign cells if `false`', done => {
         let code = 'print("#enabled:false")';
         handler.enabled = false;
         handler.rejected.connect(() => { done(); });
-        foreign.kernel.execute({ code, stop_on_error: true });
+        foreign.kernel.requestExecute({ code, stop_on_error: true });
       });
 
     });
@@ -254,7 +254,7 @@ describe('console/foreign', () => {
         let code = 'print("onIOPubMessage:disabled")';
         handler.enabled = false;
         handler.received.connect(() => { done(); });
-        foreign.kernel.execute({ code, stop_on_error: true });
+        foreign.kernel.requestExecute({ code, stop_on_error: true });
       });
 
       it('should inject relevant cells into the parent', done => {
@@ -265,7 +265,7 @@ describe('console/foreign', () => {
           expect(parent.widgets.length).to.be.greaterThan(0);
           done();
         });
-        foreign.kernel.execute({ code, stop_on_error: true });
+        foreign.kernel.requestExecute({ code, stop_on_error: true });
       });
 
       it('should not reject relevant iopub messages', done => {
@@ -279,7 +279,7 @@ describe('console/foreign', () => {
             done();
           }
         });
-        foreign.kernel.execute({ code, stop_on_error: true });
+        foreign.kernel.requestExecute({ code, stop_on_error: true });
       });
 
     });

--- a/test/src/docmanager/savehandler.spec.ts
+++ b/test/src/docmanager/savehandler.spec.ts
@@ -27,11 +27,8 @@ describe('docregistry/savehandler', () => {
   let context: Context<DocumentRegistry.IModel>;
   let handler: SaveHandler;
 
-  before((done) => {
-    ServiceManager.create().then(m => {
-      manager = m;
-      done();
-    }).catch(done);
+  before(() => {
+    manager = new ServiceManager();
   });
 
   beforeEach(() => {

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -70,11 +70,8 @@ describe('docmanager/widgetmanager', () => {
     fileExtensions: ['.txt']
   });
 
-  before((done) => {
-    ServiceManager.create().then(m => {
-      services = m;
-      done();
-    }).catch(done);
+  before(() => {
+    services = new ServiceManager();
   });
 
   beforeEach(() => {

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -92,43 +92,34 @@ describe('docregistry/context', () => {
 
     });
 
-    describe('#populated', () => {
+    describe('#isReady', () => {
 
-      it('should be emitted when the file is saved for the first time', (done) => {
-        let count = 0;
-        context.populated.connect((sender, args) => {
-          expect(sender).to.be(context);
-          expect(args).to.be(void 0);
-          count++;
-        });
-        context.save().then(() => {
-          expect(count).to.be(1);
-          return context.save();
-        }).then(() => {
-          expect(count).to.be(1);
+      it('should indicate whether the context is ready', (done) => {
+        expect(context.isReady).to.be(false);
+        context.ready().then(() => {
+          expect(context.isReady).to.be(true);
           done();
         }).catch(done);
+        context.save().catch(done);
       });
 
-      it('should be emitted when the file is reverted for the first time', (done) => {
+    });
+
+    describe('#ready()', () => {
+
+      it('should resolve when the file is saved for the first time', (done) => {
+        context.ready().then(done, done);
+        context.save().catch(done);
+      });
+
+      it('should resolve when the file is reverted for the first time', (done) => {
         manager.contents.save(context.path, {
           type: factory.contentType,
           format: factory.fileFormat,
           content: 'foo'
         });
-        let count = 0;
-        context.populated.connect((sender, args) => {
-          expect(sender).to.be(context);
-          expect(args).to.be(void 0);
-          count++;
-        });
-        context.revert().then(() => {
-          expect(count).to.be(1);
-          return context.revert();
-        }).then(() => {
-          expect(count).to.be(1);
-          done();
-        }).catch(done);
+        context.ready().then(done, done);
+        context.revert().catch(done);
       });
 
     });
@@ -192,30 +183,6 @@ describe('docregistry/context', () => {
           done();
         });
         context.save().catch(done);
-      });
-
-    });
-
-    describe('#kernelspecs', () => {
-
-      it('should be the kernelspecs model', () => {
-        let name = manager.kernelspecs.default;
-        expect(name in manager.kernelspecs.kernelspecs).to.be(true);
-      });
-
-    });
-
-    describe('#isPopulated', () => {
-
-      it('should be false before initial save', () => {
-        expect(context.isPopulated).to.be(false);
-      });
-
-      it('should be true after the initial save', (done) => {
-        context.save().then(() => {
-          expect(context.isPopulated).to.be(true);
-          done();
-        }).catch(done);
       });
 
     });
@@ -392,25 +359,6 @@ describe('docregistry/context', () => {
               return;
             }
           }
-        }).catch(done);
-      });
-
-    });
-
-    describe('#listSessions()', () => {
-
-      it('should list the running sessions', (done) => {
-        let name = manager.kernelspecs.default;
-        context.changeKernel({ name }).then(() => {
-          return context.listSessions();
-        }).then(models => {
-          for (let model of models) {
-            if (model.kernel.id === context.kernel.id) {
-              return context.changeKernel(null);
-            }
-          }
-        }).then(() => {
-          done();
         }).catch(done);
       });
 

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -25,11 +25,8 @@ describe('docregistry/context', () => {
   let manager: ServiceManager.IManager;
   let factory = new TextModelFactory();
 
-  before((done) => {
-    ServiceManager.create().then(m => {
-      manager = m;
-      done();
-    }).catch(done);
+  before(() => {
+    manager = new ServiceManager();
   });
 
   describe('Context', () => {

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -25,8 +25,9 @@ describe('docregistry/context', () => {
   let manager: ServiceManager.IManager;
   let factory = new TextModelFactory();
 
-  before(() => {
+  before((done) => {
     manager = new ServiceManager();
+    manager.ready().then(done, done);
   });
 
   describe('Context', () => {
@@ -53,7 +54,7 @@ describe('docregistry/context', () => {
     describe('#kernelChanged', () => {
 
       it('should be emitted when the kernel changes', (done) => {
-        let name = manager.kernelspecs.default;
+        let name = manager.specs.default;
         context.kernelChanged.connect((sender, args) => {
           expect(sender).to.be(context);
           expect(args.name).to.be(name);
@@ -74,7 +75,7 @@ describe('docregistry/context', () => {
           expect(args).to.be('foo');
           done();
         });
-        context.setPath('foo');
+        manager.contents.rename(context.path, 'foo');
       });
 
     });
@@ -152,7 +153,7 @@ describe('docregistry/context', () => {
       });
 
       it('should be set after switching kernels', (done) => {
-        let name = manager.kernelspecs.default;
+        let name = manager.specs.default;
         context.changeKernel({ name }).then(() => {
           expect(context.kernel.name).to.be(name);
           return context.changeKernel(null);
@@ -178,7 +179,7 @@ describe('docregistry/context', () => {
       });
 
       it('should be set after poulation', (done) => {
-        context.populated.connect(() => {
+        context.ready().then(() => {
           expect(context.contentsModel.name).to.be('foo');
           done();
         });
@@ -216,10 +217,18 @@ describe('docregistry/context', () => {
 
     });
 
+    describe('#startDefaultKernel()', () => {
+
+      it('will fail', () => {
+        expect(false).to.be(true);
+      });
+
+    });
+
     describe('#changeKernel()', () => {
 
       it('should change the kernel instance', (done) => {
-        let name = manager.kernelspecs.default;
+        let name = manager.specs.default;
         context.changeKernel({ name }).then(() => {
           expect(context.kernel.name).to.be(name);
           return context.changeKernel(null);
@@ -229,7 +238,7 @@ describe('docregistry/context', () => {
       });
 
       it('should shut down the session if given `null`', (done) => {
-        let name = manager.kernelspecs.default;
+        let name = manager.specs.default;
         context.changeKernel({ name }).then(() => {
           expect(context.kernel.name).to.be(name);
           return context.changeKernel(null);
@@ -259,6 +268,7 @@ describe('docregistry/context', () => {
       });
 
     });
+
 
     describe('#saveAs()', () => {
 

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -75,7 +75,9 @@ describe('docregistry/context', () => {
           expect(args).to.be('foo');
           done();
         });
-        manager.contents.rename(context.path, 'foo');
+        context.save().then(() => {
+          return manager.contents.rename(context.path, 'foo');
+        }).catch(done);
       });
 
     });
@@ -219,8 +221,13 @@ describe('docregistry/context', () => {
 
     describe('#startDefaultKernel()', () => {
 
-      it('will fail', () => {
-        expect(false).to.be(true);
+      it('should start the default kernel for the context', (done) => {
+        context.save().then(() => {
+          return context.startDefaultKernel();
+        }).then(kernel => {
+          expect(kernel.name).to.be.ok();
+          done();
+        }).catch(done);
       });
 
     });

--- a/test/src/docregistry/default.spec.ts
+++ b/test/src/docregistry/default.spec.ts
@@ -37,11 +37,8 @@ describe('docmanager/default', () => {
 
   let context: Context<DocumentRegistry.IModel>;
 
-  beforeEach((done) => {
-    createFileContext().then(c => {
-      context = c;
-      done();
-    });
+  beforeEach(() => {
+    context = createFileContext();
   });
 
   afterEach(() => {

--- a/test/src/filebrowser/model.spec.ts
+++ b/test/src/filebrowser/model.spec.ts
@@ -22,11 +22,8 @@ describe('filebrowser/model', () => {
   let model: FileBrowserModel;
   let name: string;
 
-  before((done) => {
-    ServiceManager.create().then(m => {
-      manager = m;
-      done();
-    });
+  before(() => {
+    manager = new ServiceManager();
   });
 
   beforeEach((done) => {
@@ -386,16 +383,15 @@ describe('filebrowser/model', () => {
 
       it('should shut down a session by session id', (done) => {
         let length = 0;
-        manager.sessions.listRunning().then(running => {
-          length = running.length;
-          return model.newUntitled({ type: 'notebook' });
-        }).then(contents => {
-          return manager.sessions.startNew({ path: contents.path });
+        let sessions = manager.sessions;
+        length = toArray(sessions.running()).length;
+        model.newUntitled({ type: 'notebook' }).then(contents => {
+          return sessions.startNew({ path: contents.path });
         }).then(session => {
           session.dispose();
           return model.shutdown(session.id);
         }).then(() => {
-          return manager.sessions.listRunning();
+          return sessions.refreshRunning();
         }).then(running => {
           expect(running.length).to.be(length);
           done();

--- a/test/src/filebrowser/model.spec.ts
+++ b/test/src/filebrowser/model.spec.ts
@@ -91,8 +91,8 @@ describe('filebrowser/model', () => {
       it('should be emitted when a file is created', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
-          expect(args.name).to.be('file');
-          expect(args.oldValue).to.be(void 0);
+          expect(args.type).to.be('new');
+          expect(args.oldValue).to.be(null);
           expect(args.newValue.type).to.be('file');
           done();
         });
@@ -102,7 +102,7 @@ describe('filebrowser/model', () => {
       it('should be emitted when a file is renamed', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
-          expect(args.name).to.be('file');
+          expect(args.type).to.be('rename');
           expect(args.oldValue.path).to.be(name);
           expect(args.newValue.path).to.be(name + '.bak');
           done();
@@ -158,14 +158,6 @@ describe('filebrowser/model', () => {
         }).then(() => {
           done();
         }).catch(done);
-      });
-
-    });
-
-    describe('#kernelspecs', () => {
-
-      it('should get the kernelspecs models', () => {
-        expect(model.kernelspecs.default).to.be(manager.kernelspecs.default);
       });
 
     });
@@ -239,8 +231,8 @@ describe('filebrowser/model', () => {
       it('should emit a fileChanged signal', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
-          expect(args.name).to.be('file');
-          expect(args.oldValue).to.be(void 0);
+          expect(args.type).to.be('new');
+          expect(args.oldValue).to.be(null);
           expect(args.newValue.path).to.be(`src/${name}`);
           done();
         });
@@ -264,9 +256,9 @@ describe('filebrowser/model', () => {
       it('should emit a fileChanged signal', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
-          expect(args.name).to.be('file');
+          expect(args.type).to.be('delete');
           expect(args.oldValue.path).to.be(name);
-          expect(args.newValue).to.be(void 0);
+          expect(args.newValue).to.be(null);
           done();
         });
         model.deleteFile(name).catch(done);
@@ -297,8 +289,8 @@ describe('filebrowser/model', () => {
       it('should emit a fileChanged signal', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
-          expect(args.name).to.be('file');
-          expect(args.oldValue).to.be(void 0);
+          expect(args.type).to.be('new');
+          expect(args.oldValue).to.be(null);
           expect(args.newValue.type).to.be('directory');
           done();
         });
@@ -319,7 +311,7 @@ describe('filebrowser/model', () => {
       it('should emit the fileChanged signal', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
-          expect(args.name).to.be('file');
+          expect(args.type).to.be('rename');
           expect(args.oldValue.path).to.be(name);
           expect(args.newValue.path).to.be(name + '.new');
           done();
@@ -367,8 +359,8 @@ describe('filebrowser/model', () => {
       it('should emit the fileChanged signal', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
-          expect(args.name).to.be('file');
-          expect(args.oldValue).to.be(void 0);
+          expect(args.type).to.be('new');
+          expect(args.oldValue).to.be(null);
           expect(args.newValue.path).to.be('hello3.html');
           done();
         });
@@ -392,8 +384,8 @@ describe('filebrowser/model', () => {
           return model.shutdown(session.id);
         }).then(() => {
           return sessions.refreshRunning();
-        }).then(running => {
-          expect(running.length).to.be(length);
+        }).then(() => {
+          expect(toArray(sessions.running()).length).to.be(length);
           done();
         }).catch(done);
       });

--- a/test/src/filebrowser/model.spec.ts
+++ b/test/src/filebrowser/model.spec.ts
@@ -91,6 +91,7 @@ describe('filebrowser/model', () => {
       it('should be emitted when a file is created', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
+          console.log(args);
           expect(args.type).to.be('new');
           expect(args.oldValue).to.be(null);
           expect(args.newValue.type).to.be('file');
@@ -108,6 +109,15 @@ describe('filebrowser/model', () => {
           done();
         });
         model.rename(name, name + '.bak').catch(done);
+      });
+
+      it('should be emitted when a file is created outside of the model', (done) => {
+        model.fileChanged.connect((sender, args) => {
+          done();
+        });
+        manager.contents.newUntitled({ path: 'src' }).then(value => {
+          manager.contents.rename(value.path, name + 'bak');
+        }).catch(done);
       });
 
     });
@@ -226,17 +236,6 @@ describe('filebrowser/model', () => {
           expect(contents.path).to.be(`src/${name}`);
           done();
         }).catch(done);
-      });
-
-      it('should emit a fileChanged signal', (done) => {
-        model.fileChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.type).to.be('new');
-          expect(args.oldValue).to.be(null);
-          expect(args.newValue.path).to.be(`src/${name}`);
-          done();
-        });
-        model.copy(name, 'src').catch(done);
       });
 
     });
@@ -359,7 +358,7 @@ describe('filebrowser/model', () => {
       it('should emit the fileChanged signal', (done) => {
         model.fileChanged.connect((sender, args) => {
           expect(sender).to.be(model);
-          expect(args.type).to.be('new');
+          expect(args.type).to.be('save');
           expect(args.oldValue).to.be(null);
           expect(args.newValue.path).to.be('hello3.html');
           done();

--- a/test/src/markdownwidget/widget.spec.ts
+++ b/test/src/markdownwidget/widget.spec.ts
@@ -45,18 +45,16 @@ class LogWidget extends MarkdownWidget {
 }
 
 
-const contextPromise = createFileContext();
-
-
 describe('markdownwidget/widget', () => {
 
   let context: Context<DocumentRegistry.IModel>;
 
-  beforeEach((done) => {
-    contextPromise.then(c => {
-      context = c;
-      done();
-    });
+  beforeEach(() => {
+    context = createFileContext();
+  });
+
+  afterEach(() => {
+    context.dispose();
   });
 
   describe('MarkdownWidgetFactory', () => {

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -301,8 +301,7 @@ describe('notebook/notebook/default-toolbar', () => {
       it('should handle a change in context', () => {
         let item = ToolbarItems.createCellTypeItem(panel);
         context.model.fromJSON(DEFAULT_CONTENT);
-        let name = context.kernelspecs.default;
-        context.changeKernel({ name });
+        context.startDefaultKernel();
         panel.context = null;
         panel.content.activeCellIndex++;
         let node = item.node.getElementsByTagName('select')[0];
@@ -314,9 +313,10 @@ describe('notebook/notebook/default-toolbar', () => {
     describe('#createKernelNameItem()', () => {
 
       it('should display the `\'display_name\'` of the kernel', (done) => {
-        return panel.kernel.spec().then(spec => {
+        let kernel = panel.kernel;
+        return kernel.ready().then(() => {
           let item = createKernelNameItem(panel);
-          expect(item.node.textContent).to.be(spec.display_name);
+          expect(item.node.textContent).to.be(kernel.spec.display_name);
           done();
         });
       });
@@ -329,7 +329,7 @@ describe('notebook/notebook/default-toolbar', () => {
 
       it('should handle a change in context', (done) => {
         let item = createKernelNameItem(panel);
-        panel.kernel.spec().then(spec => {
+        panel.kernel.ready().then(() => {
           panel.context = null;
           expect(item.node.textContent).to.be('No Kernel!');
         }).then(done, done);
@@ -382,8 +382,7 @@ describe('notebook/notebook/default-toolbar', () => {
 
       it('should handle a change to the kernel', (done) => {
         let item = createKernelStatusItem(panel);
-        let name = context.kernelspecs.default;
-        panel.context.changeKernel({ name }).then(() => {
+        panel.context.startDefaultKernel().then(() => {
           panel.kernel.statusChanged.connect(() => {
             if (!panel.kernel) {
               return;
@@ -415,8 +414,7 @@ describe('notebook/notebook/default-toolbar', () => {
         context = createNotebookContext();
         context.model.fromJSON(DEFAULT_CONTENT);
         panel.context = context;
-        let name = context.kernelspecs.default;
-        return context.changeKernel({ name }).then(() => {
+        return context.startDefaultKernel().then(() => {
           panel.kernel.statusChanged.connect(() => {
             if (!panel.kernel) {
               return;

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -79,11 +79,8 @@ describe('notebook/notebook/default-toolbar', () => {
 
   let context: Context<INotebookModel>;
 
-  beforeEach((done) => {
-    createNotebookContext().then(c => {
-      context = c;
-      done();
-    });
+  beforeEach(() => {
+    context = createNotebookContext();
   });
 
   afterEach(() => {
@@ -317,7 +314,7 @@ describe('notebook/notebook/default-toolbar', () => {
     describe('#createKernelNameItem()', () => {
 
       it('should display the `\'display_name\'` of the kernel', (done) => {
-        return panel.kernel.getSpec().then(spec => {
+        return panel.kernel.spec().then(spec => {
           let item = createKernelNameItem(panel);
           expect(item.node.textContent).to.be(spec.display_name);
           done();
@@ -332,7 +329,7 @@ describe('notebook/notebook/default-toolbar', () => {
 
       it('should handle a change in context', (done) => {
         let item = createKernelNameItem(panel);
-        panel.kernel.getSpec().then(spec => {
+        panel.kernel.spec().then(spec => {
           panel.context = null;
           expect(item.node.textContent).to.be('No Kernel!');
         }).then(done, done);
@@ -415,25 +412,23 @@ describe('notebook/notebook/default-toolbar', () => {
 
       it('should handle a change to the context', (done) => {
         let item = createKernelStatusItem(panel);
-        createNotebookContext().then(c => {
-          context = c;
-          context.model.fromJSON(DEFAULT_CONTENT);
-          panel.context = c;
-          let name = context.kernelspecs.default;
-          return context.changeKernel({ name }).then(() => {
-            panel.kernel.statusChanged.connect(() => {
-              if (!panel.kernel) {
-                return;
-              }
-              if (panel.kernel.status === 'busy') {
-                expect(item.hasClass('jp-mod-busy')).to.be(true);
-                panel.kernel.interrupt();
-              }
-              if (panel.kernel.status === 'idle') {
-                expect(item.hasClass('jp-mod-busy')).to.be(false);
-                done();
-              }
-            });
+        context = createNotebookContext();
+        context.model.fromJSON(DEFAULT_CONTENT);
+        panel.context = context;
+        let name = context.kernelspecs.default;
+        return context.changeKernel({ name }).then(() => {
+          panel.kernel.statusChanged.connect(() => {
+            if (!panel.kernel) {
+              return;
+            }
+            if (panel.kernel.status === 'busy') {
+              expect(item.hasClass('jp-mod-busy')).to.be(true);
+              panel.kernel.interrupt();
+            }
+            if (panel.kernel.status === 'idle') {
+              expect(item.hasClass('jp-mod-busy')).to.be(false);
+              done();
+            }
           });
         }).catch(done);
       });

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -4,7 +4,7 @@
 import expect = require('expect.js');
 
 import {
-  Session, utils
+  Kernel
 } from '@jupyterlab/services';
 
 import {
@@ -20,8 +20,8 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
-  Context
-} from '../../../../lib/docregistry/context';
+  Context, DocumentRegistry
+} from '../../../../lib/docregistry';
 
 import {
  CodeCellWidget, MarkdownCellWidget
@@ -72,7 +72,19 @@ import {
  */
 const rendermime = defaultRenderMime();
 const clipboard = new MimeData();
-const sessionPromise = Session.startNew({ path: utils.uuid() });
+
+
+function startKernel(context: DocumentRegistry.IContext<INotebookModel>): Promise<Kernel.IKernel> {
+  let kernel: Kernel.IKernel;
+  return context.save().then(() => {
+    return context.startDefaultKernel();
+  }).then(k => {
+    kernel = k;
+    return kernel.ready();
+  }).then(() => {
+    return kernel;
+  });
+}
 
 
 describe('notebook/notebook/default-toolbar', () => {
@@ -84,9 +96,6 @@ describe('notebook/notebook/default-toolbar', () => {
   });
 
   afterEach(() => {
-    if (context.kernel) {
-      context.kernel.dispose();
-    }
     context.dispose();
   });
 
@@ -95,15 +104,10 @@ describe('notebook/notebook/default-toolbar', () => {
     let panel: NotebookPanel;
     const renderer = CodeMirrorNotebookPanelRenderer.defaultRenderer;
 
-    beforeEach((done) => {
+    beforeEach(() => {
       panel = new NotebookPanel({ rendermime, clipboard, renderer });
       context.model.fromJSON(DEFAULT_CONTENT);
       panel.context = context;
-      sessionPromise.then(session => {
-        return context.changeKernel({ id: session.kernel.id });
-      }).then(() => {
-        return context.kernel.interrupt();
-      }).then(done, done);
     });
 
     afterEach(() => {
@@ -218,14 +222,16 @@ describe('notebook/notebook/default-toolbar', () => {
         cell.model.outputs.clear();
         next.rendered = false;
         Widget.attach(button, document.body);
-        panel.kernel.statusChanged.connect((sender, status) => {
-          if (status === 'idle' && cell.model.outputs.length > 0) {
-            expect(next.rendered).to.be(true);
-            button.dispose();
-            done();
-          }
+        startKernel(panel.context).then(kernel => {
+          kernel.statusChanged.connect((sender, status) => {
+            if (status === 'idle' && cell.model.outputs.length > 0) {
+              expect(next.rendered).to.be(true);
+              button.dispose();
+              done();
+            }
+          });
+          button.node.click();
         });
-        button.node.click();
       });
 
       it('should have the `\'jp-Notebook-toolbarRun\'` class', () => {
@@ -240,18 +246,15 @@ describe('notebook/notebook/default-toolbar', () => {
       it('should interrupt the kernel when clicked', (done) => {
         let button = createInterruptButton(panel);
         Widget.attach(button, document.body);
-        let clicked = false;
-        panel.kernel.statusChanged.connect((sender, status) => {
-          if (status === 'idle') {
-            if (!clicked) {
-              button.node.click();
-              clicked = true;
-            } else {
+        startKernel(panel.context).then(kernel => {
+          kernel.statusChanged.connect((sender, status) => {
+            if (status === 'idle') {
               button.dispose();
               done();
             }
-          }
-        });
+          });
+          button.node.click();
+        }).catch(done);
       });
 
       it('should have the `\'jp-Kernel-toolbarInterrupt\'` class', () => {
@@ -313,50 +316,53 @@ describe('notebook/notebook/default-toolbar', () => {
     describe('#createKernelNameItem()', () => {
 
       it('should display the `\'display_name\'` of the kernel', (done) => {
-        let kernel = panel.kernel;
-        return kernel.ready().then(() => {
-          let item = createKernelNameItem(panel);
-          expect(item.node.textContent).to.be(kernel.spec.display_name);
+        let item = createKernelNameItem(panel);
+        startKernel(context).then(kernel => {
+          console.log('started kernel');
+          return kernel.ready();
+        }).then(() => {
+          let name = context.kernel.spec.display_name;
+          expect(item.node.textContent).to.be(name);
           done();
-        });
+        }).catch(done);
       });
 
       it('should display `\'No Kernel!\'` if there is no kernel', () => {
-        panel.context = null;
         let item = createKernelNameItem(panel);
         expect(item.node.textContent).to.be('No Kernel!');
       });
 
       it('should handle a change in context', (done) => {
         let item = createKernelNameItem(panel);
-        panel.kernel.ready().then(() => {
+        startKernel(context).then(kernel => {
+          console.log('started kernel');
+          return kernel.ready();
+        }).then(() => {
           panel.context = null;
           expect(item.node.textContent).to.be('No Kernel!');
-        }).then(done, done);
+          done();
+        }).catch(done);
       });
 
     });
 
     describe('#createKernelStatusItem()', () => {
 
+      beforeEach((done) => {
+        startKernel(panel.context).then(() => {
+          done();
+        }).catch(done);
+      });
+
       it('should display a busy status if the kernel status is not idle', (done) => {
         let item = createKernelStatusItem(panel);
         panel.kernel.statusChanged.connect(() => {
-          if (!panel.kernel) {
-            return;
-          }
-          if (panel.kernel.status === 'idle') {
-            expect(item.hasClass('jp-mod-busy')).to.be(false);
-            panel.kernel.interrupt();
-          }
           if (panel.kernel.status === 'busy') {
             expect(item.hasClass('jp-mod-busy')).to.be(true);
             done();
           }
         });
-        if (panel.kernel.status === 'idle') {
-          panel.kernel.interrupt();
-        }
+        panel.kernel.requestExecute({ code: 'a = 1' });
       });
 
       it('should show the current status in the node title', (done) => {
@@ -364,41 +370,12 @@ describe('notebook/notebook/default-toolbar', () => {
         let status = panel.kernel.status;
         expect(item.node.title.toLowerCase()).to.contain(status);
         panel.kernel.statusChanged.connect(() => {
-          if (!panel.kernel) {
-            return;
-          }
-          if (panel.kernel.status === 'idle') {
-            panel.kernel.interrupt();
-          }
           if (panel.kernel.status === 'busy') {
             expect(item.node.title.toLowerCase()).to.contain('busy');
             done();
           }
         });
-        if (panel.kernel.status === 'idle') {
-          panel.kernel.interrupt();
-        }
-      });
-
-      it('should handle a change to the kernel', (done) => {
-        let item = createKernelStatusItem(panel);
-        panel.context.startDefaultKernel().then(() => {
-          panel.kernel.statusChanged.connect(() => {
-            if (!panel.kernel) {
-              return;
-            }
-            if (panel.kernel.status === 'idle') {
-              panel.kernel.interrupt();
-            }
-            if (panel.kernel.status === 'busy') {
-              expect(item.hasClass('jp-mod-busy')).to.be(true);
-              done();
-            }
-          });
-        }).catch(done);
-        if (panel.kernel.status === 'idle') {
-          panel.kernel.interrupt();
-        }
+        panel.kernel.requestExecute({ code: 'a = 1' });
       });
 
       it('should handle a null kernel', (done) => {
@@ -406,29 +383,17 @@ describe('notebook/notebook/default-toolbar', () => {
         panel.context.changeKernel(void 0).then(() => {
           expect(item.node.title).to.be('No Kernel!');
           expect(item.hasClass('jp-mod-busy')).to.be(true);
-        }).then(done, done);
+          done();
+        }).catch(done);
       });
 
-      it('should handle a change to the context', (done) => {
+      it('should handle a change to the context', () => {
         let item = createKernelStatusItem(panel);
         context = createNotebookContext();
         context.model.fromJSON(DEFAULT_CONTENT);
         panel.context = context;
-        return context.startDefaultKernel().then(() => {
-          panel.kernel.statusChanged.connect(() => {
-            if (!panel.kernel) {
-              return;
-            }
-            if (panel.kernel.status === 'busy') {
-              expect(item.hasClass('jp-mod-busy')).to.be(true);
-              panel.kernel.interrupt();
-            }
-            if (panel.kernel.status === 'idle') {
-              expect(item.hasClass('jp-mod-busy')).to.be(false);
-              done();
-            }
-          });
-        }).catch(done);
+        expect(item.node.title).to.be('No Kernel!');
+        expect(item.hasClass('jp-mod-busy')).to.be(true);
       });
 
     });

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -243,20 +243,6 @@ describe('notebook/notebook/default-toolbar', () => {
 
     describe('#createInterruptButton()', () => {
 
-      it('should interrupt the kernel when clicked', (done) => {
-        let button = createInterruptButton(panel);
-        Widget.attach(button, document.body);
-        startKernel(panel.context).then(kernel => {
-          kernel.statusChanged.connect((sender, status) => {
-            if (status === 'idle') {
-              button.dispose();
-              done();
-            }
-          });
-          button.node.click();
-        }).catch(done);
-      });
-
       it('should have the `\'jp-Kernel-toolbarInterrupt\'` class', () => {
         let button = createInterruptButton(panel);
         expect(button.hasClass('jp-Kernel-toolbarInterrupt')).to.be(true);

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -100,12 +100,14 @@ describe('notebook/notebook/panel', () => {
   });
 
   beforeEach(() => {
-    context = createNotebookContext();
+    context = createNotebookContext('', manager);
+  });
+
+  afterEach(() => {
+    context.dispose();
   });
 
   after(() => {
-    context.kernel.shutdown();
-    context.dispose();
     manager.dispose();
   });
 
@@ -163,7 +165,9 @@ describe('notebook/notebook/panel', () => {
           expect(args.name).to.be.ok();
           done();
         });
-        panel.context.startDefaultKernel();
+        panel.context.save().then(() => {
+          return panel.context.startDefaultKernel();
+        }).catch(done);
       });
 
     });
@@ -190,7 +194,9 @@ describe('notebook/notebook/panel', () => {
 
       it('should be the current kernel used by the panel', (done) => {
         let panel = createPanel(context);
-        context.startDefaultKernel();
+        context.save().then(() => {
+          return context.startDefaultKernel();
+        }).catch(done);
         context.kernelChanged.connect(() => {
           expect(panel.kernel.name).to.be.ok();
           done();
@@ -329,10 +335,13 @@ describe('notebook/notebook/panel', () => {
       it('should be called when the path changes', (done) => {
         let panel = createPanel(context);
         panel.methods = [];
-        manager.contents.rename(context.path, 'foo').then(() => {
+        context.save().then(() => {
+          return manager.contents.rename(context.path, 'foo.ipynb');
+        }).catch(done);
+        context.pathChanged.connect(() => {
           expect(panel.methods).to.contain('onPathChanged');
           done();
-        }).catch(done);
+        });
       });
 
       it('should be called when the context changes', () => {

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -54,7 +54,6 @@ import {
 const rendermime = defaultRenderMime();
 const clipboard = new MimeData();
 const renderer = CodeMirrorNotebookPanelRenderer.defaultRenderer;
-const contextPromise = createNotebookContext();
 
 
 class LogNotebookPanel extends NotebookPanel {
@@ -95,15 +94,13 @@ describe('notebook/notebook/panel', () => {
 
   let context: Context<INotebookModel>;
 
-  beforeEach((done) => {
-    contextPromise.then(c => {
-      context = c;
-      done();
-    });
+  beforeEach(() => {
+    context = createNotebookContext();
   });
 
   after(() => {
     context.kernel.shutdown();
+    context.dispose();
   });
 
   describe('NotebookPanel', () => {

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -78,11 +78,6 @@ class LogNotebookPanel extends NotebookPanel {
     super.onPathChanged(sender, path);
     this.methods.push('onPathChanged');
   }
-
-  protected onPopulated(sender: DocumentRegistry.IContext<INotebookModel>, args: void): void {
-    super.onPopulated(sender, args);
-    this.methods.push('onPopulated');
-  }
 }
 
 

--- a/test/src/notebook/notebook/widgetfactory.spec.ts
+++ b/test/src/notebook/notebook/widgetfactory.spec.ts
@@ -40,7 +40,6 @@ import {
 const rendermime = defaultRenderMime();
 const clipboard = new MimeData();
 const renderer = CodeMirrorNotebookPanelRenderer.defaultRenderer;
-const contextPromise = createNotebookContext();
 
 
 function createFactory(): NotebookWidgetFactory {
@@ -58,11 +57,12 @@ describe('notebook/notebook/widgetfactory', () => {
 
   let context: Context<INotebookModel>;
 
-  beforeEach((done) => {
-    contextPromise.then(c => {
-      context = c;
-      done();
-    });
+  beforeEach(() => {
+    context = createNotebookContext();
+  });
+
+  afterEach(() => {
+    context.dispose();
   });
 
   describe('NotebookWidgetFactory', () => {

--- a/test/src/notebook/output-area/model.spec.ts
+++ b/test/src/notebook/output-area/model.spec.ts
@@ -204,7 +204,7 @@ describe('notebook/output-area/model', () => {
       beforeEach((done) => {
         Kernel.startNew().then(k => {
           kernel = k;
-          return kernel.info();
+          return kernel.ready();
         }).then(() => {
           done();
         }).catch(done);

--- a/test/src/notebook/output-area/model.spec.ts
+++ b/test/src/notebook/output-area/model.spec.ts
@@ -204,7 +204,7 @@ describe('notebook/output-area/model', () => {
       beforeEach((done) => {
         Kernel.startNew().then(k => {
           kernel = k;
-          return kernel.kernelInfo();
+          return kernel.info();
         }).then(() => {
           done();
         }).catch(done);

--- a/test/src/notebook/tracker.spec.ts
+++ b/test/src/notebook/tracker.spec.ts
@@ -78,59 +78,50 @@ describe('notebook/tracker', () => {
         expect(tracker.activeCell).to.be(null);
       });
 
-      it('should be the active cell if a tracked notebook has one', (done) => {
+      it('should be the active cell if a tracked notebook has one', () => {
         let tracker = new NotebookTracker();
         let panel = new NotebookPanel({ rendermime, clipboard, renderer});
         tracker.add(panel);
         tracker.sync(panel);
-        createNotebookContext().then(context => {
-          panel.context = context;
-          panel.content.model.fromJSON(DEFAULT_CONTENT);
-          expect(tracker.activeCell).to.be.a(BaseCellWidget);
-          panel.dispose();
-          done();
-        }).catch(done);
+        panel.context = createNotebookContext();
+        panel.content.model.fromJSON(DEFAULT_CONTENT);
+        expect(tracker.activeCell).to.be.a(BaseCellWidget);
+        panel.dispose();
       });
 
     });
 
     describe('#activeCellChanged', () => {
 
-      it('should emit a signal when the active cell changes', (done) => {
+      it('should emit a signal when the active cell changes', () => {
         let tracker = new NotebookTracker();
         let panel = new NotebookPanel({ rendermime, clipboard, renderer });
         let count = 0;
         tracker.activeCellChanged.connect(() => { count++; });
-        createNotebookContext().then(context => {
-          panel.context = context;
-          panel.content.model.fromJSON(DEFAULT_CONTENT);
-          expect(count).to.be(0);
-          tracker.add(panel);
-          tracker.sync(panel);
-          expect(count).to.be(1);
-          panel.content.activeCellIndex = 1;
-          expect(count).to.be(2);
-          panel.dispose();
-          done();
-        }).catch(done);
+        panel.context = createNotebookContext();
+        panel.content.model.fromJSON(DEFAULT_CONTENT);
+        expect(count).to.be(0);
+        tracker.add(panel);
+        tracker.sync(panel);
+        expect(count).to.be(1);
+        panel.content.activeCellIndex = 1;
+        expect(count).to.be(2);
+        panel.dispose();
       });
 
     });
 
     describe('#onCurrentChanged()', () => {
 
-      it('should be called when the active cell changes', (done) => {
+      it('should be called when the active cell changes', () => {
         let tracker = new TestTracker();
         let panel = new NotebookPanel({ rendermime, clipboard, renderer});
         tracker.add(panel);
         tracker.sync(panel);
-        createNotebookContext().then(context => {
-          panel.context = context;
-          panel.content.model.fromJSON(DEFAULT_CONTENT);
-          expect(tracker.methods).to.contain('onCurrentChanged');
-          panel.dispose();
-          done();
-        }).catch(done);
+        panel.context = createNotebookContext();
+        panel.content.model.fromJSON(DEFAULT_CONTENT);
+        expect(tracker.methods).to.contain('onCurrentChanged');
+        panel.dispose();
       });
 
     });

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -100,6 +100,9 @@ export
 function acceptDialog(host: HTMLElement = document.body): Promise<void> {
   return waitForDialog(host).then(() => {
     let node = host.getElementsByClassName('jp-Dialog-okButton')[0];
+    if (!node) {
+      node = host.getElementsByClassName('jp-Dialog-warningButton')[0];
+    }
     if (node) {
       (node as HTMLElement).click();
     }

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -54,12 +54,11 @@ function defaultRenderMime(): RenderMime {
  * Create a context for a file.
  */
 export
-function createFileContext(path?: string): Promise<Context<DocumentRegistry.IModel>> {
-  return Private.servicePromise.then(manager => {
-    let factory = Private.textFactory;
-    path = path || utils.uuid() + '.txt';
-    return new Context({ manager, factory, path });
-  });
+function createFileContext(path?: string): Context<DocumentRegistry.IModel> {
+  let manager = Private.manager;
+  let factory = Private.textFactory;
+  path = path || utils.uuid() + '.txt';
+  return new Context({ manager, factory, path });
 }
 
 
@@ -67,12 +66,11 @@ function createFileContext(path?: string): Promise<Context<DocumentRegistry.IMod
  * Create a context for a notebook.
  */
 export
-function createNotebookContext(path?: string): Promise<Context<INotebookModel>> {
-  return Private.servicePromise.then(manager => {
-    let factory = Private.notebookFactory;
-    path = path || utils.uuid() + '.ipynb';
-    return new Context({ manager, factory, path });
-  });
+function createNotebookContext(path?: string): Context<INotebookModel> {
+  let manager = Private.manager;
+  let factory = Private.notebookFactory;
+  path = path || utils.uuid() + '.ipynb';
+  return new Context({ manager, factory, path });
 }
 
 
@@ -131,7 +129,7 @@ function dismissDialog(host: HTMLElement = document.body): Promise<void> {
  */
 namespace Private {
   export
-  const servicePromise: Promise<ServiceManager.IManager> = ServiceManager.create();
+  const manager = new ServiceManager();
 
   export
   const textFactory = new TextModelFactory();

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -54,8 +54,8 @@ function defaultRenderMime(): RenderMime {
  * Create a context for a file.
  */
 export
-function createFileContext(path?: string): Context<DocumentRegistry.IModel> {
-  let manager = Private.manager;
+function createFileContext(path?: string, manager?: ServiceManager.IManager): Context<DocumentRegistry.IModel> {
+  manager = manager || Private.manager;
   let factory = Private.textFactory;
   path = path || utils.uuid() + '.txt';
   return new Context({ manager, factory, path });
@@ -66,8 +66,8 @@ function createFileContext(path?: string): Context<DocumentRegistry.IModel> {
  * Create a context for a notebook.
  */
 export
-function createNotebookContext(path?: string): Context<INotebookModel> {
-  let manager = Private.manager;
+function createNotebookContext(path?: string, manager?: ServiceManager.IManager): Context<INotebookModel> {
+  manager = manager || Private.manager;
   let factory = Private.notebookFactory;
   path = path || utils.uuid() + '.ipynb';
   return new Context({ manager, factory, path });
@@ -100,9 +100,6 @@ export
 function acceptDialog(host: HTMLElement = document.body): Promise<void> {
   return waitForDialog(host).then(() => {
     let node = host.getElementsByClassName('jp-Dialog-okButton')[0];
-    if (!node) {
-      node = host.getElementsByClassName('jp-Dialog-warningButton')[0];
-    }
     if (node) {
       (node as HTMLElement).click();
     }


### PR DESCRIPTION
Fixes #1018.
Fixes #1199.

Also makes certain that we have the latest kernel specs before showing the switch kernel dialog.

Notes:
The classic notebook loads part of the notebook page before fetching the kernelspecs, but does so only once.
Freshly loading the kernelspecs before displaying a dialog causes a noticeable delay even on a local network.
The current Lab loads all of the kernel specs before showing anything, which is a poor user experience.

I think the right thing to do is:
 - load the UI before kernelspecs are available
 - make sure we have initial kernelspecs before letting any document actions get triggered
 - auto-refresh the kernelspecs once per minute, but have a command to trigger a refresh
 - Adding the forced refresh should go in a follow-on PR, as a button that is added to dialogs with kernel selection.