### PR TITLE
WIP: Include codemirror's c-like language syntax highlighting.

### DIFF
--- a/packages/codemirror/src/mode.ts
+++ b/packages/codemirror/src/mode.ts
@@ -16,6 +16,7 @@ import 'codemirror/mode/css/css';
 import 'codemirror/mode/julia/julia';
 import 'codemirror/mode/r/r';
 import 'codemirror/mode/markdown/markdown';
+import 'codemirror/mode/clike/clike';
 
 
 // Stub for the require function.


### PR DESCRIPTION
clike highlighting is broad enough that it is probably a good idea to add it regardless. But should every every syntax that people have created kernels for be imported in this file? Should there be some mechanism to import only the highlighters needed for installed kernels?