### PR TITLE
Surface the `IModelDB` of a document model.

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -167,6 +167,12 @@ namespace CodeEditor {
      * The currently selected code.
      */
     readonly selections: IObservableMap<ITextSelection[]>;
+
+    /**
+     * The underlying `IModelDB` instance in which model
+     * data is stored.
+     */
+    readonly modelDB: IModelDB;
   }
 
   /**
@@ -195,6 +201,12 @@ namespace CodeEditor {
 
       this.modelDB.createMap('selections');
     }
+
+    /**
+     * The underlying `IModelDB` instance in which model
+     * data is stored.
+     */
+    readonly modelDB: IModelDB;
 
     /**
      * A signal emitted when a mimetype changes.
@@ -257,7 +269,6 @@ namespace CodeEditor {
       });
     }
 
-    protected modelDB: IModelDB = null;
     private _isDisposed = false;
     private _mimeTypeChanged = new Signal<this, IChangedArgs<string>>(this);
   }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -581,6 +581,16 @@ namespace DocumentRegistry {
     readonly defaultKernelLanguage: string;
 
     /**
+     * The underlying `IModelDB` instance in which model
+     * data is stored.
+     *
+     * ### Notes
+     * Making direct edits to the values stored in the`IModelDB`
+     * is not recommended, and may produce unpredictable results.
+     */
+    readonly modelDB: IModelDB;
+
+    /**
      * Serialize the model to a string.
      */
     toString(): string;

--- a/test/src/codeeditor/editor.spec.ts
+++ b/test/src/codeeditor/editor.spec.ts
@@ -117,6 +117,14 @@ describe('CodeEditor.Model', () => {
 
   });
 
+  describe('#modelDB', () => {
+
+    it('should get the modelDB object associated with the model', () => {
+      expect(model.modelDB.has('value')).to.be(true);
+    });
+
+  });
+
   describe('#isDisposed', () => {
 
     it('should test whether the model is disposed', () => {


### PR DESCRIPTION
I intended to include this in #2058. If the collaborators list exists on the `IModelDB`, then it needs to be surfaced so that users of document models can access them.