### PR TITLE
Use a promise for getDownloadUrl.

### DIFF
--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -357,7 +357,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   resolveUrl(url: string): Promise<string> {
     // Ignore urls that have a protocol.
     if (utils.urlParse(url).protocol || url.indexOf('//') === 0) {
-      return url;
+      return Promise.resolve(url);
     }
     let cwd = ContentsManager.dirname(this._path);
     let path = ContentsManager.getAbsolutePath(url, cwd);

--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -354,7 +354,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   /**
    * Resolve a relative url to a correct server path.
    */
-  resolveUrl(url: string): string {
+  resolveUrl(url: string): Promise<string> {
     // Ignore urls that have a protocol.
     if (utils.urlParse(url).protocol || url.indexOf('//') === 0) {
       return url;

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -711,8 +711,10 @@ namespace DocumentRegistry {
 
     /**
      * Resolve a url to a correct server path.
+     *
+     * @returns a promise which resolves with the resolved url.
      */
-    resolveUrl(url: string): string;
+    resolveUrl(url: string): Promise<string>;
 
     /**
      * Add a sibling widget to the document manager.

--- a/src/filebrowser/model.ts
+++ b/src/filebrowser/model.ts
@@ -221,13 +221,17 @@ class FileBrowserModel implements IDisposable, IPathTracker {
    * Download a file.
    *
    * @param - path - The path of the file to be downloaded.
+   *
+   * @returns A promise which resolves when the file has begun
+   *   downloading.
    */
-  download(path: string): void {
-    this._manager.contents.getDownloadUrl(path).then((url)=>{;
+  download(path: string): Promise<void> {
+    return this._manager.contents.getDownloadUrl(path).then((url)=>{;
       let element = document.createElement('a');
       element.setAttribute('href', url);
       element.setAttribute('download', '');
       element.click();
+      return void 0;
     });
   }
 

--- a/src/filebrowser/model.ts
+++ b/src/filebrowser/model.ts
@@ -223,11 +223,12 @@ class FileBrowserModel implements IDisposable, IPathTracker {
    * @param - path - The path of the file to be downloaded.
    */
   download(path: string): void {
-    let url = this._manager.contents.getDownloadUrl(path);
-    let element = document.createElement('a');
-    element.setAttribute('href', url);
-    element.setAttribute('download', '');
-    element.click();
+    this._manager.contents.getDownloadUrl(path).then((url)=>{;
+      let element = document.createElement('a');
+      element.setAttribute('href', url);
+      element.setAttribute('download', '');
+      element.click();
+    });
   }
 
   /**

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -155,7 +155,7 @@ class RenderedHTML extends RenderedHTMLCommon {
     }
     appendHtml(this.node, source);
     if (options.resolver) {
-      resolveUrls(this.node, options.resolver);
+      this._urlResolved = resolveUrls(this.node, options.resolver);
     }
   }
 
@@ -163,8 +163,10 @@ class RenderedHTML extends RenderedHTMLCommon {
    * A message handler invoked on an `'after-attach'` message.
    */
   onAfterAttach(msg: Message): void {
-    typeset(this.node);
+    this._urlResolved.then( ()=>{typeset(this.node);} );
   }
+
+  private _urlResolved: Promise<void> = null;
 }
 
 
@@ -192,12 +194,12 @@ class RenderedMarkdown extends RenderedHTMLCommon {
       }
       appendHtml(this.node, content);
       if (options.resolver) {
-        resolveUrls(this.node, options.resolver);
+        this._urlResolved = resolveUrls(this.node, options.resolver);
       }
       this.fit();
       this._rendered = true;
       if (this.isAttached) {
-        typeset(this.node);
+        this._urlResolved.then( ()=>{typeset(this.node);} );
       }
     });
   }
@@ -212,6 +214,7 @@ class RenderedMarkdown extends RenderedHTMLCommon {
   }
 
   private _rendered = false;
+  private _urlResolved : Promise<void> = null;
 }
 
 
@@ -290,10 +293,12 @@ class RenderedSVG extends Widget {
       throw new Error('SVGRender: Error: Failed to create <svg> element');
     }
     if (options.resolver) {
-      resolveUrls(this.node, options.resolver);
+      this._urlResolved = resolveUrls(this.node, options.resolver);
     }
     this.addClass(SVG_CLASS);
   }
+
+  private _urlResolved: Promise<void> = null;
 }
 
 
@@ -318,15 +323,20 @@ class RenderedPDF extends Widget {
  * @param node - The head html element.
  *
  * @param resolver - A url resolver.
+ *
+ * @returns a promise fulfilled when the relative urls have been resolved.
  */
 export
-function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver): void {
+function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver): Promise<void> {
   let imgs = node.getElementsByTagName('img');
   for (let i = 0; i < imgs.length; i++) {
     let img = imgs[i];
     let source = img.getAttribute('src');
     if (source) {
-      img.src = resolver.resolveUrl(source);
+      return resolver.resolveUrl(source).then((url)=>{
+        img.src = url;
+        return void 0;
+      });
     }
   }
   let anchors = node.getElementsByTagName('a');
@@ -334,7 +344,10 @@ function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver): void {
     let anchor = anchors[i];
     let href = anchor.getAttribute('href');
     if (href) {
-      anchor.href = resolver.resolveUrl(href);
+      return resolver.resolveUrl(href).then((url)=>{
+        anchor.href = url;
+        return void 0;
+      });
     }
   }
 }

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -359,6 +359,6 @@ namespace RenderMime {
     /**
      * Resolve a url to a correct server path.
      */
-    resolveUrl(url: string): string;
+    resolveUrl(url: string): Promise<string>;
   }
 }

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -387,18 +387,21 @@ describe('docregistry/context', () => {
 
     describe('#resolveUrl()', () => {
 
-      it('should resolve a relative url to a correct server path', () => {
+      it('should resolve a relative url to a correct server path', (done) => {
         let resolveUrlPromise = context.resolveUrl('./foo');
         let getDownloadUrlPromise = manager.contents.getDownloadUrl('foo');
         Promise.all([resolveUrlPromise, getDownloadUrlPromise])
         .then((values)=>{
           expect(values[0]).to.be(values[1]);
-        });
+          done();
+        }).catch(done);
       });
 
-      it('should ignore urls that have a protocol', () => {
-        let path = context.resolveUrl('http://foo');
-        expect(path).to.be('http://foo');
+      it('should ignore urls that have a protocol', (done) => {
+        context.resolveUrl('http://foo').then((path)=>{
+          expect(path).to.be('http://foo');
+          done();
+        }).catch(done);
       });
 
     });

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -388,8 +388,12 @@ describe('docregistry/context', () => {
     describe('#resolveUrl()', () => {
 
       it('should resolve a relative url to a correct server path', () => {
-        let path = context.resolveUrl('./foo');
-        expect(path).to.be(manager.contents.getDownloadUrl('foo'));
+        let resolveUrlPromise = context.resolveUrl('./foo');
+        let getDownloadUrlPromise = manager.contents.getDownloadUrl('foo');
+        Promise.all([resolveUrlPromise, getDownloadUrlPromise])
+        .then((values)=>{
+          expect(values[0]).to.be(values[1]);
+        });
       });
 
       it('should ignore urls that have a protocol', () => {


### PR DESCRIPTION
Came across this when writing a `ContentsManager` for Google Drive. In that case the download url is not computable client-side from the path (it is instead based on a unique file Id hash), so in order to get the correct URL, there must be some communication with the server.
Cf. jupyterlab/services#297 and [https://github.com/ian-r-rose/jupyterlab_google_drive/tree/filebrowser]()