### PR TITLE
Cell tools

### DIFF
--- a/src/cells/model.ts
+++ b/src/cells/model.ts
@@ -30,7 +30,7 @@ import {
 } from '../common/observablestring';
 
 import {
-  IMetadataCursor, MetadataCursor
+  Metadata
 } from '../common/metadata';
 
 import {
@@ -76,7 +76,7 @@ interface ICellModel extends CodeEditor.IModel {
    * on the model.  This method is used to interact with a namespaced
    * set of metadata on the cell.
    */
-  getMetadata(name: string): IMetadataCursor;
+  getMetadata(name: string): Metadata.ICursor;
 
   /**
    * List the metadata namespace keys for the notebook.
@@ -218,14 +218,14 @@ class CellModel extends CodeEditor.Model implements ICellModel {
    * on the model.  This method is used to interact with a namespaced
    * set of metadata on the cell.
    */
-  getMetadata(name: string): IMetadataCursor {
+  getMetadata(name: string): Metadata.ICursor {
     if (this.isDisposed) {
       return null;
     }
     if (name in this._cursors) {
       return this._cursors[name];
     }
-    let cursor = new MetadataCursor(
+    let cursor = new Metadata.Cursor(
       name,
       () => {
         return this._metadata[name];
@@ -274,7 +274,7 @@ class CellModel extends CodeEditor.Model implements ICellModel {
   }
 
   private _metadata: { [key: string]: any } = Object.create(null);
-  private _cursors: { [key: string]: MetadataCursor } = Object.create(null);
+  private _cursors: { [key: string]: Metadata.Cursor } = Object.create(null);
 }
 
 

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/core/messaging';
 
 import {
-  PanelLayout
+  Panel, PanelLayout
 } from 'phosphor/lib/ui/panel';
 
 import {
@@ -124,10 +124,10 @@ class BaseCellWidget extends Widget {
 
     let model = this._model = options.model;
 
-    let factory = options.contentFactory;
+    let factory = this.contentFactory = options.contentFactory;
     let editorOptions = { model, factory: factory.editorFactory };
 
-    let editor =this._editor = factory.createCellEditor(editorOptions);
+    let editor = this._editor = factory.createCellEditor(editorOptions);
     editor.addClass(CELL_EDITOR_CLASS);
 
     this._input = factory.createInputArea({ editor });
@@ -141,6 +141,11 @@ class BaseCellWidget extends Widget {
     model.metadataChanged.connect(this.onMetadataChanged, this);
     model.stateChanged.connect(this.onModelStateChanged, this);
   }
+
+  /**
+   * The content factory used by the widget.
+   */
+  readonly contentFactory: BaseCellWidget.IContentFactory;
 
   /**
    * Get the prompt node used by the cell.
@@ -420,6 +425,11 @@ class CodeCellWidget extends BaseCellWidget {
    * The model used by the widget.
    */
   readonly model: ICodeCellModel;
+
+  /**
+   * The content factory used by the widget.
+   */
+  readonly contentFactory: CodeCellWidget.IContentFactory;
 
   /**
    * Dispose of the resources used by the widget.

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/core/messaging';
 
 import {
-  Panel, PanelLayout
+  PanelLayout
 } from 'phosphor/lib/ui/panel';
 
 import {
@@ -30,7 +30,7 @@ import {
 } from '../rendermime';
 
 import {
-  IMetadataCursor
+  Metadata
 } from '../common/metadata';
 
 import {
@@ -295,7 +295,7 @@ class BaseCellWidget extends Widget {
   private _editor: CodeEditorWidget = null;
   private _model: ICellModel = null;
   private _readOnly = false;
-  private _trustedCursor: IMetadataCursor = null;
+  private _trustedCursor: Metadata.ICursor = null;
   private _trusted = false;
 }
 
@@ -517,8 +517,8 @@ class CodeCellWidget extends BaseCellWidget {
 
   private _rendermime: RenderMime = null;
   private _output: OutputAreaWidget = null;
-  private _collapsedCursor: IMetadataCursor = null;
-  private _scrolledCursor: IMetadataCursor = null;
+  private _collapsedCursor: Metadata.ICursor = null;
+  private _scrolledCursor: Metadata.ICursor = null;
 }
 
 

--- a/src/common/metadata.css
+++ b/src/common/metadata.css
@@ -1,0 +1,47 @@
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-MetadataEditor {
+  padding-left: 10px;
+  padding-right: 10px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+
+.jp-MetadataEditor textarea {
+  min-height: 100px;
+}
+
+
+.jp-MetadataEditor.jp-mod-error textarea {
+  border-color: red;
+  outline-color: red;
+}
+
+
+.jp-MetadataEditor-buttons {
+  font-family: FontAwesome;
+  flex: 1 0 auto;
+  min-height: 13px;
+  padding-bottom: 6px;
+}
+
+
+.jp-MetadataEditor-commitButton::before {
+  content: '\f0c7'; /* save */
+  float: right;
+  margin-right: 20px;
+}
+
+
+.jp-MetadataEditor-revertButton::before {
+  content: '\f0e2'; /* undo */
+  float: right;
+  margin-right: 4px;
+}

--- a/src/common/metadata.ts
+++ b/src/common/metadata.ts
@@ -14,7 +14,7 @@ import {
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
-  JSONObject, JSONValue
+  JSONObject, JSONValue, deepEqual
 } from 'phosphor/lib/algorithm/json';
 
 import {
@@ -281,6 +281,7 @@ namespace MetadataCursor {
           } else if (target === this.confirmButtonNode) {
             if (!this.hasClass(ERROR_CLASS)) {
               this._mergeContent();
+              this._setValue();
             }
           }
           break;
@@ -326,12 +327,26 @@ namespace MetadataCursor {
      * Merge the user content.
      */
     private _mergeContent(): void {
-      let current = this._getContent();
+      let current = this._getContent() as JSONObject;
       let old = this._originalValue;
-      let user = JSON.parse(this.textareaNode.value);
-      console.log('current', current);
-      console.log('old', old);
-      console.log('user', user);
+      let user = JSON.parse(this.textareaNode.value) as JSONObject;
+      let owner = this.owner;
+      // If it is in user and has changed from old, set in current.
+      for (let key in user) {
+        if (!deepEqual(user[key], old[key])) {
+          current[key] = user[key];
+        }
+      }
+      // If it was in old and is not in user, remove from current.
+      for (let key in old) {
+        if (!(key in user)) {
+          delete current[key];
+        }
+      }
+      // Set the values.
+      for (let key in current) {
+        owner.getMetadata(key).setValue(current[key]);
+      }
     }
 
     /**

--- a/src/common/metadata.ts
+++ b/src/common/metadata.ts
@@ -310,6 +310,7 @@ namespace MetadataCursor {
      * Handle input events for the text area.
      */
     private _evtInput(event: Event): void {
+      let valid = true;
       try {
         let value = JSON.parse(this.textareaNode.value);
         this.removeClass(ERROR_CLASS);
@@ -317,9 +318,10 @@ namespace MetadataCursor {
       } catch (err) {
         this.addClass(ERROR_CLASS);
         this._inputDirty = true;
+        valid = false;
       }
       this.cancelButtonNode.hidden = !this._inputDirty;
-      this.confirmButtonNode.hidden = !this._inputDirty;
+      this.confirmButtonNode.hidden = !valid || !this._inputDirty;
     }
 
     /**

--- a/src/common/metadata.ts
+++ b/src/common/metadata.ts
@@ -57,92 +57,90 @@ const COMMIT_CLASS = 'jp-MetadataEditor-commitButton';
 
 
 /**
- * A class used to interact with user level metadata.
+ * The namespace for Metadata related data.
  */
 export
-interface IMetadataCursor {
+namespace Metadata {
   /**
-   * The metadata namespace.
+   * A class used to interact with user level metadata.
    */
-  readonly name: string;
+  export
+  interface ICursor {
+    /**
+     * The metadata namespace.
+     */
+    readonly name: string;
 
-  /**
-   * Get the value of the metadata.
-   */
-  getValue(): JSONValue;
+    /**
+     * Get the value of the metadata.
+     */
+    getValue(): JSONValue;
 
-  /**
-   * Set the value of the metdata.
-   */
-  setValue(value: JSONValue): void;
-}
-
-
-/**
- * An implementation of a metadata cursor.
- */
-export
-class MetadataCursor implements IMetadataCursor {
-  /**
-   * Construct a new metadata cursor.
-   *
-   * @param name - The metadata namespace key.
-   *
-   * @param read - The read callback.
-   *
-   * @param write - The write callback.
-   */
-  constructor(name: string, read: () => any, write: (value: JSONValue) => void) {
-    this._name = name;
-    this._read = read;
-    this._write = write;
+    /**
+     * Set the value of the metdata.
+     */
+    setValue(value: JSONValue): void;
   }
 
   /**
-   * Get the namespace key of the metadata.
+   * An implementation of a metadata cursor.
    */
-  get name(): string {
-    return this._name;
+  export
+  class Cursor implements ICursor {
+    /**
+     * Construct a new metadata cursor.
+     *
+     * @param name - The metadata namespace key.
+     *
+     * @param read - The read callback.
+     *
+     * @param write - The write callback.
+     */
+    constructor(name: string, read: () => any, write: (value: JSONValue) => void) {
+      this._name = name;
+      this._read = read;
+      this._write = write;
+    }
+
+    /**
+     * Get the namespace key of the metadata.
+     */
+    get name(): string {
+      return this._name;
+    }
+
+    /**
+     * Dispose of the resources used by the cursor.
+     *
+     * #### Notes
+     * This is not meant to be called by user code.
+     */
+    dispose(): void {
+      this._read = null;
+      this._write = null;
+    }
+
+    /**
+     * Get the value of the namespace data.
+     */
+    getValue(): JSONValue {
+      let read = this._read;
+      return read();
+    }
+
+    /**
+     * Set the value of the namespace data.
+     */
+    setValue(value: JSONValue): void {
+      let write = this._write;
+      write(value);
+    }
+
+    private _name = '';
+    private _read: () => JSONValue = null;
+    private _write: (value: JSONValue) => void = null;
   }
 
-  /**
-   * Dispose of the resources used by the cursor.
-   *
-   * #### Notes
-   * This is not meant to be called by user code.
-   */
-  dispose(): void {
-    this._read = null;
-    this._write = null;
-  }
-
-  /**
-   * Get the value of the namespace data.
-   */
-  getValue(): JSONValue {
-    let read = this._read;
-    return read();
-  }
-
-  /**
-   * Set the value of the namespace data.
-   */
-  setValue(value: JSONValue): void {
-    let write = this._write;
-    write(value);
-  }
-
-  private _name = '';
-  private _read: () => JSONValue = null;
-  private _write: (value: JSONValue) => void = null;
-}
-
-
-/**
- * The namespace for `MetadataCursor` statics.
- */
-export
-namespace MetadataCursor {
   /**
    * A class which supplies metadata.
    */
@@ -156,7 +154,7 @@ namespace MetadataCursor {
      * on the model.  This method is used to interact with a namespaced
      * set of metadata on the object.
      */
-    getMetadata(name: string): IMetadataCursor;
+    getMetadata(name: string): ICursor;
 
     /**
      * List the metadata namespace keys for the object.

--- a/src/common/metadata.ts
+++ b/src/common/metadata.ts
@@ -372,6 +372,7 @@ namespace Metadata {
       for (let key in old) {
         if (!(key in user)) {
           delete current[key];
+          owner.getMetadata(key).setValue(void 0);
         }
       }
       // Set the values.

--- a/src/common/metadata.ts
+++ b/src/common/metadata.ts
@@ -2,8 +2,38 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JSONValue
+  each
+} from 'phosphor/lib/algorithm/iteration';
+
+import {
+  Message
+} from 'phosphor/lib/core/messaging';
+
+import {
+  IIterator
+} from 'phosphor/lib/algorithm/iteration';
+
+import {
+  JSONObject, JSONValue
 } from 'phosphor/lib/algorithm/json';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
+  h, realize
+} from 'phosphor/lib/ui/vdom';
+
+import {
+  IChangedArgs
+} from '../common/interfaces';
+
+
+/**
+ * The class name added to a MetadataEditor instance.
+ */
+const METADATA_CLASS = 'jp-MetadataEditor';
 
 
 /**
@@ -85,4 +115,203 @@ class MetadataCursor implements IMetadataCursor {
   private _name = '';
   private _read: () => JSONValue = null;
   private _write: (value: JSONValue) => void = null;
+}
+
+
+/**
+ * The namespace for `MetadataCursor` statics.
+ */
+export
+namespace MetadataCursor {
+  /**
+   * A class which supplies metadata.
+   */
+  export
+  interface IOwner {
+    /**
+     * Get a metadata cursor for the object.
+     *
+     * #### Notes
+     * Metadata associated with the nbformat spec are set directly
+     * on the model.  This method is used to interact with a namespaced
+     * set of metadata on the object.
+     */
+    getMetadata(name: string): IMetadataCursor;
+
+    /**
+     * List the metadata namespace keys for the object.
+     *
+     * #### Notes
+     * Metadata associated with the nbformat are not included.
+     */
+    listMetadata(): IIterator<string>;
+  }
+
+  /**
+   * A metadata changed message.
+   */
+  export
+  class ChangeMessage extends Message {
+    /**
+     * Create a new metadata changed message.
+     */
+    constructor(args: IChangedArgs<JSONValue>) {
+      super('metadata-changed');
+      this.args = args;
+    }
+
+    /**
+     * The arguments of the metadata change.
+     */
+    readonly args: IChangedArgs<JSONValue>;
+  }
+
+  /**
+   * A widget that supports the editing of metadata.
+   */
+  export
+  class Editor extends Widget {
+    /**
+     * Construct a new metadata editor.
+     */
+    constructor() {
+      super({ node: Private.createMetadataNode() });
+    }
+
+    /**
+     * Get the text area used by the metadata editor.
+     */
+    get textarea(): HTMLTextAreaElement {
+      return this.node.getElementsByTagName('textarea')[0];
+    }
+
+    /**
+     * The metadata owner.
+     */
+    get owner(): IOwner | null {
+      return this._owner;
+    }
+    set owner(value: IOwner | null) {
+      this._owner = value;
+      this._handleOwner();
+    }
+
+    /**
+     * Process a message sent to the widget.
+     *
+     * @param msg - The message sent to the widget.
+     */
+    processMessage(msg: Message): void {
+      super.processMessage(msg);
+      switch (msg.type) {
+      case 'metadata-changed':
+        this.onMetadataChanged(msg as ChangeMessage);
+        break;
+      default:
+        break;
+      }
+    }
+
+    /**
+     * Handle the DOM events for the widget.
+     *
+     * @param event - The DOM event sent to the widget.
+     *
+     * #### Notes
+     * This method implements the DOM `EventListener` interface and is
+     * called in response to events on the notebook panel's node. It should
+     * not be called directly by user code.
+     */
+    handleEvent(event: Event): void {
+      switch (event.type) {
+        case 'input':
+          this._inputDirty = true;
+          break;
+        case 'focus':
+          break;
+        case 'blur':
+          // Update the metadata if necessary.
+          if (!this._inputDirty && this._dataDirty) {
+            this._handleOwner();
+          }
+          break;
+        default:
+          break;
+      }
+    }
+
+    /**
+     * Handle `after-attach` messages for the widget.
+     */
+    protected onAfterAttach(msg: Message): void {
+      let node = this.textarea;
+      node.addEventListener('input', this);
+      node.addEventListener('focus', this);
+      node.addEventListener('blur', this);
+    }
+
+    /**
+     * Handle `before_detach` messages for the widget.
+     */
+    protected onBeforeDetach(msg: Message): void {
+      let node = this.textarea;
+      node.removeEventListener('input', this);
+      node.removeEventListener('focus', this);
+      node.removeEventListener('blur', this);
+    }
+
+    /**
+     * Handle a change to the metadata of the active cell.
+     */
+    protected onMetadataChanged(msg: ChangeMessage) {
+      if (document.activeElement === this.textarea) {
+        this._dataDirty = true;
+      }
+      this._handleOwner();
+    }
+
+    /**
+     * Handle the owner contents.
+     */
+    private _handleOwner(): void {
+      this._dataDirty = false;
+      this._inputDirty = false;
+      let owner = this.owner;
+      if (owner) {
+        let content: JSONObject = {};
+        each(owner.listMetadata(), key => {
+          // Do not show the trusted metadata.
+          if (key === 'trusted') {
+            return;
+          }
+          content[key] = owner.getMetadata(key).getValue();
+        });
+        this.textarea.value = JSON.stringify(content, null, 2);
+      } else {
+        this.textarea.value = 'No active cell!';
+      }
+    }
+
+    private _dataDirty = false;
+    private _inputDirty = false;
+    private _owner: IOwner | null;
+  }
+}
+
+
+/**
+ * The namespace for module private data.
+ */
+namespace Private {
+  /**
+   * Create the node for a MetadataEditor.
+   */
+  export
+  function createMetadataNode(): HTMLElement {
+    let vnode = h.div({ className: METADATA_CLASS },
+                h.label({}, 'Cell Metadata'),
+                h.textarea()
+              );
+    return realize(vnode);
+  }
 }

--- a/src/common/metadata.ts
+++ b/src/common/metadata.ts
@@ -43,17 +43,17 @@ const ERROR_CLASS = 'jp-mod-error';
 /**
  * The class name added to the button area.
  */
-const BUTTON_AREA = 'jp-MetadataEditor-buttons';
+const BUTTON_AREA_CLASS = 'jp-MetadataEditor-buttons';
 
 /**
- * The class name added to the cancel button.
+ * The class name added to the revert button.
  */
-const CANCEL_BUTTON = 'jp-MetadataEditor-cancelButton';
+const REVERT_CLASS = 'jp-MetadataEditor-revertButton';
 
 /**
- * The class name added to the cancel button.
+ * The class name added to the commit button.
  */
-const CONFIRM_BUTTON = 'jp-MetadataEditor-confirmButton';
+const COMMIT_CLASS = 'jp-MetadataEditor-commitButton';
 
 
 /**
@@ -207,17 +207,17 @@ namespace MetadataCursor {
     }
 
     /**
-     * Get the cancel button used by the metadata editor.
+     * Get the revert button used by the metadata editor.
      */
-    get cancelButtonNode(): HTMLElement {
-      return this.node.getElementsByClassName(CANCEL_BUTTON)[0] as HTMLElement;
+    get revertButtonNode(): HTMLElement {
+      return this.node.getElementsByClassName(REVERT_CLASS)[0] as HTMLElement;
     }
 
     /**
-     * Get the confirm button used by the metadata editor.
+     * Get the commit button used by the metadata editor.
      */
-    get confirmButtonNode(): HTMLElement {
-      return this.node.getElementsByClassName(CONFIRM_BUTTON)[0] as HTMLElement;
+    get commitButtonNode(): HTMLElement {
+      return this.node.getElementsByClassName(COMMIT_CLASS)[0] as HTMLElement;
     }
 
     /**
@@ -229,6 +229,13 @@ namespace MetadataCursor {
     set owner(value: IOwner | null) {
       this._owner = value;
       this._setValue();
+    }
+
+    /**
+     * Get whether the editor is dirty.
+     */
+    get isDirty(): boolean {
+      return this._dataDirty || this._inputDirty;
     }
 
     /**
@@ -280,8 +287,8 @@ namespace MetadataCursor {
       let node = this.textareaNode;
       node.addEventListener('input', this);
       node.addEventListener('blur', this);
-      this.cancelButtonNode.addEventListener('click', this);
-      this.confirmButtonNode.addEventListener('click', this);
+      this.revertButtonNode.addEventListener('click', this);
+      this.commitButtonNode.addEventListener('click', this);
     }
 
     /**
@@ -291,8 +298,8 @@ namespace MetadataCursor {
       let node = this.textareaNode;
       node.removeEventListener('input', this);
       node.removeEventListener('blur', this);
-      this.cancelButtonNode.removeEventListener('click', this);
-      this.confirmButtonNode.removeEventListener('click', this);
+      this.revertButtonNode.removeEventListener('click', this);
+      this.commitButtonNode.removeEventListener('click', this);
     }
 
     /**
@@ -320,8 +327,8 @@ namespace MetadataCursor {
         this._inputDirty = true;
         valid = false;
       }
-      this.cancelButtonNode.hidden = !this._inputDirty;
-      this.confirmButtonNode.hidden = !valid || !this._inputDirty;
+      this.revertButtonNode.hidden = !this._inputDirty;
+      this.commitButtonNode.hidden = !valid || !this._inputDirty;
     }
 
     /**
@@ -339,9 +346,9 @@ namespace MetadataCursor {
      */
     private _evtClick(event: MouseEvent): void {
       let target = event.target as HTMLElement;
-      if (target === this.cancelButtonNode) {
+      if (target === this.revertButtonNode) {
         this._setValue();
-      } else if (target === this.confirmButtonNode) {
+      } else if (target === this.commitButtonNode) {
         if (!this.hasClass(ERROR_CLASS)) {
           this._mergeContent();
           this._setValue();
@@ -400,8 +407,8 @@ namespace MetadataCursor {
     private _setValue(): void {
       this._dataDirty = false;
       this._inputDirty = false;
-      this.cancelButtonNode.hidden = true;
-      this.confirmButtonNode.hidden = true;
+      this.revertButtonNode.hidden = true;
+      this.commitButtonNode.hidden = true;
       this.removeClass(ERROR_CLASS);
       let textarea = this.textareaNode;
       let content = this._getContent();
@@ -432,13 +439,14 @@ namespace Private {
    */
   export
   function createMetadataNode(): HTMLElement {
-    let vnode = h.div({ className: METADATA_CLASS },
-                h.label({}, 'Cell Metadata'),
-                h.div({ className: BUTTON_AREA },
-                  h.span({ className: CANCEL_BUTTON }),
-                  h.span({ className: CONFIRM_BUTTON })),
-                h.textarea()
-              );
-    return realize(vnode);
+    let cancelTitle = 'Revert changes to Metadata';
+    let confirmTitle = 'Commit changes to Metadata';
+    return realize(
+      h.div({ className: METADATA_CLASS },
+        h.div({ className: BUTTON_AREA_CLASS },
+          h.span({ className: REVERT_CLASS, title: cancelTitle }),
+          h.span({ className: COMMIT_CLASS, title: confirmTitle })),
+        h.textarea())
+    );
   }
 }

--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -24,6 +24,7 @@
 @import '../commandpalette/index.css';
 @import '../common/dialog.css';
 @import '../common/iframe.css';
+@import '../common/metadata.css';
 @import '../completer/index.css';
 @import '../console/index.css';
 @import '../csvwidget/index.css';

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -430,7 +430,7 @@ namespace CellTools {
           content[key] = activeCell.model.getMetadata(key).getValue();
         });
       }
-      this.textarea.value = JSON.stringify(content);
+      this.textarea.value = JSON.stringify(content, null, 2);
     }
 
     /**

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -346,7 +346,7 @@ namespace CellTools {
      * #### Notes
      * The default implementation is a no-op.
      */
-     protected onMetadataChanged(sender: ICellTools, args: IChangedArgs<JSONValue>) { /* no-op */ }
+     protected onMetadataChanged(sender: ICellTools, args: IChangedArgs<JSONValue>): void { /* no-op */ }
   }
 
   /**
@@ -375,7 +375,10 @@ namespace CellTools {
         layout.widgets.at(0).dispose();
       }
       if (!activeCell) {
-        // TODO: Use dummy content.
+        let cell = new Widget();
+        cell.addClass('jp-CellEditor');
+        cell.addClass('jp-InputArea-editor');
+        layout.addWidget(cell);
         return;
       }
       let promptNode = activeCell.promptNode.cloneNode(true) as HTMLElement;
@@ -386,7 +389,7 @@ namespace CellTools {
       model.mimeType = activeCell.model.mimeType;
       let editorWidget = new CodeEditorWidget({ model, factory });
       editorWidget.addClass('jp-CellEditor');
-      editorWidget.addClass('.jp-InputArea-editor');
+      editorWidget.addClass('jp-InputArea-editor');
       editorWidget.editor.readOnly = true;
       layout.addWidget(prompt);
       layout.addWidget(editorWidget);

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -1,0 +1,221 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  each
+} from 'phosphor/lib/algorithm/iteration';
+
+import {
+  findIndex, upperBound
+} from 'phosphor/lib/algorithm/searching';
+
+import {
+  defineSignal, ISignal
+} from 'phosphor/lib/core/signaling';
+
+import {
+  Vector
+} from 'phosphor/lib/collections/vector';
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
+  PanelLayout
+} from 'phosphor/lib/ui/panel';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
+  BaseCellWidget
+} from '../cells';
+
+import {
+  INotebookTracker
+} from './';
+
+
+/* tslint:disable */
+/**
+ * The main menu token.
+ */
+export
+const ICellTools = new Token<ICellTools>('jupyter.services.cell-tools');
+/* tslint:enable */
+
+
+/**
+ * The interface for cell metadata tools.
+ */
+export
+interface ICellTools extends CellTools {};
+
+
+/**
+ * A widget that provides cell metadata tools.
+ */
+export
+class CellTools extends Widget implements ICellTools {
+  /**
+   * Construct a new CellTools object.
+   */
+  constructor(options: CellTools.IOptions) {
+    super();
+    this._tracker = options.tracker;
+    this.layout = new PanelLayout();
+    this._tracker.activeCellChanged.connect(this._onActiveCellChanged, this);
+    this._tracker.selectionChanged.connect(this._onSelectionChanged, this);
+  }
+
+  /**
+   * A signal emitted when the current active cell changes.
+   */
+  readonly activeCellChanged: ISignal<this, BaseCellWidget>;
+
+  /**
+   * A signal emitted when the selection state changes.
+   */
+  readonly selectionChanged: ISignal<this, void>;
+
+  /**
+   * The active cell widget.
+   */
+  get activeCell(): BaseCellWidget | null {
+    return this._tracker.activeCell;
+  }
+
+  /**
+   * The currently selected cells.
+   */
+  get selectedCells(): BaseCellWidget[] {
+    let selected: BaseCellWidget[] = [];
+    let panel = this._tracker.currentWidget;
+    if (!panel) {
+      return selected;
+    }
+    each(panel.notebook.widgets, widget => {
+      if (panel.notebook.isSelected(widget)) {
+        selected.push(widget);
+      }
+    });
+    return selected;
+  }
+
+  /**
+   * Add a cell tool item.
+   */
+  addItem(options: CellTools.IAddOptions): void {
+    let widget = options.widget;
+    let rank = 'rank' in options ? options.rank : 100;
+    let rankItem = { widget, rank };
+    let index = upperBound(this._items, rankItem, Private.itemCmp);
+
+    // Upon disposal, remove the widget and its rank reference.
+    widget.disposed.connect(this._onWidgetDisposed, this);
+
+    this._items.insert(index, rankItem);
+    let layout = this.layout as PanelLayout;
+    layout.insertWidget(index, widget);
+  }
+
+  /**
+   * Handle the disposal of an item.
+   */
+  private _onWidgetDisposed(widget: Widget): void {
+    let index = findIndex(this._items, item => item.widget === widget);
+    if (index !== -1) {
+      this._items.removeAt(index);
+    }
+  }
+
+  /**
+   * Handle a change to the active cell.
+   */
+  private _onActiveCellChanged(): void {
+    this.activeCellChanged.emit(this._tracker.activeCell);
+  }
+
+  /**
+   * Handle a change in the selection.
+   */
+  private _onSelectionChanged(): void {
+    this.selectionChanged.emit(void 0);
+  }
+
+  private _items = new Vector<Private.IRankItem>();
+  private _tracker: INotebookTracker;
+}
+
+
+/**
+ * The namespace for CellTools class statics.
+ */
+export
+namespace CellTools {
+  /**
+   * The options used to create a CellTools object.
+   */
+  export
+  interface IOptions {
+    /**
+     * The notebook tracker used by the cell tools.
+     */
+    tracker: INotebookTracker;
+  }
+
+  /**
+   * The options used to add an item to the cell tools.
+   */
+  export
+  interface IAddOptions {
+    /**
+     * The widget to add to the cell tools area.
+     */
+    widget: Widget;
+
+    /**
+     * The rank order of the widget among its siblings.
+     */
+    rank?: number;
+  }
+}
+
+
+
+// Define the signals for the `CellTools` class.
+defineSignal(CellTools.prototype, 'activeCellChanged');
+defineSignal(CellTools.prototype, 'selectionChanged');
+
+
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+  /**
+   * An object which holds a widget and its sort rank.
+   */
+  export
+  interface IRankItem {
+    /**
+     * The widget for the item.
+     */
+    widget: Widget;
+
+    /**
+     * The sort rank of the menu.
+     */
+    rank: number;
+  }
+
+  /**
+   * A comparator function for widget rank items.
+   */
+  export
+  function itemCmp(first: IRankItem, second: IRankItem): number {
+    return first.rank - second.rank;
+  }
+}

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -176,8 +176,8 @@ class CellTools extends Widget {
   /**
    * Handle the removal of a child
    */
-  protected onChildRemoved(message: ChildMessage): void {
-    let index = findIndex(this._items, item => item.tool === message.child);
+  protected onChildRemoved(msg: ChildMessage): void {
+    let index = findIndex(this._items, item => item.tool === msg.child);
     if (index !== -1) {
       this._items.removeAt(index);
     }
@@ -214,7 +214,9 @@ class CellTools extends Widget {
    */
   private _onMetadataChanged(sender: ICellModel, args: IChangedArgs<JSONValue>): void {
     let message = new CellTools.MetadataMessage(args);
-    each(this.children(), widget => { sendMessage(widget, message); });
+    each(this.children(), widget => {
+      sendMessage(widget, message);
+    });
   }
 
   private _items = new Vector<Private.IRankItem>();
@@ -324,7 +326,7 @@ namespace CellTools {
      * #### Notes
      * The default implemenatation is a no-op.
      */
-    protected onActiveCellChanged(message: Message): void { /* no-op */ }
+    protected onActiveCellChanged(msg: Message): void { /* no-op */ }
 
     /**
      * Handle a change to the selection.
@@ -332,7 +334,7 @@ namespace CellTools {
      * #### Notes
      * The default implementation is a no-op.
      */
-    protected onSelectionChanged(message: Message): void { /* no-op */ }
+    protected onSelectionChanged(msg: Message): void { /* no-op */ }
 
     /**
      * Handle a change to the metadata of the active cell.
@@ -340,7 +342,7 @@ namespace CellTools {
      * #### Notes
      * The default implementation is a no-op.
      */
-     protected onMetadataChanged(message: MetadataMessage): void { /* no-op */ }
+     protected onMetadataChanged(msg: MetadataMessage): void { /* no-op */ }
   }
 
   /**
@@ -416,7 +418,7 @@ namespace CellTools {
     /**
      * Handle a change to the active cell.
      */
-    protected onActiveCellChanged(message: Message): void {
+    protected onActiveCellChanged(msg: Message): void {
       let activeCell = this.parent.activeCell;
       if (activeCell) {
         let content: JSONObject = {};
@@ -436,7 +438,7 @@ namespace CellTools {
     /**
      * Handle a change to the metadata of the active cell.
      */
-    protected onMetadataChanged(message: CellTools.MetadataMessage) {
+    protected onMetadataChanged(msg: CellTools.MetadataMessage) {
       this.onActiveCellChanged(CellTools.ActiveCellMessage);
     }
   }
@@ -498,7 +500,7 @@ namespace CellTools {
     /**
      * Handle `after-attach` messages for the widget.
      */
-    protected onAfterAttach(message: Message): void {
+    protected onAfterAttach(msg: Message): void {
       this.selectNode.addEventListener('change', this);
       this.selectNode.addEventListener('focus', this);
       this.selectNode.addEventListener('blur', this);
@@ -516,7 +518,7 @@ namespace CellTools {
     /**
      * Handle a change to the active cell.
      */
-    protected onActiveCellChanged(message: Message): void {
+    protected onActiveCellChanged(msg: Message): void {
       let select = this.selectNode;
       let activeCell = this.parent.activeCell;
       if (!activeCell) {
@@ -538,14 +540,14 @@ namespace CellTools {
     /**
      * Handle a change to the metadata of the active cell.
      */
-    protected onMetadataChanged(message: CellTools.MetadataMessage) {
+    protected onMetadataChanged(msg: CellTools.MetadataMessage) {
       if (this._changeGuard) {
         return;
       }
       let select = this.selectNode;
-      if (message.args.name === this.key) {
+      if (msg.args.name === this.key) {
         this._changeGuard = true;
-        select.value = JSON.stringify(message.args.newValue);
+        select.value = JSON.stringify(msg.args.newValue);
         this._changeGuard = false;
       }
     }

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -34,7 +34,7 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  Widget
+  ChildMessage, Widget
 } from 'phosphor/lib/ui/widget';
 
 import {
@@ -64,9 +64,9 @@ import {
 const CELLTOOLS_CLASS = 'jp-CellTools';
 
 /**
- * The class name added to a CellTools child.
+ * The class name added to a CellTools tool.
  */
-const CHILD_CLASS = 'jp-CellTools-child';
+const CHILD_CLASS = 'jp-CellTools-tool';
 
 /**
  * The class name added to a CellTools active cell.
@@ -92,11 +92,6 @@ const SELECT_WRAPPER_CLASS = 'jp-KeySelector-selectWrapper';
  * The class name added to a wrapper that has focus.
  */
 const FOCUS_CLASS = 'jp-mod-focused';
-
-/**
- * The class name added to a separator widget.
- */
-const SEPARATOR_CLASS = 'jp-CellTools-separator';
 
 
 /* tslint:disable */
@@ -169,37 +164,22 @@ class CellTools extends Widget {
 
     tool.addClass(CHILD_CLASS);
 
-    // Upon disposal, remove the widget and its rank reference.
-    tool.disposed.connect(this._onWidgetDisposed, this);
-
-    // Add the item and optionally a separator.
+    // Add the tool.
     this._items.insert(index, rankItem);
     let layout = this.layout as PanelLayout;
-    if (this._items.length > 1) {
-      let separator = new Widget();
-      separator.addClass(SEPARATOR_CLASS);
-      layout.insertWidget(index * 2 - 1, separator);
-    }
-    layout.insertWidget(index * 2, tool);
+    layout.insertWidget(index, tool);
 
     // Trigger the tool to update its active cell.
     sendMessage(tool, CellTools.ActiveCellMessage);
   }
 
   /**
-   * Handle the disposal of an item.
+   * Handle the removal of a child
    */
-  private _onWidgetDisposed(widget: Widget): void {
-    let index = findIndex(this._items, item => item.tool === widget);
+  protected onChildRemoved(message: ChildMessage): void {
+    let index = findIndex(this._items, item => item.tool === message.child);
     if (index !== -1) {
       this._items.removeAt(index);
-    }
-    let layout = this.layout as PanelLayout;
-    // Remove the separator.
-    if (index === 0 && layout.widgets.length) {
-      layout.widgets.at(0).dispose;
-    } else if (layout.widgets.length) {
-      layout.widgets.at(index * 2 - 1).dispose();
     }
   }
 

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -54,7 +54,7 @@ import {
 } from '../common/interfaces';
 
 import {
-  MetadataCursor
+  Metadata
 } from '../common/metadata';
 
 import {
@@ -232,7 +232,7 @@ class CellTools extends Widget {
    * Handle a change in the metadata.
    */
   private _onMetadataChanged(sender: ICellModel, args: IChangedArgs<JSONValue>): void {
-    let message = new MetadataCursor.ChangeMessage(args);
+    let message = new Metadata.ChangeMessage(args);
     each(this.children(), widget => {
       sendMessage(widget, message);
     });
@@ -313,7 +313,7 @@ namespace CellTools {
         this.onSelectionChanged(msg);
         break;
       case 'metadata-changed':
-        this.onMetadataChanged(msg as MetadataCursor.ChangeMessage);
+        this.onMetadataChanged(msg as Metadata.ChangeMessage);
         break;
       default:
         break;
@@ -342,7 +342,7 @@ namespace CellTools {
      * #### Notes
      * The default implementation is a no-op.
      */
-     protected onMetadataChanged(msg: MetadataCursor.ChangeMessage): void { /* no-op */ }
+     protected onMetadataChanged(msg: Metadata.ChangeMessage): void { /* no-op */ }
   }
 
   /**
@@ -508,11 +508,11 @@ namespace CellTools {
     /**
      * Handle a change to the metadata of the active cell.
      */
-    protected onMetadataChanged(msg: MetadataCursor.ChangeMessage) {
+    protected onMetadataChanged(msg: Metadata.ChangeMessage) {
       sendMessage(this._editor, msg);
     }
 
-    private _editor: MetadataCursor.Editor = new MetadataCursor.Editor();
+    private _editor: Metadata.Editor = new Metadata.Editor();
   }
 
   /**
@@ -614,7 +614,7 @@ namespace CellTools {
     /**
      * Handle a change to the metadata of the active cell.
      */
-    protected onMetadataChanged(msg: MetadataCursor.ChangeMessage) {
+    protected onMetadataChanged(msg: Metadata.ChangeMessage) {
       if (this._changeGuard) {
         return;
       }

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -384,6 +384,7 @@ namespace CellTools {
       }
       if (this._cellModel) {
         this._cellModel.value.changed.disconnect(this._onValueChanged, this);
+        this._cellModel.mimeTypeChanged.disconnect(this._onMimeTypeChanged, this);
       }
       if (!activeCell) {
         let cell = new Widget();
@@ -399,6 +400,7 @@ namespace CellTools {
 
       let cellModel = this._cellModel = activeCell.model;
       cellModel.value.changed.connect(this._onValueChanged, this);
+      cellModel.mimeTypeChanged.connect(this._onMimeTypeChanged, this);
       this._model.value.text = cellModel.value.text.split('\n')[0];
       this._model.mimeType = cellModel.mimeType;
 
@@ -416,6 +418,13 @@ namespace CellTools {
      */
     private _onValueChanged(): void {
       this._model.value.text = this._cellModel.value.text.split('\n')[0];
+    }
+
+    /**
+     * Handle a change to the current editor mimetype.
+     */
+    private _onMimeTypeChanged(): void {
+      this._model.mimeType = this._cellModel.mimeType;
     }
 
     private _model = new CodeEditor.Model();

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -213,7 +213,7 @@ class CellTools extends Widget implements ICellTools {
     // Remove the separator.
     if (index === 0 && layout.widgets.length) {
       layout.widgets.at(0).dispose;
-    } else {
+    } else if (layout.widgets.length) {
       layout.widgets.at(index * 2 - 1).dispose();
     }
   }
@@ -539,6 +539,7 @@ namespace CellTools {
       let select = this.selectNode;
       if (!activeCell) {
         select.disabled = true;
+        select.value = '';
         return;
       }
       let cellType = activeCell.model.type;
@@ -567,7 +568,7 @@ namespace CellTools {
       }
     }
 
-    private _changeGuard = true;
+    private _changeGuard = false;
     private _validCellTypes: string[];
   }
 

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -78,9 +78,24 @@ const CHILD_CLASS = 'jp-CellTools-tool';
 const ACTIVE_CELL_CLASS = 'jp-ActiveCellTool';
 
 /**
- * The class name added to a MetadataEditor instance.
+ * The class name added to the Metadata editor tool.
  */
-const METADATA_CLASS = 'jp-MetadataEditor';
+const EDITOR_CLASS = 'jp-MetadataEditorTool';
+
+/**
+ * The class name added to an Editor instance.
+ */
+const EDITOR_TITLE_CLASS = 'jp-MetadataEditorTool-header';
+
+/**
+ * The class name added to the toggle button.
+ */
+const TOGGLE_CLASS = 'jp-MetadataEditorTool-toggleButton';
+
+/**
+ * The class name added to collapsed elements.
+ */
+const COLLAPSED_CLASS = 'jp-mod-collapsed';
 
 /**
  * The class name added to a KeySelector instance.
@@ -411,14 +426,66 @@ namespace CellTools {
    * A raw metadata editor.
    */
   export
-  class MetadataEditor extends Tool {
+  class MetadataEditorTool extends Tool {
     /**
      * Construct a new raw metadata tool.
      */
     constructor() {
       super();
+      this.addClass(EDITOR_CLASS);
       let layout = this.layout = new PanelLayout();
+      let header = Private.createMetadataHeader();
+      layout.addWidget(header);
       layout.addWidget(this._editor);
+      header.addClass(COLLAPSED_CLASS);
+      this._editor.addClass(COLLAPSED_CLASS);
+      this.toggleNode.classList.add(COLLAPSED_CLASS);
+    }
+
+    /**
+     * Get the toggle node used by the editor.
+     */
+    get toggleNode(): HTMLElement {
+      return this.node.getElementsByClassName(TOGGLE_CLASS)[0] as HTMLElement;
+    }
+
+    /**
+     * Handle the DOM events for the widget.
+     *
+     * @param event - The DOM event sent to the widget.
+     *
+     * #### Notes
+     * This method implements the DOM `EventListener` interface and is
+     * called in response to events on the notebook panel's node. It should
+     * not be called directly by user code.
+     */
+    handleEvent(event: Event): void {
+      if (event.type !== 'click') {
+        return;
+      }
+      each(this.children(), widget => {
+        widget.toggleClass(COLLAPSED_CLASS);
+      });
+      let toggleNode = this.toggleNode;
+      if (this._editor.hasClass(COLLAPSED_CLASS)) {
+        toggleNode.classList.add(COLLAPSED_CLASS);
+      } else {
+        toggleNode.classList.remove(COLLAPSED_CLASS);
+      }
+    }
+
+    /**
+     * Handle `after-attach` messages for the widget.
+     */
+    protected onAfterAttach(msg: Message): void {
+      this.toggleNode.addEventListener('click', this);
+    }
+
+    /**
+     * Handle `before_detach` messages for the widget.
+     */
+    protected onBeforeDetach(msg: Message): void {
+      this.toggleNode.removeEventListener('click', this);
     }
 
     /**
@@ -688,5 +755,18 @@ namespace Private {
           h.select({},
             optionNodes)))
     );
+  }
+
+  /**
+   * Create the metadata header widget.
+   */
+  export
+  function createMetadataHeader(): Widget {
+    let node = realize(
+      h.div({ className: EDITOR_TITLE_CLASS },
+        h.label({}, 'Cell Metadata'),
+        h.span({ className: TOGGLE_CLASS }))
+    );
+    return new Widget({ node });
   }
 }

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -30,6 +30,10 @@ import {
 } from 'phosphor/lib/ui/widget';
 
 import {
+  h, realize
+} from 'phosphor/lib/ui/vdom';
+
+import {
   BaseCellWidget
 } from '../cells';
 
@@ -56,6 +60,11 @@ const CHILD_CLASS = 'jp-CellTools-child';
  * The class name added to a CellTools active cell.
  */
 const ACTIVE_CELL_CLASS = 'jp-ActiveCellTool';
+
+/**
+ * The class name added to a MetadataEditor instance.
+ */
+const METADATA_CLASS = 'jp-MetaDataEditor';
 
 /**
  * The class name added to a separator widget.
@@ -148,7 +157,7 @@ class CellTools extends Widget implements ICellTools {
     let layout = this.layout as PanelLayout;
     if (this._items.length > 1) {
       let separator = new Widget();
-      widget.addClass(SEPARATOR_CLASS);
+      separator.addClass(SEPARATOR_CLASS);
       layout.insertWidget(index * 2 - 1, separator);
     }
     layout.insertWidget(index * 2, widget);
@@ -271,7 +280,6 @@ namespace CellTools {
     private _celltools: ICellTools;
   }
 
-
   /**
    * The namespace for `ActiveCellTool` class statics.
    */
@@ -288,6 +296,65 @@ namespace CellTools {
       celltools: ICellTools;
     }
   }
+
+  /**
+   * A raw metadata editor.
+   */
+  export
+  class MetadataEditor extends Widget {
+    /**
+     * Construct a new raw metadata tool.
+     */
+    constructor(options: ActiveCellTool.IOptions) {
+      let vnode = h.div({ className: METADATA_CLASS },
+                    h.p({}, 'Cell Metadata'),
+                    h.textarea()
+                  );
+      super({ node: realize(vnode) });
+      this._celltools = options.celltools;
+      this._celltools.activeCellChanged.connect(this._onActiveCellChanged, this);
+      this._onActiveCellChanged();
+    }
+
+    /**
+     * Get the text area used by the metadata editor.
+     */
+    get textarea(): HTMLTextAreaElement {
+      return this.node.getElementsByTagName('textarea')[0];
+    }
+
+    /**
+     * Handle a change to the active cell.
+     */
+    private _onActiveCellChanged(): void {
+      let activeCell = this._celltools.activeCell;
+      if (!activeCell) {
+        // TODO: Use dummy content.
+        return;
+      }
+      this.textarea.textContent = activeCell.model.value.text;
+    }
+
+    private _celltools: ICellTools;
+  }
+
+  /**
+   * The namespace for `ActiveCellTool` class statics.
+   */
+  export
+  namespace MetadataEditor {
+    /**
+     * The options used to create a metadata editor.
+     */
+    export
+    interface IOptions {
+      /**
+       * The cell tools object.
+       */
+      celltools: ICellTools;
+    }
+  }
+
 }
 
 

--- a/src/notebook/celltools.ts
+++ b/src/notebook/celltools.ts
@@ -445,11 +445,17 @@ namespace CellTools {
       let layout = this.layout = new PanelLayout();
       let header = Private.createMetadataHeader();
       layout.addWidget(header);
-      layout.addWidget(this._editor);
+      this.editor = new Metadata.Editor();
+      layout.addWidget(this.editor);
       header.addClass(COLLAPSED_CLASS);
-      this._editor.addClass(COLLAPSED_CLASS);
+      this.editor.addClass(COLLAPSED_CLASS);
       this.toggleNode.classList.add(COLLAPSED_CLASS);
     }
+
+    /**
+     * The editor used by the tool.
+     */
+    readonly editor: Metadata.Editor;
 
     /**
      * Get the toggle node used by the editor.
@@ -476,7 +482,7 @@ namespace CellTools {
         widget.toggleClass(COLLAPSED_CLASS);
       });
       let toggleNode = this.toggleNode;
-      if (this._editor.hasClass(COLLAPSED_CLASS)) {
+      if (this.editor.hasClass(COLLAPSED_CLASS)) {
         toggleNode.classList.add(COLLAPSED_CLASS);
       } else {
         toggleNode.classList.remove(COLLAPSED_CLASS);
@@ -502,17 +508,15 @@ namespace CellTools {
      */
     protected onActiveCellChanged(msg: Message): void {
       let cell = this.parent.activeCell;
-      this._editor.owner = cell ? cell.model : null;
+      this.editor.owner = cell ? cell.model : null;
     }
 
     /**
      * Handle a change to the metadata of the active cell.
      */
     protected onMetadataChanged(msg: Metadata.ChangeMessage) {
-      sendMessage(this._editor, msg);
+      sendMessage(this.editor, msg);
     }
-
-    private _editor: Metadata.Editor = new Metadata.Editor();
   }
 
   /**

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -199,50 +199,8 @@
 }
 
 
-.jp-MetadataEditor {
-  flex-direction: column;
-  padding-left: 10px;
-  padding-right: 10px;
-  display: flex;
-  width: 100%;
-}
-
-
 .jp-MetadataEditor.jp-mod-collapsed {
   display: none;
-}
-
-
-.jp-MetadataEditor textarea {
-  min-height: 100px;
-}
-
-
-.jp-MetadataEditor.jp-mod-error textarea {
-  border-color: red;
-  outline-color: red;
-}
-
-
-.jp-MetadataEditor-buttons {
-  font-family: FontAwesome;
-  flex: 1 0 auto;
-  min-height: 13px;
-  padding-bottom: 6px;
-}
-
-
-.jp-MetadataEditor-commitButton::before {
-  content: '\f0c7'; /* save */
-  float: right;
-  margin-right: 20px;
-}
-
-
-.jp-MetadataEditor-revertButton::before {
-  content: '\f0e2'; /* undo */
-  float: right;
-  margin-right: 4px;
 }
 
 

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -138,7 +138,7 @@
 }
 
 
-.jp-CellTools-child {
+.jp-CellTools-tool {
   flex: 0 1 auto;
   display: flex;
   flex-direction: row;

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -149,18 +149,22 @@
   padding: var(--jp-private-notebook-padding);
 }
 
+
 .jp-ActiveCellTool .jp-Cell-prompt {
   flex: 0 0 auto;
 }
+
 
 .jp-ActiveCellTool .jp-CellEditor {
   flex: 1 1 auto;
 }
 
-.jp-CellTools-separator {
+
+.jp-CellTools-tool:not(:first-child) {
   margin-top: 6px;
   margin-bottom: 12px;
   border-top: 1px dotted gray;
+  padding-top: 6px;
 }
 
 
@@ -172,8 +176,8 @@
 
 
 .jp-KeySelector {
-  margin-left: 10px;
-  margin-right: 10px;
+  padding-left: 10px;
+  padding-right: 10px;
 }
 
 
@@ -192,7 +196,7 @@
 }
 
 
-.jp-KeySelector-selectWrapper{
+.jp-KeySelector-selectWrapper {
   display: flex;
   flex-direction: column;
   padding: 1px;

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -162,3 +162,10 @@
   margin-bottom: 12px;
   border-top: 1px dotted gray;
 }
+
+
+.jp-MetaDataEditor {
+  flex-direction: column;
+  padding-left: 10px;
+  padding-right: 10px;
+}

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -195,14 +195,14 @@
 .jp-MetadataEditor-confirmButton::before {
   content: '\f00c'; /* check */
   float: right;
-  margin-right: 4px;
+  margin-right: 20px;
 }
 
 
 .jp-MetadataEditor-cancelButton::before {
   content: '\f00d'; /* cancel */
   float: right;
-  margin-right: 20px;
+  margin-right: 4px;
 }
 
 

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -164,8 +164,47 @@
 }
 
 
-.jp-MetaDataEditor {
+.jp-MetadataEditor {
   flex-direction: column;
   padding-left: 10px;
   padding-right: 10px;
+}
+
+
+.jp-KeySelector {
+  margin-left: 10px;
+  margin-right: 10px;
+}
+
+
+.jp-KeySelector label {
+  padding-top: 4px;
+  padding-bottom: 4px;
+  line-height: 1.4;
+}
+
+
+.jp-KeySelector select {
+  flex: 1 1 auto;
+  height: 32px;
+  border: none;
+  outline: none;
+}
+
+
+.jp-KeySelector-selectWrapper{
+  display: flex;
+  flex-direction: column;
+  padding: 1px;
+  background: white;
+  height: 28px;
+  width: 252px;
+  box-sizing: border-box;
+  border: var(--jp-border-width) solid var(--jp-border-color1);
+  margin-bottom: 12px;
+}
+
+
+.jp-KeySelector-selectWrapper.jp-mod-focused {
+  border: 2px solid var(--md-light-blue-200);
 }

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -158,5 +158,7 @@
 }
 
 .jp-CellTools-separator {
-  
+  margin-top: 6px;
+  margin-bottom: 12px;
+  border-top: 1px dotted gray;
 }

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -178,6 +178,7 @@
   padding: 10px;
 }
 
+
 .jp-MetadataEditorTool-header label {
   flex: 0 0 auto;
 }

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -173,6 +173,7 @@
   padding-left: 10px;
   padding-right: 10px;
   display: flex;
+  width: 100%;
 }
 
 .jp-MetadataEditor textarea {

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -126,3 +126,37 @@
     text-align: center;
     line-height: var(--jp-private-notebook-dragImage-circleRadius);
 }
+
+
+.jp-CellTools {
+  display: flex;
+  flex-direction: column;
+  min-width: 300px;
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color1);
+  font-size: var(--jp-ui-font-size1);
+}
+
+
+.jp-CellTools-child {
+  flex: 0 1 auto;
+  display: flex;
+  flex-direction: row;
+}
+
+
+.jp-ActiveCellTool {
+  padding: var(--jp-private-notebook-padding);
+}
+
+.jp-ActiveCellTool .jp-Cell-prompt {
+  flex: 0 0 auto;
+}
+
+.jp-ActiveCellTool .jp-CellEditor {
+  flex: 1 1 auto;
+}
+
+.jp-CellTools-separator {
+  
+}

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -168,6 +168,37 @@
 }
 
 
+.jp-MetadataEditorTool {
+  flex-direction: column;
+}
+
+
+.jp-MetadataEditorTool-header {
+  flex: 1 0 auto;
+  padding: 10px;
+}
+
+.jp-MetadataEditorTool-header label {
+  flex: 0 0 auto;
+}
+
+
+.jp-MetadataEditorTool-toggleButton {
+  padding-left: 6px;
+  font-family: FontAwesome;
+}
+
+
+.jp-MetadataEditorTool-toggleButton::before {
+  content: '\f0d8'; /* caret-up */
+}
+
+
+.jp-MetadataEditorTool-toggleButton.jp-mod-collapsed::before {
+  content: '\f0d7'; /* caret-down */
+}
+
+
 .jp-MetadataEditor {
   flex-direction: column;
   padding-left: 10px;
@@ -175,6 +206,12 @@
   display: flex;
   width: 100%;
 }
+
+
+.jp-MetadataEditor.jp-mod-collapsed {
+  display: none;
+}
+
 
 .jp-MetadataEditor textarea {
   min-height: 100px;
@@ -190,18 +227,20 @@
 .jp-MetadataEditor-buttons {
   font-family: FontAwesome;
   flex: 1 0 auto;
+  min-height: 13px;
+  padding-bottom: 6px;
 }
 
 
-.jp-MetadataEditor-confirmButton::before {
-  content: '\f00c'; /* check */
+.jp-MetadataEditor-commitButton::before {
+  content: '\f0c7'; /* save */
   float: right;
   margin-right: 20px;
 }
 
 
-.jp-MetadataEditor-cancelButton::before {
-  content: '\f00d'; /* cancel */
+.jp-MetadataEditor-revertButton::before {
+  content: '\f0e2'; /* undo */
   float: right;
   margin-right: 4px;
 }

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -172,6 +172,37 @@
   flex-direction: column;
   padding-left: 10px;
   padding-right: 10px;
+  display: flex;
+}
+
+.jp-MetadataEditor textarea {
+  min-height: 100px;
+}
+
+
+.jp-MetadataEditor.jp-mod-error textarea {
+  border-color: red;
+  outline-color: red;
+}
+
+
+.jp-MetadataEditor-buttons {
+  font-family: FontAwesome;
+  flex: 1 0 auto;
+}
+
+
+.jp-MetadataEditor-confirmButton::before {
+  content: '\f00c'; /* check */
+  float: right;
+  margin-right: 4px;
+}
+
+
+.jp-MetadataEditor-cancelButton::before {
+  content: '\f00d'; /* cancel */
+  float: right;
+  margin-right: 20px;
 }
 
 

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 export * from './actions';
+export * from './celltools';
 export * from './default-toolbar';
 export * from './model';
 export * from './modelfactory';

--- a/src/notebook/model.ts
+++ b/src/notebook/model.ts
@@ -39,7 +39,7 @@ import {
 } from '../common/interfaces';
 
 import {
-  IMetadataCursor, MetadataCursor
+  Metadata
 } from '../common/metadata';
 
 import {
@@ -84,7 +84,7 @@ interface INotebookModel extends DocumentRegistry.IModel {
    * This method is used to interact with a namespaced
    * set of metadata on the notebook.
    */
-  getMetadata(namespace: string): IMetadataCursor;
+  getMetadata(namespace: string): Metadata.ICursor;
 
   /**
    * List the metadata namespace keys for the notebook.
@@ -308,11 +308,11 @@ class NotebookModel extends DocumentModel implements INotebookModel {
    * on the model.  This method is used to interact with a namespaced
    * set of metadata on the notebook.
    */
-  getMetadata(name: string): IMetadataCursor {
+  getMetadata(name: string): Metadata.ICursor {
     if (name in this._cursors) {
       return this._cursors[name];
     }
-    let cursor = new MetadataCursor(
+    let cursor = new Metadata.Cursor(
       name,
       () => {
         return this._metadata[name];
@@ -397,7 +397,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
 
   private _cells: IObservableUndoableVector<ICellModel> = null;
   private _metadata: { [key: string]: any } = Private.createMetadata();
-  private _cursors: { [key: string]: MetadataCursor } = Object.create(null);
+  private _cursors: { [key: string]: Metadata.Cursor } = Object.create(null);
   private _nbformat = nbformat.MAJOR_VERSION;
   private _nbformatMinor = nbformat.MINOR_VERSION;
 }

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -111,7 +111,7 @@ const contentFactoryPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
 };
 
 /**
- * The about page extension.
+ * The cell tools extension.
  */
 const cellToolsPlugin: JupyterLabPlugin<void> = {
   activate: activateCellTools,

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -148,7 +148,7 @@ function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker
   const nbConvert = CellTools.createNBConvertSelector();
   celltools.addItem({ tool: nbConvert, rank: 3 });
 
-  const metadataEditor = new CellTools.MetadataEditor();
+  const metadataEditor = new CellTools.MetadataEditorTool();
   celltools.addItem({ tool: metadataEditor, rank: 4 });
 
   restorer.add(celltools, namespace);

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -50,8 +50,9 @@ import {
 } from '../common/dialog';
 
 import {
-  CommandIDs, INotebookTracker, NotebookActions, NotebookModelFactory,
-  NotebookPanel, NotebookTracker, NotebookWidgetFactory, trustNotebook
+  CellTools, CommandIDs, INotebookTracker, NotebookActions,
+  NotebookModelFactory,  NotebookPanel, NotebookTracker, NotebookWidgetFactory,
+  trustNotebook
 } from './';
 
 
@@ -109,12 +110,37 @@ const contentFactoryPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
   }
 };
 
+/**
+ * The about page extension.
+ */
+const cellToolsPlugin: JupyterLabPlugin<void> = {
+  activate: activateCellTools,
+  id: 'jupyter.extensions.cell-tools',
+  autoStart: true,
+  requires: [IInstanceRestorer, INotebookTracker]
+};
+
 
 /**
  * Export the plugins as default.
  */
-const plugins: JupyterLabPlugin<any>[] = [contentFactoryPlugin, trackerPlugin];
+const plugins: JupyterLabPlugin<any>[] = [contentFactoryPlugin, trackerPlugin, cellToolsPlugin];
 export default plugins;
+
+
+/**
+ * Activate the cell tools extension.
+ */
+function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker: INotebookTracker): void {
+  const namespace = 'cell-tools';
+
+  const widget = new CellTools({ tracker });
+  widget.title.label = 'Cell Tools';
+  widget.id = 'cell-tools';
+
+  restorer.add(widget, namespace);
+  app.shell.addToLeftArea(widget);
+}
 
 
 /**

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -115,6 +115,7 @@ const contentFactoryPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
  */
 const cellToolsPlugin: JupyterLabPlugin<void> = {
   activate: activateCellTools,
+  provides: ICellTools,
   id: 'jupyter.extensions.cell-tools',
   autoStart: true,
   requires: [IInstanceRestorer, INotebookTracker]
@@ -131,7 +132,7 @@ export default plugins;
 /**
  * Activate the cell tools extension.
  */
-function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker: INotebookTracker): void {
+function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker: INotebookTracker): Promise<ICellTools> {
   const namespace = 'cell-tools';
 
   const widget = new CellTools({ tracker });
@@ -141,8 +142,13 @@ function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker
   const activeCellTool = new CellTools.ActiveCellTool({ celltools: widget });
   widget.addItem({ widget: activeCellTool, rank: 1 });
 
+  const metadataEditor = new CellTools.MetadataEditor({ celltools: widget });
+  widget.addItem({ widget: metadataEditor, rank: 2 });
+
   restorer.add(widget, namespace);
   app.shell.addToLeftArea(widget);
+
+  return Promise.resolve(widget);
 }
 
 

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -142,14 +142,14 @@ function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker
   const activeCellTool = new CellTools.ActiveCellTool();
   celltools.addItem({ tool: activeCellTool, rank: 1 });
 
-  const metadataEditor = new CellTools.MetadataEditor();
-  celltools.addItem({ tool: metadataEditor, rank: 2 });
-
   const slideShow = CellTools.createSlideShowSelector();
-  celltools.addItem({ tool: slideShow, rank: 3 });
+  celltools.addItem({ tool: slideShow, rank: 2 });
 
   const nbConvert = CellTools.createNBConvertSelector();
-  celltools.addItem({ tool: nbConvert, rank: 4 });
+  celltools.addItem({ tool: nbConvert, rank: 3 });
+
+  const metadataEditor = new CellTools.MetadataEditor();
+  celltools.addItem({ tool: metadataEditor, rank: 4 });
 
   restorer.add(celltools, namespace);
   app.shell.addToLeftArea(celltools);

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -139,17 +139,17 @@ function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker
   celltools.title.label = 'Cell Tools';
   celltools.id = 'cell-tools';
 
-  const activeCellTool = new CellTools.ActiveCellTool({ celltools });
-  celltools.addItem({ widget: activeCellTool, rank: 1 });
+  const activeCellTool = new CellTools.ActiveCellTool({});
+  celltools.addItem({ tool: activeCellTool, rank: 1 });
 
-  const metadataEditor = new CellTools.MetadataEditor({ celltools });
-  celltools.addItem({ widget: metadataEditor, rank: 2 });
+  const metadataEditor = new CellTools.MetadataEditor({});
+  celltools.addItem({ tool: metadataEditor, rank: 2 });
 
-  const slideShow = CellTools.createSlideShowSelector({ celltools });
-  celltools.addItem({ widget: slideShow, rank: 3 });
+  const slideShow = CellTools.createSlideShowSelector({});
+  celltools.addItem({ tool: slideShow, rank: 3 });
 
-  const nbConvert = CellTools.createNBConvertSelector({ celltools });
-  celltools.addItem({ widget: nbConvert, rank: 4 });
+  const nbConvert = CellTools.createNBConvertSelector({});
+  celltools.addItem({ tool: nbConvert, rank: 4 });
 
   restorer.add(celltools, namespace);
   app.shell.addToLeftArea(celltools);

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -135,20 +135,26 @@ export default plugins;
 function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker: INotebookTracker): Promise<ICellTools> {
   const namespace = 'cell-tools';
 
-  const widget = new CellTools({ tracker });
-  widget.title.label = 'Cell Tools';
-  widget.id = 'cell-tools';
+  const celltools = new CellTools({ tracker });
+  celltools.title.label = 'Cell Tools';
+  celltools.id = 'cell-tools';
 
-  const activeCellTool = new CellTools.ActiveCellTool({ celltools: widget });
-  widget.addItem({ widget: activeCellTool, rank: 1 });
+  const activeCellTool = new CellTools.ActiveCellTool({ celltools });
+  celltools.addItem({ widget: activeCellTool, rank: 1 });
 
-  const metadataEditor = new CellTools.MetadataEditor({ celltools: widget });
-  widget.addItem({ widget: metadataEditor, rank: 2 });
+  const metadataEditor = new CellTools.MetadataEditor({ celltools });
+  celltools.addItem({ widget: metadataEditor, rank: 2 });
 
-  restorer.add(widget, namespace);
-  app.shell.addToLeftArea(widget);
+  const slideShow = CellTools.createSlideShowSelector({ celltools });
+  celltools.addItem({ widget: slideShow, rank: 3 });
 
-  return Promise.resolve(widget);
+  const nbConvert = CellTools.createNBConvertSelector({ celltools });
+  celltools.addItem({ widget: nbConvert, rank: 4 });
+
+  restorer.add(celltools, namespace);
+  app.shell.addToLeftArea(celltools);
+
+  return Promise.resolve(celltools);
 }
 
 

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -50,7 +50,7 @@ import {
 } from '../common/dialog';
 
 import {
-  CellTools, CommandIDs, INotebookTracker, NotebookActions,
+  CellTools, CommandIDs, ICellTools, INotebookTracker, NotebookActions,
   NotebookModelFactory,  NotebookPanel, NotebookTracker, NotebookWidgetFactory,
   trustNotebook
 } from './';

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -139,16 +139,16 @@ function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker
   celltools.title.label = 'Cell Tools';
   celltools.id = 'cell-tools';
 
-  const activeCellTool = new CellTools.ActiveCellTool({});
+  const activeCellTool = new CellTools.ActiveCellTool();
   celltools.addItem({ tool: activeCellTool, rank: 1 });
 
-  const metadataEditor = new CellTools.MetadataEditor({});
+  const metadataEditor = new CellTools.MetadataEditor();
   celltools.addItem({ tool: metadataEditor, rank: 2 });
 
-  const slideShow = CellTools.createSlideShowSelector({});
+  const slideShow = CellTools.createSlideShowSelector();
   celltools.addItem({ tool: slideShow, rank: 3 });
 
-  const nbConvert = CellTools.createNBConvertSelector({});
+  const nbConvert = CellTools.createNBConvertSelector();
   celltools.addItem({ tool: nbConvert, rank: 4 });
 
   restorer.add(celltools, namespace);

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -113,7 +113,7 @@ const contentFactoryPlugin: JupyterLabPlugin<NotebookPanel.IContentFactory> = {
 /**
  * The cell tools extension.
  */
-const cellToolsPlugin: JupyterLabPlugin<void> = {
+const cellToolsPlugin: JupyterLabPlugin<ICellTools> = {
   activate: activateCellTools,
   provides: ICellTools,
   id: 'jupyter.extensions.cell-tools',

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -138,6 +138,9 @@ function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker
   widget.title.label = 'Cell Tools';
   widget.id = 'cell-tools';
 
+  const activeCellTool = new CellTools.ActiveCellTool({ celltools: widget });
+  widget.addItem({ widget: activeCellTool, rank: 1 });
+
   restorer.add(widget, namespace);
   app.shell.addToLeftArea(widget);
 }

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -33,7 +33,7 @@ interface INotebookTracker extends IInstanceTracker<NotebookPanel> {
    * #### Notes
    * If there is no cell with the focus, then this value is `null`.
    */
-  activeCell: BaseCellWidget;
+  readonly activeCell: BaseCellWidget;
 
   /**
    * A signal emitted when the current active cell changes.
@@ -41,7 +41,12 @@ interface INotebookTracker extends IInstanceTracker<NotebookPanel> {
    * #### Notes
    * If there is no cell with the focus, then `null` will be emitted.
    */
-  activeCellChanged: ISignal<this, BaseCellWidget>;
+  readonly activeCellChanged: ISignal<this, BaseCellWidget>;
+
+  /**
+   * A signal emitted when the selection state changes.
+   */
+  readonly selectionChanged: ISignal<this, void>;
 }
 
 
@@ -77,7 +82,12 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
    * #### Notes
    * If there is no cell with the focus, then `null` will be emitted.
    */
-  activeCellChanged: ISignal<this, BaseCellWidget>;
+  readonly activeCellChanged: ISignal<this, BaseCellWidget>;
+
+  /**
+   * A signal emitted when the selection state changes.
+   */
+  readonly selectionChanged: ISignal<this, void>;
 
   /**
    * Add a new notebook panel to the tracker.
@@ -87,6 +97,7 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
   add(panel: NotebookPanel): Promise<void> {
     const promise = super.add(panel);
     panel.notebook.activeCellChanged.connect(this._onActiveCellChanged, this);
+    panel.notebook.selectionChanged.connect(this._onSelectionChanged, this);
     return promise;
   }
 
@@ -126,8 +137,16 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
     }
   }
 
+  private _onSelectionChanged(sender: Notebook): void {
+    // Check if the selection change happened for the current notebook.
+    if (this.currentWidget && this.currentWidget.notebook === sender) {
+      this.selectionChanged.emit(void 0);
+    }
+  }
+
   private _activeCell: BaseCellWidget | null = null;
 }
 
 // Define the signals for the `NotebookTracker` class.
 defineSignal(NotebookTracker.prototype, 'activeCellChanged');
+defineSignal(NotebookTracker.prototype, 'selectionChanged');

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,85 +1,85 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// import './application/loader.spec';
-// import './application/shell.spec';
+import './application/loader.spec';
+import './application/shell.spec';
 
-// import './cells/model.spec';
-// import './cells/widget.spec';
+import './cells/model.spec';
+import './cells/widget.spec';
 
-// import './codeeditor/editor.spec';
-// import './codeeditor/widget.spec';
+import './codeeditor/editor.spec';
+import './codeeditor/widget.spec';
 
-// import './codemirror/editor.spec';
+import './codemirror/editor.spec';
 
-// import './commandlinker/commandlinker.spec';
+import './commandlinker/commandlinker.spec';
 
-// import './common/activitymonitor.spec';
-// import './common/dialog.spec';
-// import './common/instancetracker.spec';
-// import './common/observablestring.spec';
-// import './common/observablevector.spec';
-// import './common/undoablevector.spec';
-// import './common/sanitizer.spec';
-// import './common/vdom.spec';
+import './common/activitymonitor.spec';
+import './common/dialog.spec';
+import './common/instancetracker.spec';
+import './common/observablestring.spec';
+import './common/observablevector.spec';
+import './common/undoablevector.spec';
+import './common/sanitizer.spec';
+import './common/vdom.spec';
 
-// import './completer/handler.spec';
-// import './completer/model.spec';
-// import './completer/widget.spec';
+import './completer/handler.spec';
+import './completer/model.spec';
+import './completer/widget.spec';
 
-// import './console/foreign.spec';
-// import './console/history.spec';
-// import './console/panel.spec';
-// import './console/widget.spec';
+import './console/foreign.spec';
+import './console/history.spec';
+import './console/panel.spec';
+import './console/widget.spec';
 
-// import './csvwidget/table.spec';
-// import './csvwidget/toolbar.spec';
-// import './csvwidget/widget.spec';
+import './csvwidget/table.spec';
+import './csvwidget/toolbar.spec';
+import './csvwidget/widget.spec';
 
-// import './docmanager/manager.spec';
-// import './docmanager/savehandler.spec';
-// import './docmanager/widgetmanager.spec';
+import './docmanager/manager.spec';
+import './docmanager/savehandler.spec';
+import './docmanager/widgetmanager.spec';
 
-// import './docregistry/context.spec';
-// import './docregistry/default.spec';
-// import './docregistry/registry.spec';
+import './docregistry/context.spec';
+import './docregistry/default.spec';
+import './docregistry/registry.spec';
 
-// import './editorwidget/widget.spec';
+import './editorwidget/widget.spec';
 
-// import './filebrowser/crumbs.spec';
-// import './filebrowser/model.spec';
+import './filebrowser/crumbs.spec';
+import './filebrowser/model.spec';
 
-// import './imagewidget/widget.spec';
+import './imagewidget/widget.spec';
 
-// import './inspector/inspector.spec';
+import './inspector/inspector.spec';
 
-// import './instancerestorer/instancerestorer.spec';
+import './instancerestorer/instancerestorer.spec';
 
-// import './markdownwidget/widget.spec';
+import './markdownwidget/widget.spec';
 
-// import './renderers/renderers.spec';
-// import './renderers/latex.spec';
+import './renderers/renderers.spec';
+import './renderers/latex.spec';
 
-// import './rendermime/rendermime.spec';
+import './rendermime/rendermime.spec';
 
-// import './notebook/actions.spec';
+import './notebook/actions.spec';
 import './notebook/celltools.spec';
-// import './notebook/default-toolbar.spec';
-// import './notebook/model.spec';
-// import './notebook/modelfactory.spec';
-// import './notebook/panel.spec';
-// import './notebook/trust.spec';
-// import './notebook/widget.spec';
-// import './notebook/widgetfactory.spec';
-// import './notebook/tracker.spec';
+import './notebook/default-toolbar.spec';
+import './notebook/model.spec';
+import './notebook/modelfactory.spec';
+import './notebook/panel.spec';
+import './notebook/trust.spec';
+import './notebook/widget.spec';
+import './notebook/widgetfactory.spec';
+import './notebook/tracker.spec';
 
-// import './outputarea/model.spec';
-// import './outputarea/widget.spec';
+import './outputarea/model.spec';
+import './outputarea/widget.spec';
 
-// import './statedb/statedb.spec';
+import './statedb/statedb.spec';
 
-// import './terminal/terminal.spec';
+import './terminal/terminal.spec';
 
-// import './toolbar/toolbar.spec';
+import './toolbar/toolbar.spec';
 
 import 'phosphor/styles/base.css';

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,84 +1,85 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import './application/loader.spec';
-import './application/shell.spec';
+// import './application/loader.spec';
+// import './application/shell.spec';
 
-import './cells/model.spec';
-import './cells/widget.spec';
+// import './cells/model.spec';
+// import './cells/widget.spec';
 
-import './codeeditor/editor.spec';
-import './codeeditor/widget.spec';
+// import './codeeditor/editor.spec';
+// import './codeeditor/widget.spec';
 
-import './codemirror/editor.spec';
+// import './codemirror/editor.spec';
 
-import './commandlinker/commandlinker.spec';
+// import './commandlinker/commandlinker.spec';
 
-import './common/activitymonitor.spec';
-import './common/dialog.spec';
-import './common/instancetracker.spec';
-import './common/observablestring.spec';
-import './common/observablevector.spec';
-import './common/undoablevector.spec';
-import './common/sanitizer.spec';
-import './common/vdom.spec';
+// import './common/activitymonitor.spec';
+// import './common/dialog.spec';
+// import './common/instancetracker.spec';
+// import './common/observablestring.spec';
+// import './common/observablevector.spec';
+// import './common/undoablevector.spec';
+// import './common/sanitizer.spec';
+// import './common/vdom.spec';
 
-import './completer/handler.spec';
-import './completer/model.spec';
-import './completer/widget.spec';
+// import './completer/handler.spec';
+// import './completer/model.spec';
+// import './completer/widget.spec';
 
-import './console/foreign.spec';
-import './console/history.spec';
-import './console/panel.spec';
-import './console/widget.spec';
+// import './console/foreign.spec';
+// import './console/history.spec';
+// import './console/panel.spec';
+// import './console/widget.spec';
 
-import './csvwidget/table.spec';
-import './csvwidget/toolbar.spec';
-import './csvwidget/widget.spec';
+// import './csvwidget/table.spec';
+// import './csvwidget/toolbar.spec';
+// import './csvwidget/widget.spec';
 
-import './docmanager/manager.spec';
-import './docmanager/savehandler.spec';
-import './docmanager/widgetmanager.spec';
+// import './docmanager/manager.spec';
+// import './docmanager/savehandler.spec';
+// import './docmanager/widgetmanager.spec';
 
-import './docregistry/context.spec';
-import './docregistry/default.spec';
-import './docregistry/registry.spec';
+// import './docregistry/context.spec';
+// import './docregistry/default.spec';
+// import './docregistry/registry.spec';
 
-import './editorwidget/widget.spec';
+// import './editorwidget/widget.spec';
 
-import './filebrowser/crumbs.spec';
-import './filebrowser/model.spec';
+// import './filebrowser/crumbs.spec';
+// import './filebrowser/model.spec';
 
-import './imagewidget/widget.spec';
+// import './imagewidget/widget.spec';
 
-import './inspector/inspector.spec';
+// import './inspector/inspector.spec';
 
-import './instancerestorer/instancerestorer.spec';
+// import './instancerestorer/instancerestorer.spec';
 
-import './markdownwidget/widget.spec';
+// import './markdownwidget/widget.spec';
 
-import './renderers/renderers.spec';
-import './renderers/latex.spec';
+// import './renderers/renderers.spec';
+// import './renderers/latex.spec';
 
-import './rendermime/rendermime.spec';
+// import './rendermime/rendermime.spec';
 
-import './notebook/actions.spec';
-import './notebook/default-toolbar.spec';
-import './notebook/model.spec';
-import './notebook/modelfactory.spec';
-import './notebook/panel.spec';
-import './notebook/trust.spec';
-import './notebook/widget.spec';
-import './notebook/widgetfactory.spec';
-import './notebook/tracker.spec';
+// import './notebook/actions.spec';
+import './notebook/celltools.spec';
+// import './notebook/default-toolbar.spec';
+// import './notebook/model.spec';
+// import './notebook/modelfactory.spec';
+// import './notebook/panel.spec';
+// import './notebook/trust.spec';
+// import './notebook/widget.spec';
+// import './notebook/widgetfactory.spec';
+// import './notebook/tracker.spec';
 
-import './outputarea/model.spec';
-import './outputarea/widget.spec';
+// import './outputarea/model.spec';
+// import './outputarea/widget.spec';
 
-import './statedb/statedb.spec';
+// import './statedb/statedb.spec';
 
-import './terminal/terminal.spec';
+// import './terminal/terminal.spec';
 
-import './toolbar/toolbar.spec';
+// import './toolbar/toolbar.spec';
 
 import 'phosphor/styles/base.css';

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -4,10 +4,6 @@
 import expect = require('expect.js');
 
 import {
-  JSONValue
-} from 'phosphor/lib/algorithm/json';
-
-import {
   Message
 } from 'phosphor/lib/core/messaging';
 
@@ -24,15 +20,7 @@ import {
 } from 'simulate-event';
 
 import {
-  IChangedArgs
-} from '../../../lib/common/interfaces';
-
-import {
-  BaseCellWidget
-} from '../../../lib/cells';
-
-import {
- ICellTools, CellTools, NotebookPanel, NotebookTracker, NotebookActions
+  CellTools, NotebookPanel, NotebookTracker, NotebookActions
 } from '../../../lib/notebook';
 
 import {
@@ -44,18 +32,18 @@ class LogTool extends CellTools.Tool {
 
   methods: string[] = [];
 
-  protected onActiveCellChanged(message: Message): void {
-    super.onActiveCellChanged(message);
+  protected onActiveCellChanged(msg: Message): void {
+    super.onActiveCellChanged(msg);
     this.methods.push('onActiveCellChanged');
   }
 
-  protected onSelectionChanged(message: Message): void {
-    super.onSelectionChanged(message);
+  protected onSelectionChanged(msg: Message): void {
+    super.onSelectionChanged(msg);
     this.methods.push('onSelectionChanged');
   }
 
   protected onMetadataChanged(message: CellTools.MetadataMessage): void {
-    super.onMetadataChanged(message);
+    super.onMetadataChanged(msg);
     this.methods.push('onMetadataChanged');
   }
 }

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -20,6 +20,10 @@ import {
 } from 'simulate-event';
 
 import {
+  Metadata
+} from '../../../lib/common/metadata';
+
+import {
   CellTools, NotebookPanel, NotebookTracker, NotebookActions
 } from '../../../lib/notebook';
 
@@ -42,7 +46,7 @@ class LogTool extends CellTools.Tool {
     this.methods.push('onSelectionChanged');
   }
 
-  protected onMetadataChanged(message: CellTools.MetadataMessage): void {
+  protected onMetadataChanged(msg: Metadata.ChangeMessage): void {
     super.onMetadataChanged(msg);
     this.methods.push('onMetadataChanged');
   }
@@ -74,7 +78,7 @@ class LogKeySelector extends CellTools.KeySelector {
     this.methods.push('onActiveCellChanged');
   }
 
-  protected onMetadataChanged(message: CellTools.MetadataMessage): void {
+  protected onMetadataChanged(message: Metadata.ChangeMessage): void {
     super.onMetadataChanged(message);
     this.methods.push('onMetadataChanged');
   }
@@ -257,26 +261,26 @@ describe('notebook/celltools', () => {
 
   });
 
-  describe('CellTools.MetadataEditor', () => {
+  describe('CellTools.MetadataEditorTool', () => {
 
     it('should create a new metadata editor tool', () => {
-      let tool = new CellTools.MetadataEditor();
-      expect(tool).to.be.a(CellTools.MetadataEditor);
+      let tool = new CellTools.MetadataEditorTool();
+      expect(tool).to.be.a(CellTools.MetadataEditorTool);
     });
 
     it('should handle a change to the active cell', () => {
-      let tool = new CellTools.MetadataEditor();
+      let tool = new CellTools.MetadataEditorTool();
       celltools.addItem({ tool });
-      let textarea = tool.textarea;
+      let textarea = tool.editor.textareaNode;
       expect(textarea.value).to.be('No active cell!');
       simulate(panel0.node, 'focus');
       expect(JSON.stringify(textarea.value)).to.be.ok();
     });
 
     it('should handle a change to the metadata', () => {
-      let tool = new CellTools.MetadataEditor();
+      let tool = new CellTools.MetadataEditorTool();
       celltools.addItem({ tool });
-      let textarea = tool.textarea;
+      let textarea = tool.editor.textareaNode;
       simulate(panel0.node, 'focus');
       let previous = textarea.value;
       let cursor = celltools.activeCell.model.getMetadata('foo');

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -101,6 +101,84 @@ describe('notebook/celltools', () => {
 
     });
 
+    describe('#selectionChanged', () => {
+
+      it('should be emitted when the selection changes', () => {
+        let called = false;
+        simulate(panel0.node, 'focus');
+        celltools.selectionChanged.connect((sender) => {
+          expect(sender).to.be(celltools);
+          called = true;
+        });
+        panel0.notebook.select(panel0.notebook.widgets.at(1));
+        expect(called).to.be(true);
+      });
+
+    });
+
+    describe('#metadataChanged', () => {
+
+      it('should be emitted when the metadata changes', () => {
+        let called = false;
+        simulate(panel0.node, 'focus');
+        celltools.metadataChanged.connect((sender, args) => {
+          expect(sender).to.be(celltools);
+          expect(args.name).to.be('foo');
+          expect(args.oldValue).to.be(void 0);
+          expect(args.newValue).to.be(1);
+          called = true;
+        });
+        let cursor = celltools.activeCell.model.getMetadata('foo');
+        cursor.setValue(1);
+        expect(called).to.be(true);
+      });
+
+    });
+
+    describe('#activeCell', () => {
+
+      it('should be the active cell', () => {
+        expect(celltools.activeCell).to.be(null);
+        simulate(panel0.node, 'focus');
+        expect(celltools.activeCell).to.be(panel0.notebook.activeCell);
+        tabpanel.currentIndex = 1;
+        simulate(panel1.node, 'focus');
+        expect(celltools.activeCell).to.be(panel1.notebook.activeCell);
+      });
+
+    });
+
+    describe('#selectedCells', () => {
+
+      it('should be the currently selected cells', () => {
+        expect(celltools.selectedCells.length).to.be(0);
+        simulate(panel0.node, 'focus');
+        expect(celltools.selectedCells).to.eql([panel0.notebook.activeCell]);
+        tabpanel.currentIndex = 1;
+        simulate(panel1.node, 'focus');
+        expect(celltools.selectedCells).to.eql([panel1.notebook.activeCell]);
+        panel1.notebook.select(panel1.notebook.widgets.at(1));
+        expect(celltools.selectedCells.length).to.be(2);
+      });
+
+    });
+
+    describe('#addItem()', () => {
+
+      it('should add a cell tool item', () => {
+        let widget = new Widget();
+        celltools.addItem({ widget });
+        widget.dispose();
+      });
+
+      it('should accept a rank', () => {
+        let widget = new Widget();
+        celltools.addItem({ widget, rank: 100 });
+        widget.dispose();
+      });
+
+    });
+
   });
 
 });

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -31,7 +31,6 @@ import {
 describe('notebook/celltools', () => {
 
   let celltools: CellTools;
-  let splitpanel: SplitPanel;
   let tabpanel: TabPanel;
   let tracker: NotebookTracker;
   let panel0: NotebookPanel;
@@ -49,10 +48,9 @@ describe('notebook/celltools', () => {
     tabpanel = new TabPanel();
     tabpanel.addWidget(panel0);
     tabpanel.addWidget(panel1);
-    splitpanel = new SplitPanel();
-    splitpanel.addWidget(celltools);
-    splitpanel.addWidget(tabpanel);
-    Widget.attach(splitpanel, document.body);
+    tabpanel.addWidget(celltools);
+    tabpanel.node.style.height = '800px';
+    Widget.attach(tabpanel, document.body);
     tabpanel.currentIndex = 0;
     // Wait for posted messages.
     requestAnimationFrame(() => {
@@ -61,7 +59,6 @@ describe('notebook/celltools', () => {
   });
 
   afterEach(() => {
-    splitpanel.dispose();
     tabpanel.dispose();
     celltools.dispose();
   });
@@ -81,7 +78,7 @@ describe('notebook/celltools', () => {
       it('should be emitted when the active cell changes', () => {
         let called = false;
         celltools.activeCellChanged.connect((sender, cell) => {
-          expect(sender).to.be(tracker);
+          expect(sender).to.be(celltools);
           expect(panel0.node.contains(cell.node)).to.be(true);
           called = true;
         });
@@ -93,7 +90,7 @@ describe('notebook/celltools', () => {
         let called = false;
         simulate(panel0.node, 'focus');
         celltools.activeCellChanged.connect((sender, cell) => {
-          expect(sender).to.be(tracker);
+          expect(sender).to.be(celltools);
           expect(panel1.node.contains(cell.node)).to.be(true);
           called = true;
         });

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -272,7 +272,7 @@ describe('notebook/celltools', () => {
       let tool = new CellTools.MetadataEditorTool();
       celltools.addItem({ tool });
       let textarea = tool.editor.textareaNode;
-      expect(textarea.value).to.be('No active cell!');
+      expect(textarea.value).to.be('No data!');
       simulate(panel0.node, 'focus');
       expect(JSON.stringify(textarea.value)).to.be.ok();
     });

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -448,6 +448,7 @@ describe('notebook/celltools', () => {
 
     it('should create a slide show selector', () => {
       let tool = CellTools.createSlideShowSelector();
+      tool.selectNode.selectedIndex = -1;
       celltools.addItem({ tool });
       simulate(panel0.node, 'focus');
       tabpanel.currentIndex = 2;
@@ -469,6 +470,7 @@ describe('notebook/celltools', () => {
 
     it('should create a raw mimetype selector', () => {
       let tool = CellTools.createNBConvertSelector();
+      tool.selectNode.selectedIndex = -1;
       celltools.addItem({ tool });
       simulate(panel0.node, 'focus');
       NotebookActions.changeCellType(panel0.notebook, 'raw');
@@ -487,6 +489,7 @@ describe('notebook/celltools', () => {
 
     it('should have no effect on a code cell', () => {
       let tool = CellTools.createNBConvertSelector();
+      tool.selectNode.selectedIndex = -1;
       celltools.addItem({ tool });
       simulate(panel0.node, 'focus');
       tabpanel.currentIndex = 2;

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  SplitPanel
+} from 'phosphor/lib/ui/splitpanel';
+
+import {
+  TabPanel
+} from 'phosphor/lib/ui/tabpanel';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
+  simulate
+} from 'simulate-event';
+
+import {
+ CellTools, NotebookPanel, NotebookTracker
+} from '../../../lib/notebook';
+
+import {
+  createNotebookPanel, populateNotebook
+} from './utils';
+
+
+describe('notebook/celltools', () => {
+
+  let celltools: CellTools;
+  let splitpanel: SplitPanel;
+  let tabpanel: TabPanel;
+  let tracker: NotebookTracker;
+  let panel0: NotebookPanel;
+  let panel1: NotebookPanel;
+
+  beforeEach((done) => {
+    tracker = new NotebookTracker({ namespace: 'notebook' });
+    panel0 = createNotebookPanel();
+    populateNotebook(panel0.notebook);
+    panel1 = createNotebookPanel();
+    populateNotebook(panel1.notebook);
+    tracker.add(panel0);
+    tracker.add(panel1);
+    celltools = new CellTools({ tracker });
+    tabpanel = new TabPanel();
+    tabpanel.addWidget(panel0);
+    tabpanel.addWidget(panel1);
+    splitpanel = new SplitPanel();
+    splitpanel.addWidget(celltools);
+    splitpanel.addWidget(tabpanel);
+    Widget.attach(splitpanel, document.body);
+    tabpanel.currentIndex = 0;
+    // Wait for posted messages.
+    requestAnimationFrame(() => {
+      done();
+    });
+  });
+
+  afterEach(() => {
+    splitpanel.dispose();
+    tabpanel.dispose();
+    celltools.dispose();
+  });
+
+  describe('CellTools', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create a celltools object', () => {
+        expect(celltools).to.be.a(CellTools);
+      });
+
+    });
+
+    describe('#activeCellChanged', () => {
+
+      it('should be emitted when the active cell changes', () => {
+        let called = false;
+        celltools.activeCellChanged.connect((sender, cell) => {
+          expect(sender).to.be(tracker);
+          expect(panel0.node.contains(cell.node)).to.be(true);
+          called = true;
+        });
+        simulate(panel0.node, 'focus');
+        expect(called).to.be(true);
+      });
+
+      it('should be emitted when the active notebook changes', () => {
+        let called = false;
+        simulate(panel0.node, 'focus');
+        celltools.activeCellChanged.connect((sender, cell) => {
+          expect(sender).to.be(tracker);
+          expect(panel1.node.contains(cell.node)).to.be(true);
+          called = true;
+        });
+        tabpanel.currentIndex = 1;
+        simulate(panel1.node, 'focus');
+        expect(called).to.be(true);
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/notebook/utils.ts
+++ b/test/src/notebook/utils.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../lib/codeeditor';
 
 import {
-  NotebookPanel, Notebook
+  NotebookPanel, Notebook, NotebookModel
 } from '../../../lib/notebook';
 
 import {
@@ -121,4 +121,15 @@ function createNotebookPanel(): NotebookPanel {
     mimeTypeService,
     clipboard
   });
+}
+
+
+/**
+ * Populate a notebook with default content.
+ */
+export
+function populateNotebook(notebook: Notebook): void {
+  let model = new NotebookModel();
+  model.fromJSON(DEFAULT_CONTENT);
+  notebook.model = model;
 }


### PR DESCRIPTION
Fixes #902. 

Notes about the raw metadata editor:
- When the user focuses the the raw metadata cell, it no longer updates with programmatic changes.
- If the user makes a change to the raw metadata, commit and revert buttons are shown above the text area.
- If the user blurs the text area without having made any changes, it is updated to reflect the current data.
- If the user blurs the text area having made changes, the buttons remain and the metadata is not updated.
- If the user cancels the changes, the area is updated to reflect the current data.
- If the user commits the changes, the metadata is merged, with the input data overriding any keys that were set programatically.  Keys that were removed by the user are deleted.
- If the user has input invalid JSON, the box will be made red and the buttons will remain visible.

The raw metadata editor was written so that it could be used to edit notebook level metadata as well.  Also, when we add metadata editing for multiple cells, we can use the `Metadata.IOwner` interface to abstract over all selected cells.


Raw cell:
![image](https://cloud.githubusercontent.com/assets/2096628/22705204/44949b1c-ed30-11e6-8b7e-43461bd4af74.png)



Code cell (nbconvert selector is disabled):
![image](https://cloud.githubusercontent.com/assets/2096628/22705181/2c05148c-ed30-11e6-8a08-0d8a77dab958.png)


Editing Metadata:
![metadata_editor](https://cloud.githubusercontent.com/assets/2096628/22705258/7aa9ab3e-ed30-11e6-8adf-1dbc8e2277c4.gif)



