### PR TITLE
top-level package is private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@jupyterlab/private",
+  "private": true,
   "version": "0.1.0",
   "dependencies": {
   },


### PR DESCRIPTION
This fixes these two warnings when running `npm install`:

```
npm WARN @jupyterlab/private@0.1.0 No repository field.
npm WARN @jupyterlab/private@0.1.0 No license field.
```
