### PR TITLE
Change kernel name toolbar indicator to button that switches kernel

### DIFF
--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -240,8 +240,8 @@ namespace Toolbar {
    * from the right toolbar items.
    */
   export
-  function createSpacerItem(session: IClientSession): Widget {
-    return new Private.Spacer(session);
+  function createSpacerItem(): Widget {
+    return new Private.Spacer();
   }
 
 
@@ -405,7 +405,7 @@ namespace Private {
     /**
      * Construct a new spacer widget.
      */
-    constructor(session: IClientSession) {
+    constructor() {
       super();
       this.addClass(TOOLBAR_SPACER_CLASS);
     }

--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -58,6 +58,11 @@ const TOOLBAR_RESTART_CLASS = 'jp-RefreshIcon';
 const TOOLBAR_KERNEL_NAME_CLASS = 'jp-Toolbar-kernelName';
 
 /**
+ * The class name added to toolbar spacer.
+ */
+const TOOLBAR_SPACER_CLASS = 'jp-Toolbar-spacer';
+
+/**
  * The class name added to toolbar kernel status icon.
  */
 const TOOLBAR_KERNEL_STATUS_CLASS = 'jp-Toolbar-kernelStatus';
@@ -228,6 +233,19 @@ namespace Toolbar {
 
 
   /**
+   * Create a toolbar spacer item.
+   *
+   * #### Notes
+   * It is a flex spacer that separates the left toolbar items
+   * from the right toolbar items.
+   */
+  export
+  function createSpacerItem(session: IClientSession): Widget {
+    return new Private.Spacer(session);
+  }
+
+
+  /**
    * Create a kernel name indicator item.
    *
    * #### Notes
@@ -236,7 +254,7 @@ namespace Toolbar {
    * It can handle a change in context or kernel.
    */
   export
-  function createKernelNameItem(session: IClientSession): Widget {
+  function createKernelNameItem(session: IClientSession): ToolbarButton {
     return new Private.KernelName(session);
   }
 
@@ -380,16 +398,35 @@ namespace Private {
   });
 
   /**
+   * A spacer widget.
+   */
+  export
+  class Spacer extends Widget {
+    /**
+     * Construct a new spacer widget.
+     */
+    constructor(session: IClientSession) {
+      super();
+      this.addClass(TOOLBAR_SPACER_CLASS);
+    }
+  }
+
+  /**
    * A kernel name widget.
    */
   export
-  class KernelName extends Widget {
+  class KernelName extends ToolbarButton {
     /**
      * Construct a new kernel name widget.
      */
     constructor(session: IClientSession) {
-      super();
-      this.addClass(TOOLBAR_KERNEL_NAME_CLASS);
+      super({
+        className: TOOLBAR_KERNEL_NAME_CLASS,
+        onClick: () => {
+          session.selectKernel();
+        },
+        tooltip: 'Switch kernel'
+        });
       this._onKernelChanged(session);
       session.kernelChanged.connect(this._onKernelChanged, this);
     }

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -51,10 +51,17 @@
 }
 
 
-.jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-kernelName {
-  text-align: right;
+.jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-spacer {
   flex-grow: 1;
   flex-shrink: 1;
+}
+
+
+.jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-kernelName {
+  width: auto;
+  text-transform: none; /* kernel names can benefit from visible case */
+  letter-spacing: normal;
+  text-align: left;
   font-size: var(--jp-ui-font-size1);
   line-height: calc( var(--jp-private-toolbar-height) + 1px );
 }

--- a/packages/notebook/src/default-toolbar.ts
+++ b/packages/notebook/src/default-toolbar.ts
@@ -195,7 +195,7 @@ namespace ToolbarItems {
     toolbar.addItem('interrupt', Toolbar.createInterruptButton(panel.session));
     toolbar.addItem('restart', Toolbar.createRestartButton(panel.session));
     toolbar.addItem('cellType', createCellTypeItem(panel));
-    toolbar.addItem('spacer', Toolbar.createSpacerItem(panel.session));
+    toolbar.addItem('spacer', Toolbar.createSpacerItem());
     toolbar.addItem('kernelName', Toolbar.createKernelNameItem(panel.session));
     toolbar.addItem('kernelStatus', Toolbar.createKernelStatusItem(panel.session));
   }

--- a/packages/notebook/src/default-toolbar.ts
+++ b/packages/notebook/src/default-toolbar.ts
@@ -195,6 +195,7 @@ namespace ToolbarItems {
     toolbar.addItem('interrupt', Toolbar.createInterruptButton(panel.session));
     toolbar.addItem('restart', Toolbar.createRestartButton(panel.session));
     toolbar.addItem('cellType', createCellTypeItem(panel));
+    toolbar.addItem('spacer', Toolbar.createSpacerItem(panel.session));
     toolbar.addItem('kernelName', Toolbar.createKernelNameItem(panel.session));
     toolbar.addItem('kernelStatus', Toolbar.createKernelStatusItem(panel.session));
   }

--- a/test/src/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/default-toolbar.spec.ts
@@ -267,7 +267,7 @@ describe('@jupyterlab/notebook', () => {
         ToolbarItems.populateDefaults(panel);
         expect(toArray(panel.toolbar.names())).to.eql(['save', 'insert', 'cut',
           'copy', 'paste', 'run', 'interrupt', 'restart', 'cellType',
-          'kernelName', 'kernelStatus']);
+          'spacer', 'kernelName', 'kernelStatus']);
       });
 
     });


### PR DESCRIPTION
Fixes second part of #919.

Changes the Kernel name in the toolbar to a button that, when clicked, displays the "Switch Kernel" dialog.

Needed to add a spacer because the kernel name label presently takes up the remaining whitespace on the toolbar which would make the button look huge.