### PR TITLE
Add invisible anchor after header with standard id, refactor anchor definition

### DIFF
--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -454,6 +454,10 @@ namespace Private {
       for (let i=0; i<headers.length; i++){
         let header = headers[i];
         header.id = header.innerHTML.replace(/ /g, '-');
+        let anchor1 = document.createElement('a');
+        anchor1.target = '_self';
+        anchor1.id = header.id.toLowerCase();
+        header.appendChild(anchor1);
         let anchor = document.createElement('a');
         anchor.target = '_self';
         anchor.textContent = '¶';
@@ -473,6 +477,10 @@ namespace Private {
     if (!href) {
       return Promise.resolve(void 0);
     }
+    if ( href[0] === "#"){
+      anchor.target = '_self';
+      return Promise.resolve(void 0);
+    } 
     return resolver.resolveUrl(href).then(path => {
       if (linkHandler) {
         linkHandler.handleLink(anchor, path);

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -454,18 +454,31 @@ namespace Private {
       for (let i=0; i<headers.length; i++){
         let header = headers[i];
         header.id = header.innerHTML.replace(/ /g, '-');
-        let anchor1 = document.createElement('a');
-        anchor1.target = '_self';
-        anchor1.id = header.id.toLowerCase();
-        header.appendChild(anchor1);
-        let anchor = document.createElement('a');
-        anchor.target = '_self';
-        anchor.textContent = '¶';
-        anchor.href = '#'+ header.id;
-        anchor.classList.add('jp-InternalAnchorLink');
-        header.appendChild(anchor);
+        let fakeAnchor = postfixAnchor(header, undefined, null, null, header.id.toLowerCase(), null);
+        let realAnchor = postfixAnchor(header, undefined, '#' + header.id, ['jp-InternalAnchorLink'], null, '¶');
       };
     };
+    function postfixAnchor(node: Element, target = '_self', href?: string,
+                           localClass?: Array<string>, id?: string, content?: string): Node{
+      let anchor = document.createElement('a');
+      anchor.target = target;
+      if (href){
+        anchor.href = href; 
+      }
+      if (localClass){
+        for (let thisLocalClass of localClass){
+          anchor.classList.add(thisLocalClass);
+        }
+      }
+      if (id){
+        anchor.id = id;
+      }
+      if (content){
+        anchor.textContent = content;
+      }
+      let new_node = node.appendChild(anchor);
+      return new_node;
+    }
   }
 
   /**


### PR DESCRIPTION
This addresses the problem of the notebook and pandoc/other utilities using different schemes for autogenerating header ids. 

By adding a header with no text as an additional target, we can handle the standard solution.

The next step after this one will be to change the id generating scheme for the actual headers, swap the visible anchor's href to match the new header id and put the old style id as the previous element in the header. 

I tried to reproduce the manner of optionally assigning some values to the anchors that are created, but I never actually figured out how to make that work in a way that doesn't result in a terrible looking, incomprehensible API. 

The solution I was looking for would be the typescript equivalent of keyword arguments in python, but as far as I can tell, that doesn't really _work_.

It's also a private function that is only used immediately above the signature definition, so we may be able to get away with a terrible API since it is not exposed to anyone. 