### PR TITLE
chore: adding dialog to notebooks shutdown and rename

### DIFF
--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -36,7 +36,7 @@ namespace CommandIDs {
   const clearAllOutputs = 'notebook:clear-outputs';
 
   export
-  const closeAndHalt = 'notebook:close-and-halt';
+  const closeAndShutdown = 'notebook:close-and-shutdown';
 
   export
   const trust = 'notebook:trust';

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -46,7 +46,7 @@ import {
 } from '../services';
 
 import {
-  showDialog, okButton, cancelButton, warnButton
+  showDialog, cancelButton, warnButton
 } from '../common/dialog';
 
 import {
@@ -244,7 +244,7 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
         showDialog({
             title: 'Shutdown the notebook?',
             body: `Are you sure you want to close "${fileName}"?`,
-            buttons: [cancelButton, okButton]
+            buttons: [cancelButton, warnButton]
           }).then(result => {
             if (result.text === 'OK') {
               current.context.changeKernel(null).then(() => { current.dispose(); });

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -230,8 +230,8 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
       }
     }
   });
-  commands.addCommand(CommandIDs.closeAndHalt, {
-    label: 'Close and Halt',
+  commands.addCommand(CommandIDs.closeAndShutdown, {
+    label: 'Close and Shutdown',
     execute: () => {
       let current = tracker.currentWidget;
       if (current) {
@@ -600,7 +600,7 @@ function populatePalette(palette: ICommandPalette): void {
     CommandIDs.editMode,
     CommandIDs.commandMode,
     CommandIDs.switchKernel,
-    CommandIDs.closeAndHalt,
+    CommandIDs.closeAndShutdown,
     CommandIDs.trust
   ].forEach(command => { palette.addItem({ command, category }); });
 
@@ -659,7 +659,7 @@ function createMenu(app: JupyterLab): Menu {
   menu.addItem({ command: CommandIDs.runAll });
   menu.addItem({ command: CommandIDs.restart });
   menu.addItem({ command: CommandIDs.switchKernel });
-  menu.addItem({ command: CommandIDs.closeAndHalt });
+  menu.addItem({ command: CommandIDs.closeAndShutdown });
   menu.addItem({ command: CommandIDs.trust });
   menu.addItem({ type: 'separator' });
   menu.addItem({ type: 'submenu', menu: settings });

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -235,7 +235,10 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
     execute: () => {
       let current = tracker.currentWidget;
       if (current) {
-        current.context.changeKernel(null).then(() => { current.dispose(); });
+        current.show();
+        if (confirm('Are you sure you want to close the notebook?')) {
+          current.context.changeKernel(null).then(() => { current.dispose(); });
+        }
       }
     }
   });

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -235,7 +235,7 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
     execute: () => {
       let current = tracker.currentWidget;
       if (current) {
-        current.show();
+        app.shell.activateMain(current.id);
         if (confirm('Are you sure you want to close the notebook?')) {
           current.context.changeKernel(null).then(() => { current.dispose(); });
         }

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -46,6 +46,10 @@ import {
 } from '../services';
 
 import {
+  showDialog, okButton, cancelButton, warnButton
+} from '../common/dialog';
+
+import {
   CommandIDs, INotebookTracker, NotebookActions, NotebookModelFactory,
   NotebookPanel, NotebookTracker, NotebookWidgetFactory, trustNotebook
 } from './';
@@ -236,9 +240,19 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
       let current = tracker.currentWidget;
       if (current) {
         app.shell.activateMain(current.id);
-        if (confirm('Are you sure you want to close the notebook?')) {
-          current.context.changeKernel(null).then(() => { current.dispose(); });
-        }
+        let fileName = current.title.label;
+        showDialog({
+            title: 'Shutdown the notebook?',
+            body: `Are you sure you want to close "${fileName}"?`,
+            buttons: [cancelButton, okButton]
+          }).then(result => {
+            if (result.text === 'OK') {
+              current.context.changeKernel(null).then(() => { current.dispose(); });
+            }
+            else {
+              return false;
+            }
+        });
       }
     }
   });


### PR DESCRIPTION
Closes #1628 by renaming "Close and Halt" to "Close and Shutdown".
Closes #1629 by adding dialog on close and attempts to focus.