### PR TITLE
Refined Styling of FAQ

### DIFF
--- a/src/faq/index.css
+++ b/src/faq/index.css
@@ -28,7 +28,7 @@
 
 .jp-FAQ-h1 {
   font-size: 26px;
-  font-weight: 300;
+  font-weight: 400;
   color: #313940;
   margin: 10px 0 0 20px;
 }
@@ -36,9 +36,10 @@
 
 .jp-FAQ-h2 {
   font-size: 14px;
-  font-weight: 300;
+  font-weight: 400;
   color: #9E9E9E;
-  margin: 30px 0 0 0;
+  margin: 28px 0 0 0;
+  margin-bottom: 8px;
 }
 
 
@@ -62,7 +63,7 @@
 
 .jp-FAQ-question {
   list-style-type: none;
-  padding: 16px;
+  padding: 4px 16px;
   margin-left: -16px;
   display: inline-block;
 }


### PR DESCRIPTION
Refined styling within Frequently Asked Questions to reflect rest of JupyterLab design specifications:

Before:
![screen shot 2017-01-03 at 2 36 31 pm](https://cloud.githubusercontent.com/assets/6437976/21625765/18d2642a-d1c2-11e6-827a-fb6eee66b0f5.png)

After:
![screen shot 2017-01-03 at 2 37 57 pm](https://cloud.githubusercontent.com/assets/6437976/21625791/48fd1618-d1c2-11e6-8528-9b3be0940a37.png)
