### PR TITLE
Tooltip tweaks

### DIFF
--- a/src/tooltip/widget.ts
+++ b/src/tooltip/widget.ts
@@ -109,6 +109,8 @@ class TooltipWidget extends Widget {
     }
     switch (event.type) {
     case 'keydown':
+      this._evtKeydown(event as KeyboardEvent);
+      break;
     case 'mousedown':
       this._dismiss(event);
       break;
@@ -153,6 +155,21 @@ class TooltipWidget extends Widget {
   protected onUpdateRequest(msg: Message): void {
     this._setGeometry();
     super.onUpdateRequest(msg);
+  }
+
+  /**
+   * Handle a keydown event.
+   */
+  private _evtKeydown(event: KeyboardEvent): void {
+    // Dismiss on enter, escape, or close parens.
+    if ([13, 27, 48].indexOf(event.keyCode) !== -1) {
+      this._dismiss(event);
+      // Prevent enter from getting to the editor.
+      if (event.keyCode === 13) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }
   }
 
   /**

--- a/src/tooltip/widget.ts
+++ b/src/tooltip/widget.ts
@@ -33,11 +33,6 @@ const TOOLTIP_CLASS = 'jp-Tooltip';
 const ANCHOR_CLASS = 'jp-Tooltip-anchor';
 
 /**
- * The class name added to hidden elements.
- */
-const HIDDEN_CLASS = 'p-mod-hidden';
-
-/**
  * The minimum height of a tooltip widget.
  */
 const MIN_HEIGHT = 20;
@@ -67,7 +62,7 @@ class TooltipWidget extends Widget {
     this.model = options.model;
     this.model.contentChanged.connect(this._onContentChanged, this);
     this.addClass(TOOLTIP_CLASS);
-    this.addClass(HIDDEN_CLASS);
+    this.hide();
     this.anchor.addClass(ANCHOR_CLASS);
   }
 
@@ -199,7 +194,7 @@ class TooltipWidget extends Widget {
     this._content = this.model.content;
     if (this._content) {
       (this.layout as PanelLayout).addWidget(this._content);
-      this.removeClass(HIDDEN_CLASS);
+      this.show();
     }
     this.update();
   }

--- a/src/tooltip/widget.ts
+++ b/src/tooltip/widget.ts
@@ -33,6 +33,11 @@ const TOOLTIP_CLASS = 'jp-Tooltip';
 const ANCHOR_CLASS = 'jp-Tooltip-anchor';
 
 /**
+ * The class name added to hidden elements.
+ */
+const HIDDEN_CLASS = 'p-mod-hidden';
+
+/**
  * The minimum height of a tooltip widget.
  */
 const MIN_HEIGHT = 20;
@@ -62,6 +67,7 @@ class TooltipWidget extends Widget {
     this.model = options.model;
     this.model.contentChanged.connect(this._onContentChanged, this);
     this.addClass(TOOLTIP_CLASS);
+    this.addClass(HIDDEN_CLASS);
     this.anchor.addClass(ANCHOR_CLASS);
   }
 
@@ -176,6 +182,7 @@ class TooltipWidget extends Widget {
     this._content = this.model.content;
     if (this._content) {
       (this.layout as PanelLayout).addWidget(this._content);
+      this.removeClass(HIDDEN_CLASS);
     }
     this.update();
   }


### PR DESCRIPTION
Fixes #1682.

- Hides the tooltip until it has content.
- Dismisses on ESC, Enter, or `)`.  The Enter dismisses the tooltip but does not insert a newline in the editor.


Notes before I break for the weekend:
- `)` is too specific a character, we should stick with Esc and Enter
- The model can be simplified to just a `fetch(options: IFetchOptions): Promise` which takes the detail level.
- The widget has the rendermime and detail level and a method that calls `model.fetch` and gets the rendermime bundle and attaches itself.
