### PR TITLE
Fix completer mid-line bug and harden tests.

### DIFF
--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -124,7 +124,7 @@ class CompletionHandler implements IDisposable {
     let editor = this.editor;
     let coords = editor.getCoordinate(position) as CompleterWidget.ICoordinate;
     return {
-      text: editor.getLine(position.line),
+      text: editor.model.value.text,
       lineHeight: editor.lineHeight,
       charWidth: editor.charWidth,
       coords,
@@ -207,21 +207,17 @@ class CompletionHandler implements IDisposable {
     if (!editor || !model) {
       return;
     }
+
     let patch = model.createPatch(value);
     if (!patch) {
       return;
     }
-    if (!model.cursor || !model.original) {
-      return;
-    }
-    let { start, end, text } = patch;
-    editor.model.value.remove(start, end);
-    editor.model.value.insert(start, text);
-    let pos = editor.getPositionAt(start);
-    editor.setCursorPosition({
-      line: pos.line,
-      column: pos.column + text.length
-    });
+
+    let { offset, text } = patch;
+    editor.model.value.text = text;
+
+    let position = editor.getPositionAt(offset);
+    editor.setCursorPosition(position);
   }
 
   private _editor: CodeEditor.IEditor = null;

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -515,7 +515,7 @@ namespace CompleterWidget {
   export
   interface ITextState extends JSONObject {
     /**
-     * The current line of text.
+     * The current value of the editor.
      */
     readonly text: string;
 
@@ -617,19 +617,14 @@ namespace CompleterWidget {
   export
   interface IPatch {
     /**
-     * The patch text.
+     * The patched text.
      */
     text: string;
 
     /**
-     * The start position of the patch in the buffer.
+     * The offset of the cursor.
      */
-    start: number;
-
-    /**
-     * The end position of the patch in the buffer.
-     */
-    end: number;
+    offset: number;
   }
 
 

--- a/test/src/completer/handler.spec.ts
+++ b/test/src/completer/handler.spec.ts
@@ -434,21 +434,23 @@ describe('completer/handler', () => {
         let completer = new CompleterWidget({ model });
         let handler = new TestCompletionHandler({ completer });
         let editor = createEditorWidget().editor;
+        let text = 'eggs\nfoo # comment\nbaz';
+        let want = 'eggs\nfoobar # comment\nbaz';
         let request: CompleterWidget.ITextState = {
-          column: 0,
+          column: 2,
           line: 1,
           lineHeight: 0,
           charWidth: 0,
           coords: null,
-          text: 'foo'
+          text
         };
 
         handler.editor = editor;
-        handler.editor.model.value.text = 'eggs\nfoo\nbaz';
+        handler.editor.model.value.text = text;
         model.original = request;
         model.cursor = { start: 5, end: 8 };
         completer.selected.emit(patch);
-        expect(handler.editor.model.value.text).to.equal('eggs\nfoobar\nbaz');
+        expect(handler.editor.model.value.text).to.equal(want);
       });
 
     });

--- a/test/src/completer/handler.spec.ts
+++ b/test/src/completer/handler.spec.ts
@@ -437,7 +437,7 @@ describe('completer/handler', () => {
         let text = 'eggs\nfoo # comment\nbaz';
         let want = 'eggs\nfoobar # comment\nbaz';
         let request: CompleterWidget.ITextState = {
-          column: 2,
+          column: 5,
           line: 1,
           lineHeight: 0,
           charWidth: 0,

--- a/test/src/completer/model.spec.ts
+++ b/test/src/completer/model.spec.ts
@@ -6,7 +6,7 @@ import expect = require('expect.js');
 import {
   toArray
 } from 'phosphor/lib/algorithm/iteration';
-//
+
 import {
   CompleterModel, CompleterWidget
 } from '../../../lib/completer';
@@ -359,8 +359,7 @@ describe('completer/model', () => {
         let patch = 'foobar';
         let want: CompleterWidget.IPatch = {
           text: patch,
-          start: 0,
-          end: 3
+          offset: patch.length
         };
         let cursor: CompleterWidget.ICursorSpan = { start: 0, end: 3 };
         model.original = makeState('foo');
@@ -377,13 +376,11 @@ describe('completer/model', () => {
         let model = new CompleterModel();
         let currentValue = 'foo\nbar';
         let patch = 'barbaz';
-        let wantText = 'barbaz';
-        let start = 10;
-        let end = wantText.length;
+        let start = currentValue.length;
+        let end = currentValue.length;
         let want: CompleterWidget.IPatch = {
-          text: wantText,
-          start,
-          end
+          text: currentValue + patch,
+          offset: currentValue.length + patch.length
         };
         let cursor: CompleterWidget.ICursorSpan = { start, end };
         model.original = makeState(currentValue);


### PR DESCRIPTION
This fixes the completer's ability to be invoked and generate patches for text in the middle of a line, *e.g.*:
```python
for x in ran<INVOKE COMPLETER> # This is a comment.
```