### PR TITLE
Cell tools styling

### DIFF
--- a/src/common/dialog.css
+++ b/src/common/dialog.css
@@ -163,7 +163,7 @@
 .jp-Dialog-selectWrapper.jp-mod-focused,
 .jp-Dialog-inputWrapper.jp-mod-focused {
   border: var(--jp-border-width) solid var(--md-blue-500);
-  box-shadow: inset 0 0 4px var(--md-blue-300)
+  box-shadow: inset 0 0 4px var(--md-blue-300);
 }
 
 

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -117,7 +117,7 @@
 }
 
 
-.jp-Notebook-cell.jp-mod-dropTarget, 
+.jp-Notebook-cell.jp-mod-dropTarget,
 .jp-Notebook.jp-mod-commandMode .jp-Notebook-cell.jp-mod-active.jp-mod-selected.jp-mod-dropTarget {
   border-top-color: var(--jp-private-notebook-selected-color);
 }
@@ -181,20 +181,15 @@
 }
 
 
-.jp-CellTools-tool {
-  flex: 0 1 auto;
-  display: flex;
-  flex-direction: row;
-}
-
-
 .jp-ActiveCellTool {
-  padding: var(--jp-private-notebook-padding);
+  padding: 12px;
+  padding-bottom: 4px;
 }
 
 
 .jp-ActiveCellTool .jp-Cell-prompt {
   flex: 0 0 auto;
+  padding-left: 0px;
 }
 
 
@@ -204,10 +199,10 @@
 
 
 .jp-CellTools-tool:not(:first-child) {
-  margin-top: 6px;
-  margin-bottom: 12px;
-  border-top: 1px dotted gray;
-  padding-top: 6px;
+  margin-top: 8px;
+  margin-bottom: 4px;
+  border-top: 1px solid var(--md-grey-300);
+  padding-top: 12px;
 }
 
 
@@ -249,14 +244,12 @@
 
 
 .jp-KeySelector {
-  padding-left: 10px;
-  padding-right: 10px;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 
 .jp-KeySelector label {
-  padding-top: 4px;
-  padding-bottom: 4px;
   line-height: 1.4;
 }
 
@@ -286,13 +279,14 @@
   padding: 1px;
   background: white;
   height: 28px;
-  width: 252px;
   box-sizing: border-box;
   border: var(--jp-border-width) solid var(--jp-border-color1);
-  margin-bottom: 12px;
+  margin-top: 8px;
+  margin-bottom: 4px;
 }
 
 
 .jp-KeySelector-selectWrapper.jp-mod-focused {
-  border: 2px solid var(--md-light-blue-200);
+  border: var(--jp-border-width) solid var(--md-blue-500);
+  box-shadow: inset 0 0 4px var(--md-blue-300);
 }

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -181,9 +181,16 @@
 }
 
 
+.jp-CellTools .jp-MetadataEditor-host {
+  background-color: white;
+  border-color: var(--jp-border-color1);
+}
+
+
 .jp-ActiveCellTool {
   padding: 12px;
-  padding-bottom: 4px;
+  border-bottom: 1px solid var(--jp-border-color1);
+  background-color: var(--jp-border-color3);
 }
 
 
@@ -195,14 +202,13 @@
 
 .jp-ActiveCellTool .jp-CellEditor {
   flex: 1 1 auto;
+  background-color: white;
+  border-color: var(--jp-border-color1);
 }
 
 
 .jp-CellTools-tool:not(:first-child) {
-  margin-top: 8px;
-  margin-bottom: 4px;
   border-top: 1px solid var(--md-grey-300);
-  padding-top: 12px;
 }
 
 
@@ -244,8 +250,7 @@
 
 
 .jp-KeySelector {
-  padding-left: 12px;
-  padding-right: 12px;
+  padding: 12px;
 }
 
 


### PR DESCRIPTION
Took first pass at styling the cell tools:

- Changed so that labels for sections are now stacked instead of inline with dropdowns

- Styled <select> tags to match styling of rest of interface in :focus state

- Fixed styling of the active cell tool at the top of cell tools

- Fixed spacing between sections within cell tools

- Section dividers are now solid lines and are same color as rest of interface

- Differentiated the top active cell section from the actionable area below. Matches the styling of the command pallete.

Before:
![screen shot 2017-02-14 at 10 15 38 am](https://cloud.githubusercontent.com/assets/6437976/22943526/b6ff1ef8-f2a2-11e6-832d-72adb44a13a6.png)

After:
![screen shot 2017-02-14 at 10 42 05 am](https://cloud.githubusercontent.com/assets/6437976/22943447/75118260-f2a2-11e6-938e-9cf31007ed82.png)

