### PR TITLE
Fix editor collapsing in cells and Clean up Editor Refresh

### DIFF
--- a/src/cells/widget.ts
+++ b/src/cells/widget.ts
@@ -761,13 +761,13 @@ class InputAreaWidget extends Widget {
    * Render an input instead of the text editor.
    */
   renderInput(widget: Widget): void {
-    this._editor.hide();
     let layout = this.layout as PanelLayout;
     if (this._rendered) {
       layout.removeWidget(this._rendered);
+    } else {
+      layout.removeWidget(this._editor);
     }
     this._rendered = widget;
-    widget.show();
     layout.addWidget(widget);
   }
 
@@ -778,8 +778,8 @@ class InputAreaWidget extends Widget {
     let layout = this.layout as PanelLayout;
     if (this._rendered) {
       layout.removeWidget(this._rendered);
+      layout.addWidget(this._editor);
     }
-    this._editor.show();
   }
 
   /**

--- a/src/codeeditor/widget.ts
+++ b/src/codeeditor/widget.ts
@@ -75,6 +75,7 @@ class CodeEditorWidget extends Widget {
     this.node.addEventListener('focus', this, true);
     if (this.isVisible) {
       this._editor.refresh();
+      this._needsRefresh = false;
     }
   }
 
@@ -90,6 +91,7 @@ class CodeEditorWidget extends Widget {
    */
   protected onAfterShow(msg: Message): void {
     this._editor.refresh();
+    this._needsRefresh = false;
   }
 
   /**
@@ -100,6 +102,9 @@ class CodeEditorWidget extends Widget {
       this._editor.setSize(msg);
     } else if (this._editor.hasFocus()) {
       this._editor.refresh();
+      this._needsRefresh = false;
+    } else {
+      this._needsRefresh = true;
     }
   }
 
@@ -127,10 +132,14 @@ class CodeEditorWidget extends Widget {
    * Handle `focus` events for the widget.
    */
   private _evtFocus(event: FocusEvent): void {
-    this._editor.refresh();
+    if (this._needsRefresh) {
+      this._editor.refresh();
+      this._needsRefresh = false;
+    }
   }
 
   private _editor: CodeEditor.IEditor = null;
+  private _needsRefresh = false;
 }
 
 

