### PR TITLE
Use relative line-height for code font size

### DIFF
--- a/packages/theming/style/variables-light.css
+++ b/packages/theming/style/variables-light.css
@@ -95,7 +95,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
 
   --jp-code-font-size: 13px;
-  --jp-code-line-height: 17px;
+  --jp-code-line-height: 1.307;
   --jp-code-padding: 5px;
   --jp-code-font-family: monospace;
 


### PR DESCRIPTION
Setting the code font line-height in relative terms for users who have set a minimum font size in the browser so line-height scales with the font size.

For @fperez 