### PR TITLE
Fix layoutrestorer when there are multiple views of the same file

### DIFF
--- a/packages/apputils/src/layoutrestorer.ts
+++ b/packages/apputils/src/layoutrestorer.ts
@@ -251,7 +251,7 @@ class LayoutRestorer implements ILayoutRestorer {
     tracker.widgetAdded.connect((sender: any, widget: Widget) => {
       const widgetName = name(widget);
       if (widgetName) {
-        this.add(widget, widgetName);
+        this.add(widget, `${namespace}:${widgetName}`);
       }
     }, this);
 


### PR DESCRIPTION
Use the namespace of the tracker in the unique name.  

Fixes #2345.