### PR TITLE
FIX: favicon path should include base_url

### DIFF
--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -24,7 +24,7 @@ Distributed under the terms of the Modified BSD License.
     "wsUrl": "{{ws_url | urlencode}}"
   }</script>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{ base_url }}static/base/images/favicon.ico">{% endblock %}
 
   {% for bundle_file in jupyterlab_bundles %}
   <script src="{{ bundle_file }}" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
A small fix related to JupyterHub integration.

I verified that this change is a no-op when `jupyter lab` is run stand-alone: that is, the path is still `/static/base/images/favicon.ico`. But when JupyterLab started by the hub, the path is now correctly prepended with the user path.