### PR TITLE
Clean up test runner

### DIFF
--- a/test/run-test.py
+++ b/test/run-test.py
@@ -6,35 +6,18 @@ from __future__ import print_function, absolute_import
 import atexit
 import json
 import os
+from subprocess import Popen
 import sys
 import shutil
 import tempfile
 
+from tornado import gen
 from tornado.ioloop import IOLoop
-from tornado.process import Subprocess
 from notebook.notebookapp import NotebookApp
 from traitlets import Bool, Unicode
 
 
 HERE = os.path.dirname(__file__)
-
-
-def create_notebook_dir():
-    """Create a temporary directory with some file structure."""
-    root_dir = tempfile.mkdtemp(prefix='mock_contents')
-    os.mkdir(os.path.join(root_dir, 'src'))
-    with open(os.path.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
-        fid.write('hello')
-    atexit.register(lambda: shutil.rmtree(root_dir, True))
-    return root_dir
-
-
-def run_command(cmd):
-    """Run a task in a thread and exit with the return code."""
-    shell = os.name == 'nt'
-    p = Subprocess(cmd, shell=shell)
-    print('\n\nRunning command: "%s"\n\n' % ' '.join(cmd))
-    p.set_exit_callback(sys.exit)
 
 
 def get_command(nbapp):
@@ -57,35 +40,72 @@ def get_command(nbapp):
         document.body.appendChild(node);
         """ % json.dumps(config))
 
-    return ['karma', 'start'] + ARGS
+    return ['karma', 'start'] + sys.argv[1:]
+
+
+def create_notebook_dir():
+    """Create a temporary directory with some file structure."""
+    root_dir = tempfile.mkdtemp(prefix='mock_contents')
+    os.mkdir(os.path.join(root_dir, 'src'))
+    with open(os.path.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
+        fid.write('hello')
+    atexit.register(lambda: shutil.rmtree(root_dir, True))
+    return root_dir
+
+
+@gen.coroutine
+def run(cmd):
+    """Run the cmd and exit with the return code"""
+    yield gen.moment  # sync up with the ioloop
+
+    shell = os.name == 'nt'
+    proc = Popen(cmd, shell=shell)
+    print('\n\nRunning command: "%s"\n\n' % ' '.join(cmd))
+
+    # Poll the process once per second until finished.
+    while 1:
+        yield gen.sleep(1)
+        if proc.poll() is not None:
+            break
+
+    exit(proc.returncode)
+
+
+@gen.coroutine
+def exit(code):
+    """Safely stop the app and then exit with the given code."""
+    yield gen.moment   # sync up with the ioloop
+    IOLoop.current().stop()
+    sys.exit(code)
 
 
 class TestApp(NotebookApp):
-    """A notebook app that runs a karma test."""
+    """A notebook app that supports a unit test."""
 
     open_browser = Bool(False)
     notebook_dir = Unicode(create_notebook_dir())
     allow_origin = Unicode('*')
 
-    def start(self):
-        # Cannot run against Notebook 4.3.0 due to auth incompatibilities.
-        if self.version == '4.3.0':
-            msg = ('Cannot run unit tests against Notebook 4.3.0.  '
-                   'Please upgrade to Notebook 4.3.1+')
-            self.log.error(msg)
-            sys.exit(1)
 
-        # Run the command after the ioloop starts.
-        IOLoop.current().add_callback(run_command, get_command(self))
-        super(TestApp, self).start()
+def main():
+    """Run the unit test."""
+    app = TestApp()
+
+    if app.version == '4.3.0':
+        msg = ('Cannot run unit tests against Notebook 4.3.0.  '
+               'Please upgrade to Notebook 4.3.1+')
+        print(msg)
+        sys.exit(1)
+
+    app.initialize([])  # reserve sys.argv for the command
+    cmd = get_command(app)
+    run(cmd)
+
+    try:
+        app.start()
+    except KeyboardInterrupt:
+        exit(1)
 
 
 if __name__ == '__main__':
-    # Reserve the command line arguments for karma.
-    ARGS = sys.argv[1:]
-    sys.argv = sys.argv[:1]
-
-    try:
-        nbapp = TestApp.launch_instance()
-    except KeyboardInterrupt:
-        nbapp.stop()
+    main()


### PR DESCRIPTION
Cleans up the test runner to use tornado coroutines.  The previous method was brittle and resulted in shutdown errors.  Also, tornado's `Subprocess` does not work on Windows.