### PR TITLE
Make the mimedata injector an object

### DIFF
--- a/src/outputarea/widget.ts
+++ b/src/outputarea/widget.ts
@@ -325,15 +325,20 @@ class OutputAreaWidget extends Widget {
     let layout = this.layout as PanelLayout;
     let widget = layout.widgets.at(index) as OutputWidget;
     let output = this._model.get(index);
-    let injector: (mimetype: string, value: string | JSONObject) => void;
+    let injector: RenderMime.IInjector;
     if (output.output_type === 'display_data' ||
         output.output_type === 'execute_result') {
-      injector = (mimetype: string, value: string | JSONObject) => {
-        this._injecting = true;
-        this._model.addMimeData(
-          output as nbformat.IDisplayData, mimetype, value
-        );
-        this._injecting = false;
+      injector = {
+        add: (mimeType: string, value: string | JSONObject) => {
+          this._injecting = true;
+          this._model.addMimeData(
+            output as nbformat.IDisplayData, mimeType, value
+          );
+          this._injecting = false;
+        },
+        has: (mimeType: string) => {
+          return mimeType in (output as nbformat.IDisplayData).data;
+        }
       };
     }
     let trusted = this._trusted;
@@ -815,7 +820,7 @@ namespace OutputWidget {
     /**
      * A callback that can be used to add a mimetype to the original bundle.
      */
-    injector?: (mimetype: string, value: string) => void;
+    injector?: RenderMime.IInjector;
    }
 
 }

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -346,7 +346,7 @@ namespace RenderMime {
     /**
      * A callback that can be used to add a mimetype to the original bundle.
      */
-    injector?: (mimetype: string, value: string | JSONObject) => void;
+    injector?: IInjector;
 
     /**
      * Whether the mime bundle is trusted (the default is False).
@@ -372,7 +372,7 @@ namespace RenderMime {
     /**
      * A callback that can be used to add a mimetype to the original bundle.
      */
-    injector?: (mimetype: string, value: string | JSONObject) => void;
+    injector?: IInjector;
 
     /**
      * An optional url resolver.
@@ -390,6 +390,25 @@ namespace RenderMime {
      * An optional link handler.
      */
     linkHandler?: ILinkHandler;
+  }
+
+  /**
+   * An object that handles injecting mime types into a mime bundle.
+   */
+  export
+  interface IInjector {
+    /**
+     * Test if the bundle has the given mimeType.
+     */
+    has(mimeType: string): boolean;
+
+    /**
+     * Inject a value into the mime bundle.
+     *
+     * #### Notes
+     * This will be a no-op if the bundle alread has the given mimeType.
+     */
+    add(mimeType: string, value: string | JSONObject): void;
   }
 
   /**

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -406,7 +406,7 @@ namespace RenderMime {
      * Inject a value into the mime bundle.
      *
      * #### Notes
-     * This will be a no-op if the bundle alread has the given mimeType.
+     * This will be a no-op if the bundle already has the given mimeType.
      */
     add(mimeType: string, value: string | JSONObject): void;
   }

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -146,13 +146,18 @@ describe('rendermime/index', () => {
 
       it('should accept an injector', () => {
         let called = 0;
-        let injector = (mimetype: string, value: string | JSONObject) => {
-          if (mimetype === 'text/plain') {
-            expect(value as string).to.be('foo');
-            called++;
-          } else if (mimetype === 'application/json') {
-            expect((value as JSONObject)['foo']).to.be(1);
-            called++;
+        let injector = {
+          add: (mimetype: string, value: string | JSONObject) => {
+            if (mimetype === 'text/plain') {
+              expect(value as string).to.be('foo');
+              called++;
+            } else if (mimetype === 'application/json') {
+              expect((value as JSONObject)['foo']).to.be(1);
+              called++;
+            }
+          },
+          has: (mimeType: string) => {
+            return true;
           }
         };
         let bundle: RenderMime.MimeMap<string> = {

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -164,8 +164,8 @@ namespace Private {
      */
     render(options: RenderMime.IRendererOptions<string>): Widget {
       if (options.injector) {
-        options.injector('text/plain', 'foo');
-        options.injector('application/json', { 'foo': 1 } );
+        options.injector.add('text/plain', 'foo');
+        options.injector.add('application/json', { 'foo': 1 } );
       }
       return super.render(options);
     }


### PR DESCRIPTION
Fixes #1603.

cc @gnestor 


```typescript
  /**
   * An object that handles injecting mime types into a mime bundle.
   */
  export
  interface IInjector {
    /**
     * Test if the bundle has the given mimeType.
     */
    has(mimeType: string): boolean;

    /**
     * Inject a value into the mime bundle.
     *
     * #### Notes
     * This will be a no-op if the bundle already has the given mimeType.
     */
    add(mimeType: string, value: string | JSONObject): void;
  }
```