### PR TITLE
Make Github link open in a new tab.

### DIFF
--- a/src/about/index.ts
+++ b/src/about/index.ts
@@ -251,7 +251,7 @@ class AboutWidget extends VDomWidget<AboutModel> {
             h.b(headerText[2])
           ),
           h.p(headerText[3],
-            h.a({href: headerText[4]}, headerText[4]),
+            h.a({href: headerText[4], target: '_blank'}, headerText[4]),
             headerText[5]
           ),
           h.p(headerText[6])


### PR DESCRIPTION
Forgot to add this in yesterday. Links should open in a new tab to avoid potentially losing work.