### PR TITLE
[WIP] Cell uuid

### DIFF
--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -10,12 +10,8 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  utils
-} from '@jupyterlab/services';
-
-import {
   IObservableMap, ObservableMap, IObservableVector, ObservableVector,
-  IObservableUndoableVector, ObservableUndoableVector
+  IObservableUndoableVector, ObservableUndoableVector, uuid
 } from '@jupyterlab/coreutils';
 
 import {
@@ -33,8 +29,8 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   constructor() {
     this._cellOrder = new ObservableUndoableVector<string>({
-      toJSON: (val: string)=>{return val;},
-      fromJSON: (val: string)=>{return val;}
+      toJSON: (val: string) => { return val; },
+      fromJSON: (val: string) => { return val; }
     });
     this._cellMap = new ObservableMap<ICellModel>();
 
@@ -208,7 +204,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   set(index: number, cell: ICellModel): void {
     // Generate a new uuid for the cell.
-    let id = utils.uuid();
+    let id = uuid();
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     this._cellOrder.set(index, id);
@@ -234,7 +230,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   pushBack(cell: ICellModel): number {
     // Generate a new uuid for the cell.
-    let id = utils.uuid();
+    let id = uuid();
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     let num = this._cellOrder.pushBack(id);
@@ -288,7 +284,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   insert(index: number, cell: ICellModel): number {
     // Generate a new uuid for the cell.
-    let id = utils.uuid();
+    let id = uuid();
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     let num = this._cellOrder.insert(index, id);
@@ -395,7 +391,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     let newValues = toArray(cells);
     each(newValues, cell => {
       // Generate a new uuid for the cell.
-      let id = utils.uuid();
+      let id = uuid();
       // Set the internal data structures.
       this._cellMap.set(id, cell);
       this._cellOrder.pushBack(id);
@@ -433,7 +429,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     let newValues = toArray(cells);
     each(newValues, cell => {
       // Generate a new uuid for the cell.
-      let id = utils.uuid();
+      let id = uuid();
       this._cellMap.set(id, cell);
       this._cellOrder.beginCompoundOperation();
       this._cellOrder.insert(index++, id);
@@ -518,7 +514,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     // cell order.
     for (let key of this._cellMap.keys()) {
       if (ArrayExt.findFirstIndex(
-         toArray(this._cellOrder), id => (id)===key) === -1) {
+         toArray(this._cellOrder), id => id===key) === -1) {
         let cell = this._cellMap.get(key) as ICellModel;
         cell.dispose();
         this._cellMap.delete(key);

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -219,16 +219,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     let id = utils.uuid();
     // Set the internal data structures.
     this._cellMap.set(id, value);
-    //let oldId = this._cellOrder.at(index);
-    //let oldValue = this._cellMap.get(oldId.id);
     this._cellOrder.set(index, new CellID(id));
-    /*this._changed.emit({
-      type: 'set',
-      oldIndex: index,
-      newIndex: index,
-      oldValues: [oldValue],
-      newValues: [value]
-    });*/
   }
 
   /**
@@ -250,13 +241,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     // Set the internal data structures.
     this._cellMap.set(id, value);
     let num = this._cellOrder.pushBack(new CellID(id));
-    /*this._changed.emit({
-      type: 'add',
-      oldIndex: -1,
-      newIndex: this.length - 1,
-      oldValues: [],
-      newValues: [value]
-    });*/
     return num;
   }
 
@@ -276,13 +260,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     //Don't clear the map in case we need to reinstate the cell
     let id = this._cellOrder.popBack();
     let value = this._cellMap.get(id.id);
-    /*this._changed.emit({
-      type: 'remove',
-      oldIndex: this.length,
-      newIndex: -1,
-      oldValues: [value],
-      newValues: []
-    });*/
     return value;
   }
 
@@ -311,15 +288,8 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     // Generate a new uuid for the cell.
     let id = utils.uuid();
     // Set the internal data structures.
-    let num = this._cellOrder.insert(index, new CellID(id));
     this._cellMap.set(id, value);
-    /*this._changed.emit({
-      type: 'add',
-      oldIndex: -1,
-      newIndex: index,
-      oldValues: [],
-      newValues: [value]
-    });*/
+    let num = this._cellOrder.insert(index, new CellID(id));
     return num;
   }
 
@@ -338,7 +308,8 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * Iterators pointing at the removed value and beyond are invalidated.
    */
   remove(value: ICellModel): number {
-    let index = ArrayExt.findFirstIndex(toArray(this._cellOrder), id => (this._cellMap.get(id.id)===value));
+    let index = ArrayExt.findFirstIndex(
+      toArray(this._cellOrder), id => (this._cellMap.get(id.id)===value));
     this.removeAt(index);
     return index;
   }
@@ -363,13 +334,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   removeAt(index: number): ICellModel {
     let id= this._cellOrder.removeAt(index);
     let value = this._cellMap.get(id.id);
-    /*this._changed.emit({
-      type: 'remove',
-      oldIndex: index,
-      newIndex: -1,
-      oldValues: [value],
-      newValues: []
-    });*/
     return value;
   }
 
@@ -388,13 +352,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
       oldValues.push(this._cellMap.get(id.id));
     }
     this._cellOrder.clear();
-    /*this._changed.emit({
-      type: 'remove',
-      oldIndex: 0,
-      newIndex: 0,
-      oldValues,
-      newValues: []
-    });*/
   }
 
   /**
@@ -417,13 +374,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   move(fromIndex: number, toIndex: number): void {
     let value = this.at(fromIndex);
     this._cellOrder.move(fromIndex, toIndex);
-    /*this._changed.emit({
-      type: 'move',
-      oldIndex: fromIndex,
-      newIndex: toIndex,
-      oldValues: [value],
-      newValues: [value]
-    });*/
   }
 
   /**
@@ -449,13 +399,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
       this._cellMap.set(id, value);
       let num = this._cellOrder.pushBack(new CellID(id));
     });
-    /*this._changed.emit({
-      type: 'add',
-      oldIndex: -1,
-      newIndex,
-      oldValues: [],
-      newValues
-    });*/
     return this.length;
   }
 
@@ -489,13 +432,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
       this._cellMap.set(id, value);
       this._cellOrder.insert(index++, new CellID(id));
     });
