### PR TITLE
Use the phosphor context menu for the file browser

### DIFF
--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -12,7 +12,7 @@
     "@jupyterlab/rendermime": "^0.1.4",
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/commands": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "es6-promise": "^4.1.0"
   },
   "devDependencies": {

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -15,7 +15,7 @@
     "@jupyterlab/filebrowser": "^0.1.3",
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/commands": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "es6-promise": "^4.1.0",
     "webpack": "^2.2.1"
   },

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -15,7 +15,7 @@
     "@jupyterlab/default-theme": "^0.1.3",
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/commands": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "es6-promise": "^4.1.0"
   },
   "devDependencies": {

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -9,7 +9,7 @@
     "@jupyterlab/default-theme": "^0.1.3",
     "@jupyterlab/services": "^0.40.1",
     "@jupyterlab/terminal": "^0.1.1",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "es6-promise": "^4.1.0",
     "webpack": "^2.2.1"
   },

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "@phosphor/algorithm": "^1.0.0",
-    "@phosphor/application": "^1.0.0",
+    "@phosphor/application": "^1.0.1",
     "@phosphor/coreutils": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "@types/semver": "^5.3.31",
     "semver": "^5.3.0"
   },

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -24,7 +24,7 @@
     "@phosphor/properties": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
     "@phosphor/virtualdom": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "@types/sanitize-html": "^1.13.31",
     "sanitize-html": "^1.14.1"
   },

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -21,7 +21,7 @@
     "@phosphor/coreutils": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -18,7 +18,7 @@
     "@phosphor/disposable": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -17,7 +17,7 @@
     "@jupyterlab/codeeditor": "^0.1.4",
     "@jupyterlab/codemirror": "^0.1.4",
     "@jupyterlab/editorwidget": "^0.1.3",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -16,7 +16,7 @@
     "@jupyterlab/completer": "^0.1.4",
     "@jupyterlab/console": "^0.1.3",
     "@jupyterlab/notebook": "^0.1.3",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -22,7 +22,7 @@
     "@phosphor/domutils": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -22,7 +22,7 @@
     "@jupyterlab/rendermime": "^0.1.4",
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/coreutils": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -25,7 +25,7 @@
     "@phosphor/disposable": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/csvwidget/package.json
