### PR TITLE
Implement a way to save component state that persists after refresh.

### DIFF
--- a/examples/lab/index.js
+++ b/examples/lab/index.js
@@ -37,6 +37,7 @@ lab.registerPlugins([
   require('jupyterlab/lib/running/plugin').runningSessionsExtension,
   require('jupyterlab/lib/services/plugin').servicesProvider,
   require('jupyterlab/lib/shortcuts/plugin').shortcutsExtension,
+  require('jupyterlab/lib/statedb/plugin').stateProvider,
   require('jupyterlab/lib/terminal/plugin').terminalExtension
 ]);
 

--- a/jupyterlab/extensions.js
+++ b/jupyterlab/extensions.js
@@ -27,5 +27,6 @@ module.exports = [
   require('../lib/running/plugin').runningSessionsExtension,
   require('../lib/services/plugin').servicesProvider,
   require('../lib/shortcuts/plugin').shortcutsExtension,
+  require('../lib/statedb/plugin').stateProvider,
   require('../lib/terminal/plugin').terminalExtension
 ];

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -41,6 +41,10 @@ class JupyterLab extends Application<ApplicationShell> {
    * Start the JupyterLab application.
    */
   start(options: Application.IStartOptions = {}): Promise<void> {
+    if (this._startedFlag) {
+      return Promise.resolve(void 0);
+    }
+    this._startedFlag = true;
     return super.start(options).then(() => { this._startedResolve(); });
   }
 
@@ -51,6 +55,7 @@ class JupyterLab extends Application<ApplicationShell> {
     return new ApplicationShell();
   }
 
-  private _startedResolve: () => void;
+  private _startedFlag = false;
   private _startedPromise: Promise<void> = null;
+  private _startedResolve: () => void = null;
 }

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  utils
+} from '@jupyterlab/services';
+
+import {
   Application
 } from 'phosphor/lib/ui/application';
 
@@ -23,18 +27,10 @@ type JupyterLabPlugin<T> = Application.IPlugin<JupyterLab, T>;
 export
 class JupyterLab extends Application<ApplicationShell> {
   /**
-   * Create a new JupyterLab instance.
-   */
-  constructor() {
-    super();
-    this._startedPromise = new Promise(fn => { this._startedResolve = fn; });
-  }
-
-  /**
    * A promise that resolves when the JupyterLab application is started.
    */
   get started(): Promise<void> {
-    return this._startedPromise;
+    return this._startedDelegate.promise;
   }
 
   /**
@@ -45,7 +41,9 @@ class JupyterLab extends Application<ApplicationShell> {
       return Promise.resolve(void 0);
     }
     this._startedFlag = true;
-    return super.start(options).then(() => { this._startedResolve(); });
+    return super.start(options).then(() => {
+      this._startedDelegate.resolve(void 0);
+    });
   }
 
   /**
@@ -55,7 +53,6 @@ class JupyterLab extends Application<ApplicationShell> {
     return new ApplicationShell();
   }
 
+  private _startedDelegate = new utils.PromiseDelegate<void>();
   private _startedFlag = false;
-  private _startedPromise: Promise<void> = null;
-  private _startedResolve: () => void = null;
 }

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -23,9 +23,34 @@ type JupyterLabPlugin<T> = Application.IPlugin<JupyterLab, T>;
 export
 class JupyterLab extends Application<ApplicationShell> {
   /**
+   * Create a new JupyterLab instance.
+   */
+  constructor() {
+    super();
+    this._startedPromise = new Promise(fn => { this._startedResolve = fn; });
+  }
+
+  /**
+   * A promise that resolves when the JupyterLab application is started.
+   */
+  get started(): Promise<void> {
+    return this._startedPromise;
+  }
+
+  /**
+   * Start the JupyterLab application.
+   */
+  start(options: Application.IStartOptions = {}): Promise<void> {
+    return super.start(options).then(() => { this._startedResolve(); });
+  }
+
+  /**
    * Create the application shell for the JupyterLab application.
    */
   protected createShell(): ApplicationShell {
     return new ApplicationShell();
   }
+
+  private _startedResolve: () => void;
+  private _startedPromise: Promise<void> = null;
 }

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -6,10 +6,6 @@ import {
 } from '@jupyterlab/services';
 
 import {
-  find
-} from 'phosphor/lib/algorithm/searching';
-
-import {
   JSONObject
 } from 'phosphor/lib/algorithm/json';
 
