### PR TITLE
Rename icon -> iconClass and add iconLabel

### DIFF
--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -367,7 +367,12 @@ namespace Dialog {
     /**
      * The icon class for the button.
      */
-    icon: string;
+    iconClass: string;
+
+    /**
+     * The icon label for the button.
+     */
+    iconLabel: string;
 
     /**
      * The caption for the button.
@@ -438,7 +443,8 @@ namespace Dialog {
     let defaultLabel = value.accept ? 'OK' : 'CANCEL';
     return {
       label: value.label || defaultLabel,
-      icon: value.icon || '',
+      iconClass: value.iconClass || '',
+      iconLabel: value.iconLabel || '',
       caption: value.caption || '',
       className: value.className || '',
       accept: value.accept,
@@ -608,7 +614,8 @@ namespace Dialog {
      * @returns A virtual element representing the icon.
      */
     renderIcon(data: IButton): VirtualElement {
-      return h.div({ className: this.createIconClass(data) });
+      return h.div({ className: this.createIconClass(data) },
+                   data.iconLabel);
     }
 
     /**
@@ -620,7 +627,7 @@ namespace Dialog {
      */
     createIconClass(data: IButton): string {
       let name = 'jp-Dialog-buttonIcon';
-      let extra = data.icon;
+      let extra = data.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
 

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -203,7 +203,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.delete();
     },
-    icon: 'jp-MaterialIcon jp-CloseIcon',
+    iconClass: 'jp-MaterialIcon jp-CloseIcon',
     label: 'Delete',
     mnemonic: 0
   });
@@ -217,7 +217,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.copy();
     },
-    icon: 'jp-MaterialIcon jp-CopyIcon',
+    iconClass: 'jp-MaterialIcon jp-CopyIcon',
     label: 'Copy',
     mnemonic: 0
   });
@@ -231,7 +231,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.cut();
     },
-    icon: 'jp-MaterialIcon jp-CutIcon',
+    iconClass: 'jp-MaterialIcon jp-CutIcon',
     label: 'Cut'
   });
 
@@ -244,7 +244,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.download();
     },
-    icon: 'jp-MaterialIcon jp-DownloadIcon',
+    iconClass: 'jp-MaterialIcon jp-DownloadIcon',
     label: 'Download'
   });
 
@@ -257,7 +257,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.duplicate();
     },
-    icon: 'jp-MaterialIcon jp-CopyIcon',
+    iconClass: 'jp-MaterialIcon jp-CopyIcon',
     label: 'Duplicate'
   });
 
@@ -278,7 +278,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.open();
     },
-    icon: 'jp-MaterialIcon jp-OpenFolderIcon',
+    iconClass: 'jp-MaterialIcon jp-OpenFolderIcon',
     label: 'Open',
     mnemonic: 0,
   });
@@ -292,7 +292,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.paste();
     },
-    icon: 'jp-MaterialIcon jp-PasteIcon',
+    iconClass: 'jp-MaterialIcon jp-PasteIcon',
     label: 'Paste',
     mnemonic: 0
   });
@@ -306,7 +306,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.rename();
     },
-    icon: 'jp-MaterialIcon jp-EditIcon',
+    iconClass: 'jp-MaterialIcon jp-EditIcon',
     label: 'Rename',
     mnemonic: 0
   });
@@ -324,7 +324,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
 
       return widget.shutdownKernels();
     },
-    icon: 'jp-MaterialIcon jp-StopIcon',
+    iconClass: 'jp-MaterialIcon jp-StopIcon',
     label: 'Shutdown Kernel'
   });
 

--- a/test/src/apputils/dialog.spec.ts
+++ b/test/src/apputils/dialog.spec.ts
@@ -504,7 +504,7 @@ describe('@jupyterlab/domutils', () => {
           it('should render an icon element for a dialog item', () => {
             let node = VirtualDOM.realize(renderer.renderIcon(data));
             expect(node.className).to.contain('jp-Dialog-buttonIcon');
-            expect(node.textContent).to.be('foo');
+            expect(node.textContent).to.equal('foo');
           });
 
         });

--- a/test/src/apputils/dialog.spec.ts
+++ b/test/src/apputils/dialog.spec.ts
@@ -421,7 +421,8 @@ describe('@jupyterlab/domutils', () => {
 
         const data: Dialog.IButton = {
           label: 'foo',
-          icon: 'bar',
+          iconClass: 'bar',
+          iconLabel: 'foo',
           caption: 'hello',
           className: 'baz',
           accept: false,
@@ -503,6 +504,7 @@ describe('@jupyterlab/domutils', () => {
           it('should render an icon element for a dialog item', () => {
             let node = VirtualDOM.realize(renderer.renderIcon(data));
             expect(node.className).to.contain('jp-Dialog-buttonIcon');
+            expect(node.textContent).to.be('foo');
           });
 
         });
@@ -523,7 +525,7 @@ describe('@jupyterlab/domutils', () => {
           it('should create the class name for the button icon', () => {
             let value = renderer.createIconClass(data);
             expect(value).to.contain('jp-Dialog-buttonIcon');
-            expect(value).to.contain(data.icon);
+            expect(value).to.contain(data.iconClass);
           });
 
         });


### PR DESCRIPTION
Update to Phosphor 1.2 API for `iconClass` in a command item, and use the same pattern in `Dialog.IButton`.  Allows for the Material Design style specification of icons.  cf https://github.com/phosphorjs/phosphor/pull/263   