### PR TITLE
Pin sphinx version for docs build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 - python==3.5
-- sphinx>1.4
+- sphinx>1.4,<1.6
 - pip:
   - recommonmark==0.4.0
   - jupyter_alabaster_theme


### PR DESCRIPTION
It looks like sphinx 1.6 is not compatible with recommonmark, pinning for now.

cf https://travis-ci.org/jupyterlab/jupyterlab/jobs/233607965#L4236

```python
Exception occurred:
  File "/home/travis/miniconda/envs/test_docs/lib/python3.5/site-packages/recommonmark/states.py", line 134, in run_role
    content=content)
TypeError: 'NoneType' object is not callable
The full traceback has been saved in /tmp/sphinx-err-d3z03tgk.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [html] Error 1
```