### PR TITLE
Refactor of Notebook and Console Content Factories

### DIFF
--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -5,7 +5,7 @@
     "build": "tsc --project src && webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab || npm install",
+    "update": "(rimraf node_modules/jupyterlab || true) && npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {

--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -94,8 +94,14 @@ function startApp(session: Session.ISession) {
   }
   let sanitizer = defaultSanitizer;
   let rendermime = new RenderMime({ renderers, order, sanitizer });
-  let renderer = new ConsolePanel.Renderer({ editorServices });
-  let consolePanel = renderer.createConsole(rendermime, session);
+  let editorFactory = editorServices.factoryService.newInlineEditor;
+  let contentFactory = new ConsolePanel.ContentFactory({ editorFactory });
+  let consolePanel = new ConsolePanel({
+    rendermime,
+    session,
+    contentFactory,
+    mimeTypeService: editorServices.mimeTypeService
+  });
   consolePanel.title.label = TITLE;
 
   let palette = new CommandPalette({ commands, keymap });
@@ -119,14 +125,14 @@ function startApp(session: Session.ISession) {
   command = 'console:clear';
   commands.addCommand(command, {
     label: 'Clear',
-    execute: () => { consolePanel.content.clear(); }
+    execute: () => { consolePanel.console.clear(); }
   });
   palette.addItem({ command, category });
 
   command = 'console:execute';
   commands.addCommand(command, {
     label: 'Execute Prompt',
-    execute: () => { consolePanel.content.execute(); }
+    execute: () => { consolePanel.console.execute(); }
   });
   palette.addItem({ command, category });
   keymap.addBinding({ command,  selector,  keys: ['Enter'] });
@@ -134,7 +140,7 @@ function startApp(session: Session.ISession) {
   command = 'console:execute-forced';
   commands.addCommand(command, {
     label: 'Execute Cell (forced)',
-    execute: () => { consolePanel.content.execute(true); }
+    execute: () => { consolePanel.console.execute(true); }
   });
   palette.addItem({ command, category });
   keymap.addBinding({ command,  selector,  keys: ['Shift Enter'] });
@@ -142,7 +148,7 @@ function startApp(session: Session.ISession) {
   command = 'console:linebreak';
   commands.addCommand(command, {
     label: 'Insert Line Break',
-    execute: () => { consolePanel.content.insertLinebreak(); }
+    execute: () => { consolePanel.console.insertLinebreak(); }
   });
   palette.addItem({ command, category });
   keymap.addBinding({ command,  selector,  keys: ['Ctrl Enter'] });

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -5,7 +5,7 @@
     "build": "tsc --project src && webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab || npm install",
+    "update": "(rimraf node_modules/jupyterlab || true) && npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {

--- a/examples/lab/package.json
+++ b/examples/lab/package.json
@@ -5,7 +5,7 @@
     "build": "webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab || npm install",
+    "update": "(rimraf node_modules/jupyterlab || true) && npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src --wait 10"
   },
   "dependencies": {

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -5,7 +5,7 @@
     "build": "tsc --project src && webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab || npm install",
+    "update": "(rimraf node_modules/jupyterlab || true) && npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -129,8 +129,8 @@ function createApp(manager: ServiceManager.IManager): void {
   });
   let mFactory = new NotebookModelFactory();
   let clipboard = new MimeData();
-  let notebookRenderer = new Notebook.Renderer({ editorServices });
-  let renderer = new NotebookPanel.Renderer({ notebookRenderer });
+  let editorFactory = editorServices.factoryService.newInlineEditor;
+  let contentFactory = new NotebookPanel.ContentFactory({ editorFactory });
 
   let wFactory = new NotebookWidgetFactory({
     name: 'Notebook',
@@ -139,7 +139,8 @@ function createApp(manager: ServiceManager.IManager): void {
     defaultFor: ['.ipynb'],
     preferKernel: true,
     canStartKernel: true,
-    rendermime, clipboard, renderer
+    rendermime, clipboard, contentFactory,
+    mimeTypeService: editorServices.mimeTypeService
   });
   docRegistry.addModelFactory(mFactory);
   docRegistry.addWidgetFactory(wFactory);
@@ -182,48 +183,48 @@ function createApp(manager: ServiceManager.IManager): void {
   commands.addCommand(cmdIds.runAndAdvance, {
     label: 'Run and Advance',
     execute: () => {
-      NotebookActions.runAndAdvance(nbWidget.content, nbWidget.context.kernel);
+      NotebookActions.runAndAdvance(nbWidget.notebook, nbWidget.context.kernel);
     }
   });
   commands.addCommand(cmdIds.editMode, {
     label: 'Edit Mode',
-    execute: () => { nbWidget.content.mode = 'edit'; }
+    execute: () => { nbWidget.notebook.mode = 'edit'; }
   });
   commands.addCommand(cmdIds.commandMode, {
     label: 'Command Mode',
-    execute: () => { nbWidget.content.mode = 'command'; }
+    execute: () => { nbWidget.notebook.mode = 'command'; }
   });
   commands.addCommand(cmdIds.selectBelow, {
     label: 'Select Below',
-    execute: () => NotebookActions.selectBelow(nbWidget.content)
+    execute: () => NotebookActions.selectBelow(nbWidget.notebook)
   });
   commands.addCommand(cmdIds.selectAbove, {
     label: 'Select Above',
-    execute: () => NotebookActions.selectAbove(nbWidget.content)
+    execute: () => NotebookActions.selectAbove(nbWidget.notebook)
   });
   commands.addCommand(cmdIds.extendAbove, {
     label: 'Extend Above',
-    execute: () => NotebookActions.extendSelectionAbove(nbWidget.content)
+    execute: () => NotebookActions.extendSelectionAbove(nbWidget.notebook)
   });
   commands.addCommand(cmdIds.extendBelow, {
     label: 'Extend Below',
-    execute: () => NotebookActions.extendSelectionBelow(nbWidget.content)
+    execute: () => NotebookActions.extendSelectionBelow(nbWidget.notebook)
   });
   commands.addCommand(cmdIds.merge, {
     label: 'Merge Cells',
-    execute: () => NotebookActions.mergeCells(nbWidget.content)
+    execute: () => NotebookActions.mergeCells(nbWidget.notebook)
   });
   commands.addCommand(cmdIds.split, {
     label: 'Split Cell',
-    execute: () => NotebookActions.splitCell(nbWidget.content)
+    execute: () => NotebookActions.splitCell(nbWidget.notebook)
   });
   commands.addCommand(cmdIds.undo, {
     label: 'Undo',
-    execute: () => NotebookActions.undo(nbWidget.content)
+    execute: () => NotebookActions.undo(nbWidget.notebook)
   });
   commands.addCommand(cmdIds.redo, {
     label: 'Redo',
-    execute: () => NotebookActions.redo(nbWidget.content)
+    execute: () => NotebookActions.redo(nbWidget.notebook)
   });
 
   let category = 'Notebook Operations';

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -5,7 +5,7 @@
     "build": "tsc --project src && webpack --config webpack.conf.js",
     "clean": "rimraf build && rimraf node_modules",
     "postinstall": "node ../../scripts/dedupe.js && npm run build",
-    "update": "rimraf node_modules/jupyterlab || npm install",
+    "update": "(rimraf node_modules/jupyterlab || true) && npm install",
     "watch": "watch \"npm run update && npm run build\" ../../src src --wait 10"
   },
   "dependencies": {

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -2,6 +2,7 @@
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+set -ex
 
 npm install
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -4,7 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 set -ex
 
-npm install
+npm update
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
@@ -12,8 +12,7 @@ hash -r
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda info -a
-conda install jupyter pytest
-conda install -c conda-forge notebook
+conda install -c conda-forge notebook pytest
 
 # create jupyter base dir (needed for config retreival)
 mkdir ~/.jupyter

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -2,7 +2,7 @@
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-set -ex
+set -x
 
 npm update
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/src/codeeditor/editor.ts
+++ b/src/codeeditor/editor.ts
@@ -684,8 +684,8 @@ namespace CodeEditor {
     readOnly?: boolean;
 
    /**
-     * The default selection style for the editor.
-     */
+    * The default selection style for the editor.
+    */
     selectionStyle?: CodeEditor.ISelectionStyle;
   }
 }

--- a/src/codeeditor/widget.ts
+++ b/src/codeeditor/widget.ts
@@ -24,7 +24,14 @@ class CodeEditorWidget extends Widget {
    */
   constructor(options: CodeEditorWidget.IOptions) {
     super();
-    this._editor = options.factory({ host: this.node, model: options.model });
+    this._editor = options.factory({
+      host: this.node,
+      model: options.model,
+      uuid: options.uuid,
+      wordWrap: options.wordWrap,
+      readOnly: options.readOnly,
+      selectionStyle: options.selectionStyle
+    });
   }
 
   /**
@@ -175,5 +182,30 @@ namespace CodeEditorWidget {
      * The model used to initialize the code editor.
      */
     model: CodeEditor.IModel;
+
+    /**
+     * The desired uuid for the editor.
+     */
+    uuid?: string;
+
+    /**
+     * Whether line numbers should be displayed. Defaults to `false`.
+     */
+    lineNumbers?: boolean;
+
+    /**
+     * Set to false for horizontal scrolling. Defaults to `true`.
+     */
+    wordWrap?: boolean;
+
+    /**
+     * Whether the editor is read-only. Defaults to `false`.
+     */
+    readOnly?: boolean;
+
+   /**
+    * The default selection style for the editor.
+    */
+    selectionStyle?: CodeEditor.ISelectionStyle;
   }
 }

--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -134,7 +134,7 @@ class CellCompleterHandler implements IDisposable {
       coords,
       line: position.line,
       column: position.column
-    }
+    };
   }
 
   /**

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -86,7 +86,7 @@ class CompleterWidget extends Widget {
     super({ node: document.createElement('ul') });
     this._renderer = options.renderer || CompleterWidget.defaultRenderer;
     this.anchor = options.anchor || null;
-    this.model = options.model || null;
+    this.model = options.model;
     this.addClass(COMPLETER_CLASS);
 
     // Completer widgets are hidden until they are populated.

--- a/src/console/foreign.ts
+++ b/src/console/foreign.ts
@@ -25,7 +25,7 @@ class ForeignHandler implements IDisposable {
    */
   constructor(options: ForeignHandler.IOptions) {
     this.kernel = options.kernel;
-    this._renderer = options.renderer.createCell;
+    this._factory = options.cellFactory;
     this._parent = options.parent;
   }
 
