### PR TITLE
Clean up testing

### DIFF
--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -9,7 +9,7 @@
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.34.2",
+    "@jupyterlab/services": "^0.35.0",
     "jupyterlab": "file:../..",
     "phosphor": "^0.7.0"
   },

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -9,7 +9,7 @@
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.34.2",
+    "@jupyterlab/services": "^0.35.0",
     "jupyterlab": "file:../..",
     "phosphor": "^0.7.0"
   },

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -9,7 +9,7 @@
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.34.2",
+    "@jupyterlab/services": "^0.35.0",
     "jupyterlab": "file:../..",
     "phosphor": "^0.7.0"
   },

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -9,7 +9,7 @@
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.34.2",
+    "@jupyterlab/services": "^0.35.0",
     "jupyterlab": "file:../..",
     "phosphor": "^0.7.0",
     "xterm": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@jupyterlab/services": "^0.34.3",
+    "@jupyterlab/services": "^0.35.0",
     "ansi_up": "^1.3.0",
     "backbone": "^1.2.0",
     "codemirror": "^5.20.2",

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -12,6 +12,7 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda info -a
 conda install jupyter nose
+conda install -c conda-forge notebook
 
 # create jupyter base dir (needed for config retreival)
 mkdir ~/.jupyter

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -15,8 +15,8 @@ jupyter serverextension enable --py jupyterlab
 
 npm run clean
 npm run build
-npm test || npm test
-npm run test:coverage || npm run test:coverage
+npm test
+npm run test:coverage
 
 
 # Run the python tests

