### PR TITLE
Dropdown and dialog consistency styling refinements

### DIFF
--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -47,7 +47,7 @@
   padding-bottom: 12px;
   font-size: 20px;
   font-weight: 400;
-  color: #616161;
+  color: var(--jp-ui-font-color0);
 }
 
 
@@ -125,6 +125,7 @@
 .jp-Dialog-inputWrapper {
   display: flex;
   background: white;
+  height: 28px;
   width: 252px;
   box-sizing: border-box;
   border: var(--jp-border-width) solid var(--jp-border-color1);
@@ -137,7 +138,7 @@
   flex: 1 1 auto;
   padding: 7px;
   font-size: 15px;
-  color: #676767;
+  color: var(--jp-ui-font-color0);
   border: none;
 }
 
@@ -147,6 +148,7 @@
   flex-direction: column;
   padding: 1px;
   background: white;
+  height: 28px;
   width: 252px;
   box-sizing: border-box;
   border: var(--jp-border-width) solid var(--jp-border-color1);
@@ -159,6 +161,6 @@
   height: 32px;
   font-size: 15px;
   background: white;
-  color: #676767;
+  color: var(--jp-ui-font-color0);
   border: none;
 }

--- a/src/notebook/toolbar.css
+++ b/src/notebook/toolbar.css
@@ -18,8 +18,8 @@
 }
 
 
-.jp-Notebook-toolbarCellType .jp-Notebook-toolbarCellTypeDropdown {
-  border: var(--jp-border-width) solid var(--jp-border-color1);
+.jp-Notebook-toolbarCellType select.jp-Notebook-toolbarCellTypeDropdown {
+  border: var(--jp-border-width) solid var(--jp-border-color4);
   border-radius: 0;
   outline: none;
   width: 100%;


### PR DESCRIPTION
Removed border from dropdown in notebook to match other items in the toolbar

#### Before
![screen shot 2017-01-10 at 11 12 26 am](https://cloud.githubusercontent.com/assets/6437976/21820729/c21226de-d725-11e6-8c32-b3c7129194f4.png)

#### After
![screen shot 2017-01-10 at 11 11 38 am](https://cloud.githubusercontent.com/assets/6437976/21820734/c8b4c690-d725-11e6-87e2-09d6a2954d50.png)

Changed text color of dropdown in dialogs to match color of dropdown in notebook
Changed height of dropdown and inputs in dialogs to be 28px for compatibility

#### Before
![screen shot 2017-01-10 at 11 12 34 am](https://cloud.githubusercontent.com/assets/6437976/21820744/d3b3fa3e-d725-11e6-9227-45cde181f2ba.png)

#### After
![screen shot 2017-01-10 at 11 11 44 am](https://cloud.githubusercontent.com/assets/6437976/21820751/da791750-d725-11e6-8084-511af2a6bfbc.png)

I changed the color of the dialog prompt header as well to match the input field and dropdown. Looked funky changing one but not the other:
![screen shot 2017-01-10 at 11 21 10 am](https://cloud.githubusercontent.com/assets/6437976/21821048/e8ac11c8-d726-11e6-8f90-cc2217113496.png)


And I also noticed that when the dialog prompt header is the shade of gray, on other dialogs (such as close without saving) the styling doesn't work in regards to hierarchy:
![screen shot 2017-01-10 at 11 19 47 am](https://cloud.githubusercontent.com/assets/6437976/21821056/ef7f1edc-d726-11e6-96ec-2743316661b3.png)
![screen shot 2017-01-10 at 11 19 01 am](https://cloud.githubusercontent.com/assets/6437976/21821060/f263b4be-d726-11e6-8fdf-d19e52fa9fe7.png)

This addresses Issue #1444
