### PR TITLE
Add shell + SQL modes by default

### DIFF
--- a/packages/codemirror/src/mode.ts
+++ b/packages/codemirror/src/mode.ts
@@ -17,7 +17,8 @@ import 'codemirror/mode/julia/julia';
 import 'codemirror/mode/r/r';
 import 'codemirror/mode/markdown/markdown';
 import 'codemirror/mode/clike/clike';
-
+import 'codemirror/mode/shell/shell';
+import 'codemirror/mode/sql/sql';
 
 // Stub for the require function.
 declare var require: any;


### PR DESCRIPTION
Fairly commonly encountered when browsing around many repositories

Related to #2351. I *think* these two should be fairly uncontroversial