--- a/test/karma-cov.conf.js
+++ b/test/karma-cov.conf.js
@@ -7,7 +7,8 @@ module.exports = function (config) {
     frameworks: ['mocha'],
     client: {
       mocha: {
-        timeout : 10000 // 10 seconds - upped from 2 seconds
+        timeout : 10000, // 10 seconds - upped from 2 seconds
+        retries: 3 // Allow for slow server on CI.
       }
     },
     reporters: ['mocha', 'coverage', 'remap-coverage'],

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,7 +5,8 @@ module.exports = function (config) {
     reporters: ['mocha'],
     client: {
       mocha: {
-        timeout : 10000 // 10 seconds - upped from 2 seconds
+        timeout : 10000, // 10 seconds - upped from 2 seconds
+        retries: 3 // Allow for slow server on CI.
       }
     },
     files: [

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -79,4 +79,8 @@ if __name__ == '__main__':
     # Reserve the command line arguments for karma.
     ARGS = sys.argv[1:]
     sys.argv = sys.argv[:1]
-    TestApp.launch_instance()
+
+    try:
+        TestApp.launch_instance()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -47,8 +47,10 @@ def run_task(func, args=(), kwds={}):
 def run_karma(base_url, token, terminalsAvailable):
     config = dict(baseUrl=base_url, token=token,
                   terminalsAvailable=terminalsAvailable)
-    print('Notebook config:')
+
+    print('\n\nNotebook config:')
     print(json.dumps(config))
+
     with open(os.path.join(HERE, 'build', 'injector.js'), 'w') as fid:
         fid.write("""
         var node = document.createElement('script');
@@ -59,7 +61,8 @@ def run_karma(base_url, token, terminalsAvailable):
         """ % json.dumps(config))
 
     cmd = ['karma', 'start'] + ARGS
-    print('Running karma as: %s' % ' '.join(cmd))
+    print('\n\nRunning karma as: %s\n\n' % ' '.join(cmd))
+
     shell = os.name == 'nt'
     return subprocess.check_call(cmd, shell=shell)
 

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -46,7 +46,7 @@ def run_task(func, args=(), kwds={}):
 
 def run_karma(base_url, token, terminalsAvailable):
     config = dict(baseUrl=base_url, token=token,
-                  terminalsAvailable=terminalsAvailable)
+                  terminalsAvailable=str(terminalsAvailable))
 
     print('\n\nNotebook config:')
     print(json.dumps(config))

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -47,6 +47,8 @@ def run_task(func, args=(), kwds={}):
 def run_karma(base_url, token, terminalsAvailable):
     config = dict(baseUrl=base_url, token=token,
                   terminalsAvailable=terminalsAvailable)
+    print('Notebook config:')
+    print(json.dumps(config))
     with open(os.path.join(HERE, 'build', 'injector.js'), 'w') as fid:
         fid.write("""
         var node = document.createElement('script');
@@ -57,6 +59,7 @@ def run_karma(base_url, token, terminalsAvailable):
         """ % json.dumps(config))
 
     cmd = ['karma', 'start'] + ARGS
+    print('Running karma as: %s' % ' '.join(cmd))
     shell = os.name == 'nt'
     return subprocess.check_call(cmd, shell=shell)
 

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -1,76 +1,52 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import argparse
+from __future__ import print_function, absolute_import
+
+import atexit
+import json
+import os
 import subprocess
 import sys
-import os
-import re
-import json
 import shutil
-import threading
 import tempfile
+from multiprocessing.pool import ThreadPool
 
-
-# Set up the file structure
-root_dir = tempfile.mkdtemp(prefix='mock_contents')
-os.mkdir(os.path.join(root_dir, 'src'))
-with open(os.path.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
-    fid.write('hello')
+from tornado import ioloop
+from notebook.notebookapp import NotebookApp
+from traitlets import Bool, Unicode
 
 
 HERE = os.path.dirname(__file__)
 
-shell = (sys.platform == 'win32')
+
+def create_notebook_dir():
+    """Create a temporary directory with some file structure."""
+    root_dir = tempfile.mkdtemp(prefix='mock_contents')
+    os.mkdir(os.path.join(root_dir, 'src'))
+    with open(os.path.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
+        fid.write('hello')
+    atexit.register(lambda: shutil.rmtree(root_dir, True))
+    return root_dir
 
 
-def start_notebook():
-    nb_command = [sys.executable, '-m', 'notebook', root_dir, '--no-browser',
-                  # FIXME: allow-origin=* only required for notebook < 4.3
-                  '--NotebookApp.allow_origin="*"',
-                  # disable user password:
-                  '--NotebookApp.password=',
-                  # disable token:
-                  '--NotebookApp.token=']
-    nb_server = subprocess.Popen(nb_command, shell=shell,
-                                 stderr=subprocess.STDOUT,
-                                 stdout=subprocess.PIPE)
+def run_task(func, args=(), kwds={}):
+    """Run a task in a thread and exit with the return code."""
+    loop = ioloop.IOLoop.instance()
+    worker = ThreadPool(1)
 
-    # wait for notebook server to start up
-    while 1:
-        line = nb_server.stdout.readline().decode('utf-8').strip()
-        if not line:
-            continue
-        print(line)
-        if 'Jupyter Notebook is running at:' in line:
-            base_url = re.search(r'(http[^\?]+)', line).groups()[0]
-            break
+    def callback(result):
+        loop.add_callback(lambda: sys.exit(result))
 
-    while 1:
-        line = nb_server.stdout.readline().decode('utf-8').strip()
-        if not line:
-            continue
-        print(line)
-        if 'Control-C' in line:
-            break
+    def start():
+        worker.apply_async(func, args, kwds, callback)
 
-    def print_thread():
-        while 1:
-            line = nb_server.stdout.readline().decode('utf-8').strip()
-            if not line:
-                continue
-            print(line)
-
-    thread = threading.Thread(target=print_thread)
-    thread.setDaemon(True)
-    thread.start()
-
-    return nb_server, base_url
+    loop.call_later(1, start)
 
 
-def run_karma(base_url):
-    config = dict(baseUrl=base_url,
-                  terminalsAvailable="True")
+def run_karma(base_url, token, terminalsAvailable):
+    config = dict(baseUrl=base_url, token=token,
+                  terminalsAvailable=terminalsAvailable)
     with open(os.path.join(HERE, 'build', 'injector.js'), 'w') as fid:
         fid.write("""
         var node = document.createElement('script');
@@ -80,20 +56,27 @@ def run_karma(base_url):
         document.body.appendChild(node);
         """ % json.dumps(config))
 
-    cmd = ['karma', 'start'] + sys.argv[1:]
-    return subprocess.check_call(cmd, shell=shell, stderr=subprocess.STDOUT)
+    cmd = ['karma', 'start'] + ARGS
+    shell = os.name == 'nt'
+    return subprocess.check_call(cmd, shell=shell)
+
+
+class TestApp(NotebookApp):
+    """A notebook app that runs a karma test."""
+
+    open_browser = Bool(False)
+    notebook_dir = Unicode(create_notebook_dir())
+    allow_origin = Unicode('*')
+
+    def start(self):
+        terminals_available = self.web_app.settings['terminals_available']
+        run_task(run_karma,
+            args=(self.connection_url, self.token, terminals_available))
+        super(TestApp, self).start()
 
 
 if __name__ == '__main__':
-
-    nb_server, base_url = start_notebook()
-
-    try:
-        resp = run_karma(base_url)
-    except (subprocess.CalledProcessError, KeyboardInterrupt):
-        resp = 1
-    finally:
-        nb_server.kill()
-
-    shutil.rmtree(root_dir, True)
-    sys.exit(resp)
+    # Reserve the command line arguments for karma.
+    ARGS = sys.argv[1:]
+    sys.argv = sys.argv[:1]
+    TestApp.launch_instance()

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,85 +1,85 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import './application/loader.spec';
-import './application/shell.spec';
+// import './application/loader.spec';
+// import './application/shell.spec';
 
-import './codeeditor/editor.spec';
-import './codeeditor/widget.spec';
+// import './codeeditor/editor.spec';
+// import './codeeditor/widget.spec';
 
-import './codemirror/editor.spec';
+// import './codemirror/editor.spec';
 
-import './commandlinker/commandlinker.spec';
+// import './commandlinker/commandlinker.spec';
 
-import './common/activitymonitor.spec';
-import './common/instancetracker.spec';
-import './common/observablestring.spec';
-import './common/observablevector.spec';
-import './common/vdom.spec';
+// import './common/activitymonitor.spec';
+// import './common/instancetracker.spec';
+// import './common/observablestring.spec';
+// import './common/observablevector.spec';
+// import './common/vdom.spec';
 
-import './completer/handler.spec';
-import './completer/model.spec';
-import './completer/widget.spec';
+// import './completer/handler.spec';
+// import './completer/model.spec';
+// import './completer/widget.spec';
 
-import './console/content.spec';
-import './console/foreign.spec';
-import './console/history.spec';
-import './console/panel.spec';
+// import './console/content.spec';
+// import './console/foreign.spec';
+// import './console/history.spec';
+// import './console/panel.spec';
 
-import './csvwidget/table.spec';
-import './csvwidget/toolbar.spec';
-import './csvwidget/widget.spec';
+// import './csvwidget/table.spec';
+// import './csvwidget/toolbar.spec';
+// import './csvwidget/widget.spec';
 
-import './dialog/dialog.spec';
+// import './dialog/dialog.spec';
 
-import './docmanager/manager.spec';
-import './docmanager/savehandler.spec';
-import './docmanager/widgetmanager.spec';
+// import './docmanager/manager.spec';
+// import './docmanager/savehandler.spec';
+// import './docmanager/widgetmanager.spec';
 
-import './docregistry/context.spec';
-import './docregistry/default.spec';
-import './docregistry/registry.spec';
+// import './docregistry/context.spec';
+// import './docregistry/default.spec';
+// import './docregistry/registry.spec';
 
-import './editorwidget/widget.spec';
+// import './editorwidget/widget.spec';
 
-import './filebrowser/crumbs.spec';
-import './filebrowser/model.spec';
+// import './filebrowser/crumbs.spec';
+// import './filebrowser/model.spec';
 
-import './imagewidget/widget.spec';
+// import './imagewidget/widget.spec';
 
-import './inspector/inspector.spec';
+// import './inspector/inspector.spec';
 
-import './markdownwidget/widget.spec';
+// import './markdownwidget/widget.spec';
 
-import './renderers/renderers.spec';
-import './renderers/latex.spec';
+// import './renderers/renderers.spec';
+// import './renderers/latex.spec';
 
-import './rendermime/rendermime.spec';
+// import './rendermime/rendermime.spec';
 
-import './notebook/cells/editor.spec';
-import './notebook/cells/model.spec';
-import './notebook/cells/widget.spec';
+// import './notebook/cells/editor.spec';
+// import './notebook/cells/model.spec';
+// import './notebook/cells/widget.spec';
 
-import './notebook/common/undo.spec';
+// import './notebook/common/undo.spec';
 
-import './notebook/notebook/actions.spec';
-import './notebook/notebook/default-toolbar.spec';
-import './notebook/notebook/model.spec';
-import './notebook/notebook/modelfactory.spec';
-import './notebook/notebook/panel.spec';
-import './notebook/notebook/trust.spec';
-import './notebook/notebook/widget.spec';
-import './notebook/notebook/widgetfactory.spec';
+// import './notebook/notebook/actions.spec';
+// import './notebook/notebook/default-toolbar.spec';
+// import './notebook/notebook/model.spec';
+// import './notebook/notebook/modelfactory.spec';
+// import './notebook/notebook/panel.spec';
+// import './notebook/notebook/trust.spec';
+// import './notebook/notebook/widget.spec';
+// import './notebook/notebook/widgetfactory.spec';
 
-import './notebook/output-area/model.spec';
-import './notebook/output-area/widget.spec';
+// import './notebook/output-area/model.spec';
+// import './notebook/output-area/widget.spec';
 
-import './notebook/tracker.spec';
+// import './notebook/tracker.spec';
 
-import './sanitizer/index.spec';
+// import './sanitizer/index.spec';
 
 import './terminal/terminal.spec';
 
-import './toolbar/toolbar.spec';
+// import './toolbar/toolbar.spec';
 
 import 'phosphor/styles/base.css';

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,85 +1,85 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// import './application/loader.spec';
-// import './application/shell.spec';
+import './application/loader.spec';
+import './application/shell.spec';
 
-// import './codeeditor/editor.spec';
-// import './codeeditor/widget.spec';
+import './codeeditor/editor.spec';
+import './codeeditor/widget.spec';
 
-// import './codemirror/editor.spec';
+import './codemirror/editor.spec';
 
-// import './commandlinker/commandlinker.spec';
+import './commandlinker/commandlinker.spec';
 
-// import './common/activitymonitor.spec';
-// import './common/instancetracker.spec';
-// import './common/observablestring.spec';
-// import './common/observablevector.spec';
-// import './common/vdom.spec';
+import './common/activitymonitor.spec';
+import './common/instancetracker.spec';
+import './common/observablestring.spec';
+import './common/observablevector.spec';
+import './common/vdom.spec';
 
-// import './completer/handler.spec';
-// import './completer/model.spec';
-// import './completer/widget.spec';
+import './completer/handler.spec';
+import './completer/model.spec';
+import './completer/widget.spec';
 
-// import './console/content.spec';
-// import './console/foreign.spec';
-// import './console/history.spec';
-// import './console/panel.spec';
+import './console/content.spec';
+import './console/foreign.spec';
+import './console/history.spec';
+import './console/panel.spec';
 
-// import './csvwidget/table.spec';
-// import './csvwidget/toolbar.spec';
-// import './csvwidget/widget.spec';
+import './csvwidget/table.spec';
+import './csvwidget/toolbar.spec';
+import './csvwidget/widget.spec';
 
-// import './dialog/dialog.spec';
+import './dialog/dialog.spec';
 
-// import './docmanager/manager.spec';
-// import './docmanager/savehandler.spec';
-// import './docmanager/widgetmanager.spec';
+import './docmanager/manager.spec';
+import './docmanager/savehandler.spec';
+import './docmanager/widgetmanager.spec';
 
-// import './docregistry/context.spec';
-// import './docregistry/default.spec';
-// import './docregistry/registry.spec';
+import './docregistry/context.spec';
+import './docregistry/default.spec';
+import './docregistry/registry.spec';
 
-// import './editorwidget/widget.spec';
+import './editorwidget/widget.spec';
 
-// import './filebrowser/crumbs.spec';
-// import './filebrowser/model.spec';
+import './filebrowser/crumbs.spec';
+import './filebrowser/model.spec';
 
-// import './imagewidget/widget.spec';
+import './imagewidget/widget.spec';
 
-// import './inspector/inspector.spec';
+import './inspector/inspector.spec';
 
-// import './markdownwidget/widget.spec';
+import './markdownwidget/widget.spec';
 
-// import './renderers/renderers.spec';
-// import './renderers/latex.spec';
+import './renderers/renderers.spec';
+import './renderers/latex.spec';
 
-// import './rendermime/rendermime.spec';
+import './rendermime/rendermime.spec';
 
-// import './notebook/cells/editor.spec';
-// import './notebook/cells/model.spec';
-// import './notebook/cells/widget.spec';
+import './notebook/cells/editor.spec';
+import './notebook/cells/model.spec';
+import './notebook/cells/widget.spec';
 
-// import './notebook/common/undo.spec';
+import './notebook/common/undo.spec';
 
-// import './notebook/notebook/actions.spec';
-// import './notebook/notebook/default-toolbar.spec';
-// import './notebook/notebook/model.spec';
-// import './notebook/notebook/modelfactory.spec';
-// import './notebook/notebook/panel.spec';
-// import './notebook/notebook/trust.spec';
-// import './notebook/notebook/widget.spec';
-// import './notebook/notebook/widgetfactory.spec';
+import './notebook/notebook/actions.spec';
+import './notebook/notebook/default-toolbar.spec';
+import './notebook/notebook/model.spec';
+import './notebook/notebook/modelfactory.spec';
+import './notebook/notebook/panel.spec';
+import './notebook/notebook/trust.spec';
+import './notebook/notebook/widget.spec';
+import './notebook/notebook/widgetfactory.spec';
 
-// import './notebook/output-area/model.spec';
-// import './notebook/output-area/widget.spec';
+import './notebook/output-area/model.spec';
+import './notebook/output-area/widget.spec';
 
-// import './notebook/tracker.spec';
+import './notebook/tracker.spec';
 
-// import './sanitizer/index.spec';
+import './sanitizer/index.spec';
 
 import './terminal/terminal.spec';
 
-// import './toolbar/toolbar.spec';
+import './toolbar/toolbar.spec';
 
 import 'phosphor/styles/base.css';


### PR DESCRIPTION
- Upgrades to `@jupyterlab/services@0.35.0` for Notebook 4.3.1 compatibility.
- Cleans up the test runner to use a `NotebookApp` directly instead of parsing stdout to get the desired information.  
- Moves the failure allowance from the test suite level to allow individual tests to fail in the case of a race condition on CI.
- Checked for compatibility with Notebook 4.3.1 on Chrome and Firefox.
