### PR TITLE
Clean up the handling of execution

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -631,18 +631,9 @@ namespace CodeCell {
 
     model.executionCount = null;
     cell.setPrompt('*');
-
-    // Override the default for `stop_on_error`.
-    let content: KernelMessage.IExecuteRequest = {
-      code,
-      stop_on_error: true
-    };
-
-    let future = session.kernel.requestExecute(content);
     model.trusted = true;
-    cell.outputArea.future = future;
 
-    return future.done.then((msg: KernelMessage.IExecuteReplyMsg) => {
+    return OutputArea.execute(cell.outputArea, code, session).then(msg => {
       model.executionCount = msg.content.execution_count;
       return msg;
     });

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -633,7 +633,7 @@ namespace CodeCell {
     cell.setPrompt('*');
     model.trusted = true;
 
-    return OutputArea.execute(cell.outputArea, code, session).then(msg => {
+    return OutputArea.execute(code, cell.outputArea, session).then(msg => {
       model.executionCount = msg.content.execution_count;
       return msg;
     });

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -462,7 +462,7 @@ class CodeConsole extends Widget {
     // do in IPython or QtConsole.
     if ( source === 'clear' || source === '%clear' ) {
       this.clear();
-      return Promise.resolve(void 0)
+      return Promise.resolve(void 0);
     }
     cell.model.contentChanged.connect(this.update, this);
     let onSuccess = (value: KernelMessage.IExecuteReplyMsg) => {
@@ -494,7 +494,7 @@ class CodeConsole extends Widget {
       cell.model.contentChanged.disconnect(this.update, this);
       this.update();
     };
-    return cell.execute(this.session).then(onSuccess, onFailure);
+    return CodeCell.execute(cell, this.session).then(onSuccess, onFailure);
   }
 
   /**

--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -980,7 +980,7 @@ namespace Private {
       break;
     case 'code':
       if (session) {
-        return (child as CodeCell).execute(session).then(reply => {
+        return CodeCell.execute(child as CodeCell, session).then(reply => {
           if (child.isDisposed) {
             return false;
           }

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -428,7 +428,7 @@ namespace OutputArea {
    * Execute code on an output area.
    */
   export
-  function execute(output: OutputArea, code: string, session: IClientSession): Promise<KernelMessage.IExecuteReplyMsg> {
+  function execute(code: string, output: OutputArea, session: IClientSession): Promise<KernelMessage.IExecuteReplyMsg> {
     // Override the default for `stop_on_error`.
     let content: KernelMessage.IExecuteRequest = {
       code,

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -18,10 +18,6 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  IClientSession
-} from '@jupyterlab/apputils';
-
-import {
   nbformat
 } from '@jupyterlab/coreutils';
 
@@ -153,7 +149,7 @@ class OutputArea extends Widget {
 
   /**
    * A public signal used to indicate the number of outputs has changed.
-   * 
+   *
    * #### Notes
    * This is useful for parents who want to apply styling based on the number
    * of outputs. Emits the current number of outputs.
@@ -161,25 +157,9 @@ class OutputArea extends Widget {
   readonly outputLengthChanged = new Signal<this, number>(this);
 
   /**
-   * Execute code on a client session and handle response messages.
+   * Clear the output area.
    */
-  execute(code: string, session: IClientSession): Promise<KernelMessage.IExecuteReplyMsg> {
-    // Bail if the model is disposed.
-    if (this.model.isDisposed) {
-      return Promise.reject('Model is disposed');
-    }
-
-    // Bail if there is no kernel.
-    let kernel = session.kernel;
-    if (!kernel) {
-      return Promise.reject('No kernel exists on the session');
-    }
-
-    // Override the default for `stop_on_error`.
-    let content: KernelMessage.IExecuteRequest = {
-      code,
-      stop_on_error: true
-    };
+  clear(): void {
     this.model.clear();
 
     // Make sure there were no input widgets.
@@ -187,25 +167,33 @@ class OutputArea extends Widget {
       this._clear();
       this.outputLengthChanged.emit(this.model.length);
     }
+  }
 
-    return new Promise<KernelMessage.IExecuteReplyMsg>((resolve, reject) => {
-      let future = kernel.requestExecute(content);
-      // Handle published messages.
-      future.onIOPub = (msg: KernelMessage.IIOPubMessage) => {
-        this._onIOPub(msg);
-      };
-      // Handle the execute reply.
-      future.onReply = (msg: KernelMessage.IExecuteReplyMsg) => {
-        this._onExecuteReply(msg);
-        resolve(msg);
-      };
-      // Handle stdin.
-      future.onStdin = (msg: KernelMessage.IStdinMessage) => {
-        if (KernelMessage.isInputRequestMsg(msg)) {
-          this._onInputRequest(msg, session);
-        }
-      };
-    });
+  /**
+   * Handle messages from code execution.
+   */
+  handleExecution(future: Kernel.IFuture): Promise<void> {
+    // Bail if the model is disposed.
+    if (this.model.isDisposed) {
+      return Promise.reject('Model is disposed');
+    }
+
+    // Handle published messages.
+    future.onIOPub = (msg: KernelMessage.IIOPubMessage) => {
+      this._onIOPub(msg);
+    };
+    // Handle the execute reply.
+    future.onReply = (msg: KernelMessage.IExecuteReplyMsg) => {
+      this._onExecuteReply(msg);
+    };
+    // Handle stdin.
+    future.onStdin = (msg: KernelMessage.IStdinMessage) => {
+      if (KernelMessage.isInputRequestMsg(msg)) {
+        this._onInputRequest(msg, future);
+      }
+    };
+
+    return future.done;
   }
 
   /**
@@ -321,7 +309,7 @@ class OutputArea extends Widget {
   /**
    * Handle an input request from a kernel.
    */
-  private _onInputRequest(msg: KernelMessage.IInputRequestMsg, session: IClientSession): void {
+  private _onInputRequest(msg: KernelMessage.IInputRequestMsg, future: Kernel.IFuture): void {
     // Add an output widget to the end.
     let factory = this.contentFactory;
     let stdinPrompt = msg.content.prompt;
@@ -335,8 +323,7 @@ class OutputArea extends Widget {
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
 
-    let kernel = session.kernel;
-    let input = factory.createStdin({ prompt: stdinPrompt, password, kernel });
+    let input = factory.createStdin({ prompt: stdinPrompt, password, future });
     input.addClass(OUTPUT_AREA_OUTPUT_CLASS);
     panel.addWidget(input);
 
@@ -421,8 +408,8 @@ namespace OutputArea {
 
   /**
    * An output area widget content factory.
-   * 
-   * The content factory is used to create children in a way 
+   *
+   * The content factory is used to create children in a way
    * that can be customized.
    */
   export
@@ -542,7 +529,7 @@ class Stdin extends Widget implements IStdin {
     if (options.password) {
       this._input.type = 'password';
     }
-    this._kernel = options.kernel;
+    this._future = options.future;
   }
 
   /**
@@ -559,7 +546,7 @@ class Stdin extends Widget implements IStdin {
     let input = this._input;
     if (event.type === 'keydown') {
       if ((event as KeyboardEvent).keyCode === 13) {  // Enter
-        this._kernel.sendInputReply({
+        this._future.sendInputReply({
           value: input.value
         });
         let rendered = document.createElement('span');
@@ -596,9 +583,10 @@ class Stdin extends Widget implements IStdin {
     this._input.removeEventListener('keydown', this);
   }
 
-  private _kernel: Kernel.IKernelConnection = null;
+  private _future: Kernel.IFuture = null;
   private _input: HTMLInputElement = null;
 }
+
 
 export
 namespace Stdin {
@@ -618,9 +606,9 @@ namespace Stdin {
     password: boolean;
 
     /**
-     * The kernel associated with the request.
+     * The kernel future associated with the request.
      */
-    kernel: Kernel.IKernelConnection;
+    future: Kernel.IFuture;
   }
 }
 

--- a/packages/services/examples/browser/index.ts
+++ b/packages/services/examples/browser/index.ts
@@ -39,14 +39,14 @@ function main() {
     future.onReply = (reply) => {
       log('Got execute reply');
     };
-    future.onDone = () => {
+    return future.done;
+  }).then(() => {
       log('Future is fulfilled');
       // Shut down the session.
-      session.shutdown().then(() => {
-        log('Session shut down');
-        log('Test Complete!');
-      });
-    };
+      return session.shutdown();
+  }).then(() => {
+      log('Session shut down');
+      log('Test Complete!');
   }).catch(err => {
     console.error(err);
     log('Test Failed! See the console output for details');

--- a/packages/services/examples/node/index.js
+++ b/packages/services/examples/node/index.js
@@ -39,14 +39,14 @@ services.Session.startNew(options).then(function(s) {
   future.onReply = function(reply) {
     console.log('Got execute reply');
   }
-  future.onDone = function() {
-    console.log('Future is fulfilled');
-    // Shut down the session.
-    session.shutdown().then(function() {
-      console.log('Session shut down');
-      process.exit(0);
-    });
-  };
+  return future.done;
+}).then(function() {
+  console.log('Future is fulfilled');
+  // Shut down the session.
+  return session.shutdown();
+}).then(function() {
+  console.log('Session shut down');
+  process.exit(0);
 }).catch(function(err) {
   console.error(err);
   process.exit(1);

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -38,7 +38,7 @@
     "build": "npm run build:src",
     "test:coverage": "istanbul cover --dir test/coverage _mocha -- --retries 3 test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json",
     "test:integration": "cd test && python integration_test.py",
-    "test:devtool": "devtool node_modules/.bin/_mocha -qc ttest/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json --timeout=50000",
+    "test:devtool": "devtool node_modules/.bin/_mocha -qc test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json --timeout=50000",
     "test:debug": "mocha test/build/**/*.spec.js test/build/*.spec.js  --jupyter-config-data=./test/config.json --debug-brk",
     "test": "mocha --retries 3 test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json"
   },

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1403,11 +1403,7 @@ namespace Private {
     } catch (e) {
       return Promise.reject(e);
     }
-    return new Promise<any>((resolve, reject) => {
-      future.onReply = (reply: KernelMessage.IMessage) => {
-        resolve(reply);
-      };
-    });
+    return future.done;
   }
 
   /**

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -266,7 +266,7 @@ class DefaultKernel implements Kernel.IKernel {
     }
     let future = new KernelFutureHandler(() => {
       this._futures.delete(msg.header.msg_id);
-    }, msg, expectReply, disposeOnDone);
+    }, msg, expectReply, disposeOnDone, this);
     this._futures.set(msg.header.msg_id, future);
     return future;
   }

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -46,7 +46,7 @@ class KernelFutureHandler extends DisposableDelegate implements Kernel.IFuture {
   /**
    * A promise that resolves when the future is done.
    */
-  get done(): Promise<void> {
+  get done(): Promise<KernelMessage.IShellMessage> {
     return this._done.promise;
   }
 
@@ -167,6 +167,7 @@ class KernelFutureHandler extends DisposableDelegate implements Kernel.IFuture {
   private _handleReply(msg: KernelMessage.IShellMessage): void {
     let reply = this._reply;
     if (reply) { reply(msg); }
+    this._replyMsg = msg;
     this._setFlag(Private.KernelFutureFlag.GotReply);
     if (this._testFlag(Private.KernelFutureFlag.GotIdle)) {
       this._handleDone();
@@ -196,7 +197,7 @@ class KernelFutureHandler extends DisposableDelegate implements Kernel.IFuture {
       return;
     }
     this._setFlag(Private.KernelFutureFlag.IsDone);
-    this._done.resolve(void 0);
+    this._done.resolve(this._replyMsg);
     if (this._disposeOnDone) {
       this.dispose();
     }
@@ -221,7 +222,8 @@ class KernelFutureHandler extends DisposableDelegate implements Kernel.IFuture {
   private _stdin: (msg: KernelMessage.IStdinMessage) => void = null;
   private _iopub: (msg: KernelMessage.IIOPubMessage) => void = null;
   private _reply: (msg: KernelMessage.IShellMessage) => void = null;
-  private _done = new PromiseDelegate<void>();
+  private _done = new PromiseDelegate<KernelMessage.IShellMessage>();
+  private _replyMsg: KernelMessage.IShellMessage;
   private _hooks = new Private.HookList<KernelMessage.IIOPubMessage>();
   private _disposeOnDone = true;
   private _kernel: Kernel.IKernel;

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  nbformat
+} from '@jupyterlab/coreutils';
+
+import {
   IIterator
 } from '@phosphor/algorithm';
 
@@ -671,8 +675,10 @@ namespace Kernel {
 
     /**
      * A promise that resolves when the future is done.
+     *
+     * The contents of the promise is the reply message.
      */
-    readonly done: Promise<void>;
+    readonly done: Promise<KernelMessage.IShellMessage>;
 
     /**
      * The reply handler for the kernel future.

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  nbformat
-} from '@jupyterlab/coreutils';
-
-import {
   IIterator
 } from '@phosphor/algorithm';
 

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -670,9 +670,9 @@ namespace Kernel {
     readonly msg: KernelMessage.IShellMessage;
 
     /**
-     * Whether the future is done.
+     * A promise that resolves when the future is done.
      */
-    readonly isDone: boolean;
+    readonly done: Promise<void>;
 
     /**
      * The reply handler for the kernel future.
@@ -688,11 +688,6 @@ namespace Kernel {
      * The iopub handler for the kernel future.
      */
     onIOPub: (msg: KernelMessage.IIOPubMessage) => void;
-
-    /**
-     * The done handler for the kernel future.
-     */
-    onDone: () => void;
 
     /**
      * Register hook for IOPub messages.
@@ -718,6 +713,11 @@ namespace Kernel {
      * If a hook is removed during the hook processing, it will be deactivated immediately.
      */
     removeMessageHook(hook: (msg: KernelMessage.IIOPubMessage) => boolean): void;
+
+    /**
+     * Send an `input_reply` message.
+     */
+    sendInputReply(content: KernelMessage.IInputReply): void;
   }
 
   /**

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -633,6 +633,14 @@ namespace KernelMessage {
   }
 
   /**
+   * Test whether a kernel message is an `'execute_reply'` message.
+   */
+  export
+  function isExecuteReplyMsg(msg: IMessage): msg is IExecuteReplyMsg {
+    return msg.header.msg_type === 'execute_reply';
+  }
+
+  /**
    * An `'input_request'` message on the `'stdin'` channel.
    *
    * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#messages-on-the-stdin-router-dealer-sockets).

--- a/packages/services/test/src/integration.ts
+++ b/packages/services/test/src/integration.ts
@@ -133,17 +133,10 @@ describe('jupyter.services - Integration', () => {
         };
         return kernel.requestHistory(options);
       }).then(msg => {
-        return new Promise<void>((resolve, reject) => {
-          let future = kernel.requestExecute({ code: 'a = 1\n' });
-          future.onReply = (reply: KernelMessage.IExecuteReplyMsg) => {
-            expect(reply.content.status).to.be('ok');
-          };
-          future.onDone = () => {
-            console.log('Execute finished');
-            resolve(void 0);
-          };
-        });
-      }).then(() => {
+        let future = kernel.requestExecute({ code: 'a = 1\n' });
+        return future.done;
+      }).then(msg => {
+        expect(msg.content.status).to.be('ok');
         return kernel.shutdown();
       });
     });

--- a/packages/services/test/src/kernel/comm.spec.ts
+++ b/packages/services/test/src/kernel/comm.spec.ts
@@ -21,14 +21,13 @@ describe('jupyter.services - Comm', () => {
   let tester: KernelTester;
   let kernel: Kernel.IKernel;
 
-  beforeEach((done) => {
+  beforeEach(() => {
     tester = new KernelTester();
-    Kernel.startNew().then(k => {
+    debugger;
+    return Kernel.startNew().then(k => {
       kernel = k;
       return kernel.ready;
-    }).then(() => {
-      done();
-    }).catch(done);
+    });
   });
 
   afterEach(() => {

--- a/test/src/apputils/toolbar.spec.ts
+++ b/test/src/apputils/toolbar.spec.ts
@@ -177,7 +177,7 @@ describe('@jupyterlab/apputils', () => {
         });
       });
 
-      it('should display a busy status if the kernel status is not idle', (done) => {
+      it('should display a busy status if the kernel status is not idle', () => {
         let item = Toolbar.createKernelStatusItem(session);
         let called = false;
         let future = session.kernel.requestExecute({ code: 'a = 1' });
@@ -187,13 +187,12 @@ describe('@jupyterlab/apputils', () => {
             called = true;
           }
         };
-        future.onDone = () => {
+        return future.done.then(() => {
           expect(called).to.be(true);
-          done();
-        };
+        });
       });
 
-      it('should show the current status in the node title', (done) => {
+      it('should show the current status in the node title', () => {
         let item = Toolbar.createKernelStatusItem(session);
         let status = session.status;
         expect(item.node.title.toLowerCase()).to.contain(status);
@@ -205,10 +204,9 @@ describe('@jupyterlab/apputils', () => {
             called = true;
           }
         };
-        future.onDone = () => {
+        return future.done.then(() => {
           expect(called).to.be(true);
-          done();
-        };
+        });
       });
 
       it('should handle a starting session', () => {

--- a/test/src/cells/widget.spec.ts
+++ b/test/src/cells/widget.spec.ts
@@ -409,41 +409,6 @@ describe('cells/widget', () => {
 
     });
 
-    describe('#execute()', () => {
-
-      let session: IClientSession;
-
-      beforeEach(() => {
-        return createClientSession().then(s => {
-          session = s;
-          return s.initialize();
-        }).then(() => {
-          return session.kernel.ready;
-        });
-      });
-
-      afterEach(() => {
-        return session.shutdown();
-      });
-
-      it('should fulfill a promise if there is no code to execute', () => {
-        let widget = new CodeCell({ model, rendermime, contentFactory });
-        return widget.execute(session);
-      });
-
-      it('should fulfill a promise if there is code to execute', () => {
-        let widget = new CodeCell({ model, rendermime, contentFactory });
-        let originalCount: number;
-        widget.model.value.text = 'foo';
-        originalCount = (widget.model).executionCount;
-        return widget.execute(session).then(() => {
-          let executionCount = (widget.model).executionCount;
-          expect(executionCount).to.not.equal(originalCount);
-        });
-      });
-
-    });
-
     describe('#onUpdateRequest()', () => {
 
       it('should update the widget', () => {
@@ -463,6 +428,41 @@ describe('cells/widget', () => {
         expect(widget.methods).to.not.contain(method);
         widget.model.metadata.set('foo', 1);
         expect(widget.methods).to.contain(method);
+      });
+
+    });
+
+    describe('.execute()', () => {
+
+      let session: IClientSession;
+
+      beforeEach(() => {
+        return createClientSession().then(s => {
+          session = s;
+          return s.initialize();
+        }).then(() => {
+          return session.kernel.ready;
+        });
+      });
+
+      afterEach(() => {
+        return session.shutdown();
+      });
+
+      it('should fulfill a promise if there is no code to execute', () => {
+        let widget = new CodeCell({ model, rendermime, contentFactory });
+        return CodeCell.execute(widget, session);
+      });
+
+      it('should fulfill a promise if there is code to execute', () => {
+        let widget = new CodeCell({ model, rendermime, contentFactory });
+        let originalCount: number;
+        widget.model.value.text = 'foo';
+        originalCount = (widget.model).executionCount;
+        return CodeCell.execute(widget, session).then(() => {
+          let executionCount = (widget.model).executionCount;
+          expect(executionCount).to.not.equal(originalCount);
+        });
       });
 
     });

--- a/test/src/outputarea/widget.spec.ts
+++ b/test/src/outputarea/widget.spec.ts
@@ -213,7 +213,7 @@ describe('outputarea/widget', () => {
 
       it('should execute code on a kernel and send outputs to the model', () => {
         return session.kernel.ready.then(() => {
-          return OutputArea.execute(widget, CODE, session).then(reply => {
+          return OutputArea.execute(CODE, widget, session).then(reply => {
             expect(reply.content.execution_count).to.be.ok();
             expect(reply.content.status).to.be('ok');
             expect(model.length).to.be(1);
@@ -223,7 +223,7 @@ describe('outputarea/widget', () => {
 
       it('should clear existing outputs', () => {
         widget.model.fromJSON(DEFAULT_OUTPUTS);
-        return OutputArea.execute(widget, CODE, session).then(reply => {
+        return OutputArea.execute(CODE, widget, session).then(reply => {
           expect(reply.content.execution_count).to.be.ok();
           expect(model.length).to.be(1);
         });


### PR DESCRIPTION
The output area needs much of the raw information from the kernel messages to render output, clear output, handle response payloads, and stdin messages.  This PR modifies the `Kernel.IFuture` to provide a simpler interface that can be consumed by the output area.