### PR TITLE
Build System Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ MANIFEST
 build
 dist
 lib
-jupyterlab/static
+jupyterlab/build
 
 node_modules
 .cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ env:
   global:
   - GH_REF: github.com/jupyterlab/jupyterlab.git
   - secure: MWpTI6cj3/Bnmtrr0Oqlp2JeWqDneB9aEjlQDaRxLOkqVbxhqDcYW9qAgZZP+sq29vT5oVMWzyCirteKxJfG2vy3HQE1XNLhz82Sf/7sE6DQ51gohl0CcOeA/uA8hCXEw97hneFWsZgHKqSoch7nVDsE3qfYgO+930jHlnxYApJGP9hZFv2Q2NVa6+99kipEYS4BY/yBDYKy6/t4kXcnBrUlNaPtdjnXcrY9esLZ7EQtkaG5VqcQVIBaLJKGF5Q7Aufj5nCFaZ6hZDF1Bi/AbmIbVWFyiT+22i8DZK6YwenECckyzoWkl+bEhYepWsgBKh/BDgPBAmPWKHgU5V4apDaGqZBhF7FP6H02AdZYYuCwl47jyakqvWLZW7oDmorL+HsWG5HQ3m0tMT2ywdbwNOiD39tiPPXjsvROh5ys9vL6NzQvxILCeEOnzcZrFuxi2LGEZfnlqRIjkh1llUAvNc3mOycRLWDOwVQa2+U59qDRXCSY2RD+MOfcdFUGengVujTMaAPMBUa3E33/ZIOOKJtR5TIajYZvd9B2uDlz02QfvTK+hrTaNYJjRZ8WCaeSM/CIKdoLw+29MNO6eqtchw0/vNvM8c9EkhrhMQKcY04OecVhmZkemFhd4SD5l92VX3z3xSxLkmazfNkj3CigWDXNxfDd2ORoGjA46Pga8RM=
+before_install:
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver-v0.11.1-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver
 install:
 - bash ./scripts/travis_install.sh
 script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,5 +10,6 @@ include setupbase.py
 include jupyterlab/package.template.json
 include jupyterlab/webpack.config.js
 include jupyterlab/index.template.js
+include jupyterlab/package_list.txt
 
 prune jupyterlab/tests

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -203,14 +203,14 @@ def clean(app_dir=None):
             shutil.rmtree(target)
 
 
-def build(app_dir=None, name=None, version=None, publicPath=None):
+def build(app_dir=None, name=None, version=None):
     """Build the JupyterLab application."""
     # Set up the build directory.
     app_dir = get_app_dir(app_dir)
     if app_dir == here:
         raise ValueError('Cannot build extensions in the core app')
 
-    _ensure_package(app_dir, name, version, publicPath)
+    _ensure_package(app_dir, name, version)
     staging = pjoin(app_dir, 'staging')
 
     # Make sure packages are installed.

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -253,7 +253,7 @@ def _ensure_package(app_dir, name='JupyterLab', version=None):
         os.makedirs(staging)
 
     for name in ['index.template.js', 'webpack.config.js']:
-        dest = pjoin(staging, name)
+        dest = pjoin(staging, name.replace('.template', ''))
         shutil.copy2(pjoin(here, name), dest)
 
     # Template the package.json file.

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -230,7 +230,7 @@ def build(app_dir=None, name=None, version=None, publicPath=None):
     shutil.copytree(pjoin(staging, 'build'), static)
 
 
-def _ensure_package(app_dir, name='JupyterLab', version=None, publicPath=None):
+def _ensure_package(app_dir, name='JupyterLab', version=None):
     """Make sure the build dir is set up.
     """
     if not os.path.exists(pjoin(app_dir, 'extensions')):
@@ -275,10 +275,6 @@ def _ensure_package(app_dir, name='JupyterLab', version=None, publicPath=None):
     if version:
         data['jupyterlab']['version'] = version
 
