### PR TITLE
Tweak dialog styling

### DIFF
--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -46,7 +46,7 @@
   flex: 0 0 auto;
   padding-bottom: 12px;
   font-size: 20px;
-  font-weight: 300;
+  font-weight: 400;
   color: #616161;
 }
 
@@ -115,7 +115,10 @@
 
 .jp-Dialog-bodyContent > label {
   padding-top: 4px;
-  padding-bottom: 4px
+  padding-bottom: 4px;
+  line-height: 1.4;
+  font-size: 13px;
+  color: var(--md-grey-700);
 }
 
 


### PR DESCRIPTION
Tweaked the dialog styling. 

Header text is now a heavier weight
The subheaders for the input fields and dropdowns are now smaller and a more subtle color to not confuse the user that it is editable text and is not in the forefront as much.

Before:
![screen shot 2017-01-03 at 3 26 25 pm](https://cloud.githubusercontent.com/assets/6437976/21626917/1d490df4-d1c9-11e6-97f8-f92d5820ac32.png)


After:
![screen shot 2017-01-03 at 3 23 43 pm](https://cloud.githubusercontent.com/assets/6437976/21626908/0c1be768-d1c9-11e6-8fcc-6c14bb43b359.png)
