### PR TITLE
Create and use CSS variables for `font-family`

### DIFF
--- a/examples/console/index.css
+++ b/examples/console/index.css
@@ -7,7 +7,7 @@ body {
   background: white;
   margin: 0;
   padding: 0;
-  font-family: sans-serif;
+  font-family: var(--jp-ui-font-family);
 }
 
 

--- a/src/about/index.css
+++ b/src/about/index.css
@@ -14,7 +14,7 @@
   scroll-snap-points-y: repeat(100%);
   scroll-snap-type: mandatory;
   scroll-snap-destination: 100% 0%;
-  font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  font-family: var(--jp-ui-font-family);
   text-align: center;
 }
 
@@ -136,7 +136,7 @@
 }
 
 #about .jp-About-content-desc {
-  font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  font-family: var(--jp-code-font-family);
   font-size: 13px;
   max-width: 550px;
   margin: 0 auto;

--- a/src/application/index.css
+++ b/src/application/index.css
@@ -16,7 +16,7 @@ body {
   margin: 0;
   padding: 0;
   overflow: hidden;
-  font-family: sans-serif;
+  font-family: var(--jp-ui-font-family);
   background: var(--jp-layout-color3);
 }
 

--- a/src/cells/index.css
+++ b/src/cells/index.css
@@ -16,7 +16,7 @@
   --jp-private-cell-prompt-width: 90px;
   --jp-private-cell-inprompt-color: #303F9F;
   --jp-private-cell-outprompt-color: #D84315;
-  --jp-private-cell-font-family: 'Helvetica';
+  --jp-private-cell-font-family: var(--jp-ui-font-family);
   --jp-private-cell-prompt-letter-spacing: 2px;
 }
 

--- a/src/commandpalette/index.css
+++ b/src/commandpalette/index.css
@@ -169,6 +169,6 @@
     width: 100px;
     display: block;
     font-size: var(--jp-ui-font-size2);
-    font-family: sans-serif;
+    font-family: var(--jp-ui-font-family);
     font-weight: lighter;
 }

--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -50,6 +50,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-ui-font-size2: calc(var(--jp-ui-font-size1)*var(--jp-ui-font-scale-factor));
   --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
   --jp-ui-icon-font-size: 14px; /* Ensures px perfect FontAwesome icons */
+  --jp-ui-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 
   /* Use these font colors against the corresponding main layout colors.
      In a light theme, these go from dark to light.
@@ -90,6 +91,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-code-font-size: 13px;
   --jp-code-line-height: 17px;
   --jp-code-padding: 5px;
+  --jp-code-font-family: monospace;
 
   /* Layout
 

--- a/src/faq/index.css
+++ b/src/faq/index.css
@@ -5,7 +5,7 @@
 
 
 .jp-FAQ {
-  font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-family: var(--jp-ui-font-family);
   outline: none;
   overflow-y: auto;
 }

--- a/src/outputarea/index.css
+++ b/src/outputarea/index.css
@@ -46,7 +46,7 @@
 
 
 .jp-Output-stdinInput {
-  font-family: monospace;
+  font-family: var(--jp-code-font-family);
   font-size: inherit;
   color: inherit;
   width: auto;
@@ -66,7 +66,7 @@
 
 .jp-Output-prompt {
   color: var(--jp-private-outputarea-prompt-color);
-  font-family: monospace;
+  font-family: var(--jp-code-font-family);
   text-align: right;
   vertical-align: middle;
   padding: var(--jp-code-padding);

--- a/src/terminal/index.css
+++ b/src/terminal/index.css
@@ -15,7 +15,7 @@
 
 
 .jp-TerminalWidget-body {
-  font-family: monospace;
+  font-family: var(--jp-code-font-family);
   outline: none;
   user-select: text;
   -webkit-user-select: text;
@@ -23,7 +23,7 @@
 
 
 .terminal {
-  font-family: monospace;
+  font-family: var(--jp-code-font-family);
 }
 
 


### PR DESCRIPTION
We were hand coding `monospace` and `sans-serif` and other font faces throughout our code base. I have created two new CSS variables for code/ui `font-family` and used them throughout the code base. I am using the sans serif approach of the classic notebook:

```
  --jp-ui-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
```