### PR TITLE
Clean up the top level build

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -3,7 +3,7 @@
   "name": "@jupyterlab/main",
   "version": "0.1.3",
   "scripts": {
-    "build": "cd ../packages/extension-builder && npm run build && cd ../../jupyterlab && tsc && webpack",
+    "build": "tsc && webpack",
     "clean": "rimraf build",
     "watch": "watch \"npm run build\" ../packages --wait 10 --filter=../scripts/watch-filter.js"
   },

--- a/jupyterlab/src/builder.ts
+++ b/jupyterlab/src/builder.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+export * from '@jupyterlab/extension-builder';

--- a/jupyterlab/src/typings.d.ts
+++ b/jupyterlab/src/typings.d.ts
@@ -4,5 +4,6 @@
 /// <reference path="../../packages/codemirror/typings/codemirror/codemirror.d.ts"/>
 /// <reference path="../../packages/coreutils/typings/path-posix/path-posix.d.ts"/>
 /// <reference path="../../packages/coreutils/typings/url-parse/url-parse.d.ts"/>
+/// <reference path="../../packages/extension-builder/typings/webpack-config/webpack-config.d.ts"/>
 /// <reference path="../../packages/rendermime/typings/ansi_up/ansi_up.d.ts"/>
 /// <reference path="../../packages/terminal/typings/xterm/xterm.d.ts"/>

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -3,10 +3,10 @@
 
 // Support for Node 0.10
 // See https://github.com/webpack/css-loader/issues/144
-require('es6-promise').polyfill();
+require('es6-promise/auto');
 
 var childProcess = require('child_process');
-var buildExtension = require('@jupyterlab/extension-builder/lib/builder').buildExtension;
+var buildExtension = require('./build/jupyterlab/src/builder').buildExtension;
 var webpack = require('webpack');
 var path = require('path');
 var fs = require('fs-extra');

--- a/packages/extension-builder/package.json
+++ b/packages/extension-builder/package.json
@@ -39,7 +39,7 @@
     "build:test": "tsc --project test",
     "clean": "rimraf lib",
     "test:coverage": "istanbul cover --dir test/coverage _mocha -- --timeout=10000 test/build/**/**.spec.js",
-    "test:debug": "mocha test/build/**/**.spec.js --timeout=10000 --debug-brk",
+    "test:debug": "mocha --timeout=10000 test/build/**/**.spec.js --debug-brk",
     "test": "mocha --timeout=10000 test/build/**/**.spec.js",
     "watch": "tsc -w"
   },

--- a/test/karma-cov.conf.js
+++ b/test/karma-cov.conf.js
@@ -7,7 +7,7 @@ module.exports = function (config) {
     frameworks: ['mocha'],
     client: {
       mocha: {
-        timeout : 10000, // 10 seconds - upped from 2 seconds
+        timeout : 5000, // 5 seconds - upped from 2 seconds
         retries: 3 // Allow for slow server on CI.
       }
     },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function (config) {
     reporters: ['mocha'],
     client: {
       mocha: {
-        timeout : 10000, // 10 seconds - upped from 2 seconds
+        timeout : 5000, // 5 seconds - upped from 2 seconds
         retries: 3 // Allow for slow server on CI.
       }
     },


### PR DESCRIPTION
Use a single TypeScript build for the main package, and increase the timeout for the extension builder tests.