### PR TITLE
Refine style of tooltip

### DIFF
--- a/src/tooltip/index.css
+++ b/src/tooltip/index.css
@@ -4,10 +4,16 @@
 |----------------------------------------------------------------------------*/
 
 .jp-Tooltip {
-  background: var(--jp-success-color3);
-  border: var(--jp-border-width) solid var(--jp-border-color3);
+  background: var(--jp-layout-color1);
+  border: var(--jp-border-width) solid var(--jp-border-color1);
   font-size: var(--jp-ui-font-size0);
+  box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.2);
   max-width: 500px;
   overflow: auto;
   z-index: 10001;
+  padding: 4px;
+}
+
+.jp-Tooltip pre {
+  margin: 0;
 }


### PR DESCRIPTION
This makes the style of the tooltip consistent with the completer:

Completer:

<img width="356" alt="screen shot 2017-02-08 at 2 53 04 pm" src="https://cloud.githubusercontent.com/assets/27600/22761176/7afc009e-ee0e-11e6-9285-fe0df75c2e8b.png">

Tooltip:

<img width="697" alt="screen shot 2017-02-08 at 2 52 55 pm" src="https://cloud.githubusercontent.com/assets/27600/22761178/7ed47d68-ee0e-11e6-92a1-1fa394e27efe.png">