@@ -149,7 +149,7 @@ class ForeignHandler implements IDisposable {
    * Create a new code cell for an input originated from a foreign session.
    */
   private _newCell(parentMsgId: string): CodeCellWidget {
-    let cell = this._renderer();
+    let cell = this._factory();
     this._cells.set(parentMsgId, cell);
     this._parent.addCell(cell);
     return cell;
@@ -160,7 +160,7 @@ class ForeignHandler implements IDisposable {
   private _isDisposed = false;
   private _kernel: Kernel.IKernel = null;
   private _parent: ForeignHandler.IReceiver = null;
-  private _renderer: () => CodeCellWidget = null;
+  private _factory: () => CodeCellWidget = null;
 }
 
 
@@ -185,20 +185,9 @@ namespace ForeignHandler {
     parent: IReceiver;
 
     /**
-     * The renderer for creating cells to inject into the parent.
+     * The cell factory for foreign handlers.
      */
-    renderer: IRenderer;
-  }
-
-  /**
-   * A renderer for foreign handlers.
-   */
-  export
-  interface IRenderer {
-    /**
-     * Create a code cell.
-     */
-    createCell: () => CodeCellWidget;
+    cellFactory: () => CodeCellWidget;
   }
 
   /**

--- a/src/console/index.css
+++ b/src/console/index.css
@@ -18,7 +18,7 @@
 }
 
 
-.jp-ConsoleContent {
+.jp-CodeConsole {
   height: 100%;
   padding: 0;
   display: flex;
@@ -26,26 +26,26 @@
 }
 
 
-.jp-ConsoleContent-content {
+.jp-CodeConsole-content {
   background-color: var(--jp-layout-color2);
   flex: 1 1 auto;
   overflow: auto;
 }
 
 
-.jp-ConsoleContent-content .jp-Cell.jp-ConsoleContent-foreignCell {
+.jp-CodeConsole-content .jp-Cell.jp-CodeConsole-foreignCell {
   background-color: var(--jp-layout-color3);
   flex: 1 1 auto;
   overflow: auto;
 }
 
 
-.jp-ConsoleContent-content .jp-Cell.jp-CodeCell.jp-mod-collapsed.jp-mod-readOnly {
+.jp-CodeConsole-content .jp-Cell.jp-CodeCell.jp-mod-collapsed.jp-mod-readOnly {
   padding-left: calc(2*var(--jp-private-console-cell-padding))
 }
 
 
-.jp-ConsoleContent-input {
+.jp-CodeConsole-input {
   max-height: 80%;
   flex: 0 0 auto;
   overflow: auto;
@@ -59,26 +59,26 @@
 }
 
 
-.jp-ConsoleContent-content .jp-InputArea-editor.jp-CellEditor {
+.jp-CodeConsole-content .jp-InputArea-editor.jp-CellEditor {
   background: transparent;
   border-color: transparent;
 }
 
 
 /* TODO: we should be able to use notebook styles for this */
-.jp-ConsoleContent-input .jp-ConsoleContent-prompt.jp-Cell {
+.jp-CodeConsole-input .jp-CodeConsole-prompt.jp-Cell {
   background: linear-gradient(to right, #66BB6A -40px, #66BB6A 5px, transparent 5px, transparent 100%);
   border-color: #66BB6A;
   border-left-width: var(--jp-border-width);
 }
 
 
-.jp-ConsoleContent-input .jp-ConsoleContent-prompt .jp-InputArea {
+.jp-CodeConsole-input .jp-CodeConsole-prompt .jp-InputArea {
   height: 100%;
   min-height: 100%;
 }
 
 
-.jp-ConsoleContent-content .jp-ConsoleContent-banner .jp-Cell-prompt {
+.jp-CodeConsole-content .jp-CodeConsole-banner .jp-Cell-prompt {
   display: none;
 }

--- a/src/console/index.ts
+++ b/src/console/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-export * from './tracker';
-export * from './content';
 export * from './panel';
+export * from './tracker';
+export * from './widget';

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -18,10 +18,6 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  Widget
-} from 'phosphor/lib/ui/widget';
-
-import {
   IEditorMimeTypeService, CodeEditor
 } from '../codeeditor';
 

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -6,7 +6,7 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
-  Session
+  Session, Kernel
 } from '@jupyterlab/services';
 
 import {
@@ -93,8 +93,8 @@ class ConsolePanel extends Panel {
       kernel: options.session.kernel
     });
 
+    // Connect to change events.
     this.console.promptCreated.connect(this._onPromptCreated, this);
-
     options.session.kernelChanged.connect(this._onKernelChanged, this);
   }
 
@@ -158,8 +158,7 @@ class ConsolePanel extends Panel {
   /**
    * Handle a change to the kernel.
    */
-  private _onKernelChanged(): void {
-    let kernel = this.console.session.kernel;
+  private _onKernelChanged(sender: Session.ISession, kernel: Kernel.IKernel): void {
     this._completerHandler.kernel = kernel;
     this.inspectionHandler.kernel = kernel;
   }

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -22,7 +22,7 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
-  IEditorMimeTypeService
+  IEditorMimeTypeService, CodeEditor
 } from '../codeeditor';
 
 import {
@@ -34,8 +34,12 @@ import {
 } from '../inspector';
 
 import {
-  CodeCellWidget
+  BaseCellWidget, CodeCellWidget
 } from '../notebook/cells';
+
+import {
+  OutputAreaWidget
+} from '../notebook/output-area';
 
 import {
   IRenderMime
@@ -209,7 +213,12 @@ namespace ConsolePanel {
   export
   interface IContentFactory {
     /**
-     * The console content factory.
+     * The editor factory used by the content factory.
+     */
+    readonly editorFactory: CodeEditor.Factory;
+
+    /**
+     * The factory for code console content.
      */
     readonly consoleContentFactory: CodeConsole.IContentFactory;
 
@@ -243,11 +252,24 @@ namespace ConsolePanel {
      * Create a new content factory.
      */
     constructor(options: ContentFactory.IOptions) {
-      this.consoleContentFactory = options.consoleContentFactory;
+      this.editorFactory = options.editorFactory;
+      this.consoleContentFactory = (options.consoleContentFactory ||
+        new CodeConsole.ContentFactory({
+          editorFactory: this.editorFactory,
+          outputAreaContentFactory: options.outputAreaContentFactory,
+          codeCellContentFactory: options.codeCellContentFactory,
+          rawCellContentFactory: options.rawCellContentFactory
+        })
+      );
     }
 
     /**
-     * The console content factory.
+     * The editor factory used by the content factory.
+     */
+    readonly editorFactory: CodeEditor.Factory;
+
+    /**
+     * The factory for code console content.
      */
     readonly consoleContentFactory: CodeConsole.IContentFactory;
 
@@ -291,9 +313,32 @@ namespace ConsolePanel {
     export
     interface IOptions {
       /**
-       * The notebook content factory.
+       * The editor factory.  This will be used to create a
+       * consoleContentFactory if none is given.
        */
-      consoleContentFactory: CodeConsole.IContentFactory;
+      editorFactory: CodeEditor.Factory;
+
+      /**
+       * The factory for output area content.
+       */
+      outputAreaContentFactory?: OutputAreaWidget.IContentFactory;
+
+      /**
+       * The factory for code cell widget content.  If given, this will
+       * take precedence over the `outputAreaContentFactory`.
+       */
+      codeCellContentFactory?: CodeCellWidget.IContentFactory;
+
+      /**
+       * The factory for raw cell widget content.
+       */
+      rawCellContentFactory?: BaseCellWidget.IContentFactory;
+
+      /**
+       * The factory for console wiget content.  If given, this will
+       * take precedence over the output area and cell factories.
+       */
+      consoleContentFactory?: CodeConsole.IContentFactory;
     }
   }
 

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -18,6 +18,10 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
   IEditorMimeTypeService, CodeEditor
 } from '../codeeditor';
 
@@ -81,6 +85,7 @@ class ConsolePanel extends Panel {
 
     // Set the completer widget's anchor node to peg its position.
     this._completer.anchor = this.node;
+    Widget.attach(this._completer, document.body);
 
     // Instantiate the completer handler.
     this._completerHandler = factory.createCompleterHandler({

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -26,7 +26,7 @@ import {
 } from '../codeeditor';
 
 import {
-  CellCompleterHandler, CompleterWidget
+  CellCompleterHandler, CompleterModel, CompleterWidget
 } from '../completer';
 
 import {
@@ -77,7 +77,7 @@ class ConsolePanel extends Panel {
     });
 
     // Instantiate the completer.
-    this._completer = factory.createCompleter({});
+    this._completer = factory.createCompleter({ model: new CompleterModel() });
 
     // Set the completer widget's anchor node to peg its position.
     this._completer.anchor = this.node;
@@ -109,23 +109,26 @@ class ConsolePanel extends Panel {
   readonly inspectionHandler: InspectionHandler;
 
   /**
+   * Test whether the widget is disposed.
+   */
+  get isDisposed(): boolean {
+    return this._completer == null;
+  }
+
+  /**
    * Dispose of the resources held by the widget.
    */
   dispose(): void {
     if (this.isDisposed) {
       return;
     }
-
-    // Dispose console widget.
-    this._content.dispose();
-    this._content = null;
-
+    let completer = this._completer;
+    this._completer = null;
+    completer.dispose();
+    this.console.dispose();
     this._completerHandler.dispose();
     this._completerHandler = null;
-    this._completer.dispose();
-    this._completer = null;
     this.inspectionHandler.dispose();
-
     super.dispose();
   }
 
@@ -163,7 +166,6 @@ class ConsolePanel extends Panel {
     this.inspectionHandler.kernel = kernel;
   }
 
-  private _content: CodeConsole = null;
   private _completer: CompleterWidget = null;
   private _completerHandler: CellCompleterHandler = null;
 

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -42,7 +42,7 @@ import {
 } from '../rendermime';
 
 import {
-  Console
+  CodeConsole
 } from './widget';
 
 
@@ -101,7 +101,7 @@ class ConsolePanel extends Panel {
   /**
    * The console widget used by the panel.
    */
-  readonly console: Console;
+  readonly console: CodeConsole;
 
   /**
    * The inspection handler used by the console.
@@ -147,7 +147,7 @@ class ConsolePanel extends Panel {
   /**
    * Handle the creation of a new prompt.
    */
-  private _onPromptCreated(sender: Console, prompt: CodeCellWidget): void {
+  private _onPromptCreated(sender: CodeConsole, prompt: CodeCellWidget): void {
     this._completer.reset();
 
     // Associate the new prompt with the completer and inspection handlers.
@@ -163,7 +163,7 @@ class ConsolePanel extends Panel {
     this.inspectionHandler.kernel = kernel;
   }
 
-  private _content: Console = null;
+  private _content: CodeConsole = null;
   private _completer: CompleterWidget = null;
   private _completerHandler: CellCompleterHandler = null;
 
@@ -209,12 +209,12 @@ namespace ConsolePanel {
     /**
      * The console content factory.
      */
-    readonly consoleContentFactory: Console.IContentFactory;
+    readonly consoleContentFactory: CodeConsole.IContentFactory;
 
     /**
      * Create a new console panel.
      */
-    createConsole(options: Console.IOptions): Console;
+    createConsole(options: CodeConsole.IOptions): CodeConsole;
 
     /**
      * The inspection handler for a console widget.
@@ -247,13 +247,13 @@ namespace ConsolePanel {
     /**
      * The console content factory.
      */
-    readonly consoleContentFactory: Console.IContentFactory;
+    readonly consoleContentFactory: CodeConsole.IContentFactory;
 
     /**
      * Create a new console panel.
      */
-    createConsole(options: Console.IOptions): Console {
-      return new Console(options);
+    createConsole(options: CodeConsole.IOptions): CodeConsole {
+      return new CodeConsole(options);
     }
 
     /**
@@ -291,7 +291,7 @@ namespace ConsolePanel {
       /**
        * The notebook content factory.
        */
-      consoleContentFactory: Console.IContentFactory;
+      consoleContentFactory: CodeConsole.IContentFactory;
     }
   }
 

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -86,11 +86,6 @@ class ConsolePanel extends Panel {
     // Set the completer widget's anchor node to peg its position.
     this._completer.anchor = this.node;
 
-    // Because a completer widget may be passed in, check if it is attached.
-    if (!this._completer.isAttached) {
-      Widget.attach(this._completer, document.body);
-    }
-
     // Instantiate the completer handler.
     this._completerHandler = factory.createCompleterHandler({
       completer: this._completer,
@@ -335,7 +330,7 @@ namespace ConsolePanel {
       rawCellContentFactory?: BaseCellWidget.IContentFactory;
 
       /**
-       * The factory for console wiget content.  If given, this will
+       * The factory for console widget content.  If given, this will
        * take precedence over the output area and cell factories.
        */
       consoleContentFactory?: CodeConsole.IContentFactory;

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -100,8 +100,7 @@ const contentFactoryPlugin: JupyterLabPlugin<ConsolePanel.IContentFactory> = {
   autoStart: true,
   activate: (app: JupyterLab, editorServices: IEditorServices) => {
     let editorFactory = editorServices.factoryService.newInlineEditor;
-    let consoleContentFactory = new CodeConsole.ContentFactory({ editorFactory });
-    return new ConsolePanel.ContentFactory({ consoleContentFactory });
+    return new ConsolePanel.ContentFactory({ editorFactory });
   }
 };
 

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -146,7 +146,7 @@ interface ICreateConsoleArgs extends JSONObject {
 function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, inspector: IInspector, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: IInstanceRestorer): IConsoleTracker {
   let manager = services.sessions;
   let { commands, keymap } = app;
-  let category = 'CodeConsole';
+  let category = 'Console';
   let command: string;
   let count = 0;
   let menu = new Menu({ commands, keymap });

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -165,7 +165,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   // Set the source of the code inspector.
   tracker.currentChanged.connect((sender, widget) => {
     if (widget) {
-      inspector.source = widget.console.inspectionHandler;
+      inspector.source = widget.inspectionHandler;
     }
   });
 
@@ -388,7 +388,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       panel.title.caption = Private.caption(captionOptions);
     });
     // Immediately set the inspector source to the current console.
-    inspector.source = panel.console.inspectionHandler;
+    inspector.source = panel.inspectionHandler;
     // Add the console panel to the tracker.
     tracker.add(panel);
     app.shell.addToMainArea(panel);

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -62,7 +62,7 @@ import {
 } from '../services';
 
 import {
-  IConsoleTracker, ConsolePanel, Console
+  IConsoleTracker, ConsolePanel, CodeConsole
 } from './index';
 
 
@@ -100,7 +100,7 @@ const contentFactoryPlugin: JupyterLabPlugin<ConsolePanel.IContentFactory> = {
   autoStart: true,
   activate: (app: JupyterLab, editorServices: IEditorServices) => {
     let editorFactory = editorServices.factoryService.newInlineEditor;
-    let consoleContentFactory = new Console.ContentFactory({ editorFactory });
+    let consoleContentFactory = new CodeConsole.ContentFactory({ editorFactory });
     return new ConsolePanel.ContentFactory({ consoleContentFactory });
   }
 };
@@ -146,7 +146,7 @@ interface ICreateConsoleArgs extends JSONObject {
 function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, inspector: IInspector, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: IInstanceRestorer): IConsoleTracker {
   let manager = services.sessions;
   let { commands, keymap } = app;
-  let category = 'Console';
+  let category = 'CodeConsole';
   let command: string;
   let count = 0;
   let menu = new Menu({ commands, keymap });
@@ -175,7 +175,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   command = 'console:create';
   commands.addCommand(command, {
     execute: (args: ICreateConsoleArgs) => {
-      let name = `Console ${++count}`;
+      let name = `CodeConsole ${++count}`;
 
       args = args || {};
 
@@ -184,7 +184,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
         return manager.ready.then(() => manager.connectTo(args.id))
           .then(session => {
             name = session.path.split('/').pop();
-            name = `Console ${name.match(CONSOLE_REGEX)[1]}`;
+            name = `CodeConsole ${name.match(CONSOLE_REGEX)[1]}`;
             createConsole(session, name);
             return session.id;
           });
@@ -219,7 +219,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
 
   command = 'console:create-new';
   commands.addCommand(command, {
-    label: 'Start New Console',
+    label: 'Start New CodeConsole',
     execute: () => commands.execute('console:create', { })
   });
   palette.addItem({ command, category });

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -516,11 +516,7 @@ class CodeConsole extends Widget {
       if (this.isDisposed) {
         return;
       }
-      this.executed.emit(new Date());
-      if (!value) {
-        return;
-      }
-      if (value.content.status === 'ok') {
+      if (value && value.content.status === 'ok') {
         let content = value.content as KernelMessage.IExecuteOkReply;
         // Use deprecated payloads for backwards compatibility.
         if (content.payload && content.payload.length) {
@@ -536,6 +532,7 @@ class CodeConsole extends Widget {
       }
       cell.model.contentChanged.disconnect(this.update, this);
       this.update();
+      this.executed.emit(new Date());
     };
     let onFailure = () => {
       if (this.isDisposed) {

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -139,11 +139,11 @@ class Console extends Widget {
       kernel: this.session.kernel,
       parent: this,
       cellFactory: () => this._createForeignCell(),
-    }, this);
+    });
 
     this._history = factory.createConsoleHistory({
       kernel: this.session.kernel
-    }, this);
+    });
 
     this.session.kernelChanged.connect(this._onKernelChanged, this);
   }
@@ -354,6 +354,9 @@ class Console extends Widget {
     // Create a prompt if necessary.
     if (!this.prompt) {
       this.newPrompt();
+    } else {
+      this.prompt.editor.focus();
+      this.update();
     }
   }
 
@@ -408,9 +411,10 @@ class Console extends Widget {
     editor.edgeRequested.connect(this.onEdgeRequest, this);
     editor.model.value.changed.connect(this.onTextChange, this);
 
-    prompt.editor.focus();
-    this.update();
-
+    if (this.isAttached) {
+      prompt.editor.focus();
+      this.update();
+    }
     this.promptCreated.emit(prompt);
   }
 
@@ -616,9 +620,7 @@ class Console extends Widget {
     this._initialize();
     this._history.kernel = kernel;
     this._foreignHandler.kernel = kernel;
-    if (this.isAttached) {
-      this.newPrompt();
-    }
+    this.newPrompt();
   }
 
   private _mimeTypeService: IEditorMimeTypeService;
@@ -686,12 +688,12 @@ namespace Console {
     /**
      * The history manager for a console widget.
      */
-    createConsoleHistory(options: ConsoleHistory.IOptions, parent: Console): IConsoleHistory;
+    createConsoleHistory(options: ConsoleHistory.IOptions): IConsoleHistory;
 
     /**
      * The foreign handler for a console widget.
      */
-    createForeignHandler(options: ForeignHandler.IOptions, parent: Console):
+    createForeignHandler(options: ForeignHandler.IOptions):
     ForeignHandler;
 
     /**
@@ -741,14 +743,14 @@ namespace Console {
     /**
      * The history manager for a console widget.
      */
-    createConsoleHistory(options: ConsoleHistory.IOptions, parent: Console): IConsoleHistory {
+    createConsoleHistory(options: ConsoleHistory.IOptions): IConsoleHistory {
       return new ConsoleHistory(options);
     }
 
     /**
      * The foreign handler for a console widget.
      */
-    createForeignHandler(options: ForeignHandler.IOptions, parent: Console):
+    createForeignHandler(options: ForeignHandler.IOptions):
     ForeignHandler {
       return new ForeignHandler(options);
     }

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -613,7 +613,7 @@ class CodeConsole extends Widget {
    * Handle a keydown event on an editor.
    */
   private _onEditorKeydown(editor: CodeEditor.IEditor, event: KeyboardEvent) {
-    // Suppres "Enter" events.
+    // Suppress "Enter" events.
     return event.keyCode === 13;
   }
 

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -428,8 +428,11 @@ class Console extends Widget {
     prompt.addClass(PROMPT_CLASS);
     this._input.addWidget(prompt);
 
-    // Hook up history handling.
+    // Suppress the default "Enter" key handling.
     let editor = prompt.editor;
+    editor.addKeydownHandler(this._onEditorKeydown);
+
+    // Hook up history handling.
     editor.edgeRequested.connect(this.onEdgeRequest, this);
     editor.model.value.changed.connect(this.onTextChange, this);
 
@@ -627,6 +630,14 @@ class Console extends Widget {
     });
   }
 
+  /**
+   * Handle a keydown event on an editor.
+   */
+  private _onEditorKeydown(editor: CodeEditor.IEditor, event: KeyboardEvent) {
+    // Suppres "Enter" events.
+    return event.keyCode === 13;
+  }
+
   private _mimeTypeService: IEditorMimeTypeService;
   private _cells: IObservableVector<BaseCellWidget> = null;
   private _completer: CompleterWidget = null;
@@ -807,13 +818,7 @@ namespace Console {
      * Create a new prompt widget.
      */
     createPrompt(options: CodeCellWidget.IOptions, parent: Console): CodeCellWidget {
-      let widget = new CodeCellWidget(options);
-      // Suppress the default "Enter" key handling.
-      let cb = (editor: CodeEditor.IEditor, event: KeyboardEvent) => {
-        return event.keyCode === 13;  // Enter;
-      };
-      widget.editor.addKeydownHandler(cb);
-      return widget;
+      return new CodeCellWidget(options);
     }
 
     /**

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -53,32 +53,32 @@ import {
 /**
  * The class name added to console widgets.
  */
-const CONSOLE_CLASS = 'jp-Console';
+const CONSOLE_CLASS = 'jp-CodeConsole';
 
 /**
  * The class name added to the console banner.
  */
-const BANNER_CLASS = 'jp-Console-banner';
+const BANNER_CLASS = 'jp-CodeConsole-banner';
 
 /**
  * The class name of a cell whose input originated from a foreign session.
  */
-const FOREIGN_CELL_CLASS = 'jp-Console-foreignCell';
+const FOREIGN_CELL_CLASS = 'jp-CodeConsole-foreignCell';
 
 /**
  * The class name of the active prompt
  */
-const PROMPT_CLASS = 'jp-Console-prompt';
+const PROMPT_CLASS = 'jp-CodeConsole-prompt';
 
 /**
  * The class name of the panel that holds cell content.
  */
-const CONTENT_CLASS = 'jp-Console-content';
+const CONTENT_CLASS = 'jp-CodeConsole-content';
 
 /**
  * The class name of the panel that holds prompts.
  */
-const INPUT_CLASS = 'jp-Console-input';
+const INPUT_CLASS = 'jp-CodeConsole-input';
 
 /**
  * The timeout in ms for execution requests to the kernel.
@@ -90,15 +90,15 @@ const EXECUTION_TIMEOUT = 250;
  * A widget containing a Jupyter console.
  *
  * #### Notes
- * The Console class is intended to be used within a ConsolePanel
+ * The CodeConsole class is intended to be used within a ConsolePanel
  * instance. Under most circumstances, it is not instantiated by user code.
  */
 export
-class Console extends Widget {
+class CodeConsole extends Widget {
   /**
    * Construct a console widget.
    */
-  constructor(options: Console.IOptions) {
+  constructor(options: CodeConsole.IOptions) {
     super();
     this.addClass(CONSOLE_CLASS);
 
@@ -161,7 +161,7 @@ class Console extends Widget {
   /**
    * The content factory used by the console.
    */
-  readonly contentFactory: Console.IContentFactory;
+  readonly contentFactory: CodeConsole.IContentFactory;
 
   /**
    * The rendermime instance used by the console.
@@ -639,16 +639,16 @@ class Console extends Widget {
 }
 
 
-// Define the signals for the `Console` class.
-defineSignal(Console.prototype, 'executed');
-defineSignal(Console.prototype, 'promptCreated');
+// Define the signals for the `CodeConsole` class.
+defineSignal(CodeConsole.prototype, 'executed');
+defineSignal(CodeConsole.prototype, 'promptCreated');
 
 
 /**
- * A namespace for Console statics.
+ * A namespace for CodeConsole statics.
  */
 export
-namespace Console {
+namespace CodeConsole {
   /**
    * The initialization options for a console widget.
    */
@@ -704,17 +704,17 @@ namespace Console {
     /**
      * Create a new banner widget.
      */
-    createBanner(options: RawCellWidget.IOptions, parent: Console): RawCellWidget;
+    createBanner(options: RawCellWidget.IOptions, parent: CodeConsole): RawCellWidget;
 
     /**
      * Create a new prompt widget.
      */
-    createPrompt(options: CodeCellWidget.IOptions, parent: Console): CodeCellWidget;
+    createPrompt(options: CodeCellWidget.IOptions, parent: CodeConsole): CodeCellWidget;
 
     /**
      * Create a code cell whose input originated from a foreign session.
      */
-    createForeignCell(options: CodeCellWidget.IOptions, parent: Console): CodeCellWidget;
+    createForeignCell(options: CodeCellWidget.IOptions, parent: CodeConsole): CodeCellWidget;
   }
 
   /**
@@ -762,21 +762,21 @@ namespace Console {
     /**
      * Create a new banner widget.
      */
-    createBanner(options: RawCellWidget.IOptions, parent: Console): RawCellWidget {
+    createBanner(options: RawCellWidget.IOptions, parent: CodeConsole): RawCellWidget {
       return new RawCellWidget(options);
     }
 
     /**
      * Create a new prompt widget.
      */
-    createPrompt(options: CodeCellWidget.IOptions, parent: Console): CodeCellWidget {
+    createPrompt(options: CodeCellWidget.IOptions, parent: CodeConsole): CodeCellWidget {
       return new CodeCellWidget(options);
     }
 
     /**
      * Create a new code cell widget for an input from a foreign session.
      */
-    createForeignCell(options: CodeCellWidget.IOptions, parent: Console): CodeCellWidget {
+    createForeignCell(options: CodeCellWidget.IOptions, parent: CodeConsole): CodeCellWidget {
       return new CodeCellWidget(options);
     }
   }

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -123,7 +123,7 @@ class Console extends Widget {
     // Create the banner.
     let model = new RawCellModel();
     model.value.text = '...';
-    let banner = factory.createBanner({
+    let banner = this.banner = factory.createBanner({
       model,
       contentFactory: factory.rawContentFactory
     }, this);
@@ -172,6 +172,11 @@ class Console extends Widget {
    * The session used by the console.
    */
   readonly session: Session.ISession;
+
+  /**
+   * The console banner widget.
+   */
+  readonly banner: RawCellWidget;
 
   /**
    * The list of content cells in the console.

--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -14,10 +14,6 @@ import {
 } from 'phosphor/lib/core/signaling';
 
 import {
-  CodeEditor
-} from '../codeeditor';
-
-import {
   BaseCellWidget
 } from '../notebook/cells/widget';
 

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -370,7 +370,7 @@ namespace BaseCellWidget {
   }
 
   /**
-   * The namespace for the `Renderer` class statics.
+   * The namespace for the `ContentFactory` class statics.
    */
   export
   namespace ContentFactory {
@@ -402,7 +402,10 @@ class CodeCellWidget extends BaseCellWidget {
     let rendermime = this._rendermime = options.rendermime;
 
     let factory = options.contentFactory;
-    this._output = factory.createOutputArea({ rendermime });
+    this._output = factory.createOutputArea({
+      rendermime,
+      contentFactory: factory.outputAreaContentFactory
+    });
     (this.layout as PanelLayout).addWidget(this._output);
 
     let model = this.model;
@@ -541,6 +544,11 @@ namespace CodeCellWidget {
   export
   interface IContentFactory extends BaseCellWidget.IContentFactory {
     /**
+     * The factory for output area content.
+     */
+    readonly outputAreaContentFactory: OutputAreaWidget.IContentFactory;
+
+    /**
      * Create a new output area for the widget.
      */
     createOutputArea(options: OutputAreaWidget.IOptions): OutputAreaWidget;
@@ -552,10 +560,47 @@ namespace CodeCellWidget {
   export
   class ContentFactory extends BaseCellWidget.ContentFactory implements IContentFactory {
     /**
+     * Construct a new code cell content factory
+     */
+    constructor(options: ContentFactory.IOptions) {
+      super(options);
+      this.outputAreaContentFactory = (options.outputAreaContentFactory ||
+        OutputAreaWidget.defaultContentFactory
+      );
+    }
+
+    /**
+     * The factory for output area content.
+     */
+    readonly outputAreaContentFactory: OutputAreaWidget.IContentFactory;
+
+    /**
      * Create an output area widget.
      */
     createOutputArea(options: OutputAreaWidget.IOptions): OutputAreaWidget {
       return new OutputAreaWidget(options);
+    }
+  }
+
+  /**
+   * The namespace for the `ContentFactory` class statics.
+   */
+  export
+  namespace ContentFactory {
+    /**
+     * An options object for initializing a renderer.
+     */
+    export
+    interface IOptions {
+      /**
+       * A code editor factory.
+       */
+      editorFactory: CodeEditor.Factory;
+
+      /**
+       * The factory to use for output area widget content.
+       */
+      outputAreaContentFactory?: OutputAreaWidget.IContentFactory;
     }
   }
 }

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -127,10 +127,10 @@ class BaseCellWidget extends Widget {
     let factory = options.contentFactory;
     let editorOptions = { model, factory: factory.editorFactory };
 
-    let editor =this._editor = factory.createCellEditor(editorOptions, this);
+    let editor =this._editor = factory.createCellEditor(editorOptions);
     editor.addClass(CELL_EDITOR_CLASS);
 
-    this._input = factory.createInputArea({ editor }, this);
+    this._input = factory.createInputArea({ editor });
     (this.layout as PanelLayout).addWidget(this._input);
 
     // Handle trusted cursor.
@@ -329,12 +329,12 @@ namespace BaseCellWidget {
     /**
      * Create a new cell editor for the widget.
      */
-    createCellEditor(options: CodeEditorWidget.IOptions, parent: BaseCellWidget): CodeEditorWidget;
+    createCellEditor(options: CodeEditorWidget.IOptions): CodeEditorWidget;
 
     /**
      * Create a new input area for the widget.
      */
-    createInputArea(options: InputAreaWidget.IOptions, parent: BaseCellWidget): InputAreaWidget;
+    createInputArea(options: InputAreaWidget.IOptions): InputAreaWidget;
   }
 
   /**
@@ -357,14 +357,14 @@ namespace BaseCellWidget {
     /**
      * Create a new cell editor for the widget.
      */
-    createCellEditor(options: CodeEditorWidget.IOptions, parent: BaseCellWidget): CodeEditorWidget {
+    createCellEditor(options: CodeEditorWidget.IOptions): CodeEditorWidget {
       return new CodeEditorWidget(options);
     }
 
     /**
      * Create a new input area for the widget.
      */
-    createInputArea(options: InputAreaWidget.IOptions, parent: BaseCellWidget): InputAreaWidget {
+    createInputArea(options: InputAreaWidget.IOptions): InputAreaWidget {
       return new InputAreaWidget(options);
     }
   }
@@ -402,7 +402,7 @@ class CodeCellWidget extends BaseCellWidget {
     let rendermime = this._rendermime = options.rendermime;
 
     let factory = options.contentFactory;
-    this._output = factory.createOutputArea({ rendermime }, this);
+    this._output = factory.createOutputArea({ rendermime });
     (this.layout as PanelLayout).addWidget(this._output);
 
     let model = this.model;
@@ -543,7 +543,7 @@ namespace CodeCellWidget {
     /**
      * Create a new output area for the widget.
      */
-    createOutputArea(options: OutputAreaWidget.IOptions, parent: BaseCellWidget): OutputAreaWidget;
+    createOutputArea(options: OutputAreaWidget.IOptions): OutputAreaWidget;
   }
 
   /**
@@ -554,7 +554,7 @@ namespace CodeCellWidget {
     /**
      * Create an output area widget.
      */
-    createOutputArea(options: OutputAreaWidget.IOptions, parent: BaseCellWidget): OutputAreaWidget {
+    createOutputArea(options: OutputAreaWidget.IOptions): OutputAreaWidget {
       return new OutputAreaWidget(options);
     }
   }

--- a/src/notebook/notebook/default-toolbar.ts
+++ b/src/notebook/notebook/default-toolbar.ts
@@ -102,7 +102,7 @@ namespace ToolbarItems {
   function createInsertButton(panel: NotebookPanel): ToolbarButton {
     return new ToolbarButton({
       className: TOOLBAR_INSERT_CLASS,
-      onClick: () => { NotebookActions.insertBelow(panel.content); },
+      onClick: () => { NotebookActions.insertBelow(panel.notebook); },
       tooltip: 'Insert a cell below'
     });
   }
@@ -115,7 +115,7 @@ namespace ToolbarItems {
     return new ToolbarButton({
       className: TOOLBAR_CUT_CLASS,
       onClick: () => {
-        NotebookActions.cut(panel.content, panel.clipboard);
+        NotebookActions.cut(panel.notebook, panel.clipboard);
       },
       tooltip: 'Cut the selected cell(s)'
     });
@@ -129,7 +129,7 @@ namespace ToolbarItems {
     return new ToolbarButton({
       className: TOOLBAR_COPY_CLASS,
       onClick: () => {
-        NotebookActions.copy(panel.content, panel.clipboard);
+        NotebookActions.copy(panel.notebook, panel.clipboard);
       },
       tooltip: 'Copy the selected cell(s)'
     });
@@ -143,7 +143,7 @@ namespace ToolbarItems {
     return new ToolbarButton({
       className: TOOLBAR_PASTE_CLASS,
       onClick: () => {
-        NotebookActions.paste(panel.content, panel.clipboard);
+        NotebookActions.paste(panel.notebook, panel.clipboard);
       },
       tooltip: 'Paste cell(s) from the clipboard'
     });
@@ -157,7 +157,7 @@ namespace ToolbarItems {
     return new ToolbarButton({
       className: TOOLBAR_RUN_CLASS,
       onClick: () => {
-        NotebookActions.runAndAdvance(panel.content, panel.kernel);
+        NotebookActions.runAndAdvance(panel.notebook, panel.kernel);
       },
       tooltip: 'Run the selected cell(s) and advance'
     });
@@ -176,7 +176,7 @@ namespace ToolbarItems {
    */
   export
   function createCellTypeItem(panel: NotebookPanel): Widget {
-    return new CellTypeSwitcher(panel.content);
+    return new CellTypeSwitcher(panel.notebook);
   }
 
   /**

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -93,8 +93,13 @@ class NotebookPanel extends Widget {
     let factory = this.contentFactory = options.contentFactory;
 
     this.layout = new PanelLayout();
-    let rendermime = this.rendermime;
-    this.notebook = factory.createNotebook(rendermime);
+    let nbOptions = {
+      rendermime: this.rendermime,
+      languagePreference: options.languagePreference,
+      contentFactory: factory.notebookContentFactory,
+      mimeTypeService: options.mimeTypeService
+    };
+    this.notebook = factory.createNotebook(nbOptions);
     let toolbar = factory.createToolbar();
 
     let layout = this.layout as PanelLayout;
@@ -375,9 +380,19 @@ export namespace NotebookPanel {
     clipboard: IClipboard;
 
     /**
+     * The language preference for the model.
+     */
+    languagePreference?: string;
+
+    /**
      * The content factory for the panel.
      */
     contentFactory: IContentFactory;
+
+    /**
+     * The mimeType service.
+     */
+    readonly mimeTypeService: IEditorMimeTypeService;
   }
 
   /**
@@ -386,9 +401,14 @@ export namespace NotebookPanel {
   export
   interface IContentFactory {
     /**
+     * The notebook content factory.
+     */
+    readonly notebookContentFactory: Notebook.IContentFactory;
+
+    /**
      * Create a new content area for the panel.
      */
-    createNotebook(rendermime: RenderMime): Notebook;
+    createNotebook(options: Notebook.IOptions): Notebook;
 
     /**
      * Create a new toolbar for the panel.
@@ -398,7 +418,7 @@ export namespace NotebookPanel {
     /**
      * Create a new completer widget for the panel.
      */
-    createCompleter(): CompleterWidget;
+    createCompleter(options?: CompleterWidget.IOptions): CompleterWidget;
   }
 
   /**
@@ -407,16 +427,6 @@ export namespace NotebookPanel {
   export
   class ContentFactory implements IContentFactory {
     /**
-     * The notebook content factory.
-     */
-    readonly notebookContentFactory: Notebook.IContentFactory;
-
-    /**
-     * The mimeType service.
-     */
-    readonly mimeTypeService: IEditorMimeTypeService;
-
-    /**
      * Creates a new renderer.
      */
     constructor(options: ContentFactory.IOptions) {
@@ -424,14 +434,15 @@ export namespace NotebookPanel {
     }
 
     /**
+     * The notebook content factory.
+     */
+    readonly notebookContentFactory: Notebook.IContentFactory;
+
+    /**
      * Create a new content area for the panel.
      */
-    createNotebook(rendermime: RenderMime): Notebook {
-      return new Notebook({
-        rendermime,
-        contentFactory: this.notebookContentFactory,
-        mimeTypeService: this.mimeTypeService
-      });
+    createNotebook(options: Notebook.IOptions): Notebook {
+      return new Notebook(options);
     }
 
     /**
@@ -444,8 +455,8 @@ export namespace NotebookPanel {
     /**
      * Create a new completer widget.
      */
-    createCompleter(): CompleterWidget {
-      return new CompleterWidget({ model: new CompleterModel() });
+    createCompleter(options: CompleterWidget.IOptions = {}): CompleterWidget {
+      return new CompleterWidget(options);
     }
   }
 
@@ -463,11 +474,6 @@ export namespace NotebookPanel {
        * The notebook content factory.
        */
       readonly notebookContentFactory: Notebook.IContentFactory;
-
-      /**
-       * The mimeType service.
-       */
-      readonly mimeTypeService: IEditorMimeTypeService;
     }
   }
 
@@ -476,6 +482,6 @@ export namespace NotebookPanel {
    * The notebook renderer token.
    */
   export
-  const IContentFactory = new Token<IContentFactory>('jupyter.services.notebook.factory');
+  const IContentFactory = new Token<IContentFactory>('jupyter.services.notebook.content-factory');
   /* tslint:enable */
 }

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -130,11 +130,6 @@ class NotebookPanel extends Widget {
     // Set the completer widget's anchor node to peg its position.
     this._completer.anchor = this.notebook.node;
 
-    // Because a completer widget may be passed in, check if it is attached.
-    if (!this._completer.isAttached) {
-      Widget.attach(this._completer, document.body);
-    }
-
     // Instantiate the completer handler.
     this._completerHandler = factory.createCompleterHandler({
       completer: this._completer

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -422,7 +422,7 @@ export namespace NotebookPanel {
     /**
      * The mimeType service.
      */
-    readonly mimeTypeService: IEditorMimeTypeService;
+    mimeTypeService: IEditorMimeTypeService;
   }
 
   /**

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -50,7 +50,7 @@ import {
 } from '../../rendermime';
 
 import {
-  CompleterWidget, CellCompleterHandler
+  CompleterModel, CompleterWidget, CellCompleterHandler
 } from '../../completer';
 
 import {
@@ -117,15 +117,14 @@ class NotebookPanel extends Widget {
 
     // Set up the inspection handler.
     this.inspectionHandler = factory.createInspectionHandler({
-      kernel: this.context.kernel,
       rendermime: this.rendermime
     });
 
     // Instantiate the completer.
-    this._completer = factory.createCompleter({});
+    this._completer = factory.createCompleter({ model: new CompleterModel() });
 
     // Set the completer widget's anchor node to peg its position.
-    this._completer.anchor = this.node;
+    this._completer.anchor = this.notebook.node;
 
     // Because a completer widget may be passed in, check if it is attached.
     if (!this._completer.isAttached) {
@@ -134,9 +133,9 @@ class NotebookPanel extends Widget {
 
     // Instantiate the completer handler.
     this._completerHandler = factory.createCompleterHandler({
-      completer: this._completer,
-      kernel: this.context.kernel
+      completer: this._completer
     });
+    this._completerHandler.activeCell = this.notebook.activeCell;
   }
 
   /**
@@ -376,6 +375,7 @@ class NotebookPanel extends Widget {
    */
   private _onActiveCellChanged(sender: Notebook, widget: BaseCellWidget) {
     this.inspectionHandler.activeCell = widget;
+    this._completerHandler.activeCell = widget;
   }
 
   private _completer: CompleterWidget = null;

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -30,7 +30,7 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
-  IEditorMimeTypeService
+  IEditorMimeTypeService, CodeEditor
 } from '../../codeeditor';
 
 import {
@@ -54,8 +54,12 @@ import {
 } from '../../completer';
 
 import {
-  BaseCellWidget
+  BaseCellWidget, CodeCellWidget
 } from '../cells';
+
+import {
+  OutputAreaWidget
+} from '../output-area';
 
 import {
   INotebookModel
@@ -431,7 +435,12 @@ export namespace NotebookPanel {
   export
   interface IContentFactory {
     /**
-     * The notebook content factory.
+     * The editor factory.
+     */
+    readonly editorFactory: CodeEditor.Factory;
+
+    /**
+     * The factory for notebook cell widget content.
      */
     readonly notebookContentFactory: Notebook.IContentFactory;
 
@@ -470,11 +479,25 @@ export namespace NotebookPanel {
      * Creates a new renderer.
      */
     constructor(options: ContentFactory.IOptions) {
-      this.notebookContentFactory = options.notebookContentFactory;
+      this.editorFactory = options.editorFactory;
+      this.notebookContentFactory = (options.notebookContentFactory ||
+        new Notebook.ContentFactory({
+          editorFactory: this.editorFactory,
+          outputAreaContentFactory: options.outputAreaContentFactory,
+          codeCellContentFactory: options.codeCellContentFactory,
+          rawCellContentFactory: options.rawCellContentFactory,
+          markdownCellContentFactory: options.markdownCellContentFactory
+        })
+      );
     }
 
     /**
-     * The notebook content factory.
+     * The editor factory.
+     */
+    readonly editorFactory: CodeEditor.Factory;
+
+    /**
+     * The factory for notebook cell widget content.
      */
     readonly notebookContentFactory: Notebook.IContentFactory;
 
@@ -520,14 +543,41 @@ export namespace NotebookPanel {
   export
   namespace ContentFactory {
     /**
-     * An initialization options for a notebook panel factory.
+     * An initialization options for a notebook panel content factory.
      */
     export
     interface IOptions {
       /**
-       * The notebook content factory.
+       * The editor factory.
        */
-      readonly notebookContentFactory: Notebook.IContentFactory;
+      editorFactory: CodeEditor.Factory;
+
+      /**
+       * The factory for output area content.
+       */
+      outputAreaContentFactory?: OutputAreaWidget.IContentFactory;
+
+      /**
+       * The factory for code cell widget content.  If given, this will
+       * take precedence over the `outputAreaContentFactory`.
+       */
+      codeCellContentFactory?: CodeCellWidget.IContentFactory;
+
+      /**
+       * The factory for raw cell widget content.
+       */
+      rawCellContentFactory?: BaseCellWidget.IContentFactory;
+
+      /**
+       * The factory for markdown cell widget content.
+       */
+      markdownCellContentFactory?: BaseCellWidget.IContentFactory;
+
+      /**
+       * The factory for notebook cell widget content. If given, this will
+       * take precedence over the the cell and output area factories.
+       */
+      notebookContentFactory?: Notebook.IContentFactory;
     }
   }
 

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -129,6 +129,7 @@ class NotebookPanel extends Widget {
 
     // Set the completer widget's anchor node to peg its position.
     this._completer.anchor = this.notebook.node;
+    Widget.attach(this._completer, document.body);
 
     // Instantiate the completer handler.
     this._completerHandler = factory.createCompleterHandler({

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -62,10 +62,6 @@ import {
 } from '../../common/observablevector';
 
 import {
-  InspectionHandler
-} from '../../inspector';
-
-import {
   RenderMime
 } from '../../rendermime';
 
@@ -74,10 +70,9 @@ import {
 } from '../../codeeditor';
 
 import {
-  ICellModel, BaseCellWidget, MarkdownCellModel,
+  ICellModel, BaseCellWidget, IMarkdownCellModel,
   CodeCellWidget, MarkdownCellWidget,
-  CodeCellModel, RawCellWidget, RawCellModel,
-  ICodeCellModel, IMarkdownCellModel, IRawCellModel
+  ICodeCellModel, RawCellWidget, IRawCellModel,
 } from '../cells';
 
 import {
@@ -389,13 +384,13 @@ class StaticNotebook extends Widget {
     let widget: BaseCellWidget;
     switch (cell.type) {
     case 'code':
-      widget = this._createCodeCell(cell as CodeCellModel);
+      widget = this._createCodeCell(cell as ICodeCellModel);
       break;
     case 'markdown':
-      widget = this._createMarkdownCell(cell as MarkdownCellModel);
+      widget = this._createMarkdownCell(cell as IMarkdownCellModel);
       break;
     default:
-      widget = this._createRawCell(cell as RawCellModel);
+      widget = this._createRawCell(cell as IRawCellModel);
     }
     cell.mimeType = this._mimetype;
     widget.addClass(NB_CELL_CLASS);
@@ -407,7 +402,7 @@ class StaticNotebook extends Widget {
   /**
    * Create a code cell widget from a code cell model.
    */
-  private _createCodeCell(model: CodeCellModel): CodeCellWidget {
+  private _createCodeCell(model: ICodeCellModel): CodeCellWidget {
     let contentFactory = this.contentFactory.codeContentFactory;
     let rendermime = this.rendermime;
     let options = { model, rendermime, contentFactory };
@@ -417,7 +412,7 @@ class StaticNotebook extends Widget {
   /**
    * Create a markdown cell widget from a markdown cell model.
    */
-  private _createMarkdownCell(model: MarkdownCellModel): MarkdownCellWidget {
+  private _createMarkdownCell(model: IMarkdownCellModel): MarkdownCellWidget {
     let contentFactory = this.contentFactory.markdownContentFactory;
     let rendermime = this.rendermime;
     let options = { model, rendermime, contentFactory };
@@ -427,7 +422,7 @@ class StaticNotebook extends Widget {
   /**
    * Create a raw cell widget from a raw cell model.
    */
-  private _createRawCell(model: RawCellModel): RawCellWidget {
+  private _createRawCell(model: IRawCellModel): RawCellWidget {
     let contentFactory = this.contentFactory.rawContentFactory;
     let options = { model, contentFactory };
     return this.contentFactory.createRawCell(options, this);
@@ -646,13 +641,6 @@ class Notebook extends StaticNotebook {
   constructor(options: StaticNotebook.IOptions) {
     super(options);
     this.node.tabIndex = -1;  // Allow the widget to take focus.
-    // Set up the inspection handler.
-    this._inspectionHandler = new InspectionHandler({
-      rendermime: this.rendermime
-    });
-    this.activeCellChanged.connect((s, cell) => {
-      this._inspectionHandler.activeCell = cell;
-    });
     this._scrollHandler = new DragScrollHandler({ node: this.node });
   }
 
@@ -674,13 +662,6 @@ class Notebook extends StaticNotebook {
    * A signal emitted when the selection state of the notebook changes.
    */
   readonly selectionChanged: ISignal<this, void>;
-
-  /**
-   * Get the inspection handler used by the console.
-   */
-  get inspectionHandler(): InspectionHandler {
-    return this._inspectionHandler;
-  }
 
   /**
    * The interactivity mode of the notebook.
@@ -767,8 +748,6 @@ class Notebook extends StaticNotebook {
       return;
     }
     this._activeCell = null;
-    this._inspectionHandler.dispose();
-    this._inspectionHandler = null;
     super.dispose();
   }
 
@@ -1392,7 +1371,6 @@ class Notebook extends StaticNotebook {
 
   private _activeCellIndex = -1;
   private _activeCell: BaseCellWidget = null;
-  private _inspectionHandler: InspectionHandler = null;
   private _mode: NotebookMode = 'command';
   private _drag: Drag = null;
   private _dragData: { pressX: number, pressY: number, index: number } = null;

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -181,6 +181,7 @@ class StaticNotebook extends Widget {
     this.addClass(NB_CLASS);
     this.rendermime = options.rendermime;
     this.layout = new Private.NotebookPanelLayout();
+    this.contentFactory = options.contentFactory;
     this._mimetypeService = options.mimeTypeService;
   }
 

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -76,6 +76,10 @@ import {
 } from '../cells';
 
 import {
+  OutputAreaWidget
+} from '../output-area';
+
+import {
   INotebookModel
 } from './model';
 
@@ -177,7 +181,6 @@ class StaticNotebook extends Widget {
     this.addClass(NB_CLASS);
     this.rendermime = options.rendermime;
     this.layout = new Private.NotebookPanelLayout();
-    this.contentFactory = options.contentFactory;
     this._mimetypeService = options.mimeTypeService;
   }
 
@@ -403,29 +406,32 @@ class StaticNotebook extends Widget {
    * Create a code cell widget from a code cell model.
    */
   private _createCodeCell(model: ICodeCellModel): CodeCellWidget {
-    let contentFactory = this.contentFactory.codeContentFactory;
+    let factory = this.contentFactory;
+    let contentFactory = factory.codeCellContentFactory;
     let rendermime = this.rendermime;
     let options = { model, rendermime, contentFactory };
-    return this.contentFactory.createCodeCell(options, this);
+    return factory.createCodeCell(options, this);
   }
 
   /**
    * Create a markdown cell widget from a markdown cell model.
    */
   private _createMarkdownCell(model: IMarkdownCellModel): MarkdownCellWidget {
-    let contentFactory = this.contentFactory.markdownContentFactory;
+    let factory = this.contentFactory;
+    let contentFactory = factory.markdownCellContentFactory;
     let rendermime = this.rendermime;
     let options = { model, rendermime, contentFactory };
-    return this.contentFactory.createMarkdownCell(options, this);
+    return factory.createMarkdownCell(options, this);
   }
 
   /**
    * Create a raw cell widget from a raw cell model.
    */
   private _createRawCell(model: IRawCellModel): RawCellWidget {
-    let contentFactory = this.contentFactory.rawContentFactory;
+    let factory = this.contentFactory;
+    let contentFactory = factory.rawCellContentFactory;
     let options = { model, contentFactory };
-    return this.contentFactory.createRawCell(options, this);
+    return factory.createRawCell(options, this);
   }
 
   /**
@@ -508,19 +514,24 @@ namespace StaticNotebook {
   export
   interface IContentFactory {
     /**
-     * The code cell factory.
+     * The editor factory.
      */
-    readonly codeContentFactory: CodeCellWidget.IContentFactory;
+    readonly editorFactory: CodeEditor.Factory;
 
     /**
-     * The markdown cell content factory.
+     * The factory for code cell widget content.
      */
-    readonly markdownContentFactory: BaseCellWidget.IContentFactory;
+    readonly codeCellContentFactory?: CodeCellWidget.IContentFactory;
 
     /**
-     * The raw cell content factory.
+     * The factory for raw cell widget content.
      */
-    readonly rawContentFactory: BaseCellWidget.IContentFactory;
+    readonly rawCellContentFactory?: BaseCellWidget.IContentFactory;
+
+    /**
+     * The factory for markdown cell widget content.
+     */
+    readonly markdownCellContentFactory?: BaseCellWidget.IContentFactory;
 
     /**
      * Create a new code cell widget.
@@ -548,31 +559,42 @@ namespace StaticNotebook {
      */
     constructor(options: ContentFactory.IOptions) {
       let editorFactory = options.editorFactory;
-      this.codeContentFactory = (options.codeContentFactory ||
-        new CodeCellWidget.ContentFactory({ editorFactory })
+      let outputAreaContentFactory = (options.outputAreaContentFactory ||
+        OutputAreaWidget.defaultContentFactory
       );
-      this.markdownContentFactory = (options.markdownContentFactory ||
-        new BaseCellWidget.ContentFactory({ editorFactory })
+      this.codeCellContentFactory = (options.codeCellContentFactory ||
+        new CodeCellWidget.ContentFactory({
+          editorFactory,
+          outputAreaContentFactory
+        })
       );
-      this.rawContentFactory = (options.rawContentFactory ||
-        new BaseCellWidget.ContentFactory({ editorFactory })
+      this.rawCellContentFactory = (options.rawCellContentFactory ||
+        new RawCellWidget.ContentFactory({ editorFactory })
+      );
+      this.markdownCellContentFactory = (options.markdownCellContentFactory ||
+        new MarkdownCellWidget.ContentFactory({ editorFactory })
       );
     }
 
     /**
-     * The code cell factory.
+     * The editor factory.
      */
-    readonly codeContentFactory: CodeCellWidget.IContentFactory;
+    readonly editorFactory: CodeEditor.Factory;
 
     /**
-     * The markdown cell content factory.
+     * The factory for code cell widget content.
      */
-    readonly markdownContentFactory: BaseCellWidget.IContentFactory;
+    readonly codeCellContentFactory: CodeCellWidget.IContentFactory;
 
     /**
-     * The raw cell content factory.
+     * The factory for raw cell widget content.
      */
-    readonly rawContentFactory: BaseCellWidget.IContentFactory;
+    readonly rawCellContentFactory: BaseCellWidget.IContentFactory;
+
+    /**
+     * The factory for markdown cell widget content.
+     */
+    readonly markdownCellContentFactory: BaseCellWidget.IContentFactory;
 
     /**
      * Create a new code cell widget.
@@ -612,19 +634,25 @@ namespace StaticNotebook {
       editorFactory: CodeEditor.Factory;
 
       /**
-       * A factory for code cells.
+       * The factory for output area content.
        */
-      codeContentFactory?: CodeCellWidget.IContentFactory;
+      outputAreaContentFactory?: OutputAreaWidget.IContentFactory;
 
       /**
-       * A factory for markdown cells.
+       * The factory for code cell widget content.  If given, this will
+       * take precedence over the `outputAreaContentFactory`.
        */
-      markdownContentFactory?: BaseCellWidget.IContentFactory;
+      codeCellContentFactory?: CodeCellWidget.IContentFactory;
 
       /**
-       * A factory for raw cells.
+       * The factory for raw cell widget content.
        */
-      rawContentFactory?: BaseCellWidget.IContentFactory;
+      rawCellContentFactory?: BaseCellWidget.IContentFactory;
+
+      /**
+       * The factory for markdown cell widget content.
+       */
+      markdownCellContentFactory?: BaseCellWidget.IContentFactory;
     }
   }
 }

--- a/src/notebook/notebook/widgetfactory.ts
+++ b/src/notebook/notebook/widgetfactory.ts
@@ -2,12 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Kernel
-} from '@jupyterlab/services';
-
-import {
   MimeData as IClipboard
 } from 'phosphor/lib/core/mimedata';
+
+import {
+  IEditorMimeTypeService
+} from '../../codeeditor';
 
 import {
   ABCWidgetFactory, DocumentRegistry
@@ -42,10 +42,30 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
    */
   constructor(options: NotebookWidgetFactory.IOptions) {
     super(options);
-    this._rendermime = options.rendermime;
-    this._clipboard = options.clipboard;
-    this._renderer = options.renderer;
+    this.rendermime = options.rendermime;
+    this.clipboard = options.clipboard;
+    this.contentFactory = options.contentFactory;
   }
+
+  /*
+   * The rendermime instance.
+   */
+  readonly rendermime: RenderMime;
+
+  /**
+   * The content factory used by the widget factory.
+   */
+  readonly contentFactory: NotebookPanel.IContentFactory;
+
+  /**
+   * A clipboard instance.
+   */
+  readonly clipboard: IClipboard;
+
+  /**
+   * The service used to look up mime types.
+   */
+  readonly mimeTypeService: IEditorMimeTypeService;
 
   /**
    * Dispose of the resources used by the factory.
@@ -54,8 +74,6 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
     if (this.isDisposed) {
       return;
     }
-    this._rendermime = null;
-    this._clipboard = null;
     super.dispose();
   }
 
@@ -67,20 +85,16 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
    * the default toolbar items using `ToolbarItems.populateDefaults`.
    */
   protected createNewWidget(context: DocumentRegistry.IContext<INotebookModel>): NotebookPanel {
-    let rendermime = this._rendermime.clone();
+    let rendermime = this.rendermime.clone();
     let panel = new NotebookPanel({
       rendermime,
-      clipboard: this._clipboard,
-      renderer: this._renderer
+      clipboard: this.clipboard,
+      contentFactory: this.contentFactory
     });
     panel.context = context;
     ToolbarItems.populateDefaults(panel);
     return panel;
   }
-
-  private _rendermime: RenderMime = null;
-  private _clipboard: IClipboard = null;
-  private _renderer: NotebookPanel.IRenderer = null;
 }
 
 
@@ -105,8 +119,8 @@ namespace NotebookWidgetFactory {
     clipboard: IClipboard;
 
     /**
-     * A notebook panel renderer.
+     * A notebook panel content factory.
      */
-    renderer: NotebookPanel.IRenderer;
+    contentFactory: NotebookPanel.IContentFactory;
   }
 }

--- a/src/notebook/notebook/widgetfactory.ts
+++ b/src/notebook/notebook/widgetfactory.ts
@@ -89,7 +89,8 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
     let panel = new NotebookPanel({
       rendermime,
       clipboard: this.clipboard,
-      contentFactory: this.contentFactory
+      contentFactory: this.contentFactory,
+      mimeTypeService: this.mimeTypeService
     });
     panel.context = context;
     ToolbarItems.populateDefaults(panel);

--- a/src/notebook/notebook/widgetfactory.ts
+++ b/src/notebook/notebook/widgetfactory.ts
@@ -45,6 +45,7 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
     this.rendermime = options.rendermime;
     this.clipboard = options.clipboard;
     this.contentFactory = options.contentFactory;
+    this.mimeTypeService = options.mimeTypeService;
   }
 
   /*
@@ -123,5 +124,10 @@ namespace NotebookWidgetFactory {
      * A notebook panel content factory.
      */
     contentFactory: NotebookPanel.IContentFactory;
+
+    /**
+     * The service used to look up mime types.
+     */
+    mimeTypeService: IEditorMimeTypeService;
   }
 }

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -163,7 +163,7 @@ class OutputAreaWidget extends Widget {
     super();
     this.addClass(OUTPUT_AREA_CLASS);
     this._rendermime = options.rendermime;
-    this._renderer = options.renderer || OutputAreaWidget.defaultRenderer;
+    this._renderer = options.renderer || OutputAreaWidget.defaultContentFactory;
     this.layout = new PanelLayout();
   }
 
@@ -472,18 +472,18 @@ namespace OutputAreaWidget {
     rendermime: RenderMime;
 
     /**
-     * The output widget renderer.
+     * The output widget content factory.
      *
-     * Defaults to a shared `IRenderer` instance.
+     * Defaults to a shared `IContentFactory` instance.
      */
-     renderer?: IRenderer;
+     contentFactory?: IContentFactory;
   }
 
   /**
-   * An output widget renderer.
+   * An output widget content factory.
    */
   export
-  interface IRenderer {
+  interface IContentFactory {
     /**
      * Create an output widget.
      *
@@ -494,10 +494,10 @@ namespace OutputAreaWidget {
   }
 
   /**
-   * The default implementation of `IRenderer`.
+   * The default implementation of `IContentFactory`.
    */
   export
-  class Renderer implements IRenderer {
+  class ContentFactory implements IContentFactory {
     /**
      * Create an output widget.
      *
@@ -510,11 +510,12 @@ namespace OutputAreaWidget {
   }
 
   /**
-   * The default `Renderer` instance.
+   * The default `ContentFactory` instance.
    */
   export
-  const defaultRenderer = new Renderer();
+  const defaultContentFactory = new ContentFactory();
 }
+
 
 /**
  * The gutter on the left side of the OutputWidget

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -162,8 +162,10 @@ class OutputAreaWidget extends Widget {
   constructor(options: OutputAreaWidget.IOptions) {
     super();
     this.addClass(OUTPUT_AREA_CLASS);
-    this._rendermime = options.rendermime;
-    this._renderer = options.renderer || OutputAreaWidget.defaultContentFactory;
+    this.rendermime = options.rendermime;
+    this.contentFactory = (
+      options.contentFactory || OutputAreaWidget.defaultContentFactory
+    );
     this.layout = new PanelLayout();
   }
 
@@ -171,9 +173,9 @@ class OutputAreaWidget extends Widget {
    * Create a mirrored output widget.
    */
   mirror(): OutputAreaWidget {
-    let rendermime = this._rendermime;
-    let renderer = this._renderer;
-    let widget = new OutputAreaWidget({ rendermime, renderer });
+    let rendermime = this.rendermime;
+    let contentFactory = this.contentFactory;
+    let widget = new OutputAreaWidget({ rendermime, contentFactory });
     widget.model = this._model;
     widget.trusted = this._trusted;
     widget.title.label = 'Mirrored Output';
@@ -185,12 +187,22 @@ class OutputAreaWidget extends Widget {
   /**
    * A signal emitted when the widget's model changes.
    */
-  modelChanged: ISignal<this, void>;
+  readonly modelChanged: ISignal<this, void>;
 
   /**
    * A signal emitted when the widget's model is disposed.
    */
-  modelDisposed: ISignal<this, void>;
+  readonly modelDisposed: ISignal<this, void>;
+
+  /**
+   * Te rendermime instance used by the widget.
+   */
+  readonly rendermime: RenderMime;
+
+  /**
+   * The content factory used by the widget.
+   */
+  readonly contentFactory: OutputAreaWidget.IContentFactory;
 
   /**
    * A read-only sequence of the widgets in the output area.
@@ -215,20 +227,6 @@ class OutputAreaWidget extends Widget {
     this._onModelChanged(oldValue, newValue);
     this.onModelChanged(oldValue, newValue);
     this.modelChanged.emit(void 0);
-  }
-
-  /**
-   * Get the rendermime instance used by the widget.
-   */
-  get rendermime(): RenderMime {
-    return this._rendermime;
-  }
-
-  /**
-   * Get the renderer used by the widget.
-   */
-  get renderer(): OutputAreaWidget.IRenderer {
-    return this._renderer;
   }
 
   /**
@@ -286,8 +284,6 @@ class OutputAreaWidget extends Widget {
       return;
     }
     this._model = null;
-    this._rendermime = null;
-    this._renderer = null;
     super.dispose();
   }
 
@@ -311,7 +307,8 @@ class OutputAreaWidget extends Widget {
    * Add a child to the layout.
    */
   protected addChild(): void {
-    let widget = this._renderer.createOutput({ rendermime: this.rendermime });
+    let rendermime = this.rendermime;
+    let widget = this.contentFactory.createOutput({ rendermime });
     let layout = this.layout as PanelLayout;
     layout.addWidget(widget);
     this.updateChild(layout.widgets.length - 1);
@@ -450,8 +447,6 @@ class OutputAreaWidget extends Widget {
   private _collapsed = false;
   private _minHeightTimeout: number = null;
   private _model: OutputAreaModel = null;
-  private _rendermime: RenderMime = null;
-  private _renderer: OutputAreaWidget.IRenderer = null;
   private _injecting = false;
 }
 

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -471,7 +471,7 @@ namespace OutputAreaWidget {
      *
      * Defaults to a shared `IContentFactory` instance.
      */
-     contentFactory?: IContentFactory;
+     contentFactory: IContentFactory;
   }
 
   /**

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -151,10 +151,7 @@ const contentFactoryPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
   autoStart: true,
   activate: (app: JupyterLab, editorServices: IEditorServices) => {
     let editorFactory = editorServices.factoryService.newInlineEditor;
-    const nbFactory = new Notebook.ContentFactory({ editorFactory });
-    return new NotebookPanel.ContentFactory({
-      notebookContentFactory: nbFactory
-    });
+    return new NotebookPanel.ContentFactory({ editorFactory });
   }
 };
 

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -197,7 +197,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
   // Set the source of the code inspector.
   tracker.currentChanged.connect((sender, widget) => {
     if (widget) {
-      inspector.source = widget.notebook.inspectionHandler;
+      inspector.source = widget.inspectionHandler;
     }
   });
 
@@ -225,7 +225,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     widget.id = widget.id || `notebook-${++id}`;
     widget.title.icon = `${PORTRAIT_ICON_CLASS} ${NOTEBOOK_ICON_CLASS}`;
     // Immediately set the inspector source to the current notebook.
-    inspector.source = widget.notebook.inspectionHandler;
+    inspector.source = widget.inspectionHandler;
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => { tracker.save(widget); });
     // Add the notebook panel to the tracker.

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -143,7 +143,7 @@ const trackerPlugin: JupyterLabPlugin<INotebookTracker> = {
  * The notebook cell factory provider.
  */
 export
-const rendererPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
+const contentFactoryPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
   id: 'jupyter.services.notebook-renderer',
   provides: NotebookPanel.IContentFactory,
   requires: [IEditorServices],
@@ -152,8 +152,7 @@ const rendererPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
     let editorFactory = editorServices.factoryService.newInlineEditor;
     const nbFactory = new Notebook.ContentFactory({ editorFactory });
     return new NotebookPanel.ContentFactory({
-      notebookContentFactory: nbFactory,
-      mimeTypeService: editorServices.mimeTypeService
+      notebookContentFactory: nbFactory
     });
   }
 };
@@ -162,7 +161,7 @@ const rendererPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
 /**
  * Export the plugins as default.
  */
-const plugins: JupyterLabPlugin<any>[] = [rendererPlugin, trackerPlugin];
+const plugins: JupyterLabPlugin<any>[] = [contentFactoryPlugin, trackerPlugin];
 export default plugins;
 
 

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -132,6 +132,7 @@ const trackerPlugin: JupyterLabPlugin<INotebookTracker> = {
     ICommandPalette,
     IInspector,
     NotebookPanel.IContentFactory,
+    IEditorServices,
     IInstanceRestorer
   ],
   activate: activateNotebookHandler,
@@ -168,7 +169,7 @@ export default plugins;
 /**
  * Activate the notebook handler extension.
  */
-function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, clipboard: IClipboard, mainMenu: IMainMenu, palette: ICommandPalette, inspector: IInspector, contentFactory: NotebookPanel.IContentFactory, restorer: IInstanceRestorer): INotebookTracker {
+function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, clipboard: IClipboard, mainMenu: IMainMenu, palette: ICommandPalette, inspector: IInspector, contentFactory: NotebookPanel.IContentFactory, editorServices: IEditorServices, restorer: IInstanceRestorer): INotebookTracker {
 
   const factory = new NotebookWidgetFactory({
     name: FACTORY,
@@ -179,7 +180,8 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     canStartKernel: true,
     rendermime,
     clipboard,
-    contentFactory
+    contentFactory,
+    mimeTypeService: editorServices.mimeTypeService
   });
 
   const tracker = new NotebookTracker({ namespace: 'notebook' });

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -68,7 +68,7 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
     if (!widget) {
       return null;
     }
-    return widget.content.activeCell || null;
+    return widget.notebook.activeCell || null;
   }
 
   /**
@@ -118,7 +118,7 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
     }
 
     // Since the notebook has changed, immediately signal an active cell change.
-    this.activeCellChanged.emit(widget.content.activeCell || null);
+    this.activeCellChanged.emit(widget.notebook.activeCell || null);
   }
 
   private _onActiveCellChanged(sender: Notebook, cell: BaseCellWidget): void {

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -86,7 +86,7 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
    */
   add(panel: NotebookPanel): Promise<void> {
     const promise = super.add(panel);
-    panel.content.activeCellChanged.connect(this._onActiveCellChanged, this);
+    panel.notebook.activeCellChanged.connect(this._onActiveCellChanged, this);
     return promise;
   }
 
@@ -123,7 +123,7 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
 
   private _onActiveCellChanged(sender: Notebook, cell: BaseCellWidget): void {
     // Check if the active cell change happened for the current notebook.
-    if (this.currentWidget && this.currentWidget.content === sender) {
+    if (this.currentWidget && this.currentWidget.notebook === sender) {
       this._activeCell = cell || null;
       this.activeCellChanged.emit(this._activeCell);
     }

--- a/src/shortcuts/plugin.ts
+++ b/src/shortcuts/plugin.ts
@@ -257,22 +257,22 @@ const SHORTCUTS = [
   },
   {
     command: 'console:run',
-    selector: '.jp-ConsoleContent-prompt',
+    selector: '.jp-CodeConsole-prompt',
     keys: ['Enter']
   },
   {
     command: 'console:run-forced',
-    selector: '.jp-ConsoleContent-prompt',
+    selector: '.jp-CodeConsole-prompt',
     keys: ['Shift Enter']
   },
   {
     command: 'console:linebreak',
-    selector: '.jp-ConsoleContent-prompt',
+    selector: '.jp-CodeConsole-prompt',
     keys: ['Ctrl Enter']
   },
   {
     command: 'console:toggle-inspectors',
-    selector: '.jp-ConsoleContent-promptt',
+    selector: '.jp-CodeConsole-promptt',
     keys: ['Accel I']
   },
   {

--- a/test/src/completer/handler.spec.ts
+++ b/test/src/completer/handler.spec.ts
@@ -24,11 +24,11 @@ import {
 } from '../../../lib/completer';
 
 import {
-  createBaseCellRenderer
+  createBaseCellFactory
 } from '../notebook/utils';
 
 
-const renderer = createBaseCellRenderer();
+const contentFactory = createBaseCellFactory();
 
 
 class TestCompleterModel extends CompleterModel {
@@ -80,7 +80,7 @@ const kernelPromise = Kernel.startNew();
 
 
 function createCellWidget(): BaseCellWidget {
-  return new BaseCellWidget({ model: new CellModel(), renderer });
+  return new BaseCellWidget({ model: new CellModel(), contentFactory });
 }
 
 

--- a/test/src/console/foreign.spec.ts
+++ b/test/src/console/foreign.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../lib/notebook/cells';
 
 import {
-  createCodeCellRenderer
+  createCodeCellFactory
 } from '../notebook/utils';
 
 import {
@@ -82,13 +82,12 @@ defineSignal(TestHandler.prototype, 'rejected');
 
 
 const rendermime = defaultRenderMime();
-const renderer: ForeignHandler.IRenderer = {
-  createCell: () => {
-    let renderer = createCodeCellRenderer();
-    let model = new CodeCellModel();
-    let cell = new CodeCellWidget({ model, rendermime, renderer });
-    return cell;
-  }
+
+function cellFactory(): CodeCellWidget {
+  let contentFactory = createCodeCellFactory();
+  let model = new CodeCellModel();
+  let cell = new CodeCellWidget({ model, rendermime, contentFactory });
+  return cell;
 };
 const relevantTypes = [
   'execute_input',
@@ -110,7 +109,8 @@ describe('console/foreign', () => {
     describe('#constructor()', () => {
 
       it('should create a new foreign handler', () => {
-        let handler = new TestHandler({ kernel: null, parent: null, renderer });
+        let handler = new TestHandler({ kernel: null, parent: null,
+                                        cellFactory });
         expect(handler).to.be.a(ForeignHandler);
       });
 
@@ -129,7 +129,7 @@ describe('console/foreign', () => {
         Promise.all(sessions).then(([one, two]) => {
           local = one;
           foreign = two;
-          handler = new TestHandler({ kernel: local.kernel, parent, renderer });
+          handler = new TestHandler({ kernel: local.kernel, parent, cellFactory });
           done();
         }).catch(done);
       });
@@ -165,7 +165,7 @@ describe('console/foreign', () => {
     describe('#isDisposed', () => {
 
       it('should indicate whether the handler is disposed', () => {
-        let handler = new TestHandler({ kernel: null, parent: null, renderer });
+        let handler = new TestHandler({ kernel: null, parent: null, cellFactory });
         expect(handler.isDisposed).to.be(false);
         handler.dispose();
         expect(handler.isDisposed).to.be(true);
@@ -176,12 +176,12 @@ describe('console/foreign', () => {
     describe('#kernel', () => {
 
       it('should be set upon instantiation', () => {
-        let handler = new TestHandler({ kernel: null, parent: null, renderer });
+        let handler = new TestHandler({ kernel: null, parent: null, cellFactory });
         expect(handler.kernel).to.be(null);
       });
 
       it('should be resettable', done => {
-        let handler = new TestHandler({ kernel: null, parent: null, renderer });
+        let handler = new TestHandler({ kernel: null, parent: null, cellFactory });
         Session.startNew({ path: utils.uuid() }).then(session => {
           expect(handler.kernel).to.be(null);
           handler.kernel = session.kernel;
@@ -198,7 +198,7 @@ describe('console/foreign', () => {
 
       it('should be set upon instantiation', () => {
         let parent = new TestParent();
-        let handler = new TestHandler({ kernel: null, parent, renderer });
+        let handler = new TestHandler({ kernel: null, parent, cellFactory });
         expect(handler.parent).to.be(parent);
       });
 
@@ -207,14 +207,14 @@ describe('console/foreign', () => {
     describe('#dispose()', () => {
 
       it('should dispose the resources held by the handler', () => {
-        let handler = new TestHandler({ kernel: null, parent: null, renderer });
+        let handler = new TestHandler({ kernel: null, parent: null, cellFactory });
         expect(handler.isDisposed).to.be(false);
         handler.dispose();
         expect(handler.isDisposed).to.be(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let handler = new TestHandler({ kernel: null, parent: null, renderer });
+        let handler = new TestHandler({ kernel: null, parent: null, cellFactory });
         expect(handler.isDisposed).to.be(false);
         handler.dispose();
         handler.dispose();
@@ -236,7 +236,7 @@ describe('console/foreign', () => {
         Promise.all(sessions).then(([one, two]) => {
           local = one;
           foreign = two;
-          handler = new TestHandler({ kernel: local.kernel, parent, renderer });
+          handler = new TestHandler({ kernel: local.kernel, parent, cellFactory });
           done();
         }).catch(done);
       });

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -28,8 +28,7 @@ import {
 } from '../../../lib/inspector';
 
 import {
-  createConsolePanelFactory, rendermime, mimeTypeService,
-  createConsoleFactory
+  createConsolePanelFactory, rendermime, mimeTypeService, editorFactory
 } from './utils';
 
 
@@ -153,9 +152,7 @@ describe('console/panel', () => {
       describe('#constructor', () => {
 
         it('should create a new code console factory', () => {
-          let factory = new ConsolePanel.ContentFactory({
-            consoleContentFactory: createConsoleFactory()
-          });
+          let factory = new ConsolePanel.ContentFactory({ editorFactory });
           expect(factory).to.be.a(ConsolePanel.ContentFactory);
         });
 

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -147,14 +147,32 @@ describe('console/panel', () => {
 
     });
 
-    describe('#contentFactory', () => {
+    describe('.ContentFactory', () => {
+
+      describe('#constructor', () => {
+
+        it('should create a new code console factory', () => {
+          let factory = new ConsolePanel.ContentFactory({
+            consoleContentFactory: createConsoleFactory()
+          });
+          expect(factory).to.be.a(ConsolePanel.ContentFactory);
+        });
+
+      });
+
+      describe('#consoleContentFactory', () => {
+
+        it('should be the console content factory used by the panel factory', () => {
+          expect(contentFactory.consoleContentFactory).to.be.a(CodeConsole.ContentFactory);
+        });
+
+      });
 
       describe('#createConsole()', () => {
 
         it('should create a notebook widget', () => {
-          let consoleContentFactory = createConsoleFactory();
           let options = {
-            contentFactory: consoleContentFactory,
+            contentFactory: contentFactory.consoleContentFactory,
             rendermime,
             mimeTypeService,
             session
@@ -193,6 +211,7 @@ describe('console/panel', () => {
       });
 
     });
+
 
   });
 

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -20,11 +20,11 @@ import {
 } from '../../../lib/console';
 
 import {
-  defaultRenderMime
-} from '../utils';
+  InspectionHandler
+} from '../../../lib/inspector';
 
 import {
-  createRenderer
+  createConsolePanelFactory, rendermime, mimeTypeService
 } from './utils';
 
 
@@ -44,8 +44,7 @@ class TestPanel extends ConsolePanel {
 }
 
 
-const renderer = createRenderer();
-const rendermime = defaultRenderMime();
+const contentFactory = createConsolePanelFactory();
 
 
 describe('console/panel', () => {
@@ -56,8 +55,8 @@ describe('console/panel', () => {
   beforeEach(done => {
     Session.startNew({ path: utils.uuid() }).then(newSession => {
       session = newSession;
-      const content = new CodeConsole({ renderer, rendermime, session });
-      panel = new TestPanel({ content });
+      panel = new TestPanel({ contentFactory, rendermime, session,
+                              mimeTypeService });
       done();
     });
   });
@@ -81,10 +80,19 @@ describe('console/panel', () => {
 
     });
 
-    describe('#content', () => {
+    describe('#console', () => {
 
-      it('should be a console content widget created at instantiation', () => {
-        expect(panel.content).to.be.a(CodeConsole);
+      it('should be a code console widget created at instantiation', () => {
+        expect(panel.console).to.be.a(CodeConsole);
+      });
+
+    });
+
+    describe('#inspectionHandler', () => {
+
+      it('should exist after instantiation', () => {
+        Widget.attach(panel, document.body);
+        expect(panel.inspectionHandler).to.be.an(InspectionHandler);
       });
 
     });
@@ -92,9 +100,9 @@ describe('console/panel', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the panel', () => {
-        expect(panel.content).to.be.ok();
+        expect(panel.console).to.be.ok();
         panel.dispose();
-        expect(panel.content).to.not.be.ok();
+        expect(panel.console).to.not.be.ok();
       });
 
     });
@@ -108,7 +116,7 @@ describe('console/panel', () => {
           panel.activate();
           requestAnimationFrame(() => {
             expect(panel.methods).to.contain('onActivateRequest');
-            expect(panel.content.prompt.editor.hasFocus()).to.be(true);
+            expect(panel.console.prompt.editor.hasFocus()).to.be(true);
             done();
           });
         });

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -16,6 +16,10 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
+  CellCompleterHandler, CompleterWidget
+} from '../../../lib/completer';
+
+import {
   CodeConsole, ConsolePanel
 } from '../../../lib/console';
 
@@ -24,7 +28,8 @@ import {
 } from '../../../lib/inspector';
 
 import {
-  createConsolePanelFactory, rendermime, mimeTypeService
+  createConsolePanelFactory, rendermime, mimeTypeService,
+  createConsoleFactory
 } from './utils';
 
 
@@ -138,6 +143,53 @@ describe('console/panel', () => {
             done();
           });
         });
+      });
+
+    });
+
+    describe('#contentFactory', () => {
+
+      describe('#createConsole()', () => {
+
+        it('should create a notebook widget', () => {
+          let consoleContentFactory = createConsoleFactory();
+          let options = {
+            contentFactory: consoleContentFactory,
+            rendermime,
+            mimeTypeService,
+            session
+          };
+          expect(contentFactory.createConsole(options)).to.be.a(CodeConsole);
+        });
+
+      });
+
+      describe('#createInspectionHandler()', () => {
+
+        it('should create an inspection handler', () => {
+          let inspector = contentFactory.createInspectionHandler({ rendermime });
+          expect(inspector).to.be.an(InspectionHandler);
+        });
+
+      });
+
+
+      describe('#createCompleter()', () => {
+
+        it('should create a completer widget', () => {
+          expect(contentFactory.createCompleter({})).to.be.a(CompleterWidget);
+        });
+
+      });
+
+      describe('#createCompleterHandler()', () => {
+
+        it('should create a completer handler', () => {
+          let options = { completer:  new CompleterWidget({}) };
+          let handler = contentFactory.createCompleterHandler(options);
+          expect(handler).to.be.a(CellCompleterHandler);
+        });
+
       });
 
     });

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -16,12 +16,8 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
-  ConsoleContent
-} from '../../../lib/console/content';
-
-import {
-  ConsolePanel
-} from '../../../lib/console/panel';
+  CodeConsole, ConsolePanel
+} from '../../../lib/console';
 
 import {
   defaultRenderMime
@@ -60,7 +56,7 @@ describe('console/panel', () => {
   beforeEach(done => {
     Session.startNew({ path: utils.uuid() }).then(newSession => {
       session = newSession;
-      const content = new ConsoleContent({ renderer, rendermime, session });
+      const content = new CodeConsole({ renderer, rendermime, session });
       panel = new TestPanel({ content });
       done();
     });
@@ -88,7 +84,7 @@ describe('console/panel', () => {
     describe('#content', () => {
 
       it('should be a console content widget created at instantiation', () => {
-        expect(panel.content).to.be.a(ConsoleContent);
+        expect(panel.content).to.be.a(CodeConsole);
       });
 
     });

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -105,9 +105,10 @@ describe('console/panel', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the panel', () => {
-        expect(panel.console).to.be.ok();
         panel.dispose();
-        expect(panel.console).to.not.be.ok();
+        expect(panel.isDisposed).to.be(true);
+        panel.dispose();
+        expect(panel.isDisposed).to.be(true);
       });
 
     });

--- a/test/src/console/utils.ts
+++ b/test/src/console/utils.ts
@@ -38,6 +38,5 @@ function createConsoleFactory(): CodeConsole.IContentFactory {
  */
 export
 function createConsolePanelFactory(): ConsolePanel.IContentFactory {
-  const consoleContentFactory = createConsoleFactory();
-  return new ConsolePanel.ContentFactory({ consoleContentFactory });
+  return new ConsolePanel.ContentFactory({ editorFactory });
 }

--- a/test/src/console/utils.ts
+++ b/test/src/console/utils.ts
@@ -6,14 +6,38 @@ import {
 } from '../../../lib/codemirror';
 
 import {
-  ConsoleContent
+  CodeConsole, ConsolePanel
 } from '../../../lib/console';
+
+import {
+  defaultRenderMime
+} from '../utils';
+
+
+export
+const editorFactory = editorServices.factoryService.newInlineEditor;
+
+export
+const mimeTypeService = editorServices.mimeTypeService;
+
+export
+const rendermime = defaultRenderMime();
 
 
 /**
- * Create a console renderer.
+ * Create a console content factory.
  */
 export
-function createRenderer(): ConsoleContent.Renderer {
-  return new ConsoleContent.Renderer({ editorServices });
+function createConsoleFactory(): CodeConsole.IContentFactory {
+  return new CodeConsole.ContentFactory({ editorFactory });
+}
+
+
+/**
+ * Create a panel content factory.
+ */
+export
+function createConsolePanelFactory(): ConsolePanel.IContentFactory {
+  const consoleContentFactory = createConsoleFactory();
+  return new ConsolePanel.ContentFactory({ consoleContentFactory });
 }

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -405,31 +405,28 @@ describe('console/widget', () => {
     describe('#onEdgeRequest()', () => {
 
       it('should be called upon an editor edge request', done => {
-        let history = new TestHistory({ kernel: session.kernel });
         let code = 'print("#onEdgeRequest()")';
         let force = true;
-        history.ready.connect(() => {
-          let local = new TestConsole({
-            contentFactory, rendermime, session, mimeTypeService
-          });
-          local.edgeRequested.connect(() => {
+        let callback = () => {
+          widget.edgeRequested.connect(() => {
             expect(local.methods).to.contain('onEdgeRequest');
             requestAnimationFrame(() => {
-              expect(local.prompt.model.value.text).to.be(code);
-              local.dispose();
+              expect(widget.prompt.model.value.text).to.be(code);
+              widget._history.ready.disconnect(callback);
               done();
             });
           });
           Widget.attach(local, document.body);
           requestAnimationFrame(() => {
-            local.prompt.model.value.text = code;
-            local.execute(force).then(() => {
-              expect(local.prompt.model.value.text).to.not.be(code);
-              expect(local.methods).to.not.contain('onEdgeRequest');
-              local.prompt.editor.edgeRequested.emit('top');
+            widget.prompt.model.value.text = code;
+            widget.execute(force).then(() => {
+              expect(widget.prompt.model.value.text).to.not.be(code);
+              expect(widget.methods).to.not.contain('onEdgeRequest');
+              widget.prompt.editor.edgeRequested.emit('top');
             }).catch(done);
           });
-        });
+        };
+        widget._history.ready.connect(callback);
       });
 
     });

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -469,18 +469,18 @@ describe('console/widget', () => {
 
       });
 
-      describe('#rawContentFactory', () => {
+      describe('#rawCellContentFactory', () => {
 
         it('should be the raw cell ContentFactory used by the factory', () => {
-          expect(contentFactory.rawContentFactory).to.be.a(BaseCellWidget.ContentFactory);
+          expect(contentFactory.rawCellContentFactory).to.be.a(BaseCellWidget.ContentFactory);
         });
 
       });
 
-      describe('#codeContentFactory', () => {
+      describe('#codeCellContentFactory', () => {
 
         it('should be the code cell ContentFactory used by the factory', () => {
-          expect(contentFactory.codeContentFactory).to.be.a(CodeCellWidget.ContentFactory);
+          expect(contentFactory.codeCellContentFactory).to.be.a(CodeCellWidget.ContentFactory);
         });
 
       });
@@ -500,7 +500,7 @@ describe('console/widget', () => {
           let cellFactory = () => {
             let model = new CodeCellModel();
             let rendermime = widget.rendermime;
-            let factory = contentFactory.codeContentFactory;
+            let factory = contentFactory.codeCellContentFactory;
             let options: CodeCellWidget.IOptions = {
               model, rendermime, contentFactory: factory
             };
@@ -522,7 +522,7 @@ describe('console/widget', () => {
           let model = new RawCellModel();
           let banner = contentFactory.createBanner({
             model,
-            contentFactory: contentFactory.rawContentFactory
+            contentFactory: contentFactory.rawCellContentFactory
           }, widget);
           expect(banner).to.be.a(RawCellWidget);
         });
@@ -536,7 +536,7 @@ describe('console/widget', () => {
           let prompt = contentFactory.createPrompt({
             rendermime: widget.rendermime,
             model,
-            contentFactory: contentFactory.codeContentFactory
+            contentFactory: contentFactory.codeCellContentFactory
           }, widget);
           expect(prompt).to.be.a(CodeCellWidget);
         });
@@ -550,7 +550,7 @@ describe('console/widget', () => {
           let prompt = contentFactory.createForeignCell({
             rendermime: widget.rendermime,
             model,
-            contentFactory: contentFactory.codeContentFactory
+            contentFactory: contentFactory.codeCellContentFactory
           }, widget);
           expect(prompt).to.be.a(CodeCellWidget);
         });

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -409,14 +409,14 @@ describe('console/widget', () => {
         let force = true;
         let callback = () => {
           widget.edgeRequested.connect(() => {
-            expect(local.methods).to.contain('onEdgeRequest');
+            expect(widget.methods).to.contain('onEdgeRequest');
             requestAnimationFrame(() => {
               expect(widget.prompt.model.value.text).to.be(code);
-              widget._history.ready.disconnect(callback);
+              (widget as any)._history.ready.disconnect(callback);
               done();
             });
           });
-          Widget.attach(local, document.body);
+          Widget.attach(widget, document.body);
           requestAnimationFrame(() => {
             widget.prompt.model.value.text = code;
             widget.execute(force).then(() => {
@@ -426,7 +426,7 @@ describe('console/widget', () => {
             }).catch(done);
           });
         };
-        widget._history.ready.connect(callback);
+        (widget as any)._history.ready.connect(callback);
       });
 
     });

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -24,8 +24,8 @@ import {
 } from '../../../lib/codeeditor';
 
 import {
-  ConsoleContent
-} from '../../../lib/console/content';
+  CodeConsole
+} from '../../../lib/console';
 
 import {
   ConsoleHistory
@@ -52,7 +52,7 @@ import {
 } from './utils';
 
 
-class TestContent extends ConsoleContent {
+class TestContent extends CodeConsole {
 
   readonly edgeRequested: ISignal<this, void>;
 
@@ -126,7 +126,7 @@ const rendermime = defaultRenderMime();
 
 describe('console/content', () => {
 
-  describe('ConsoleContent', () => {
+  describe('CodeConsole', () => {
 
     let session: Session.ISession;
     let widget: TestContent;
@@ -151,8 +151,8 @@ describe('console/content', () => {
 
       it('should create a new console content widget', () => {
         Widget.attach(widget, document.body);
-        expect(widget).to.be.a(ConsoleContent);
-        expect(widget.node.classList).to.contain('jp-ConsoleContent');
+        expect(widget).to.be.a(CodeConsole);
+        expect(widget.node.classList).to.contain('jp-CodeConsole');
       });
 
     });

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -4,7 +4,7 @@
 import expect = require('expect.js');
 
 import {
-  KernelMessage, Session, utils
+  Session, utils
 } from '@jupyterlab/services';
 
 import {
@@ -12,16 +12,12 @@ import {
 } from 'phosphor/lib/core/messaging';
 
 import {
-  clearSignalData, defineSignal, ISignal
+  clearSignalData, ISignal
 } from 'phosphor/lib/core/signaling';
 
 import {
   Widget
 } from 'phosphor/lib/ui/widget';
-
-import {
-  CodeEditor
-} from '../../../lib/codeeditor';
 
 import {
   CodeConsole
@@ -77,13 +73,6 @@ class TestConsole extends CodeConsole {
     this.methods.push('onAfterAttach');
   }
 
-  protected onEdgeRequest(editor: CodeEditor.IEditor, location: CodeEditor.EdgeLocation): Promise<void> {
-    return super.onEdgeRequest(editor, location).then(() => {
-      this.methods.push('onEdgeRequest');
-      this.edgeRequested.emit(void 0);
-    });
-  }
-
   protected onTextChange(): void {
     super.onTextChange();
     this.methods.push('onTextChange');
@@ -95,8 +84,6 @@ class TestConsole extends CodeConsole {
   }
 }
 
-
-defineSignal(TestConsole.prototype, 'edgeRequested');
 
 const contentFactory = createConsoleFactory();
 
@@ -380,33 +367,6 @@ describe('console/widget', () => {
         Widget.attach(widget, document.body);
         expect(widget.methods).to.contain('onAfterAttach');
         expect(widget.prompt).to.be.ok();
-      });
-
-    });
-
-    describe('#onEdgeRequest()', () => {
-
-      it('should be called upon an editor edge request', done => {
-        let code = 'print("#onEdgeRequest()")';
-        let force = true;
-        (widget as any)._history.kernel = null;
-        widget.edgeRequested.connect(() => {
-          expect(widget.methods).to.contain('onEdgeRequest');
-          requestAnimationFrame(() => {
-            expect(widget.prompt.model.value.text).to.be(code);
-            (widget as any)._history.kernel = widget.session.kernel;
-            done();
-          });
-        });
-        Widget.attach(widget, document.body);
-        requestAnimationFrame(() => {
-          widget.prompt.model.value.text = code;
-          widget.execute(force).then(() => {
-            expect(widget.prompt.model.value.text).to.not.be(code);
-            expect(widget.methods).to.not.contain('onEdgeRequest');
-            widget.prompt.editor.edgeRequested.emit('top');
-          }).catch(done);
-        });
       });
 
     });

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -246,11 +246,10 @@ describe('console/widget', () => {
         let force = true;
         Widget.attach(widget, document.body);
         widget.execute(force).then(() => {
-          expect(widget.cells.length).to.be.greaterThan(1);
-          expect(widget.cells.length).to.be(1);
+          expect(widget.cells.length).to.be.greaterThan(0);
           widget.clear();
-          expect(widget.cells.length).to.be(1);
           expect(widget.cells.length).to.be(0);
+          expect(widget.prompt.model.value.text).to.be('');
           done();
         }).catch(done);
       });
@@ -281,9 +280,9 @@ describe('console/widget', () => {
       it('should execute contents of the prompt if forced', done => {
         let force = true;
         Widget.attach(widget, document.body);
-        expect(widget.cells.length).to.be(1);
+        expect(widget.cells.length).to.be(0);
         widget.execute(force).then(() => {
-          expect(widget.cells.length).to.be.greaterThan(1);
+          expect(widget.cells.length).to.be.greaterThan(0);
           done();
         }).catch(done);
       });
@@ -293,9 +292,9 @@ describe('console/widget', () => {
         let timeout = 9000;
         Widget.attach(widget, document.body);
         widget.prompt.model.value.text = 'for x in range(5):';
-        expect(widget.cells.length).to.be(1);
+        expect(widget.cells.length).to.be(0);
         widget.execute(force, timeout).then(() => {
-          expect(widget.cells.length).to.be(1);
+          expect(widget.cells.length).to.be(0);
           done();
         }).catch(done);
       });
@@ -307,9 +306,9 @@ describe('console/widget', () => {
       it('should add a code cell and execute it', done => {
         let code = 'print("#inject()")';
         Widget.attach(widget, document.body);
-        expect(widget.cells.length).to.be(1);
+        expect(widget.cells.length).to.be(0);
         widget.inject(code).then(() => {
-          expect(widget.cells.length).to.be.greaterThan(1);
+          expect(widget.cells.length).to.be.greaterThan(0);
           done();
         }).catch(done);
       });

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -21,10 +21,10 @@ import './completer/handler.spec';
 import './completer/model.spec';
 import './completer/widget.spec';
 
-import './console/content.spec';
 import './console/foreign.spec';
 import './console/history.spec';
 import './console/panel.spec';
+import './console/widget.spec';
 
 import './csvwidget/table.spec';
 import './csvwidget/toolbar.spec';

--- a/test/src/notebook/cells/widget.spec.ts
+++ b/test/src/notebook/cells/widget.spec.ts
@@ -348,12 +348,30 @@ describe('notebook/cells/widget', () => {
 
     });
 
-    describe('.contentFactory', () => {
+    describe('#contentFactory', () => {
 
-      describe('#constructor()', () => {
+      it('should be a contentFactory', () => {
+        expect(contentFactory).to.be.a(BaseCellWidget.ContentFactory);
+      });
 
-        it('should create a contentFactory', () => {
-          expect(contentFactory).to.be.a(BaseCellWidget.ContentFactory);
+    });
+
+    describe('.ContentFactory', () => {
+
+      describe('#constructor', () => {
+
+        it('should create a ContentFactory', () => {
+          let factory = new BaseCellWidget.ContentFactory({ editorFactory });
+          expect(factory).to.be.a(BaseCellWidget.ContentFactory);
+        });
+
+      });
+
+      describe('#editorFactory', () => {
+
+        it('should be the editor factory used by the content factory', () => {
+          let factory = new BaseCellWidget.ContentFactory({ editorFactory });
+          expect(factory.editorFactory).to.be(editorFactory);
         });
 
       });
@@ -361,8 +379,11 @@ describe('notebook/cells/widget', () => {
       describe('#createCellEditor()', () => {
 
         it('should create a code editor widget', () => {
-          let factory = editorFactory;
-          let editor = contentFactory.createCellEditor({ model, factory });
+          let factory = new BaseCellWidget.ContentFactory({ editorFactory });
+          let editor = factory.createCellEditor({
+            model,
+            factory: editorFactory
+          });
           expect(editor).to.be.a(CodeEditorWidget);
         });
 
@@ -371,18 +392,12 @@ describe('notebook/cells/widget', () => {
       describe('#createInputArea()', () => {
 
         it('should create an input area widget', () => {
-          let factory = editorFactory;
-          let editor = contentFactory.createCellEditor({ model, factory });
+          let factory = new BaseCellWidget.ContentFactory({ editorFactory });
+          let editor = factory.createCellEditor({
+            model,
+            factory: editorFactory });
           let input = contentFactory.createInputArea({ editor });
           expect(input).to.be.an(InputAreaWidget);
-        });
-
-      });
-
-      describe('#defaultRenderer', () => {
-
-        it('should be a ContentFactory', () => {
-          expect(contentFactory).to.be.a(BaseCellWidget.ContentFactory);
         });
 
       });
@@ -496,12 +511,22 @@ describe('notebook/cells/widget', () => {
 
     });
 
-    describe('.contentFactory', () => {
+    describe('#contentFactory', () => {
 
-      describe('#constructor()', () => {
+      it('should be a ContentFactory', () => {
+        expect(contentFactory).to.be.a(CodeCellWidget.ContentFactory);
+      });
+
+    });
+
+    describe('.ContentFactory', () => {
+
+      describe('#constructor', () => {
 
         it('should create a ContentFactory', () => {
-          expect(contentFactory).to.be.a(CodeCellWidget.ContentFactory);
+          let factory = new CodeCellWidget.ContentFactory({ editorFactory });
+          expect(factory).to.be.a(CodeCellWidget.ContentFactory);
+          expect(factory).to.be.a(BaseCellWidget.ContentFactory);
         });
 
       });
@@ -509,16 +534,9 @@ describe('notebook/cells/widget', () => {
       describe('#createOutputArea()', () => {
 
         it('should create an output area widget', () => {
-          let output = contentFactory.createOutputArea({ rendermime });
+          let factory = new CodeCellWidget.ContentFactory({ editorFactory });
+          let output = factory.createOutputArea({ rendermime });
           expect(output).to.be.an(OutputAreaWidget);
-        });
-
-      });
-
-      describe('#defaultRenderer', () => {
-
-        it('should be a contentFactory', () => {
-          expect(contentFactory).to.be.a(CodeCellWidget.ContentFactory);
         });
 
       });

--- a/test/src/notebook/cells/widget.spec.ts
+++ b/test/src/notebook/cells/widget.spec.ts
@@ -30,11 +30,8 @@ import {
 } from '../../../../lib/notebook/output-area';
 
 import {
-  defaultRenderMime
-} from '../../utils';
-
-import {
-  createBaseCellRenderer, createCodeCellRenderer, createCellEditor
+  createBaseCellFactory, createCodeCellFactory, createCellEditor, rendermime,
+  editorFactory
 } from '../utils';
 
 
@@ -42,15 +39,13 @@ const RENDERED_CLASS = 'jp-mod-rendered';
 
 const PROMPT_CLASS = 'jp-Cell-prompt';
 
-const rendermime = defaultRenderMime();
-
 
 class LogBaseCell extends BaseCellWidget {
 
   methods: string[] = [];
 
   constructor() {
-    super({ model: new CellModel(), renderer: createBaseCellRenderer() });
+    super({ model: new CellModel(), contentFactory: createBaseCellFactory() });
   }
 
   renderInput(widget: Widget): void {
@@ -95,8 +90,8 @@ class LogCodeCell extends CodeCellWidget {
   methods: string[] = [];
 
   constructor() {
-    super({ model: new CodeCellModel(), renderer: createCodeCellRenderer(),
-            rendermime: defaultRenderMime() });
+    super({ model: new CodeCellModel(), contentFactory: createCodeCellFactory(),
+            rendermime });
   }
 
   protected onUpdateRequest(msg: Message): void {
@@ -131,19 +126,19 @@ describe('notebook/cells/widget', () => {
 
   describe('BaseCellWidget', () => {
 
-    let renderer = createBaseCellRenderer();
+    let contentFactory = createBaseCellFactory();
     let model = new CellModel();
 
     describe('#constructor()', () => {
 
       it('should create a base cell widget', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(widget).to.be.a(BaseCellWidget);
       });
 
-      it('should accept a custom renderer', () => {
-        renderer = createBaseCellRenderer();
-        let widget = new BaseCellWidget({ model, renderer });
+      it('should accept a custom contentFactory', () => {
+        contentFactory = createBaseCellFactory();
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(widget).to.be.a(BaseCellWidget);
       });
 
@@ -153,7 +148,7 @@ describe('notebook/cells/widget', () => {
 
       it('should be the model used by the widget', () => {
         let model = new CellModel();
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(widget.model).to.be(model);
       });
 
@@ -162,7 +157,7 @@ describe('notebook/cells/widget', () => {
     describe('#editorWidget', () => {
 
       it('should be a code editor widget', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(widget.editorWidget).to.be.a(CodeEditorWidget);
       });
 
@@ -171,7 +166,7 @@ describe('notebook/cells/widget', () => {
     describe('#editor', () => {
 
       it('should be a cell editor', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(widget.editor.uuid).to.be.ok();
       });
 
@@ -180,19 +175,19 @@ describe('notebook/cells/widget', () => {
     describe('#readOnly', () => {
 
       it('should be a boolean', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(typeof widget.readOnly).to.be('boolean');
       });
 
       it('should default to false', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(widget.readOnly).to.be(false);
       });
 
       it('should be settable', () => {
         let widget = new BaseCellWidget({
           model,
-          renderer
+          contentFactory
         });
         widget.readOnly = true;
         expect(widget.readOnly).to.be(true);
@@ -213,17 +208,17 @@ describe('notebook/cells/widget', () => {
     describe('#trusted', () => {
 
       it('should be a boolean', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(typeof widget.trusted).to.be('boolean');
       });
 
       it('should default to false', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(widget.trusted).to.be(false);
       });
 
       it('should be settable', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         widget.trusted = true;
         expect(widget.trusted).to.be(true);
       });
@@ -251,7 +246,7 @@ describe('notebook/cells/widget', () => {
     describe('#setPrompt()', () => {
 
       it('should not throw an error (full test in input area)', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         expect(() => { widget.setPrompt(void 0); }).to.not.throwError();
         expect(() => { widget.setPrompt(null); }).to.not.throwError();
         expect(() => { widget.setPrompt(''); }).to.not.throwError();
@@ -288,13 +283,13 @@ describe('notebook/cells/widget', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the widget', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         widget.dispose();
         expect(widget.isDisposed).to.be(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let widget = new BaseCellWidget({ model, renderer });
+        let widget = new BaseCellWidget({ model, contentFactory });
         widget.dispose();
         widget.dispose();
         expect(widget.isDisposed).to.be(true);
@@ -353,12 +348,12 @@ describe('notebook/cells/widget', () => {
 
     });
 
-    describe('.Renderer', () => {
+    describe('.contentFactory', () => {
 
       describe('#constructor()', () => {
 
-        it('should create a renderer', () => {
-          expect(renderer).to.be.a(BaseCellWidget.Renderer);
+        it('should create a contentFactory', () => {
+          expect(contentFactory).to.be.a(BaseCellWidget.ContentFactory);
         });
 
       });
@@ -366,7 +361,8 @@ describe('notebook/cells/widget', () => {
       describe('#createCellEditor()', () => {
 
         it('should create a code editor widget', () => {
-          let editor = renderer.createCellEditor(model);
+          let factory = editorFactory;
+          let editor = contentFactory.createCellEditor({ model, factory });
           expect(editor).to.be.a(CodeEditorWidget);
         });
 
@@ -375,8 +371,9 @@ describe('notebook/cells/widget', () => {
       describe('#createInputArea()', () => {
 
         it('should create an input area widget', () => {
-          let editor = renderer.createCellEditor(model);
-          let input = renderer.createInputArea(editor);
+          let factory = editorFactory;
+          let editor = contentFactory.createCellEditor({ model, factory });
+          let input = contentFactory.createInputArea({ editor });
           expect(input).to.be.an(InputAreaWidget);
         });
 
@@ -384,8 +381,8 @@ describe('notebook/cells/widget', () => {
 
       describe('#defaultRenderer', () => {
 
-        it('should be a renderer', () => {
-          expect(renderer).to.be.a(BaseCellWidget.Renderer);
+        it('should be a ContentFactory', () => {
+          expect(contentFactory).to.be.a(BaseCellWidget.ContentFactory);
         });
 
       });
@@ -396,19 +393,19 @@ describe('notebook/cells/widget', () => {
 
   describe('CodeCellWidget', () => {
 
-    let renderer = createCodeCellRenderer();
+    let contentFactory = createCodeCellFactory();
     let model = new CodeCellModel();
 
     describe('#constructor()', () => {
 
       it('should create a code cell widget', () => {
-        let widget = new CodeCellWidget({ model, rendermime, renderer });
+        let widget = new CodeCellWidget({ model, rendermime, contentFactory });
         expect(widget).to.be.a(CodeCellWidget);
       });
 
-      it('should accept a custom renderer', () => {
-        renderer = createCodeCellRenderer();
-        let widget = new CodeCellWidget({ model, renderer, rendermime });
+      it('should accept a custom contentFactory', () => {
+        contentFactory = createCodeCellFactory();
+        let widget = new CodeCellWidget({ model, contentFactory, rendermime });
         expect(widget).to.be.a(CodeCellWidget);
       });
 
@@ -417,13 +414,13 @@ describe('notebook/cells/widget', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the widget', () => {
-        let widget = new CodeCellWidget({ model, rendermime, renderer });
+        let widget = new CodeCellWidget({ model, rendermime, contentFactory });
         widget.dispose();
         expect(widget.isDisposed).to.be(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let widget = new CodeCellWidget({ model, rendermime, renderer });
+        let widget = new CodeCellWidget({ model, rendermime, contentFactory });
         widget.dispose();
         widget.dispose();
         expect(widget.isDisposed).to.be(true);
@@ -434,7 +431,7 @@ describe('notebook/cells/widget', () => {
     describe('#execute()', () => {
 
       it('should fulfill a promise if there is no code to execute', (done) => {
-        let widget = new CodeCellWidget({ model, rendermime, renderer });
+        let widget = new CodeCellWidget({ model, rendermime, contentFactory });
         Kernel.startNew().then(kernel => {
           return widget.execute(kernel).then(() => {
             kernel.shutdown();
@@ -444,7 +441,7 @@ describe('notebook/cells/widget', () => {
       });
 
       it('should fulfill a promise if there is code to execute', (done) => {
-        let widget = new CodeCellWidget({ model, rendermime, renderer });
+        let widget = new CodeCellWidget({ model, rendermime, contentFactory });
         Kernel.startNew().then(kernel => {
           widget.model.value.text = 'foo';
 
@@ -499,12 +496,12 @@ describe('notebook/cells/widget', () => {
 
     });
 
-    describe('.Renderer', () => {
+    describe('.contentFactory', () => {
 
       describe('#constructor()', () => {
 
-        it('should create a renderer', () => {
-          expect(renderer).to.be.a(CodeCellWidget.Renderer);
+        it('should create a ContentFactory', () => {
+          expect(contentFactory).to.be.a(CodeCellWidget.ContentFactory);
         });
 
       });
@@ -512,7 +509,7 @@ describe('notebook/cells/widget', () => {
       describe('#createOutputArea()', () => {
 
         it('should create an output area widget', () => {
-          let output = renderer.createOutputArea(rendermime);
+          let output = contentFactory.createOutputArea({ rendermime });
           expect(output).to.be.an(OutputAreaWidget);
         });
 
@@ -520,8 +517,8 @@ describe('notebook/cells/widget', () => {
 
       describe('#defaultRenderer', () => {
 
-        it('should be a renderer', () => {
-          expect(renderer).to.be.a(CodeCellWidget.Renderer);
+        it('should be a contentFactory', () => {
+          expect(contentFactory).to.be.a(CodeCellWidget.ContentFactory);
         });
 
       });
@@ -532,23 +529,23 @@ describe('notebook/cells/widget', () => {
 
   describe('MarkdownCellWidget', () => {
 
-    let renderer = createBaseCellRenderer();
+    let contentFactory = createBaseCellFactory();
     let model = new MarkdownCellModel();
 
     describe('#constructor()', () => {
 
       it('should create a markdown cell widget', () => {
-        let widget = new MarkdownCellWidget({ model, rendermime, renderer });
+        let widget = new MarkdownCellWidget({ model, rendermime, contentFactory });
         expect(widget).to.be.a(MarkdownCellWidget);
       });
 
-      it('should accept a custom renderer', () => {
-        let widget = new MarkdownCellWidget({ model, rendermime, renderer });
+      it('should accept a custom contentFactory', () => {
+        let widget = new MarkdownCellWidget({ model, rendermime, contentFactory });
         expect(widget).to.be.a(MarkdownCellWidget);
       });
 
       it('should set the default mimetype to text/x-ipythongfm', () => {
-        let widget = new MarkdownCellWidget({ model, rendermime, renderer });
+        let widget = new MarkdownCellWidget({ model, rendermime, contentFactory });
         expect(widget.model.mimeType).to.be('text/x-ipythongfm');
       });
 
@@ -557,7 +554,7 @@ describe('notebook/cells/widget', () => {
     describe('#rendered', () => {
 
       it('should default to true', (done) => {
-        let widget = new MarkdownCellWidget({ model, rendermime, renderer });
+        let widget = new MarkdownCellWidget({ model, rendermime, contentFactory });
         Widget.attach(widget, document.body);
         expect(widget.rendered).to.be(true);
         requestAnimationFrame(() => {
@@ -568,7 +565,7 @@ describe('notebook/cells/widget', () => {
       });
 
       it('should unrender the widget', (done) => {
-        let widget = new MarkdownCellWidget({ model, rendermime, renderer });
+        let widget = new MarkdownCellWidget({ model, rendermime, contentFactory });
         Widget.attach(widget, document.body);
         widget.rendered = false;
         requestAnimationFrame(() => {
@@ -579,7 +576,7 @@ describe('notebook/cells/widget', () => {
       });
 
       it('should ignore being set to the same value', (done) => {
-        let widget = new LogMarkdownCell({ model, rendermime, renderer });
+        let widget = new LogMarkdownCell({ model, rendermime, contentFactory });
         Widget.attach(widget, document.body);
         widget.rendered = false;
         widget.rendered = false;
@@ -597,13 +594,13 @@ describe('notebook/cells/widget', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the widget', () => {
-        let widget = new MarkdownCellWidget({ model, rendermime, renderer });
+        let widget = new MarkdownCellWidget({ model, rendermime, contentFactory });
         widget.dispose();
         expect(widget.isDisposed).to.be(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let widget = new MarkdownCellWidget({ model, rendermime, renderer });
+        let widget = new MarkdownCellWidget({ model, rendermime, contentFactory });
         widget.dispose();
         widget.dispose();
         expect(widget.isDisposed).to.be(true);
@@ -614,7 +611,7 @@ describe('notebook/cells/widget', () => {
     describe('#onUpdateRequest()', () => {
 
       it('should update the widget', () => {
-        let widget = new LogMarkdownCell({ model, rendermime, renderer });
+        let widget = new LogMarkdownCell({ model, rendermime, contentFactory });
         expect(widget.methods).to.not.contain('onUpdateRequest');
         sendMessage(widget, WidgetMessage.UpdateRequest);
         expect(widget.methods).to.contain('onUpdateRequest');
@@ -626,13 +623,13 @@ describe('notebook/cells/widget', () => {
 
   describe('RawCellWidget', () => {
 
-    let renderer = createBaseCellRenderer();
+    let contentFactory = createBaseCellFactory();
 
     describe('#constructor()', () => {
 
       it('should create a raw cell widget', () => {
         let model = new RawCellModel();
-        let widget = new RawCellWidget({ model, renderer });
+        let widget = new RawCellWidget({ model, contentFactory });
         expect(widget).to.be.a(RawCellWidget);
       });
 
@@ -646,7 +643,7 @@ describe('notebook/cells/widget', () => {
 
       it('should create an input area widget', () => {
         let editor = createCellEditor();
-        let widget = new InputAreaWidget(editor);
+        let widget = new InputAreaWidget({ editor });
         expect(widget).to.be.an(InputAreaWidget);
       });
 
@@ -656,7 +653,7 @@ describe('notebook/cells/widget', () => {
 
       it('should change the value of the input prompt', () => {
         let editor = createCellEditor();
-        let widget = new InputAreaWidget(editor);
+        let widget = new InputAreaWidget({ editor });
         let prompt = widget.node.querySelector(`.${PROMPT_CLASS}`);
         expect(prompt.textContent).to.be.empty();
         widget.setPrompt('foo');
@@ -665,7 +662,7 @@ describe('notebook/cells/widget', () => {
 
       it('should treat the string value "null" as special', () => {
         let editor = createCellEditor();
-        let widget = new InputAreaWidget(editor);
+        let widget = new InputAreaWidget({ editor });
         let prompt = widget.node.querySelector(`.${PROMPT_CLASS}`);
         expect(prompt.textContent).to.be.empty();
         widget.setPrompt('null');

--- a/test/src/notebook/cells/widget.spec.ts
+++ b/test/src/notebook/cells/widget.spec.ts
@@ -535,7 +535,10 @@ describe('notebook/cells/widget', () => {
 
         it('should create an output area widget', () => {
           let factory = new CodeCellWidget.ContentFactory({ editorFactory });
-          let output = factory.createOutputArea({ rendermime });
+          let output = factory.createOutputArea({
+            rendermime,
+            contentFactory: OutputAreaWidget.defaultContentFactory
+          });
           expect(output).to.be.an(OutputAreaWidget);
         });
 

--- a/test/src/notebook/notebook/actions.spec.ts
+++ b/test/src/notebook/notebook/actions.spec.ts
@@ -12,10 +12,6 @@ import {
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
-  MimeData
-} from 'phosphor/lib/core/mimedata';
-
-import {
   CodeCellWidget, MarkdownCellWidget, RawCellWidget
 } from '../../../../lib/notebook/cells/widget';
 
@@ -32,15 +28,11 @@ import {
 } from '../../../../lib/notebook/notebook/widget';
 
 import {
-  defaultRenderMime
-} from '../../utils';
-
-import {
-  DEFAULT_CONTENT, createNotebookRenderer
+  DEFAULT_CONTENT, createNotebookFactory, clipboard, rendermime,
+  mimeTypeService
 } from '../utils';
 
 
-const clipboard = new MimeData();
 const ERROR_INPUT = 'a = foo';
 const kernelPromise = Kernel.startNew();
 
@@ -54,8 +46,9 @@ describe('notebook/notebook/actions', () => {
 
     beforeEach((done) => {
       widget = new Notebook({
-        rendermime: defaultRenderMime(),
-        renderer: createNotebookRenderer()
+        rendermime,
+        contentFactory: createNotebookFactory(),
+        mimeTypeService
       });
       let model = new NotebookModel();
       model.fromJSON(DEFAULT_CONTENT);

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -201,7 +201,6 @@ describe('notebook/notebook/default-toolbar', () => {
     describe('#createRunButton()', () => {
 
       it('should run and advance when clicked', (done) => {
-        console.log('\n\n***createRunButton');
         let button = ToolbarItems.createRunButton(panel);
         let widget = panel.notebook;
         let next = widget.widgets.at(1) as MarkdownCellWidget;
@@ -210,13 +209,9 @@ describe('notebook/notebook/default-toolbar', () => {
         cell.model.outputs.clear();
         next.rendered = false;
         Widget.attach(button, document.body);
-        console.log('\n\n***starting Kernel');
         startKernel(panel.context).then(kernel => {
-          console.log('\n\n***kernel started');
           kernel.statusChanged.connect((sender, status) => {
-            console.log('\n\n***status changed', status);
             if (status === 'idle' && cell.model.outputs.length > 0) {
-              console.log('\n\n***isrendered', next.rendered);
               expect(next.rendered).to.be(true);
               button.dispose();
               done();

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -201,6 +201,7 @@ describe('notebook/notebook/default-toolbar', () => {
     describe('#createRunButton()', () => {
 
       it('should run and advance when clicked', (done) => {
+        console.log('\n\n***createRunButton');
         let button = ToolbarItems.createRunButton(panel);
         let widget = panel.notebook;
         let next = widget.widgets.at(1) as MarkdownCellWidget;
@@ -209,9 +210,13 @@ describe('notebook/notebook/default-toolbar', () => {
         cell.model.outputs.clear();
         next.rendered = false;
         Widget.attach(button, document.body);
+        console.log('\n\n***starting Kernel');
         startKernel(panel.context).then(kernel => {
+          console.log('\n\n***kernel started');
           kernel.statusChanged.connect((sender, status) => {
+            console.log('\n\n***status changed', status);
             if (status === 'idle' && cell.model.outputs.length > 0) {
+              console.log('\n\n***isrendered', next.rendered)
               expect(next.rendered).to.be(true);
               button.dispose();
               done();

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -216,7 +216,7 @@ describe('notebook/notebook/default-toolbar', () => {
           kernel.statusChanged.connect((sender, status) => {
             console.log('\n\n***status changed', status);
             if (status === 'idle' && cell.model.outputs.length > 0) {
-              console.log('\n\n***isrendered', next.rendered)
+              console.log('\n\n***isrendered', next.rendered);
               expect(next.rendered).to.be(true);
               button.dispose();
               done();

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -53,6 +53,7 @@ import {
  * Default data.
  */
 const contentFactory = createNotebookPanelFactory();
+const notebookContentFactory = createNotebookFactory();
 const options = { rendermime, clipboard, mimeTypeService, contentFactory };
 
 
@@ -355,14 +356,30 @@ describe('notebook/notebook/panel', () => {
 
     });
 
-    describe('#contentFactory', () => {
+    describe('.ContentFactory', () => {
+
+      describe('#constructor', () => {
+
+        it('should create a new ContentFactory', () => {
+          let factory = new NotebookPanel.ContentFactory({ notebookContentFactory });
+          expect(factory).to.be.a(NotebookPanel.ContentFactory);
+        });
+
+      });
+
+      describe('#notebookContentFactory', () => {
+
+        it('should be the content factory for notebook widgets', () => {
+          expect(contentFactory.notebookContentFactory).to.be.a(Notebook.ContentFactory);
+        });
+
+      });
 
       describe('#createNotebook()', () => {
 
         it('should create a notebook widget', () => {
-          let notebookContentFactory = createNotebookFactory();
           let options = {
-            contentFactory: notebookContentFactory,
+            contentFactory: contentFactory.notebookContentFactory,
             rendermime,
             mimeTypeService
           };

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -8,10 +8,6 @@ import {
 } from '@jupyterlab/services';
 
 import {
-  MimeData
-} from 'phosphor/lib/core/mimedata';
-
-import {
   IChangedArgs
 } from '../../../../lib/common/interfaces';
 
@@ -40,20 +36,20 @@ import {
 } from '../../../../lib/notebook/notebook/widget';
 
 import {
-  createNotebookContext, defaultRenderMime
+  createNotebookContext
 } from '../../utils';
 
 import {
-  DEFAULT_CONTENT, createNotebookPanelRenderer
+  DEFAULT_CONTENT, createNotebookPanelFactory, rendermime, clipboard,
+  mimeTypeService, createNotebookFactory
 } from '../utils';
 
 
 /**
  * Default data.
  */
-const rendermime = defaultRenderMime();
-const clipboard = new MimeData();
-const renderer = createNotebookPanelRenderer();
+const contentFactory = createNotebookPanelFactory();
+const options = { rendermime, clipboard, mimeTypeService, contentFactory };
 
 
 class LogNotebookPanel extends NotebookPanel {
@@ -78,7 +74,7 @@ class LogNotebookPanel extends NotebookPanel {
 
 
 function createPanel(context: Context<INotebookModel>): LogNotebookPanel {
-  let panel = new LogNotebookPanel({ rendermime, clipboard, renderer });
+  let panel = new LogNotebookPanel(options);
   context.model.fromJSON(DEFAULT_CONTENT);
   panel.context = context;
   return panel;
@@ -112,17 +108,17 @@ describe('notebook/notebook/panel', () => {
     describe('#constructor()', () => {
 
       it('should create a notebook panel', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer});
+        let panel = new NotebookPanel(options);
         expect(panel).to.be.a(NotebookPanel);
       });
 
 
-      it('should accept an optional render', () => {
-        let newRenderer = createNotebookPanelRenderer();
+      it('should accept an optional content factory', () => {
+        let newFactory = createNotebookPanelFactory();
         let panel = new NotebookPanel({
-          rendermime, clipboard, renderer: newRenderer
+          mimeTypeService, rendermime, clipboard, contentFactory: newFactory
         });
-        expect(panel.renderer).to.be(newRenderer);
+        expect(panel.contentFactory).to.be(newFactory);
       });
 
     });
@@ -130,7 +126,7 @@ describe('notebook/notebook/panel', () => {
     describe('#contextChanged', () => {
 
       it('should be emitted when the context on the panel changes', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         let called = false;
         panel.contextChanged.connect((sender, args) => {
           expect(sender).to.be(panel);
@@ -142,7 +138,7 @@ describe('notebook/notebook/panel', () => {
       });
 
       it('should not be emitted if the context does not change', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         let called = false;
         panel.context = context;
         panel.contextChanged.connect(() => { called = true; });
@@ -171,7 +167,7 @@ describe('notebook/notebook/panel', () => {
     describe('#toolbar', () => {
 
       it('should be the toolbar used by the widget', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         expect(panel.toolbar).to.be.a(Toolbar);
       });
 
@@ -180,8 +176,8 @@ describe('notebook/notebook/panel', () => {
     describe('#content', () => {
 
       it('should be the content area used by the widget', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
-        expect(panel.content).to.be.a(Notebook);
+        let panel = new NotebookPanel(options);
+        expect(panel.notebook).to.be.a(Notebook);
       });
 
     });
@@ -204,18 +200,19 @@ describe('notebook/notebook/panel', () => {
     describe('#rendermime', () => {
 
       it('should be the rendermime instance used by the widget', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         expect(panel.rendermime).to.be(rendermime);
       });
 
     });
 
-    describe('#renderer', () => {
+    describe('#contentFactory', () => {
 
-      it('should be the renderer used by the widget', () => {
-        let r = createNotebookPanelRenderer();
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer: r });
-        expect(panel.renderer).to.be(r);
+      it('should be the contentFactory used by the widget', () => {
+        let r = createNotebookPanelFactory();
+        let panel = new NotebookPanel({
+          mimeTypeService, rendermime, clipboard, contentFactory: r });
+        expect(panel.contentFactory).to.be(r);
       });
 
     });
@@ -223,7 +220,7 @@ describe('notebook/notebook/panel', () => {
     describe('#clipboard', () => {
 
       it('should be the clipboard instance used by the widget', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         expect(panel.clipboard).to.be(clipboard);
       });
 
@@ -232,11 +229,11 @@ describe('notebook/notebook/panel', () => {
     describe('#model', () => {
 
       it('should be the model for the widget', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         expect(panel.model).to.be(null);
         panel.context = context;
         expect(panel.model).to.be(context.model);
-        expect(panel.content.model).to.be(context.model);
+        expect(panel.notebook.model).to.be(context.model);
       });
 
     });
@@ -244,18 +241,18 @@ describe('notebook/notebook/panel', () => {
     describe('#context', () => {
 
       it('should get the document context for the widget', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         expect(panel.context).to.be(null);
       });
 
       it('should set the document context for the widget', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         panel.context = context;
         expect(panel.context).to.be(context);
       });
 
       it('should emit the `contextChanged` signal', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         let called = false;
         panel.contextChanged.connect(() => { called = true; });
         panel.context = context;
@@ -264,7 +261,7 @@ describe('notebook/notebook/panel', () => {
 
 
       it('should initialize the model state', (done) => {
-        let panel = new LogNotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new LogNotebookPanel(options);
         let model = context.model;
         model.fromJSON(DEFAULT_CONTENT);
         expect(model.cells.canUndo).to.be(true);
@@ -281,14 +278,14 @@ describe('notebook/notebook/panel', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources used by the widget', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         panel.context = context;
         panel.dispose();
         expect(panel.isDisposed).to.be(true);
       });
 
       it('should be safe to call more than once', () => {
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new NotebookPanel(options);
         panel.dispose();
         panel.dispose();
         expect(panel.isDisposed).to.be(true);
@@ -299,7 +296,7 @@ describe('notebook/notebook/panel', () => {
     describe('#onContextChanged()', () => {
 
       it('should be called when the context changes', () => {
-        let panel = new LogNotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new LogNotebookPanel(options);
         panel.methods = [];
         panel.context = context;
         expect(panel.methods).to.contain('onContextChanged');
@@ -341,7 +338,7 @@ describe('notebook/notebook/panel', () => {
       });
 
       it('should be called when the context changes', () => {
-        let panel = new LogNotebookPanel({ rendermime, clipboard, renderer });
+        let panel = new LogNotebookPanel(options);
         panel.methods = [];
         panel.context = context;
         expect(panel.methods).to.contain('onPathChanged');
@@ -354,12 +351,18 @@ describe('notebook/notebook/panel', () => {
 
     });
 
-    describe('.Renderer', () => {
+    describe('.contentFactory', () => {
 
-      describe('#createContent()', () => {
+      describe('#createNotebook()', () => {
 
         it('should create a notebook widget', () => {
-          expect(renderer.createContent(rendermime)).to.be.a(Notebook);
+          let notebookContentFactory = createNotebookFactory();
+          let options = {
+            contentFactory: notebookContentFactory,
+            rendermime,
+            mimeTypeService
+          };
+          expect(contentFactory.createNotebook(options)).to.be.a(Notebook);
         });
 
       });
@@ -367,15 +370,32 @@ describe('notebook/notebook/panel', () => {
       describe('#createToolbar()', () => {
 
         it('should create a notebook toolbar', () => {
-          expect(renderer.createToolbar()).to.be.a(Toolbar);
+          expect(contentFactory.createToolbar()).to.be.a(Toolbar);
         });
 
       });
 
+      describe('#createInspectionHandler()', () => {
+
+        it('should create an inspection handler', () => {
+          throw new Error('not implemented');
+        });
+
+      });
+
+
       describe('#createCompleter()', () => {
 
         it('should create a completer widget', () => {
-          expect(renderer.createCompleter()).to.be.a(CompleterWidget);
+          expect(contentFactory.createCompleter({})).to.be.a(CompleterWidget);
+        });
+
+      });
+
+      describe('#createCompleterHandler()', () => {
+
+        it('should create a completer handler', () => {
+          throw new Error('not implemented');
         });
 
       });

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -45,7 +45,7 @@ import {
 
 import {
   DEFAULT_CONTENT, createNotebookPanelFactory, rendermime, clipboard,
-  mimeTypeService, createNotebookFactory
+  mimeTypeService, createNotebookFactory, editorFactory
 } from '../utils';
 
 
@@ -53,7 +53,6 @@ import {
  * Default data.
  */
 const contentFactory = createNotebookPanelFactory();
-const notebookContentFactory = createNotebookFactory();
 const options = { rendermime, clipboard, mimeTypeService, contentFactory };
 
 
@@ -361,7 +360,7 @@ describe('notebook/notebook/panel', () => {
       describe('#constructor', () => {
 
         it('should create a new ContentFactory', () => {
-          let factory = new NotebookPanel.ContentFactory({ notebookContentFactory });
+          let factory = new NotebookPanel.ContentFactory({ editorFactory });
           expect(factory).to.be.a(NotebookPanel.ContentFactory);
         });
 

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -16,8 +16,12 @@ import {
 } from '../../../../lib/docregistry';
 
 import {
-  CompleterWidget
+  CompleterWidget, CellCompleterHandler
 } from '../../../../lib/completer';
+
+import {
+  InspectionHandler
+} from '../../../../lib/inspector';
 
 import {
   INotebookModel
@@ -351,7 +355,7 @@ describe('notebook/notebook/panel', () => {
 
     });
 
-    describe('.contentFactory', () => {
+    describe('#contentFactory', () => {
 
       describe('#createNotebook()', () => {
 
@@ -378,7 +382,8 @@ describe('notebook/notebook/panel', () => {
       describe('#createInspectionHandler()', () => {
 
         it('should create an inspection handler', () => {
-          throw new Error('not implemented');
+          let inspector = contentFactory.createInspectionHandler({ rendermime });
+          expect(inspector).to.be.an(InspectionHandler);
         });
 
       });
@@ -395,7 +400,9 @@ describe('notebook/notebook/panel', () => {
       describe('#createCompleterHandler()', () => {
 
         it('should create a completer handler', () => {
-          throw new Error('not implemented');
+          let options = { completer:  new CompleterWidget({}) };
+          let handler = contentFactory.createCompleterHandler(options);
+          expect(handler).to.be.a(CellCompleterHandler);
         });
 
       });

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -37,21 +37,20 @@ import {
 } from '../../../../lib/notebook/notebook/widget';
 
 import {
-  defaultRenderMime
-} from '../../utils';
-
-import {
-  DEFAULT_CONTENT, createNotebookRenderer
+  DEFAULT_CONTENT, createNotebookFactory, rendermime, mimeTypeService,
+  createCodeCellFactory, createBaseCellFactory
 } from '../utils';
 
 
-const rendermime = defaultRenderMime();
-const renderer = createNotebookRenderer();
+const contentFactory = createNotebookFactory();
+const options: Notebook.IOptions = {
+  rendermime, contentFactory, mimeTypeService
+};
 
 
 function createWidget(): LogStaticNotebook {
   let model = new NotebookModel();
-  let widget = new LogStaticNotebook({ rendermime, renderer });
+  let widget = new LogStaticNotebook(options);
   widget.model = model;
   return widget;
 }
@@ -143,7 +142,7 @@ class LogNotebook extends Notebook {
 
 function createActiveWidget(): LogNotebook {
   let model = new NotebookModel();
-  let widget = new LogNotebook({ rendermime, renderer });
+  let widget = new LogNotebook(options);
   widget.model = model;
   return widget;
 }
@@ -156,19 +155,18 @@ describe('notebook/notebook/widget', () => {
     describe('#constructor()', () => {
 
       it('should create a notebook widget', () => {
-        let widget = new StaticNotebook({ rendermime, renderer });
+        let widget = new StaticNotebook(options);
         expect(widget).to.be.a(StaticNotebook);
       });
 
       it('should add the `jp-Notebook` class', () => {
-        let widget = new StaticNotebook({ rendermime, renderer });
+        let widget = new StaticNotebook(options);
         expect(widget.hasClass('jp-Notebook')).to.be(true);
       });
 
       it('should accept an optional render', () => {
-        let renderer = createNotebookRenderer();
-        let widget = new StaticNotebook({ rendermime, renderer });
-        expect(widget.renderer).to.be(renderer);
+        let widget = new StaticNotebook(options);
+        expect(widget.contentFactory).to.be(contentFactory);
       });
 
     });
@@ -176,7 +174,7 @@ describe('notebook/notebook/widget', () => {
     describe('#modelChanged', () => {
 
       it('should be emitted when the model changes', () => {
-        let widget = new StaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new StaticNotebook(options);
         let model = new NotebookModel();
         let called = false;
         widget.modelChanged.connect((sender, args) => {
@@ -193,7 +191,7 @@ describe('notebook/notebook/widget', () => {
     describe('#modelContentChanged', () => {
 
       it('should be emitted when a cell is added', () => {
-        let widget = new StaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new StaticNotebook(options);
         widget.model = new NotebookModel();
         let called = false;
         widget.modelContentChanged.connect(() => { called = true; });
@@ -203,7 +201,7 @@ describe('notebook/notebook/widget', () => {
       });
 
       it('should be emitted when metadata is set', () => {
-        let widget = new StaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new StaticNotebook(options);
         widget.model = new NotebookModel();
         let called = false;
         widget.modelContentChanged.connect(() => { called = true; });
@@ -217,19 +215,19 @@ describe('notebook/notebook/widget', () => {
     describe('#model', () => {
 
       it('should get the model for the widget', () => {
-        let widget = new StaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new StaticNotebook(options);
         expect(widget.model).to.be(null);
       });
 
       it('should set the model for the widget', () => {
-        let widget = new StaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new StaticNotebook(options);
         let model = new NotebookModel();
         widget.model = model;
         expect(widget.model).to.be(model);
       });
 
       it('should emit the `modelChanged` signal', () => {
-        let widget = new StaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new StaticNotebook(options);
         let model = new NotebookModel();
         widget.model = model;
         let called = false;
@@ -239,7 +237,7 @@ describe('notebook/notebook/widget', () => {
       });
 
       it('should be a no-op if the value does not change', () => {
-        let widget = new StaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new StaticNotebook(options);
         let model = new NotebookModel();
         widget.model = model;
         let called = false;
@@ -249,7 +247,7 @@ describe('notebook/notebook/widget', () => {
       });
 
       it('should add the model cells to the layout', () => {
-        let widget = new LogStaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new LogStaticNotebook(options);
         let model = new NotebookModel();
         model.fromJSON(DEFAULT_CONTENT);
         widget.model = model;
@@ -257,7 +255,7 @@ describe('notebook/notebook/widget', () => {
       });
 
       it('should set the mime types of the cell widgets', () => {
-        let widget = new LogStaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new LogStaticNotebook(options);
         let model = new NotebookModel();
         let cursor = model.getMetadata('language_info');
         cursor.setValue({ name: 'python', codemirror_mode: 'python' });
@@ -324,17 +322,17 @@ describe('notebook/notebook/widget', () => {
     describe('#rendermime', () => {
 
       it('should be the rendermime instance used by the widget', () => {
-        let widget = new StaticNotebook({ rendermime, renderer });
+        let widget = new StaticNotebook(options);
         expect(widget.rendermime).to.be(rendermime);
       });
 
     });
 
-    describe('#renderer', () => {
+    describe('#contentFactory', () => {
 
-      it('should be the cell widget renderer used by the widget', () => {
-        let widget = new StaticNotebook({ rendermime, renderer });
-        expect(widget.renderer).to.be(renderer);
+      it('should be the cell widget contentFactory used by the widget', () => {
+        let widget = new StaticNotebook(options);
+        expect(widget.contentFactory).to.be(contentFactory);
       });
 
     });
@@ -342,12 +340,12 @@ describe('notebook/notebook/widget', () => {
     describe('#codeMimetype', () => {
 
       it('should get the mime type for code cells', () => {
-        let widget = new StaticNotebook({ rendermime, renderer });
+        let widget = new StaticNotebook(options);
         expect(widget.codeMimetype).to.be('text/plain');
       });
 
       it('should be set from language metadata', () => {
-        let widget = new LogStaticNotebook({ rendermime: defaultRenderMime(), renderer });
+        let widget = new LogStaticNotebook(options);
         let model = new NotebookModel();
         let cursor = model.getMetadata('language_info');
         cursor.setValue({ name: 'python', codemirror_mode: 'python' });
@@ -403,7 +401,7 @@ describe('notebook/notebook/widget', () => {
     describe('#onModelChanged()', () => {
 
       it('should be called when the model changes', () => {
-        let widget = new LogStaticNotebook({ rendermime, renderer });
+        let widget = new LogStaticNotebook(options);
         widget.model = new NotebookModel();
         expect(widget.methods).to.contain('onModelChanged');
       });
@@ -477,14 +475,16 @@ describe('notebook/notebook/widget', () => {
 
     });
 
-    describe('.Renderer', () => {
+    describe('.contentFactory', () => {
 
       describe('#createCodeCell()', () => {
 
         it('should create a `CodeCellWidget`', () => {
-          let renderer = createNotebookRenderer();
+          let parent = new StaticNotebook(options);
           let model = new CodeCellModel();
-          let widget = renderer.createCodeCell(model, rendermime);
+          let factory = createCodeCellFactory();
+          let codeOptions = { model, rendermime, contentFactory: factory };
+          let widget = contentFactory.createCodeCell(codeOptions, parent);
           expect(widget).to.be.a(CodeCellWidget);
         });
 
@@ -493,9 +493,11 @@ describe('notebook/notebook/widget', () => {
       describe('#createMarkdownCell()', () => {
 
         it('should create a `MarkdownCellWidget`', () => {
-          let renderer = createNotebookRenderer();
+          let parent = new StaticNotebook(options);
           let model = new MarkdownCellModel();
-          let widget = renderer.createMarkdownCell(model, rendermime);
+          let factory = createBaseCellFactory();
+          let mdOptions = { model, rendermime, contentFactory: factory };
+          let widget = contentFactory.createMarkdownCell(mdOptions, parent);
           expect(widget).to.be.a(MarkdownCellWidget);
         });
 
@@ -504,35 +506,12 @@ describe('notebook/notebook/widget', () => {
       describe('#createRawCell()', () => {
 
         it('should create a `RawCellWidget`', () => {
-          let renderer = createNotebookRenderer();
+          let parent = new StaticNotebook(options);
           let model = new RawCellModel();
-          let widget = renderer.createRawCell(model);
+          let factory = createBaseCellFactory();
+          let rawOptions = { model, contentFactory: factory };
+          let widget = contentFactory.createRawCell(rawOptions, parent);
           expect(widget).to.be.a(RawCellWidget);
-        });
-
-      });
-
-      describe('#updateCell()', () => {
-
-        it('should be a no-op', () => {
-          let renderer = createNotebookRenderer();
-          let model = new CodeCellModel();
-          let widget = renderer.createCodeCell(model, rendermime);
-          renderer.updateCell(widget);
-          expect(widget).to.be.a(CodeCellWidget);
-        });
-
-      });
-
-      describe('#getCodeMimetype()', () => {
-
-        it('should get the preferred mime for code cells in the notebook', () => {
-          let renderer = createNotebookRenderer();
-          let model = new NotebookModel();
-          let cursor = model.getMetadata('language_info');
-          cursor.setValue({ name: 'python', mimetype: 'text/x-python' });
-          let info = cursor.getValue() as nbformat.ILanguageInfoMetadata;
-          expect(renderer.getCodeMimetype(info)).to.be('text/x-python');
         });
 
       });

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -479,29 +479,29 @@ describe('notebook/notebook/widget', () => {
 
       });
 
-      describe('#codeContentFactory', () => {
+      describe('#codeCellContentFactory', () => {
 
         it('should be a CodeCellWidget.ContentFactory', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
-          expect(factory.codeContentFactory).to.be.a(CodeCellWidget.ContentFactory);
+          expect(factory.codeCellContentFactory).to.be.a(CodeCellWidget.ContentFactory);
         });
 
       });
 
-      describe('#markdownContentFactory', () => {
+      describe('#markdownCellContentFactory', () => {
 
         it('should be a BaseCellWidget.ContentFactory', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
-          expect(factory.markdownContentFactory).to.be.a(BaseCellWidget.ContentFactory);
+          expect(factory.markdownCellContentFactory).to.be.a(BaseCellWidget.ContentFactory);
         });
 
       });
 
-      describe('#rawContentFactory', () => {
+      describe('#rawCellContentFactory', () => {
 
         it('should be a BaseCellWidget.ContentFactory', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
-          expect(factory.rawContentFactory).to.be.a(BaseCellWidget.ContentFactory);
+          expect(factory.rawCellContentFactory).to.be.a(BaseCellWidget.ContentFactory);
         });
 
       });
@@ -510,7 +510,7 @@ describe('notebook/notebook/widget', () => {
 
         it('should create a `CodeCellWidget`', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
-          let contentFactory = factory.codeContentFactory;
+          let contentFactory = factory.codeCellContentFactory;
           let model = new CodeCellModel();
           let codeOptions = { model, rendermime, contentFactory };
           let parent = new StaticNotebook(options);
@@ -524,7 +524,7 @@ describe('notebook/notebook/widget', () => {
 
         it('should create a `MarkdownCellWidget`', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
-          let contentFactory = factory.markdownContentFactory;
+          let contentFactory = factory.markdownCellContentFactory;
           let model = new MarkdownCellModel();
           let mdOptions = { model, rendermime, contentFactory };
           let parent = new StaticNotebook(options);
@@ -538,7 +538,7 @@ describe('notebook/notebook/widget', () => {
 
         it('should create a `RawCellWidget`', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
-          let contentFactory = factory.rawContentFactory;
+          let contentFactory = factory.rawCellContentFactory;
           let model = new RawCellModel();
           let rawOptions = { model, contentFactory };
           let parent = new StaticNotebook(options);

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -4,10 +4,6 @@
 import expect = require('expect.js');
 
 import {
-  nbformat
-} from '@jupyterlab/services';
-
-import {
   sendMessage, Message
 } from 'phosphor/lib/core/messaging';
 
@@ -38,7 +34,7 @@ import {
 
 import {
   DEFAULT_CONTENT, createNotebookFactory, rendermime, mimeTypeService,
-  createCodeCellFactory, createBaseCellFactory
+  editorFactory
 } from '../utils';
 
 
@@ -332,7 +328,7 @@ describe('notebook/notebook/widget', () => {
 
       it('should be the cell widget contentFactory used by the widget', () => {
         let widget = new StaticNotebook(options);
-        expect(widget.contentFactory).to.be(contentFactory);
+        expect(widget.contentFactory).to.be(StaticNotebook.ContentFactory);
       });
 
     });
@@ -475,16 +471,53 @@ describe('notebook/notebook/widget', () => {
 
     });
 
-    describe('.contentFactory', () => {
+    describe('.ContentFactory', () => {
+
+      describe('#constructor', () => {
+
+        it('should create a new ContentFactory', () => {
+          let factory = new StaticNotebook.ContentFactory({ editorFactory });
+          expect(factory).to.be.a(StaticNotebook.ContentFactory);
+        });
+
+      });
+
+      describe('#codeContentFactory', () => {
+
+        it('should be a CodeCellWidget.ContentFactory', () => {
+          let factory = new StaticNotebook.ContentFactory({ editorFactory });
+          expect(factory.codeContentFactory).to.be.a(CodeCellWidget.ContentFactory);
+        });
+
+      });
+
+      describe('#markdownContentFactory', () => {
+
+        it('should be a BaseCellWidget.ContentFactory', () => {
+          let factory = new StaticNotebook.ContentFactory({ editorFactory });
+          expect(factory.markdownContentFactory).to.be.a(BaseCellWidget.ContentFactory);
+        });
+
+      });
+
+      describe('#rawContentFactory', () => {
+
+        it('should be a BaseCellWidget.ContentFactory', () => {
+          let factory = new StaticNotebook.ContentFactory({ editorFactory });
+          expect(factory.rawContentFactory).to.be.a(BaseCellWidget.ContentFactory);
+        });
+
+      });
 
       describe('#createCodeCell()', () => {
 
         it('should create a `CodeCellWidget`', () => {
-          let parent = new StaticNotebook(options);
+          let factory = new StaticNotebook.ContentFactory({ editorFactory });
+          let contentFactory = factory.codeContentFactory;
           let model = new CodeCellModel();
-          let factory = createCodeCellFactory();
-          let codeOptions = { model, rendermime, contentFactory: factory };
-          let widget = contentFactory.createCodeCell(codeOptions, parent);
+          let codeOptions = { model, rendermime, contentFactory };
+          let parent = new StaticNotebook(options);
+          let widget = factory.createCodeCell(codeOptions, parent);
           expect(widget).to.be.a(CodeCellWidget);
         });
 
@@ -493,11 +526,12 @@ describe('notebook/notebook/widget', () => {
       describe('#createMarkdownCell()', () => {
 
         it('should create a `MarkdownCellWidget`', () => {
-          let parent = new StaticNotebook(options);
+          let factory = new StaticNotebook.ContentFactory({ editorFactory });
+          let contentFactory = factory.markdownContentFactory;
           let model = new MarkdownCellModel();
-          let factory = createBaseCellFactory();
-          let mdOptions = { model, rendermime, contentFactory: factory };
-          let widget = contentFactory.createMarkdownCell(mdOptions, parent);
+          let mdOptions = { model, rendermime, contentFactory };
+          let parent = new StaticNotebook(options);
+          let widget = factory.createMarkdownCell(mdOptions, parent);
           expect(widget).to.be.a(MarkdownCellWidget);
         });
 
@@ -506,11 +540,12 @@ describe('notebook/notebook/widget', () => {
       describe('#createRawCell()', () => {
 
         it('should create a `RawCellWidget`', () => {
-          let parent = new StaticNotebook(options);
+          let factory = new StaticNotebook.ContentFactory({ editorFactory });
+          let contentFactory = factory.rawContentFactory;
           let model = new RawCellModel();
-          let factory = createBaseCellFactory();
-          let rawOptions = { model, contentFactory: factory };
-          let widget = contentFactory.createRawCell(rawOptions, parent);
+          let rawOptions = { model, contentFactory };
+          let parent = new StaticNotebook(options);
+          let widget = factory.createRawCell(rawOptions, parent);
           expect(widget).to.be.a(RawCellWidget);
         });
 

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -328,7 +328,7 @@ describe('notebook/notebook/widget', () => {
 
       it('should be the cell widget contentFactory used by the widget', () => {
         let widget = new StaticNotebook(options);
-        expect(widget.contentFactory).to.be(StaticNotebook.ContentFactory);
+        expect(widget.contentFactory).to.be.a(StaticNotebook.ContentFactory);
       });
 
     });
@@ -378,11 +378,8 @@ describe('notebook/notebook/widget', () => {
 
       it('should dispose of the resources held by the widget', () => {
         let widget = createWidget();
-        let model = widget.model;
         widget.dispose();
-        expect(widget.model).to.be(null);
-        expect(model.isDisposed).to.be(false);
-        expect(widget.rendermime).to.be(null);
+        expect(widget.isDisposed).to.be(true);
       });
 
       it('should be safe to call multiple times', () => {

--- a/test/src/notebook/notebook/widgetfactory.spec.ts
+++ b/test/src/notebook/notebook/widgetfactory.spec.ts
@@ -8,10 +8,6 @@ import {
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
-  MimeData
-} from 'phosphor/lib/core/mimedata';
-
-import {
   INotebookModel
 } from '../../../../lib/notebook/notebook/model';
 
@@ -28,17 +24,15 @@ import {
 } from '../../../../lib/docregistry/context';
 
 import {
-  createNotebookContext, defaultRenderMime
+  createNotebookContext
 } from '../../utils';
 
 import {
-  createNotebookPanelRenderer
+  createNotebookPanelFactory, clipboard, rendermime, mimeTypeService
 } from '../utils';
 
 
-const rendermime = defaultRenderMime();
-const clipboard = new MimeData();
-const renderer = createNotebookPanelRenderer();
+const contentFactory = createNotebookPanelFactory();
 
 
 function createFactory(): NotebookWidgetFactory {
@@ -47,7 +41,8 @@ function createFactory(): NotebookWidgetFactory {
     fileExtensions: ['.ipynb'],
     rendermime,
     clipboard,
-    renderer
+    contentFactory,
+    mimeTypeService
   });
 }
 

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -28,6 +28,8 @@ import {
  * The default rendermime instance to use for testing.
  */
 const rendermime = defaultRenderMime();
+const contentFactory = OutputAreaWidget.defaultContentFactory;
+const OPTIONS = { rendermime, contentFactory };
 
 
 class LogOutputAreaWidget extends OutputAreaWidget {
@@ -65,7 +67,7 @@ class CustomOutputWidget extends OutputWidget {
 
 
 function createWidget(): LogOutputAreaWidget {
-  let widget = new LogOutputAreaWidget({ rendermime });
+  let widget = new LogOutputAreaWidget(OPTIONS);
   let model = new OutputAreaModel();
   for (let output of DEFAULT_OUTPUTS) {
     model.add(output);
@@ -82,7 +84,7 @@ describe('notebook/output-area/widget', () => {
     describe('#constructor()', () => {
 
       it('should take an options object', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         expect(widget).to.be.an(OutputAreaWidget);
       });
 
@@ -93,7 +95,7 @@ describe('notebook/output-area/widget', () => {
       });
 
       it('should add the `jp-OutputArea` class', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         expect(widget.hasClass('jp-OutputArea')).to.be(true);
       });
 
@@ -102,7 +104,7 @@ describe('notebook/output-area/widget', () => {
     describe('#modelChanged', () => {
 
       it('should be emitted when the model of the widget changes', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         let called = false;
         widget.modelChanged.connect((sender, args) => {
           expect(sender).to.be(widget);
@@ -118,19 +120,19 @@ describe('notebook/output-area/widget', () => {
     describe('#model', () => {
 
       it('should default to `null`', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         expect(widget.model).to.be(null);
       });
 
       it('should set the model', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         let model = new OutputAreaModel();
         widget.model = model;
         expect(widget.model).to.be(model);
       });
 
       it('should emit `modelChanged` when the model changes', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         let called = false;
         widget.modelChanged.connect(() => { called = true; });
         widget.model = new OutputAreaModel();
@@ -138,7 +140,7 @@ describe('notebook/output-area/widget', () => {
       });
 
       it('should not emit `modelChanged` when the model does not change', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         let called = false;
         let model = new OutputAreaModel();
         widget.model = model;
@@ -168,7 +170,7 @@ describe('notebook/output-area/widget', () => {
     describe('#rendermime', () => {
 
       it('should be the rendermime instance used by the widget', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         expect(widget.rendermime).to.be(rendermime);
       });
 
@@ -187,12 +189,12 @@ describe('notebook/output-area/widget', () => {
     describe('#trusted', () => {
 
       it('should get the trusted state of the widget', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         expect(widget.trusted).to.be(false);
       });
 
       it('should set the trusted state of the widget', () => {
-        let widget = new OutputAreaWidget({ rendermime });
+        let widget = new OutputAreaWidget(OPTIONS);
         widget.trusted = true;
         expect(widget.trusted).to.be(true);
       });
@@ -213,7 +215,7 @@ describe('notebook/output-area/widget', () => {
       });
 
       it('should post an update request', (done) => {
-        let widget = new LogOutputAreaWidget({ rendermime });
+        let widget = new LogOutputAreaWidget(OPTIONS);
         widget.collapsed = true;
         requestAnimationFrame(() => {
           expect(widget.methods).to.contain('onUpdateRequest');
@@ -237,7 +239,7 @@ describe('notebook/output-area/widget', () => {
       });
 
       it('should post an update request', (done) => {
-        let widget = new LogOutputAreaWidget({ rendermime });
+        let widget = new LogOutputAreaWidget(OPTIONS);
         widget.fixedHeight = true;
         requestAnimationFrame(() => {
           expect(widget.methods).to.contain('onUpdateRequest');
@@ -299,13 +301,13 @@ describe('notebook/output-area/widget', () => {
     describe('#onModelChanged()', () => {
 
       it('should be called when the model changes', () => {
-        let widget = new LogOutputAreaWidget({ rendermime });
+        let widget = new LogOutputAreaWidget(OPTIONS);
         widget.model = new OutputAreaModel();
         expect(widget.methods).to.contain('onModelChanged');
       });
 
       it('should not be called when the model does not change', () => {
-        let widget = new LogOutputAreaWidget({ rendermime });
+        let widget = new LogOutputAreaWidget(OPTIONS);
         widget.model = new OutputAreaModel();
         widget.methods = [];
         widget.model = widget.model;
@@ -320,7 +322,7 @@ describe('notebook/output-area/widget', () => {
 
         it('should create a on output widget', () => {
           let contentFactory = new OutputAreaWidget.ContentFactory();
-          let widget = contentFactory.createOutput({ rendermime });
+          let widget = contentFactory.createOutput(OPTIONS);
           expect(widget).to.be.an(OutputWidget);
         });
 
@@ -343,12 +345,12 @@ describe('notebook/output-area/widget', () => {
     describe('#constructor()', () => {
 
       it('should accept a rendermime instance', () => {
-        let widget = new OutputWidget({ rendermime });
+        let widget = new OutputWidget(OPTIONS);
         expect(widget).to.be.an(OutputWidget);
       });
 
       it('should add the `jp-OutputArea-output` class', () => {
-        let widget = new OutputWidget({ rendermime });
+        let widget = new OutputWidget(OPTIONS);
         expect(widget.hasClass('jp-Output')).to.be(true);
       });
 
@@ -357,7 +359,7 @@ describe('notebook/output-area/widget', () => {
     describe('#prompt', () => {
 
       it('should get the prompt widget used by the output widget', () => {
-        let widget = new OutputWidget({ rendermime });
+        let widget = new OutputWidget(OPTIONS);
         expect(widget.prompt.hasClass('jp-Output-prompt')).to.be(true);
       });
 
@@ -366,7 +368,7 @@ describe('notebook/output-area/widget', () => {
     describe('#output', () => {
 
       it('should get the rendered output used by the output widget', () => {
-        let widget = new OutputWidget({ rendermime });
+        let widget = new OutputWidget(OPTIONS);
         expect(widget.output.hasClass('jp-Output-result')).to.be(true);
       });
 
@@ -375,7 +377,7 @@ describe('notebook/output-area/widget', () => {
     describe('#clear()', () => {
 
       it('should clear the current output', () => {
-        let widget = new OutputWidget({ rendermime });
+        let widget = new OutputWidget(OPTIONS);
         widget.render({ output: DEFAULT_OUTPUTS[0], trusted: true });
         let output = widget.output;
         widget.clear();
@@ -388,7 +390,7 @@ describe('notebook/output-area/widget', () => {
     describe('#render()', () => {
 
       it('should handle all bundle types when trusted', () => {
-        let widget = new OutputWidget({ rendermime });
+        let widget = new OutputWidget(OPTIONS);
         for (let i = 0; i < DEFAULT_OUTPUTS.length; i++) {
           let output = DEFAULT_OUTPUTS[i];
           widget.render({ output, trusted: true });
@@ -396,7 +398,7 @@ describe('notebook/output-area/widget', () => {
       });
 
       it('should handle all bundle types when not trusted', () => {
-        let widget = new OutputWidget({ rendermime });
+        let widget = new OutputWidget(OPTIONS);
         for (let i = 0; i < DEFAULT_OUTPUTS.length; i++) {
           let output = DEFAULT_OUTPUTS[i];
           widget.render({ output, trusted: false });
@@ -408,14 +410,14 @@ describe('notebook/output-area/widget', () => {
     describe('#setOutput()', () => {
 
       it('should set the rendered output widget used by the output widget', () => {
-        let widget = new CustomOutputWidget({ rendermime });
+        let widget = new CustomOutputWidget(OPTIONS);
         let child = new Widget();
         widget.setOutput(child);
         expect(widget.output).to.be(child);
       });
 
       it('should default to a placeholder if set to `null`', () => {
-        let widget = new CustomOutputWidget({ rendermime });
+        let widget = new CustomOutputWidget(OPTIONS);
         widget.setOutput(null);
         expect(widget.output).to.be.a(Widget);
       });

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -252,9 +252,7 @@ describe('notebook/output-area/widget', () => {
       it('should dispose of the resources held by the widget', () => {
         let widget = createWidget();
         widget.dispose();
-        expect(widget.model).to.be(null);
-        expect(widget.rendermime).to.be(null);
-        expect(widget.contentFactory).to.be(null);
+        expect(widget.isDisposed).to.be(true);
       });
 
       it('should be safe to call more than once', () => {

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -86,10 +86,10 @@ describe('notebook/output-area/widget', () => {
         expect(widget).to.be.an(OutputAreaWidget);
       });
 
-      it('should take an optional renderer', () => {
-        let renderer = Object.create(OutputAreaWidget.defaultRenderer);
-        let widget = new OutputAreaWidget({ rendermime, renderer });
-        expect(widget.renderer).to.be(renderer);
+      it('should take an optional contentFactory', () => {
+        let contentFactory = Object.create(OutputAreaWidget.defaultContentFactory);
+        let widget = new OutputAreaWidget({ rendermime, contentFactory });
+        expect(widget.contentFactory).to.be(contentFactory);
       });
 
       it('should add the `jp-OutputArea` class', () => {
@@ -174,12 +174,12 @@ describe('notebook/output-area/widget', () => {
 
     });
 
-    describe('#renderer', () => {
+    describe('#contentFactory', () => {
 
-      it('should be the renderer used by the widget', () => {
-        let renderer = new OutputAreaWidget.Renderer();
-        let widget = new OutputAreaWidget({ rendermime, renderer });
-        expect(widget.renderer).to.be(renderer);
+      it('should be the contentFactory used by the widget', () => {
+        let contentFactory = new OutputAreaWidget.ContentFactory();
+        let widget = new OutputAreaWidget({ rendermime, contentFactory });
+        expect(widget.contentFactory).to.be(contentFactory);
       });
 
     });
@@ -254,7 +254,7 @@ describe('notebook/output-area/widget', () => {
         widget.dispose();
         expect(widget.model).to.be(null);
         expect(widget.rendermime).to.be(null);
-        expect(widget.renderer).to.be(null);
+        expect(widget.contentFactory).to.be(null);
       });
 
       it('should be safe to call more than once', () => {
@@ -316,13 +316,13 @@ describe('notebook/output-area/widget', () => {
 
     });
 
-    describe('.Renderer', () => {
+    describe('.contentFactory', () => {
 
       describe('#createOutput()', () => {
 
         it('should create a on output widget', () => {
-          let renderer = new OutputAreaWidget.Renderer();
-          let widget = renderer.createOutput({ rendermime });
+          let contentFactory = new OutputAreaWidget.ContentFactory();
+          let widget = contentFactory.createOutput({ rendermime });
           expect(widget).to.be.an(OutputWidget);
         });
 
@@ -330,10 +330,10 @@ describe('notebook/output-area/widget', () => {
 
     });
 
-    describe('.defaultRenderer', () => {
+    describe('.defaultContentFactory', () => {
 
-      it('should be a `Renderer` instance', () => {
-        expect(OutputAreaWidget.defaultRenderer).to.be.an(OutputAreaWidget.Renderer);
+      it('should be a `contentFactory` instance', () => {
+        expect(OutputAreaWidget.defaultContentFactory).to.be.an(OutputAreaWidget.ContentFactory);
       });
 
     });

--- a/test/src/notebook/tracker.spec.ts
+++ b/test/src/notebook/tracker.spec.ts
@@ -4,10 +4,6 @@
 import expect = require('expect.js');
 
 import {
-  MimeData
-} from 'phosphor/lib/core/mimedata';
-
-import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
@@ -20,19 +16,15 @@ import {
 } from '../../../lib/notebook/cells';
 
 import {
-  NotebookPanel
-} from '../../../lib/notebook/notebook/panel';
-
-import {
   NotebookTracker
 } from '../../../lib/notebook/tracker';
 
 import {
-  createNotebookContext, defaultRenderMime
+  createNotebookContext
 } from '../utils';
 
 import {
-  DEFAULT_CONTENT, createNotebookPanelRenderer
+  DEFAULT_CONTENT, createNotebookPanel
 } from './utils';
 
 
@@ -47,14 +39,6 @@ class TestTracker extends NotebookTracker {
     this.methods.push('onCurrentChanged');
   }
 }
-
-
-/**
- * Default notebook panel data.
- */
-const rendermime = defaultRenderMime();
-const clipboard = new MimeData();
-const renderer = createNotebookPanelRenderer();
 
 
 describe('notebook/tracker', () => {
@@ -79,17 +63,17 @@ describe('notebook/tracker', () => {
 
       it('should be `null` if a tracked notebook has no active cell', () => {
         let tracker = new NotebookTracker({ namespace: NAMESPACE });
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer});
+        let panel = createNotebookPanel();
         tracker.add(panel);
         expect(tracker.activeCell).to.be(null);
       });
 
       it('should be the active cell if a tracked notebook has one', () => {
         let tracker = new NotebookTracker({ namespace: NAMESPACE });
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer});
+        let panel = createNotebookPanel();
         tracker.add(panel);
         panel.context = createNotebookContext();
-        panel.content.model.fromJSON(DEFAULT_CONTENT);
+        panel.notebook.model.fromJSON(DEFAULT_CONTENT);
         expect(tracker.activeCell).to.be(null);
         Widget.attach(panel, document.body);
         simulate(panel.node, 'focus');
@@ -103,17 +87,17 @@ describe('notebook/tracker', () => {
 
       it('should emit a signal when the active cell changes', () => {
         let tracker = new NotebookTracker({ namespace: NAMESPACE });
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        let panel = createNotebookPanel();
         let count = 0;
         tracker.activeCellChanged.connect(() => { count++; });
         panel.context = createNotebookContext();
-        panel.content.model.fromJSON(DEFAULT_CONTENT);
+        panel.notebook.model.fromJSON(DEFAULT_CONTENT);
         tracker.add(panel);
         expect(count).to.be(0);
         Widget.attach(panel, document.body);
         simulate(panel.node, 'focus');
         expect(count).to.be(1);
-        panel.content.activeCellIndex = 1;
+        panel.notebook.activeCellIndex = 1;
         expect(count).to.be(2);
         panel.dispose();
       });
@@ -124,10 +108,10 @@ describe('notebook/tracker', () => {
 
       it('should be called when the active cell changes', () => {
         let tracker = new TestTracker({ namespace: NAMESPACE });
-        let panel = new NotebookPanel({ rendermime, clipboard, renderer});
+        let panel = createNotebookPanel();
         tracker.add(panel);
         panel.context = createNotebookContext();
-        panel.content.model.fromJSON(DEFAULT_CONTENT);
+        panel.notebook.model.fromJSON(DEFAULT_CONTENT);
         expect(tracker.methods).to.not.contain('onCurrentChanged');
         Widget.attach(panel, document.body);
         simulate(panel.node, 'focus');

--- a/test/src/notebook/utils.ts
+++ b/test/src/notebook/utils.ts
@@ -71,9 +71,9 @@ function createCodeCellFactory(): CodeCellWidget.IContentFactory {
  * Create a cell editor widget.
  */
 export
-function createCellEditor(): CodeEditorWidget {
+function createCellEditor(model?: CodeCellModel): CodeEditorWidget {
   return new CodeEditorWidget({
-    model: new CodeCellModel(),
+    model: model || new CodeCellModel(),
     factory: editorFactory
   });
 }

--- a/test/src/notebook/utils.ts
+++ b/test/src/notebook/utils.ts
@@ -6,6 +6,10 @@ import {
 } from '@jupyterlab/services';
 
 import {
+  MimeData
+} from 'phosphor/lib/core/mimedata';
+
+import {
   editorServices
 } from '../../../lib/codemirror';
 
@@ -21,6 +25,9 @@ import {
   BaseCellWidget, CodeCellWidget, CodeCellModel
 } from '../../../lib/notebook/cells';
 
+import {
+  defaultRenderMime
+} from '../utils';
 
 /**
  * The default notebook content.
@@ -29,62 +36,90 @@ export
 const DEFAULT_CONTENT: nbformat.INotebookContent = require('../../../examples/notebook/test.ipynb') as nbformat.INotebookContent;
 
 
+export
+const editorFactory = editorServices.factoryService.newInlineEditor;
+
+export
+const mimeTypeService = editorServices.mimeTypeService;
+
+export
+const rendermime = defaultRenderMime();
+
+export
+const clipboard = new MimeData();
+
+
 /**
- * Create a base cell renderer.
+ * Create a base cell content factory.
  */
 export
-function createBaseCellRenderer(): BaseCellWidget.Renderer {
-  return new BaseCellWidget.Renderer({
-    editorFactory: options => {
-      options.wordWrap = true;
-      return editorServices.factoryService.newInlineEditor(options);
-    }
-  });
+function createBaseCellFactory(): BaseCellWidget.IContentFactory {
+  return new BaseCellWidget.ContentFactory({ editorFactory });
 };
 
 
 /**
- * Create a new code cell renderer.
+ * Create a new code cell content factory.
  */
 export
-function createCodeCellRenderer(): CodeCellWidget.Renderer {
-  return new CodeCellWidget.Renderer({
-    editorFactory: options => {
-      return editorServices.factoryService.newInlineEditor(options);
-    }
-  });
+function createCodeCellFactory(): CodeCellWidget.IContentFactory {
+  return new CodeCellWidget.ContentFactory({ editorFactory });
 }
 
 
 /**
- * Create a cell editor widget given a factory.
+ * Create a cell editor widget.
  */
 export
 function createCellEditor(): CodeEditorWidget {
   return new CodeEditorWidget({
     model: new CodeCellModel(),
-    factory: options => {
-      options.wordWrap = true;
-      return editorServices.factoryService.newInlineEditor(options);
-    }
+    factory: editorFactory
   });
 }
 
 
 /**
- * Create a default notebook renderer.
+ * Create a default notebook content factory.
  */
 export
-function createNotebookRenderer(): Notebook.Renderer {
-  return new Notebook.Renderer({ editorServices });
+function createNotebookFactory(): Notebook.IContentFactory {
+  return new Notebook.ContentFactory({ editorFactory });
 }
 
 
 /**
- * Create a default notebook panel renderer.
+ * Create a default notebook panel content factory.
  */
 export
-function createNotebookPanelRenderer(): NotebookPanel.Renderer {
-  const notebookRenderer = createNotebookRenderer();
-  return new NotebookPanel.Renderer({ notebookRenderer });
+function createNotebookPanelFactory(): NotebookPanel.IContentFactory {
+  const notebookContentFactory = createNotebookFactory();
+  return new NotebookPanel.ContentFactory({ notebookContentFactory });
+}
+
+
+/**
+ * Create a notebook widget.
+ */
+export
+function createNotebook(): Notebook {
+  return new Notebook({
+    rendermime,
+    contentFactory: createNotebookFactory(),
+    mimeTypeService
+  });
+}
+
+
+/**
+ * Create a notebook panel widget.
+ */
+export
+function createNotebookPanel(): NotebookPanel {
+  return new NotebookPanel({
+    rendermime,
+    contentFactory: createNotebookPanelFactory(),
+    mimeTypeService,
+    clipboard
+  });
 }

--- a/test/src/notebook/utils.ts
+++ b/test/src/notebook/utils.ts
@@ -93,8 +93,7 @@ function createNotebookFactory(): Notebook.IContentFactory {
  */
 export
 function createNotebookPanelFactory(): NotebookPanel.IContentFactory {
-  const notebookContentFactory = createNotebookFactory();
-  return new NotebookPanel.ContentFactory({ notebookContentFactory });
+  return new NotebookPanel.ContentFactory({ editorFactory });
 }
 
 


### PR DESCRIPTION
Renames `IRenderer` to `IContentFactory` and cleans up implementation and naming consistency down the line across Console and Notebook/Cell/Output Area.

Fixes #905.  Fixes #1415.  Fixes #1414.

The intent of this PR is to enable dependency injection of lower-level components into a hierarchy without subclassing any of the intermediate components.  For example, one can inject a custom output area from the notebook panel level.