### PR TITLE
Add script for temporarily adding sibling packages to lerna build so they may be built against master.

### DIFF
--- a/docs/extensions_dev.md
+++ b/docs/extensions_dev.md
@@ -109,7 +109,17 @@ npm run addsibling <path-or-url>
 
 in the JupyterLab root directory, where `<path-or-url>` refers either to an 
 extension npm package on the local filesystem, or a URL to a git 
-repository for an extension npm package.
+repository for an extension npm package. This operation may be subsequently
+reversed by running
+
+```
+npm run addsibling <extension-name>
+```
+
+This will remove the package metadata from the source tree, but wil **not**
+remove any files added by the `addsibling` script, which should be removed
+manually.
+
 
 The package should export EMCAScript 5 compatible JavaScript.  It can 
 import CSS using the syntax `require('foo.css')`.  The CSS files

--- a/docs/extensions_dev.md
+++ b/docs/extensions_dev.md
@@ -98,7 +98,18 @@ only copy the current contents of the source folder.
 Note that the application is built against **released** versions of the
 core JupyterLab extensions.  If your extension depends on JupyterLab
 extensions, it should be compatible with the versions used in the
-`jupyterlab/package.template.json` entry point file.
+`jupyterlab/package.template.json` entry point file.  If you must
+install a extension into a development branch of JupyterLab, you
+have to graft it into the source tree of JupyterLab itself.
+This may be done using the command
+
+```
+npm run addsibling <path-or-url>
+```
+
+in the JupyterLab root directory, where `<path-or-url>` refers either to an 
+extension npm package on the local filesystem, or a URL to a git 
+repository for an extension npm package.
 
 The package should export EMCAScript 5 compatible JavaScript.  It can 
 import CSS using the syntax `require('foo.css')`.  The CSS files

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "update:dependency": "node scripts/update-dependency.js",
     "watch": "watch \"npm run build\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
     "watch:main": "watch \"npm run build:main\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
-    "addsibling": "node scripts/add-sibling.js"
+    "addsibling": "node scripts/add-sibling.js",
+    "removesibling": "node scripts/remove-sibling.js"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "publish": "npm update && npm install && npm run clean && npm run build && lerna publish -m \"Publish\"",
     "update:dependency": "node scripts/update-dependency.js",
     "watch": "watch \"npm run build\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
