### PR TITLE
Clean up file rename behavior

### DIFF
--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -173,7 +173,7 @@ const DESCENDING_CLASS = 'jp-mod-descending';
 /**
  * The minimum duration for a rename select in ms.
  */
-const RENAME_DURATION = 500;
+const RENAME_DURATION = 1000;
 
 /**
  * The threshold in pixels to start a drag event.
@@ -1020,6 +1020,8 @@ class DirListing extends Widget {
     // Fetch common variables.
     let items = this._sortedItems;
     let index = Private.hitTestNodes(this._items, event.clientX, event.clientY);
+    let target = event.target as HTMLElement;
+    let inText = target.classList.contains(ITEM_TEXT_CLASS);
 
     clearTimeout(this._selectTimer);
 
@@ -1052,7 +1054,7 @@ class DirListing extends Widget {
     // Default to selecting the only the item.
     } else {
       // Handle a rename.
-      if (selected.length === 1 && selected[0] === name) {
+      if (inText && selected.length === 1 && selected[0] === name) {
         this._selectTimer = setTimeout(() => {
           if (this._noSelectTimer === -1) {
             this._doRename();


### PR DESCRIPTION
Fixes #1396.

The rename is now only triggered when clicking on the text itself, which fixes part of the behavior.   A rename pre-empted by a browser `dblclick` event, which is within the user's control to set the speed.  Is that good enough, @willingc, or should we disable the slow-double-click behavior altogether?