### PR TITLE
Simplify config directory handling for now

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -24,7 +24,7 @@ else:
 
 
 here = osp.dirname(osp.abspath(__file__))
-CONFIG_PATH = os.environ.get('JUPYTER_CONFIG_DIR', ENV_CONFIG_PATH[0])
+CONFIG_PATH = os.environ.get('JUPYTERLAB_CONFIG_DIR', ENV_CONFIG_PATH[0])
 BUILD_PATH = ENV_JUPYTER_PATH[0]
 
 

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -10,7 +10,7 @@ from tornado import web
 from notebook.base.handlers import IPythonHandler, FileFindHandler
 from jinja2 import FileSystemLoader
 from notebook.utils import url_path_join as ujoin
-from .commands import _get_build_dir, _get_config, DEFAULT_CONFIG_PATH
+from .commands import _get_build_dir, _get_config, _get_config_dir
 
 
 #-----------------------------------------------------------------------------
@@ -88,14 +88,9 @@ def add_handlers(app):
     prefix = ujoin(base_url, PREFIX)
 
     # Handle page config data.
-    config_dir = getattr(app, 'lab_config_dir', DEFAULT_CONFIG_PATH)
-    if 'LabApp' in app.config:
-        if 'lab_config_dir' in app.config['LabApp']:
-            config_dir = app.config['LabApp']['lab_config_dir']
-
-    config = _get_config(config_dir)
+    config = _get_config()
     page_config_data = web_app.settings.get('page_config_data', {})
-    page_config_file = os.path.join(config_dir, 'page_config_data.json')
+    page_config_file = os.path.join(_get_config_dir(), 'page_config_data.json')
     if os.path.exists(page_config_file):
         with open(page_config_file) as fid:
             page_config_data.update(json.load(fid))

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -6,13 +6,12 @@
 
 from notebook.notebookapp import NotebookApp, flags
 from jupyter_core.application import JupyterApp
-from jupyter_core.paths import ENV_CONFIG_PATH
 
 from traitlets import Bool, Unicode
 
 from ._version import __version__
 from .extension import load_jupyter_server_extension
-from .commands import build, clean, describe, DEFAULT_CONFIG_PATH
+from .commands import build, clean, describe
 
 
 class LabBuildApp(JupyterApp):

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -75,9 +75,6 @@ class LabApp(NotebookApp):
     dev_mode = Bool(False, config=True,
         help="Whether to start the app in dev mode")
 
-    lab_config_dir = Unicode(DEFAULT_CONFIG_PATH, config=True,
-        help="The lab configuration directory")
-
     def init_server_extensions(self):
         """Load any extensions specified by config.
 

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -7,8 +7,7 @@ import os
 import sys
 
 from jupyter_core.application import JupyterApp, base_flags
-from jupyter_core.paths import ENV_CONFIG_PATH
-from traitlets import Bool, Unicode
+from traitlets import Bool
 
 from ._version import __version__
 from .commands import (
@@ -28,9 +27,6 @@ class BaseExtensionApp(JupyterApp):
     version = __version__
     flags = flags
 
-    lab_config_dir = Unicode(ENV_CONFIG_PATH[0], config=True,
-        help="The lab configuration directory")
-
     should_build = Bool(True, config=True,
         help="Whether to build the app after the action")
 
@@ -40,7 +36,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        [install_extension(arg, self.config_dir) for arg in self.extra_args]
+        [install_extension(arg) for arg in self.extra_args]
         if self.should_build:
             build()
 
@@ -50,7 +46,7 @@ class LinkLabExtensionApp(BaseExtensionApp):
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        [link_extension(arg, self.config_dir) for arg in self.extra_args]
+        [link_extension(arg) for arg in self.extra_args]
         if self.should_build:
             build()
 
@@ -60,7 +56,7 @@ class UnlinkLabExtensionApp(BaseExtensionApp):
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        ans = any([unlink_extension(arg, self.config_dir)
+        ans = any([unlink_extension(arg)
                    for arg in self.extra_args])
         if ans and self.should_build:
             build()
@@ -71,7 +67,7 @@ class UninstallLabExtensionApp(BaseExtensionApp):
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        ans = any([uninstall_extension(arg, self.config_dir)
+        ans = any([uninstall_extension(arg)
                    for arg in self.extra_args])
         if ans and self.should_build:
             build()


### PR DESCRIPTION
Pending discussion in #2063, this allows for a short term solution for a 0.20 release.  The config directory defaults to the `sys-prefix` location unless overridden by the `JUPYTERLAB_CONFIG_DIR` environment variable.