### PR TITLE
Clean up handling of toolbar buttons

### DIFF
--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -304,15 +304,10 @@ class ToolbarButton extends Widget {
       break;
     case 'mousedown':
       this.addClass(TOOLBAR_PRESSED_CLASS);
-      this._originalNode = document.activeElement as HTMLElement;
       break;
     case 'mouseup':
     case 'mouseout':
       this.removeClass(TOOLBAR_PRESSED_CLASS);
-      if (this._originalNode) {
-        this._originalNode.focus();
-        this._originalNode = null;
-      }
       break;
     default:
       break;
@@ -340,7 +335,6 @@ class ToolbarButton extends Widget {
   }
 
   private _onClick: () => void;
-  private _originalNode: HTMLElement;
 }
 
 

--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -18,7 +18,7 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  IClientSession
+  IClientSession, Styling
 } from '.';
 
 
@@ -266,7 +266,8 @@ class ToolbarButton extends Widget {
    * Construct a new toolbar button.
    */
   constructor(options: ToolbarButton.IOptions = {}) {
-    super({ node: document.createElement('span') });
+    super({ node: document.createElement('button') });
+    Styling.styleNodeByTag(this.node, 'button');
     options = options || {};
     this.addClass(TOOLBAR_BUTTON_CLASS);
     this._onClick = options.onClick;
@@ -303,10 +304,15 @@ class ToolbarButton extends Widget {
       break;
     case 'mousedown':
       this.addClass(TOOLBAR_PRESSED_CLASS);
+      this._originalNode = document.activeElement as HTMLElement;
       break;
     case 'mouseup':
     case 'mouseout':
       this.removeClass(TOOLBAR_PRESSED_CLASS);
+      if (this._originalNode) {
+        this._originalNode.focus();
+        this._originalNode = null;
+      }
       break;
     default:
       break;
@@ -334,6 +340,7 @@ class ToolbarButton extends Widget {
   }
 
   private _onClick: () => void;
+  private _originalNode: HTMLElement;
 }
 
 

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -81,23 +81,20 @@
 }
 
 
-button.jp-mod-styled.jp-mod-accept,
-button.jp-mod-styled.jp-mod-accept:hover {
+button.jp-mod-styled.jp-mod-accept {
   background: var(--jp-brand-color1);
   color: var(--jp-inverse-ui-font-color0);
 }
 
 
-button.jp-mod-styled.jp-mod-reject,
-button.jp-mod-styled.jp-mod-reject:hover {
+button.jp-mod-styled.jp-mod-reject {
   background: #9E9E9E;
   margin-right: 12px;
   color: var(--jp-inverse-ui-font-color0);
 }
 
 
-button.jp-mod-styled.jp-mod-warn,
-button.jp-mod-styled.jp-mod-warn:hover {
+button.jp-mod-styled.jp-mod-warn {
   background: var(--jp-error-color1);
   color: var(--jp-inverse-ui-font-color0);
 }

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -81,20 +81,23 @@
 }
 
 
-button.jp-mod-accept {
+button.jp-mod-styled.jp-mod-accept,
+button.jp-mod-styled.jp-mod-accept:hover {
   background: var(--jp-brand-color1);
   color: var(--jp-inverse-ui-font-color0);
 }
 
 
-button.jp-mod-reject {
+button.jp-mod-styled.jp-mod-reject,
+button.jp-mod-styled.jp-mod-reject:hover {
   background: #9E9E9E;
   margin-right: 12px;
   color: var(--jp-inverse-ui-font-color0);
 }
 
 
-button.jp-mod-warn {
+button.jp-mod-styled.jp-mod-warn,
+button.jp-mod-styled.jp-mod-warn:hover {
   background: var(--jp-error-color1);
   color: var(--jp-inverse-ui-font-color0);
 }

--- a/packages/apputils/style/styling.css
+++ b/packages/apputils/style/styling.css
@@ -7,15 +7,20 @@
 
 button.jp-mod-styled {
   font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color0);
   border: none;
   box-sizing: border-box;
-  outline: none;
   text-transform: uppercase;
+  text-align: center;
   line-height: 32px;
   height: 32px;
   padding: 0px 4px;
   letter-spacing: 1px;
   outline: none;
+  background-color: white;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 16px;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -55,14 +60,17 @@ button.jp-mod-styled:focus {
 }
 
 
-.jp-select-wrapper.jp-mod-focused{
+.jp-select-wrapper.jp-mod-focused {
   border: var(--jp-border-width) solid var(--md-blue-500);
   box-shadow: inset 0 0 4px var(--md-blue-300);
 }
 
 
 .jp-select-wrapper:hover,
- input.jp-mod-styled:hover {
+ input.jp-mod-styled:hover,
+ button.jp-mod-styled:hover {
+  cursor: pointer;
+  color: var(--jp-ui-font-color0);
   background-color: var(--md-grey-200);
   box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
 }

--- a/packages/apputils/style/styling.css
+++ b/packages/apputils/style/styling.css
@@ -17,10 +17,6 @@ button.jp-mod-styled {
   padding: 0px 4px;
   letter-spacing: 1px;
   outline: none;
-  background-color: white;
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 16px;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -43,8 +39,7 @@ input.jp-mod-styled {
 }
 
 
-input.jp-mod-styled:focus,
-button.jp-mod-styled:focus {
+input.jp-mod-styled:focus {
   border: var(--jp-border-width) solid var(--md-blue-500);
   box-shadow: inset 0 0 4px var(--md-blue-300);
 }
@@ -67,8 +62,7 @@ button.jp-mod-styled:focus {
 
 
 .jp-select-wrapper:hover,
- input.jp-mod-styled:hover,
- button.jp-mod-styled:hover {
+input.jp-mod-styled:hover {
   cursor: pointer;
   color: var(--jp-ui-font-color0);
   background-color: var(--md-grey-200);

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -32,6 +32,7 @@
 .jp-Toolbar-item.jp-Toolbar-button {
   display: inline-block;
   width: 32px;
+  background-color: white;
   background-repeat: no-repeat;
   background-position: center;
   background-size: 16px;
@@ -39,14 +40,14 @@
 
 
 .jp-Toolbar-button.jp-mod-pressed {
-    background-color: var(--jp-layout-color3);
-    box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
+  background-color: var(--jp-layout-color3);
+  box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
 }
 
 
 .jp-Toolbar-button:hover {
-    background-color: var(--jp-layout-color2);
-    box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
+  background-color: var(--jp-layout-color2);
+  box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
 }
 
 

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -190,6 +190,47 @@ class NotebookPanel extends Widget {
   }
 
   /**
+   * Handle the DOM events for the widget.
+   *
+   * @param event - The DOM event sent to the widget.
+   *
+   * #### Notes
+   * This method implements the DOM `EventListener` interface and is
+   * called in response to events on the dock panel's node. It should
+   * not be called directly by user code.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+    case 'mouseup':
+    case 'mouseout':
+      let target = event.target as HTMLElement;
+      if (this.toolbar.node.contains(document.activeElement) &&
+          target.localName !== 'select') {
+        this.notebook.node.focus();
+      }
+      break;
+    default:
+      break;
+    }
+  }
+
+  /**
+   * Handle `after-attach` messages for the widget.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this.toolbar.node.addEventListener('mouseup', this);
+    this.toolbar.node.addEventListener('mouseout', this);
+  }
+
+  /**
+   * Handle `before-detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    this.toolbar.node.removeEventListener('mouseup', this);
+    this.toolbar.node.removeEventListener('mouseout', this);
+  }
+
+  /**
    * Handle `'activate-request'` messages.
    */
   protected onActivateRequest(msg: Message): void {


### PR DESCRIPTION
Fixes #2072.  Makes toolbar buttons HTML button elements and handles associated focus on the panel.

![image](https://cloud.githubusercontent.com/assets/2096628/25588213/0278f952-2e6d-11e7-8e61-e2639a08923f.png)
