### PR TITLE
Add url resolving for other rendered elements

### DIFF
--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -341,7 +341,7 @@ function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandl
   // Handle HTML Elements with src attributes.
   let nodes = node.querySelectorAll('*[src]');
   for (let i = 0; i < nodes.length; i++) {
-    promises.push(handleSource(nodes[i] as HTMLImageElement, resolver));
+    promises.push(handleAttr(nodes[i] as HTMLElement, 'src', resolver));
   }
   let anchors = node.getElementsByTagName('a');
   for (let i = 0; i < anchors.length; i++) {
@@ -349,25 +349,25 @@ function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandl
   }
   let links = node.getElementsByTagName('link');
   for (let i = 0; i < links.length; i++) {
-    promises.push(handleLink(links[i], resolver));
+    promises.push(handleAttr(links[i], 'href', resolver));
   }
   return Promise.all(promises).then(() => { return void 0; });
 }
 
 
 /**
- * Handle a node with a `src` attribute.
+ * Handle a node with a `src` or `href` attribute.
  */
-function handleSource(node: HTMLImageElement, resolver: RenderMime.IResolver): Promise<void> {
-  let source = node.getAttribute('src');
+function handleAttr(node: HTMLElement, name: 'src' | 'href', resolver: RenderMime.IResolver): Promise<void> {
+  let source = node.getAttribute(name);
   if (!source) {
     return Promise.resolve(void 0);
   }
-  node.src = '';
+  node.setAttribute(name, '');
   return resolver.resolveUrl(source).then(path => {
     return resolver.getDownloadUrl(path);
   }).then(url => {
-    node.src = url;
+    node.setAttribute(name, url);
   });
 }
 
@@ -388,23 +388,6 @@ function handleAnchor(anchor: HTMLAnchorElement, resolver: RenderMime.IResolver,
     return resolver.getDownloadUrl(path);
   }).then(url => {
     anchor.href = url;
-  });
-}
-
-
-/**
- * Handle a link node.
- */
-function handleLink(node: HTMLLinkElement, resolver: RenderMime.IResolver): Promise<void> {
-  let href = node.getAttribute('href');
-  if (!href) {
-    return Promise.resolve(void 0);
-  }
-  node.href = '';
-  return resolver.resolveUrl(href).then(path => {
-    return resolver.getDownloadUrl(path);
-  }).then(url => {
-    node.href = url;
   });
 }
 

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -397,6 +397,9 @@ function handleAnchor(anchor: HTMLAnchorElement, resolver: RenderMime.IResolver,
  */
 function handleLink(node: HTMLLinkElement, resolver: RenderMime.IResolver): Promise<void> {
   let href = node.getAttribute('href');
+  if (!href) {
+    return Promise.resolve(void 0);
+  }
   node.href = '';
   return resolver.resolveUrl(href).then(path => {
     return resolver.getDownloadUrl(path);

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -352,6 +352,10 @@ function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandl
   for (let i = 0; i < anchors.length; i++) {
     promises.push(handleAnchor(anchors[i], resolver, pathHandler));
   }
+  let links = node.getElementsByTagName('link');
+  for (let i = 0; i < links.length; i++) {
+    promises.push(handleLink(links[i], resolver));
+  }
   return Promise.all(promises).then(() => { return void 0; });
 }
 
@@ -361,6 +365,9 @@ function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandl
  */
 function handleSource(node: HTMLImageElement, resolver: RenderMime.IResolver): Promise<void> {
   let source = node.getAttribute('src');
+  if (!source) {
+    return Promise.resolve(void 0);
+  }
   node.src = '';
   return resolver.resolveUrl(source).then(path => {
     return resolver.getDownloadUrl(path);
@@ -383,6 +390,20 @@ function handleAnchor(anchor: HTMLAnchorElement, resolver: RenderMime.IResolver,
     return resolver.getDownloadUrl(path);
   }).then(url => {
     anchor.href = url;
+  });
+}
+
+
+/**
+ * Handle a link node.
+ */
+function handleLink(node: HTMLLinkElement, resolver: RenderMime.IResolver): Promise<void> {
+  let href = node.getAttribute('href');
+  node.href = '';
+  return resolver.resolveUrl(href).then(path => {
+    return resolver.getDownloadUrl(path);
+  }).then(url => {
+    node.href = url;
   });
 }
 

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -325,7 +325,7 @@ class RenderedPDF extends Widget {
 
 
 /**
- * Resolve the relative urls in the image and anchor tags of a node tree.
+ * Resolve the relative urls in element `src` and `href` attributes.
  *
  * @param node - The head html element.
  *

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -383,6 +383,9 @@ function handleSource(node: HTMLImageElement, resolver: RenderMime.IResolver): P
 function handleAnchor(anchor: HTMLAnchorElement, resolver: RenderMime.IResolver, pathHandler: RenderMime.IPathHandler): Promise<void> {
   anchor.target = '_blank';
   let href = anchor.getAttribute('href');
+  if (!href) {
+    return Promise.resolve(void 0);
+  }
   return resolver.resolveUrl(href).then(path => {
     if (pathHandler) {
       pathHandler.handlePath(anchor, path);

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -339,9 +339,7 @@ export
 function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandler: RenderMime.IPathHandler | null): Promise<void> {
   let promises: Promise<void>[] = [];
   // Handle HTML Elements with src attributes.
-  // http://www.w3schools.com/tags/att_src.asp
-  let sources = ['audio', 'embed', 'iframe', 'img', 'input', 'script',
-                 'source', 'track', 'video'];
+  let sources = node.querySelectorAll('*[src]');
   for (let source of sources) {
     let nodes = node.getElementsByTagName(source);
     for (let i = 0; i < nodes.length; i++) {

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -346,6 +346,10 @@ function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandl
   for (let i = 0; i < anchors.length; i++) {
     promises.push(handleAnchor(anchors[i], resolver, pathHandler));
   }
+  let iframes = node.getElementsByTagName('iframe');
+  for (let i = 0; i < iframes.length; i++) {
+    promises.push(handleIFrame(iframes[i], resolver));
+  }
   return Promise.all(promises).then(() => { return void 0; });
 }
 
@@ -362,6 +366,21 @@ function handleImage(img: HTMLImageElement, resolver: RenderMime.IResolver): Pro
     img.src = url;
   });
 }
+
+
+/**
+ * Handle an iframe node.
+ */
+function handleIFrame(frame: HTMLIFrameElement, resolver: RenderMime.IResolver): Promise<void> {
+  let source = frame.getAttribute('src');
+  frame.src = '';
+  return resolver.resolveUrl(source).then(path => {
+    return resolver.getDownloadUrl(path);
+  }).then(url => {
+    frame.src = url;
+  });
+}
+
 
 /**
  * Handle an anchor node.

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -339,12 +339,9 @@ export
 function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandler: RenderMime.IPathHandler | null): Promise<void> {
   let promises: Promise<void>[] = [];
   // Handle HTML Elements with src attributes.
-  let sources = node.querySelectorAll('*[src]');
-  for (let source of sources) {
-    let nodes = node.getElementsByTagName(source);
-    for (let i = 0; i < nodes.length; i++) {
-      promises.push(handleSource(nodes[i] as HTMLImageElement, resolver));
-    }
+  let nodes = node.querySelectorAll('*[src]');
+  for (let i = 0; i < nodes.length; i++) {
+    promises.push(handleSource(nodes[i] as HTMLImageElement, resolver));
   }
   let anchors = node.getElementsByTagName('a');
   for (let i = 0; i < anchors.length; i++) {

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -338,46 +338,34 @@ class RenderedPDF extends Widget {
 export
 function handleUrls(node: HTMLElement, resolver: RenderMime.IResolver, pathHandler: RenderMime.IPathHandler | null): Promise<void> {
   let promises: Promise<void>[] = [];
-  let imgs = node.getElementsByTagName('img');
-  for (let i = 0; i < imgs.length; i++) {
-    promises.push(handleImage(imgs[i], resolver));
+  // Handle HTML Elements with src attributes.
+  // http://www.w3schools.com/tags/att_src.asp
+  let sources = ['audio', 'embed', 'iframe', 'img', 'input', 'script',
+                 'source', 'track', 'video'];
+  for (let source of sources) {
+    let nodes = node.getElementsByTagName(source);
+    for (let i = 0; i < nodes.length; i++) {
+      promises.push(handleSource(nodes[i] as HTMLImageElement, resolver));
+    }
   }
   let anchors = node.getElementsByTagName('a');
   for (let i = 0; i < anchors.length; i++) {
     promises.push(handleAnchor(anchors[i], resolver, pathHandler));
-  }
-  let iframes = node.getElementsByTagName('iframe');
-  for (let i = 0; i < iframes.length; i++) {
-    promises.push(handleIFrame(iframes[i], resolver));
   }
   return Promise.all(promises).then(() => { return void 0; });
 }
 
 
 /**
- * Handle an image node.
+ * Handle a node with a `src` attribute.
  */
-function handleImage(img: HTMLImageElement, resolver: RenderMime.IResolver): Promise<void> {
-  let source = img.getAttribute('src');
-  img.src = '';
+function handleSource(node: HTMLImageElement, resolver: RenderMime.IResolver): Promise<void> {
+  let source = node.getAttribute('src');
+  node.src = '';
   return resolver.resolveUrl(source).then(path => {
     return resolver.getDownloadUrl(path);
   }).then(url => {
-    img.src = url;
-  });
-}
-
-
-/**
- * Handle an iframe node.
- */
-function handleIFrame(frame: HTMLIFrameElement, resolver: RenderMime.IResolver): Promise<void> {
-  let source = frame.getAttribute('src');
-  frame.src = '';
-  return resolver.resolveUrl(source).then(path => {
-    return resolver.getDownloadUrl(path);
-  }).then(url => {
-    frame.src = url;
+    node.src = url;
   });
 }
 


### PR DESCRIPTION
Fixes #1584.  Handles all nodes with `src` attributes.  Also handles the `href` for link nodes.

<image src="https://cloud.githubusercontent.com/assets/2096628/22442639/afc0f9ec-e701-11e6-9636-9c6dc8721bdb.png" width=500>
