### PR TITLE
Clean up the CodeMirror API

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -803,6 +803,6 @@ namespace Private {
  * character or first multiple of tabsize tabstop.
  */
 CodeMirrorEditor.addCommand(
-  'delSpaceToPrevTabStop'], Private.delSpaceToPrevTabStop
+  'delSpaceToPrevTabStop', Private.delSpaceToPrevTabStop
 );
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -33,7 +33,7 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  loadModeByMIME
+  Mode
 } from './mode';
 
 import 'codemirror/addon/edit/matchbrackets.js';
@@ -492,7 +492,9 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   private _onMimeTypeChanged(): void {
     const mime = this._model.mimeType;
     let editor = this._editor;
-    loadModeByMIME(editor, mime);
+    Mode.ensure(mime).then(spec => {
+      editor.setOption('mode', spec.mime);
+    });
     let isCode = (mime !== 'text/plain') && (mime !== 'text/x-ipythongfm');
     editor.setOption('matchBrackets', isCode);
     editor.setOption('autoCloseBrackets', isCode);
@@ -713,6 +715,18 @@ namespace CodeMirrorEditor {
    */
   export
   const DEFAULT_THEME: string = 'jupyter';
+
+  /**
+   * Add a command to CodeMirror.
+   *
+   * @param name - The name of the command to add.
+   *
+   * @param command - The command function.
+   */
+  export
+  function addCommand(name: string, command: (cm: CodeMirror.Editor) => void) {
+    CodeMirror.commands[name] = command;
+  }
 }
 
 
@@ -786,7 +800,9 @@ namespace Private {
 
 /**
  * Add a CodeMirror command to delete until previous non blanking space
- * character or first multiple of 4 tabstop.
+ * character or first multiple of tabsize tabstop.
  */
-CodeMirror.commands['delSpaceToPrevTabStop'] = Private.delSpaceToPrevTabStop;
+CodeMirrorEditor.addCommand(
+  'delSpaceToPrevTabStop'], Private.delSpaceToPrevTabStop
+);
 

--- a/packages/codemirror/src/mimetype.ts
+++ b/packages/codemirror/src/mimetype.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import * as CodeMirror
-  from 'codemirror';
-
 import {
   IEditorMimeTypeService
 } from '@jupyterlab/codeeditor';
@@ -13,7 +10,7 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  findMode
+  Mode
 } from '.';
 
 /**
@@ -29,19 +26,19 @@ class CodeMirrorMimeTypeService implements IEditorMimeTypeService {
    */
   getMimeTypeByLanguage(info: nbformat.ILanguageInfoMetadata): string {
     if (info.codemirror_mode) {
-      return findMode(info.codemirror_mode as any).mime;
+      return Mode.find(info.codemirror_mode as any).mime;
     }
-    let mode = CodeMirror.findModeByMIME(info.mimetype || '');
+    let mode = Mode.findByMIME(info.mimetype || '');
     if (mode) {
       return info.mimetype!;
     }
     let ext = info.file_extension || '';
     ext = ext.split('.').slice(-1)[0];
-    mode = CodeMirror.findModeByExtension(ext || '');
+    mode = Mode.findByExtension(ext || '');
     if (mode) {
       return mode.mime;
     }
-    mode = CodeMirror.findModeByName(info.name || '');
+    mode = Mode.findByName(info.name || '');
     return mode ? mode.mime : IEditorMimeTypeService.defaultMimeType;
   }
   /**
@@ -54,7 +51,7 @@ class CodeMirrorMimeTypeService implements IEditorMimeTypeService {
     if (PathExt.extname(path) === '.ipy') {
       return 'text/x-python';
     }
-    const mode = CodeMirror.findModeByFileName(path);
+    const mode = Mode.findByFileName(path);
     return mode ? mode.mime : IEditorMimeTypeService.defaultMimeType;
   }
 }

--- a/packages/codemirror/src/mimetype.ts
+++ b/packages/codemirror/src/mimetype.ts
@@ -25,10 +25,14 @@ class CodeMirrorMimeTypeService implements IEditorMimeTypeService {
    * If a mime type cannot be found returns the defaul mime type `text/plain`, never `null`.
    */
   getMimeTypeByLanguage(info: nbformat.ILanguageInfoMetadata): string {
+    let mode: Mode.ISpec;
     if (info.codemirror_mode) {
-      return Mode.find(info.codemirror_mode as any).mime;
+      mode = Mode.findBest(info.codemirror_mode as any);
+      if (mode) {
+        return mode.mime;
+      }
     }
-    let mode = Mode.findByMIME(info.mimetype || '');
+    mode = Mode.findByMIME(info.mimetype || '');
     if (mode) {
       return info.mimetype!;
     }
@@ -41,6 +45,7 @@ class CodeMirrorMimeTypeService implements IEditorMimeTypeService {
     mode = Mode.findByName(info.name || '');
     return mode ? mode.mime : IEditorMimeTypeService.defaultMimeType;
   }
+
   /**
    * Returns a mime type for the given file path.
    *

--- a/packages/codemirror/src/mode.ts
+++ b/packages/codemirror/src/mode.ts
@@ -50,17 +50,14 @@ namespace Mode {
   /**
    * Ensure a codemirror mode is available by name or Codemirror spec.
    *
-   * @param mode - The mode to ensure.  If it is a string, uses [find]
+   * @param mode - The mode to ensure.  If it is a string, uses [findBest]
    *   to get the appropriate spec.
    *
    * @returns A promise that resolves when the mode is available.
    */
   export
   function ensure(mode: string | ISpec): Promise<ISpec> {
-    let spec = find(mode);
-    if (!spec) {
-      return CodeMirror.modes['null'];
-    }
+    let spec = findBest(mode);
 
     // Simplest, cheapest check by mode name.
     if (CodeMirror.modes.hasOwnProperty(spec.mode)) {
@@ -79,15 +76,15 @@ namespace Mode {
    * Find a codemirror mode by name or CodeMirror spec.
    */
   export
-  function find(mode: string | ISpec): ISpec {
+  function findBest(mode: string | ISpec): ISpec {
     let modename = (typeof mode === 'string') ? mode :
         mode.mode || mode.name;
-    let mimetype = (typeof mode !== 'string') ? mode.mime : '';
+    let mimetype = (typeof mode !== 'string') ? mode.mime : modename;
 
     return (
       CodeMirror.findModeByName(modename) ||
       CodeMirror.findModeByMIME(mimetype) ||
-      CodeMirror.modes['null']
+      CodeMirror.findModeByMIME('text/plain')
     );
   }
 

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -228,7 +228,8 @@ class TextModelFactory implements DocumentRegistry.CodeModelFactory {
    * Get the preferred kernel language given an extension.
    */
   preferredLanguage(ext: string): string {
-    return Mode.findByExtension(ext.slice(1)).mode;
+    let mode = Mode.findByExtension(ext.slice(1));
+    return mode && mode.mode;
   }
 
   private _isDisposed = false;

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  findModeByExtension
+  Mode
 } from '@jupyterlab/codemirror';
 
 import {
@@ -228,7 +228,7 @@ class TextModelFactory implements DocumentRegistry.CodeModelFactory {
    * Get the preferred kernel language given an extension.
    */
   preferredLanguage(ext: string): string {
-    return findModeByExtension(ext.slice(1));
+    return Mode.findByExtension(ext.slice(1)).mode;
   }
 
   private _isDisposed = false;

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -6,7 +6,7 @@ import {
 } from 'ansi_up';
 
 import {
-  requireMode, runMode, CodeMirrorEditor
+  Mode, CodeMirrorEditor
 } from '@jupyterlab/codemirror';
 
 import * as marked
@@ -479,7 +479,7 @@ namespace Private {
                 return code;
             }
         }
-        requireMode(lang).then(spec => {
+        Mode.ensure(lang).then(spec => {
           let el = document.createElement('div');
           if (!spec) {
               console.log(`No CodeMirror mode: ${lang}`);
@@ -487,7 +487,7 @@ namespace Private {
               return;
           }
           try {
-            runMode(code, spec.mime, el);
+            Mode.run(code, spec.mime, el);
             callback(null, el.innerHTML);
           } catch (err) {
             console.log(`Failed to highlight ${lang} code`, err);


### PR DESCRIPTION
Use a `Mode` namespace for mode-related functions and add a `CodeMirrorEditor.addCommand` API.

Fixes #2234.