### PR TITLE
Populate the launcher using optional services

### DIFF
--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -19,6 +19,7 @@
     "@jupyterlab/coreutils": "^0.1.1",
     "@jupyterlab/docregistry": "^0.1.4",
     "@jupyterlab/filebrowser": "^0.1.3",
+    "@jupyterlab/launcher": "^0.1.3",
     "@jupyterlab/rendermime": "^0.1.4",
     "@jupyterlab/services": "^0.40.1",
     "@phosphor/coreutils": "^1.0.0",

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -43,6 +43,10 @@ import {
 } from '@jupyterlab/filebrowser';
 
 import {
+  ILauncher
+} from '@jupyterlab/launcher';
+
+import {
   IRenderMime, RenderMime
 } from '@jupyterlab/rendermime';
 
@@ -102,6 +106,7 @@ const trackerPlugin: JupyterLabPlugin<IConsoleTracker> = {
     IEditorServices,
     ILayoutRestorer
   ],
+  optional: [ILauncher],
   activate: activateConsole,
   autoStart: true
 };
@@ -145,7 +150,7 @@ const CONSOLE_REGEX = /^console-(\d)+-[0-9a-f]+$/;
 /**
  * Activate the console extension.
  */
-function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: ILayoutRestorer): IConsoleTracker {
+function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, pathTracker: IPathTracker, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: ILayoutRestorer, launcher: ILauncher | null): IConsoleTracker {
   let manager = services.sessions;
   let { commands, shell } = app;
   let category = 'Console';
@@ -166,6 +171,14 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     name: panel => panel.console.session && panel.console.session.id,
     when: manager.ready
   });
+
+  // Add a launcher item if the launcher is available.
+  if (launcher) {
+    launcher.add({
+      name: 'Code Console',
+      command: CommandIDs.create
+    });
+  }
 
   // Set the main menu title.
   menu.title.label = category;

--- a/packages/editorwidget-extension/package.json
+++ b/packages/editorwidget-extension/package.json
@@ -16,7 +16,8 @@
     "@jupyterlab/apputils": "^0.1.1",
     "@jupyterlab/codeeditor": "^0.1.4",
     "@jupyterlab/docregistry": "^0.1.4",
-    "@jupyterlab/editorwidget": "^0.1.3"
+    "@jupyterlab/editorwidget": "^0.1.3",
+    "@jupyterlab/launcher": "^0.1.3"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/packages/editorwidget-extension/src/index.ts
+++ b/packages/editorwidget-extension/src/index.ts
@@ -21,6 +21,10 @@ import {
   IEditorTracker, EditorWidget, EditorWidgetFactory, addDefaultCommands
 } from '@jupyterlab/editorwidget';
 
+import {
+  ILauncher
+} from '@jupyterlab/launcher';
+
 
 /**
  * The class name for the text editor icon from the default theme.
@@ -40,6 +44,7 @@ const plugin: JupyterLabPlugin<IEditorTracker> = {
   activate,
   id: 'jupyter.services.editor-tracker',
   requires: [IDocumentRegistry, ILayoutRestorer, IEditorServices],
+  optional: [ILauncher],
   provides: IEditorTracker,
   autoStart: true
 };
@@ -53,7 +58,7 @@ export default plugin;
 /**
  * Activate the editor tracker plugin.
  */
