### PR TITLE
Console clear

### DIFF
--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -457,6 +457,8 @@ class CodeConsole extends Widget {
   private _execute(cell: CodeCell): Promise<void> {
     let source = cell.model.value.text;
     this._history.push(source);
+    // If the source of the console is just "clear", clear the console as we
+    // do in IPython or QtConsole.
     if (source === 'clear') {
       this.clear();
       return Promise.resolve(void 0)

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -455,7 +455,12 @@ class CodeConsole extends Widget {
    * Execute the code in the current prompt cell.
    */
   private _execute(cell: CodeCell): Promise<void> {
-    this._history.push(cell.model.value.text);
+    let source = cell.model.value.text;
+    this._history.push(source);
+    if (source === 'clear') {
+      this.clear();
+      return Promise.resolve(void 0)
+    }
     cell.model.contentChanged.connect(this.update, this);
     let onSuccess = (value: KernelMessage.IExecuteReplyMsg) => {
       if (this.isDisposed) {

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -459,7 +459,7 @@ class CodeConsole extends Widget {
     this._history.push(source);
     // If the source of the console is just "clear", clear the console as we
     // do in IPython or QtConsole.
-    if (source === 'clear') {
+    if ( source === 'clear' || source === '%clear' ) {
       this.clear();
       return Promise.resolve(void 0)
     }


### PR DESCRIPTION
Fixes #2048 

Running `clear` or `%clear` in the console work as in classic IPython or the QtConsole. Total hack, but strong reasons to accept the hack for feature parity...

@rgbkrk 