### PR TITLE
Fixes for widget activation and console title

### DIFF
--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -371,7 +371,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    */
   private _onCurrentChanged(sender: any, args: FocusTracker.IChangedArgs<T>): void {
     // Bail if the active widget did not change.
-    if (args.newValue === this._lastCurrent) {
+    if (args.newValue === this._currentWidget) {
       return;
     }
     this._currentWidget = args.newValue;

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -160,11 +160,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * widget if no widget has taken focus.
    */
   get currentWidget(): T | null{
-    return (
-      this._tracker.currentWidget ||
-      this._widgets[this._widgets.length - 1] ||
-      null
-    );
+    return this._currentWidget;
   }
 
   /**
@@ -217,7 +213,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
 
     // If there is no focused widget, set this as the current widget.
     if (!this._tracker.currentWidget) {
-      this._lastCurrent = widget;
+      this._currentWidget = widget;
       this.onCurrentChanged(widget);
     }
 
@@ -378,7 +374,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     if (args.newValue === this._lastCurrent) {
       return;
     }
-    this._lastCurrent = args.newValue;
+    this._currentWidget = args.newValue;
     this.onCurrentChanged(args.newValue);
   }
 
@@ -395,9 +391,13 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     ArrayExt.removeFirstOf(this._widgets, widget);
 
     // Handle a current changed.
-    if (widget === this._lastCurrent) {
-      let current = this._lastCurrent = this.currentWidget;
-      this.onCurrentChanged(current);
+    if (widget === this._currentWidget) {
+      this._currentWidget = (
+        this._tracker.currentWidget ||
+        this._widgets[this._widgets.length - 1] ||
+        null
+      );
+      this.onCurrentChanged(this._currentWidget);
     }
 
     if (!this._restore) {
@@ -417,7 +417,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   private _currentChanged = new Signal<this, T>(this);
   private _widgetAdded = new Signal<this, T>(this);
   private _widgets: T[] = [];
-  private _lastCurrent: T | null = null;
+  private _currentWidget: T | null = null;
 }
 
 

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -215,7 +215,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     if (!this._tracker.currentWidget) {
       this._currentWidget = widget;
       this.onCurrentChanged(widget);
-      this._currentChanged.emit(value);
+      this._currentChanged.emit(widget);
     }
 
     // Emit the widget added signal.
@@ -363,9 +363,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * #### Notes
    * The default implementation is a no-op.
    */
-  protected onCurrentChanged(value: T): void {
-
-  }
+  protected onCurrentChanged(value: T): void { /* no-op */ }
 
   /**
    * Handle the current change signal from the internal focus tracker.
@@ -399,7 +397,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
         this._widgets[this._widgets.length - 1] ||
         null
       );
-      this._currentChanged.emit(value);
+      this._currentChanged.emit(this._currentWidget);
       this.onCurrentChanged(this._currentWidget);
     }
 

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -64,8 +64,8 @@ interface IInstanceTracker<T extends Widget> extends IDisposable {
    * The current widget is the most recently focused or added widget.
    *
    * #### Notes
-   * If a widget is added and no widget currently has focus, it will
-   * be set as the current widget.
+   * It is the most recently added or focused widget, where focus
+   * takes precedence.
    */
   readonly currentWidget: T;
 
@@ -156,8 +156,8 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * The current widget is the most recently focused or added widget.
    *
    * #### Notes
-   * If a widget is added and no widget currently has focus, it will
-   * be set as the current widget.
+   * It is the most recently added or focused widget, where focus
+   * takes precedence.
    */
   get currentWidget(): T {
     return this._currentWidget;

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -215,6 +215,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     if (!this._tracker.currentWidget) {
       this._currentWidget = widget;
       this.onCurrentChanged(widget);
+      this._currentChanged.emit(value);
     }
 
     // Emit the widget added signal.
@@ -360,10 +361,10 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * Handle the current change event.
    *
    * #### Notes
-   * The default implementation emits the `currentChanged` signal.
+   * The default implementation is a no-op.
    */
   protected onCurrentChanged(value: T): void {
-    this._currentChanged.emit(value);
+
   }
 
   /**
@@ -376,6 +377,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     }
     this._currentWidget = args.newValue;
     this.onCurrentChanged(args.newValue);
+    this._currentChanged.emit(value);
   }
 
   /**
@@ -397,6 +399,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
         this._widgets[this._widgets.length - 1] ||
         null
       );
+      this._currentChanged.emit(value);
       this.onCurrentChanged(this._currentWidget);
     }
 

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -61,7 +61,9 @@ interface IInstanceTracker<T extends Widget> extends IDisposable {
   readonly widgetAdded: ISignal<this, T>;
 
   /**
-   * The current widget is the most recently focused widget.
+   * The current widget is the most recently focused widget, or the
+   * most recently added widget if the most recently added widget
+   * has not gotten focus.
    */
   readonly currentWidget: T;
 
@@ -149,10 +151,12 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   readonly namespace: string;
 
   /**
-   * The current widget is the most recently focused widget.
+   * The current widget is the most recently focused widget, or the
+   * most recently added widget if the most recently added widget
+   * has not gotten focus.
    */
   get currentWidget(): T {
-    return this._tracker.currentWidget;
+    return this._currentWidget;
   }
 
   /**
@@ -200,6 +204,8 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
         }
       }
     }
+
+    this._currentWidget = widget;
 
     // Emit the widget added signal.
     this._widgetAdded.emit(widget);
@@ -356,6 +362,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    */
   private _onCurrentChanged(sender: any, args: FocusTracker.IChangedArgs<T>): void {
     this.onCurrentChanged();
+    this._currentWidget = args.newValue;
     this._currentChanged.emit(args.newValue);
   }
 
@@ -380,6 +387,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   private _tracker = new FocusTracker<T>();
   private _currentChanged = new Signal<this, T>(this);
   private _widgetAdded = new Signal<this, T>(this);
+  private _currentWidget: T;
 }
 
 

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -387,7 +387,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   private _tracker = new FocusTracker<T>();
   private _currentChanged = new Signal<this, T>(this);
   private _widgetAdded = new Signal<this, T>(this);
-  private _currentWidget: T;
+  private _currentWidget: T | null = null;
 }
 
 

--- a/src/common/instancetracker.ts
+++ b/src/common/instancetracker.ts
@@ -375,7 +375,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     }
     this._currentWidget = args.newValue;
     this.onCurrentChanged(args.newValue);