-function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayoutRestorer, editorServices: IEditorServices): IEditorTracker {
+function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayoutRestorer, editorServices: IEditorServices, launcher: ILauncher | null): IEditorTracker {
   const factory = new EditorWidgetFactory({
     editorServices,
     factoryOptions: {
@@ -84,5 +89,14 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
   registry.addWidgetFactory(factory);
 
   addDefaultCommands(tracker, app.commands);
+
+  // Add a launcher item if the launcher is available.
+  if (launcher) {
+    launcher.add({
+      name: 'Text Editor',
+      command: 'file-operations:new-text-file'
+    });
+  }
+
   return tracker;
 }

--- a/packages/launcher-extension/src/index.ts
+++ b/packages/launcher-extension/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from '@jupyterlab/filebrowser';
 
 import {
-  ILauncher, ILauncherItem, LauncherModel, LauncherWidget
+  ILauncher, LauncherModel, LauncherWidget
 } from '@jupyterlab/launcher';
 
 
@@ -77,33 +77,6 @@ function activate(app: JupyterLab, services: IServiceManager, pathTracker: IPath
   // application state (e.g. setting the launcher as the current side bar
   // widget).
   restorer.add(widget, 'launcher');
-
-  // Hardcoded defaults.
-  let defaults: ILauncherItem[] = [
-    {
-      name: 'Notebook',
-      command: 'file-operations:new-notebook'
-    },
-    {
-      name: 'Code Console',
-      command: 'console:create'
-    },
-    {
-      name: 'Text Editor',
-      command: 'file-operations:new-text-file'
-    }
-  ];
-
-  if (services.terminals.isAvailable()) {
-    defaults.push({
-      name: 'Terminal',
-      command: 'terminal:create-new'
-    });
-  }
-
-  // Note: we do not retain a handle on the items added by default, which
-  // means we have to way of removing them after the fact.
-  defaults.forEach(options => { model.add(options); });
 
   commands.addCommand(CommandIDs.show, {
     label: 'Show Launcher',

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -16,6 +16,7 @@
     "@jupyterlab/apputils": "^0.1.1",
     "@jupyterlab/codeeditor": "^0.1.4",
     "@jupyterlab/docregistry": "^0.1.4",
+    "@jupyterlab/launcher": "^0.1.3",
     "@jupyterlab/notebook": "^0.1.3",
     "@jupyterlab/rendermime": "^0.1.4",
     "@jupyterlab/services": "^0.40.1",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -19,6 +19,10 @@ import {
 } from '@jupyterlab/docregistry';
 
 import {
+  ILauncher
+} from '@jupyterlab/launcher';
+
+import {
   CellTools, ICellTools, INotebookTracker, NotebookActions,
   NotebookModelFactory,  NotebookPanel, NotebookTracker, NotebookWidgetFactory,
   trustNotebook
@@ -206,6 +210,7 @@ const trackerPlugin: JupyterLabPlugin<INotebookTracker> = {
     IEditorServices,
     ILayoutRestorer
   ],
+  optional: [ILauncher],
   activate: activateNotebookHandler,
   autoStart: true
 };
@@ -316,7 +321,7 @@ function activateCellTools(app: JupyterLab, tracker: INotebookTracker, editorSer
 /**
  * Activate the notebook handler extension.
  */
-function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, contentFactory: NotebookPanel.IContentFactory, editorServices: IEditorServices, restorer: ILayoutRestorer): INotebookTracker {
+function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, palette: ICommandPalette, contentFactory: NotebookPanel.IContentFactory, editorServices: IEditorServices, restorer: ILayoutRestorer, launcher: ILauncher | null): INotebookTracker {
 
   const factory = new NotebookWidgetFactory({
     name: FACTORY,
@@ -373,8 +378,17 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
   // Add main menu notebook menu.
   mainMenu.addMenu(createMenu(app), { rank: 20 });
 
+  // Add a launcher item if the launcher is available.
+  if (launcher) {
+    launcher.add({
+      name: 'Notebook',
+      command: 'file-operations:new-notebook'
+    });
+  }
+
   return tracker;
 }
+
 
 
 /**

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@jupyterlab/application": "^0.1.1",
     "@jupyterlab/apputils": "^0.1.1",
+    "@jupyterlab/launcher": "^0.1.3",
     "@jupyterlab/services": "^0.40.1",
     "@jupyterlab/terminal": "^0.1.1",
     "@phosphor/widgets": "^1.0.0"

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -18,6 +18,10 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
+  ILauncher
+} from '@jupyterlab/launcher';
+
+import {
   TerminalWidget, ITerminalTracker, addDefaultCommands
 } from '@jupyterlab/terminal';
 
@@ -64,6 +68,7 @@ const plugin: JupyterLabPlugin<ITerminalTracker> = {
   requires: [
     IServiceManager, IMainMenu, ICommandPalette, ILayoutRestorer
   ],
+  optional: [ILauncher],
   autoStart: true
 };
 
@@ -77,7 +82,7 @@ export default plugin;
 /**
  * Activate the terminal plugin.
  */
-function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMenu, palette: ICommandPalette, restorer: ILayoutRestorer): ITerminalTracker {
+function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMenu, palette: ICommandPalette, restorer: ILayoutRestorer, launcher: ILauncher | null): ITerminalTracker {
   // Bail if there are no terminals available.
   if (!services.terminals.isAvailable()) {
     console.log('Disabling terminals plugin because they are not available on the server');
@@ -165,6 +170,14 @@ function activate(app: JupyterLab, services: IServiceManager, mainMenu: IMainMen
     menu.addItem({ command });
   });
   mainMenu.addMenu(menu, {rank: 40});
+
+  // Add a launcher item if the launcher is available.
+  if (launcher) {
+    launcher.add({
+      name: 'Terminal',
+      command: CommandIDs.createNew
+    });
+  }
 
   return tracker;
 }


### PR DESCRIPTION
Fixes #1771, other services like `IMainMenu` can be made optional later if we so choose.

<image src="https://cloud.githubusercontent.com/assets/2096628/24428243/61a5fcea-13d3-11e7-8c41-3fdaa0f1fdf0.png" width=300>
