### PR TITLE
renderers/index.css: Adjust HTML table style

### DIFF
--- a/src/renderers/index.css
+++ b/src/renderers/index.css
@@ -270,11 +270,9 @@ margin-top = 14, 14, 14, 14, 8, 8
   text-align: right;
   vertical-align: middle;
   padding: 0.5em 0.5em;
-  line-height: 1.0;
-  white-space: nowrap;
-  max-width: 150px;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  line-height: normal;
+  white-space: normal;
+  max-width: none;
   border: none;
 }
 


### PR DESCRIPTION
Port changes made to Jupyter notebook tables in Issue https://github.com/jupyter/notebook/issues/2209 and Pull Request https://github.com/jupyter/notebook/pull/2231. Set the max-width to none so that libraries like Pandas which want to set the max width can do it properly.

Tested with the same data mentioned by Joris.

**Before**:
<img width="880" alt="screen shot 2017-03-10 at 7 10 17 pm" src="https://cloud.githubusercontent.com/assets/2200743/23797436/e0ad089c-05c5-11e7-9cb8-a69132452e02.png">

----
**After**:
<img width="859" alt="screen shot 2017-03-10 at 7 11 47 pm" src="https://cloud.githubusercontent.com/assets/2200743/23797459/f93becfc-05c5-11e7-8b8b-1f5a48fc102d.png">
