### PR TITLE
Optimize webpack build

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "css-loader": "^0.27.3",
-    "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.10.1",
     "fs-extra": "^2.1.2",
     "handlebars": "^4.0.6",

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -29,17 +29,6 @@ var digest = hash.digest('hex');
 fs.writeFileSync(path.resolve(buildDir, 'hash.md5'), digest);
 
 
-// Note that we have to use an explicit local public path
-// otherwise the urls in the extracted CSS will point to the wrong
-// location.
-// See https://github.com/webpack-contrib/extract-text-webpack-plugin/tree/75cb09eed13d15cec8f974b1210920a7f249f8e2
-var cssLoader = ExtractTextPlugin.extract({
-  use: 'css-loader',
-  fallback: 'style-loader',
-  publicPath: './'
-});
-
-
 module.exports = {
   entry:  path.resolve(buildDir, 'index.out.js'),
   output: {
@@ -48,7 +37,7 @@ module.exports = {
   },
   module: {
     rules: [
-      { test: /\.css$/, use: cssLoader },
+      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
       { test: /\.json$/, use: 'json-loader' },
       { test: /\.html$/, use: 'file-loader' },
       { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
@@ -64,8 +53,5 @@ module.exports = {
     fs: 'empty'
   },
   bail: true,
-  devtool: 'source-map',
-  plugins: [
-      new ExtractTextPlugin('[name].css')
-    ]
+  devtool: 'cheap-source-map'
 }

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -22,7 +22,7 @@ if [[ $GROUP == tests ]]; then
 
     # Make sure we have CSS that can be converted with postcss
     npm install -g postcss-cli
-    postcss jupyterlab/build/*.css > /dev/null
+    postcss packages/**/style/*.css --dir /tmp
 
     # Run the publish script in jupyterlab
     cd jupyterlab


### PR DESCRIPTION
The build on my machine went from ~12s -> ~9s and 0.5GB -> 0.4GB maximum resident set size as measured by `/usr/bin/time -l npm run build`.  There is no noticeable memory change if we disable source maps entirely.

Partially addresses https://github.com/jupyterlab/jupyterlab/issues/2251.