### PR TITLE
Allow override of model factories

### DIFF
--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -30,7 +30,7 @@ import {
 } from '@jupyterlab/services';
 
 import {
-  NotebookPanel, NotebookWidgetFactory, Notebook,
+  NotebookPanel, NotebookWidgetFactory,
   NotebookModelFactory, NotebookActions
 } from 'jupyterlab/lib/notebook';
 
@@ -127,7 +127,7 @@ function createApp(manager: ServiceManager.IManager): void {
     manager,
     opener
   });
-  let mFactory = new NotebookModelFactory();
+  let mFactory = new NotebookModelFactory({});
   let clipboard = new MimeData();
   let editorFactory = editorServices.factoryService.newInlineEditor;
   let contentFactory = new NotebookPanel.ContentFactory({ editorFactory });

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -70,7 +70,10 @@ class ConsolePanel extends Panel {
     let factory = options.contentFactory;
     let { rendermime, session, mimeTypeService } = options;
     let contentFactory = factory.consoleContentFactory;
-    let consoleOpts = { rendermime, session, mimeTypeService, contentFactory };
+    let modelFactory = options.modelFactory;
+    let consoleOpts = {
+      rendermime, session, mimeTypeService, contentFactory, modelFactory
+    };
     this.console = factory.createConsole(consoleOpts);
     this.addWidget(this.console);
 
@@ -191,6 +194,11 @@ namespace ConsolePanel {
      * The session for the console widget.
      */
     session: Session.ISession;
+
+    /**
+     * The model factory for the console widget.
+     */
+    modelFactory?: CodeConsole.IModelFactory;
 
     /**
      * The service used to look up mime types.

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -857,7 +857,7 @@ namespace CodeConsole {
      *   `codeCellContentFactory` will be used.
      */
     createCodeCell(options: CodeCellModel.IOptions): ICodeCellModel {
-      if (options.contentFactory) {
+      if (!options.contentFactory) {
         options.contentFactory = this.codeCellContentFactory;
       }
       return new CodeCellModel(options);

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -537,8 +537,7 @@ class CodeConsole extends Widget {
     let factory = this.contentFactory;
     let contentFactory = factory.codeCellContentFactory;
     let modelFactory = this.modelFactory;
-    let outputAreaFactory = modelFactory.outputAreaFactory;
-    let model = modelFactory.createCodeCell({ outputAreaFactory });
+    let model = modelFactory.createCodeCell({ });
     let rendermime = this.rendermime;
     return { model, rendermime, contentFactory };
   }
@@ -704,7 +703,7 @@ namespace CodeConsole {
     /**
      * Create a new content factory.
      */
-    constructor(options: ContentFactory.IOptions) {
+    constructor(options: IContentFactoryOptions) {
       let editorFactory = options.editorFactory;
       let outputAreaContentFactory = (options.outputAreaContentFactory ||
         OutputAreaWidget.defaultContentFactory
@@ -770,38 +769,31 @@ namespace CodeConsole {
       return new CodeCellWidget(options);
     }
   }
-
   /**
-   * The namespace for `ContentFactory` class statics.
+   * An initialize options for `ContentFactory`.
    */
   export
-  namespace ContentFactory {
+  interface IContentFactoryOptions {
     /**
-     * An initialize options for `ContentFactory`.
+     * The editor factory.
      */
-    export
-    interface IOptions {
-      /**
-       * The editor factory.
-       */
-      editorFactory: CodeEditor.Factory;
+    editorFactory: CodeEditor.Factory;
 
-      /**
-       * The factory for output area content.
-       */
-      outputAreaContentFactory?: OutputAreaWidget.IContentFactory;
+    /**
+     * The factory for output area content.
+     */
+    outputAreaContentFactory?: OutputAreaWidget.IContentFactory;
 
-      /**
-       * The factory for code cell widget content.  If given, this will
-       * take precedence over the `outputAreaContentFactory`.
-       */
-      codeCellContentFactory?: CodeCellWidget.IContentFactory;
+    /**
+     * The factory for code cell widget content.  If given, this will
+     * take precedence over the `outputAreaContentFactory`.
+     */
+    codeCellContentFactory?: CodeCellWidget.IContentFactory;
 
-      /**
-       * The factory for raw cell widget content.
-       */
-      rawCellContentFactory?: BaseCellWidget.IContentFactory;
-    }
+    /**
+     * The factory for raw cell widget content.
+     */
+    rawCellContentFactory?: BaseCellWidget.IContentFactory;
   }
 
   /**
@@ -810,9 +802,9 @@ namespace CodeConsole {
   export
   interface IModelFactory {
    /**
-    * The factory for output area models.
+    * The factory for code cell content.
     */
-    readonly outputAreaFactory: CodeCellModel.IOutputAreaFactory;
+    readonly codeCellContentFactory: CodeCellModel.IContentFactory;
 
     /**
      * Create a new code cell.
@@ -823,6 +815,7 @@ namespace CodeConsole {
      *   new cell will be intialized with the data from the source.
      */
     createCodeCell(options: CodeCellModel.IOptions): ICodeCellModel;
+
     /**
      * Create a new raw cell.
      *
@@ -843,15 +836,15 @@ namespace CodeConsole {
      * Create a new cell model factory.
      */
     constructor(options: IModelFactoryOptions) {
-      this.outputAreaFactory = (options.outputAreaFactory ||
-        CodeCellModel.defaultOutputAreaFactory
+      this.codeCellContentFactory = (options.codeCellContentFactory ||
+        CodeCellModel.defaultContentFactory
       );
     }
 
     /**
      * The factory for output area models.
      */
-    readonly outputAreaFactory: CodeCellModel.IOutputAreaFactory;
+    readonly codeCellContentFactory: CodeCellModel.IContentFactory;
 
     /**
      * Create a new code cell.
@@ -860,8 +853,13 @@ namespace CodeConsole {
      *
      * @returns A new code cell. If a source cell is provided, the
      *   new cell will be intialized with the data from the source.
+     *   If the contentFactory is not provided, the instance
+     *   `codeCellContentFactory` will be used.
      */
     createCodeCell(options: CodeCellModel.IOptions): ICodeCellModel {
+      if (options.contentFactory) {
+        options.contentFactory = this.codeCellContentFactory;
+      }
       return new CodeCellModel(options);
     }
 
@@ -886,7 +884,7 @@ namespace CodeConsole {
     /**
      * The factory for output area models.
      */
-    outputAreaFactory?: CodeCellModel.IOutputAreaFactory;
+    codeCellContentFactory?: CodeCellModel.IContentFactory;
   }
 
   /**

--- a/src/notebook/cells/model.ts
+++ b/src/notebook/cells/model.ts
@@ -339,8 +339,8 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
    */
   constructor(options: CodeCellModel.IOptions) {
     super(options);
-    let factory = (options.outputAreaFactory ||
-      CodeCellModel.defaultOutputAreaFactory
+    let factory = (options.contentFactory ||
+      CodeCellModel.defaultContentFactory
     );
     this._outputs = factory.createOutputArea();
     let cell = options.cell as nbformat.ICodeCell;
@@ -441,14 +441,14 @@ namespace CodeCellModel {
     /**
      * The factory for output area model creation.
      */
-    outputAreaFactory?: IOutputAreaFactory;
+    contentFactory?: IContentFactory;
   }
 
   /**
-   * A factory for creating cell models.
+   * A factory for creating code cell model content.
    */
   export
-  interface IOutputAreaFactory {
+  interface IContentFactory {
     /**
      * Create an output area.
      */
@@ -456,10 +456,10 @@ namespace CodeCellModel {
   }
 
   /**
-   * The default implementation of an `IOutpuAreaFactory`.
+   * The default implementation of an `IContentFactory`.
    */
   export
-  class OutputAreaFactory {
+  class ContentFactory {
     /**
      * Create an output area.
      */
@@ -469,8 +469,8 @@ namespace CodeCellModel {
   }
 
   /**
-   * The shared `OutputAreaFactory` instance.
+   * The shared `ConetntFactory` instance.
    */
   export
-  const defaultOutputAreaFactory = new OutputAreaFactory();
+  const defaultContentFactory = new ContentFactory();
 }

--- a/src/notebook/cells/model.ts
+++ b/src/notebook/cells/model.ts
@@ -34,7 +34,7 @@ import {
 } from '../common/metadata';
 
 import {
-  OutputAreaModel
+  IOutputAreaModel, OutputAreaModel
 } from '../output-area';
 
 
@@ -109,7 +109,7 @@ interface ICodeCellModel extends ICellModel {
   /**
    * The cell outputs.
    */
-  outputs: OutputAreaModel;
+  outputs: IOutputAreaModel;
 }
 
 
@@ -379,7 +379,7 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
   /**
    * The cell outputs.
    */
-  get outputs(): OutputAreaModel {
+  get outputs(): IOutputAreaModel {
     return this._outputs;
   }
 
@@ -419,7 +419,7 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
     this.contentChanged.emit(void 0);
   }
 
-  private _outputs: OutputAreaModel = null;
+  private _outputs: IOutputAreaModel = null;
   private _executionCount: nbformat.ExecutionCount = null;
 }
 
@@ -452,7 +452,7 @@ namespace CodeCellModel {
     /**
      * Create an output area.
      */
-    createOutputArea(): OutputAreaModel;
+    createOutputArea(): IOutputAreaModel;
   }
 
   /**
@@ -463,7 +463,7 @@ namespace CodeCellModel {
     /**
      * Create an output area.
      */
-    createOutputArea(): OutputAreaModel {
+    createOutputArea(): IOutputAreaModel {
       return new OutputAreaModel();
     }
   }

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -230,8 +230,9 @@ namespace NotebookActions {
     if (!widget.model || !widget.activeCell) {
       return;
     }
-    let cell = Private.createCodeCell(widget.model);
-    widget.model.cells.insert(widget.activeCellIndex, cell);
+    let model = widget.model;
+    let cell = model.contentFactory.createCodeCell({ });
+    model.cells.insert(widget.activeCellIndex, cell);
     widget.deselectAll();
   }
 
@@ -251,8 +252,9 @@ namespace NotebookActions {
     if (!widget.model || !widget.activeCell) {
       return;
     }
-    let cell = Private.createCodeCell(widget.model);
-    widget.model.cells.insert(widget.activeCellIndex + 1, cell);
+    let model = widget.model;
+    let cell = model.contentFactory.createCodeCell({});
+    model.cells.insert(widget.activeCellIndex + 1, cell);
     widget.activeCellIndex++;
     widget.deselectAll();
   }
@@ -438,7 +440,7 @@ namespace NotebookActions {
     let promise = run(widget, kernel);
     let model = widget.model;
     if (widget.activeCellIndex === widget.widgets.length - 1) {
-      let cell = Private.createCodeCell(model);
+      let cell = model.contentFactory.createCodeCell({});
       model.cells.pushBack(cell);
       widget.activeCellIndex++;
       widget.mode = 'edit';
@@ -471,7 +473,7 @@ namespace NotebookActions {
     }
     let promise = run(widget, kernel);
     let model = widget.model;
-    let cell = Private.createCodeCell(model);
+    let cell = model.contentFactory.createCodeCell({});
     model.cells.insert(widget.activeCellIndex + 1, cell);
     widget.activeCellIndex++;
     widget.scrollToActiveCell();
@@ -939,16 +941,6 @@ namespace Private {
   }
 
   /**
-   * Create an empty code cell for a notebook model.
-   */
-  export
-  function createCodeCell(model: INotebookModel): ICodeCellModel {
-    let factory = model.contentFactory;
-    let outputAreaFactory = factory.outputAreaFactory;
-    return factory.createCodeCell({ outputAreaFactory });
-  }
-
-  /**
    * Handle payloads from an execute reply.
    *
    * #### Notes
@@ -974,7 +966,7 @@ namespace Private {
     }
 
     // Create a new code cell and add as the next cell.
-    let cell = createCodeCell(parent.model);
+    let cell = parent.model.contentFactory.createCodeCell({});
     cell.value.text = text;
     let cells = parent.model.cells;
     let i = indexOf(cells, child.model);

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -340,16 +340,17 @@ namespace NotebookActions {
         return;
       }
       if (child.model.type !== value) {
+        let cell: nbformat.IBaseCell = child.model.toJSON();
         let newCell: ICellModel;
         switch (value) {
         case 'code':
-          newCell = model.contentFactory.createCodeCell(child.model.toJSON());
+          newCell = model.contentFactory.createCodeCell({ cell });
           break;
         case 'markdown':
-          newCell = model.contentFactory.createMarkdownCell(child.model.toJSON());
+          newCell = model.contentFactory.createMarkdownCell({ cell });
           break;
         default:
-          newCell = model.contentFactory.createRawCell(child.model.toJSON());
+          newCell = model.contentFactory.createRawCell({ cell });
         }
         cells.set(i, newCell);
       }
@@ -702,16 +703,16 @@ namespace NotebookActions {
     let newCells: ICellModel[] = [];
     widget.mode = 'command';
 
-    each(values, value => {
-      switch (value.cell_type) {
+    each(values, cell => {
+      switch (cell.cell_type) {
       case 'code':
-        newCells.push(model.contentFactory.createCodeCell(value));
+        newCells.push(model.contentFactory.createCodeCell({ cell }));
         break;
       case 'markdown':
-        newCells.push(model.contentFactory.createMarkdownCell(value));
+        newCells.push(model.contentFactory.createMarkdownCell({ cell }));
         break;
       default:
-        newCells.push(model.contentFactory.createRawCell(value));
+        newCells.push(model.contentFactory.createRawCell({ cell }));
         break;
       }
     });

--- a/src/notebook/notebook/model.ts
+++ b/src/notebook/notebook/model.ts
@@ -438,7 +438,7 @@ namespace NotebookModel {
     /**
      * The factory for output area models.
      */
-    readonly outputAreaFactory: CodeCellModel.IOutputAreaFactory;
+    readonly codeCellContentFactory: CodeCellModel.IContentFactory;
 
     /**
      * Create a new code cell.
@@ -480,15 +480,15 @@ namespace NotebookModel {
      * Create a new cell model factory.
      */
     constructor(options: IContentFactoryOptions) {
-      this.outputAreaFactory = (options.outputAreaFactory ||
-        CodeCellModel.defaultOutputAreaFactory
+      this.codeCellContentFactory = (options.codeCellContentFactory ||
+        CodeCellModel.defaultContentFactory
       );
     }
 
     /**
-     * The factory for output area models.
+     * The factory for code cell content.
      */
-    readonly outputAreaFactory: CodeCellModel.IOutputAreaFactory;
+    readonly codeCellContentFactory: CodeCellModel.IContentFactory;
 
     /**
      * Create a new code cell.
@@ -497,12 +497,12 @@ namespace NotebookModel {
      *
      * @returns A new code cell. If a source cell is provided, the
      *   new cell will be intialized with the data from the source.
-     *   If the outputAreaFactory is not provided, the instance
-     *   level version will be used.
+     *   If the contentFactory is not provided, the instance
+     *   `codeCellContentFactory` will be used.
      */
     createCodeCell(options: CodeCellModel.IOptions): ICodeCellModel {
-      if (options.outputAreaFactory) {
-        options.outputAreaFactory = this.outputAreaFactory;
+      if (options.contentFactory) {
+        options.contentFactory = this.codeCellContentFactory;
       }
       return new CodeCellModel(options);
     }
@@ -538,9 +538,9 @@ namespace NotebookModel {
   export
   interface IContentFactoryOptions {
     /**
-     * The factory for output area models.
+     * The factory for code cell model content.
      */
-    outputAreaFactory?: CodeCellModel.IOutputAreaFactory;
+    codeCellContentFactory?: CodeCellModel.IContentFactory;
   }
 
   /**

--- a/src/notebook/notebook/modelfactory.ts
+++ b/src/notebook/notebook/modelfactory.ts
@@ -10,6 +10,10 @@ import {
 } from '../../docregistry';
 
 import {
+  CodeCellModel
+} from '../cells';
+
+import {
   INotebookModel, NotebookModel
 } from './model';
 
@@ -19,6 +23,21 @@ import {
  */
 export
 class NotebookModelFactory implements DocumentRegistry.IModelFactory<INotebookModel> {
+  /**
+   * Construct a new notebook model factory.
+   */
+  constructor(options: NotebookModelFactory.IOptions) {
+    let outputAreaFactory = options.outputAreaFactory;
+    this.contentFactory = (options.contentFactory ||
+      new NotebookModel.ContentFactory({ outputAreaFactory })
+    );
+  }
+
+  /**
+   * The content model factory used by the NotebookModelFactory.
+   */
+  readonly contentFactory: NotebookModel.IContentFactory;
+
   /**
    * The name of the model.
    */
@@ -62,7 +81,8 @@ class NotebookModelFactory implements DocumentRegistry.IModelFactory<INotebookMo
    * @returns A new document model.
    */
   createNew(languagePreference?: string): INotebookModel {
-    return new NotebookModel({ languagePreference });
+    let contentFactory = this.contentFactory;
+    return new NotebookModel({ languagePreference, contentFactory });
   }
 
   /**
@@ -73,4 +93,28 @@ class NotebookModelFactory implements DocumentRegistry.IModelFactory<INotebookMo
   }
 
   private _disposed = false;
+}
+
+
+/**
+ * The namespace for notebook model factory statics.
+ */
+export
+namespace NotebookModelFactory {
+  /**
+   * The options used to initialize a NotebookModelFactory.
+   */
+  export
+  interface IOptions {
+    /**
+     * The factory for output area models.
+     */
+    outputAreaFactory?: CodeCellModel.IOutputAreaFactory;
+
+    /**
+     * The content factory used by the NotebookModelFactory.  If
+     * given, it will supercede the `outputAreaFactory`.
+     */
+    contentFactory?: NotebookModel.IContentFactory;
+  }
 }

--- a/src/notebook/notebook/modelfactory.ts
+++ b/src/notebook/notebook/modelfactory.ts
@@ -27,9 +27,9 @@ class NotebookModelFactory implements DocumentRegistry.IModelFactory<INotebookMo
    * Construct a new notebook model factory.
    */
   constructor(options: NotebookModelFactory.IOptions) {
-    let outputAreaFactory = options.outputAreaFactory;
+    let codeCellContentFactory = options.codeCellContentFactory;
     this.contentFactory = (options.contentFactory ||
-      new NotebookModel.ContentFactory({ outputAreaFactory })
+      new NotebookModel.ContentFactory({ codeCellContentFactory })
     );
   }
 
@@ -107,13 +107,13 @@ namespace NotebookModelFactory {
   export
   interface IOptions {
     /**
-     * The factory for output area models.
+     * The factory for code cell content.
      */
-    outputAreaFactory?: CodeCellModel.IOutputAreaFactory;
+    codeCellContentFactory?: CodeCellModel.IContentFactory;
 
     /**
      * The content factory used by the NotebookModelFactory.  If
-     * given, it will supercede the `outputAreaFactory`.
+     * given, it will supercede the `codeCellContentFactory`.
      */
     contentFactory?: NotebookModel.IContentFactory;
   }

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -558,7 +558,7 @@ namespace StaticNotebook {
     /**
      * Creates a new renderer.
      */
-    constructor(options: ContentFactory.IOptions) {
+    constructor(options: IContentFactoryOptions) {
       let editorFactory = options.editorFactory;
       let outputAreaContentFactory = (options.outputAreaContentFactory ||
         OutputAreaWidget.defaultContentFactory
@@ -620,41 +620,35 @@ namespace StaticNotebook {
   }
 
   /**
-   * The namespace for the `ContentFactory` class statics.
+   * An options object for initializing a notebook content factory.
    */
   export
-  namespace ContentFactory {
+  interface IContentFactoryOptions {
     /**
-     * An options object for initializing a notebook renderer.
+     * The editor factory.
      */
-    export
-    interface IOptions {
-      /**
-       * The editor factory.
-       */
-      editorFactory: CodeEditor.Factory;
+    editorFactory: CodeEditor.Factory;
 
-      /**
-       * The factory for output area content.
-       */
-      outputAreaContentFactory?: OutputAreaWidget.IContentFactory;
+    /**
+     * The factory for output area content.
+     */
+    outputAreaContentFactory?: OutputAreaWidget.IContentFactory;
 
-      /**
-       * The factory for code cell widget content.  If given, this will
-       * take precedence over the `outputAreaContentFactory`.
-       */
-      codeCellContentFactory?: CodeCellWidget.IContentFactory;
+    /**
+     * The factory for code cell widget content.  If given, this will
+     * take precedence over the `outputAreaContentFactory`.
+     */
+    codeCellContentFactory?: CodeCellWidget.IContentFactory;
 
-      /**
-       * The factory for raw cell widget content.
-       */
-      rawCellContentFactory?: BaseCellWidget.IContentFactory;
+    /**
+     * The factory for raw cell widget content.
+     */
+    rawCellContentFactory?: BaseCellWidget.IContentFactory;
 
-      /**
-       * The factory for markdown cell widget content.
-       */
-      markdownCellContentFactory?: BaseCellWidget.IContentFactory;
-    }
+    /**
+     * The factory for markdown cell widget content.
+     */
+    markdownCellContentFactory?: BaseCellWidget.IContentFactory;
   }
 }
 
@@ -1250,14 +1244,13 @@ class Notebook extends StaticNotebook {
     let model = this.model;
     let values = event.mimeData.getData(JUPYTER_CELL_MIME);
     let factory = model.contentFactory;
-    let outputAreaFactory = factory.outputAreaFactory;
 
     // Insert the copies of the original cells.
     each(values, (cell: nbformat.ICell) => {
       let value: ICellModel;
       switch (cell.cell_type) {
       case 'code':
-        value = factory.createCodeCell({ cell, outputAreaFactory });
+        value = factory.createCodeCell({ cell });
         break;
       case 'markdown':
         value = factory.createMarkdownCell({ cell });

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -1249,22 +1249,24 @@ class Notebook extends StaticNotebook {
     }
     let model = this.model;
     let values = event.mimeData.getData(JUPYTER_CELL_MIME);
+    let factory = model.contentFactory;
+    let outputAreaFactory = factory.outputAreaFactory;
 
     // Insert the copies of the original cells.
-    each(values, (value: nbformat.ICell) => {
-      let cell: ICellModel;
-      switch (value.cell_type) {
+    each(values, (cell: nbformat.ICell) => {
+      let value: ICellModel;
+      switch (cell.cell_type) {
       case 'code':
-        cell = model.factory.createCodeCell(value);
+        value = factory.createCodeCell({ cell, outputAreaFactory });
         break;
       case 'markdown':
-        cell = model.factory.createMarkdownCell(value);
+        value = factory.createMarkdownCell({ cell });
         break;
       default:
-        cell = model.factory.createRawCell(value);
+        value = factory.createRawCell({ cell });
         break;
       }
-      model.cells.insert(index, cell);
+      model.cells.insert(index, value);
     });
     // Activate the last cell.
     this.activeCellIndex = index + values.length - 1;

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -69,7 +69,7 @@ interface IOutputAreaModel extends IDisposable {
    *
    * @param wait Delay clearing the output until the next message is added.
    */
-  clear(wait: boolean = false): void;
+  clear(wait?: boolean): void;
 
   /**
    * Add a mime type to an output data bundle.

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -50,7 +50,7 @@ import {
 } from '../../rendermime';
 
 import {
-  OutputAreaModel
+  IOutputAreaModel, OutputAreaModel
 } from './model';
 
 
@@ -214,10 +214,10 @@ class OutputAreaWidget extends Widget {
   /**
    * The model for the widget.
    */
-  get model(): OutputAreaModel {
+  get model(): IOutputAreaModel {
     return this._model;
   }
-  set model(newValue: OutputAreaModel) {
+  set model(newValue: IOutputAreaModel) {
     if (!newValue && !this._model || newValue === this._model) {
       return;
     }
@@ -347,7 +347,7 @@ class OutputAreaWidget extends Widget {
   /**
    * Follow changes on the model state.
    */
-  protected onModelStateChanged(sender: OutputAreaModel, args: ObservableVector.IChangedArgs<nbformat.IOutput>) {
+  protected onModelStateChanged(sender: IOutputAreaModel, args: ObservableVector.IChangedArgs<nbformat.IOutput>) {
     switch (args.type) {
     case 'add':
       // Children are always added at the end.
@@ -394,14 +394,14 @@ class OutputAreaWidget extends Widget {
    * internally and before the `modelChanged` signal is emitted.
    * The default implementation is a no-op.
    */
-  protected onModelChanged(oldValue: OutputAreaModel, newValue: OutputAreaModel): void {
+  protected onModelChanged(oldValue: IOutputAreaModel, newValue: IOutputAreaModel): void {
     // no-op
   }
 
   /**
    * Handle a change to the model.
    */
-  private _onModelChanged(oldValue: OutputAreaModel, newValue: OutputAreaModel): void {
+  private _onModelChanged(oldValue: IOutputAreaModel, newValue: IOutputAreaModel): void {
     let layout = this.layout as PanelLayout;
     if (oldValue) {
       oldValue.changed.disconnect(this.onModelStateChanged, this);
@@ -433,7 +433,7 @@ class OutputAreaWidget extends Widget {
   /**
    * Handle a model disposal.
    */
-  protected onModelDisposed(oldValue: OutputAreaModel, newValue: OutputAreaModel): void {
+  protected onModelDisposed(oldValue: IOutputAreaModel, newValue: IOutputAreaModel): void {
     // no-op
   }
 
@@ -446,7 +446,7 @@ class OutputAreaWidget extends Widget {
   private _fixedHeight = false;
   private _collapsed = false;
   private _minHeightTimeout: number = null;
-  private _model: OutputAreaModel = null;
+  private _model: IOutputAreaModel = null;
   private _injecting = false;
 }
 

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -198,7 +198,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     }
   });
 
-  registry.addModelFactory(new NotebookModelFactory());
+  registry.addModelFactory(new NotebookModelFactory({}));
   registry.addWidgetFactory(factory);
   registry.addFileType({
     name: 'Notebook',

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -55,8 +55,9 @@ def create_notebook_dir():
 
 @gen.coroutine
 def run(cmd):
-    """Start the task."""
-    """Run a task in a thread and exit with the return code."""
+    """Run the cmd and exit with the return code"""
+    yield gen.moment  # sync up with the ioloop
+
     shell = os.name == 'nt'
     proc = Popen(cmd, shell=shell)
     print('\n\nRunning command: "%s"\n\n' % ' '.join(cmd))
@@ -71,10 +72,11 @@ def run(cmd):
 
 
 @gen.coroutine
-def exit(returncode):
+def exit(code):
     """Safely stop the app and then exit with the given code."""
+    yield gen.moment   # sync up with the ioloop
     IOLoop.current().stop()
-    sys.exit(returncode)
+    sys.exit(code)
 
 
 class TestApp(NotebookApp):
@@ -96,7 +98,8 @@ def main():
         sys.exit(1)
 
     app.initialize([])  # reserve sys.argv for the command
-    run(get_command(app))
+    cmd = get_command(app)
+    run(cmd)
 
     try:
         app.start()

--- a/test/run-test.py
+++ b/test/run-test.py
@@ -6,35 +6,18 @@ from __future__ import print_function, absolute_import
 import atexit
 import json
 import os
+from subprocess import Popen
 import sys
 import shutil
 import tempfile
 
+from tornado import gen
 from tornado.ioloop import IOLoop
-from tornado.process import Subprocess
 from notebook.notebookapp import NotebookApp
 from traitlets import Bool, Unicode
 
 
 HERE = os.path.dirname(__file__)
-
-
-def create_notebook_dir():
-    """Create a temporary directory with some file structure."""
-    root_dir = tempfile.mkdtemp(prefix='mock_contents')
-    os.mkdir(os.path.join(root_dir, 'src'))
-    with open(os.path.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
-        fid.write('hello')
-    atexit.register(lambda: shutil.rmtree(root_dir, True))
-    return root_dir
-
-
-def run_command(cmd):
-    """Run a task in a thread and exit with the return code."""
-    shell = os.name == 'nt'
-    p = Subprocess(cmd, shell=shell)
-    print('\n\nRunning command: "%s"\n\n' % ' '.join(cmd))
-    p.set_exit_callback(sys.exit)
 
 
 def get_command(nbapp):
@@ -57,35 +40,85 @@ def get_command(nbapp):
         document.body.appendChild(node);
         """ % json.dumps(config))
 
-    return ['karma', 'start'] + ARGS
+    return ['karma', 'start'] + sys.argv[1:]
+
+
+def create_notebook_dir():
+    """Create a temporary directory with some file structure."""
+    root_dir = tempfile.mkdtemp(prefix='mock_contents')
+    os.mkdir(os.path.join(root_dir, 'src'))
+    with open(os.path.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
+        fid.write('hello')
+    atexit.register(lambda: shutil.rmtree(root_dir, True))
+    return root_dir
+
+
+class TaskRunner(object):
+    """Run a task using the notebook app and exit with the return code.
+    """
+
+    def __init__(self, nbapp):
+        self.nbapp = nbapp
+
+    def start(self, cmd):
+        """Start the task."""
+        # Run the command after the ioloop starts.
+        self._command = cmd
+        IOLoop.current().add_callback(self._run_command)
+
+    def exit(self, returncode):
+        """Safely stop the app and then exit with the given code."""
+        self._return_code = returncode
+        self.nbapp.io_loop.add_callback(self._exit)
+
+    @gen.coroutine
+    def _run_command(self):
+        """Run a task in a thread and exit with the return code."""
+        cmd = self._command
+        shell = os.name == 'nt'
+        proc = Popen(cmd, shell=shell)
+        print('\n\nRunning command: "%s"\n\n' % ' '.join(cmd))
+
+        # Poll the process once per second until finished.
+        while 1:
+            yield gen.sleep(1)
+            if proc.poll() is not None:
+                break
+
+        self.exit(proc.returncode)
+
+    def _exit(self):
+        self.nbapp.io_loop.stop()
+        sys.exit(self._return_code)
 
 
 class TestApp(NotebookApp):
-    """A notebook app that runs a karma test."""
+    """A notebook app that supports a unit test."""
 
     open_browser = Bool(False)
     notebook_dir = Unicode(create_notebook_dir())
     allow_origin = Unicode('*')
 
-    def start(self):
-        # Cannot run against Notebook 4.3.0 due to auth incompatibilities.
-        if self.version == '4.3.0':
-            msg = ('Cannot run unit tests against Notebook 4.3.0.  '
-                   'Please upgrade to Notebook 4.3.1+')
-            self.log.error(msg)
-            sys.exit(1)
 
-        # Run the command after the ioloop starts.
-        IOLoop.current().add_callback(run_command, get_command(self))
-        super(TestApp, self).start()
+def main():
+    """Run the unit test."""
+    app = TestApp()
+
+    if app.version == '4.3.0':
+        msg = ('Cannot run unit tests against Notebook 4.3.0.  '
+               'Please upgrade to Notebook 4.3.1+')
+        print(msg)
+        sys.exit(1)
+
+    app.initialize([])  # reserve sys.argv for the command
+    task = TaskRunner(app)
+    task.start(get_command(app))
+
+    try:
+        app.start()
+    except KeyboardInterrupt:
+        task.exit(1)
 
 
 if __name__ == '__main__':
-    # Reserve the command line arguments for karma.
-    ARGS = sys.argv[1:]
-    sys.argv = sys.argv[:1]
-
-    try:
-        nbapp = TestApp.launch_instance()
-    except KeyboardInterrupt:
-        nbapp.stop()
+    main()

--- a/test/src/completer/handler.spec.ts
+++ b/test/src/completer/handler.spec.ts
@@ -81,6 +81,11 @@ class TestCompletionHandler extends CompletionHandler {
 const kernelPromise = Kernel.startNew();
 
 
+function createCellWidget(): BaseCellWidget {
+  return new BaseCellWidget({ model: new CellModel({}), contentFactory });
+}
+
+
 describe('completer/handler', () => {
 
   let kernel: Kernel.IKernel;

--- a/test/src/completer/handler.spec.ts
+++ b/test/src/completer/handler.spec.ts
@@ -81,11 +81,6 @@ class TestCompletionHandler extends CompletionHandler {
 const kernelPromise = Kernel.startNew();
 
 
-function createCellWidget(): BaseCellWidget {
-  return new BaseCellWidget({ model: new CellModel({}), contentFactory });
-}
-
-
 describe('completer/handler', () => {
 
   let kernel: Kernel.IKernel;

--- a/test/src/console/foreign.spec.ts
+++ b/test/src/console/foreign.spec.ts
@@ -85,7 +85,7 @@ const rendermime = defaultRenderMime();
 
 function cellFactory(): CodeCellWidget {
   let contentFactory = createCodeCellFactory();
-  let model = new CodeCellModel();
+  let model = new CodeCellModel({});
   let cell = new CodeCellWidget({ model, rendermime, contentFactory });
   return cell;
 };

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -466,6 +466,60 @@ describe('console/widget', () => {
 
     });
 
+    describe('.ModelFactory', () => {
+
+      describe('#constructor()', () => {
+
+        it('should create a new model factory', () => {
+          let factory = new CodeConsole.ModelFactory({});
+          expect(factory).to.be.a(CodeConsole.ModelFactory);
+        });
+
+        it('should accept a codeCellContentFactory', () => {
+          let codeCellContentFactory = new CodeCellModel.ContentFactory();
+          let factory = new CodeConsole.ModelFactory({ codeCellContentFactory });
+          expect(factory.codeCellContentFactory).to.be(codeCellContentFactory);
+        });
+
+      });
+
+      describe('#codeCellContentFactory', () => {
+
+        it('should be the code cell content factory used by the factory', () => {
+          let factory = new CodeConsole.ModelFactory({});
+          expect(factory.codeCellContentFactory).to.be(CodeCellModel.defaultContentFactory);
+        });
+
+      });
+
+      describe('#createCodeCell()', () => {
+
+        it('should create a code cell', () => {
+          let factory = new CodeConsole.ModelFactory({});
+          expect(factory.createCodeCell({})).to.be.a(CodeCellModel);
+        });
+
+      });
+
+      describe('#createRawCell()', () => {
+
+        it('should create a raw cell model', () => {
+          let factory = new CodeConsole.ModelFactory({});
+          expect(factory.createRawCell({})).to.be.a(RawCellModel);
+        });
+
+      });
+
+    });
+
+    describe('.defaultModelFactory', () => {
+
+      it('should be a ModelFactory', () => {
+        expect(CodeConsole.defaultModelFactory).to.be.a(CodeConsole.ModelFactory);
+      });
+
+    });
+
   });
 
 });

--- a/test/src/console/widget.spec.ts
+++ b/test/src/console/widget.spec.ts
@@ -180,7 +180,7 @@ describe('console/widget', () => {
 
       it('should add a code cell to the content widget', () => {
         let contentFactory = createCodeCellFactory();
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         let cell = new CodeCellWidget({ model, contentFactory, rendermime });
         Widget.attach(widget, document.body);
         expect(widget.cells.length).to.be(0);
@@ -405,7 +405,7 @@ describe('console/widget', () => {
 
         it('should create a ForeignHandler', () => {
           let cellFactory = () => {
-            let model = new CodeCellModel();
+            let model = new CodeCellModel({});
             let rendermime = widget.rendermime;
             let factory = contentFactory.codeCellContentFactory;
             let options: CodeCellWidget.IOptions = {
@@ -426,7 +426,7 @@ describe('console/widget', () => {
       describe('#createBanner', () => {
 
         it('should create a banner cell', () => {
-          let model = new RawCellModel();
+          let model = new RawCellModel({});
           let banner = contentFactory.createBanner({
             model,
             contentFactory: contentFactory.rawCellContentFactory
@@ -439,7 +439,7 @@ describe('console/widget', () => {
       describe('#createPrompt', () => {
 
         it('should create a prompt cell', () => {
-          let model = new CodeCellModel();
+          let model = new CodeCellModel({});
           let prompt = contentFactory.createPrompt({
             rendermime: widget.rendermime,
             model,
@@ -453,7 +453,7 @@ describe('console/widget', () => {
       describe('#createForeignCell', () => {
 
         it('should create a foreign cell', () => {
-          let model = new CodeCellModel();
+          let model = new CodeCellModel({});
           let prompt = contentFactory.createForeignCell({
             rendermime: widget.rendermime,
             model,

--- a/test/src/notebook/cells/model.spec.ts
+++ b/test/src/notebook/cells/model.spec.ts
@@ -40,7 +40,7 @@ describe('notebook/cells/model', () => {
     describe('#constructor()', () => {
 
       it('should create a cell model', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         expect(model).to.be.a(CellModel);
       });
 
@@ -71,7 +71,7 @@ describe('notebook/cells/model', () => {
     describe('#contentChanged', () => {
 
       it('should signal when model content has changed', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         let called = false;
         model.contentChanged.connect(() => { called = true; });
         expect(called).to.be(false);
@@ -84,7 +84,7 @@ describe('notebook/cells/model', () => {
     describe('#stateChanged', () => {
 
       it('should signal when model state has changed', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         let called = false;
         let listener = (sender: any, args: IChangedArgs<any>) => {
           expect(args.newValue).to.be(1);
@@ -96,7 +96,7 @@ describe('notebook/cells/model', () => {
       });
 
       it('should not signal when model state has not changed', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         let called = 0;
         model.stateChanged.connect(() => { called++; });
         expect(called).to.be(0);
@@ -111,7 +111,7 @@ describe('notebook/cells/model', () => {
     describe('#metadataChanged', () => {
 
       it('should signal when model metadata has changed', () => {
-        let model = new TestModel();
+        let model = new TestModel({});
         let listener = (sender: any, args: IChangedArgs<any>) => {
           value = args.newValue;
         };
@@ -123,7 +123,7 @@ describe('notebook/cells/model', () => {
       });
 
       it('should not signal when model metadata has not changed', () => {
-        let model = new TestModel();
+        let model = new TestModel({});
         let called = 0;
         model.metadataChanged.connect(() => { called++; });
         expect(called).to.be(0);
@@ -138,12 +138,12 @@ describe('notebook/cells/model', () => {
     describe('#source', () => {
 
       it('should default to an empty string', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         expect(model.value.text).to.be.empty();
       });
 
       it('should be settable', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         expect(model.value.text).to.be.empty();
         model.value.text = 'foo';
         expect(model.value.text).to.be('foo');
@@ -154,12 +154,12 @@ describe('notebook/cells/model', () => {
     describe('#isDisposed', () => {
 
       it('should be false by default', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         expect(model.isDisposed).to.be(false);
       });
 
       it('should be true after model is disposed', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         model.dispose();
         expect(model.isDisposed).to.be(true);
       });
@@ -169,7 +169,7 @@ describe('notebook/cells/model', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the model', () => {
-        let model = new TestModel();
+        let model = new TestModel({});
 
         model.setCursorData('foo', 'bar');
         expect(model.getMetadata('foo').getValue()).to.be('bar');
@@ -179,7 +179,7 @@ describe('notebook/cells/model', () => {
       });
 
       it('should be safe to call multiple times', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         model.dispose();
         model.dispose();
         expect(model.isDisposed).to.be(true);
@@ -217,7 +217,7 @@ describe('notebook/cells/model', () => {
     describe('#getMetadata()', () => {
 
       it('should get a metadata cursor for the cell', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         let c1 = model.getMetadata('foo');
 
         expect(c1.getValue()).to.be(void 0);
@@ -237,7 +237,7 @@ describe('notebook/cells/model', () => {
     describe('#listMetadata()', () => {
 
       it('should get a list of user metadata keys', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         let cursor = model.getMetadata('foo');
         expect(toArray(model.listMetadata())).to.be.empty();
         cursor.setValue(1);
@@ -253,7 +253,7 @@ describe('notebook/cells/model', () => {
     describe('#type', () => {
 
       it('should be set with type "raw"', () => {
-        let model = new RawCellModel();
+        let model = new RawCellModel({});
         expect(model.type).to.be('raw');
       });
 
@@ -266,7 +266,7 @@ describe('notebook/cells/model', () => {
     describe('#type', () => {
 
       it('should be set with type "markdown"', () => {
-        let model = new MarkdownCellModel();
+        let model = new MarkdownCellModel({});
         expect(model.type).to.be('markdown');
       });
 
@@ -279,7 +279,7 @@ describe('notebook/cells/model', () => {
     describe('#constructor()', () => {
 
       it('should create a code cell model', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         expect(model).to.be.a(CodeCellModel);
       });
 
@@ -308,7 +308,7 @@ describe('notebook/cells/model', () => {
           data: { 'text/plain': 'foo' },
           metadata: {}
         } as nbformat.IDisplayData;
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         let called = false;
         model.contentChanged.connect(() => { called = true; });
         expect(called).to.be(false);
@@ -321,7 +321,7 @@ describe('notebook/cells/model', () => {
     describe('#type', () => {
 
       it('should be set with type "code"', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         expect(model.type).to.be('code');
       });
 
@@ -342,14 +342,14 @@ describe('notebook/cells/model', () => {
       });
 
       it('should be settable', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         expect(model.executionCount).to.be(null);
         model.executionCount = 1;
         expect(model.executionCount).to.be(1);
       });
 
       it('should emit a state change signal when set', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         let called = false;
         model.stateChanged.connect(() => { called = true; });
         expect(model.executionCount).to.be(null);
@@ -360,7 +360,7 @@ describe('notebook/cells/model', () => {
       });
 
       it('should not signal when state has not changed', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         let called = 0;
         model.stateChanged.connect(() => { called++; });
         expect(model.executionCount).to.be(null);
@@ -376,7 +376,7 @@ describe('notebook/cells/model', () => {
     describe('#outputs', () => {
 
       it('should be an output area model', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         expect(model.outputs).to.be.an(OutputAreaModel);
       });
 
@@ -385,7 +385,7 @@ describe('notebook/cells/model', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the model', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         expect(model.outputs).to.be.an(OutputAreaModel);
         model.dispose();
         expect(model.isDisposed).to.be(true);
@@ -393,7 +393,7 @@ describe('notebook/cells/model', () => {
       });
 
       it('should be safe to call multiple times', () => {
-        let model = new CodeCellModel();
+        let model = new CodeCellModel({});
         model.dispose();
         model.dispose();
         expect(model.isDisposed).to.be(true);

--- a/test/src/notebook/cells/model.spec.ts
+++ b/test/src/notebook/cells/model.spec.ts
@@ -45,25 +45,25 @@ describe('notebook/cells/model', () => {
       });
 
       it('should accept a base cell argument', () => {
-        let base: nbformat.IBaseCell = {
+        let cell: nbformat.IBaseCell = {
           cell_type: 'raw',
           source: 'foo',
           metadata: { trusted: false }
         };
-        let model = new CellModel(base);
+        let model = new CellModel({ cell });
         expect(model).to.be.a(CellModel);
-        expect(model.value.text).to.equal(base.source);
+        expect(model.value.text).to.equal(cell.source);
       });
 
       it('should accept a base cell argument with a multiline source', () => {
-        let base: nbformat.IBaseCell = {
+        let cell: nbformat.IBaseCell = {
           cell_type: 'raw',
           source: ['foo', 'bar', 'baz'],
           metadata: { trusted: false }
         };
-        let model = new CellModel(base);
+        let model = new CellModel({ cell });
         expect(model).to.be.a(CellModel);
-        expect(model.value.text).to.equal((base.source as string[]).join('\n'));
+        expect(model.value.text).to.equal((cell.source as string[]).join('\n'));
       });
 
     });
@@ -190,26 +190,26 @@ describe('notebook/cells/model', () => {
     describe('#toJSON()', () => {
 
       it('should return a base cell encapsulation of the model value', () => {
-        let base: nbformat.IBaseCell = {
+        let cell: nbformat.IBaseCell = {
           cell_type: 'raw',
           source: 'foo',
           metadata: { trusted: false }
         };
-        let model = new TestModel(base);
-        expect(model.toJSON()).to.not.equal(base);
-        expect(model.toJSON()).to.eql(base);
+        let model = new TestModel({ cell });
+        expect(model.toJSON()).to.not.equal(cell);
+        expect(model.toJSON()).to.eql(cell);
       });
 
       it('should always return a string source', () => {
-        let base: nbformat.IBaseCell = {
+        let cell: nbformat.IBaseCell = {
           cell_type: 'raw',
           source: ['foo', 'bar', 'baz'],
           metadata: { trusted: false }
         };
-        let model = new TestModel(base);
-        base.source = (base.source as string[]).join('\n');
-        expect(model.toJSON()).to.not.equal(base);
-        expect(model.toJSON()).to.eql(base);
+        let model = new TestModel({ cell });
+        cell.source = (cell.source as string[]).join('\n');
+        expect(model.toJSON()).to.not.equal(cell);
+        expect(model.toJSON()).to.eql(cell);
       });
 
     });
@@ -297,7 +297,7 @@ describe('notebook/cells/model', () => {
           source: 'foo',
           metadata: { trusted: false }
         };
-        let model = new CodeCellModel(cell);
+        let model = new CodeCellModel({ cell });
         expect(model).to.be.a(CodeCellModel);
         expect(model.value.text).to.equal(cell.source);
       });
@@ -337,7 +337,7 @@ describe('notebook/cells/model', () => {
           source: 'foo',
           metadata: { trusted: false }
         };
-        let model = new CodeCellModel(cell);
+        let model = new CodeCellModel({ cell });
         expect(model.executionCount).to.be(1);
       });
 
@@ -420,12 +420,42 @@ describe('notebook/cells/model', () => {
           source: 'foo',
           metadata: { trusted: false }
         };
-        let model = new CodeCellModel(cell);
+        let model = new CodeCellModel({ cell });
         let serialized = model.toJSON();
         expect(serialized).to.not.equal(cell);
         expect(serialized).to.eql(cell);
         let output = serialized.outputs[0] as any;
         expect(output.data['application/json']['bar']).to.be(1);
+      });
+
+    });
+
+    describe('.ContentFactory', () => {
+
+      describe('#constructor()', () => {
+
+        it('should create a new output area factory', () => {
+          let factory = new CodeCellModel.ContentFactory();
+          expect(factory).to.be.a(CodeCellModel.ContentFactory);
+        });
+
+      });
+
+      describe('#createOutputArea()', () => {
+
+        it('should create an output area model', () => {
+          let factory = new CodeCellModel.ContentFactory();
+          expect(factory.createOutputArea()).to.be.an(OutputAreaModel);
+        });
+
+      });
+
+    });
+
+    describe('.defaultContentFactory', () => {
+
+      it('should be an ContentFactory', () => {
+        expect(CodeCellModel.defaultContentFactory).to.be.a(CodeCellModel.ContentFactory);
       });
 
     });

--- a/test/src/notebook/cells/widget.spec.ts
+++ b/test/src/notebook/cells/widget.spec.ts
@@ -45,7 +45,7 @@ class LogBaseCell extends BaseCellWidget {
   methods: string[] = [];
 
   constructor() {
-    super({ model: new CellModel(), contentFactory: createBaseCellFactory() });
+    super({ model: new CellModel({}), contentFactory: createBaseCellFactory() });
   }
 
   renderInput(widget: Widget): void {
@@ -90,7 +90,7 @@ class LogCodeCell extends CodeCellWidget {
   methods: string[] = [];
 
   constructor() {
-    super({ model: new CodeCellModel(), contentFactory: createCodeCellFactory(),
+    super({ model: new CodeCellModel({}), contentFactory: createCodeCellFactory(),
             rendermime });
   }
 
@@ -127,7 +127,7 @@ describe('notebook/cells/widget', () => {
   describe('BaseCellWidget', () => {
 
     let contentFactory = createBaseCellFactory();
-    let model = new CellModel();
+    let model = new CellModel({});
 
     describe('#constructor()', () => {
 
@@ -147,7 +147,7 @@ describe('notebook/cells/widget', () => {
     describe('#model', () => {
 
       it('should be the model used by the widget', () => {
-        let model = new CellModel();
+        let model = new CellModel({});
         let widget = new BaseCellWidget({ model, contentFactory });
         expect(widget.model).to.be(model);
       });
@@ -409,7 +409,7 @@ describe('notebook/cells/widget', () => {
   describe('CodeCellWidget', () => {
 
     let contentFactory = createCodeCellFactory();
-    let model = new CodeCellModel();
+    let model = new CodeCellModel({});
 
     describe('#constructor()', () => {
 
@@ -551,7 +551,7 @@ describe('notebook/cells/widget', () => {
   describe('MarkdownCellWidget', () => {
 
     let contentFactory = createBaseCellFactory();
-    let model = new MarkdownCellModel();
+    let model = new MarkdownCellModel({});
 
     describe('#constructor()', () => {
 
@@ -649,7 +649,7 @@ describe('notebook/cells/widget', () => {
     describe('#constructor()', () => {
 
       it('should create a raw cell widget', () => {
-        let model = new RawCellModel();
+        let model = new RawCellModel({});
         let widget = new RawCellWidget({ model, contentFactory });
         expect(widget).to.be.a(RawCellWidget);
       });

--- a/test/src/notebook/notebook/actions.spec.ts
+++ b/test/src/notebook/notebook/actions.spec.ts
@@ -70,7 +70,7 @@ describe('notebook/notebook/actions', () => {
       kernel.shutdown();
     });
 
-    describe('#splitCell()', () => {
+    describe('#splitCell({})', () => {
 
       it('should split the active cell into two cells', () => {
         let cell = widget.activeCell;
@@ -511,11 +511,11 @@ describe('notebook/notebook/actions', () => {
       });
 
       it('should stop executing code cells on an error', (done) => {
-        let cell = widget.model.factory.createCodeCell();
+        let cell = widget.model.contentFactory.createCodeCell({});
         cell.value.text = ERROR_INPUT;
         widget.model.cells.insert(2, cell);
         widget.select(widget.widgets.at(2));
-        cell = widget.model.factory.createCodeCell();
+        cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.pushBack(cell);
         widget.select(widget.widgets.at(widget.widgets.length - 1));
         NotebookActions.run(widget, kernel).then(result => {
@@ -526,7 +526,7 @@ describe('notebook/notebook/actions', () => {
       });
 
       it('should render all markdown cells on an error', () => {
-        let cell = widget.model.factory.createMarkdownCell();
+        let cell = widget.model.contentFactory.createMarkdownCell({});
         widget.model.cells.pushBack(cell);
         let child = widget.widgets.at(widget.widgets.length - 1) as MarkdownCellWidget;
         child.rendered = false;
@@ -618,7 +618,7 @@ describe('notebook/notebook/actions', () => {
 
       it('should stop executing code cells on an error', (done) => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.model.factory.createCodeCell();
+        let cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.pushBack(cell);
         widget.select(widget.widgets.at(widget.widgets.length - 1));
         NotebookActions.runAndAdvance(widget, kernel).then(result => {
@@ -706,7 +706,7 @@ describe('notebook/notebook/actions', () => {
 
       it('should stop executing code cells on an error', (done) => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.model.factory.createCodeCell();
+        let cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.pushBack(cell);
         widget.select(widget.widgets.at(widget.widgets.length - 1));
         NotebookActions.runAndInsert(widget, kernel).then(result => {
@@ -787,7 +787,7 @@ describe('notebook/notebook/actions', () => {
 
       it('should stop executing code cells on an error', (done) => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.model.factory.createCodeCell();
+        let cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.pushBack(cell);
         NotebookActions.runAll(widget, kernel).then(result => {
           expect(result).to.be(false);

--- a/test/src/notebook/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/notebook/default-toolbar.spec.ts
@@ -268,7 +268,7 @@ describe('notebook/notebook/default-toolbar', () => {
         let item = ToolbarItems.createCellTypeItem(panel);
         let node = item.node.getElementsByTagName('select')[0] as HTMLSelectElement;
         expect(node.value).to.be('code');
-        let cell = panel.model.factory.createCodeCell();
+        let cell = panel.model.contentFactory.createCodeCell({});
         panel.model.cells.insert(1, cell);
         panel.notebook.select(panel.notebook.widgets.at(1));
         expect(node.value).to.be('code');

--- a/test/src/notebook/notebook/model.spec.ts
+++ b/test/src/notebook/notebook/model.spec.ts
@@ -196,84 +196,6 @@ describe('notebook/notebook/model', () => {
         expect(model.contentFactory).to.be(NotebookModel.defaultContentFactory);
       });
 
-      context('createCodeCell({})', () => {
-
-        it('should create a new code cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
-          expect(cell.type).to.be('code');
-        });
-
-        it('should clone an existing code cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
-          cell.value.text = 'foo';
-          let newCell = model.contentFactory.createCodeCell(cell.toJSON());
-          expect(newCell.value.text).to.be('foo');
-        });
-
-        it('should clone an existing raw cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createRawCell({});
-          cell.value.text = 'foo';
-          let newCell = model.contentFactory.createCodeCell(cell.toJSON());
-          expect(newCell.value.text).to.be('foo');
-        });
-
-      });
-
-      context('createRawCell({})', () => {
-
-        it('should create a new raw cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createRawCell({});
-          expect(cell.type).to.be('raw');
-        });
-
-        it('should clone an existing raw cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createRawCell({});
-          cell.value.text = 'foo';
-          let newCell = model.contentFactory.createRawCell(cell.toJSON());
-          expect(newCell.value.text).to.be('foo');
-        });
-
-        it('should clone an existing code cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
-          cell.value.text = 'foo';
-          let newCell = model.contentFactory.createRawCell(cell.toJSON());
-          expect(newCell.value.text).to.be('foo');
-        });
-
-      });
-
-      describe('createMarkdownCell({})', () => {
-
-        it('should create a new markdown cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createMarkdownCell({});
-          expect(cell.type).to.be('markdown');
-        });
-
-        it('should clone an existing markdown cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createMarkdownCell({});
-          cell.value.text = 'foo';
-          let newCell = model.contentFactory.createMarkdownCell(cell.toJSON());
-          expect(newCell.value.text).to.be('foo');
-        });
-
-        it('should clone an existing raw cell', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createRawCell({});
-          cell.value.text = 'foo';
-          let newCell = model.contentFactory.createMarkdownCell(cell.toJSON());
-          expect(newCell.value.text).to.be('foo');
-        });
-
-      });
-
     });
 
     describe('#nbformat', () => {
@@ -468,6 +390,109 @@ describe('notebook/notebook/model', () => {
         cursor.setValue(1);
         keys.push('foo');
         expect(toArray(model.listMetadata())).to.eql(keys);
+      });
+
+    });
+
+    describe('.ContentFactory', () => {
+
+      let factory = new NotebookModel.ContentFactory({});
+
+      context('#codeCellContentFactory', () => {
+
+        it('should be an output area factory', () => {
+          expect(factory.outputAreaFactory).to.be(CodeCellModel.defaultOutputAreaFactory);
+        });
+
+        it('should be settable in the constructor', () => {
+          let outputAreaFactory = new CodeCellModel.OutputAreaFactory();
+          factory = new NotebookModel.ContentFactory({ outputAreaFactory });
+          expect(factory.outputAreaFactory).to.be(outputAreaFactory);
+        });
+
+      });
+
+      context('#createCodeCell()', () => {
+
+        it('should create a new code cell', () => {
+          let cell = factory.createCodeCell({});
+          expect(cell.type).to.be('code');
+        });
+
+        it('should clone an existing code cell', () => {
+          let orig = factory.createCodeCell({});
+          orig.value.text = 'foo';
+          let cell = orig.toJSON();
+          let newCell = factory.createCodeCell({ cell });
+          expect(newCell.value.text).to.be('foo');
+        });
+
+        it('should clone an existing raw cell', () => {
+          let orig = factory.createRawCell({});
+          orig.value.text = 'foo';
+          let cell = orig.toJSON();
+          let newCell = factory.createCodeCell({ cell });
+          expect(newCell.value.text).to.be('foo');
+        });
+
+      });
+
+      context('#createRawCell()', () => {
+
+        it('should create a new raw cell', () => {
+          let cell = factory.createRawCell({});
+          expect(cell.type).to.be('raw');
+        });
+
+        it('should clone an existing raw cell', () => {
+          let orig = factory.createRawCell({});
+          orig.value.text = 'foo';
+          let cell = orig.toJSON();
+          let newCell = factory.createRawCell({ cell });
+          expect(newCell.value.text).to.be('foo');
+        });
+
+        it('should clone an existing code cell', () => {
+          let orig = factory.createCodeCell({});
+          orig.value.text = 'foo';
+          let cell = orig.toJSON();
+          let newCell = factory.createRawCell({ cell });
+          expect(newCell.value.text).to.be('foo');
+        });
+
+      });
+
+      describe('#createMarkdownCell()', () => {
+
+        it('should create a new markdown cell', () => {
+          let cell = factory.createMarkdownCell({});
+          expect(cell.type).to.be('markdown');
+        });
+
+        it('should clone an existing markdown cell', () => {
+          let orig = factory.createMarkdownCell({});
+          orig.value.text = 'foo';
+          let cell = orig.toJSON();
+          let newCell = factory.createMarkdownCell({ cell });
+          expect(newCell.value.text).to.be('foo');
+        });
+
+        it('should clone an existing raw cell', () => {
+          let orig = factory.createRawCell({});
+          orig.value.text = 'foo';
+          let cell = orig.toJSON();
+          let newCell = factory.createMarkdownCell({ cell });
+          expect(newCell.value.text).to.be('foo');
+        });
+
+      });
+
+    });
+
+    describe('.defaultContentFactory', () => {
+
+      it('should be a ContentFactory', () => {
+        expect(NotebookModel.defaultContentFactory).to.be.a(NotebookModel.ContentFactory);
       });
 
     });

--- a/test/src/notebook/notebook/model.spec.ts
+++ b/test/src/notebook/notebook/model.spec.ts
@@ -53,9 +53,9 @@ describe('notebook/notebook/model', () => {
       });
 
       it('should accept an optional factory', () => {
-        let factory = new NotebookModel.Factory();
-        let model = new NotebookModel({ factory });
-        expect(model.factory).to.be(factory);
+        let contentFactory = new NotebookModel.ContentFactory({});
+        let model = new NotebookModel({ contentFactory });
+        expect(model.contentFactory).to.be(contentFactory);
       });
 
     });
@@ -99,7 +99,7 @@ describe('notebook/notebook/model', () => {
 
       it('should be reset when loading from disk', () => {
         let model = new NotebookModel();
-        let cell = model.factory.createCodeCell();
+        let cell = model.contentFactory.createCodeCell({});
         model.cells.pushBack(cell);
         model.fromJSON(DEFAULT_CONTENT);
         expect(indexOf(model.cells, cell)).to.be(-1);
@@ -108,7 +108,7 @@ describe('notebook/notebook/model', () => {
 
       it('should allow undoing a change', () => {
         let model = new NotebookModel();
-        let cell = model.factory.createCodeCell();
+        let cell = model.contentFactory.createCodeCell({});
         cell.value.text = 'foo';
         model.cells.pushBack(cell);
         model.fromJSON(DEFAULT_CONTENT);
@@ -122,7 +122,7 @@ describe('notebook/notebook/model', () => {
 
         it('should emit a `contentChanged` signal', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           let called = false;
           model.contentChanged.connect(() => { called = true; });
           model.cells.pushBack(cell);
@@ -131,14 +131,14 @@ describe('notebook/notebook/model', () => {
 
         it('should set the dirty flag', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           model.cells.pushBack(cell);
           expect(model.dirty).to.be(true);
         });
 
         it('should dispose of old cells', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           model.cells.pushBack(cell);
           model.cells.clear();
           expect(cell.isDisposed).to.be(true);
@@ -160,14 +160,14 @@ describe('notebook/notebook/model', () => {
 
         it('should be called when a cell content changes', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           model.cells.pushBack(cell);
           cell.value.text = 'foo';
         });
 
         it('should emit the `contentChanged` signal', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           model.cells.pushBack(cell);
           let called = false;
           model.contentChanged.connect(() => { called = true; });
@@ -178,7 +178,7 @@ describe('notebook/notebook/model', () => {
 
         it('should set the dirty flag', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           model.cells.pushBack(cell);
           model.dirty = false;
           cell.value.text = 'foo';
@@ -189,86 +189,86 @@ describe('notebook/notebook/model', () => {
 
     });
 
-    describe('#factory', () => {
+    describe('#contentFactory', () => {
 
       it('should be the cell model factory used by the model', () => {
         let model = new NotebookModel();
-        expect(model.factory).to.be(NotebookModel.defaultFactory);
+        expect(model.contentFactory).to.be(NotebookModel.defaultContentFactory);
       });
 
-      context('createCodeCell()', () => {
+      context('createCodeCell({})', () => {
 
         it('should create a new code cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           expect(cell.type).to.be('code');
         });
 
         it('should clone an existing code cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           cell.value.text = 'foo';
-          let newCell = model.factory.createCodeCell(cell.toJSON());
+          let newCell = model.contentFactory.createCodeCell(cell.toJSON());
           expect(newCell.value.text).to.be('foo');
         });
 
         it('should clone an existing raw cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createRawCell();
+          let cell = model.contentFactory.createRawCell({});
           cell.value.text = 'foo';
-          let newCell = model.factory.createCodeCell(cell.toJSON());
+          let newCell = model.contentFactory.createCodeCell(cell.toJSON());
           expect(newCell.value.text).to.be('foo');
         });
 
       });
 
-      context('createRawCell()', () => {
+      context('createRawCell({})', () => {
 
         it('should create a new raw cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createRawCell();
+          let cell = model.contentFactory.createRawCell({});
           expect(cell.type).to.be('raw');
         });
 
         it('should clone an existing raw cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createRawCell();
+          let cell = model.contentFactory.createRawCell({});
           cell.value.text = 'foo';
-          let newCell = model.factory.createRawCell(cell.toJSON());
+          let newCell = model.contentFactory.createRawCell(cell.toJSON());
           expect(newCell.value.text).to.be('foo');
         });
 
         it('should clone an existing code cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createCodeCell();
+          let cell = model.contentFactory.createCodeCell({});
           cell.value.text = 'foo';
-          let newCell = model.factory.createRawCell(cell.toJSON());
+          let newCell = model.contentFactory.createRawCell(cell.toJSON());
           expect(newCell.value.text).to.be('foo');
         });
 
       });
 
-      describe('createMarkdownCell()', () => {
+      describe('createMarkdownCell({})', () => {
 
         it('should create a new markdown cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createMarkdownCell();
+          let cell = model.contentFactory.createMarkdownCell({});
           expect(cell.type).to.be('markdown');
         });
 
         it('should clone an existing markdown cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createMarkdownCell();
+          let cell = model.contentFactory.createMarkdownCell({});
           cell.value.text = 'foo';
-          let newCell = model.factory.createMarkdownCell(cell.toJSON());
+          let newCell = model.contentFactory.createMarkdownCell(cell.toJSON());
           expect(newCell.value.text).to.be('foo');
         });
 
         it('should clone an existing raw cell', () => {
           let model = new NotebookModel();
-          let cell = model.factory.createRawCell();
+          let cell = model.contentFactory.createRawCell({});
           cell.value.text = 'foo';
-          let newCell = model.factory.createMarkdownCell(cell.toJSON());
+          let newCell = model.contentFactory.createMarkdownCell(cell.toJSON());
           expect(newCell.value.text).to.be('foo');
         });
 

--- a/test/src/notebook/notebook/model.spec.ts
+++ b/test/src/notebook/notebook/model.spec.ts
@@ -400,14 +400,14 @@ describe('notebook/notebook/model', () => {
 
       context('#codeCellContentFactory', () => {
 
-        it('should be an output area factory', () => {
-          expect(factory.outputAreaFactory).to.be(CodeCellModel.defaultOutputAreaFactory);
+        it('should be a code cell content factory', () => {
+          expect(factory.codeCellContentFactory).to.be(CodeCellModel.defaultContentFactory);
         });
 
         it('should be settable in the constructor', () => {
-          let outputAreaFactory = new CodeCellModel.OutputAreaFactory();
-          factory = new NotebookModel.ContentFactory({ outputAreaFactory });
-          expect(factory.outputAreaFactory).to.be(outputAreaFactory);
+          let codeCellContentFactory = new CodeCellModel.ContentFactory();
+          factory = new NotebookModel.ContentFactory({ codeCellContentFactory });
+          expect(factory.codeCellContentFactory).to.be(codeCellContentFactory);
         });
 
       });

--- a/test/src/notebook/notebook/modelfactory.spec.ts
+++ b/test/src/notebook/notebook/modelfactory.spec.ts
@@ -19,7 +19,7 @@ describe('notebook/notebook/modelfactory', () => {
     describe('#name', () => {
 
       it('should get the name of the model factory', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         expect(factory.name).to.be('notebook');
       });
 
@@ -28,7 +28,7 @@ describe('notebook/notebook/modelfactory', () => {
     describe('#contentType', () => {
 
       it('should get the file type', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         expect(factory.contentType).to.be('notebook');
       });
 
@@ -37,7 +37,7 @@ describe('notebook/notebook/modelfactory', () => {
     describe('#fileFormat', () => {
 
       it('should get the file format', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         expect(factory.fileFormat).to.be('json');
       });
 
@@ -46,7 +46,7 @@ describe('notebook/notebook/modelfactory', () => {
     describe('#isDisposed', () => {
 
       it('should get whether the factory is disposed', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         expect(factory.isDisposed).to.be(false);
         factory.dispose();
         expect(factory.isDisposed).to.be(true);
@@ -57,13 +57,13 @@ describe('notebook/notebook/modelfactory', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the model factory', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         factory.dispose();
         expect(factory.isDisposed).to.be(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         factory.dispose();
         factory.dispose();
         expect(factory.isDisposed).to.be(true);
@@ -74,20 +74,20 @@ describe('notebook/notebook/modelfactory', () => {
     describe('#createNew()', () => {
 
       it('should create a new model for a given path', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         let model = factory.createNew();
         expect(model).to.be.a(NotebookModel);
       });
 
       it('should add an empty code cell by default', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         let model = factory.createNew();
         expect(model.cells.length).to.be(1);
         expect(model.cells.at(0).type).to.be('code');
       });
 
       it('should accept a language preference', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         let model = factory.createNew('foo');
         expect(model.defaultKernelLanguage).to.be('foo');
       });
@@ -97,7 +97,7 @@ describe('notebook/notebook/modelfactory', () => {
     describe('#preferredLanguage()', () => {
 
       it('should always return an empty string', () => {
-        let factory = new NotebookModelFactory();
+        let factory = new NotebookModelFactory({});
         expect(factory.preferredLanguage('')).to.be('');
         expect(factory.preferredLanguage('.ipynb')).to.be('');
       });

--- a/test/src/notebook/notebook/modelfactory.spec.ts
+++ b/test/src/notebook/notebook/modelfactory.spec.ts
@@ -15,10 +15,6 @@ import {
   NotebookModelFactory
 } from '../../../../lib/notebook/notebook/modelfactory';
 
-import {
-  OutputAreaModel
-} from '../../../../lib/notebook/output-area';
-
 
 describe('notebook/notebook/modelfactory', () => {
 
@@ -31,10 +27,25 @@ describe('notebook/notebook/modelfactory', () => {
         expect(factory).to.be.a(NotebookModelFactory);
       });
 
-      it('should accept an output area factory', () => {
-        let outputAreaFactory = new CodeCellModel.OutputAreaFactory();
-        let factory = new NotebookModelFactory({ outputAreaFactory });
-        expect(factory);
+      it('should accept a code cell content factory', () => {
+        let codeCellContentFactory = new CodeCellModel.ContentFactory();
+        let factory = new NotebookModelFactory({ codeCellContentFactory });
+        expect(factory.contentFactory.codeCellContentFactory).to.be(codeCellContentFactory);
+      });
+
+      it('should accept a notebook model content factory', () => {
+        let contentFactory = new NotebookModel.ContentFactory({});
+        let factory = new NotebookModelFactory({ contentFactory });
+        expect(factory.contentFactory).to.be(contentFactory);
+      });
+
+    });
+
+    describe('#contentFactory', () => {
+
+      it('should be the content factory used by the model factory', () => {
+        let factory = new NotebookModelFactory({});
+        expect(factory.contentFactory).to.be.a(NotebookModel.ContentFactory);
       });
 
     });

--- a/test/src/notebook/notebook/modelfactory.spec.ts
+++ b/test/src/notebook/notebook/modelfactory.spec.ts
@@ -4,6 +4,10 @@
 import expect = require('expect.js');
 
 import {
+  CodeCellModel
+} from '../../../../lib/notebook/cells/model';
+
+import {
   NotebookModel
 } from '../../../../lib/notebook/notebook/model';
 
@@ -11,10 +15,29 @@ import {
   NotebookModelFactory
 } from '../../../../lib/notebook/notebook/modelfactory';
 
+import {
+  OutputAreaModel
+} from '../../../../lib/notebook/output-area';
+
 
 describe('notebook/notebook/modelfactory', () => {
 
-  describe('NotebookModel', () => {
+  describe('NotebookModelFactory', () => {
+
+    describe('#constructor', () => {
+
+      it('should create a new notebook model factory', () => {
+        let factory = new NotebookModelFactory({});
+        expect(factory).to.be.a(NotebookModelFactory);
+      });
+
+      it('should accept an output area factory', () => {
+        let outputAreaFactory = new CodeCellModel.OutputAreaFactory();
+        let factory = new NotebookModelFactory({ outputAreaFactory });
+        expect(factory);
+      });
+
+    });
 
     describe('#name', () => {
 

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -191,7 +191,7 @@ describe('notebook/notebook/widget', () => {
         widget.model = new NotebookModel();
         let called = false;
         widget.modelContentChanged.connect(() => { called = true; });
-        let cell = widget.model.factory.createCodeCell();
+        let cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.pushBack(cell);
         expect(called).to.be(true);
       });
@@ -292,7 +292,7 @@ describe('notebook/notebook/widget', () => {
         });
 
         it('should handle an add', () => {
-          let cell = widget.model.factory.createCodeCell();
+          let cell = widget.model.contentFactory.createCodeCell({});
           widget.model.cells.pushBack(cell);
           expect(widget.widgets.length).to.be(7);
           let child = widget.widgets.at(0);
@@ -306,7 +306,8 @@ describe('notebook/notebook/widget', () => {
         });
 
         it('should handle a clear', () => {
-          let cell = widget.model.factory.createCodeCell();
+          let cell = widget.model.contentFactory.createCodeCell({});
+          widget.model.cells.pushBack(cell);
           widget.model.cells.clear();
           expect(widget.widgets.length).to.be(0);
         });
@@ -506,12 +507,12 @@ describe('notebook/notebook/widget', () => {
 
       });
 
-      describe('#createCodeCell()', () => {
+      describe('#createCodeCell({})', () => {
 
         it('should create a `CodeCellWidget`', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
           let contentFactory = factory.codeCellContentFactory;
-          let model = new CodeCellModel();
+          let model = new CodeCellModel({});
           let codeOptions = { model, rendermime, contentFactory };
           let parent = new StaticNotebook(options);
           let widget = factory.createCodeCell(codeOptions, parent);
@@ -520,12 +521,12 @@ describe('notebook/notebook/widget', () => {
 
       });
 
-      describe('#createMarkdownCell()', () => {
+      describe('#createMarkdownCell({})', () => {
 
         it('should create a `MarkdownCellWidget`', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
           let contentFactory = factory.markdownCellContentFactory;
-          let model = new MarkdownCellModel();
+          let model = new MarkdownCellModel({});
           let mdOptions = { model, rendermime, contentFactory };
           let parent = new StaticNotebook(options);
           let widget = factory.createMarkdownCell(mdOptions, parent);
@@ -539,7 +540,7 @@ describe('notebook/notebook/widget', () => {
         it('should create a `RawCellWidget`', () => {
           let factory = new StaticNotebook.ContentFactory({ editorFactory });
           let contentFactory = factory.rawCellContentFactory;
-          let model = new RawCellModel();
+          let model = new RawCellModel({});
           let rawOptions = { model, contentFactory };
           let parent = new StaticNotebook(options);
           let widget = factory.createRawCell(rawOptions, parent);
@@ -696,7 +697,7 @@ describe('notebook/notebook/widget', () => {
         let widget = createActiveWidget();
         Widget.attach(widget, document.body);
         sendMessage(widget, WidgetMessage.ActivateRequest);
-        let cell = widget.model.factory.createMarkdownCell();
+        let cell = widget.model.contentFactory.createMarkdownCell({});
         widget.model.cells.pushBack(cell);
         let child = widget.widgets.at(widget.widgets.length - 1) as MarkdownCellWidget;
         expect(child.rendered).to.be(true);
@@ -888,7 +889,7 @@ describe('notebook/notebook/widget', () => {
         });
 
         it('should preserve "command" mode if in a markdown cell', () => {
-          let cell = widget.model.factory.createMarkdownCell();
+          let cell = widget.model.contentFactory.createMarkdownCell({});
           widget.model.cells.pushBack(cell);
           let count = widget.widgets.length;
           let child = widget.widgets.at(count - 1) as MarkdownCellWidget;
@@ -903,7 +904,7 @@ describe('notebook/notebook/widget', () => {
       context('dblclick', () => {
 
         it('should unrender a markdown cell', () => {
-          let cell = widget.model.factory.createMarkdownCell();
+          let cell = widget.model.contentFactory.createMarkdownCell({});
           widget.model.cells.pushBack(cell);
           let child = widget.widgets.at(widget.widgets.length - 1) as MarkdownCellWidget;
           expect(child.rendered).to.be(true);
@@ -914,7 +915,7 @@ describe('notebook/notebook/widget', () => {
         });
 
         it('should be a no-op if the model is read only', () => {
-          let cell = widget.model.factory.createMarkdownCell();
+          let cell = widget.model.contentFactory.createMarkdownCell({});
           widget.model.cells.pushBack(cell);
           widget.model.readOnly = true;
           let child = widget.widgets.at(widget.widgets.length - 1) as MarkdownCellWidget;

--- a/test/src/notebook/utils.ts
+++ b/test/src/notebook/utils.ts
@@ -73,7 +73,7 @@ function createCodeCellFactory(): CodeCellWidget.IContentFactory {
 export
 function createCellEditor(model?: CodeCellModel): CodeEditorWidget {
   return new CodeEditorWidget({
-    model: model || new CodeCellModel(),
+    model: model || new CodeCellModel({}),
     factory: editorFactory
   });
 }

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -134,7 +134,7 @@ namespace Private {
   const textFactory = new TextModelFactory();
 
   export
-  const notebookFactory = new NotebookModelFactory();
+  const notebookFactory = new NotebookModelFactory({});
 
 
   class JSONRenderer extends HTMLRenderer {


### PR DESCRIPTION
Fixes #1499.

Allows override of cell and output area models from the notebook and console level.