### PR TITLE
Fix cell tools styling

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -256,6 +256,11 @@
 
 
 .jp-KeySelector .jp-select-wrapper {
+  background: white;
+}
+
+
+.jp-KeySelector select.jp-mod-styled {
   font-size: var(--jp-ui-font-size1);
   color: var(--jp-ui-font-color0);
 }

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -214,6 +214,7 @@
 .jp-MetadataEditorTool-header {
   flex: 1 0 auto;
   padding: 10px;
+  padding-bottom: 16px;
 }
 
 

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -181,12 +181,6 @@
 }
 
 
-.jp-CellTools .jp-MetadataEditor-host {
-  background-color: white;
-  border-color: var(--jp-border-color1);
-}
-
-
 .jp-ActiveCellTool {
   padding: 12px;
   border-bottom: 1px solid var(--jp-border-color1);
@@ -244,13 +238,31 @@
 }
 
 
-.jp-MetadataEditor.jp-mod-collapsed {
+.jp-MetadataEditorTool .jp-JSONEditorWidget {
+  background-color: white;
+  border: var(--jp-border-width) solid var(--jp-border-color1);
+  margin: 8px;
+}
+
+
+.jp-MetadataEditorTool .jp-JSONEditorWidget.jp-mod-collapsed {
   display: none;
 }
 
 
 .jp-KeySelector {
   padding: 12px;
+}
+
+
+.jp-KeySelector .jp-select-wrapper {
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color0);
+}
+
+
+.jp-KeySelector .jp-select-wrapper:not(.jp-mod-focused) {
+  border: var(--jp-border-width) solid var(--jp-border-color1);
 }
 
 


### PR DESCRIPTION
Fixes regressions from the refactor:

Before:
<image src="https://cloud.githubusercontent.com/assets/2096628/24118071/80a0d8fe-0d7a-11e7-8ce4-006c5c25dcca.png" width=300>

After:
<image src="https://cloud.githubusercontent.com/assets/2096628/24137484/f48e5784-0de1-11e7-96e6-bbf13a3dfeb2.png" width=300>


Screenshots from Cameron's last change in https://github.com/jupyterlab/jupyterlab/pull/1716:

![image](https://cloud.githubusercontent.com/assets/2096628/22943600/b7a973ba-f2b3-11e6-9e70-ee9028cf7b01.png)

<image src="https://cloud.githubusercontent.com/assets/2096628/22943632/d75aba5c-f2b3-11e6-8144-049ab942910a.png" width=300>
