### PR TITLE
Validate saved layouts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/algorithm": "^0.1.0",
-    "@phosphor/application": "^0.2.0",
+    "@phosphor/application": "^0.3.0",
     "@phosphor/commands": "^0.1.3",
     "@phosphor/coreutils": "^0.1.1",
     "@phosphor/disposable": "^0.1.0",
@@ -20,7 +20,7 @@
     "@phosphor/properties": "^0.1.0",
     "@phosphor/signaling": "^0.1.1",
     "@phosphor/virtualdom": "^0.1.0",
-    "@phosphor/widgets": "^0.2.0",
+    "@phosphor/widgets": "^0.3.0",
     "ansi_up": "^1.3.0",
     "codemirror": "^5.23",
     "d3-dsv": "^1.0.0",

--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -455,7 +455,7 @@ class ApplicationShell extends Widget {
     let data: ApplicationShell.ILayout = {
       mainArea: {
         currentWidget: this._tracker.currentWidget,
-        dock: this._dockPanel.saveLayout({ version: '1' }),
+        dock: this._dockPanel.saveLayout()
       },
       leftArea: this._leftHandler.dehydrate(),
       rightArea: this._rightHandler.dehydrate()
@@ -596,7 +596,7 @@ namespace ApplicationShell {
     /**
      * The contents of the main application dock panel.
      */
-    readonly dock: DockLayout.ILayoutConfigV1 | null;
+    readonly dock: DockLayout.ILayoutConfig | null;
   };
 
   /**

--- a/src/apputils/layoutrestorer.ts
+++ b/src/apputils/layoutrestorer.ts
@@ -640,7 +640,7 @@ namespace Private {
 
     return {
       currentWidget: name && names.has(name) && names.get(name) || null,
-      dock: dock ? { main: deserializeArea(dock, names), version: '1' } : null
+      dock: dock ? { main: deserializeArea(dock, names) } : null
     };
   }
 }


### PR DESCRIPTION
Use to the newest phosphor API that validates/normalizes saved layouts and ignores malfunctioning widgets.