### PR TITLE
Console History Cleanup

### DIFF
--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -416,61 +416,13 @@ class CodeConsole extends Widget {
     let editor = prompt.editor;
     editor.addKeydownHandler(this._onEditorKeydown);
 
-    // Hook up history handling.
-    editor.edgeRequested.connect(this.onEdgeRequest, this);
-    editor.model.value.changed.connect(this.onTextChange, this);
+    this._history.editor = editor;
 
     if (this.isAttached) {
       prompt.editor.focus();
       this.update();
     }
     this.promptCreated.emit(prompt);
-  }
-
-  /**
-   * Handle an edge requested signal.
-   */
-  protected onEdgeRequest(editor: CodeEditor.IEditor, location: CodeEditor.EdgeLocation): Promise<void> {
-    let prompt = this.prompt;
-    let model = prompt.model;
-    let source = prompt.model.value.text;
-
-    if (location === 'top') {
-      return this._history.back(source).then(value => {
-        if (this.isDisposed || !value) {
-          return;
-        }
-        if (model.value.text === value) {
-          return;
-        }
-        this._setByHistory = true;
-        model.value.text = value;
-        editor.setCursorPosition({ line: 0, column: 0 });
-      });
-    }
-    return this._history.forward(source).then(value => {
-      if (this.isDisposed) {
-        return;
-      }
-      let text = value || this._history.placeholder;
-      if (model.value.text === text) {
-        return;
-      }
-      this._setByHistory = true;
-      model.value.text = text;
-      editor.setCursorPosition(editor.getPositionAt(text.length));
-    });
-  }
-
-  /**
-   * Handle a text change signal from the editor.
-   */
-  protected onTextChange(): void {
-    if (this._setByHistory) {
-      this._setByHistory = false;
-      return;
-    }
-    this._history.reset();
   }
 
   /**
@@ -636,7 +588,6 @@ class CodeConsole extends Widget {
   private _history: IConsoleHistory = null;
   private _input: Panel = null;
   private _mimetype = 'text/x-ipython';
-  private _setByHistory = false;
 }
 
 

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -12,10 +12,6 @@ import {
 } from 'phosphor/lib/core/messaging';
 
 import {
-  clearSignalData, ISignal
-} from 'phosphor/lib/core/signaling';
-
-import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
@@ -46,17 +42,7 @@ import {
 
 class TestConsole extends CodeConsole {
 
-  readonly edgeRequested: ISignal<this, void>;
-
   methods: string[] = [];
-
-  dispose(): void {
-    if (this.isDisposed) {
-      return;
-    }
-    super.dispose();
-    clearSignalData(this);
-  }
 
   protected newPrompt(): void {
     super.newPrompt();
@@ -71,11 +57,6 @@ class TestConsole extends CodeConsole {
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     this.methods.push('onAfterAttach');
-  }
-
-  protected onTextChange(): void {
-    super.onTextChange();
-    this.methods.push('onTextChange');
   }
 
   protected onUpdateRequest(msg: Message): void {
@@ -367,17 +348,6 @@ describe('console/widget', () => {
         Widget.attach(widget, document.body);
         expect(widget.methods).to.contain('onAfterAttach');
         expect(widget.prompt).to.be.ok();
-      });
-
-    });
-
-    describe('#onTextChange()', () => {
-
-      it('should be called upon an editor text change', () => {
-        Widget.attach(widget, document.body);
-        expect(widget.methods).to.not.contain('onTextChange');
-        widget.prompt.model.value.text = 'foo';
-        expect(widget.methods).to.contain('onTextChange');
       });
 
     });


### PR DESCRIPTION
Adds an `editor` attribute to the `IConsoleHistory` to be consistent with `InspectionHandler` and `CompletionHandler`.  cf #1505 