### PR TITLE
Clean up bootstrap again

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -159,19 +159,19 @@ class LabApp(NotebookApp):
             'Extensions are loaded in alphabetical order')
     )
 
-    def init_webapp(self):
-        """initialize tornado webapp and httpserver.
+    def init_web_app(self):
+        """initialize tornado web_app and httpserver.
         """
-        super(LabApp, self).init_webapp()
-        self.add_lab_handlers(self.web_app)
-        self.add_labextensions(self.web_app)
+        super(LabApp, self).init_web_app()
+        self.add_lab_handlers()
+        self.add_labextensions()
 
-    def add_labextensions(self, webapp):
+    def add_labextensions(self):
         """Get the enabledd and valid lab extensions.
 
         Notes
         -------
-        Adds a `labextensions` property to the webapp, which is a dict
+        Adds a `labextensions` property to the web_app, which is a dict
         containing manifest data for each enabled and active extension,
         and optionally its associated python_module.
         """
@@ -190,12 +190,13 @@ class LabApp(NotebookApp):
                 continue
             data['python_module'] = config.get('python_module', None)
             out[name] = data
-        webapp.labextensions = out
+        self.web_app.labextensions = out
 
-    def add_lab_handlers(self, webapp):
+    def add_lab_handlers(self):
         """Add the lab-specific handlers to the tornado app."""
-        base_url = webapp.settings['base_url']
-        webapp.add_handlers(".*$",
+        web_app = self.web_app
+        base_url = web_app.settings['base_url']
+        web_app.add_handlers(".*$",
             [(ujoin(base_url, h[0]),) + h[1:] for h in default_handlers])
         extension_prefix = ujoin(base_url, EXTENSION_PREFIX)
         labextension_handler = (
@@ -204,7 +205,7 @@ class LabApp(NotebookApp):
                 'no_cache_paths': ['/'],  # don't cache anything in labbextensions
             }
         )
-        webapp.add_handlers(".*$", [labextension_handler])
+        web_app.add_handlers(".*$", [labextension_handler])
         base_dir = os.path.realpath(os.path.join(HERE, '..'))
         dev_mode = os.path.exists(os.path.join(base_dir, '.git'))
         if dev_mode:
@@ -218,9 +219,10 @@ def bootstrap_from_nbapp(nbapp):
     # Load the config file
     labapp.config_file_name = nbapp.config_file_name
     labapp.load_config_file()
-    webapp = nbapp.web_app
-    labapp.add_lab_handlers(webapp)
-    labapp.add_labextensions(webapp)
+    labapp.log = nbapp.log
+    LabApp.web_app = nbapp.web_app
+    labapp.add_lab_handlers()
+    labapp.add_labextensions()
 
 
 #-----------------------------------------------------------------------------

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -159,10 +159,10 @@ class LabApp(NotebookApp):
             'Extensions are loaded in alphabetical order')
     )
 
-    def init_web_app(self):
-        """initialize tornado web_app and httpserver.
+    def init_webapp(self):
+        """initialize tornado webapp and httpserver.
         """
-        super(LabApp, self).init_web_app()
+        super(LabApp, self).init_webapp()
         self.add_lab_handlers()
         self.add_labextensions()
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -215,7 +215,9 @@ def bootstrap_from_nbapp(nbapp):
     """Bootstrap the lab app on top of a notebook app.
     """
     labapp = LabApp()
-    labapp.initialize()
+    # Load the config file
+    labapp.config_file_name = nbapp.config_file_name
+    labapp.load_config_file()
     webapp = nbapp.web_app
     labapp.add_lab_handlers(webapp)
     labapp.add_labextensions(webapp)

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -19,5 +19,5 @@ mkdir ~/.jupyter
 
 
 # Install and enable the server extension
-pip install --upgrade -v -e ".[test]"
+pip install -v -e ".[test]"
 jupyter serverextension enable --py jupyterlab


### PR DESCRIPTION
Fixes #1516.

Use the same configuration file as the main notebook app.  Does not take into account command line arguments, because they are not necessarily applicable to the `LabApp` would cause a config error (cf https://github.com/jupyterlab/jupyterlab/issues/1516#issuecomment-274072283).