### PR TITLE
Support for node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ cache:
   directories:
     - node_modules
     - $HOME/.npm
+matrix:
+  include:
+    - node_js: '4.3'
+      env: GROUP=tests
+    - node_js: '5'
+      env: GROUP=coverage_and_docs
+    - node_js: '6'
+      env: GROUP=cli
 env:
-  matrix:
-    include:
-      - node_js: '4.3'
-        env: GROUP=tests
-      - node_js: '5'
-        env: GROUP=coverage_and_docs
-      - node_js: '6'
-        env: GROUP=cli
   global:
   - GH_REF: github.com/jupyterlab/jupyterlab.git
   - secure: MWpTI6cj3/Bnmtrr0Oqlp2JeWqDneB9aEjlQDaRxLOkqVbxhqDcYW9qAgZZP+sq29vT5oVMWzyCirteKxJfG2vy3HQE1XNLhz82Sf/7sE6DQ51gohl0CcOeA/uA8hCXEw97hneFWsZgHKqSoch7nVDsE3qfYgO+930jHlnxYApJGP9hZFv2Q2NVa6+99kipEYS4BY/yBDYKy6/t4kXcnBrUlNaPtdjnXcrY9esLZ7EQtkaG5VqcQVIBaLJKGF5Q7Aufj5nCFaZ6hZDF1Bi/AbmIbVWFyiT+22i8DZK6YwenECckyzoWkl+bEhYepWsgBKh/BDgPBAmPWKHgU5V4apDaGqZBhF7FP6H02AdZYYuCwl47jyakqvWLZW7oDmorL+HsWG5HQ3m0tMT2ywdbwNOiD39tiPPXjsvROh5ys9vL6NzQvxILCeEOnzcZrFuxi2LGEZfnlqRIjkh1llUAvNc3mOycRLWDOwVQa2+U59qDRXCSY2RD+MOfcdFUGengVujTMaAPMBUa3E33/ZIOOKJtR5TIajYZvd9B2uDlz02QfvTK+hrTaNYJjRZ8WCaeSM/CIKdoLw+29MNO6eqtchw0/vNvM8c9EkhrhMQKcY04OecVhmZkemFhd4SD5l92VX3z3xSxLkmazfNkj3CigWDXNxfDd2ORoGjA46Pga8RM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '5'
+- '4'
 sudo: false
 addons:
   firefox: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '4'
+- '4.3'
 sudo: false
 addons:
   firefox: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ matrix:
       env: GROUP=tests
     - node_js: '5'
       env: GROUP=coverage_and_docs
-    - node_js: '4.3'
+    - node_js: '5'
       env: GROUP=cli
+    - node_js: '4'
+      env: GROUP=legacy
 env:
   global:
   - GH_REF: github.com/jupyterlab/jupyterlab.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       env: GROUP=coverage_and_docs
     - node_js: '5'
       env: GROUP=cli
-    - node_js: '4'
+    - node_js: '4.3'
       env: GROUP=legacy
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-node_js:
-- '4.3'
 sudo: false
 addons:
   firefox: latest
@@ -10,9 +8,13 @@ cache:
     - $HOME/.npm
 env:
   matrix:
-    - GROUP=tests
-    - GROUP=coverage_and_docs
-    - GROUP=cli
+    include:
+      - node_js: '4.3'
+        env: GROUP=tests
+      - node_js: '5'
+        env: GROUP=coverage_and_docs
+      - node_js: '6'
+        env: GROUP=cli
   global:
   - GH_REF: github.com/jupyterlab/jupyterlab.git
   - secure: MWpTI6cj3/Bnmtrr0Oqlp2JeWqDneB9aEjlQDaRxLOkqVbxhqDcYW9qAgZZP+sq29vT5oVMWzyCirteKxJfG2vy3HQE1XNLhz82Sf/7sE6DQ51gohl0CcOeA/uA8hCXEw97hneFWsZgHKqSoch7nVDsE3qfYgO+930jHlnxYApJGP9hZFv2Q2NVa6+99kipEYS4BY/yBDYKy6/t4kXcnBrUlNaPtdjnXcrY9esLZ7EQtkaG5VqcQVIBaLJKGF5Q7Aufj5nCFaZ6hZDF1Bi/AbmIbVWFyiT+22i8DZK6YwenECckyzoWkl+bEhYepWsgBKh/BDgPBAmPWKHgU5V4apDaGqZBhF7FP6H02AdZYYuCwl47jyakqvWLZW7oDmorL+HsWG5HQ3m0tMT2ywdbwNOiD39tiPPXjsvROh5ys9vL6NzQvxILCeEOnzcZrFuxi2LGEZfnlqRIjkh1llUAvNc3mOycRLWDOwVQa2+U59qDRXCSY2RD+MOfcdFUGengVujTMaAPMBUa3E33/ZIOOKJtR5TIajYZvd9B2uDlz02QfvTK+hrTaNYJjRZ8WCaeSM/CIKdoLw+29MNO6eqtchw0/vNvM8c9EkhrhMQKcY04OecVhmZkemFhd4SD5l92VX3z3xSxLkmazfNkj3CigWDXNxfDd2ORoGjA46Pga8RM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ cache:
     - $HOME/.npm
 matrix:
   include:
