### PR TITLE
Add collapsing behavior to JSONEditor

### DIFF
--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -233,7 +233,7 @@ class JSONEditor extends Widget {
   protected onBeforeDetach(msg: Message): void {
     let node = this.editorHostNode;
     node.removeEventListener('blur', this, true);
-    this.headerNode.addEventListener('click', this);
+    this.headerNode.removeEventListener('click', this);
   }
 
   /**

--- a/packages/codeeditor/style/index.css
+++ b/packages/codeeditor/style/index.css
@@ -7,8 +7,6 @@
 
 
 .jp-JSONEditor {
-  padding-left: 10px;
-  padding-right: 10px;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -21,6 +19,8 @@
   border-radius: 0px;
   background: #f7f7f7;
   min-height: 50px;
+  margin-left: 12px;
+  margin-right: 12px;
 }
 
 
@@ -30,23 +30,51 @@
 }
 
 
-.jp-JSONEditor-buttons {
-  font-family: FontAwesome;
+.jp-JSONEditor-header {
+  display: flex;
   flex: 1 0 auto;
   min-height: 13px;
-  padding-bottom: 6px;
+  padding: 12px;
+}
+
+
+.jp-JSONEditor-header label {
+  flex: 0 0 auto;
 }
 
 
 .jp-JSONEditor-commitButton::before {
+  font-family: FontAwesome;
   content: '\f00c'; /* check */
-  float: right;
-  margin-right: 20px;
+  padding-left: 4px;
 }
 
 
 .jp-JSONEditor-revertButton::before {
+  font-family: FontAwesome;
   content: '\f0e2'; /* undo */
-  float: right;
-  margin-right: 4px;
+}
+
+
+.jp-JSONEditor-collapser {
+  flex: 1 1 auto;
+}
+
+
+.jp-JSONEditor-collapser.jp-mod-collapse-enabled::before {
+  padding-left: 6px;
+  font-family: FontAwesome;
+  content: '\f0d8'; /* caret-up */
+}
+
+
+.jp-JSONEditor-collapser.jp-mod-collapse-enabled.jp-mod-collapsed::before {
+  padding-left: 6px;
+  font-family: FontAwesome;
+  content: '\f0d7'; /* caret-down */
+}
+
+
+.jp-JSONEditor-host.jp-mod-collapsed {
+  display: none;
 }

--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -58,24 +58,9 @@ const CHILD_CLASS = 'jp-CellTools-tool';
 const ACTIVE_CELL_CLASS = 'jp-ActiveCellTool';
 
 /**
- * The class name added to the Metadata editor tool.
- */
-const EDITOR_CLASS = 'jp-MetadataEditorTool';
-
-/**
  * The class name added to an Editor instance.
  */
-const EDITOR_TITLE_CLASS = 'jp-MetadataEditorTool-header';
-
-/**
- * The class name added to the toggle button.
- */
-const TOGGLE_CLASS = 'jp-MetadataEditorTool-toggleButton';
-
-/**
- * The class name added to collapsed elements.
- */
-const COLLAPSED_CLASS = 'jp-mod-collapsed';
+const EDITOR_CLASS = 'jp-MetadataEditorTool';
 
 /**
  * The class name added to a KeySelector instance.
@@ -414,68 +399,17 @@ namespace CellTools {
       let editorFactory = options.editorFactory;
       this.addClass(EDITOR_CLASS);
       let layout = this.layout = new PanelLayout();
-      let header = Private.createMetadataHeader();
-      layout.addWidget(header);
-      this.editor = new JSONEditor({ editorFactory });
+      this.editor = new JSONEditor({
+        editorFactory,
+        title: 'Cell Metadata'
+      });
       layout.addWidget(this.editor);
-      header.addClass(COLLAPSED_CLASS);
-      this.editor.addClass(COLLAPSED_CLASS);
-      this.toggleNode.classList.add(COLLAPSED_CLASS);
     }
 
     /**
      * The editor used by the tool.
      */
     readonly editor: JSONEditor;
