### PR TITLE
Remove unused import

### DIFF
--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -6,7 +6,6 @@
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@jupyterlab/about-extension": "^0.5.0",
     "@jupyterlab/application": "^0.6.0",
     "@jupyterlab/application-extension": "^0.6.0",
     "@jupyterlab/apputils-extension": "^0.6.0",


### PR DESCRIPTION
This was causing old versions of `@jupyterlab/` to creep into the top level `node_modules`.