### PR TITLE
Add in Missing about id

### DIFF
--- a/src/about/index.ts
+++ b/src/about/index.ts
@@ -371,7 +371,7 @@ class AboutWidget extends VDomWidget<AboutModel> {
       )
     );
 
-    return h.div(
+    return h.div({id: 'about' },
       h.div({ className: SECTION_CLASS },
         h.div({ className: SECTION_CENTER_CLASS },
           h.div({ className: CONTAINER_CLASS },


### PR DESCRIPTION
Added back about id for the plugin. This id provides proper spacing among the different tour pages.

Before: 
![screen shot 2016-11-30 at 2 18 17 pm](https://cloud.githubusercontent.com/assets/16314651/20773717/0a968eb0-b708-11e6-812f-cb84a81c953e.png)

After:
![screen shot 2016-11-30 at 2 16 21 pm](https://cloud.githubusercontent.com/assets/16314651/20773723/117942cc-b708-11e6-8faa-dced7e3c3d47.png)
