### PR TITLE
Clean up commands

### DIFF
--- a/src/about/index.ts
+++ b/src/about/index.ts
@@ -225,7 +225,7 @@ const NOTEBOOK_DESC = [
  */
 export
 const cmdIds = {
-  show: 'about-jupyterlab:show'
+  open: 'about-jupyterlab:open'
 };
 
 

--- a/src/about/plugin.ts
+++ b/src/about/plugin.ts
@@ -41,7 +41,7 @@ export default plugin;
 function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstanceRestorer): void {
   const namespace = 'about-jupyterlab';
   const model = new AboutModel({ version: app.info.version });
-  const command = cmdIds.show;
+  const command = cmdIds.open;
   const category = 'Help';
   const tracker = new InstanceTracker<AboutWidget>({ namespace });
 

--- a/src/faq/index.ts
+++ b/src/faq/index.ts
@@ -9,5 +9,5 @@ export * from './widget';
  */
 export
 const cmdIds = {
-  show: 'faq-jupyterlab:show',
+  open: 'faq-jupyterlab:open',
 };

--- a/src/faq/plugin.ts
+++ b/src/faq/plugin.ts
@@ -48,7 +48,7 @@ export default plugin;
  */
 function activate(app: JupyterLab, palette: ICommandPalette, linker: ICommandLinker, restorer: IInstanceRestorer): void {
   const category = 'Help';
-  const command = cmdIds.show;
+  const command = cmdIds.open;
   const model = new FaqModel();
   const tracker = new InstanceTracker<FaqWidget>({ namespace: 'faq' });
 
@@ -72,7 +72,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, linker: ICommandLin
   }
 
   app.commands.addCommand(command, {
-    label: 'Frequently Asked Questions',
+    label: 'Open FAQ',
     execute: () => {
       if (!widget || widget.isDisposed) {
         widget = newWidget();

--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -12,5 +12,5 @@ const cmdIds = {
   show: 'help-jupyterlab:show',
   hide: 'help-jupyterlab:hide',
   toggle: 'help-jupyterlab:toggle',
-  openClassic: 'classic-notebook:open'
+  launchClassic: 'classic-notebook:launchClassic'
 };

--- a/src/help/plugin.ts
+++ b/src/help/plugin.ts
@@ -117,6 +117,10 @@ const RESOURCES = [
   }
 ];
 
+RESOURCES.sort((a: any, b: any) => {
+  return a.text.localeCompare(b.text);
+});
+
 
 /**
  * The help handler extension.
@@ -193,12 +197,12 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
     let menu = new Menu({ commands, keymap });
     menu.title.label = category;
 
-    menu.addItem({ command: aboutCmdIds.show });
-    menu.addItem({ command: faqCmdIds.show });
-    menu.addItem({ command: cmdIds.openClassic });
-
+    menu.addItem({ command: aboutCmdIds.open });
+    menu.addItem({ command: faqCmdIds.open });
+    menu.addItem({ command: cmdIds.launchClassic });
+    menu.addItem({ type: 'separator' });
     RESOURCES.forEach(args => { menu.addItem({ args, command }); });
-
+    menu.addItem({ type: 'separator' });
     menu.addItem({ command: statedbCmdIds.clear });
 
     return menu;
@@ -281,11 +285,10 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
 
   palette.addItem({ command: statedbCmdIds.clear, category });
 
-  let openClassicNotebookId = cmdIds.openClassic;
-  app.commands.addCommand(openClassicNotebookId, {
-    label: 'Open Classic Notebook',
+  app.commands.addCommand(cmdIds.launchClassic, {
+    label: 'Launch Classic Notebook',
     execute: () => { window.open(utils.getBaseUrl() + 'tree'); }
   });
-  palette.addItem({ command: openClassicNotebookId, category });
+  palette.addItem({ command: cmdIds.launchClassic, category });
   mainMenu.addMenu(menu, {});
 }

--- a/src/landing/index.ts
+++ b/src/landing/index.ts
@@ -9,5 +9,5 @@ export * from './widget';
  */
 export
 const cmdIds = {
-  show: 'landing-jupyterlab:show',
+  open: 'landing-jupyterlab:open',
 };

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -56,7 +56,7 @@ export default plugin;
  */
 function activate(app: JupyterLab, pathTracker: IPathTracker, palette: ICommandPalette, services: IServiceManager, restorer: IInstanceRestorer): void {
   const category = 'Help';
-  const command = cmdIds.show;
+  const command = cmdIds.open;
   const model = new LandingModel(services.terminals.isAvailable());
   const tracker = new InstanceTracker<LandingWidget>({ namespace: 'landing' });
 
@@ -73,7 +73,7 @@ function activate(app: JupyterLab, pathTracker: IPathTracker, palette: ICommandP
     let widget = new LandingWidget(app);
     widget.model = model;
     widget.id = 'landing-jupyterlab';
-    widget.title.label = 'Launcher';
+    widget.title.label = 'Landing';
     widget.title.closable = true;
     widget.addClass(LANDING_CLASS);
     tracker.add(widget);
@@ -81,7 +81,7 @@ function activate(app: JupyterLab, pathTracker: IPathTracker, palette: ICommandP
   }
 
   app.commands.addCommand(command, {
-    label: 'Show Landing',
+    label: 'Open Landing',
     execute: () => {
       if (!widget || widget.isDisposed) {
         widget = newWidget();


### PR DESCRIPTION
Fixes #1513.

- Use "Open" when opening in the main area, and "Show" for a side panel.
- "Open Classic Notebook" -> "Launch Classic Notebook".
- Rename "Launcher" command and title to "Launcher".
- Alphabetize the help links.

<img src="https://cloud.githubusercontent.com/assets/2096628/22291871/22eba1b6-e2ce-11e6-9063-8537429ee35f.png" alt="Help Screenshot" width=300/>

@sgornick, I left "About JupyterLab" as-is because that is a pattern used in a lot of applications.