### PR TITLE
Accept a dialog by hitting enter

### DIFF
--- a/src/common/dialog.ts
+++ b/src/common/dialog.ts
@@ -425,6 +425,10 @@ class Dialog extends Panel {
         this._first.focus();
       }
       break;
+    case 13:
+      this.close();
+      this.resolve(this._buttons[this._buttons.length - 1]);
+      break;
     default:
       break;
     }


### PR DESCRIPTION
Fixes #1583.

Allows one to restart a kernel by typing `0, 0, Enter`, or to accept a new notebook dialog default by hitting enter.