### PR TITLE
Inspector cleanup

### DIFF
--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -69,6 +69,13 @@ interface IInstanceTracker<T extends Widget> extends IDisposable {
   forEach(fn: (widget: T) => void): void;
 
   /**
+   * Check if this tracker has the specified widget.
+   *
+   * @param widget - The widget whose existence is being checked.
+   */
+  has(widget: Widget): boolean;
+
+  /**
    * Inject a foreign widget into the instance tracker.
    *
    * @param widget - The widget to inject into the tracker.

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -62,6 +62,15 @@ interface IInstanceTracker<T extends Widget> extends IDisposable {
   readonly size: number;
 
   /**
+   * A signal emitted when a widget is added.
+   *
+   * #### Notes
+   * This signal will only fire when a widget is added to the tracker. It will
+   * not fire if a widget is injected into the tracker.
+   */
+  readonly widgetAdded: ISignal<this, T>;
+
+  /**
    * Iterate through each widget in the tracker.
    *
    * @param fn - The function to call on each widget.
@@ -127,6 +136,15 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   readonly currentChanged: ISignal<this, T>;
 
   /**
+   * A signal emitted when a widget is added.
+   *
+   * #### Notes
+   * This signal will only fire when a widget is added to the tracker. It will
+   * not fire if a widget is injected into the tracker.
+   */
+  readonly widgetAdded: ISignal<this, T>;
+
+  /**
    * The current widget is the most recently focused widget.
    */
   get currentWidget(): T {
@@ -154,10 +172,14 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     this._tracker.add(widget);
 
     let injected = Private.injectedProperty.get(widget);
-    let promise: Promise<void>;
+    let promise: Promise<void> = Promise.resolve(void 0);
+
+    if (injected) {
+      return promise;
+    }
 
     // Handle widget state restoration.
-    if (!injected && this._restore) {
+    if (this._restore) {
       let { restorer, state } = this._restore;
       let widgetName = this._restore.name(widget);
 
@@ -175,7 +197,10 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
       }
     }
 
-    return promise || Promise.resolve(void 0);
+    // Emit the widget added signal.
+    this.widgetAdded.emit(widget);
+
+    return promise;
   }
 
   /**
@@ -361,6 +386,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
 
 // Define the signals for the `InstanceTracker` class.
 defineSignal(InstanceTracker.prototype, 'currentChanged');
+defineSignal(InstanceTracker.prototype, 'widgetAdded');
 
 
 /**

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -30,10 +30,6 @@ import {
 } from '../completer';
 
 import {
-  InspectionHandler
-} from '../inspector';
-
-import {
   BaseCellWidget, CodeCellWidget
 } from '../cells';
 
@@ -77,12 +73,6 @@ class ConsolePanel extends Panel {
     this.console = factory.createConsole(consoleOpts);
     this.addWidget(this.console);
 
-    // Set up the inspection handler.
-    this.inspectionHandler = factory.createInspectionHandler({
-      kernel: options.session.kernel,
-      rendermime: this.console.rendermime
-    });
-
     // Instantiate the completer.
     this._completer = factory.createCompleter({ model: new CompleterModel() });
 
@@ -107,11 +97,6 @@ class ConsolePanel extends Panel {
   readonly console: CodeConsole;
 
   /**
-   * The inspection handler used by the console.
-   */
-  readonly inspectionHandler: InspectionHandler;
-
-  /**
    * Dispose of the resources held by the widget.
    */
   dispose(): void {
@@ -126,7 +111,6 @@ class ConsolePanel extends Panel {
     completerHandler.dispose();
 
     this.console.dispose();
-    this.inspectionHandler.dispose();
     super.dispose();
   }
 
@@ -151,9 +135,8 @@ class ConsolePanel extends Panel {
   private _onPromptCreated(sender: CodeConsole, prompt: CodeCellWidget): void {
     this._completer.reset();
 
-    // Associate the new prompt with the completer and inspection handlers.
+    // Associate the new prompt with the completer.
     this._completerHandler.editor = prompt.editor;
-    this.inspectionHandler.editor = prompt.editor;
   }
 
   /**
@@ -161,7 +144,6 @@ class ConsolePanel extends Panel {
    */
   private _onKernelChanged(sender: Session.ISession, kernel: Kernel.IKernel): void {
     this._completerHandler.kernel = kernel;
-    this.inspectionHandler.kernel = kernel;
   }
 
   private _completer: CompleterWidget = null;
@@ -227,11 +209,6 @@ namespace ConsolePanel {
     createConsole(options: CodeConsole.IOptions): CodeConsole;
 
     /**
-     * The inspection handler for a console widget.
-     */
-    createInspectionHandler(options: InspectionHandler.IOptions): InspectionHandler;
-
-    /**
      * The completer widget for a console widget.
      */
     createCompleter(options: CompleterWidget.IOptions): CompleterWidget;
@@ -277,13 +254,6 @@ namespace ConsolePanel {
      */
     createConsole(options: CodeConsole.IOptions): CodeConsole {
       return new CodeConsole(options);
-    }
-
-    /**
-     * The inspection handler for a console widget.
-     */
-    createInspectionHandler(options: InspectionHandler.IOptions): InspectionHandler {
-      return new InspectionHandler(options);
     }
 
     /**

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -42,10 +42,6 @@ import {
 } from '../filebrowser';
 
 import {
-  IInspector
-} from '../inspector';
-
-import {
   IInstanceRestorer
 } from '../instancerestorer';
 
@@ -77,7 +73,6 @@ const trackerPlugin: JupyterLabPlugin<IConsoleTracker> = {
     IServiceManager,
     IRenderMime,
     IMainMenu,
-    IInspector,
     ICommandPalette,
     IPathTracker,
     ConsolePanel.IContentFactory,
@@ -131,7 +126,7 @@ const CONSOLE_REGEX = /^console-(\d)+-[0-9a-f]+$/;
 /**
  * Activate the console extension.
  */
-function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, inspector: IInspector, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: IInstanceRestorer): IConsoleTracker {
+function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: IInstanceRestorer): IConsoleTracker {
   let manager = services.sessions;
   let { commands, keymap } = app;
   let category = 'Console';
@@ -148,13 +143,6 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     args: panel => ({ id: panel.console.session.id }),
     name: panel => panel.console.session && panel.console.session.id,
     when: manager.ready
-  });
-
-  // Set the source of the code inspector.
-  tracker.currentChanged.connect((sender, widget) => {
-    if (widget) {
-      inspector.source = widget.inspectionHandler;
-    }
   });
 
   // Set the main menu title.
@@ -376,8 +364,6 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       captionOptions.executed = null;
       panel.title.caption = Private.caption(captionOptions);
     });
-    // Immediately set the inspector source to the current console.
-    inspector.source = panel.inspectionHandler;
     // Add the console panel to the tracker.
     tracker.add(panel);
     app.shell.addToMainArea(panel);

--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -37,6 +37,7 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
   constructor(options: InspectionHandler.IOptions) {
     this._kernel = options.kernel || null;
     this._rendermime = options.rendermime;
+    options.parent.disposed.connect(this.dispose, this);
   }
 
   /**
@@ -117,15 +118,11 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
    * Update the hints inspector based on a text change.
    */
   protected onTextChanged(): void {
-    let update: Inspector.IInspectorUpdate = {
-      content: null,
-      type: 'hints'
-    };
-
     let editor = this.editor;
     let code = editor.model.value.text;
     let position = editor.getCursorPosition();
     let offset = editor.getOffsetAt(position);
+    let update: Inspector.IInspectorUpdate = { content: null, type: 'hints' };
 
     // Clear hints if the new text value is empty or kernel is unavailable.
     if (!code || !this._kernel) {
@@ -177,8 +174,8 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
 
 
 // Define the signals for the `InspectionHandler` class.
-defineSignal(InspectionHandler.prototype, 'ephemeralCleared');
 defineSignal(InspectionHandler.prototype, 'disposed');
+defineSignal(InspectionHandler.prototype, 'ephemeralCleared');
 defineSignal(InspectionHandler.prototype, 'inspected');
 
 
@@ -198,8 +195,24 @@ namespace InspectionHandler {
     kernel?: Kernel.IKernel;
 
     /**
+     * The disposable parent of the inspector.
+     */
+    parent: IDisposedEmitter;
+
+    /**
      * The mime renderer for the inspection handler.
      */
     rendermime: RenderMime;
+  }
+
+  /**
+   * A disposable object that emits a `disposed` signal.
+   */
+  export
+  interface IDisposedEmitter extends IDisposable {
+    /**
+     * A signal emitted when the object is disposed.
+     */
+    readonly disposed: ISignal<any, any>;
   }
 }

--- a/src/inspector/inspector.ts
+++ b/src/inspector/inspector.ts
@@ -158,7 +158,7 @@ class Inspector extends TabPanel implements IInspector {
     this.source = null;
 
     // Dispose the inspector child items.
-    Object.keys(items).forEach(i => { items[i].dispose(); });
+    Object.keys(items || {}).forEach(i => { items[i].dispose(); });
 
     super.dispose();
   }

--- a/src/inspector/inspector.ts
+++ b/src/inspector/inspector.ts
@@ -6,7 +6,7 @@ import {
 } from 'phosphor/lib/core/messaging';
 
 import {
-  clearSignalData, ISignal
+  ISignal
 } from 'phosphor/lib/core/signaling';
 
 import {

--- a/src/inspector/inspector.ts
+++ b/src/inspector/inspector.ts
@@ -158,7 +158,9 @@ class Inspector extends TabPanel implements IInspector {
     this.source = null;
 
     // Dispose the inspector child items.
-    Object.keys(items || {}).forEach(i => { items[i].dispose(); });
+    if (items) {
+      Object.keys(items).forEach(i => { items[i].dispose(); });
+    }
 
     super.dispose();
   }
@@ -413,7 +415,9 @@ class InspectorItem extends Panel {
     this._toolbar = null;
     this._history = null;
 
-    history.forEach(widget => widget.dispose());
+    if (history) {
+      history.forEach(widget => widget.dispose());
+    }
     toolbar.dispose();
     super.dispose();
   }

--- a/src/inspector/manager.ts
+++ b/src/inspector/manager.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  IInspector, Inspector
+} from './';
+
+
+/**
+ * A class that manages inspector widget instances and offers persistent
+ * `IInspector` instance that other plugins can communicate with.
+ */
+export
+class InspectorManager implements IInspector {
+  /**
+   * The current inspector widget.
+   */
+  get inspector(): Inspector {
+    return this._inspector;
+  }
+  set inspector(inspector: Inspector) {
+    if (this._inspector === inspector) {
+      return;
+    }
+    this._inspector = inspector;
+    // If an inspector was added and it has no source
+    if (inspector && !inspector.source) {
+      inspector.source = this._source;
+    }
+  }
+
+  /**
+   * The source of events the inspector panel listens for.
+   */
+  get source(): Inspector.IInspectable {
+    return this._source;
+  }
+  set source(source: Inspector.IInspectable) {
+    if (this._source !== source) {
+      if (this._source) {
+        this._source.disposed.disconnect(this._onSourceDisposed, this);
+      }
+      this._source = source;
+      this._source.disposed.connect(this._onSourceDisposed, this);
+    }
+    if (this._inspector && !this._inspector.isDisposed) {
+      this._inspector.source = this._source;
+    }
+  }
+
+  /**
+   * Handle the source disposed signal.
+   */
+  private _onSourceDisposed() {
+    this._source = null;
+  }
+
+  private _inspector: Inspector = null;
+  private _source: Inspector.IInspectable = null;
+}

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -131,10 +131,11 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstance
     // Associate the handler to the widget.
     handlers.set(parent, handler);
     // Set the initial editor.
-    handler.editor = parent.console.prompt.editor;
+    let cell = parent.console.prompt;
+    handler.editor = cell && cell.editor;
     // Listen for prompt creation.
-    parent.console.promptCreated.connect((sender, prompt) => {
-      handler.editor = prompt.editor;
+    parent.console.promptCreated.connect((sender, cell) => {
+      handler.editor = cell && cell.editor;
     });
     // Listen for kernel changes.
     session.kernelChanged.connect((sender, kernel) => {
@@ -150,10 +151,11 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstance
     // Associate the handler to the widget.
     handlers.set(parent, handler);
     // Set the initial editor.
-    handler.editor = parent.notebook.activeCell.editor;
+    let cell = parent.notebook.activeCell;
+    handler.editor = cell && cell.editor;
     // Listen for active cell changes.
     parent.notebook.activeCellChanged.connect((sender, cell) => {
-      handler.editor = cell.editor;
+      handler.editor = cell && cell.editor;
     });
     // Listen for kernel changes.
     parent.kernelChanged.connect((sender, kernel) => {

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -53,133 +53,154 @@ const manager = new InspectorManager();
 const tracker = new InstanceTracker<Inspector>({ namespace: 'inspector' });
 
 /**
- * A service providing an inspector panel.
+ * A service providing code introspection.
  */
-const plugin: JupyterLabPlugin<IInspector> = {
-  activate,
+const service: JupyterLabPlugin<IInspector> = {
   id: 'jupyter.services.inspector',
-  requires: [
-    ICommandPalette, IInstanceRestorer, IConsoleTracker, INotebookTracker
-  ],
+  requires: [ICommandPalette, IInstanceRestorer],
   provides: IInspector,
-  autoStart: true
+  autoStart: true,
+  activate: (app: JupyterLab, palette: ICommandPalette, restorer: IInstanceRestorer): IInspector => {
+    const category = 'Inspector';
+    const command = CommandIDs.open;
+    const label = 'Open Inspector';
+
+    /**
+     * Create and track a new inspector.
+     */
+    function newInspector(): Inspector {
+      let inspector = new Inspector({ items: Private.defaultInspectorItems });
+      inspector.id = 'jp-inspector';
+      inspector.title.label = 'Inspector';
+      inspector.title.closable = true;
+      inspector.disposed.connect(() => {
+        if (manager.inspector === inspector) {
+          manager.inspector = null;
+        }
+      });
+      tracker.add(inspector);
+      return inspector;
+    }
+
+    // Handle state restoration.
+    restorer.restore(tracker, {
+      command,
+      args: () => null,
+      name: () => 'inspector'
+    });
+
+    // Add command to registry and palette.
+    app.commands.addCommand(command, {
+      label,
+      execute: () => {
+        if (!manager.inspector || manager.inspector.isDisposed) {
+          manager.inspector = newInspector();
+          app.shell.addToMainArea(manager.inspector);
+        }
+        if (manager.inspector.isAttached) {
+          app.shell.activateMain(manager.inspector.id);
+        }
+      }
+    });
+    palette.addItem({ command, category });
+
+    return manager;
+  }
 };
 
-
 /**
- * Export the plugin as default.
+ * An extension that registers consoles for inspection.
  */
-export default plugin;
-
-
-/**
- * Create and track a new inspector.
- */
-function newInspector(): Inspector {
-  let inspector = new Inspector({ items: Private.defaultInspectorItems });
-  inspector.id = 'jp-inspector';
-  inspector.title.label = 'Inspector';
-  inspector.title.closable = true;
-  inspector.disposed.connect(() => {
-    if (manager.inspector === inspector) {
-      manager.inspector = null;
-    }
-  });
-  tracker.add(inspector);
-  return inspector;
-}
-
-
-/**
- * Activate the console extension.
- */
-function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstanceRestorer, consoles: IConsoleTracker, notebooks: INotebookTracker): IInspector {
-  const category = 'Inspector';
-  const command = CommandIDs.open;
-  const label = 'Open Inspector';
-  const handlers = new AttachedProperty<Widget, InspectionHandler>({
-    name: 'handler'
-  });
-
-  // Handle state restoration.
-  restorer.restore(tracker, {
-    command,
-    args: () => null,
-    name: () => 'inspector'
-  });
-
-  // Keep track of console and notebook instances and set inspector source.
-  app.shell.currentChanged.connect((sender, args) => {
-    let widget = args.newValue;
-    if (!widget) {
-      return;
-    }
-    if (consoles.has(widget) || notebooks.has(widget)) {
-      let source = handlers.get(widget);
+const consolePlugin: JupyterLabPlugin<void> = {
+  id: 'jupyter.extensions.console-inspector',
+  requires: [IConsoleTracker],
+  provides: IInspector,
+  autoStart: true,
+  activate: (app: JupyterLab, consoles: IConsoleTracker): void => {
+    // Create a handler for each console that is created.
+    consoles.widgetAdded.connect((sender, parent) => {
+      const session = parent.console.session;
+      const kernel = session.kernel;
+      const rendermime = parent.console.rendermime;
+      const handler = new InspectionHandler({ kernel, parent, rendermime });
+      // Associate the handler to the widget.
+      Private.handlers.set(parent, handler);
+      // Set the initial editor.
+      let cell = parent.console.prompt;
+      handler.editor = cell && cell.editor;
+      // Listen for prompt creation.
+      parent.console.promptCreated.connect((sender, cell) => {
+        handler.editor = cell && cell.editor;
+      });
+      // Listen for kernel changes.
+      session.kernelChanged.connect((sender, kernel) => {
+        handler.kernel = kernel;
+      });
+    });
+    // Keep track of console instances and set inspector source.
+    app.shell.currentChanged.connect((sender, args) => {
+      let widget = args.newValue;
+      if (!widget || !consoles.has(widget)) {
+        return;
+      }
+      let source = Private.handlers.get(widget);
       if (source) {
         manager.source = source;
       }
-    }
-  });
+    });
+  }
+};
 
-  // Create a handler for each console that is created.
-  consoles.widgetAdded.connect((sender, parent) => {
-    const session = parent.console.session;
-    const kernel = session.kernel;
-    const rendermime = parent.console.rendermime;
-    const handler = new InspectionHandler({ kernel, parent, rendermime });
-    // Associate the handler to the widget.
-    handlers.set(parent, handler);
-    // Set the initial editor.
-    let cell = parent.console.prompt;
-    handler.editor = cell && cell.editor;
-    // Listen for prompt creation.
-    parent.console.promptCreated.connect((sender, cell) => {
+/**
+ * An extension that registers notebooks for inspection.
+ */
+const notebookPlugin: JupyterLabPlugin<void> = {
+  id: 'jupyter.extensions.notebook-inspector',
+  requires: [INotebookTracker],
+  provides: IInspector,
+  autoStart: true,
+  activate: (app: JupyterLab, notebooks: INotebookTracker): void => {
+    // Create a handler for each notebook that is created.
+    notebooks.widgetAdded.connect((sender, parent) => {
+      const kernel = parent.kernel;
+      const rendermime = parent.rendermime;
+      const handler = new InspectionHandler({ kernel, parent, rendermime });
+      // Associate the handler to the widget.
+      Private.handlers.set(parent, handler);
+      // Set the initial editor.
+      let cell = parent.notebook.activeCell;
       handler.editor = cell && cell.editor;
+      // Listen for active cell changes.
+      parent.notebook.activeCellChanged.connect((sender, cell) => {
+        handler.editor = cell && cell.editor;
+      });
+      // Listen for kernel changes.
+      parent.kernelChanged.connect((sender, kernel) => {
+        handler.kernel = kernel;
+      });
     });
-    // Listen for kernel changes.
-    session.kernelChanged.connect((sender, kernel) => {
-      handler.kernel = kernel;
-    });
-  });
-
-  // Create a handler for each notebook that is created.
-  notebooks.widgetAdded.connect((sender, parent) => {
-    const kernel = parent.kernel;
-    const rendermime = parent.rendermime;
-    const handler = new InspectionHandler({ kernel, parent, rendermime });
-    // Associate the handler to the widget.
-    handlers.set(parent, handler);
-    // Set the initial editor.
-    let cell = parent.notebook.activeCell;
-    handler.editor = cell && cell.editor;
-    // Listen for active cell changes.
-    parent.notebook.activeCellChanged.connect((sender, cell) => {
-      handler.editor = cell && cell.editor;
-    });
-    // Listen for kernel changes.
-    parent.kernelChanged.connect((sender, kernel) => {
-      handler.kernel = kernel;
-    });
-  });
-
-  // Add command to registry and palette.
-  app.commands.addCommand(command, {
-    label,
-    execute: () => {
-      if (!manager.inspector || manager.inspector.isDisposed) {
-        manager.inspector = newInspector();
-        app.shell.addToMainArea(manager.inspector);
+    // Keep track of notebook instances and set inspector source.
+    app.shell.currentChanged.connect((sender, args) => {
+      let widget = args.newValue;
+      if (!widget || !notebooks.has(widget)) {
+        return;
       }
-      if (manager.inspector.isAttached) {
-        app.shell.activateMain(manager.inspector.id);
+      let source = Private.handlers.get(widget);
+      if (source) {
+        manager.source = source;
       }
-    }
-  });
-  palette.addItem({ command, category });
+    });
+  }
+};
 
-  return manager;
-}
+/**
+ * Export the plugins as default.
+ */
+const plugins: JupyterLabPlugin<any>[] = [
+  service, consolePlugin, notebookPlugin
+];
+export default plugins;
+
 
 /**
  * A namespace for private data.
@@ -197,4 +218,12 @@ namespace Private {
       type: 'hints'
     }
   ];
+
+  /**
+   * A property that associates inspection handlers with their referent widgets.
+   */
+  export
+  const handlers = new AttachedProperty<Widget, InspectionHandler>({
+    name: 'handler'
+  });
 }

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -19,9 +19,24 @@ import {
 } from '../instancerestorer';
 
 import {
+import {
+  InspectorManager
+} from './manager';
+
+import {
   CommandIDs, IInspector, Inspector
 } from './';
 
+
+/**
+ * The inspector manager instance.
+ */
+const manager = new InspectorManager();
+
+/**
+ * The inspector instance tracker.
+ */
+const tracker = new InstanceTracker<Inspector>({ namespace: 'inspector' });
 
 /**
  * A service providing an inspector panel.
@@ -41,55 +56,8 @@ export default plugin;
 
 
 /**
- * A class that manages inspector widget instances and offers persistent
- * `IInspector` instance that other plugins can communicate with.
  */
-class InspectorManager implements IInspector {
-  /**
-   * The current inspector widget.
-   */
-  get inspector(): Inspector {
-    return this._inspector;
-  }
-  set inspector(inspector: Inspector) {
-    if (this._inspector === inspector) {
-      return;
     }
-    this._inspector = inspector;
-    // If an inspector was added and it has no source
-    if (inspector && !inspector.source) {
-      inspector.source = this._source;
-    }
-  }
-
-  /**
-   * The source of events the inspector panel listens for.
-   */
-  get source(): Inspector.IInspectable {
-    return this._source;
-  }
-  set source(source: Inspector.IInspectable) {
-    if (this._source !== source) {
-      if (this._source) {
-        this._source.disposed.disconnect(this._onSourceDisposed, this);
-      }
-      this._source = source;
-      this._source.disposed.connect(this._onSourceDisposed, this);
-    }
-    if (this._inspector && !this._inspector.isDisposed) {
-      this._inspector.source = this._source;
-    }
-  }
-
-  /**
-   * Handle the source disposed signal.
-   */
-  private _onSourceDisposed() {
-    this._source = null;
-  }
-
-  private _inspector: Inspector = null;
-  private _source: Inspector.IInspectable = null;
 }
 
 
@@ -100,8 +68,6 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstance
   const category = 'Inspector';
   const command = CommandIDs.open;
   const label = 'Open Inspector';
-  const manager = new InspectorManager();
-  const tracker = new InstanceTracker<Inspector>({ namespace: 'inspector' });
 
   // Handle state restoration.
   restorer.restore(tracker, {

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -108,7 +108,8 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstance
     }
     if (notebooks.has(args.newValue)) {
       let widget = args.newValue as NotebookPanel;
-      manager.source = widget.inspectionHandler;
+      // TODO: set the source of the inspection manager.
+      manager.source = null;
     }
   });
 
@@ -118,6 +119,10 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstance
     const kernel = session.kernel;
     const rendermime = parent.console.rendermime;
     const handler = new InspectionHandler({ kernel, parent, rendermime });
+    // Listen for prompt creation.
+    parent.console.promptCreated.connect((sender, prompt) => {
+      handler.editor = prompt.editor;
+    });
     // Listen for kernel changes.
     session.kernelChanged.connect((sender, kernel) => {
       handler.kernel = kernel;

--- a/src/notebook/panel.ts
+++ b/src/notebook/panel.ts
@@ -50,10 +50,6 @@ import {
 } from '../docregistry';
 
 import {
-  InspectionHandler
-} from '../inspector';
-
-import {
   OutputAreaWidget
 } from '../outputarea';
 
@@ -119,12 +115,6 @@ class NotebookPanel extends Widget {
     layout.addWidget(toolbar);
     layout.addWidget(this.notebook);
 
-    // Set up the inspection handler.
-    this.inspectionHandler = factory.createInspectionHandler({
-      rendermime: this.rendermime
-    });
-
-
     // Instantiate the completer.
     this._completer = factory.createCompleter({ model: new CompleterModel() });
 
@@ -139,7 +129,6 @@ class NotebookPanel extends Widget {
 
     let activeCell = this.notebook.activeCell;
     if (activeCell) {
-      this.inspectionHandler.editor = activeCell.editor;
       this._completerHandler.editor = activeCell.editor;
     }
   }
@@ -178,11 +167,6 @@ class NotebookPanel extends Widget {
    * The notebook used by the widget.
    */
   readonly notebook: Notebook;
-
-  /**
-   * The inspection handler used by the widget.
-   */
-  readonly inspectionHandler: InspectionHandler;
 
   /**
    * Get the toolbar used by the widget.
@@ -245,7 +229,6 @@ class NotebookPanel extends Widget {
     this.notebook.dispose();
     completerHandler.dispose();
     completer.dispose();
-    this.inspectionHandler.dispose();
     super.dispose();
   }
 
@@ -333,7 +316,6 @@ class NotebookPanel extends Widget {
    */
   private _onKernelChanged(context: DocumentRegistry.IContext<INotebookModel>, kernel: Kernel.IKernel): void {
     this._completerHandler.kernel = kernel;
-    this.inspectionHandler.kernel = kernel;
     this.kernelChanged.emit(kernel);
     if (!this.model || !kernel) {
       return;
@@ -390,7 +372,6 @@ class NotebookPanel extends Widget {
    */
   private _onActiveCellChanged(sender: Notebook, widget: BaseCellWidget) {
     let editor = widget ? widget.editor : null;
-    this.inspectionHandler.editor = editor;
     this._completerHandler.editor = editor;
   }
 
@@ -467,11 +448,6 @@ export namespace NotebookPanel {
     createToolbar(): Toolbar<Widget>;
 
     /**
-     * The inspection handler for a console widget.
-     */
-    createInspectionHandler(options: InspectionHandler.IOptions): InspectionHandler;
-
-    /**
      * The completer widget for a console widget.
      */
     createCompleter(options: CompleterWidget.IOptions): CompleterWidget;
@@ -525,13 +501,6 @@ export namespace NotebookPanel {
      */
     createToolbar(): Toolbar<Widget> {
       return new Toolbar();
-    }
-
-    /**
-     * The inspection handler for a console widget.
-     */
-    createInspectionHandler(options: InspectionHandler.IOptions): InspectionHandler {
-      return new InspectionHandler(options);
     }
 
     /**

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -34,10 +34,6 @@ import {
 } from '../filebrowser';
 
 import {
-  IInspector
-} from '../inspector';
-
-import {
   IInstanceRestorer
 } from '../instancerestorer';
 
@@ -85,7 +81,6 @@ const trackerPlugin: JupyterLabPlugin<INotebookTracker> = {
     IClipboard,
     IMainMenu,
     ICommandPalette,
-    IInspector,
     NotebookPanel.IContentFactory,
     IEditorServices,
     IInstanceRestorer
@@ -121,7 +116,7 @@ export default plugins;
 /**
  * Activate the notebook handler extension.
  */
-function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, clipboard: IClipboard, mainMenu: IMainMenu, palette: ICommandPalette, inspector: IInspector, contentFactory: NotebookPanel.IContentFactory, editorServices: IEditorServices, restorer: IInstanceRestorer): INotebookTracker {
+function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, clipboard: IClipboard, mainMenu: IMainMenu, palette: ICommandPalette, contentFactory: NotebookPanel.IContentFactory, editorServices: IEditorServices, restorer: IInstanceRestorer): INotebookTracker {
 
   const factory = new NotebookWidgetFactory({
     name: FACTORY,
@@ -144,13 +139,6 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     args: panel => ({ path: panel.context.path, factory: FACTORY }),
     name: panel => panel.context.path,
     when: services.ready
-  });
-
-  // Set the source of the code inspector.
-  tracker.currentChanged.connect((sender, widget) => {
-    if (widget) {
-      inspector.source = widget.inspectionHandler;
-    }
   });
 
   registry.addModelFactory(new NotebookModelFactory({}));
@@ -176,8 +164,6 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     // If the notebook panel does not have an ID, assign it one.
     widget.id = widget.id || `notebook-${++id}`;
     widget.title.icon = `${PORTRAIT_ICON_CLASS} ${NOTEBOOK_ICON_CLASS}`;
-    // Immediately set the inspector source to the current notebook.
-    inspector.source = widget.inspectionHandler;
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => { tracker.save(widget); });
     // Add the notebook panel to the tracker.

--- a/test/src/common/instancetracker.spec.ts
+++ b/test/src/common/instancetracker.spec.ts
@@ -59,6 +59,37 @@ describe('common/instancetracker', () => {
 
     });
 
+    describe('#widgetAdded', () => {
+
+      it('should emit when a widget has been added', done => {
+        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let widget = new Widget();
+        tracker.widgetAdded.connect((sender, added) => {
+          expect(added).to.be(widget);
+          done();
+        });
+        tracker.add(widget);
+      });
+
+      it('should not emit when a widget has been injected', done => {
+        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let one = new Widget();
+        let two = new Widget({ node: document.createElement('input') });
+        let total = 0;
+        tracker.widgetAdded.connect(() => { total++; });
+        tracker.currentChanged.connect(() => {
+          expect(total).to.be(1);
+          done();
+        });
+        tracker.add(one);
+        tracker.inject(two);
+        Widget.attach(two, document.body);
+        simulate(two.node, 'focus');
+        Widget.detach(two);
+      });
+
+    });
+
     describe('#currentWidget', () => {
 
       it('should default to null', () => {

--- a/test/src/console/panel.spec.ts
+++ b/test/src/console/panel.spec.ts
@@ -92,15 +92,6 @@ describe('console/panel', () => {
 
     });
 
-    describe('#inspectionHandler', () => {
-
-      it('should exist after instantiation', () => {
-        Widget.attach(panel, document.body);
-        expect(panel.inspectionHandler).to.be.an(InspectionHandler);
-      });
-
-    });
-
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the panel', () => {
@@ -179,16 +170,6 @@ describe('console/panel', () => {
         });
 
       });
-
-      describe('#createInspectionHandler()', () => {
-
-        it('should create an inspection handler', () => {
-          let inspector = contentFactory.createInspectionHandler({ rendermime });
-          expect(inspector).to.be.an(InspectionHandler);
-        });
-
-      });
-
 
       describe('#createCompleter()', () => {
 

--- a/test/src/notebook/panel.spec.ts
+++ b/test/src/notebook/panel.spec.ts
@@ -395,16 +395,6 @@ describe('notebook/notebook/panel', () => {
 
       });
 
-      describe('#createInspectionHandler()', () => {
-
-        it('should create an inspection handler', () => {
-          let inspector = contentFactory.createInspectionHandler({ rendermime });
-          expect(inspector).to.be.an(InspectionHandler);
-        });
-
-      });
-
-
       describe('#createCompleter()', () => {
 
         it('should create a completer widget', () => {


### PR DESCRIPTION
In a nutshell, this PR removes *all traces* of inspection handling from notebooks and consoles. Conceptually, it presents the inspector as a plugin that adds functionality, so it should not *need* to be embedded in a notebook or a console.

More granularly, here are some of the details:

* Places the responsibility of tracking which notebook or console is a `source` of data on the inspector plugin instead of imposing that burden on the console and notebook plugins.
* Fixes a bug that prevented the `source` of the inspector manager from being set when tabs were switched (this is fall out from the instance tracker refactor a few weeks ago).
* Adds a `has` method to the minimal `IInstanceTracker` interface.
* Adds a `widgetAdded` signal to the `IInstanceTracker` interface to indicate *only* when widgets are `add`ed and not `inject`ed.
* Refactors the inspector plugin.

**Note:** This functionality contains backward-*incompatible* API changes so it necessitates a version update whenever it is released.