### PR TITLE
chore(splitCell): change behavior to match classic notebook

### DIFF
--- a/src/notebook/actions.ts
+++ b/src/notebook/actions.ts
@@ -76,8 +76,8 @@ namespace NotebookActions {
     if (clone0.type === 'code') {
       (clone0 as ICodeCellModel).outputs.clear();
     }
-    clone0.value.text = orig.slice(0, offset);
-    clone1.value.text = orig.slice(offset).replace(/^\s+/g, '');
+    clone0.value.text = orig.slice(0, offset).replace(/^\n+/, '').replace(/\n+$/, '');
+    clone1.value.text = orig.slice(offset).replace(/^\n+/, '').replace(/\n+$/, '');
 
     // Make the changes while preserving history.
     let cells = nbModel.cells;

--- a/test/src/notebook/actions.spec.ts
+++ b/test/src/notebook/actions.spec.ts
@@ -85,14 +85,14 @@ describe('notebook/notebook/actions', () => {
         expect(newSource).to.be(source);
       });
 
-      it('should remove leading white space in the second cell', () => {
+      it('should preserve leading white space in the second cell', () => {
         let cell = widget.activeCell;
         let source = 'this\n\n   is a test';
         cell.model.value.text = source;
         let editor = cell.editor;
         editor.setCursorPosition(editor.getPositionAt(4));
         NotebookActions.splitCell(widget);
-        expect(widget.activeCell.model.value.text).to.be('is a test');
+        expect(widget.activeCell.model.value.text).to.be('   is a test');
       });
 
       it('should clear the existing selection', () => {


### PR DESCRIPTION
Closes #303.

Adjusts split cell behavior to conform to split cell in classic notebook. Also changes test that previously stripped leading white space to preserve it instead, to match classic notebook.