### PR TITLE
Add focus style for command palette input

### DIFF
--- a/src/commandpalette/index.css
+++ b/src/commandpalette/index.css
@@ -43,6 +43,12 @@
 }
 
 
+.p-CommandPalette.p-mod-focused .p-CommandPalette-wrapper {
+  border: var(--jp-border-width) solid var(--md-blue-500);
+  box-shadow: inset 0 0 4px var(--md-blue-300);
+}
+
+
 .p-CommandPalette-wrapper::after {
   content: " ";
   color: white;


### PR DESCRIPTION
Fixes #1472.

<image src="https://cloud.githubusercontent.com/assets/2096628/23258447/ee98dbdc-f98d-11e6-820d-8403bb3eb178.png" width=300>
