### PR TITLE
renderers: No margin for second level lists

### DIFF
--- a/src/renderers/index.css
+++ b/src/renderers/index.css
@@ -214,13 +214,17 @@ margin-top = 14, 14, 14, 14, 8, 8
 }
 
 
+.jp-RenderedHTMLCommon * + ol,
 .jp-RenderedHTMLCommon * + ul {
   margin-top: 1em;
 }
 
 
-.jp-RenderedHTMLCommon * + ol {
-  margin-top: 1em;
+.jp-RenderedHTMLCommon ul * + ul,
+.jp-RenderedHTMLCommon ul * + ol,
+.jp-RenderedHTMLCommon ol * + ul,
+.jp-RenderedHTMLCommon ol * + ol {
+  margin-top: 0em;
 }
 
 


### PR DESCRIPTION
There was a margin put in lists to separate it from paragraphs,
header, and other tags in general. But this margin is also causing a
space in the second level list if the first level list item has a html
tag. Hence, we add a new CSS selector which sets the margin in this case
back to 0.

FIxes https://github.com/jupyterlab/jupyterlab/issues/1615