### PR TITLE
Bump to xterm 2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "sanitize-html": "^1.12.0",
     "semver": "^5.3.0",
     "simulate-event": "^1.2.0",
-    "xterm": "^2.2.3"
+    "xterm": "^2.3.0"
   },
   "devDependencies": {
     "@jupyterlab/extension-builder": "^0.10.1",


### PR DESCRIPTION
Lots of goodies in this one, but the API we're using is preserved.  https://github.com/sourcelair/xterm.js/releases/tag/2.3.0