### PR TITLE
Simplify inspector and completer handlers

### DIFF
--- a/src/codemirror/editor.ts
+++ b/src/codemirror/editor.ts
@@ -101,7 +101,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   /**
    * Construct a CodeMirror editor.
    */
-  constructor(options: CodeEditor.IOptions, config: CodeMirror.EditorConfiguration) {
+  constructor(options: CodeEditor.IOptions, config: CodeMirror.EditorConfiguration={}) {
     let host = this._host = options.host;
     host.classList.add(EDITOR_CLASS);
 

--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -14,23 +14,19 @@ import {
 } from '../codeeditor';
 
 import {
-  BaseCellWidget
-} from '../notebook/cells/widget';
-
-import {
   CompleterWidget
 } from './widget';
 
 
 /**
- * A completer handler for cell widgets.
+ * A completion handler for editors.
  */
 export
-class CellCompleterHandler implements IDisposable {
+class CompletionHandler implements IDisposable {
   /**
-   * Construct a new completer handler for a widget.
+   * Construct a new completion handler for a widget.
    */
-  constructor(options: CellCompleterHandler.IOptions) {
+  constructor(options: CompletionHandler.IOptions) {
     this._completer = options.completer;
     this._completer.selected.connect(this.onCompletionSelected, this);
     this._completer.visibilityChanged.connect(this.onVisibilityChanged, this);
@@ -38,7 +34,7 @@ class CellCompleterHandler implements IDisposable {
   }
 
   /**
-   * The kernel used by the completer handler.
+   * The kernel used by the completion handler.
    */
   get kernel(): Kernel.IKernel {
     return this._kernel;
@@ -48,31 +44,31 @@ class CellCompleterHandler implements IDisposable {
   }
 
   /**
-   * The cell widget used by the completer handler.
+   * The editor used by the completion handler.
    */
-  get activeCell(): BaseCellWidget {
-    return this._activeCell;
+  get editor(): CodeEditor.IEditor {
+    return this._editor;
   }
-  set activeCell(newValue: BaseCellWidget) {
-    if (newValue === this._activeCell) {
+  set editor(newValue: CodeEditor.IEditor) {
+    if (newValue === this._editor) {
       return;
     }
 
-    if (this._activeCell && !this._activeCell.isDisposed) {
-      const editor = this._activeCell.editor;
+    let editor = this._editor;
+    if (editor && !editor.isDisposed) {
       editor.model.value.changed.disconnect(this.onTextChanged, this);
       editor.completionRequested.disconnect(this.onCompletionRequested, this);
     }
-    this._activeCell = newValue;
-    if (this._activeCell) {
-      const editor = this._activeCell.editor;
+
+    editor = this._editor = newValue;
+    if (editor) {
       editor.model.value.changed.connect(this.onTextChanged, this);
       editor.completionRequested.connect(this.onCompletionRequested, this);
     }
   }
 
   /**
-   * Get whether the completer handler is disposed.
+   * Get whether the completion handler is disposed.
    *
    * #### Notes
    * This is a read-only property.
@@ -90,7 +86,7 @@ class CellCompleterHandler implements IDisposable {
     }
     this._completer = null;
     this._kernel = null;
-    this._activeCell = null;
+    this._editor = null;
   }
 
   /**
@@ -101,15 +97,15 @@ class CellCompleterHandler implements IDisposable {
       return Promise.reject(new Error('no kernel for completion request'));
     }
 
-    let cell = this.activeCell;
-    if (!cell) {
-      return Promise.reject(new Error('No active cell'));
+    let editor = this.editor;
+    if (!editor) {
+      return Promise.reject(new Error('No active editor'));
     }
 
-    let offset = cell.editor.getOffsetAt(position);
+    let offset = editor.getOffsetAt(position);
 
     let content: KernelMessage.ICompleteRequest = {
-      code: cell.model.value.text,
+      code: editor.model.value.text,
       cursor_pos: offset
     };
     let pending = ++this._pending;
@@ -125,7 +121,7 @@ class CellCompleterHandler implements IDisposable {
    * Get the state of the text editor at the given position.
    */
   protected getState(position: CodeEditor.IPosition): CompleterWidget.ITextState {
-    let editor = this.activeCell.editor;
+    let editor = this.editor;
     let coords = editor.getCoordinate(position) as CompleterWidget.ICoordinate;
     return {
       text: editor.getLine(position.line),
@@ -174,7 +170,7 @@ class CellCompleterHandler implements IDisposable {
     if (!this._completer.model) {
       return;
     }
-    let editor = this.activeCell.editor;
+    let editor = this.editor;
     let position = editor.getCursorPosition();
     let request = this.getState(position);
     this._completer.model.handleTextChange(request);
@@ -192,12 +188,12 @@ class CellCompleterHandler implements IDisposable {
 
 
   /**
-   * Handle a visiblity change signal from a completer widget.
+   * Handle a visiblity change signal from a completion widget.
    */
-  protected onVisibilityChanged(completer: CompleterWidget): void {
-    if (completer.isDisposed || completer.isHidden) {
-      if (this._activeCell) {
-        this._activeCell.activate();
+  protected onVisibilityChanged(completion: CompleterWidget): void {
+    if (completion.isDisposed || completion.isHidden) {
+      if (this._editor) {
+        this._editor.focus();
       }
     }
   }
@@ -206,20 +202,19 @@ class CellCompleterHandler implements IDisposable {
    * Handle a completion selected signal from the completion widget.
    */
   protected onCompletionSelected(widget: CompleterWidget, value: string): void {
-    if (!this._activeCell || !this._completer.model) {
+    if (!this._editor || !this._completer.model) {
       return;
     }
     let patch = this._completer.model.createPatch(value);
     if (!patch) {
       return;
     }
-    let cell = this._activeCell;
-    cell.model.value.text = patch.text;
-    let editor = cell.editor;
+    let editor = this._editor;
+    editor.model.value.text = patch.text;
     editor.setCursorPosition(editor.getPositionAt(patch.position));
   }
 
-  private _activeCell: BaseCellWidget = null;
+  private _editor: CodeEditor.IEditor = null;
   private _completer: CompleterWidget = null;
   private _kernel: Kernel.IKernel = null;
   private _pending = 0;
@@ -227,22 +222,22 @@ class CellCompleterHandler implements IDisposable {
 
 
 /**
- * A namespace for cell completer handler statics.
+ * A namespace for cell completion handler statics.
  */
 export
-namespace CellCompleterHandler {
+namespace CompletionHandler {
   /**
-   * The instantiation options for cell completer handlers.
+   * The instantiation options for cell completion handlers.
    */
   export
   interface IOptions {
     /**
-     * The completer widget the handler will connect to.
+     * The completion widget the handler will connect to.
      */
     completer: CompleterWidget;
 
     /**
-     * The kernel for the completer handler.
+     * The kernel for the completion handler.
      */
     kernel?: Kernel.IKernel;
   }

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -26,7 +26,7 @@ import {
 } from '../codeeditor';
 
 import {
-  CellCompleterHandler, CompleterModel, CompleterWidget
+  CompletionHandler, CompleterModel, CompleterWidget
 } from '../completer';
 
 import {
@@ -154,8 +154,8 @@ class ConsolePanel extends Panel {
     this._completer.reset();
 
     // Associate the new prompt with the completer and inspection handlers.
-    this._completerHandler.activeCell = prompt;
-    this.inspectionHandler.activeCell = prompt;
+    this._completerHandler.editor = prompt.editor;
+    this.inspectionHandler.editor = prompt.editor;
   }
 
   /**
@@ -167,7 +167,7 @@ class ConsolePanel extends Panel {
   }
 
   private _completer: CompleterWidget = null;
-  private _completerHandler: CellCompleterHandler = null;
+  private _completerHandler: CompletionHandler = null;
 
 }
 
@@ -236,7 +236,7 @@ namespace ConsolePanel {
     /**
      * The completer handler for a console widget.
      */
-    createCompleterHandler(options: CellCompleterHandler.IOptions): CellCompleterHandler;
+    createCompleterHandler(options: CompletionHandler.IOptions): CompletionHandler;
   }
 
   /**
@@ -293,8 +293,8 @@ namespace ConsolePanel {
     /**
      * The completer handler for a console widget.
      */
-   createCompleterHandler(options: CellCompleterHandler.IOptions): CellCompleterHandler {
-      return new CellCompleterHandler(options);
+   createCompleterHandler(options: CompletionHandler.IOptions): CompletionHandler {
+      return new CompletionHandler(options);
    }
   }
 

--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -14,8 +14,8 @@ import {
 } from 'phosphor/lib/core/signaling';
 
 import {
-  BaseCellWidget
-} from '../notebook/cells/widget';
+  CodeEditor
+} from '../codeeditor';
 
 import {
   RenderMime
@@ -55,25 +55,23 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
   readonly inspected: ISignal<InspectionHandler, Inspector.IInspectorUpdate>;
 
   /**
-   * The cell widget used by the inspection handler.
+   * The editor widget used by the inspection handler.
    */
-  get activeCell(): BaseCellWidget {
-    return this._activeCell;
+  get editor(): CodeEditor.IEditor {
+    return this._editor;
   }
-  set activeCell(newValue: BaseCellWidget) {
-    if (newValue === this._activeCell) {
+  set editor(newValue: CodeEditor.IEditor) {
+    if (newValue === this._editor) {
       return;
     }
 
-    if (this._activeCell && !this._activeCell.isDisposed) {
-      const editor = this._activeCell.editor;
-      editor.model.value.changed.disconnect(this.onTextChanged, this);
+    if (this._editor && !this._editor.isDisposed) {
+      this._editor.model.value.changed.disconnect(this.onTextChanged, this);
     }
-    this._activeCell = newValue;
-    if (this._activeCell) {
+    let editor = this._editor = newValue;
+    if (editor) {
       // Clear ephemeral inspectors in preparation for a new editor.
       this.ephemeralCleared.emit(void 0);
-      const editor = this._activeCell.editor;
       editor.model.value.changed.connect(this.onTextChanged, this);
     }
   }
@@ -106,7 +104,7 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
       return;
     }
     this._isDisposed = true;
-    this._activeCell = null;
+    this._editor = null;
     this.disposed.emit(void 0);
     clearSignalData(this);
   }
@@ -123,10 +121,10 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
       type: 'hints'
     };
 
-    let editor = this.activeCell.editor;
+    let editor = this.editor;
     let code = editor.model.value.text;
     let position = editor.getCursorPosition();
-    let offset = editor.getOffsetAt(position)
+    let offset = editor.getOffsetAt(position);
 
     // Clear hints if the new text value is empty or kernel is unavailable.
     if (!code || !this._kernel) {
@@ -170,7 +168,7 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
     });
   }
 
-  private _activeCell: BaseCellWidget = null;
+  private _editor: CodeEditor.IEditor = null;
   private _isDisposed = false;
   private _kernel: Kernel.IKernel = null;
   private _pending = 0;

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -50,7 +50,7 @@ import {
 } from '../../rendermime';
 
 import {
-  CompleterModel, CompleterWidget, CellCompleterHandler
+  CompleterModel, CompleterWidget, CompletionHandler
 } from '../../completer';
 
 import {
@@ -124,6 +124,7 @@ class NotebookPanel extends Widget {
       rendermime: this.rendermime
     });
 
+
     // Instantiate the completer.
     this._completer = factory.createCompleter({ model: new CompleterModel() });
 
@@ -135,7 +136,12 @@ class NotebookPanel extends Widget {
     this._completerHandler = factory.createCompleterHandler({
       completer: this._completer
     });
-    this._completerHandler.activeCell = this.notebook.activeCell;
+
+    let activeCell = this.notebook.activeCell;
+    if (activeCell) {
+      this.inspectionHandler.editor = activeCell.editor;
+      this._completerHandler.editor = activeCell.editor;
+    }
   }
 
   /**
@@ -374,12 +380,12 @@ class NotebookPanel extends Widget {
    * Handle a change to the active cell.
    */
   private _onActiveCellChanged(sender: Notebook, widget: BaseCellWidget) {
-    this.inspectionHandler.activeCell = widget;
-    this._completerHandler.activeCell = widget;
+    this.inspectionHandler.editor = widget.editor;
+    this._completerHandler.editor = widget.editor;
   }
 
   private _completer: CompleterWidget = null;
-  private _completerHandler: CellCompleterHandler = null;
+  private _completerHandler: CompletionHandler = null;
   private _context: DocumentRegistry.IContext<INotebookModel> = null;
 }
 
@@ -463,7 +469,7 @@ export namespace NotebookPanel {
     /**
      * The completer handler for a console widget.
      */
-   createCompleterHandler(options: CellCompleterHandler.IOptions): CellCompleterHandler;
+   createCompleterHandler(options: CompletionHandler.IOptions): CompletionHandler;
   }
 
   /**
@@ -528,8 +534,8 @@ export namespace NotebookPanel {
     /**
      * The completer handler for a console widget.
      */
-   createCompleterHandler(options: CellCompleterHandler.IOptions): CellCompleterHandler {
-      return new CellCompleterHandler(options);
+   createCompleterHandler(options: CompletionHandler.IOptions): CompletionHandler {
+      return new CompletionHandler(options);
    }
   }
 

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -16,7 +16,7 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
-  CellCompleterHandler, CompleterWidget
+  CompletionHandler, CompleterWidget
 } from '../../../lib/completer';
 
 import {
@@ -203,7 +203,7 @@ describe('console/panel', () => {
         it('should create a completer handler', () => {
           let options = { completer:  new CompleterWidget({}) };
           let handler = contentFactory.createCompleterHandler(options);
-          expect(handler).to.be.a(CellCompleterHandler);
+          expect(handler).to.be.a(CompletionHandler);
         });
 
       });

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../../lib/docregistry';
 
 import {
-  CompleterWidget, CellCompleterHandler
+  CompleterWidget, CompletionHandler
 } from '../../../../lib/completer';
 
 import {
@@ -45,7 +45,7 @@ import {
 
 import {
   DEFAULT_CONTENT, createNotebookPanelFactory, rendermime, clipboard,
-  mimeTypeService, createNotebookFactory, editorFactory
+  mimeTypeService, editorFactory
 } from '../utils';
 
 
@@ -418,7 +418,7 @@ describe('notebook/notebook/panel', () => {
         it('should create a completer handler', () => {
           let options = { completer:  new CompleterWidget({}) };
           let handler = contentFactory.createCompleterHandler(options);
-          expect(handler).to.be.a(CellCompleterHandler);
+          expect(handler).to.be.a(CompletionHandler);
         });
 
       });


### PR DESCRIPTION
Use a `CodeEditor.IEditor` instead of a whole cell.  Fixes #1490.