### PR TITLE
Support dotted extensions

### DIFF
--- a/src/csvwidget/widget.ts
+++ b/src/csvwidget/widget.ts
@@ -185,27 +185,6 @@ namespace CSVWidget {
 export
 class CSVWidgetFactory extends ABCWidgetFactory<CSVWidget, DocumentRegistry.IModel> {
   /**
-   * The name of the widget to display in dialogs.
-   */
-  get name(): string {
-    return 'Table';
-  }
-
-  /**
-   * The file extensions the widget can view.
-   */
-  get fileExtensions(): string[] {
-    return ['.csv'];
-  }
-
-  /**
-   * The file extensions for which the factory should be the default.
-   */
-  get defaultFor(): string[] {
-    return ['.csv'];
-  }
-
-  /**
    * Create a new widget given a context.
    */
   protected createNewWidget(context: DocumentRegistry.Context): CSVWidget {

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -199,7 +199,8 @@ class DocumentManager implements IDisposable {
    */
   findWidget(path: string, widgetName='default'): Widget {
     if (widgetName === 'default') {
-      let factory = this._registry.defaultWidgetFactory(ContentsManager.extname(path));
+      let extname = DocumentRegistry.extname(path);
+      let factory = this._registry.defaultWidgetFactory(extname);
       if (!factory) {
         return;
       }
@@ -317,7 +318,8 @@ class DocumentManager implements IDisposable {
   private _widgetFactoryFor(path: string, widgetName: string): DocumentRegistry.WidgetFactory {
     let registry = this._registry;
     if (widgetName === 'default') {
-      let factory = registry.defaultWidgetFactory(ContentsManager.extname(path));
+      let extname = DocumentRegistry.extname(path);
+      let factory = registry.defaultWidgetFactory(extname);
       if (!factory) {
         return;
       }

--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -53,7 +53,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     this._factory = options.factory;
     this._opener = options.opener;
     this._path = options.path;
-    let ext = ContentsManager.extname(this._path);
+    let ext = DocumentRegistry.extname(this._path);
     let lang = this._factory.preferredLanguage(ext);
     this._model = this._factory.createNew(lang);
     manager.sessions.runningChanged.connect(this._onSessionsChanged, this);

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Contents, Kernel
+  Contents, ContentsManager, Kernel
 } from '@jupyterlab/services';
 
 import {
@@ -751,7 +751,8 @@ namespace DocumentRegistry {
      *
      * #### Notes
      * Use "*" to denote all files. Specific file extensions must be preceded
-     * with '.', like '.png', '.txt', etc.
+     * with '.', like '.png', '.txt', etc.  They may themselves contain a
+     * period (e.g. .table.json).
      */
     readonly fileExtensions: string[];
 
@@ -910,7 +911,8 @@ namespace DocumentRegistry {
     readonly name: string;
 
     /**
-     * The extension of the file type (e.g. `".txt"`).
+     * The extension of the file type (e.g. `".txt"`).  Can be a compound
+     * extension (e.g. `".table.json:`).
      */
     readonly extension: string;
 
@@ -980,6 +982,21 @@ namespace DocumentRegistry {
      * Whether the item was added or removed.
      */
     readonly change: 'added' | 'removed';
+  }
+
+  /**
+   * Get the extension name of a path.
+   *
+   * @param file - string.
+   *
+   * #### Notes
+   * Dotted filenames (e.g. `".table.json"` are allowed.
+   */
+  export
+  function extname(path: string): string {
+    let parts = ContentsManager.basename(path).split('.');
+    parts.shift();
+    return '.' + parts.join('.');
   }
 }
 

--- a/src/filebrowser/dialogs.ts
+++ b/src/filebrowser/dialogs.ts
@@ -141,7 +141,7 @@ class OpenWithHandler extends Widget {
     this._manager = manager;
 
     this.inputNode.textContent = path;
-    this._ext = path.split('.').pop();
+    this._ext = DocumentRegistry.extname(path);
 
     this.populateFactories();
     this.widgetDropdown.onchange = this.widgetChanged.bind(this);
@@ -454,7 +454,7 @@ class CreateNewHandler extends Widget {
    * Get the current extension for the file.
    */
   get ext(): string {
-    return this.inputNode.value.split('.').pop();
+    return DocumentRegistry.extname(this.inputNode.value);
   }
 
   /**

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -26,7 +26,7 @@ import {
 } from '../docmanager';
 
 import {
-  IDocumentRegistry
+  IDocumentRegistry, DocumentRegistry
 } from '../docregistry';
 
 import {
@@ -152,7 +152,7 @@ function activate(app: JupyterLab, manager: IServiceManager, documentManager: ID
   node.addEventListener('contextmenu', (event: MouseEvent) => {
     event.preventDefault();
     let path = fbWidget.pathForClick(event) || '';
-    let ext = '.' + path.split('.').pop();
+    let ext = DocumentRegistry.extname(path);
     let factories = registry.preferredWidgetFactories(ext);
     let widgetNames = toArray(map(factories, factory => factory.name));
     let prefix = `file-browser-contextmenu-${++Private.id}`;

--- a/test/src/docregistry/registry.spec.ts
+++ b/test/src/docregistry/registry.spec.ts
@@ -43,8 +43,8 @@ class WidgetExtension implements DocumentRegistry.WidgetExtension {
 function createFactory() {
   return new WidgetFactory({
     name: utils.uuid(),
-    fileExtensions: ['.txt'],
-    defaultFor: ['.txt']
+    fileExtensions: ['.txt', '.foo.bar'],
+    defaultFor: ['.txt', '.foo.bar']
   });
 }
 
@@ -130,7 +130,7 @@ describe('docregistry/registry', () => {
         registry.addWidgetFactory(createFactory());
         let factory = createFactory();
         registry.addWidgetFactory(factory);
-        expect(registry.defaultWidgetFactory('.txt')).to.be(factory);
+        expect(registry.defaultWidgetFactory('.foo.bar')).to.be(factory);
       });
 
       it('should be removed from the registry when disposed', () => {
@@ -275,7 +275,7 @@ describe('docregistry/registry', () => {
           defaultFor: ['*']
         });
         registry.addWidgetFactory(gFactory);
-        let factories = registry.preferredWidgetFactories('.txt');
+        let factories = registry.preferredWidgetFactories('.foo.bar');
         expect(toArray(factories)).to.eql([factory, gFactory]);
       });
 
@@ -336,7 +336,7 @@ describe('docregistry/registry', () => {
           defaultFor: ['.md']
         });
         registry.addWidgetFactory(mdFactory);
-        expect(registry.defaultWidgetFactory('.txt')).to.be(factory);
+        expect(registry.defaultWidgetFactory('.foo.bar')).to.be(factory);
         expect(registry.defaultWidgetFactory('.md')).to.be(mdFactory);
         expect(registry.defaultWidgetFactory()).to.be(gFactory);
       });
@@ -349,13 +349,16 @@ describe('docregistry/registry', () => {
         expect(toArray(registry.fileTypes()).length).to.be(0);
         let fileTypes = [
           { name: 'notebook', extension: '.ipynb' },
-          { name: 'python', extension: '.py' }
+          { name: 'python', extension: '.py' },
+          { name: 'table', extension: '.table.json' }
         ];
         registry.addFileType(fileTypes[0]);
         registry.addFileType(fileTypes[1]);
+        registry.addFileType(fileTypes[2]);
         let values = registry.fileTypes();
         expect(values.next()).to.be(fileTypes[0]);
         expect(values.next()).to.be(fileTypes[1]);
+        expect(values.next()).to.be(fileTypes[2]);
       });
 
     });


### PR DESCRIPTION
Fixes #1453.   Allows `.table.json` to be registered in addition to `.json`.