### PR TITLE
Expose renderers on `RenderMime` + MIME bundle utils

### DIFF
--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -799,58 +799,6 @@ class OutputWidget extends Widget {
     }
   }
 
-  /**
-   * Get the mime bundle for an output.
-   *
-   * @params output - A kernel output message payload.
-   *
-   * @returns - A mime bundle for the payload.
-   */
-  protected getBundle(output: nbformat.IOutput): nbformat.IMimeBundle {
-    let bundle: nbformat.IMimeBundle;
-    switch (output.output_type) {
-    case 'execute_result':
-      bundle = (output as nbformat.IExecuteResult).data;
-      break;
-    case 'display_data':
-      bundle = (output as nbformat.IDisplayData).data;
-      break;
-    case 'stream':
-      let text = (output as nbformat.IStream).text;
-      bundle = {
-        'application/vnd.jupyter.console-text': text
-      };
-      break;
-    case 'error':
-      let out: nbformat.IError = output as nbformat.IError;
-      let traceback = out.traceback.join('\n');
-      bundle = {
-        'application/vnd.jupyter.console-text': traceback ||
-          `${out.ename}: ${out.evalue}`
-      };
-      break;
-    default:
-      break;
-    }
-    return bundle || {};
-  }
-
-  /**
-   * Convert a mime bundle to a mime map.
-   */
-  protected convertBundle(bundle: nbformat.IMimeBundle): RenderMime.MimeMap<string> {
-    let map: RenderMime.MimeMap<string> = Object.create(null);
-    for (let mimeType in bundle) {
-      let value = bundle[mimeType];
-      if (Array.isArray(value)) {
-        map[mimeType] = (value as string[]).join('\n');
-      } else {
-        map[mimeType] = value as string;
-      }
-    }
-    return map;
-  }
-
   private _rendermime: RenderMime = null;
   private _placeholder: Widget = null;
 }
@@ -975,6 +923,60 @@ namespace OutputWidget {
      * The rendermime instance used by the widget.
      */
     rendermime: RenderMime;
+  }
+
+  /**
+   * Get the mime bundle for an output.
+   *
+   * @params output - A kernel output message payload.
+   *
+   * @returns - A mime bundle for the payload.
+   */
+  export
+  function getBundle(output: nbformat.IOutput): nbformat.IMimeBundle {
+    let bundle: nbformat.IMimeBundle;
+    switch (output.output_type) {
+    case 'execute_result':
+      bundle = (output as nbformat.IExecuteResult).data;
+      break;
+    case 'display_data':
+      bundle = (output as nbformat.IDisplayData).data;
+      break;
+    case 'stream':
+      let text = (output as nbformat.IStream).text;
+      bundle = {
+        'application/vnd.jupyter.console-text': text
+      };
+      break;
+    case 'error':
+      let out: nbformat.IError = output as nbformat.IError;
+      let traceback = out.traceback.join('\n');
+      bundle = {
+        'application/vnd.jupyter.console-text': traceback ||
+          `${out.ename}: ${out.evalue}`
+      };
+      break;
+    default:
+      break;
+    }
+    return bundle || {};
+  }
+
+  /**
+   * Convert a mime bundle to a mime map.
+   */
+  export
+  function convertBundle(bundle: nbformat.IMimeBundle): RenderMime.MimeMap<string> {
+    let map: RenderMime.MimeMap<string> = Object.create(null);
+    for (let mimeType in bundle) {
+      let value = bundle[mimeType];
+      if (Array.isArray(value)) {
+        map[mimeType] = (value as string[]).join('\n');
+      } else {
+        map[mimeType] = value as string;
+      }
+    }
+    return map;
   }
 }
 

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -731,8 +731,8 @@ class OutputWidget extends Widget {
     }
     // Extract the data from the output and sanitize if necessary.
     let rendermime = this._rendermime;
-    let bundle = OutputWidget.getBundle(output as nbformat.IOutput);
-    let data = OutputWidget.convertBundle(bundle);
+    let bundle = OutputAreaModel.getBundle(output as nbformat.IOutput);
+    let data = OutputAreaModel.convertBundle(bundle);
     // Clear the content.
     this.clear();
 
