### PR TITLE
Porting hub app over to lab

### DIFF
--- a/jupyterlab/hubapp.py
+++ b/jupyterlab/hubapp.py
@@ -1,0 +1,24 @@
+from .labapp import LabApp
+
+try:
+    from jupyterhub.singleuser import SingleUserNotebookApp
+except ImportError:
+    SingleUserLabApp = None
+    raise ImportError('You must have jupyterhub installed for this to work.')
+else:
+    class SingleUserLabApp(SingleUserNotebookApp, LabApp):
+        def init_webapp(self, *args, **kwargs):
+            super().init_webapp(*args, **kwargs)
+            settings = self.web_app.settings
+            if 'page_config_data' not in settings:
+                settings['page_config_data'] = {}
+            settings['page_config_data']['hub_prefix'] = self.hub_prefix
+            settings['page_config_data']['hub_host'] = self.hub_host
+
+
+def main(argv=None):
+    return SingleUserLabApp.launch_instance(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ if 'setuptools' in sys.modules:
         'console_scripts': [
             'jupyter-lab = jupyterlab.labapp:main',
             'jupyter-labextension = jupyterlab.labextensions:main',
+            'jupyter-labhub = jupyterlab.labapp:main'
         ]
     }
     setup_args.pop('scripts', None)


### PR DESCRIPTION
This will make it much easier for users/devops folks to run lab with JuptyerHub as it allows the jupyterhub-lab extension to be pure npm/js code:

https://github.com/jupyterhub/jupyterlab-hub

