### PR TITLE
"IDrive" concept for ContentsManager

### DIFF
--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -130,7 +130,10 @@ namespace PathExt {
 
   /**
    * Remove the leading slash from a path.
+   *
+   * @param path: the path from which to remove a leading slash.
    */
+  export
   function removeSlash(path: string): string {
     if (path.indexOf('/') === 0) {
       path = path.slice(1);

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -406,13 +406,14 @@ class DocumentManager implements IDisposable {
       this._widgetManager.adoptWidget(context, widget);
       this._opener.open(widget);
     };
+    let modelDBFactory = this.services.contents.getModelDBFactory(path) || null;
     let context = new Context({
       opener: adopter,
       manager: this.services,
       factory,
       path,
       kernelPreference,
-      modelDBFactory: this._modelDBFactory
+      modelDBFactory
     });
     let handler = new SaveHandler({
       context,

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -53,7 +53,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     let lang = this._factory.preferredLanguage(ext);
 
     if (options.modelDBFactory) {
-      this._modelDB = options.modelDBFactory.createNew(this._path);
+      this._modelDB = options.modelDBFactory.createNew(this._path.split(':').pop());
       this._model = this._factory.createNew(lang, this._modelDB);
     } else {
       this._model = this._factory.createNew(lang);

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -126,6 +126,7 @@ function activateFactory(app: JupyterLab, docManager: IDocumentManager, state: I
     createFileBrowser(id: string, options: IFileBrowserFactory.IOptions = {}): FileBrowser {
       const model = new FileBrowserModel({
         manager: options.documentManager || docManager,
+        driveName: options.driveName || '',
         state: options.state === null ? null : options.state || state
       });
       const widget = new FileBrowser({

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -125,7 +125,7 @@ function activateFactory(app: JupyterLab, docManager: IDocumentManager, state: I
   return {
     createFileBrowser(id: string, options: IFileBrowserFactory.IOptions = {}): FileBrowser {
       const model = new FileBrowserModel({
-        manager: options.documentManager || docManager,
+        manager: docManager,
         driveName: options.driveName || '',
         state: options.state === null ? null : options.state || state
       });
@@ -152,15 +152,13 @@ function activateFactory(app: JupyterLab, docManager: IDocumentManager, state: I
   };
 }
 
-
 /**
  * Activate the file browser in the sidebar.
  */
 function activateFileBrowser(app: JupyterLab, factory: IFileBrowserFactory, docManager: IDocumentManager, mainMenu: IMainMenu, palette: ICommandPalette, restorer: ILayoutRestorer): void {
   const { commands } = app;
   const fbWidget = factory.createFileBrowser('filebrowser', {
-    commands,
-    documentManager: docManager
+    commands
   });
 
   // Let the application restorer track the primary file browser (that is

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -347,6 +347,8 @@ namespace Private {
       node.removeChild(node.firstChild.nextSibling);
     }
 
+    let localPath = path.split(':').pop();
+    let localParts = localPath.split('/');
     let parts = path.split('/');
     if (parts.length > 2) {
       node.appendChild(separators[0]);
@@ -358,13 +360,13 @@ namespace Private {
     if (path) {
       if (parts.length >= 2) {
         node.appendChild(separators[1]);
-        breadcrumbs[Crumb.Parent].textContent = parts[parts.length - 2];
+        breadcrumbs[Crumb.Parent].textContent = localParts[localParts.length - 2];
         node.appendChild(breadcrumbs[Crumb.Parent]);
         let parent = parts.slice(0, parts.length - 1).join('/');
         breadcrumbs[Crumb.Parent].title = parent;
       }
       node.appendChild(separators[2]);
-      breadcrumbs[Crumb.Current].textContent = parts[parts.length - 1];
+      breadcrumbs[Crumb.Current].textContent = localParts[localParts.length - 1];
       node.appendChild(breadcrumbs[Crumb.Current]);
       breadcrumbs[Crumb.Current].title = path;
     }

--- a/packages/filebrowser/src/factory.ts
+++ b/packages/filebrowser/src/factory.ts
@@ -97,6 +97,13 @@ namespace IFileBrowserFactory {
     documentManager?: IDocumentManager;
 
     /**
+     * An optional `Contents.IDrive` name for the model.
+     * If given, the model will prepend `driveName:` to
+     * all paths used in file operations.
+     */
+    driveName?: string;
+
+    /**
      * The state database to use for saving file browser state and restoring it.
      *
      * #### Notes

--- a/packages/filebrowser/src/factory.ts
+++ b/packages/filebrowser/src/factory.ts
@@ -6,10 +6,6 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  IDocumentManager
-} from '@jupyterlab/docmanager';
-
-import {
   CommandRegistry
 } from '@phosphor/commands';
 
@@ -72,11 +68,11 @@ namespace IFileBrowserFactory {
    * The options for creating a file browser using a file browser factory.
    *
    * #### Notes
-   * In future versions of JupyterLab, these options may disappear altogether,
+   * In future versions of JupyterLab, some of these options may disappear,
    * which is a backward-incompatible API change and will necessitate a new
    * version release. This is because in future versions, there will likely be
-   * an application-wide notion of a singleton document manager, a single
-   * command registry, a single services manager, and a single state database.
+   * an application-wide notion of a singleton command registry and a singleton
+   * state database.
    */
   export
   interface IOptions {
@@ -87,14 +83,6 @@ namespace IFileBrowserFactory {
      * If no command registry is provided, the application default will be used.
      */
     commands?: CommandRegistry;
-
-    /**
-     * The document manager used by the file browser.
-     *
-     * #### Notes
-     * If no manager is provided, the application default will be used.
-     */
-    documentManager?: IDocumentManager;
 
     /**
      * An optional `Contents.IDrive` name for the model.

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -259,8 +259,9 @@ class FileBrowserModel implements IDisposable {
       }
 
       const path = cwd['path'] as string;
+      const localPath = path.split(':').pop();
       return manager.services.contents.get(path)
-        .then(() => this.cd(path))
+        .then(() => this.cd(localPath))
         .catch(() => state.remove(key));
     }).catch(() => state.remove(key))
       .then(() => { this._key = key; }); // Set key after restoration is done.

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -55,7 +55,9 @@ class FileBrowserModel implements IDisposable {
    */
   constructor(options: FileBrowserModel.IOptions) {
     this.manager = options.manager;
-    this._model = { path: '', name: '/', type: 'directory' };
+    this._driveName = options.driveName || '';
+    let rootPath = this._driveName ? this._driveName + ':' : '';
+    this._model = { path: rootPath, name: '/', type: 'directory' };
     this._state = options.state || null;
 
     const { services } = options.manager;
@@ -442,6 +444,7 @@ class FileBrowserModel implements IDisposable {
   private _sessions: Session.IModel[] = [];
   private _state: IStateDB | null = null;
   private _timeoutId = -1;
+  private _driveName: string;
 }
 
 
@@ -459,6 +462,13 @@ namespace FileBrowserModel {
      * A document manager instance.
      */
     manager: IDocumentManager;
+
+    /**
+     * An optional `Contents.IDrive` name for the model.
+     * If given, the model will prepend `driveName:` to
+     * all paths used in file operations.
+     */
+    driveName?: string;
 
     /**
      * An optional state database. If provided, the model will restore which
@@ -500,6 +510,12 @@ namespace Private {
    */
   export
   function normalizePath(root: string, path: string): string {
-    return PathExt.resolve(root, path);
+    let parts = root.split(':');
+    if (parts.length === 1) {
+      return PathExt.resolve(root, path);
+    } else {
+      let resolved = PathExt.resolve(parts[1], path)
+      return parts[0] + ':' + resolved;
+    }
   }
 }

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -121,7 +121,7 @@ class FileEditor extends CodeEditorWrapper {
     const path = this._context.path;
 
     editor.model.mimeType = this._mimeTypeService.getMimeTypeByFilePath(path);
-    this.title.label = path.split('/').pop();
+    this.title.label = path.split(':').pop().split('/').pop();
   }
 
   protected _context: DocumentRegistry.Context;

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -548,17 +548,17 @@ class ContentsManager implements Contents.IManager {
       if (contentsModel.type === 'directory') {
         each(contentsModel.content, (item: Contents.IModel) => {
           listing.push({
-            path: this._toGlobalPath(drive, item.path),
-            ...item
+            ...item,
+            path: this._toGlobalPath(drive, item.path)
           } as Contents.IModel);
         });
         return {
+          ...contentsModel,
           path: path,
-          content: listing,
-          ...contentsModel
+          content: listing
         } as Contents.IModel;
       } else {
-        return { path: path, ...contentsModel } as Contents.IModel;
+        return { ...contentsModel, path: path } as Contents.IModel;
       }
     }); 
   }
@@ -587,8 +587,8 @@ class ContentsManager implements Contents.IManager {
   newUntitled(options: Contents.ICreateOptions = {}): Promise<Contents.IModel> {
     if (options.path) {
       let [drive, localPath] = this._driveForPath(options.path);
-      return drive.newUntitled({path: localPath, ...options}).then( contentsModel => {
-        return { path: options.path, ...contentsModel } as Contents.IModel;
+      return drive.newUntitled({ ...options, path: localPath }).then( contentsModel => {
+        return { ...contentsModel, path: options.path } as Contents.IModel;
       });
     } else {
       return this._defaultDrive.newUntitled(options);
@@ -624,7 +624,7 @@ class ContentsManager implements Contents.IManager {
       throw Error('ContentsManager: renaming files must occur within a Drive');
     }
     return drive1.rename(path1, path2).then(contentsModel => {
-      return { path: path, ...contentsModel } as Contents.IModel;
+      return { ...contentsModel, path: path } as Contents.IModel;
     });
   }
 
@@ -643,8 +643,8 @@ class ContentsManager implements Contents.IManager {
    */
   save(path: string, options: Contents.IModel = {}): Promise<Contents.IModel> {
     let [drive, localPath] = this._driveForPath(path);
-    return drive.save(localPath, {path: localPath, ...options}).then(contentsModel => {
-      return {path: path, ...contentsModel} as Contents.IModel;
+    return drive.save(localPath, { ...options, path: localPath }).then(contentsModel => {
+      return { ...contentsModel, path: path } as Contents.IModel;
     });
   }
 
@@ -667,8 +667,8 @@ class ContentsManager implements Contents.IManager {
     if (drive1 === drive2) {
       return drive1.copy(path1, path2).then(contentsModel => {
         return {
-          path: this._toGlobalPath(drive1, contentsModel.path),
-          ...contentsModel
+          ...contentsModel,
+          path: this._toGlobalPath(drive1, contentsModel.path)
         } as Contents.IModel;
       });
     } else {
@@ -742,7 +742,11 @@ class ContentsManager implements Contents.IManager {
    * @returns the fully qualified path.
    */
   private _toGlobalPath(drive: Contents.IDrive, localPath: string): string {
-    return drive.name + ':' + localPath;
+    if (drive === this._defaultDrive) {
+      return localPath;
+    } else {
+      return drive.name + ':' + localPath;
+    }
   }
 
   /**
@@ -776,10 +780,10 @@ class ContentsManager implements Contents.IManager {
       let newValue: Contents.IModel = null;
       let oldValue: Contents.IModel = null;
       if (args.newValue) {
-        newValue = { path: args.newValue.path, ...args.newValue };
+        newValue = { ...args.newValue, path: args.newValue.path };
       }
       if (args.oldValue) {
-        oldValue = { path: args.oldValue.path, ...args.oldValue };
+        oldValue = { ...args.oldValue, path: args.oldValue.path };
       }
       this._fileChanged.emit({
         type: args.type,

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  URLExt, PathExt
+  URLExt, PathExt, ModelDB
 } from '@jupyterlab/coreutils';
 
 import {
@@ -221,6 +221,13 @@ namespace Contents {
     addDrive(drive: IDrive): void;
 
     /**
+     * Given a path, get a ModelDB.IFactory from the
+     * relevant backend. Returns `null` if the backend
+     * does not provide one.
+     */
+    getModelDBFactory(path: string): ModelDB.IFactory;
+
+    /**
      * Get a file or directory.
      *
      * @param path: The path to the file.
@@ -353,6 +360,12 @@ namespace Contents {
      * The server settings of the manager.
      */
     readonly serverSettings: ServerConnection.ISettings;
+
+    /**
+     * An optional ModelDB.IFactory instance for the
+     * drive.
+     */
+    readonly modelDBFactory?: ModelDB.IFactory;
 
     /**
      * A signal emitted when a file operation takes place.
@@ -523,13 +536,22 @@ class ContentsManager implements Contents.IManager {
     Signal.clearData(this);
   }
 
-
   /**
    * Add an `IDrive` to the manager.
    */
   addDrive(drive: Contents.IDrive): void {
     this._additionalDrives.set(drive.name, drive);
     drive.fileChanged.connect(this._onFileChanged, this);
+  }
+
+  /**
+   * Given a path, get a ModelDB.IFactory from the
+   * relevant backend. Returns `null` if the backend
+   * does not provide one.
+   */
+  getModelDBFactory(path: string): ModelDB.IFactory {
+    let [drive,] = this._driveForPath(path);
+    return drive.modelDBFactory || null;
   }
 
   /**

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  URLExt
+  URLExt, PathExt
 } from '@jupyterlab/coreutils';
 
 import {
@@ -588,7 +588,10 @@ class ContentsManager implements Contents.IManager {
     if (options.path) {
       let [drive, localPath] = this._driveForPath(options.path);
       return drive.newUntitled({ ...options, path: localPath }).then( contentsModel => {
-        return { ...contentsModel, path: options.path } as Contents.IModel;
+        return {
+          ...contentsModel,
+          path: PathExt.join(options.path, contentsModel.name)
+        } as Contents.IModel;
       });
     } else {
       return this._defaultDrive.newUntitled(options);

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -30,9 +30,9 @@ import * as validate
 
 
 /**
- * The url for the contents service.
+ * The url for the default drive service.
  */
-const SERVICE_CONTENTS_URL = 'api/contents';
+const SERVICE_DRIVE_URL = 'api/contents';
 
 /**
  * The url for the file access.
@@ -848,6 +848,7 @@ class Drive implements Contents.IDrive {
    */
   constructor(options: Drive.IOptions = {}) {
     this.name = options.name || 'Default';
+    this._apiEndpoint = options.apiEndpoint || SERVICE_DRIVE_URL;
     this.serverSettings = options.serverSettings || ServerConnection.makeSettings();
   }
 
@@ -1264,10 +1265,11 @@ class Drive implements Contents.IDrive {
   private _getUrl(...args: string[]): string {
     let parts = args.map(path => URLExt.encodeParts(path));
     let baseUrl = this.serverSettings.baseUrl;
-    return URLExt.join(baseUrl, SERVICE_CONTENTS_URL,
+    return URLExt.join(baseUrl, this._apiEndpoint,
                        ...parts);
   }
 
+  private _apiEndpoint: string;
   private _isDisposed = false;
   private _fileChanged = new Signal<this, Contents.IChangedArgs>(this);
 }
@@ -1310,6 +1312,13 @@ namespace Drive {
      * The server settings for the server.
      */
     serverSettings?: ServerConnection.ISettings;
+
+    /**
+     * A REST endpoint for drive requests.
+     * If not given, defaults to the Jupyter
+     * REST API given by [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/contents).
+     */
+    apiEndpoint?: string;
   }
 }
 

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -576,13 +576,13 @@ class ContentsManager implements Contents.IManager {
         });
         return {
           ...contentsModel,
-          path: Private.normalize(path),
+          path: this._toGlobalPath(drive, localPath),
           content: listing
         } as Contents.IModel;
       } else {
         return {
           ...contentsModel,
-          path: Private.normalize(path)
+          path: this._toGlobalPath(drive, localPath)
         } as Contents.IModel;
       }
     }); 
@@ -653,7 +653,10 @@ class ContentsManager implements Contents.IManager {
       throw Error('ContentsManager: renaming files must occur within a Drive');
     }
     return drive1.rename(path1, path2).then(contentsModel => {
-      return { ...contentsModel, path: path } as Contents.IModel;
+      return {
+        ...contentsModel,
+        path: this._toGlobalPath(drive1, path2)
+      } as Contents.IModel;
     });
   }
 
@@ -771,9 +774,9 @@ class ContentsManager implements Contents.IManager {
    */
   private _toGlobalPath(drive: Contents.IDrive, localPath: string): string {
     if (drive === this._defaultDrive) {
-      return PathExt.normalize(localPath);
+      return PathExt.removeSlash(localPath);
     } else {
-      return drive.name + ':' + PathExt.normalize(localPath);
+      return drive.name + ':' + PathExt.removeSlash(localPath);
     }
   }
 
@@ -1042,7 +1045,7 @@ class Drive implements Contents.IDrive {
     let request = {
       url: this._getUrl(oldLocalPath),
       method: 'PATCH',
-      data: JSON.stringify({ localPath: newLocalPath })
+      data: JSON.stringify({ path: newLocalPath })
     };
     return ServerConnection.makeRequest(request, this.serverSettings).then(response => {
       if (response.xhr.status !== 200) {

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -804,6 +804,12 @@ class ContentsManager implements Contents.IManager {
       return [drive, Private.normalize(parts[1])];
     }
   }
+
+  /**
+   * Respond to fileChanged signals from the drives attached to
+   * the manager. This prepends the drive name to the path if necessary,
+   * and then forwards the signal.
+   */
   private _onFileChanged(sender: Contents.IDrive, args: Contents.IChangedArgs) {
     if (sender === this._defaultDrive) {
       this._fileChanged.emit(args);
@@ -833,7 +839,6 @@ class ContentsManager implements Contents.IManager {
   private _isDisposed = false;
   private _additionalDrives = new Map<string, Contents.IDrive>();
   private _defaultDrive: Contents.IDrive = null;
-
   private _fileChanged = new Signal<this, Contents.IChangedArgs>(this);
 }
 

--- a/packages/services/test/src/contents/index.spec.ts
+++ b/packages/services/test/src/contents/index.spec.ts
@@ -4,7 +4,7 @@
 import expect = require('expect.js');
 
 import {
-  Contents, ContentsManager, ServerConnection
+  Contents, ContentsManager, Drive, ServerConnection
 } from '../../../lib';
 
 import {
@@ -14,13 +14,16 @@ import {
 
 let DEFAULT_DIR: Contents.IModel = {
   name: 'bar',
-  path: '/foo/bar',
-  type: 'file',
+  path: 'foo/bar',
+  type: 'directory',
   created: 'yesterday',
   last_modified: 'today',
   writable: false,
   mimetype: '',
-  content: '["buzz.txt", "bazz.py"]',
+  content: [
+    { name: 'buzz.txt', path: 'foo/bar/buzz.txt'},
+    { name: 'bazz.py', path: 'foo/bar/bazz.py'}
+  ],
   format: 'json'
 };
 
@@ -41,7 +44,7 @@ describe('contents', () => {
 
     it('should accept options', () => {
       let contents = new ContentsManager({
-        serverSettings
+        defaultDrive: new Drive()
       });
       expect(contents).to.be.a(ContentsManager);
     });
@@ -64,6 +67,20 @@ describe('contents', () => {
       });
       contents.newUntitled().catch(done);
     });
+
+    it('should include the full path for additional drives', (done) => {
+      let contents = new ContentsManager();
+      contents.addDrive(new Drive({ name: 'other' }));
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      contents.fileChanged.connect((sender, args) => {
+        expect(args.newValue.path).to.be('other:'+DEFAULT_FILE.path);
+        done();
+      });
+      contents.newUntitled({ path: 'other:' }).catch(done);
+    });
+
 
   });
 
@@ -91,6 +108,21 @@ describe('contents', () => {
 
   });
 
+  describe('#addDrive()', () => {
+
+    it('should add a new drive to the manager', (done) => {
+      let contents = new ContentsManager();
+      contents.addDrive(new Drive({ name: 'other' }));
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      contents.get('other:').then( () => {
+        done();
+      });
+    });
+
+  });
+
   describe('#get()', () => {
 
     it('should get a file', (done) => {
@@ -101,7 +133,7 @@ describe('contents', () => {
       let options: Contents.IFetchOptions = { type: 'file' };
       let get = contents.get('/foo', options);
       get.then(model => {
-        expect(model.path).to.be(DEFAULT_FILE.path);
+        expect(model.path).to.be('foo');
         done();
       });
     });
@@ -114,20 +146,36 @@ describe('contents', () => {
       let options: Contents.IFetchOptions = { type: 'directory' };
       let get = contents.get('/foo', options);
       get.then(model => {
-        expect(model.content).to.be(DEFAULT_DIR.content);
+        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
         done();
       });
     });
 
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
+    it('should get a file from an additional drive', (done) => {
+      let contents = new ContentsManager();
+      contents.addDrive(new Drive({ name: 'other' }));
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let options: Contents.IFetchOptions = { type: 'file' };
+      let get = contents.get('other:/foo', options);
+      get.then(model => {
+        expect(model.path).to.be('other:foo');
+        done();
+      });
+    });
+
+    it('should get a directory from an additional drive', (done) => {
+      let contents = new ContentsManager();
+      contents.addDrive(new Drive({ name: 'other' }));
       let handler = new RequestHandler(() => {
         handler.respond(200, DEFAULT_DIR);
       });
       let options: Contents.IFetchOptions = { type: 'directory' };
-      let get = contents.get('/foo', options);
+      let get = contents.get('other:/foo', options);
       get.then(model => {
-        expect(model.content).to.be(DEFAULT_DIR.content);
+        console.error(model.content[0].path)
+        expect(model.content[0].path).to.be('other:foo/bar/buzz.txt');
         done();
       });
     });
@@ -150,7 +198,8 @@ describe('contents', () => {
     });
 
     it('should get the url of a file', () => {
-      let contents = new ContentsManager({ serverSettings: settings });
+      let drive = new Drive({ serverSettings: settings });
+      let contents = new ContentsManager({ defaultDrive: drive });
       let test1 = contents.getDownloadUrl('bar.txt');
       let test2 = contents.getDownloadUrl('fizz/buzz/bar.txt');
       let test3 = contents.getDownloadUrl('/bar.txt');
@@ -162,18 +211,35 @@ describe('contents', () => {
     });
 
     it('should encode characters', () => {
-      let contents = new ContentsManager({ serverSettings: settings });
+      let drive = new Drive({ serverSettings: settings });
+      let contents = new ContentsManager({ defaultDrive: drive });
       return contents.getDownloadUrl('b ar?3.txt').then(url => {
         expect(url).to.be('http://foo/files/b%20ar%3F3.txt');
       });
     });
 
     it('should not handle relative paths', () => {
-      let contents = new ContentsManager({ serverSettings: settings });
+      let drive = new Drive({ serverSettings: settings });
+      let contents = new ContentsManager({ defaultDrive: drive });
       return contents.getDownloadUrl('fizz/../bar.txt').then(url => {
         expect(url).to.be('http://foo/files/fizz/../bar.txt');
       });
     });
+
+    it('should get the url of a file from an additional drive', () => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other', serverSettings: settings });
+      contents.addDrive(other);
+      let test1 = contents.getDownloadUrl('other:bar.txt');
+      let test2 = contents.getDownloadUrl('other:fizz/buzz/bar.txt');
+      let test3 = contents.getDownloadUrl('other:/bar.txt');
+      return Promise.all([test1, test2, test3]).then(urls => {
+        expect(urls[0]).to.be('http://foo/files/bar.txt');
+        expect(urls[1]).to.be('http://foo/files/fizz/buzz/bar.txt');
+        expect(urls[2]).to.be('http://foo/files/bar.txt');
+      });
+    });
+
 
   });
 
@@ -185,7 +251,7 @@ describe('contents', () => {
         handler.respond(201, DEFAULT_FILE);
       });
       contents.newUntitled({ path: '/foo' }).then(model => {
-        expect(model.path).to.be(DEFAULT_FILE.path);
+        expect(model.path).to.be('foo/test');
         done();
       });
     });
@@ -201,29 +267,54 @@ describe('contents', () => {
       };
       let newDir = contents.newUntitled(options);
       newDir.then(model => {
-        expect(model.content).to.be(DEFAULT_DIR.content);
+        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
         done();
       });
     });
 
-    it('should emit the fileChanged signal', () => {
-
+    it('should create a file on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      contents.newUntitled({ path: 'other:/foo' }).then(model => {
+        expect(model.path).to.be('other:foo/test');
+        done();
+      });
     });
 
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
+    it('should create a directory on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
       let handler = new RequestHandler(() => {
         handler.respond(201, DEFAULT_DIR);
       });
       let options: Contents.ICreateOptions = {
-        path: '/foo',
-        type: 'file',
-        ext: 'txt'
+        path: 'other:/foo',
+        type: 'directory'
       };
-      contents.newUntitled(options).then(model => {
-        expect(model.content).to.be(DEFAULT_DIR.content);
+      let newDir = contents.newUntitled(options);
+      newDir.then(model => {
+        expect(model.path).to.be('other:'+DEFAULT_DIR.path);
         done();
       });
+    });
+
+    it('should emit the fileChanged signal', (done) => {
+      let contents = new ContentsManager();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      contents.fileChanged.connect((sender, args) => {
+        expect(args.type).to.be('new');
+        expect(args.oldValue).to.be(null);
+        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+      contents.newUntitled({ type: 'file', name: 'test' }).catch(done);
     });
 
     it('should fail for an incorrect model', (done) => {
@@ -265,6 +356,18 @@ describe('contents', () => {
       });
     });
 
+    it('should delete a file on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
+      let handler = new RequestHandler(() => {
+        handler.respond(204, { });
+      });
+      contents.delete('other:/foo/bar.txt').then(() => {
+        done();
+      });
+    });
+
     it('should emit the fileChanged signal', (done) => {
       let contents = new ContentsManager();
       let path = '/foo/bar.txt';
@@ -277,16 +380,6 @@ describe('contents', () => {
         done();
       });
       contents.delete(path).catch(done);
-    });
-
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
-      let handler = new RequestHandler(() => {
-        handler.respond(204, { });
-      });
-      contents.delete('/foo/bar.txt').then(() => {
-        done();
-      });
     });
 
     it('should fail for an incorrect response', (done) => {
@@ -332,6 +425,20 @@ describe('contents', () => {
       });
     });
 
+    it('should rename a file on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let rename = contents.rename('other:/foo/bar.txt', 'other:/foo/baz.txt');
+      rename.then(model => {
+        expect(model.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
     it('should emit the fileChanged signal', (done) => {
       let contents = new ContentsManager();
       let handler = new RequestHandler(() => {
@@ -344,18 +451,6 @@ describe('contents', () => {
         done();
       });
       contents.rename('/foo/bar.txt', '/foo/baz.txt').catch(done);
-    });
-
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
-      let handler = new RequestHandler(() => {
-        handler.respond(200, DEFAULT_FILE);
-      });
-      let rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
-      rename.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
-        done();
-      });
     });
 
     it('should fail for an incorrect model', (done) => {
@@ -394,6 +489,20 @@ describe('contents', () => {
       });
     });
 
+    it('should save a file on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let save = contents.save('other:/foo', { type: 'file', name: 'test' });
+      save.then(model => {
+        expect(model.path).to.be('other:foo');
+        done();
+      });
+    });
+
     it('should create a new file', (done) => {
       let contents = new ContentsManager();
       let handler = new RequestHandler(() => {
@@ -418,18 +527,6 @@ describe('contents', () => {
         done();
       });
       contents.save('/foo', { type: 'file', name: 'test' }).catch(done);
-    });
-
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
-      let handler = new RequestHandler(() => {
-        handler.respond(200, DEFAULT_FILE);
-      });
-      let save = contents.save('/foo', { type: 'file', name: 'test' });
-      save.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
-        done();
-      });
     });
 
     it('should fail for an incorrect model', (done) => {
@@ -467,6 +564,19 @@ describe('contents', () => {
       });
     });
 
+    it('should copy a file on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      contents.copy('other:/foo/test', 'other:/baz').then(model => {
+        expect(model.path).to.be('other:foo/test');
+        done();
+      });
+    });
+
     it('should emit the fileChanged signal', (done) => {
       let contents = new ContentsManager();
       let handler = new RequestHandler(() => {
@@ -479,17 +589,6 @@ describe('contents', () => {
         done();
       });
       contents.copy('/foo/bar.txt', '/baz').catch(done);
-    });
-
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
-      let handler = new RequestHandler(() => {
-        handler.respond(201, DEFAULT_FILE);
-      });
-      contents.copy('/foo/bar.txt', '/baz').then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
-        done();
-      });
     });
 
     it('should fail for an incorrect model', (done) => {
@@ -528,12 +627,14 @@ describe('contents', () => {
       });
     });
 
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
+    it('should create a checkpoint on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
       let handler = new RequestHandler(() => {
         handler.respond(201, DEFAULT_CP);
       });
-      let checkpoint = contents.createCheckpoint('/foo/bar.txt');
+      let checkpoint = contents.createCheckpoint('other:/foo/bar.txt');
       checkpoint.then(model => {
         expect(model.last_modified).to.be(DEFAULT_CP.last_modified);
         done();
@@ -576,12 +677,14 @@ describe('contents', () => {
       });
     });
 
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
+    it('should list the checkpoints on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
       let handler = new RequestHandler(() => {
         handler.respond(200, [DEFAULT_CP, DEFAULT_CP]);
       });
-      let checkpoints = contents.listCheckpoints('/foo/bar.txt');
+      let checkpoints = contents.listCheckpoints('other:/foo/bar.txt');
       checkpoints.then(models => {
         expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
         done();
@@ -620,7 +723,7 @@ describe('contents', () => {
 
   describe('#restoreCheckpoint()', () => {
 
-    it('should create a checkpoint', (done) => {
+    it('should restore a checkpoint', (done) => {
       let contents = new ContentsManager();
       let handler = new RequestHandler(() => {
         handler.respond(204, { });
@@ -632,12 +735,14 @@ describe('contents', () => {
       });
     });
 
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
+    it('should restore a checkpoint on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
       let handler = new RequestHandler(() => {
         handler.respond(204, { });
       });
-      let checkpoint = contents.restoreCheckpoint('/foo/bar.txt',
+      let checkpoint = contents.restoreCheckpoint('other:/foo/bar.txt',
                                                   DEFAULT_CP.id);
       checkpoint.then(() => {
         done();
@@ -667,12 +772,14 @@ describe('contents', () => {
       .then(() => { done(); });
     });
 
-    it('should accept server settings', (done) => {
-      let contents = new ContentsManager({ serverSettings });
+    it('should delete a checkpoint on an additional drive', (done) => {
+      let contents = new ContentsManager();
+      let other = new Drive({ name: 'other' });
+      contents.addDrive(other);
       let handler = new RequestHandler(() => {
         handler.respond(204, { });
       });
-      contents.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id)
+      contents.deleteCheckpoint('other:/foo/bar.txt', DEFAULT_CP.id)
       .then(() => { done(); });
     });
 
@@ -682,6 +789,687 @@ describe('contents', () => {
         handler.respond(200, { });
       });
       let checkpoint = contents.deleteCheckpoint('/foo/bar.txt',
+                                                  DEFAULT_CP.id);
+      expectAjaxError(checkpoint, done, 'Invalid Status: 200');
+    });
+
+  });
+
+});
+
+
+describe('drive', () => {
+
+  describe('#constructor()', () => {
+
+    it('should accept no options', () => {
+      let drive = new Drive();
+      expect(drive).to.be.a(Drive);
+    });
+
+    it('should accept options', () => {
+      let drive = new Drive({
+        name: 'name'
+      });
+      expect(drive).to.be.a(Drive);
+    });
+
+  });
+
+  describe('#name', () => {
+    it('should return the name of the drive', () => {
+      let drive = new Drive({
+        name: 'name'
+      });
+      expect(drive.name).to.be('name');
+    });
+
+  });
+
+  describe('#fileChanged', () => {
+
+    it('should be emitted when a file changes', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      drive.fileChanged.connect((sender, args) => {
+        expect(sender).to.be(drive);
+        expect(args.type).to.be('new');
+        expect(args.oldValue).to.be(null);
+        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+      drive.newUntitled().catch(done);
+    });
+
+  });
+
+  describe('#isDisposed', () => {
+
+    it('should test whether the drive is disposed', () => {
+      let drive = new Drive();
+      expect(drive.isDisposed).to.be(false);
+      drive.dispose();
+      expect(drive.isDisposed).to.be(true);
+    });
+
+  });
+
+  describe('#dispose()', () => {
+
+    it('should dispose of the resources used by the drive', () => {
+      let drive = new Drive();
+      expect(drive.isDisposed).to.be(false);
+      drive.dispose();
+      expect(drive.isDisposed).to.be(true);
+      drive.dispose();
+      expect(drive.isDisposed).to.be(true);
+    });
+
+  });
+
+  describe('#get()', () => {
+
+    it('should get a file', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let options: Contents.IFetchOptions = { type: 'file' };
+      let get = drive.get('/foo', options);
+      get.then(model => {
+        expect(model.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+    });
+
+    it('should get a directory', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_DIR);
+      });
+      let options: Contents.IFetchOptions = { type: 'directory' };
+      let get = drive.get('/foo', options);
+      get.then(model => {
+        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        done();
+      });
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_DIR);
+      });
+      let options: Contents.IFetchOptions = { type: 'directory' };
+      let get = drive.get('/foo', options);
+      get.then(model => {
+        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        done();
+      });
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_DIR);
+      });
+      let get = drive.get('/foo');
+      expectAjaxError(get, done, 'Invalid Status: 201');
+    });
+
+  });
+
+  describe('#getDownloadUrl()', () => {
+
+    let settings = ServerConnection.makeSettings({
+      baseUrl: 'http://foo'
+    });
+
+    it('should get the url of a file', () => {
+      let drive = new Drive({ serverSettings: settings });
+      let test1 = drive.getDownloadUrl('bar.txt');
+      let test2 = drive.getDownloadUrl('fizz/buzz/bar.txt');
+      let test3 = drive.getDownloadUrl('/bar.txt');
+      return Promise.all([test1, test2, test3]).then(urls => {
+        expect(urls[0]).to.be('http://foo/files/bar.txt');
+        expect(urls[1]).to.be('http://foo/files/fizz/buzz/bar.txt');
+        expect(urls[2]).to.be('http://foo/files/bar.txt');
+      });
+    });
+
+    it('should encode characters', () => {
+      let drive = new Drive({ serverSettings: settings });
+      return drive.getDownloadUrl('b ar?3.txt').then(url => {
+        expect(url).to.be('http://foo/files/b%20ar%3F3.txt');
+      });
+    });
+
+    it('should not handle relative paths', () => {
+      let drive = new Drive({ serverSettings: settings });
+      return drive.getDownloadUrl('fizz/../bar.txt').then(url => {
+        expect(url).to.be('http://foo/files/fizz/../bar.txt');
+      });
+    });
+
+  });
+
+  describe('#newUntitled()', () => {
+
+    it('should create a file', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      drive.newUntitled({ path: '/foo' }).then(model => {
+        expect(model.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+    });
+
+    it('should create a directory', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_DIR);
+      });
+      let options: Contents.ICreateOptions = {
+        path: '/foo',
+        type: 'directory'
+      };
+      let newDir = drive.newUntitled(options);
+      newDir.then(model => {
+        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        done();
+      });
+    });
+
+    it('should emit the fileChanged signal', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      drive.fileChanged.connect((sender, args) => {
+        expect(args.type).to.be('new');
+        expect(args.oldValue).to.be(null);
+        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+      drive.newUntitled({ type: 'file', name: 'test' }).catch(done);
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_DIR);
+      });
+      let options: Contents.ICreateOptions = {
+        path: '/foo',
+        type: 'file',
+        ext: 'txt'
+      };
+      drive.newUntitled(options).then(model => {
+        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        done();
+      });
+    });
+
+    it('should fail for an incorrect model', (done) => {
+      let drive = new Drive();
+      let dir = JSON.parse(JSON.stringify(DEFAULT_DIR));
+      dir.name = 1;
+      let handler = new RequestHandler(() => {
+        handler.respond(201, dir);
+      });
+      let options: Contents.ICreateOptions = {
+        path: '/foo',
+        type: 'file',
+        ext: 'py'
+      };
+      let newFile = drive.newUntitled(options);
+      expectFailure(newFile, done);
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_DIR);
+      });
+      let newDir = drive.newUntitled();
+      expectAjaxError(newDir, done, 'Invalid Status: 200');
+    });
+
+  });
+
+  describe('#delete()', () => {
+
+    it('should delete a file', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(204, { });
+      });
+      drive.delete('/foo/bar.txt').then(() => {
+        done();
+      });
+    });
+
+    it('should emit the fileChanged signal', (done) => {
+      let drive = new Drive();
+      let path = '/foo/bar.txt';
+      let handler = new RequestHandler(() => {
+        handler.respond(204, { path });
+      });
+      drive.fileChanged.connect((sender, args) => {
+        expect(args.type).to.be('delete');
+        expect(args.oldValue.path).to.be(path);
+        done();
+      });
+      drive.delete(path).catch(done);
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(204, { });
+      });
+      drive.delete('/foo/bar.txt').then(() => {
+        done();
+      });
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, { });
+      });
+      let del = drive.delete('/foo/bar.txt');
+      expectAjaxError(del, done, 'Invalid Status: 200');
+    });
+
+    it('should throw a specific error', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(400, { });
+      });
+      let del = drive.delete('/foo/');
+      expectFailure(del, done, '');
+    });
+
+    it('should throw a general error', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(500, { });
+      });
+      let del = drive.delete('/foo/');
+      expectFailure(del, done, '');
+    });
+
+  });
+
+  describe('#rename()', () => {
+
+    it('should rename a file', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
+      rename.then(model => {
+        expect(model.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should emit the fileChanged signal', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      drive.fileChanged.connect((sender, args) => {
+        expect(args.type).to.be('rename');
+        expect(args.oldValue.path).to.be('/foo/bar.txt');
+        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+      drive.rename('/foo/bar.txt', '/foo/baz.txt').catch(done);
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
+      rename.then(model => {
+        expect(model.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should fail for an incorrect model', (done) => {
+      let drive = new Drive();
+      let dir = JSON.parse(JSON.stringify(DEFAULT_FILE));
+      delete dir.path;
+      let handler = new RequestHandler(() => {
+        handler.respond(200, dir);
+      });
+      let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
+      expectFailure(rename, done);
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
+      expectAjaxError(rename, done, 'Invalid Status: 201');
+    });
+
+  });
+
+  describe('#save()', () => {
+
+    it('should save a file', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      save.then(model => {
+        expect(model.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should create a new file', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      save.then(model => {
+        expect(model.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should emit the fileChanged signal', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      drive.fileChanged.connect((sender, args) => {
+        expect(args.type).to.be('save');
+        expect(args.oldValue).to.be(null);
+        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+      drive.save('/foo', { type: 'file', name: 'test' }).catch(done);
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      save.then(model => {
+        expect(model.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should fail for an incorrect model', (done) => {
+      let drive = new Drive();
+      let file = JSON.parse(JSON.stringify(DEFAULT_FILE));
+      delete file.format;
+      let handler = new RequestHandler(() => {
+        handler.respond(200, file);
+      });
+      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      expectFailure(save, done);
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(204, DEFAULT_FILE);
+      });
+      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      expectAjaxError(save, done, 'Invalid Status: 204');
+    });
+
+  });
+
+  describe('#copy()', () => {
+
+    it('should copy a file', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      drive.copy('/foo/bar.txt', '/baz').then(model => {
+        expect(model.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should emit the fileChanged signal', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      drive.fileChanged.connect((sender, args) => {
+        expect(args.type).to.be('new');
+        expect(args.oldValue).to.be(null);
+        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        done();
+      });
+      drive.copy('/foo/bar.txt', '/baz').catch(done);
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_FILE);
+      });
+      drive.copy('/foo/bar.txt', '/baz').then(model => {
+        expect(model.created).to.be(DEFAULT_FILE.created);
+        done();
+      });
+    });
+
+    it('should fail for an incorrect model', (done) => {
+      let drive = new Drive();
+      let file = JSON.parse(JSON.stringify(DEFAULT_FILE));
+      delete file.type;
+      let handler = new RequestHandler(() => {
+        handler.respond(201, file);
+      });
+      let copy = drive.copy('/foo/bar.txt', '/baz');
+      expectFailure(copy, done);
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_FILE);
+      });
+      let copy = drive.copy('/foo/bar.txt', '/baz');
+      expectAjaxError(copy, done, 'Invalid Status: 200');
+    });
+
+  });
+
+  describe('#createCheckpoint()', () => {
+
+    it('should create a checkpoint', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_CP);
+      });
+      let checkpoint = drive.createCheckpoint('/foo/bar.txt');
+      checkpoint.then(model => {
+        expect(model.last_modified).to.be(DEFAULT_CP.last_modified);
+        done();
+      });
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(201, DEFAULT_CP);
+      });
+      let checkpoint = drive.createCheckpoint('/foo/bar.txt');
+      checkpoint.then(model => {
+        expect(model.last_modified).to.be(DEFAULT_CP.last_modified);
+        done();
+      });
+    });
+
+    it('should fail for an incorrect model', (done) => {
+      let drive = new Drive();
+      let cp = JSON.parse(JSON.stringify(DEFAULT_CP));
+      delete cp.last_modified;
+      let handler = new RequestHandler(() => {
+        handler.respond(201, cp);
+      });
+      let checkpoint = drive.createCheckpoint('/foo/bar.txt');
+      expectFailure(checkpoint, done);
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, DEFAULT_CP);
+      });
+      let checkpoint = drive.createCheckpoint('/foo/bar.txt');
+      expectAjaxError(checkpoint, done, 'Invalid Status: 200');
+    });
+
+  });
+
+  describe('#listCheckpoints()', () => {
+
+    it('should list the checkpoints', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, [DEFAULT_CP, DEFAULT_CP]);
+      });
+      let checkpoints = drive.listCheckpoints('/foo/bar.txt');
+      checkpoints.then(models => {
+        expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
+        done();
+      });
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(200, [DEFAULT_CP, DEFAULT_CP]);
+      });
+      let checkpoints = drive.listCheckpoints('/foo/bar.txt');
+      checkpoints.then(models => {
+        expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
+        done();
+      });
+    });
+
+    it('should fail for an incorrect model', (done) => {
+      let drive = new Drive();
+      let cp = JSON.parse(JSON.stringify(DEFAULT_CP));
+      delete cp.id;
+      let handler = new RequestHandler(() => {
+        handler.respond(200, [cp, DEFAULT_CP]);
+      });
+      let checkpoints = drive.listCheckpoints('/foo/bar.txt');
+      let second = () => {
+        handler.onRequest = () => {
+          handler.respond(200, DEFAULT_CP);
+        };
+        let newCheckpoints = drive.listCheckpoints('/foo/bar.txt');
+        expectAjaxError(newCheckpoints, done, 'Invalid Checkpoint list');
+      };
+
+      expectFailure(checkpoints, second);
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(201, { });
+      });
+      let checkpoints = drive.listCheckpoints('/foo/bar.txt');
+      expectAjaxError(checkpoints, done, 'Invalid Status: 201');
+    });
+
+  });
+
+  describe('#restoreCheckpoint()', () => {
+
+    it('should restore a checkpoint', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(204, { });
+      });
+      let checkpoint = drive.restoreCheckpoint('/foo/bar.txt',
+                                                  DEFAULT_CP.id);
+      checkpoint.then(() => {
+        done();
+      });
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(204, { });
+      });
+      let checkpoint = drive.restoreCheckpoint('/foo/bar.txt',
+                                                  DEFAULT_CP.id);
+      checkpoint.then(() => {
+        done();
+      });
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, { });
+      });
+      let checkpoint = drive.restoreCheckpoint('/foo/bar.txt',
+                                                  DEFAULT_CP.id);
+      expectAjaxError(checkpoint, done, 'Invalid Status: 200');
+    });
+
+  });
+
+  describe('#deleteCheckpoint()', () => {
+
+    it('should delete a checkpoint', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(204, { });
+      });
+      drive.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id)
+      .then(() => { done(); });
+    });
+
+    it('should accept server settings', (done) => {
+      let drive = new Drive({ serverSettings });
+      let handler = new RequestHandler(() => {
+        handler.respond(204, { });
+      });
+      drive.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id)
+      .then(() => { done(); });
+    });
+
+    it('should fail for an incorrect response', (done) => {
+      let drive = new Drive();
+      let handler = new RequestHandler(() => {
+        handler.respond(200, { });
+      });
+      let checkpoint = drive.deleteCheckpoint('/foo/bar.txt',
                                                   DEFAULT_CP.id);
       expectAjaxError(checkpoint, done, 'Invalid Status: 200');
     });

--- a/packages/services/test/src/utils.ts
+++ b/packages/services/test/src/utils.ts
@@ -111,7 +111,7 @@ const PYTHON_SPEC: JSONObject = {
 export
 const DEFAULT_FILE: Contents.IModel = {
   name: 'test',
-  path: '',
+  path: 'foo/test',
   type: 'file',
   created: 'yesterday',
   last_modified: 'today',


### PR DESCRIPTION
Proposal for multiple "drive" backends to the contents manager. Basic structure:
1. The `ContentsManager` has a default `Drive` backend which talks to the normal filesystem.
2. It also has the ability to add new `IDrives`, which can talk to filesystems on other servers.
3. Drive backends are distinguished via their paths, where paths have a structure given by `driveName:path/to/file`.
4. The `ContentsManager` becomes essentially a routing system, deciding which `IDrive` to dispatch file operations to.
4. `FileBrowserModel`s can take an optional `driveName` argument, which they prepend to the path for file operations, so that a given `FileBrowserModel` talks to a specific drive (though still through the DocumentManager/ContentsManager).
5. This will allow for the `DocumentManager` and `ServicesManager` to be singletons.