### PR TITLE
Adjust prompt widths based on notebook/console width

### DIFF
--- a/src/cells/index.css
+++ b/src/cells/index.css
@@ -14,6 +14,8 @@
   --jp-private-cell-editor-background: #f7f7f7;
   --jp-private-cell-editor-border: #cfcfcf;
   --jp-private-cell-prompt-width: 90px;
+  --jp-private-cell-prompt-width-small: 70px;
+  --jp-private-cell-prompt-width-tiny: 30px;
   --jp-private-cell-inprompt-color: #303F9F;
   --jp-private-cell-outprompt-color: #D84315;
   --jp-private-cell-font-family: 'Helvetica';
@@ -48,6 +50,27 @@
   line-height: var(--jp-code-line-height);
   font-size: var(--jp-code-font-size);
   border: var(--jp-border-width) solid transparent;
+}
+
+.jp-width-small .jp-Cell-prompt {
+  flex-basis: var(--jp-private-cell-prompt-width-small);
+}
+
+.jp-width-small .jp-Cell-promptType {
+  display: none;
+}
+
+.jp-width-tiny .jp-Cell-prompt {
+  flex-basis: var(--jp-private-cell-prompt-width-tiny);
+  width: var(--jp-private-cell-prompt-width-tiny);
+}
+
+.jp-width-tiny .jp-Cell-promptCounter {
+  display: none;
+}
+
+.jp-width-tiny .jp-Cell-promptType {
+  display: none;
 }
 
 

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -53,6 +53,9 @@ const CELL_CLASS = 'jp-Cell';
  */
 const PROMPT_CLASS = 'jp-Cell-prompt';
 
+const PROMPT_TYPE_CLASS = 'jp-Cell-promptType';
+const PROMPT_COUNTER_CLASS = 'jp-Cell-promptCounter';
+
 /**
  * The class name added to input area widgets.
  */
@@ -838,8 +841,15 @@ class InputAreaWidget extends Widget {
     if (value === 'null') {
       value = ' ';
     }
-    let text = `In [${value || ' '}]:`;
-    this._prompt.node.textContent = text;
+    let promptType = document.createElement("span");
+    promptType.textContent = "In ";
+    promptType.classList.add(PROMPT_TYPE_CLASS);
+    let promptCounter = document.createElement("span");
+    promptCounter.textContent = `[${value || ' '}]:`;
+    promptCounter.classList.add(PROMPT_COUNTER_CLASS);
+    this._prompt.node.innerHTML = '';
+    this._prompt.node.appendChild(promptType);
+    this._prompt.node.appendChild(promptCounter);
   }
 
   private _prompt: Widget;

