### PR TITLE
Fix dialog interactions

### DIFF
--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -31,6 +31,7 @@
   margin-right: auto;
   background: #FAFAFA;
   padding: 24px;
+  padding-bottom: 12px;
   min-width: 300px;
   max-width: 500px;
   min-height: 300px;
@@ -66,9 +67,14 @@
 
 
 .jp-Dialog-footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
   flex: 0 0 auto;
-  float: right;
-  margin-top: 24px;
+  margin-top: 12px;
+  margin-left: -12px;
+  margin-right: -12px;
+  padding: 12px;
 }
 
 
@@ -84,7 +90,6 @@
   border: none;
   text-transform: uppercase;
   line-height: 38px;
-  outline: none;
   padding: 0px 24px;
 }
 

--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -61,7 +61,6 @@
 
 .jp-Dialog-bodyContent {
   font-size: 15px;
-  outline: none;
   overflow: auto;
 }
 

--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -112,27 +112,29 @@
 }
 
 .jp-Dialog-inputWrapper {
-  padding: 7px;
+  display: flex;
   background: white;
   width: 252px;
   box-sizing: border-box;
   border: var(--jp-border-width) solid var(--jp-border-color1);
   margin-bottom: 8px;
+  padding: 1px;
 }
 
 
 .jp-Dialog-input {
+  flex: 1 1 auto;
+  padding: 7px;
   font-size: 15px;
   color: #676767;
-  width: 100%;
-  outline: none;
   border: none;
 }
 
 
 .jp-Dialog-selectWrapper {
-  padding-top: 6px;
-  padding-bottom: 6px;
+  display: flex;
+  flex-direction: column;
+  padding: 1px;
   background: white;
   width: 252px;
   box-sizing: border-box;
@@ -142,10 +144,10 @@
 
 
 .jp-Dialog-select {
+  flex: 1 1 auto;
+  height: 32px;
   font-size: 15px;
   background: white;
   color: #676767;
-  width: 100%;
-  outline: none;
   border: none;
 }

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -200,6 +200,13 @@ interface IDialogOptions {
    * An additional CSS class to apply to the dialog.
    */
   dialogClass?: string;
+
+  /**
+   * The primary element or button index that should take focus in the dialog.
+   *
+   * The default is the last button.
+   */
+   primary?: HTMLElement | number;
 }
 
 
@@ -287,6 +294,11 @@ class Dialog extends Panel {
     this._buttonNodes.map(buttonNode => {
       footer.node.appendChild(buttonNode);
     });
+    let primary = options.primary || this.lastButtonNode;
+    if (typeof primary === 'number') {
+      primary = this._buttonNodes[primary];
+    }
+    this._primary = primary as HTMLElement;
   }
 
   /**
@@ -340,7 +352,7 @@ class Dialog extends Panel {
     node.addEventListener('click', this, true);
     document.addEventListener('focus', this, true);
     this._original = document.activeElement as HTMLElement;
-    this.lastButtonNode.focus();
+    this._primary.focus();
   }
 
 
@@ -447,6 +459,7 @@ class Dialog extends Panel {
   private _buttons: IButtonItem[];
   private _original: HTMLElement;
   private _first: HTMLElement;
+  private _primary: HTMLElement;
 }
 
 

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -354,7 +354,7 @@ class Dialog extends Panel {
     node.removeEventListener('keydown', this, true);
     node.removeEventListener('contextmenu', this, true);
     node.removeEventListener('click', this, true);
-    document.addEventListener('focus', this, true);
+    document.removeEventListener('focus', this, true);
     this._original.focus();
   }
 

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -226,6 +226,9 @@ function showDialog(options?: IDialogOptions): Promise<IButtonItem> {
   // NOTE: This code assumes only one dialog is shown at the time:
   okButton.text = options.okText ? options.okText : 'OK';
   options.buttons = options.buttons || [cancelButton, okButton];
+  if (!options.buttons.length) {
+    options.buttons = [okButton];
+  }
   if (!(options.body instanceof Widget)) {
     options.body = createDialogBody(options.body);
   }

--- a/src/filebrowser/dialogs.ts
+++ b/src/filebrowser/dialogs.ts
@@ -66,6 +66,7 @@ function openWithDialog(path: string, manager: DocumentManager, host?: HTMLEleme
     return showDialog({
       title: 'Open File',
       body: handler.node,
+      primary: handler.inputNode,
       okText: 'OPEN'
     });
   }).then(result => {
@@ -88,6 +89,7 @@ function createNewDialog(model: FileBrowserModel, manager: DocumentManager, host
       title: 'Create New File',
       host,
       body: handler.node,
+      primary: handler.inputNode,
       okText: 'CREATE'
     });
   }).then(result => {
@@ -281,6 +283,7 @@ class CreateFromHandler extends Widget {
     return showDialog({
       title: `Create New ${this._creatorName}`,
       body: this.node,
+      primary: this.inputNode,
       okText: 'CREATE'
     }).then(result => {
       if (result.text === 'CREATE') {
@@ -333,7 +336,8 @@ class CreateFromHandler extends Widget {
     }
 
     return model.newUntitled({ ext, type }).then(contents => {
-      this.inputNode.value = contents.name;
+      let value = this.inputNode.value = contents.name;
+      this.inputNode.setSelectionRange(0, value.length - ext.length);
       this._orig = contents;
     });
   }
@@ -389,6 +393,7 @@ class CreateNewHandler extends Widget {
     let name = time.toJSON().slice(0, 10);
     name += '-' + time.getHours() + time.getMinutes() + time.getSeconds();
     this.inputNode.value = name + '.txt';
+    this.inputNode.setSelectionRange(0, name.length);
 
     // Check for name conflicts when the inputNode changes.
     this.inputNode.addEventListener('input', () => {


### PR DESCRIPTION
Fixes #1275.  Fixes #1001.  Fixes #5.   <--- Wowzers!

Uses recommendations from #911, specifically https://www.smashingmagazine.com/2014/09/making-modal-windows-better-for-everyone/

- [x] Focused items are indicated visually - removes all the `outline:none` CSS. 
- [x] Tabbing focuses items in the dialog.
- [x] The dialog has an immediately focused element.
- [x] The dialog focuses the previously active element after closing.
- [x] Clicking in the overlay area dismisses the dialog.
- [x] Tabbing does not focus items outside the modal. 

This does not yet address ARIA compatibility explicitly.

cc @annabu @jasongrout 


![dialog-interaction](https://cloud.githubusercontent.com/assets/2096628/20684570/2be65ea8-b576-11e6-9224-77f8a2870853.gif)
