### PR TITLE
Lab General Style Refinements

### DIFF
--- a/src/commandpalette/index.css
+++ b/src/commandpalette/index.css
@@ -29,7 +29,7 @@
 
 
 .p-CommandPalette-search {
-  padding: 8px 12px;
+  padding: 8px;
   background-color: var(--jp-border-color3);
   border-bottom: 1px solid var(--jp-border-color1);
 }
@@ -47,8 +47,9 @@
   color: white;
   background-color: var(--jp-brand-color1);
   position: absolute;
-  right: 12px;
-  height: 30px;
+  top: 8px;
+  right: 8px;
+  height: 32px;
   width: 12px;
   padding: 0px 12px;
   background-image: url(../default-theme/icons/md/search.svg);

--- a/src/commandpalette/index.css
+++ b/src/commandpalette/index.css
@@ -39,6 +39,7 @@
   padding: 0px 8px;
   border: 1px solid var(--jp-border-color1);
   background-color: white;
+  height: 30px;
 }
 
 

--- a/src/common/dialog.css
+++ b/src/common/dialog.css
@@ -173,4 +173,10 @@
   color: var(--jp-ui-font-color0);
   border: none;
   outline: none;
+  -webkit-appearance: none;
+  padding-left: 8px;
+  background-image: url('../default-theme/images/down_caret.svg');
+  background-repeat: no-repeat;
+  background-position: 224px 50%;
+  background-size: 20px;
 }

--- a/src/common/dialog.css
+++ b/src/common/dialog.css
@@ -160,7 +160,8 @@
 
 .jp-Dialog-selectWrapper.jp-mod-focused,
 .jp-Dialog-inputWrapper.jp-mod-focused {
-  border: 2px solid var(--md-light-blue-200);
+  border: var(--jp-border-width) solid var(--md-blue-500);
+  box-shadow: inset 0 0 4px var(--md-blue-300)
 }
 
 

--- a/src/common/dialog.css
+++ b/src/common/dialog.css
@@ -172,6 +172,7 @@
   background: white;
   color: var(--jp-ui-font-color0);
   border: none;
+  border-radius: 0px;
   outline: none;
   -webkit-appearance: none;
   padding-left: 8px;

--- a/src/default-theme/icons.css
+++ b/src/default-theme/icons.css
@@ -77,7 +77,7 @@
   background-image: url(icons/jupyter/jupyter.svg);
   background-size: 16px;
   margin: 2px;
-  margin-left: 10px;
+  margin-left: 8px;
   margin-right: 0px;
   padding-right: 0px;
 }
@@ -93,7 +93,7 @@
 .jp-MainAreaPortraitIcon {
   background-position: 0 2px;
   background-repeat: no-repeat;
-  margin-right: 0;
+  margin-right: 2px;
   width: 20px;
 }
 

--- a/src/default-theme/images.css
+++ b/src/default-theme/images.css
@@ -38,7 +38,7 @@
   background-image: url(images/jupyter.svg);
   background-size: 16px;
   margin: 2px;