--- a/src/common/sizewatcher.ts
+++ b/src/common/sizewatcher.ts
@@ -90,7 +90,6 @@ export class SizeWatcher {
     let hasTiny = widget.hasClass(tinyClass);
     let hasSmall = widget.hasClass(smallClass);
 
-    console.log(size, this.tinySize, this.smallSize);
     if (size > this.smallSize) {
       if (hasSmall) {
         widget.removeClass(smallClass);

--- a/src/common/sizewatcher.ts
+++ b/src/common/sizewatcher.ts
@@ -1,0 +1,148 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+/*
+ * The default direction.
+ */
+const DEFAULT_DIRECTION = 'width';
+
+/*
+ * The default size for the tiny CSS class to be applied.
+ */
+const DEFAULT_TINY = 300;
+
+/*
+ * The default size for the small CSS class to be applied.
+ */
+const DEFAULT_SMALL = 500;
+
+/*
+ * A helper class for applying size based CSS classes.
+ * 
+ * This is used to apply CSS classes such as jp-width-small, jp-width-tiny,
+ * jp-height-small, jp-height-tiny based on the size of a Widget.
+ * 
+ * For an example of how this is used, see the NotebookPanel class.
+ */
+export class SizeWatcher {
+  /**
+   * Construct a new notebook panel.
+   */
+  constructor(options: SizeWatcher.IOptions) {
+    this.direction = options.direction || DEFAULT_DIRECTION;
+    this.tinySize = options.tinySize || DEFAULT_TINY;
+    this.smallSize = options.smallSize || DEFAULT_SMALL;
+  }
+
+  /* 
+   * Get the direction (usually "width" or "height").
+   */
+  get direction(): string {
+    return this._direction;
+  }
+
+  /*
+   * Set the direction (usually "width" or "height").
+   */
+  set direction(value: string) {
+    this._direction = value;
+  }
+
+  /* 
+   * Get tinySize in px.
+   */
+  get tinySize(): number {
+    return this._tinySize
+  }
+
+  /* 
+   * Set tinySize in px.
+   */
+  set tinySize(value: number) {
+    this._tinySize = value;
+  }
+
+  /* 
+   * Get smallSize in px.
+   */
+  get smallSize(): number {
+    return this._smallSize
+  }
+
+  /* 
+   * Set smallSize in px.
+   */
+  set smallSize(value: number) {
+    this._smallSize = value;
+  }
+  
+  /*
+   * Add or remove CSS classes based on the size of a widget.
+   */
+  update(size: number, widget: Widget) {
+    let direction = this.direction;
+    let smallClass = `jp-${direction}-small`;
+    let tinyClass = `jp-${direction}-tiny`;
+    let hasTiny = widget.hasClass(tinyClass);
+    let hasSmall = widget.hasClass(smallClass);
+
+    console.log(size, this.tinySize, this.smallSize);
+    if (size > this.smallSize) {
+      if (hasSmall) {
+        widget.removeClass(smallClass);
+      }
+      if (hasTiny) {
+        widget.removeClass(tinyClass);
+      }
+    } else if (size > this.tinySize && size < this.smallSize) {
+      if (!hasSmall) {
+        widget.addClass(smallClass);
+      }
+      if (hasTiny) {
+        widget.removeClass(tinyClass);
+      }
+    } else if (size < this.tinySize) {
+      if (!hasTiny) {
+        widget.addClass(tinyClass);
+      }
+      if (hasSmall) {
+        widget.removeClass(smallClass);
+      }
+    }
+  }
+
+  private _tinySize: number;
+  private _smallSize: number;
+  private _direction: string;
+}
+
+
+/**
+ * A namespace for `SizeWatcher` statics.
+ */
+export namespace SizeWatcher {
+  /**
+   * An options interface for SizeWatcher.
+   */
+  export
+  interface IOptions {
+    /**
+     * The direction (usually "width" or "height");
+     */
+    direction?: string;
+
+    /**
+     * The tinySize in px.
+     */
+    tinySize?: number;
+
+    /**
+     * The smallSize in px.
+     */
+    smallSize?: number;
+  }
+}

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -18,8 +18,12 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  Widget
+  Widget, ResizeMessage
 } from 'phosphor/lib/ui/widget';
+
+import {
+  SizeWatcher
+} from '../common/sizewatcher'
 
 import {
   IEditorMimeTypeService, CodeEditor
@@ -51,6 +55,15 @@ import {
  */
 const PANEL_CLASS = 'jp-ConsolePanel';
 
+/*
+ * The width, below which, this panel will get the jp-width-tiny CSS class
+*/
+const TINY_WIDTH = 300;
+
+/*
+ * The width, below which, this panel will get the jp-width-small CSS class
+*/
+const SMALL_WIDTH = 500;
 
 /**
  * A panel which contains a console and the ability to add other children.
@@ -72,6 +85,11 @@ class ConsolePanel extends Panel {
     };
     this.console = factory.createConsole(consoleOpts);
     this.addWidget(this.console);
+
+    // Instantiate the SizeWatcher for adding/removing CSS classes based on with.
+    this._widthWatcher = new SizeWatcher(
+      { direction: "width", tinySize: TINY_WIDTH, smallSize: SMALL_WIDTH}
+    );
 
     // Instantiate the completer.
     this._completer = factory.createCompleter({ model: new CompleterModel() });
@@ -114,6 +132,17 @@ class ConsolePanel extends Panel {
     super.dispose();
   }
 
+  /*
+   * Handle the ResizeMessage, adding/removing size based CSS classes.
+   */
+  protected onResize(msg: ResizeMessage): void {
+    super.onResize(msg);
+    let width = msg.width;
+    if (this.parent.isVisible) {
+      this._widthWatcher.update(width, this);
+    }
+  }
+
   /**
    * Handle `'activate-request'` messages.
    */
@@ -148,7 +177,7 @@ class ConsolePanel extends Panel {
 
   private _completer: CompleterWidget = null;
   private _completerHandler: CompletionHandler = null;
-
+  private _widthWatcher: SizeWatcher = null;
 }
 
 

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -58,12 +58,12 @@ const PANEL_CLASS = 'jp-ConsolePanel';
 /*
  * The width, below which, this panel will get the jp-width-tiny CSS class
 */
-const TINY_WIDTH = 300;
+const TINY_WIDTH = 400;
 
 /*
  * The width, below which, this panel will get the jp-width-small CSS class
 */
-const SMALL_WIDTH = 500;
+const SMALL_WIDTH = 600;
 
 /**
  * A panel which contains a console and the ability to add other children.

--- a/src/notebook/panel.ts
+++ b/src/notebook/panel.ts
@@ -87,12 +87,12 @@ const DIRTY_CLASS = 'jp-mod-dirty';
 /*
  * The width, below which, this panel will get the jp-width-tiny CSS class
 */
-const TINY_WIDTH = 300;
+const TINY_WIDTH = 400;
 
 /*
  * The width, below which, this panel will get the jp-width-small CSS class
 */
-const SMALL_WIDTH = 500;
+const SMALL_WIDTH = 600;
 
 /**
  * A widget that hosts a notebook toolbar and content area.

--- a/src/notebook/panel.ts
+++ b/src/notebook/panel.ts
@@ -26,7 +26,7 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  Widget
+  Widget, ResizeMessage
 } from 'phosphor/lib/ui/widget';
 
 import {
@@ -44,6 +44,10 @@ import {
 import {
   IChangedArgs
 } from '../common/interfaces';
+
+import {
+  SizeWatcher
+} from '../common/sizewatcher'
 
 import {
   DocumentRegistry
@@ -80,6 +84,15 @@ const NB_PANEL = 'jp-Notebook-panel';
  */
 const DIRTY_CLASS = 'jp-mod-dirty';
 
+/*
+ * The width, below which, this panel will get the jp-width-tiny CSS class
+*/
+const TINY_WIDTH = 300;
+
+/*
+ * The width, below which, this panel will get the jp-width-small CSS class
+*/
+const SMALL_WIDTH = 500;
 
 /**
  * A widget that hosts a notebook toolbar and content area.
@@ -110,6 +123,11 @@ class NotebookPanel extends Widget {
     this.notebook = factory.createNotebook(nbOptions);
     this.notebook.activeCellChanged.connect(this._onActiveCellChanged, this);
     let toolbar = factory.createToolbar();
+
+    // Instantiate the SizeWatcher for adding/removing CSS classes based on with.
+    this._widthWatcher = new SizeWatcher(
+      { direction: "width", tinySize: TINY_WIDTH, smallSize: SMALL_WIDTH}
+    );
 
     let layout = this.layout as PanelLayout;
     layout.addWidget(toolbar);
@@ -238,6 +256,17 @@ class NotebookPanel extends Widget {
   protected onActivateRequest(msg: Message): void {
     this.notebook.activate();
     this.activated.emit(void 0);
+  }
+
+  /*
+   * Handle the ResizeMessage, adding/removing size based CSS classes.
+   */
+  protected onResize(msg: ResizeMessage): void {
+    super.onResize(msg);
+    let width = msg.width;
+    if (this.parent.isVisible) {
+      this._widthWatcher.update(width, this);
+    }
   }
 
   /**
@@ -378,6 +407,7 @@ class NotebookPanel extends Widget {
   private _completer: CompleterWidget = null;
   private _completerHandler: CompletionHandler = null;
   private _context: DocumentRegistry.IContext<INotebookModel> = null;
+  private _widthWatcher: SizeWatcher = null;
 }
 
 

--- a/src/outputarea/index.css
+++ b/src/outputarea/index.css
@@ -11,6 +11,8 @@
 :root {
   --jp-private-outputarea-prompt-color: #D84315;
   --jp-private-outputarea-prompt-width: 90px;
+  --jp-private-outputarea-prompt-width-small: 70px;
+  --jp-private-outputarea-prompt-width-tiny: 30px;
 }
 
 
@@ -77,6 +79,26 @@
   box-sizing: border-box;
 }
 
+.jp-width-small .jp-Output-prompt {
+  flex-basis: var(--jp-private-outputarea-prompt-width-small);
+}
+
+.jp-width-small .jp-Output-promptType {
+  display: none;
+}
+
+.jp-width-tiny .jp-Output-prompt {
+  flex-basis: var(--jp-private-outputarea-prompt-width-tiny);
+  width: var(--jp-private-outputarea-prompt-width-tiny);
+}
+
+.jp-width-tiny .jp-Output-promptCounter {
+  display: none;
+}
+
+.jp-width-tiny .jp-Output-promptType {
+  display: none;
+}
 
 .jp-Output-prompt:hover {
   background: var(--md-grey-100);

--- a/src/outputarea/widget.ts
+++ b/src/outputarea/widget.ts
@@ -139,6 +139,10 @@ const COLLAPSED_CLASS = 'jp-mod-collapsed';
  */
 const PROMPT_CLASS = 'jp-Output-prompt';
 
+const PROMPT_TYPE_CLASS = 'jp-Output-promptType';
+const PROMPT_COUNTER_CLASS = 'jp-Output-promptCounter';
+
+
 /**
  * The class name added to output area results.
  */
@@ -742,7 +746,15 @@ class OutputWidget extends Widget {
     case 'execute_result':
       child.addClass(EXECUTE_CLASS);
       let count = (output as nbformat.IExecuteResult).execution_count;
-      this.prompt.node.textContent = `Out[${count === null ? ' ' : count}]:`;
+      let promptType = document.createElement("span");
+      promptType.textContent = "Out";
+      promptType.classList.add(PROMPT_TYPE_CLASS);
+      let promptCounter = document.createElement("span");
+      promptCounter.textContent = `[${count === null ? ' ' : count}]:`;
+      promptCounter.classList.add(PROMPT_COUNTER_CLASS);
+      this.prompt.node.innerHTML = '';
+      this.prompt.node.appendChild(promptType);
+      this.prompt.node.appendChild(promptCounter);
       break;
     case 'display_data':
       child.addClass(DISPLAY_CLASS);


### PR DESCRIPTION
This fixes #1614 and makes it much nicer to work with notebook and consoles that are narrow. There are three different options:

* Full prompt `In [10]:`.
* Abbreviated `[10]:`.
* None

It is easy to adjust at what widths these different versions appear. Currently use 600/400px.

Based on the widths. Here is a screen shot:

<img width="1278" alt="screen shot 2017-02-05 at 4 18 02 pm" src="https://cloud.githubusercontent.com/assets/27600/22630878/faabfbe8-ebbe-11e6-9fe1-1585cb9757b5.png">
