### PR TITLE
Clean up markdown cell sizing

### DIFF
--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -775,11 +775,11 @@ class InputAreaWidget extends Widget {
    * Show the text editor.
    */
   showEditor(): void {
-    this._editor.show();
     let layout = this.layout as PanelLayout;
     if (this._rendered) {
       layout.removeWidget(this._rendered);
     }
+    this._editor.show();
   }
 
   /**

--- a/src/codeeditor/widget.ts
+++ b/src/codeeditor/widget.ts
@@ -56,6 +56,7 @@ class CodeEditorWidget extends Widget {
       return;
     }
     clearTimeout(this._resizing);
+    this._resizing = -1;
     super.dispose();
     this._editor.dispose();
     this._editor = null;
@@ -93,10 +94,8 @@ class CodeEditorWidget extends Widget {
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
-    if (this._needsRefresh) {
-      this._editor.refresh();
-      this._needsRefresh = false;
-    }
+    this._editor.refresh();
+    this._needsRefresh = false;
   }
 
   /**
@@ -118,6 +117,7 @@ class CodeEditorWidget extends Widget {
       }
     } else {
       this._editor.setSize(msg);
+      this._needsResize = false;
     }
     this._needsRefresh = true;
   }


### PR DESCRIPTION
Show the editor *after* hiding the rendered output so it measures properly, and clean up handling of  internal state flags in the codeeditorwidget.