### PR TITLE
Remove the staging directory on a version mismatch

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -344,6 +344,7 @@ def _ensure_package(app_dir, name='JupyterLab', version=None):
 
     data['scripts']['build'] = 'webpack'
 
+    pkg_path = pjoin(staging, 'package.json')
     with open(pkg_path, 'w') as fid:
         json.dump(data, fid, indent=4)
 

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -307,6 +307,15 @@ def _ensure_package(app_dir, name='JupyterLab', version=None):
                 raise
 
     staging = pjoin(app_dir, 'staging')
+
+    # Look for mismatched version.
+    pkg_path = pjoin(staging, 'package.json')
+    if os.path.exists(pkg_path):
+        with open(pkg_path) as fid:
+            data = json.load(fid)
+        if data['jupyterlab'].get('version', '') != __version__:
+            shutil.rmtree(staging)
+
     if not os.path.exists(staging):
         os.makedirs(staging)
 
@@ -335,7 +344,6 @@ def _ensure_package(app_dir, name='JupyterLab', version=None):
 
     data['scripts']['build'] = 'webpack'
 
-    pkg_path = pjoin(staging, 'package.json')
     with open(pkg_path, 'w') as fid:
         json.dump(data, fid, indent=4)
 


### PR DESCRIPTION
This prevents a problem I saw when upgrading from 0.21 -> 0.22 where the previous JupyterLab packages were in still around, resulting in the app failing to load.