### PR TITLE
handle surrogate pair offsets in cursor_pos

### DIFF
--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^0.6.0",
     "@jupyterlab/codeeditor": "^0.6.0",
+    "@jupyterlab/coreutils": "^0.6.0",
     "@jupyterlab/services": "^0.45.0",
     "@phosphor/algorithm": "^1.1.0",
     "@phosphor/coreutils": "^1.1.0",

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -14,6 +14,10 @@ import {
 } from '@phosphor/messaging';
 
 import {
+  Text
+} from '@jupyterlab/coreutils';
+
+import {
   IClientSession
 } from '@jupyterlab/apputils';
 
@@ -166,8 +170,9 @@ class CompletionHandler implements IDisposable {
     if (!editor) {
       return Promise.reject(new Error('No active editor'));
     }
-
-    let offset = editor.getOffsetAt(position);
+    
+    const code = editor.model.value.text;
+    const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), code);
     let content: KernelMessage.ICompleteRequest = {
       code: editor.model.value.text,
       cursor_pos: offset
@@ -256,7 +261,11 @@ class CompletionHandler implements IDisposable {
     model.setOptions(value.matches || []);
 
     // Update the cursor.
-    model.cursor = { start: value.cursor_start, end: value.cursor_end };
+    const text = state.text;
+    model.cursor = {
+      start: Text.charIndexToJsIndex(value.cursor_start, text),
+      end: Text.charIndexToJsIndex(value.cursor_end, text),
+    };
   }
 
   /**

--- a/packages/coreutils/src/index.ts
+++ b/packages/coreutils/src/index.ts
@@ -14,6 +14,7 @@ export * from './pageconfig';
 export * from './path';
 export * from './settingregistry';
 export * from './statedb';
+export * from './text';
 export * from './time';
 export * from './undoablelist';
 export * from './url';

--- a/packages/coreutils/src/text.ts
+++ b/packages/coreutils/src/text.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+/**
+ * The namespace for text-related functions.
+ */
+export
+namespace Text {
+
+  // javascript stores text as utf16 and string indices use "code units",
+  // which stores high-codepoint characters as "surrogate pairs",
+  // which occupy two indices in the javascript string.
+  // We need to translate cursor_pos in the Jupyter protocol (in characters)
+  // to js offset (with surrogate pairs taking two spots).
+
+  const HAS_SURROGATES: boolean = ('𝐚'.length > 1);
+
+  /**
+   * Convert a javascript string index into a unicode character offset
+   *
+   * @param jsIdx - The javascript string index (counting surrogate pairs)
+   *
+   * @param text - The text in which the offset is calculated
+   *
+   * @returns The unicode character offset
+   */
+  export
+  function jsIndexToCharIndex (jsIdx: number, text: string): number {
+    if (HAS_SURROGATES) {
+      // not using surrogates, nothing to do
+      return jsIdx;
+    }
+    var charIdx = jsIdx;
+    for (var i = 0; i + 1 < text.length && i < jsIdx; i++) {
+      var charCode = text.charCodeAt(i);
+      // check for surrogate pair
+      if (charCode >= 0xD800 && charCode <= 0xDBFF) {
+        var nextCharCode = text.charCodeAt(i+1);
+        if (nextCharCode >= 0xDC00 && nextCharCode <= 0xDFFF) {
+          charIdx--;
+          i++;
+        }
+      }
+    }
+    return charIdx;
+  }
+
+  /**
+   * Convert a unicode character offset to a javascript string index.
+   *
+   * @param charIdx - The index in unicode characters
+   *
+   * @param text - The text in which the offset is calculated
+   *
+   * @returns The js-native index
+   */
+  export
+  function charIndexToJsIndex (charIdx: number, text: string): number {
+    if (HAS_SURROGATES) {
+      // not using surrogates, nothing to do
+      return charIdx;
+    }
+    var jsIdx = charIdx;
+    for (var i = 0; i + 1 < text.length && i < jsIdx; i++) {
+      var charCode = text.charCodeAt(i);
+      // check for surrogate pair
+      if (charCode >= 0xD800 && charCode <= 0xDBFF) {
+        var nextCharCode = text.charCodeAt(i+1);
+        if (nextCharCode >= 0xDC00 && nextCharCode <= 0xDFFF) {
+          jsIdx++;
+          i++;
+        }
+      }
+    }
+    return jsIdx;
+  }
+}

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^0.6.0",
     "@jupyterlab/codeeditor": "^0.6.0",
+    "@jupyterlab/coreutils": "^0.6.0",
     "@jupyterlab/rendermime": "^0.6.0",
     "@jupyterlab/services": "^0.45.0",
     "@phosphor/coreutils": "^1.1.0",

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -10,6 +10,10 @@ import {
 } from '@phosphor/disposable';
 
 import {
+  Text
+} from '@jupyterlab/coreutils';
+
+import {
   ISignal, Signal
 } from '@phosphor/signaling';
 
@@ -143,7 +147,7 @@ class InspectionHandler implements IDisposable, IInspector.IInspectable {
     const editor = this.editor;
     const code = editor.model.value.text;
     const position = editor.getCursorPosition();
-    const offset = editor.getOffsetAt(position);
+    const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), code);
     let update: IInspector.IInspectorUpdate = { content: null, type: 'hints' };
 
     // Clear hints if the new text value is empty or kernel is unavailable.

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -27,7 +27,7 @@ namespace KernelMessage {
     return {
       header: {
         username: options.username || '',
-        version: '5.0',
+        version: '5.2',
         session: options.session,
         msg_id: options.msgId || uuid(),
         msg_type: options.msgType

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -15,6 +15,7 @@
     "@jupyterlab/application": "^0.6.0",
     "@jupyterlab/codeeditor": "^0.6.0",
     "@jupyterlab/console": "^0.6.0",
+    "@jupyterlab/coreutils": "^0.6.0",
     "@jupyterlab/notebook": "^0.6.0",
     "@jupyterlab/services": "^0.45.0",
     "@jupyterlab/tooltip": "^0.6.0",

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -14,6 +14,10 @@ import {
 } from '@phosphor/widgets';
 
 import {
+  Text
+} from '@jupyterlab/coreutils';
+
+import {
   JupyterLab, JupyterLabPlugin
 } from '@jupyterlab/application';
 
@@ -190,7 +194,7 @@ namespace Private {
     let { detail, editor, kernel } = options;
     let code = editor.model.value.text;
     let position = editor.getCursorPosition();
-    let offset = editor.getOffsetAt(position);
+    let offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), code);
 
     // Clear hints if the new text value is empty or kernel is unavailable.
     if (!code || !kernel) {


### PR DESCRIPTION
Jupyter protocol defines cursor_pos as unicode character offset. javascript implementations (today, at least) stores high-codepoint offsets as utf16 "surrogate pairs", counting as two slots in js string indices.

Adds coreutils.Text transforms back and forth between the two index calculations.

closes #2255

cf https://github.com/jupyter/jupyter_client/pull/262 for protocol spec 5.2 definition related to this

equivalent PR to jupyter/notebook: https://github.com/jupyter/notebook/pull/2560