-    this._currentChanged.emit(value);
+    this._currentChanged.emit(args.newValue);
   }
 
   /**

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -132,7 +132,7 @@ const CONSOLE_REGEX = /^console-(\d)+-[0-9a-f]+$/;
  */
 function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: IInstanceRestorer): IConsoleTracker {
   let manager = services.sessions;
-  let { commands } = app;
+  let { commands, shell } = app;
   let category = 'Console';
   let command: string;
   let count = 0;
@@ -204,7 +204,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     let widget = tracker.currentWidget;
     let activate = !args || args && args['activate'] !== false;
     if (activate && widget) {
-      widget.activate();
+      shell.activateMain(widget.id);
     }
     return widget;
   }
@@ -324,7 +324,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       tracker.find(widget => {
         if (widget.console.session.id === id) {
           if (args['activate'] !== false) {
-            widget.activate();
+            shell.activateMain(widget.id);
           }
           widget.console.inject(args['code'] as string);
           return true;
@@ -343,7 +343,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
         }
       });
       if (widget) {
-        app.shell.activateMain(widget.id);
+        shell.activateMain(widget.id);
       } else {
         app.commands.execute(CommandIDs.create, { id });
       }
@@ -413,16 +413,16 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     // Update the caption of the tab when the kernel changes.
     panel.console.session.kernelChanged.connect(() => {
       let newName = panel.console.session.kernel.name;
-      name = specs.kernelspecs[name].display_name;
-      captionOptions.displayName = newName;
+      name = specs.kernelspecs[newName].display_name;
+      captionOptions.displayName = name;
       captionOptions.connected = new Date();
       captionOptions.executed = null;
       panel.title.caption = Private.caption(captionOptions);
     });
     // Add the console panel to the tracker.
     tracker.add(panel);
