### PR TITLE
Running Sessions and Command Pallete Quick Style Changes

### DIFF
--- a/src/running/index.css
+++ b/src/running/index.css
@@ -135,6 +135,7 @@
 
 
 .jp-RunningSessions-itemLabel {
+  font-size: var(--jp-ui-font-size1);
   flex: 1 1 auto;
   margin-right: 4px;
   text-overflow: ellipsis;
@@ -152,4 +153,5 @@
   cursor: pointer;
   height: var(--jp-private-running-shutdown-button-height);
   line-height: var(--jp-private-running-shutdown-button-height);
+  letter-spacing: .8px;
 }


### PR DESCRIPTION
- Fixed the font sizing of session names and added letter spacing for the shutdown labels

Before:
<img width="303" alt="screen shot 2017-02-14 at 11 33 26 am" src="https://cloud.githubusercontent.com/assets/6437976/22945543/7990434c-f2a9-11e6-8a16-486b666a19d7.png">

After:
<img width="303" alt="screen shot 2017-02-14 at 11 29 36 am" src="https://cloud.githubusercontent.com/assets/6437976/22945393/f80b9f10-f2a8-11e6-929f-7b03419f9328.png">

- Brought the font weight down on command pallete search items to match the styling of the rest of the sidebar typography

Before:
<img width="302" alt="screen shot 2017-02-14 at 11 33 35 am" src="https://cloud.githubusercontent.com/assets/6437976/22945557/83ca0604-f2a9-11e6-8384-f96dc7bd2205.png">

After:
<img width="302" alt="screen shot 2017-02-14 at 11 33 08 am" src="https://cloud.githubusercontent.com/assets/6437976/22945562/882f5bea-f2a9-11e6-846d-36c2b32db0e8.png">

