### PR TITLE
Examples cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,7 @@ sudo: false
 cache:
   directories:
     - node_modules
-    - examples/console/node_modules
-    - examples/filebrowser/node_modules
-    - examples/lab/node_modules
-    - examples/notebook/node_modules
-    - examples/terminal/node_modules
+    - $HOME/.npm
 env:
   matrix:
     - GROUP=tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ sudo: false
 cache:
   directories:
     - node_modules
+    - examples/console/node_modules
+    - examples/filebrowser/node_modules
+    - examples/lab/node_modules
+    - examples/notebook/node_modules
+    - examples/terminal/node_modules
 env:
   matrix:
     - GROUP=tests

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -5,7 +5,7 @@
     "build": "tsc --project src && webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab && npm install",
+    "update": "rimraf node_modules/jupyterlab || npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -5,7 +5,7 @@
     "build": "tsc --project src && webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab && npm install",
+    "update": "rimraf node_modules/jupyterlab || npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {

--- a/examples/lab/package.json
+++ b/examples/lab/package.json
@@ -5,7 +5,7 @@
     "build": "webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab && npm install",
+    "update": "rimraf node_modules/jupyterlab || npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src --wait 10"
   },
   "dependencies": {

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -5,7 +5,7 @@
     "build": "tsc --project src && webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab && npm install",
+    "update": "rimraf node_modules/jupyterlab || npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -5,7 +5,7 @@
     "build": "tsc --project src && webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab && npm install",
+    "update": "rimraf node_modules/jupyterlab || npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {

--- a/scripts/buildexamples.js
+++ b/scripts/buildexamples.js
@@ -11,7 +11,7 @@ for (var i = 0; i < dirs.length; i++) {
   console.log('\n********');
   console.log('Building: ' + dirs[i] + '...');
   process.chdir('examples/' + dirs[i]);
-  childProcess.execSync('npm run update', { stdio: [0, 1, 2] });
+  childProcess.execSync('rimraf node_modules/jupyterlab && npm install --cache-min 9999999', { stdio: [0, 1, 2] });
   process.chdir('../..');
 }
 console.log('\n********\nDone building examples!');


### PR DESCRIPTION
Force the use of the npm cache and allow `npm run update` to work when before `rimraf` is installed in the folders.