### PR TITLE
Rename code mode to dev mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,15 +83,16 @@ version of `jupyterlab_launcher` is out of date. Run
 
 ### Run JupyterLab
 
-Start JupyterLab in Core Mode:
+Start JupyterLab in development mode:
 
 ```bash
-jupyter lab --core-mode
+jupyter lab --dev-mode
 ```
 
-Core mode ensures that you are running the core application.  When
-running from source, the page will have a red banner at the top to
-indicate it is an unreleased version.
+Development mode ensures that you are running the development/source version of the
+JupyterLab npm packages.  You can tell you are in development mode as the JupyterLab
+application will have a red stripe at the top of the page to indicate it is an
+unreleased version.
 
 ### Build and run the tests
 
@@ -182,9 +183,8 @@ and refresh the browser.
 
 ## Notes
 - By default, the application will load from the JupyterLab staging directory (default is `<sys-prefix>/share/jupyter/lab/build`.  If you wish to run
-the core application in `<git root>/jupyterlab/build`, 
-run `jupyter lab --core-mode`.  This is the core application that will
-be shipped.
+the development application in `<git root>/jupyterlab/build`, 
+run `jupyter lab --dev-mode`.
 
 - If working with extensions, see the extension documentation on
 https://jupyterlab-tutorial.readthedocs.io/en/latest/index.html.

--- a/docs/extensions_user.md
+++ b/docs/extensions_user.md
@@ -104,5 +104,5 @@ application.  The `staging` folder is used to create the build and then
 populate the `static` folder.
 
 Running `jupyter lab` will attempt to run the `static` assets in the 
-application folder if they exist.  You can run `jupyter lab --core-mode`
-to load the core JupyterLab application instead.
+application folder if they exist.  You can run `jupyter lab --dev-mode`
+to load the development JupyterLab application instead.

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -51,13 +51,13 @@ def load_jupyter_server_extension(nbapp):
     config.dev_mode = False
 
     # Check for core mode.
-    core_mode = ''
-    if hasattr(nbapp, 'core_mode'):
-        core_mode = nbapp.core_mode
+    dev_mode = ''
+    if hasattr(nbapp, 'dev_mode'):
+        dev_mode = nbapp.dev_mode
 
     # Check for an app dir that is local.
     if app_dir == here or app_dir == os.path.join(here, 'build'):
-        core_mode = True
+        dev_mode = True
         config.settings_dir = ''
 
     # Run core mode if explicit or there is no static dir and no
@@ -67,13 +67,13 @@ def load_jupyter_server_extension(nbapp):
 
     web_app.settings.setdefault('page_config_data', dict())
 
-    if not core_mode:
+    if not dev_mode:
         build_needed, msg = should_build(app_dir)
         if build_needed:
             nbapp.log.warn('Build required: %s' % msg)
             web_app.settings['page_config_data']['buildRequired'] = msg
 
-    if core_mode or fallback:
+    if dev_mode or fallback:
         config.assets_dir = os.path.join(here, 'build')
         if not os.path.exists(config.assets_dir):
             msg = 'Static assets not built, please see CONTRIBUTING.md'
@@ -84,7 +84,7 @@ def load_jupyter_server_extension(nbapp):
 
     if config.dev_mode:
         nbapp.log.info(DEV_NOTE_NPM)
-    elif core_mode or fallback:
+    elif dev_mode or fallback:
         nbapp.log.info(CORE_NOTE.strip())
 
     add_handlers(web_app, config)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -81,9 +81,9 @@ lab_aliases = dict(aliases)
 lab_aliases['app-dir'] = 'LabApp.app_dir'
 
 lab_flags = dict(flags)
-lab_flags['core-mode'] = (
-    {'LabApp': {'core_mode': True}},
-    "Start the app in core mode."
+lab_flags['dev-mode'] = (
+    {'LabApp': {'dev_mode': True}},
+    "Start the app in dev mode."
 )
 
 
@@ -96,7 +96,7 @@ class LabApp(NotebookApp):
     This launches a Tornado based HTML Server that serves up an
     HTML5/Javascript JupyterLab client.
 
-    If run in core mode (e.g. `jupyter lab --core-mode`), it will run
+    If run in development mode (e.g. `jupyter lab --dev-mode`), it will run
     the shipped JupyterLab application with no installed extensions.
 
     Otherwise, it will run using the assets in the JupyterLab app
@@ -124,8 +124,8 @@ class LabApp(NotebookApp):
     app_dir = Unicode('', config=True,
         help="The app directory to launch")
 
-    core_mode = Bool(False, config=True,
-        help="Whether to start the app in core mode")
+    dev_mode = Bool(False, config=True,
+        help="Whether to start the app in dev mode")
 
     def init_server_extensions(self):
         """Load any extensions specified by config.

--- a/jupyterlab/selenium_check.py
+++ b/jupyterlab/selenium_check.py
@@ -22,7 +22,7 @@ here = os.path.dirname(__file__)
 
 test_flags = dict(flags)
 test_flags['core-mode'] = (
-    {'TestApp': {'core_mode': True}},
+    {'TestApp': {'dev_mode': True}},
     "Start the app in core mode."
 )
 
@@ -39,7 +39,7 @@ class TestApp(NotebookApp):
     flags = test_flags
     aliases = test_aliases
 
-    core_mode = Bool(False, config=True,
+    dev_mode = Bool(False, config=True,
         help="Whether to start the app in core mode")
 
     app_dir = Unicode('', config=True,
@@ -48,7 +48,7 @@ class TestApp(NotebookApp):
     def start(self):
         self.io_loop = ioloop.IOLoop.current()
         config = LabConfig()
-        if self.core_mode:
+        if self.dev_mode:
             config.assets_dir = os.path.join(here, 'build')
         elif self.app_dir:
             config.assets_dir = os.path.join(self.app_dir, 'static')

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -65,7 +65,7 @@ fi
 if [[ $GROUP == cli ]]; then
     # Make sure we can successfully load the core app.
     pip install selenium
-    python -m jupyterlab.selenium_check --core-mode
+    python -m jupyterlab.selenium_check --dev-mode
 
     # Make sure we can build and run the app.
     jupyter lab build


### PR DESCRIPTION
A few of us were debugging jupyterlab build/install things and found that that the phrase "core mode" was confusing. This PR renames it back to "dev mode" in code and docs.

@blink1073 