### PR TITLE
Clean up build scripts and handling of lab extension urls

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -87,6 +87,7 @@ class LabHandler(IPythonHandler):
         configData = dict(
             terminalsAvailable=self.settings.get('terminals_available', False),
         )
+        extension_prefix = ujoin(self.base_url, EXTENSION_PREFIX)
 
         # Gather the lab extension files and entry points.
         for (name, data) in sorted(labextensions.items()):
@@ -96,12 +97,12 @@ class LabHandler(IPythonHandler):
                 if value.get('entry', None):
                     entries.append(value['entry'])
                     bundles.append('%s/%s/%s' % (
-                        EXTENSION_PREFIX, name, value['files'][0]
+                        extension_prefix, name, value['files'][0]
                     ))
                 for fname in value['files']:
                     if os.path.splitext(fname)[1] == '.css':
                         css_files.append('%s/%s/%s' % (
-                            EXTENSION_PREFIX, name, fname
+                            extension_prefix, name, fname
                         ))
             python_module = data.get('python_module', None)
             if python_module:
@@ -196,8 +197,9 @@ class LabApp(NotebookApp):
         base_url = webapp.settings['base_url']
         webapp.add_handlers(".*$",
             [(ujoin(base_url, h[0]),) + h[1:] for h in default_handlers])
+        extension_prefix = ujoin(base_url, EXTENSION_PREFIX)
         labextension_handler = (
-            r"%s/(.*)" % EXTENSION_PREFIX, FileFindHandler, {
+            r"%s/(.*)" % extension_prefix, FileFindHandler, {
                 'path': jupyter_path('labextensions'),
                 'no_cache_paths': ['/'],  # don't cache anything in labbextensions
             }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "clean:slate": "npm run clean && npm run clean:examples && rimraf jupyterlab/node_modules && rimraf node_modules && npm install",
     "docs": "typedoc --mode modules --module commonjs --excludeNotExported --target es5 --moduleResolution node --out docs/ src",
     "postinstall": "node scripts/dedupe.js",
-    "prepublish": "npm run build",
+    "preversion": "npm run clean && npm run build",
     "test": "npm run test:firefox",
     "test:chrome": "npm run build:test && cd test && python run-test.py --browsers=Chrome karma.conf.js",
     "test:coverage": "tsc --project test/src && webpack --config test/webpack-cov.conf.js && cd test && python run-test.py karma-cov.conf.js",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "clean:slate": "npm run clean && npm run clean:examples && rimraf jupyterlab/node_modules && rimraf node_modules && npm install",
     "docs": "typedoc --mode modules --module commonjs --excludeNotExported --target es5 --moduleResolution node --out docs/ src",
     "postinstall": "node scripts/dedupe.js",
-    "preversion": "npm run clean && npm run build",
+    "preversion": "npm update && npm run postinstall && npm run clean && npm run build:all",
     "test": "npm run test:firefox",
     "test:chrome": "npm run build:test && cd test && python run-test.py --browsers=Chrome karma.conf.js",
     "test:coverage": "tsc --project test/src && webpack --config test/webpack-cov.conf.js && cd test && python run-test.py karma-cov.conf.js",

--- a/setupbase.py
+++ b/setupbase.py
@@ -129,14 +129,9 @@ class NPM(Command):
         if not has_npm:
             log.error("`npm` unavailable. If you're running this command using sudo, make sure `npm` is available to sudo")
         log.info("Installing build dependencies with npm. This may take a while...")
-        # This command will fail if `rimraf` is not yet installed 
-        # in node_modules.
-        try:
-            run(['npm', 'run', 'clean'], cwd=here)
-        except Exception:
-            pass
         run(['npm', 'install'], cwd=here)
-        run(['npm', 'run', 'build:serverextension'], cwd=here)
+        run(['npm', 'run', 'clean'], cwd=here)
+        run(['npm', 'run', 'build:all'], cwd=here)
 
         for t in self.targets:
             if not os.path.exists(t):


### PR DESCRIPTION
In response to gitter debugging with @epifanio.  Fixes #1502.  Fixes #1498.

Tested locally as `jupyter lab --NotebookApp.base_url=/foo/bar` and verified that extensions were loaded properly.