### PR TITLE
Fixed dialog box spacing

### DIFF
--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -34,7 +34,6 @@
   padding-bottom: 12px;
   min-width: 300px;
   max-width: 500px;
-  min-height: 300px;
   max-height: 500px;
   box-sizing: border-box;
   box-shadow: 0px 2px 2px 0px rgba(0,0,0,0.5);

--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -33,6 +33,7 @@
   padding: 24px;
   padding-bottom: 12px;
   min-width: 300px;
+  min-height: 150px;
   max-width: 500px;
   max-height: 500px;
   box-sizing: border-box;


### PR DESCRIPTION
Updated the min-height variable on dialog box content to reflect new styling of dialogs, gets rid of awkward spacing between the content and footer buttons:

#### Before
![screen shot 2016-11-29 at 5 13 09 pm](https://cloud.githubusercontent.com/assets/6437976/20735773/27a42f14-b657-11e6-9985-db624dfc232b.png)
![screen shot 2016-11-29 at 5 13 13 pm](https://cloud.githubusercontent.com/assets/6437976/20735774/27a4a8cc-b657-11e6-8623-8449b8030ada.png)


#### After
![screen shot 2016-11-29 at 5 12 20 pm](https://cloud.githubusercontent.com/assets/6437976/20735776/2bf2d0d4-b657-11e6-9703-5cbc63589a1c.png)
![screen shot 2016-11-29 at 5 12 25 pm](https://cloud.githubusercontent.com/assets/6437976/20735777/2bfe7510-b657-11e6-8057-d6d95c654cf5.png)


