### PR TITLE
Style refinements to notebook, running sessions, tab manager

### DIFF
--- a/packages/default-theme/style/icons/md/circle-inverse.svg
+++ b/packages/default-theme/style/icons/md/circle-inverse.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 18 18" style="enable-background:new 0 0 18 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M0,0h18v18H0V0z"/>
+<circle class="st1" cx="9" cy="9" r="8"/>
+</svg>

--- a/packages/default-theme/style/icons/md/close-inverse.svg
+++ b/packages/default-theme/style/icons/md/close-inverse.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:none;}
+</style>
+<path class="st0" d="M12.7,4.3l-0.9-0.9L8,7.1L4.3,3.3L3.3,4.3L7.1,8l-3.7,3.7l0.9,0.9L8,8.9l3.7,3.7l0.9-0.9L8.9,8L12.7,4.3z"/>
+<path class="st1" d="M0,0h16v16H0V0z"/>
+</svg>

--- a/packages/default-theme/style/variables.css
+++ b/packages/default-theme/style/variables.css
@@ -181,7 +181,9 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-icon-file: url('./icons/md/file.svg');
   --jp-icon-refresh: url('./icons/md/refresh.svg');
   --jp-icon-close: url('./icons/md/close.svg');
+  --jp-inverse-icon-close: url('./icons/md/close-inverse.svg');
   --jp-icon-circle: url('./icons/md/circle.svg');
+  --jp-inverse-icon-circle: url('./icons/md/circle-inverse.svg');
   --jp-icon-close-black: url('./icons/md/close-black.svg');
   --jp-icon-search: url('./icons/md/search.svg');
 }

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -39,9 +39,7 @@
 
 
 .jp-NotebookPanel-toolbar {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),
-              0 3px 1px -2px rgba(0, 0, 0, 0.2),
-              0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: 0px 0.4px 6px 0px rgba(0,0,0,0.1);
   z-index: 1;
 }
 

--- a/packages/running/style/index.css
+++ b/packages/running/style/index.css
@@ -6,7 +6,7 @@
   --jp-private-running-button-height: 28px;
   --jp-private-running-button-width: 48px;
   --jp-private-running-item-height: 24px;
