### PR TITLE
Expose default renderers (in order)

### DIFF
--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -38,11 +38,6 @@ import {
 } from 'jupyterlab/lib/rendermime';
 
 import {
-  HTMLRenderer, LatexRenderer, ImageRenderer, TextRenderer,
-  JavascriptRenderer, SVGRenderer, MarkdownRenderer
-} from 'jupyterlab/lib/renderers';
-
-import {
   defaultSanitizer
 } from 'jupyterlab/lib/sanitizer';
 
@@ -88,15 +83,7 @@ function startApp(session: Session.ISession) {
     keymap.processKeydownEvent(event);
   });
 
-  const transformers = [
-    new JavascriptRenderer(),
-    new MarkdownRenderer(),
-    new HTMLRenderer(),
-    new ImageRenderer(),
-    new SVGRenderer(),
-    new LatexRenderer(),
-    new TextRenderer()
-  ];
+  const transformers = RenderMime.defaultRenderers();
   let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
   let order: string[] = [];
   for (let t of transformers) {

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -51,11 +51,6 @@ import {
 } from 'jupyterlab/lib/rendermime';
 
 import {
-  HTMLRenderer, LatexRenderer, ImageRenderer, TextRenderer,
-  JavascriptRenderer, SVGRenderer, MarkdownRenderer
-} from 'jupyterlab/lib/renderers';
-
-import {
   defaultSanitizer
 } from 'jupyterlab/lib/sanitizer';
 
@@ -108,15 +103,7 @@ function createApp(manager: ServiceManager.IManager): void {
     keymap.processKeydownEvent(event);
   }, useCapture);
 
-  const transformers = [
-    new JavascriptRenderer(),
-    new MarkdownRenderer(),
-    new HTMLRenderer(),
-    new ImageRenderer(),
-    new SVGRenderer(),
-    new LatexRenderer(),
-    new TextRenderer()
-  ];
+  const transformers = RenderMime.defaultRenderers();
   let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
   let order: string[] = [];
   for (let t of transformers) {

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -26,6 +26,11 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
+  HTMLRenderer, LatexRenderer, ImageRenderer, TextRenderer,
+  JavascriptRenderer, SVGRenderer, MarkdownRenderer, PDFRenderer
+} from '../renderers';
+
+import {
   ISanitizer
 } from '../sanitizer';
 
@@ -235,6 +240,23 @@ namespace RenderMime {
    */
   export
   type MimeMap<T> = { [mimetype: string]: T };
+
+  /**
+   * Default renderer order
+   */
+  export
+  function defaultRenderers(): IRenderer[] {
+    return [
+      new JavascriptRenderer(),
+      new HTMLRenderer(),
+      new MarkdownRenderer(),
+      new LatexRenderer(),
+      new SVGRenderer(),
+      new ImageRenderer(),
+      new PDFRenderer(),
+      new TextRenderer()
+    ];
+  }
 
   /**
    * The interface for a renderer.

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   HTMLRenderer, LatexRenderer, ImageRenderer, TextRenderer,
-  JavascriptRenderer, SVGRenderer, MarkdownRenderer
+  JavascriptRenderer, SVGRenderer, MarkdownRenderer, PDFRenderer
 } from '../renderers';
 
 import {
@@ -30,11 +30,12 @@ const plugin: JupyterLabPlugin<IRenderMime> = {
     let sanitizer = defaultSanitizer;
     const transformers = [
       new JavascriptRenderer(),
-      new MarkdownRenderer(),
       new HTMLRenderer(),
-      new ImageRenderer(),
-      new SVGRenderer(),
+      new MarkdownRenderer(),
       new LatexRenderer(),
+      new SVGRenderer(),
+      new ImageRenderer(),
+      new PDFRenderer(),
       new TextRenderer()
     ];
     let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -6,11 +6,6 @@ import {
 } from '../application';
 
 import {
-  HTMLRenderer, LatexRenderer, ImageRenderer, TextRenderer,
-  JavascriptRenderer, SVGRenderer, MarkdownRenderer, PDFRenderer
-} from '../renderers';
-
-import {
   defaultSanitizer
 } from '../sanitizer';
 
@@ -28,16 +23,7 @@ const plugin: JupyterLabPlugin<IRenderMime> = {
   provides: IRenderMime,
   activate: (): IRenderMime => {
     let sanitizer = defaultSanitizer;
-    const transformers = [
-      new JavascriptRenderer(),
-      new HTMLRenderer(),
-      new MarkdownRenderer(),
-      new LatexRenderer(),
-      new SVGRenderer(),
-      new ImageRenderer(),
-      new PDFRenderer(),
-      new TextRenderer()
-    ];
+    const transformers = RenderMime.defaultRenderers();
     let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
     let order: string[] = [];
     for (let t of transformers) {

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -28,8 +28,7 @@ import {
 } from '../../lib/notebook/notebook/modelfactory';
 
 import {
-  LatexRenderer, PDFRenderer, JavascriptRenderer,
-  SVGRenderer, MarkdownRenderer, TextRenderer, HTMLRenderer, ImageRenderer
+  TextRenderer, HTMLRenderer
 } from '../../lib/renderers';
 
 import {
@@ -172,18 +171,7 @@ namespace Private {
     }
   }
 
-  const TRANSFORMERS = [
-    new JavascriptRenderer(),
-    new JSONRenderer(),
-    new MarkdownRenderer(),
-    new HTMLRenderer(),
-    new PDFRenderer(),
-    new ImageRenderer(),
-    new SVGRenderer(),
-    new LatexRenderer(),
-    new InjectionRenderer(),
-    new TextRenderer()
-  ];
+  const TRANSFORMERS = RenderMime.defaultRenderers();
 
   let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
   let order: string[] = [];

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -171,7 +171,10 @@ namespace Private {
     }
   }
 
-  const TRANSFORMERS = RenderMime.defaultRenderers();
+  const TRANSFORMERS = RenderMime.defaultRenderers().concat([
+    new JSONRenderer(),
+    new InjectionRenderer()
+  ]);
 
   let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
   let order: string[] = [];


### PR DESCRIPTION
Builds on #1392.

For applications which use jupyterlab as a library, and want to replicate the renderers (and renderer order) of jupyterlab/notebooks, the current solution is to copy and paste the list from the internal jupyterlab code. If this then changes in JL, the applications will have to mirror the changes in JL.

This PR suggests to have JL expose its default list, which also consolidates the lists of renderers used internally.