### PR TITLE
Drag operations

### DIFF
--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1244,7 +1244,7 @@ class Notebook extends StaticNotebook {
     }
 
     let source: Notebook = event.source
-    if(source === this) {
+    if (source === this) {
       // Handle the case where we are moving cells within
       // the same notebook.
       event.dropAction = 'move';
@@ -1253,16 +1253,16 @@ class Notebook extends StaticNotebook {
       //Compute the to/from indices for the move.
       let fromIndex = ArrayExt.firstIndexOf(this.widgets, toMove[0]);
       let toIndex = this._findCell(target);
-      if(toIndex === -1) {
+      if (toIndex === -1) {
         toIndex = this.widgets.length;
       }
       //Don't move if we are within the block of selected cells.
-      if(toIndex-fromIndex > 0 && toIndex-fromIndex <= toMove.length) {
+      if (toIndex - fromIndex > 0 && toIndex - fromIndex <= toMove.length) {
         return;
       }
       // Move the cells one by one
       this.model.cells.beginCompoundOperation();
-      if(fromIndex < toIndex) {
+      if (fromIndex < toIndex) {
         each(toMove, (cellWidget)=> {
           this.model.cells.move(fromIndex, toIndex);
         });
@@ -1337,7 +1337,7 @@ class Notebook extends StaticNotebook {
       source: this
     });
     this._drag.mimeData.setData(JUPYTER_CELL_MIME, selected);
-    // Add mimeData for the fully reified cell models, for the
+    // Add mimeData for the fully reified cell widgets, for the
     // case where the target is in the same notebook and we
     // can just move the cells.
     this._drag.mimeData.setData('internal:cells', toMove);

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1233,7 +1233,6 @@ class Notebook extends StaticNotebook {
       event.dropAction = 'none';
       return;
     }
-    event.dropAction = event.proposedAction;
 
     let target = event.target as HTMLElement;
     while (target && target.parentElement) {
@@ -1246,8 +1245,9 @@ class Notebook extends StaticNotebook {
 
     let source: Notebook = event.source
     if(source === this) {
-      //Handle the case where we are moving cells within
-      //the same notebook.
+      // Handle the case where we are moving cells within
+      // the same notebook.
+      event.dropAction = 'move';
       let toMove: BaseCellWidget[] = event.mimeData.getData('internal:cells');
 
       // Move the cells one by one
@@ -1265,6 +1265,9 @@ class Notebook extends StaticNotebook {
       } //no-op if fromIndex === toIndex
       this.model.cells.endCompoundOperation();
     } else {
+      // Handle the case where we are copying cells between
+      // notebooks.
+      event.dropAction = 'copy';
       // Find the target cell and insert the copied cells.
       let index = this._findCell(target);
       if (index === -1) {
@@ -1332,8 +1335,8 @@ class Notebook extends StaticNotebook {
     this._drag = new Drag({
       mimeData: new MimeData(),
       dragImage,
-      supportedActions: 'move',
-      proposedAction: 'move',
+      supportedActions: 'copy-move',
+      proposedAction: 'copy',
       source: this
     });
     this._drag.mimeData.setData(JUPYTER_CELL_MIME, selected);
@@ -1351,9 +1354,6 @@ class Notebook extends StaticNotebook {
       }
       this._drag = null;
       each(toMove, widget => { widget.removeClass(DROP_SOURCE_CLASS); });
-      if (action === 'none') {
-        return;
-      }
     });
 
   }

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1253,11 +1253,13 @@ class Notebook extends StaticNotebook {
       //Compute the to/from indices for the move.
       let fromIndex = ArrayExt.firstIndexOf(this.widgets, toMove[0]);
       let toIndex = this._findCell(target);
-      if (toIndex === -1) {
-        toIndex = this.widgets.length;
+      if (toIndex !== -1 && toIndex > fromIndex) {
+        toIndex -= 1;
+      } else if (toIndex === -1) {
+        toIndex = this.widgets.length - 1;
       }
       //Don't move if we are within the block of selected cells.
-      if (toIndex - fromIndex > 0 && toIndex - fromIndex <= toMove.length) {
+      if (toIndex - fromIndex > 0 && toIndex - fromIndex < toMove.length) {
         return;
       }
       // Move the cells one by one

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1457,7 +1457,6 @@ class Notebook extends StaticNotebook {
   private _activeCell: BaseCellWidget = null;
   private _mode: NotebookMode = 'command';
   private _drag: Drag = null;
-  private _dragDone: utils.PromiseDelegate<'intra' | 'inter'>;
   private _dragData: { pressX: number, pressY: number, index: number } = null;
   private _activeCellChanged = new Signal<this, BaseCellWidget>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1250,19 +1250,28 @@ class Notebook extends StaticNotebook {
       event.dropAction = 'move';
       let toMove: BaseCellWidget[] = event.mimeData.getData('internal:cells');
 
-      // Move the cells one by one
+      //Compute the to/from indices for the move.
       let fromIndex = ArrayExt.firstIndexOf(this.widgets, toMove[0]);
       let toIndex = this._findCell(target);
+      if(toIndex === -1) {
+        toIndex = this.widgets.length;
+      }
+      console.log(fromIndex, toIndex);
+      //Don't move if we are within the block of selected cells.
+      if(toIndex-fromIndex > 0 && toIndex-fromIndex <= toMove.length) {
+        return;
+      }
+      // Move the cells one by one
       this.model.cells.beginCompoundOperation();
       if(fromIndex < toIndex) {
         each(toMove, (cellWidget)=> {
-          this.model.cells.move(fromIndex, toIndex++);
+          this.model.cells.move(fromIndex, toIndex);
         });
       } else if (fromIndex > toIndex) {
         each(toMove, (cellWidget)=> {
           this.model.cells.move(fromIndex++, toIndex++);
         });
-      } //no-op if fromIndex === toIndex
+      }
       this.model.cells.endCompoundOperation();
     } else {
       // Handle the case where we are copying cells between

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1256,7 +1256,6 @@ class Notebook extends StaticNotebook {
       if(toIndex === -1) {
         toIndex = this.widgets.length;
       }
-      console.log(fromIndex, toIndex);
       //Don't move if we are within the block of selected cells.
       if(toIndex-fromIndex > 0 && toIndex-fromIndex <= toMove.length) {
         return;

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1275,7 +1275,6 @@ class Notebook extends StaticNotebook {
       }
       let model = this.model;
       let values = event.mimeData.getData(JUPYTER_CELL_MIME);
-      let toRemove: BaseCellWidget[] = event.mimeData.getData('internal:cells');
       let factory = model.contentFactory;
 
       // Insert the copies of the original cells.
@@ -1298,16 +1297,6 @@ class Notebook extends StaticNotebook {
       model.cells.endCompoundOperation();
       // Activate the last cell.
       this.activeCellIndex = index - 1;
-
-      // Now remove the cells from the source notebook.
-      let activeCell = source.model.cells.at(source.activeCellIndex);
-      source.model.cells.beginCompoundOperation();
-      each(toRemove, widget => {
-        source.model.cells.remove(widget.model);
-      });
-      source.model.cells.endCompoundOperation();
-      source.activeCellIndex =
-        ArrayExt.firstIndexOf(toArray(source.model.cells), activeCell);
     }
   }
 

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -1253,13 +1253,17 @@ class Notebook extends StaticNotebook {
       //Compute the to/from indices for the move.
       let fromIndex = ArrayExt.firstIndexOf(this.widgets, toMove[0]);
       let toIndex = this._findCell(target);
+      // This check is needed for consistency with the view.
       if (toIndex !== -1 && toIndex > fromIndex) {
         toIndex -= 1;
       } else if (toIndex === -1) {
+        // If the drop is within the notebook but not on any cell,
+        // most often this means it is past the cell areas, so
+        // set it to move the cells to the end of the notebook.
         toIndex = this.widgets.length - 1;
       }
       //Don't move if we are within the block of selected cells.
-      if (toIndex - fromIndex > 0 && toIndex - fromIndex < toMove.length) {
+      if (toIndex >= fromIndex && toIndex < fromIndex + toMove.length) {
         return;
       }
       // Move the cells one by one

--- a/src/notebook/widget.ts
+++ b/src/notebook/widget.ts
@@ -42,10 +42,6 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  utils
-} from '@jupyterlab/services';
-
-import {
   ICellModel, BaseCellWidget, IMarkdownCellModel,
   CodeCellWidget, MarkdownCellWidget,
   ICodeCellModel, RawCellWidget, IRawCellModel,
@@ -1243,7 +1239,7 @@ class Notebook extends StaticNotebook {
       target = target.parentElement;
     }
 
-    let source: Notebook = event.source
+    let source: Notebook = event.source;
     if (source === this) {
       // Handle the case where we are moving cells within
       // the same notebook.


### PR DESCRIPTION
This is unfortunately complicated, so I am open to other ways of accomplishing this. The goal is to address the third problem identified in #1895. This does two things: (1) it batches the move operations into a single compound operation, and (2) if the movement happens within a single notebook, it performs the operation via moves instead of insertions/deletions.

Because the handling in the origin of the drop is different depending on the destination, a message is passed back to the origin from the destination based upon the resolution of a promise delegate. It is uncomfortably hacky, but I did not see an easier way to do it.