### PR TITLE
Add the ability to edit notebooks without a kernel.

### DIFF
--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -258,7 +258,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       return manager.ready.then(() => {
         return getKernel(args, name);
       }).then(kernel => {
-        if (!kernel) {
+        if (!kernel || (kernel && !kernel.id && !kernel.name)) {
           return;
         }
         // Start the session.

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -134,9 +134,12 @@ class DocumentManager implements IDisposable {
       context.revert();
     }
     // Handle the kernel for the context.
-    if (kernel && widgetFactory.canStartKernel) {
+    if (kernel && (kernel.id || kernel.name) && widgetFactory.canStartKernel) {
       context.changeKernel(kernel);
-    } else if (widgetFactory.preferKernel && !context.kernel) {
+    } else if (widgetFactory.preferKernel &&
+               //Don't start the default kernel if we pass in a null kernel
+               !(kernel && !kernel.id && !kernel.name) &&
+               !context.kernel) {
       context.startDefaultKernel();
     }
     let widget = this._widgetManager.createWidget(widgetFactory.name, context);
@@ -172,9 +175,12 @@ class DocumentManager implements IDisposable {
     // Immediately save the contents to disk.
     context.save();
     // Handle the kernel for the context.
-    if (kernel && widgetFactory.canStartKernel) {
+    if (kernel && (kernel.id || kernel.name) && widgetFactory.canStartKernel) {
       context.changeKernel(kernel);
-    } else if (widgetFactory.preferKernel && !context.kernel) {
+    } else if (widgetFactory.preferKernel &&
+               //Don't start the default kernel if we pass in a null kernel
+               !(kernel && !kernel.id && !kernel.name) &&
+               !context.kernel) {
       context.startDefaultKernel();
     }
     let widget = this._widgetManager.createWidget(widgetFactory.name, context);

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -281,7 +281,7 @@ class DocumentManager implements IDisposable {
    * The two cases differ in how the document context is handled, but the creation
    * of the widget and launching of the kernel are identical.
    */
-  private _createOrOpenDocument(which: string, path: string, widgetName='default', kernel?: Kernel.IModel): Widget {
+  private _createOrOpenDocument(which: 'open'|'create', path: string, widgetName='default', kernel?: Kernel.IModel): Widget {
     let widgetFactory = this._widgetFactoryFor(path, widgetName);
     if (!widgetFactory) {
       return;
@@ -306,9 +306,6 @@ class DocumentManager implements IDisposable {
       context = this._createContext(path, factory);
       // Immediately save the contents to disk.
       context.save();
-    } else {
-      //Should not reach here
-      console.log('Invalid option for _createOrOpenDocument()');
     }
 
     // Maybe launch/connect the kernel for the context.

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -140,8 +140,10 @@ function selectKernelForContext(context: DocumentRegistry.IContext<DocumentRegis
     };
     return selectKernel(options);
   }).then(kernel => {
-    if (kernel) {
+    if (kernel && (kernel.id || kernel.name)) {
       context.changeKernel(kernel);
+    } else if (kernel && !kernel.id && !kernel.name) {
+      context.changeKernel();
     }
   });
 }
@@ -247,6 +249,12 @@ function populateKernels(node: HTMLSelectElement, options: IPopulateOptions): vo
     let name = specs.default;
     node.appendChild(optionForName(name, displayNames[name]));
   }
+
+  // Add a separator.
+  node.appendChild(createSeparatorOption(maxLength));
+  // Add an option for no kernel
+  node.appendChild(optionForNone());
+
   // Add a separator.
   node.appendChild(createSeparatorOption(maxLength));
   // Add the rest of the kernel names in alphabetical order.
@@ -324,6 +332,15 @@ function optionForName(name: string, displayName: string): HTMLOptionElement {
   return option;
 }
 
+/**
+ * Create an option for no kernel.
+ */
+function optionForNone(): HTMLOptionElement {
+  let option = document.createElement('option');
+  option.text = 'None';
+  option.value = JSON.stringify({id: null, name: null});
+  return option;
+}
 
 /**
  * Create an option element for a session.

--- a/test/src/docmanager/manager.spec.ts
+++ b/test/src/docmanager/manager.spec.ts
@@ -151,6 +151,16 @@ describe('docmanager/manager', () => {
         }).catch(done);
       });
 
+      it('should not start a kernel if given an invalid one', (done) => {
+        services.contents.newUntitled({ type: 'file', ext: '.txt'}).then(model => {
+          let name = services.specs.default;
+          let widget = manager.open(model.path, 'default');
+          let context = manager.contextForWidget(widget);
+          expect(context.kernel).to.be(null);
+          done();
+        }).catch(done);
+      });
+
       it('should return undefined if the factory is not found', (done) => {
         services.contents.newUntitled({ type: 'file', ext: '.txt'}).then(model => {
           let widget = manager.open(model.path, 'foo');
@@ -208,6 +218,16 @@ describe('docmanager/manager', () => {
             expect(context.kernel.name).to.be(name);
             done();
           });
+        }).catch(done);
+      });
+
+      it('should not start a kernel if given an invalid one', (done) => {
+        services.contents.newUntitled({ type: 'file', ext: '.txt'}).then(model => {
+          let name = services.specs.default;
+          let widget = manager.createNew(model.path, 'default');
+          let context = manager.contextForWidget(widget);
+          expect(context.kernel).to.be(null);
+          done();
         }).catch(done);
       });
 

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -24,6 +24,7 @@ import './csvwidget/widget.spec';
 
 import './dialog/dialog.spec';
 
+import './docmanager/manager.spec';
 import './docmanager/savehandler.spec';
 import './docmanager/widgetmanager.spec';
 


### PR DESCRIPTION
This starts to address #1178. It does the following
1. Adds a "None" option to the kernel dropdown menu. The comments for this function actually already had a note describing that, so presumably it has been considered before.
2. Allows the user to change from an active kernel to no kernel and back again using the `Switch kernel` menu item.
Behind the scenes, I have represented a "None" kernel by an `Kernel.IModel` object with `null` for both the `name` and `id` fields. It is not represented by a `null` value for the kernel model itself for compatibility with the current behavior, which launches a kernel using the default language when a kernel is not explicitly selected.

A couple of related things that this does not address at the moment:
* Syntax highlighting is fussy, and does not adapt to the type of kernel active (somewhat related to #963).
* What should the user experience be when they try to execute a cell without a kernel?
* If a notebook is written targeting a kernel that is not installed on the system, JupyterLab defaults to opening it with the Python kernel. I think it would make more sense in this case to open it with no kernel.
The classic notebook gives the option for opening with no kernel, or a selection from available kernels.