### PR TITLE
Dispose of the terminal if we can't find a session for it

### DIFF
--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -112,7 +112,6 @@ function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMen
 
       let promise = name ?
         services.terminals.connectTo(name)
-          .catch(() => services.terminals.startNew())
         : services.terminals.startNew();
 
       return promise.then(session => {


### PR DESCRIPTION
The server does not support starting a terminal with a name: it provides the name.  Therefore, if the  terminal we are trying to hydrate is not running on the server, we need to dispose of the widget.  We can't simply start a new session, because if the name of the session created does not match the previous name, the terminal will be un-parented during the layout restore.