### PR TITLE
Add/remove CSS classes based on the width of a Widget

### DIFF
--- a/src/common/sizewatcher.ts
+++ b/src/common/sizewatcher.ts
@@ -90,7 +90,6 @@ export class SizeWatcher {
     let hasTiny = widget.hasClass(tinyClass);
     let hasSmall = widget.hasClass(smallClass);
 
-    console.log(size, this.tinySize, this.smallSize);
     if (size > this.smallSize) {
       if (hasSmall) {
         widget.removeClass(smallClass);

--- a/src/common/sizewatcher.ts
+++ b/src/common/sizewatcher.ts
@@ -1,0 +1,148 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+/*
+ * The default direction.
+ */
+const DEFAULT_DIRECTION = 'width';
+
+/*
+ * The default size for the tiny CSS class to be applied.
+ */
+const DEFAULT_TINY = 300;
+
+/*
+ * The default size for the small CSS class to be applied.
+ */
+const DEFAULT_SMALL = 500;
+
+/*
+ * A helper class for applying size based CSS classes.
+ * 
+ * This is used to apply CSS classes such as jp-width-small, jp-width-tiny,
+ * jp-height-small, jp-height-tiny based on the size of a Widget.
+ * 
+ * For an example of how this is used, see the NotebookPanel class.
+ */
+export class SizeWatcher {
+  /**
+   * Construct a new notebook panel.
+   */
+  constructor(options: SizeWatcher.IOptions) {
+    this.direction = options.direction || DEFAULT_DIRECTION;
+    this.tinySize = options.tinySize || DEFAULT_TINY;
+    this.smallSize = options.smallSize || DEFAULT_SMALL;
+  }
+
+  /* 
+   * Get the direction (usually "width" or "height").
+   */
+  get direction(): string {
+    return this._direction;
+  }
+
+  /*
+   * Set the direction (usually "width" or "height").
+   */
+  set direction(value: string) {
+    this._direction = value;
+  }
+
+  /* 
+   * Get tinySize in px.
+   */
+  get tinySize(): number {
+    return this._tinySize
+  }
+
+  /* 
+   * Set tinySize in px.
+   */
+  set tinySize(value: number) {
+    this._tinySize = value;
+  }
+
+  /* 
+   * Get smallSize in px.
+   */
+  get smallSize(): number {
+    return this._smallSize
+  }
+
+  /* 
+   * Set smallSize in px.
+   */
+  set smallSize(value: number) {
+    this._smallSize = value;
+  }
+  
+  /*
+   * Add or remove CSS classes based on the size of a widget.
+   */
+  update(size: number, widget: Widget) {
+    let direction = this.direction;
+    let smallClass = `jp-${direction}-small`;
+    let tinyClass = `jp-${direction}-tiny`;
+    let hasTiny = widget.hasClass(tinyClass);
+    let hasSmall = widget.hasClass(smallClass);
+
+    console.log(size, this.tinySize, this.smallSize);
+    if (size > this.smallSize) {
+      if (hasSmall) {
+        widget.removeClass(smallClass);
+      }
+      if (hasTiny) {
+        widget.removeClass(tinyClass);
+      }
+    } else if (size > this.tinySize && size < this.smallSize) {
+      if (!hasSmall) {
+        widget.addClass(smallClass);
+      }
+      if (hasTiny) {
+        widget.removeClass(tinyClass);
+      }
+    } else if (size < this.tinySize) {
+      if (!hasTiny) {
+        widget.addClass(tinyClass);
+      }
+      if (hasSmall) {
+        widget.removeClass(smallClass);
+      }
+    }
+  }
+
+  private _tinySize: number;
+  private _smallSize: number;
+  private _direction: string;
+}
+
+
+/**
+ * A namespace for `SizeWatcher` statics.
+ */
+export namespace SizeWatcher {
+  /**
+   * An options interface for SizeWatcher.
+   */
+  export
+  interface IOptions {
+    /**
+     * The direction (usually "width" or "height");
+     */
+    direction?: string;
+
+    /**
+     * The tinySize in px.
+     */
+    tinySize?: number;
+
+    /**
+     * The smallSize in px.
+     */
+    smallSize?: number;
+  }
+}

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -18,8 +18,12 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  Widget
+  Widget, ResizeMessage
 } from 'phosphor/lib/ui/widget';
+
+import {
+  SizeWatcher
+} from '../common/sizewatcher'
 
 import {
   IEditorMimeTypeService, CodeEditor
@@ -51,6 +55,15 @@ import {
  */
 const PANEL_CLASS = 'jp-ConsolePanel';
 
+/*
+ * The width, below which, this panel will get the jp-width-tiny CSS class
+*/
+const TINY_WIDTH = 300;
+
+/*
+ * The width, below which, this panel will get the jp-width-small CSS class
+*/
+const SMALL_WIDTH = 500;
 
 /**
  * A panel which contains a console and the ability to add other children.
@@ -72,6 +85,11 @@ class ConsolePanel extends Panel {
     };
     this.console = factory.createConsole(consoleOpts);
     this.addWidget(this.console);
+
+    // Instantiate the SizeWatcher for adding/removing CSS classes based on with.
+    this._widthWatcher = new SizeWatcher(
+      { direction: "width", tinySize: TINY_WIDTH, smallSize: SMALL_WIDTH}
+    );
 
     // Instantiate the completer.
     this._completer = factory.createCompleter({ model: new CompleterModel() });
@@ -114,6 +132,17 @@ class ConsolePanel extends Panel {
     super.dispose();
   }
 
+  /*
+   * Handle the ResizeMessage, adding/removing size based CSS classes.
+   */
+  protected onResize(msg: ResizeMessage): void {
+    super.onResize(msg);
+    let width = msg.width;
+    if (this.parent.isVisible) {
+      this._widthWatcher.update(width, this);
+    }
+  }
+
   /**
    * Handle `'activate-request'` messages.
    */
@@ -148,7 +177,7 @@ class ConsolePanel extends Panel {
 
   private _completer: CompleterWidget = null;
   private _completerHandler: CompletionHandler = null;
-
+  private _widthWatcher: SizeWatcher = null;
 }
 
 

--- a/src/notebook/panel.ts
+++ b/src/notebook/panel.ts
@@ -26,7 +26,7 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  Widget
+  Widget, ResizeMessage
 } from 'phosphor/lib/ui/widget';
 
 import {
@@ -44,6 +44,10 @@ import {
 import {
   IChangedArgs
 } from '../common/interfaces';
+
+import {
+  SizeWatcher
+} from '../common/sizewatcher'
 
 import {
   DocumentRegistry
@@ -80,6 +84,15 @@ const NB_PANEL = 'jp-Notebook-panel';
  */
 const DIRTY_CLASS = 'jp-mod-dirty';
 
+/*
+ * The width, below which, this panel will get the jp-width-tiny CSS class
+*/
+const TINY_WIDTH = 300;
+
+/*
+ * The width, below which, this panel will get the jp-width-small CSS class
+*/
+const SMALL_WIDTH = 500;
 
 /**
  * A widget that hosts a notebook toolbar and content area.
@@ -110,6 +123,11 @@ class NotebookPanel extends Widget {
     this.notebook = factory.createNotebook(nbOptions);
     this.notebook.activeCellChanged.connect(this._onActiveCellChanged, this);
     let toolbar = factory.createToolbar();
+
+    // Instantiate the SizeWatcher for adding/removing CSS classes based on with.
+    this._widthWatcher = new SizeWatcher(
+      { direction: "width", tinySize: TINY_WIDTH, smallSize: SMALL_WIDTH}
+    );
 
     let layout = this.layout as PanelLayout;
     layout.addWidget(toolbar);
@@ -238,6 +256,17 @@ class NotebookPanel extends Widget {
   protected onActivateRequest(msg: Message): void {
     this.notebook.activate();
     this.activated.emit(void 0);
+  }
+
+  /*
+   * Handle the ResizeMessage, adding/removing size based CSS classes.
+   */
+  protected onResize(msg: ResizeMessage): void {
+    super.onResize(msg);
+    let width = msg.width;
+    if (this.parent.isVisible) {
+      this._widthWatcher.update(width, this);
+    }
   }
 
   /**
@@ -378,6 +407,7 @@ class NotebookPanel extends Widget {
   private _completer: CompleterWidget = null;
   private _completerHandler: CompletionHandler = null;
   private _context: DocumentRegistry.IContext<INotebookModel> = null;
+  private _widthWatcher: SizeWatcher = null;
 }
 
 


### PR DESCRIPTION
Fixes #1613 and adds a general way to add/remove CSS classes based on the size of a Widget.