-    publicPath = publicPath or uuid4().hex
-    if not publicPath.endswith('/'):
-        publicPath += '/'
-    data['jupyterlab']['publicPath'] = publicPath
     data['scripts']['build'] = 'webpack'
 
     pkg_path = pjoin(staging, 'package.json')

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -3,16 +3,17 @@ require('font-awesome/css/font-awesome.min.css');
 require('@jupyterlab/default-theme/style/index.css');
 
 var app = require('@jupyterlab/application').JupyterLab;
-var utils = require('@jupyterlab/services').utils;
+var PageConfig = require('@jupyterlab/coreutils').PageConfig;
 
+__webpack_public_path__ = PageConfig.getOption('publicUrl');
 
 function main() {
-    var version = utils.getConfigOption('appVersion') || 'unknown';
-    var name = utils.getConfigOption('appName') || 'JupyterLab';
-    var namespace = utils.getConfigOption('appNamespace') || 'jupyterlab';
-    var devMode = utils.getConfigOption('devMode') || 'false';
-    var settingsDir = utils.getConfigOption('settingsDir') || '';
-    var assetsDir = utils.getConfigOption('assetsDir') || '';
+    var version = PageConfig.getOption('appVersion') || 'unknown';
+    var name = PageConfig.getOption('appName') || 'JupyterLab';
+    var namespace = PageConfig.getOption('appNamespace') || 'jupyterlab';
+    var devMode = PageConfig.getOption('devMode') || 'false';
+    var settingsDir = PageConfig.getOption('settingsDir') || '';
+    var assetsDir = PageConfig.getOption('assetsDir') || '';
 
     if (version[0] === 'v') {
         version = version.slice(1);
@@ -35,7 +36,7 @@ function main() {
     {{/each}}
     var ignorePlugins = [];
     try {
-        var option = utils.getConfigOption('ignorePlugins');
+        var option = PageConfig.getOption('ignorePlugins');
         ignorePlugins = JSON.parse(option);
     } catch (e) {
         console.error("Invalid ignorePlugins config:", option);

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -35,11 +35,8 @@ class LabBuildApp(JupyterApp):
     version = Unicode('', config=True,
         help="The version of the built application")
 
-    publicPath = Unicode('', config=True,
-        help="The public path for assets in the built application")
-
     def start(self):
-        build(self.app_dir, self.name, self.version, self.publicPath)
+        build(self.app_dir, self.name, self.version)
 
 
 clean_aliases = dict(base_aliases)

--- a/jupyterlab/make-release.js
+++ b/jupyterlab/make-release.js
@@ -11,9 +11,13 @@ version = version.toString().trim();
 var data = require('./package.json');
 data['jupyterlab']['version'] = version;
 
+// Update our package.json files.
 var text = JSON.stringify(data, null, 2) + '\n';
 fs.writeFileSync('./package.json', text);
 fs.writeFileSync('./package.template.json', text);
+
+// Update our template file.
+fs.copyFileSync('./index.js', './index.template.js')
 
 // Run a standard build.
 childProcess.execSync('npm run build');

--- a/jupyterlab/make-release.js
+++ b/jupyterlab/make-release.js
@@ -2,6 +2,7 @@ var childProcess = require('child_process');
 var fs = require('fs-extra');
 var path = require('path');
 
+
 // Get the current version of JupyterLab
 var cwd = path.resolve('..');
 var version = childProcess.execSync('python setup.py --version', { cwd: cwd });
@@ -26,3 +27,7 @@ childProcess.execSync('npm run build');
 var release_data = { version: version };
 text = JSON.stringify(release_data, null, 2) + '\n';
 fs.writeFileSync('./build/release_data.json', text);
+
+// Get the lerna package data.
+var lerna_info = childProcess.execSync('lerna ls', { cwd: cwd });
+fs.writeFileSync('./package_list.txt', lerna_info);

--- a/jupyterlab/make-release.js
+++ b/jupyterlab/make-release.js
@@ -18,7 +18,7 @@ fs.writeFileSync('./package.json', text);
 fs.writeFileSync('./package.template.json', text);
 
 // Update our template file.
-fs.copyFileSync('./index.js', './index.template.js')
+fs.copySync('./index.js', './index.template.js')
 
 // Run a standard build.
 childProcess.execSync('npm run build');

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -80,7 +80,6 @@
       "@jupyterlab/terminal-extension",
       "@jupyterlab/tooltip-extension"
     ],
-    "publicPath": "/lab/",
     "name": "JupyterLab",
     "version": "0.21.0"
   }

--- a/jupyterlab/package.template.json
+++ b/jupyterlab/package.template.json
@@ -79,7 +79,6 @@
       "@jupyterlab/terminal-extension",
       "@jupyterlab/tooltip-extension"
     ],
-    "publicPath": "/lab/",
     "name": "JupyterLab",
     "version": "0.21.0"
   }