--- a/src/codeeditor/widget.ts
+++ b/src/codeeditor/widget.ts
@@ -98,6 +98,8 @@ class CodeEditorWidget extends Widget {
   protected onResize(msg: Widget.ResizeMessage): void {
     if (msg.width >= 0 && msg.height >= 0) {
       this._editor.setSize(msg);
+    } else if (this._editor.hasFocus()) {
+      this._editor.refresh();
     }
   }
 

--- a/src/codeeditor/widget.ts
+++ b/src/codeeditor/widget.ts
@@ -94,7 +94,8 @@ class CodeEditorWidget extends Widget {
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
-    this._editor.refresh();
+    this._editor.setSize(null);
+    this._needsResize = false;
     this._needsRefresh = false;
   }
 

--- a/src/codeeditor/widget.ts
+++ b/src/codeeditor/widget.ts
@@ -75,12 +75,9 @@ class CodeEditorWidget extends Widget {
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     this.node.addEventListener('focus', this, true);
-    if (!this.isVisible) {
-      this._needsRefresh = true;
-      return;
+    if (this.isVisible) {
+      this._editor.refresh();
     }
-    this._editor.refresh();
-    this._needsRefresh = false;
   }
 
   /**
@@ -94,9 +91,7 @@ class CodeEditorWidget extends Widget {
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
-    this._editor.setSize(null);
-    this._needsResize = false;
-    this._needsRefresh = false;
+    this._editor.refresh();
   }
 
   /**
@@ -120,7 +115,6 @@ class CodeEditorWidget extends Widget {
       this._editor.setSize(msg);
       this._needsResize = false;
     }
-    this._needsRefresh = true;
   }
 
   /**
@@ -147,14 +141,10 @@ class CodeEditorWidget extends Widget {
    * Handle `focus` events for the widget.
    */
   private _evtFocus(event: FocusEvent): void {
-    if (this._needsRefresh) {
-      this._editor.refresh();
-      this._needsRefresh = false;
-    }
+    this._editor.refresh();
   }
 
   private _editor: CodeEditor.IEditor = null;
-  private _needsRefresh = true;
   private _needsResize = false;
   private _resizing = -1;
 }

--- a/src/codeeditor/widget.ts
+++ b/src/codeeditor/widget.ts
@@ -100,6 +100,7 @@ class CodeEditorWidget extends Widget {
   protected onResize(msg: Widget.ResizeMessage): void {
     if (msg.width >= 0 && msg.height >= 0) {
       this._editor.setSize(msg);
+      this._needsRefresh = false;
     } else if (this._editor.hasFocus()) {
       this._editor.refresh();
       this._needsRefresh = false;

--- a/src/codeeditor/widget.ts
+++ b/src/codeeditor/widget.ts
@@ -55,8 +55,6 @@ class CodeEditorWidget extends Widget {
     if (this.isDisposed) {
       return;
     }
-    clearTimeout(this._resizing);
-    this._resizing = -1;
     super.dispose();
     this._editor.dispose();
     this._editor = null;
@@ -98,22 +96,8 @@ class CodeEditorWidget extends Widget {
    * A message handler invoked on an `'resize'` message.
    */
   protected onResize(msg: Widget.ResizeMessage): void {
-    if (msg.width < 0 || msg.height < 0) {
-      if (this._resizing === -1) {
-        this._editor.setSize(null);
-        this._resizing = window.setTimeout(() => {
-          if (this._needsResize) {
-            this._editor.setSize(null);
-            this._needsResize = false;
-          }
-          this._resizing = -1;
-        }, 500);
-      } else {
-        this._needsResize = true;
-      }
-    } else {
+    if (msg.width >= 0 && msg.height >= 0) {
       this._editor.setSize(msg);
-      this._needsResize = false;
     }
   }
 
@@ -145,8 +129,6 @@ class CodeEditorWidget extends Widget {
   }
 
   private _editor: CodeEditor.IEditor = null;
-  private _needsResize = false;
-  private _resizing = -1;
 }
 
 

--- a/test/src/codeeditor/widget.spec.ts
+++ b/test/src/codeeditor/widget.spec.ts
@@ -126,15 +126,21 @@ describe('CodeEditorWidget', () => {
 
     context('focus', () => {
 
-      it('should refresh the editor', () => {
+      it('should be a no-op if the editor was not resized', () => {
         Widget.attach(widget, document.body);
-        widget.methods = [];
-        widget.editor.focus();
-        widget.node.tabIndex = -1;
-        simulate(widget.node, 'focus');
-        expect(widget.events).to.contain('focus');
         let editor = widget.editor as LogEditor;
-        expect(editor.methods).to.contain('refresh');
+        editor.methods = [];
+        simulate(editor.editor.getInputField(), 'focus');
+        expect(editor.methods).to.eql([]);
+      });
+
+      it('should refresh if editor was resized', () => {
+        Widget.attach(widget, document.body);
+        let editor = widget.editor as LogEditor;
+        MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
+        editor.methods = [];
+        simulate(editor.editor.getInputField(), 'focus');
+        expect(editor.methods).to.eql(['refresh']);
       });
 
     });
@@ -210,16 +216,19 @@ describe('CodeEditorWidget', () => {
       let editor = widget.editor as LogEditor;
       Widget.attach(widget, document.body);
       editor.focus();
+      editor.methods = [];
       MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
       expect(editor.methods).to.contain('refresh');
     });
 
-    it('should be a no-op', () => {
+    it('should defer the refresh until focused', () => {
       let editor = widget.editor as LogEditor;
       Widget.attach(widget, document.body);
-      widget.methods = [];
+      editor.methods = [];
       MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
-      expect(editor.methods).to.eql(['onResize']);
+      expect(editor.methods).to.eql([]);
+      simulate(editor.editor.getInputField(), 'focus');
+      expect(editor.methods).to.eql(['refresh']);
     });
 
   });

--- a/test/src/codeeditor/widget.spec.ts
+++ b/test/src/codeeditor/widget.spec.ts
@@ -217,7 +217,7 @@ describe('CodeEditorWidget', () => {
     it('should be a no-op', () => {
       let editor = widget.editor as LogEditor;
       Widget.attach(widget, document.body);
-      widget.messages = [];
+      widget.methods = [];
       MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
       expect(editor.methods).to.eql(['onResize']);
     });

--- a/test/src/codeeditor/widget.spec.ts
+++ b/test/src/codeeditor/widget.spec.ts
@@ -206,19 +206,20 @@ describe('CodeEditorWidget', () => {
       expect(editor.methods).to.contain('setSize');
     });
 
-    it('should set the size of the editor', () => {
+    it('should refresh the editor', () => {
       let editor = widget.editor as LogEditor;
+      Widget.attach(widget, document.body);
+      editor.focus();
       MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
-      expect(editor.methods).to.contain('setSize');
+      expect(editor.methods).to.contain('refresh');
     });
 
-    it('should make a subsequent request wait', () => {
+    it('should be a no-op', () => {
       let editor = widget.editor as LogEditor;
+      Widget.attach(widget, document.body);
+      widget.messages = [];
       MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
-      expect(editor.methods).to.contain('setSize');
-      editor.methods = [];
-      MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
-      expect(editor.methods).to.not.contain('setSize');
+      expect(editor.methods).to.eql(['onResize']);
     });
 
   });


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/1827.

Also, avoid calling refresh on the editor for null-size events unless the editor has focus.
cf https://github.com/jupyterlab/jupyterlab/issues/1587


Resizing a 100 empty cell notebook:

Before:

<img width="214" alt="screen shot 2017-03-03 at 6 23 49 am" src="https://cloud.githubusercontent.com/assets/2096628/23551069/072ffa52-ffda-11e6-9b8e-b42e83bc50ff.png">


After:
<img width="398" alt="screen shot 2017-03-03 at 6 20 40 am" src="https://cloud.githubusercontent.com/assets/2096628/23551087/24e4d298-ffda-11e6-8f31-e1aac4e6e5ec.png">