-    /*this._changed.emit({
-      type: 'add',
-      oldIndex: -1,
-      newIndex,
-      oldValues: [],
-      newValues
-    });*/
     return this.length;
   }
 
@@ -523,13 +459,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
       let id = this._cellOrder.removeAt(startIndex);
       oldValues.push(this._cellMap.get(id.id));
     }
-    /*this._changed.emit({
-      type: 'remove',
-      oldIndex: startIndex,
-      newIndex: -1,
-      oldValues,
-      newValues: []
-    });*/
     return this.length;
   }
 

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -1,0 +1,610 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  JSONObject
+} from '@phosphor/coreutils';
+
+import {
+  ArrayExt, IIterator, IterableOrArrayLike, each, toArray, ArrayIterator
+} from '@phosphor/algorithm';
+
+import {
+  ISignal, Signal
+} from '@phosphor/signaling';
+
+import {
+  utils
+} from '@jupyterlab/services';
+
+import {
+  IObservableMap, ObservableMap, IObservableVector, ObservableVector,
+  IObservableUndoableVector, ObservableUndoableVector, ISerializable
+} from '@jupyterlab/coreutils';
+
+import {
+  ICellModel
+} from '@jupyterlab/cells';
+
+
+/**
+ * Unfortunate, this.
+ */
+class CellID implements ISerializable { 
+  constructor(id: string) {
+    this.id = id;
+  }
+
+  readonly id: string;
+
+  toJSON(): JSONObject {
+    return { id: this.id };
+  }
+}
+
+/**
+ * A cell list object that supports undo/redo.
+ */
+export
+class CellList implements IObservableUndoableVector<ICellModel> {
+  /**
+   * Construct the cell list.
+   */
+  constructor() {
+    this._cellOrder = new ObservableUndoableVector<CellID>((id: JSONObject) => {
+      return new CellID((id as any).id);
+    });
+    this._cellMap = new ObservableMap<ICellModel>();
+
+    this._cellOrder.changed.connect(this._onOrderChanged, this);
+  }
+
+  /**
+   * A signal emitted when the cell list has changed.
+   */
+  get changed(): ISignal<this, ObservableVector.IChangedArgs<ICellModel>> {
+    return this._changed;
+  }
+
+  /**
+   * Test whether the cell list has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Test whether the list is empty.
+   *
+   * @returns `true` if the vector is empty, `false` otherwise.
+   *
+   * #### Notes
+   * This is a read-only property.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * No changes.
+   */
+  get isEmpty(): boolean {
+    return this._cellOrder.length === 0;
+  }
+
+  /**
+   * Get the length of the vector.
+   *
+   * @return The number of values in the vector.
+   *
+   * #### Notes
+   * This is a read-only property.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * No changes.
+   */
+  get length(): number {
+    return this._cellOrder.length;
+  }
+
+  /**
+   * Get the value at the front of the vector.
+   *
+   * @returns The value at the front of the vector, or `undefined` if
+   *   the vector is empty.
+   *
+   * #### Notes
+   * This is a read-only property.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * No changes.
+   */
+  get front(): ICellModel {
+    return this.at(0);
+  }
+
+  /**
+   * Get the value at the back of the vector.
+   *
+   * @returns The value at the back of the vector, or `undefined` if
+   *   the vector is empty.
+   *
+   * #### Notes
+   * This is a read-only property.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * No changes.
+   */
+  get back(): ICellModel {
+    return this.at(this.length-1);
+  }
+
+  /**
+   * Create an iterator over the values in the vector.
+   *
+   * @returns A new iterator starting at the front of the vector.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * No changes.
+   */
+  iter(): IIterator<ICellModel> {
+    let arr: ICellModel[] = [];
+    for(let id of toArray(this._cellOrder)) {
+      arr.push(this._cellMap.get(id.id));
+    }
+    return new ArrayIterator<ICellModel>(arr);
+  }
+
+  /**
+   * Dispose of the resources held by the vector.
+   */
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    Signal.clearData(this);
+    this.clear();
+  }
+
+  /**
+   * Get the value at the specified index.
+   *
+   * @param index - The positive integer index of interest.
+   *
+   * @returns The value at the specified index.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * No changes.
+   *
+   * #### Undefined Behavior
+   * An `index` which is non-integral or out of range.
+   */
+  at(index: number): ICellModel {
+    return this._cellMap.get(this._cellOrder.at(index).id) as ICellModel;
+  }
+
+  /**
+   * Set the value at the specified index.
+   *
+   * @param index - The positive integer index of interest.
+   *
+   * @param value - The value to set at the specified index.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * No changes.
+   *
+   * #### Undefined Behavior
+   * An `index` which is non-integral or out of range.
+   */
+  set(index: number, value: ICellModel): void {
+    // Generate a new uuid for the cell.
+    let id = utils.uuid();
+    // Set the internal data structures.
+    this._cellMap.set(id, value);
+    //let oldId = this._cellOrder.at(index);
+    //let oldValue = this._cellMap.get(oldId.id);
+    this._cellOrder.set(index, new CellID(id));
+    /*this._changed.emit({
+      type: 'set',
+      oldIndex: index,
+      newIndex: index,
+      oldValues: [oldValue],
+      newValues: [value]
+    });*/
+  }
+
+  /**
+   * Add a value to the back of the vector.
+   *
+   * @param value - The value to add to the back of the vector.
+   *
+   * @returns The new length of the vector.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * No changes.
+   */
+  pushBack(value: ICellModel): number {
+    // Generate a new uuid for the cell.
+    let id = utils.uuid();
+    // Set the internal data structures.
+    this._cellMap.set(id, value);
+    let num = this._cellOrder.pushBack(new CellID(id));
+    /*this._changed.emit({
+      type: 'add',
+      oldIndex: -1,
+      newIndex: this.length - 1,
+      oldValues: [],
+      newValues: [value]
+    });*/
+    return num;
+  }
+
+  /**
+   * Remove and return the value at the back of the vector.
+   *
+   * @returns The value at the back of the vector, or `undefined` if
+   *   the vector is empty.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * Iterators pointing at the removed value are invalidated.
+   */
+  popBack(): ICellModel {
+    //Don't clear the map in case we need to reinstate the cell
+    let id = this._cellOrder.popBack();
+    let value = this._cellMap.get(id.id);
+    /*this._changed.emit({
+      type: 'remove',
+      oldIndex: this.length,
+      newIndex: -1,
+      oldValues: [value],
+      newValues: []
+    });*/
+    return value;
+  }
+
+  /**
+   * Insert a value into the vector at a specific index.
+   *
+   * @param index - The index at which to insert the value.
+   *
+   * @param value - The value to set at the specified index.
+   *
+   * @returns The new length of the vector.
+   *
+   * #### Complexity
+   * Linear.
+   *
+   * #### Iterator Validity
+   * No changes.
+   *
+   * #### Notes
+   * The `index` will be clamped to the bounds of the vector.
+   *
+   * #### Undefined Behavior
+   * An `index` which is non-integral.
+   */
+  insert(index: number, value: ICellModel): number {
+    // Generate a new uuid for the cell.
+    let id = utils.uuid();
+    // Set the internal data structures.
+    let num = this._cellOrder.insert(index, new CellID(id));
+    this._cellMap.set(id, value);
+    /*this._changed.emit({
+      type: 'add',
+      oldIndex: -1,
+      newIndex: index,
+      oldValues: [],
+      newValues: [value]
+    });*/
+    return num;
+  }
+
+  /**
+   * Remove the first occurrence of a value from the vector.
+   *
+   * @param value - The value of interest.
+   *
+   * @returns The index of the removed value, or `-1` if the value
+   *   is not contained in the vector.
+   *
+   * #### Complexity
+   * Linear.
+   *
+   * #### Iterator Validity
+   * Iterators pointing at the removed value and beyond are invalidated.
+   */
+  remove(value: ICellModel): number {
+    let index = ArrayExt.findFirstIndex(toArray(this._cellOrder), id => (this._cellMap.get(id.id)===value));
+    this.removeAt(index);
+    return index;
+  }
+
+  /**
+   * Remove and return the value at a specific index.
+   *
+   * @param index - The index of the value of interest.
+   *
+   * @returns The value at the specified index, or `undefined` if the
+   *   index is out of range.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * Iterators pointing at the removed value and beyond are invalidated.
+   *
+   * #### Undefined Behavior
+   * An `index` which is non-integral.
+   */
+  removeAt(index: number): ICellModel {
+    let id= this._cellOrder.removeAt(index);
+    let value = this._cellMap.get(id.id);
+    /*this._changed.emit({
+      type: 'remove',
+      oldIndex: index,
+      newIndex: -1,
+      oldValues: [value],
+      newValues: []
+    });*/
+    return value;
+  }
+
+  /**
+   * Remove all values from the vector.
+   *
+   * #### Complexity
+   * Linear.
+   *
+   * #### Iterator Validity
+   * All current iterators are invalidated.
+   */
+  clear(): void {
+    let oldValues: ICellModel[] = []
+    for(let id of toArray(this._cellOrder)) {
+      oldValues.push(this._cellMap.get(id.id));
+    }
+    this._cellOrder.clear();
+    /*this._changed.emit({
+      type: 'remove',
+      oldIndex: 0,
+      newIndex: 0,
+      oldValues,
+      newValues: []
+    });*/
+  }
+
+  /**
+   * Move a value from one index to another.
+   *
+   * @parm fromIndex - The index of the element to move.
+   *
+   * @param toIndex - The index to move the element to.
+   *
+   * #### Complexity
+   * Constant.
+   *
+   * #### Iterator Validity
+   * Iterators pointing at the lesser of the `fromIndex` and the `toIndex`
+   * and beyond are invalidated.
+   *
+   * #### Undefined Behavior
+   * A `fromIndex` or a `toIndex` which is non-integral.
+   */
+  move(fromIndex: number, toIndex: number): void {
+    let value = this.at(fromIndex);
+    this._cellOrder.move(fromIndex, toIndex);
+    /*this._changed.emit({
+      type: 'move',
+      oldIndex: fromIndex,
+      newIndex: toIndex,
+      oldValues: [value],
+      newValues: [value]
+    });*/
+  }
+
+  /**
+   * Push a set of values to the back of the vector.
+   *
+   * @param values - An iterable or array-like set of values to add.
+   *
+   * @returns The new length of the vector.
+   *
+   * #### Complexity
+   * Linear.
+   *
+   * #### Iterator Validity
+   * No changes.
+   */
+  pushAll(values: IterableOrArrayLike<ICellModel>): number {
+    let newIndex = this.length;
+    let newValues = toArray(values);
+    each(newValues, value => {
+      // Generate a new uuid for the cell.
+      let id = utils.uuid();
+      // Set the internal data structures.
+      this._cellMap.set(id, value);
+      let num = this._cellOrder.pushBack(new CellID(id));
+    });
+    /*this._changed.emit({
+      type: 'add',
+      oldIndex: -1,
+      newIndex,
+      oldValues: [],
+      newValues
+    });*/
+    return this.length;
+  }
+
+  /**
+   * Insert a set of items into the vector at the specified index.
+   *
+   * @param index - The index at which to insert the values.
+   *
+   * @param values - The values to insert at the specified index.
+   *
+   * @returns The new length of the vector.
+   *
+   * #### Complexity.
+   * Linear.
+   *
+   * #### Iterator Validity
+   * No changes.
+   *
+   * #### Notes
+   * The `index` will be clamped to the bounds of the vector.
+   *
+   * #### Undefined Behavior.
+   * An `index` which is non-integral.
+   */
+  insertAll(index: number, values: IterableOrArrayLike<ICellModel>): number {
+    let newIndex = index;
+    let newValues = toArray(values);
+    each(newValues, value => {
+      // Generate a new uuid for the cell.
+      let id = utils.uuid();
+      this._cellMap.set(id, value);
+      this._cellOrder.insert(index++, new CellID(id));
+    });
+    /*this._changed.emit({
+      type: 'add',
+      oldIndex: -1,
+      newIndex,
+      oldValues: [],
+      newValues
+    });*/
+    return this.length;
+  }
+
+  /**
+   * Remove a range of items from the vector.
+   *
+   * @param startIndex - The start index of the range to remove (inclusive).
+   *
+   * @param endIndex - The end index of the range to remove (exclusive).
+   *
+   * @returns The new length of the vector.
+   *
+   * #### Complexity
+   * Linear.
+   *
+   * #### Iterator Validity
+   * Iterators pointing to the first removed value and beyond are invalid.
+   *
+   * #### Undefined Behavior
+   * A `startIndex` or `endIndex` which is non-integral.
+   */
+  removeRange(startIndex: number, endIndex: number): number {
+    let oldValues: ICellModel[] = [];
+    for (let i = startIndex; i < endIndex; i++) {
+      let id = this._cellOrder.removeAt(startIndex);
+      oldValues.push(this._cellMap.get(id.id));
+    }
+    /*this._changed.emit({
+      type: 'remove',
+      oldIndex: startIndex,
+      newIndex: -1,
+      oldValues,
+      newValues: []
+    });*/
+    return this.length;
+  }
+
+  /**
+   * Whether the object can redo changes.
+   */
+  get canRedo(): boolean {
+    return this._cellOrder.canRedo;
+  }
+
+  /**
+   * Whether the object can undo changes.
+   */
+  get canUndo(): boolean {
+    return this._cellOrder.canUndo;
+  }
+
+  /**
+   * Begin a compound operation.
+   *
+   * @param isUndoAble - Whether the operation is undoable.
+   *   The default is `true`.
+   */
+  beginCompoundOperation(isUndoAble?: boolean): void {
+    this._cellOrder.beginCompoundOperation(isUndoAble);
+  }
+
+  /**
+   * End a compound operation.
+   */
+  endCompoundOperation(): void {
+    this._cellOrder.endCompoundOperation();
+  }
+
+  /**
+   * Undo an operation.
+   */
+  undo(): void {
+    this._cellOrder.undo();
+  }
+
+  /**
+   * Redo an operation.
+   */
+  redo(): void {
+    this._cellOrder.redo();
+  }
+
+  /**
+   * Clear the change stack.
+   */
+  clearUndo(): void {
+    this._cellOrder.clearUndo();
+  }
+
+  private _onOrderChanged(order: IObservableVector<CellID>, change: ObservableVector.IChangedArgs<CellID>): void {
+    let newValues: ICellModel[] = [];
+    let oldValues: ICellModel[] = [];
+    each(change.newValues, (id)=>{
+      newValues.push(this._cellMap.get(id.id));
+    });
+    each(change.oldValues, (id)=>{
+      oldValues.push(this._cellMap.get(id.id));
+    });
+    this._changed.emit({
+      type: change.type,
+      oldIndex: change.oldIndex,
+      newIndex: change.newIndex,
+      oldValues,
+      newValues
+    });
+  }
+
+  private _isDisposed: boolean = false;
+  private _cellOrder: IObservableUndoableVector<CellID> = null;
+  private _cellMap: IObservableMap<ICellModel> = null;
+  private _changed = new Signal<this, ObservableVector.IChangedArgs<ICellModel>>(this);
+}

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JSONObject
-} from '@phosphor/coreutils';
-
-import {
   ArrayExt, IIterator, IterableOrArrayLike, each, toArray, ArrayIterator
 } from '@phosphor/algorithm';
 