-
-    /**
-     * Get the toggle node used by the editor.
-     */
-    get toggleNode(): HTMLElement {
-      return this.node.getElementsByClassName(TOGGLE_CLASS)[0] as HTMLElement;
-    }
-
-    /**
-     * Handle the DOM events for the widget.
-     *
-     * @param event - The DOM event sent to the widget.
-     *
-     * #### Notes
-     * This method implements the DOM `EventListener` interface and is
-     * called in response to events on the notebook panel's node. It should
-     * not be called directly by user code.
-     */
-    handleEvent(event: Event): void {
-      if (event.type !== 'click') {
-        return;
-      }
-      each(this.children(), widget => {
-        widget.toggleClass(COLLAPSED_CLASS);
-      });
-      let toggleNode = this.toggleNode;
-      if (this.editor.hasClass(COLLAPSED_CLASS)) {
-        toggleNode.classList.add(COLLAPSED_CLASS);
-      } else {
-        toggleNode.classList.remove(COLLAPSED_CLASS);
-      }
-      this.editor.editor.refresh();
-    }
-
-    /**
-     * Handle `after-attach` messages for the widget.
-     */
-    protected onAfterAttach(msg: Message): void {
-      this.toggleNode.addEventListener('click', this);
-      let cell = this.parent.activeCell;
-      this.editor.source = cell ? cell.model.metadata : null;
-    }
-
-    /**
-     * Handle `before-detach` messages for the widget.
-     */
-    protected onBeforeDetach(msg: Message): void {
-      this.toggleNode.removeEventListener('click', this);
-    }
 
     /**
      * Handle a change to the active cell.
@@ -746,18 +680,5 @@ namespace Private {
     );
     Styling.styleNode(node);
     return node;
-  }
-
-  /**
-   * Create the metadata header widget.
-   */
-  export
-  function createMetadataHeader(): Widget {
-    let node = VirtualDOM.realize(
-      h.div({ className: EDITOR_TITLE_CLASS },
-        h.label({}, 'Edit Metadata'),
-        h.span({ className: TOGGLE_CLASS }))
-    );
-    return new Widget({ node });
   }
 }

--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -401,7 +401,7 @@ namespace CellTools {
       let layout = this.layout = new PanelLayout();
       this.editor = new JSONEditor({
         editorFactory,
-        title: 'Cell Metadata',
+        title: 'Edit Metadata',
         collapsable: true
       });
       layout.addWidget(this.editor);

--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -401,7 +401,8 @@ namespace CellTools {
       let layout = this.layout = new PanelLayout();
       this.editor = new JSONEditor({
         editorFactory,
-        title: 'Cell Metadata'
+        title: 'Cell Metadata',
+        collapsable: true
       });
       layout.addWidget(this.editor);
     }

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -227,39 +227,6 @@
 }
 
 
-.jp-MetadataEditorTool-header {
-  flex: 1 0 auto;
-  padding: 10px;
-  padding-bottom: 16px;
-}
-
-
-.jp-MetadataEditorTool-header label {
-  flex: 0 0 auto;
-}
-
-
-.jp-MetadataEditorTool-toggleButton {
-  padding-left: 6px;
-  font-family: FontAwesome;
-}
-
-
-.jp-MetadataEditorTool-toggleButton::before {
-  content: '\f0d8'; /* caret-up */
-}
-
-
-.jp-MetadataEditorTool-toggleButton.jp-mod-collapsed::before {
-  content: '\f0d7'; /* caret-down */
-}
-
-
-.jp-MetadataEditorTool .jp-JSONEditor.jp-mod-collapsed {
-  display: none;
-}
-
-
 .jp-KeySelector {
   padding: 12px;
 }