@@ -923,60 +923,6 @@ namespace OutputWidget {
      * The rendermime instance used by the widget.
      */
     rendermime: RenderMime;
-  }
-
-  /**
-   * Get the mime bundle for an output.
-   *
-   * @params output - A kernel output message payload.
-   *
-   * @returns - A mime bundle for the payload.
-   */
-  export
-  function getBundle(output: nbformat.IOutput): nbformat.IMimeBundle {
-    let bundle: nbformat.IMimeBundle;
-    switch (output.output_type) {
-    case 'execute_result':
-      bundle = (output as nbformat.IExecuteResult).data;
-      break;
-    case 'display_data':
-      bundle = (output as nbformat.IDisplayData).data;
-      break;
-    case 'stream':
-      let text = (output as nbformat.IStream).text;
-      bundle = {
-        'application/vnd.jupyter.console-text': text
-      };
-      break;
-    case 'error':
-      let out: nbformat.IError = output as nbformat.IError;
-      let traceback = out.traceback.join('\n');
-      bundle = {
-        'application/vnd.jupyter.console-text': traceback ||
-          `${out.ename}: ${out.evalue}`
-      };
-      break;
-    default:
-      break;
-    }
-    return bundle || {};
-  }
-
-  /**
-   * Convert a mime bundle to a mime map.
-   */
-  export
-  function convertBundle(bundle: nbformat.IMimeBundle): RenderMime.MimeMap<string> {
-    let map: RenderMime.MimeMap<string> = Object.create(null);
-    for (let mimeType in bundle) {
-      let value = bundle[mimeType];
-      if (Array.isArray(value)) {
-        map[mimeType] = (value as string[]).join('\n');
-      } else {
-        map[mimeType] = value as string;
-      }
-    }
-    return map;
   }
 }
 

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -731,8 +731,8 @@ class OutputWidget extends Widget {
     }
     // Extract the data from the output and sanitize if necessary.
     let rendermime = this._rendermime;
-    let bundle = this.getBundle(output as nbformat.IOutput);
-    let data = this.convertBundle(bundle);
+    let bundle = OutputWidget.getBundle(output as nbformat.IOutput);
+    let data = OutputWidget.convertBundle(bundle);
     // Clear the content.
     this.clear();
 

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -195,6 +195,8 @@ class RenderMime {
    * Get a renderer by mimetype.
    *
    * @param mimetype - The mimetype of the renderer.
+   *
+   * @returns The renderer for the given mimetype, or undefined if the mimetype is unknown.
    */
   getRenderer(mimetype: string): RenderMime.IRenderer {
     return this._renderers[mimetype];

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -183,10 +183,21 @@ class RenderMime {
 
   /**
    * Remove a renderer by mimetype.
+   *
+   * @param mimetype - The mimetype of the renderer.
    */
   removeRenderer(mimetype: string): void {
     delete this._renderers[mimetype];
     this._order.remove(mimetype);
+  }
+
+  /**
+   * Get a renderer by mimetype.
+   *
+   * @param mimetype - The mimetype of the renderer.
+   */
+  getRenderer(mimetype: string): RenderMime.IRenderer {
+    return this._renderers[mimetype];
   }
 
   private _renderers: RenderMime.MimeMap<RenderMime.IRenderer> = Object.create(null);

--- a/test/src/notebook/output-area/model.spec.ts
+++ b/test/src/notebook/output-area/model.spec.ts
@@ -290,6 +290,38 @@ describe('notebook/output-area/model', () => {
 
     });
 
+    describe('#getBundle()', () => {
+
+      it('should handle all bundle types', () => {
+        for (let i = 0; i < DEFAULT_OUTPUTS.length; i++) {
+          let output = DEFAULT_OUTPUTS[i];
+          let bundle = OutputAreaModel.getBundle(output);
+          expect(Object.keys(bundle).length).to.not.be(0);
+        }
+      });
+
+    });
+
+    describe('#convertBundle()', () => {
+
+      it('should handle bundles with strings', () => {
+        let bundle: nbformat.IMimeBundle = {
+          'text/plain': 'foo'
+        };
+        let map = OutputAreaModel.convertBundle(bundle);
+        expect(map).to.eql(bundle);
+      });
+
+      it('should handle bundles with string arrays', () => {
+        let bundle: nbformat.IMimeBundle = {
+          'text/plain': ['foo', 'bar']
+        };
+        let map = OutputAreaModel.convertBundle(bundle);
+        expect(map).to.eql({ 'text/plain': 'foo\nbar' });
+      });
+
+    });
+
   });
 
 });

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -4,10 +4,6 @@
 import expect = require('expect.js');
 
 import {
-  nbformat
-} from '@jupyterlab/services';
-
-import {
   Message
 } from 'phosphor/lib/core/messaging';
 
