### PR TITLE
Improvements to file browser listing

### DIFF
--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -1161,13 +1161,14 @@ class DirListing extends Widget {
       return renameFile(this._model, original, newName).catch(error => {
         utils.showErrorMessage('Rename Error', error);
         return original;
-      }).then(value => {
+      }).then(() => {
         // Make sure the new file is available.
         return this.model.cd('.').then(() => {
-          this._selection = Object.create(null);
-          this._selection[newName] = true;
+          items = this._sortedItems;
+          index = findIndex(items, value => value.name === newName);
+          this._selectItem(index, false);
           this.update();
-          return value;
+          return newName;
         });
       });
     });

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -1152,14 +1152,23 @@ class DirListing extends Widget {
     let nameNode = this.renderer.getNameNode(row);
     let original = item.name;
     this._editNode.value = original;
+    this._selectItem(index, false);
 
     return Private.doRename(nameNode, this._editNode).then(newName => {
       if (newName === original) {
-        return;
+        return original;
       }
       return renameFile(this._model, original, newName).catch(error => {
         utils.showErrorMessage('Rename Error', error);
-        return newName;
+        return original;
+      }).then(value => {
+        // Make sure the new file is available.
+        return this.model.cd('.').then(() => {
+          this._selection = Object.create(null);
+          this._selection[newName] = true;
+          this.update();
+          return value;
+        });
       });
     });
   }

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -1578,6 +1578,20 @@ namespace Private {
           changed = false;
           edit.blur();
           break;
+        case 38:  // Up arrow
+          event.stopPropagation();
+          event.preventDefault();
+          if (edit.selectionStart !== edit.selectionEnd) {
+            edit.selectionStart = edit.selectionEnd = 0;
+          }
+          break;
+        case 40:  // Down arrow
+          event.stopPropagation();
+          event.preventDefault();
+          if (edit.selectionStart !== edit.selectionEnd) {
+            edit.selectionStart = edit.selectionEnd = edit.value.length;
+          }
+          break;
         default:
           break;
         }


### PR DESCRIPTION
Fixes #1272.  Fixes #693, replaces #761.  cf #213.

- Selection is preserved while renaming and after renaming, even if there is a refresh
- Hitting up or down removes the text selection and go to beginning or end of name
- Creating a new folder scrolls to the folder and selects it for rename
- Creating a new file scrolls to the file and selects it
