### PR TITLE
Phosphor 0.7 upgrade fixes

### DIFF
--- a/src/about/plugin.ts
+++ b/src/about/plugin.ts
@@ -44,9 +44,8 @@ function activateAbout(app: JupyterLab, palette: ICommandPalette): void {
     execute: () => {
       if (!widget.isAttached) {
         app.shell.addToMainArea(widget);
-      } else {
-        app.shell.activateMain(widget.id);
       }
+      app.shell.activateMain(widget.id);
     }
   });
   palette.addItem({ command, category: 'Help' });

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -238,12 +238,12 @@ class ApplicationShell extends Widget {
    * Widgets must have a unique `id` property, which will be used as the DOM id.
    */
   addToMainArea(widget: Widget): void {
-    // TODO
     if (!widget.id) {
       console.error('widgets added to app shell must have unique id property');
       return;
     }
     this._dockPanel.addWidget(widget, { mode: 'tab-after' });
+    this._dockPanel.activateWidget(widget);
   }
 
   /**

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -97,16 +97,7 @@ class ApplicationShell extends Widget {
 
     let topPanel = this._topPanel = new Panel();
     let hboxPanel = this._hboxPanel = new BoxPanel();
-    let dockPanel = this._dockPanel = new DockPanel({
-      renderer: {
-        createTabBar: () => {
-          let bar = new TabBar();
-          bar.addClass('jp-mod-top');
-          return bar;
-        },
-        createHandle: DockPanel.defaultRenderer.createHandle
-      }
-    });
+    let dockPanel = this._dockPanel = new DockPanel();
     let hsplitPanel = this._hsplitPanel = new SplitPanel();
     let leftHandler = this._leftHandler = new SideBarHandler('left');
     let rightHandler = this._rightHandler = new SideBarHandler('right');

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -234,7 +234,6 @@ class ApplicationShell extends Widget {
       return;
     }
     this._dockPanel.addWidget(widget, { mode: 'tab-after' });
-    this._dockPanel.activateWidget(widget);
   }
 
   /**

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -97,7 +97,16 @@ class ApplicationShell extends Widget {
 
     let topPanel = this._topPanel = new Panel();
     let hboxPanel = this._hboxPanel = new BoxPanel();
-    let dockPanel = this._dockPanel = new DockPanel();
+    let dockPanel = this._dockPanel = new DockPanel({
+      renderer: {
+        createTabBar: () => {
+          let bar = new TabBar();
+          bar.addClass('jp-mod-top');
+          return bar;
+        },
+        createHandle: DockPanel.defaultRenderer.createHandle
+      }
+    });
     let hsplitPanel = this._hsplitPanel = new SplitPanel();
     let leftHandler = this._leftHandler = new SideBarHandler('left');
     let rightHandler = this._rightHandler = new SideBarHandler('right');

--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -16,11 +16,11 @@
 
 
 /*-----------------------------------------------------------------------------
-| TabBar
+| Tabs in the dock panel
 |----------------------------------------------------------------------------*/
 
 
-.p-TabBar {
+.p-DockPanel-tabBar {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
   overflow: visible;
   color: var(--jp-ui-font-color1);
@@ -28,28 +28,24 @@
 }
 
 
-.p-TabBar.p-mod-horizontal {
+.p-DockPanel-tabBar.p-mod-horizontal {
   min-height: calc(var(--jp-private-horizontal-tab-height) + 2 * var(--jp-border-width));
 }
 
 
-.p-TabBar.p-mod-vertical {
+.p-DockPanel-tabBar.p-mod-vertical {
   min-width: 80px;
 }
 
 
-.p-TabBar-content {
+.p-DockPanel-tabBar > .p-TabBar-content {
+  align-items: flex-end;
   min-width: 0;
   min-height: 0;
 }
 
 
-.p-TabBar > .p-TabBar-content {
-  align-items: flex-end;
-}
-
-
-.p-TabBar-tab {
+.p-DockPanel-tabBar .p-TabBar-tab {
   flex: 0 1 var(--jp-private-horizontal-tab-width);
   min-height: calc(var(--jp-private-horizontal-tab-height) + var(--jp-border-width));
   /* For some reason Firefox needs us to give a max-height as well...*/
@@ -66,18 +62,17 @@
 }
 
 
-.p-TabBar-tab:hover:not(.p-mod-current) {
+.p-DockPanel-tabBar .p-TabBar-tab:hover:not(.p-mod-current) {
   background: var(--jp-layout-color1);
 }
 
 
-.p-TabBar-tab:first-child {
+.p-DockPanel-tabBar .p-TabBar-tab:first-child {
   margin-left: 0;
 }
 
-/* .p-mod-current state */
-
-.p-TabBar-tab.p-mod-current {
+/* This is a current tab of a tab bar in the dock panel: each tab bar has 1. */
+.p-DockPanel-tabBar .p-TabBar-tab.p-mod-current {
   background: var(--jp-layout-color1);
   color: var(--jp-ui-font-color0);
   min-height: calc(var(--jp-private-horizontal-tab-height) + 2 * var(--jp-border-width));
@@ -85,61 +80,73 @@
 }
 
 
-.p-TabBar.p-mod-left .p-TabBar-tab,
-.p-TabBar.p-mod-right .p-TabBar-tab {
+/* This is the main application level current tab: only 1 exists. */
+.p-DockPanel-tabBar .p-TabBar-tab.jp-mod-current:before {
+  position: absolute;
+  top: calc(-1 * var(--jp-border-width));
+  left: calc(-1 * var(--jp-border-width));
+  content: '';
+  height: var(--jp-private-horizontal-tab-active-top-border);
+  width: calc(100% + 2*var(--jp-border-width));
+  background: var(--jp-brand-color1);
+}
+
+
+.p-DockPanel-tabBar .p-TabBar.p-mod-left .p-TabBar-tab,
+.p-DockPanel-tabBar .p-TabBar.p-mod-right .p-TabBar-tab {
   flex: 0 1 40px;
   margin-top: -1px;
   line-height: 40px;
 }
 
 
-.p-TabBar.p-mod-left .p-TabBar-tab {
+.p-DockPanel-tabBar .p-TabBar.p-mod-left .p-TabBar-tab {
   border-right: none;
 }
 
 
-.p-TabBar.p-mod-right .p-TabBar-tab {
+.p-DockPanel-tabBar .p-TabBar.p-mod-right .p-TabBar-tab {
   border-left: none;
 }
 
 
-.p-TabBar.p-mod-left .p-TabBar-tab:first-child,
-.p-TabBar.p-mod-right .p-TabBar-tab:first-child {
+.p-DockPanel-tabBar .p-TabBar.p-mod-left .p-TabBar-tab:first-child,
+.p-DockPanel-tabBar .p-TabBar.p-mod-right .p-TabBar-tab:first-child {
   margin-top: 0;
 }
 
 
-.p-TabBar.p-mod-left .p-TabBar-tab.p-mod-current,
-.p-TabBar.p-mod-right .p-TabBar-tab.p-mod-current {
+.p-DockPanel-tabBar .p-TabBar.p-mod-left .p-TabBar-tab.p-mod-current,
+.p-DockPanel-tabBar .p-TabBar.p-mod-right .p-TabBar-tab.p-mod-current {
   min-width: 80px;
   max-width: 80px;
 }
 
 
-.p-TabBar.p-mod-right .p-TabBar-tab.p-mod-current {
+.p-DockPanel-tabBar .p-TabBar.p-mod-right .p-TabBar-tab.p-mod-current {
   transform: translateX(-1px);
 }
 
 
-.p-TabBar-tabIcon,
-.p-TabBar-tabLabel,
-.p-TabBar-tabCloseIcon {
+.p-DockPanel-tabBar .p-TabBar-tabIcon,
+.p-DockPanel-tabBar .p-TabBar-tabLabel,
+.p-DockPanel-tabBar .p-TabBar-tabCloseIcon {
   display: inline-block;
 }
 
 
-.p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
+.p-DockPanel-tabBar .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
   margin-left: 4px;
 }
 
 
-.p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:before {
+.p-DockPanel-tabBar .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:before {
   content: '\f00d';  /* close */
   font-family: FontAwesome;
 }
 
 
-.p-TabBar-tab.p-mod-closable.jp-mod-dirty > .p-TabBar-tabCloseIcon:before {
+.p-DockPanel-tabBar .p-TabBar-tab.p-mod-closable.jp-mod-dirty > .p-TabBar-tabCloseIcon:before {
   font-family: FontAwesome;
   content: '\f111'; /* circle */
   font-size: 10px;
@@ -147,15 +154,16 @@
 
 
 .p-TabBar-tab.p-mod-drag-image {
-  min-height: var(--jp-private-horizontal-tab-height);
-  min-width: var(--jp-private-horizontal-tab-width);
-  line-height: var(--jp-private-horizontal-tab-height);
-  color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
   border: var(--jp-border-width) solid var(--jp-border-color1);
   border-top: var(--jp-border-width) solid var(--jp-brand-color1);
-  font-size: var(--jp-ui-font-size1);
   box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  line-height: var(--jp-private-horizontal-tab-height);
+  min-height: var(--jp-private-horizontal-tab-height);
+  min-width: var(--jp-private-horizontal-tab-width);
+  padding: 0px 10px;
   transform: translateX(-40%) translateY(-58%);
 }
 

--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -19,7 +19,6 @@
 | Tabs in the dock panel
 |----------------------------------------------------------------------------*/
 
-
 .p-DockPanel-tabBar {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
   overflow: visible;
@@ -48,8 +47,6 @@
 .p-DockPanel-tabBar .p-TabBar-tab {
   flex: 0 1 var(--jp-private-horizontal-tab-width);
   min-height: calc(var(--jp-private-horizontal-tab-height) + var(--jp-border-width));
-  /* For some reason Firefox needs us to give a max-height as well...*/
-  /*max-height: calc(var(--jp-private-horizontal-tab-height) + var(--jp-border-width));*/
   min-width: 35px;
   margin-left: calc(-1*var(--jp-border-width));
   line-height: var(--jp-private-horizontal-tab-height);
@@ -165,52 +162,4 @@
   min-width: var(--jp-private-horizontal-tab-width);
   padding: 0px 10px;
   transform: translateX(-40%) translateY(-58%);
-}
-
-
-/*-----------------------------------------------------------------------------
-| TabPanel
-|----------------------------------------------------------------------------*/
-
-
-.p-TabPanel-stackedPanel {
-  padding: 0px;
-  background: var(--jp-dockpanel-content-background);
-  border: var(--jp-border-width) solid #C0C0C0;
-}
-
-
-.p-TabPanel.p-mod-top-to-bottom > .p-TabPanel-stackedPanel {
-  border-top: none;
-}
-
-
-.p-TabPanel.p-mod-bottom-to-top > .p-TabPanel-stackedPanel {
-  border-bottom: none;
-}
-
-
-.p-TabPanel.p-mod-left-to-right > .p-TabPanel-stackedPanel {
-  border-left: none;
-}
-
-
-.p-TabPanel.p-mod-right-to-left > .p-TabPanel-stackedPanel {
-  border-right: none;
-}
-
-
-/*-----------------------------------------------------------------------------
-| Tabs in the dock panel
-|----------------------------------------------------------------------------*/
-
-
-.p-DockPanel-tabBar .p-TabBar-tab.jp-mod-current:before {
-  position: absolute;
-  top: calc(-1 * var(--jp-border-width));
-  left: calc(-1 * var(--jp-border-width));
-  content: '';
-  height: var(--jp-private-horizontal-tab-active-top-border);
-  width: calc(100% + 2*var(--jp-border-width));
-  background: var(--jp-brand-color1);
 }

--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -21,6 +21,7 @@
 
 
 .p-TabBar {
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
   overflow: visible;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
@@ -28,32 +29,12 @@
 
 
 .p-TabBar.p-mod-horizontal {
-  min-height: calc(var(--jp-private-horizontal-tab-height) + 2.0 * var(--jp-border-width));
+  min-height: calc(var(--jp-private-horizontal-tab-height) + 2 * var(--jp-border-width));
 }
 
 
 .p-TabBar.p-mod-vertical {
   min-width: 80px;
-}
-
-
-.p-TabBar.jp-mod-top {
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
-}
-
-
-.p-TabBar.jp-mod-bottom {
-  border-top: var(--jp-border-width) solid var(--jp-border-color1);
-}
-
-
-.p-TabBar.p-mod-left {
-  border-right: var(--jp-border-width) solid var(--jp-border-color1);
-}
-
-
-.p-TabBar.p-mod-right {
-  border-left: var(--jp-border-width) solid var(--jp-border-color1);
 }
 
 
@@ -63,32 +44,12 @@
 }
 
 
-.p-TabBar.jp-mod-top > .p-TabBar-content {
+.p-TabBar > .p-TabBar-content {
   align-items: flex-end;
 }
 
 
-.p-TabBar.jp-mod-bottom > .p-TabBar-content {
-  align-items: flex-start;
-}
-
-
-.p-TabBar-tab {
-  padding: 0px 10px;
-  background: var(--jp-layout-color2);
-  border: var(--jp-border-width) solid var(--jp-border-color1);
-  position: relative;
-  overflow: visible;
-}
-
-
-.p-TabBar-tab:hover:not(.p-mod-current) {
-  background: var(--jp-layout-color1);
-}
-
-
-.p-TabBar.jp-mod-top .p-TabBar-tab,
-.p-TabBar.jp-mod-bottom .p-TabBar-tab {
+.p-TabBar .p-TabBar-tab {
   flex: 0 1 var(--jp-private-horizontal-tab-width);
   min-height: calc(var(--jp-private-horizontal-tab-height) + var(--jp-border-width));
   /* For some reason Firefox needs us to give a max-height as well...*/
@@ -96,21 +57,21 @@
   min-width: 35px;
   margin-left: calc(-1*var(--jp-border-width));
   line-height: var(--jp-private-horizontal-tab-height);
-}
-
-
-.p-TabBar.jp-mod-top .p-TabBar-tab {
+  padding: 0px 10px;
+  background: var(--jp-layout-color2);
+  border: var(--jp-border-width) solid var(--jp-border-color1);
   border-bottom: none;
+  position: relative;
+  overflow: visible;
 }
 
 
-.p-TabBar.jp-mod-bottom .p-TabBar-tab {
-  border-top: none;
+.p-TabBar .p-TabBar-tab:hover:not(.p-mod-current) {
+  background: var(--jp-layout-color1);
 }
 
 
-.p-TabBar.jp-mod-top .p-TabBar-tab:first-child,
-.p-TabBar.jp-mod-bottom .p-TabBar-tab:first-child {
+.p-TabBar .p-TabBar-tab:first-child {
   margin-left: 0;
 }
 
@@ -118,26 +79,9 @@
 
 .p-TabBar-tab.p-mod-current {
   background: var(--jp-layout-color1);
-}
-
-
-.p-TabBar-tab.p-mod-current {
   color: var(--jp-ui-font-color0);
-}
-
-.p-TabBar.jp-mod-top .p-TabBar-tab.p-mod-current,
-.p-TabBar.jp-mod-bottom .p-TabBar-tab.p-mod-current {
-  min-height: calc(var(--jp-private-horizontal-tab-height) + 2*var(--jp-border-width));
-}
-
-
-.p-TabBar.jp-mod-top .p-TabBar-tab.p-mod-current {
+  min-height: calc(var(--jp-private-horizontal-tab-height) + 2 * var(--jp-border-width));
   transform: translateY(var(--jp-border-width));
-}
-
-
-.p-TabBar.jp-mod-bottom .p-TabBar-tab.p-mod-current {
-  transform: translateY(-1*var(--jp-border-width));
 }
 
 

--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -28,7 +28,7 @@
 
 
 .p-TabBar.p-mod-horizontal {
-  min-height: calc( var(--jp-private-horizontal-tab-height) + 2.0*var(--jp-border-width) );
+  min-height: calc(var(--jp-private-horizontal-tab-height) + 2.0 * var(--jp-border-width));
 }
 
 
@@ -37,12 +37,12 @@
 }
 
 
-.p-TabBar.p-mod-top {
+.p-TabBar.jp-mod-top {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
 }
 
 
-.p-TabBar.p-mod-bottom {
+.p-TabBar.jp-mod-bottom {
   border-top: var(--jp-border-width) solid var(--jp-border-color1);
 }
 
@@ -63,12 +63,12 @@
 }
 
 
-.p-TabBar.p-mod-top > .p-TabBar-content {
+.p-TabBar.jp-mod-top > .p-TabBar-content {
   align-items: flex-end;
 }
 
 
-.p-TabBar.p-mod-bottom > .p-TabBar-content {
+.p-TabBar.jp-mod-bottom > .p-TabBar-content {
   align-items: flex-start;
 }
 
@@ -87,8 +87,8 @@
 }
 
 
-.p-TabBar.p-mod-top .p-TabBar-tab,
-.p-TabBar.p-mod-bottom .p-TabBar-tab {
+.p-TabBar.jp-mod-top .p-TabBar-tab,
+.p-TabBar.jp-mod-bottom .p-TabBar-tab {
   flex: 0 1 var(--jp-private-horizontal-tab-width);
   min-height: calc(var(--jp-private-horizontal-tab-height) + var(--jp-border-width));
   /* For some reason Firefox needs us to give a max-height as well...*/
@@ -99,18 +99,18 @@
 }
 
 
-.p-TabBar.p-mod-top .p-TabBar-tab {
+.p-TabBar.jp-mod-top .p-TabBar-tab {
   border-bottom: none;
 }
 
 
-.p-TabBar.p-mod-bottom .p-TabBar-tab {
+.p-TabBar.jp-mod-bottom .p-TabBar-tab {
   border-top: none;
 }
 
 
-.p-TabBar.p-mod-top .p-TabBar-tab:first-child,
-.p-TabBar.p-mod-bottom .p-TabBar-tab:first-child {
+.p-TabBar.jp-mod-top .p-TabBar-tab:first-child,
+.p-TabBar.jp-mod-bottom .p-TabBar-tab:first-child {
   margin-left: 0;
 }
 
@@ -125,18 +125,18 @@
   color: var(--jp-ui-font-color0);
 }
 
-.p-TabBar.p-mod-top .p-TabBar-tab.p-mod-current,
-.p-TabBar.p-mod-bottom .p-TabBar-tab.p-mod-current {
+.p-TabBar.jp-mod-top .p-TabBar-tab.p-mod-current,
+.p-TabBar.jp-mod-bottom .p-TabBar-tab.p-mod-current {
   min-height: calc(var(--jp-private-horizontal-tab-height) + 2*var(--jp-border-width));
 }
 
 
-.p-TabBar.p-mod-top .p-TabBar-tab.p-mod-current {
+.p-TabBar.jp-mod-top .p-TabBar-tab.p-mod-current {
   transform: translateY(var(--jp-border-width));
 }
 
 
-.p-TabBar.p-mod-bottom .p-TabBar-tab.p-mod-current {
+.p-TabBar.jp-mod-bottom .p-TabBar-tab.p-mod-current {
   transform: translateY(-1*var(--jp-border-width));
 }
 

--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -49,7 +49,7 @@
 }
 
 
-.p-TabBar .p-TabBar-tab {
+.p-TabBar-tab {
   flex: 0 1 var(--jp-private-horizontal-tab-width);
   min-height: calc(var(--jp-private-horizontal-tab-height) + var(--jp-border-width));
   /* For some reason Firefox needs us to give a max-height as well...*/
@@ -66,12 +66,12 @@
 }
 
 
-.p-TabBar .p-TabBar-tab:hover:not(.p-mod-current) {
+.p-TabBar-tab:hover:not(.p-mod-current) {
   background: var(--jp-layout-color1);
 }
 
 
-.p-TabBar .p-TabBar-tab:first-child {
+.p-TabBar-tab:first-child {
   margin-left: 0;
 }
 

--- a/src/console/index.css
+++ b/src/console/index.css
@@ -14,7 +14,7 @@
   flex: 1 1 auto;
   flex-direction: column;
   border-top: var(--jp-border-width) solid var(--jp-border-color1);
-  margin-top: 4px;
+  margin-top: -1px;
 }
 
 

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -347,6 +347,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     panel.title.icon = `${LANDSCAPE_ICON_CLASS} ${CONSOLE_ICON_CLASS}`;
     panel.title.closable = true;
     app.shell.addToMainArea(panel);
+    app.shell.activateMain(panel.id);
     // Update the caption of the tab with the last execution time.
     panel.content.executed.connect((sender, executed) => {
       captionOptions.executed = executed;

--- a/src/editorwidget/index.css
+++ b/src/editorwidget/index.css
@@ -6,5 +6,5 @@
 
 .jp-EditorWidget {
     border-top: var(--jp-border-width) solid var(--jp-border-color1);
-    margin-top: 4px;
+    margin-top: -1px;
 }

--- a/src/faq/plugin.ts
+++ b/src/faq/plugin.ts
@@ -333,9 +333,8 @@ function activateFAQ(app: JupyterLab, palette: ICommandPalette): void {
     execute: () => {
       if (!widget.isAttached) {
         app.shell.addToMainArea(widget);
-      } else {
-        app.shell.activateMain(widget.id);
       }
+      app.shell.activateMain(widget.id);
     }
   });
 

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -105,11 +105,9 @@ function activateInspector(app: JupyterLab, palette: ICommandPalette): IInspecto
     if (!manager.inspector || manager.inspector.isDisposed) {
       manager.inspector = newInspector();
       app.shell.addToMainArea(manager.inspector);
-      return;
     }
     if (manager.inspector.isAttached) {
       app.shell.activateMain(manager.inspector.id);
-      return;
     }
   }
 

--- a/src/landing/index.css
+++ b/src/landing/index.css
@@ -6,7 +6,6 @@
 
 .jp-Landing {
   position: absolute;
-  z-index: 10000;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -139,9 +139,8 @@ function activateLanding(app: JupyterLab, services: IServiceManager, pathTracker
     execute: () => {
       if (!widget.isAttached) {
         app.shell.addToMainArea(widget);
-      } else {
-        app.shell.activateMain(widget.id);
       }
+      app.shell.activateMain(widget.id);
     }
   });
 
@@ -151,4 +150,5 @@ function activateLanding(app: JupyterLab, services: IServiceManager, pathTracker
   });
 
   app.shell.addToMainArea(widget);
+  app.shell.activateMain(widget.id);
 }

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -89,6 +89,7 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
       term.title.closable = true;
       term.title.icon = `${LANDSCAPE_ICON_CLASS} ${TERMINAL_ICON_CLASS}`;
       app.shell.addToMainArea(term);
+      app.shell.activateMain(term.id);
       tracker.add(term);
       let promise: Promise<TerminalSession.ISession>;
       if (name) {


### PR DESCRIPTION
- [x] Activates widgets that are added to the main area. (Fixes https://github.com/jupyterlab/jupyterlab/issues/1217)
- [x] Fixes tab layout:

**before:**
<img width="224" alt="old tab layout" src="https://cloud.githubusercontent.com/assets/159529/20198950/7a201f62-a79f-11e6-8acd-d9ed92acc6ea.png">

**after:**
<img width="342" alt="new tab layout" src="https://cloud.githubusercontent.com/assets/159529/20198956/7a4cb3b0-a79f-11e6-8f49-1ca7a031fcf7.png">

- [x] Fixes space above console:

**before:**
<img width="613" alt="console before" src="https://cloud.githubusercontent.com/assets/159529/20198951/7a200ed2-a79f-11e6-8807-4e1b9b9f754d.png">

**after:**
<img width="280" alt="screen shot 2016-11-10 at 11 41 45 pm" src="https://cloud.githubusercontent.com/assets/159529/20198955/7a4b9db8-a79f-11e6-97e2-01246c352572.png">

- [x] Fixes #1216 space above text editor:

**before:**
<img width="507" alt="text editor before" src="https://cloud.githubusercontent.com/assets/159529/20198953/7a3d3584-a79f-11e6-8b03-521eeb5bad83.png">

**after:**
<img width="342" alt="text editor after" src="https://cloud.githubusercontent.com/assets/159529/20198957/7a503152-a79f-11e6-8ea8-495da00ae50d.png">

- [x] Fixes overlay being covered up by landing:

**before:**
<img src="https://cloud.githubusercontent.com/assets/159529/20198954/7a4014c0-a79f-11e6-820c-8ac9a3ad7bbf.png">

**after:**
<img src="https://cloud.githubusercontent.com/assets/159529/20198958/7a567ab2-a79f-11e6-8d45-b0fb64e10e79.png">