-    "watch:main": "watch \"npm run build:main\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles"
+    "watch:main": "watch \"npm run build:main\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
+    "addsibling": "node scripts/add-sibling.js"
   },
   "dependencies": {},
   "devDependencies": {

--- a/scripts/add-sibling.js
+++ b/scripts/add-sibling.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 var fs = require('fs');
 var path = require('path');
-var glob = require('glob');
 var childProcess = require('child_process');
 
 // Make sure we have required command line arguments.
@@ -20,7 +19,7 @@ if (target[0] === '.' || target[0] === '/') {
   // If the target starts with a '.' or a '/', treat it as a local path.
   packagePath = path.resolve(target);
   packageDirName = target.split('/').pop();
-  // Create a symbolic link to the package.
+  // Copy the package directory contents to the sibling package.
   var linkPath = path.join(basePath, 'packages', packageDirName);
   childProcess.execSync('cp -r ' + packagePath + ' ' + linkPath);
 
@@ -53,9 +52,3 @@ var jupyterlabPackage = require(jupyterlabPackagePath);
 jupyterlabPackage.dependencies[package.name] = '~'+String(package.version);
 jupyterlabPackage.jupyterlab.extensions.push(package.name);
 fs.writeFileSync(jupyterlabPackagePath, JSON.stringify(jupyterlabPackage, null, 2) + '\n');
-
-// Add the submodule to jupyterlab/package_list.txt
-var packageListPath = path.join(basePath, 'jupyterlab', 'package_list.txt');
-var packageList = fs.readFileSync(packageListPath);
-packageList = packageList + '    ~'+String(package.version)+'\n';
-fs.writeFileSync(packageListPath, packageList);

--- a/scripts/add-sibling.js
+++ b/scripts/add-sibling.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+var fs = require('fs');
+var path = require('path');
+var glob = require('glob');
+var childProcess = require('child_process');
+
+// Make sure we have required command line arguments.
+if (process.argv.length < 3) {
+    var msg = '** Must supply a target extension';
+    process.stderr.write(msg);
+    process.exit(1);
+}
+
+// Extract the desired git repository and repository name.
+var target = process.argv[2];
+var basePath = path.resolve('.');
+
+var packagePath = '';
+if (target[0] === '.' || target[0] === '/') {
+  // If the target starts with a '.' or a '/', treat it as a local path.
+  packagePath = path.resolve(target);
+  packageDirName = target.split('/').pop();
+  // Create a symbolic link to the package.
+  var linkPath = path.join(basePath, 'packages', packageDirName);
+  childProcess.execSync('cp -r ' + packagePath + ' ' + linkPath);
+
+} else { 
+  // Otherwise treat it as a git reposotory and try to add it.
+  var packageDirName = target.split('/').pop().split('.')[0];
+  var packagePath = path.join(basePath, 'packages', packageDirName);
+  // Add the repository as a submodule.
+  childProcess.execSync('git submodule add --force '+ target + ' ' + packagePath);
+}
+
+// Get the package.json of the submodule.
+var package = require(path.join(packagePath, 'package.json'));
+
+// Add the submodule to packages/all-packages/package.json
+var allPackagesPath = path.join(basePath, 'packages', 'all-packages', 'package.json');
+var allPackages = require(allPackagesPath);
+allPackages.dependencies[package.name] = '~'+String(package.version);
+fs.writeFileSync(allPackagesPath, JSON.stringify(allPackages, null, 2) + '\n');
+
+// Add the submodule to packages/all-packages/src/index.ts
+var indexPath = path.join(basePath, 'packages', 'all-packages', 'src', 'index.ts');
+var index = fs.readFileSync(indexPath);
+index = index + 'import "' + package.name + '";\n';
+fs.writeFileSync(indexPath, index);
+
+// Add the submodule to jupyterlab/package.json
+var jupyterlabPackagePath = path.join(basePath, 'jupyterlab', 'package.json');
+var jupyterlabPackage = require(jupyterlabPackagePath);
+jupyterlabPackage.dependencies[package.name] = '~'+String(package.version);
+jupyterlabPackage.jupyterlab.extensions.push(package.name);
+fs.writeFileSync(jupyterlabPackagePath, JSON.stringify(jupyterlabPackage, null, 2) + '\n');
+
+// Add the submodule to jupyterlab/package_list.txt
+var packageListPath = path.join(basePath, 'jupyterlab', 'package_list.txt');
+var packageList = fs.readFileSync(packageListPath);
+packageList = packageList + '    ~'+String(package.version)+'\n';
+fs.writeFileSync(packageListPath, packageList);

--- a/scripts/remove-sibling.js
+++ b/scripts/remove-sibling.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+/**
+ * Remove an extension from the relevant metadata
+ * files of the JupyterLab source tree so that it
+ * is not included in the build. Intended for testing
+ * adding/removing extensions against development
+ * branches of JupyterLab.
+ */
+
+var fs = require('fs');
+var path = require('path');
+var childProcess = require('child_process');
+
+// Make sure we have required command line arguments.
+if (process.argv.length < 3) {
+    var msg = '** Must supply a target extension name';
+    process.stderr.write(msg);
+    process.exit(1);
+}
+
+// Get the repository name.
+var target = process.argv[2];
+var basePath = path.resolve('.');
+
+// Get the package.json of the extension.
+var packagePath = path.join(basePath, 'packages', target);
+var package = require(path.join(packagePath, 'package.json'));
+
+// Remove the extension from packages/all-packages/package.json
+var allPackagesPath = path.join(basePath, 'packages', 'all-packages', 'package.json');
+var allPackages = require(allPackagesPath);
+allPackages.dependencies[package.name] = undefined;
+fs.writeFileSync(allPackagesPath, JSON.stringify(allPackages, null, 2) + '\n');
+
+// Remove the extension from packages/all-packages/src/index.ts
+var indexPath = path.join(basePath, 'packages', 'all-packages', 'src', 'index.ts');
+var index = fs.readFileSync(indexPath, 'utf8');
+var indexEntries = index.split('\n');
+var indexEntries = indexEntries.filter(function(e) {
+  return e.indexOf(package.name) === -1;
+});
+fs.writeFileSync(indexPath, indexEntries.join('\n'));
+
+// Remove the extension from jupyterlab/package.json
+var jupyterlabPackagePath = path.join(basePath, 'jupyterlab', 'package.json');
+var jupyterlabPackage = require(jupyterlabPackagePath);
+jupyterlabPackage.dependencies[package.name] = undefined;
+let extensions = jupyterlabPackage.jupyterlab.extensions.filter(function(e) {
+  return e.indexOf(package.name) === -1;
+});
+jupyterlabPackage.jupyterlab.extensions = extensions;
+fs.writeFileSync(jupyterlabPackagePath, JSON.stringify(jupyterlabPackage, null, 2) + '\n');

--- a/scripts/remove-sibling.js
+++ b/scripts/remove-sibling.js
@@ -6,6 +6,11 @@
  * is not included in the build. Intended for testing
  * adding/removing extensions against development
  * branches of JupyterLab.
+ *
+ * Note: this does not remove any files or submodules
+ * that may have been copied by the add-sibling.js
+ * script, and as such they are not true inverses of
+ * each other.
  */
 
 var fs = require('fs');


### PR DESCRIPTION
Quick and dirty script to add a sibling package to the lerna build. The intention is for testing extensions against jupyterlab master. You can either give a link to a remote github repository or a path to a local directory with a `package.json`.

This assumes a vaguely POSIX-y system, and is probably fairly brittle, but works with my testing.

cc @gnestor @jasongrout @fperez 