### PR TITLE
Include necessary files for installing new extensions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,8 @@ include README.md
 include package.json
 include setupbase.py
 
+include jupyterlab/package.json
+include jupyterlab/webpack.config.js
+include jupyterlab/index.template.js
+
 prune jupyterlab/tests

--- a/setupbase.py
+++ b/setupbase.py
@@ -64,7 +64,7 @@ def find_package_data():
     Find package_data.
     """
     return {
-        'jupyterlab': ['build/*', 'lab.html']
+        'jupyterlab': ['build/*', 'lab.html', 'package.json', 'index.template.js', 'webpack.config.js']
     }
 
 


### PR DESCRIPTION
Installing an extension triggers a build, which complains that a few files are missing in the installed package.