### PR TITLE
SVG should not be sanitizable

### DIFF
--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -162,7 +162,7 @@ class SVGRenderer implements RenderMime.IRenderer {
    * Whether the input can safely sanitized for a given mimetype.
    */
   isSanitizable(mimetype: string): boolean {
-    return this.mimetypes.indexOf(mimetype) !== -1;
+    return false;
   }
 
   /**

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -285,11 +285,7 @@ class RenderedSVG extends Widget {
 
   constructor(options: RenderMime.IRendererOptions<string>) {
     super();
-    let source = options.source;
-    if (options.sanitizer) {
-      source = options.sanitizer.sanitize(source);
-    }
-    this.node.innerHTML = source;
+    this.node.innerHTML = options.source;
     let svgElement = this.node.getElementsByTagName('svg')[0];
     if (!svgElement) {
       throw new Error('SVGRender: Error: Failed to create <svg> element');

--- a/test/src/renderers/renderers.spec.ts
+++ b/test/src/renderers/renderers.spec.ts
@@ -237,9 +237,9 @@ describe('renderers', () => {
 
     describe('#isSanitizable()', () => {
 
-      it('should be `true`', () => {
+      it('should be `false`', () => {
         let t = new SVGRenderer();
-        expect(t.isSanitizable('image/svg+xml')).to.be(true);
+        expect(t.isSanitizable('image/svg+xml')).to.be(false);
       });
 
     });
@@ -261,15 +261,6 @@ describe('renderers', () => {
         let w = t.render({ mimetype: 'image/svg+xml', source });
         let svgEl = w.node.getElementsByTagName('svg')[0];
         expect(svgEl).to.be.ok();
-      });
-
-      it('should sanitize when a sanitizer is given', () => {
-        const source = '<svg><script>window.x = 1</script></svg>';
-        let t = new SVGRenderer();
-        let w = t.render({
-          mimetype: 'image/svg+xml', source, sanitizer: defaultSanitizer
-        });
-        expect(w.node.innerHTML).to.be('<svg></svg>');
       });
 
     });

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -98,16 +98,6 @@ describe('rendermime/index', () => {
         expect(widget.node.innerHTML).to.be('<h1>foo </h1>');
       });
 
-      it('should sanitize svg', () => {
-        let bundle: RenderMime.MimeMap<string> = {
-          'image/svg+xml': '<svg><script>windox.x=1</script></svg>'
-        };
-        let r = defaultRenderMime();
-        let widget = r.render({ bundle });
-        expect(widget.node.innerHTML.indexOf('svg')).to.not.be(-1);
-        expect(widget.node.innerHTML.indexOf('script')).to.be(-1);
-      });
-
       it('should render json data', () => {
         let bundle: RenderMime.MimeMap<JSONObject> = {
           'application/json': { 'foo': 1 }


### PR DESCRIPTION
Fixes #1212, matches classic notebook behavior.

![image](https://cloud.githubusercontent.com/assets/2096628/20355051/a36b474e-abe5-11e6-8ed3-0939b6b03110.png)
