### PR TITLE
Prevent the loading-from-disk step from being in the editor history.

### DIFF
--- a/src/editorwidget/widget.ts
+++ b/src/editorwidget/widget.ts
@@ -82,7 +82,12 @@ class EditorWidget extends CodeMirrorWidget {
     let editor = this.editor;
     let model = context.model;
     let doc = editor.getDoc();
-    doc.setValue(model.toString());
+    //Prevent the initial loading from disk from
+    //being in the editor history.
+    context.ready.then( () => {
+      doc.setValue(model.toString());
+      doc.clearHistory();
+    });
     this.title.label = context.path.split('/').pop();
     loadModeByFileName(editor, context.path);
     model.stateChanged.connect((m, args) => {


### PR DESCRIPTION
In the current behavior, one is able to undo the initial loading of a text file, effectively deleting all the text. This fixes that.

This PR should conflict with #1140, so I am happy to hold off or rebase when that is resolved.