### PR TITLE
Fix move

### DIFF
--- a/src/coreutils/observablevector.ts
+++ b/src/coreutils/observablevector.ts
@@ -547,13 +547,15 @@ class ObservableVector<T> extends Vector<T> implements IObservableVector<T> {
    * A `fromIndex` or a `toIndex` which is non-integral.
    */
   move(fromIndex: number, toIndex: number): void {
-    let value = this.at(fromIndex);
-    super.removeAt(fromIndex);
-    if (toIndex < fromIndex) {
-      super.insert(toIndex - 1, value);
-    } else {
-      super.insert(toIndex, value);
+    if(this.length <= 1 || fromIndex === toIndex) {
+      return;
     }
+    let value = this.at(fromIndex);
+    let step = fromIndex < toIndex ? 1 : -1;
+    for (let i = fromIndex; i !== toIndex; i += step) {
+      super.set(i, this.at(i + step));
+    }
+    super.set(toIndex, value);
     let arr = [value];
     this._changed.emit({
       type: 'move',

--- a/test/src/coreutils/observablevector.spec.ts
+++ b/test/src/coreutils/observablevector.spec.ts
@@ -205,6 +205,8 @@ describe('common/ObservableVector', () => {
         let value = new ObservableVector<number>({ values: [1, 2, 3] });
         value.move(1, 2);
         expect(toArray(value)).to.eql([1, 3, 2]);
+        value.move(2, 0);
+        expect(toArray(value)).to.eql([2, 1, 3]);
       });
 
       it('should trigger a changed signal', () => {


### PR DESCRIPTION
The move implementation in `ObservableVector` was broken. This should fix it.