### PR TITLE
Removed bottom border under refresh control

### DIFF
--- a/src/running/index.css
+++ b/src/running/index.css
@@ -17,7 +17,6 @@
   flex: 0 0 auto;
   display: flex;
   flex-direction: row;
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
 }
 
 


### PR DESCRIPTION
Removed the bottom border under the refresh control to be consistent with the other action buttons within the left sidebar. See below difference:

#### Revised without bottom border
![screen shot 2016-11-08 at 4 04 05 pm](https://cloud.githubusercontent.com/assets/6437976/20122496/024be21a-a5cd-11e6-81ea-3115566e1b12.png)

#### Before with border
![screen shot 2016-11-08 at 4 03 39 pm](https://cloud.githubusercontent.com/assets/6437976/20122498/03b8e85a-a5cd-11e6-8898-457988893b50.png)
