### PR TITLE
Fix non-rendering if initial completer load has a subset match for all available options.

### DIFF
--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -169,7 +169,13 @@ class CompletionHandler implements IDisposable {
    * Handle `invoke-request` messages.
    */
   protected onInvokeRequest(msg: Message): void {
+    // If there is neither a kernel or a completer model, bail.
     if (!this._kernel || !this._completer.model) {
+      return;
+    }
+
+    // If a completer session is already active, bail.
+    if (this._completer.model.original) {
       return;
     }
 

--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -202,7 +202,7 @@ class CompletionHandler implements IDisposable {
     }
     // Completion request failures or negative results fail silently.
     if (value.status !== 'ok') {
-      model.reset();
+      model.reset(true);
       return;
     }
     // Update the original request.

--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -236,16 +236,17 @@ class CompletionHandler implements IDisposable {
 
     // Allow completion if the current or a preceding char is not whitespace.
     const position = editor.getCursorPosition();
-    const currentLine = editor.getLine(position.line);
-    if (!currentLine.substring(0, position.column).match(/\S/)) {
-      model.reset();
+    const { column, line } = position;
+    const currentLine = editor.getLine(line);
+    const currentChar = currentLine[column && column - 1];
+    if (!currentChar || !currentChar.match(/\w/)) {
+      model.reset(true);
       return;
     }
 
     const request = this.getState(position);
 
     host.classList.add(COMPLETABLE_CLASS);
-
     this._completer.model.handleTextChange(request);
   }
 

--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -28,6 +28,12 @@ import {
 export
 const COMPLETABLE_CLASS: string = 'jp-mod-completable';
 
+/**
+ * A class added to editors that have an active completer.
+ */
+export
+const COMPLETER_ACTIVE_CLASS: string = 'jp-mod-completer-active';
+
 
 /**
  * A completion handler for editors.
@@ -42,6 +48,13 @@ class CompletionHandler implements IDisposable {
     this._completer.selected.connect(this.onCompletionSelected, this);
     this._completer.visibilityChanged.connect(this.onVisibilityChanged, this);
     this._kernel = options.kernel || null;
+  }
+
+  /**
+   * The completer widget managed by the handler.
+   */
+  get completer(): CompleterWidget {
+    return this._completer;
   }
 
   /**
@@ -254,10 +267,18 @@ class CompletionHandler implements IDisposable {
    * Handle a visiblity change signal from a completion widget.
    */
   protected onVisibilityChanged(completion: CompleterWidget): void {
+    // Completer is not active.
     if (completion.isDisposed || completion.isHidden) {
       if (this._editor) {
+        this._editor.host.classList.remove(COMPLETER_ACTIVE_CLASS);
         this._editor.focus();
       }
+      return;
+    }
+
+    // Completer is active.
+    if (this._editor) {
+      this._editor.host.classList.add(COMPLETER_ACTIVE_CLASS);
     }
   }
 

--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -194,7 +194,7 @@ class CompletionHandler implements IDisposable {
    * Handle `invoke-request` messages.
    */
   protected onInvokeRequest(msg: Message): void {
-    // If there is neither a kernel or a completer model, bail.
+    // If there is neither a kernel nor a completer model, bail.
     if (!this._kernel || !this._completer.model) {
       return;
     }
@@ -210,22 +210,30 @@ class CompletionHandler implements IDisposable {
 
   /**
    * Receive a completion reply from the kernel.
+   *
+   * @param state - The state of the editor when completion request was made.
+   *
+   * @param reply - The API response returned for a completion request.
    */
-  protected onReply(request: CompleterWidget.ITextState, msg: KernelMessage.ICompleteReplyMsg): void {
-    let value = msg.content;
-    let model = this._completer.model;
+  protected onReply(state: CompleterWidget.ITextState, reply: KernelMessage.ICompleteReplyMsg): void {
+    const model = this._completer.model;
     if (!model) {
       return;
     }
+
     // Completion request failures or negative results fail silently.
+    const value = reply.content;
     if (value.status !== 'ok') {
       model.reset(true);
       return;
     }
+
     // Update the original request.
-    model.original = request;
+    model.original = state;
+
     // Update the options.
     model.setOptions(value.matches || []);
+
     // Update the cursor.
     model.cursor = { start: value.cursor_start, end: value.cursor_end };
   }

--- a/src/completer/index.ts
+++ b/src/completer/index.ts
@@ -36,6 +36,15 @@ namespace CommandIDs {
 
   export
   const invokeNotebook: string = 'completer:invoke-notebook';
+
+  export
+  const select: string = 'completer:select';
+
+  export
+  const selectConsole: string = 'completer:select-console';
+
+  export
+  const selectNotebook: string = 'completer:select-notebook';
 }
 
 

--- a/src/completer/model.ts
+++ b/src/completer/model.ts
@@ -247,8 +247,17 @@ class CompleterModel implements CompleterWidget.IModel {
 
   /**
    * Reset the state of the model and emit a state change signal.
+   *
+   * @param hard - Reset even if a subset match is in progress.
    */
-  reset() {
+  reset(hard = false) {
+    // When the completer detects a common subset prefix for all options,
+    // it updates the model and sets the model source to that value, but this
+    // text change should be ignored.
+    if (!hard && this._subsetMatch) {
+      return;
+    }
+    this._subsetMatch = false;
     this._reset();
     this._stateChanged.emit(void 0);
   }

--- a/src/completer/model.ts
+++ b/src/completer/model.ts
@@ -207,9 +207,10 @@ class CompleterModel implements CompleterWidget.IModel {
     // When the completer detects a common subset prefix for all options,
     // it updates the model and sets the model source to that value, but this
     // text change should be ignored.
-    if (this.subsetMatch) {
+    if (this._subsetMatch) {
       return;
     }
+
     let { text, column } = request;
 
     // If last character entered is not whitespace, update completion.

--- a/src/completer/model.ts
+++ b/src/completer/model.ts
@@ -253,8 +253,8 @@ class CompleterModel implements CompleterWidget.IModel {
    */
   reset(hard = false) {
     // When the completer detects a common subset prefix for all options,
-    // it updates the model and sets the model source to that value, but this
-    // text change should be ignored.
+    // it updates the model and sets the model source to that value, triggering
+    // a reset. Unless explicitly a hard reset, this should be ignored.
     if (!hard && this._subsetMatch) {
       return;
     }

--- a/src/completer/model.ts
+++ b/src/completer/model.ts
@@ -76,6 +76,7 @@ class CompleterModel implements CompleterWidget.IModel {
     if (!this.original) {
       return;
     }
+
     // Cursor must always be set before a text change. This happens
     // automatically in the completer handler, but since `current` is a public
     // attribute, this defensive check is necessary.

--- a/src/completer/plugin.ts
+++ b/src/completer/plugin.ts
@@ -18,7 +18,7 @@ import {
 } from '../notebook';
 
 import {
-  CommandIDs, COMPLETABLE_CLASS, COMPLETER_ACTIVE_CLASS, CompleterModel,
+  CommandIDs, COMPLETER_ACTIVE_CLASS, CompleterModel,
   CompleterWidget, CompletionHandler, ICompletionManager
 } from './';
 

--- a/src/completer/plugin.ts
+++ b/src/completer/plugin.ts
@@ -18,8 +18,8 @@ import {
 } from '../notebook';
 
 import {
-  CommandIDs, CompleterModel, CompleterWidget, CompletionHandler,
-  ICompletionManager
+  CommandIDs, COMPLETABLE_CLASS, COMPLETER_ACTIVE_CLASS, CompleterModel,
+  CompleterWidget, CompletionHandler, ICompletionManager
 } from './';
 
 
@@ -35,7 +35,7 @@ const service: JupyterLabPlugin<ICompletionManager> = {
 
     app.commands.addCommand(CommandIDs.invoke, {
       execute: args => {
-        let id = args['id'] as string;
+        let id = args && (args['id'] as string);
         if (!id) {
           return;
         }
@@ -43,6 +43,20 @@ const service: JupyterLabPlugin<ICompletionManager> = {
         const handler = handlers[id];
         if (handler) {
           handler.invoke();
+        }
+      }
+    });
+
+    app.commands.addCommand(CommandIDs.select, {
+      execute: args => {
+        let id = args && (args['id'] as string);
+        if (!id) {
+          return;
+        }
+
+        const handler = handlers[id];
+        if (handler) {
+          handler.completer.selectActive();
         }
       }
     });
@@ -107,7 +121,7 @@ const consolePlugin: JupyterLabPlugin<void> = {
       });
     });
 
-    // Add console completer command.
+    // Add console completer invoke command.
     app.commands.addCommand(CommandIDs.invokeConsole, {
       execute: () => {
         const id = consoles.currentWidget && consoles.currentWidget.id;
@@ -116,6 +130,24 @@ const consolePlugin: JupyterLabPlugin<void> = {
         }
         return app.commands.execute(CommandIDs.invoke, { id });
       }
+    });
+
+    // Add console completer select command.
+    app.commands.addCommand(CommandIDs.selectConsole, {
+      execute: () => {
+        const id = consoles.currentWidget && consoles.currentWidget.id;
+        if (!id) {
+          return;
+        }
+        return app.commands.execute(CommandIDs.select, { id });
+      }
+    });
+
+    // Set enter key for console completer select command.
+    app.commands.addKeyBinding({
+      command: CommandIDs.selectConsole,
+      keys: ['Enter'],
+      selector: `.jp-ConsolePanel .${COMPLETER_ACTIVE_CLASS}`
     });
   }
 };
@@ -154,6 +186,24 @@ const notebookPlugin: JupyterLabPlugin<void> = {
         const id = notebooks.currentWidget && notebooks.currentWidget.id;
         return app.commands.execute(CommandIDs.invoke, { id });
       }
+    });
+
+    // Add notebook completer select command.
+    app.commands.addCommand(CommandIDs.selectNotebook, {
+      execute: () => {
+        const id = notebooks.currentWidget && notebooks.currentWidget.id;
+        if (!id) {
+          return;
+        }
+        return app.commands.execute(CommandIDs.select, { id });
+      }
+    });
+
+    // Set enter key for notebook completer select command.
+    app.commands.addKeyBinding({
+      command: CommandIDs.selectNotebook,
+      keys: ['Enter'],
+      selector: `.jp-Notebook .${COMPLETER_ACTIVE_CLASS}`
     });
   }
 };

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -285,8 +285,12 @@ class CompleterWidget extends Widget {
     // If this is the first time the current completer session has loaded,
     // populate any initial subset match.
     if (this._model.subsetMatch) {
-      this._populateSubset();
+      let populated = this._populateSubset();
       this.model.subsetMatch = false;
+      if (populated) {
+        this.update();
+        return;
+      }
     }
   }
 
@@ -413,7 +417,6 @@ class CompleterWidget extends Widget {
     if (subset && subset !== query && subset.indexOf(query) === 0) {
       this.model.query = subset;
       this._selected.emit(subset);
-      this.update();
       return true;
     }
     return false;

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -169,7 +169,7 @@ class CompleterWidget extends Widget {
   reset(): void {
     this._reset();
     if (this._model) {
-      this._model.reset();
+      this._model.reset(true);
     }
   }
 
@@ -245,7 +245,7 @@ class CompleterWidget extends Widget {
 
     // If there are no items, reset and bail.
     if (!items || !items.length) {
-      this._reset();
+      this.reset();
       if (!this.isHidden) {
         this.hide();
         this._visibilityChanged.emit(void 0);
@@ -463,7 +463,7 @@ class CompleterWidget extends Widget {
   private _selectActive(): void {
     let active = this.node.querySelector(`.${ACTIVE_CLASS}`) as HTMLElement;
     if (!active) {
-      this._reset();
+      this.reset();
       return;
     }
     this._selected.emit(active.getAttribute('data-value'));

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -607,9 +607,11 @@ namespace CompleterWidget {
     createPatch(patch: string): IPatch;
 
     /**
-     * Reset the state of the model.
+     * Reset the state of the model and emit a state change signal.
+     *
+     * @param hard - Reset even if a subset match is in progress.
      */
-    reset(): void;
+    reset(hard?: boolean): void;
   }
 
   /**

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -508,7 +508,7 @@ namespace CompleterWidget {
 
 
   /**
-   * An interface for a completion request.
+   * An interface for a completion request reflecting the state of the editor.
    */
   export
   interface ITextState extends JSONObject {

--- a/src/completer/widget.ts
+++ b/src/completer/widget.ts
@@ -203,6 +203,19 @@ class CompleterWidget extends Widget {
   }
 
   /**
+   * Emit the selected signal for the current active item and reset.
+   */
+  selectActive(): void {
+    let active = this.node.querySelector(`.${ACTIVE_CLASS}`) as HTMLElement;
+    if (!active) {
+      this.reset();
+      return;
+    }
+    this._selected.emit(active.getAttribute('data-value'));
+    this.reset();
+  }
+
+  /**
    * Handle `after-attach` messages for the widget.
    */
   protected onAfterAttach(msg: Message): void {
@@ -334,13 +347,7 @@ class CompleterWidget extends Widget {
         if (populated) {
           return;
         }
-        this._selectActive();
-        return;
-      case 13: // Enter key
-        event.preventDefault();
-        event.stopPropagation();
-        event.stopImmediatePropagation();
-        this._selectActive();
+        this.selectActive();
         return;
       case 27: // Esc key
         event.preventDefault();
@@ -455,19 +462,6 @@ class CompleterWidget extends Widget {
       maxHeight: MAX_HEIGHT,
       minHeight: MIN_HEIGHT
     });
-  }
-
-  /**
-   * Emit the selected signal for the current active item and reset.
-   */
-  private _selectActive(): void {
-    let active = this.node.querySelector(`.${ACTIVE_CLASS}`) as HTMLElement;
-    if (!active) {
-      this.reset();
-      return;
-    }
-    this._selected.emit(active.getAttribute('data-value'));
-    this.reset();
   }
 
   private _anchor: Widget | null = null;

--- a/test/src/completer/handler.spec.ts
+++ b/test/src/completer/handler.spec.ts
@@ -57,8 +57,8 @@ class TestCompletionHandler extends CompletionHandler {
     return promise;
   }
 
-  onReply(pending: number, request: CompleterWidget.ITextState, msg: KernelMessage.ICompleteReplyMsg): void {
-    super.onReply(pending, request, msg);
+  onReply(state: CompleterWidget.ITextState, reply: KernelMessage.ICompleteReplyMsg): void {
+    super.onReply(state, reply);
     this.methods.push('onReply');
   }
 
@@ -249,25 +249,6 @@ describe('completer/handler', () => {
 
     describe('#onReply()', () => {
 
-      it('should do nothing if handler has been disposed', () => {
-        let completer = new CompleterWidget();
-        let handler = new TestCompletionHandler({ completer });
-        completer.model = new CompleterModel();
-        completer.model.setOptions(['foo', 'bar', 'baz']);
-        handler.dispose();
-        handler.onReply(0, null, null);
-        expect(completer.model).to.be.ok();
-      });
-
-      it('should do nothing if pending request ID does not match', () => {
-        let completer = new CompleterWidget();
-        let handler = new TestCompletionHandler({ completer });
-        completer.model = new CompleterModel();
-        completer.model.setOptions(['foo', 'bar', 'baz']);
-        handler.onReply(2, null, null);
-        expect(completer.model).to.be.ok();
-      });
-
       it('should reset model if status is not ok', () => {
         let completer = new CompleterWidget();
         let handler = new TestCompletionHandler({ completer });
@@ -297,7 +278,7 @@ describe('completer/handler', () => {
         completer.model = new CompleterModel();
         completer.model.setOptions(options);
         expect(toArray(completer.model.options())).to.eql(options);
-        handler.onReply(0, request, reply);
+        handler.onReply(request, reply);
         expect(toArray(completer.model.options())).to.eql([]);
       });
 
@@ -330,7 +311,7 @@ describe('completer/handler', () => {
         completer.model = new CompleterModel();
         completer.model.setOptions(options);
         expect(toArray(completer.model.options())).to.eql(options);
-        handler.onReply(0, request, reply);
+        handler.onReply(request, reply);
         expect(toArray(completer.model.options())).to.eql(reply.content.matches);
       });
 
@@ -349,22 +330,21 @@ describe('completer/handler', () => {
       });
 
       it('should call model change handler if model exists', () => {
-        // TODO: reinstate in fix for #1795
-        // let completer = new CompleterWidget({
-        //   model: new TestCompleterModel()
-        // });
-        // let handler = new TestCompletionHandler({ completer });
-        // let editor = createEditorWidget().editor;
-        // let model = completer.model as TestCompleterModel;
+        let completer = new CompleterWidget({
+          model: new TestCompleterModel()
+        });
+        let handler = new TestCompletionHandler({ completer });
+        let editor = createEditorWidget().editor;
+        let model = completer.model as TestCompleterModel;
 
-        // handler.editor = editor;
-        // expect(model.methods).to.not.contain('handleTextChange');
-        // editor.model.value.text = 'bar';
-        // editor.setCursorPosition({ line: 0, column: 2 });
-        // // This signal is emitted (again) because the cursor position that
-        // // a natural user would create need to be recreated here.
-        // (editor.model.value.changed as any).emit(void 0);
-        // expect(model.methods).to.contain('handleTextChange');
+        handler.editor = editor;
+        expect(model.methods).to.not.contain('handleTextChange');
+        editor.model.value.text = 'bar';
+        editor.setCursorPosition({ line: 0, column: 2 });
+        // This signal is emitted (again) because the cursor position that
+        // a natural user would create need to be recreated here.
+        (editor.model.value.changed as any).emit(void 0);
+        expect(model.methods).to.contain('handleTextChange');
       });
 
     });

--- a/test/src/completer/widget.spec.ts
+++ b/test/src/completer/widget.spec.ts
@@ -121,7 +121,7 @@ describe('completer/widget', () => {
         Widget.attach(widget, document.body);
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
         expect(value).to.be('');
-        simulate(anchor.node, 'keydown', { keyCode: 13 }); // Enter
+        simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab
         expect(value).to.be('foo');
         widget.dispose();
         anchor.dispose();
@@ -293,29 +293,6 @@ describe('completer/widget', () => {
           MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
           expect(widget.isHidden).to.be(true);
           expect(model.options().next()).to.be(void 0);
-          widget.dispose();
-          anchor.dispose();
-        });
-
-        it('should trigger a selected signal on enter key', () => {
-          let anchor = new Widget();
-          let model = new CompleterModel();
-          let options: CompleterWidget.IOptions = { anchor, model };
-          let value = '';
-          let listener = (sender: any, selected: string) => {
-            value = selected;
-          };
-          model.setOptions(['foo', 'bar', 'baz']);
-          Widget.attach(anchor, document.body);
-
-          let widget = new CompleterWidget(options);
-
-          widget.selected.connect(listener);
-          Widget.attach(widget, document.body);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          expect(value).to.be('');
-          simulate(anchor.node, 'keydown', { keyCode: 13 }); // Enter
-          expect(value).to.be('foo');
           widget.dispose();
           anchor.dispose();
         });


### PR DESCRIPTION
* Fixes https://github.com/jupyterlab/jupyterlab/issues/1768
* Fixes an issue where the tab key interferes with completer behavior if tab is set as the invocation shortcut to bring up a completer and a completer session is already active
* Fixes an issue where completer did not properly invoke if a document had been loaded but no text in the document had been changed before completer invocation (thanks @ian-r-rose)
* Fixes an issue where the enter key was caught in contention between console/notebook commands and completer item selection
* Simplified the heuristic for when completer invocation should be ignored: *only empty whitespace lines* are ignored, all other invocations are sent to the kernel because this is the behavior of the classic notebook and some language kernels require it (cheers @Carreau). This behavior may be tweaked in the future.