### PR TITLE
style(launcherWidgetBody): remove padding to fix browser compatibility

### DIFF
--- a/src/launcher/index.css
+++ b/src/launcher/index.css
@@ -62,8 +62,6 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
-  padding-left: 20px;
-  padding-right: 20px;
 }
 
 


### PR DESCRIPTION
Addresses #1353 by removing padding (which seemed to be unused by any browser except Safari) to make launcher style in Safari consistent with all other browsers. Here's a picture in Safari now: 
![screen shot 2016-12-02 at 9 42 16 am](https://cloud.githubusercontent.com/assets/15242567/20837820/c9830bd4-b873-11e6-8f89-42b863220f80.png)
