### PR TITLE
Restyles "In []" notebook prompt

### DIFF
--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -15,8 +15,8 @@
   --jp-private-notebook-cell-prompt-width: 90px;
   --jp-private-notebook-cell-inprompt-color: #303F9F;
   --jp-private-notebook-cell-outprompt-color: #D84315;
-  --jp-private-notebook-cell-font-family: 'Helvetica';
-  --jp-private-notebook-cell-prompt-letter-spacing: 2px;
+  --jp-private-notebook-cell-font-family: monospace;
+  --jp-private-notebook-cell-prompt-letter-spacing: 0px;
 }
 
 


### PR DESCRIPTION
In the input prompt CSS, I change

* font-family from `'Helvetica'` => `monospace`
* prompt-letter-padding: `2px` => `0px`

This PR reverts a change found in 1dc93121f0c41c6c941819a56b72a913fd04c4a0

| Before | After |
|:--:|:--:|
| <img width="157" alt="screen shot 2017-01-06 at 4 24 49 pm" src="https://cloud.githubusercontent.com/assets/1320475/21735221/b77dd1a0-d42d-11e6-9671-f57b5db357b3.png"> | <img width="158" alt="screen shot 2017-01-06 at 4 25 20 pm" src="https://cloud.githubusercontent.com/assets/1320475/21735227/c021cc76-d42d-11e6-9b7f-1ed5466ac27b.png"> |

I made this change with Chrome's CSS inspection but haven't tested the variable passing, though I expect it to work.