-    app.shell.addToMainArea(panel);
-    app.shell.activateMain(panel.id);
+    shell.addToMainArea(panel);
+    shell.activateMain(panel.id);
   }
 
   command = CommandIDs.switchKernel;

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -114,7 +114,7 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInsta
       return;
     }
     widget.editor.lineNumbers = !widget.editor.lineNumbers;
-    if (args['activate'] !== false) {
+    if ((args && args['activate']) !== false) {
       widget.activate();
     }
   }

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -105,6 +105,8 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInsta
   });
   registry.addWidgetFactory(factory);
 
+  let { commands, shell } = app;
+
   /**
    * Toggle editor line numbers
    */
@@ -115,7 +117,7 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInsta
     }
     widget.editor.lineNumbers = !widget.editor.lineNumbers;
     if ((args && args['activate']) !== false) {
-      widget.activate();
+      shell.activateMain(widget.id);
     }
   }
 
@@ -128,8 +130,8 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInsta
       return;
     }
     widget.editor.wordWrap = !widget.editor.wordWrap;
-    if (args['activate'] !== false) {
-      widget.activate();
+    if ((args && args['activate']) !== false) {
+      shell.activateMain(widget.id);
     }
   }
 
@@ -140,8 +142,6 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInsta
     name: 'sessionId',
     create: () => ''
   });
