### PR TITLE
Fix a couple of path-related things.

### DIFF
--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -14,10 +14,6 @@ import {
 } from '@phosphor/coreutils';
 
 import {
-  PathExt
-} from './path';
-
-import {
   ObservableMap
 } from './observablemap';
 
@@ -591,7 +587,7 @@ class ModelDB implements IModelDB {
     if (this._basePath) {
       path = this._basePath + '.' + path;
     }
-    return PathExt.normalize(path);
+    return path;
   }
 
   private _basePath: string;

--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -68,11 +68,15 @@ namespace PathExt {
   /**
    * Normalize a string path, reducing '..' and '.' parts.
    * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used.
+   * When an empty path is given, returns the root path.
    *
    * @param path - The string path to normalize.
    */
   export
   function normalize(path: string): string {
+    if (path === '') {
+      return '';
+    }
     return removeSlash(posix.normalize(path));
   }
 

--- a/test/src/coreutils/path.spec.ts
+++ b/test/src/coreutils/path.spec.ts
@@ -61,6 +61,11 @@ describe('@jupyterlab/coreutils', () => {
         expect(path).to.equal('fixtures/b/c.js');
       });
 
+      it('should not return "." for an empty path', () => {
+        let path = PathExt.normalize('');
+        expect(path).to.equal('');
+      });
+
     });
 
     describe('.resolve()', () => {


### PR DESCRIPTION
`posix-path.normalize()` returns `'.'` when given an empty path. I don't think that is the expected behavior for `PathExt.normalize()`, and it caused me some troubles today.