### PR TITLE
Update instance tracker to allow for automatic save/restore behavior.

### DIFF
--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -66,12 +66,12 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     this._restore = options.restore;
     if (this._restore) {
       let { command, namespace, registry, state, when } = this._restore;
-      Promise.all([state.fetchNamespace(namespace), when]).then(([saved]) => {
+      let promises = [state.fetchNamespace(namespace)].concat(when);
+      Promise.all(promises).then(([saved]) => {
         saved.forEach(args => {
-          registry.execute(command, args.value).catch(() => {
-            // If the command fails, delete the state restore data.
-            state.remove(args.id);
-          });
+          // Execute the command and if it fails, delete the state restore data.
+          registry.execute(command, args.value)
+            .catch(() => { state.remove(args.id); });
         });
       });
     }
@@ -286,7 +286,7 @@ namespace InstanceTracker {
     /**
      * The point after which it is safe to restore state.
      */
-    when: Promise<void>;
+    when: Promise<any> | Array<Promise<any>>;
   }
 
   /**

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -202,11 +202,14 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     let oldName = Private.nameProperty.get(widget);
     let newName = this._restore.name(widget);
 
-    if (oldName !== newName) {
+    if (oldName && oldName !== newName) {
       state.remove(oldName);
       Private.nameProperty.set(widget, newName);
     }
-    state.save(newName, this._restore.args(widget));
+
+    if (newName) {
+      state.save(newName, this._restore.args(widget));
+    }
   }
 
   /**

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -198,14 +198,17 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
       return;
     }
 
-    let { state } = this._restore;
+    let { namespace, state } = this._restore;
+    let widgetName = this._restore.name(widget);
     let oldName = Private.nameProperty.get(widget);
-    let newName = this._restore.name(widget);
+    let newName = widgetName ? `${namespace}:${widgetName}` : null;
 
     if (oldName && oldName !== newName) {
       state.remove(oldName);
-      Private.nameProperty.set(widget, newName);
     }
+
+    // Set the name property irrespective of whether the new name is null.
+    Private.nameProperty.set(widget, newName);
 
     if (newName) {
       state.save(newName, this._restore.args(widget));

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -112,9 +112,13 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     // Handle widget state restoration.
     if (this._restore) {
       let { namespace, state } = this._restore;
-      let name = `${namespace}:${this._restore.name(widget)}`;
-      Private.nameProperty.set(widget, name);
-      state.save(name, this._restore.args(widget));
+      let widgetName = this._restore.name(widget);
+
+      if (widgetName) {
+        let name = `${namespace}:${widgetName}`;
+        Private.nameProperty.set(widget, name);
+        state.save(name, this._restore.args(widget));
+      }
     }
 
     // Handle widget disposal.
@@ -123,7 +127,11 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
       // If restore data was saved, delete it from the database.
       if (this._restore) {
         let { state } = this._restore;
-        state.remove(Private.nameProperty.get(widget));
+        let name = Private.nameProperty.get(widget);
+
+        if (name) {
+          state.remove(name);
+        }
       }
       // If this was the last widget being disposed, emit null.
       if (!this._widgets.size) {

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -127,7 +127,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   let command: string;
   let menu = new Menu({ commands, keymap });
 
-  // Create an instance tracker for all terminal widgets.
+  // Create an instance tracker for all console panels.
   const tracker = new InstanceTracker<ConsolePanel>({
     restore: {
       state,

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -383,7 +383,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       items.forEach(item => {
         app.commands.execute('console:create', item.value).catch(() => {
           // Remove console from the state database if session does not exist.
-          state.remove(`${NAMESPACE}:${item.id}`);
+          state.remove(item.id);
         });
       });
   });

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -53,6 +53,7 @@ function activateCSVWidget(app: JupyterLab, registry: IDocumentRegistry, state: 
       state,
       command: 'file-operations:open',
       args: widget => ({ path: widget.context.path }),
+      name: widget => widget.context.path,
       namespace: 'csvwidgets',
       when: app.started,
       registry: app.commands

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -43,8 +43,9 @@ const csvHandlerExtension: JupyterLabPlugin<void> = {
  * Activate the table widget extension.
  */
 function activateCSVWidget(app: JupyterLab, registry: IDocumentRegistry, state: IStateDB): void {
+  const factoryName = 'Table';
   const factory = new CSVWidgetFactory({
-    name: 'Table',
+    name: factoryName,
     fileExtensions: ['.csv'],
     defaultFor: ['.csv']
   });
@@ -52,7 +53,7 @@ function activateCSVWidget(app: JupyterLab, registry: IDocumentRegistry, state: 
     restore: {
       state,
       command: 'file-operations:open',
-      args: widget => ({ path: widget.context.path }),
+      args: widget => ({ path: widget.context.path, factory: factoryName }),
       name: widget => widget.context.path,
       namespace: 'csvwidgets',
       when: app.started,

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -2,8 +2,17 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  JSONObject
+} from 'phosphor/lib/algorithm/json';
+
+
+import {
   JupyterLab, JupyterLabPlugin
 } from '../application';
+
+import {
+  InstanceTracker
+} from '../common/instancetracker';
 
 import {
   IDocumentRegistry
@@ -14,14 +23,8 @@ import {
 } from '../statedb';
 
 import {
-  CSVWidgetFactory
+  CSVWidget, CSVWidgetFactory
 } from './widget';
-
-
-/**
- * The state database namespace for CSV widgets.
- */
-const NAMESPACE = 'csvwidgets';
 
 
 /**
@@ -45,27 +48,22 @@ function activateCSVWidget(app: JupyterLab, registry: IDocumentRegistry, state: 
     fileExtensions: ['.csv'],
     defaultFor: ['.csv']
   });
-
-  registry.addWidgetFactory(factory);
-
-  factory.widgetCreated.connect((sender, widget) => {
-    // Add the CSV path to the state database.
-    let key = `${NAMESPACE}:${widget.context.path}`;
-    state.save(key, { path: widget.context.path });
-    // Remove the CSV path from the state database on disposal.
-    widget.disposed.connect(() => { state.remove(key); });
-    // Keep track of path changes in the state database.
-    widget.context.pathChanged.connect((sender, path) => {
-      state.remove(key);
-      key = `${NAMESPACE}:${path}`;
-      state.save(key, { path });
-    });
+  const tracker = new InstanceTracker<CSVWidget>({
+    restore: {
+      state,
+      command: 'file-operations:open',
+      args: widget => ({ path: widget.context.path }),
+      namespace: 'csvwidgets',
+      when: app.started,
+      registry: app.commands
+    }
   });
 
-  // Reload any CSV widgets whose state has been stored.
-  Promise.all([state.fetchNamespace(NAMESPACE), app.started])
-    .then(([items]) => {
-      let open = 'file-operations:open';
-      items.forEach(item => { app.commands.execute(open, item.value); });
-    });
+  registry.addWidgetFactory(factory);
+  factory.widgetCreated.connect((sender, widget) => {
+    // Track the widget.
+    tracker.add(widget);
+    // Notify the instance tracker if restore data needs to update.
+    widget.context.pathChanged.connect(() => { tracker.save(widget); });
+  });
 }

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -2,11 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JSONObject
-} from 'phosphor/lib/algorithm/json';
-
-
-import {
   JupyterLab, JupyterLabPlugin
 } from '../application';
 
@@ -38,7 +33,7 @@ const FACTORY = 'Table';
  */
 export
 const csvHandlerExtension: JupyterLabPlugin<void> = {
-  id: 'jupyter.extensions.csvHandler',
+  id: 'jupyter.extensions.csv-handler',
   requires: [IDocumentRegistry, IStateDB],
   activate: activateCSVWidget,
   autoStart: true

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -28,6 +28,12 @@ import {
 
 
 /**
+ * The name of the factory that creates CSV widgets.
+ */
+const FACTORY = 'Table';
+
+
+/**
  * The table file handler extension.
  */
 export
@@ -43,9 +49,8 @@ const csvHandlerExtension: JupyterLabPlugin<void> = {
  * Activate the table widget extension.
  */
 function activateCSVWidget(app: JupyterLab, registry: IDocumentRegistry, state: IStateDB): void {
-  const factoryName = 'Table';
   const factory = new CSVWidgetFactory({
-    name: factoryName,
+    name: FACTORY,
     fileExtensions: ['.csv'],
     defaultFor: ['.csv']
   });
@@ -53,7 +58,7 @@ function activateCSVWidget(app: JupyterLab, registry: IDocumentRegistry, state: 
     restore: {
       state,
       command: 'file-operations:open',
-      args: widget => ({ path: widget.context.path, factory: factoryName }),
+      args: widget => ({ path: widget.context.path, factory: FACTORY }),
       name: widget => widget.context.path,
       namespace: 'csvwidgets',
       when: app.started,

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -98,7 +98,7 @@ const editorHandlerProvider: JupyterLabPlugin<IEditorTracker> = {
  * Sets up the editor widget
  */
 function activateEditorHandler(app: JupyterLab, registry: IDocumentRegistry, mainMenu: IMainMenu, palette: ICommandPalette, state: IStateDB): IEditorTracker {
-  const widgetFactory = new EditorWidgetFactory({
+  const factory = new EditorWidgetFactory({
     name: FACTORY,
     fileExtensions: ['*'],
     defaultFor: ['*']
@@ -120,13 +120,13 @@ function activateEditorHandler(app: JupyterLab, registry: IDocumentRegistry, mai
     tracker.sync(args.newValue);
   });
 
-  widgetFactory.widgetCreated.connect((sender, widget) => {
+  factory.widgetCreated.connect((sender, widget) => {
     widget.title.icon = `${PORTRAIT_ICON_CLASS} ${EDITOR_ICON_CLASS}`;
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => { tracker.save(widget); });
     tracker.add(widget);
   });
-  registry.addWidgetFactory(widgetFactory);
+  registry.addWidgetFactory(factory);
 
   /**
    * An attached property for the session id associated with an editor widget.

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -62,9 +62,9 @@ const PORTRAIT_ICON_CLASS = 'jp-MainAreaPortraitIcon';
 const EDITOR_ICON_CLASS = 'jp-ImageTextEditor';
 
 /**
- * The state database namespace for editor widgets.
+ * The name of the factory that creates editor widgets.
  */
-const NAMESPACE = 'editorwidgets';
+const FACTORY = 'Editor';
 
 /**
  * The map of command ids used by the editor.
@@ -79,11 +79,6 @@ const cmdIds = {
   createConsole: 'editor:create-console',
   runCode: 'editor:run-code'
 };
-
-/**
- * The editor widget instance tracker.
- */
-const tracker = new InstanceTracker<EditorWidget>();
 
 
 /**
@@ -103,10 +98,21 @@ const editorHandlerProvider: JupyterLabPlugin<IEditorTracker> = {
  * Sets up the editor widget
  */
 function activateEditorHandler(app: JupyterLab, registry: IDocumentRegistry, mainMenu: IMainMenu, palette: ICommandPalette, state: IStateDB): IEditorTracker {
-  let widgetFactory = new EditorWidgetFactory({
-    name: 'Editor',
+  const widgetFactory = new EditorWidgetFactory({
+    name: FACTORY,
     fileExtensions: ['*'],
     defaultFor: ['*']
+  });
+  const tracker = new InstanceTracker<EditorWidget>({
+    restore: {
+      state,
+      command: 'file-operations:open',
+      args: widget => ({ path: widget.context.path, factory: FACTORY }),
+      name: widget => widget.context.path,
+      namespace: 'editors',
+      when: app.started,
+      registry: app.commands
+    }
   });
 
   // Sync tracker with currently focused widget.
@@ -116,20 +122,109 @@ function activateEditorHandler(app: JupyterLab, registry: IDocumentRegistry, mai
 
   widgetFactory.widgetCreated.connect((sender, widget) => {
     widget.title.icon = `${PORTRAIT_ICON_CLASS} ${EDITOR_ICON_CLASS}`;
-    // Add the file path to the state database.
-    let key = `${NAMESPACE}:${widget.context.path}`;
-    state.save(key, { path: widget.context.path });
-    // Remove the file path from the state database on disposal.
-    widget.disposed.connect(() => { state.remove(key); });
-    // Keep track of path changes in the state database.
-    widget.context.pathChanged.connect((sender, path) => {
-      state.remove(key);
-      key = `${NAMESPACE}:${path}`;
-      state.save(key, { path });
-    });
+    // Notify the instance tracker if restore data needs to update.
+    widget.context.pathChanged.connect(() => { tracker.save(widget); });
     tracker.add(widget);
   });
   registry.addWidgetFactory(widgetFactory);
+
+  /**
+   * An attached property for the session id associated with an editor widget.
+   */
+  const sessionIdProperty = new AttachedProperty<EditorWidget, string>({
+    name: 'sessionId'
+  });
+
+  /**
+   * Toggle editor line numbers
+   */
+  function toggleLineNums() {
+    if (tracker.currentWidget) {
+      let editor = tracker.currentWidget.editor;
+      editor.setOption('lineNumbers', !editor.getOption('lineNumbers'));
+    }
+  }
+
+  /**
+   * Toggle editor line wrap
+   */
+  function toggleLineWrap() {
+    if (tracker.currentWidget) {
+      let editor = tracker.currentWidget.editor;
+      editor.setOption('lineWrapping', !editor.getOption('lineWrapping'));
+    }
+  }
+
+  /**
+   * Toggle editor matching brackets
+   */
+  function toggleMatchBrackets() {
+    if (tracker.currentWidget) {
+      let editor = tracker.currentWidget.editor;
+      editor.setOption('matchBrackets', !editor.getOption('matchBrackets'));
+    }
+  }
+
+  /**
+   * Toggle the editor's vim mode
+   */
+  function toggleVim() {
+    tracker.forEach(widget => {
+      let keymap = widget.editor.getOption('keyMap') === 'vim' ? 'default'
+        : 'vim';
+      widget.editor.setOption('keyMap', keymap);
+    });
+  }
+
+  /**
+   * Close all currently open text editor files
+   */
+  function closeAllFiles() {
+    tracker.forEach(widget => { widget.close(); });
+  }
+
+  /**
+   * Create a menu for the editor.
+   */
+  function createMenu(app: JupyterLab): Menu {
+    let { commands, keymap } = app;
+    let settings = new Menu({ commands, keymap });
+    let theme = new Menu({ commands, keymap });
+    let menu = new Menu({ commands, keymap });
+
+    menu.title.label = 'Editor';
+    settings.title.label = 'Settings';
+    theme.title.label = 'Theme';
+
+    settings.addItem({ command: cmdIds.lineNumbers });
+    settings.addItem({ command: cmdIds.lineWrap });
+    settings.addItem({ command: cmdIds.matchBrackets });
+    settings.addItem({ command: cmdIds.vimMode });
+
+    commands.addCommand(cmdIds.changeTheme, {
+      label: args => args['theme'] as string,
+      execute: args => {
+        let name: string = args['theme'] as string || DEFAULT_CODEMIRROR_THEME;
+        tracker.forEach(widget => { widget.editor.setOption('theme', name); });
+      }
+    });
+
+    [
+     'jupyter', 'default', 'abcdef', 'base16-dark', 'base16-light',
+     'hopscotch', 'material', 'mbo', 'mdn-like', 'seti', 'the-matrix',
+     'xq-light', 'zenburn'
+    ].forEach(name => theme.addItem({
+      command: 'editor:change-theme',
+      args: { theme: name }
+    }));
+
+    menu.addItem({ command: cmdIds.closeAll });
+    menu.addItem({ type: 'separator' });
+    menu.addItem({ type: 'submenu', menu: settings });
+    menu.addItem({ type: 'submenu', menu: theme });
+
+    return menu;
+  }
 
   mainMenu.addMenu(createMenu(app), {rank: 30});
 
@@ -210,117 +305,5 @@ function activateEditorHandler(app: JupyterLab, registry: IDocumentRegistry, mai
     cmdIds.runCode,
   ].forEach(command => palette.addItem({ command, category: 'Editor' }));
 
-  // Reload any editor widgets whose state has been stored.
-  Promise.all([state.fetchNamespace(NAMESPACE), app.started])
-    .then(([items]) => {
-      let open = 'file-operations:open';
-      items.forEach(item => { app.commands.execute(open, item.value); });
-    });
-
   return tracker;
-}
-
-
-/**
- * An attached property for the session id associated with an editor widget.
- */
-const sessionIdProperty = new AttachedProperty<EditorWidget, string>({ name: 'sessionId' });
-
-
-/**
- * Toggle editor line numbers
- */
-function toggleLineNums() {
-  if (tracker.currentWidget) {
-    let editor = tracker.currentWidget.editor;
-    editor.setOption('lineNumbers', !editor.getOption('lineNumbers'));
-  }
-}
-
-
-/**
- * Toggle editor line wrap
- */
-function toggleLineWrap() {
-  if (tracker.currentWidget) {
-    let editor = tracker.currentWidget.editor;
-    editor.setOption('lineWrapping', !editor.getOption('lineWrapping'));
-  }
-}
-
-
-/**
- * Toggle editor matching brackets
- */
-function toggleMatchBrackets() {
-  if (tracker.currentWidget) {
-    let editor = tracker.currentWidget.editor;
-    editor.setOption('matchBrackets', !editor.getOption('matchBrackets'));
-  }
-}
-
-
-/**
- * Toggle the editor's vim mode
- */
-function toggleVim() {
-  tracker.forEach(widget => {
-    let keymap = widget.editor.getOption('keyMap') === 'vim' ? 'default'
-      : 'vim';
-    widget.editor.setOption('keyMap', keymap);
-  });
-}
-
-
-/**
- * Close all currently open text editor files
- */
-function closeAllFiles() {
-  tracker.forEach(widget => { widget.close(); });
-}
-
-
-/**
- * Create a menu for the editor.
- */
-function createMenu(app: JupyterLab): Menu {
-  let { commands, keymap } = app;
-  let settings = new Menu({ commands, keymap });
-  let theme = new Menu({ commands, keymap });
-  let menu = new Menu({ commands, keymap });
-
-  menu.title.label = 'Editor';
-  settings.title.label = 'Settings';
-  theme.title.label = 'Theme';
-
-  settings.addItem({ command: cmdIds.lineNumbers });
-  settings.addItem({ command: cmdIds.lineWrap });
-  settings.addItem({ command: cmdIds.matchBrackets });
-  settings.addItem({ command: cmdIds.vimMode });
-
-  commands.addCommand(cmdIds.changeTheme, {
-    label: args => {
-      return args['theme'] as string;
-    },
-    execute: args => {
-      let name: string = args['theme'] as string || DEFAULT_CODEMIRROR_THEME;
-      tracker.forEach(widget => { widget.editor.setOption('theme', name); });
-    }
-  });
-
-  [
-   'jupyter', 'default', 'abcdef', 'base16-dark', 'base16-light',
-   'hopscotch', 'material', 'mbo', 'mdn-like', 'seti', 'the-matrix',
-   'xq-light', 'zenburn'
-  ].forEach(name => theme.addItem({
-    command: 'editor:change-theme',
-    args: { theme: name }
-  }));
-
-  menu.addItem({ command: cmdIds.closeAll });
-  menu.addItem({ type: 'separator' });
-  menu.addItem({ type: 'submenu', menu: settings });
-  menu.addItem({ type: 'submenu', menu: theme });
-
-  return menu;
 }

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -278,7 +278,8 @@ function addCommands(app: JupyterLab, fbWidget: FileBrowser, docManager: Documen
   commands.addCommand(cmdIds.open, {
     execute: args => {
       let path = args['path'] as string;
-      return fbWidget.openPath(path);
+      let factory = args['factory'] as string || void 0;
+      return fbWidget.openPath(path, factory);
     }
   });
 

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -143,9 +143,13 @@ function activateFileBrowser(app: JupyterLab, manager: IServiceManager, registry
   });
 
   // Restore the state of the file browser on reload.
-  Promise.all([state.fetch(`${NAMESPACE}:cwd`), app.started]).then(([cwd]) => {
+  let key = `${NAMESPACE}:cwd`;
+  Promise.all([state.fetch(key), app.started, manager.ready]).then(([cwd]) => {
     if (cwd) {
-      fbModel.cd((cwd as any).path);
+      let path = cwd['path'] as string;
+      manager.contents.get(path)
+        .then(() => { fbModel.cd(path); })
+        .catch(() => { state.remove(key); });
     }
   });
 

--- a/src/imagewidget/plugin.ts
+++ b/src/imagewidget/plugin.ts
@@ -56,7 +56,8 @@ function activateImageWidget(app: JupyterLab, registry: IDocumentRegistry, palet
   let zoomInImage = 'image-widget:zoom-in';
   let zoomOutImage = 'image-widget:zoom-out';
   let resetZoomImage = 'image-widget:reset-zoom';
-  let image = new ImageWidgetFactory({
+
+  const factory = new ImageWidgetFactory({
     name: FACTORY,
     modelName: 'base64',
     fileExtensions: EXTENSIONS,
@@ -80,9 +81,9 @@ function activateImageWidget(app: JupyterLab, registry: IDocumentRegistry, palet
     tracker.sync(args.newValue);
   });
 
-  registry.addWidgetFactory(image);
+  registry.addWidgetFactory(factory);
 
-  image.widgetCreated.connect((sender, widget) => {
+  factory.widgetCreated.connect((sender, widget) => {
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => { tracker.save(widget); });
     tracker.add(widget);

--- a/src/imagewidget/plugin.ts
+++ b/src/imagewidget/plugin.ts
@@ -18,14 +18,13 @@ import {
 } from '../docregistry';
 
 import {
+  IStateDB
+} from '../statedb';
+
+import {
   ImageWidget, ImageWidgetFactory
 } from './widget';
 
-
-/**
- * The image widget instance tracker.
- */
-const tracker = new InstanceTracker<ImageWidget>();
 
 /**
  * The list of file extensions for images.
@@ -33,6 +32,10 @@ const tracker = new InstanceTracker<ImageWidget>();
 const EXTENSIONS = ['.png', '.gif', '.jpeg', '.jpg', '.svg', '.bmp', '.ico',
   '.xbm', '.tiff', '.tif'];
 
+/**
+ * The name of the factory that creates image widgets.
+ */
+const FACTORY = 'Image';
 
 /**
  * The image file handler extension.
@@ -40,7 +43,7 @@ const EXTENSIONS = ['.png', '.gif', '.jpeg', '.jpg', '.svg', '.bmp', '.ico',
 export
 const imageHandlerExtension: JupyterLabPlugin<void> = {
   id: 'jupyter.extensions.image-handler',
-  requires: [IDocumentRegistry, ICommandPalette],
+  requires: [IDocumentRegistry, ICommandPalette, IStateDB],
   activate: activateImageWidget,
   autoStart: true
 };
@@ -49,15 +52,27 @@ const imageHandlerExtension: JupyterLabPlugin<void> = {
 /**
  * Activate the image widget extension.
  */
-function activateImageWidget(app: JupyterLab, registry: IDocumentRegistry, palette: ICommandPalette): void {
+function activateImageWidget(app: JupyterLab, registry: IDocumentRegistry, palette: ICommandPalette, state: IStateDB): void {
   let zoomInImage = 'image-widget:zoom-in';
   let zoomOutImage = 'image-widget:zoom-out';
   let resetZoomImage = 'image-widget:reset-zoom';
   let image = new ImageWidgetFactory({
-    name: 'Image',
+    name: FACTORY,
     modelName: 'base64',
     fileExtensions: EXTENSIONS,
     defaultFor: EXTENSIONS
+  });
+
+  const tracker = new InstanceTracker<ImageWidget>({
+    restore: {
+      state,
+      command: 'file-operations:open',
+      args: widget => ({ path: widget.context.path, factory: FACTORY }),
+      name: widget => widget.context.path,
+      namespace: 'images',
+      when: app.started,
+      registry: app.commands
+    }
   });
 
   // Sync tracker with currently focused widget.
@@ -67,24 +82,29 @@ function activateImageWidget(app: JupyterLab, registry: IDocumentRegistry, palet
 
   registry.addWidgetFactory(image);
 
-  image.widgetCreated.connect((sender, newWidget) => {
-    tracker.add(newWidget);
+  image.widgetCreated.connect((sender, widget) => {
+    // Notify the instance tracker if restore data needs to update.
+    widget.context.pathChanged.connect(() => { tracker.save(widget); });
+    tracker.add(widget);
   });
 
   app.commands.addCommand(zoomInImage, {
     execute: zoomIn,
     label: 'Zoom In'
   });
+
   app.commands.addCommand(zoomOutImage, {
     execute: zoomOut,
     label: 'Zoom Out'
   });
+
   app.commands.addCommand(resetZoomImage, {
     execute: resetZoom,
     label: 'Reset Zoom'
   });
 
   let category = 'Image Widget';
+
   [zoomInImage, zoomOutImage, resetZoomImage]
     .forEach(command => palette.addItem({ command, category }));
 

--- a/src/imagewidget/widget.ts
+++ b/src/imagewidget/widget.ts
@@ -40,9 +40,16 @@ class ImageWidget extends Widget {
     if (context.model.toString()) {
       this.update();
     }
-    context.pathChanged.connect(() => this.update());
-    context.model.contentChanged.connect(() => this.update());
-    context.fileChanged.connect(() => this.update());
+    context.pathChanged.connect(() => { this.update(); });
+    context.model.contentChanged.connect(() => { this.update(); });
+    context.fileChanged.connect(() => { this.update(); });
+  }
+
+  /**
+   * The image widget's context.
+   */
+  get context(): DocumentRegistry.IContext<DocumentRegistry.IModel> {
+    return this._context;
   }
 
   /**

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -15,7 +15,6 @@ import {
 } from './';
 
 
-
 /**
  * A service providing an inspector panel.
  */

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -6,6 +6,10 @@ import {
 } from '../application';
 
 import {
+  InstanceTracker
+} from '../common/instancetracker';
+
+import {
   IDocumentRegistry
 } from '../docregistry';
 
@@ -14,7 +18,11 @@ import {
 } from '../rendermime';
 
 import {
-  MarkdownWidgetFactory
+  IStateDB
+} from '../statedb';
+
+import {
+  MarkdownWidget, MarkdownWidgetFactory
 } from './widget';
 
 
@@ -28,6 +36,11 @@ const PORTRAIT_ICON_CLASS = 'jp-MainAreaPortraitIcon';
  */
 const TEXTEDITOR_ICON_CLASS = 'jp-ImageTextEditor';
 
+/**
+ * The name of the factory that creates markdown widgets.
+ */
+const FACTORY = 'Rendered Markdown';
+
 
 /**
  * The markdown handler extension.
@@ -35,17 +48,40 @@ const TEXTEDITOR_ICON_CLASS = 'jp-ImageTextEditor';
 export
 const markdownHandlerExtension: JupyterLabPlugin<void> = {
   id: 'jupyter.extensions.rendered-markdown',
-  requires: [IDocumentRegistry, IRenderMime],
-  activate: (app: JupyterLab, registry: IDocumentRegistry, rendermime: IRenderMime) => {
-    let factory = new MarkdownWidgetFactory({
-      name: 'Rendered Markdown',
+  requires: [IDocumentRegistry, IRenderMime, IStateDB],
+  activate: (app: JupyterLab, registry: IDocumentRegistry, rendermime: IRenderMime, state: IStateDB) => {
+    const factory = new MarkdownWidgetFactory({
+      name: FACTORY,
       fileExtensions: ['.md'],
       rendermime
     });
+
+    const tracker = new InstanceTracker<MarkdownWidget>({
+      restore: {
+        state,
+        command: 'file-operations:open',
+        args: widget => ({ path: widget.context.path, factory: FACTORY }),
+        name: widget => widget.context.path,
+        namespace: 'rendered-markdown',
+        when: app.started,
+        registry: app.commands
+      }
+    });
+
     let icon = `${PORTRAIT_ICON_CLASS} ${TEXTEDITOR_ICON_CLASS}`;
+
+    // Sync tracker with currently focused widget.
+    app.shell.currentChanged.connect((sender, args) => {
+      tracker.sync(args.newValue);
+    });
+
     factory.widgetCreated.connect((sender, widget) => {
       widget.title.icon = icon;
+      // Notify the instance tracker if restore data needs to update.
+      widget.context.pathChanged.connect(() => { tracker.save(widget); });
+      tracker.add(widget);
     });
+
     registry.addWidgetFactory(factory);
   },
   autoStart: true

--- a/src/markdownwidget/widget.ts
+++ b/src/markdownwidget/widget.ts
@@ -71,6 +71,13 @@ class MarkdownWidget extends Widget {
   }
 
   /**
+   * The markdown widget's context.
+   */
+  get context(): DocumentRegistry.IContext<DocumentRegistry.IModel> {
+    return this._context;
+  }
+
+  /**
    * Dispose of the resources held by the widget.
    */
   dispose(): void {

--- a/src/statedb/plugin.ts
+++ b/src/statedb/plugin.ts
@@ -2,16 +2,16 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JSONObject
-} from 'phosphor/lib/algorithm/json';
-
-import {
   JupyterLabPlugin
 } from '../application';
 
 import {
-  IStateDB, IStateItem
+  IStateDB
 } from './index';
+
+import {
+  StateDB
+} from './statedb';
 
 
 /**
@@ -24,116 +24,3 @@ const stateProvider: JupyterLabPlugin<IStateDB> = {
   autoStart: true,
   provides: IStateDB
 };
-
-
-/**
- * The default concrete implementation of a state database.
- */
-class StateDB implements IStateDB {
-  /**
-   * The maximum allowed length of the data after it has been serialized.
-   */
-  readonly maxLength = 2000;
-
-  /**
-   * Retrieve a saved bundle from the database.
-   *
-   * @param id - The identifier used to retrieve a data bundle.
-   *
-   * @returns A promise that bears a data payload if available.
-   *
-   * #### Notes
-   * The `id` values of stored items in the state database are formatted:
-   * `'namespace:identifier'`, which is the same convention that command
-   * identifiers in JupyterLab use as well. While this is not a technical
-   * requirement for `fetch()`, `remove()`, and `save()`, it *is* necessary for
-   * using the `fetchNamespace()` method.
-   *
-   * The promise returned by this method may be rejected if an error occurs in
-   * retrieving the data. Non-existence of an `id` will succeed, however.
-   */
-  fetch(id: string): Promise<JSONObject> {
-    try {
-      return Promise.resolve(JSON.parse(window.localStorage.getItem(id)));
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  }
-
-  /**
-   * Retrieve all the saved bundles for a namespace.
-   *
-   * @param namespace - The namespace to retrieve.
-   *
-   * @returns A promise that bears a collection data payloads for a namespace.
-   *
-   * #### Notes
-   * Namespaces are entirely conventional entities. The `id` values of stored
-   * items in the state database are formatted: `'namespace:identifier'`, which
-   * is the same convention that command identifiers in JupyterLab use as well.
-   *
-   * If there are any errors in retrieving the data, they will be logged to the
-   * console in order to optimistically return any extant data without failing.
-   * This promise will always succeed.
-   */
-  fetchNamespace(namespace: string): Promise<IStateItem[]> {
-    let items: IStateItem[] = [];
-    for (let i = 0, len = window.localStorage.length; i < len; i++) {
-      let key = window.localStorage.key(i);
-      if (key.indexOf(`${namespace}:`) === 0) {
-        try {
-          items.push({
-            id: key,
-            value: JSON.parse(window.localStorage.getItem(key))
-          });
-        } catch (error) {
-          console.warn(error);
-        }
-      }
-    }
-    return Promise.resolve(items);
-  }
-
-  /**
-   * Remove a value from the database.
-   *
-   * @param id - The identifier for the data being removed.
-   *
-   * @returns A promise that is rejected if remove fails and succeeds otherwise.
-   */
-  remove(id: string): Promise<void> {
-    window.localStorage.removeItem(id);
-    return Promise.resolve(void 0);
-  }
-
-  /**
-   * Save a value in the database.
-   *
-   * @param id - The identifier for the data being saved.
-   *
-   * @param value - The data being saved.
-   *
-   * @returns A promise that is rejected if saving fails and succeeds otherwise.
-   *
-   * #### Notes
-   * The `id` values of stored items in the state database are formatted:
-   * `'namespace:identifier'`, which is the same convention that command
-   * identifiers in JupyterLab use as well. While this is not a technical
-   * requirement for `fetch()`, `remove()`, and `save()`, it *is* necessary for
-   * using the `fetchNamespace()` method.
-   */
-  save(id: string, value: JSONObject): Promise<void> {
-    try {
-      let serialized = JSON.stringify(value);
-      let length = serialized.length;
-      let max = this.maxLength;
-      if (length > max) {
-        throw new Error(`Serialized data (${length}) exceeds maximum (${max})`);
-      }
-      window.localStorage.setItem(id, serialized);
-      return Promise.resolve(void 0);
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  }
-}

--- a/src/statedb/plugin.ts
+++ b/src/statedb/plugin.ts
@@ -30,17 +30,22 @@ const stateProvider: JupyterLabPlugin<IStateDB> = {
 };
 
 
+/**
+ * Activate the state database.
+ */
 function activateState(): Promise<IStateDB> {
   let state = new StateDB();
   let version = (window as any).jupyter.version;
   let key = 'statedb:version';
   let fetch = state.fetch(key);
   let save = () => state.save(key, { version });
-  let overwrite = () => state.clear().then(save);
+  let reset = () => state.clear().then(save);
   let check = (value: JSONObject) => {
-    if (!value || (value as any).version !== version) {
-      return overwrite();
+    let old = value && (value as any).version;
+    if (!old || old !== version) {
+      console.log(`Upgraded: ${old || 'unknown'} to ${version}. Resetting DB.`);
+      return reset();
     }
   };
-  return fetch.then(check, overwrite).then(() => state);
+  return fetch.then(check, reset).then(() => state);
 }

--- a/src/statedb/statedb.ts
+++ b/src/statedb/statedb.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  JSONObject
+} from 'phosphor/lib/algorithm/json';
+
+import {
+  IStateDB, IStateItem
+} from './index';
+
+
+/**
+ * The default concrete implementation of a state database.
+ */
+export
+class StateDB implements IStateDB {
+  /**
+   * The maximum allowed length of the data after it has been serialized.
+   */
+  readonly maxLength = 2000;
+
+  /**
+   * Retrieve a saved bundle from the database.
+   *
+   * @param id - The identifier used to retrieve a data bundle.
+   *
+   * @returns A promise that bears a data payload if available.
+   *
+   * #### Notes
+   * The `id` values of stored items in the state database are formatted:
+   * `'namespace:identifier'`, which is the same convention that command
+   * identifiers in JupyterLab use as well. While this is not a technical
+   * requirement for `fetch()`, `remove()`, and `save()`, it *is* necessary for
+   * using the `fetchNamespace()` method.
+   *
+   * The promise returned by this method may be rejected if an error occurs in
+   * retrieving the data. Non-existence of an `id` will succeed, however.
+   */
+  fetch(id: string): Promise<JSONObject> {
+    try {
+      return Promise.resolve(JSON.parse(window.localStorage.getItem(id)));
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  /**
+   * Retrieve all the saved bundles for a namespace.
+   *
+   * @param namespace - The namespace to retrieve.
+   *
+   * @returns A promise that bears a collection data payloads for a namespace.
+   *
+   * #### Notes
+   * Namespaces are entirely conventional entities. The `id` values of stored
+   * items in the state database are formatted: `'namespace:identifier'`, which
+   * is the same convention that command identifiers in JupyterLab use as well.
+   *
+   * If there are any errors in retrieving the data, they will be logged to the
+   * console in order to optimistically return any extant data without failing.
+   * This promise will always succeed.
+   */
+  fetchNamespace(namespace: string): Promise<IStateItem[]> {
+    let items: IStateItem[] = [];
+    for (let i = 0, len = window.localStorage.length; i < len; i++) {
+      let key = window.localStorage.key(i);
+      if (key.indexOf(`${namespace}:`) === 0) {
+        try {
+          items.push({
+            id: key,
+            value: JSON.parse(window.localStorage.getItem(key))
+          });
+        } catch (error) {
+          console.warn(error);
+        }
+      }
+    }
+    return Promise.resolve(items);
+  }
+
+  /**
+   * Remove a value from the database.
+   *
+   * @param id - The identifier for the data being removed.
+   *
+   * @returns A promise that is rejected if remove fails and succeeds otherwise.
+   */
+  remove(id: string): Promise<void> {
+    window.localStorage.removeItem(id);
+    return Promise.resolve(void 0);
+  }
+
+  /**
+   * Save a value in the database.
+   *
+   * @param id - The identifier for the data being saved.
+   *
+   * @param value - The data being saved.
+   *
+   * @returns A promise that is rejected if saving fails and succeeds otherwise.
+   *
+   * #### Notes
+   * The `id` values of stored items in the state database are formatted:
+   * `'namespace:identifier'`, which is the same convention that command
+   * identifiers in JupyterLab use as well. While this is not a technical
+   * requirement for `fetch()`, `remove()`, and `save()`, it *is* necessary for
+   * using the `fetchNamespace()` method.
+   */
+  save(id: string, value: JSONObject): Promise<void> {
+    try {
+      let serialized = JSON.stringify(value);
+      let length = serialized.length;
+      let max = this.maxLength;
+      if (length > max) {
+        throw new Error(`Serialized data (${length}) exceeds maximum (${max})`);
+      }
+      window.localStorage.setItem(id, serialized);
+      return Promise.resolve(void 0);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+}

--- a/src/statedb/statedb.ts
+++ b/src/statedb/statedb.ts
@@ -21,6 +21,14 @@ class StateDB implements IStateDB {
   readonly maxLength = 2000;
 
   /**
+   * Clear the entire database.
+   */
+  clear(): Promise<void> {
+    window.localStorage.clear();
+    return Promise.resolve(void 0);
+  }
+
+  /**
    * Retrieve a saved bundle from the database.
    *
    * @param id - The identifier used to retrieve a data bundle.

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -84,9 +84,8 @@ class TerminalWidget extends Widget {
     if (!value) {
       return;
     }
-
-    value.ready.then(() => {
-      this._session = value;
+    this._session = value;
+    this._session.ready.then(() => {
       this._session.messageReceived.connect(this._onMessage, this);
       this.title.label = `Terminal ${this._session.name}`;
       this._resizeTerminal(-1, -1);

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -48,16 +48,6 @@ const LANDSCAPE_ICON_CLASS = 'jp-MainAreaLandscapeIcon';
  */
 const TERMINAL_ICON_CLASS = 'jp-ImageTerminal';
 
-/**
- * The terminal plugin state namespace.
- */
-const NAMESPACE = 'terminals';
-
-/**
- * The terminal widget instance tracker.
- */
-const tracker = new InstanceTracker<TerminalWidget>();
-
 
 /**
  * The default terminal extension.
@@ -89,6 +79,19 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
     fontSize: 13
   };
 
+  // Create an instance tracker for al terminal widgets.
+  const tracker = new InstanceTracker<TerminalWidget>({
+    restore: {
+      state,
+      command: 'terminal:create-new',
+      args: widget => ({ name: widget.session.name }),
+      name: widget => widget.session && widget.session.name,
+      namespace: 'terminals',
+      when: app.started,
+      registry: app.commands
+    }
+  });
+
   // Sync tracker with currently focused widget.
   app.shell.currentChanged.connect((sender, args) => {
     tracker.sync(args.newValue);
@@ -100,12 +103,6 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
     caption: 'Start a new terminal session',
     execute: args => {
       let name = args ? args['name'] as string : '';
-      let term = new TerminalWidget(options);
-      term.title.closable = true;
-      term.title.icon = `${LANDSCAPE_ICON_CLASS} ${TERMINAL_ICON_CLASS}`;
-      app.shell.addToMainArea(term);
-      app.shell.activateMain(term.id);
-      tracker.add(term);
       let promise: Promise<TerminalSession.ISession>;
       if (name) {
         promise = services.terminals.connectTo(name);
@@ -113,10 +110,15 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
         promise = services.terminals.startNew();
       }
       promise.then(session => {
-        let key = `${NAMESPACE}:${session.name}`;
-        term.session = session;
-        state.save(key, { name: session.name });
-        term.disposed.connect(() => { state.remove(key); });
+        session.ready.then(() => {
+          let term = new TerminalWidget(options);
+          term.session = session;
+          term.title.closable = true;
+          term.title.icon = `${LANDSCAPE_ICON_CLASS} ${TERMINAL_ICON_CLASS}`;
+          app.shell.addToMainArea(term);
+          app.shell.activateMain(term.id);
+          tracker.add(term);
+        });
       });
     }
   });
@@ -172,13 +174,6 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
       }
     }
   });
-
-  // Reload any terminals whose state has been stored.
-  Promise.all([state.fetchNamespace(NAMESPACE), app.started])
-    .then(([items]) => {
-      let create = 'terminal:create-new';
-      items.forEach(item => { app.commands.execute(create, item.value); });
-    });
 
   // Add command palette items.
   let category = 'Terminal';

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -79,7 +79,7 @@ function activateTerminal(app: JupyterLab, services: IServiceManager, mainMenu: 
     fontSize: 13
   };
 
-  // Create an instance tracker for al terminal widgets.
+  // Create an instance tracker for all terminal widgets.
   const tracker = new InstanceTracker<TerminalWidget>({
     restore: {
       state,


### PR DESCRIPTION
This PR folds the state save/restore behaviors allowed by the state database into the widget instance tracker. That means that aside from plugins that need to store specific data (like the file browser, which wants to store the current working directory), almost all other plugins can simply provide some configuration options to the `InstanceTracker` that keeps track of them and it will automatically take care of the save/restore cycle.

Additionally, the state database defensively clears the database if a new version of JupyterLab is detected. We may choose to disable this as the application matures.

***Nota bene***, since the state database is implemented on top of `localStorage`, when the state database clears itself, it clears *all* of the local storage values. That means a plugin that was using local storage may find its state gone as well. For this reason, this defensive behavior will likely change in the future.
