### PR TITLE
Collaborator hover

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -21,6 +21,14 @@ import {
 } from '@phosphor/signaling';
 
 import {
+  Widget
+} from '@phosphor/widgets';
+
+import {
+  HoverBox
+} from '@jupyterlab/apputils';
+
+import {
   CodeEditor
 } from '@jupyterlab/codeeditor';
 
@@ -544,11 +552,6 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       markers.forEach(marker => { marker.clear(); });
     }
     delete this.selectionMarkers[uuid];
-    const carets = this.caretMarkers[uuid];
-    if (carets) {
-      carets.forEach(caret => { document.body.removeChild(caret); });
-    }
-    delete this.caretMarkers[uuid];
   }
 
   /**
@@ -556,7 +559,6 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    */
   private _markSelections(uuid: string, selections: CodeEditor.ITextSelection[]) {
     const markers: CodeMirror.TextMarker[] = [];
-    const carets: HTMLElement[] = [];
 
     // If we can id the selection to a specific collaborator,
     // use that information.
@@ -574,13 +576,12 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
         const markerOptions = this._toTextMarkerOptions(selection.style);
         markers.push(this.doc.markText(anchor, head, markerOptions));
       } else {
-        let caret = this._getCaret(selection.end, collaborator);
-        document.body.appendChild(caret);
-        carets.push(caret);
+        let caret = this._getCaret(collaborator);
+        markers.push(this.doc.setBookmark(
+          this._toCodeMirrorPosition(selection.end), {widget: caret}));
       }
     });
     this.selectionMarkers[uuid] = markers;
-    this.caretMarkers[uuid] = carets;
   }
 
   /**
@@ -759,24 +760,42 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    * Construct a caret element representing the position
    * of a collaborator's cursor.
    */
-  private _getCaret(position: CodeEditor.IPosition, collaborator: ICollaborator): HTMLElement {
+  private _getCaret(collaborator: ICollaborator): HTMLElement {
     let name = collaborator ? collaborator.displayName : 'Anonymous';
     let color = collaborator ? collaborator.color : this._selectionStyle.color;
     let caret: HTMLElement = document.createElement('span');
-    caret.dataset.name = name; // Allows getting from :after element.
-    caret.className = `jp-CollaboratorCursor`;
-    caret.style.backgroundColor = color; // Allows inheritence in :after element.
+    caret.className = 'jp-CollaboratorCursor';
     caret.style.borderBottomColor = color;
-    let coordinates = this.getCoordinateForPosition(position);
-    caret.style.top = `${coordinates.bottom}px`;
-    caret.style.left = `${coordinates.left}px`;
+    caret.onmouseenter = () => {
+      if (this._caretHover) {
+        this._caretHover.dispose();
+      }
+      let hover = new Widget();
+      hover.addClass('jp-CollaboratorCursor-hover');
+      HoverBox.setGeometry({
+        anchor: caret.getBoundingClientRect(),
+        host: this.host,
+        maxHeight: 100,
+        minHeight: 0,
+        node: hover.node
+      });
+      hover.node.textContent = name;
+      hover.node.style.backgroundColor = color;
+      this._caretHover = hover;
+      Widget.attach(hover, document.body);
+    };
+    caret.onmouseleave = () => {
+      if (this._caretHover) {
+        this._caretHover.dispose();
+      }
+    };
     return caret;
   }
 
   private _model: CodeEditor.IModel;
   private _editor: CodeMirror.Editor;
   protected selectionMarkers: { [key: string]: CodeMirror.TextMarker[] | undefined } = {};
-  protected caretMarkers: { [key: string]: HTMLElement[] | undefined } = {};
+  private _caretHover: Widget = null;
   private _keydownHandlers = new Array<CodeEditor.KeydownHandler>();
   private _changeGuard = false;
   private _selectionStyle: CodeEditor.ISelectionStyle;

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -751,8 +751,9 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     let name = collaborator ? collaborator.displayName : 'Anonymous';
     let color = collaborator ? collaborator.color : this._selectionStyle.color;
     let caret: HTMLElement = document.createElement('span');
-    caret.dataset.name = name;
+    caret.dataset.name = name; // Allows getting from :after element.
     caret.className = `jp-CollaboratorCursor`;
+    caret.style.backgroundColor = color; // Allows inheritence in :after element.
     caret.style.borderBottomColor = color;
     return caret;
   }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -754,7 +754,6 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     caret.dataset.name = name;
     caret.className = `jp-CollaboratorCursor`;
     caret.style.borderBottomColor = color;