--- a/jupyterlab/package_list.txt
+++ b/jupyterlab/package_list.txt
@@ -1,0 +1,61 @@
+@jupyterlab/application-top          v0.3.0     (private)
+@jupyterlab/example-app              v0.4.0     (private)
+@jupyterlab/example-console          v0.4.0     (private)
+@jupyterlab/example-filebrowser      v0.4.0     (private)
+@jupyterlab/example-notebook         v0.4.0     (private)
+jupyterlab-example-terminal          v0.4.0     (private)
+@jupyterlab/about-extension          v0.4.0              
+@jupyterlab/all-packages             v0.3.0     (private)
+@jupyterlab/application-extension    v0.4.0              
+@jupyterlab/application              v0.4.0              
+@jupyterlab/apputils-extension       v0.4.0              
+@jupyterlab/apputils                 v0.4.0              
+@jupyterlab/cells                    v0.4.0              
+@jupyterlab/codeeditor               v0.4.0              
+@jupyterlab/codemirror-extension     v0.4.0              
+@jupyterlab/codemirror               v0.4.0              
+@jupyterlab/completer-extension      v0.4.0              
+@jupyterlab/completer                v0.4.0              
+@jupyterlab/console-extension        v0.4.0              
+@jupyterlab/console                  v0.4.0              
+@jupyterlab/coreutils                v0.4.0              
+@jupyterlab/csvviewer-extension      v0.4.0              
+@jupyterlab/csvviewer                v0.4.0              
+@jupyterlab/default-theme            v0.4.0              
+@jupyterlab/docmanager-extension     v0.4.0              
+@jupyterlab/docmanager               v0.4.0              
+@jupyterlab/docregistry-extension    v0.4.0              
+@jupyterlab/docregistry              v0.4.0              
+@jupyterlab/faq-extension            v0.4.0              
+@jupyterlab/filebrowser-extension    v0.4.0              
+@jupyterlab/filebrowser              v0.4.0              
+@jupyterlab/fileeditor-extension     v0.4.0              
+@jupyterlab/fileeditor               v0.4.0              
+@jupyterlab/help-extension           v0.4.0              
+@jupyterlab/imageviewer-extension    v0.4.0              
+@jupyterlab/imageviewer              v0.4.0              
+@jupyterlab/inspector-extension      v0.4.0              
+@jupyterlab/inspector                v0.4.0              
+@jupyterlab/landing-extension        v0.4.0              
+@jupyterlab/launcher-extension       v0.4.0              
+@jupyterlab/launcher                 v0.4.0              
+@jupyterlab/markdownviewer-extension v0.4.0              
+@jupyterlab/markdownviewer           v0.4.0              
+@jupyterlab/notebook-extension       v0.4.0              
+@jupyterlab/notebook                 v0.4.0              
+@jupyterlab/outputarea               v0.4.0              
+@jupyterlab/rendermime-extension     v0.4.0              
+@jupyterlab/rendermime               v0.4.0              
+@jupyterlab/running-extension        v0.4.0              
+@jupyterlab/running                  v0.4.0              
+@jupyterlab/services-extension       v0.4.0              
+@jupyterlab/services                 v0.43.0             
+@jupyterlab/shortcuts-extension      v0.4.0              
+@jupyterlab/tabmanager-extension     v0.4.0              
+@jupyterlab/terminal-extension       v0.4.0              
+@jupyterlab/terminal                 v0.4.0              
+@jupyterlab/tooltip-extension        v0.4.0              
+@jupyterlab/tooltip                  v0.4.0              
+browser-example                      vundefined (private)
+node-example                         vundefined (private)
+@jupyterlab/test-all                 v0.4.0     (private)

