### PR TITLE
Prepare for new binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/jupyterlab/jupyterlab.svg)](https://greenkeeper.io/)
 
 [![Build Status](https://travis-ci.org/jupyterlab/jupyterlab.svg?branch=master)](https://travis-ci.org/jupyterlab/jupyterlab)
-[![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/jupyterlab/jupyterlab/lab)
 [![Documentation Status](https://readthedocs.org/projects/jupyterlab-tutorial/badge/?version=latest)](https://jupyterlab-tutorial.readthedocs.io/en/latest/?badge=latest)
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: jupyterlab
 channels:
-  - nodefaults
   - conda-forge
 dependencies:
   - jupyterlab


### PR DESCRIPTION
Remove link to old binder and update `environment.yml` for compatibility with the new JupyterHub based binder.