### PR TITLE
Fix up jupyter labextension list

### DIFF
--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -81,12 +81,12 @@ class ListLabExtensionsApp(BaseExtensionApp):
     should_build = False
 
     def start(self):
-        [print(ext) for ext in list_extensions(self.config_dir)]
+        [print(ext) for ext in list_extensions()]
 
 
 _examples = """
 jupyter labextension list                        # list all configured labextensions
-jupyter labextension install <extension name>    # install a labextension 
+jupyter labextension install <extension name>    # install a labextension
 jupyter labextension uninstall <extension name>  # uninstall a labextension
 """
 


### PR DESCRIPTION
Currently `list_labextensions` doesn't take an argument... but the `ListLabExtensionsApp` was giving one, so `jupyter labextension list` was failing.

This PR just gets rid of the `self.config_dir` argument, as this is all apparently taken care of by stuff in `commands`!

Would it be worth adding actual "CLI" tests for the various apps? For the actual CLI via `subprocess`?