### PR TITLE
Clean up of tooltips and rendered text

### DIFF
--- a/packages/apputils/src/hoverbox.ts
+++ b/packages/apputils/src/hoverbox.ts
@@ -160,7 +160,8 @@ namespace HoverBox {
 
     // Position the box horizontally.
     const offsetHorizontal = options.offset && options.offset.horizontal || 0;
-    const left = anchor.left + offsetHorizontal;
+    let left = anchor.left + offsetHorizontal;
+
     node.style.left = `${Math.ceil(left)}px`;
     node.style.width = 'auto';
 
@@ -168,6 +169,13 @@ namespace HoverBox {
     if (node.scrollHeight >= maxHeight) {
       node.style.width = `${2 * node.offsetWidth - node.clientWidth}`;
       node.scrollTop = 0;
+    }
+
+    // Move left to fit in the window.
+    let right = node.getBoundingClientRect().right;
+    if (right > window.innerWidth) {
+      left -= right - window.innerWidth;
+      node.style.left = `${Math.ceil(left)}px`;
     }
   }
 }

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -18,9 +18,6 @@
   padding: 0px;
   overflow-x: auto;
   overflow-y: auto;
-  word-break: break-all;
-  word-wrap: break-word;
-  white-space: pre-wrap;
 }
 
 

--- a/packages/tooltip/style/index.css
+++ b/packages/tooltip/style/index.css
@@ -8,11 +8,12 @@
   border: var(--jp-border-width) solid var(--jp-border-color1);
   font-size: var(--jp-ui-font-size0);
   box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.2);
-  max-width: 500px;
-  overflow: auto;
+  max-width: 650px;
   z-index: 10001;
   padding: 4px;
+  overflow: auto;
 }
+
 
 .jp-Tooltip:focus {
   outline: 0;
@@ -20,9 +21,4 @@
 
 .jp-Tooltip pre {
   margin: 0;
-}
-
-
-.jp-Tooltip > .jp-RenderedText {
-    overflow: visible;
 }


### PR DESCRIPTION
Fixes #1976.  Widens the tooltip to accommodate 80 characters and enables horizontal scrolling.

Before:

![image](https://cloud.githubusercontent.com/assets/2069677/24203281/9518b256-0f15-11e7-8ff0-19f23c8c748d.png)


After:

![image](https://cloud.githubusercontent.com/assets/2096628/24427546/e5682a42-13d0-11e7-9e58-4a3bda836b9d.png)

![image](https://cloud.githubusercontent.com/assets/2096628/24427556/ed8a8ba2-13d0-11e7-9a41-c0dd89806aec.png)

![image](https://cloud.githubusercontent.com/assets/2096628/24427563/f67d96a0-13d0-11e7-8d81-076245480e76.png)

![image](https://cloud.githubusercontent.com/assets/2096628/24427573/ff3e063a-13d0-11e7-9248-eba723cb84df.png)

