### PR TITLE
Expose IDocumentManager

### DIFF
--- a/jupyterlab/extensions.js
+++ b/jupyterlab/extensions.js
@@ -9,6 +9,7 @@ module.exports = [
   require('../lib/console/plugin').consoleTrackerProvider,
   require('../lib/console/codemirror/plugin').rendererProvider,
   require('../lib/csvwidget/plugin').csvHandlerExtension,
+  require('../lib/docmanager/plugin').docManagerProvider,
   require('../lib/docregistry/plugin').docRegistryProvider,
   require('../lib/editorwidget/plugin').editorHandlerProvider,
   require('../lib/faq/plugin').faqExtension,

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -26,6 +26,10 @@ import {
 } from 'phosphor/lib/core/properties';
 
 import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
@@ -41,6 +45,20 @@ import {
   DocumentWidgetManager
 } from './widgetmanager';
 
+/* tslint:disable */
+/**
+ * The document registry token.
+ */
+export
+const IDocumentManager = new Token<IDocumentManager>('jupyter.services.document-manager');
+/* tslint:enable */
+
+
+/**
+ * The interface for a document manager.
+ */
+export
+interface IDocumentManager extends DocumentManager {}
 
 /**
  * The document manager.

--- a/src/docmanager/plugin.ts
+++ b/src/docmanager/plugin.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  JupyterLabPlugin
+} from '../application';
+
+import {
+  DocumentManager, IDocumentManager
+} from './index';
+
+import {
+  IDocumentRegistry
+} from '../docregistry';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
+  JupyterLab
+} from '../application';
+
+import {
+  IServiceManager
+} from '../services';
+
+/**
+ * The default document manager provider.
+ */
+export const docManagerProvider: JupyterLabPlugin<IDocumentManager> = {
+  id: 'jupyter.services.document-manager',
+  provides: IDocumentManager,
+  requires: [IServiceManager, IDocumentRegistry],
+  activate: (app: JupyterLab, manager: IServiceManager, registry: IDocumentRegistry): IDocumentManager => {
+    
+    let id = 1;
+    let opener: DocumentManager.IWidgetOpener = {
+      open: widget => {
+        if (!widget.id) {
+          widget.id = `document-manager-${++id}`;
+        }
+        if (!widget.isAttached) {
+          app.shell.addToMainArea(widget);
+        }
+        app.shell.activateMain(widget.id);
+      }
+    };
+
+    let documentManager = new DocumentManager( {
+      registry,
+      manager,
+      opener
+    });
+    
+    return documentManager;
+  }
+};

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -218,11 +218,19 @@ function activateFileBrowser(app: JupyterLab, manager: IServiceManager, document
 function addCommands(app: JupyterLab, fbWidget: FileBrowser, docManager: IDocumentManager): void {
   let commands = app.commands;
 
+  let isEnabled: () => boolean = () => {
+      if (app.shell.currentWidget && docManager.contextForWidget(app.shell.currentWidget)) {
+        return true;
+      }
+      return false;
+    };
+
   commands.addCommand(cmdIds.save, {
     label: 'Save',
     caption: 'Save and create checkpoint',
+    isEnabled,
     execute: () => {
-      if (app.shell.currentWidget) {
+      if (isEnabled()) {
         let context = docManager.contextForWidget(app.shell.currentWidget);
         return context.save().then(() => {
           return context.createCheckpoint();
@@ -234,12 +242,13 @@ function addCommands(app: JupyterLab, fbWidget: FileBrowser, docManager: IDocume
   commands.addCommand(cmdIds.restoreCheckpoint, {
     label: 'Revert to Checkpoint',
     caption: 'Revert contents to previous checkpoint',
+    isEnabled,
     execute: () => {
-      if (app.shell.currentWidget) {
+      if (isEnabled()) {
         let context = docManager.contextForWidget(app.shell.currentWidget);
         context.restoreCheckpoint().then(() => {
           context.revert();
-        });
+        });        
       }
     }
   });
@@ -247,8 +256,9 @@ function addCommands(app: JupyterLab, fbWidget: FileBrowser, docManager: IDocume
   commands.addCommand(cmdIds.saveAs, {
     label: 'Save As...',
     caption: 'Save with new path and create checkpoint',
+    isEnabled,
     execute: () => {
-      if (app.shell.currentWidget) {
+      if (isEnabled()) {
         let context = docManager.contextForWidget(app.shell.currentWidget);
         return context.saveAs().then(() => {
           return context.createCheckpoint();


### PR DESCRIPTION
Sorry, I messed up the first PR :-| .

@blink1073 as for your comments. I fixed the undefined problems for non document based widgets and also added 'isEnabled' to the commands so they are inactive for those widgets.

Regarding the 'Close' and 'Close All' command it was on purpose, because "Close All" suggests to me that it closes all widgets, not only those that are backed by a file. I know it is part of the File menu, but still it doesn't meet my expectations.

My assumption is that having multiple "close all X" actions are too detailed to be useful. When I do close all I usually want a blank slate. So ideally these commands shouldn't be registered by the file browser plug-in but at a more central base plug-in.

Btw. the editor plugin also registers a "close all editors" action, which seems to do exactly what the file browser close all did before more change.

Anyway, If you want to have it like it was I'd like to propose having the same filtering for close (and close all), that is done for save.





