### PR TITLE
[WIP] Model database for realtime collaboration

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,8 +3,7 @@
   "packages": [
     "jupyterlab",
     "examples/*",
-    "packages/*",
-    "test"
+    "packages/*"
   ],
   "version": "independent"
 }

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -257,6 +257,11 @@ namespace CellModel {
      * An IModelDB in which to store cell data.
      */
     modelDB?: IModelDB;
+
+    /**
+     * A unique identifier for this cell.
+     */
+    uuid?: string;
   }
 }
 

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -404,12 +404,7 @@ namespace CodeCellModel {
   /**
    * The options used to initialize a `CodeCellModel`.
    */
-  export interface IOptions {
-    /**
-     * The source cell data.
-     */
-    cell?: nbformat.IBaseCell;
-
+  export interface IOptions extends CellModel.IOptions {
     /**
      * The factory for output area model creation.
      */

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -128,11 +128,13 @@ class CellModel extends CodeEditor.Model implements ICellModel {
     super({modelDB: options.modelDB});
     this.value.changed.connect(this.onGenericChange, this);
     let cell = options.cell;
+    let trusted = this._modelDB.createValue();
     if (!cell) {
-      this._modelDB.set('trusted', new ObservableValue(false));
+      trusted.set(false);
+      this._modelDB.set('trusted', trusted);
       return;
     }
-    let trusted = new ObservableValue(!!cell.metadata['trusted']);
+    trusted.set(!!cell.metadata['trusted']);
     this._modelDB.set('trusted', trusted);
     delete cell.metadata['trusted'];
 
@@ -317,12 +319,14 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
     let trusted = this.trusted;
     let cell = options.cell as nbformat.ICodeCell;
     let outputs: nbformat.IOutput[] = [];
+    let executionCount = this._modelDB.createValue();
     if (cell && cell.cell_type === 'code') {
-      let executionCount = new ObservableValue(cell.execution_count || null);
+      executionCount.set(cell.execution_count || null);
       this._modelDB.set('executionCount', executionCount);
       outputs = cell.outputs;
     } else {
-      this._modelDB.set('executionCount', new ObservableValue(null));
+      executionCount.set(null);
+      this._modelDB.set('executionCount', executionCount);
     }
     this._outputs = factory.createOutputArea({
       trusted,

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -139,6 +139,14 @@ class CellModel extends CodeEditor.Model implements ICellModel {
     }
     trusted.set(!!cell.metadata['trusted']);
     delete cell.metadata['trusted'];
+    trusted.changed.connect((value, args) => {
+      this.onTrustedChanged(args.newValue as boolean);
+      this.stateChanged.emit({
+        name: 'trusted',
+        oldValue: args.oldValue,
+        newValue: args.newValue
+      });
+    });
 
     if (Array.isArray(cell.source)) {
       this.value.text = (cell.source as string[]).join('\n');
@@ -197,8 +205,6 @@ class CellModel extends CodeEditor.Model implements ICellModel {
       return;
     }
     (this._modelDB.get('trusted') as IObservableValue).set(newValue);
-    this.onTrustedChanged(newValue);
-    this.stateChanged.emit({ name: 'trusted', oldValue, newValue });
   }
 
   /**
@@ -393,8 +399,6 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
 
   /**
    * Handle a change to the trusted state.
-   *
-   * The default implementation is a no-op.
    */
   onTrustedChanged(value: boolean): void {
     this._outputs.trusted = value;

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -123,6 +123,10 @@ class CellModel extends CodeEditor.Model implements ICellModel {
    */
   constructor(options: CellModel.IOptions) {
     super({modelDB: options.modelDB});
+
+    let cellType = this._modelDB.createValue('type');
+    cellType.set(this.type);
+
     this.value.changed.connect(this.onGenericChange, this);
     let cell = options.cell;
     let trusted = this._modelDB.createValue('trusted');
@@ -320,11 +324,13 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
     let cell = options.cell as nbformat.ICodeCell;
     let outputs: nbformat.IOutput[] = [];
     let executionCount = this._modelDB.createValue('executionCount');
-    if (cell && cell.cell_type === 'code') {
-      executionCount.set(cell.execution_count || null);
-      outputs = cell.outputs;
-    } else {
-      executionCount.set(null);
+    if (!executionCount.get()) {
+      if (cell && cell.cell_type === 'code') {
+        executionCount.set(cell.execution_count || null);
+        outputs = cell.outputs;
+      } else {
+        executionCount.set(null);
+      }
     }
     this._outputs = factory.createOutputArea({
       trusted,

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -328,7 +328,8 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
     }
     this._outputs = factory.createOutputArea({
       trusted,
-      values: outputs
+      values: outputs,
+      modelDB: this._modelDB
     });
     this._outputs.stateChanged.connect(this.onGenericChange, this);
   }

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -18,16 +18,13 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  IObservableJSON, ObservableJSON
+  IObservableJSON, ObservableJSON,
+  IModelDB, IObservableValue
 } from '@jupyterlab/coreutils';
 
 import {
   IOutputAreaModel, OutputAreaModel
 } from '@jupyterlab/outputarea';
-
-import {
-  IModelDB, ObservableValue, IObservableValue
-} from '../coreutils/modeldb';
 
 
 /**

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -332,6 +332,14 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
         executionCount.set(null);
       }
     }
+    executionCount.changed.connect((value, args) => {
+      this.contentChanged.emit(void 0);
+      this.stateChanged.emit({
+        name: 'executionCount',
+        oldValue: args.oldValue,
+        newValue: args.newValue });
+    });
+
     this._outputs = factory.createOutputArea({
       trusted,
       values: outputs,
@@ -359,8 +367,6 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
       return;
     }
     (this._modelDB.get('executionCount') as IObservableValue).set(newValue || null);
-    this.contentChanged.emit(void 0);
-    this.stateChanged.emit({ name: 'executionCount', oldValue, newValue });
   }
 
   /**

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -27,7 +27,7 @@ import {
 
 import {
   IModelDB, ObservableValue, IObservableValue
-} from '../common/modeldb';
+} from '../coreutils/modeldb';
 
 
 /**

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -125,14 +125,12 @@ class CellModel extends CodeEditor.Model implements ICellModel {
     super({modelDB: options.modelDB});
     this.value.changed.connect(this.onGenericChange, this);
     let cell = options.cell;
-    let trusted = this._modelDB.createValue();
+    let trusted = this._modelDB.createValue('trusted');
     if (!cell) {
       trusted.set(false);
-      this._modelDB.set('trusted', trusted);
       return;
     }
     trusted.set(!!cell.metadata['trusted']);
-    this._modelDB.set('trusted', trusted);
     delete cell.metadata['trusted'];
 
     if (Array.isArray(cell.source)) {
@@ -316,14 +314,12 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
     let trusted = this.trusted;
     let cell = options.cell as nbformat.ICodeCell;
     let outputs: nbformat.IOutput[] = [];
-    let executionCount = this._modelDB.createValue();
+    let executionCount = this._modelDB.createValue('executionCount');
     if (cell && cell.cell_type === 'code') {
       executionCount.set(cell.execution_count || null);
-      this._modelDB.set('executionCount', executionCount);
       outputs = cell.outputs;
     } else {
       executionCount.set(null);
-      this._modelDB.set('executionCount', executionCount);
     }
     this._outputs = factory.createOutputArea({
       trusted,

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -125,14 +125,14 @@ class CellModel extends CodeEditor.Model implements ICellModel {
 
     this.value.changed.connect(this.onGenericChange, this);
 
-    let cellType = this._modelDB.createValue('type');
+    let cellType = this.modelDB.createValue('type');
     cellType.set(this.type);
 
-    let observableMetadata = this._modelDB.createJSON('metadata');
+    let observableMetadata = this.modelDB.createJSON('metadata');
     observableMetadata.changed.connect(this.onGenericChange, this);
 
     let cell = options.cell;
-    let trusted = this._modelDB.createValue('trusted');
+    let trusted = this.modelDB.createValue('trusted');
     if (!cell) {
       trusted.set(false);
       return;
@@ -186,14 +186,14 @@ class CellModel extends CodeEditor.Model implements ICellModel {
    * The metadata associated with the cell.
    */
   get metadata(): IObservableJSON {
-    return this._modelDB.get('metadata') as IObservableJSON;
+    return this.modelDB.get('metadata') as IObservableJSON;
   }
 
   /**
    * Get the trusted state of the model.
    */
   get trusted(): boolean {
-    return (this._modelDB.get('trusted') as IObservableValue).get() as boolean;
+    return (this.modelDB.get('trusted') as IObservableValue).get() as boolean;
   }
 
   /**
@@ -204,7 +204,7 @@ class CellModel extends CodeEditor.Model implements ICellModel {
     if (oldValue === newValue) {
       return;
     }
-    (this._modelDB.get('trusted') as IObservableValue).set(newValue);
+    (this.modelDB.get('trusted') as IObservableValue).set(newValue);
   }
 
   /**
@@ -322,7 +322,7 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
     let trusted = this.trusted;
     let cell = options.cell as nbformat.ICodeCell;
     let outputs: nbformat.IOutput[] = [];
-    let executionCount = this._modelDB.createValue('executionCount');
+    let executionCount = this.modelDB.createValue('executionCount');
     if (!executionCount.get()) {
       if (cell && cell.cell_type === 'code') {
         executionCount.set(cell.execution_count || null);
@@ -342,7 +342,7 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
     this._outputs = factory.createOutputArea({
       trusted,
       values: outputs,
-      modelDB: this._modelDB
+      modelDB: this.modelDB
     });
     this._outputs.stateChanged.connect(this.onGenericChange, this);
   }
@@ -358,14 +358,14 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
    * The execution count of the cell.
    */
   get executionCount(): nbformat.ExecutionCount {
-    return (this._modelDB.get('executionCount') as IObservableValue).get() as number || null;
+    return (this.modelDB.get('executionCount') as IObservableValue).get() as number || null;
   }
   set executionCount(newValue: nbformat.ExecutionCount) {
     let oldValue = this.executionCount;
     if (newValue === oldValue) {
       return;
     }
-    (this._modelDB.get('executionCount') as IObservableValue).set(newValue || null);
+    (this.modelDB.get('executionCount') as IObservableValue).set(newValue || null);
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -587,7 +587,11 @@ class MarkdownCellWidget extends BaseCellWidget {
       signal: this.model.contentChanged,
       timeout: RENDER_TIMEOUT
     });
-    this._monitor.activityStopped.connect(this.update, this);
+    this._monitor.activityStopped.connect(()=>{
+      if(this._rendered) {
+        this.update();
+      }
+    }, this);
   }
 
   /**

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -44,7 +44,7 @@ namespace CodeEditor {
    * A zero-based position in the editor.
    */
   export
-  interface IPosition {
+  interface IPosition extends JSONObject {
     /**
      * The cursor line number.
      */
@@ -82,7 +82,7 @@ namespace CodeEditor {
    * A range.
    */
   export
-  interface IRange {
+  interface IRange extends JSONObject {
     /**
      * The position of the first character in the current range.
      *
@@ -106,7 +106,7 @@ namespace CodeEditor {
    * A selection style.
    */
   export
-  interface ISelectionStyle {
+  interface ISelectionStyle extends JSONObject {
     /**
      * A class name added to a selection.
      */
@@ -190,15 +190,18 @@ namespace CodeEditor {
      */
     constructor(options?: Model.IOptions) {
       options = options || {};
-      let value = new ObservableString(options.value);
-      let mimeType = new ObservableValue(options.mimeType || 'text/plain');
-      let selections = new ObservableMap<ITextSelection[]>();
 
       if(options.modelDB) {
         this._modelDB = options.modelDB;
       } else {
         this._modelDB = new ModelDB();
       }
+
+      let value = this._modelDB.createString();
+      value.text = options.value || '';
+      let mimeType = this._modelDB.createValue();
+      mimeType.set(options.mimeType || 'text/plain');
+      let selections = this._modelDB.createMap<ITextSelection[]>();
 
       this._modelDB.set('value', value);
       this._modelDB.set('selections', selections);

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -27,7 +27,7 @@ import {
 
 import {
   IModelDB, ModelDB, IObservableValue, ObservableValue
-} from '../common/modeldb';
+} from '../coreutils/modeldb';
 
 
 /**

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -186,15 +186,12 @@ namespace CodeEditor {
         this._modelDB = new ModelDB();
       }
 
-      let value = this._modelDB.createString();
+      let value = this._modelDB.createString('value');
       value.text = options.value || '';
-      let mimeType = this._modelDB.createValue();
+      let mimeType = this._modelDB.createValue('mimeType');
       mimeType.set(options.mimeType || 'text/plain');
-      let selections = this._modelDB.createMap<ITextSelection[]>();
+      this._modelDB.createMap<ITextSelection[]>('selections');
 
-      this._modelDB.set('value', value);
-      this._modelDB.set('selections', selections);
-      this._modelDB.set('mimeType', mimeType);
       mimeType.changed.connect((val, args)=>{
         this._mimeTypeChanged.emit({
           name: 'mimeType',

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -110,6 +110,11 @@ namespace CodeEditor {
      * A CSS string to apply to the selection.
      */
     css?: string;
+
+    /**
+     * A color for the selection.
+     */
+    color?: string;
   }
 
   /**

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -197,7 +197,7 @@ namespace CodeEditor {
       }
 
       let value = this._modelDB.createString('value');
-      value.text = options.value || '';
+      value.text = value.text || options.value || '';
       let mimeType = this._modelDB.createValue('mimeType');
       mimeType.set(options.mimeType || 'text/plain');
       this._modelDB.createMap<ITextSelection[]>('selections');

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -191,16 +191,16 @@ namespace CodeEditor {
       options = options || {};
 
       if(options.modelDB) {
-        this._modelDB = options.modelDB;
+        this.modelDB = options.modelDB;
       } else {
-        this._modelDB = new ModelDB();
+        this.modelDB = new ModelDB();
       }
 
-      let value = this._modelDB.createString('value');
+      let value = this.modelDB.createString('value');
       value.text = value.text || options.value || '';
-      let mimeType = this._modelDB.createValue('mimeType');
+      let mimeType = this.modelDB.createValue('mimeType');
       mimeType.set(options.mimeType || 'text/plain');
-      this._modelDB.createMap<ITextSelection[]>('selections');
+      this.modelDB.createMap<ITextSelection[]>('selections');
 
       mimeType.changed.connect((val, args)=>{
         this._mimeTypeChanged.emit({
@@ -222,28 +222,28 @@ namespace CodeEditor {
      * Get the value of the model.
      */
     get value(): IObservableString {
-      return this._modelDB.get('value') as IObservableString;
+      return this.modelDB.get('value') as IObservableString;
     }
 
     /**
      * Get the selections for the model.
      */
     get selections(): IObservableMap<ITextSelection[]> {
-      return this._modelDB.get('selections') as IObservableMap<ITextSelection[]>;
+      return this.modelDB.get('selections') as IObservableMap<ITextSelection[]>;
     }
 
     /**
      * A mime type of the model.
      */
     get mimeType(): string {
-      return (this._modelDB.get('mimeType') as IObservableValue).get() as string;
+      return (this.modelDB.get('mimeType') as IObservableValue).get() as string;
     }
     set mimeType(newValue: string) {
       const oldValue = this.mimeType;
       if (oldValue === newValue) {
         return;
       }
-      (this._modelDB.get('mimeType') as IObservableValue).set(newValue);
+      (this.modelDB.get('mimeType') as IObservableValue).set(newValue);
     }
 
     /**
@@ -265,7 +265,7 @@ namespace CodeEditor {
     }
 
 
-    protected _modelDB: IModelDB = null;
+    protected modelDB: IModelDB = null;
     private _isDisposed = false;
     private _mimeTypeChanged = new Signal<this, IChangedArgs<string>>(this);
   }

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -194,6 +194,12 @@ namespace CodeEditor {
       let mimeType = new ObservableValue(options.mimeType || 'text/plain');
       let selections = new ObservableMap<ITextSelection[]>();
 
+      if(options.modelDB) {
+        this._modelDB = options.modelDB;
+      } else {
+        this._modelDB = new ModelDB();
+      }
+
       this._modelDB.set('value', value);
       this._modelDB.set('selections', selections);
       this._modelDB.set('mimeType', mimeType);
@@ -260,7 +266,7 @@ namespace CodeEditor {
     }
 
 
-    protected _modelDB = new ModelDB();
+    protected _modelDB: IModelDB = null;
     private _isDisposed = false;
     private _mimeTypeChanged = new Signal<this, IChangedArgs<string>>(this);
   }
@@ -575,6 +581,11 @@ namespace CodeEditor {
        * The mimetype of the model.
        */
       mimeType?: string;
+
+      /**
+       * An optional modelDB for storing model state.
+       */
+      modelDB?: IModelDB;
     }
   }
 }

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -14,20 +14,9 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  IChangedArgs
+  IModelDB, ModelDB, IObservableValue,
+  IObservableMap, IObservableString, IChangedArgs
 } from '@jupyterlab/coreutils';
-
-import {
-  IObservableString, ObservableString
-} from '@jupyterlab/coreutils';
-
-import {
-  IObservableMap, ObservableMap
-} from '@jupyterlab/coreutils';
-
-import {
-  IModelDB, ModelDB, IObservableValue, ObservableValue
-} from '../coreutils/modeldb';
 
 
 /**

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -105,6 +105,11 @@ namespace CodeEditor {
      * A display name added to a selection.
      */
     displayName?: string;
+
+    /**
+     * A CSS string to apply to the selection.
+     */
+    css?: string;
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -565,9 +565,17 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    * Converts an editor selection to a code mirror selection.
    */
   private _toCodeMirrorSelection(selection: CodeEditor.IRange): CodeMirror.Selection {
+    //Selections only appear to render correctly if the anchor
+    //is before the head in the document. That is, reverse selections
+    //do not appear as intended.
+    let forward: boolean = (selection.start.line < selection.end.line) ||
+                           (selection.start.line === selection.end.line &&
+                            selection.start.column <= selection.end.column);
+    let anchor = forward ? selection.start : selection.end;
+    let head = forward ? selection.end : selection.start;
     return {
-      anchor: this._toCodeMirrorPosition(selection.start),
-      head: this._toCodeMirrorPosition(selection.end)
+      anchor: this._toCodeMirrorPosition(anchor),
+      head: this._toCodeMirrorPosition(head)
     };
   }
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -628,7 +628,23 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       return;
     }
     this._changeGuard = true;
-    this.doc.setValue(this._model.value.text);
+    let doc = this.doc;
+    switch (args.type) {
+     case 'insert':
+       let pos = doc.posFromIndex(args.start);
+       doc.replaceRange(args.value, pos, pos);
+       break;
+     case 'remove':
+       let from = doc.posFromIndex(args.start);
+       let to = doc.posFromIndex(args.end);
+       doc.replaceRange('', from, to);
+       break;
+     case 'set':
+       doc.setValue(args.value);
+       break;
+     default:
+       break;
+    }
     this._changeGuard = false;
   }
 
@@ -640,7 +656,17 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       return;
     }
     this._changeGuard = true;
-    this._model.value.text = this.doc.getValue();
+    let value = this._model.value;
+    let start = doc.indexFromPos(change.from);
+    let inserted = change.text.join('\n');
+    let removed = change.removed.join('\n');
+
+    if (removed) {
+      value.remove(start, start + removed.length);
+    }
+    if (inserted) {
+      value.insert(start, inserted);
+    }
     this._changeGuard = false;
   }
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -494,7 +494,9 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     const uuid = args.key;
     if (uuid !== this.uuid) {
       this._cleanSelections(uuid);
-      this._markSelections(uuid, args.newValue);
+      if(args.type !== 'remove') {
+        this._markSelections(uuid, args.newValue);
+      }
     }
   }
 
@@ -516,8 +518,11 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     const markers: CodeMirror.TextMarker[] = [];
     selections.forEach(selection => {
       const { anchor, head } = this._toCodeMirrorSelection(selection);
-      const markerOptions = this._toTextMarkerOptions(selection);
-      this.doc.markText(anchor, head, markerOptions);
+      const markerOptions = this._toTextMarkerOptions(selection.style);
+      markers.push(this.doc.markText(anchor, head, markerOptions));
+      let caret = this._getCaret(selection.uuid);
+      markers.push(this.doc.setBookmark(
+        this._toCodeMirrorPosition(selection.end), {widget: caret}));
     });
     this.selectionMarkers[uuid] = markers;
   }
@@ -549,7 +554,8 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     if (style) {
       return {
         className: style.className,
-        title: style.displayName
+        title: style.displayName,
+        css: style.css
       };
     }
     return undefined;
@@ -619,6 +625,30 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     this._changeGuard = false;
   }
 
+  private _getCaret(uuid: string) {
+    let caret: HTMLElement = document.createElement('span');
+    caret.className = 'CodeMirror-cursor';
+    let color: string = '';
+    if((this.model as any).realtimeHandler) {
+      let collaborator: any =
+        (this.model as any).realtimeHandler.collaborators.get(uuid);
+      color = collaborator ? collaborator.color || '' : '';
+      let me: any =
+        (this.model as any).realtimeHandler.collaborators.get((this.model as any).realtimeHandler.localCollaborator);
+      let myColor: string = me ? me.color || '' : '';
+
+      if(myColor) {
+        let r: number = parseInt(myColor.slice(1,3), 16);
+        let g: number  = parseInt(myColor.slice(3,5), 16);
+        let b: number  = parseInt(myColor.slice(5,7), 16);
+        this.selectionStyle = { css: `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`};
+      }
+    }
+    caret.style.borderLeft=`2px ${color} solid`;
+    caret.appendChild(document.createTextNode('\u00a0'));
+    return caret;
+  }
+
   private _model: CodeEditor.IModel;
   private _editor: CodeMirror.Editor;
   protected selectionMarkers: { [key: string]: CodeMirror.TextMarker[] | undefined } = {};
@@ -630,8 +660,8 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
 
 
 /**
- * The namespace for `CodeMirrorEditor` statics.
- */
+* The namespace for `CodeMirrorEditor` statics.
+*/
 export
 namespace CodeMirrorEditor {
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -625,26 +625,10 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     this._changeGuard = false;
   }
 
-  private _getCaret(uuid: string) {
+  private _getCaret(uuid: string): HTMLElement {
     let caret: HTMLElement = document.createElement('span');
     caret.className = 'CodeMirror-cursor';
-    let color: string = '';
-    if((this.model as any).realtimeHandler) {
-      let collaborator: any =
-        (this.model as any).realtimeHandler.collaborators.get(uuid);
-      color = collaborator ? collaborator.color || '' : '';
-      let me: any =
-        (this.model as any).realtimeHandler.collaborators.get((this.model as any).realtimeHandler.localCollaborator);
-      let myColor: string = me ? me.color || '' : '';
-
-      if(myColor) {
-        let r: number = parseInt(myColor.slice(1,3), 16);
-        let g: number  = parseInt(myColor.slice(3,5), 16);
-        let b: number  = parseInt(myColor.slice(5,7), 16);
-        this.selectionStyle = { css: `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`};
-      }
-    }
-    caret.style.borderLeft=`2px ${color} solid`;
+    caret.style.borderLeft=`2px ${this._selectionStyle.color} solid`;
     caret.appendChild(document.createTextNode('\u00a0'));
     return caret;
   }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -635,8 +635,8 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
 
   private _getCaret(uuid: string): HTMLElement {
     let caret: HTMLElement = document.createElement('span');
-    caret.className = 'CodeMirror-cursor';
-    caret.style.borderLeft=`2px ${this._selectionStyle.color} solid`;
+    caret.className = 'jp-CollaboratorCursor';
+    caret.style.borderBottomColor=`${this._selectionStyle.color}`
     caret.appendChild(document.createTextNode('\u00a0'));
     return caret;
   }

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -66,6 +66,16 @@
   margin-left: calc(-1 * var(--jp-code-padding));
 }
 
+.jp-CollaboratorCursor {
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: none;
+  border-bottom: 3px solid;
+  position: absolute;
+  top: -1px;
+  width: 0;
+}
+
 
 /*
   Here is our jupyter theme for CodeMirror syntax highlighting

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -72,7 +72,6 @@
   border-top: none;
   border-bottom: 3px solid;
   position: absolute;
-  top: -1px;
   width: 0;
 }
 

--- a/packages/coreutils/src/index.ts
+++ b/packages/coreutils/src/index.ts
@@ -14,3 +14,4 @@ export * from './undoablevector';
 export * from './url';
 export * from './uuid';
 export * from './vector';
+export * from './modeldb';

--- a/packages/coreutils/src/index.ts
+++ b/packages/coreutils/src/index.ts
@@ -15,3 +15,4 @@ export * from './url';
 export * from './uuid';
 export * from './vector';
 export * from './modeldb';
+export * from './realtime';

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -489,7 +489,13 @@ class ModelDB implements IModelDB {
   }
 
   /**
-   * Set a value at a path.
+   * Set a value at a path. Not intended to
+   * be called by user code, instead use the
+   * `create*` factory methods.
+   *
+   * @param path: the path to set the value at.
+   *
+   * @param value: the value to set at the path.
    */
   set(path: string, value: IObservable): void {
     this._db.set(this._resolvePath(path), value);

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -21,6 +21,10 @@ import {
   IObservableVector, ObservableVector
 } from './observablevector';
 
+import {
+  IObservableUndoableVector, ObservableUndoableVector
+} from './undoablevector';
+
 
 export
 interface IObservable {
@@ -70,6 +74,8 @@ interface IModelDB {
   createString(path: string): IObservableString;
 
   createVector<T extends JSONValue>(path: string): IObservableVector<T>;
+
+  createUndoableVector<T extends JSONValue>(path: string): IObservableUndoableVector<T>;
 
   createMap<T extends JSONValue>(path: string): IObservableMap<T>;
 
@@ -167,6 +173,13 @@ class ModelDB implements IModelDB {
 
   createVector(path: string): IObservableVector<JSONValue> {
     let vec = new ObservableVector<JSONValue>();
+    this.set(path, vec);
+    return vec;
+  }
+
+  createUndoableVector(path: string): IObservableUndoableVector<JSONValue> {
+    let vec = new ObservableUndoableVector<JSONValue>(
+      new ObservableUndoableVector.IdentitySerializer());
     this.set(path, vec);
     return vec;
   }

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -52,6 +52,8 @@ interface IModelDB {
   get(path: string): IObservable;
 
   set(path: string, value: IObservable): void;
+
+  view(basePath: string): IModelDB;
 }
 
 export
@@ -114,17 +116,17 @@ class ModelDB implements IModelDB {
 
   get(path: string): IObservable {
     if(this._baseDB) {
-      return this._baseDB.get(this._basePath+path);
+      return this._baseDB.get(this._basePath+'/'+path);
     } else {
-      return this._db.get(this._basePath + path);
+      return this._db.get(this._basePath+'/'+path);
     }
   }
 
   set(path: string, value: IObservable): void {
     if(this._baseDB) {
-      this._baseDB.set(this._basePath+path, value);
+      this._baseDB.set(this._basePath+'/'+path, value);
     } else {
-      this._db.set(this._basePath + path, value);
+      this._db.set(this._basePath+'/'+path, value);
     }
   }
 

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -54,7 +54,7 @@ interface IObservableValueChangedArgs extends IObservableChangedArgs {
 
 export
 interface IModelDBFactory {
-  createNew(path: string): Promise<IModelDB>;
+  createNew(path: string): IModelDB;
 }
 
 export
@@ -109,8 +109,8 @@ class ObservableValue implements IObservableValue {
 
 export
 class ModelDBFactory implements IModelDBFactory {
-  createNew(path: string): Promise<ModelDB> {
-    return Promise.resolve(new ModelDB());
+  createNew(path: string): ModelDB {
+    return new ModelDB();
   }
 }
 

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -10,8 +10,17 @@ import {
 } from '@phosphor/coreutils';
 
 import {
-  ObservableMap
+  IObservableMap, ObservableMap
 } from './observablemap';
+
+import {
+  IObservableString, ObservableString
+} from './observablestring';
+
+import {
+  IObservableVector, ObservableVector
+} from './observablevector';
+
 
 export
 interface IObservable {
@@ -53,12 +62,20 @@ interface IModelDB {
 
   set(path: string, value: IObservable): void;
 
+  createString(): IObservableString;
+
+  createVector<T extends JSONValue>(): IObservableVector<T>;
+
+  createMap<T extends JSONValue>(): IObservableMap<T>;
+
+  createValue(): IObservableValue;
+
   view(basePath: string): IModelDB;
 }
 
 export
 class ObservableValue implements IObservableValue {
-  constructor(initialValue: JSONValue) {
+  constructor(initialValue?: JSONValue) {
     this._value = initialValue;
   }
 
@@ -128,6 +145,22 @@ class ModelDB implements IModelDB {
     } else {
       this._db.set(this._basePath+'/'+path, value);
     }
+  }
+
+  createString(): IObservableString {
+    return new ObservableString();
+  }
+
+  createVector(): IObservableVector<JSONValue> {
+    return new ObservableVector<JSONValue>();
+  }
+
+  createMap(): IObservableMap<JSONValue> {
+    return new ObservableMap<JSONValue>();
+  }
+
+  createValue(): IObservableValue {
+    return new ObservableValue();
   }
 
   view(basePath: string): ModelDB {

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -6,7 +6,7 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  JSONValue, JSONObject
+  JSONValue
 } from '@phosphor/coreutils';
 
 import {

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -53,6 +53,11 @@ interface IObservableValueChangedArgs extends IObservableChangedArgs {
 }
 
 export
+interface IModelDBFactory {
+  createNew(): IModelDB;
+}
+
+export
 interface IModelDB {
   changed: ISignal<IModelDB, ModelDB.IChangedArgs>
 
@@ -100,6 +105,13 @@ class ObservableValue implements IObservableValue {
 
   private _value: JSONValue = null;
   private _changed = new Signal<ObservableValue, IObservableValueChangedArgs>(this);
+}
+
+export
+class ModelDBFactory implements IModelDBFactory {
+  createNew(): ModelDB {
+    return new ModelDB();
+  }
 }
 
 export

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -197,11 +197,6 @@ interface IModelDB extends IDisposable {
   view(basePath: string): IModelDB;
 
   /**
-   * Set a value at a path.
-   */
-  set(path: string, value: IObservable): void;
-
-  /**
    * Dispose of the resources held by the database.
    */
   dispose(): void;
@@ -498,7 +493,7 @@ class ModelDB implements IModelDB {
   }
 
   private _basePath: string;
-  private _db: IModelDB | ObservableMap<IObservable> = null;
+  private _db: ModelDB | ObservableMap<IObservable> = null;
   private _toDispose = true;
   private _disposables = new DisposableSet();
 }

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -67,13 +67,13 @@ interface IModelDB {
 
   set(path: string, value: IObservable): void;
 
-  createString(): IObservableString;
+  createString(path: string): IObservableString;
 
-  createVector<T extends JSONValue>(): IObservableVector<T>;
+  createVector<T extends JSONValue>(path: string): IObservableVector<T>;
 
-  createMap<T extends JSONValue>(): IObservableMap<T>;
+  createMap<T extends JSONValue>(path: string): IObservableMap<T>;
 
-  createValue(): IObservableValue;
+  createValue(path: string): IObservableValue;
 
   view(basePath: string): IModelDB;
 }
@@ -159,20 +159,28 @@ class ModelDB implements IModelDB {
     }
   }
 
-  createString(): IObservableString {
-    return new ObservableString();
+  createString(path: string): IObservableString {
+    let str = new ObservableString();
+    this.set(path, str);
+    return str;
   }
 
-  createVector(): IObservableVector<JSONValue> {
-    return new ObservableVector<JSONValue>();
+  createVector(path: string): IObservableVector<JSONValue> {
+    let vec = new ObservableVector<JSONValue>();
+    this.set(path, vec);
+    return vec;
   }
 
-  createMap(): IObservableMap<JSONValue> {
-    return new ObservableMap<JSONValue>();
+  createMap(path: string): IObservableMap<JSONValue> {
+    let map = new ObservableMap<JSONValue>();
+    this.set(path, map);
+    return map;
   }
 
-  createValue(): IObservableValue {
-    return new ObservableValue();
+  createValue(path: string): IObservableValue {
+    let val = new ObservableValue();
+    this.set(path, val);
+    return val;
   }
 
   view(basePath: string): ModelDB {

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  IDisposable
+  IDisposable, DisposableSet
 } from '@phosphor/disposable';
 
 import {
@@ -364,7 +364,7 @@ class ModelDB implements IModelDB {
    */
   createString(path: string): IObservableString {
     let str = new ObservableString();
-    this._createdObjects.push(str);
+    this._disposables.add(str);
     this.set(path, str);
     return str;
   }
@@ -382,7 +382,7 @@ class ModelDB implements IModelDB {
    */
   createVector(path: string): IObservableVector<JSONValue> {
     let vec = new ObservableVector<JSONValue>();
-    this._createdObjects.push(vec);
+    this._disposables.add(vec);
     this.set(path, vec);
     return vec;
   }
@@ -401,7 +401,7 @@ class ModelDB implements IModelDB {
   createUndoableVector(path: string): IObservableUndoableVector<JSONValue> {
     let vec = new ObservableUndoableVector<JSONValue>(
       new ObservableUndoableVector.IdentitySerializer());
-    this._createdObjects.push(vec);
+    this._disposables.add(vec);
     this.set(path, vec);
     return vec;
   }
@@ -419,7 +419,7 @@ class ModelDB implements IModelDB {
    */
   createMap(path: string): IObservableMap<JSONValue> {
     let map = new ObservableMap<JSONValue>();
-    this._createdObjects.push(map);
+    this._disposables.add(map);
     this.set(path, map);
     return map;
   }
@@ -433,7 +433,7 @@ class ModelDB implements IModelDB {
    */
   createJSON(path: string): IObservableJSON {
     let json = new ObservableJSON();
-    this._createdObjects.push(json);
+    this._disposables.add(json);
     this.set(path, json);
     return json;
   }
@@ -447,7 +447,7 @@ class ModelDB implements IModelDB {
    */
   createValue(path: string): IObservableValue {
     let val = new ObservableValue();
-    this._createdObjects.push(val);
+    this._disposables.add(val);
     this.set(path, val);
     return val;
   }
@@ -484,10 +484,7 @@ class ModelDB implements IModelDB {
     if (this._toDispose) {
       db.dispose();
     }
-    for (let item of this._createdObjects) {
-      item.dispose();
-    }
-    this._createdObjects = null;
+    this._disposables.dispose();
   }
 
   /**
@@ -503,7 +500,7 @@ class ModelDB implements IModelDB {
   private _basePath: string;
   private _db: IModelDB | ObservableMap<IObservable> = null;
   private _toDispose = true;
-  private _createdObjects: IObservable[] = [];
+  private _disposables = new DisposableSet();
 }
 
 /**

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -103,6 +103,18 @@ interface IModelDB extends IDisposable {
   readonly isDisposed: boolean;
 
   /**
+   * Whether the database has been populated
+   * with model values prior to connection.
+   */
+  readonly isPrepopulated: boolean;
+
+  /**
+   * A promise that resolves when the database
+   * has connected to its backend, if any.
+   */
+  readonly connected: Promise<void>;
+
+  /**
    * Get a value for a path.
    *
    * @param path: the path for the object.
@@ -326,6 +338,23 @@ class ModelDB implements IModelDB {
    */
   get isDisposed(): boolean {
     return this._db === null;
+  }
+
+  /**
+   * Whether the model has been populated with
+   * any model values.
+   */
+  get isPrepopulated(): boolean {
+    return true;
+  }
+
+  /**
+   * A promise resolved when the model is connected
+   * to its backend. For the in-memory ModelDB it
+   * is immediately resolved.
+   */
+  get connected(): Promise<void> {
+    return Promise.resolve(void 0);
   }
 
   /**

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -18,6 +18,10 @@ import {
 } from './observablemap';
 
 import {
+  IObservableJSON, ObservableJSON
+} from './observablejson';
+
+import {
   IObservableString, ObservableString
 } from './observablestring';
 
@@ -35,7 +39,7 @@ import {
  * created and placed in the IModelDB interface.
  */
 export
-type ObservableType = 'JSONValue' | 'Map' | 'Vector' | 'String' | 'JSONObject'
+type ObservableType = 'Map' | 'Vector' | 'String' | 'Value';
 
 /**
  * Base interface for Observable objects.
@@ -57,7 +61,7 @@ interface IObservableValue extends IObservable {
   /**
    * The type of this object.
    */
-  type: 'JSONValue';
+  type: 'Value';
 
   /**
    * The changed signal.
@@ -156,11 +160,20 @@ interface IModelDB {
   createMap<T extends JSONValue>(path: string): IObservableMap<T>;
 
   /**
-   * Create a string and insert it in the database.
+   * Create an `IObservableJSON` and insert it in the database.
    *
-   * @param path: the path for the string.
+   * @param path: the path for the object.
    *
-   * @returns the string that was created.
+   * @returns the object that wsa created.
+   */
+  createJSON(path: string): IObservableJSON;
+
+  /**
+   * Create an opaque value and insert it in the database.
+   *
+   * @param path: the path for the value.
+   *
+   * @returns the value that was created.
    */
   createValue(path: string): IObservableValue;
 
@@ -197,7 +210,7 @@ class ObservableValue implements IObservableValue {
   /**
    * The observable type.
    */
-  readonly type: 'JSONValue';
+  readonly type: 'Value';
 
   /**
    * The changed signal.
@@ -366,11 +379,24 @@ class ModelDB implements IModelDB {
   }
 
   /**
-   * Create a string and insert it in the database.
+   * Create an `IObservableJSON` and insert it in the database.
    *
-   * @param path: the path for the string.
+   * @param path: the path for the object.
    *
-   * @returns the string that was created.
+   * @returns the object that wsa created.
+   */
+  createJSON(path: string): IObservableJSON {
+    let json = new ObservableJSON();
+    this.set(path, json);
+    return json;
+  }
+
+  /**
+   * Create an opaque value and insert it in the database.
+   *
+   * @param path: the path for the value.
+   *
+   * @returns the value that was created.
    */
   createValue(path: string): IObservableValue {
     let val = new ObservableValue();

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -54,7 +54,7 @@ interface IObservableValueChangedArgs extends IObservableChangedArgs {
 
 export
 interface IModelDBFactory {
-  createNew(): IModelDB;
+  createNew(path: string): Promise<IModelDB>;
 }
 
 export
@@ -109,8 +109,8 @@ class ObservableValue implements IObservableValue {
 
 export
 class ModelDBFactory implements IModelDBFactory {
-  createNew(): ModelDB {
-    return new ModelDB();
+  createNew(path: string): Promise<ModelDB> {
+    return Promise.resolve(new ModelDB());
   }
 }
 

--- a/packages/coreutils/src/observablemap.ts
+++ b/packages/coreutils/src/observablemap.ts
@@ -9,12 +9,21 @@ import {
   ISignal, Signal
 } from '@phosphor/signaling';
 
+import {
+  IObservable
+} from './modeldb';
+
 
 /**
  * A map which can be observed for changes.
  */
 export
-interface IObservableMap<T> extends IDisposable {
+interface IObservableMap<T> extends IDisposable, IObservable {
+  /**
+   * The type of the Observable.
+   */
+  type: 'Map';
+
   /**
    * A signal emitted when the map has changed.
    */
@@ -107,6 +116,12 @@ class ObservableMap<T> implements IObservableMap<T> {
       }
     }
   }
+
+  /**
+   * The type of the Observable.
+   */
+  type: 'Map';
+
 
   /**
    * A signal emitted when the map has changed.

--- a/packages/coreutils/src/observablestring.ts
+++ b/packages/coreutils/src/observablestring.ts
@@ -9,12 +9,21 @@ import {
   ISignal, Signal
 } from '@phosphor/signaling';
 
+import {
+  IObservable
+} from './modeldb';
+
 
 /**
  * A string which can be observed for changes.
  */
 export
-interface IObservableString extends IDisposable {
+interface IObservableString extends IDisposable, IObservable {
+  /**
+   * The type of the Observable.
+   */
+  type: 'String';
+
   /**
    * A signal emitted when the string has changed.
    */
@@ -66,6 +75,11 @@ class ObservableString implements IObservableString {
   constructor(initialText: string = '') {
     this._text = initialText;
   }
+
+  /**
+   * The type of the Observable.
+   */
+  type: 'String';
 
   /**
    * A signal emitted when the string has changed.

--- a/packages/coreutils/src/observablevector.ts
+++ b/packages/coreutils/src/observablevector.ts
@@ -17,12 +17,21 @@ import {
   Vector
 } from './vector';
 
+import {
+  IObservable
+} from './modeldb';
+
 
 /**
  * A vector which can be observed for changes.
  */
 export
-interface IObservableVector<T> extends IDisposable {
+interface IObservableVector<T> extends IDisposable, IObservable {
+  /**
+   * The type of the Observable.
+   */
+  type: 'Vector';
+
   /**
    * A signal emitted when the vector has changed.
    */
@@ -309,6 +318,11 @@ class ObservableVector<T> extends Vector<T> implements IObservableVector<T> {
     super(options.values || []);
     this._itemCmp = options.itemCmp || Private.itemCmp;
   }
+
+  /**
+   * The type of the Observable.
+   */
+  type: 'Vector';
 
   /**
    * A signal emitted when the vector has changed.

--- a/packages/coreutils/src/realtime.ts
+++ b/packages/coreutils/src/realtime.ts
@@ -1,0 +1,178 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  IDisposable
+} from '@phosphor/disposable';
+
+import {
+  JSONObject, Token
+} from '@phosphor/coreutils';
+
+import {
+  IObservableString
+} from './observablestring';
+
+import {
+  IObservableVector
+} from './observablevector';
+
+import {
+  IObservableMap
+} from './observablemap';
+
+import {
+  IModelDB
+} from './modeldb';
+
+/* tslint:disable */
+/**
+ * The realtime service token.
+ */
+export
+const IRealtime = new Token<IRealtime>('jupyter.services.realtime');
+/* tslint:enable */
+
+
+/**
+ * Interface for a Realtime service.
+ */
+export
+interface IRealtime {
+
+  /**
+   * Share a realtime model with a collaborator.
+   *
+   * @param model: The model to be shared.
+   *
+   * @returns a promise that is resolved when the model
+   *   has been successfully shared.
+   */
+  addCollaborator(model: IRealtimeModel): Promise<void>;
+
+  /**
+   * Share a model through the realtime services.
+   *
+   * @param model: The model to be shared.
+   *
+   * @param uid: Optional unique identifier for the model,
+   *   which can be used to identify it across different clients.
+   *
+   * @returns a promise that is resolved when the model
+   *   has been successfully opened.
+   */
+  shareModel(model: IRealtimeModel, uid?: string): Promise<void>;
+
+  /**
+   * The realtime services may require some setup before
+   * it can be used (e.g., loading external APIs, authorization).
+   * This promise is resolved when the services are ready to
+   * be used.
+   */
+  ready: Promise<void>;
+}
+
+/**
+ * Interface for an object which has the ability to be shared via
+ * the realtime interface. These objects are required to implement
+ * method `registerCollaborative( handler : IRealtimeHandler)`
+ * which describes to the handler the members which are realtime-enabled.
+ */
+export
+interface IRealtimeModel {
+
+  /**
+   * The realtime handler associated with this realtime model.
+   * Should only be non-null after registerCollaborative() has
+   * successfully resolved.
+   */
+  readonly realtimeHandler: IRealtimeHandler;
+
+  /**
+   * Register this object as collaborative.
+   *
+   * @param handler: the realtime handler to which the model
+   *   describes itself.
+   *
+   * @returns a promise that is resolved when the model is done
+   * registering itself as collaborative.
+   */
+  registerCollaborative (handler: IRealtimeHandler): Promise<void>;
+}
+
+
+/**
+ * Interface for an object that coordinates realtime collaboration between
+ * objects. These objects are expected to subscribe to the handler using
+ * IRealtimeModel.registerCollaborative( handler : IRealtimeHandller)`.
+ * There should be one realtime handler per realtime model.
+ */
+export
+interface IRealtimeHandler extends IDisposable {
+
+  /**
+   * A map of the currently active collaborators
+   * for the handler, including the local user.
+   */
+  readonly collaborators: IObservableMap<ICollaborator>;
+
+  /**
+   * The local collaborator.
+   */
+  readonly localCollaborator: ICollaborator;
+
+  /**
+   * An IModelDB for this handler.
+   */
+  readonly modelDB: IModelDB;
+
+  /**
+   * A promise resolved when the handler is ready to
+   * be used.
+   */
+  readonly ready: Promise<void>;
+}
+
+/**
+ * A type which is able to be synchronized between collaborators
+ */
+export
+type Synchronizable = JSONObject | IObservableMap<any> | IObservableVector<any> | IObservableString;
+
+export
+interface IRealtimeConverter<T> {
+  from(value: Synchronizable): T;
+
+  to(value: T): Synchronizable;
+}
+
+/**
+ * Interface for an object representing a single collaborator
+ * on a realtime model.
+ */
+export
+interface ICollaborator {
+  /**
+   * A user id for the collaborator.
+   * This might not be unique, if the user has more than
+   * one editing session at a time.
+   */
+  readonly userId: string;
+
+  /**
+   * A session id, which should be unique to a
+   * particular view on a collaborative model.
+   */
+  readonly sessionId: string;
+
+  /**
+   * A human-readable display name for a collaborator.
+   */
+  readonly displayName: string;
+
+  /**
+   * A color to be used to identify the collaborator in
+   * UI elements.
+   */
+  readonly color: string;
+}

--- a/packages/coreutils/src/realtime.ts
+++ b/packages/coreutils/src/realtime.ts
@@ -6,7 +6,7 @@ import {
 } from '@phosphor/disposable';
 
 import {
-  JSONObject, Token
+  JSONValue, Token
 } from '@phosphor/coreutils';
 
 import {
@@ -39,30 +39,6 @@ const IRealtime = new Token<IRealtime>('jupyter.services.realtime');
  */
 export
 interface IRealtime {
-
-  /**
-   * Share a realtime model with a collaborator.
-   *
-   * @param model: The model to be shared.
-   *
-   * @returns a promise that is resolved when the model
-   *   has been successfully shared.
-   */
-  addCollaborator(model: IRealtimeModel): Promise<void>;
-
-  /**
-   * Share a model through the realtime services.
-   *
-   * @param model: The model to be shared.
-   *
-   * @param uid: Optional unique identifier for the model,
-   *   which can be used to identify it across different clients.
-   *
-   * @returns a promise that is resolved when the model
-   *   has been successfully opened.
-   */
-  shareModel(model: IRealtimeModel, uid?: string): Promise<void>;
-
   /**
    * The realtime services may require some setup before
    * it can be used (e.g., loading external APIs, authorization).
@@ -70,34 +46,12 @@ interface IRealtime {
    * be used.
    */
   ready: Promise<void>;
-}
-
-/**
- * Interface for an object which has the ability to be shared via
- * the realtime interface. These objects are required to implement
- * method `registerCollaborative( handler : IRealtimeHandler)`
- * which describes to the handler the members which are realtime-enabled.
- */
-export
-interface IRealtimeModel {
 
   /**
-   * The realtime handler associated with this realtime model.
-   * Should only be non-null after registerCollaborative() has
-   * successfully resolved.
+   * Create an IRealtimeHandler for use with a document or other
+   * model.
    */
-  readonly realtimeHandler: IRealtimeHandler;
-
-  /**
-   * Register this object as collaborative.
-   *
-   * @param handler: the realtime handler to which the model
-   *   describes itself.
-   *
-   * @returns a promise that is resolved when the model is done
-   * registering itself as collaborative.
-   */
-  registerCollaborative (handler: IRealtimeHandler): Promise<void>;
+  createHandler(path: string): IRealtimeHandler;
 }
 
 
@@ -109,7 +63,6 @@ interface IRealtimeModel {
  */
 export
 interface IRealtimeHandler extends IDisposable {
-
   /**
    * A map of the currently active collaborators
    * for the handler, including the local user.
@@ -137,14 +90,7 @@ interface IRealtimeHandler extends IDisposable {
  * A type which is able to be synchronized between collaborators
  */
 export
-type Synchronizable = JSONObject | IObservableMap<any> | IObservableVector<any> | IObservableString;
-
-export
-interface IRealtimeConverter<T> {
-  from(value: Synchronizable): T;
-
-  to(value: T): Synchronizable;
-}
+type Synchronizable = JSONValue | IObservableMap<JSONValue> | IObservableVector<JSONValue> | IObservableString;
 
 /**
  * Interface for an object representing a single collaborator

--- a/packages/coreutils/src/undoablevector.ts
+++ b/packages/coreutils/src/undoablevector.ts
@@ -296,3 +296,29 @@ class ObservableUndoableVector<T> extends ObservableVector<T> implements IObserv
   private _stack: ObservableVector.IChangedArgs<JSONValue>[][] = [];
   private _serializer: ISerializer<T> = null;
 }
+
+/**
+ * Namespace for ObservableUndoableVector utilities.
+ */
+export
+namespace ObservableUndoableVector {
+  /**
+   * A default, identity serializer.
+   */
+  export
+  class IdentitySerializer implements ISerializer<JSONValue> {
+    /**
+     * Identity serialize.
+     */
+    toJSON(value: JSONValue): JSONValue {
+      return value;
+    }
+
+    /**
+     * Identity deserialize.
+     */
+    fromJSON(value: JSONValue): JSONValue {
+      return value;
+    }
+  }
+}

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -30,6 +30,10 @@ import {
 } from '@phosphor/widgets';
 
 import {
+  IModelDBFactory
+} from '@jupyterlab/coreutils';
+
+import {
   DocumentRegistry, Context
 } from '@jupyterlab/docregistry';
 
@@ -75,6 +79,7 @@ class DocumentManager implements IDisposable {
     this._registry = options.registry;
     this._serviceManager = options.manager;
     this._opener = options.opener;
+    this._modelDBFactory = options.modelDBFactory;
     this._widgetManager = new DocumentWidgetManager({
       registry: this._registry
     });
@@ -295,7 +300,8 @@ class DocumentManager implements IDisposable {
       opener: adopter,
       manager: this._serviceManager,
       factory,
-      path
+      path,
+      modelDBFactory: this._modelDBFactory
     });
     let handler = new SaveHandler({
       context,
@@ -397,6 +403,7 @@ class DocumentManager implements IDisposable {
   private _contexts: Private.IContext[] = [];
   private _opener: DocumentManager.IWidgetOpener = null;
   private _activateRequested = new Signal<this, string>(this);
+  private _modelDBFactory: IModelDBFactory;
 }
 
 
@@ -424,6 +431,12 @@ namespace DocumentManager {
      * A widget opener for sibling widgets.
      */
     opener: IWidgetOpener;
+
+    /**
+     * A factory for a database in which to store
+     * model data.
+     */
+    modelDBFactory?: IModelDBFactory;
   }
 
   /**

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -365,11 +365,13 @@ class DocumentManager implements IDisposable {
       context = this._findContext(path, factory.name);
       if (!context) {
         context = this._createContext(path, factory);
+        // If there is a live realtime handler on the
+        // context, we don't want to revert to a checkpoint.
         if (!context.realtimeHandler) {
           // Load the contents from disk.
           context.revert();
         } else {
-          // Load the contents from disk.
+          // Save the contents to disk.
           context.save();
         }
       }

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -30,7 +30,7 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  IModelDBFactory
+  IRealtime
 } from '@jupyterlab/coreutils';
 
 import {
@@ -79,7 +79,7 @@ class DocumentManager implements IDisposable {
     this._registry = options.registry;
     this._serviceManager = options.manager;
     this._opener = options.opener;
-    this._modelDBFactory = options.modelDBFactory;
+    this._realtimeServices = options.realtimeServices;
     this._widgetManager = new DocumentWidgetManager({
       registry: this._registry
     });
@@ -301,7 +301,7 @@ class DocumentManager implements IDisposable {
       manager: this._serviceManager,
       factory,
       path,
-      modelDBFactory: this._modelDBFactory
+      realtimeServices: this._realtimeServices
     });
     let handler = new SaveHandler({
       context,
@@ -403,7 +403,7 @@ class DocumentManager implements IDisposable {
   private _contexts: Private.IContext[] = [];
   private _opener: DocumentManager.IWidgetOpener = null;
   private _activateRequested = new Signal<this, string>(this);
-  private _modelDBFactory: IModelDBFactory;
+  private _realtimeServices: IRealtime;
 }
 
 
@@ -433,10 +433,9 @@ namespace DocumentManager {
     opener: IWidgetOpener;
 
     /**
-     * A factory for a database in which to store
-     * model data.
+     * A provider for realtime services.
      */
-    modelDBFactory?: IModelDBFactory;
+    realtimeServices?: IRealtime;
   }
 
   /**

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -365,8 +365,13 @@ class DocumentManager implements IDisposable {
       context = this._findContext(path, factory.name);
       if (!context) {
         context = this._createContext(path, factory);
-        // Load the contents from disk.
-        context.revert();
+        if (!(context as any)._realtimeHandler) {
+          // Load the contents from disk.
+          context.revert();
+        } else {
+          // Load the contents from disk.
+          context.save();
+        }
       }
     } else if (which === 'create') {
       context = this._createContext(path, factory);

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -365,15 +365,9 @@ class DocumentManager implements IDisposable {
       context = this._findContext(path, factory.name);
       if (!context) {
         context = this._createContext(path, factory);
-        // If there is a live realtime handler on the
-        // context, we don't want to revert to a checkpoint.
-        if (!context.realtimeHandler) {
-          // Load the contents from disk.
-          context.revert();
-        } else {
-          // Save the contents to disk.
-          context.save();
-        }
+        // Populate the model, either from disk or a
+        // model backend.
+        context.fromStore();
       }
     } else if (which === 'create') {
       context = this._createContext(path, factory);

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -365,7 +365,7 @@ class DocumentManager implements IDisposable {
       context = this._findContext(path, factory.name);
       if (!context) {
         context = this._createContext(path, factory);
-        if (!(context as any)._realtimeHandler) {
+        if (!context.realtimeHandler) {
           // Load the contents from disk.
           context.revert();
         } else {

--- a/packages/docmanager/src/savehandler.ts
+++ b/packages/docmanager/src/savehandler.ts
@@ -36,7 +36,7 @@ class SaveHandler implements IDisposable {
   constructor(options: SaveHandler.IOptions) {
     this._manager = options.manager;
     this._context = options.context;
-    this._minInterval = options.saveInterval * 1000 || 120000;
+    this._minInterval = options.saveInterval * 1000 || 1200000000;
     this._interval = this._minInterval;
     // Restart the timer when the contents model is updated.
     this._context.fileChanged.connect(this._setTimer, this);

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -201,6 +201,26 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   }
 
   /**
+   * Populate the contents of the model, either from
+   * disk or from the realtime handler.
+   *
+   * @returns a promise that resolves upon model population.
+   */
+  fromStore(): Promise<void> {
+    if (this.realtimeHandler) {
+      return this._modelDB.connected.then(() => {
+        if (this._modelDB.isPrepopulated) {
+          return this.save();
+        } else {
+          return this.revert();
+        }
+      });
+    } else {
+      return this.revert();
+    }
+  }
+
+  /**
    * Start the default kernel for the context.
    *
    * @returns A promise that resolves with the new kernel.

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -30,7 +30,7 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  PathExt, URLExt
+  PathExt, URLExt, IModelDB
 } from '@jupyterlab/coreutils';
 
 import {
@@ -55,7 +55,11 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     this._path = options.path;
     let ext = DocumentRegistry.extname(this._path);
     let lang = this._factory.preferredLanguage(ext);
-    this._model = this._factory.createNew(lang);
+    let modelDB: IModelDB;
+    if(options.modelDBFactory) {
+      modelDB = options.modelDBFactory.createNew();
+    }
+    this._model = this._factory.createNew(lang, modelDB);
     manager.sessions.runningChanged.connect(this._onSessionsChanged, this);
     manager.contents.fileChanged.connect(this._onFileChanged, this);
     this._readyPromise = manager.ready.then(() => {
@@ -575,6 +579,12 @@ export namespace Context {
      * The initial path of the file.
      */
     path: string;
+
+    /**
+     * An IModelDB factory for creating a database
+     * in which to store model data.
+     */
+    modelDBFactory?: any;
 
     /**
      * An optional callback for opening sibling widgets.

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -161,14 +161,19 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     }
     let model = this._model;
     let session = this._session;
+    let realtimeHandler = this._realtimeHandler;
     this._model = null;
     this._session = null;
     this._manager = null;
     this._factory = null;
+    this._realtimeHandler = null;
 
     model.dispose();
     if (session) {
       session.dispose();
+    }
+    if (realtimeHandler) {
+      realtimeHandler.dispose();
     }
     this._disposed.emit(void 0);
     Signal.clearData(this);

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -30,7 +30,7 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  PathExt, URLExt, IModelDB, IModelDBFactory
+  PathExt, URLExt, IModelDB, IRealtime, IRealtimeHandler
 } from '@jupyterlab/coreutils';
 
 import {
@@ -55,8 +55,9 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     this._path = options.path;
     let ext = DocumentRegistry.extname(this._path);
     let lang = this._factory.preferredLanguage(ext);
-    if(options.modelDBFactory) {
-      this._modelDB = options.modelDBFactory.createNew(options.path);
+    if(options.realtimeServices) {
+      this._realtimeHandler = options.realtimeServices.createHandler(this._path);
+      this._modelDB = this._realtimeHandler.modelDB;
       this._model = this._factory.createNew(lang, this._modelDB);
     } else {
       this._model = this._factory.createNew(lang);
@@ -543,6 +544,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   private _opener: (widget: Widget) => void = null;
   private _model: T = null;
   private _modelDB: IModelDB;
+  private _realtimeHandler: IRealtimeHandler = null;
   private _path = '';
   private _session: Session.ISession = null;
   private _factory: DocumentRegistry.IModelFactory<T> = null;
@@ -583,10 +585,9 @@ export namespace Context {
     path: string;
 
     /**
-     * An IModelDB factory for creating a database
-     * in which to store model data.
+     * Provider for realtime services.
      */
-    modelDBFactory?: IModelDBFactory;
+    realtimeServices?: IRealtime;
 
     /**
      * An optional callback for opening sibling widgets.

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -129,6 +129,13 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   }
 
   /**
+   * The realtime handler associated with the document.
+   */
+  get realtimeHandler(): IRealtimeHandler {
+    return this._realtimeHandler;
+  }
+
+  /**
    * Get the model factory name.
    *
    * #### Notes

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -38,8 +38,8 @@ class DocumentModel extends CodeEditor.Model implements DocumentRegistry.ICodeMo
   /**
    * Construct a new document model.
    */
-  constructor(languagePreference?: string) {
-    super();
+  constructor(languagePreference?: string, modelDB?: IModelDB) {
+    super({modelDB});
     this._defaultLang = languagePreference || '';
     this.value.changed.connect(this.triggerContentChange, this);
   }
@@ -227,8 +227,8 @@ class TextModelFactory implements DocumentRegistry.CodeModelFactory {
    *
    * @returns A new document model.
    */
-  createNew(languagePreference?: string): DocumentRegistry.ICodeModel {
-    return new DocumentModel(languagePreference);
+  createNew(languagePreference?: string, modelDB?: IModelDB): DocumentRegistry.ICodeModel {
+    return new DocumentModel(languagePreference, modelDB);
   }
 
   /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -109,13 +109,6 @@ class DocumentModel extends CodeEditor.Model implements DocumentRegistry.ICodeMo
   }
 
   /**
-   * Return the model database used by the document.
-   */
-  get modelDB(): IModelDB {
-    return this._modelDB;
-  }
-
-  /**
    * Serialize the model to a string.
    */
   toString(): string {

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -29,6 +29,10 @@ import {
   DocumentRegistry
 } from './index';
 
+import {
+  IModelDB
+} from '../common/modeldb';
+
 
 /**
  * The default implementation of a document model.
@@ -106,6 +110,13 @@ class DocumentModel extends CodeEditor.Model implements DocumentRegistry.ICodeMo
    */
   get defaultKernelLanguage(): string {
     return this._defaultLang;
+  }
+
+  /**
+   * Return the model database used by the document.
+   */
+  get modelDB(): IModelDB {
+    return this._modelDB;
   }
 
   /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -31,7 +31,7 @@ import {
 
 import {
   IModelDB
-} from '../common/modeldb';
+} from '../coreutils/modeldb';
 
 
 /**

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -22,16 +22,12 @@ import {
 } from '@jupyterlab/codeeditor';
 
 import {
-  IChangedArgs
+  IChangedArgs, IModelDB
 } from '@jupyterlab/coreutils';
 
 import {
   DocumentRegistry
 } from './index';
-
-import {
-  IModelDB
-} from '../coreutils/modeldb';
 
 
 /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -35,7 +35,7 @@ import {
 
 import {
   IModelDB
-} from '../common/modeldb';
+} from '../coreutils/modeldb';
 
 /* tslint:disable */
 /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -887,7 +887,7 @@ namespace DocumentRegistry {
      *
      * @returns A new document model.
      */
-    createNew(languagePreference?: string): T;
+    createNew(languagePreference?: string, modelDB?: IModelDB): T;
 
     /**
      * Get the preferred kernel language given an extension.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -33,6 +33,9 @@ import {
   IChangedArgs as IChangedArgsGeneric, PathExt
 } from '@jupyterlab/coreutils';
 
+import {
+  IModelDB
+} from '../common/modeldb';
 
 /* tslint:disable */
 /**
@@ -570,6 +573,11 @@ namespace DocumentRegistry {
      * The default kernel language of the document.
      */
     readonly defaultKernelLanguage: string;
+
+    /**
+     * The database for the model content.
+     */
+    readonly modelDB: IModelDB;
 
     /**
      * Serialize the model to a string.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -30,12 +30,8 @@ import {
 } from '@jupyterlab/codeeditor';
 
 import {
-  IChangedArgs as IChangedArgsGeneric, PathExt
+  IChangedArgs as IChangedArgsGeneric, PathExt, IModelDB
 } from '@jupyterlab/coreutils';
-
-import {
-  IModelDB
-} from '../coreutils/modeldb';
 
 /* tslint:disable */
 /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -30,7 +30,7 @@ import {
 } from '@jupyterlab/codeeditor';
 
 import {
-  IChangedArgs as IChangedArgsGeneric, PathExt, IModelDB
+  IChangedArgs as IChangedArgsGeneric, PathExt, IModelDB, IRealtimeHandler
 } from '@jupyterlab/coreutils';
 
 /* tslint:disable */
@@ -656,6 +656,13 @@ namespace DocumentRegistry {
      * It will be `null` until the context is ready.
      */
     readonly contentsModel: Contents.IModel;
+
+    /**
+     * An optional `IRealtimeHandler for the document.
+     * It will be null unless the `IContext` is given an
+     * `IRealtime` object at creation time.
+     */
+    readonly realtimeHandler: IRealtimeHandler;
 
     /**
      * Whether the context is ready.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -571,11 +571,6 @@ namespace DocumentRegistry {
     readonly defaultKernelLanguage: string;
 
     /**
-     * The database for the model content.
-     */
-    readonly modelDB: IModelDB;
-
-    /**
      * Serialize the model to a string.
      */
     toString(): string;

--- a/packages/editorwidget/src/widget.ts
+++ b/packages/editorwidget/src/widget.ts
@@ -61,16 +61,9 @@ class EditorWidget extends CodeEditorWidget {
           color: realtime.localCollaborator.color
         };
 
-        //if there are selections corresponding to non-collaborators,
-        //they are stale and should be removed.
-        realtime.collaborators.changed.connect((collaborators, change) => {
-          this.editor.uuid = realtime.localCollaborator.sessionId;
-          for(let key of context.model.selections.keys()) {
-            if(!collaborators.has(key)) {
-              context.model.selections.delete(key);
-            }
-          }
-        });
+        realtime.collaborators.changed.connect(this._onCollaboratorsChanged, this);
+        //Trigger an initial onCollaboratorsChanged event.
+        this._onCollaboratorsChanged();
       });
     }
   }
@@ -142,6 +135,16 @@ class EditorWidget extends CodeEditorWidget {
     let path = this._context.path;
     editor.model.mimeType = this._mimeTypeService.getMimeTypeByFilePath(path);
     this.title.label = path.split('/').pop();
+  }
+
+  private _onCollaboratorsChanged(): void {
+    //if there are selections corresponding to non-collaborators,
+    //they are stale and should be removed.
+    for(let key of this.editor.model.selections.keys()) {
+      if(!this._context.realtimeHandler.collaborators.has(key)) {
+        this.editor.model.selections.delete(key);
+      }
+    }
   }
 
   protected _context: DocumentRegistry.Context;

--- a/packages/editorwidget/src/widget.ts
+++ b/packages/editorwidget/src/widget.ts
@@ -50,11 +50,21 @@ class EditorWidget extends CodeEditorWidget {
     if(context.realtimeHandler) {
       let realtime = context.realtimeHandler;
       realtime.ready.then(() => {
+        //Setup the selection style for collaborators
         this.editor.uuid = realtime.localCollaborator.sessionId;
+        let color = realtime.localCollaborator.color;
+        let r = parseInt(color.slice(1,3), 16);
+        let g  = parseInt(color.slice(3,5), 16);
+        let b  = parseInt(color.slice(5,7), 16);
+        this.editor.selectionStyle = {
+          css: `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`,
+          color: realtime.localCollaborator.color
+        };
+
+        //if there are selections corresponding to non-collaborators,
+        //they are stale and should be removed.
         realtime.collaborators.changed.connect((collaborators, change) => {
           this.editor.uuid = realtime.localCollaborator.sessionId;
-          //if there are selections corresponding to non-collaborators,
-          //they are stale and should be removed.
           for(let key of context.model.selections.keys()) {
             if(!collaborators.has(key)) {
               context.model.selections.delete(key);

--- a/packages/editorwidget/src/widget.ts
+++ b/packages/editorwidget/src/widget.ts
@@ -47,6 +47,22 @@ class EditorWidget extends CodeEditorWidget {
     context.ready.then(() => {
       this._onContextReady();
     });
+    if(context.realtimeHandler) {
+      let realtime = context.realtimeHandler;
+      realtime.ready.then(() => {
+        this.editor.uuid = realtime.localCollaborator.sessionId;
+        realtime.collaborators.changed.connect((collaborators, change) => {
+          this.editor.uuid = realtime.localCollaborator.sessionId;
+          //if there are selections corresponding to non-collaborators,
+          //they are stale and should be removed.
+          for(let key of context.model.selections.keys()) {
+            if(!collaborators.has(key)) {
+              context.model.selections.delete(key);
+            }
+          }
+        });
+      });
+    }
   }
 
   /**

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -209,7 +209,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   set(index: number, cell: ICellModel): void {
     // Generate a new uuid for the cell.
-    let id = (cell as any)._modelDB._basePath;
+    let id = (cell as any).modelDB.basePath;
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     this._cellOrder.set(index, id);
@@ -235,7 +235,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   pushBack(cell: ICellModel): number {
     // Generate a new uuid for the cell.
-    let id = (cell as any)._modelDB._basePath;
+    let id = (cell as any).modelDB.basePath;
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     let num = this._cellOrder.pushBack(id);
@@ -289,7 +289,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   insert(index: number, cell: ICellModel): number {
     // Generate a new uuid for the cell.
-    let id = (cell as any)._modelDB._basePath;
+    let id = (cell as any).modelDB.basePath;
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     let num = this._cellOrder.insert(index, id);
@@ -396,7 +396,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     let newValues = toArray(cells);
     each(newValues, cell => {
       // Generate a new uuid for the cell.
-      let id = (cell as any)._modelDB._basePath;
+      let id = (cell as any).modelDB.basePath;
       // Set the internal data structures.
       this._cellMap.set(id, cell);
       this._cellOrder.pushBack(id);
@@ -434,7 +434,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     let newValues = toArray(cells);
     each(newValues, cell => {
       // Generate a new uuid for the cell.
-      let id = (cell as any)._modelDB._basePath;
+      let id = (cell as any).modelDB.basePath;
       this._cellMap.set(id, cell);
       this._cellOrder.beginCompoundOperation();
       this._cellOrder.insert(index++, id);

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -10,7 +10,7 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  IObservableMap, ObservableMap, IObservableVector, ObservableVector,
+  IObservableMap, ObservableMap, ObservableVector,
   IObservableUndoableVector, IModelDB
 } from '@jupyterlab/coreutils';
 
@@ -34,7 +34,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   constructor(modelDB: IModelDB, factory: NotebookModel.IContentFactory) {
     this._modelDB = modelDB;
     this._factory = factory;
-    this._cellOrder = modelDB.createVector<string>('cellOrder') as IObservableUndoableVector<string>;
+    this._cellOrder = modelDB.createUndoableVector<string>('cellOrder');
     this._cellMap = new ObservableMap<ICellModel>();
 
     this._cellOrder.changed.connect(this._onOrderChanged, this);
@@ -470,14 +470,14 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * Whether the object can redo changes.
    */
   get canRedo(): boolean {
-    return false;//this._cellOrder.canRedo;
+    return this._cellOrder.canRedo;
   }
 
   /**
    * Whether the object can undo changes.
    */
   get canUndo(): boolean {
-    return false;//this._cellOrder.canUndo;
+    return this._cellOrder.canUndo;
   }
 
   /**
@@ -487,28 +487,28 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    *   The default is `true`.
    */
   beginCompoundOperation(isUndoAble?: boolean): void {
-    //this._cellOrder.beginCompoundOperation(isUndoAble);
+    this._cellOrder.beginCompoundOperation(isUndoAble);
   }
 
   /**
    * End a compound operation.
    */
   endCompoundOperation(): void {
-    //this._cellOrder.endCompoundOperation();
+    this._cellOrder.endCompoundOperation();
   }
 
   /**
    * Undo an operation.
    */
   undo(): void {
-    //this._cellOrder.undo();
+    this._cellOrder.undo();
   }
 
   /**
    * Redo an operation.
    */
   redo(): void {
-    //this._cellOrder.redo();
+    this._cellOrder.redo();
   }
 
   /**
@@ -525,10 +525,10 @@ class CellList implements IObservableUndoableVector<ICellModel> {
         this._cellMap.delete(key);
       }
     }
-    //this._cellOrder.clearUndo();
+    this._cellOrder.clearUndo();
   }
 
-  private _onOrderChanged(order: IObservableVector<string>, change: ObservableVector.IChangedArgs<string>): void {
+  private _onOrderChanged(order: IObservableUndoableVector<string>, change: ObservableVector.IChangedArgs<string>): void {
     if (change.type === 'add' || change.type === 'set') {
       each(change.newValues, (id) => {
         if (!this._cellMap.has(id)) {

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -37,6 +37,8 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     this._cellOrder.changed.connect(this._onOrderChanged, this);
   }
 
+  type: 'Vector';
+
   /**
    * A signal emitted when the cell list has changed.
    */

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   IObservableMap, ObservableMap, IObservableVector, ObservableVector,
-  IObservableUndoableVector, ObservableUndoableVector, uuid
+  IObservableUndoableVector, IModelDB
 } from '@jupyterlab/coreutils';
 
 import {
@@ -27,11 +27,8 @@ class CellList implements IObservableUndoableVector<ICellModel> {
   /**
    * Construct the cell list.
    */
-  constructor() {
-    this._cellOrder = new ObservableUndoableVector<string>({
-      toJSON: (val: string) => { return val; },
-      fromJSON: (val: string) => { return val; }
-    });
+  constructor(modelDB: IModelDB) {
+    this._cellOrder = modelDB.createVector<string>('cellOrder') as IObservableUndoableVector<string>;
     this._cellMap = new ObservableMap<ICellModel>();
 
     this._cellOrder.changed.connect(this._onOrderChanged, this);
@@ -206,7 +203,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   set(index: number, cell: ICellModel): void {
     // Generate a new uuid for the cell.
-    let id = uuid();
+    let id = (cell as any)._modelDB._basePath;
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     this._cellOrder.set(index, id);
@@ -232,7 +229,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   pushBack(cell: ICellModel): number {
     // Generate a new uuid for the cell.
-    let id = uuid();
+    let id = (cell as any)._modelDB._basePath;
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     let num = this._cellOrder.pushBack(id);
@@ -286,7 +283,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    */
   insert(index: number, cell: ICellModel): number {
     // Generate a new uuid for the cell.
-    let id = uuid();
+    let id = (cell as any)._modelDB._basePath;
     // Set the internal data structures.
     this._cellMap.set(id, cell);
     let num = this._cellOrder.insert(index, id);
@@ -393,7 +390,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     let newValues = toArray(cells);
     each(newValues, cell => {
       // Generate a new uuid for the cell.
-      let id = uuid();
+      let id = (cell as any)._modelDB._basePath;
       // Set the internal data structures.
       this._cellMap.set(id, cell);
       this._cellOrder.pushBack(id);
@@ -431,7 +428,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     let newValues = toArray(cells);
     each(newValues, cell => {
       // Generate a new uuid for the cell.
-      let id = uuid();
+      let id = (cell as any)._modelDB._basePath;
       this._cellMap.set(id, cell);
       this._cellOrder.beginCompoundOperation();
       this._cellOrder.insert(index++, id);
@@ -467,14 +464,14 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    * Whether the object can redo changes.
    */
   get canRedo(): boolean {
-    return this._cellOrder.canRedo;
+    return false;//this._cellOrder.canRedo;
   }
 
   /**
    * Whether the object can undo changes.
    */
   get canUndo(): boolean {
-    return this._cellOrder.canUndo;
+    return false;//this._cellOrder.canUndo;
   }
 
   /**
@@ -484,28 +481,28 @@ class CellList implements IObservableUndoableVector<ICellModel> {
    *   The default is `true`.
    */
   beginCompoundOperation(isUndoAble?: boolean): void {
-    this._cellOrder.beginCompoundOperation(isUndoAble);
+    //this._cellOrder.beginCompoundOperation(isUndoAble);
   }
 
   /**
    * End a compound operation.
    */
   endCompoundOperation(): void {
-    this._cellOrder.endCompoundOperation();
+    //this._cellOrder.endCompoundOperation();
   }
 
   /**
    * Undo an operation.
    */
   undo(): void {
-    this._cellOrder.undo();
+    //this._cellOrder.undo();
   }
 
   /**
    * Redo an operation.
    */
   redo(): void {
-    this._cellOrder.redo();
+    //this._cellOrder.redo();
   }
 
   /**
@@ -522,7 +519,7 @@ class CellList implements IObservableUndoableVector<ICellModel> {
         this._cellMap.delete(key);
       }
     }
-    this._cellOrder.clearUndo();
+    //this._cellOrder.clearUndo();
   }
 
   private _onOrderChanged(order: IObservableVector<string>, change: ObservableVector.IChangedArgs<string>): void {

--- a/packages/notebook/src/celllist.ts
+++ b/packages/notebook/src/celllist.ts
@@ -532,8 +532,21 @@ class CellList implements IObservableUndoableVector<ICellModel> {
     if (change.type === 'add' || change.type === 'set') {
       each(change.newValues, (id) => {
         if (!this._cellMap.has(id)) {
-          let cellDB = this._modelDB.view(id);
-          let cell = this._factory.createCodeCell({modelDB: cellDB, uuid: id});
+          let cellDB = this._factory.modelDB;
+          let cellType = (cellDB as any).getGoogleObject(id+'/type');
+          let cell: ICellModel;
+          switch (cellType) {
+            case 'code':
+              cell = this._factory.createCodeCell({ uuid: id});
+              break;
+            case 'markdown':
+              cell = this._factory.createMarkdownCell({ uuid: id});
+              break;
+            case 'raw':
+            default:
+              cell = this._factory.createRawCell({ uuid: id});
+              break;
+          }
           this._cellMap.set(id, cell);
         }
       });

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -16,7 +16,7 @@ import {
 
 import {
   IObservableJSON, ObservableJSON, IObservableUndoableVector,
-  IObservableVector, ObservableVector, nbformat
+  IObservableVector, ObservableVector, nbformat, IModelDB
 } from '@jupyterlab/coreutils';
 
 import {
@@ -435,6 +435,11 @@ namespace NotebookModel {
      * The factory for code cell model content.
      */
     codeCellContentFactory?: CodeCellModel.IContentFactory;
+
+    /**
+     * The modelDB in which to place new content.
+     */
+    modelDB?: IModelDB;
   }
 
   /**

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -6,7 +6,7 @@ import {
 } from '@phosphor/algorithm';
 
 import {
-  nbformat, utils
+  utils
 } from '@jupyterlab/services';
 
 import {

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -75,7 +75,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
     );
     factory.modelDB = this._modelDB.view('cells');
     this.contentFactory = factory;
-    this._cells = new CellList();
+    let cells = new CellList();
     // Add an initial code cell by default.
     cells.pushBack(factory.createCodeCell({}));
     cells.changed.connect(this._onCellsChanged, this);

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -73,10 +73,10 @@ class NotebookModel extends DocumentModel implements INotebookModel {
     let factory = (
       options.contentFactory || NotebookModel.defaultContentFactory
     );
-    let cellDB = this._modelDB.view('cells');
+    let cellDB = this.modelDB.view('cells');
     factory.modelDB = cellDB;
     this.contentFactory = factory;
-    this._cells = new CellList(this._modelDB, this.contentFactory);
+    this._cells = new CellList(this.modelDB, this.contentFactory);
     // Add an initial code cell by default.
     if (!this._cells.length) {
       this._cells.pushBack(factory.createCodeCell({}));
@@ -84,7 +84,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
     this._cells.changed.connect(this._onCellsChanged, this);
 
     // Handle initial metadata.
-    let metadata = this._modelDB.createJSON('metadata');
+    let metadata = this.modelDB.createJSON('metadata');
     if (!metadata.has('language_info')) {
       let name = options.languagePreference || '';
       metadata.set('language_info', { name });
@@ -102,7 +102,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
    * The metadata associated with the notebook.
    */
   get metadata(): IObservableJSON {
-    return this._modelDB.get('metadata') as IObservableJSON;
+    return this.modelDB.get('metadata') as IObservableJSON;
   }
 
   /**

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -76,9 +76,11 @@ class NotebookModel extends DocumentModel implements INotebookModel {
     let cellDB = this._modelDB.view('cells');
     factory.modelDB = cellDB;
     this.contentFactory = factory;
-    this._cells = new CellList(cellDB);
+    this._cells = new CellList(this._modelDB, this.contentFactory);
     // Add an initial code cell by default.
-    this._cells.pushBack(factory.createCodeCell({}));
+    if (!this._cells.length) {
+      this._cells.pushBack(factory.createCodeCell({}));
+    }
     this._cells.changed.connect(this._onCellsChanged, this);
 
     // Handle initial metadata.
@@ -421,7 +423,7 @@ namespace NotebookModel {
         options.contentFactory = this.codeCellContentFactory;
       }
       if(this._modelDB) {
-        options.modelDB = this._modelDB.view(utils.uuid());
+        options.modelDB = this._modelDB.view(options.uuid || utils.uuid());
       }
       return new CodeCellModel(options);
     }
@@ -436,7 +438,7 @@ namespace NotebookModel {
      */
     createMarkdownCell(options: CellModel.IOptions): IMarkdownCellModel {
       if(this._modelDB) {
-        options.modelDB = this._modelDB.view(utils.uuid());
+        options.modelDB = this._modelDB.view(options.uuid || utils.uuid());
       }
       return new MarkdownCellModel(options);
     }
@@ -451,7 +453,7 @@ namespace NotebookModel {
      */
     createRawCell(options: CellModel.IOptions): IRawCellModel {
       if(this._modelDB) {
-        options.modelDB = this._modelDB.view(utils.uuid());
+        options.modelDB = this._modelDB.view(options.uuid || utils.uuid());
       }
      return new RawCellModel(options);
     }

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -69,7 +69,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
    * Construct a new notebook model.
    */
   constructor(options: NotebookModel.IOptions = {}) {
-    super(options.languagePreference);
+    super(options.languagePreference, options.modelDB);
     let factory = (
       options.contentFactory || NotebookModel.defaultContentFactory
     );
@@ -327,6 +327,12 @@ namespace NotebookModel {
      * The default is a shared factory instance.
      */
     contentFactory?: IContentFactory;
+
+
+    /**
+     * An optional modelDB for storing notebook data.
+     */
+    modelDB?: IModelDB;
   }
 
   /**

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -6,6 +6,10 @@ import {
 } from '@jupyterlab/services';
 
 import {
+  IModelDB
+} from '@jupyterlab/coreutils';
+
+import {
   DocumentRegistry
 } from '@jupyterlab/docregistry';
 
@@ -80,9 +84,9 @@ class NotebookModelFactory implements DocumentRegistry.IModelFactory<INotebookMo
    *
    * @returns A new document model.
    */
-  createNew(languagePreference?: string): INotebookModel {
+  createNew(languagePreference?: string, modelDB?: IModelDB): INotebookModel {
     let contentFactory = this.contentFactory;
-    return new NotebookModel({ languagePreference, contentFactory });
+    return new NotebookModel({ languagePreference, contentFactory, modelDB });
   }
 
   /**

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -252,7 +252,7 @@ class NotebookPanel extends Widget {
     if (context.kernel !== oldKernel) {
       this._onKernelChanged(this._context, this._context.kernel);
     }
-    this.notebook.model = newValue.model;
+    this.notebook.context = newValue;
     this._handleDirtyState();
     newValue.model.stateChanged.connect(this.onModelStateChanged, this);
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1000,27 +1000,29 @@ class Notebook extends StaticNotebook {
     if(this.context.realtimeHandler) {
       let realtime = this.context.realtimeHandler;
       realtime.ready.then(() => {
-        //Setup the selection style for collaborators
-        cell.editor.uuid = realtime.localCollaborator.sessionId;
-        let color = realtime.localCollaborator.color;
-        let r = parseInt(color.slice(1,3), 16);
-        let g  = parseInt(color.slice(3,5), 16);
-        let b  = parseInt(color.slice(5,7), 16);
-        cell.editor.selectionStyle = {
-          css: `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`,
-          color: realtime.localCollaborator.color
-        };
-
-        //if there are selections corresponding to non-collaborators,
-        //they are stale and should be removed.
-        realtime.collaborators.changed.connect((collaborators, change) => {
+        if (!cell.isDisposed) {
+          //Setup the selection style for collaborators
           cell.editor.uuid = realtime.localCollaborator.sessionId;
-          for(let key of cell.model.selections.keys()) {
-            if(!collaborators.has(key)) {
-              cell.model.selections.delete(key);
+          let color = realtime.localCollaborator.color;
+          let r = parseInt(color.slice(1,3), 16);
+          let g  = parseInt(color.slice(3,5), 16);
+          let b  = parseInt(color.slice(5,7), 16);
+          cell.editor.selectionStyle = {
+            css: `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`,
+            color: realtime.localCollaborator.color
+          };
+
+          //if there are selections corresponding to non-collaborators,
+          //they are stale and should be removed.
+          realtime.collaborators.changed.connect((collaborators, change) => {
+            cell.editor.uuid = realtime.localCollaborator.sessionId;
+            for(let key of cell.model.selections.keys()) {
+              if(!collaborators.has(key)) {
+                cell.model.selections.delete(key);
+              }
             }
-          }
-        });
+          });
+        }
       });
     }
     cell.editor.edgeRequested.connect(this._onEdgeRequest, this);

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -313,7 +313,7 @@ class StaticNotebook extends Widget {
    *
    * The default implementation is a no-op
    */
-  protected onCellRemoved(cell: BaseCellWidget): void {
+  protected onCellRemoved(index: number, cell: BaseCellWidget): void {
     // This is a no-op.
   }
 
@@ -449,7 +449,7 @@ class StaticNotebook extends Widget {
     let layout = this.layout as PanelLayout;
     let widget = layout.widgets[index] as BaseCellWidget;
     widget.parent = null;
-    this.onCellRemoved(widget);
+    this.onCellRemoved(index, widget);
     widget.dispose();
   }
 
@@ -1028,8 +1028,10 @@ class Notebook extends StaticNotebook {
       });
     }
     cell.editor.edgeRequested.connect(this._onEdgeRequest, this);
-    // Trigger an update of the active cell.
-    this.activeCellIndex = this.activeCellIndex;
+    // If the insertion happened above, increment the active cell
+    // index, otherwise it stays the same.
+    this.activeCellIndex = index <= this.activeCellIndex ?
+      this.activeCellIndex + 1 : this.activeCellIndex ;
   }
 
   /**
@@ -1044,9 +1046,11 @@ class Notebook extends StaticNotebook {
   /**
    * Handle a cell being removed.
    */
-  protected onCellRemoved(cell: BaseCellWidget): void {
-    // Trigger an update of the active cell.
-    this.activeCellIndex = this.activeCellIndex;
+  protected onCellRemoved(index:number, cell: BaseCellWidget): void {
+    // If the removal happened above, decrement the active
+    // cell index, otherwise it stays the same.
+    this.activeCellIndex = index < this.activeCellIndex ?
+      this.activeCellIndex - 1 : this.activeCellIndex ;
     if (this.isSelected(cell)) {
       this._selectionChanged.emit(void 0);
     }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1015,10 +1015,12 @@ class Notebook extends StaticNotebook {
           //if there are selections corresponding to non-collaborators,
           //they are stale and should be removed.
           realtime.collaborators.changed.connect((collaborators, change) => {
-            cell.editor.uuid = realtime.localCollaborator.sessionId;
-            for(let key of cell.model.selections.keys()) {
-              if(!collaborators.has(key)) {
-                cell.model.selections.delete(key);
+            if (!cell.isDisposed) {
+              cell.editor.uuid = realtime.localCollaborator.sessionId;
+              for(let key of cell.model.selections.keys()) {
+                if(!collaborators.has(key)) {
+                  cell.model.selections.delete(key);
+                }
               }
             }
           });

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -48,6 +48,8 @@ class OutputAreaModel implements IOutputAreaModel {
       this._serialized = this._modelDB.createValue('outputs');
       if (this._serialized.get()) {
         this.fromJSON(this._serialized.get() as nbformat.IOutput[]);
+      } else {
+        this._serialized.set(this.toJSON());
       }
       this._serialized.changed.connect((obs, args) => {
         if(!changeGuard) {

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -46,6 +46,9 @@ class OutputAreaModel implements IOutputAreaModel {
       let changeGuard = false;
       this._modelDB = options.modelDB;
       this._serialized = this._modelDB.createValue('outputs');
+      if (this._serialized.get()) {
+        this.fromJSON(this._serialized.get() as nbformat.IOutput[]);
+      }
       this._serialized.changed.connect((obs, args) => {
         if(!changeGuard) {
           changeGuard = true;
@@ -60,9 +63,6 @@ class OutputAreaModel implements IOutputAreaModel {
           changeGuard = false;
         }
       });
-      // Trigger a changed to update if the outputs
-      // already exist.
-      this._serialized.set(this._serialized.get());
     }
   }
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -43,7 +43,7 @@ import {
 
 import {
   IModelDB
-} from '../common/modeldb';
+} from '../coreutils/modeldb';
 
 
 /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -41,6 +41,10 @@ import {
   IOutputModel, RenderMime
 } from '@jupyterlab/rendermime';
 
+import {
+  IModelDB
+} from '../common/modeldb';
+
 
 /**
  * The threshold in pixels to start a drag event.
@@ -862,6 +866,11 @@ namespace IOutputAreaModel {
      * If not given, a default factory will be used.
      */
     contentFactory?: IContentFactory;
+
+    /**
+     * An optional IModelDB to store the output area model.
+     */
+    modelDB?: IModelDB;
   }
 
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -34,16 +34,12 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  ObservableVector, nbformat
+  ObservableVector, nbformat, IModelDB
 } from '@jupyterlab/coreutils';
 
 import {
   IOutputModel, RenderMime
 } from '@jupyterlab/rendermime';
-
-import {
-  IModelDB
-} from '../coreutils/modeldb';
 
 
 /**

--- a/src/common/modeldb.ts
+++ b/src/common/modeldb.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  ISignal, Signal
+} from '@phosphor/signaling';
+
+import {
+  JSONValue, JSONObject
+} from '@phosphor/coreutils';
+
+import {
+  ObservableMap
+} from './observablemap';
+
+export
+interface IObservable {
+  readonly type: string;
+
+  readonly changed: ISignal<IObservable, IObservableChangedArgs>;
+}
+
+export
+interface IObservableChangedArgs {
+}
+
+export
+interface IObservableValue extends IObservable{
+
+  type: 'value';
+
+  readonly changed: ISignal<IObservableValue, IObservableValueChangedArgs> 
+
+  get(): JSONValue;
+
+  set(value: JSONValue): void;
+}
+
+export
+interface IObservableValueChangedArgs extends IObservableChangedArgs {
+  oldValue: JSONValue;
+
+  newValue: JSONValue;
+}
+
+export
+interface IModelDB {
+  changed: ISignal<IModelDB, IModelDBChangedArgs>
+
+  get(path: string): IObservable;
+
+  set(path: string, value: IObservable): void;
+}
+
+export
+interface IModelDBChangedArgs {
+  path: string;
+
+  oldValue: IObservable;
+
+  newValue: IObservable;
+}
+
+export
+class ObservableValue implements IObservableValue {
+  constructor(initialValue: JSONValue) {
+    this._value = initialValue;
+  }
+
+  readonly type: 'value';
+
+  get changed(): ISignal<this, IObservableValueChangedArgs> {
+    return this._changed;
+  }
+
+  get(): JSONValue {
+    return this._value;
+  }
+
+  set(value: JSONValue): void {
+    let oldValue = this._value;
+    this._value = value;
+    this._changed.emit({
+      oldValue: oldValue,
+      newValue: value
+    });
+  }
+
+  private _value: JSONValue = null;
+  private _changed = new Signal<ObservableValue, IObservableValueChangedArgs>(this);
+}
+
+export
+class ModelDB implements IModelDB {
+  constructor() {
+    this._db.changed.connect((db, args)=>{
+      this._changed.emit({
+        path: args.key,
+        newValue: args.newValue,
+        oldValue: args.oldValue
+      });
+    });
+  }
+  get changed(): ISignal<this, IModelDBChangedArgs> {
+    return this._changed;
+  }
+
+  get(path: string): IObservable {
+    return this._db.get(path);
+  }
+
+  set(path: string, value: IObservable): void {
+    this._db.set(path, value);
+  }
+
+  private _changed = new Signal<this, IModelDBChangedArgs>(this);
+  private _db = new ObservableMap<IObservable>();
+}


### PR DESCRIPTION
This is a (very much) work in progress implementation of an abstract database for storing document model objects. This is a different approach than (and supersedes) #1432. The idea is that different backends can be implemented to generate `IObservable` primitives and store them in some way (cf. #1767, #1959, #1961). The default implementation is just an in-memory database. The observable primitives at the moment are:
* `IObservableString`
* `IObservableVector<JSONValue>`
* `IObservableMap<JSONValue>`
* `IObservableJSON`
* `IObservableValue`

Not coincidentally, these are the observable primitives that are needed to describe the current document models. At the moment, the interface for the `IModelDB` is very simple: it consists of factory methods for the above, as well as a getter for previously created objects.

At the moment, this does not implement any kind of path-based query language, and there are a number of places where the type-safety can be improved. I am in no way knowledgeable about database design, so I view this as a description of what I need the interface to *do*, rather than what the interface should ultimately *be*.

cc. @blink1073 , @sccolbert , @ellisonbg .