### PR TITLE
Only update notebook mime type if information is available.

### DIFF
--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -468,6 +468,9 @@ class StaticNotebook extends Widget {
    */
   private _updateMimetype(): void {
     let info = this._model.metadata.get('language_info') as nbformat.ILanguageInfoMetadata;
+    if (!info) {
+      return;
+    }
     this._mimetype = this._mimetypeService.getMimeTypeByLanguage(info);
     each(this.widgets, widget => {
       if (widget.model.type === 'code') {

--- a/tutorial/notebook.md
+++ b/tutorial/notebook.md
@@ -87,7 +87,7 @@ also contains an [OutputAreaWidget](http://jupyterlab.github.io/jupyterlab/class
 An OutputAreaWidget is responsible for rendering the outputs in the
 [OutputAreaModel](http://jupyterlab.github.io/jupyterlab/classes/_outputarea_model_.outputareamodel.html)
 list. An OutputAreaWidget uses a
-notebook-specific [RenderMime](http://jupyterlab.github.io/jupyterlab/classes/_rendermime_index_.rendermime.html)
+notebook-specific [RenderMime](http://jupyterlab.github.io/jupyterlab/classes/_rendermime_rendermime_.rendermime.html)
 object to render `display_data` output messages.
 
 #### Rendering output messages


### PR DESCRIPTION
Bug fix for loading a notebook that caused an error when changing mime type:

<img width="570" alt="screen shot 2017-02-20 at 5 16 39 pm" src="https://cloud.githubusercontent.com/assets/159529/23138161/a59e7d84-f79d-11e6-85ea-58c9ad8c6100.png">