+++ b/packages/csvwidget/package.json
@@ -19,7 +19,7 @@
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
     "@phosphor/virtualdom": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "@types/d3-dsv": "^1.0.30",
     "d3-dsv": "^1.0.5"
   },

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -22,7 +22,7 @@
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/properties": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -21,7 +21,7 @@
     "@phosphor/coreutils": "^1.0.0",
     "@phosphor/disposable": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "codemirror": "^5.24.2"
   },
   "devDependencies": {

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -387,7 +387,8 @@ class DocumentRegistry implements IDisposable {
    * This is equivalent to the first value in [[preferredWidgetFactories]].
    */
   defaultWidgetFactory(ext: string = '*'): DocumentRegistry.WidgetFactory {
-    return this.preferredWidgetFactories(ext)[0];
+    let factories = this.preferredWidgetFactories(ext);
+    return factories ? factories[0] : void 0;
   }
 
   /**

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@jupyterlab/application": "^0.1.1",
     "@jupyterlab/apputils": "^0.1.1",
+    "@jupyterlab/coreutils": "^0.1.1",
     "@jupyterlab/docmanager": "^0.1.3",
     "@jupyterlab/docregistry": "^0.1.4",
     "@jupyterlab/filebrowser": "^0.1.3",

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -21,7 +21,7 @@
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/algorithm": "^1.0.0",
     "@phosphor/disposable": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -329,11 +329,11 @@ function createMenu(app: JupyterLab, creatorCmds: string[]): Menu {
 
 
 /**
- * Create a context menu for the file browser listing.
+ * Populated the context menu for the file browser listing.
  *
  * #### Notes
- * This function generates temporary commands with an incremented name. These
- * commands are disposed when the menu itself is disposed.
+ * The Open With menu is dynamically added/removed as the selection on
+ * the file browser changes.
  */
 function populateContextMenu(fbWidget: FileBrowser, menu: ContextMenu, commands: CommandRegistry) {
   let selector = '.jp-DirListing-content';

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -329,7 +329,7 @@ function createMenu(app: JupyterLab, creatorCmds: string[]): Menu {
 
 
 /**
- * Populated the context menu for the file browser listing.
+ * Populate the context menu for the file browser listing.
  *
  * #### Notes
  * The Open With menu is dynamically added/removed as the selection on

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -332,7 +332,7 @@ function createMenu(app: JupyterLab, creatorCmds: string[]): Menu {
  * Populate the context menu for the file browser listing.
  *
  * #### Notes
- * The Open With menu is dynamically added/removed as the selection on
+ * The `"Open With"` menu is dynamically added/removed as the selection on
  * the file browser changes.
  */
 function populateContextMenu(fbWidget: FileBrowser, menu: ContextMenu, commands: CommandRegistry) {

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -26,7 +26,7 @@
     "@phosphor/dragdrop": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -128,6 +128,13 @@ class FileBrowser extends Widget {
   }
 
   /**
+   * Get the listing content node.
+   */
+  get listingContentNode(): HTMLElement {
+    return this._listing.contentNode;
+  }
+
+  /**
    * Dispose of the resources held by the file browser.
    */
   dispose() {
@@ -152,19 +159,16 @@ class FileBrowser extends Widget {
    *
    * Changes to the first directory encountered.
    */
-  open(): void {
+  open(widgetName='default'): void {
     let foundDir = false;
-    each(this._model.items(), item => {
-      if (!this._listing.isSelected(item.name)) {
-        return;
-      }
+    each(this._listing.selection(), item => {
       if (item.type === 'directory') {
         if (!foundDir) {
           foundDir = true;
           this._model.cd(item.name);
         }
       } else {
-        this.openPath(item.path);
+        this.openPath(item.path, widgetName);
       }
     });
   }

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -18,7 +18,7 @@
     "@jupyterlab/coreutils": "^0.1.1",
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/messaging": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/imagewidget/package.json
+++ b/packages/imagewidget/package.json
@@ -18,7 +18,7 @@
     "@phosphor/commands": "^1.0.0",
     "@phosphor/coreutils": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -21,7 +21,7 @@
     "@phosphor/disposable": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/markdownwidget/package.json
+++ b/packages/markdownwidget/package.json
@@ -17,7 +17,7 @@
     "@jupyterlab/docregistry": "^0.1.4",
     "@jupyterlab/rendermime": "^0.1.4",
     "@phosphor/messaging": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -20,7 +20,7 @@
     "@jupyterlab/rendermime": "^0.1.4",
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/coreutils": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -29,7 +29,7 @@
     "@phosphor/properties": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
     "@phosphor/virtualdom": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -22,7 +22,7 @@
     "@phosphor/dragdrop": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -20,7 +20,7 @@
     "@phosphor/algorithm": "^1.0.0",
     "@phosphor/coreutils": "^1.0.0",
     "@phosphor/disposable": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "@types/marked": "0.0.28",
     "@types/mathjax": "0.0.31",
     "ansi_up": "^1.3.0",

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -18,7 +18,7 @@
     "@phosphor/domutils": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -16,7 +16,7 @@
     "@jupyterlab/apputils": "^0.1.1",
     "@jupyterlab/services": "^0.40.1",
     "@jupyterlab/terminal": "^0.1.1",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -18,7 +18,7 @@
     "@phosphor/coreutils": "^1.0.0",
     "@phosphor/domutils": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "xterm": "^2.4.0"
   },
   "devDependencies": {

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -19,7 +19,7 @@
     "@jupyterlab/services": "^0.40.1",
     "@jupyterlab/tooltip": "^0.1.3",
     "@phosphor/coreutils": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -19,7 +19,7 @@
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/coreutils": "^1.0.0",
     "@phosphor/messaging": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0"
+    "@phosphor/widgets": "^1.0.1"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/test/package.json
+++ b/test/package.json
@@ -40,7 +40,7 @@
     "@phosphor/messaging": "^1.0.0",
     "@phosphor/signaling": "^1.0.0",
     "@phosphor/virtualdom": "^1.0.0",
-    "@phosphor/widgets": "^1.0.0",
+    "@phosphor/widgets": "^1.0.1",
     "expect.js": "^0.3.1",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",


### PR DESCRIPTION
Also cleans up the logic around selection in the file listing, exposing a `selectionChanged` signal and a `selection(): IIterator<Contents.IModel>` method.

Adds enabled state to `openWith`, and the ability to open more than one file at time.