### PR TITLE
Activate the notebook after any action that changes cells

### DIFF
--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -146,11 +146,11 @@ function createApp(manager: ServiceManager.IManager): void {
   });
   commands.addCommand(cmdIds.restart, {
     label: 'Restart Kernel',
-    execute: () => restartKernel(nbWidget.kernel, nbWidget.node)
+    execute: () => restartKernel(nbWidget.kernel, nbWidget)
   });
   commands.addCommand(cmdIds.switchKernel, {
     label: 'Switch Kernel',
-    execute: () => selectKernelForContext(nbWidget.context, manager.sessions, nbWidget.node)
+    execute: () => selectKernelForContext(nbWidget.context, manager.sessions, nbWidget)
   });
   commands.addCommand(cmdIds.runAndAdvance, {
     label: 'Run and Advance',

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -363,7 +363,6 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
         specs: manager.specs,
         sessions: manager.running(),
         preferredLanguage: args.preferredLanguage || '',
-        host: document.body
       };
       return selectKernel(options);
     });
@@ -447,7 +446,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
           sessions: manager.running(),
           preferredLanguage: lang,
           kernel: session.kernel.model,
-          host: widget.parent.node
+          host: widget
         };
         return selectKernel(options);
       }).then((kernelId: Kernel.IModel) => {

--- a/src/docregistry/kernelactions.ts
+++ b/src/docregistry/kernelactions.ts
@@ -6,6 +6,10 @@ import {
 } from '@jupyterlab/services';
 
 import {
+  Widget
+} from '@phosphor/widgets';
+
+import {
   showDialog, cancelButton, warnButton
 } from '../common/dialog';
 
@@ -15,7 +19,7 @@ import {
  *
  * @param kernel - The kernel to restart.
  *
- * @param host - The optional host element for the dialog.
+ * @param host - The optional host widget that should be activated.
  *
  * @returns A promise that resolves to `true` the user elects to restart.
  *
@@ -23,7 +27,7 @@ import {
  * This is a no-op if there is no kernel.
  */
 export
-function restartKernel(kernel: Kernel.IKernel, host?: HTMLElement): Promise<boolean> {
+function restartKernel(kernel: Kernel.IKernel, host?: Widget): Promise<boolean> {
   if (!kernel) {
     return Promise.resolve(false);
   }
@@ -32,6 +36,9 @@ function restartKernel(kernel: Kernel.IKernel, host?: HTMLElement): Promise<bool
     body: 'Do you want to restart the current kernel? All variables will be lost.',
     buttons: [cancelButton, warnButton]
   }).then(result => {
+    if (host) {
+      host.activate();
+    }
     if (!kernel.isDisposed && result.text === 'OK') {
       return kernel.restart().then(() => { return true; });
     } else {

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -10,6 +10,10 @@ import {
 } from '@phosphor/algorithm';
 
 import {
+  Widget
+} from '@phosphor/widgets';
+
+import {
   showDialog
 } from '../common/dialog';
 
@@ -49,9 +53,9 @@ interface IKernelSelection {
   kernel?: Kernel.IModel;
 
   /**
-   * The host node for the dialog.
+   * The host widget to be selected after the dialog is shown.
    */
-  host?: HTMLElement;
+  host?: Widget;
 }
 
 
@@ -100,10 +104,6 @@ function selectKernel(options: IKernelSelection): Promise<Kernel.IModel> {
   text.innerHTML = `Select kernel for: "${options.name}"`;
   body.appendChild(text);
 
-  if (kernel) {
-    let displayName = specs.kernelspecs[kernel.name].display_name;
-  }
-
   let selector = document.createElement('select');
   body.appendChild(selector);
 
@@ -127,7 +127,7 @@ function selectKernel(options: IKernelSelection): Promise<Kernel.IModel> {
  * Change the kernel on a context.
  */
 export
-function selectKernelForContext(context: DocumentRegistry.Context, manager: Session.IManager, host?: HTMLElement): Promise<void> {
+function selectKernelForContext(context: DocumentRegistry.Context, manager: Session.IManager, host?: Widget): Promise<void> {
   return manager.ready.then(() => {
     let options: IKernelSelection = {
       name: context.path.split('/').pop(),
@@ -135,10 +135,12 @@ function selectKernelForContext(context: DocumentRegistry.Context, manager: Sess
       sessions: manager.running(),
       preferredLanguage: context.model.defaultKernelLanguage,
       kernel: context.kernel ? context.kernel.model : null,
-      host
     };
     return selectKernel(options);
   }).then(kernel => {
+    if (host) {
+      host.activate();
+    }
     if (kernel && (kernel.id || kernel.name)) {
       context.changeKernel(kernel);
     } else if (kernel && !kernel.id && !kernel.name) {

--- a/src/notebook/actions.ts
+++ b/src/notebook/actions.ts
@@ -814,19 +814,35 @@ namespace NotebookActions {
  */
 namespace Private {
   /**
+   * The interface for a widget state.
+   */
+  export
+  interface IState {
+    /**
+     * Whether the widget had focus.
+     */
+    wasFocused: boolean;
+  }
+
+  /**
    * Get the state of a widget before running an action.
    */
   export
-  function getState(widget: Notebook): boolean {
-    return false;
+  function getState(widget: Notebook): IState {
+    return {
+      wasFocused: widget.node.contains(document.activeElement)
+    };
   }
 
   /**
    * Handle the state of a widget after running an action.
    */
   export
-  function handleState(widget: Notebook, state: boolean): void {
-    // TODO
+  function handleState(widget: Notebook, state: IState): void {
+    if (state.wasFocused) {
+      widget.activate();
+    }
+    widget.scrollToActiveCell();
   }
 
   /**

--- a/src/notebook/actions.ts
+++ b/src/notebook/actions.ts
@@ -163,6 +163,7 @@ namespace NotebookActions {
     }
 
     widget.activeCellIndex -= offset;
+    widget.activate();
   }
 
   /**
@@ -214,6 +215,8 @@ namespace NotebookActions {
     // Deselect any remaining, undeletable cells. Do this even if we don't
     // delete anything so that users are aware *something* happened.
     widget.deselectAll();
+
+    widget.activate();
   }
 
   /**
@@ -236,6 +239,7 @@ namespace NotebookActions {
     let cell = model.contentFactory.createCodeCell({ });
     model.cells.insert(widget.activeCellIndex, cell);
     widget.deselectAll();
+    widget.activate();
   }
 
   /**
@@ -259,6 +263,7 @@ namespace NotebookActions {
     model.cells.insert(widget.activeCellIndex + 1, cell);
     widget.activeCellIndex++;
     widget.deselectAll();
+    widget.activate();
   }
 
   /**
@@ -287,6 +292,7 @@ namespace NotebookActions {
       }
     }
     cells.endCompoundOperation();
+    widget.activate();
   }
 
   /**
@@ -315,6 +321,7 @@ namespace NotebookActions {
       }
     }
     cells.endCompoundOperation();
+    widget.activate();
   }
 
   /**
@@ -366,6 +373,7 @@ namespace NotebookActions {
     });
     cells.endCompoundOperation();
     widget.deselectAll();
+    widget.activate();
   }
 
   /**
@@ -399,6 +407,7 @@ namespace NotebookActions {
     });
     widget.activeCellIndex = lastIndex;
     widget.deselectAll();
+    widget.activate();
 
     let promises: Promise<boolean>[] = [];
     each(selected, child => {
@@ -450,6 +459,7 @@ namespace NotebookActions {
       widget.activeCellIndex++;
     }
     widget.scrollToActiveCell();
+    widget.activate();
 
     return promise;
   }
@@ -651,6 +661,7 @@ namespace NotebookActions {
      } else {
        widget.deselectAll();
      }
+     widget.activate();
    }
 
   /**
@@ -731,6 +742,7 @@ namespace NotebookActions {
 
     widget.activeCellIndex += newCells.length;
     widget.deselectAll();
+    widget.activate();
   }
 
   /**
@@ -749,6 +761,7 @@ namespace NotebookActions {
     widget.mode = 'command';
     widget.model.cells.undo();
     widget.deselectAll();
+    widget.activate();
   }
 
   /**
@@ -767,6 +780,7 @@ namespace NotebookActions {
     widget.mode = 'command';
     widget.model.cells.redo();
     widget.deselectAll();
+    widget.activate();
   }
 
   /**

--- a/src/notebook/default-toolbar.ts
+++ b/src/notebook/default-toolbar.ts
@@ -6,6 +6,10 @@ import {
 } from '@jupyterlab/services';
 
 import {
+  Message
+} from '@phosphor/messaging';
+
+import {
   Widget
 } from '@phosphor/widgets';
 
@@ -215,23 +219,10 @@ class CellTypeSwitcher extends Widget {
     super({ node: createCellTypeSwitcherNode() });
     this.addClass(TOOLBAR_CELLTYPE_CLASS);
 
-    let select = this._select = this.node.firstChild as HTMLSelectElement;
+    this._select = this.node.firstChild as HTMLSelectElement;
     this._wildCard = document.createElement('option');
     this._wildCard.value = '-';
     this._wildCard.textContent = '-';
-
-    // Change current cell type on a change in the dropdown.
-    select.addEventListener('change', event => {
-      if (select.value === '-') {
-        return;
-      }
-      if (!this._changeGuard) {
-        let value = select.value as nbformat.CellType;
-        NotebookActions.changeCellType(widget, value);
-        widget.activate();
-      }
-    });
-
     this._notebook = widget;
 
     // Set the initial value.
@@ -244,6 +235,75 @@ class CellTypeSwitcher extends Widget {
 
     // Follow a change in the selection.
     widget.selectionChanged.connect(this._updateValue, this);
+  }
+
+  /**
+   * Handle the DOM events for the widget.
+   *
+   * @param event - The DOM event sent to the widget.
+   *
+   * #### Notes
+   * This method implements the DOM `EventListener` interface and is
+   * called in response to events on the dock panel's node. It should
+   * not be called directly by user code.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+    case 'change':
+      this._evtChange(event);
+      break;
+    case 'keydown':
+      this._evtKeyDown(event as KeyboardEvent);
+      break;
+    default:
+      break;
+    }
+  }
+
+  /**
+   * Handle `after-attach` messages for the widget.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this._select.addEventListener('change', this);
+    this._select.addEventListener('keydown', this);
+  }
+
+  /**
+   * Handle `before_detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    this._select.removeEventListener('change', this);
+    this._select.removeEventListener('keydown', this);
+  }
+
+  /**
+   * Handle `changed` events for the widget.
+   */
+  private _evtChange(event: Event): void {
+    let select = this._select;
+    let widget = this._notebook;
+    if (select.value === '-') {
+      return;
+    }
+    if (!this._changeGuard) {
+      let value = select.value as nbformat.CellType;
+      NotebookActions.changeCellType(widget, value);
+      widget.activate();
+    }
+  }
+
+  /**
+   * Handle `keydown` events for the widget.
+   */
+  private _evtKeyDown(event: KeyboardEvent): void {
+    switch (event.keyCode) {
+    case 13:  // Enter
+    case 27:  // Escape
+      this._notebook.activate();
+      break;
+    default:
+      break;
+    }
   }
 
   /**

--- a/src/notebook/default-toolbar.ts
+++ b/src/notebook/default-toolbar.ts
@@ -104,7 +104,9 @@ namespace ToolbarItems {
   function createInsertButton(panel: NotebookPanel): ToolbarButton {
     return new ToolbarButton({
       className: TOOLBAR_INSERT_CLASS,
-      onClick: () => { NotebookActions.insertBelow(panel.notebook); },
+      onClick: () => {
+        NotebookActions.insertBelow(panel.notebook);
+      },
       tooltip: 'Insert a cell below'
     });
   }
@@ -226,6 +228,7 @@ class CellTypeSwitcher extends Widget {
       if (!this._changeGuard) {
         let value = select.value as nbformat.CellType;
         NotebookActions.changeCellType(widget, value);
+        widget.activate();
       }
     });
 

--- a/src/notebook/default-toolbar.ts
+++ b/src/notebook/default-toolbar.ts
@@ -296,13 +296,8 @@ class CellTypeSwitcher extends Widget {
    * Handle `keydown` events for the widget.
    */
   private _evtKeyDown(event: KeyboardEvent): void {
-    switch (event.keyCode) {
-    case 13:  // Enter
-    case 27:  // Escape
+    if (event.keyCode === 13) {  // Enter
       this._notebook.activate();
-      break;
-    default:
-      break;
     }
   }
 

--- a/src/notebook/default-toolbar.ts
+++ b/src/notebook/default-toolbar.ts
@@ -196,7 +196,7 @@ namespace ToolbarItems {
     toolbar.addItem('paste', createPasteButton(panel));
     toolbar.addItem('run', createRunButton(panel));
     toolbar.addItem('interrupt', createInterruptButton(panel));
-    toolbar.addItem('restart', createRestartButton(panel, panel.node));
+    toolbar.addItem('restart', createRestartButton(panel));
     toolbar.addItem('cellType', createCellTypeItem(panel));
     toolbar.addItem('kernelName', createKernelNameItem(panel));
     toolbar.addItem('kernelStatus', createKernelStatusItem(panel));

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -330,58 +330,32 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
   });
   commands.addCommand(CommandIDs.restartClear, {
     label: 'Restart Kernel & Clear Outputs',
-<<<<<<< HEAD
     execute: args => {
       let current = getCurrent(args);
       if (!current) {
         return;
       }
-      let promise = restartKernel(current.kernel, current.node);
+      let promise = restartKernel(current.kernel, current);
       promise.then(result => {
-        current.activate();
         if (result) {
           return NotebookActions.clearAllOutputs(current.notebook);
         }
       });
       return promise;
-=======
-    execute: () => {
-      let current = tracker.currentWidget;
-      if (current) {
-        let promise = restartKernel(current.kernel, current);
-        promise.then(result => {
-          if (result) {
-            NotebookActions.clearAllOutputs(current.notebook);
-          }
-        });
-      }
->>>>>>> a7569a5a... Clean up the handling of focus for kernel actions
     }
   });
   commands.addCommand(CommandIDs.restartRunAll, {
     label: 'Restart Kernel & Run All',
-<<<<<<< HEAD
     execute: args => {
       let current = getCurrent(args);
       if (!current) {
         return;
       }
-      let promise = restartKernel(current.kernel, current.node);
+      let promise = restartKernel(current.kernel, current);
       promise.then(result => {
-        current.activate();
         NotebookActions.runAll(current.notebook, current.context.kernel);
       });
       return promise;
-=======
-    execute: () => {
-      let current = tracker.currentWidget;
-      if (current) {
-        let promise = restartKernel(current.kernel, current);
-        promise.then(result => {
-          NotebookActions.runAll(current.notebook, current.context.kernel);
-        });
-      }
->>>>>>> a7569a5a... Clean up the handling of focus for kernel actions
     }
   });
   commands.addCommand(CommandIDs.clearAllOutputs, {

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -292,9 +292,7 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
       if (!current) {
         return;
       }
-      return restartKernel(current.kernel, current.node).then(() => {
-        current.activate();
-      });
+      restartKernel(current.kernel, current);
     }
   });
   commands.addCommand(CommandIDs.closeAndShutdown, {
@@ -332,6 +330,7 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
   });
   commands.addCommand(CommandIDs.restartClear, {
     label: 'Restart Kernel & Clear Outputs',
+<<<<<<< HEAD
     execute: args => {
       let current = getCurrent(args);
       if (!current) {
@@ -345,10 +344,23 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
         }
       });
       return promise;
+=======
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        let promise = restartKernel(current.kernel, current);
+        promise.then(result => {
+          if (result) {
+            NotebookActions.clearAllOutputs(current.notebook);
+          }
+        });
+      }
+>>>>>>> a7569a5a... Clean up the handling of focus for kernel actions
     }
   });
   commands.addCommand(CommandIDs.restartRunAll, {
     label: 'Restart Kernel & Run All',
+<<<<<<< HEAD
     execute: args => {
       let current = getCurrent(args);
       if (!current) {
@@ -360,6 +372,16 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
         NotebookActions.runAll(current.notebook, current.context.kernel);
       });
       return promise;
+=======
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        let promise = restartKernel(current.kernel, current);
+        promise.then(result => {
+          NotebookActions.runAll(current.notebook, current.context.kernel);
+        });
+      }
+>>>>>>> a7569a5a... Clean up the handling of focus for kernel actions
     }
   });
   commands.addCommand(CommandIDs.clearAllOutputs, {
@@ -627,10 +649,18 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
   });
   commands.addCommand(CommandIDs.switchKernel, {
     label: 'Switch Kernel',
+<<<<<<< HEAD
     execute: args => {
       let current = getCurrent(args);
       if (!current) {
         return;
+=======
+    execute: () => {
+      let current = tracker.currentWidget;
+      if (current) {
+        let context = current.context;
+        selectKernelForContext(context, services.sessions, current);
+>>>>>>> a7569a5a... Clean up the handling of focus for kernel actions
       }
       let context = current.context;
       let node = current.node;

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -623,25 +623,13 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
   });
   commands.addCommand(CommandIDs.switchKernel, {
     label: 'Switch Kernel',
-<<<<<<< HEAD
     execute: args => {
       let current = getCurrent(args);
       if (!current) {
         return;
-=======
-    execute: () => {
-      let current = tracker.currentWidget;
-      if (current) {
-        let context = current.context;
-        selectKernelForContext(context, services.sessions, current);
->>>>>>> a7569a5a... Clean up the handling of focus for kernel actions
       }
       let context = current.context;
-      let node = current.node;
-      let sessions = services.sessions;
-      return selectKernelForContext(context, sessions, node).then(() => {
-        current.activate();
-      });
+      return selectKernelForContext(context, services.sessions, current);
     }
   });
   commands.addCommand(CommandIDs.markdown1, {

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -140,9 +140,6 @@ class Toolbar<T extends Widget> extends Widget {
         this.parent.activate();
       }
       break;
-    case 'blur':
-      this.parent.activate();
-      break;
     default:
       break;
     }
@@ -153,7 +150,6 @@ class Toolbar<T extends Widget> extends Widget {
    */
   protected onAfterAttach(msg: Message): void {
     this.node.addEventListener('click', this);
-    this.node.addEventListener('blur', this);
   }
 
   /**
@@ -161,7 +157,6 @@ class Toolbar<T extends Widget> extends Widget {
    */
   protected onBeforeDetach(msg: Message): void {
     this.node.removeEventListener('click', this);
-    this.node.removeEventListener('blur', this);
   }
 }
 

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -122,6 +122,47 @@ class Toolbar<T extends Widget> extends Widget {
     let layout = this.layout as PanelLayout;
     layout.removeWidget(widget);
   }
+
+  /**
+   * Handle the DOM events for the widget.
+   *
+   * @param event - The DOM event sent to the widget.
+   *
+   * #### Notes
+   * This method implements the DOM `EventListener` interface and is
+   * called in response to events on the dock panel's node. It should
+   * not be called directly by user code.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+    case 'click':
+      if (!this.node.contains(document.activeElement)) {
+        this.parent.activate();
+      }
+      break;
+    case 'blur':
+      this.parent.activate();
+      break;
+    default:
+      break;
+    }
+  }
+
+  /**
+   * Handle `after-attach` messages for the widget.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this.node.addEventListener('click', this);
+    this.node.addEventListener('blur', this);
+  }
+
+  /**
+   * Handle `before_detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    this.node.removeEventListener('click', this);
+    this.node.removeEventListener('blur', this);
+  }
 }
 
 

--- a/src/toolbar/kernel.ts
+++ b/src/toolbar/kernel.ts
@@ -84,16 +84,14 @@ function createInterruptButton(kernelOwner: IKernelOwner): ToolbarButton {
  * Create a restart toolbar item.
  */
 export
-function createRestartButton(kernelOwner: IKernelOwner, host?: HTMLElement): ToolbarButton {
+function createRestartButton(kernelOwner: IKernelOwner): ToolbarButton {
   return new ToolbarButton({
     className: TOOLBAR_RESTART_CLASS,
     onClick: () => {
       if (!kernelOwner.kernel) {
         return;
       }
-      restartKernel(kernelOwner.kernel, host).then(() => {
-        kernelOwner.activate();
-      });
+      restartKernel(kernelOwner.kernel, kernelOwner);
     },
     tooltip: 'Restart the kernel'
   });

--- a/src/toolbar/kernel.ts
+++ b/src/toolbar/kernel.ts
@@ -51,7 +51,7 @@ const TOOLBAR_BUSY_CLASS = 'jp-mod-busy';
  * A kernel owner interface.
  */
 export
-interface IKernelOwner {
+interface IKernelOwner extends Widget {
   /**
    * An associated kernel.
    */
@@ -88,7 +88,12 @@ function createRestartButton(kernelOwner: IKernelOwner, host?: HTMLElement): Too
   return new ToolbarButton({
     className: TOOLBAR_RESTART_CLASS,
     onClick: () => {
-      restartKernel(kernelOwner.kernel, host);
+      if (!kernelOwner.kernel) {
+        return;
+      }
+      restartKernel(kernelOwner.kernel, host).then(() => {
+        kernelOwner.activate();
+      });
     },
     tooltip: 'Restart the kernel'
   });


### PR DESCRIPTION
Fixes #1683.   Fixes #1706.

Normalizes the handling of focus and scroll state across notebook actions.  
All notebook actions preserve the focus of the notebook and make sure the active cell is visible.
All toolbar actions activate the panel when finished.