### PR TITLE
Add ability to uninstall core extensions

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -71,6 +71,10 @@ def install_extension(extension, app_dir=None):
     data = _read_package(pjoin(target, name))
     _validate_package(data, extension)
 
+    _ensure_package(app_dir)
+    staging = pjoin(app_dir, 'staging')
+    run(['npm', 'install', pjoin(target, name)], cwd=staging)
+
 
 def link_package(path, app_dir=None):
     """Link a package against the JupyterLab build.

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -121,8 +121,8 @@ class TestExtension(TestCase):
 
     def test_uninstall_core_extension(self):
         uninstall_extension('@jupyterlab/console-extension')
-        _ensure_package()
         app_dir = get_app_dir()
+        _ensure_package(app_dir)
         with open(pjoin(app_dir, 'staging', 'package.json')) as fid:
             data = json.load(fid)
         assert '@jupyterlab/console-extension' not in data['extensions']

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -4,6 +4,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import glob
+import json
 import os
 import sys
 from os.path import join as pjoin
@@ -26,7 +27,7 @@ from jupyterlab.extension import (
 from jupyterlab.commands import (
     install_extension, uninstall_extension, list_extensions,
     build, link_package, unlink_package, get_app_dir,
-    _get_linked_packages
+    _get_linked_packages, _ensure_package
 )
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -117,6 +118,14 @@ class TestExtension(TestCase):
         path = pjoin(get_app_dir(), 'extensions', '*python_tests*.tgz')
         assert not glob.glob(path)
         assert '@jupyterlab/python-tests' not in list_extensions()
+
+    def test_uninstall_core_extension(self):
+        uninstall_extension('@jupyterlab/console-extension')
+        _ensure_package()
+        app_dir = get_app_dir()
+        with open(pjoin(app_dir, 'staging', 'package.json')) as fid:
+            data = json.load(fid)
+        assert '@jupyterlab/console-extension' not in data['extensions']
 
     def test_link_package(self):
         link_package(self.source_dir)

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -125,7 +125,8 @@ class TestExtension(TestCase):
         _ensure_package(app_dir)
         with open(pjoin(app_dir, 'staging', 'package.json')) as fid:
             data = json.load(fid)
-        assert '@jupyterlab/console-extension' not in data['extensions']
+        extensions = data['jupyterlab']['extensions']
+        assert '@jupyterlab/console-extension' not in extensions
 
     def test_link_package(self):
         link_package(self.source_dir)

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,6 @@
 
 from __future__ import print_function
 
-# the name of the project
-name = 'jupyterlab'
-
 #-----------------------------------------------------------------------------
 # Minimal Python version sanity check
 #-----------------------------------------------------------------------------
@@ -28,7 +25,6 @@ PY3 = (sys.version_info[0] >= 3)
 #-----------------------------------------------------------------------------
 
 from distutils import log
-import io
 import json
 import os
 from glob import glob
@@ -45,7 +41,9 @@ from setupbase import (
     find_packages,
     find_package_data,
     js_prerelease,
-    CheckAssets
+    CheckAssets,
+    version_ns,
+    name
 )
 
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
@@ -58,11 +56,6 @@ pjoin = os.path.join
 
 DESCRIPTION = 'An alpha preview of the JupyterLab notebook server extension.'
 LONG_DESCRIPTION = 'This is an alpha preview of JupyterLab. It is not ready for general usage yet. Development happens on https://github.com/jupyter/jupyterlab, with chat on https://gitter.im/jupyter/jupyterlab.'
-
-
-version_ns = {}
-with io.open(pjoin(here, name, '_version.py'), encoding="utf8") as f:
-    exec(f.read(), {}, version_ns)
 
 
 setup_args = dict(

--- a/tutorial/extensions_user.md
+++ b/tutorial/extensions_user.md
@@ -65,12 +65,25 @@ variable.  If not specified, it will default to
 site-specific directory prefix of the current Python environment.  You can
 query the current application path using `jupyter lab path`.
 
-The `settings` directory contains `page_config.json` and `linked_packages.json`
+The `settings` directory contains `page_config.json` and `build_config.json`
 files.
 The `page_config.json` data is used to provide config data to the application
 environment.  For example, the `ignoredPlugins` data is used to ignore registered plugins by the name of the token they provide.
-The `linked_packages.json` file is used to track the folders that have been
-added using `jupyter labextension link <folder>`.
+The `build_config.json` file is used to track the folders that have been
+added using `jupyter labextension link <folder>`, as well as core extensions
+that have been explicitly uninstalled.  e.g.
+
+```bash
+$ cat settings/build_config.json
+{
+    "uninstalled_core_extensions": [
+        "@jupyterlab/markdownwidget-extension"
+    ],
+    "linked_packages": {
+        "@jupyterlab/python-tests": "/path/to/my/extension"
+    }
+}
+```
 
 The other folders in the app directory are: `extensions`, `static`, and
 `staging`.  The `extensions` folder has the packed tarballs for each of the


### PR DESCRIPTION
Covers the advanced use case of completely removing core plugins, primarily for spin authors, but could also be instrumental in theming support.

Also adds an explicitly version check in the static assets when creating the python distributables.