### PR TITLE
Pin python to 3.5 to correct RTD build

### DIFF
--- a/tutorial/environment.yml
+++ b/tutorial/environment.yml
@@ -2,7 +2,7 @@ name: lab_tutorial
 channels:
   - conda-forge
 dependencies:
-- python=3
+- python==3.5
 - sphinx>1.4
 - sphinx_rtd_theme
 - pip:


### PR DESCRIPTION
There's open issues currently on RTD re: Python 3.6 support. We need to pin to 3.5 until RTD supports 3.6 or the build fails.