### PR TITLE
Cleanup for 0.13 Release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
       PYTHON_VERSION: "3.5.x"
       PYTHON_MAJOR: 3
       PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_MAJOR: 2
-      PYTHON_ARCH: "32"
 
 # build cache to preserve files/folders between builds
 cache:

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -115,12 +115,11 @@ class ConsolePanel extends Panel {
     if (this._completer == null) {
       return;
     }
-    let completer = this._completer;
+    this._completer.dispose();
     this._completer = null;
-    completer.dispose();
-    this.console.dispose();
     this._completerHandler.dispose();
     this._completerHandler = null;
+    this.console.dispose();
     this.inspectionHandler.dispose();
     super.dispose();
   }

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -122,6 +122,7 @@ class ConsolePanel extends Panel {
     if (this.isDisposed) {
       return;
     }
+    super.dispose();
     let completer = this._completer;
     this._completer = null;
     completer.dispose();
@@ -129,7 +130,6 @@ class ConsolePanel extends Panel {
     this._completerHandler.dispose();
     this._completerHandler = null;
     this.inspectionHandler.dispose();
-    super.dispose();
   }
 
   /**

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -109,20 +109,12 @@ class ConsolePanel extends Panel {
   readonly inspectionHandler: InspectionHandler;
 
   /**
-   * Test whether the widget is disposed.
-   */
-  get isDisposed(): boolean {
-    return this._completer == null;
-  }
-
-  /**
    * Dispose of the resources held by the widget.
    */
   dispose(): void {
-    if (this.isDisposed) {
+    if (this._completer == null) {
       return;
     }
-    super.dispose();
     let completer = this._completer;
     this._completer = null;
     completer.dispose();
@@ -130,6 +122,7 @@ class ConsolePanel extends Panel {
     this._completerHandler.dispose();
     this._completerHandler = null;
     this.inspectionHandler.dispose();
+    super.dispose();
   }
 
   /**

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -115,10 +115,13 @@ class ConsolePanel extends Panel {
     if (this._completer === null) {
       return;
     }
-    this._completer.dispose();
+    let completer = this._completer;
+    let completerHandler = this._completerHandler;
     this._completer = null;
-    this._completerHandler.dispose();
     this._completerHandler = null;
+    completer.dispose();
+    completerHandler.dispose();
+
     this.console.dispose();
     this.inspectionHandler.dispose();
     super.dispose();

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -112,7 +112,7 @@ class ConsolePanel extends Panel {
    * Dispose of the resources held by the widget.
    */
   dispose(): void {
-    if (this._completer == null) {
+    if (this._completer === null) {
       return;
     }
     this._completer.dispose();

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -62,7 +62,7 @@ import {
 } from '../services';
 
 import {
-  IConsoleTracker, ConsolePanel, CodeConsole
+  IConsoleTracker, ConsolePanel
 } from './index';
 
 
@@ -174,7 +174,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   command = 'console:create';
   commands.addCommand(command, {
     execute: (args: ICreateConsoleArgs) => {
-      let name = `CodeConsole ${++count}`;
+      let name = `Console ${++count}`;
 
       args = args || {};
 
@@ -183,7 +183,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
         return manager.ready.then(() => manager.connectTo(args.id))
           .then(session => {
             name = session.path.split('/').pop();
-            name = `CodeConsole ${name.match(CONSOLE_REGEX)[1]}`;
+            name = `Console ${name.match(CONSOLE_REGEX)[1]}`;
             createConsole(session, name);
             return session.id;
           });
@@ -218,7 +218,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
 
   command = 'console:create-new';
   commands.addCommand(command, {
-    label: 'Start New CodeConsole',
+    label: 'Start New Console',
     execute: () => commands.execute('console:create', { })
   });
   palette.addItem({ command, category });

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -386,8 +386,9 @@ class NotebookPanel extends Widget {
    * Handle a change to the active cell.
    */
   private _onActiveCellChanged(sender: Notebook, widget: BaseCellWidget) {
-    this.inspectionHandler.editor = widget.editor;
-    this._completerHandler.editor = widget.editor;
+    let editor = widget ? widget.editor : null;
+    this.inspectionHandler.editor = editor;
+    this._completerHandler.editor = editor;
   }
 
   private _completer: CompleterWidget = null;

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -48,7 +48,7 @@ import {
 
 import {
   INotebookTracker, NotebookModelFactory, NotebookPanel, NotebookTracker,
-  NotebookWidgetFactory, NotebookActions, Notebook, trustNotebook
+  NotebookWidgetFactory, NotebookActions, trustNotebook
 } from './index';
 
 


### PR DESCRIPTION
Based on UAT for 0.13 release.

- Fixes console error when the notebook activeCell is `null`.
- Fixes disposal logic error in Console Panel that prevented the `disposed` signal from firing, which manifested as closed Consoles still showing up after a refresh.
- Removes extraneous imports and changes `CodeConsole` -> `Console` where appropriate for user display.