### PR TITLE
allowing line of text to be run in console based on cursor placement, not just cursor selection

### DIFF
--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -216,9 +216,13 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
       const selection = editor.getSelection();
       const start = editor.getOffsetAt(selection.start);
       const end = editor.getOffsetAt(selection.end);
+      let targetText = editor.model.value.text.substring(start, end);
+      if (start == end) {
+        targetText = editor.getLine(selection.start.line); 
+      }
       const options: JSONObject = {
         path: widget.context.path,
-        code: editor.model.value.text.substring(start, end),
+        code: targetText,
         activate: args['activate']
       };
       return commands.execute('console:inject', options);


### PR DESCRIPTION
Related to issue #450 and #1356.

Currently, only a higlighted block of text in the editor will be sent to the console on Shift-Enter. With this change, if no text is highlighted, the line indicated by the cursor location is sent to the console with Shift-Enter. This change will complement the feature described in #1356. 