### PR TITLE
Fix widget extensions.

### DIFF
--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -98,7 +98,7 @@ class DocumentWidgetManager implements IDisposable {
 
     // Handle widget extensions.
     let disposables = new DisposableSet();
-    each(this._registry.widgetExtensions(name), extender => {
+    each(this._registry.widgetExtensions(factory.name), extender => {
       disposables.add(extender.createNew(widget, context));
     });
     Private.disposablesProperty.set(widget, disposables);


### PR DESCRIPTION
This fixes an oversight in 4e159625a9b0614805991f0c44e9ccc91c779c0c, which prevented loading widget extensions.

CC @blink1073 