### PR TITLE
Fix labapp bootstrap

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -215,7 +215,7 @@ def bootstrap_from_nbapp(nbapp):
     """Bootstrap the lab app on top of a notebook app.
     """
     labapp = LabApp()
-    labapp.load_config_file()
+    labapp.initialize()
     webapp = nbapp.web_app
     labapp.add_lab_handlers(webapp)
     labapp.add_labextensions(webapp)


### PR DESCRIPTION
Fixes #1516.  Verified by:

- Disabled an extension in the main config
- Ran `jupyter notebook`
- Browsed to `/lab`
- Verified that extension was not loaded

Then:
- Enabled the extension in `test.json`
- Ran `jupyter notebook --LabApp.config_file_name=test.json`
- Browsed to `/lab`
- Verified that the extension was loaded.

Thanks to @rsinha25 for the detailed report!