### PR TITLE
Restyle of dockpanel tab image and spacing

### DIFF
--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -50,7 +50,7 @@
   min-width: 35px;
   margin-left: calc(-1*var(--jp-border-width));
   line-height: var(--jp-private-horizontal-tab-height);
-  padding: 0px 10px;
+  padding: 0px 8px;
   background: var(--jp-layout-color2);
   border: var(--jp-border-width) solid var(--jp-border-color1);
   border-bottom: none;
@@ -142,6 +142,11 @@
   display: inline-block;
 }
 
+
+.p-DockPanel-tabBar .p-TabBar-tabIcon {
+  width: 14px;
+  margin-top: 2px;
+}
 .p-TabBar-WindowTabLabel {
   margin-top: 4px;
 }


### PR DESCRIPTION
Changed the tab icons width and margin to be in line with rest of spacing within the tab. 

Changed the side padding from 10px to 8px to conform to the 4px scale that we use throughout the application.

The tabs are much more proportional now.

Before:
<img width="158" alt="screen shot 2017-02-07 at 2 44 57 pm" src="https://cloud.githubusercontent.com/assets/6437976/22715047/11d53c86-ed44-11e6-94cf-c0429c03c54f.png">


After:
<img width="157" alt="screen shot 2017-02-07 at 2 44 01 pm" src="https://cloud.githubusercontent.com/assets/6437976/22715032/0a33d83e-ed44-11e6-941f-e289ac000dbf.png">