### PR TITLE
Celltools restore

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -10,6 +10,10 @@ import {
 } from '@phosphor/coreutils';
 
 import {
+  MessageLoop
+} from '@phosphor/messaging';
+
+import {
   ISignal, Signal
 } from '@phosphor/signaling';
 
@@ -373,7 +377,13 @@ class ApplicationShell extends Widget {
 
       // Set restored flag, save state, and resolve the restoration promise.
       this._isRestored = true;
-      return this._save().then(() => { this._restored.resolve(saved); });
+      return this._save().then(() => {
+        // Make sure all messages in the queue are finished before notifying
+        // any extensions that are waiting for the promise that guarantees the
+        // application state has been restored.
+        MessageLoop.flush();
+        this._restored.resolve(saved);
+      });
     });
 
     // Catch current changed events on the side handlers.


### PR DESCRIPTION
This PR updates cell tools restoration behavior:

* If there are any available notebooks when the page loads, then the cell tools are added to the sidebar but they are not open.
* If they were last open before the page was refreshed, then they will open, irrespective of what type of tab has the focus.
* When tabs are switched, cell tools will remain open as long as there is at least one notebook.