### PR TITLE
Save help state on refresh.

### DIFF
--- a/src/iframe/index.ts
+++ b/src/iframe/index.ts
@@ -18,7 +18,7 @@ const IFRAME_CLASS = 'jp-IFrame';
 export
 class IFrame extends Widget {
   /**
-   * Create a new iframe widget.
+   * Create a new IFrame widget.
    */
   constructor() {
     super({ node: Private.createNode() });
@@ -26,11 +26,12 @@ class IFrame extends Widget {
   }
 
   /**
-   * Load a URL into the iframe.
-   *
-   * @param url - The URL to load into the iframe widget.
+   * The IFrame's URL.
    */
-  loadURL(url: string): void {
+  get url(): string {
+    return this.node.querySelector('iframe').getAttribute('src');
+  }
+  set url(url: string) {
     this.node.querySelector('iframe').setAttribute('src', url);
   }
 }


### PR DESCRIPTION
This PR saves the state of the help right panel frame if it is open.

***Nota bene:*** Once full layout rehydration is implemented, the `WidgetMessage.BeforeHide` message hook used in this PR will be replaced with true layout restoration.