@@ -374,7 +370,6 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * A `fromIndex` or a `toIndex` which is non-integral.
    */
   move(fromIndex: number, toIndex: number): void {
-    let cell = this.at(fromIndex);
     this._cellOrder.move(fromIndex, toIndex);
   }
 
@@ -397,14 +392,13 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * not be called by other actors.
    */
   pushAll(cells: IterableOrArrayLike<ICellModel>): number {
-    let newIndex = this.length;
     let newValues = toArray(cells);
     each(newValues, cell => {
       // Generate a new uuid for the cell.
       let id = utils.uuid();
       // Set the internal data structures.
       this._cellMap.set(id, cell);
-      let num = this._cellOrder.pushBack(id);
+      this._cellOrder.pushBack(id);
     });
     return this.length;
   }

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -28,7 +28,9 @@ import {
 
 
 /**
- * Unfortunate, this.
+ * Unfortunately, the current implementation of the ObservableUndoableVector
+ * requires the values to implement to/from JSON. This should not be 
+ * necessary for primitives (in this case strings).
  */
 class CellID implements ISerializable { 
   constructor(id: string) {
@@ -76,7 +78,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   /**
    * Test whether the list is empty.
    *
-   * @returns `true` if the vector is empty, `false` otherwise.
+   * @returns `true` if the cell list is empty, `false` otherwise.
    *
    * #### Notes
    * This is a read-only property.
@@ -92,9 +94,9 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   }
 
   /**
-   * Get the length of the vector.
+   * Get the length of the cell list.
    *
-   * @return The number of values in the vector.
+   * @return The number of cells in the cell list.
    *
    * #### Notes
    * This is a read-only property.
@@ -110,10 +112,10 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   }
 
   /**
-   * Get the value at the front of the vector.
+   * Get the cell at the front of the cell list.
    *
-   * @returns The value at the front of the vector, or `undefined` if
-   *   the vector is empty.
+   * @returns The cell at the front of the cell list, or `undefined` if
+   *   the cell list is empty.
    *
    * #### Notes
    * This is a read-only property.
@@ -129,10 +131,10 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   }
 
   /**
-   * Get the value at the back of the vector.
+   * Get the cell at the back of the cell list.
    *
-   * @returns The value at the back of the vector, or `undefined` if
-   *   the vector is empty.
+   * @returns The cell at the back of the cell list, or `undefined` if
+   *   the cell list is empty.
    *
    * #### Notes
    * This is a read-only property.
@@ -148,9 +150,9 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   }
 
   /**
-   * Create an iterator over the values in the vector.
+   * Create an iterator over the cells in the cell list.
    *
-   * @returns A new iterator starting at the front of the vector.
+   * @returns A new iterator starting at the front of the cell list.
    *
    * #### Complexity
    * Constant.
@@ -167,7 +169,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   }
 
   /**
-   * Dispose of the resources held by the vector.
+   * Dispose of the resources held by the cell list.
    */
   dispose(): void {
     if (this._isDisposed) {
@@ -179,11 +181,11 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   }
 
   /**
-   * Get the value at the specified index.
+   * Get the cell at the specified index.
    *
    * @param index - The positive integer index of interest.
    *
-   * @returns The value at the specified index.
+   * @returns The cell at the specified index.
    *
    * #### Complexity
    * Constant.
@@ -199,11 +201,11 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   }
 
   /**
-   * Set the value at the specified index.
+   * Set the cell at the specified index.
    *
    * @param index - The positive integer index of interest.
    *
-   * @param value - The value to set at the specified index.
+   * @param cell - The cell to set at the specified index.
    *
    * #### Complexity
    * Constant.
@@ -214,20 +216,20 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * #### Undefined Behavior
    * An `index` which is non-integral or out of range.
    */
-  set(index: number, value: ICellModel): void {
+  set(index: number, cell: ICellModel): void {
     // Generate a new uuid for the cell.
     let id = utils.uuid();
     // Set the internal data structures.
-    this._cellMap.set(id, value);
+    this._cellMap.set(id, cell);
     this._cellOrder.set(index, new CellID(id));
   }
 
   /**
-   * Add a value to the back of the vector.
+   * Add a cell to the back of the cell list.
    *
-   * @param value - The value to add to the back of the vector.
+   * @param cell - The cell to add to the back of the cell list.
    *
-   * @returns The new length of the vector.
+   * @returns The new length of the cell list.
    *
    * #### Complexity
    * Constant.
@@ -235,42 +237,42 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * #### Iterator Validity
    * No changes.
    */
-  pushBack(value: ICellModel): number {
+  pushBack(cell: ICellModel): number {
     // Generate a new uuid for the cell.
     let id = utils.uuid();
     // Set the internal data structures.
-    this._cellMap.set(id, value);
+    this._cellMap.set(id, cell);
     let num = this._cellOrder.pushBack(new CellID(id));
     return num;
   }
 
   /**
-   * Remove and return the value at the back of the vector.
+   * Remove and return the cell at the back of the cell list.
    *
-   * @returns The value at the back of the vector, or `undefined` if
-   *   the vector is empty.
+   * @returns The cell at the back of the cell list, or `undefined` if
+   *   the cell list is empty.
    *
    * #### Complexity
    * Constant.
    *
    * #### Iterator Validity
-   * Iterators pointing at the removed value are invalidated.
+   * Iterators pointing at the removed cell are invalidated.
    */
   popBack(): ICellModel {
     //Don't clear the map in case we need to reinstate the cell
     let id = this._cellOrder.popBack();
-    let value = this._cellMap.get(id.id);
-    return value;
+    let cell = this._cellMap.get(id.id);
+    return cell;
   }
 
   /**
-   * Insert a value into the vector at a specific index.
+   * Insert a cell into the cell list at a specific index.
    *
-   * @param index - The index at which to insert the value.
+   * @param index - The index at which to insert the cell.
    *
-   * @param value - The value to set at the specified index.
+   * @param cell - The cell to set at the specified index.
    *
-   * @returns The new length of the vector.
+   * @returns The new length of the cell list.
    *
    * #### Complexity
    * Linear.
@@ -279,66 +281,66 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * No changes.
    *
    * #### Notes
-   * The `index` will be clamped to the bounds of the vector.
+   * The `index` will be clamped to the bounds of the cell list.
    *
    * #### Undefined Behavior
    * An `index` which is non-integral.
    */
-  insert(index: number, value: ICellModel): number {
+  insert(index: number, cell: ICellModel): number {
     // Generate a new uuid for the cell.
     let id = utils.uuid();
     // Set the internal data structures.
-    this._cellMap.set(id, value);
+    this._cellMap.set(id, cell);
     let num = this._cellOrder.insert(index, new CellID(id));
     return num;
   }
 
   /**
-   * Remove the first occurrence of a value from the vector.
+   * Remove the first occurrence of a cell from the cell list.
    *
-   * @param value - The value of interest.
+   * @param cell - The cell of interest.
    *
-   * @returns The index of the removed value, or `-1` if the value
-   *   is not contained in the vector.
+   * @returns The index of the removed cell, or `-1` if the cell
+   *   is not contained in the cell list.
    *
    * #### Complexity
    * Linear.
    *
    * #### Iterator Validity
-   * Iterators pointing at the removed value and beyond are invalidated.
+   * Iterators pointing at the removed cell and beyond are invalidated.
    */
-  remove(value: ICellModel): number {
+  remove(cell: ICellModel): number {
     let index = ArrayExt.findFirstIndex(
-      toArray(this._cellOrder), id => (this._cellMap.get(id.id)===value));
+      toArray(this._cellOrder), id => (this._cellMap.get(id.id)===cell));
     this.removeAt(index);
     return index;
   }
 
   /**
-   * Remove and return the value at a specific index.
+   * Remove and return the cell at a specific index.
    *
-   * @param index - The index of the value of interest.
+   * @param index - The index of the cell of interest.
    *
-   * @returns The value at the specified index, or `undefined` if the
+   * @returns The cell at the specified index, or `undefined` if the
    *   index is out of range.
    *
    * #### Complexity
    * Constant.
    *
    * #### Iterator Validity
-   * Iterators pointing at the removed value and beyond are invalidated.
+   * Iterators pointing at the removed cell and beyond are invalidated.
    *
    * #### Undefined Behavior
    * An `index` which is non-integral.
    */
   removeAt(index: number): ICellModel {
     let id= this._cellOrder.removeAt(index);
-    let value = this._cellMap.get(id.id);
-    return value;
+    let cell = this._cellMap.get(id.id);
+    return cell;
   }
 
   /**
-   * Remove all values from the vector.
+   * Remove all cells from the cell list.
    *
    * #### Complexity
    * Linear.
@@ -355,7 +357,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   }
 
   /**
-   * Move a value from one index to another.
+   * Move a cell from one index to another.
    *
    * @parm fromIndex - The index of the element to move.
    *
@@ -372,16 +374,16 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * A `fromIndex` or a `toIndex` which is non-integral.
    */
   move(fromIndex: number, toIndex: number): void {
-    let value = this.at(fromIndex);
+    let cell = this.at(fromIndex);
     this._cellOrder.move(fromIndex, toIndex);
   }
 
   /**
-   * Push a set of values to the back of the vector.
+   * Push a set of cells to the back of the cell list.
    *
-   * @param values - An iterable or array-like set of values to add.
+   * @param cells - An iterable or array-like set of cells to add.
    *
-   * @returns The new length of the vector.
+   * @returns The new length of the cell list.
    *
    * #### Complexity
    * Linear.
@@ -389,27 +391,27 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * #### Iterator Validity
    * No changes.
    */
-  pushAll(values: IterableOrArrayLike<ICellModel>): number {
+  pushAll(cells: IterableOrArrayLike<ICellModel>): number {
     let newIndex = this.length;
-    let newValues = toArray(values);
-    each(newValues, value => {
+    let newValues = toArray(cells);
+    each(newValues, cell => {
       // Generate a new uuid for the cell.
       let id = utils.uuid();
       // Set the internal data structures.
-      this._cellMap.set(id, value);
+      this._cellMap.set(id, cell);
       let num = this._cellOrder.pushBack(new CellID(id));
     });
     return this.length;
   }
 
   /**
-   * Insert a set of items into the vector at the specified index.
+   * Insert a set of items into the cell list at the specified index.
    *
-   * @param index - The index at which to insert the values.
+   * @param index - The index at which to insert the cells.
    *
-   * @param values - The values to insert at the specified index.
+   * @param cells - The cells to insert at the specified index.
    *
-   * @returns The new length of the vector.
+   * @returns The new length of the cell list.
    *
    * #### Complexity.
    * Linear.
@@ -418,37 +420,37 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * No changes.
    *
    * #### Notes
-   * The `index` will be clamped to the bounds of the vector.
+   * The `index` will be clamped to the bounds of the cell list.
    *
    * #### Undefined Behavior.
    * An `index` which is non-integral.
    */
-  insertAll(index: number, values: IterableOrArrayLike<ICellModel>): number {
+  insertAll(index: number, cells: IterableOrArrayLike<ICellModel>): number {
     let newIndex = index;
-    let newValues = toArray(values);
-    each(newValues, value => {
+    let newValues = toArray(cells);
+    each(newValues, cell => {
       // Generate a new uuid for the cell.
       let id = utils.uuid();
-      this._cellMap.set(id, value);
+      this._cellMap.set(id, cell);
       this._cellOrder.insert(index++, new CellID(id));
     });
     return this.length;
   }
 
   /**
-   * Remove a range of items from the vector.
+   * Remove a range of items from the cell list.
    *
    * @param startIndex - The start index of the range to remove (inclusive).
    *
    * @param endIndex - The end index of the range to remove (exclusive).
    *
-   * @returns The new length of the vector.
+   * @returns The new length of the cell list.
    *
    * #### Complexity
    * Linear.
    *
    * #### Iterator Validity
-   * Iterators pointing to the first removed value and beyond are invalid.
+   * Iterators pointing to the first removed cell and beyond are invalid.
    *
    * #### Undefined Behavior
    * A `startIndex` or `endIndex` which is non-integral.

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -511,6 +511,16 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * Clear the change stack.
    */
   clearUndo(): void {
+    //dispose of cells not in the current
+    //cell order.
+    for(let key of this._cellMap.keys()) {
+      if(ArrayExt.findFirstIndex(
+         toArray(this._cellOrder), id => (id.id)===key) === -1) {
+        let cell = this._cellMap.get(key) as ICellModel;
+        cell.dispose();
+        this._cellMap.delete(key);
+      }
+    }
     this._cellOrder.clearUndo();
   }
 

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -259,7 +259,6 @@ class NotebookModel extends DocumentModel implements INotebookModel {
       break;
     case 'remove':
       each(change.oldValues, cell => {
-        //cell.dispose();
       });
       break;
     case 'set':
@@ -267,7 +266,6 @@ class NotebookModel extends DocumentModel implements INotebookModel {
         cell.contentChanged.connect(this.triggerContentChange, this);
       });
       each(change.oldValues, cell => {
-        //cell.dispose();
       });
       break;
     default:

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -16,8 +16,12 @@ import {
 
 import {
   IObservableJSON, ObservableJSON, IObservableUndoableVector,
-  ObservableUndoableVector, IObservableVector, ObservableVector, nbformat
+  IObservableVector, ObservableVector, nbformat
 } from '@jupyterlab/coreutils';
+
+import {
+  CellList
+} from './celllist';
 
 
 /**
@@ -66,16 +70,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
       options.contentFactory || NotebookModel.defaultContentFactory
     );
     this.contentFactory = factory;
-    this._cells = new ObservableUndoableVector<ICellModel>((cell: nbformat.IBaseCell) => {
-      switch (cell.cell_type) {
-        case 'code':
-          return factory.createCodeCell({ cell });
-        case 'markdown':
-          return factory.createMarkdownCell({ cell });
-        default:
-          return factory.createRawCell({ cell });
-      }
-    });
+    this._cells = new CellList();
     // Add an initial code cell by default.
     this._cells.pushBack(factory.createCodeCell({}));
     this._cells.changed.connect(this._onCellsChanged, this);
@@ -264,7 +259,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
       break;
     case 'remove':
       each(change.oldValues, cell => {
-        cell.dispose();
+        //cell.dispose();
       });
       break;
     case 'set':
@@ -272,7 +267,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
         cell.contentChanged.connect(this.triggerContentChange, this);
       });
       each(change.oldValues, cell => {
-        cell.dispose();
+        //cell.dispose();
       });
       break;
     default:

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -142,10 +142,6 @@ class NotebookModel extends DocumentModel implements INotebookModel {
     let cells = this._cells;
     this._cells = null;
     this._metadata.dispose();
-    for (let i = 0; i < cells.length; i++) {
-      let cell = cells.at(i);
-      cell.dispose();
-    }
     cells.dispose();
     super.dispose();
   }

--- a/test/src/notebook/model.spec.ts
+++ b/test/src/notebook/model.spec.ts
@@ -108,7 +108,7 @@ describe('notebook/notebook/model', () => {
         model.cells.undo();
         expect(model.cells.length).to.be(2);
         expect(model.cells.at(1).value.text).to.be('foo');
-        expect(model.cells.at(1)).to.not.be(cell);  // should be a clone.
+        expect(model.cells.at(1)).to.be(cell);  // should be ===.
       });
 
       context('cells `changed` signal', () => {
@@ -127,14 +127,6 @@ describe('notebook/notebook/model', () => {
           let cell = model.contentFactory.createCodeCell({});
           model.cells.pushBack(cell);
           expect(model.dirty).to.be(true);
-        });
-
-        it('should dispose of old cells', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
-          model.cells.pushBack(cell);
-          model.cells.clear();
-          expect(cell.isDisposed).to.be(true);
         });
 
         it('should add a new code cell when cells are cleared', (done) => {

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -282,7 +282,7 @@ describe('notebook/widget', () => {
           let cell = widget.model.cells.at(1);
           let child = widget.widgets[1];
           widget.model.cells.remove(cell);
-          expect(cell.isDisposed).to.be(true);
+          expect(cell.isDisposed).to.be(false);
           expect(child.isDisposed).to.be(true);
         });
 


### PR DESCRIPTION
Proof-of-concept for a cell list that stores cells in an internal map with uuids (cf. discussions in #1767, #1895).

This, in a sense, represents a minimal implementation, since it implements a `CellList` object which satisfies the `IObservableUndoableVector` interface, and is therefore mostly a drop-in replacement for the current cell vector.

One subtle complication involves ownership of cells. Undo of cell deletions can be accomplished by keeping them in the cell map and restoring them from that on request. Using this implementation fixes the first point of #1895. This means, however, that the `CellList` in some sense owns deleted cells, and so `cell.dispose()` should not be called by other objects.