### PR TITLE
JSON Editor Fixes

### DIFF
--- a/packages/codeeditor/style/index.css
+++ b/packages/codeeditor/style/index.css
@@ -6,7 +6,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.jp-ObservableJSONWidget {
+.jp-JSONEditorWidget {
   padding-left: 10px;
   padding-right: 10px;
   display: flex;
@@ -15,7 +15,7 @@
 }
 
 
-.jp-ObservableJSONWidget-host {
+.jp-JSONEditorWidget-host {
   flex: 1 1 auto;
   border: var(--jp-border-width) solid #cfcfcf;
   border-radius: 0px;
@@ -24,13 +24,13 @@
 }
 
 
-.jp-ObservableJSONWidget.jp-mod-error .jp-ObservableJSONWidget-host {
+.jp-JSONEditorWidget.jp-mod-error .jp-JSONEditorWidget-host {
   border-color: red;
   outline-color: red;
 }
 
 
-.jp-ObservableJSONWidget-buttons {
+.jp-JSONEditorWidget-buttons {
   font-family: FontAwesome;
   flex: 1 0 auto;
   min-height: 13px;
@@ -38,14 +38,14 @@
 }
 
 
-.jp-ObservableJSONWidget-commitButton::before {
-  content: '\f0c7'; /* save */
+.jp-JSONEditorWidget-commitButton::before {
+  content: '\f00c'; /* check */
   float: right;
   margin-right: 20px;
 }
 
 
-.jp-ObservableJSONWidget-revertButton::before {
+.jp-JSONEditorWidget-revertButton::before {
   content: '\f0e2'; /* undo */
   float: right;
   margin-right: 4px;

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -239,13 +239,6 @@
 }
 
 
-.jp-MetadataEditorTool .jp-JSONEditorWidget {
-  background-color: white;
-  border: var(--jp-border-width) solid var(--jp-border-color1);
-  margin: 8px;
-}
-
-
 .jp-MetadataEditorTool .jp-JSONEditorWidget.jp-mod-collapsed {
   display: none;
 }


### PR DESCRIPTION
Fixes #1983.  Fallout from the big split, should be backported to 0.18.  Also, the use of the save icon was confusing because it does not save the file, so switched to a check mark.

Before:
<img width="308" alt="screen shot 2017-03-23 at 2 20 43 pm" src="https://cloud.githubusercontent.com/assets/2096628/24270917/0016a638-0fe5-11e7-811b-333fd4c98cb3.png">

After:

<img width="304" alt="screen shot 2017-03-23 at 4 21 56 pm" src="https://cloud.githubusercontent.com/assets/2096628/24270910/fcb801da-0fe4-11e7-8501-d24a56031ab1.png">


