### PR TITLE
Proper nesting of scrolling on tooltip

### DIFF
--- a/src/tooltip/index.css
+++ b/src/tooltip/index.css
@@ -20,5 +20,5 @@
 
 
 .jp-Tooltip > .jp-RenderedText {
-    overflow: auto;
+    overflow: visible;
 }


### PR DESCRIPTION
Previously the tooltip would get vertical and horizontal scroll bars on different divs. This makes a single div scroll as needed:

![screen shot 2017-02-09 at 9 00 51 pm](https://cloud.githubusercontent.com/assets/27600/22814771/002537b6-ef0b-11e6-843b-416585c32e90.png)

Partially addresses #1682