-    caret.appendChild(document.createTextNode('\u00a0'));
     return caret;
   }
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -570,6 +570,11 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   private _markSelections(uuid: string, selections: CodeEditor.ITextSelection[]) {
     const markers: CodeMirror.TextMarker[] = [];
 
+    // If we are marking selections corresponding to an active hover,
+    // remove it.
+    if (uuid === this._hoverId) {
+      this._clearHover();
+    }
     // If we can id the selection to a specific collaborator,
     // use that information.
     let collaborator: ICollaborator;

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -588,7 +588,15 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       // In that case, we don't need to render the cursor.
       if (!JSONExt.deepEqual(selection.start, selection.end)) {
         const { anchor, head } = this._toCodeMirrorSelection(selection);
-        const markerOptions = this._toTextMarkerOptions(selection.style);
+        let markerOptions: CodeMirror.TextMarkerOptions;
+        if (collaborator) {
+          markerOptions = this._toTextMarkerOptions({
+            ...selection.style,
+            color: collaborator.color
+          });
+        } else {
+          markerOptions = this._toTextMarkerOptions(selection.style);
+        }
         markers.push(this.doc.markText(anchor, head, markerOptions));
       } else {
         let caret = this._getCaret(collaborator);
@@ -633,7 +641,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
         let r = parseInt(style.color.slice(1,3), 16);
         let g  = parseInt(style.color.slice(3,5), 16);
         let b  = parseInt(style.color.slice(5,7), 16);
-        css = `background-color: rgba( ${r}, ${g}, ${b}, 0.1)`;
+        css = `background-color: rgba( ${r}, ${g}, ${b}, 0.15)`;
       }
       return {
         className: style.className,

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -71,6 +71,7 @@
   border-right: 5px solid transparent;
   border-top: none;
   border-bottom: 3px solid;
+  background-clip: content-box;
   margin-left: -5px;
   margin-right: -5px;
 }
@@ -80,7 +81,7 @@
   position: absolute;
   z-index: 1;
   transform: translateX(-50%) translateY(100%);
-  background-color: var(--jp-brand-color2);
+  background-color: inherit;
   color: white;
   border-radius: 3px;
   padding: 1px;

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -67,6 +67,7 @@
 }
 
 .jp-CollaboratorCursor {
+  position: absolute;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   border-top: none;
@@ -80,7 +81,7 @@
   content: attr(data-name);
   position: absolute;
   z-index: 1;
-  transform: translateX(-50%) translateY(100%);
+  transform: translateX(-50%) translateY(3px);
   background-color: inherit;
   color: white;
   border-radius: 3px;

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -75,6 +75,23 @@
   width: 0;
 }
 
+.jp-CollaboratorCursor:hover:after {
+  content: attr(data-name);
+  position: absolute;
+  bottom: -21px;
+  min-width: 30px;
+  height: var(--jp-code-line-height);
+  font-size: var(--jp-code-font-size);
+  background-color: var(--jp-brand-color2);
+  color: white;
+  border-radius: 3px;
+  padding: 1px;
+  text-align: center;
+  white-space: nowrap;
+  transform: translateX(-50%);
+}
+
+
 
 /*
   Here is our jupyter theme for CodeMirror syntax highlighting

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -67,7 +67,6 @@
 }
 
 .jp-CollaboratorCursor {
-  position: absolute;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   border-top: none;
@@ -77,12 +76,10 @@
   margin-right: -5px;
 }
 
-.jp-CollaboratorCursor:hover:after {
-  content: attr(data-name);
+.jp-CollaboratorCursor-hover {
   position: absolute;
   z-index: 1;
-  transform: translateX(-50%) translateY(3px);
-  background-color: inherit;
+  transform: translateX(-50%);
   color: white;
   border-radius: 3px;
   padding: 1px;

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -71,24 +71,21 @@
   border-right: 5px solid transparent;
   border-top: none;
   border-bottom: 3px solid;
-  position: absolute;
-  width: 0;
+  margin-left: -5px;
+  margin-right: -5px;
 }
 
 .jp-CollaboratorCursor:hover:after {
   content: attr(data-name);
   position: absolute;
-  bottom: -21px;
-  min-width: 30px;
-  height: var(--jp-code-line-height);
-  font-size: var(--jp-code-font-size);
+  z-index: 1;
+  transform: translateX(-50%) translateY(100%);
   background-color: var(--jp-brand-color2);
   color: white;
   border-radius: 3px;
   padding: 1px;
   text-align: center;
   white-space: nowrap;
-  transform: translateX(-50%);
 }
 
 


### PR DESCRIPTION
Adds a hover css selector for collaborator cursors that shows the name of the collaborator.
Example:
![hover](https://cloud.githubusercontent.com/assets/5728311/26659113/4fc3f1e4-4623-11e7-8b2d-f88d51d4f63b.png)
