### PR TITLE
Remove exported constants

### DIFF
--- a/packages/csvviewer/src/table.ts
+++ b/packages/csvviewer/src/table.ts
@@ -19,7 +19,6 @@ import {
 /**
  * The hard limit on the number of rows to display.
  */
-export
 const DISPLAY_LIMIT: number = 1000;
 
 /**

--- a/packages/csvviewer/src/toolbar.ts
+++ b/packages/csvviewer/src/toolbar.ts
@@ -21,13 +21,11 @@ import {
 /**
  * The supported parsing delimiters.
  */
-export
 const DELIMITERS = [',', ';', '\t'];
 
 /**
  * The labels for each delimiter as they appear in the dropdown menu.
  */
-export
 const LABELS = [',', ';', '\\t'];
 
 /**

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -67,6 +67,16 @@ const BREADCRUMB_ITEM_CLASS = 'jp-BreadCrumbs-item';
  */
 const BREAD_CRUMB_PATHS = ['/', '../../', '../', ''];
 
+/**
+ * The mime type for a contents drag object.
+ */
+const CONTENTS_MIME = 'application/x-jupyter-icontents';
+
+/**
+ * The class name added to drop targets.
+ */
+const DROP_TARGET_CLASS = 'jp-mod-dropTarget';
+
 
 /**
  * A class which hosts folder breadcrumbs.
@@ -187,11 +197,11 @@ class BreadCrumbs extends Widget {
    * Handle the `'p-dragenter'` event for the widget.
    */
   private _evtDragEnter(event: IDragEvent): void {
-    if (event.mimeData.hasData(utils.CONTENTS_MIME)) {
+    if (event.mimeData.hasData(CONTENTS_MIME)) {
       let index = ArrayExt.findFirstIndex(this._crumbs, node => ElementExt.hitTest(node, event.clientX, event.clientY));
       if (index !== -1) {
         if (index !== Private.Crumb.Current) {
-          this._crumbs[index].classList.add(utils.DROP_TARGET_CLASS);
+          this._crumbs[index].classList.add(DROP_TARGET_CLASS);
           event.preventDefault();
           event.stopPropagation();
         }
@@ -205,9 +215,9 @@ class BreadCrumbs extends Widget {
   private _evtDragLeave(event: IDragEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    let dropTarget = DOMUtils.findElement(this.node, utils.DROP_TARGET_CLASS);
+    let dropTarget = DOMUtils.findElement(this.node, DROP_TARGET_CLASS);
     if (dropTarget) {
-      dropTarget.classList.remove(utils.DROP_TARGET_CLASS);
+      dropTarget.classList.remove(DROP_TARGET_CLASS);
     }
   }
 
@@ -218,13 +228,13 @@ class BreadCrumbs extends Widget {
     event.preventDefault();
     event.stopPropagation();
     event.dropAction = event.proposedAction;
-    let dropTarget = DOMUtils.findElement(this.node, utils.DROP_TARGET_CLASS);
+    let dropTarget = DOMUtils.findElement(this.node, DROP_TARGET_CLASS);
     if (dropTarget) {
-      dropTarget.classList.remove(utils.DROP_TARGET_CLASS);
+      dropTarget.classList.remove(DROP_TARGET_CLASS);
     }
     let index = ArrayExt.findFirstIndex(this._crumbs, node => ElementExt.hitTest(node, event.clientX, event.clientY));
     if (index !== -1) {
-      this._crumbs[index].classList.add(utils.DROP_TARGET_CLASS);
+      this._crumbs[index].classList.add(DROP_TARGET_CLASS);
     }
   }
 
@@ -238,15 +248,15 @@ class BreadCrumbs extends Widget {
       event.dropAction = 'none';
       return;
     }
-    if (!event.mimeData.hasData(utils.CONTENTS_MIME)) {
+    if (!event.mimeData.hasData(CONTENTS_MIME)) {
       return;
     }
     event.dropAction = event.proposedAction;
 
     let target = event.target as HTMLElement;
     while (target && target.parentElement) {
-      if (target.classList.contains(utils.DROP_TARGET_CLASS)) {
-        target.classList.remove(utils.DROP_TARGET_CLASS);
+      if (target.classList.contains(DROP_TARGET_CLASS)) {
+        target.classList.remove(DROP_TARGET_CLASS);
         break;
       }
       target = target.parentElement;
@@ -263,7 +273,7 @@ class BreadCrumbs extends Widget {
 
     // Move all of the items.
     let promises: Promise<any>[] = [];
-    let names = event.mimeData.getData(utils.CONTENTS_MIME) as string[];
+    let names = event.mimeData.getData(CONTENTS_MIME) as string[];
     for (let name of names) {
       let newPath = path + name;
       promises.push(model.manager.rename(name, newPath).catch(error => {

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -49,7 +49,7 @@ import * as utils
   from './utils';
 
 import {
-  SELECTED_CLASS, showErrorMessage
+  showErrorMessage
 } from './utils';
 
 
@@ -124,6 +124,21 @@ const MODIFIED_ID_CLASS = 'jp-id-modified';
 const FILE_TYPE_CLASS = 'jp-FileIcon';
 
 /**
+ * The mime type for a contents drag object.
+ */
+const CONTENTS_MIME = 'application/x-jupyter-icontents';
+
+/**
+ * The class name added to drop targets.
+ */
+const DROP_TARGET_CLASS = 'jp-mod-dropTarget';
+
+/**
+ * The class name added to selected rows.
+ */
+const SELECTED_CLASS = 'jp-mod-selected';
+
+/**
  * The class name added to a material icon content item.
  */
 const FOLDER_MATERIAL_ICON_CLASS = 'jp-OpenFolderIcon';
@@ -166,8 +181,8 @@ const DESCENDING_CLASS = 'jp-mod-descending';
 const RENAME_DURATION = 1000;
 
 /**
-  * The maximum duration between two key presses when selecting files by prefix.
-  */
+ * The maximum duration between two key presses when selecting files by prefix.
+ */
 const PREFIX_APPEND_DURATION = 1000;
 
 /**
@@ -941,7 +956,7 @@ class DirListing extends Widget {
    * Handle the `'p-dragenter'` event for the widget.
    */
   private _evtDragEnter(event: IDragEvent): void {
-    if (event.mimeData.hasData(utils.CONTENTS_MIME)) {
+    if (event.mimeData.hasData(CONTENTS_MIME)) {
       let index = Private.hitTestNodes(this._items, event.clientX, event.clientY);
       if (index === -1) {
         return;
@@ -951,7 +966,7 @@ class DirListing extends Widget {
         return;
       }
       let target = event.target as HTMLElement;
-      target.classList.add(utils.DROP_TARGET_CLASS);
+      target.classList.add(DROP_TARGET_CLASS);
       event.preventDefault();
       event.stopPropagation();
     }
@@ -963,9 +978,9 @@ class DirListing extends Widget {
   private _evtDragLeave(event: IDragEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    let dropTarget = DOMUtils.findElement(this.node, utils.DROP_TARGET_CLASS);
+    let dropTarget = DOMUtils.findElement(this.node, DROP_TARGET_CLASS);
     if (dropTarget) {
-      dropTarget.classList.remove(utils.DROP_TARGET_CLASS);
+      dropTarget.classList.remove(DROP_TARGET_CLASS);
     }
   }
 
@@ -976,12 +991,12 @@ class DirListing extends Widget {
     event.preventDefault();
     event.stopPropagation();
     event.dropAction = event.proposedAction;
-    let dropTarget = DOMUtils.findElement(this.node, utils.DROP_TARGET_CLASS);
+    let dropTarget = DOMUtils.findElement(this.node, DROP_TARGET_CLASS);
     if (dropTarget) {
-      dropTarget.classList.remove(utils.DROP_TARGET_CLASS);
+      dropTarget.classList.remove(DROP_TARGET_CLASS);
     }
     let index = Private.hitTestNodes(this._items, event.clientX, event.clientY);
-    this._items[index].classList.add(utils.DROP_TARGET_CLASS);
+    this._items[index].classList.add(DROP_TARGET_CLASS);
   }
 
   /**
@@ -995,15 +1010,15 @@ class DirListing extends Widget {
       event.dropAction = 'none';
       return;
     }
-    if (!event.mimeData.hasData(utils.CONTENTS_MIME)) {
+    if (!event.mimeData.hasData(CONTENTS_MIME)) {
       return;
     }
     event.dropAction = event.proposedAction;
 
     let target = event.target as HTMLElement;
     while (target && target.parentElement) {
-      if (target.classList.contains(utils.DROP_TARGET_CLASS)) {
-        target.classList.remove(utils.DROP_TARGET_CLASS);
+      if (target.classList.contains(DROP_TARGET_CLASS)) {
+        target.classList.remove(DROP_TARGET_CLASS);
         break;
       }
       target = target.parentElement;
@@ -1017,7 +1032,7 @@ class DirListing extends Widget {
 
     // Move all of the items.
     const promises: Promise<Contents.IModel>[] = [];
-    const names = event.mimeData.getData(utils.CONTENTS_MIME) as string[];
+    const names = event.mimeData.getData(CONTENTS_MIME) as string[];
     for (let name of names) {
       let newPath = path + name;
       promises.push(renameFileDialog(manager, name, newPath, this._model.path));
@@ -1055,7 +1070,7 @@ class DirListing extends Widget {
       supportedActions: 'move',
       proposedAction: 'move'
     });
-    this._drag.mimeData.setData(utils.CONTENTS_MIME, selectedNames);
+    this._drag.mimeData.setData(CONTENTS_MIME, selectedNames);
     if (item && item.type !== 'directory') {
       this._drag.mimeData.setData(FACTORY_MIME, () => {
         let path = item.path;

--- a/packages/filebrowser/src/utils.ts
+++ b/packages/filebrowser/src/utils.ts
@@ -5,26 +5,6 @@ import {
   Dialog, showDialog
 } from '@jupyterlab/apputils';
 
-
-/**
- * The class name added to drop targets.
- */
-export
-const DROP_TARGET_CLASS = 'jp-mod-dropTarget';
-
-/**
- * The class name added to selected rows.
- */
-export
-const SELECTED_CLASS = 'jp-mod-selected';
-
-/**
- * The mime type for a contents drag object.
- */
-export
-const CONTENTS_MIME = 'application/x-jupyter-icontents';
-
-
 /**
  * An error message dialog to show in the filebrowser widget.
  */

--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -31,8 +31,14 @@ import {
 } from './model';
 
 import {
-  Notebook, JUPYTER_CELL_MIME
+  Notebook
 } from './widget';
+
+
+/**
+ * The mimetype used for Jupyter cell data.
+ */
+const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
 
 
 /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -128,8 +128,7 @@ const FILLED_CIRCLE_CLASS = 'jp-filledCircle';
 /**
  * The mimetype used for Jupyter cell data.
  */
-export
-const JUPYTER_CELL_MIME: string = 'application/vnd.jupyter.cells';
+const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
 
 /**
  * The threshold in pixels to start a drag event.

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -32,7 +32,6 @@ import {
 /*
  * The class name added to common rendered HTML.
  */
-export
 const HTML_COMMON_CLASS = 'jp-RenderedHTMLCommon';
 
 /*

--- a/test/src/csvviewer/table.spec.ts
+++ b/test/src/csvviewer/table.spec.ts
@@ -8,12 +8,15 @@ import {
 } from '@phosphor/virtualdom';
 
 import {
-  CSVModel, CSVTable, DISPLAY_LIMIT
+  CSVModel, CSVTable
 } from '@jupyterlab/csvviewer';
 
 import {
   CSV_DATA
 } from './data.csv';
+
+
+const DISPLAY_LIMIT: number = 1000;
 
 
 class TestTable extends CSVTable {

--- a/test/src/csvviewer/toolbar.spec.ts
+++ b/test/src/csvviewer/toolbar.spec.ts
@@ -12,8 +12,11 @@ import {
 } from 'simulate-event';
 
 import {
-  CSVToolbar, DELIMITERS
+  CSVToolbar
 } from '@jupyterlab/csvviewer';
+
+
+const DELIMITERS = [',', ';', '\t'];
 
 
 describe('csvviewer/toolbar', () => {

--- a/test/src/notebook/actions.spec.ts
+++ b/test/src/notebook/actions.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '@jupyterlab/notebook';
 
 import {
-  Notebook, JUPYTER_CELL_MIME
+  Notebook
 } from '@jupyterlab/notebook';
 
 import {
@@ -38,6 +38,8 @@ import {
 
 
 const ERROR_INPUT = 'a = foo';
+
+const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
 
 
 describe('@jupyterlab/notebook', () => {

--- a/test/src/notebook/default-toolbar.spec.ts
+++ b/test/src/notebook/default-toolbar.spec.ts
@@ -36,10 +36,6 @@ import {
 } from '@jupyterlab/notebook';
 
 import {
-  JUPYTER_CELL_MIME
-} from '@jupyterlab/notebook';
-
-import {
  NotebookPanel
 } from '@jupyterlab/notebook';
 
@@ -51,6 +47,9 @@ import {
   DEFAULT_CONTENT, createNotebookPanelFactory, rendermime, clipboard,
   mimeTypeService
 } from './utils';
+
+
+const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
 
 
 function startSession(context: DocumentRegistry.IContext<INotebookModel>): Promise<IClientSession> {


### PR DESCRIPTION
Enforces the pattern of not exporting constants across the packages unless they are tokens.  Found by searching the lib files for `export declare const`.