### PR TITLE
Further Dialog Style Fixes

### DIFF
--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -45,7 +45,7 @@
 .jp-Dialog-header {
   flex: 0 0 auto;
   padding-bottom: 12px;
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 400;
   color: var(--jp-ui-font-color0);
 }
@@ -90,8 +90,9 @@
   font-size: 13px;
   border: none;
   text-transform: uppercase;
-  line-height: 38px;
-  padding: 0px 24px;
+  line-height: 28px;
+  padding: 0px 12px;
+  letter-spacing: .4px;
 }
 
 

--- a/src/dialog/index.css
+++ b/src/dialog/index.css
@@ -45,7 +45,7 @@
 .jp-Dialog-header {
   flex: 0 0 auto;
   padding-bottom: 12px;
-  font-size: 18px;
+  font-size: var(--jp-ui-font-size3);
   font-weight: 400;
   color: var(--jp-ui-font-color0);
 }
@@ -53,7 +53,7 @@
 
 .jp-Dialog-body {
   flex: 1 1 auto;
-  font-size: 15px;
+  font-size: var(--jp-ui-font-size2);
   background: #FAFAFA;
   overflow: auto;
 }
@@ -62,7 +62,7 @@
 .jp-Dialog-bodyContent {
   display: flex;
   flex-direction: column;
-  font-size: 15px;
+  font-size: var(--jp-ui-font-size2);
   overflow: auto;
 }
 
@@ -87,7 +87,7 @@
 
 
 .jp-Dialog-button {
-  font-size: 13px;
+  font-size: var(--jp-ui-font-size1);
   border: none;
   text-transform: uppercase;
   line-height: 28px;
@@ -98,19 +98,19 @@
 
 .jp-Dialog-okButton {
   background: var(--jp-brand-color1);
-  color: white;
+  color: var(--jp-inverse-ui-font-color0);
 }
 
 
 .jp-Dialog-cancelButton {
   background: #9E9E9E;
   margin-right: 12px;
-  color: white;
+  color: var(--jp-inverse-ui-font-color0);
 }
 
 .jp-Dialog-warningButton {
   background: var(--jp-error-color1);
-  color: white;
+  color: var(--jp-inverse-ui-font-color0);
 }
 
 
@@ -118,7 +118,7 @@
   padding-top: 4px;
   padding-bottom: 4px;
   line-height: 1.4;
-  font-size: 13px;
+  font-size: var(--jp-ui-font-size1);
   color: var(--md-grey-700);
 }
 
@@ -138,7 +138,7 @@
 .jp-Dialog-input {
   flex: 1 1 auto;
   padding: 7px;
-  font-size: 15px;
+  font-size: var(--jp-ui-font-size2);
   color: var(--jp-ui-font-color0);
   border: none;
 }
@@ -160,7 +160,7 @@
 .jp-Dialog-select {
   flex: 1 1 auto;
   height: 32px;
-  font-size: 15px;
+  font-size: var(--jp-ui-font-size2);
   background: white;
   color: var(--jp-ui-font-color0);
   border: none;


### PR DESCRIPTION
- Changed out hard-coded for dialogs into the variables from default-theme's variables.css

- Changed the dialog header font size to match new input field and dropdown styling

- Changed dialog button's line height and padding to reflect new input and dropdowns

Before:
![screen shot 2017-01-12 at 9 43 51 am](https://cloud.githubusercontent.com/assets/6437976/21901347/2c5616b8-d8ac-11e6-83d6-f0513be3e5a0.png)

After:
![screen shot 2017-01-12 at 9 42 50 am](https://cloud.githubusercontent.com/assets/6437976/21901352/32f0c9c8-d8ac-11e6-9c92-cde0d52903b0.png)

Before:
![screen shot 2017-01-12 at 9 43 56 am](https://cloud.githubusercontent.com/assets/6437976/21901358/38db62f8-d8ac-11e6-8155-c33b394f44df.png)

After:
![screen shot 2017-01-12 at 9 42 56 am](https://cloud.githubusercontent.com/assets/6437976/21901365/3e2ad46e-d8ac-11e6-821a-29b43eab7782.png)
