### PR TITLE
Collaborator cursors

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -679,7 +679,7 @@ class MarkdownCell extends Cell {
       signal: this.model.contentChanged,
       timeout: RENDER_TIMEOUT
     });
-    this._monitor.activityStopped.connect(()=>{
+    this._monitor.activityStopped.connect(() => {
       if (this._rendered) {
         this.update();
       }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -22,11 +22,12 @@ import {
 } from '@phosphor/widgets';
 
 import {
+<<<<<<< HEAD
   IClientSession
 } from '@jupyterlab/apputils';
 
 import {
-  IChangedArgs
+  IChangedArgs, ActivityMonitor
 } from '@jupyterlab/coreutils';
 
 import {
@@ -142,6 +143,10 @@ const NO_OUTPUTS_CLASS = 'jp-mod-noOutputs';
  */
 const DEFAULT_MARKDOWN_TEXT = 'Type Markdown and LaTeX: $ α^2 $';
 
+/**
+ * The timeout to wait for change activity to have ceased before rendering.
+ */
+const RENDER_TIMEOUT = 1000;
 
 /******************************************************************************
  * Cell
@@ -669,6 +674,17 @@ class MarkdownCell extends Cell {
     this.addClass(MARKDOWN_CELL_CLASS);
     this._rendermime = options.rendermime;
     this.editor.wordWrap = true;
+
+    // Throttle the rendering rate of the widget.
+    this._monitor = new ActivityMonitor({
+      signal: this.model.contentChanged,
+      timeout: RENDER_TIMEOUT
+    });
+    this._monitor.activityStopped.connect(()=>{
+      if(this._rendered) {
+        this.update();
+      }
+    }, this);
   }
 
   /**
@@ -759,6 +775,7 @@ class MarkdownCell extends Cell {
     this._prevTrusted = trusted;
   }
 
+  private _monitor: ActivityMonitor<any, any> = null;
   private _rendermime: RenderMime = null;
   private _renderedInput: Widget = null;
   private _rendered = true;

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -22,7 +22,6 @@ import {
 } from '@phosphor/widgets';
 
 import {
-<<<<<<< HEAD
   IClientSession
 } from '@jupyterlab/apputils';
 
@@ -681,7 +680,7 @@ class MarkdownCell extends Cell {
       timeout: RENDER_TIMEOUT
     });
     this._monitor.activityStopped.connect(()=>{
-      if(this._rendered) {
+      if (this._rendered) {
         this.update();
       }
     }, this);

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -105,6 +105,16 @@ namespace CodeEditor {
      * A display name added to a selection.
      */
     displayName?: string;
+
+    /**
+     * A CSS string to apply to the selection.
+     */
+    css?: string;
+
+    /**
+     * A color for cursors.
+     */
+    color?: string;
   }
 
   /**

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -107,12 +107,7 @@ namespace CodeEditor {
     displayName?: string;
 
     /**
-     * A CSS string to apply to the selection.
-     */
-    css?: string;
-
-    /**
-     * A color for cursors.
+     * A color for UI elements.
      */
     color?: string;
   }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -611,9 +611,9 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    * Converts an editor selection to a code mirror selection.
    */
   private _toCodeMirrorSelection(selection: CodeEditor.IRange): CodeMirror.Selection {
-    //Selections only appear to render correctly if the anchor
-    //is before the head in the document. That is, reverse selections
-    //do not appear as intended.
+    // Selections only appear to render correctly if the anchor
+    // is before the head in the document. That is, reverse selections
+    // do not appear as intended.
     let forward: boolean = (selection.start.line < selection.end.line) ||
                            (selection.start.line === selection.end.line &&
                             selection.start.column <= selection.end.column);

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -560,8 +560,12 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    * Handles a cursor activity event.
    */
   private _onCursorActivity(): void {
-    const selections = this.getSelections();
-    this.model.selections.set(this.uuid, selections);
+    // Only add selections if the editor has focus. This avoids unwanted
+    // triggering of cursor activity due to collaborator actions.
+    if (this._editor.hasFocus()) {
+      const selections = this.getSelections();
+      this.model.selections.set(this.uuid, selections);
+    }
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -585,10 +585,17 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    */
   private _toTextMarkerOptions(style: CodeEditor.ISelectionStyle | undefined): CodeMirror.TextMarkerOptions | undefined {
     if (style) {
+      let css: string;
+      if (style.color) {
+        let r = parseInt(style.color.slice(1,3), 16);
+        let g  = parseInt(style.color.slice(3,5), 16);
+        let b  = parseInt(style.color.slice(5,7), 16);
+        css = `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`;
+      }
       return {
         className: style.className,
         title: style.displayName,
-        css: style.css
+        css
       };
     }
     return undefined;

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -414,6 +414,12 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   setCursorPosition(position: CodeEditor.IPosition): void {
     const cursor = this._toCodeMirrorPosition(position);
     this.doc.setCursor(cursor);
+    // If the editor does not have focus, this cursor change
+    // will get screened out in _onCursorsChanged(). Make an
+    // exception for this method.
+    if (!this.editor.hasFocus()) {
+      this.model.selections.set(this.uuid, this.getSelections());
+    }
   }
 
   /**

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -66,6 +66,15 @@
   margin-left: calc(-1 * var(--jp-code-padding));
 }
 
+.jp-CollaboratorCursor {
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: none;
+  border-bottom: 3px solid;
+  position: absolute;
+  width: 0;
+}
+
 
 /*
   Here is our jupyter theme for CodeMirror syntax highlighting

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -140,6 +140,10 @@ class FileEditor extends CodeEditorWrapper {
     this.title.label = path.split('/').pop();
   }
 
+  /**
+   * Handle a change to the collaborators on the model
+   * by updating UI elements associated with them.
+   */
   private _onCollaboratorsChanged(): void {
     // If there are selections corresponding to non-collaborators,
     // they are stale and should be removed.

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -52,7 +52,7 @@ class FileEditor extends CodeEditorWrapper {
     if (context.model.modelDB.isCollaborative) {
       let modelDB = context.model.modelDB;
       modelDB.connected.then(() => {
-        //Setup the selection style for collaborators
+        // Setup the selection style for collaborators
         let localCollaborator = modelDB.collaborators.localCollaborator;
         this.editor.uuid = localCollaborator.sessionId;
         this.editor.selectionStyle = {
@@ -60,7 +60,7 @@ class FileEditor extends CodeEditorWrapper {
         };
 
         modelDB.collaborators.changed.connect(this._onCollaboratorsChanged, this);
-        //Trigger an initial onCollaboratorsChanged event.
+        // Trigger an initial onCollaboratorsChanged event.
         this._onCollaboratorsChanged();
       });
     }
@@ -141,8 +141,8 @@ class FileEditor extends CodeEditorWrapper {
   }
 
   private _onCollaboratorsChanged(): void {
-    //if there are selections corresponding to non-collaborators,
-    //they are stale and should be removed.
+    // If there are selections corresponding to non-collaborators,
+    // they are stale and should be removed.
     for (let key of this.editor.model.selections.keys()) {
       if (!this._context.model.modelDB.collaborators.has(key)) {
         this.editor.model.selections.delete(key);

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -55,12 +55,7 @@ class FileEditor extends CodeEditorWrapper {
         //Setup the selection style for collaborators
         let localCollaborator = modelDB.collaborators.localCollaborator;
         this.editor.uuid = localCollaborator.sessionId;
-        let color = localCollaborator.color;
-        let r = parseInt(color.slice(1,3), 16);
-        let g  = parseInt(color.slice(3,5), 16);
-        let b  = parseInt(color.slice(5,7), 16);
         this.editor.selectionStyle = {
-          css: `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`,
           color: localCollaborator.color
         };
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -210,7 +210,7 @@ class StaticNotebook extends Widget {
           this._onCollaboratorsChanged, this);
       });
     }
-    if (newValue.modelDB.isCollaborative) {
+    if (newValue && newValue.modelDB.isCollaborative) {
       newValue.modelDB.connected.then(() => {
         newValue.modelDB.collaborators.changed.connect(
           this._onCollaboratorsChanged, this);
@@ -960,7 +960,7 @@ class Notebook extends StaticNotebook {
    * Handle a cell being inserted.
    */
   protected onCellInserted(index: number, cell: Cell): void {
-    if (this.model.modelDB.isCollaborative) {
+    if (this.model && this.model.modelDB.isCollaborative) {
       let modelDB = this.model.modelDB;
       modelDB.connected.then(() => {
         if (!cell.isDisposed) {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -964,7 +964,7 @@ class Notebook extends StaticNotebook {
       let modelDB = this.model.modelDB;
       modelDB.connected.then(() => {
         if (!cell.isDisposed) {
-          //Setup the selection style for collaborators
+          // Setup the selection style for collaborators.
           let localCollaborator = modelDB.collaborators.localCollaborator;
           cell.editor.uuid = localCollaborator.sessionId;
           cell.editor.selectionStyle = {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -967,12 +967,7 @@ class Notebook extends StaticNotebook {
           //Setup the selection style for collaborators
           let localCollaborator = modelDB.collaborators.localCollaborator;
           cell.editor.uuid = localCollaborator.sessionId;
-          let color = localCollaborator.color;
-          let r = parseInt(color.slice(1,3), 16);
-          let g  = parseInt(color.slice(3,5), 16);
-          let b  = parseInt(color.slice(5,7), 16);
           cell.editor.selectionStyle = {
-            css: `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`,
             color: localCollaborator.color
           };
         }


### PR DESCRIPTION
Adds rendering of collaborator cursors to the codemirror instances. In general, it is a lot easier to add a cursor marker than to remove one, so they tend to pile up. I have tried to be pretty aggressive in removing them, but there are still places where we can cull them even more.

cc @cameronoelsen 