### PR TITLE
Single Document / Multiple Document feedback PR

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -80,7 +80,7 @@ const plugin: JupyterLabPlugin<void> = {
     app.commands.addCommand(command, {
       label: () => {
         return app.shell.mode === 'multiple-document' ?
-          'Enable Single-Document Mode' : 'Enable Multiple-Document Mode';
+          'Toggle Single-Document Mode' : 'Toggle Multiple-Document Mode';
       },
       execute: () => {
         const args = app.shell.mode === 'multiple-document' ?

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -78,10 +78,7 @@ const plugin: JupyterLabPlugin<void> = {
 
     command = CommandIDs.toggleMode;
     app.commands.addCommand(command, {
-      label: () => {
-        return app.shell.mode === 'multiple-document' ?
-          'Toggle Single-Document Mode' : 'Toggle Multiple-Document Mode';
-      },
+      label: 'Toggle Single-Document Mode',
       execute: () => {
         const args = app.shell.mode === 'multiple-document' ?
           { mode: 'single-document' } : { mode: 'multiple-document' };

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -189,6 +189,8 @@ class ApplicationShell extends Widget {
     dock.mode = mode;
     // Restore the original layout.
     if (this._cachedLayout) {
+      // Remove any disposed widgets in the cached layout.
+      Private.normalizeAreaConfig(this._cachedLayout.main);
       dock.restoreLayout(this._cachedLayout);
       this._cachedLayout = null;
     }
@@ -737,6 +739,18 @@ namespace Private {
   export
   function itemCmp(first: IRankItem, second: IRankItem): number {
     return first.rank - second.rank;
+  }
+
+  /**
+   * Removes widgets that have been disposed from an area config, mutates area.
+   */
+  export
+  function normalizeAreaConfig(area: DockLayout.AreaConfig): void {
+    if (area.type === 'tab-area') {
+      area.widgets = area.widgets.filter(widget => !widget.isDisposed);
+      return;
+    }
+    area.children.forEach(child => { normalizeAreaConfig(child); });
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -921,8 +921,8 @@ namespace Private {
      * Handle the `currentChanged` signal from the sidebar.
      */
     private _onCurrentChanged(sender: TabBar<Widget>, args: TabBar.ICurrentChangedArgs<Widget>): void {
-      let oldWidget = this._findWidgetByTitle(args.previousTitle);
-      let newWidget = this._findWidgetByTitle(args.currentTitle);
+      const oldWidget = this._findWidgetByTitle(args.previousTitle);
+      const newWidget = this._findWidgetByTitle(args.currentTitle);
       if (oldWidget) {
         oldWidget.hide();
       }
@@ -930,9 +930,10 @@ namespace Private {
         newWidget.show();
       }
       if (newWidget) {
-        document.body.setAttribute(`data-${this._side}-area`, newWidget.id);
+        const id = newWidget.id;
+        document.body.setAttribute(`data-${this._side}-sidebar-widget`, id);
       } else {
-        document.body.removeAttribute(`data-${this._side}-area`);
+        document.body.removeAttribute(`data-${this._side}-sidebar-widget`);
       }
       this._refreshVisibility();
     }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -432,11 +432,11 @@ class ApplicationShell extends Widget {
         if (dock) {
           this._dockPanel.restoreLayout(dock);
         }
+        if (mode) {
+          this.mode = mode;
+        }
         if (currentWidget) {
           this.activateById(currentWidget.id);
-        }
-        if (mode) {
-          this._dockPanel.mode = mode;
         }
       }
 
@@ -561,10 +561,15 @@ class ApplicationShell extends Widget {
     if (!this._database || !this._isRestored) {
       return;
     }
-    let data: ApplicationShell.ILayout = {
+
+    // If the application is in single document mode, use the cached layout if
+    // available. Otherwise, default to querying the dock panel for layout.
+    const data: ApplicationShell.ILayout = {
       mainArea: {
         currentWidget: this._tracker.currentWidget,
-        dock: this._dockPanel.saveLayout(),
+        dock: this.mode === 'single-document' ?
+          this._cachedLayout || this._dockPanel.saveLayout()
+            : this._dockPanel.saveLayout(),
         mode: this._dockPanel.mode
       },
       leftArea: this._leftHandler.dehydrate(),

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -171,7 +171,17 @@ class ApplicationShell extends Widget {
     return this._dockPanel.mode;
   }
   set mode(mode: DockPanel.Mode) {
-    this._dockPanel.mode = mode;
+    const dock = this._dockPanel;
+    if (mode === dock.mode) {
+      return;
+    }
+
+    dock.mode = mode;
+    if (mode === 'single-document') {
+      // In case the active widget in the dock panel is *not* the active widget
+      // of the application, defer to the application.
+      dock.activateWidget(this.currentWidget);
+    }
   }
 
   /**
@@ -190,8 +200,8 @@ class ApplicationShell extends Widget {
     } else if (this._rightHandler.has(id)) {
       this._rightHandler.activate(id);
     } else {
-      let dock = this._dockPanel;
-      let widget = find(dock.widgets(), value => value.id === id);
+      const dock = this._dockPanel;
+      const widget = find(dock.widgets(), value => value.id === id);
       if (widget) {
         dock.activateWidget(widget);
       }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -193,7 +193,7 @@ class ApplicationShell extends Widget {
     if (this._cachedLayout) {
 
       // Remove any disposed widgets in the cached layout and restore.
-      Private.normalizeAreaConfig(this._cachedLayout.main);
+      Private.normalizeAreaConfig(dock, this._cachedLayout.main);
       dock.restoreLayout(this._cachedLayout);
       this._cachedLayout = null;
     }
@@ -755,12 +755,13 @@ namespace Private {
    * Removes widgets that have been disposed from an area config, mutates area.
    */
   export
-  function normalizeAreaConfig(area: DockLayout.AreaConfig): void {
+  function normalizeAreaConfig(parent: DockPanel, area: DockLayout.AreaConfig): void {
     if (area.type === 'tab-area') {
-      area.widgets = area.widgets.filter(widget => !widget.isDisposed);
+      area.widgets = area.widgets
+        .filter(widget => !widget.isDisposed && widget.parent === parent);
       return;
     }
-    area.children.forEach(child => { normalizeAreaConfig(child); });
+    area.children.forEach(child => { normalizeAreaConfig(parent, child); });
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -179,6 +179,7 @@ class ApplicationShell extends Widget {
     if (mode === 'single-document') {
       this._cachedLayout = dock.saveLayout();
       dock.mode = mode;
+
       // In case the active widget in the dock panel is *not* the active widget
       // of the application, defer to the application.
       dock.activateWidget(this.currentWidget);
@@ -187,13 +188,16 @@ class ApplicationShell extends Widget {
 
     // Otherwise, toggle back to multiple document mode.
     dock.mode = mode;
+
     // Restore the original layout.
     if (this._cachedLayout) {
-      // Remove any disposed widgets in the cached layout.
+
+      // Remove any disposed widgets in the cached layout and restore.
       Private.normalizeAreaConfig(this._cachedLayout.main);
       dock.restoreLayout(this._cachedLayout);
       this._cachedLayout = null;
     }
+
     // Add any widgets created during single document mode.
     this._cachedAddedWidgets.forEach(widget => {
       if (!widget.isDisposed) {
@@ -201,6 +205,7 @@ class ApplicationShell extends Widget {
       }
     });
     this._cachedAddedWidgets.length = 0;
+
     // In case the active widget in the dock panel is *not* the active widget
     // of the application, defer to the application.
     dock.activateWidget(this.currentWidget);

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -10,7 +10,7 @@ import {
 } from '@phosphor/coreutils';
 
 import {
-  MessageLoop
+  Message, MessageLoop
 } from '@phosphor/messaging';
 
 import {
@@ -43,11 +43,15 @@ const CURRENT_CLASS = 'jp-mod-current';
  */
 const ACTIVE_CLASS = 'jp-mod-active';
 
-
 /**
  * The default rank of items added to a sidebar.
  */
 const DEFAULT_RANK = 500;
+
+/**
+ * The data attribute added to the document body indicating shell's mode.
+ */
+const MODE_ATTRIBUTE = 'data-shell-mode';
 
 
 /**
@@ -183,6 +187,9 @@ class ApplicationShell extends Widget {
       // In case the active widget in the dock panel is *not* the active widget
       // of the application, defer to the application.
       dock.activateWidget(this.currentWidget);
+
+      // Set the mode data attribute on the document body.
+      document.body.setAttribute(MODE_ATTRIBUTE, mode);
       return;
     }
 
@@ -213,6 +220,9 @@ class ApplicationShell extends Widget {
     // In case the active widget in the dock panel is *not* the active widget
     // of the application, defer to the application.
     dock.activateWidget(this.currentWidget);
+
+    // Set the mode data attribute on the document body.
+    document.body.setAttribute(MODE_ATTRIBUTE, mode);
   }
 
   /**
@@ -481,6 +491,13 @@ class ApplicationShell extends Widget {
       default:
         break;
     }
+  }
+
+  /**
+   * Handle `after-attach` messages for the application shell.
+   */
+  protected onAfterAttach(msg: Message): void {
+    document.body.setAttribute(MODE_ATTRIBUTE, this.mode);
   }
 
   /*
@@ -913,9 +930,9 @@ namespace Private {
         newWidget.show();
       }
       if (newWidget) {
-        document.body.setAttribute(`data-${this._side}Area`, newWidget.id);
+        document.body.setAttribute(`data-${this._side}-area`, newWidget.id);
       } else {
-        document.body.removeAttribute(`data-${this._side}Area`);
+        document.body.removeAttribute(`data-${this._side}-area`);
       }
       this._refreshVisibility();
     }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -306,7 +306,7 @@ class ApplicationShell extends Widget {
    */
   addToLeftArea(widget: Widget, options: ApplicationShell.ISideAreaOptions = {}): void {
     if (!widget.id) {
-      console.error('widgets added to app shell must have unique id property');
+      console.error('Widgets added to app shell must have unique id property.');
       return;
     }
     let rank = 'rank' in options ? options.rank : DEFAULT_RANK;
@@ -324,7 +324,7 @@ class ApplicationShell extends Widget {
    */
   addToMainArea(widget: Widget): void {
     if (!widget.id) {
-      console.error('widgets added to app shell must have unique id property');
+      console.error('Widgets added to app shell must have unique id property.');
       return;
     }
 


### PR DESCRIPTION
* Bug fix: toggling SDI/MDI mode always makes sure the application's "current" widget gets the focus.
* Restores the layout of multiple-document mode when toggling between SDI/MDI.
![restore upon toggle](https://cloud.githubusercontent.com/assets/159529/25181883/dfab8324-250a-11e7-8989-57a700ca9ee5.gif)
* Handles tabs that were created in single-document mode when user switches back to multiple-document mode.
![handle new tabs in SDI](https://cloud.githubusercontent.com/assets/159529/25182613/175f2a44-250d-11e7-94a1-e93449d0d318.gif)
* Handles tabs that were closed while in single-document mode when the user toggles back to multiple-document mode.
![handle closed tabs in SDI](https://cloud.githubusercontent.com/assets/159529/25182724/7b5c5328-250d-11e7-9cb1-1b38d54bf29d.gif)
* Remembers the multiple-document layout of the application after refresh even if the application is refreshed while in single-document mode.
![restore after refresh](https://cloud.githubusercontent.com/assets/159529/25181129/671f3d9e-2508-11e7-96b4-2c2831f09904.gif)

Fixes https://github.com/jupyterlab/jupyterlab/issues/2046
cc: @ellisonbg @cameronoelsen 