### PR TITLE
Set the output area font color to the default content color.

### DIFF
--- a/src/notebook/output-area/index.css
+++ b/src/notebook/output-area/index.css
@@ -62,6 +62,7 @@
 .jp-Output {
   display: flex;
   flex-direction: row;
+  color: var(--jp-content-font-color1);
 }
 
 


### PR DESCRIPTION
CC @ellisonbg - otherwise a dark theme has output that is black on black.