--- a/jupyterlab/selenium_check.py
+++ b/jupyterlab/selenium_check.py
@@ -29,6 +29,7 @@ class TestApp(NotebookApp):
 
     default_url = Unicode('/lab')
     open_browser = Bool(False)
+    base_url = '/foo'
 
     def start(self):
         self.io_loop = ioloop.IOLoop.current()

--- a/jupyterlab/selenium_check.py
+++ b/jupyterlab/selenium_check.py
@@ -55,6 +55,8 @@ class TestApp(NotebookApp):
         else:
             config.assets_dir = os.path.join(get_app_dir(), 'static')
 
+        print('****Testing assets dir %s' % config.assets_dir)
+
         config.settings_dir = ''
 
         add_handlers(self.web_app, config)

--- a/jupyterlab/selenium_check.py
+++ b/jupyterlab/selenium_check.py
@@ -1,0 +1,87 @@
+
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import
+
+import os
+import sys
+import time
+import threading
+
+from tornado import ioloop
+from notebook.notebookapp import NotebookApp
+from traitlets import Bool, Unicode
+from jupyterlab_launcher import LabConfig, add_handlers
+
+from selenium import webdriver
+
+try:
+    import coloroma
+    coloroma.init()
+    COLOR = True
+except ImportError:
+    COLOR = os.name != 'nt'
+
+
+here = os.path.dirname(__file__)
+
+
+class TestApp(NotebookApp):
+
+    default_url = Unicode('/lab')
+    open_browser = Bool(False)
+
+    def start(self):
+        self.io_loop = ioloop.IOLoop.current()
+        config = LabConfig()
+        config.assets_dir = os.path.join(here, 'build')
+        config.settings_dir = ''
+
+        add_handlers(self.web_app, config)
+        self.io_loop.call_later(1, self._run_selenium)
+        super(TestApp, self).start()
+
+    def _run_selenium(self):
+        thread = threading.Thread(target=run_selenium,
+            args=(self.display_url, self._selenium_finished))
+        thread.start()
+
+    def _selenium_finished(self, result):
+        self.io_loop.add_callback(lambda: sys.exit(result))
+
+
+def run_selenium(url, callback):
+    """Run the selenium test and call the callback with the exit code.exit
+    """
+
+    print('Starting Firefox Driver')
+    driver = webdriver.Firefox()
+
+    print('Navigating to page:', url)
+    driver.get(url)
+
+    completed = False
+
+    # Start a poll loop.
+    t0 = time.time()
+    while time.time() - t0 < 10:
+        el = driver.find_element_by_id('main')
+        if el:
+            completed = True
+            break
+
+        # Avoid hogging the main thread.
+        time.sleep(0.5)
+
+    driver.quit()
+
+    # Return the exit code.
+    if not completed:
+        callback(1)
+    else:
+        if os.path.exists('./geckodriver.log'):
+            os.remove('./geckodriver.log')
+        callback(0)
+
+
+if __name__ == '__main__':
+    TestApp.launch_instance()

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -14,7 +14,7 @@ fs.ensureDirSync(buildDir);
 fs.copySync('./package.json', './build/package.json');
 
 // Create the entry point file.
