### PR TITLE
Reintroduce diffing on strings for the CodeMirror editor.

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -106,7 +106,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       }
     });
     CodeMirror.on(editor, 'cursorActivity', () => this._onCursorActivity());
-    CodeMirror.on(editor.getDoc(), 'change', (instance, change) => {
+    CodeMirror.on(editor.getDoc(), 'beforeChange', (instance, change) => {
       this._onDocChanged(instance, change);
     });
   }
@@ -633,11 +633,11 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     this._changeGuard = true;
     let value = this._model.value;
     let start = doc.indexFromPos(change.from);
+    let end = doc.indexFromPos(change.to);
     let inserted = change.text.join('\n');
-    let removed = change.removed.join('\n');
 
-    if (removed) {
-      value.remove(start, start + removed.length);
+    if (end-start) {
+      value.remove(start, end);
     }
     if (inserted) {
       value.insert(start, inserted);

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -603,7 +603,23 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       return;
     }
     this._changeGuard = true;
-    this.doc.setValue(this._model.value.text);
+    let doc = this.doc;
+    switch (args.type) {
+     case 'insert':
+       let pos = doc.posFromIndex(args.start);
+       doc.replaceRange(args.value, pos, pos);
+       break;
+     case 'remove':
+       let from = doc.posFromIndex(args.start);
+       let to = doc.posFromIndex(args.end);
+       doc.replaceRange('', from, to);
+       break;
+     case 'set':
+       doc.setValue(args.value);
+       break;
+     default:
+       break;
+    }
     this._changeGuard = false;
   }
 
@@ -615,7 +631,17 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       return;
     }
     this._changeGuard = true;
-    this._model.value.text = this.doc.getValue();
+    let value = this._model.value;
+    let start = doc.indexFromPos(change.from);
+    let inserted = change.text.join('\n');
+    let removed = change.removed.join('\n');
+
+    if (removed) {
+      value.remove(start, start + removed.length);
+    }
+    if (inserted) {
+      value.insert(start, inserted);
+    }
     this._changeGuard = false;
   }
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -636,7 +636,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     let end = doc.indexFromPos(change.to);
     let inserted = change.text.join('\n');
 
-    if (end-start) {
+    if (end !== start) {
       value.remove(start, end);
     }
     if (inserted) {


### PR DESCRIPTION
This would reintroduce diff-based updates to the CodeMirror editor. It was removed due to some subtle bugs in the sync between the model and the CodeMirror editor in #1791.

I am having a difficult time reproducing those bugs in master (cf. #1828). The current approach using `doc.setValue` for all diffs should not scale well to larger documents, and it causes problems when multiple collaborators are editing the same document at the same time (upon `setValue`, collaborator cursors go to the start of the document).