@@ -328,9 +324,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
    */
   function createConsole(session: Session.ISession, name: string): void {
     let panel = new ConsolePanel({
-      session,
-      rendermime: rendermime.clone(),
-      renderer: renderer
+      session, rendermime: rendermime.clone(), renderer
     });
     let specs = manager.specs;
     let displayName = specs.kernelspecs[session.kernel.name].display_name;

--- a/src/statedb/index.ts
+++ b/src/statedb/index.ts
@@ -35,8 +35,8 @@ interface IStateDB {
    * The `id` values of stored items in the state database are formatted:
    * `'namespace:identifier'`, which is the same convention that command
    * identifiers in JupyterLab use as well. While this is not a technical
-   * requirement for `fetch()` and `save()`, it *is* necessary for using the
-   * `fetchNamespace()` method.
+   * requirement for `fetch()`, `remove()`, and `save()`, it *is* necessary for
+   * using the `fetchNamespace()` method.
    *
    * The promise returned by this method may be rejected if an error occurs in
    * retrieving the data. Non-existence of an `id` will succeed, however.
@@ -62,6 +62,15 @@ interface IStateDB {
   fetchNamespace(namespace: string): Promise<JSONValue[]>;
 
   /**
+   * Remove a value from the database.
+   *
+   * @param id - The identifier for the data being removed.
+   *
+   * @returns A promise that is rejected if remove fails and succeeds otherwise.
+   */
+  remove(id: string): Promise<void>;
+
+  /**
    * Save a value in the database.
    *
    * @param id - The identifier for the data being saved.
@@ -74,8 +83,8 @@ interface IStateDB {
    * The `id` values of stored items in the state database are formatted:
    * `'namespace:identifier'`, which is the same convention that command
    * identifiers in JupyterLab use as well. While this is not a technical
-   * requirement for `fetch()` and `save()`, it *is* necessary for using the
-   * `fetchNamespace()` method.
+   * requirement for `fetch()`, `remove()`, and `save()`, it *is* necessary for
+   * using the `fetchNamespace()` method.
    */
   save(id: string, data: JSONValue): Promise<void>;
 }

--- a/src/statedb/index.ts
+++ b/src/statedb/index.ts
@@ -25,6 +25,11 @@ const IStateDB = new Token<IStateDB>('jupyter.services.statedb');
 export
 interface IStateDB {
   /**
+   * The maximum allowed length of the data after it has been serialized.
+   */
+  readonly maxLength: number;
+
+  /**
    * Retrieve a saved bundle from the database.
    *
    * @param id - The identifier used to save retrieve a data bundle.

--- a/src/statedb/index.ts
+++ b/src/statedb/index.ts
@@ -51,6 +51,21 @@ interface ISaveBundle {
  */
 export
 interface IStateDB {
-  fetch(): Promise<ISaveBundle>;
-  save(): Promise<void>;
+  /**
+   * Retrieve a saved bundle from the database.
+   *
+   * #### Notes
+   * If a namespace is not provided, the default value will be `'statedb'`.
+   */
+  fetch(id: string, namespace?: string): Promise<ISaveBundle>;
+
+  /**
+   * Retrieve all the saved bundles for a namespace.
+   */
+  fetchNamespace(namespace: string): Promise<ISaveBundle[]>;
+
+  /**
+   * Save a bundle in the database.
+   */
+  save(bundle: ISaveBundle): Promise<void>;
 }

--- a/src/statedb/index.ts
+++ b/src/statedb/index.ts
@@ -20,33 +20,6 @@ const IStateDB = new Token<IStateDB>('jupyter.services.statedb');
 
 
 /**
- * The value that is saved and retrieved from the database.
- */
-export
-interface ISaveBundle {
-  /**
-   * The identifier used to save retrieve a data bundle.
-   */
-  id: string;
-
-  /**
-   * The actual value being stored or retrieved.
-   */
-  data: JSONValue;
-
-  /**
-   * An optional namespace to help categories saved bundles.
-   *
-   * #### Notes
-   * If a namespace is not provided, the default value will be `'statedb'`. An
-   * example of a namespace value would be a widget type, e.g., `'notebook'` or
-   * `'console'`.
-   */
-  namespace?: string;
-}
-
-
-/**
  * The description of a state database.
  */
 export
@@ -56,30 +29,53 @@ interface IStateDB {
    *
    * @param id - The identifier used to save retrieve a data bundle.
    *
-   * @param namespace - An optional namespace to help categories saved bundles.
-   *
-   * @returns A promise that bears a saved bundle or rejects if unavailable.
+   * @returns A promise that bears a data payload if available.
    *
    * #### Notes
-   * If a namespace is not provided, the default value will be `'statedb'`.
+   * The `id` values of stored items in the state database are formatted:
+   * `'namespace:identifier'`, which is the same convention that command
+   * identifiers in JupyterLab use as well. While this is not a technical
+   * requirement for `fetch()` and `save()`, it *is* necessary for using the
+   * `fetchNamespace()` method.
+   *
+   * The promise returned by this method may be rejected if an error occurs in
+   * retrieving the data. Non-existence of an `id` will succeed, however.
    */
-  fetch(id: string, namespace?: string): Promise<ISaveBundle>;
+  fetch(id: string): Promise<JSONValue>;
 
   /**
    * Retrieve all the saved bundles for a namespace.
    *
    * @param namespace - The namespace to retrieve.
    *
-   * @returns A promise that bears a collection of saved bundles.
+   * @returns A promise that bears a collection data payloads for a namespace.
+   *
+   * #### Notes
+   * Namespaces are entirely conventional entities. The `id` values of stored
+   * items in the state database are formatted: `'namespace:identifier'`, which
+   * is the same convention that command identifiers in JupyterLab use as well.
+   *
+   * If there are any errors in retrieving the data, they will be logged to the
+   * console in order to optimistically return any extant data without failing.
+   * This promise will always succeed.
    */
-  fetchNamespace(namespace: string): Promise<ISaveBundle[]>;
+  fetchNamespace(namespace: string): Promise<JSONValue[]>;
 
   /**
-   * Save a bundle in the database.
+   * Save a value in the database.
    *
-   * @param bundle - The bundle being saved.
+   * @param id - The identifier for the data being saved.
+   *
+   * @param data - The data being saved.
    *
    * @returns A promise that is rejected if saving fails and succeeds otherwise.
+   *
+   * #### Notes
+   * The `id` values of stored items in the state database are formatted:
+   * `'namespace:identifier'`, which is the same convention that command
+   * identifiers in JupyterLab use as well. While this is not a technical
+   * requirement for `fetch()` and `save()`, it *is* necessary for using the
+   * `fetchNamespace()` method.
    */
-  save(bundle: ISaveBundle): Promise<void>;
+  save(id: string, data: JSONValue): Promise<void>;
 }

--- a/src/statedb/index.ts
+++ b/src/statedb/index.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
+
+
+/* tslint:disable */
+/**
+ * The default state database token.
+ */
+export
+const IStateDB = new Token<IStateDB>('jupyter.services.statedb');
+/* tslint:enable */
+
+
+/**
+ * The description of a state database.
+ */
+export
+interface IStateDB {
+  fetch(): Promise<void>;
+  save(): Promise<void>;
+}

--- a/src/statedb/index.ts
+++ b/src/statedb/index.ts
@@ -58,7 +58,7 @@ interface IStateDB {
    *
    * @param namespace - An optional namespace to help categories saved bundles.
    *
-   * @returns A promise that bears a the saved bundle.
+   * @returns A promise that bears a saved bundle or rejects if unavailable.
    *
    * #### Notes
    * If a namespace is not provided, the default value will be `'statedb'`.

--- a/src/statedb/index.ts
+++ b/src/statedb/index.ts
@@ -54,6 +54,12 @@ interface IStateDB {
   /**
    * Retrieve a saved bundle from the database.
    *
+   * @param id - The identifier used to save retrieve a data bundle.
+   *
+   * @param namespace - An optional namespace to help categories saved bundles.
+   *
+   * @returns A promise that bears a the saved bundle.
+   *
    * #### Notes
    * If a namespace is not provided, the default value will be `'statedb'`.
    */
@@ -61,11 +67,19 @@ interface IStateDB {
 
   /**
    * Retrieve all the saved bundles for a namespace.
+   *
+   * @param namespace - The namespace to retrieve.
+   *
+   * @returns A promise that bears a collection of saved bundles.
    */
   fetchNamespace(namespace: string): Promise<ISaveBundle[]>;
 
   /**
    * Save a bundle in the database.
+   *
+   * @param bundle - The bundle being saved.
+   *
+   * @returns A promise that is rejected if saving fails and succeeds otherwise.
    */
   save(bundle: ISaveBundle): Promise<void>;
 }

--- a/src/statedb/index.ts
+++ b/src/statedb/index.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  JSONValue
+} from 'phosphor/lib/algorithm/json';
+
+import {
   Token
 } from 'phosphor/lib/core/token';
 
@@ -16,10 +20,37 @@ const IStateDB = new Token<IStateDB>('jupyter.services.statedb');
 
 
 /**
+ * The value that is saved and retrieved from the database.
+ */
+export
+interface ISaveBundle {
+  /**
+   * The identifier used to save retrieve a data bundle.
+   */
+  id: string;
+
+  /**
+   * The actual value being stored or retrieved.
+   */
+  data: JSONValue;
+
+  /**
+   * An optional namespace to help categories saved bundles.
+   *
+   * #### Notes
+   * If a namespace is not provided, the default value will be `'statedb'`. An
+   * example of a namespace value would be a widget type, e.g., `'notebook'` or
+   * `'console'`.
+   */
+  namespace?: string;
+}
+
+
+/**
  * The description of a state database.
  */
 export
 interface IStateDB {
-  fetch(): Promise<void>;
+  fetch(): Promise<ISaveBundle>;
   save(): Promise<void>;
 }

--- a/src/statedb/plugin.ts
+++ b/src/statedb/plugin.ts
@@ -11,6 +11,12 @@ import {
 
 
 /**
+ * The default namespace used by the application state database.
+ */
+const NAMESPACE = 'statedb';
+
+
+/**
  * The default state database for storing application state.
  */
 export
@@ -32,13 +38,18 @@ class StateDB implements IStateDB {
    *
    * @param namespace - An optional namespace to help categories saved bundles.
    *
-   * @returns A promise that bears a the saved bundle.
+   * @returns A promise that bears a saved bundle or rejects if unavailable.
    *
    * #### Notes
    * If a namespace is not provided, the default value will be `'statedb'`.
    */
   fetch(id: string, namespace?: string): Promise<ISaveBundle> {
-    return null;
+    let key = `${namespace || NAMESPACE}:${id}`;
+    try {
+      return Promise.resolve(JSON.parse(window.localStorage.getItem(key)));
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   /**
@@ -49,7 +60,18 @@ class StateDB implements IStateDB {
    * @returns A promise that bears a collection of saved bundles.
    */
   fetchNamespace(namespace: string): Promise<ISaveBundle[]> {
-    return null;
+    let bundles: ISaveBundle[] = [];
+    for (let i = 0, len = window.localStorage.length; i < len; i++) {
+      let key = window.localStorage.key(i);
+      if (key.indexOf(`${key}:`) === 0) {
+        try {
+          bundles.push(JSON.parse(window.localStorage.getItem(key)));
+        } catch (error) {
+          console.warn(error);
+        }
+      }
+    }
+    return Promise.resolve(bundles);
   }
 
   /**
@@ -60,6 +82,8 @@ class StateDB implements IStateDB {
    * @returns A promise that is rejected if saving fails and succeeds otherwise.
    */
   save(bundle: ISaveBundle): Promise<void> {
-    return null;
+    let key = `${bundle.namespace || NAMESPACE}:${bundle.id}`;
+    window.localStorage.setItem(key, JSON.stringify(bundle));
+    return Promise.resolve(void 0);
   }
 }

--- a/src/statedb/plugin.ts
+++ b/src/statedb/plugin.ts
@@ -40,8 +40,8 @@ class StateDB implements IStateDB {
    * The `id` values of stored items in the state database are formatted:
    * `'namespace:identifier'`, which is the same convention that command
    * identifiers in JupyterLab use as well. While this is not a technical
-   * requirement for `fetch()` and `save()`, it *is* necessary for using the
-   * `fetchNamespace()` method.
+   * requirement for `fetch()`, `remove()`, and `save()`, it *is* necessary for
+   * using the `fetchNamespace()` method.
    *
    * The promise returned by this method may be rejected if an error occurs in
    * retrieving the data. Non-existence of an `id` will succeed, however.
@@ -86,6 +86,18 @@ class StateDB implements IStateDB {
   }
 
   /**
+   * Remove a value from the database.
+   *
+   * @param id - The identifier for the data being removed.
+   *
+   * @returns A promise that is rejected if remove fails and succeeds otherwise.
+   */
+  remove(id: string): Promise<void> {
+    window.localStorage.removeItem(id);
+    return Promise.resolve(void 0);
+  }
+
+  /**
    * Save a value in the database.
    *
    * @param id - The identifier for the data being saved.
@@ -98,8 +110,8 @@ class StateDB implements IStateDB {
    * The `id` values of stored items in the state database are formatted:
    * `'namespace:identifier'`, which is the same convention that command
    * identifiers in JupyterLab use as well. While this is not a technical
-   * requirement for `fetch()` and `save()`, it *is* necessary for using the
-   * `fetchNamespace()` method.
+   * requirement for `fetch()`, `remove()`, and `save()`, it *is* necessary for
+   * using the `fetchNamespace()` method.
    */
   save(id: string, data: JSONValue): Promise<void> {
     window.localStorage.setItem(id, JSON.stringify(data));

--- a/src/statedb/plugin.ts
+++ b/src/statedb/plugin.ts
@@ -32,7 +32,7 @@ class StateDB implements IStateDB {
   /**
    * The maximum allowed length of the data after it has been serialized.
    */
-  readonly maxLength = 2048;
+  readonly maxLength = 2000;
 
   /**
    * Retrieve a saved bundle from the database.
@@ -124,7 +124,7 @@ class StateDB implements IStateDB {
       let length = serialized.length;
       let max = this.maxLength;
       if (length > max) {
-        throw new Error(`serialized data (${length}) exceeds maximum (${max})`);
+        throw new Error(`Serialized data (${length}) exceeds maximum (${max})`);
       }
       window.localStorage.setItem(id, serialized);
       return Promise.resolve(void 0);

--- a/src/statedb/plugin.ts
+++ b/src/statedb/plugin.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  JupyterLab, JupyterLabPlugin
+} from '../application';
+
+import {
+  ISaveBundle, IStateDB
+} from './index';
+
+
+/**
+ * The default state database for storing application state.
+ */
+export
+const stateProvider: JupyterLabPlugin<IStateDB> = {
+  id: 'jupyter.providers.statedb',
+  activate: (app: JupyterLab): IStateDB => new StateDB(),
+  autoStart: true
+};
+
+
+/**
+ * The default concrete implementation of a state database.
+ */
+class StateDB implements IStateDB {
+  /**
+   * Retrieve a saved bundle from the database.
+   *
+   * @param id - The identifier used to save retrieve a data bundle.
+   *
+   * @param namespace - An optional namespace to help categories saved bundles.
+   *
+   * @returns A promise that bears a the saved bundle.
+   *
+   * #### Notes
+   * If a namespace is not provided, the default value will be `'statedb'`.
+   */
+  fetch(id: string, namespace?: string): Promise<ISaveBundle> {
+    return null;
+  }
+
+  /**
+   * Retrieve all the saved bundles for a namespace.
+   *
+   * @param namespace - The namespace to retrieve.
+   *
+   * @returns A promise that bears a collection of saved bundles.
+   */
+  fetchNamespace(namespace: string): Promise<ISaveBundle[]> {
+    return null;
+  }
+
+  /**
+   * Save a bundle in the database.
+   *
+   * @param bundle - The bundle being saved.
+   *
+   * @returns A promise that is rejected if saving fails and succeeds otherwise.
+   */
+  save(bundle: ISaveBundle): Promise<void> {
+    return null;
+  }
+}

--- a/src/statedb/plugin.ts
+++ b/src/statedb/plugin.ts
@@ -19,9 +19,10 @@ import {
  */
 export
 const stateProvider: JupyterLabPlugin<IStateDB> = {
-  id: 'jupyter.providers.statedb',
-  activate: () => new StateDB(),
-  autoStart: true
+  id: 'jupyter.services.statedb',
+  activate: (): IStateDB => new StateDB(),
+  autoStart: true,
+  provides: IStateDB
 };
 
 

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -89,12 +89,7 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
     tracker.sync(args.newValue);
   });
 
-  // Reload any terminals whose state has been stored.
-  state.fetchNamespace(NAMESPACE).then(terms => {
-    let create = 'terminal:create-new';
-    terms.forEach(name => { app.commands.execute(create, { name }); });
-  });
-
+  // Add terminal commands.
   commands.addCommand(newTerminalId, {
     label: 'New Terminal',
     caption: 'Start a new terminal session',
@@ -173,6 +168,14 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
     }
   });
 
+  // Reload any terminals whose state has been stored.
+  Promise.all([state.fetchNamespace(NAMESPACE), app.started])
+    .then(([terms]) => {
+      let create = 'terminal:create-new';
+      terms.forEach(name => { app.commands.execute(create, { name }); });
+    });
+
+  // Add command palette items.
   let category = 'Terminal';
   [
     newTerminalId,
@@ -181,6 +184,7 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
     toggleTerminalTheme
   ].forEach(command => palette.addItem({ command, category }));
 
+  // Add menu items.
   let menu = new Menu({ commands, keymap });
   menu.title.label = 'Terminal';
   menu.addItem({ command: newTerminalId });


### PR DESCRIPTION
- [x] This PR introduces the concept of a state database (`interface IStateDB`) that can be used to persistently store state data by different JupyterLab plugins.
- [x] Use the state database store the paths of all open notebooks so that they re-open upon page refresh.
- [x] Use the state database to store the names of all terminal sessions so that they re-open upon page refresh.
- [x] Use the state database to store the IDs of all console sessions so that they re-open upon page refresh.
- [x] The core `JupyterLab extends Application` class now has a `started` attribute that is a `Promise` that resolves after the application has started and has finished loading the initial set of launch plugins.