-    - node_js: '4.3'
+    - node_js: '6'
       env: GROUP=tests
     - node_js: '5'
       env: GROUP=coverage_and_docs
-    - node_js: '6'
+    - node_js: '4.3'
       env: GROUP=cli
 env:
   global:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,5 +11,6 @@ include jupyterlab/package.template.json
 include jupyterlab/webpack.config.js
 include jupyterlab/index.template.js
 include jupyterlab/package_list.txt
+include jupyterlab/dedupe.js
 
 prune jupyterlab/tests

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -273,7 +273,6 @@ def build(app_dir=None, name=None, version=None):
 
     # Make sure packages are installed.
     run(['npm', 'install'], cwd=staging)
-    run(['npm', 'install', 'minimist'], cwd=staging)
 
     # Install the linked extensions.
     for path in _get_linked_packages(app_dir).values():

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -273,6 +273,7 @@ def build(app_dir=None, name=None, version=None):
 
     # Make sure packages are installed.
     run(['npm', 'install'], cwd=staging)
+    run(['npm', 'install minimist'], cwd=staging)
 
     # Install the linked extensions.
     for path in _get_linked_packages(app_dir).values():

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -333,8 +333,6 @@ def _ensure_package(app_dir, name=None, version=None):
     if version:
         data['jupyterlab']['version'] = version
 
-    data['scripts']['build'] = 'webpack'
-
     pkg_path = pjoin(staging, 'package.json')
     with open(pkg_path, 'w') as fid:
         json.dump(data, fid, indent=4)

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -273,7 +273,7 @@ def build(app_dir=None, name=None, version=None):
 
     # Make sure packages are installed.
     run(['npm', 'install'], cwd=staging)
-    run(['npm', 'install minimist'], cwd=staging)
+    run(['npm', 'install', 'minimist'], cwd=staging)
 
     # Install the linked extensions.
     for path in _get_linked_packages(app_dir).values():

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -333,7 +333,7 @@ def _ensure_package(app_dir, name=None, version=None):
     if version:
         data['jupyterlab']['version'] = version
 
-    data['scripts']['build'] = 'npm dedupe && webpack'
+    data['scripts']['build'] = 'webpack'
 
     pkg_path = pjoin(staging, 'package.json')
     with open(pkg_path, 'w') as fid:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -310,8 +310,8 @@ def _ensure_package(app_dir, name=None, version=None):
     if not os.path.exists(staging):
         os.makedirs(staging)
 
-    for fname in ['index.template.js', 'webpack.config.js']:
-        dest = pjoin(staging, fname.replace('.template', ''))
+    for fname in ['index.template.js', 'webpack.config.js', 'dedupe.js']:
+        dest = pjoin(staging, name.replace('.template', ''))
         shutil.copy2(pjoin(here, fname), dest)
 
     # Template the package.json file.

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -333,7 +333,7 @@ def _ensure_package(app_dir, name=None, version=None):
     if version:
         data['jupyterlab']['version'] = version
 
-    data['scripts']['build'] = 'webpack'
+    data['scripts']['build'] = 'npm dedupe && webpack'
 
     pkg_path = pjoin(staging, 'package.json')
     with open(pkg_path, 'w') as fid:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -311,7 +311,7 @@ def _ensure_package(app_dir, name=None, version=None):
         os.makedirs(staging)
 
     for fname in ['index.template.js', 'webpack.config.js', 'dedupe.js']:
-        dest = pjoin(staging, name.replace('.template', ''))
+        dest = pjoin(staging, fname.replace('.template', ''))
         shutil.copy2(pjoin(here, fname), dest)
 
     # Template the package.json file.

--- a/jupyterlab/dedupe.js
+++ b/jupyterlab/dedupe.js
@@ -1,0 +1,11 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+var childProcess = require('child_process');
+var semver = require('semver');
+var required = '3.0.0';
+var version = childProcess.execSync('npm --version', { encoding: 'utf8' });
+
+if (semver.lt(version, required)) {
+  childProcess.execSync('npm dedupe', { stdio: [0, 1, 2] });
+}

