### PR TITLE
Add blur to editor and clean up notebook focus handling

### DIFF
--- a/src/codeeditor/editor.ts
+++ b/src/codeeditor/editor.ts
@@ -461,6 +461,11 @@ namespace CodeEditor {
     hasFocus(): boolean;
 
     /**
+     * Explicitly blur the editor.
+     */
+    blur(): void;
+
+    /**
      * Repaint the editor.
      */
     refresh(): void;

--- a/src/codemirror/editor.ts
+++ b/src/codemirror/editor.ts
@@ -193,6 +193,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       this.host.classList.add(READ_ONLY_CLASS);
     } else {
       this.host.classList.remove(READ_ONLY_CLASS);
+      this.blur();
     }
   }
 
@@ -295,6 +296,13 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    */
   hasFocus(): boolean {
     return this._editor.hasFocus();
+  }
+
+  /**
+   * Explicitly blur the editor.
+   */
+  blur(): void {
+    this._editor.getInputField().blur();
   }
 
   /**

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1043,10 +1043,7 @@ class Notebook extends StaticNotebook {
    */
   private _ensureFocus(force=false): void {
     let activeCell = this.activeCell;
-    if (!activeCell) {
-      this.mode = 'command';
-    }
-    if (this.mode === 'edit') {
+    if (this.mode === 'edit' && activeCell) {
       activeCell.editor.focus();
     } else if (activeCell) {
       activeCell.editor.blur();

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1043,9 +1043,12 @@ class Notebook extends StaticNotebook {
    */
   private _ensureFocus(force=false): void {
     let activeCell = this.activeCell;
+    if (!activeCell) {
+      this.mode = 'command';
+    }
     if (this.mode === 'edit') {
       activeCell.editor.focus();
-    } else {
+    } else if (activeCell) {
       activeCell.editor.blur();
     }
     if (force && !this.node.contains(document.activeElement)) {

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1045,15 +1045,8 @@ class Notebook extends StaticNotebook {
     let activeCell = this.activeCell;
     if (this.mode === 'edit') {
       activeCell.editor.focus();
-    } else if (this.node.contains(document.activeElement)) {
-      // If an editor currently has focus, focus our node.
-      // Otherwise, another input field has focus and should keep it.
-      let w = find(this.layout, widget => {
-        return (widget as BaseCellWidget).editor.hasFocus();
-      });
-      if (w) {
-        this.node.focus();
-      }
+    } else {
+      activeCell.editor.blur();
     }
     if (force && !this.node.contains(document.activeElement)) {
       this.node.focus();
@@ -1344,12 +1337,12 @@ class Notebook extends StaticNotebook {
   }
 
   /**
-   * Handle `blur` events for the widget.
+   * Handle `blur` events for the notebook.
    */
   private _evtBlur(event: MouseEvent): void {
     let relatedTarget = event.relatedTarget as HTMLElement;
     if (!this.node.contains(relatedTarget)) {
-      this.mode = 'command';
+      return;
     }
     // If the root node is not blurring and we are in command mode,
     // focus ourselves.

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -140,7 +140,7 @@ function createActiveWidget(): LogNotebook {
 }
 
 
-describe('notebook/notebook/widget', () => {
+describe('notebook/widget', () => {
 
   describe('StaticNotebook', () => {
 
@@ -944,12 +944,25 @@ describe('notebook/notebook/widget', () => {
 
       context('blur', () => {
 
-        it('should set the mode to `command`', () => {
+        it('should preserve the mode', () => {
           simulate(widget.node, 'focus');
           widget.mode = 'edit';
           let other = document.createElement('div');
           simulate(widget.node, 'blur', { relatedTarget: other });
+          expect(widget.mode).to.be('edit');
+          MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
+          expect(widget.mode).to.be('edit');
+          expect(widget.activeCell.editor.hasFocus()).to.be(true);
+        });
+
+        it('should give focus back to the notebook', () => {
+          simulate(widget.node, 'focus');
+          let other = document.createElement('div');
+          simulate(widget.node, 'blur', { relatedTarget: other });
           expect(widget.mode).to.be('command');
+          MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
+          expect(widget.mode).to.be('command');
+          expect(widget.activeCell.editor.hasFocus()).to.be(false);
         });
 
       });


### PR DESCRIPTION
Preserves edit mode until another node within the notebook takes focus.

Fixes https://github.com/jupyterlab/jupyterlab/issues/1407.
Fixes #1737.

cf #906.