-  margin-left: 10px;
+  margin-left: 8px;
   margin-right: 0px;
   padding-right: 0px;
 }

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -96,9 +96,9 @@ function selectKernel(options: IKernelSelection): Promise<Kernel.IModel> {
 
   // Create the dialog body.
   let body = document.createElement('div');
-  let text = `Select kernel for: "${options.name}"`;
-  body.appendChild(document.createTextNode(text));
-  body.appendChild(document.createElement('br'));
+  let text = document.createElement('label');
+  text.innerHTML = `Select kernel for: "${options.name}"`;
+  body.appendChild(text);
 
   if (kernel) {
     let displayName = specs.kernelspecs[kernel.name].display_name;

--- a/src/notebook/toolbar.css
+++ b/src/notebook/toolbar.css
@@ -18,6 +18,12 @@
 }
 
 
+.jp-Notebook-toolbarCellType:hover {
+    background-color: #EEEEEE;
+    box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
+}
+
+
 .jp-Notebook-toolbarCellType select.jp-Notebook-toolbarCellTypeDropdown {
   border: var(--jp-border-width) solid var(--jp-border-color4);
   border-radius: 0;
@@ -27,6 +33,18 @@
   height: 20px;
   margin-top: 2px;
   margin-bottom: 2px;
+  -webkit-appearance: none;
+  padding-left: 4px;
+  padding-right: 16px;
+  background-image: url('../default-theme/images/down_caret.svg');
+  background-repeat: no-repeat;
+  background-position: right;
+  background-size: 16px;
+}
+
+
+.jp-Notebook-toolbarCellType:hover > .jp-Notebook-toolbarCellTypeDropdown {
+    background-color: #EEEEEE;
 }
 
 
@@ -174,4 +192,3 @@
 .jp-NBToolbar-item.jp-NBToolbar-kernelIndicator.jp-mod-busy::before {
     content: "\f111";  /* Circle */
 }
-


### PR DESCRIPTION
- Realigned Jupyter icon in the top left of lab to be aligned center with the left sidebar and to be consistent with rest of interface (based on 4px increments)

- Fixed new code console dialog to match styling of rest of dialogs
Before:
![screen shot 2017-02-02 at 9 15 30 am](https://cloud.githubusercontent.com/assets/6437976/22560188/80cacd56-e928-11e6-999f-a81536a3ec5f.png)

After:
![screen shot 2017-02-02 at 9 12 15 am](https://cloud.githubusercontent.com/assets/6437976/22560195/861e7456-e928-11e6-8a2b-8565ba94f70f.png)

- Changed padding of the command pallete search to bring back to 8px padding all around, after looking at the 8px 12px padding for a while, it just doesn't look right.

Before:
![screen shot 2017-02-02 at 9 19 39 am](https://cloud.githubusercontent.com/assets/6437976/22560344/12fd05b8-e929-11e6-8bbb-f0e5908a59f2.png)

After:
![screen shot 2017-02-02 at 9 20 51 am](https://cloud.githubusercontent.com/assets/6437976/22560348/16441c16-e929-11e6-95d7-b554008d93db.png)

-  Fixed Command Pallete Styling in Safari & Firefox
Before:
![screen shot 2017-02-02 at 9 26 06 am](https://cloud.githubusercontent.com/assets/6437976/22560495/b1391d48-e929-11e6-9ebc-e891c5d77fdf.png)

After:
![screen shot 2017-02-02 at 9 24 59 am](https://cloud.githubusercontent.com/assets/6437976/22560500/b62f6d7a-e929-11e6-9a65-21a9097ba3e1.png)

- Got rid of webkit styling of dropdowns and used material design dropdown icon so that dropdowns are now consistent across browsers. Dropdown in the notebook on hover now shows the user that it is clickable.

Before (Dialog Dropdown):
![screen shot 2017-02-02 at 9 31 48 am](https://cloud.githubusercontent.com/assets/6437976/22560720/7c50d69c-e92a-11e6-8fb4-8f99ae5f5bdb.png)

After (Dialog Dropdown):
![screen shot 2017-02-02 at 9 30 41 am](https://cloud.githubusercontent.com/assets/6437976/22560722/812ddd36-e92a-11e6-9e69-ed7ad5403e85.png)

Before (Notebook Dropdown):
![screen shot 2017-02-02 at 9 31 38 am](https://cloud.githubusercontent.com/assets/6437976/22560732/85fcc584-e92a-11e6-8747-86eb12821228.png)

After (Notebook Dropdown):
![screen shot 2017-02-02 at 9 30 29 am](https://cloud.githubusercontent.com/assets/6437976/22560736/8a309a72-e92a-11e6-8bcd-be23b8acfc7c.png)

![screen shot 2017-02-02 at 9 33 09 am](https://cloud.githubusercontent.com/assets/6437976/22560757/a2ba7112-e92a-11e6-8df9-ac04a4b01d1c.png)


