### PR TITLE
Completer bug fixes.

### DIFF
--- a/packages/apputils/src/hoverbox.ts
+++ b/packages/apputils/src/hoverbox.ts
@@ -100,9 +100,11 @@ namespace HoverBox {
     // Add hover box class if it does not exist.
     node.classList.add(HOVERBOX_CLASS);
 
+    // Hide the hover box until its dimensions and visibility are known.
+    node.classList.add(OUTOFVIEW_CLASS);
+
     // If the current coordinates are not visible, bail.
     if (!host.contains(document.elementFromPoint(anchor.left, anchor.top))) {
-      node.classList.add(OUTOFVIEW_CLASS);
       return;
     }
 

--- a/packages/apputils/src/hoverbox.ts
+++ b/packages/apputils/src/hoverbox.ts
@@ -100,7 +100,7 @@ namespace HoverBox {
     // Add hover box class if it does not exist.
     node.classList.add(HOVERBOX_CLASS);
 
-    // Hide the hover box until its dimensions and visibility are known.
+    // Hide the hover box before querying the DOM for the anchor coordinates.
     node.classList.add(OUTOFVIEW_CLASS);
 
     // If the current coordinates are not visible, bail.
@@ -114,7 +114,7 @@ namespace HoverBox {
     // Clear any programmatically set margin-top.
     node.style.marginTop = '';
 
-    // Make sure the node is visible.
+    // Make sure the node is visible so that its dimensions can be queried.
     node.classList.remove(OUTOFVIEW_CLASS);
 
     const style = window.getComputedStyle(node);

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -274,12 +274,16 @@ class CompletionHandler implements IDisposable {
    */
   protected onSelectionsChanged(): void {
     const model = this._completer.model;
+    const editor = this._editor;
+    const host = editor.host;
+
+    // If there is no model, return.
     if (!model) {
+      this._enabled = false;
+      host.classList.remove(COMPLETER_ENABLED_CLASS);
       return;
     }
 
-    const editor = this._editor;
-    const host = editor.host;
     const position = editor.getCursorPosition();
     const line = editor.getLine(position.line);
     const { start, end } = editor.getSelection();
@@ -300,13 +304,14 @@ class CompletionHandler implements IDisposable {
       return;
     }
 
-    // If the completer is already enabled, return;
-    if (this._enabled) {
-      return;
+    // Enable completion.
+    if (!this._enabled) {
+      this._enabled = true;
+      host.classList.add(COMPLETER_ENABLED_CLASS);
     }
 
-    this._enabled = true;
-    host.classList.add(COMPLETER_ENABLED_CLASS);
+    // Dispath the cursor change.
+    model.handleCursorChange(this.getState(editor.getCursorPosition()));
   }
 
   /**
@@ -325,8 +330,8 @@ class CompletionHandler implements IDisposable {
       return;
     }
 
-    const request = this.getState(editor.getCursorPosition());
-    model.handleTextChange(request);
+    // Dispatch the text change.
+    model.handleTextChange(this.getState(editor.getCursorPosition()));
   }
 
   /**

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -310,7 +310,7 @@ class CompletionHandler implements IDisposable {
       host.classList.add(COMPLETER_ENABLED_CLASS);
     }
 
-    // Dispath the cursor change.
+    // Dispatch the cursor change.
     model.handleCursorChange(this.getState(editor.getCursorPosition()));
   }
 

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -87,7 +87,8 @@ class CompletionHandler implements IDisposable {
     // Update the editor and signal connections.
     editor = this._editor = newValue;
     if (editor) {
-      let model = editor.model;
+      const model = editor.model;
+      this._enabled = false;
       model.selections.changed.connect(this.onSelectionsChanged, this);
       model.value.changed.connect(this.onTextChanged, this);
       // On initial load, manually check the cursor position.
@@ -283,7 +284,7 @@ class CompletionHandler implements IDisposable {
     const line = editor.getLine(position.line);
     const { start, end } = editor.getSelection();
 
-    // If there is a text selection, no completion is allowed.
+    // If there is a text selection, return.
     if (start.column !== end.column || start.line !== end.line) {
       this._enabled = false;
       model.reset(true);
@@ -291,13 +292,19 @@ class CompletionHandler implements IDisposable {
       return;
     }
 
-    // If the entire line the curson is on consists of whitespace, bail.
+    // If the entire line is white space, return.
     if (line.match(/^\W*$/)) {
       this._enabled = false;
       model.reset(true);
       host.classList.remove(COMPLETER_ENABLED_CLASS);
       return;
     }
+
+    // If the completer is already enabled, return;
+    if (this._enabled) {
+      return;
+    }
+
     this._enabled = true;
     host.classList.add(COMPLETER_ENABLED_CLASS);
   }

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -79,16 +79,17 @@ class CompleterModel implements CompleterWidget.IModel {
     if (!this._cursor) {
       return;
     }
-    this._current = newValue;
 
+    this._current = newValue;
     if (!this._current) {
       this._stateChanged.emit(void 0);
       return;
     }
-    let original = this._original;
-    let current = this._current;
-    let originalLine = original.text.split('\n')[original.line];
-    let currentLine = current.text.split('\n')[current.line];
+
+    const original = this._original;
+    const current = this._current;
+    const originalLine = original.text.split('\n')[original.line];
+    const currentLine = current.text.split('\n')[current.line];
 
     // If the text change means that the original start point has been preceded,
     // then the completion is no longer valid and should be reset.
@@ -97,11 +98,11 @@ class CompleterModel implements CompleterWidget.IModel {
       return;
     }
 
-    let { start, end } = this._cursor;
+    const { start, end } = this._cursor;
     // Clip the front of the current line.
     let query = current.text.substring(start);
     // Clip the back of the current line by calculating the end of the original.
-    let ending = original.text.substring(end);
+    const ending = original.text.substring(end);
     query = query.substring(0, query.lastIndexOf(ending));
     this._query = query;
     this._stateChanged.emit(void 0);

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -184,13 +184,12 @@ class CompleterModel implements CompleterWidget.IModel {
    * Set the avilable options in the completer menu.
    */
   setOptions(newValue: IterableOrArrayLike<string>) {
-    let values = toArray(newValue || []);
+    const values = toArray(newValue || []);
     if (JSONExt.deepEqual(values, this._options)) {
       return;
     }
     if (values.length) {
-      this._options = [];
-      this._options.push(...values);
+      this._options = values;
       this._subsetMatch = true;
     } else {
       this._options = [];

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -208,16 +208,29 @@ class CompleterModel implements CompleterWidget.IModel {
 
     const { column, line } = change;
     const { original } = this;
+
     // If a cursor change results in a the cursor being on a different line
-    // than the original request, cancel completion.
+    // than the original request, cancel.
     if (line !== original.line) {
       this.reset(true);
       return;
     }
 
     // If a cursor change results in the cursor being set to a position that
-    // precedes the original request, cancel completion.
+    // precedes the original request, cancel.
     if (column < original.column) {
+      this.reset(true);
+      return;
+    }
+
+    // If a cursor change results in the cursor being set to a position beyond
+    // the end of the area that would be affected by completion, cancel.
+    const { current } = this;
+    const cursorDelta = this._cursor.end - this._cursor.start;
+    const originalLine = original.text.split('\n')[original.line];
+    const currentLine = current.text.split('\n')[current.line];
+    const inputDelta = currentLine.length - originalLine.length;
+    if (column > original.column + cursorDelta + inputDelta) {
       this.reset(true);
       return;
     }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -272,12 +272,6 @@ class CompleterWidget extends Widget {
     let active = node.querySelectorAll(`.${ITEM_CLASS}`)[this._activeIndex];
     active.classList.add(ACTIVE_CLASS);
 
-    if (this.isHidden) {
-      this.show();
-      this._visibilityChanged.emit(void 0);
-    }
-    this._setGeometry();
-
     // If this is the first time the current completer session has loaded,
     // populate any initial subset match.
     if (this._model.subsetMatch) {
@@ -287,6 +281,13 @@ class CompleterWidget extends Widget {
         this.update();
         return;
       }
+    }
+
+    this._setGeometry();
+
+    if (this.isHidden) {
+      this.show();
+      this._visibilityChanged.emit(void 0);
     }
   }
 

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -141,16 +141,6 @@ class CompleterWidget extends Widget {
   }
 
   /**
-   * Reset the widget.
-   */
-  reset(): void {
-    this._reset();
-    if (this._model) {
-      this._model.reset(true);
-    }
-  }
-
-  /**
    * Handle the DOM events for the widget.
    *
    * @param event - The DOM event sent to the widget.
@@ -176,6 +166,16 @@ class CompleterWidget extends Widget {
       break;
     default:
       break;
+    }
+  }
+
+  /**
+   * Reset the widget.
+   */
+  reset(): void {
+    this._reset();
+    if (this._model) {
+      this._model.reset(true);
     }
   }
 
@@ -223,8 +223,17 @@ class CompleterWidget extends Widget {
    * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {
-    let model = this._model;
+    const model = this._model;
     if (!model) {
+      return;
+    }
+
+    if (this._resetFlag) {
+      this._resetFlag = false;
+      if (!this.isHidden) {
+        this.hide();
+        this._visibilityChanged.emit(void 0);
+      }
       return;
     }
 
@@ -232,7 +241,8 @@ class CompleterWidget extends Widget {
 
     // If there are no items, reset and bail.
     if (!items || !items.length) {
-      this._reset();
+      this._resetFlag = true;
+      this.reset();
       if (!this.isHidden) {
         this.hide();
         this._visibilityChanged.emit(void 0);
@@ -456,6 +466,7 @@ class CompleterWidget extends Widget {
   private _editor: CodeEditor.IEditor | null = null;
   private _model: CompleterWidget.IModel | null = null;
   private _renderer: CompleterWidget.IRenderer | null = null;
+  private _resetFlag = false;
   private _selected = new Signal<this, string>(this);
   private _visibilityChanged = new Signal<this, void>(this);
 }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -173,7 +173,7 @@ class CompleterWidget extends Widget {
    * Reset the widget.
    */
   reset(): void {
-    this._reset();
+    this._activeIndex = 0;
     if (this._model) {
       this._model.reset(true);
     }
@@ -215,6 +215,7 @@ class CompleterWidget extends Widget {
    */
   protected onModelStateChanged(): void {
     if (this.isAttached) {
+      this._activeIndex = 0;
       this.update();
     }
   }
@@ -294,6 +295,11 @@ class CompleterWidget extends Widget {
 
   /**
    * Cycle through the available completer items.
+   *
+   * #### Notes
+   * When the user cycles all the way `down` to the last index, subsequent
+   * `down` cycles will remain on the last index. When the user cycles `up` to
+   * the first item, subsequent `up` cycles will remain on the first cycle.
    */
   private _cycle(direction: 'up' | 'down'): void {
     let items = this.node.querySelectorAll(`.${ITEM_CLASS}`);
@@ -301,9 +307,9 @@ class CompleterWidget extends Widget {
     let active = this.node.querySelector(`.${ACTIVE_CLASS}`) as HTMLElement;
     active.classList.remove(ACTIVE_CLASS);
     if (direction === 'up') {
-      this._activeIndex = index === 0 ? items.length - 1 : index - 1;
+      this._activeIndex = index === 0 ? index : index - 1;
     } else {
-      this._activeIndex = index < items.length - 1 ? index + 1 : 0;
+      this._activeIndex = index < items.length - 1 ? index + 1 : index;
     }
     active = items[this._activeIndex] as HTMLElement;
     active.classList.add(ACTIVE_CLASS);
@@ -423,13 +429,6 @@ class CompleterWidget extends Widget {
       return true;
     }
     return false;
-  }
-
-  /**
-   * Reset the internal flags to defaults.
-   */
-  private _reset(): void {
-    this._activeIndex = 0;
   }
 
   /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -283,11 +283,12 @@ class CompleterWidget extends Widget {
       }
     }
 
-    this._setGeometry();
-
     if (this.isHidden) {
       this.show();
+      this._setGeometry();
       this._visibilityChanged.emit(void 0);
+    } else {
+      this._setGeometry();
     }
   }
 

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -579,6 +579,11 @@ namespace CompleterWidget {
     setOptions(options: IterableOrArrayLike<string>): void;
 
     /**
+     * Handle a cursor change.
+     */
+    handleCursorChange(change: CompleterWidget.ITextState): void;
+
+    /**
      * Handle a completion request.
      */
     handleTextChange(change: CompleterWidget.ITextState): void;

--- a/test/src/completer/widget.spec.ts
+++ b/test/src/completer/widget.spec.ts
@@ -393,11 +393,11 @@ describe('completer/widget', () => {
           expect(items[0].classList).to.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
-          simulate(target, 'keydown', { keyCode: 40 });  // Down
+          simulate(anchor.node, 'keydown', { keyCode: 40 });  // Down
           expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
-          simulate(target, 'keydown', { keyCode: 40 });  // Down
+          simulate(anchor.node, 'keydown', { keyCode: 40 });  // Down
           expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.contain(ACTIVE_CLASS);

--- a/test/src/completer/widget.spec.ts
+++ b/test/src/completer/widget.spec.ts
@@ -337,7 +337,7 @@ describe('completer/widget', () => {
           anchor.dispose();
         });
 
-        it('should select the item below and cycle back on down', () => {
+        it('should select the item below and not progress past last', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: CompleterWidget.IOptions = {
@@ -367,14 +367,14 @@ describe('completer/widget', () => {
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.contain(ACTIVE_CLASS);
           simulate(target, 'keydown', { keyCode: 40 });  // Down
-          expect(items[0].classList).to.contain(ACTIVE_CLASS);
+          expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
-          expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
+          expect(items[2].classList).to.contain(ACTIVE_CLASS);
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should select the item above and cycle back on up', () => {
+        it('should select the item above and not progress beyond first', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: CompleterWidget.IOptions = {
@@ -393,13 +393,21 @@ describe('completer/widget', () => {
           expect(items[0].classList).to.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
-          simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
+          simulate(target, 'keydown', { keyCode: 40 });  // Down
+          expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
+          expect(items[1].classList).to.contain(ACTIVE_CLASS);
+          expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
+          simulate(target, 'keydown', { keyCode: 40 });  // Down
           expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.contain(ACTIVE_CLASS);
           simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
           expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.contain(ACTIVE_CLASS);
+          expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
+          simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
+          expect(items[0].classList).to.contain(ACTIVE_CLASS);
+          expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
           simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
           expect(items[0].classList).to.contain(ACTIVE_CLASS);


### PR DESCRIPTION
* Bug fix: when a completer is closed by typing text that removes all options, make sure it does not remain in an "open" state in memory.
* Bug fix: when a new editor is set on a completion handler, make sure its `enabled` status is re-evaluated.
* Bug fix: hide the hover box until its dimensions and visibility are known. (This bug manifested by sometimes returning the hover box element when calling `elementFromPoint`, thus resulting in non-rendering even when the box was within bounds.)
* Bug fix: set the geometry of the completer immediately upon making it visible. (This bug manifested in a noticeable "jumping" effect as the completer set its geometry.)
* Bug fix: if the cursor is moved to a column preceding the point where the completer was invoked, dismiss the completer. (Partly fixes https://github.com/jupyterlab/jupyterlab/issues/1975)
* Bug fix: if the cursor is moved to a column after the point where completion affects the text, dismiss the completer.  (Fixes https://github.com/jupyterlab/jupyterlab/issues/1975)
![completer-bounds](https://cloud.githubusercontent.com/assets/159529/24309434/a9f12a6e-10c3-11e7-88ba-14d956a142c7.gif)
* When users cycle up or down in completer choices, do not loop. (cc: @jasongrout @willingc @ellisonbg)
