### PR TITLE
Clean up kernel reset behavior

### DIFF
--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -133,6 +133,9 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   let command: string;
   let count = 0;
   let menu = new Menu({ commands });
+  const DEAD_SESSION_MSG = (
+    'Console session was shut down, please start a new console.'
+  );
 
   // Create an instance tracker for all console panels.
   const tracker = new InstanceTracker<ConsolePanel>({
@@ -287,6 +290,10 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       let kernel = current.console.session.kernel;
       if (kernel) {
         return kernel.restart();
+      } else {
+        return showDialog({
+          body: DEAD_SESSION_MSG
+        })
       }
     }
   });
@@ -435,6 +442,13 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
       let session = widget.session;
       let lang = '';
       manager.ready.then(() => {
+        if (session.isDisposed) {
+          return showDialog({
+            body: DEAD_SESSION_MSG
+          }).then(() => {
+            return Promise.reject<Kernel.IModel>(DEAD_SESSION_MSG);
+          });
+        }
         let specs = manager.specs;
         if (session.kernel) {
           lang = specs.kernelspecs[session.kernel.name].language;

--- a/src/docregistry/kernelactions.ts
+++ b/src/docregistry/kernelactions.ts
@@ -13,13 +13,15 @@ import {
   showDialog, cancelButton, warnButton
 } from '../common/dialog';
 
+import {
+  DocumentRegistry
+} from '.'
+
 
 /**
  * Restart a kernel after presenting a dialog.
  *
- * @param kernel - The kernel to restart.
- *
- * @param host - The optional host widget that should be activated.
+ * @param owner: The kernel owner.
  *
  * @returns A promise that resolves to `true` the user elects to restart.
  *
@@ -27,20 +29,17 @@ import {
  * This is a no-op if there is no kernel.
  */
 export
-function restartKernel(kernel: Kernel.IKernel, host?: Widget): Promise<boolean> {
-  if (!kernel) {
-    return Promise.resolve(false);
+function restartKernel(owner: DocumentRegistry.IKernelOwner): Promise<boolean> {
+  if (!owner.kernel) {
+    return owner.startDefaultKernel().then(() => true);
   }
   return showDialog({
     title: 'Restart Kernel?',
     body: 'Do you want to restart the current kernel? All variables will be lost.',
     buttons: [cancelButton, warnButton]
   }).then(result => {
-    if (host) {
-      host.activate();
-    }
-    if (!kernel.isDisposed && result.text === 'OK') {
-      return kernel.restart().then(() => { return true; });
+    if (!owner.kernel.isDisposed && result.text === 'OK') {
+      return owner.kernel.restart().then(() => true);
     } else {
       return false;
     }

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -605,15 +605,41 @@ namespace DocumentRegistry {
   interface ICodeModel extends IModel, CodeEditor.IModel { }
 
   /**
+   * A kernel owner interface.
+   */
+  export
+  interface IKernelOwner {
+    /**
+     * An associated kernel.
+     */
+    readonly kernel: Kernel.IKernel;
+
+    /**
+     * A signal emitted when the kernel is changed.
+     */
+    readonly kernelChanged: ISignal<IKernelOwner, Kernel.IKernel>;
+
+    /**
+     * Start the default kernel for the owner.
+     *
+     * @returns A promise that resolves with the new kernel.
+     */
+    startDefaultKernel(): Promise<Kernel.IKernel>;
+
+    /**
+     * Change the current kernel associated with the owner.
+     *
+     * #### Notes
+     * If no options are given, the session is shut down.
+     */
+    changeKernel(options?: Kernel.IModel): Promise<Kernel.IKernel>;
+  }
+
+  /**
    * The document context object.
    */
   export
-  interface IContext<T extends IModel> extends IDisposable {
-    /**
-     * A signal emitted when the kernel changes.
-     */
-    kernelChanged: ISignal<this, Kernel.IKernel>;
-
+  interface IContext<T extends IModel> extends IDisposable, IKernelOwner {
     /**
      * A signal emitted when the path changes.
      */
@@ -633,11 +659,6 @@ namespace DocumentRegistry {
      * Get the model associated with the document.
      */
     readonly model: T;
-
-    /**
-     * The current kernel associated with the document.
-     */
-    readonly kernel: Kernel.IKernel;
 
     /**
      * The current path associated with the document.
@@ -662,21 +683,6 @@ namespace DocumentRegistry {
      * A promise that is fulfilled when the context is ready.
      */
     readonly ready: Promise<void>;
-
-    /**
-     * Start the default kernel for the context.
-     *
-     * @returns A promise that resolves with the new kernel.
-     */
-    startDefaultKernel(): Promise<Kernel.IKernel>;
-
-    /**
-     * Change the current kernel associated with the document.
-     *
-     * #### Notes
-     * If no options are given, the session is shut down.
-     */
-    changeKernel(options?: Kernel.IModel): Promise<Kernel.IKernel>;
 
     /**
      * Save the document contents to disk.

--- a/src/notebook/default-toolbar.ts
+++ b/src/notebook/default-toolbar.ts
@@ -199,11 +199,11 @@ namespace ToolbarItems {
     toolbar.addItem('copy', createCopyButton(panel));
     toolbar.addItem('paste', createPasteButton(panel));
     toolbar.addItem('run', createRunButton(panel));
-    toolbar.addItem('interrupt', createInterruptButton(panel));
-    toolbar.addItem('restart', createRestartButton(panel));
+    toolbar.addItem('interrupt', createInterruptButton(panel.context));
+    toolbar.addItem('restart', createRestartButton(panel.context));
     toolbar.addItem('cellType', createCellTypeItem(panel));
-    toolbar.addItem('kernelName', createKernelNameItem(panel));
-    toolbar.addItem('kernelStatus', createKernelStatusItem(panel));
+    toolbar.addItem('kernelName', createKernelNameItem(panel.context));
+    toolbar.addItem('kernelStatus', createKernelStatusItem(panel.context));
   }
 }
 

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -293,7 +293,7 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
       if (!current) {
         return;
       }
-      restartKernel(current.kernel, current);
+      return restartKernel(current.context).then(() => { getCurrent(args) });
     }
   });
   commands.addCommand(CommandIDs.closeAndShutdown, {
@@ -325,6 +325,7 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
         return;
       }
       return trustNotebook(current.context.model).then(() => {
+        getCurrent(args);
         return current.context.save();
       });
     }
@@ -336,9 +337,10 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
       if (!current) {
         return;
       }
-      let promise = restartKernel(current.kernel, current);
+      let promise = restartKernel(current.context);
       promise.then(result => {
         if (result) {
+          getCurrent(args);
           return NotebookActions.clearAllOutputs(current.notebook);
         }
       });
@@ -352,8 +354,9 @@ function addCommands(app: JupyterLab, services: IServiceManager, tracker: Notebo
       if (!current) {
         return;
       }
-      let promise = restartKernel(current.kernel, current);
+      let promise = restartKernel(current.context);
       promise.then(result => {
+        getCurrent(args);
         NotebookActions.runAll(current.notebook, current.context.kernel);
       });
       return promise;

--- a/src/toolbar/kernel.ts
+++ b/src/toolbar/kernel.ts
@@ -14,7 +14,7 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  restartKernel
+  DocumentRegistry
 } from '../docregistry';
 
 import {
@@ -46,28 +46,18 @@ const TOOLBAR_INDICATOR_CLASS = 'jp-Kernel-toolbarKernelIndicator';
  */
 const TOOLBAR_BUSY_CLASS = 'jp-mod-busy';
 
-
 /**
- * A kernel owner interface.
+ * An alias for a kernel owner.
  */
 export
-interface IKernelOwner extends Widget {
-  /**
-   * An associated kernel.
-   */
-  kernel: Kernel.IKernel;
-  /**
-   * A signal emitted when the kernel is changed.
-   */
-  kernelChanged: ISignal<IKernelOwner, Kernel.IKernel>;
-}
+type KernelOwner = DocumentRegistry.IKernelOwner;
 
 
 /**
  * Create an interrupt toolbar item.
  */
 export
-function createInterruptButton(kernelOwner: IKernelOwner): ToolbarButton {
+function createInterruptButton(kernelOwner: KernelOwner): ToolbarButton {
   return new ToolbarButton({
     className: TOOLBAR_INTERRUPT_CLASS,
     onClick: () => {
@@ -84,14 +74,15 @@ function createInterruptButton(kernelOwner: IKernelOwner): ToolbarButton {
  * Create a restart toolbar item.
  */
 export
-function createRestartButton(kernelOwner: IKernelOwner): ToolbarButton {
+function createRestartButton(kernelOwner: KernelOwner): ToolbarButton {
   return new ToolbarButton({
     className: TOOLBAR_RESTART_CLASS,
     onClick: () => {
-      if (!kernelOwner.kernel) {
-        return;
+      if (kernelOwner.kernel) {
+        kernelOwner.kernel.restart();
+      } else {
+        kernelOwner.startDefaultKernel();
       }
-      restartKernel(kernelOwner.kernel, kernelOwner);
     },
     tooltip: 'Restart the kernel'
   });
@@ -107,7 +98,7 @@ function createRestartButton(kernelOwner: IKernelOwner): ToolbarButton {
  * It can handle a change in context or kernel.
  */
 export
-function createKernelNameItem(kernelOwner: IKernelOwner): Widget {
+function createKernelNameItem(kernelOwner: KernelOwner): Widget {
   return new KernelName(kernelOwner);
 }
 
@@ -119,7 +110,7 @@ class KernelName extends Widget {
   /**
    * Construct a new kernel name widget.
    */
-  constructor(kernelOwner: IKernelOwner) {
+  constructor(kernelOwner: KernelOwner) {
     super();
     this.addClass(TOOLBAR_KERNEL_CLASS);
     this._onKernelChanged(kernelOwner, kernelOwner.kernel);
@@ -129,7 +120,7 @@ class KernelName extends Widget {
   /**
    * Update the text of the kernel name item.
    */
-  _onKernelChanged(sender: IKernelOwner, kernel: Kernel.IKernel): void {
+  _onKernelChanged(sender: KernelOwner, kernel: Kernel.IKernel): void {
     this.node.textContent = 'No Kernel!';
     if (!kernel) {
       return;
@@ -153,7 +144,7 @@ class KernelName extends Widget {
  * It can handle a change to the context or the kernel.
  */
 export
-function createKernelStatusItem(kernelOwner: IKernelOwner): Widget {
+function createKernelStatusItem(kernelOwner: KernelOwner): Widget {
   return new KernelIndicator(kernelOwner);
 }
 
@@ -165,7 +156,7 @@ class KernelIndicator extends Widget {
   /**
    * Construct a new kernel status widget.
    */
-  constructor(kernelOwner: IKernelOwner) {
+  constructor(kernelOwner: KernelOwner) {
     super();
     this.addClass(TOOLBAR_INDICATOR_CLASS);
     this._onKernelChanged(kernelOwner, kernelOwner.kernel);
@@ -175,7 +166,7 @@ class KernelIndicator extends Widget {
   /**
    * Handle a change in kernel.
    */
-  private _onKernelChanged(sender: IKernelOwner, kernel: Kernel.IKernel): void {
+  private _onKernelChanged(sender: KernelOwner, kernel: Kernel.IKernel): void {
     if (this._kernel) {
       this._kernel.statusChanged.disconnect(this._handleStatus, this);
     }

--- a/test/src/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/default-toolbar.spec.ts
@@ -231,7 +231,7 @@ describe('notebook/notebook/default-toolbar', () => {
     describe('#createInterruptButton()', () => {
 
       it('should have the `\'jp-StopIcon\'` class', () => {
-        let button = createInterruptButton(panel);
+        let button = createInterruptButton(panel.context);
         expect(button.hasClass('jp-StopIcon')).to.be(true);
       });
 
@@ -240,7 +240,7 @@ describe('notebook/notebook/default-toolbar', () => {
     describe('#createRestartButton()', () => {
 
       it('should have the `\'jp-RefreshIcon\'` class', () => {
-        let button = createRestartButton(panel);
+        let button = createRestartButton(panel.context);
         expect(button.hasClass('jp-RefreshIcon')).to.be(true);
       });
 
@@ -289,7 +289,7 @@ describe('notebook/notebook/default-toolbar', () => {
     describe('#createKernelNameItem()', () => {
 
       it('should display the `\'display_name\'` of the kernel', (done) => {
-        let item = createKernelNameItem(panel);
+        let item = createKernelNameItem(panel.context);
         startKernel(context).then(kernel => {
           console.log('started kernel');
           return kernel.getSpec();
@@ -301,12 +301,12 @@ describe('notebook/notebook/default-toolbar', () => {
       });
 
       it('should display `\'No Kernel!\'` if there is no kernel', () => {
-        let item = createKernelNameItem(panel);
+        let item = createKernelNameItem(panel.context);
         expect(item.node.textContent).to.be('No Kernel!');
       });
 
       it('should handle a change in context', (done) => {
-        let item = createKernelNameItem(panel);
+        let item = createKernelNameItem(panel.context);
         startKernel(context).then(kernel => {
           console.log('started kernel');
           return kernel.ready;
@@ -328,7 +328,7 @@ describe('notebook/notebook/default-toolbar', () => {
       });
 
       it('should display a busy status if the kernel status is not idle', (done) => {
-        let item = createKernelStatusItem(panel);
+        let item = createKernelStatusItem(panel.context);
         panel.kernel.statusChanged.connect(() => {
           if (panel.kernel.status === 'busy') {
             expect(item.hasClass('jp-mod-busy')).to.be(true);
@@ -339,7 +339,7 @@ describe('notebook/notebook/default-toolbar', () => {
       });
 
       it('should show the current status in the node title', (done) => {
-        let item = createKernelStatusItem(panel);
+        let item = createKernelStatusItem(panel.context);
         let status = panel.kernel.status;
         expect(item.node.title.toLowerCase()).to.contain(status);
         panel.kernel.statusChanged.connect(() => {
@@ -352,7 +352,7 @@ describe('notebook/notebook/default-toolbar', () => {
       });
 
       it('should handle a null kernel', (done) => {
-        let item = createKernelStatusItem(panel);
+        let item = createKernelStatusItem(panel.context);
         panel.context.changeKernel(void 0).then(() => {
           expect(item.node.title).to.be('No Kernel!');
           expect(item.hasClass('jp-mod-busy')).to.be(true);
@@ -361,7 +361,7 @@ describe('notebook/notebook/default-toolbar', () => {
       });
 
       it('should handle a change to the context', () => {
-        let item = createKernelStatusItem(panel);
+        let item = createKernelStatusItem(panel.context);
         context = createNotebookContext();
         context.model.fromJSON(DEFAULT_CONTENT);
         panel.context = context;


### PR DESCRIPTION
Fixes #1835. 

A notebook that has been shut down will restart it's previous kernel.
A console that has been shut down triggers a warning, because it's session is read-only:

<image src="https://cloud.githubusercontent.com/assets/2096628/23578534/950d42d4-009e-11e7-9720-a44001a58a95.png" width=300>
