### PR TITLE
Command Pallete & Running Style Fixes

### DIFF
--- a/src/commandpalette/index.css
+++ b/src/commandpalette/index.css
@@ -102,7 +102,7 @@
   cursor: pointer;
   text-transform: uppercase;
   border-bottom: solid var(--jp-border-width) var(--jp-border-color2);
-  letter-spacing: .8px;
+  letter-spacing: 1px;
 }
 
 

--- a/src/commandpalette/index.css
+++ b/src/commandpalette/index.css
@@ -102,7 +102,7 @@
   cursor: pointer;
   text-transform: uppercase;
   border-bottom: solid var(--jp-border-width) var(--jp-border-color2);
-  letter-spacing: 1.2px;
+  letter-spacing: .8px;
 }
 
 
@@ -128,7 +128,7 @@
   padding: 4px 12px;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
-  font-weight: 500;
+  font-weight: 400;
 }
 
 

--- a/src/running/index.css
+++ b/src/running/index.css
@@ -70,7 +70,7 @@
   font-weight: 600;
   text-transform: uppercase;
   border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
-  letter-spacing: .8px;
+  letter-spacing: 1px;
 }
 
 

--- a/src/running/index.css
+++ b/src/running/index.css
@@ -70,7 +70,7 @@
   font-weight: 600;
   text-transform: uppercase;
   border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
-  letter-spacing: 1.2px;
+  letter-spacing: .8px;
 }
 
 


### PR DESCRIPTION
- Fixed font weight on command palette items to be the font weight of the rest of the interface. This makes it easier to differentiate between the section headers and the command palette items. 

- Changed the letter spacing of the section headers in the command palette and the running sessions tab to be closer together. This increases the readability and I felt like they were a little too far spaced out to begin with.

#### Command Pallete Style Changes
Before:
![screen shot 2017-02-16 at 2 08 49 pm](https://cloud.githubusercontent.com/assets/6437976/23043559/88a1a174-f451-11e6-9303-d7a2fabf8a45.png)

After:
![screen shot 2017-02-16 at 2 07 25 pm](https://cloud.githubusercontent.com/assets/6437976/23043585/a54ed256-f451-11e6-8dc8-911852f17773.png)


#### Running Sessions Style Changes
Before:
![screen shot 2017-02-16 at 2 09 00 pm](https://cloud.githubusercontent.com/assets/6437976/23043601/b216e2ee-f451-11e6-91c8-4a9a0f32c95b.png)

After:
![screen shot 2017-02-16 at 2 07 59 pm](https://cloud.githubusercontent.com/assets/6437976/23043605/b68e637e-f451-11e6-8ab9-68a972326076.png)

