### PR TITLE
Use an after selector to add a page of text below a notebook

### DIFF
--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -93,7 +93,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-code-padding: 5px;
   --jp-code-font-family: monospace;
 
-  --jp-notebook-scroll-padding: 100px;
 
   /* Layout
 
@@ -139,5 +138,9 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-info-color1: var(--md-cyan-500);
   --jp-info-color2: var(--md-cyan-300);
   --jp-info-color3: var(--md-cyan-100);
+
+  /* Notebook specific styles */
+
+  --jp-notebook-scroll-padding: 100px;
 
 }

--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -93,6 +93,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-code-padding: 5px;
   --jp-code-font-family: monospace;
 
+  --jp-notebook-scrollPadding: 100px;
+
   /* Layout
 
   The following are the main layout colors use in JupyterLab. In a light

--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -93,7 +93,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-code-padding: 5px;
   --jp-code-font-family: monospace;
 
-  --jp-notebook-scrollPadding: 100px;
+  --jp-notebook-scroll-padding: 100px;
 
   /* Layout
 

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -34,16 +34,23 @@
 
 
 .jp-Notebook {
-  padding-left: var(--jp-private-notebook-padding);
-  padding-right: var(--jp-private-notebook-padding);
-  padding-top: var(--jp-private-notebook-padding);
-  padding-bottom: calc( 4 * var(--jp-private-notebook-padding) );
+  padding: var(--jp-private-notebook-padding);
   min-width: 50px;
   min-height: 50px;
   outline: none;
   overflow: auto;
   background: var(--jp-layout-color1);
 }
+
+
+.jp-Notebook::after {
+  content: ' ';
+  width: 100%;
+  min-height: 100px;
+  position: absolute;
+  transition: height .2s ease;
+}
+
 
 
 .jp-Notebook-panel {

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -53,7 +53,6 @@
 }
 
 
-
 .jp-Notebook-panel {
   display: flex;
   flex-direction: column;

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -35,8 +35,6 @@
 
 
 .jp-Notebook {
-  display: flex;
-  flex-direction: column;
   padding: var(--jp-private-notebook-padding);
   min-width: 50px;
   min-height: 50px;
@@ -47,8 +45,8 @@
 
 
 .jp-Notebook::after {
-  content: ' ';
-  width: 100%;
+  display: block;
+  content: '';
   min-height: var(--jp-notebook-scrollPadding);
 }
 

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -46,7 +46,7 @@
 .jp-Notebook::after {
   display: block;
   content: '';
-  min-height: var(--jp-notebook-scrollPadding);
+  min-height: var(--jp-notebook-scroll-padding);
 }
 
 

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -9,6 +9,7 @@
 
 
 :root {
+  --jp-notebook-scrollPadding: 100px;
   --jp-private-notebook-padding: 10px;
   --jp-private-notebook-dragImage-width: 90px;
   --jp-private-notebook-dragImage-height: 39px;
@@ -46,7 +47,7 @@
 .jp-Notebook::after {
   content: ' ';
   width: 100%;
-  min-height: 100px;
+  min-height: var(--jp-notebook-scrollPadding);
   position: absolute;
   transition: height .2s ease;
 }

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -9,7 +9,6 @@
 
 
 :root {
-  --jp-notebook-scrollPadding: 100px;
   --jp-private-notebook-padding: 10px;
   --jp-private-notebook-dragImage-width: 90px;
   --jp-private-notebook-dragImage-height: 39px;

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -35,6 +35,8 @@
 
 
 .jp-Notebook {
+  display: flex;
+  flex-direction: column;
   padding: var(--jp-private-notebook-padding);
   min-width: 50px;
   min-height: 50px;
@@ -48,8 +50,6 @@
   content: ' ';
   width: 100%;
   min-height: var(--jp-notebook-scrollPadding);
-  position: absolute;
-  transition: height .2s ease;
 }
 
 


### PR DESCRIPTION
Fixes #488.

Fills the whole panel:
![image](https://cloud.githubusercontent.com/assets/2096628/22829576/e0b7e014-ef68-11e6-9762-24f6849dfabb.png)


But adds space after the last cell:
![image](https://cloud.githubusercontent.com/assets/2096628/22829584/e7efe656-ef68-11e6-9c8a-f7a3d933c4a4.png)
