### PR TITLE
Add a getPositionForCoordinate method to IEditor

### DIFF
--- a/src/codeeditor/editor.ts
+++ b/src/codeeditor/editor.ts
@@ -505,7 +505,17 @@ namespace CodeEditor {
      *
      * @returns The coordinates of the position.
      */
-    getCoordinate(position: IPosition): ICoordinate;
+    getCoordinateForPosition(position: IPosition): ICoordinate;
+
+    /**
+     * Get the cursor position given window coordinates.
+     *
+     * @param coordinate - The desired coordinate.
+     *
+     * @returns The position of the coordinates, or null if not
+     *   contained in the editor.
+     */
+    getPositionForCoordinate(coordinate: ICoordinate): IPosition | null;
   }
 
   /**

--- a/src/codemirror/editor.ts
+++ b/src/codemirror/editor.ts
@@ -348,8 +348,20 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   /**
    * Get the window coordinates given a cursor position.
    */
-  getCoordinate(position: CodeEditor.IPosition): CodeEditor.ICoordinate {
+  getCoordinateForPosition(position: CodeEditor.IPosition): CodeEditor.ICoordinate {
     return this.editor.charCoords(this._toCodeMirrorPosition(position), 'page');
+  }
+
+  /**
+   * Get the cursor position given window coordinates.
+   *
+   * @param coordinate - The desired coordinate.
+   *
+   * @returns The position of the coordinates, or null if not
+   *   contained in the editor.
+   */
+  getPositionForCoordinate(coordinate: CodeEditor.ICoordinate): CodeEditor.IPosition | null {
+    return this._toPosition(this.editor.coordsChar(coordinate)) || null;
   }
 
   /**

--- a/src/completer/handler.ts
+++ b/src/completer/handler.ts
@@ -123,7 +123,7 @@ class CompletionHandler implements IDisposable {
    */
   protected getState(position: CodeEditor.IPosition): CompleterWidget.ITextState {
     let editor = this.editor;
-    let coords = editor.getCoordinate(position) as CompleterWidget.ICoordinate;
+    let coords = editor.getCoordinateForPosition(position) as CompleterWidget.ICoordinate;
     return {
       text: editor.model.value.text,
       lineHeight: editor.lineHeight,

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1373,7 +1373,8 @@ class Notebook extends StaticNotebook {
     }
     this.activeCellIndex = i;
     if (model.cells.at(i).type === 'markdown') {
-      this.mode = 'edit';
+      let widget = this.widgets[i] as MarkdownCellWidget;
+      widget.rendered = false;
     } else if (target.localName === 'img') {
       target.classList.toggle(UNCONFINED_CLASS);
     }

--- a/src/tooltip/widget.ts
+++ b/src/tooltip/widget.ts
@@ -191,7 +191,7 @@ class TooltipWidget extends Widget {
     let node = this.node;
     let editor = this._editor;
     let { charWidth, lineHeight } = editor;
-    let coords = editor.getCoordinate(editor.getCursorPosition());
+    let coords = editor.getCoordinateForPosition(editor.getCursorPosition());
 
     // Calculate the geometry of the completer.
     HoverBox.setGeometry({

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -409,6 +409,7 @@ describe('CodeMirrorEditor', () => {
   describe('#getCursorPosition()', () => {
 
     it('should get the primary position of the cursor', () => {
+      model.value.text = TEXT;
       let pos = editor.getCursorPosition();
       expect(pos.line).to.be(0);
       expect(pos.column).to.be(0);

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -44,6 +44,7 @@ describe('CodeMirrorEditor', () => {
 
   beforeEach(() => {
     host = document.createElement('div');
+    host.style.height = '200px';
     document.body.appendChild(host);
     model = new CodeEditor.Model();
     editor = new LogEditorWidget({ host, model }, {});
@@ -384,11 +385,23 @@ describe('CodeMirrorEditor', () => {
 
   });
 
-  describe('#getCoordinate()', () => {
+  describe('#getCoordinateForPosition()', () => {
 
     it('should get the window coordinates given a cursor position', () => {
-      let coord = editor.getCoordinate({ line: 10, column: 1 });
+      model.value.text = TEXT;
+      let coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
       expect(coord.left).to.be.above(0);
+    });
+
+  });
+
+  describe('#getPositionForCoordinate()', () => {
+
+    it('should get the window coordinates given a cursor position', () => {
+      model.value.text = TEXT;
+      let pos = { line: 10, column: 1 };
+      let coord = editor.getCoordinateForPosition(pos);
+      expect(editor.getPositionForCoordinate(coord)).to.eql(pos);
     });
 
   });
@@ -399,7 +412,7 @@ describe('CodeMirrorEditor', () => {
       let pos = editor.getCursorPosition();
       expect(pos.line).to.be(0);
       expect(pos.column).to.be(0);
-      model.value.text = TEXT;
+
       editor.setCursorPosition({ line: 12, column: 3 });
       pos = editor.getCursorPosition();
       expect(pos.line).to.be(12);

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -384,11 +384,21 @@ describe('CodeMirrorEditor', () => {
 
   });
 
-  describe('#getCoordinate()', () => {
+  describe('#getCoordinateForPosition()', () => {
 
     it('should get the window coordinates given a cursor position', () => {
-      let coord = editor.getCoordinate({ line: 10, column: 1 });
+      let coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
       expect(coord.left).to.be.above(0);
+    });
+
+  });
+
+  describe('#getPositionForCoordinate()', () => {
+
+    it('should get the window coordinates given a cursor position', () => {
+      let pos = { line: 10, column: 1 };
+      let coord = editor.getCoordinateForPosition(pos);
+      expect(editor.getPositionForCoordinate(coord)).to.eql(pos);
     });
 
   });

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -384,21 +384,11 @@ describe('CodeMirrorEditor', () => {
 
   });
 
-  describe('#getCoordinateForPosition()', () => {
+  describe('#getCoordinate()', () => {
 
     it('should get the window coordinates given a cursor position', () => {
-      let coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
+      let coord = editor.getCoordinate({ line: 10, column: 1 });
       expect(coord.left).to.be.above(0);
-    });
-
-  });
-
-  describe('#getPositionForCoordinate()', () => {
-
-    it('should get the window coordinates given a cursor position', () => {
-      let pos = { line: 10, column: 1 };
-      let coord = editor.getCoordinateForPosition(pos);
-      expect(editor.getPositionForCoordinate(coord)).to.eql(pos);
     });
 
   });

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -904,7 +904,7 @@ describe('notebook/notebook/widget', () => {
           expect(child.rendered).to.be(true);
           expect(widget.mode).to.be('command');
           simulate(child.node, 'dblclick');
-          expect(widget.mode).to.be('edit');
+          expect(widget.mode).to.be('command');
           expect(child.rendered).to.be(false);
         });
 


### PR DESCRIPTION
Adds symmetry with the existing `getCoordinate` method.

Fixes #1757.  The behavior of the classic notebook on double click of a markdown cell is to unrender it but leave it in command mode.  This PR does that instead of trying to associate the position of the click with a cursor position, because the rendered markdown geometry is different.