### PR TITLE
Active cell updating

### DIFF
--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -120,7 +120,6 @@ namespace NotebookActions {
     let cells = model.cells;
     let primary = widget.activeCell;
     let index = widget.activeCellIndex;
-    let offset = 0;
 
     // Get the cells to merge.
     each(widget.widgets, (child, i) => {
@@ -128,9 +127,6 @@ namespace NotebookActions {
         toMerge.push(child.model.value.text);
         if (i !== index) {
           toDelete.push(child.model);
-          if (i < index) {
-            offset += 1;
-          }
         }
       }
     });
@@ -171,7 +167,6 @@ namespace NotebookActions {
       cell.rendered = false;
     }
 
-    widget.activeCellIndex -= offset;
     Private.handleState(widget, state);
   }
 
@@ -214,7 +209,10 @@ namespace NotebookActions {
     let state = Private.getState(widget);
     let model = widget.model;
     let cell = model.contentFactory.createCodeCell({ });
-    model.cells.insert(widget.activeCellIndex, cell);
+    let index = widget.activeCellIndex;
+    model.cells.insert(index, cell);
+    // Make the newly inserted cell active.
+    widget.activeCellIndex = index;
     widget.deselectAll();
     Private.handleState(widget, state);
   }
@@ -239,6 +237,7 @@ namespace NotebookActions {
     let model = widget.model;
     let cell = model.contentFactory.createCodeCell({});
     model.cells.insert(widget.activeCellIndex + 1, cell);
+    // Make the newly inserted cell active.
     widget.activeCellIndex++;
     widget.deselectAll();
     Private.handleState(widget, state);

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -300,7 +300,7 @@ class StaticNotebook extends Widget {
    *
    * The default implementation is a no-op
    */
-  protected onCellRemoved(cell: BaseCellWidget): void {
+  protected onCellRemoved(index: number, cell: BaseCellWidget): void {
     // This is a no-op.
   }
 
@@ -436,7 +436,7 @@ class StaticNotebook extends Widget {
     let layout = this.layout as PanelLayout;
     let widget = layout.widgets[index] as BaseCellWidget;
     widget.parent = null;
-    this.onCellRemoved(widget);
+    this.onCellRemoved(index, widget);
     widget.dispose();
   }
 
@@ -983,8 +983,10 @@ class Notebook extends StaticNotebook {
    */
   protected onCellInserted(index: number, cell: BaseCellWidget): void {
     cell.editor.edgeRequested.connect(this._onEdgeRequest, this);
-    // Trigger an update of the active cell.
-    this.activeCellIndex = this.activeCellIndex;
+    // If the insertion happened above, increment the active cell
+    // index, otherwise it stays the same.
+    this.activeCellIndex = index <= this.activeCellIndex ?
+      this.activeCellIndex + 1 : this.activeCellIndex ;
   }
 
   /**
@@ -999,9 +1001,11 @@ class Notebook extends StaticNotebook {
   /**
    * Handle a cell being removed.
    */
-  protected onCellRemoved(cell: BaseCellWidget): void {
-    // Trigger an update of the active cell.
-    this.activeCellIndex = this.activeCellIndex;
+  protected onCellRemoved(index:number, cell: BaseCellWidget): void {
+    // If the removal happened above, decrement the active
+    // cell index, otherwise it stays the same.
+    this.activeCellIndex = index < this.activeCellIndex ?
+      this.activeCellIndex - 1 : this.activeCellIndex ;
     if (this.isSelected(cell)) {
       this._selectionChanged.emit(void 0);
     }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -356,8 +356,11 @@ class StaticNotebook extends Widget {
       // TODO: reuse existing widgets if possible.
       index = args.newIndex;
       each(args.newValues, value => {
-        this._removeCell(index);
+        // Note: this ordering (insert then remove)
+        // is important for getting the active cell
+        // index for the editable notebook correct.
         this._insertCell(index, value);
+        this._removeCell(index+1);
         index++;
       });
       break;
@@ -1001,10 +1004,10 @@ class Notebook extends StaticNotebook {
   /**
    * Handle a cell being removed.
    */
-  protected onCellRemoved(index:number, cell: BaseCellWidget): void {
+  protected onCellRemoved(index: number, cell: BaseCellWidget): void {
     // If the removal happened above, decrement the active
     // cell index, otherwise it stays the same.
-    this.activeCellIndex = index < this.activeCellIndex ?
+    this.activeCellIndex = index <= this.activeCellIndex ?
       this.activeCellIndex - 1 : this.activeCellIndex ;
     if (this.isSelected(cell)) {
       this._selectionChanged.emit(void 0);

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -77,8 +77,8 @@ class LogStaticNotebook extends StaticNotebook {
     this.methods.push('onCellMoved');
   }
 
-  protected onCellRemoved(cell: BaseCellWidget): void {
-    super.onCellRemoved(cell);
+  protected onCellRemoved(index: number, cell: BaseCellWidget): void {
+    super.onCellRemoved(index, cell);
     this.methods.push('onCellRemoved');
   }
 }
@@ -125,8 +125,8 @@ class LogNotebook extends Notebook {
     this.methods.push('onCellMoved');
   }
 
-  protected onCellRemoved(cell: BaseCellWidget): void {
-    super.onCellRemoved(cell);
+  protected onCellRemoved(index: number, cell: BaseCellWidget): void {
+    super.onCellRemoved(index, cell);
     this.methods.push('onCellRemoved');
   }
 }
@@ -1128,6 +1128,15 @@ describe('notebook/widget', () => {
         expect(widget.activeCell).to.be(widget.widgets[0]);
       });
 
+      it('should keep the currently active cell active', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+        widget.activeCellIndex = 1;
+        let cell = widget.model.contentFactory.createCodeCell({});
+        widget.model.cells.insert(1, cell);
+        expect(widget.activeCell).to.be(widget.widgets[2]);
+      });
+
       context('`edgeRequested` signal', () => {
 
         it('should activate the previous cell if top is requested', () => {
@@ -1180,6 +1189,14 @@ describe('notebook/widget', () => {
         widget.model.fromJSON(DEFAULT_CONTENT);
         widget.model.cells.removeAt(0);
         expect(widget.activeCell).to.be(widget.widgets[0]);
+      });
+
+      it('should keep the currently active cell active', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+        widget.activeCellIndex = 2;
+        widget.model.cells.removeAt(1);
+        expect(widget.activeCell).to.be(widget.widgets[1]);
       });
 
     });


### PR DESCRIPTION
If a collaborator performs a cell operation, this can trigger an unwanted change in the active cell index for the local user.

This PR makes it so that the notebook widget attempts to keep the active cell the same upon cell operations (for instance, incrementing the active cell index if a cell is inserted above). Explicit changes to the active cell are thus only caused by local user actions, such as clicking on a cell or running a command in the `NotebookActions` scope.