### PR TITLE
change build directory from tutorial to docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,4 @@
 conda:
-    file: tutorial/environment.yml
+    file: docs/environment.yml
 python:
     version: 3


### PR DESCRIPTION
Readthedocs build is failing since it's looking for environment.yml in the wrong place.