### PR TITLE
Fix the rendering of files with whitespace and hyphens

### DIFF
--- a/src/running/index.css
+++ b/src/running/index.css
@@ -140,6 +140,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   direction: rtl;
+  white-space: nowrap;
 }
 
 .jp-RunningSessions-itemShutdown {


### PR DESCRIPTION
Fixes #1611.  Notice that we can see the end of the file names in the after shot.

Before:
![image](https://cloud.githubusercontent.com/assets/2096628/22765278/f76a1fb4-ee34-11e6-8515-9c91e40491bf.png)


After:

![image](https://cloud.githubusercontent.com/assets/2096628/22781723/6a9a219c-ee89-11e6-921b-d151bdffdb4d.png)