-  --jp-private-running-shutdown-button-height: 20px;
+  --jp-private-running-shutdown-button-height: 24px;
 }
 
 /*-----------------------------------------------------------------------------
@@ -98,11 +98,6 @@
 }
 
 
-.jp-RunningSessions-item:hover {
-    background: var(--jp-layout-color2);
-}
-
-
 .jp-RunningSessions-itemIcon {
   flex: 0 0 auto;
   padding: 0px 8px;
@@ -139,16 +134,44 @@
   font-size: var(--jp-ui-font-size1);
   flex: 1 1 auto;
   margin-right: 4px;
+  padding-left: 4px;
   text-overflow: ellipsis;
   overflow: hidden;
   direction: rtl;
   white-space: nowrap;
+  border-radius: 2px;
+  transition: background-color 0.1s ease;
+}
+
+
+.jp-RunningSessions-itemLabel:hover {
+  background-color: rgba(153,153,153,.1);
+}
+
+
+.jp-RunningSessions-itemLabel:focus {
+  background-color: rgba(153,153,153,.2);
 }
 
 .jp-RunningSessions-itemShutdown.jp-mod-styled {
-  margin: 2px 8px 2px 0px;
-  color: var(--jp-inverse-ui-font-color0);
-  background: var(--jp-warn-color1);
+  margin: 0px 4px;
+  color: var(--jp-warn-color1);
+  font-weight: 500;
+  background-color: transparent;
   height: var(--jp-private-running-shutdown-button-height);
   line-height: var(--jp-private-running-shutdown-button-height);
+  transition: background-color 0.1s ease;
+  border-radius: 2px;
+}
+
+
+.jp-RunningSessions-itemShutdown.jp-mod-styled:hover {
+  background-color: rgba(153,153,153,.1);
+}
+
+
+.jp-RunningSessions-itemShutdown.jp-mod-styled:focus {
+  border: none;
+  box-shadow: none;
+  background-color: rgba(153,153,153,.2);
 }

--- a/packages/tabmanager-extension/style/index.css
+++ b/packages/tabmanager-extension/style/index.css
@@ -105,6 +105,17 @@
   background-image: var(--jp-icon-circle);
 }
 
+
+#tab-manager .p-TabBar-tab.p-mod-closable.jp-mod-dirty.jp-mod-active > .p-TabBar-tabCloseIcon {
+  background-size: 10px;
+  background-image: var(--jp-inverse-icon-circle);
+}
+
+
+#tab-manager .p-TabBar-tab.p-mod-closable.jp-mod-active > .p-TabBar-tabCloseIcon {
+  background-image: var(--jp-inverse-icon-close);
+}
+
 #tab-manager .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:hover {
   background-size: 16px;
   background-image: var(--jp-icon-close-black);

--- a/packages/tabmanager-extension/style/index.css
+++ b/packages/tabmanager-extension/style/index.css
@@ -60,9 +60,8 @@
 
 
 #tab-manager .p-TabBar-tab.jp-mod-active {
-  border-top: var(--jp-border-width) solid var(--jp-brand-color1);
-  border-bottom: var(--jp-border-width) solid var(--jp-brand-color1);
-  color: var(--jp-ui-font-color0);
+  color: var(--jp-inverse-ui-font-color0);
+  background: var(--jp-brand-color1);
 }
 
 


### PR DESCRIPTION
Just made a few refinements to the notebook shadow under the toolbar to be more subtle, changed the design of the running sessions items to be more consistent with material design and more subtle, refined the states of the tab manager items to be consistent with the rest of the UI. Here are some screenshots of before and after!:

### Notebook Toolbar Shadow

#### Before
![screen shot 2017-05-25 at 10 35 17 am](https://cloud.githubusercontent.com/assets/6437976/26462580/379ff9f6-4136-11e7-9f10-7137cfe6bd4e.png)

#### After
![screen shot 2017-05-25 at 10 29 30 am](https://cloud.githubusercontent.com/assets/6437976/26462585/3f5e38e2-4136-11e7-99db-1b461b9d1e62.png)


### Running Sessions Items

#### Before
![screen shot 2017-05-25 at 10 34 11 am](https://cloud.githubusercontent.com/assets/6437976/26462604/554f1dd8-4136-11e7-982a-3b2078d70f82.png)

#### After
![screen shot 2017-05-25 at 10 29 47 am](https://cloud.githubusercontent.com/assets/6437976/26462617/6200f9fc-4136-11e7-9d9c-04d8a186ea4a.png)

##### Shutdown button hover state
![screen shot 2017-05-25 at 10 29 58 am](https://cloud.githubusercontent.com/assets/6437976/26462634/6e6f2966-4136-11e7-9dab-7903dbdd73f0.png)

##### Shutdown button focus state
![screen shot 2017-05-25 at 10 30 46 am](https://cloud.githubusercontent.com/assets/6437976/26462647/79f94640-4136-11e7-8bc2-2dca2f247d63.png)

##### Shutdown item title hover state (the title is clickable and will open the document in the docpanel)
![screen shot 2017-05-25 at 10 31 05 am](https://cloud.githubusercontent.com/assets/6437976/26462679/9736a194-4136-11e7-89c4-8366b7f72d5e.png)

### Tab manager item style refinement

#### Before
![screen shot 2017-05-25 at 10 37 31 am](https://cloud.githubusercontent.com/assets/6437976/26462720/b7798426-4136-11e7-8162-e2517f73d6ac.png)

#### After
![screen shot 2017-05-25 at 10 32 18 am](https://cloud.githubusercontent.com/assets/6437976/26462729/bee1fbf8-4136-11e7-9787-d7fb2a2eb2e6.png)
![screen shot 2017-05-25 at 10 32 28 am](https://cloud.githubusercontent.com/assets/6437976/26462735/c3c89b54-4136-11e7-85d2-37be8d2d5261.png)
