### PR TITLE
Adding top-level CSS variables to theme notebook+cells more

### DIFF
--- a/src/cells/index.css
+++ b/src/cells/index.css
@@ -9,26 +9,13 @@
 |----------------------------------------------------------------------------*/
 
 
-:root {
-  --jp-private-padding: 10px;
-  --jp-private-cell-editor-background: #f7f7f7;
-  --jp-private-cell-editor-border: #cfcfcf;
-  --jp-private-cell-prompt-width: 90px;
-  --jp-private-cell-inprompt-color: #303F9F;
-  --jp-private-cell-outprompt-color: #D84315;
-  --jp-private-cell-font-family: var(--jp-ui-font-family);
-  --jp-private-cell-prompt-letter-spacing: 2px;
-}
-
-
-
 /*-----------------------------------------------------------------------------
 | Cell
 |----------------------------------------------------------------------------*/
 
 
 .jp-Cell {
-  padding: 5px;
+  padding: var(--jp-cell-padding);
   margin: 0px;
   border: var(--jp-border-width) solid transparent;
   outline: none;
@@ -39,12 +26,13 @@
 .jp-Cell-prompt {
   flex-grow: 0;
   flex-shrink: 0;
-  flex-basis: var(--jp-private-cell-prompt-width);
-  color: var(--jp-private-cell-inprompt-color);
-  font-family: var(--jp-private-cell-font-family);
+  flex-basis: var(--jp-cell-prompt-width);
+  color: var(--jp-cell-inprompt-font-color);
+  font-family: var(--jp-cell-prompt-font-family);
   padding: var(--jp-code-padding);
   text-align: right;
-  letter-spacing: var(--jp-private-cell-prompt-letter-spacing);
+  letter-spacing: var(--jp-cell-prompt-letter-spacing);
+  opacity: var(--jp-cell-prompt-opacity);
   line-height: var(--jp-code-line-height);
   font-size: var(--jp-code-font-size);
   border: var(--jp-border-width) solid transparent;
@@ -93,7 +81,7 @@
 
 
 .jp-CellEditor {
-  border: var(--jp-border-width) solid var(--jp-private-cell-editor-border);
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
   border-radius: 0px;
-  background: var(--jp-private-cell-editor-background);
+  background: var(--jp-cell-editor-background);
 }

--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -789,7 +789,7 @@ class InputAreaWidget extends Widget {
     if (value === 'null') {
       value = ' ';
     }
-    let text = `In [${value || ' '}]:`;
+    let text = `In[${value || ' '}]:`;
     this._prompt.node.textContent = text;
   }
 

--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -146,9 +146,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-prompt-width: 90px;
   --jp-cell-prompt-font-family: var(--jp-ui-font-family);
   --jp-cell-prompt-letter-spacing: 3px;
-  --jp-cell-prompt-opacity: 0.5;
-  --jp-cell-inprompt-font-color: var(--md-blue-900);
-  --jp-cell-outprompt-font-color: var(--md-orange-900);
+  --jp-cell-prompt-opacity: 1.0;
+  /* This is MD Blue 900 with a different s+l */
+  --jp-cell-inprompt-font-color: hsl(216, 30%, 60%);
+  /* This is MD Orange 900 with a different s+l */
+  --jp-cell-outprompt-font-color: hsl(21, 30%, 60%);
   --jp-cell-padding: 5px;
 
   /* Notebook specific styles */

--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -25,6 +25,9 @@ all of MD as it is not optimized for dense, information rich UIs.
 */
 
 
+@import url('https://fonts.googleapis.com/css?family=Droid+Sans+Mono');
+
+
 :root {
 
   /* Borders
@@ -144,13 +147,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-background: #f7f7f7;
   --jp-cell-editor-border-color: #cfcfcf;
   --jp-cell-prompt-width: 90px;
-  --jp-cell-prompt-font-family: var(--jp-ui-font-family);
-  --jp-cell-prompt-letter-spacing: 3px;
+  --jp-cell-prompt-font-family: 'Droid Sans Mono', monospace;
+  --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1.0;
-  /* This is MD Blue 900 with a different s+l */
-  --jp-cell-inprompt-font-color: hsl(216, 30%, 60%);
-  /* This is MD Orange 900 with a different s+l */
-  --jp-cell-outprompt-font-color: hsl(21, 30%, 60%);
+  --jp-cell-inprompt-font-color: var(--md-grey-800);
+  --jp-cell-outprompt-font-color: var(--md-grey-800);
   --jp-cell-padding: 5px;
 
   /* Notebook specific styles */

--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -25,7 +25,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 */
 
 
-@import url('https://fonts.googleapis.com/css?family=Droid+Sans+Mono');
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono');
 
 
 :root {
@@ -147,11 +147,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-background: #f7f7f7;
   --jp-cell-editor-border-color: #cfcfcf;
   --jp-cell-prompt-width: 90px;
-  --jp-cell-prompt-font-family: 'Droid Sans Mono', monospace;
+  --jp-cell-prompt-font-family: 'Roboto Mono', monospace;
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1.0;
-  --jp-cell-inprompt-font-color: var(--md-grey-800);
-  --jp-cell-outprompt-font-color: var(--md-grey-800);
+  --jp-cell-inprompt-font-color: var(--md-grey-700);
+  --jp-cell-outprompt-font-color: var(--md-grey-700);
   --jp-cell-padding: 5px;
 
   /* Notebook specific styles */

--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -139,8 +139,22 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-info-color2: var(--md-cyan-300);
   --jp-info-color3: var(--md-cyan-100);
 
+  /* Cell specific styles */
+
+  --jp-cell-editor-background: #f7f7f7;
+  --jp-cell-editor-border-color: #cfcfcf;
+  --jp-cell-prompt-width: 90px;
+  --jp-cell-prompt-font-family: var(--jp-ui-font-family);
+  --jp-cell-prompt-letter-spacing: 3px;
+  --jp-cell-prompt-opacity: 0.5;
+  --jp-cell-inprompt-font-color: var(--md-blue-900);
+  --jp-cell-outprompt-font-color: var(--md-orange-900);
+  --jp-cell-padding: 5px;
+
   /* Notebook specific styles */
 
+  --jp-notebook-padding: 10px;
+  --jp-notebook-cell-border-color: #ababab;
   --jp-notebook-scroll-padding: 100px;
 
   /* The caret used for select dropdown styling. */

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -14,6 +14,7 @@
   --jp-private-notebook-dragImage-circleRadius: 20px;
   --jp-private-notebook-selected-color: var(--md-blue-400);
   --jp-private-notebook-multiselected-color: var(--md-blue-50);
+  --jp-private-notebook-left-border-width: 5px;
   --jp-private-notebook-active-color: var(--md-green-400);
 }
 

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -9,15 +9,12 @@
 
 
 :root {
-  --jp-private-notebook-padding: 10px;
-  --jp-private-notebook-dragImage-width: 90px;
+  --jp-private-notebook-dragImage-width: var(--jp-cell-prompt-width);
   --jp-private-notebook-dragImage-height: 39px;
   --jp-private-notebook-dragImage-circleRadius: 20px;
   --jp-private-notebook-selected-color: var(--md-blue-400);
   --jp-private-notebook-multiselected-color: var(--md-blue-50);
   --jp-private-notebook-active-color: var(--md-green-400);
-  --jp-private-notebook-cell-border-color: #ABABAB;
-  --jp-private-notebook-left-border-width: 5px;
 }
 
 /*-----------------------------------------------------------------------------
@@ -34,7 +31,10 @@
 
 
 .jp-Notebook {
-  padding: var(--jp-private-notebook-padding);
+  padding-left: var(--jp-notebook-padding);
+  padding-right: var(--jp-notebook-padding);
+  padding-top: var(--jp-notebook-padding);
+  padding-bottom: calc( 4 * var(--jp-notebook-padding) );
   min-width: 50px;
   min-height: 50px;
   outline: none;
@@ -57,13 +57,14 @@
 }
 
 
+
 .jp-Notebook .jp-Cell.jp-Notebook-cell {
   overflow: visible
 }
 
 
 .jp-Notebook.jp-mod-commandMode .jp-Notebook-cell.jp-mod-active.jp-mod-selected {
-  border-color: var(--jp-private-notebook-cell-border-color);
+  border-color: var(--jp-notebook-cell-border-color);
 }
 
 
@@ -137,7 +138,7 @@
   position: absolute;
   width: var(--jp-private-notebook-dragImage-width);
   height: var(--jp-private-notebook-dragImage-height);
-  border: var(--jp-border-width) solid var(--jp-private-notebook-cell-border-color);
+  border: var(--jp-border-width) solid var(--jp-notebook-cell-border-color);
   background: var(--jp-layout-color1);
   overflow: visible;
 }

--- a/src/outputarea/index.css
+++ b/src/outputarea/index.css
@@ -8,12 +8,6 @@
 |----------------------------------------------------------------------------*/
 
 
-:root {
-  --jp-private-outputarea-prompt-color: #D84315;
-  --jp-private-outputarea-prompt-width: 90px;
-}
-
-
 /*-----------------------------------------------------------------------------
 | Main OutputAreaWidget
 | OutputAreaWidget has a list of Outputs
@@ -65,16 +59,18 @@
 
 
 .jp-OutputAreaWidget-gutter {
-  color: var(--jp-private-outputarea-prompt-color);
-  font-family: var(--jp-code-font-family);
+  color: var(--jp-cell-outprompt-font-color);
+  font-family: var(--jp-cell-prompt-font-family);
   text-align: right;
   vertical-align: middle;
   padding: var(--jp-code-padding);
   font-size: var(--jp-code-font-size);
+  letter-spacing: var(--jp-cell-prompt-letter-spacing);
   line-height: var(--jp-code-line-height);
   border: var(--jp-border-width) solid transparent;
-  flex: 0 0 var(--jp-private-outputarea-prompt-width);
+  flex: 0 0 var(--jp-cell-prompt-width);
   box-sizing: border-box;
+  opacity: var(--jp-cell-prompt-opacity);
 }
 
 


### PR DESCRIPTION
Previously most of the notebook+cell styles were done with private CSS variables (not ones in the theme). I have moved a few of these to the top level to better let us play with notebook design. I have deliberately made some provocative style changes to the In/Out prompts. I am not at all convinced these are better than our usual monospaced ones. I mainly want to get all of us thinking about better ways of improving the design of the notebook. Here are some of the ideas I had in mind:

* User content first. The old prompts were much too visually strong and detracted from the users content (code!). Because of this I have applied a bit of opacity to reduce the impact of the prompts. Might be too much.
* Less clash with our material design colors. Our old colors go way back and pretty much clash with the other colors we are using in juptyerlab. I have picked material design colors that are close to the old ones, but more in lines with the MD colors we are using.
* Better typography. I know the old monospace prompts have a long history, but as I played around, with different fonts and typographical options (letter spacing, font weight, etc), it became clear that there *may* be some better alternative designs.

My proposal is that we merge this, open an issue to track everyones opinions (and ideas!!!) as we approach beta. I want to emphasize that I view this as an exploration and am very open to going in other directions or even back to our original ones. Another option that I didn't explor here would be to get rid of the `In/Out` part and just keep the `[N]:` portion. But I sort of like wider prompts as it keep line lengths short in wide notebook panels. I have played around with width dependent prompts as well here: #1624 