--- a/jupyterlab/dedupe.js
+++ b/jupyterlab/dedupe.js
@@ -2,10 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 var childProcess = require('child_process');
-var semver = require('semver');
-var required = '3.0.0';
+var required = 3;
 var version = childProcess.execSync('npm --version', { encoding: 'utf8' });
 
-if (semver.lt(version, required)) {
+if (parseInt(version[0]) < required) {
   childProcess.execSync('npm dedupe', { stdio: [0, 1, 2] });
 }

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -4,6 +4,7 @@
   "version": "0.4.1",
   "scripts": {
     "build": "npm dedupe && webpack",
+    "postinstall": "node dedupe.js",
     "publish": "node make-release.js"
   },
   "dependencies": {

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -3,7 +3,7 @@
   "name": "@jupyterlab/application-top",
   "version": "0.4.1",
   "scripts": {
-    "build": "webpack",
+    "build": "npm dedupe && webpack",
     "publish": "node make-release.js"
   },
   "dependencies": {

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -3,7 +3,7 @@
   "name": "@jupyterlab/application-top",
   "version": "0.4.1",
   "scripts": {
-    "build": "npm dedupe && webpack",
+    "build": "webpack",
     "postinstall": "node dedupe.js",
     "publish": "node make-release.js"
   },

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -3,8 +3,7 @@
   "name": "@jupyterlab/application-top",
   "version": "0.4.1",
   "scripts": {
-    "build": "webpack",
-    "postinstall": "node dedupe.js",
+    "build": "node dedupe.js && webpack",
     "publish": "node make-release.js"
   },
   "dependencies": {

--- a/jupyterlab/package.template.json
+++ b/jupyterlab/package.template.json
@@ -44,6 +44,7 @@
     "css-loader": "^0.27.3",
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.10.1",
+    "minimist": "^1.2.0",
     "fs-extra": "^2.1.2",
     "handlebars": "^4.0.6",
     "json-loader": "^0.5.4",

--- a/jupyterlab/package.template.json
+++ b/jupyterlab/package.template.json
@@ -3,7 +3,7 @@
   "name": "@jupyterlab/application-top",
   "version": "0.4.1",
   "scripts": {
-    "build": "webpack",
+    "build": "node dedupe.js && webpack",
     "publish": "node make-release.js"
   },
   "dependencies": {

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -17,6 +17,7 @@
     "@phosphor/disposable": "^1.1.0",
     "@phosphor/messaging": "^1.2.0",
     "@phosphor/signaling": "^1.2.0",
+    "minimist": "^1.2.0",
     "moment": "^2.17.1",
     "path-posix": "^1.0.0",
     "url-parse": "^1.1.8"

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -10,9 +10,7 @@
     "@phosphor/coreutils": "^1.1.0",
     "@phosphor/disposable": "^1.1.0",
     "@phosphor/signaling": "^1.2.0",
-    "@types/minimist": "^1.2.0",
     "@types/text-encoding": "0.0.30",
-    "minimist": "^1.2.0",
     "path-posix": "^1.0.0",
     "url-parse": "^1.1.8"
   },

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -22,9 +22,6 @@ conda update -q conda
 conda info -a
 conda install -c conda-forge notebook pytest
 
-if [[ $GROUP == cli ]]; then
-   conda install -c javascript nodejs
-fi
 
 # create jupyter base dir (needed for config retrieval)
 mkdir ~/.jupyter

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -10,7 +10,7 @@ if [[ $GROUP == tests || $GROUP == cli ]]; then
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 fi
 
-if [[ $GROUP == coverage_and_docs ]]; then
+if [[ $GROUP == coverage_and_docs || $GROUP=legacy ]]; then
     wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
 fi
 

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -22,6 +22,10 @@ conda update -q conda
 conda info -a
 conda install -c conda-forge notebook pytest
 
+if [[ $GROUP == cli ]]; then
+   conda install -c javascript nodejs
+fi
+
 # create jupyter base dir (needed for config retrieval)
 mkdir ~/.jupyter
 

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -95,3 +95,8 @@ if [[ $GROUP == cli ]]; then
     jupyter labextension uninstall -h 
     jupyter labextension list -h
 fi
+
+
+if [[ $GROUP == cli ]]; then
+    jupyter lab build
+fi

--- a/setupbase.py
+++ b/setupbase.py
@@ -76,7 +76,8 @@ def find_package_data():
     """
     return {
         'jupyterlab': ['build/*', 'index.template.js', 'webpack.config.js',
-                       'package.template.json', 'package_list.txt']
+                       'package.template.json', 'package_list.txt',
+                       'dedupe.js']
     }
 
 


### PR DESCRIPTION
Verified locally that these changes along with #2257 fix #2251.  Also exposed the fact that `@jupyterlab/coreutils` needs to depend on `minimist`.  The workaround here (manually installing in `package.template.json` will be overridden in the next release.