### PR TITLE
Use the command linker for rendered links

### DIFF
--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -380,7 +380,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     }
     let cwd = ContentsManager.dirname(this._path);
     let path = ContentsManager.getAbsolutePath(url, cwd);
-    return this._manager.contents.getDownloadUrl(path);
+    return Promise.resolve(path);
   }
 
   /**

--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -373,14 +373,17 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   /**
    * Resolve a relative url to a correct server path.
    */
-  resolveUrl(url: string): Promise<string> {
+  resolveUrl(url: string, local: boolean): Promise<string> {
     // Ignore urls that have a protocol.
     if (utils.urlParse(url).protocol || url.indexOf('//') === 0) {
       return Promise.resolve(url);
     }
     let cwd = ContentsManager.dirname(this._path);
     let path = ContentsManager.getAbsolutePath(url, cwd);
-    return Promise.resolve(path);
+    if (local) {
+      return Promise.resolve(path);
+    }
+    return this._manager.contents.getDownloadUrl(path);
   }
 
   /**

--- a/src/docregistry/context.ts
+++ b/src/docregistry/context.ts
@@ -373,14 +373,22 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   /**
    * Resolve a relative url to a correct server path.
    */
-  resolveUrl(url: string, local: boolean): Promise<string> {
+  resolveUrl(url: string): Promise<string> {
     // Ignore urls that have a protocol.
     if (utils.urlParse(url).protocol || url.indexOf('//') === 0) {
       return Promise.resolve(url);
     }
     let cwd = ContentsManager.dirname(this._path);
     let path = ContentsManager.getAbsolutePath(url, cwd);
-    if (local) {
+    return Promise.resolve(path);
+  }
+
+  /**
+   * Get the download url of a given absolute server path.
+   */
+  getDownloadUrl(path: string): Promise<string> {
+    // Ignore urls that have a protocol.
+    if (utils.urlParse(path).protocol || path.indexOf('//') === 0) {
       return Promise.resolve(path);
     }
     return this._manager.contents.getDownloadUrl(path);

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -734,16 +734,14 @@ namespace DocumentRegistry {
     listCheckpoints(): Promise<Contents.ICheckpointModel[]>;
 
     /**
-     * Resolve a url to a correct server path.
-     *
-     * @param url - The source url.
-     *
-     * @param local - Whether to to return the local path versus
-     *   a download path.
-     *
-     * @returns a promise which resolves with the resolved url.
+     * Resolve a relative url to a correct server path.
      */
-    resolveUrl(url: string, local: boolean): Promise<string>;
+    resolveUrl(url: string): Promise<string>;
+
+    /**
+     * Get the download url of a given absolute server path.
+     */
+    getDownloadUrl(path: string): Promise<string>;
 
     /**
      * Add a sibling widget to the document manager.

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -736,9 +736,14 @@ namespace DocumentRegistry {
     /**
      * Resolve a url to a correct server path.
      *
+     * @param url - The source url.
+     *
+     * @param local - Whether to to return the local path versus
+     *   a download path.
+     *
      * @returns a promise which resolves with the resolved url.
      */
-    resolveUrl(url: string): Promise<string>;
+    resolveUrl(url: string, local: boolean): Promise<string>;
 
     /**
      * Add a sibling widget to the document manager.

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -355,6 +355,7 @@ function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandl
  */
 function handleImage(img: HTMLImageElement, resolver: RenderMime.IResolver): Promise<void> {
   let source = img.getAttribute('src');
+  img.src = '';
   return resolver.resolveUrl(source).then(path => {
     return resolver.getDownloadUrl(path);
   }).then(url => {

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -346,23 +346,25 @@ class RenderedPDF extends Widget {
 export
 function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver,
                      linker: ICommandLinker | null): Promise<void> {
+  let promises: Promise<void>[] = [];
   let imgs = node.getElementsByTagName('img');
   for (let i = 0; i < imgs.length; i++) {
     let img = imgs[i];
     let source = img.getAttribute('src');
     if (source) {
-      return resolver.resolveUrl(source).then(url => {
+      promises.push(resolver.resolveUrl(source).then(url => {
         img.src = url;
         return void 0;
-      });
+      }));
     }
   }
   let anchors = node.getElementsByTagName('a');
   for (let i = 0; i < anchors.length; i++) {
     let anchor = anchors[i];
     let href = anchor.getAttribute('href');
+    anchor.target = '_blank';
     if (href) {
-      return resolver.resolveUrl(href).then(url => {
+      promises.push(resolver.resolveUrl(href).then(url => {
         anchor.href = url;
         if (linker && !utils.urlParse(url).protocol) {
           linker.connectNode(anchor, CommandIDs.open, {
@@ -370,9 +372,10 @@ function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver,
           });
         }
         return void 0;
-      });
+      }));
     }
   }
+  return Promise.all(promises).then(() => { return void 0; });
 }
 
 

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -352,7 +352,7 @@ function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver,
     let img = imgs[i];
     let source = img.getAttribute('src');
     if (source) {
-      promises.push(resolver.resolveUrl(source).then(url => {
+      promises.push(resolver.resolveUrl(source, false).then(url => {
         img.src = url;
         return void 0;
       }));
@@ -364,9 +364,10 @@ function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver,
     let href = anchor.getAttribute('href');
     anchor.target = '_blank';
     if (href) {
-      promises.push(resolver.resolveUrl(href).then(url => {
+      let local = linker && !utils.urlParse(href).protocol;
+      promises.push(resolver.resolveUrl(href, local).then(url => {
         anchor.href = url;
-        if (linker && !utils.urlParse(url).protocol) {
+        if (local) {
           linker.connectNode(anchor, CommandIDs.open, {
             path: url
           });

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -22,14 +22,6 @@ import {
   CodeMirrorEditor
 } from '../codemirror/editor';
 
-import {
-  ICommandLinker
-} from '../commandlinker';
-
-import {
-  CommandIDs
-} from '../filebrowser';
-
 import * as marked
   from 'marked';
 
@@ -167,8 +159,8 @@ class RenderedHTML extends RenderedHTMLCommon {
     }
     appendHtml(this.node, source);
     if (options.resolver) {
-      this._urlResolved = resolveUrls(this.node, options.resolver,
-                                      options.commandLinker);
+      this._urlResolved = handleUrls(this.node, options.resolver,
+                                      options.pathHandler);
     }
   }
 
@@ -207,8 +199,8 @@ class RenderedMarkdown extends RenderedHTMLCommon {
       }
       appendHtml(this.node, content);
       if (options.resolver) {
-        this._urlResolved = resolveUrls(this.node, options.resolver,
-                                        options.commandLinker);
+        this._urlResolved = handleUrls(this.node, options.resolver,
+                                        options.pathHandler);
       }
       this.fit();
       this._rendered = true;
@@ -307,8 +299,8 @@ class RenderedSVG extends Widget {
       throw new Error('SVGRender: Error: Failed to create <svg> element');
     }
     if (options.resolver) {
-      this._urlResolved = resolveUrls(this.node, options.resolver,
-                                      options.commandLinker);
+      this._urlResolved = handleUrls(this.node, options.resolver,
+                                      options.pathHandler);
     }
     this.addClass(SVG_CLASS);
   }
@@ -339,44 +331,51 @@ class RenderedPDF extends Widget {
  *
  * @param resolver - A url resolver.
  *
- * @param linker - A command linker.
+ * @param pathHandler - An optional url path handler.
  *
  * @returns a promise fulfilled when the relative urls have been resolved.
  */
 export
-function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver,
-                     linker: ICommandLinker | null): Promise<void> {
+function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandler: RenderMime.IPathHandler | null): Promise<void> {
   let promises: Promise<void>[] = [];
   let imgs = node.getElementsByTagName('img');
   for (let i = 0; i < imgs.length; i++) {
-    let img = imgs[i];
-    let source = img.getAttribute('src');
-    if (source) {
-      promises.push(resolver.resolveUrl(source, false).then(url => {
-        img.src = url;
-        return void 0;
-      }));
-    }
+    promises.push(handleImage(imgs[i], resolver));
   }
   let anchors = node.getElementsByTagName('a');
   for (let i = 0; i < anchors.length; i++) {
-    let anchor = anchors[i];
-    let href = anchor.getAttribute('href');
-    anchor.target = '_blank';
-    if (href) {
-      let local = linker && !utils.urlParse(href).protocol;
-      promises.push(resolver.resolveUrl(href, local).then(url => {
-        anchor.href = url;
-        if (local) {
-          linker.connectNode(anchor, CommandIDs.open, {
-            path: url
-          });
-        }
-        return void 0;
-      }));
-    }
+    promises.push(handleAnchor(anchors[i], resolver, pathHandler));
   }
   return Promise.all(promises).then(() => { return void 0; });
+}
+
+
+/**
+ * Handle an image node.
+ */
+function handleImage(img: HTMLImageElement, resolver: RenderMime.IResolver): Promise<void> {
+  let source = img.getAttribute('src');
+  return resolver.resolveUrl(source).then(path => {
+    return resolver.getDownloadUrl(path);
+  }).then(url => {
+    img.src = url;
+  });
+}
+
+/**
+ * Handle an anchor node.
+ */
+function handleAnchor(anchor: HTMLAnchorElement, resolver: RenderMime.IResolver, pathHandler: RenderMime.IPathHandler): Promise<void> {
+  anchor.target = '_blank';
+  let href = anchor.getAttribute('href');
+  return resolver.resolveUrl(href).then(path => {
+    if (pathHandler) {
+      pathHandler.handlePath(anchor, path);
+    }
+    return resolver.getDownloadUrl(path);
+  }).then(url => {
+    anchor.href = url;
+  });
 }
 
 

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -30,6 +30,10 @@ import {
 } from '../common/sanitizer';
 
 import {
+  ICommandLinker
+} from '../commandlinker';
+
+import {
   HTMLRenderer, LatexRenderer, ImageRenderer, TextRenderer,
   JavascriptRenderer, SVGRenderer, MarkdownRenderer, PDFRenderer
 } from '../renderers';
@@ -79,6 +83,7 @@ class RenderMime {
     this._order = new Vector(options.order);
     this._sanitizer = options.sanitizer;
     this._resolver = options.resolver || null;
+    this._linker = options.commandLinker || null;
   }
 
   /**
@@ -125,7 +130,8 @@ class RenderMime {
       source: bundle[mimetype],
       injector,
       resolver: this._resolver,
-      sanitizer: trusted ? null : this._sanitizer
+      sanitizer: trusted ? null : this._sanitizer,
+      commandLinker: this._linker
     };
     return this._renderers[mimetype].render(rendererOptions);
   }
@@ -160,7 +166,8 @@ class RenderMime {
     return new RenderMime({
       renderers: this._renderers,
       order: this._order.iter(),
-      sanitizer: this._sanitizer
+      sanitizer: this._sanitizer,
+      commandLinker: this._linker
     });
   }
 
@@ -206,6 +213,7 @@ class RenderMime {
   private _order: Vector<string>;
   private _sanitizer: ISanitizer = null;
   private _resolver: RenderMime.IResolver;
+  private _linker: ICommandLinker;
 }
 
 
@@ -240,6 +248,11 @@ namespace RenderMime {
      * The default is `null`.
      */
     resolver?: IResolver;
+
+    /**
+     * The optional command linker object.
+     */
+    commandLinker?: ICommandLinker;
   }
 
   /**
@@ -362,6 +375,11 @@ namespace RenderMime {
      * If given, should be used to sanitize raw html.
      */
     sanitizer?: ISanitizer;
+
+    /**
+     * An optional command linker.
+     */
+    commandLinker: ICommandLinker;
   }
 
   /**

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -389,7 +389,14 @@ namespace RenderMime {
   interface IResolver {
     /**
      * Resolve a url to a correct server path.
+     *
+     * @param url - The source url.
+     *
+     * @param local - Whether to to return the local path versus
+     *   a download path.
+     *
+     * @returns a promise which resolves with the resolved url.
      */
-    resolveUrl(url: string): Promise<string>;
+    resolveUrl(url: string, local: boolean): Promise<string>;
   }
 }

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -256,7 +256,7 @@ namespace RenderMime {
     resolver?: IResolver;
 
     /**
-     * An optional path handler
+     * An optional path handler.
      */
     pathHandler?: IPathHandler;
   }

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -10,10 +10,6 @@ import {
 } from '../application';
 
 import {
-  IFrame
-} from '../common/iframe';
-
-import {
   defaultSanitizer
 } from '../common/sanitizer';
 

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -2,8 +2,16 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  utils
+} from '@jupyterlab/services';
+
+import {
   JupyterLabPlugin, JupyterLab
 } from '../application';
+
+import {
+  IFrame
+} from '../common/iframe';
 
 import {
   defaultSanitizer
@@ -12,6 +20,10 @@ import {
 import {
   ICommandLinker
 } from '../commandlinker';
+
+import {
+  CommandIDs
+} from '../filebrowser';
 
 import {
   IRenderMime, RenderMime
@@ -35,8 +47,6 @@ const plugin: JupyterLabPlugin<IRenderMime> = {
  */
 export default plugin;
 
-
-
 /**
  * Activate the rendermine plugin.
  */
@@ -51,10 +61,17 @@ function activate(app: JupyterLab, linker: ICommandLinker): IRenderMime {
       order.push(m);
     }
   }
+  let pathHandler = {
+    handlePath: (node: HTMLElement, path: string) => {
+      if (!utils.urlParse(path).protocol && path.indexOf('//') !== 0) {
+        linker.connectNode(node, CommandIDs.open, { path });
+      }
+    }
+  };
   return new RenderMime({
     renderers,
     order,
     sanitizer,
-    commandLinker: linker
+    pathHandler
   });
 };

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -2,12 +2,16 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JupyterLabPlugin
+  JupyterLabPlugin, JupyterLab
 } from '../application';
 
 import {
   defaultSanitizer
 } from '../common/sanitizer';
+
+import {
+  ICommandLinker
+} from '../commandlinker';
 
 import {
   IRenderMime, RenderMime
@@ -19,20 +23,10 @@ import {
  */
 const plugin: JupyterLabPlugin<IRenderMime> = {
   id: 'jupyter.services.rendermime',
+  requires: [ICommandLinker],
   provides: IRenderMime,
-  activate: (): IRenderMime => {
-    let sanitizer = defaultSanitizer;
-    const transformers = RenderMime.defaultRenderers();
-    let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
-    let order: string[] = [];
-    for (let t of transformers) {
-      for (let m of t.mimetypes) {
-        renderers[m] = t;
-        order.push(m);
-      }
-    }
-    return new RenderMime({ renderers, order, sanitizer });
-  }
+  activate,
+  autoStart: true
 };
 
 
@@ -40,3 +34,27 @@ const plugin: JupyterLabPlugin<IRenderMime> = {
  * Export the plugin as default.
  */
 export default plugin;
+
+
+
+/**
+ * Activate the rendermine plugin.
+ */
+function activate(app: JupyterLab, linker: ICommandLinker): IRenderMime {
+  let sanitizer = defaultSanitizer;
+  const transformers = RenderMime.defaultRenderers();
+  let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
+  let order: string[] = [];
+  for (let t of transformers) {
+    for (let m of t.mimetypes) {
+      renderers[m] = t;
+      order.push(m);
+    }
+  }
+  return new RenderMime({
+    renderers,
+    order,
+    sanitizer,
+    commandLinker: linker
+  });
+};

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -388,7 +388,7 @@ describe('docregistry/context', () => {
     describe('#resolveUrl()', () => {
 
       it('should resolve a relative url to a correct server path', (done) => {
-        context.resolve('./foo').then(path => {
+        context.resolveUrl('./foo').then(path => {
           expect(path).to.be('foo');
         }).then(done, done);
       });

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -388,17 +388,34 @@ describe('docregistry/context', () => {
     describe('#resolveUrl()', () => {
 
       it('should resolve a relative url to a correct server path', (done) => {
-        let resolveUrlPromise = context.resolveUrl('./foo');
-        let getDownloadUrlPromise = manager.contents.getDownloadUrl('foo');
-        Promise.all([resolveUrlPromise, getDownloadUrlPromise])
-        .then((values)=>{
+        context.resolve('./foo').then(path => {
+          expect(path).to.be('foo');
+        }).then(done, done);
+      });
+
+      it('should ignore urls that have a protocol', (done) => {
+        context.resolveUrl('http://foo').then(path => {
+          expect(path).to.be('http://foo');
+          done();
+        }).catch(done);
+      });
+
+    });
+
+    describe('#getDownloadUrl()', () => {
+
+      it('should resolve an absolute server url to a download url', (done) => {
+        let contextPromise = context.getDownloadUrl('foo');
+        let contentsPromise = manager.contents.getDownloadUrl('foo');
+        Promise.all([contextPromise, contentsPromise])
+        .then(values => {
           expect(values[0]).to.be(values[1]);
           done();
         }).catch(done);
       });
 
       it('should ignore urls that have a protocol', (done) => {
-        context.resolveUrl('http://foo').then((path)=>{
+        context.getDownloadUrl('http://foo').then(path => {
           expect(path).to.be('http://foo');
           done();
         }).catch(done);


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/1442.  Moved the text of the last item of #1442 to https://github.com/jupyterlab/jupyterlab/issues/1075.

Uses the download path as the `href` for anchor tags in rendered output, but also uses the command linker to open the path in JupyterLab if clicked. 

For now, opens external links in a new tab.  I tried adding an iframe handler, but immediately ran into a CSP problem trying to show a Github page.

```javascript
Refused to display 'https://github.com/jupyterlab/jupyterlab/issues/1442' in a frame because an ancestor violates the following Content Security Policy directive: "frame-ancestors 'none'".
```
