### PR TITLE
match in and out prompt styles

### DIFF
--- a/src/cells/index.css
+++ b/src/cells/index.css
@@ -16,8 +16,6 @@
   --jp-private-cell-prompt-width: 90px;
   --jp-private-cell-inprompt-color: #303F9F;
   --jp-private-cell-outprompt-color: #D84315;
-  --jp-private-cell-font-family: var(--jp-ui-font-family);
-  --jp-private-cell-prompt-letter-spacing: 2px;
 }
 
 
@@ -41,12 +39,11 @@
   flex-shrink: 0;
   flex-basis: var(--jp-private-cell-prompt-width);
   color: var(--jp-private-cell-inprompt-color);
-  font-family: var(--jp-private-cell-font-family);
+  font-family: var(--jp-prompt-font-family);
+  font-size: var(--jp-prompt-font-size);
   padding: var(--jp-code-padding);
   text-align: right;
-  letter-spacing: var(--jp-private-cell-prompt-letter-spacing);
   line-height: var(--jp-code-line-height);
-  font-size: var(--jp-code-font-size);
   border: var(--jp-border-width) solid transparent;
 }
 

--- a/src/default-theme/variables.css
+++ b/src/default-theme/variables.css
@@ -93,6 +93,9 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-code-padding: 5px;
   --jp-code-font-family: monospace;
 
+  --jp-prompt-font-family: var(--jp-code-font-family);
+  --jp-prompt-font-size: var(--jp-code-font-size);
+
 
   /* Layout
 

--- a/src/outputarea/index.css
+++ b/src/outputarea/index.css
@@ -66,11 +66,11 @@
 
 .jp-OutputAreaWidget-gutter {
   color: var(--jp-private-outputarea-prompt-color);
-  font-family: var(--jp-code-font-family);
+  font-family: var(--jp-prompt-font-family);
+  font-size: var(--jp-prompt-font-size);
   text-align: right;
   vertical-align: middle;
   padding: var(--jp-code-padding);
-  font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
   border: var(--jp-border-width) solid transparent;
   flex: 0 0 var(--jp-private-outputarea-prompt-width);


### PR DESCRIPTION
use the same `jp-prompt-font` variables for both, so they match.

I realize there's an ongoing discussion in #1692 about what to do with prompts, but they should presumably at least match each other in the meantime.