### PR TITLE
Changed the appearance of the drag and drop view of file browser items

### DIFF
--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -284,11 +284,11 @@
   padding-left: 4px;
   margin-left: 4px;
   width: 160px;
-  background-color: #FFFFFF;
+  background-color: rgba(255,255,255,.7);
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
   border-radius: 0px;
   color: var(--jp-ui-font-color1);
-  transform: translateX(-40%) translateY(-58%);
+  transform: translateX(-2%) translateY(4%);
 }
 
 


### PR DESCRIPTION
Now when you pick up to move a file browser item, it is semi transparent (so you can see the items underneath them). Also moved the cursor so that it is placed at the top left of the drag image so you can see more of the content underneath to place.

![ezgif-1-2642698a2c](https://cloud.githubusercontent.com/assets/6437976/26512302/cbfcad44-421a-11e7-9615-5db7f1700213.gif)
