### PR TITLE
Restore styling for cell drop targets.

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -151,6 +151,7 @@
 .jp-Notebook-cell.jp-mod-dropTarget,
 .jp-Notebook.jp-mod-commandMode .jp-Notebook-cell.jp-mod-active.jp-mod-selected.jp-mod-dropTarget {
   border-top-color: var(--jp-private-notebook-selected-color);
+  border-top-style: solid;
 }
 
 


### PR DESCRIPTION
The target class styling for cell drag-drop appears to have been broken by some of the recent notebook restylings. This fixes it.