### PR TITLE
rendermime: Don't stop if error in canRender

### DIFF
--- a/src/rendermime/rendermime.ts
+++ b/src/rendermime/rendermime.ts
@@ -146,7 +146,14 @@ class RenderMime {
       if (model.data.has(mimeType)) {
         let options = { mimeType, model, sanitizer };
         let renderer = this._renderers[mimeType];
-        if (renderer.canRender(options)) {
+        let canRender = false;
+        try {
+          canRender = renderer.canRender(options);
+        } catch (err) {
+          console.error(
+            `Got an error when checking the renderer for the mimeType '${mimeType}'\n`, err);
+        }
+        if (canRender) {
           return true;
         }
       }


### PR DESCRIPTION
In rendermime, if an error occured when the canRender() function is
called, the notebook should not stop and break. Rather it should
continue and attempt others.

Fixes https://github.com/jupyterlab/jupyterlab/issues/1866
