### PR TITLE
Move instancetracker to application and clean up shell interface

### DIFF
--- a/src/about/plugin.ts
+++ b/src/about/plugin.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   InstanceTracker
-} from '../common/instancetracker';
+} from '../application';
 
 import {
   IInstanceRestorer
@@ -43,7 +43,8 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstance
   const model = new AboutModel({ version: app.info.version });
   const command = CommandIDs.open;
   const category = 'Help';
-  const tracker = new InstanceTracker<AboutWidget>({ namespace });
+  const { shell, commands } = app;
+  const tracker = new InstanceTracker<AboutWidget>({ namespace, shell });
 
   restorer.restore(tracker, {
     command,
@@ -63,14 +64,14 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstance
     return widget;
   }
 
-  app.commands.addCommand(command, {
+  commands.addCommand(command, {
     label: 'About JupyterLab',
     execute: () => {
       if (!widget || widget.isDisposed) {
         widget = newWidget();
-        app.shell.addToMainArea(widget);
+        shell.addToMainArea(widget);
       }
-      app.shell.activateMain(widget.id);
+      tracker.activate(widget);
     }
   });
 

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -19,6 +19,7 @@ import {
 
 export { ModuleLoader } from './loader';
 export { ApplicationShell } from './shell';
+export * from './instancetracker';
 
 
 /**

--- a/src/application/instancetracker.ts
+++ b/src/application/instancetracker.ts
@@ -37,6 +37,10 @@ import {
   IStateDB
 } from '../statedb';
 
+import {
+  ApplicationShell
+} from './shell';
+
 
 /**
  * An object that tracks widget instances.
@@ -104,11 +108,16 @@ interface IInstanceTracker<T extends Widget> extends IDisposable {
    * the parent plugin's instance tracker.
    */
   inject(widget: T): void;
+
+  /**
+   * Activate the given widget in the application, making it current.
+   */
+  activate(widget: T): void;
 }
 
 
 /**
- * A class that keeps track of widget instances.
+ * A class that keeps track of widget instances on an Application shell.
  *
  * #### Notes
  * The API surface area of this concrete implementation is substantially larger
@@ -125,6 +134,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    * @param options - The instantiation options for an instance tracker.
    */
   constructor(options: InstanceTracker.IOptions) {
+    this._shell = options.shell;
     this.namespace = options.namespace;
     this._tracker.currentChanged.connect(this._onCurrentChanged, this);
   }
@@ -295,6 +305,13 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   }
 
   /**
+   * Activate the given widget in the application shell.
+   */
+  activate(widget: T): void {
+    this._shell.activateById(widget.id);
+  }
+
+  /**
    * Restore the widgets in this tracker's namespace.
    *
    * @param options - The configuration options that describe restoration.
@@ -419,6 +436,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
   private _widgetAdded = new Signal<this, T>(this);
   private _widgets: T[] = [];
   private _currentWidget: T | null = null;
+  private _shell: ApplicationShell;
 }
 
 
@@ -433,6 +451,11 @@ namespace InstanceTracker {
    */
   export
   interface IOptions {
+    /**
+     * The application shell associated with the tracker.
+     */
+    shell: ApplicationShell;
+
     /**
      * A namespace for all tracked widgets, (e.g., `notebook`).
      */

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -145,17 +145,21 @@ class ApplicationShell extends Widget {
   }
 
   /**
-   * True if left area is empty.
+   * True if the given area is empty.
    */
-  get leftAreaIsEmpty(): boolean {
-    return this._leftHandler.stackedPanel.widgets.length === 0;
-  }
-
-  /**
-   * True if main area is empty.
-   */
-  get mainAreaIsEmpty(): boolean {
-    return this._dockPanel.isEmpty;
+  isEmpty(area: ApplicationShell.Area): boolean {
+    switch (area) {
+    case 'left':
+      return this._leftHandler.stackedPanel.widgets.length === 0;
+    case 'main':
+      return this._dockPanel.isEmpty;
+    case 'top':
+      return this._topPanel.widgets.length === 0;
+    case 'right':
+      return this._rightHandler.stackedPanel.widgets.length === 0;
+    default:
+      return true;
+    }
   }
 
   /**
@@ -166,34 +170,19 @@ class ApplicationShell extends Widget {
   }
 
   /**
-   * True if right area is empty.
+   * Activate a widget in it's area.
    */
-  get rightAreaIsEmpty(): boolean {
-    return this._rightHandler.stackedPanel.widgets.length === 0;
-  }
-
-  /**
-   * True if top area is empty.
-   */
-  get topAreaIsEmpty(): boolean {
-    return this._topPanel.widgets.length === 0;
-  }
-
-  /**
-   * Activate a widget in the left area.
-   */
-  activateLeft(id: string): void {
-    this._leftHandler.activate(id);
-  }
-
-  /**
-   * Activate a widget in the main area.
-   */
-  activateMain(id: string): void {
-    let dock = this._dockPanel;
-    let widget = find(dock.widgets(), value => value.id === id);
-    if (widget) {
-      dock.activateWidget(widget);
+  activateById(id: string): void {
+    if (this._leftHandler.has(id)) {
+      this._leftHandler.activate(id);
+    } else if (this._rightHandler.has(id)) {
+      this._rightHandler.activate(id);
+    } else {
+      let dock = this._dockPanel;
+      let widget = find(dock.widgets(), value => value.id === id);
+      if (widget) {
+        dock.activateWidget(widget);
+      }
     }
   }
 
@@ -240,13 +229,6 @@ class ApplicationShell extends Widget {
         }
       }
     }
-  }
-
-  /**
-   * Activate a widget in the right area.
-   */
-  activateRight(id: string): void {
-    this._rightHandler.activate(id);
   }
 
   /**
@@ -361,7 +343,7 @@ class ApplicationShell extends Widget {
         this._rightHandler.rehydrate(rightArea);
       }
       if (currentWidget) {
-        this.activateMain(currentWidget.id);
+        this.activateById(currentWidget.id);
       }
       this._isRestored = true;
       return this._save().then(() => { this._restored.resolve(saved); });
@@ -592,6 +574,13 @@ namespace Private {
         this._sideBar.currentTitle = widget.title;
         widget.activate();
       }
+    }
+
+    /**
+     * Test whether the sidebar has the given widget by id.
+     */
+    has(id: string): boolean {
+      return this._findWidgetByID(id) !== null;
     }
 
     /**

--- a/src/commandpalette/plugin.ts
+++ b/src/commandpalette/plugin.ts
@@ -91,7 +91,7 @@ export default plugin;
  * Activate the command palette.
  */
 function activate(app: JupyterLab, restorer: IInstanceRestorer): ICommandPalette {
-  const { commands } = app;
+  const { commands, shell } = app;
   const palette = new CommandPalette({ commands });
 
   // Let the application restorer track the command palette for restoration of
@@ -102,33 +102,33 @@ function activate(app: JupyterLab, restorer: IInstanceRestorer): ICommandPalette
   palette.id = 'command-palette';
   palette.title.label = 'Commands';
 
-  app.commands.addCommand(CommandIDs.activate, {
-    execute: () => { app.shell.activateLeft(palette.id); },
+  commands.addCommand(CommandIDs.activate, {
+    execute: () => { shell.activateById(palette.id); },
     label: 'Activate Command Palette'
   });
 
-  app.commands.addCommand(CommandIDs.hide, {
+  commands.addCommand(CommandIDs.hide, {
     execute: () => {
       if (!palette.isHidden) {
-        app.shell.collapseLeft();
+        shell.collapseLeft();
       }
     },
     label: 'Hide Command Palette'
   });
 
-  app.commands.addCommand(CommandIDs.toggle, {
+  commands.addCommand(CommandIDs.toggle, {
     execute: () => {
       if (palette.isHidden) {
-        return app.commands.execute(CommandIDs.activate, void 0);
+        return commands.execute(CommandIDs.activate, void 0);
       }
-      return app.commands.execute(CommandIDs.hide, void 0);
+      return commands.execute(CommandIDs.hide, void 0);
     },
     label: 'Toggle Command Palette'
   });
 
   palette.inputNode.placeholder = 'SEARCH';
 
-  app.shell.addToLeftArea(palette);
+  shell.addToLeftArea(palette);
 
   return new Palette(palette);
 }

--- a/src/console/tracker.ts
+++ b/src/console/tracker.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   IInstanceTracker
-} from '../common/instancetracker';
+} from '../application';
 
 import {
   ConsolePanel

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -2,12 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JupyterLab, JupyterLabPlugin
+  InstanceTracker, JupyterLab, JupyterLabPlugin
 } from '../application';
-
-import {
-  InstanceTracker
-} from '../common/instancetracker';
 
 import {
   IDocumentRegistry
@@ -58,7 +54,10 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInsta
     fileExtensions: ['.csv'],
     defaultFor: ['.csv']
   });
-  const tracker = new InstanceTracker<CSVWidget>({ namespace: 'csvwidget' });
+  const tracker = new InstanceTracker<CSVWidget>({
+    namespace: 'csvwidget',
+    shell: app.shell
+  });
 
   // Handle state restoration.
   restorer.restore(tracker, {

--- a/src/docmanager/plugin.ts
+++ b/src/docmanager/plugin.ts
@@ -38,7 +38,7 @@ const plugin: JupyterLabPlugin<IDocumentManager> = {
         if (!widget.isAttached) {
           app.shell.addToMainArea(widget);
         }
-        app.shell.activateMain(widget.id);
+        app.shell.activateById(widget.id);
       }
     };
     return new DocumentManager({ registry, manager, opener });

--- a/src/editorwidget/index.ts
+++ b/src/editorwidget/index.ts
@@ -6,10 +6,6 @@ import {
 } from '@phosphor/application';
 
 import {
-  IInstanceTracker
-} from '../common/instancetracker';
-
-import {
   CommandRegistry
 } from '@phosphor/commands';
 
@@ -20,6 +16,10 @@ import {
 import {
   AttachedProperty
 } from '@phosphor/properties';
+
+import {
+  IInstanceTracker
+} from '../application';
 
 import {
   CommandIDs as ConsoleCommandIDs

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -2,16 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JupyterLab, JupyterLabPlugin
+  InstanceTracker, JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
   IEditorServices
 } from '../codeeditor';
-
-import {
-  InstanceTracker
-} from '../common/instancetracker';
 
 import {
   IDocumentRegistry
@@ -75,7 +71,11 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInsta
       defaultFor: ['*']
     }
   });
-  const tracker = new InstanceTracker<EditorWidget>({ namespace: 'editor' });
+  const shell = app.shell;
+  const tracker = new InstanceTracker<EditorWidget>({
+    namespace: 'editor',
+    shell
+  });
 
   // Handle state restoration.
   restorer.restore(tracker, {

--- a/src/faq/plugin.ts
+++ b/src/faq/plugin.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JupyterLab, JupyterLabPlugin
+  InstanceTracker, JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
@@ -12,10 +12,6 @@ import {
 import {
   ICommandPalette
 } from '../commandpalette';
-
-import {
-  InstanceTracker
-} from '../common/instancetracker';
 
 import {
   IInstanceRestorer
@@ -50,7 +46,8 @@ function activate(app: JupyterLab, palette: ICommandPalette, linker: ICommandLin
   const category = 'Help';
   const command = CommandIDs.open;
   const model = new FaqModel();
-  const tracker = new InstanceTracker<FaqWidget>({ namespace: 'faq' });
+  const { commands, shell } = app;
+  const tracker = new InstanceTracker<FaqWidget>({ namespace: 'faq', shell  });
 
   // Handle state restoration.
   restorer.restore(tracker, {
@@ -71,14 +68,14 @@ function activate(app: JupyterLab, palette: ICommandPalette, linker: ICommandLin
     return widget;
   }
 
-  app.commands.addCommand(command, {
+  commands.addCommand(command, {
     label: 'Open FAQ',
     execute: () => {
       if (!widget || widget.isDisposed) {
         widget = newWidget();
-        app.shell.addToMainArea(widget);
+        shell.addToMainArea(widget);
       }
-      app.shell.activateMain(widget.id);
+      tracker.activate(widget);
     }
   });
 

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -279,7 +279,7 @@ function addCommands(app: JupyterLab, fbWidget: FileBrowser, docManager: IDocume
   });
 
   commands.addCommand(CommandIDs.showBrowser, {
-    execute: () => { app.shell.activateLeft(fbWidget.id); }
+    execute: () => { app.shell.activateById(fbWidget.id); }
   });
 
   commands.addCommand(CommandIDs.hideBrowser, {

--- a/src/help/plugin.ts
+++ b/src/help/plugin.ts
@@ -18,16 +18,12 @@ import {
 } from '../about';
 
 import {
-  JupyterLab, JupyterLabPlugin
+  InstanceTracker, JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
   IFrame
 } from '../common/iframe';
-
-import {
-  InstanceTracker
-} from '../common/instancetracker';
 
 import {
   ICommandPalette
@@ -163,7 +159,8 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
   const namespace = 'help-doc';
   const command = CommandIDs.open;
   const menu = createMenu();
-  const tracker = new InstanceTracker<ClosableIFrame>({ namespace });
+  const { commands, shell } = app;
+  const tracker = new InstanceTracker<ClosableIFrame>({ namespace, shell });
 
   // Handle state restoration.
   restorer.restore(tracker, {
@@ -205,7 +202,7 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
     return menu;
   }
 
-  app.commands.addCommand(command, {
+  commands.addCommand(command, {
     label: args => args['text'] as string,
     execute: args => {
       const url = args['url'] as string;
@@ -218,13 +215,13 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
       }
 
       let iframe = newClosableIFrame(url, text);
-      app.shell.addToMainArea(iframe);
-      app.shell.activateMain(iframe.id);
+      shell.addToMainArea(iframe);
+      tracker.activate(iframe);
     }
   });
 
 
-  app.commands.addCommand(CommandIDs.launchClassic, {
+  commands.addCommand(CommandIDs.launchClassic, {
     label: 'Launch Classic Notebook',
     execute: () => { window.open(utils.getBaseUrl() + 'tree'); }
   });

--- a/src/imagewidget/index.ts
+++ b/src/imagewidget/index.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   IInstanceTracker
-} from '../common/instancetracker';
+} from '../application';
 
 import {
   ImageWidget

--- a/src/imagewidget/plugin.ts
+++ b/src/imagewidget/plugin.ts
@@ -2,16 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JupyterLab, JupyterLabPlugin
+  InstanceTracker, JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
   ICommandPalette
 } from '../commandpalette';
-
-import {
-  InstanceTracker
-} from '../common/instancetracker';
 
 import {
   IDocumentRegistry
@@ -70,7 +66,8 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, palette: IComman
     fileExtensions: EXTENSIONS,
     defaultFor: EXTENSIONS
   });
-  const tracker = new InstanceTracker<ImageWidget>({ namespace });
+  const { shell } = app;
+  const tracker = new InstanceTracker<ImageWidget>({ namespace, shell });
 
   // Handle state restoration.
   restorer.restore(tracker, {

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -2,24 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  AttachedProperty
-} from '@phosphor/properties';
-
-import {
-  Widget
-} from '@phosphor/widgets';
-
-import {
-  JupyterLab, JupyterLabPlugin
+  InstanceTracker, JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
   ICommandPalette
 } from '../commandpalette';
-
-import {
-  InstanceTracker
-} from '../common/instancetracker';
 
 import {
   IConsoleTracker
@@ -43,11 +31,6 @@ import {
 
 
 /**
- * The inspector instance tracker.
- */
-const tracker = new InstanceTracker<Inspector>({ namespace: 'inspector' });
-
-/**
  * A service providing code introspection.
  */
 const service: JupyterLabPlugin<IInspector> = {
@@ -56,10 +39,15 @@ const service: JupyterLabPlugin<IInspector> = {
   provides: IInspector,
   autoStart: true,
   activate: (app: JupyterLab, palette: ICommandPalette, restorer: IInstanceRestorer): IInspector => {
+    const { commands, shell } = app;
     const manager = new InspectorManager();
     const category = 'Inspector';
     const command = CommandIDs.open;
     const label = 'Open Inspector';
+    const tracker = new InstanceTracker<Inspector>({
+      namespace: 'inspector',
+      shell
+    });
 
     /**
      * Create and track a new inspector.
@@ -86,15 +74,15 @@ const service: JupyterLabPlugin<IInspector> = {
     });
 
     // Add command to registry and palette.
-    app.commands.addCommand(command, {
+    commands.addCommand(command, {
       label,
       execute: () => {
         if (!manager.inspector || manager.inspector.isDisposed) {
           manager.inspector = newInspector();
-          app.shell.addToMainArea(manager.inspector);
+          shell.addToMainArea(manager.inspector);
         }
         if (manager.inspector.isAttached) {
-          app.shell.activateMain(manager.inspector.id);
+          tracker.activate(manager.inspector);
         }
       }
     });

--- a/src/instancerestorer/instancerestorer.ts
+++ b/src/instancerestorer/instancerestorer.ts
@@ -25,7 +25,7 @@ import {
 
 import {
   InstanceTracker
-} from '../common/instancetracker';
+} from '../application';
 
 import {
   IStateDB

--- a/src/launcher/plugin.ts
+++ b/src/launcher/plugin.ts
@@ -70,6 +70,8 @@ export default plugin;
  * Activate the launcher.
  */
 function activate(app: JupyterLab, services: IServiceManager, pathTracker: IPathTracker, palette: ICommandPalette, linker: ICommandLinker, restorer: IInstanceRestorer): ILauncher {
+  const { commands, shell } = app;
+
   let model = new LauncherModel();
 
   // Set launcher path and track the path as it changes.
@@ -114,18 +116,18 @@ function activate(app: JupyterLab, services: IServiceManager, pathTracker: IPath
   // means we have to way of removing them after the fact.
   defaults.forEach(options => { model.add(options); });
 
-  app.commands.addCommand(CommandIDs.show, {
+  commands.addCommand(CommandIDs.show, {
     label: 'Show Launcher',
     execute: () => {
       if (!widget.isAttached) {
-        app.shell.addToLeftArea(widget);
+        shell.addToLeftArea(widget);
       }
-      app.shell.activateLeft(widget.id);
+      shell.activateById(widget.id);
     }
   });
   palette.addItem({ command: CommandIDs.show, category: 'Help' });
 
-  app.shell.addToLeftArea(widget);
+  shell.addToLeftArea(widget);
 
   return model;
 }

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -2,12 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin, InstanceTracker
 } from '../application';
-
-import {
-  InstanceTracker
-} from '../common/instancetracker';
 
 import {
   IDocumentRegistry
@@ -66,8 +62,9 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, rendermime: IRen
       fileExtensions: ['.md'],
       rendermime
     });
+    const shell = app.shell;
     const namespace = 'rendered-markdown';
-    const tracker = new InstanceTracker<MarkdownWidget>({ namespace });
+    const tracker = new InstanceTracker<MarkdownWidget>({ namespace, shell });
     let icon = `${PORTRAIT_ICON_CLASS} ${TEXTEDITOR_ICON_CLASS}`;
 
     // Handle state restoration.

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -181,7 +181,8 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
     mimeTypeService: editorServices.mimeTypeService
   });
 
-  const tracker = new NotebookTracker({ namespace: 'notebook' });
+  const shell = app.shell;
+  const tracker = new NotebookTracker({ namespace: 'notebook', shell });
 
   // Handle state restoration.
   restorer.restore(tracker, {
@@ -230,14 +231,14 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
  * Add the notebook commands to the application's command registry.
  */
 function addCommands(app: JupyterLab, services: IServiceManager, tracker: NotebookTracker): void {
-  let { commands, shell } = app;
+  let { commands } = app;
 
   // Get the current widget and activate unless the args specify otherwise.
   function getCurrent(args: JSONObject): NotebookPanel | null {
     let widget = tracker.currentWidget;
-    let activate = !args || args && args['activate'] !== false;
+    let activate = args['activate'] !== false;
     if (activate && widget) {
-      shell.activateMain(widget.id);
+      tracker.activate(widget);
     }
     return widget;
   }

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   IInstanceTracker, InstanceTracker
-} from '../common/instancetracker';
+} from '../application';
 
 import {
   NotebookPanel, Notebook

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -6,12 +6,12 @@ import {
 } from '@phosphor/application';
 
 import {
-  IInstanceTracker
-} from '../common/instancetracker';
-
-import {
   CommandRegistry
 } from '@phosphor/commands';
+
+import {
+  IInstanceTracker
+} from '../application';
 
 import {
   TerminalWidget

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -1,16 +1,13 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import {
-  InstanceTracker
-} from '../common/instancetracker';
 
 import {
   Menu
 } from '@phosphor/widgets';
 
 import {
-  JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin, InstanceTracker
 } from '../application';
 
 import {
@@ -75,11 +72,10 @@ function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMen
     return;
   }
 
+  const { commands, shell } = app;
   const category = 'Terminal';
   const namespace = 'terminal';
-  const tracker = new InstanceTracker<TerminalWidget>({ namespace });
-
-  let { commands, shell } = app;
+  const tracker = new InstanceTracker<TerminalWidget>({ namespace, shell });
 
   // Handle state restoration.
   restorer.restore(tracker, {
@@ -101,7 +97,7 @@ function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMen
       term.title.icon = `${LANDSCAPE_ICON_CLASS} ${TERMINAL_ICON_CLASS}`;
       tracker.add(term);
       shell.addToMainArea(term);
-      shell.activateMain(term.id);
+      tracker.activate(term);
 
       if (name) {
         services.terminals.connectTo(name).then(session => {
@@ -121,7 +117,7 @@ function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMen
       // Check for a running terminal with the given name.
       let widget = tracker.find(value => value.session.name === name);
       if (widget) {
-        shell.activateMain(widget.id);
+        tracker.activate(widget);
       } else {
         // Otherwise, create a new terminal with a given name.
         return commands.execute(CommandIDs.createNew, { name });
@@ -137,7 +133,7 @@ function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMen
       if (!current) {
         return;
       }
-      shell.activateMain(current.id);
+      tracker.activate(current);
       return current.refresh().then(() => {
         current.activate();
       });

--- a/test/src/application/instancetracker.spec.ts
+++ b/test/src/application/instancetracker.spec.ts
@@ -16,11 +16,12 @@ import {
 } from 'simulate-event';
 
 import {
-  InstanceTracker
-} from '../../../lib/common/instancetracker';
+  ApplicationShell, InstanceTracker
+} from '../../../lib/application';
 
 
-const NAMESPACE = 'instance-tracker-test';
+const namespace = 'instance-tracker-test';
+const shell = new ApplicationShell();
 
 
 class TestTracker<T extends Widget> extends InstanceTracker<T> {
@@ -50,7 +51,7 @@ describe('common/instancetracker', () => {
     describe('#constructor()', () => {
 
       it('should create an InstanceTracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         expect(tracker).to.be.an(InstanceTracker);
       });
 
@@ -59,7 +60,7 @@ describe('common/instancetracker', () => {
     describe('#currentChanged', () => {
 
       it('should emit when the current widget has been updated', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         widget.node.tabIndex = -1;
         let called = false;
@@ -76,7 +77,7 @@ describe('common/instancetracker', () => {
     describe('#widgetAdded', () => {
 
       it('should emit when a widget has been added', done => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         tracker.widgetAdded.connect((sender, added) => {
           expect(added).to.be(widget);
@@ -86,7 +87,7 @@ describe('common/instancetracker', () => {
       });
 
       it('should not emit when a widget has been injected', done => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let one = new Widget();
         let two = new Widget();
         two.node.tabIndex = -1;
@@ -108,12 +109,12 @@ describe('common/instancetracker', () => {
     describe('#currentWidget', () => {
 
       it('should default to null', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         expect(tracker.currentWidget).to.be(null);
       });
 
       it('should be updated when a widget is added', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         widget.node.tabIndex = -1;
         tracker.add(widget);
@@ -122,7 +123,7 @@ describe('common/instancetracker', () => {
       });
 
       it('should be updated if when the first widget is focused', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let panel = new Panel();
         let widget0 = createWidget();
         tracker.add(widget0);
@@ -140,7 +141,7 @@ describe('common/instancetracker', () => {
       });
 
       it('should revert to the previously added widget on widget disposal', () => {
-        let tracker = new TestTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new TestTracker<Widget>({ namespace, shell });
         let widget0 = new Widget();
         tracker.add(widget0);
         let widget1 = new Widget();
@@ -152,7 +153,7 @@ describe('common/instancetracker', () => {
 
       it('should preserve the tracked widget on widget disposal', () => {
         let panel = new Panel();
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widgets = [createWidget(), createWidget(), createWidget()];
         each(widgets, widget => {
           tracker.add(widget);
@@ -176,7 +177,7 @@ describe('common/instancetracker', () => {
 
       it('should select the previously added widget on widget disposal', () => {
         let panel = new Panel();
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widgets = [createWidget(), createWidget(), createWidget()];
         each(widgets, widget => {
           tracker.add(widget);
@@ -200,7 +201,7 @@ describe('common/instancetracker', () => {
     describe('#isDisposed', () => {
 
       it('should test whether the tracker is disposed', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         expect(tracker.isDisposed).to.be(false);
         tracker.dispose();
         expect(tracker.isDisposed).to.be(true);
@@ -211,7 +212,7 @@ describe('common/instancetracker', () => {
     describe('#add()', () => {
 
       it('should add a widget to the tracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         expect(tracker.has(widget)).to.be(false);
         tracker.add(widget);
@@ -219,7 +220,7 @@ describe('common/instancetracker', () => {
       });
 
       it('should remove an added widget if it is disposed', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         tracker.add(widget);
         expect(tracker.has(widget)).to.be(true);
@@ -232,14 +233,14 @@ describe('common/instancetracker', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources used by the tracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         expect(tracker.isDisposed).to.be(false);
         tracker.dispose();
         expect(tracker.isDisposed).to.be(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         expect(tracker.isDisposed).to.be(false);
         tracker.dispose();
         tracker.dispose();
@@ -251,7 +252,7 @@ describe('common/instancetracker', () => {
     describe('#find()', () => {
 
       it('should find a tracked item that matches a filter function', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widgetA = new Widget();
         let widgetB = new Widget();
         let widgetC = new Widget();
@@ -265,7 +266,7 @@ describe('common/instancetracker', () => {
       });
 
       it('should return a void if no item is found', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widgetA = new Widget();
         let widgetB = new Widget();
         let widgetC = new Widget();
@@ -283,7 +284,7 @@ describe('common/instancetracker', () => {
     describe('#forEach()', () => {
 
       it('should iterate through all the tracked items', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widgetA = new Widget();
         let widgetB = new Widget();
         let widgetC = new Widget();
@@ -303,7 +304,7 @@ describe('common/instancetracker', () => {
     describe('#has()', () => {
 
       it('should return `true` if an item exists in the tracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         expect(tracker.has(widget)).to.be(false);
         tracker.add(widget);
@@ -315,7 +316,7 @@ describe('common/instancetracker', () => {
     describe('#inject()', () => {
 
       it('should inject a widget into the tracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         expect(tracker.has(widget)).to.be(false);
         tracker.inject(widget);
@@ -323,7 +324,7 @@ describe('common/instancetracker', () => {
       });
 
       it('should remove an injected widget if it is disposed', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new InstanceTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         tracker.inject(widget);
         expect(tracker.has(widget)).to.be(true);
@@ -336,7 +337,7 @@ describe('common/instancetracker', () => {
     describe('#onCurrentChanged()', () => {
 
       it('should be called when the current widget is changed', () => {
-        let tracker = new TestTracker<Widget>({ namespace: NAMESPACE });
+        let tracker = new TestTracker<Widget>({ namespace, shell });
         let widget = new Widget();
         tracker.add(widget);
         expect(tracker.methods).to.contain('onCurrentChanged');

--- a/test/src/application/shell.spec.ts
+++ b/test/src/application/shell.spec.ts
@@ -66,50 +66,38 @@ describe('ApplicationShell', () => {
 
   });
 
-  describe('#mainAreaIsEmpty', () => {
+  describe('#isEmpty()', () => {
 
     it('should test whether the main area is empty', () => {
-      expect(shell.mainAreaIsEmpty).to.be(true);
+      expect(shell.isEmpty('top')).to.be(true);
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToMainArea(widget);
-      expect(shell.mainAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('main')).to.be(false);
     });
 
-  });
-
-  describe('#topAreaIsEmpty', () => {
-
     it('should test whether the top area is empty', () => {
-      expect(shell.topAreaIsEmpty).to.be(true);
+      expect(shell.isEmpty('top')).to.be(true);
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget);
-      expect(shell.topAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('top')).to.be(false);
     });
 
-  });
-
-  describe('#leftAreaIsEmpty', () => {
-
     it('should test whether the left area is empty', () => {
-      expect(shell.leftAreaIsEmpty).to.be(true);
+      expect(shell.isEmpty('left')).to.be(true);
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
-      expect(shell.leftAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('left')).to.be(false);
     });
 
-  });
-
-  describe('#rightAreaIsEmpty', () => {
-
     it('should test whether the right area is empty', () => {
-      expect(shell.rightAreaIsEmpty).to.be(true);
+      expect(shell.isEmpty('right')).to.be(true);
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
-      expect(shell.rightAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('right')).to.be(false);
     });
 
   });
@@ -120,20 +108,20 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget);
-      expect(shell.topAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('top')).to.be(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
       let widget = new Widget();
       shell.addToTopArea(widget);
-      expect(shell.topAreaIsEmpty).to.be(true);
+      expect(shell.isEmpty('top')).to.be(true);
     });
 
     it('should accept options', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget, { rank: 10 });
-      expect(shell.topAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('top')).to.be(false);
     });
 
   });
@@ -144,20 +132,20 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
-      expect(shell.leftAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('left')).to.be(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
       let widget = new Widget();
       shell.addToLeftArea(widget);
-      expect(shell.leftAreaIsEmpty).to.be(true);
+      expect(shell.isEmpty('left')).to.be(true);
     });
 
     it('should accept options', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget, { rank: 10 });
-      expect(shell.leftAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('left')).to.be(false);
     });
 
   });
@@ -168,20 +156,20 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
-      expect(shell.rightAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('right')).to.be(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
       let widget = new Widget();
       shell.addToRightArea(widget);
-      expect(shell.rightAreaIsEmpty).to.be(true);
+      expect(shell.isEmpty('right')).to.be(true);
     });
 
     it('should accept options', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget, { rank: 10 });
-      expect(shell.rightAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('right')).to.be(false);
     });
 
   });
@@ -192,25 +180,25 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToMainArea(widget);
-      expect(shell.mainAreaIsEmpty).to.be(false);
+      expect(shell.isEmpty('main')).to.be(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
       let widget = new Widget();
       shell.addToMainArea(widget);
-      expect(shell.mainAreaIsEmpty).to.be(true);
+      expect(shell.isEmpty('main')).to.be(true);
     });
 
   });
 
-  describe('#activateLeft()', () => {
+  describe('#activateById()', () => {
 
     it('should activate a widget in the left area', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
       expect(widget.isVisible).to.be(false);
-      shell.activateLeft('foo');
+      shell.activateById('foo');
       expect(widget.isVisible).to.be(true);
     });
 
@@ -218,20 +206,16 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       expect(widget.isVisible).to.be(false);
-      shell.activateLeft('foo');
+      shell.activateById('foo');
       expect(widget.isVisible).to.be(false);
     });
-
-  });
-
-  describe('#activateRight()', () => {
 
     it('should activate a widget in the right area', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
       expect(widget.isVisible).to.be(false);
-      shell.activateRight('foo');
+      shell.activateById('foo');
       expect(widget.isVisible).to.be(true);
     });
 
@@ -239,19 +223,15 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       expect(widget.isVisible).to.be(false);
-      shell.activateRight('foo');
+      shell.activateById('foo');
       expect(widget.isVisible).to.be(false);
     });
-
-  });
-
-  describe('#activateMain()', () => {
 
     it('should activate a widget in the main area', (done) => {
       let widget = new ContentWidget();
       widget.id = 'foo';
       shell.addToMainArea(widget);
-      shell.activateMain('foo');
+      shell.activateById('foo');
       requestAnimationFrame(() => {
         expect(widget.activated).to.be(true);
         done();
@@ -261,7 +241,7 @@ describe('ApplicationShell', () => {
     it('should be a no-op if the widget is not in the main area', (done) => {
       let widget = new ContentWidget();
       widget.id = 'foo';
-      shell.activateMain('foo');
+      shell.activateById('foo');
       requestAnimationFrame(() => {
         expect(widget.activated).to.be(false);
         done();
@@ -276,7 +256,7 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
-      shell.activateLeft('foo');
+      shell.activateById('foo');
       expect(widget.isVisible).to.be(true);
       shell.collapseLeft();
       expect(widget.isVisible).to.be(false);
@@ -290,7 +270,7 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
-      shell.activateRight('foo');
+      shell.activateById('foo');
       expect(widget.isVisible).to.be(true);
       shell.collapseRight();
       expect(widget.isVisible).to.be(false);

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -3,6 +3,7 @@
 
 import '@phosphor/widgets/style/index.css';
 
+import './application/instancetracker.spec';
 import './application/loader.spec';
 import './application/shell.spec';
 
@@ -19,7 +20,6 @@ import './commandlinker/commandlinker.spec';
 
 import './common/activitymonitor.spec';
 import './common/dialog.spec';
-import './common/instancetracker.spec';
 import './common/observablejson.spec';
 import './common/observablestring.spec';
 import './common/observablevector.spec';

--- a/test/src/instancerestorer/instancerestorer.spec.ts
+++ b/test/src/instancerestorer/instancerestorer.spec.ts
@@ -20,8 +20,8 @@ import {
 } from '../../../lib/instancerestorer/instancerestorer';
 
 import {
-  InstanceTracker
-} from '../../../lib/common/instancetracker';
+  ApplicationShell, InstanceTracker
+} from '../../../lib/application';
 
 import {
   StateDB
@@ -147,7 +147,10 @@ describe('instancerestorer/instancerestorer', () => {
     describe('#restore()', () => {
 
       it('should restore the widgets in a tracker', done => {
-        let tracker = new InstanceTracker<Widget>({ namespace: 'foo-widget' });
+        let tracker = new InstanceTracker<Widget>({
+          namespace: 'foo-widget',
+          shell: new ApplicationShell()
+        });
         let registry = new CommandRegistry();
         let state = new StateDB({ namespace: NAMESPACE });
         let ready = new utils.PromiseDelegate<void>();

--- a/test/src/notebook/celltools.spec.ts
+++ b/test/src/notebook/celltools.spec.ts
@@ -16,6 +16,10 @@ import {
 } from 'simulate-event';
 
 import {
+  ApplicationShell
+} from '../../../lib/application';
+
+import {
   CodeMirrorEditorFactory
 } from '../../../lib/codemirror';
 
@@ -99,7 +103,10 @@ describe('notebook/celltools', () => {
   let panel1: NotebookPanel;
 
   beforeEach((done) => {
-    tracker = new NotebookTracker({ namespace: 'notebook' });
+    tracker = new NotebookTracker({
+      namespace: 'notebook',
+      shell: new ApplicationShell()
+    });
     panel0 = createNotebookPanel();
     populateNotebook(panel0.notebook);
     panel1 = createNotebookPanel();

--- a/test/src/notebook/tracker.spec.ts
+++ b/test/src/notebook/tracker.spec.ts
@@ -4,6 +4,10 @@
 import expect = require('expect.js');
 
 import {
+  ApplicationShell
+} from '../../../lib/application';
+
+import {
   BaseCellWidget
 } from '../../../lib/cells';
 
@@ -20,7 +24,8 @@ import {
 } from './utils';
 
 
-const NAMESPACE = 'notebook-tracker-test';
+const namespace = 'notebook-tracker-test';
+const shell = new ApplicationShell();
 
 
 class TestTracker extends NotebookTracker {
@@ -40,7 +45,7 @@ describe('notebook/tracker', () => {
     describe('#constructor()', () => {
 
       it('should create a NotebookTracker', () => {
-        let tracker = new NotebookTracker({ namespace: NAMESPACE });
+        let tracker = new NotebookTracker({ namespace, shell });
         expect(tracker).to.be.a(NotebookTracker);
       });
 
@@ -49,19 +54,19 @@ describe('notebook/tracker', () => {
     describe('#activeCell', () => {
 
       it('should be `null` if there is no tracked notebook panel', () => {
-        let tracker = new NotebookTracker({ namespace: NAMESPACE });
+        let tracker = new NotebookTracker({ namespace, shell });
         expect(tracker.activeCell).to.be(null);
       });
 
       it('should be `null` if a tracked notebook has no active cell', () => {
-        let tracker = new NotebookTracker({ namespace: NAMESPACE });
+        let tracker = new NotebookTracker({ namespace, shell });
         let panel = createNotebookPanel();
         tracker.add(panel);
         expect(tracker.activeCell).to.be(null);
       });
 
       it('should be the active cell if a tracked notebook has one', () => {
-        let tracker = new NotebookTracker({ namespace: NAMESPACE });
+        let tracker = new NotebookTracker({ namespace, shell });
         let panel = createNotebookPanel();
         tracker.add(panel);
         panel.context = createNotebookContext();
@@ -75,7 +80,7 @@ describe('notebook/tracker', () => {
     describe('#activeCellChanged', () => {
 
       it('should emit a signal when the active cell changes', () => {
-        let tracker = new NotebookTracker({ namespace: NAMESPACE });
+        let tracker = new NotebookTracker({ namespace, shell });
         let panel = createNotebookPanel();
         let count = 0;
         tracker.activeCellChanged.connect(() => { count++; });
@@ -93,7 +98,7 @@ describe('notebook/tracker', () => {
     describe('#onCurrentChanged()', () => {
 
       it('should be called when the active cell changes', () => {
-        let tracker = new TestTracker({ namespace: NAMESPACE });
+        let tracker = new TestTracker({ namespace, shell });
         let panel = createNotebookPanel();
         tracker.add(panel);
         expect(tracker.methods).to.contain('onCurrentChanged');


### PR DESCRIPTION
- We can now use an instancetracker outside of the plugin and still activate the widget on its shell
- Simplifies the logic of activation on the shell
- Simplifies the `isEmpty` logic on the shell

Also, instancetracker needed to move out of common moving forward because it uses `stateDb`.