@@ -18,10 +14,6 @@ import {
 import {
   OutputAreaModel, OutputAreaWidget, OutputWidget
 } from '../../../../lib/notebook/output-area';
-
-import {
-  RenderMime
-} from '../../../../lib/rendermime';
 
 import {
   defaultRenderMime
@@ -428,38 +420,6 @@ describe('notebook/output-area/widget', () => {
         let widget = new CustomOutputWidget({ rendermime });
         widget.setOutput(null);
         expect(widget.output).to.be.a(Widget);
-      });
-
-    });
-
-    describe('#getBundle()', () => {
-
-      it('should handle all bundle types', () => {
-        for (let i = 0; i < DEFAULT_OUTPUTS.length; i++) {
-          let output = DEFAULT_OUTPUTS[i];
-          let bundle = OutputWidget.getBundle(output);
-          expect(Object.keys(bundle).length).to.not.be(0);
-        }
-      });
-
-    });
-
-    describe('#convertBundle()', () => {
-
-      it('should handle bundles with strings', () => {
-        let bundle: nbformat.IMimeBundle = {
-          'text/plain': 'foo'
-        };
-        let map = OutputWidget.convertBundle(bundle);
-        expect(map).to.eql(bundle);
-      });
-
-      it('should handle bundles with string arrays', () => {
-        let bundle: nbformat.IMimeBundle = {
-          'text/plain': ['foo', 'bar']
-        };
-        let map = OutputWidget.convertBundle(bundle);
-        expect(map).to.eql({ 'text/plain': 'foo\nbar' });
       });
 
     });

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -69,14 +69,6 @@ class CustomOutputWidget extends OutputWidget {
   setOutput(value: Widget): void {
     super.setOutput(value);
   }
-
-  getBundle(output: nbformat.IOutput): nbformat.IMimeBundle {
-    return super.getBundle(output);
-  }
-
-  convertBundle(bundle: nbformat.IMimeBundle): RenderMime.MimeMap<string> {
-    return super.convertBundle(bundle);
-  }
 }
 
 
@@ -443,10 +435,9 @@ describe('notebook/output-area/widget', () => {
     describe('#getBundle()', () => {
 
       it('should handle all bundle types', () => {
-        let widget = new CustomOutputWidget({ rendermime });
         for (let i = 0; i < DEFAULT_OUTPUTS.length; i++) {
           let output = DEFAULT_OUTPUTS[i];
-          let bundle = widget.getBundle(output);
+          let bundle = OutputWidget.getBundle(output);
           expect(Object.keys(bundle).length).to.not.be(0);
         }
       });
@@ -459,8 +450,7 @@ describe('notebook/output-area/widget', () => {
         let bundle: nbformat.IMimeBundle = {
           'text/plain': 'foo'
         };
-        let widget = new CustomOutputWidget({ rendermime });
-        let map = widget.convertBundle(bundle);
+        let map = OutputWidget.convertBundle(bundle);
         expect(map).to.eql(bundle);
       });
 
@@ -468,8 +458,7 @@ describe('notebook/output-area/widget', () => {
         let bundle: nbformat.IMimeBundle = {
           'text/plain': ['foo', 'bar']
         };
-        let widget = new CustomOutputWidget({ rendermime });
-        let map = widget.convertBundle(bundle);
+        let map = OutputWidget.convertBundle(bundle);
         expect(map).to.eql({ 'text/plain': 'foo\nbar' });
       });
 

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -217,6 +217,20 @@ describe('rendermime/index', () => {
 
     });
 
+    describe('#getRenderer()', () => {
+
+      it('should get a renderer by mimetype', () => {
+        let r = defaultRenderMime();
+        expect(r.getRenderer('text/plain')).to.be.a(TextRenderer);
+      });
+
+      it('should return undefined for missing mimetype', () => {
+        let r = defaultRenderMime();
+        expect(r.getRenderer('foo/bar')).to.be(undefined);
+      });
+
+    });
+
     describe('#mimetypes()', () => {
 
       it('should get the ordered list of mimetypes', () => {

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -226,7 +226,7 @@ describe('rendermime/index', () => {
 
       it('should return undefined for missing mimetype', () => {
         let r = defaultRenderMime();
-        expect(r.getRenderer('foo/bar')).to.be(undefined);
+        expect(r.getRenderer('hello/world')).to.be(undefined);
       });
 
     });


### PR DESCRIPTION
 - Allow access to `IRenderer`s on `RenderMime`, while still protecting internal dict against direct modification.
 - Move `getBundle()` and `convertBundle()` from protected methods on `OutputWidget` class, to exported functions on `OutputWidget` namespace. These could possibly be better placed somewhere else (model?).

My current use case where access to the renderers/utils is necessary: To query whether a given output will be sanitized or not. After this PR, the following pattern can be used:

```ts
function willSanitize(output: nbformat.IOutput, rendermime: IRenderMime) {
  let bundle = OutputWidget.getBundle(output);
  let data = OutputWidget.convertBundle(bundle);
  if (!data) {
    return false;
  }
  let preferred = rendermime.preferredMimetype(data, false);
  let renderer = rendermime.getRenderer(preferred);
  return renderer.isSanitizable(preferred);
}
```

Alternative (preferable) solutions to solving the use case is of course welcome :)