### PR TITLE
Clean up cell scroll position behavior

### DIFF
--- a/src/notebook/actions.ts
+++ b/src/notebook/actions.ts
@@ -852,7 +852,8 @@ namespace Private {
       widget.activate();
     }
     // Scroll to the appropriate client position.
-    if (state.activeCell && widget.mode === 'command') {
+    if (state.activeCell && !state.activeCell.isDisposed &&
+        widget.mode === 'command') {
       // Scroll to the top of the previous output.
       let er = state.activeCell.editorWidget.node.getBoundingClientRect();
       widget.scrollToPosition(er.bottom);

--- a/src/notebook/actions.ts
+++ b/src/notebook/actions.ts
@@ -10,6 +10,10 @@ import {
 } from '@phosphor/algorithm';
 
 import {
+  ElementExt
+} from '@phosphor/domutils';
+
+import {
   Clipboard
 } from '../apputils';
 
@@ -821,6 +825,11 @@ namespace Private {
      * Whether the widget had focus.
      */
     wasFocused: boolean;
+
+    /**
+     * The active cell before the action.
+     */
+    activeCell: BaseCellWidget;
   }
 
   /**
@@ -829,7 +838,8 @@ namespace Private {
   export
   function getState(widget: Notebook): IState {
     return {
-      wasFocused: widget.node.contains(document.activeElement)
+      wasFocused: widget.node.contains(document.activeElement),
+      activeCell: widget.activeCell
     };
   }
 
@@ -841,7 +851,16 @@ namespace Private {
     if (state.wasFocused) {
       widget.activate();
     }
-    widget.scrollToActiveCell();
+    // Scroll to the appropriate client position.
+    if (state.activeCell && widget.mode === 'command') {
+      // Scroll to the top of the previous output.
+      let er = state.activeCell.editorWidget.node.getBoundingClientRect();
+      widget.scrollToPosition(er.bottom);
+    } else if (widget.activeCell) {
+      // Scroll to the top of the next active cell.
+      let er = widget.activeCell.node.getBoundingClientRect();
+      widget.scrollToPosition(er.top);
+    }
   }
 
   /**

--- a/src/notebook/actions.ts
+++ b/src/notebook/actions.ts
@@ -10,10 +10,6 @@ import {
 } from '@phosphor/algorithm';
 
 import {
-  ElementExt
-} from '@phosphor/domutils';
-
-import {
   Clipboard
 } from '../apputils';
 


### PR DESCRIPTION
Fixes #1810.   Fixes #1526.

Any time a cell enters edit mode, it is scrolled into view.  After a cell action, we scroll to the top of the previous active cell output if we are in command mode, otherwise we scroll to the top of the new active cell.  We only scroll if the desired position is a configurable percentage from the center of the viewable area (defaulting to 25).

![cell_scroll](https://cloud.githubusercontent.com/assets/2096628/23948231/2403431c-0950-11e7-9101-98038e523863.gif)
