### PR TITLE
Clean up handling of Lab Config

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -132,6 +132,7 @@ default_handlers = [
 
 class LabApp(NotebookApp):
     version = __version__
+    name = 'jupyterlab'
 
     description = """
         JupyterLab - An extensible computational environment for Jupyter.
@@ -215,12 +216,23 @@ class LabApp(NotebookApp):
 def bootstrap_from_nbapp(nbapp):
     """Bootstrap the lab app on top of a notebook app.
     """
+    if isinstance(nbapp, LabApp):
+        return
+
     labapp = LabApp()
-    # Load the config file
-    labapp.config_file_name = nbapp.config_file_name
-    labapp.load_config_file()
+
+    # Get data from the nbapp.
+    labapp.config_dir = nbapp.config_dir
     labapp.log = nbapp.log
-    LabApp.web_app = nbapp.web_app
+    labapp.web_app = nbapp.web_app
+    cli_config = nbapp.cli_config.get('LabApp', {})
+
+    # Handle config.
+    labapp.update_config(cli_config)
+    labapp.load_config_file()
+    # Enforce cli override.
+    labapp.update_config(cli_config)
+
     labapp.add_lab_handlers()
     labapp.add_labextensions()
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -225,7 +225,8 @@ def bootstrap_from_nbapp(nbapp):
     labapp.config_dir = nbapp.config_dir
     labapp.log = nbapp.log
     labapp.web_app = nbapp.web_app
-    cli_config = nbapp.cli_config.get('LabApp', {})
+    cli_config = nbapp.cli_config.get('NotebookApp', {})
+    cli_config.update = nbapp.cli_config.get('LabApp', {})
 
     # Handle config.
     labapp.update_config(cli_config)

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -39,7 +39,7 @@ GREEN_ENABLED = '\033[32menabled \033[0m' if os.name != 'nt' else 'enabled '
 RED_DISABLED = '\033[31mdisabled\033[0m' if os.name != 'nt' else 'disabled'
 
 
-CONFIG_NAME = 'jupyter_notebook_config'
+CONFIG_NAME = 'jupyterlab_config'
 
 #------------------------------------------------------------------------------
 # Public API


### PR DESCRIPTION
Fixes #1454.

Creates a separate `jupyterlab_config.json` file for `LabApp` data, mirroring what `JupyterHub` does.  
Stops short of having a `labconfig/` subdirectory because `labextensions` are more like `serverextension` than `nbextension` data, which are handled using the `config` REST endpoint.

Also cleans up the bootstrap code for launching `jupyter notebook` and browsing to the `lab/` page to take into account command line args.