### PR TITLE
nbformat: codemirror_mode is optional

### DIFF
--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -43,9 +43,9 @@ namespace nbformat {
   interface ILanguageInfoMetadata extends  JSONObject {
     name: string;
     codemirror_mode?: string | JSONObject;
-    file_extension: string;
-    mimetype: string;
-    pygments_lexer: string;
+    file_extension?: string;
+    mimetype?: string;
+    pygments_lexer?: string;
   }
 
   /**

--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -42,7 +42,7 @@ namespace nbformat {
   export
   interface ILanguageInfoMetadata extends  JSONObject {
     name: string;
-    codemirror_mode: string | JSONObject;
+    codemirror_mode?: string | JSONObject;
     file_extension: string;
     mimetype: string;
     pygments_lexer: string;


### PR DESCRIPTION
According to the specs, `codemirror_mode` is optional.