### PR TITLE
Switch kernel dialog fix

### DIFF
--- a/src/common/dialog.css
+++ b/src/common/dialog.css
@@ -56,6 +56,7 @@
   font-size: var(--jp-ui-font-size2);
   background: #FAFAFA;
   overflow: auto;
+  max-width: 252px;
 }
 
 

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -102,12 +102,6 @@ function selectKernel(options: IKernelSelection): Promise<Kernel.IModel> {
 
   if (kernel) {
     let displayName = specs.kernelspecs[kernel.name].display_name;
-    let current = document.createElement('span');
-    current.textContent = `Current: "${displayName}"`;
-    current.title = `Kernel Name: ${displayName}\n` +
-       `Kernel Id: ${kernel.id}`;
-    body.appendChild(current);
-    body.appendChild(document.createElement('br'));
   }
 
   let selector = document.createElement('select');

--- a/src/filebrowser/index.css
+++ b/src/filebrowser/index.css
@@ -285,7 +285,6 @@
   border-radius: 3px;
   color: var(--jp-ui-font-color1);
   transform: translateX(-40%) translateY(-58%);
-  cursor: pointer;
 }
 
 

--- a/src/filebrowser/index.css
+++ b/src/filebrowser/index.css
@@ -280,11 +280,13 @@
 
 .jp-DirListing-item.p-mod-drag-image,
 .jp-DirListing-item.jp-mod-selected.p-mod-drag-image {
+  font-size: var(--jp-ui-font-size1);
   background-color: #FFFFFF;
-  box-shadow: 5px 5px 10px rgba(46,46,46,0.5);
-  border-radius: 3px;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  border-radius: 0px;
   color: var(--jp-ui-font-color1);
-  transform: translateX(-40%) translateY(-58%);
+  transform: translateX(-15%) translateY(-58%);
+  cursor: pointer;
 }
 
 

--- a/src/filebrowser/index.css
+++ b/src/filebrowser/index.css
@@ -280,12 +280,11 @@
 
 .jp-DirListing-item.p-mod-drag-image,
 .jp-DirListing-item.jp-mod-selected.p-mod-drag-image {
-  font-size: var(--jp-ui-font-size1);
   background-color: #FFFFFF;
-  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
-  border-radius: 0px;
+  box-shadow: 5px 5px 10px rgba(46,46,46,0.5);
+  border-radius: 3px;
   color: var(--jp-ui-font-color1);
-  transform: translateX(-15%) translateY(-58%);
+  transform: translateX(-40%) translateY(-58%);
   cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes styling of the switch kernel dialog and added a max width to the dialog body content so that if a notebook's name is larger than the area available to present, the title will overflow to the next line instead of changing the styling of the dialog width. Got rid of the unnecessary "Current:" kernel title since the dropdown conveys this to the user already.

Before:
![39117698-ec72-11e6-9a86-a8943b201084](https://cloud.githubusercontent.com/assets/6437976/22707626/444ff2bc-ed28-11e6-8e73-bfa444d015a2.png)

After:
![screen shot 2017-02-07 at 11 26 09 am](https://cloud.githubusercontent.com/assets/6437976/22707634/4c80e694-ed28-11e6-98b9-48c922e66269.png)
