### PR TITLE
Fix tab switching shortcut

### DIFF
--- a/src/shortcuts/plugin.ts
+++ b/src/shortcuts/plugin.ts
@@ -73,12 +73,12 @@ const SHORTCUTS = [
   {
     command: ApplicationCommandIDs.activateNextTab,
     selector: 'body',
-    keys: ['Accel ArrowRight']
+    keys: ['Ctrl Shift ]']
   },
   {
     command: ApplicationCommandIDs.activatePreviousTab,
     selector: 'body',
-    keys: ['Accel ArrowLeft']
+    keys: ['Ctrl Shift [']
   },
   {
     command: CommandPaletteCommandIDs.activate,


### PR DESCRIPTION
Use `Ctrl + Shift + [` on all platforms to avoid collisions with well known shortcuts.

Fixes #1681.