### PR TITLE
Allow markdown table cells to expand

### DIFF
--- a/src/renderers/index.css
+++ b/src/renderers/index.css
@@ -243,6 +243,12 @@ margin-top = 14, 14, 14, 14, 8, 8
 }
 
 
+.jp-RenderedMarkdown.jp-RenderedHTMLCommon td,
+.jp-RenderedMarkdown.jp-RenderedHTMLCommon th {
+  max-width: none;
+}
+
+
 .jp-RenderedHTMLCommon th {
   font-weight: bold;
 }


### PR DESCRIPTION
Fixes #1436.  The `max-width` for rendered table cells is already `150px`.

Before:

<img width="382" alt="screen shot 2017-01-26 at 4 34 08 pm" src="https://cloud.githubusercontent.com/assets/2096628/22353326/86ad0c0e-e3e5-11e6-82cd-b51fe70a1604.png">


After:

![image](https://cloud.githubusercontent.com/assets/2096628/22353346/91ef2926-e3e5-11e6-96f7-ac9e0fc55b4e.png)
