### PR TITLE
Add active widget handling

### DIFF
--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -538,17 +538,7 @@ namespace ApplicationShell {
    * An arguments object for the changed signals.
    */
   export
-  interface IChangedArgs {
-    /**
-     * The old value for the widget.
-     */
-    oldValue: Widget;
-
-    /**
-     * The new value for the widget.
-     */
-    newValue: Widget;
-  }
+  type IChangedArgs = FocusTracker.IChangedArgs<Widget>;
 }
 
 

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -61,6 +61,11 @@ const SIDEBAR_CLASS = 'jp-SideBar';
  */
 const CURRENT_CLASS = 'jp-mod-current';
 
+/**
+ * The class name added to the active widget's title.
+ */
+const ACTIVE_CLASS = 'jp-mod-active';
+
 
 /**
  * The application shell for JupyterLab.
@@ -131,6 +136,7 @@ class ApplicationShell extends Widget {
     this.layout = rootLayout;
 
     this._tracker.currentChanged.connect(this._onCurrentChanged, this);
+    this._tracker.activeChanged.connect(this._onActiveChanged, this);
   }
 
   /**
@@ -141,10 +147,24 @@ class ApplicationShell extends Widget {
   }
 
   /**
+   * A signal emitted when main area's active focus changes.
+   */
+  get activeChanged(): ISignal<any, FocusTracker.IChangedArgs<Widget>> {
+    return this._tracker.activeChanged;
+  }
+
+  /**
    * The current widget in the shell's main area.
    */
-  get currentWidget(): Widget {
+  get currentWidget(): Widget | null {
     return this._tracker.currentWidget;
+  }
+
+  /**
+   * The active widget in the shell's main area.
+   */
+  get activeWidget(): Widget | null {
+    return this._tracker.activeWidget;
   }
 
   /**
@@ -457,6 +477,19 @@ class ApplicationShell extends Widget {
     if (args.oldValue) {
       let title = args.oldValue.title;
       title.className = title.className.replace(CURRENT_CLASS, '');
+    }
+  }
+
+  /**
+   * Handle a change to the dock area active widget.
+   */
+  private _onActiveChanged(sender: any, args: FocusTracker.IChangedArgs<Widget>): void {
+    if (args.newValue) {
+      args.newValue.title.className += ` ${ACTIVE_CLASS}`;
+    }
+    if (args.oldValue) {
+      let title = args.oldValue.title;
+      title.className = title.className.replace(ACTIVE_CLASS, '');
     }
   }
 

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -10,7 +10,7 @@ import {
 } from '@phosphor/algorithm';
 
 import {
-  ISignal
+  ISignal, Signal
 } from '@phosphor/signaling';
 
 import {
@@ -142,15 +142,15 @@ class ApplicationShell extends Widget {
   /**
    * A signal emitted when main area's current focus changes.
    */
-  get currentChanged(): ISignal<any, FocusTracker.IChangedArgs<Widget>> {
-    return this._tracker.currentChanged;
+  get currentChanged(): ISignal<this, ApplicationShell.IChangedArgs> {
+    return this._currentChanged;
   }
 
   /**
    * A signal emitted when main area's active focus changes.
    */
-  get activeChanged(): ISignal<any, FocusTracker.IChangedArgs<Widget>> {
-    return this._tracker.activeChanged;
+  get activeChanged(): ISignal<this, ApplicationShell.IChangedArgs> {
+    return this._activeChanged;
   }
 
   /**
@@ -475,9 +475,11 @@ class ApplicationShell extends Widget {
       args.newValue.title.className += ` ${CURRENT_CLASS}`;
     }
     if (args.oldValue) {
-      let title = args.oldValue.title;
-      title.className = title.className.replace(CURRENT_CLASS, '');
+      args.oldValue.title.className = (
+        args.oldValue.title.className.replace(CURRENT_CLASS, '')
+      );
     }
+    this._currentChanged.emit(args);
   }
 
   /**
@@ -488,9 +490,11 @@ class ApplicationShell extends Widget {
       args.newValue.title.className += ` ${ACTIVE_CLASS}`;
     }
     if (args.oldValue) {
-      let title = args.oldValue.title;
-      title.className = title.className.replace(ACTIVE_CLASS, '');
+      args.oldValue.title.className = (
+        args.oldValue.title.className.replace(ACTIVE_CLASS, '')
+      );
     }
+    this._activeChanged.emit(args);
   }
 
   private _database: IInstanceRestorer.ILayoutDB = null;
@@ -503,6 +507,8 @@ class ApplicationShell extends Widget {
   private _rightHandler: Private.SideBarHandler;
   private _topPanel: Panel;
   private _tracker = new FocusTracker<Widget>();
+  private _currentChanged = new Signal<this, ApplicationShell.IChangedArgs>(this);
+  private _activeChanged = new Signal<this, ApplicationShell.IChangedArgs>(this);
 }
 
 
@@ -526,6 +532,22 @@ namespace ApplicationShell {
      * The rank order of the widget among its siblings.
      */
     rank?: number;
+  }
+
+  /**
+   * An arguments object for the changed signals.
+   */
+  export
+  interface IChangedArgs {
+    /**
+     * The old value for the widget.
+     */
+    oldValue: Widget;
+
+    /**
+     * The new value for the widget.
+     */
+    newValue: Widget;
   }
 }
 

--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -77,8 +77,8 @@
 }
 
 
-/* This is the main application level current tab: only 1 exists. */
-.p-DockPanel-tabBar .p-TabBar-tab.jp-mod-current:before {
+/* This is the main application level active tab: only 1 exists. */
+.p-DockPanel-tabBar .p-TabBar-tab.jp-mod-active:before {
   position: absolute;
   top: calc(-1 * var(--jp-border-width));
   left: calc(-1 * var(--jp-border-width));


### PR DESCRIPTION
Uses the new `activeWidget` from Phosphor's `FocusTracker` to only style the tab of a widget in the dock panel if it actually has focus.