--- a/test/src/apputils/jsoneditor.spec.ts
+++ b/test/src/apputils/jsoneditor.spec.ts
@@ -76,6 +76,61 @@ describe('apputils', () => {
 
     });
 
+    describe('#collapsable', () => {
+
+      it('should default to false', () => {
+        expect(editor.collapsable).to.be(false);
+      });
+
+      it ('should be settable in the constructor', () => {
+        let newEditor = new JSONEditor({ editorFactory, collapsable: true });
+        expect(newEditor.collapsable).to.be(true);
+      });
+
+    });
+
+    describe('#editorTitle', () => {
+
+      it('should default to empty string', () => {
+        expect(editor.editorTitle).to.be('');
+      });
+
+      it ('should be settable in the constructor', () => {
+        let newEditor = new JSONEditor({ editorFactory, title: 'foo' });
+        expect(newEditor.editorTitle).to.be('foo');
+      });
+
+      it('should be settable', () => {
+        editor.editorTitle = 'foo';
+        expect(edit.editorTitle).to.be('foo');
+      });
+
+    });
+
+    describe('#headerNode', () => {
+
+      it('should be the header node used by the editor', () => {
+        expect(editor.headerNode.classList).to.contain('jp-JSONEditor-header');
+      });
+
+    });
+
+    describe('#titleNode', () => {
+
+      it('should be the title node used by the editor', () => {
+        expect(editor.titleNode.classList).to.contain('jp-JSONEditor-title');
+      });
+
+    });
+
+    describe('#collapserNode', () => {
+
+      it('should be the collapser node used by the editor', () => {
+        expect(editor.collapserNode.classList).to.contain('jp-JSONEditor-collapser');
+      });
+
+    });
+
     describe('#editorHostNode', () => {
 
       it('should be the editor host node used by the editor', () => {
@@ -306,6 +361,20 @@ describe('apputils', () => {
           let expected = '{\n  "foo": 2,\n  "bar": 3\n}';
           expect(editor.model.value.text).to.be(expected);
         });
+
+        it('should collapse the editor', () => {
+          editor.dispose();
+          editor = new LogEditor({ editorFactory, collapsable: true });
+          Widget.attach(editor, document.body);
+          simulate(editor.titleNode, 'click');
+          expect(editor.editorHostNode.classList).to.contain('jp-mod-collapsed');
+        });
+
+        it('should have no effect if the editor is not collapsable', () => {
+          simulate(editor.titleNode, 'click');
+          expect(editor.editorHostNode.classList).to.not.contain('jp-mod-collapsed');
+        });
+
 
       });
 

--- a/test/src/apputils/jsoneditor.spec.ts
+++ b/test/src/apputils/jsoneditor.spec.ts
@@ -102,7 +102,7 @@ describe('apputils', () => {
 
       it('should be settable', () => {
         editor.editorTitle = 'foo';
-        expect(edit.editorTitle).to.be('foo');
+        expect(editor.editorTitle).to.be('foo');
       });
 
     });


### PR DESCRIPTION
Fixes #2242.  Moves collapsing behavior into the JSONEditor so it can be used in other places besides Cell Tools.  Styling can now be done in one place as well.

Before:
<image src="https://cloud.githubusercontent.com/assets/2096628/26276339/20ced5f2-3d3b-11e7-8b74-070776196055.png" width=300>

After with no collapser:
<image src="https://cloud.githubusercontent.com/assets/2096628/26276327/db2934ac-3d3a-11e7-8c25-1d45348b951a.png" width=300>

After with collapser:
<image src="https://cloud.githubusercontent.com/assets/2096628/26276335/0f943a98-3d3b-11e7-90ff-d144938edb2a.png" width=300>

<image src="https://cloud.githubusercontent.com/assets/2096628/26276337/15370cfa-3d3b-11e7-8358-39746b935629.png" width=300>

Note that I updated the title back to "Edit Metadata" after seeing that they were mismatched in the screenshots.
