### PR TITLE
Minor improvements to the inspector UI/UX

### DIFF
--- a/packages/inspector/style/index.css
+++ b/packages/inspector/style/index.css
@@ -18,7 +18,6 @@
 |----------------------------------------------------------------------------*/
 
 .jp-Inspector {
-  border: none;
   outline: none;
 }
 
@@ -59,7 +58,6 @@
   min-width: var(--jp-private-inspector-tab-width);
   padding: 0px 8px;
   background: var(--jp-layout-color1);
-  border: none;
   transform: none;
   margin-right: 0px;
   line-height: var(--jp-private-inspector-tab-height);
@@ -89,7 +87,7 @@
 }
 
 .jp-InspectorItem-content {
-  height: calc(100% - 24px); /* Subtract the height of the toolbar. */
+  height: 100%;
   overflow: auto;
   padding: 4px;
 }
@@ -114,7 +112,6 @@
   font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
   margin: 0;
-  white-space: pre-wrap;
 }
 
 

--- a/packages/inspector/style/index.css
+++ b/packages/inspector/style/index.css
@@ -89,7 +89,7 @@
 .jp-InspectorItem-content {
   height: 100%;
   overflow: auto;
-  padding: 4px;
+  padding: 8px;
 }
 
 

--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -144,7 +144,7 @@ const SHORTCUTS = [
   },
   {
     command: 'inspector:open',
-    selector: '.jp-CodeConsole-promptCell',
+    selector: 'body',
     keys: ['Accel I']
   },
   {


### PR DESCRIPTION
* `4px` to `8px` padding.
* No word wrap (like tooltip).
* Make items have 100% height.
* Border around dock panel.