### PR TITLE
Command Pallete 'no matches' styling

### DIFF
--- a/src/commandpalette/index.css
+++ b/src/commandpalette/index.css
@@ -178,3 +178,12 @@
     font-family: var(--jp-ui-font-family);
     font-weight: lighter;
 }
+
+.p-CommandPalette-emptyMessage {
+  text-align: center;
+  margin-top: 24px;
+  line-height: 1.32;
+  padding: 0px 8px;
+  color: var(--jp-content-font-color3);
+
+}


### PR DESCRIPTION
Just took a design pass at the no matches message in the command pallete!

Before:
<img width="303" alt="screen shot 2017-02-24 at 2 21 36 pm" src="https://cloud.githubusercontent.com/assets/6437976/23323277/c9570f32-fa9c-11e6-8063-4b114fd77b88.png">

After:
<img width="303" alt="screen shot 2017-02-24 at 2 19 36 pm" src="https://cloud.githubusercontent.com/assets/6437976/23323286/d1b4406e-fa9c-11e6-9edc-8495b68cd99b.png">