-
-  let commands = app.commands;
 
   commands.addCommand(CommandIDs.lineNumbers, {
     execute: args => { toggleLineNums(args); },

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -230,14 +230,14 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
  * Add the notebook commands to the application's command registry.
  */
 function addCommands(app: JupyterLab, services: IServiceManager, tracker: NotebookTracker): void {
-  let commands = app.commands;
+  let { commands, shell } = app;
 
   // Get the current widget and activate unless the args specify otherwise.
   function getCurrent(args: JSONObject): NotebookPanel | null {
     let widget = tracker.currentWidget;
     let activate = !args || args && args['activate'] !== false;
     if (activate && widget) {
-      widget.activate();
+      shell.activateMain(widget.id);
     }
     return widget;
   }

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -124,9 +124,6 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
     }
     this._activeCell = activeCell;
 
-    // Call the base method to emit the changed signal.
-    super.onCurrentChanged(widget);
-
     if (!widget) {
       return;
     }

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -116,7 +116,7 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
   /**
    * Handle the current change event.
    */
-  protected onCurrentChanged(): void {
+  protected onCurrentChanged(widget: NotebookPanel): void {
     // Store an internal reference to active cell to prevent false positives.
     let activeCell = this.activeCell;
     if (activeCell && activeCell === this._activeCell) {
@@ -124,7 +124,9 @@ class NotebookTracker extends InstanceTracker<NotebookPanel> implements INoteboo
     }
     this._activeCell = activeCell;
 
-    let widget = this.currentWidget;
+    // Call the base method to emit the changed signal.
+    super.onCurrentChanged(widget);
+
     if (!widget) {
       return;
     }

--- a/src/outputarea/model.ts
+++ b/src/outputarea/model.ts
@@ -103,7 +103,7 @@ class OutputAreaModel implements IOutputAreaModel {
    * Test whether the model is disposed.
    */
   get isDisposed(): boolean {
-    return this.list === null;
+    return this._isDisposed;
   }
 
   /**
@@ -113,9 +113,8 @@ class OutputAreaModel implements IOutputAreaModel {
     if (this.isDisposed) {
       return;
     }
-    let list = this.list;
-    this.list = null;
-    list.dispose();
+    this._isDisposed = true;
+    this.list.dispose();
     Signal.clearData(this);
   }
 
@@ -252,6 +251,7 @@ class OutputAreaModel implements IOutputAreaModel {
   private _lastStream: string;
   private _lastName: 'stdout' | 'stderr';
   private _trusted = false;
+  private _isDisposed = false;
   private _stateChanged = new Signal<IOutputAreaModel, void>(this);
   private _changed = new Signal<this, ObservableVector.IChangedArgs<IOutputModel>>(this);
 }

--- a/test/src/common/instancetracker.spec.ts
+++ b/test/src/common/instancetracker.spec.ts
@@ -4,7 +4,7 @@
 import expect = require('expect.js');
 
 import {
-  Widget
+  Panel, Widget
 } from '@phosphor/widgets';
 
 import {
@@ -104,20 +104,31 @@ describe('common/instancetracker', () => {
         widget.node.tabIndex = -1;
         tracker.add(widget);
         expect(tracker.currentWidget).to.be(widget);
-        Widget.detach(widget);
+        widget.dispose();
       });
 
       it('should be updated if when the first widget is focused', () => {
         let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
-        let widget0 = new Widget();
-        widget0.node.tabIndex = -1;
+        let panel = new Panel();
+
+        function createWidget(): Widget {
+          let widget = new Widget();
+          widget.node.style.minHeight = '20px';
+          widget.node.style.minWidth = '20px';
+          widget.node.tabIndex = -1;
+          return widget;
+        }
+        let widget0 = createWidget();
         tracker.add(widget0);
-        let widget1 = new Widget();
+        let widget1 = createWidget();
         tracker.add(widget1);
-        Widget.attach(widget, document.body);
+        panel.addWidget(widget0);
+        panel.addWidget(widget1);
+        Widget.attach(panel, document.body);
         expect(tracker.currentWidget).to.be(widget1);
         simulate(widget0.node, 'focus');
         expect(tracker.currentWidget).to.be(widget0);
+        panel.dispose();
         widget0.dispose();
         widget1.dispose();
       });

--- a/test/src/common/instancetracker.spec.ts
+++ b/test/src/common/instancetracker.spec.ts
@@ -98,16 +98,28 @@ describe('common/instancetracker', () => {
         expect(tracker.currentWidget).to.be(null);
       });
 
-      it('should be updated if when the widget is focused', () => {
+      it('should be updated when a widget is added', () => {
         let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
         let widget = new Widget();
         widget.node.tabIndex = -1;
         tracker.add(widget);
-        Widget.attach(widget, document.body);
-        expect(tracker.currentWidget).to.be(null);
-        simulate(widget.node, 'focus');
         expect(tracker.currentWidget).to.be(widget);
         Widget.detach(widget);
+      });
+
+      it('should be updated if when the first widget is focused', () => {
+        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let widget0 = new Widget();
+        widget0.node.tabIndex = -1;
+        tracker.add(widget0);
+        let widget1 = new Widget();
+        tracker.add(widget1);
+        Widget.attach(widget, document.body);
+        expect(tracker.currentWidget).to.be(widget1);
+        simulate(widget0.node, 'focus');
+        expect(tracker.currentWidget).to.be(widget0);
+        widget0.dispose();
+        widget1.dispose();
       });
 
     });

--- a/test/src/common/instancetracker.spec.ts
+++ b/test/src/common/instancetracker.spec.ts
@@ -276,13 +276,8 @@ describe('common/instancetracker', () => {
       it('should be called when the current widget is changed', () => {
         let tracker = new TestTracker<Widget>({ namespace: NAMESPACE });
         let widget = new Widget();
-        widget.node.tabIndex = -1;
         tracker.add(widget);
-        expect(tracker.methods).to.not.contain('onCurrentChanged');
-        Widget.attach(widget, document.body);
-        simulate(widget.node, 'focus');
         expect(tracker.methods).to.contain('onCurrentChanged');
-        Widget.detach(widget);
       });
 
     });

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -138,8 +138,6 @@ describe('notebook/celltools', () => {
     describe('#activeCell', () => {
 
       it('should be the active cell', () => {
-        expect(celltools.activeCell).to.be(null);
-        simulate(panel0.node, 'focus');
         expect(celltools.activeCell).to.be(panel0.notebook.activeCell);
         tabpanel.currentIndex = 1;
         simulate(panel1.node, 'focus');
@@ -151,8 +149,6 @@ describe('notebook/celltools', () => {
     describe('#selectedCells', () => {
 
       it('should be the currently selected cells', () => {
-        expect(celltools.selectedCells.length).to.be(0);
-        simulate(panel0.node, 'focus');
         expect(celltools.selectedCells).to.eql([panel0.notebook.activeCell]);
         tabpanel.currentIndex = 1;
         simulate(panel1.node, 'focus');
@@ -219,7 +215,6 @@ describe('notebook/celltools', () => {
       it('should be called when the selection changes', () => {
         let tool = new LogTool({});
         celltools.addItem({ tool });
-        simulate(panel0.node, 'focus');
         tool.methods = [];
         panel0.notebook.select(panel0.notebook.widgets[1]);
         expect(tool.methods).to.contain('onSelectionChanged');
@@ -232,7 +227,6 @@ describe('notebook/celltools', () => {
       it('should be called when the metadata changes', () => {
         let tool = new LogTool({});
         celltools.addItem({ tool });
-        simulate(panel0.node, 'focus');
         tool.methods = [];
         let metadata = celltools.activeCell.model.metadata;
         metadata.set('foo', 1);

--- a/test/src/notebook/tracker.spec.ts
+++ b/test/src/notebook/tracker.spec.ts
@@ -90,9 +90,6 @@ describe('notebook/tracker', () => {
         panel.context = createNotebookContext();
         panel.notebook.model.fromJSON(DEFAULT_CONTENT);
         tracker.add(panel);
-        expect(count).to.be(0);
-        Widget.attach(panel, document.body);
-        simulate(panel.node, 'focus');
         expect(count).to.be(1);
         panel.notebook.activeCellIndex = 1;
         expect(count).to.be(2);
@@ -107,13 +104,7 @@ describe('notebook/tracker', () => {
         let tracker = new TestTracker({ namespace: NAMESPACE });
         let panel = createNotebookPanel();
         tracker.add(panel);
-        panel.context = createNotebookContext();
-        panel.notebook.model.fromJSON(DEFAULT_CONTENT);
-        expect(tracker.methods).to.not.contain('onCurrentChanged');
-        Widget.attach(panel, document.body);
-        simulate(panel.node, 'focus');
         expect(tracker.methods).to.contain('onCurrentChanged');
-        panel.dispose();
       });
 
     });

--- a/test/src/notebook/tracker.spec.ts
+++ b/test/src/notebook/tracker.spec.ts
@@ -74,9 +74,6 @@ describe('notebook/tracker', () => {
         tracker.add(panel);
         panel.context = createNotebookContext();
         panel.notebook.model.fromJSON(DEFAULT_CONTENT);
-        expect(tracker.activeCell).to.be(null);
-        Widget.attach(panel, document.body);
-        simulate(panel.node, 'focus');
         expect(tracker.activeCell).to.be.a(BaseCellWidget);
         panel.dispose();
       });

--- a/test/src/notebook/tracker.spec.ts
+++ b/test/src/notebook/tracker.spec.ts
@@ -4,20 +4,12 @@
 import expect = require('expect.js');
 
 import {
-  Widget
-} from '@phosphor/widgets';
-
-import {
-  simulate
-} from 'simulate-event';
-
-import {
   BaseCellWidget
 } from '../../../lib/cells';
 
 import {
-  NotebookTracker
-} from '../../../lib/notebook/tracker';
+  NotebookPanel, NotebookTracker
+} from '../../../lib/notebook';
 
 import {
   createNotebookContext
@@ -34,8 +26,8 @@ const NAMESPACE = 'notebook-tracker-test';
 class TestTracker extends NotebookTracker {
   methods: string[] = [];
 
-  protected onCurrentChanged(): void {
-    super.onCurrentChanged();
+  protected onCurrentChanged(widget: NotebookPanel): void {
+    super.onCurrentChanged(widget);
     this.methods.push('onCurrentChanged');
   }
 }


### PR DESCRIPTION
Fixes #1792.  Fixes #1796. 

Changes instance tracker to consider current to be *either* the most recently focused or the most recently added, with focus taking precedence.