### PR TITLE
Adding commands+shortcuts for keyboard nav of tabs in dock panel.

### DIFF
--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -32,6 +32,12 @@ export
 namespace CommandIDs {
   export
   const closeAll = 'main-jupyterlab:close-all';
+
+  export
+  const activateNextTab = 'main-jupyterlab:activate-next-tab';
+
+  export
+  const activatePreviousTab = 'main-jupyterlab:activate-previous-tab';
 };
 
 

--- a/src/application/plugin.ts
+++ b/src/application/plugin.ts
@@ -17,12 +17,26 @@ const plugin: JupyterLabPlugin<void> = {
   id: 'jupyter.extensions.main',
   requires: [ICommandPalette],
   activate: (app: JupyterLab, palette: ICommandPalette) => {
+
     let command = CommandIDs.closeAll;
     app.commands.addCommand(command, {
       label: 'Close All Widgets',
       execute: () => { app.shell.closeAll(); }
     });
+    palette.addItem({ command, category: 'Main Area' });
 
+    command = CommandIDs.activateNextTab;
+    app.commands.addCommand(command, {
+      label: 'Activate Next Tab',
+      execute: () => { app.shell.activateNextTab() }
+    });
+    palette.addItem({ command, category: 'Main Area' });
+
+    command = CommandIDs.activatePreviousTab;
+    app.commands.addCommand(command, {
+      label: 'Activate Previous Tab',
+      execute: () => { app.shell.activatePreviousTab() }
+    });
     palette.addItem({ command, category: 'Main Area' });
 
     const message = 'Are you sure you want to exit JupyterLab?\n' +

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
-  contains, find, findIndex, upperBound
+  contains, find, indexOf, findIndex, upperBound
 } from 'phosphor/lib/algorithm/searching';
 
 import {
@@ -342,7 +342,17 @@ class ApplicationShell extends Widget {
           if (ci > 0) {
             tabBar.currentIndex -= 1;
             tabBar.currentTitle.owner.activate();
-          }
+          } 
+          // else if (ci === 0) {
+          //   let prevBar = null;
+          //   each(this._dockPanel.tabBars(), (bar) => {
+          //     if (bar.title === title && (prevBar === null)) {
+          //       prevVar = bar;
+          //       this._dockPanel.tab
+          //     }
+          //     prevBar = bar;
+          //   });
+          // }
         }
       }
     }

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -316,10 +316,10 @@ class ApplicationShell extends Widget {
     if (current) {
       let ci = current.currentIndex;
       if (ci !== -1) {
-        if (ci < current.titles.length-1) {
+        if (ci < current.titles.length - 1) {
           current.currentIndex += 1;
           current.currentTitle.owner.activate();
-        } else if (ci === current.titles.length-1) {
+        } else if (ci === current.titles.length - 1) {
           let nextBar = this._nextTabBar();
           if (nextBar) {
             nextBar.currentIndex = 0;
@@ -345,7 +345,7 @@ class ApplicationShell extends Widget {
           let prevBar = this._previousTabBar();
           if (prevBar) {
             let len = prevBar.titles.length;
-            prevBar.currentIndex = len-1;
+            prevBar.currentIndex = len - 1;
             prevBar.currentTitle.owner.activate();
           }
         }
@@ -410,9 +410,9 @@ class ApplicationShell extends Widget {
       let ci = bars.indexOf(current);
       let prevBar: TabBar = null;
       if (ci > 0) {
-        prevBar = bars[ci-1];
+        prevBar = bars[ci - 1];
       } else if (ci === 0) {
-        prevBar = bars[len-1];
+        prevBar = bars[len - 1];
       }
       return prevBar;
     }
@@ -429,9 +429,9 @@ class ApplicationShell extends Widget {
       let len = bars.length;
       let ci = bars.indexOf(current);
       let nextBar: TabBar = null;
-      if (ci < (len-1)) {
-        nextBar = bars[ci+1];
-      } else if (ci === len-1) {
+      if (ci < (len - 1)) {
+        nextBar = bars[ci + 1];
+      } else if (ci === len - 1) {
         nextBar = bars[0];
       }
       return nextBar;

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -309,19 +309,21 @@ class ApplicationShell extends Widget {
   }
 
   /*
-   * Activate the next tab in the panel of the currently active tab.
+   * Activate the next Tab in the active TabBar.
   */
   activateNextTab(): void {
-    let current = this._dockPanel.currentWidget;
+    let current = this._currentTabBar();
     if (current) {
-      let title = current.title;
-      let tabBar = find(this._dockPanel.tabBars(), bar => contains(bar.titles, title));
-      if (tabBar) {
-        let ci = tabBar.currentIndex;
-        if (ci !== -1) {
-          if (ci < (tabBar.titles.length-1)) {
-            tabBar.currentIndex += 1;
-            tabBar.currentTitle.owner.activate();
+      let ci = current.currentIndex;
+      if (ci !== -1) {
+        if (ci < (current.titles.length-1)) {
+          current.currentIndex += 1;
+          current.currentTitle.owner.activate();
+        } else if (ci === (current.titles.length-1)) {
+          let nextBar = this._nextTabBar();
+          if (nextBar) {
+            nextBar.currentIndex = 0;
+            nextBar.currentTitle.owner.activate();
           }
         }
       }
@@ -329,30 +331,23 @@ class ApplicationShell extends Widget {
   }
 
   /*
-   * Activate the previous tab in the panel of the currently active tab.
+   * Activate the previous Tab in the active TabBar.
   */
   activatePreviousTab(): void {
-    let current = this._dockPanel.currentWidget;
+    let current = this._currentTabBar();
     if (current) {
-      let title = current.title;
-      let tabBar = find(this._dockPanel.tabBars(), bar => contains(bar.titles, title));
-      if (tabBar) {
-        let ci = tabBar.currentIndex;
-        if (ci !== -1) {
-          if (ci > 0) {
-            tabBar.currentIndex -= 1;
-            tabBar.currentTitle.owner.activate();
-          } 
-          // else if (ci === 0) {
-          //   let prevBar = null;
-          //   each(this._dockPanel.tabBars(), (bar) => {
-          //     if (bar.title === title && (prevBar === null)) {
-          //       prevVar = bar;
-          //       this._dockPanel.tab
-          //     }
-          //     prevBar = bar;
-          //   });
-          // }
+      let ci = current.currentIndex;
+      if (ci !== -1) {
+        if (ci > 0) {
+          current.currentIndex -= 1;
+          current.currentTitle.owner.activate();
+        } else if (ci === 0) {
+          let prevBar = this._previousTabBar();
+          if (prevBar) {
+            let len = prevBar.titles.length;
+            prevBar.currentIndex = len-1;
+            prevBar.currentTitle.owner.activate();
+          }
         }
       }
     }
@@ -390,6 +385,60 @@ class ApplicationShell extends Widget {
     this._leftHandler.sideBar.currentChanged.connect(this._save, this);
     this._rightHandler.sideBar.currentChanged.connect(this._save, this);
   }
+
+  /*
+   * Return the TabBar that has the currently active Widget or undefined.
+   */
+  private _currentTabBar(): TabBar {
+    let current = this._dockPanel.currentWidget;
+    if (current) {
+      let title = current.title;
+      let tabBar = find(this._dockPanel.tabBars(), bar => contains(bar.titles, title));
+      return tabBar
+    }
+    return void 0;
+  }
+
+  /*
+   * Return the TabBar previous to the current TabBar (see above) or undefined.
+   */
+  private _previousTabBar(): TabBar {
+    let current = this._currentTabBar();
+    if (current) {
+      let bars = toArray<TabBar>(this._dockPanel.tabBars());
+      let len = bars.length;
+      let ci = bars.indexOf(current);
+      let prevBar: TabBar = null;
+      if (ci > 0) {
+        prevBar = bars[ci-1];
+      } else if (ci === 0) {
+        prevBar = bars[len-1];
+      }
+      return prevBar;
+    }
+    return void 0;
+  }
+
+  /*
+   * Return the TabBar next to the current TabBar (see above) or undefined.
+   */
+  private _nextTabBar(): TabBar {
+    let current = this._currentTabBar();
+    if (current) {
+      let bars = toArray<TabBar>(this._dockPanel.tabBars());
+      let len = bars.length;
+      let ci = bars.indexOf(current);
+      let nextBar: TabBar = null;
+      if (ci < (len-1)) {
+        nextBar = bars[ci+1];
+      } else if (ci === (len-1)) {
+        nextBar = bars[0];
+      }
+      return nextBar;
+    }
+    return void 0;
+  }
+
 
   /**
    * Save the dehydrated state of the application shell.

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -316,10 +316,10 @@ class ApplicationShell extends Widget {
     if (current) {
       let ci = current.currentIndex;
       if (ci !== -1) {
-        if (ci < (current.titles.length-1)) {
+        if (ci < current.titles.length-1) {
           current.currentIndex += 1;
           current.currentTitle.owner.activate();
-        } else if (ci === (current.titles.length-1)) {
+        } else if (ci === current.titles.length-1) {
           let nextBar = this._nextTabBar();
           if (nextBar) {
             nextBar.currentIndex = 0;
@@ -405,7 +405,7 @@ class ApplicationShell extends Widget {
   private _previousTabBar(): TabBar {
     let current = this._currentTabBar();
     if (current) {
-      let bars = toArray<TabBar>(this._dockPanel.tabBars());
+      let bars = toArray(this._dockPanel.tabBars());
       let len = bars.length;
       let ci = bars.indexOf(current);
       let prevBar: TabBar = null;
@@ -425,13 +425,13 @@ class ApplicationShell extends Widget {
   private _nextTabBar(): TabBar {
     let current = this._currentTabBar();
     if (current) {
-      let bars = toArray<TabBar>(this._dockPanel.tabBars());
+      let bars = toArray(this._dockPanel.tabBars());
       let len = bars.length;
       let ci = bars.indexOf(current);
       let nextBar: TabBar = null;
       if (ci < (len-1)) {
         nextBar = bars[ci+1];
-      } else if (ci === (len-1)) {
+      } else if (ci === len-1) {
         nextBar = bars[0];
       }
       return nextBar;

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/algorithm/iteration';
 
 import {
-  find, findIndex, upperBound
+  contains, find, findIndex, upperBound
 } from 'phosphor/lib/algorithm/searching';
 
 import {
@@ -306,6 +306,46 @@ class ApplicationShell extends Widget {
   closeAll(): void {
     each(toArray(this._dockPanel.widgets()), widget => { widget.close(); });
     this._save();
+  }
+
+  /*
+   * Activate the next tab in the panel of the currently active tab.
+  */
+  activateNextTab(): void {
+    let current = this._dockPanel.currentWidget;
+    if (current) {
+      let title = current.title;
+      let tabBar = find(this._dockPanel.tabBars(), bar => contains(bar.titles, title));
+      if (tabBar) {
+        let ci = tabBar.currentIndex;
+        if (ci !== -1) {
+          if (ci < (tabBar.titles.length-1)) {
+            tabBar.currentIndex += 1;
+            tabBar.currentTitle.owner.activate();
+          }
+        }
+      }
+    }
+  }
+
+  /*
+   * Activate the previous tab in the panel of the currently active tab.
+  */
+  activatePreviousTab(): void {
+    let current = this._dockPanel.currentWidget;
+    if (current) {
+      let title = current.title;
+      let tabBar = find(this._dockPanel.tabBars(), bar => contains(bar.titles, title));
+      if (tabBar) {
+        let ci = tabBar.currentIndex;
+        if (ci !== -1) {
+          if (ci > 0) {
+            tabBar.currentIndex -= 1;
+            tabBar.currentTitle.owner.activate();
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/src/shortcuts/plugin.ts
+++ b/src/shortcuts/plugin.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin, CommandIDs as ApplicationCommandIDs
 } from '../application';
 
 import {
@@ -70,6 +70,16 @@ const SHORTCUTS = [
     command: CommandPaletteCommandIDs.activate,
     selector: 'body',
     keys: ['Accel Shift P']
+  },
+  {
+    command: ApplicationCommandIDs.activateNextTab,
+    selector: 'body',
+    keys: ['Accel ArrowRight']
+  },
+  {
+    command: ApplicationCommandIDs.activatePreviousTab,
+    selector: 'body',
+    keys: ['Accel ArrowLeft']
   },
   {
     command: ConsoleCommandIDs.run,


### PR DESCRIPTION
Fixes #1637 

This works, but I have a few questions:

* Have got the logic right for these methods on `ApplicationShell`?
* What keyboard shortcuts to use (currently accel left+right)?
* Right now the terminal swallows these keyboard shortcuts, how do I make the terminal ignore them.

