### PR TITLE
notebook actions: Set untrusted for code->other

### DIFF
--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -1045,9 +1045,15 @@ namespace Private {
           break;
         case 'markdown':
           newCell = model.contentFactory.createMarkdownCell({ cell });
+          if (child.model.type == "code") {
+            newCell.trusted = false;
+          }
           break;
         default:
           newCell = model.contentFactory.createRawCell({ cell });
+          if (child.model.type == "code") {
+            newCell.trusted = false;
+          }
         }
         cells.set(i, newCell);
       }


### PR DESCRIPTION
If a cell is being changed to a markdown cell, explicitly set that it is
untrusted. Otherwise, the renderer will not do the appropriate
sanitization required.