### PR TITLE
default-theme: Show close icon even if dirty

### DIFF
--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -168,6 +168,10 @@
   background-image: url(../default-theme/icons/md/circle.svg);
 }
 
+.p-DockPanel-tabBar .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:hover {
+  background-size: 16px;
+  background-image: url(../default-theme/icons/md/close-black.svg);
+}
 
 .p-TabBar-tab.p-mod-drag-image {
   background: var(--jp-layout-color1);

--- a/src/default-theme/icons/md/close-black.svg
+++ b/src/default-theme/icons/md/close-black.svg
@@ -1,0 +1,6 @@
+<svg fill="#ffffff" height="16" width="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <!-- The black circle background -->
+    <circle cx="12" cy="12" r="11" fill="#000000"/>
+    <!-- The cross (close icon) -->
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
When the tab is dirty (unsaved changes), it used to show a dot. This is
confusing for new users, so the new approach is to show a black dot with
a white cross in it.

Fixes https://github.com/jupyterlab/jupyterlab/issues/1594