### PR TITLE
Don't use null value in weak map.

### DIFF
--- a/packages/chatbox-extension/src/index.ts
+++ b/packages/chatbox-extension/src/index.ts
@@ -119,7 +119,7 @@ function activateChatbox(app: JupyterLab, rendermime: IRenderMime, palette: ICom
       }
       panel.context = context;
     }
-  }
+  };
 
   app.restored.then(() => {
     updateDocumentContext();

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -162,7 +162,7 @@ class DocumentWidgetManager implements IDisposable {
    * @returns The context associated with the widget, or `undefined`.
    */
   contextForWidget(widget: Widget): DocumentRegistry.Context {
-    return Private.contextProperty.get(widget);
+    return !widget ? void 0 : Private.contextProperty.get(widget);
   }
 
   /**


### PR DESCRIPTION
Shortcut using `null` as a key for a weak map.