### PR TITLE
Add docs integrity check

### DIFF
--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -34,11 +34,13 @@ npm install -g postcss-cli
 postcss jupyterlab/build/*.css > /dev/null
 
 # Verify docs build
-conda create -n docs -f tutorial/environment.yml
+pushd tutorial
+conda create -n docs -f environment.yml
 source activate docs
-make -C tutorial linkcheck
-make -C tutorial html
+make linkcheck
+make html
 source deactivate
+popd
 
 # Make sure we can start and kill the lab server
 jupyter lab --no-browser &

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -33,6 +33,13 @@ cp jupyter-plugins-demo.gif docs
 npm install -g postcss-cli
 postcss jupyterlab/build/*.css > /dev/null
 
+# Verify docs build
+conda create -n docs -f tutorial/environment.yml
+source activate docs
+make -C tutorial makelinks
+make -C tutorial html
+source deactivate
+
 # Make sure we can start and kill the lab server
 jupyter lab --no-browser &
 TASK_PID=$!

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -36,7 +36,7 @@ postcss jupyterlab/build/*.css > /dev/null
 # Verify docs build
 conda create -n docs -f tutorial/environment.yml
 source activate docs
-make -C tutorial makelinks
+make -C tutorial linkcheck
 make -C tutorial html
 source deactivate
 

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -35,8 +35,8 @@ postcss jupyterlab/build/*.css > /dev/null
 
 # Verify docs build
 pushd tutorial
-conda create -n docs -f environment.yml
-source activate docs
+conda env create -n test_docs -f environment.yml
+source activate test_docs
 make linkcheck
 make html
 source deactivate

--- a/tutorial/notebook.md
+++ b/tutorial/notebook.md
@@ -78,7 +78,7 @@ corresponding to the cell models in its cell list.
 
 - Each cell widget contains an [InputAreaWidget](http://jupyterlab.github.io/jupyterlab/classes/_notebook_cells_widget_.inputareawidget.html),
 
-    + which contains a [CellEditorWidget](http://jupyterlab.github.io/jupyterlab/classes/_notebook_cells_editor_.celleditorwidget.html),
+    + which contains a [CellEditorWidget](http://jupyterlab.github.io/jupyterlab/interfaces/_notebook_cells_editor_.icelleditorwidget.html),
 
         - which contains a JavaScript CodeMirror instance.
 


### PR DESCRIPTION
Verifies external links in tutorials and makes sure they build on Travis.

Note: if we change an API, the external link will need to be changed in the tutorial, but it will not yet be available online.  We must make a separate follow-on PR to update the docs, or it will be caught by the next build after merging.

ht @willingc 