### PR TITLE
Separate lab config from server launch config

### DIFF
--- a/jupyterlab/__init__.py
+++ b/jupyterlab/__init__.py
@@ -9,16 +9,9 @@ except ImportError as e:
     # when we are python 3 only, add 'from e' at the end to chain the exception.
     raise ImportError("No module named 'jupyter._version'. Build the jupyterlab package to generate this module, for example, with `pip install -e /path/to/jupyterlab/repo`.")
 
-from .labapp import LabApp, HERE, bootstrap_from_nbapp
-
+from .labapp import load_jupyter_server_extension
 
 def _jupyter_server_extension_paths():
     return [{
         "module": "jupyterlab"
     }]
-
-
-def load_jupyter_server_extension(nbapp):
-    if not isinstance(nbapp, LabApp):
-        bootstrap_from_nbapp(nbapp)
-    nbapp.log.info('JupyterLab alpha preview extension loaded from %s' % HERE)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -18,7 +18,7 @@ from .labextensions import (
     find_labextension, validate_labextension_folder,
     get_labextension_manifest_data_by_name,
     get_labextension_manifest_data_by_folder,
-    get_labextension_config_python, LabConfig
+    get_labextension_config_python, CONFIG_SECTION
 )
 
 #-----------------------------------------------------------------------------
@@ -141,15 +141,12 @@ def load_jupyter_server_extension(nbapp):
         nbapp.log.info(DEV_NOTE_NPM)
 
     # Get the appropriate lab config.
-    config_app = LabConfig()
-    config_app.config_dir = nbapp.config_dir
-    config_app.load_config_file()
-
+    lab_config = nbapp.config.get(CONFIG_SECTION, {})
     web_app = nbapp.web_app
 
     # Add the lab extensions to the web app.
     out = dict()
-    for (name, ext_config) in config_app.labextensions.items():
+    for (name, ext_config) in lab_config.labextensions.items():
         if not ext_config['enabled']:
             continue
         folder = find_labextension(name)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -151,24 +151,22 @@ def add_handlers(web_app, labextensions):
     """Add the appropriate handlers to the web app.
     """
     base_url = web_app.settings['base_url']
+    prefix = ujoin(base_url, PREFIX)
     extension_prefix = ujoin(base_url, EXTENSION_PREFIX)
