### PR TITLE
Change instance restorer to layout restorer.

### DIFF
--- a/examples/lab/index.js
+++ b/examples/lab/index.js
@@ -13,6 +13,7 @@ require('jupyterlab/lib/default-theme/index.css');
 var mods = [
   require('jupyterlab/lib/about-extension'),
   require('jupyterlab/lib/application/plugin'),
+  require('jupyterlab/lib/apputils/plugin'),
   require('jupyterlab/lib/codemirror/plugin'),
   require('jupyterlab/lib/commandlinker/plugin'),
   require('jupyterlab/lib/commandpalette/plugin'),
@@ -29,7 +30,6 @@ var mods = [
   require('jupyterlab/lib/inspector/plugin'),
   require('jupyterlab/lib/landing-extension'),
   require('jupyterlab/lib/launcher/plugin'),
-  require('jupyterlab/lib/instancerestorer/plugin'),
   require('jupyterlab/lib/mainmenu/plugin'),
   require('jupyterlab/lib/markdownwidget/plugin'),
   require('jupyterlab/lib/notebook/plugin'),

--- a/jupyterlab/src/main.ts
+++ b/jupyterlab/src/main.ts
@@ -20,6 +20,7 @@ polyfill();
 const mods: JupyterLab.IPluginModule[] = [
   require('../../lib/about-extension'),
   require('../../lib/application/plugin'),
+  require('../../lib/apputils/plugin'),
   require('../../lib/codemirror/plugin'),
   require('../../lib/commandlinker/plugin'),
   require('../../lib/commandpalette/plugin'),
@@ -36,7 +37,6 @@ const mods: JupyterLab.IPluginModule[] = [
   require('../../lib/inspector/plugin'),
   require('../../lib/landing-extension'),
   require('../../lib/launcher/plugin'),
-  require('../../lib/instancerestorer/plugin'),
   require('../../lib/mainmenu/plugin'),
   require('../../lib/markdownwidget/plugin'),
   require('../../lib/notebook/plugin'),

--- a/src/about-extension/index.ts
+++ b/src/about-extension/index.ts
@@ -10,11 +10,7 @@ import {
 } from '../commandpalette';
 
 import {
-  InstanceTracker
-} from '../application';
-
-import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/about-extension/index.ts
+++ b/src/about-extension/index.ts
@@ -14,8 +14,8 @@ import {
 } from '../application';
 
 import {
-  IInstanceRestorer
-} from '../instancerestorer';
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
 
 import {
   AboutModel, AboutWidget
@@ -38,7 +38,7 @@ const plugin: JupyterLabPlugin<void> = {
   activate,
   id: 'jupyter.extensions.about',
   autoStart: true,
-  requires: [ICommandPalette, IInstanceRestorer]
+  requires: [ICommandPalette, ILayoutRestorer]
 };
 
 
@@ -48,7 +48,7 @@ const plugin: JupyterLabPlugin<void> = {
 export default plugin;
 
 
-function activate(app: JupyterLab, palette: ICommandPalette, restorer: IInstanceRestorer): void {
+function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRestorer): void {
   const namespace = 'about-jupyterlab';
   const model = new AboutModel({ version: app.info.version });
   const command = CommandIDs.open;

--- a/src/about-extension/index.ts
+++ b/src/about-extension/index.ts
@@ -15,7 +15,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   AboutModel, AboutWidget

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -15,7 +15,6 @@ import {
 
 export { ModuleLoader } from './loader';
 export { ApplicationShell } from './shell';
-export * from './instancetracker';
 
 
 /**

--- a/src/application/instancetracker.ts
+++ b/src/application/instancetracker.ts
@@ -31,7 +31,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   IStateDB

--- a/src/application/instancetracker.ts
+++ b/src/application/instancetracker.ts
@@ -30,8 +30,8 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  IInstanceRestorer
-} from '../instancerestorer';
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
 
 import {
   IStateDB
@@ -320,7 +320,7 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    *
    * #### Notes
    * This function should almost never be invoked by client code. Its primary
-   * use case is to be invoked by an instance restorer plugin that handles
+   * use case is to be invoked by a layout restorer plugin that handles
    * multiple instance trackers and, when ready, asks them each to restore their
    * respective widgets.
    */
@@ -466,11 +466,11 @@ namespace InstanceTracker {
    * The state restoration configuration options.
    */
   export
-  interface IRestoreOptions<T extends Widget> extends IInstanceRestorer.IRestoreOptions<T> {
+  interface IRestoreOptions<T extends Widget> extends ILayoutRestorer.IRestoreOptions<T> {
     /*
-     * The instance restorer to use to recreate restored widgets.
+     * The layout restorer to use to recreate restored widgets.
      */
-    restorer: IInstanceRestorer;
+    restorer: ILayoutRestorer;
 
     /**
      * The command registry which holds the restore command.

--- a/src/apputils/index.ts
+++ b/src/apputils/index.ts
@@ -7,6 +7,7 @@ export * from './domutils';
 export * from './hoverbox';
 export * from './iframe';
 export * from './jsoneditor';
+export * from './layoutrestorer';
 export * from './sanitizer';
 export * from './styling';
 export * from './vdom';

--- a/src/apputils/index.ts
+++ b/src/apputils/index.ts
@@ -6,6 +6,7 @@ export * from './dialog';
 export * from './domutils';
 export * from './hoverbox';
 export * from './iframe';
+export * from './instancetracker';
 export * from './jsoneditor';
 export * from './layoutrestorer';
 export * from './sanitizer';

--- a/src/apputils/instancetracker.ts
+++ b/src/apputils/instancetracker.ts
@@ -34,12 +34,12 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  IStateDB
-} from '../statedb';
+  ApplicationShell
+} from '../application';
 
 import {
-  ApplicationShell
-} from './shell';
+  IStateDB
+} from '../statedb';
 
 
 /**

--- a/src/apputils/layoutrestorer.ts
+++ b/src/apputils/layoutrestorer.ts
@@ -34,10 +34,10 @@ import {
 
 /* tslint:disable */
 /**
- * The instance restorer token.
+ * The layout restorer token.
  */
 export
-const IInstanceRestorer = new Token<IInstanceRestorer>('jupyter.services.instance-restorer');
+const ILayoutRestorer = new Token<ILayoutRestorer>('jupyter.services.layout-restorer');
 /* tslint:enable */
 
 
@@ -45,14 +45,14 @@ const IInstanceRestorer = new Token<IInstanceRestorer>('jupyter.services.instanc
  * A static class that restores the widgets of the application when it reloads.
  */
 export
-interface IInstanceRestorer {
+interface ILayoutRestorer {
   /**
-   * A promise resolved when the instance restorer is ready to receive signals.
+   * A promise resolved when the layout restorer is ready to receive signals.
    */
   restored: Promise<void>;
 
   /**
-   * Add a widget to be tracked by the instance restorer.
+   * Add a widget to be tracked by the layout restorer.
    */
   add(widget: Widget, name: string): void;
 
@@ -63,15 +63,15 @@ interface IInstanceRestorer {
    *
    * @param options - The restoration options.
    */
-  restore(tracker: InstanceTracker<any>, options: IInstanceRestorer.IRestoreOptions<any>): void;
+  restore(tracker: InstanceTracker<any>, options: ILayoutRestorer.IRestoreOptions<any>): void;
 }
 
 
 /**
- * A namespace for instance restorers.
+ * A namespace for the layout restorer.
  */
 export
-namespace IInstanceRestorer {
+namespace ILayoutRestorer {
   /**
    * The state restoration configuration options.
    */
@@ -107,44 +107,44 @@ namespace IInstanceRestorer {
 /**
  * The state database key for restorer data.
  */
-const KEY = 'instance-restorer:data';
+const KEY = 'layout-restorer:data';
 
 
 /**
- * The default implementation of an instance restorer.
+ * The default implementation of a layout restorer.
  *
  * #### Notes
  * The lifecycle for state restoration is subtle. The sequence of events is:
  *
- * 1. The instance restorer plugin is instantiated. It installs itself as the
+ * 1. The layout restorer plugin is instantiated. It installs itself as the
  *    layout database that the application shell can use to `fetch` and `save`
  *    layout restoration data.
  *
- * 2. Other plugins that care about state restoration require the instance
+ * 2. Other plugins that care about state restoration require the layout
  *    restorer as a dependency.
  *
  * 3. As each load-time plugin initializes (which happens before the lab
- *    application has `started`), it instructs the instance restorer whether
+ *    application has `started`), it instructs the layout restorer whether
  *    the restorer ought to `restore` its state by passing in its tracker.
  *    Alternatively, a plugin that does not require its own instance tracker
  *    (because perhaps it only creates a single widget, like a command palette),
  *    can simply `add` its widget along with a persistent unique name to the
- *    instance restorer so that its layout state can be restored when the lab
+ *    layout restorer so that its layout state can be restored when the lab
  *    application restores.
  *
  * 4. After all the load-time plugins have finished initializing, the lab
  *    application `started` promise will resolve. This is the `first`
- *    promise that the instance restorer waits for. By this point, all of the
+ *    promise that the layout restorer waits for. By this point, all of the
  *    plugins that care about restoration will have instructed the instance
  *    restorer to `restore` their state.
  *
- * 5. The instance restorer will then instruct each plugin's instance tracker
+ * 5. The layout restorer will then instruct each plugin's instance tracker
  *    to restore its state and reinstantiate whichever widgets it wants. The
- *    tracker returns a promise to the instance restorer that resolves when it
+ *    tracker returns a promise to the layout restorer that resolves when it
  *    has completed restoring the tracked widgets it cares about.
  *
  * 6. As each instance finishes restoring, it resolves the promise that was
- *    made to the instance restorer (in step 5). After all of the promises that
+ *    made to the layout restorer (in step 5). After all of the promises that
  *    the restorer is awaiting have resolved, the restorer then resolves its
  *    `restored` promise allowing the application shell to rehydrate its saved
  *    layout.
@@ -155,11 +155,11 @@ const KEY = 'instance-restorer:data';
  * widget has been created and added to the plugin's instance tracker.
  */
 export
-class InstanceRestorer implements IInstanceRestorer {
+class LayoutRestorer implements ILayoutRestorer {
   /**
-   * Create an instance restorer.
+   * Create a layout restorer.
    */
-  constructor(options: InstanceRestorer.IOptions) {
+  constructor(options: LayoutRestorer.IOptions) {
     this._registry = options.registry;
     this._state = options.state;
     this._first = options.first;
@@ -173,14 +173,14 @@ class InstanceRestorer implements IInstanceRestorer {
   }
 
   /**
-   * A promise resolved when the instance restorer is ready to receive signals.
+   * A promise resolved when the layout restorer is ready to receive signals.
    */
   get restored(): Promise<void> {
     return this._restored.promise;
   }
 
   /**
-   * Add a widget to be tracked by the instance restorer.
+   * Add a widget to be tracked by the layout restorer.
    */
   add(widget: Widget, name: string): void {
     Private.nameProperty.set(widget, name);
@@ -231,7 +231,7 @@ class InstanceRestorer implements IInstanceRestorer {
    *
    * @param options - The restoration options.
    */
-  restore(tracker: InstanceTracker<Widget>, options: IInstanceRestorer.IRestoreOptions<Widget>): Promise<any> {
+  restore(tracker: InstanceTracker<Widget>, options: ILayoutRestorer.IRestoreOptions<Widget>): Promise<any> {
     if (!this._promises) {
       let warning = 'restore() can only be called before `first` has resolved.';
       console.warn(warning);
@@ -365,12 +365,12 @@ class InstanceRestorer implements IInstanceRestorer {
 
 
 /**
- * A namespace for `InstanceRestorer` statics.
+ * A namespace for `LayoutRestorer` statics.
  */
 export
-namespace InstanceRestorer {
+namespace LayoutRestorer {
   /**
-   * The configuration options for instance restorer instantiation.
+   * The configuration options for layout restorer instantiation.
    */
   export
   interface IOptions {

--- a/src/apputils/layoutrestorer.ts
+++ b/src/apputils/layoutrestorer.ts
@@ -24,12 +24,16 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  ApplicationShell, InstanceTracker
+  ApplicationShell
 } from '../application';
 
 import {
   IStateDB
 } from '../statedb';
+
+import {
+  InstanceTracker
+} from './';
 
 
 /* tslint:disable */

--- a/src/apputils/plugin.ts
+++ b/src/apputils/plugin.ts
@@ -20,7 +20,7 @@ import {
  * The default layout restorer provider.
  */
 const plugin: JupyterLabPlugin<ILayoutRestorer> = {
-  id: 'jupyter.services.instance-restorer',
+  id: 'jupyter.services.layout-restorer',
   requires: [IStateDB],
   activate: (app: JupyterLab, state: IStateDB) => {
     const first = app.started;

--- a/src/apputils/plugin.ts
+++ b/src/apputils/plugin.ts
@@ -12,27 +12,27 @@ import {
 } from '../statedb';
 
 import {
-  IInstanceRestorer, InstanceRestorer
-} from './instancerestorer';
+  ILayoutRestorer, LayoutRestorer
+} from './layoutrestorer';
 
 
 /**
- * The default instance restorer provider.
+ * The default layout restorer provider.
  */
-const plugin: JupyterLabPlugin<IInstanceRestorer> = {
+const plugin: JupyterLabPlugin<ILayoutRestorer> = {
   id: 'jupyter.services.instance-restorer',
   requires: [IStateDB],
   activate: (app: JupyterLab, state: IStateDB) => {
     const first = app.started;
     const registry = app.commands;
     const shell = app.shell;
-    let restorer = new InstanceRestorer({ first, registry, state });
+    let restorer = new LayoutRestorer({ first, registry, state });
     // Use the restorer as the application shell's layout database.
     shell.setLayoutDB(restorer);
     return restorer;
   },
   autoStart: true,
-  provides: IInstanceRestorer
+  provides: ILayoutRestorer
 };
 
 

--- a/src/commandpalette/plugin.ts
+++ b/src/commandpalette/plugin.ts
@@ -16,8 +16,8 @@ import {
 } from '../application';
 
 import {
-  IInstanceRestorer
-} from '../instancerestorer';
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
 
 import {
   CommandIDs, ICommandPalette, IPaletteItem
@@ -76,7 +76,7 @@ const plugin: JupyterLabPlugin<ICommandPalette> = {
   activate,
   id: 'jupyter.services.commandpalette',
   provides: ICommandPalette,
-  requires: [IInstanceRestorer],
+  requires: [ILayoutRestorer],
   autoStart: true
 };
 
@@ -90,7 +90,7 @@ export default plugin;
 /**
  * Activate the command palette.
  */
-function activate(app: JupyterLab, restorer: IInstanceRestorer): ICommandPalette {
+function activate(app: JupyterLab, restorer: ILayoutRestorer): ICommandPalette {
   const { commands, shell } = app;
   const palette = new CommandPalette({ commands });
 

--- a/src/commandpalette/plugin.ts
+++ b/src/commandpalette/plugin.ts
@@ -17,7 +17,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   CommandIDs, ICommandPalette, IPaletteItem

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -30,7 +30,7 @@ import {
 } from '../coreutils';
 
 import {
-  showDialog, Dialog
+  Dialog, ILayoutRestorer, showDialog
 } from '../apputils';
 
 import {
@@ -40,10 +40,6 @@ import {
 import {
   IPathTracker
 } from '../filebrowser';
-
-import {
-  ILayoutRestorer
-} from '../apputils/layoutrestorer';
 
 import {
   IMainMenu

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -42,8 +42,8 @@ import {
 } from '../filebrowser';
 
 import {
-  IInstanceRestorer
-} from '../instancerestorer';
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
 
 import {
   IMainMenu
@@ -77,7 +77,7 @@ const trackerPlugin: JupyterLabPlugin<IConsoleTracker> = {
     IPathTracker,
     ConsolePanel.IContentFactory,
     IEditorServices,
-    IInstanceRestorer
+    ILayoutRestorer
   ],
   activate: activateConsole,
   autoStart: true
@@ -121,7 +121,7 @@ const CONSOLE_REGEX = /^console-(\d)+-[0-9a-f]+$/;
 /**
  * Activate the console extension.
  */
-function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: IInstanceRestorer): IConsoleTracker {
+function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: ILayoutRestorer): IConsoleTracker {
   let manager = services.sessions;
   let { commands, shell } = app;
   let category = 'Console';

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -14,8 +14,12 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  InstanceTracker, JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin
 } from '../application';
+
+import {
+  InstanceTracker
+} from '../apputils';
 
 import {
   IEditorServices

--- a/src/console/tracker.ts
+++ b/src/console/tracker.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   IInstanceTracker
-} from '../application';
+} from '../apputils';
 
 import {
   ConsolePanel

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  InstanceTracker, JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -14,8 +14,8 @@ import {
 } from '../filebrowser';
 
 import {
-  IInstanceRestorer
-} from '../instancerestorer';
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
 
 import {
   CSVWidget, CSVWidgetFactory
@@ -34,7 +34,7 @@ const FACTORY = 'Table';
 const plugin: JupyterLabPlugin<void> = {
   activate,
   id: 'jupyter.extensions.csv-handler',
-  requires: [IDocumentRegistry, IInstanceRestorer],
+  requires: [IDocumentRegistry, ILayoutRestorer],
   autoStart: true
 };
 
@@ -48,7 +48,7 @@ export default plugin;
 /**
  * Activate the table widget extension.
  */
-function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInstanceRestorer): void {
+function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayoutRestorer): void {
   const factory = new CSVWidgetFactory({
     name: FACTORY,
     fileExtensions: ['.csv'],

--- a/src/csvwidget/plugin.ts
+++ b/src/csvwidget/plugin.ts
@@ -6,16 +6,16 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils';
+
+import {
   IDocumentRegistry
 } from '../docregistry';
 
 import {
   CommandIDs as FileBrowserCommandIDs
 } from '../filebrowser';
-
-import {
-  ILayoutRestorer
-} from '../apputils/layoutrestorer';
 
 import {
   CSVWidget, CSVWidgetFactory

--- a/src/editorwidget/index.ts
+++ b/src/editorwidget/index.ts
@@ -19,7 +19,7 @@ import {
 
 import {
   IInstanceTracker
-} from '../application';
+} from '../apputils';
 
 import {
   CommandIDs as ConsoleCommandIDs

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -6,6 +6,10 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   IEditorServices
 } from '../codeeditor';
 
@@ -18,11 +22,7 @@ import {
 } from '../filebrowser';
 
 import {
-  IInstanceRestorer
-} from '../instancerestorer';
-
-import {
-  IEditorTracker, EditorWidget, EditorWidgetFactory, CommandIDs, addDefaultCommands
+  IEditorTracker, EditorWidget, EditorWidgetFactory, addDefaultCommands
 } from './';
 
 
@@ -43,7 +43,7 @@ const FACTORY = 'Editor';
 const plugin: JupyterLabPlugin<IEditorTracker> = {
   activate,
   id: 'jupyter.services.editor-tracker',
-  requires: [IDocumentRegistry, IInstanceRestorer, IEditorServices],
+  requires: [IDocumentRegistry, ILayoutRestorer, IEditorServices],
   provides: IEditorTracker,
   autoStart: true
 };
@@ -57,7 +57,7 @@ export default plugin;
 /**
  * Activate the editor tracker plugin.
  */
-function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: IInstanceRestorer, editorServices: IEditorServices): IEditorTracker {
+function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayoutRestorer, editorServices: IEditorServices): IEditorTracker {
   const factory = new EditorWidgetFactory({
     editorServices,
     factoryOptions: {

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  InstanceTracker, JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   IEditorServices

--- a/src/faq-extension/index.ts
+++ b/src/faq-extension/index.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  InstanceTracker, JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/faq-extension/index.ts
+++ b/src/faq-extension/index.ts
@@ -6,16 +6,16 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils';
+
+import {
   ICommandLinker
 } from '../commandlinker';
 
 import {
   ICommandPalette
 } from '../commandpalette';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   FaqModel, FaqWidget
@@ -37,7 +37,7 @@ namespace CommandIDs {
 const plugin: JupyterLabPlugin<void> = {
   activate,
   id: 'jupyter.extensions.faq',
-  requires: [ICommandPalette, ICommandLinker, IInstanceRestorer],
+  requires: [ICommandPalette, ICommandLinker, ILayoutRestorer],
   autoStart: true
 };
 
@@ -51,7 +51,7 @@ export default plugin;
 /**
  * Activate the FAQ plugin.
  */
-function activate(app: JupyterLab, palette: ICommandPalette, linker: ICommandLinker, restorer: IInstanceRestorer): void {
+function activate(app: JupyterLab, palette: ICommandPalette, linker: ICommandLinker, restorer: ILayoutRestorer): void {
   const category = 'Help';
   const command = CommandIDs.open;
   const model = new FaqModel();

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -18,6 +18,10 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   ICommandPalette
 } from '../commandpalette';
 
@@ -28,10 +32,6 @@ import {
 import {
   IDocumentRegistry, DocumentRegistry
 } from '../docregistry';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   IMainMenu
@@ -63,7 +63,7 @@ const plugin: JupyterLabPlugin<IPathTracker> = {
     IDocumentRegistry,
     IMainMenu,
     ICommandPalette,
-    IInstanceRestorer,
+    ILayoutRestorer,
     IStateDB
   ],
   autoStart: true
@@ -84,7 +84,7 @@ const NAMESPACE = 'filebrowser';
 /**
  * Activate the file browser.
  */
-function activate(app: JupyterLab, manager: IServiceManager, documentManager: IDocumentManager, registry: IDocumentRegistry, mainMenu: IMainMenu, palette: ICommandPalette, restorer: IInstanceRestorer, state: IStateDB): IPathTracker {
+function activate(app: JupyterLab, manager: IServiceManager, documentManager: IDocumentManager, registry: IDocumentRegistry, mainMenu: IMainMenu, palette: ICommandPalette, restorer: ILayoutRestorer, state: IStateDB): IPathTracker {
   const { commands } = app;
   let fbModel = new FileBrowserModel({ manager });
   let fbWidget = new FileBrowser({

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -19,7 +19,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   ICommandPalette

--- a/src/help-extension/index.ts
+++ b/src/help-extension/index.ts
@@ -14,11 +14,11 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  InstanceTracker, JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  IFrameWidget, ILayoutRestorer
+  IFrameWidget, ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/help-extension/index.ts
+++ b/src/help-extension/index.ts
@@ -18,11 +18,7 @@ import {
 } from '../application';
 
 import {
-  ILayoutRestorer
-} from '../apputils/layoutrestorer';
-
-import {
-  IFrameWidget
+  IFrameWidget, ILayoutRestorer
 } from '../apputils';
 
 import {

--- a/src/help-extension/index.ts
+++ b/src/help-extension/index.ts
@@ -18,6 +18,10 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   IFrameWidget
 } from '../apputils';
 
@@ -28,10 +32,6 @@ import {
 import {
   ICommandPalette
 } from '../commandpalette';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   IMainMenu
@@ -139,7 +139,7 @@ RESOURCES.sort((a: any, b: any) => {
 const plugin: JupyterLabPlugin<void> = {
   activate,
   id: 'jupyter.extensions.help-handler',
-  requires: [IMainMenu, ICommandPalette, IInstanceRestorer],
+  requires: [IMainMenu, ICommandPalette, ILayoutRestorer],
   autoStart: true
 };
 
@@ -172,7 +172,7 @@ class ClosableIFrame extends IFrameWidget {
  *
  * returns A promise that resolves when the extension is activated.
  */
-function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette, restorer: IInstanceRestorer): void {
+function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette, restorer: ILayoutRestorer): void {
   let counter = 0;
   const category = 'Help';
   const namespace = 'help-doc';

--- a/src/imagewidget/index.ts
+++ b/src/imagewidget/index.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   IInstanceTracker
-} from '../application';
+} from '../apputils';
 
 import {
   ImageWidget

--- a/src/imagewidget/plugin.ts
+++ b/src/imagewidget/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   ICommandPalette

--- a/src/imagewidget/plugin.ts
+++ b/src/imagewidget/plugin.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  InstanceTracker, JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/imagewidget/plugin.ts
+++ b/src/imagewidget/plugin.ts
@@ -6,6 +6,10 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   ICommandPalette
 } from '../commandpalette';
 
@@ -16,10 +20,6 @@ import {
 import {
   CommandIDs as FileBrowserCommandIDs
 } from '../filebrowser';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   CommandIDs, ImageWidget, ImageWidgetFactory, IImageTracker
@@ -44,7 +44,7 @@ const plugin: JupyterLabPlugin<IImageTracker> = {
   activate,
   id: 'jupyter.extensions.image-handler',
   provides: IImageTracker,
-  requires: [IDocumentRegistry, ICommandPalette, IInstanceRestorer],
+  requires: [IDocumentRegistry, ICommandPalette, ILayoutRestorer],
   autoStart: true
 };
 
@@ -58,7 +58,7 @@ export default plugin;
 /**
  * Activate the image widget extension.
  */
-function activate(app: JupyterLab, registry: IDocumentRegistry, palette: ICommandPalette, restorer: IInstanceRestorer): IImageTracker {
+function activate(app: JupyterLab, registry: IDocumentRegistry, palette: ICommandPalette, restorer: ILayoutRestorer): IImageTracker {
   const namespace = 'image-widget';
   const factory = new ImageWidgetFactory({
     name: FACTORY,

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -6,16 +6,16 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   ICommandPalette
 } from '../commandpalette';
 
 import {
   IConsoleTracker
 } from '../console';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   INotebookTracker
@@ -35,10 +35,10 @@ import {
  */
 const service: JupyterLabPlugin<IInspector> = {
   id: 'jupyter.services.inspector',
-  requires: [ICommandPalette, IInstanceRestorer],
+  requires: [ICommandPalette, ILayoutRestorer],
   provides: IInspector,
   autoStart: true,
-  activate: (app: JupyterLab, palette: ICommandPalette, restorer: IInstanceRestorer): IInspector => {
+  activate: (app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRestorer): IInspector => {
     const { commands, shell } = app;
     const manager = new InspectorManager();
     const category = 'Inspector';

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   ICommandPalette

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  InstanceTracker, JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/instancerestorer/index.ts
+++ b/src/instancerestorer/index.ts
@@ -1,8 +1,0 @@
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-export {
-  IInstanceRestorer
-} from './instancerestorer';

--- a/src/landing-extension/index.ts
+++ b/src/landing-extension/index.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   ICommandPalette

--- a/src/landing-extension/index.ts
+++ b/src/landing-extension/index.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  InstanceTracker, JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/landing-extension/index.ts
+++ b/src/landing-extension/index.ts
@@ -6,16 +6,16 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   ICommandPalette
 } from '../commandpalette';
 
 import {
   IPathTracker
 } from '../filebrowser';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   IServiceManager
@@ -46,7 +46,7 @@ const LANDING_CLASS = 'jp-Landing';
 const plugin: JupyterLabPlugin<void> = {
   activate,
   id: 'jupyter.extensions.landing',
-  requires: [IPathTracker, ICommandPalette, IServiceManager, IInstanceRestorer],
+  requires: [IPathTracker, ICommandPalette, IServiceManager, ILayoutRestorer],
   autoStart: true
 };
 
@@ -60,7 +60,7 @@ export default plugin;
 /**
  * Activate the landing plugin.
  */
-function activate(app: JupyterLab, pathTracker: IPathTracker, palette: ICommandPalette, services: IServiceManager, restorer: IInstanceRestorer): void {
+function activate(app: JupyterLab, pathTracker: IPathTracker, palette: ICommandPalette, services: IServiceManager, restorer: ILayoutRestorer): void {
   const { commands, shell } = app;
   const category = 'Help';
   const command = CommandIDs.open;

--- a/src/launcher/plugin.ts
+++ b/src/launcher/plugin.ts
@@ -6,6 +6,10 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   ICommandLinker
 } from '../commandlinker';
 
@@ -20,10 +24,6 @@ import {
 import {
   CommandIDs as FileBrowserCommandIDs
 } from '../filebrowser';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   IPathTracker
@@ -53,7 +53,7 @@ const plugin: JupyterLabPlugin<ILauncher> = {
     IPathTracker,
     ICommandPalette,
     ICommandLinker,
-    IInstanceRestorer
+    ILayoutRestorer
   ],
   provides: ILauncher,
   autoStart: true
@@ -69,7 +69,7 @@ export default plugin;
 /**
  * Activate the launcher.
  */
-function activate(app: JupyterLab, services: IServiceManager, pathTracker: IPathTracker, palette: ICommandPalette, linker: ICommandLinker, restorer: IInstanceRestorer): ILauncher {
+function activate(app: JupyterLab, services: IServiceManager, pathTracker: IPathTracker, palette: ICommandPalette, linker: ICommandLinker, restorer: ILayoutRestorer): ILauncher {
   const { commands, shell } = app;
 
   let model = new LauncherModel();

--- a/src/launcher/plugin.ts
+++ b/src/launcher/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   ICommandLinker

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   IDocumentRegistry

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JupyterLab, JupyterLabPlugin, InstanceTracker
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -6,16 +6,16 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   IDocumentRegistry
 } from '../docregistry';
 
 import {
   CommandIDs as FileBrowserCommandIDs
 } from '../filebrowser';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   IRenderMime
@@ -43,7 +43,7 @@ const FACTORY = 'Rendered Markdown';
 const plugin: JupyterLabPlugin<void> = {
   activate,
   id: 'jupyter.extensions.rendered-markdown',
-  requires: [IDocumentRegistry, IRenderMime, IInstanceRestorer],
+  requires: [IDocumentRegistry, IRenderMime, ILayoutRestorer],
   autoStart: true
 };
 
@@ -51,7 +51,7 @@ const plugin: JupyterLabPlugin<void> = {
 /**
  * Activate the markdown plugin.
  */
-function activate(app: JupyterLab, registry: IDocumentRegistry, rendermime: IRenderMime, restorer: IInstanceRestorer) {
+function activate(app: JupyterLab, registry: IDocumentRegistry, rendermime: IRenderMime, restorer: ILayoutRestorer) {
     const factory = new MarkdownWidgetFactory({
       name: FACTORY,
       fileExtensions: ['.md'],

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -14,6 +14,10 @@ import {
 } from '../application';
 
 import {
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
+
+import {
   IEditorServices
 } from '../codeeditor';
 
@@ -32,10 +36,6 @@ import {
 import {
   CommandIDs as FileBrowserCommandIDs
 } from '../filebrowser';
-
-import {
-  IInstanceRestorer
-} from '../instancerestorer';
 
 import {
   IRenderMime
@@ -82,7 +82,7 @@ const trackerPlugin: JupyterLabPlugin<INotebookTracker> = {
     ICommandPalette,
     NotebookPanel.IContentFactory,
     IEditorServices,
-    IInstanceRestorer
+    ILayoutRestorer
   ],
   activate: activateNotebookHandler,
   autoStart: true
@@ -112,7 +112,7 @@ const cellToolsPlugin: JupyterLabPlugin<ICellTools> = {
   provides: ICellTools,
   id: 'jupyter.extensions.cell-tools',
   autoStart: true,
-  requires: [IInstanceRestorer, INotebookTracker, IEditorServices]
+  requires: [ILayoutRestorer, INotebookTracker, IEditorServices]
 };
 
 
@@ -126,7 +126,7 @@ export default plugins;
 /**
  * Activate the cell tools extension.
  */
-function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker: INotebookTracker, editorServices: IEditorServices): Promise<ICellTools> {
+function activateCellTools(app: JupyterLab, restorer: ILayoutRestorer, tracker: INotebookTracker, editorServices: IEditorServices): Promise<ICellTools> {
   const namespace = 'cell-tools';
 
   const celltools = new CellTools({ tracker });
@@ -168,7 +168,7 @@ function activateCellTools(app: JupyterLab, restorer: IInstanceRestorer, tracker
 /**
  * Activate the notebook handler extension.
  */
-function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, contentFactory: NotebookPanel.IContentFactory, editorServices: IEditorServices, restorer: IInstanceRestorer): INotebookTracker {
+function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, contentFactory: NotebookPanel.IContentFactory, editorServices: IEditorServices, restorer: ILayoutRestorer): INotebookTracker {
 
   const factory = new NotebookWidgetFactory({
     name: FACTORY,

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -15,7 +15,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   IEditorServices

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   IInstanceTracker, InstanceTracker
-} from '../application';
+} from '../apputils';
 
 import {
   NotebookPanel, Notebook

--- a/src/running/plugin.ts
+++ b/src/running/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   CommandIDs as ConsoleCommandIDs

--- a/src/running/plugin.ts
+++ b/src/running/plugin.ts
@@ -6,12 +6,12 @@ import {
 } from '../application';
 
 import {
-  CommandIDs as ConsoleCommandIDs
-} from '../console';
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
 
 import {
-  IInstanceRestorer
-} from '../instancerestorer';
+  CommandIDs as ConsoleCommandIDs
+} from '../console';
 
 import {
   CommandIDs as FileBrowserCommandIDs
@@ -36,7 +36,7 @@ import {
 const plugin: JupyterLabPlugin<void> = {
   activate,
   id: 'jupyter.extensions.running-sessions',
-  requires: [IServiceManager, IInstanceRestorer],
+  requires: [IServiceManager, ILayoutRestorer],
   autoStart: true
 };
 
@@ -50,7 +50,7 @@ export default plugin;
 /**
  * Activate the running plugin.
  */
-function activate(app: JupyterLab, services: IServiceManager, restorer: IInstanceRestorer): void {
+function activate(app: JupyterLab, services: IServiceManager, restorer: ILayoutRestorer): void {
   let running = new RunningSessions({ manager: services });
   running.id = 'jp-running-sessions';
   running.title.label = 'Running';

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   IInstanceTracker
-} from '../application';
+} from '../apputils';
 
 import {
   TerminalWidget

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   ILayoutRestorer
-} from '../apputils/layoutrestorer';
+} from '../apputils';
 
 import {
   ICommandPalette

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -11,12 +11,12 @@ import {
 } from '../application';
 
 import {
-  ICommandPalette
-} from '../commandpalette';
+  ILayoutRestorer
+} from '../apputils/layoutrestorer';
 
 import {
-  IInstanceRestorer
-} from '../instancerestorer';
+  ICommandPalette
+} from '../commandpalette';
 
 import {
   IMainMenu
@@ -45,7 +45,7 @@ const plugin: JupyterLabPlugin<ITerminalTracker> = {
   id: 'jupyter.extensions.terminal',
   provides: ITerminalTracker,
   requires: [
-    IServiceManager, IMainMenu, ICommandPalette, IInstanceRestorer
+    IServiceManager, IMainMenu, ICommandPalette, ILayoutRestorer
   ],
   autoStart: true
 };
@@ -60,7 +60,7 @@ export default plugin;
 /**
  * Activate the terminal plugin.
  */
-function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMenu, palette: ICommandPalette, restorer: IInstanceRestorer): ITerminalTracker {
+function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMenu, palette: ICommandPalette, restorer: ILayoutRestorer): ITerminalTracker {
   // Bail if there are no terminals available.
   if (!services.terminals.isAvailable()) {
     console.log('Disabling terminals plugin because they are not available on the server');

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -7,11 +7,11 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  JupyterLab, JupyterLabPlugin, InstanceTracker
+  JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  ILayoutRestorer
+  ILayoutRestorer, InstanceTracker
 } from '../apputils';
 
 import {

--- a/test/src/apputils/instancetracker.spec.ts
+++ b/test/src/apputils/instancetracker.spec.ts
@@ -16,8 +16,12 @@ import {
 } from 'simulate-event';
 
 import {
-  ApplicationShell, InstanceTracker
+  ApplicationShell
 } from '../../../lib/application';
+
+import {
+  InstanceTracker
+} from '../../../lib/apputils';
 
 
 const namespace = 'instance-tracker-test';

--- a/test/src/apputils/layoutrestorer.spec.ts
+++ b/test/src/apputils/layoutrestorer.spec.ts
@@ -20,30 +20,30 @@ import {
 } from '../../../lib/application';
 
 import {
-  InstanceRestorer
-} from '../../../lib/instancerestorer/instancerestorer';
+  LayoutRestorer
+} from '../../../lib/apputils/layoutrestorer';
 
 import {
   StateDB
 } from '../../../lib/statedb/statedb';
 
 
-const NAMESPACE = 'jupyterlab-instance-restorer-tests';
+const NAMESPACE = 'jupyterlab-layout-restorer-tests';
 
 
-describe('instancerestorer/instancerestorer', () => {
+describe('apputils', () => {
 
-  describe('InstanceRestorer', () => {
+  describe('LayoutRestorer', () => {
 
     describe('#constructor()', () => {
 
       it('should construct a new layout restorer', () => {
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: Promise.resolve<void>(void 0),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
         });
-        expect(restorer).to.be.an(InstanceRestorer);
+        expect(restorer).to.be.a(LayoutRestorer);
       });
 
     });
@@ -51,7 +51,7 @@ describe('instancerestorer/instancerestorer', () => {
     describe('#restored', () => {
 
       it('should be a promise available right away', () => {
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: Promise.resolve<void>(void 0),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -61,7 +61,7 @@ describe('instancerestorer/instancerestorer', () => {
 
       it('should resolve when restorer is done', done => {
         let ready = new utils.PromiseDelegate<void>();
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: ready.promise,
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -76,7 +76,7 @@ describe('instancerestorer/instancerestorer', () => {
 
       it('should add a widget to be tracked by the restorer', done => {
         let ready = new utils.PromiseDelegate<void>();
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: ready.promise,
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -102,7 +102,7 @@ describe('instancerestorer/instancerestorer', () => {
     describe('#fetch()', () => {
 
       it('should always return a value', done => {
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: Promise.resolve(void 0),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -115,7 +115,7 @@ describe('instancerestorer/instancerestorer', () => {
 
       it('should fetch saved data', done => {
         let ready = new utils.PromiseDelegate<void>();
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: ready.promise,
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -154,7 +154,7 @@ describe('instancerestorer/instancerestorer', () => {
         let registry = new CommandRegistry();
         let state = new StateDB({ namespace: NAMESPACE });
         let ready = new utils.PromiseDelegate<void>();
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: ready.promise, registry, state
         });
         let called = false;
@@ -182,7 +182,7 @@ describe('instancerestorer/instancerestorer', () => {
     describe('#save()', () => {
 
       it('should not run before `first` promise', done => {
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: new Promise(() => { /* no op */ }),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -199,7 +199,7 @@ describe('instancerestorer/instancerestorer', () => {
 
       it('should save data', done => {
         let ready = new utils.PromiseDelegate<void>();
-        let restorer = new InstanceRestorer({
+        let restorer = new LayoutRestorer({
           first: ready.promise,
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })

--- a/test/src/apputils/layoutrestorer.spec.ts
+++ b/test/src/apputils/layoutrestorer.spec.ts
@@ -16,12 +16,12 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  ApplicationShell, InstanceTracker
+  ApplicationShell
 } from '../../../lib/application';
 
 import {
-  LayoutRestorer
-} from '../../../lib/apputils/layoutrestorer';
+  InstanceTracker, LayoutRestorer
+} from '../../../lib/apputils';
 
 import {
   StateDB

--- a/test/src/apputils/layoutrestorer.spec.ts
+++ b/test/src/apputils/layoutrestorer.spec.ts
@@ -37,7 +37,7 @@ describe('instancerestorer/instancerestorer', () => {
 
     describe('#constructor()', () => {
 
-      it('should construct a new instance restorer', () => {
+      it('should construct a new layout restorer', () => {
         let restorer = new InstanceRestorer({
           first: Promise.resolve<void>(void 0),
           registry: new CommandRegistry(),

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -3,12 +3,12 @@
 
 import '@phosphor/widgets/style/index.css';
 
-import './application/instancetracker.spec';
 import './application/loader.spec';
 import './application/shell.spec';
 
 import './apputils/dialog.spec';
 import './apputils/iframe.spec';
+import './apputils/instancetracker.spec';
 import './apputils/jsoneditor.spec';
 import './apputils/layoutrestorer.spec';
 import './apputils/sanitizer.spec';

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -10,6 +10,7 @@ import './application/shell.spec';
 import './apputils/dialog.spec';
 import './apputils/iframe.spec';
 import './apputils/jsoneditor.spec';
+import './apputils/layoutrestorer.spec';
 import './apputils/sanitizer.spec';
 import './apputils/styling.spec';
 import './apputils/vdom.spec';
@@ -66,8 +67,6 @@ import './filebrowser/model.spec';
 import './imagewidget/widget.spec';
 
 import './inspector/inspector.spec';
-
-import './instancerestorer/instancerestorer.spec';
 
 import './markdownwidget/widget.spec';
 

--- a/tutorial/plugins.md
+++ b/tutorial/plugins.md
@@ -28,9 +28,9 @@ exporting a plugin object or array of plugin objects as the default export.
 
 The default plugins in the JupyterLab application include:
 - [Terminal](https://github.com/jupyterlab/jupyterlab/blob/master/src/terminal/plugin.ts) - Adds the ability to create command prompt terminals.
-- [Shortcuts](https://github.com/jupyterlab/jupyterlab/blob/master/src/shortcuts/plugin.ts) - Provides the default set of shortcuts for the application.
+- [Shortcuts](https://github.com/jupyterlab/jupyterlab/blob/master/src/shortcuts-extension/index.ts) - Sets the default set of shortcuts for the application.
 - [Images](https://github.com/jupyterlab/jupyterlab/blob/master/src/imagewidget/plugin.ts) - Adds a widget factory for displaying image files.
-- [Help](https://github.com/jupyterlab/jupyterlab/blob/master/src/help/plugin.ts) - Adds a side bar widget for displaying external documentation.
+- [Help](https://github.com/jupyterlab/jupyterlab/blob/master/src/help-extension/index.ts) - Adds a side bar widget for displaying external documentation.
 - [File Browser](https://github.com/jupyterlab/jupyterlab/blob/master/src/filebrowser/plugin.ts) - Creates the file browser and the document manager and the file browser to the side bar.
 - [Editor](https://github.com/jupyterlab/jupyterlab/blob/master/src/editorwidget/plugin.ts) - Add a widget factory for displaying editable source files.
 - [Console](https://github.com/jupyterlab/jupyterlab/blob/master/src/console/plugin.ts) - Adds the ability to launch Jupyter Console instances for

--- a/tutorial/plugins.md
+++ b/tutorial/plugins.md
@@ -38,7 +38,6 @@ interactive kernel console sessions.
 - [Services](https://github.com/jupyterlab/jupyterlab/blob/master/src/services/plugin.ts) - An application-specific interface to `@jupyterlab/services`.
 - [RenderMime](https://github.com/jupyterlab/jupyterlab/blob/master/src/rendermime/plugin.ts) - The registry for adding kernel `display_data` renderers.
 - [Document Registry](https://github.com/jupyterlab/jupyterlab/blob/master/src/docregistry/plugin.ts) - Used to add functionality around widgets backed by files.
-- [Instance Restorer](https://github.com/jupyterlab/jupyterlab/blob/master/src/instancerestorer/instancerestorer.ts) - The application-wide instance restorer, which takes care of the application state restoration lifecycle.
 
 ## Application Object
 The JupyterLab Application object is given to each plugin in


### PR DESCRIPTION
- [x] Rename instance restorer to layout restorer.
- [x] Move layout restorer it into `apputils` and expose it as a plugin.
- [x] Remove all references to instance restorer from instance tracker.
- [x] Move instance tracker to `apputils`.