### PR TITLE
default build/watch build the whole app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ version 4.2 or later is installed.
 When you make a change to JupyterLab npm package source files, run:
 
 ```bash
-npm run build:main
+npm run build
 ```
 
 to build the changes and then refresh your browser to see the changes.
@@ -185,7 +185,7 @@ to build the changes and then refresh your browser to see the changes.
 To have the system build after each source file change, run:
 
 ```bash
-npm run watch:main
+npm run watch
 ```
 
 and refresh the browser.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,14 +156,14 @@ npm install --save jupyterlab
 git clone https://github.com/jupyterlab/jupyterlab.git
 cd jupyterlab
 npm install
-npm run build
+npm run build:packages
 ```
 
 **Rebuild**
 
 ```bash
 npm run clean
-npm run build
+npm run build:packages
 ```
 
 ## The Jupyter Server Extension

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "private": true,
   "scripts": {
     "install": "lerna bootstrap --hoist",
-    "build": "cd packages/all-packages && npm run build",
+    "build:packages": "cd packages/all-packages && npm run build",
     "build:examples": "lerna run build --scope \"@jupyterlab/example-*\"",
-    "build:main": "npm run build && cd jupyterlab && npm run build",
+    "build": "npm run build:packages && cd jupyterlab && npm run build",
+    "build:main": "npm run build",
     "build:src": "lerna run build --scope \"@jupyterlab/!(test-|example-)*\"",
     "build:test": "lerna run build:test",
     "clean": "node scripts/clean-packages.js examples packages",
@@ -21,8 +22,9 @@
     "test:ie": "lerna run test:ie --concurrency 1 --stream",
     "publish": "npm update && npm install && npm run clean && npm run build && lerna publish -m \"Publish\"",
     "update:dependency": "node scripts/update-dependency.js",
+    "watch:packages": "watch \"npm run build:packages\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
     "watch": "watch \"npm run build\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
-    "watch:main": "watch \"npm run build:main\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
+    "watch:main": "npm run watch",
     "addsibling": "node scripts/add-sibling.js",
     "removesibling": "node scripts/remove-sibling.js"
   },


### PR DESCRIPTION
swaps (build, build:main) for (build:packages, build) so that the default build/watch commands build everything instead of just the lerna packages