-    default_handlers = [
-        (PREFIX + r'/?', LabHandler, {
+    handlers = [
+        (prefix + r'/?', LabHandler, {
             'labextensions': labextensions,
             'extension_prefix': extension_prefix
         }),
-        (PREFIX + r"/(.*)", FileFindHandler,
-            {'path': BUILT_FILES}),
-    ]
-    web_app.add_handlers(".*$",
-        [(ujoin(base_url, h[0]),) + h[1:] for h in default_handlers])
-    labextension_handler = (
-        r"%s/(.*)" % extension_prefix, FileFindHandler, {
+        (prefix + r"/(.*)", FileFindHandler, {
+            'path': BUILT_FILES
+        }),
+        (extension_prefix + r"/(.*)", FileFindHandler, {
             'path': jupyter_path('labextensions'),
-            'no_cache_paths': ['/'],  # don't cache anything in labbextensions
-        }
-    )
-    web_app.add_handlers(".*$", [labextension_handler])
+            'no_cache_paths': ['/'],  # don't cache anything in labextensions
+        })
+    ]
+    web_app.add_handlers(".*$", handlers)
 
 
 def load_jupyter_server_extension(nbapp):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -22,6 +22,7 @@ from ipython_genutils.path import ensure_dir_exists
 from ipython_genutils.py3compat import string_types, cast_unicode_py2
 from ._version import __version__
 
+from traitlets import Dict
 from traitlets.config.manager import BaseJSONConfigManager
 from traitlets.utils.importstring import import_item
 
@@ -289,7 +290,7 @@ def _set_labextension_state(name, state,
             name
         ))
     labextensions = (
-        cfg.setdefault("LabApp", {})
+        cfg.setdefault("LabConfig", {})
         .setdefault("labextensions", {})
     )
 
@@ -653,6 +654,19 @@ aliases = {
     "labextensions" : "InstallLabExtensionApp.labextensions_dir",
 }
 
+
+class LabConfig(JupyterApp):
+    name = 'jupyterlab'
+
+    labextensions = Dict({}, config=True,
+        help=('Dict of Python modules to load as lab extensions.'
+            'Each entry consists of a required `enabled` key used'
+            'to enable or disable the extension, and an optional'
+            '`python_module` key for the associated python module.'
+            'Extensions are loaded in alphabetical order')
+    )
+
+
 class InstallLabExtensionApp(BaseLabExtensionApp):
     """Entry point for installing JupyterLab extensions"""
     description = """Install JupyterLab extensions
@@ -897,7 +911,7 @@ class ListLabExtensionsApp(BaseLabExtensionApp):
             cm = BaseJSONConfigManager(parent=self, config_dir=config_dir)
             data = cm.get(CONFIG_NAME)
             labextensions = (
-                data.setdefault("LabApp", {})
+                data.setdefault("LabConfig", {})
                 .setdefault("labextensions", {})
             )
             if labextensions:

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -41,6 +41,7 @@ RED_DISABLED = '\033[31mdisabled\033[0m' if os.name != 'nt' else 'disabled'
 
 
 CONFIG_NAME = 'jupyterlab_config'
+APP_NAME = 'LabConfig'
 
 #------------------------------------------------------------------------------
 # Public API
@@ -290,7 +291,7 @@ def _set_labextension_state(name, state,
             name
         ))
     labextensions = (
-        cfg.setdefault("LabConfig", {})
+        cfg.setdefault(APP_NAME, {})
         .setdefault("labextensions", {})
     )
 
@@ -911,7 +912,7 @@ class ListLabExtensionsApp(BaseLabExtensionApp):
             cm = BaseJSONConfigManager(parent=self, config_dir=config_dir)
             data = cm.get(CONFIG_NAME)
             labextensions = (
-                data.setdefault("LabConfig", {})
+                data.setdefault(APP_NAME, {})
                 .setdefault("labextensions", {})
             )
             if labextensions:

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -22,7 +22,6 @@ from ipython_genutils.path import ensure_dir_exists
 from ipython_genutils.py3compat import string_types, cast_unicode_py2
 from ._version import __version__
 
-from traitlets import Dict
 from traitlets.config.manager import BaseJSONConfigManager
 from traitlets.utils.importstring import import_item
 
@@ -40,8 +39,8 @@ GREEN_ENABLED = '\033[32menabled \033[0m' if os.name != 'nt' else 'enabled '
 RED_DISABLED = '\033[31mdisabled\033[0m' if os.name != 'nt' else 'disabled'
 
 
-CONFIG_NAME = 'jupyterlab_config'
-APP_NAME = 'LabConfig'
+CONFIG_NAME = 'jupyter_notebook_config'
+CONFIG_SECTION = 'LabConfig'
 
 #------------------------------------------------------------------------------
 # Public API
@@ -291,7 +290,7 @@ def _set_labextension_state(name, state,
             name
         ))
     labextensions = (
-        cfg.setdefault(APP_NAME, {})
+        cfg.setdefault(CONFIG_SECTION, {})
         .setdefault("labextensions", {})
     )
 
@@ -656,18 +655,6 @@ aliases = {
 }
 
 
-class LabConfig(JupyterApp):
-    name = 'jupyterlab'
-
-    labextensions = Dict({}, config=True,
-        help=('Dict of Python modules to load as lab extensions.'
-            'Each entry consists of a required `enabled` key used'
-            'to enable or disable the extension, and an optional'
-            '`python_module` key for the associated python module.'
-            'Extensions are loaded in alphabetical order')
-    )
-
-
 class InstallLabExtensionApp(BaseLabExtensionApp):
     """Entry point for installing JupyterLab extensions"""
     description = """Install JupyterLab extensions
@@ -912,7 +899,7 @@ class ListLabExtensionsApp(BaseLabExtensionApp):
             cm = BaseJSONConfigManager(parent=self, config_dir=config_dir)
             data = cm.get(CONFIG_NAME)
             labextensions = (
-                data.setdefault(APP_NAME, {})
+                data.setdefault(CONFIG_SECTION, {})
                 .setdefault("labextensions", {})
             )
             if labextensions:

--- a/jupyterlab/tests/test_labextensions.py
+++ b/jupyterlab/tests/test_labextensions.py
@@ -30,7 +30,7 @@ from jupyterlab.labextensions import (install_labextension, check_labextension,
     get_labextension_config_python,
     get_labextension_manifest_data_by_name,
     get_labextension_manifest_data_by_folder,
-    _read_config_data
+    _read_config_data, APP_NAME
 )
 
 
@@ -230,7 +230,7 @@ class TestInstallLabExtension(TestCase):
             enable_labextension(self.name)
 
         data = _read_config_data(user=True)
-        config = data.get('LabApp', {}).get('labextensions', {}).get(self.name, {})
+        config = data.get(APP_NAME, {}).get('labextensions', {}).get(self.name, {})
         assert config['enabled'] == True
         assert 'python_module' not in config
 
@@ -239,7 +239,7 @@ class TestInstallLabExtension(TestCase):
         disable_labextension(self.name)
 
         data = _read_config_data(user=True)
-        config = data.get('LabApp', {}).get('labextensions', {}).get(self.name, {})
+        config = data.get(APP_NAME, {}).get('labextensions', {}).get(self.name, {})
         assert not config['enabled']
         assert 'python_module' not in config
 
@@ -296,7 +296,7 @@ class TestInstallLabExtension(TestCase):
         enable_labextension_python('mockextension')
         
         data = _read_config_data(user=True)
-        config = data.get('LabApp', {}).get('labextensions', {}).get('mockextension', False)
+        config = data.get(APP_NAME, {}).get('labextensions', {}).get('mockextension', False)
         assert config['enabled'] == True
         assert config['python_module'] == 'mockextension'
         
@@ -307,7 +307,7 @@ class TestInstallLabExtension(TestCase):
         disable_labextension_python('mockextension', user=True)
         
         data = _read_config_data(user=True)
-        config = data.get('LabApp', {}).get('labextensions', {}).get('mockextension', {})
+        config = data.get(APP_NAME, {}).get('labextensions', {}).get('mockextension', {})
         assert not config['enabled']
 
     def test_labextensionpy_validate(self):

--- a/jupyterlab/tests/test_labextensions.py
+++ b/jupyterlab/tests/test_labextensions.py
@@ -30,7 +30,7 @@ from jupyterlab.labextensions import (install_labextension, check_labextension,
     get_labextension_config_python,
     get_labextension_manifest_data_by_name,
     get_labextension_manifest_data_by_folder,
-    _read_config_data, APP_NAME
+    _read_config_data, CONFIG_SECTION
 )
 
 
@@ -230,7 +230,7 @@ class TestInstallLabExtension(TestCase):
             enable_labextension(self.name)
 
         data = _read_config_data(user=True)
-        config = data.get(APP_NAME, {}).get('labextensions', {}).get(self.name, {})
+        config = data.get(CONFIG_SECTION, {}).get('labextensions', {}).get(self.name, {})
         assert config['enabled'] == True
         assert 'python_module' not in config
 
@@ -239,7 +239,7 @@ class TestInstallLabExtension(TestCase):
         disable_labextension(self.name)
 
         data = _read_config_data(user=True)
-        config = data.get(APP_NAME, {}).get('labextensions', {}).get(self.name, {})
+        config = data.get(CONFIG_SECTION, {}).get('labextensions', {}).get(self.name, {})
         assert not config['enabled']
         assert 'python_module' not in config
 
@@ -296,7 +296,7 @@ class TestInstallLabExtension(TestCase):
         enable_labextension_python('mockextension')
         
         data = _read_config_data(user=True)
-        config = data.get(APP_NAME, {}).get('labextensions', {}).get('mockextension', False)
+        config = data.get(CONFIG_SECTION, {}).get('labextensions', {}).get('mockextension', False)
         assert config['enabled'] == True
         assert config['python_module'] == 'mockextension'
         
@@ -307,7 +307,7 @@ class TestInstallLabExtension(TestCase):
         disable_labextension_python('mockextension', user=True)
         
         data = _read_config_data(user=True)
-        config = data.get(APP_NAME, {}).get('labextensions', {}).get('mockextension', {})
+        config = data.get(CONFIG_SECTION, {}).get('labextensions', {}).get('mockextension', {})
         assert not config['enabled']
 
     def test_labextensionpy_validate(self):


### PR DESCRIPTION
Fixes #1552.

The lab config is now added as a separate entry in the `jupyter_notebook_config.json` file.  We use the notebook app to fetch the appropriate config for our server extension.

cc @Carreau @jasongrout @SylvainCorlay 