-var source = fs.readFileSync('index.template.js').toString();
+var source = fs.readFileSync('index.js').toString();
 var template = Handlebars.compile(source);
 var data = { jupyterlab_extensions: package_data.jupyterlab.extensions };
 var result = template(data);

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -44,8 +44,7 @@ module.exports = {
   entry:  path.resolve(buildDir, 'index.out.js'),
   output: {
     path: path.resolve(buildDir),
-    filename: '[name].bundle.js',
-    publicPath: package_data['jupyterlab']['publicPath']
+    filename: '[name].bundle.js'
   },
   module: {
     rules: [

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -76,7 +76,8 @@ namespace PageConfig {
       configData = Object.create(null);
     } else {
       for (let key in configData) {
-        configData[key] = String(configData[key]);
+        // Quote characters are escaped, unescape them.
+        configData[key] = String(configData[key]).split('&#39;').join('"');
       }
     }
     return configData[name] || '';

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -26,7 +26,6 @@
     "requirejs": "^2.2.0",
     "rimraf": "^2.5.2",
     "text-encoding": "^0.5.2",
-    "typedoc": "^0.5.0",
     "typescript": "^2.2.1",
     "webpack": "^2.2.1",
     "ws": "^1.1.1",

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -32,6 +32,13 @@ if [[ $GROUP == tests ]]; then
     npm install -g postcss-cli
     postcss jupyterlab/build/*.css > /dev/null
 
+    # Run the publish script in jupyterlab
+    cd jupyterlab
+    npm run publish
+
+    if [ ! -f ./build/release_data.json ]; then
+        echo "npm publish in jupyterlab unsucessful!"
+    fi
 fi
 
 

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -13,7 +13,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 if [[ $GROUP == tests ]]; then
     # Make sure we can successfully load the page
     pip install selenium
-    python selenium_check.py
+    python jupyterlab/selenium_check.py
 
     # Run the JS and python tests
     py.test

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -11,9 +11,14 @@ export PATH="$HOME/miniconda/bin:$PATH"
 
 
 if [[ $GROUP == tests ]]; then
-    # Make sure we can successfully load the page
+    # Make sure we can successfully load the core app.
     pip install selenium
-    python jupyterlab/selenium_check.py
+    python -m jupyterlab.selenium_check --core-mode
+
+    # Make sure we can build and run the app.
+    jupyter lab build
+    python -m jupyterlab.selenium_check 
+    jupyter labextension list
 
     # Run the JS and python tests
     py.test

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -11,14 +11,9 @@ export PATH="$HOME/miniconda/bin:$PATH"
 
 
 if [[ $GROUP == tests ]]; then
-    # Make sure we can start and kill the lab server
-    jupyter lab --no-browser &
-    TASK_PID=$!
-    # Make sure the task is running
-    ps -p $TASK_PID || exit 1
-    sleep 5
-    kill $TASK_PID
-    wait $TASK_PID
+    # Make sure we can successfully load the page
+    pip install selenium
+    python selenium_check.py
 
     # Run the JS and python tests
     py.test

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup_args['cmdclass'] = cmdclass
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'notebook>=4.2.0',
-    'jupyterlab_launcher>=0.2.6'
+    'jupyterlab_launcher>=0.2.8'
 ]
 
 extras_require = setuptools_args['extras_require'] = {

--- a/setupbase.py
+++ b/setupbase.py
@@ -75,7 +75,7 @@ def find_package_data():
     """
     return {
         'jupyterlab': ['build/*', 'index.template.js', 'webpack.config.js',
-                       'package.template.json']
+                       'package.template.json', 'package_list.txt']
     }
 
 

--- a/test/package.json
+++ b/test/package.json
@@ -77,7 +77,6 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
-    "typedoc": "^0.5.0",
     "typescript": "^2.2.1",
     "url-loader": "^0.5.7",
     "watch": "^1.0.2",


### PR DESCRIPTION
- Adds a selenium tests to make sure the page loads (with an alternate `base_url`), in both core and app mode on Travis
- Separates the local `index.js` from `index.template.js`.
- Fixes handling of `ignorePlugins` config by unescaping quote characters
- Removes `publicPath` config in favor of the local handling now done in `jupyterlab_launcher`
- Adds a `package_list.txt` to the release that includes all of the associated npm packages.