### PR TITLE
Improve handling of file deletion

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -358,13 +358,13 @@ class DirListing extends Widget {
         names.push(item.name);
       }
     });
-    let message = `Permanently delete these ${names.length} files?`;
+    let message = `Are you sure you want to permanently delete the ${names.length} files/folders selected?`;
     if (names.length === 1) {
-      message = `Permanently delete file "${names[0]}"?`;
+      message = `Are you sure you want to permanently delete: ${names[0]}?`;
     }
     if (names.length) {
       return showDialog({
-        title: 'Delete file?',
+        title: 'Delete',
         body: message,
         buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'DELETE'})]
       }).then(result => {
@@ -1193,11 +1193,12 @@ class DirListing extends Widget {
     const promises: Promise<void>[] = [];
     const basePath = this._model.path;
     for (let name of names) {
-      promises.push(this._model.manager.deleteFile(name, basePath));
+      let promise = this._model.manager.deleteFile(name, basePath).catch(err => {
+        utils.showErrorMessage('Delete Failed', err);
+      });
+      promises.push(promise);
     }
-    return Promise.all(promises).catch(error => {
-      utils.showErrorMessage('Delete file', error);
-    });
+    return Promise.all(promises).then(() => undefined);
   }
 
   /**

--- a/packages/filebrowser/src/utils.ts
+++ b/packages/filebrowser/src/utils.ts
@@ -29,11 +29,11 @@ const CONTENTS_MIME = 'application/x-jupyter-icontents';
  * An error message dialog to show in the filebrowser widget.
  */
 export
-function showErrorMessage(title: string, error: Error): Promise<void> {
+function showErrorMessage(title: string, error: any): Promise<void> {
   console.error(error);
   let options = {
     title: title,
-    body: error.message || `File ${title}`,
+    body: error.throwError || error.message || `File ${title}`,
     buttons: [Dialog.okButton()],
     okText: 'DISMISS'
   };


### PR DESCRIPTION
Fixes #2146.  Deleted items are handled individually, with better error messages on failure.

<image src="https://cloud.githubusercontent.com/assets/2096628/25908274/65e00996-356f-11e7-9a04-db3bb2dd8629.png" width=300>

<image src="https://cloud.githubusercontent.com/assets/2096628/25908296/713e8268-356f-11e7-8e0b-9098bdad9f22.png" width=300>
