### PR TITLE
Shortcuts UI/UX review

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -10,7 +10,7 @@ import {
 } from '@phosphor/coreutils';
 
 import {
-  Message, MessageLoop, IMessageHook, IMessageHandler, MessageHook
+  Message, MessageLoop, IMessageHandler
 } from '@phosphor/messaging';
 
 import {
@@ -72,7 +72,7 @@ class ApplicationShell extends Widget {
     let topPanel = this._topPanel = new Panel();
     let hboxPanel = this._hboxPanel = new BoxPanel();
     let dockPanel = this._dockPanel = new DockPanel();
-    MessageLoop.installMessageHook(dockPanel, Private.ActivityClassHook as MessageHook);
+    MessageLoop.installMessageHook(dockPanel, Private.activityClassHook);
 
     let hsplitPanel = this._hsplitPanel = new SplitPanel();
     let leftHandler = this._leftHandler = new Private.SideBarHandler('left');
@@ -964,18 +964,17 @@ namespace Private {
     private _stackedPanel: StackedPanel;
   }
 
+  /**
+   * A message hook that adds and removes the .jp-Activity class to widgets in the dock panel.
+   */
   export
-  class ActivityClassHook implements IMessageHook {
-
-    messageHook(handler: IMessageHandler, msg: Message): boolean {
-      
-      if (msg.type === 'child-added') {
-        (handler as Widget).addClass(ACTIVITY_CLASS)
-      } else if (msg.type === 'child-removed') {
-        (handler as Widget).removeClass(ACTIVITY_CLASS)
-      }
-      return true;
+  var activityClassHook = (handler: IMessageHandler, msg: Message): boolean => {      
+    if (msg.type === 'child-added') {
+      (msg as Widget.ChildMessage).child.addClass(ACTIVITY_CLASS)
+    } else if (msg.type === 'child-removed') {
+      (msg as Widget.ChildMessage).child.removeClass(ACTIVITY_CLASS)
     }
+    return true;
   }
 
 }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -10,7 +10,7 @@ import {
 } from '@phosphor/coreutils';
 
 import {
-  Message, MessageLoop
+  Message, MessageLoop, IMessageHook, IMessageHandler, MessageHook
 } from '@phosphor/messaging';
 
 import {
@@ -53,6 +53,8 @@ const DEFAULT_RANK = 500;
  */
 const MODE_ATTRIBUTE = 'data-shell-mode';
 
+const ACTIVITY_CLASS = 'jp-Activity';
+
 
 /**
  * The application shell for JupyterLab.
@@ -70,6 +72,8 @@ class ApplicationShell extends Widget {
     let topPanel = this._topPanel = new Panel();
     let hboxPanel = this._hboxPanel = new BoxPanel();
     let dockPanel = this._dockPanel = new DockPanel();
+    MessageLoop.installMessageHook(dockPanel, Private.ActivityClassHook as MessageHook);
+
     let hsplitPanel = this._hsplitPanel = new SplitPanel();
     let leftHandler = this._leftHandler = new Private.SideBarHandler('left');
     let rightHandler = this._rightHandler = new Private.SideBarHandler('right');
@@ -959,4 +963,20 @@ namespace Private {
     private _sideBar: TabBar<Widget>;
     private _stackedPanel: StackedPanel;
   }
+
+  export
+  class ActivityClassHook implements IMessageHook {
+
+    messageHook(handler: IMessageHandler, msg: Message): boolean {
+      
+      if (msg.type === 'child-added') {
+        (handler as Widget).addClass(ACTIVITY_CLASS)
+      } else if (msg.type === 'child-removed') {
+        (handler as Widget).removeClass(ACTIVITY_CLASS)
+      }
+      return true;
+    }
+  }
+
 }
+

--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -114,12 +114,12 @@ const SHORTCUTS = [
   },
   {
     command: 'file-operations:close',
-    selector: '.jp-Document',
+    selector: '.jp-Activity',
     keys: ['Ctrl Q']
   },
   {
     command: 'file-operations:close-all-files',
-    selector: '.jp-Document',
+    selector: 'body',
     keys: ['Ctrl Shift Q']
   },
   {


### PR DESCRIPTION
Right now the file commands close and close all work with any activity in the dock panel. However, their keyboard shortcuts of ctrl+Q and ctrl+shift+Q don't. This PR adds a message hook to the dock panel that adds and removes a new `.jp-Activity` CSS class to all widgets in the dock panel. It then scopes the selectors of the close and close all commands to that class or body.