### PR TITLE
Running Sessions Style Fixes

### DIFF
--- a/src/running/index.css
+++ b/src/running/index.css
@@ -135,6 +135,7 @@
 
 
 .jp-RunningSessions-itemLabel {
+  font-size: var(--jp-ui-font-size1);
   flex: 1 1 auto;
   margin-right: 4px;
   text-overflow: ellipsis;
@@ -144,6 +145,7 @@
 }
 
 .jp-RunningSessions-itemShutdown {
+  letter-spacing: .8px;
   flex: 0 0 auto;
   padding: 0px 4px;
   margin: 2px 8px 2px 0px;


### PR DESCRIPTION
- Changed font size of a running sessions item to be back to 13px. 

- Added some spacing in between the characters in the 'shutdown' button so there is greater readability

Before:
![screen shot 2017-02-16 at 1 53 58 pm](https://cloud.githubusercontent.com/assets/6437976/23042925/6b2af08e-f44f-11e6-87e2-227d650f5ef3.png)

After:
![screen shot 2017-02-16 at 1 53 07 pm](https://cloud.githubusercontent.com/assets/6437976/23042927/6dd46284-f44f-11e6-8bd6-2879ebf2fcd0.png)
