### PR TITLE
Update and refactor help plugin commands.

### DIFF
--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -14,6 +14,9 @@ namespace CommandIDs {
   const activate = 'help-jupyterlab:activate';
 
   export
+  const close = 'help-jupyterlab:close';
+
+  export
   const show = 'help-jupyterlab:show';
 
   export


### PR DESCRIPTION
* Makes sure `toggle` help command does not cause error.
* Removes manual use of message hooks to restore state as instance + state restorer now handle this automatically.
* Adds `close` command for help since there was no other way to permanently dismiss help (without clearing application state).