### PR TITLE
Add ability to enable and disable extensions

### DIFF
--- a/docs/extensions_user.md
+++ b/docs/extensions_user.md
@@ -46,7 +46,24 @@ jupyter labextension uninstall <bar>
 ```
 
 Where `<bar>` is the name of the extension, as printed in the extension
-list.
+list.  Core extensions can also be uninstalled this way (and can later be 
+re-installed).
+
+Extensions can be disabled by running the command:
+
+```
+jupyter labextension disable <foo>
+```
+
+Where `<foo>` is the name of the extension.  This will prevent the 
+extension from loading on the front end, but does not require a rebuild.
+The extension can be re-enabled using the command:
+
+```
+jupyter labextension enable <foo>
+```
+
+Core plugins can also be disabled (and then re-enabled).
 
 
 ## Advanced usage

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -328,6 +328,7 @@ def list_extensions(app_dir=None):
             continue
         app.append(key)
 
+    print('JupyterLab v%s' % __version__)
     print('Known labextensions:')
     if app:
         print('   app dir: %s' % app_dir)
@@ -360,7 +361,7 @@ def list_extensions(app_dir=None):
     uninstalled_core = _get_uinstalled_core_extensions(app_dir)
     if uninstalled_core:
         print('\nUninstalled core extensiosn:')
-        [print(item) for item in sorted(uninstalled_core)]
+        [print('    %s' % item) for item in sorted(uninstalled_core)]
 
     core_extensions = _get_core_extensions()
 
@@ -371,7 +372,7 @@ def list_extensions(app_dir=None):
 
     if disabled_core:
         print('\nDisabled core extensions:')
-        [print(item) for item in sorted(disabled_core)]
+        [print('    %s' % item) for item in sorted(disabled_core)]
 
 
 def clean(app_dir=None):

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -249,12 +249,14 @@ def _toggle_extension(extension, value, app_dir=None):
     if extension not in extensions and extension not in core_extensions:
         raise ValueError('Extension %s is not installed' % extension)
     disabled = config.get('disabledExtensions', [])
-    if extension in disabled:
+    if value and extension not in disabled:
+        disabled.append(extension)
+    if not value and extension in disabled:
         disabled.remove(extension)
 
     # Prune extensions that are not installed.
     disabled = [ext for ext in disabled
-                if (ext not in extensions and ext not in core_extensions)]
+                if (ext in extensions or ext in core_extensions)]
     config['disabledExtensions'] = disabled
     _write_page_config(config, app_dir)
 

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 import tarfile
 from jupyter_core.paths import ENV_JUPYTER_PATH
+from notebook.extensions import GREEN_ENABLED, RED_DISABLED
 
 from ._version import __version__
 
@@ -28,6 +29,7 @@ else:
 
 
 here = osp.dirname(osp.abspath(__file__))
+sys_path = pjoin(ENV_JUPYTER_PATH[0], 'lab', 'extensions')
 
 
 def get_app_dir(app_dir=None):
@@ -153,6 +155,18 @@ def unlink_package(package, app_dir=None):
     return True
 
 
+def enable_extension(extension, app_dir=None):
+    """Enable a JupyterLab extension.
+    """
+    _toggle_extension(extension, True, app_dir)
+
+
+def disable_extension(extension, app_dir=None):
+    """Disable a JupyterLab package.
+    """
+    _toggle_extension(extension, False, app_dir)
+
+
 def should_build(app_dir=None):
     """Determine whether JupyterLab should be built.
 
@@ -213,11 +227,50 @@ def _get_build_config(app_dir):
             return json.load(fid)
 
 
+def _get_page_config(app_dir):
+    """Get the page config data for the given app dir
+    """
+    target = pjoin(app_dir, 'settings', 'page_config.json')
+    if not os.path.exists(target):
+        return {}
+    else:
+        with open(target) as fid:
+            return json.load(fid)
+
+
+def _toggle_extension(extension, value, app_dir=None):
+    """Enable or disable a lab extension.
+    """
+    app_dir = get_app_dir(app_dir)
+    config = _get_page_config(app_dir)
+    extensions = _get_extensions(app_dir)
+    if extension not in extensions:
+        raise ValueError('Extension %s is not installed' % extension)
+    disabled = config.get('disabled_extensions', dict())
+    disabled[extension] = value
+
+    # Prune extensions that are not installed.
+    for key in list(disabled):
+        if (key not in extensions):
+            del disabled[key]
+    config['disabled_extensions'] = disabled
+    _write_page_config(config)
+
+
 def _write_build_config(config, app_dir):
     """Write the build config to the app dir.
     """
     _ensure_package(app_dir)
     target = pjoin(app_dir, 'settings', 'build_config.json')
+    with open(target, 'w') as fid:
+        json.dump(config, fid, indent=4)
+
+
+def _write_page_config(config, app_dir):
+    """Write the build config to the app dir.
+    """
+    _ensure_package(app_dir)
+    target = pjoin(app_dir, 'settings', 'page_config.json')
     with open(target, 'w') as fid:
         json.dump(config, fid, indent=4)
 
@@ -253,10 +306,70 @@ def uninstall_extension(name, app_dir=None):
 
 
 def list_extensions(app_dir=None):
-    """List installed extensions.
+    """List the extensions.
     """
     app_dir = get_app_dir(app_dir)
-    return sorted(_get_extensions(app_dir).keys())
+    extensions = _get_extensions(app_dir)
+    disabled = _get_disabled(app_dir)
+    linked = _get_linked_packages(app_dir)
+    app = []
+    sys = []
+    linked = []
+
+    # We want to organize by dir.
+    for (key, value) in extensions.items():
+        if key in linked:
+            linked.append(key)
+        if value['path'] == sys_path and sys_path != app_dir:
+            sys.append(key)
+            continue
+        app.append(key)
+
+    print('Known labextensions:')
+    if app:
+        print('   app dir: %s' % app_dir)
+        for item in sorted(app):
+            extra = ''
+            if item in linked:
+                extra += '*'
+            if disabled.get(item, False):
+                extra += ' %s' % RED_DISABLED
+            else:
+                extra += ' %s' % GREEN_ENABLED
+            print('        %s%s' % (item, extra))
+
+    if sys:
+        print('   sys dir: %s' % sys_path)
+        for item in sorted(sys):
+            extra = ''
+            if item in linked:
+                extra += '*'
+            if disabled.get(item, False):
+                extra += ' %s' % RED_DISABLED
+            else:
+                extra += ' %s' % GREEN_ENABLED
+            print('        %s%s' % (item, extra))
+
+    if linked:
+        print('* Denotes linked packages')
+
+    # Handle uninstalled and disabled core packages
+    uninstalled_core = _get_uinstalled_core_extensions(app_dir)
+    if uninstalled_core:
+        print('\nUninstalled core extensiosn:')
+        [print(item) for item in sorted(uninstalled_core)]
+
+    with open(pjoin(here, 'package.app.json')) as fid:
+        core_extensions = json.load(fid)['jupyterlab']['extensions']
+
+    disabled_core = []
+    for key in core_extensions:
+        if disabled.get(key, False):
+            disabled_core.append(key)
+
+    if disabled_core:
+        print('\nDisabled core extensions:')
+        [print(item) for item in sorted(disabled_core)]
 
 
 def clean(app_dir=None):
@@ -343,8 +456,7 @@ def _ensure_package(app_dir, name=None, version=None):
         data['dependencies'][key] = value['path']
         data['jupyterlab']['extensions'].append(key)
 
-    config = _get_build_config(app_dir)
-    for item in config.get('uninstalled_core_extensions', []):
+    for item in _get_uinstalled_core_extensions(app_dir):
         data['jupyterlab']['extensions'].remove(item)
 
     data['jupyterlab']['name'] = name or 'JupyterLab'
@@ -368,6 +480,13 @@ def _is_extension(data):
     return data['jupyterlab'].get('extension', False)
 
 
+def _get_uinstalled_core_extensions(app_dir):
+    """Get the uninstalled core extensions.
+    """
+    config = _get_build_config(app_dir)
+    return config.get('uninstalled_core_extensions', [])
+
+
 def _validate_package(data, extension):
     """Validate package.json data.
     """
@@ -376,18 +495,25 @@ def _validate_package(data, extension):
         raise ValueError(msg)
 
 
+def _get_disabled(app_dir):
+    """Get the disabled extensions.
+    """
+    config = _get_page_config(app_dir)
+    return config.get('disabled_extensions', dict())
+
+
 def _get_extensions(app_dir):
     """Get the extensions in a given app dir.
     """
     extensions = dict()
 
-    # Look in sys_prefix and app_dir if different
-    sys_path = pjoin(ENV_JUPYTER_PATH[0], 'lab', 'extensions')
+    # Get system level packages
     for target in glob.glob(pjoin(sys_path, '*.tgz')):
         data = _read_package(target)
         extensions[data['name']] = dict(path=os.path.realpath(target),
                                         version=data['version'])
 
+    # Look in app_dir if different
     app_path = pjoin(app_dir, 'extensions')
     if app_path == sys_path or not os.path.exists(app_path):
         return extensions

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -248,13 +248,13 @@ def _toggle_extension(extension, value, app_dir=None):
 
     if extension not in extensions and extension not in core_extensions:
         raise ValueError('Extension %s is not installed' % extension)
-    disabled = config.get('disabled_extensions', dict())
-    disabled[extension] = value
+    disabled = config.get('disabled_extensions', [])
+    if extension in disabled:
+        disabled.remove(extension)
 
     # Prune extensions that are not installed.
-    for key in list(disabled):
-        if (key not in extensions and key not in core_extensions):
-            del disabled[key]
+    disabled = [ext for ext in disabled
+                if (ext not in extensions and ext not in core_extensions)]
     config['disabled_extensions'] = disabled
     _write_page_config(config, app_dir)
 
@@ -335,7 +335,7 @@ def list_extensions(app_dir=None):
             extra = ''
             if item in linked:
                 extra += '*'
-            if disabled.get(item, False):
+            if item in disabled:
                 extra += ' %s' % RED_DISABLED
             else:
                 extra += ' %s' % GREEN_ENABLED
@@ -347,7 +347,7 @@ def list_extensions(app_dir=None):
             extra = ''
             if item in linked:
                 extra += '*'
-            if disabled.get(item, False):
+            if item in disabled:
                 extra += ' %s' % RED_DISABLED
             else:
                 extra += ' %s' % GREEN_ENABLED
@@ -366,7 +366,7 @@ def list_extensions(app_dir=None):
 
     disabled_core = []
     for key in core_extensions:
-        if disabled.get(key, False):
+        if key in disabled:
             disabled_core.append(key)
 
     if disabled_core:
@@ -501,7 +501,7 @@ def _get_disabled(app_dir):
     """Get the disabled extensions.
     """
     config = _get_page_config(app_dir)
-    return config.get('disabled_extensions', dict())
+    return config.get('disabled_extensions', [])
 
 
 def _get_core_extensions():

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -3,6 +3,7 @@
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+from __future__ import print_function
 from distutils.version import LooseVersion
 import errno
 import json

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -29,7 +29,6 @@ else:
 
 
 here = osp.dirname(osp.abspath(__file__))
-sys_path = pjoin(ENV_JUPYTER_PATH[0], 'lab', 'extensions')
 
 
 def get_app_dir(app_dir=None):
@@ -319,6 +318,7 @@ def list_extensions(app_dir=None):
     linked = []
 
     # We want to organize by dir.
+    sys_path = pjoin(get_app_dir(), 'extensions')
     for (key, value) in extensions.items():
         if key in linked:
             linked.append(key)
@@ -516,6 +516,7 @@ def _get_extensions(app_dir):
     extensions = dict()
 
     # Get system level packages
+    sys_path = pjoin(get_app_dir(), 'extensions')
     for target in glob.glob(pjoin(sys_path, '*.tgz')):
         data = _read_package(target)
         extensions[data['name']] = dict(path=os.path.realpath(target),

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -248,14 +248,14 @@ def _toggle_extension(extension, value, app_dir=None):
 
     if extension not in extensions and extension not in core_extensions:
         raise ValueError('Extension %s is not installed' % extension)
-    disabled = config.get('disabled_extensions', [])
+    disabled = config.get('disabledExtensions', [])
     if extension in disabled:
         disabled.remove(extension)
 
     # Prune extensions that are not installed.
     disabled = [ext for ext in disabled
                 if (ext not in extensions and ext not in core_extensions)]
-    config['disabled_extensions'] = disabled
+    config['disabledExtensions'] = disabled
     _write_page_config(config, app_dir)
 
 
@@ -502,7 +502,7 @@ def _get_disabled(app_dir):
     """Get the disabled extensions.
     """
     config = _get_page_config(app_dir)
-    return config.get('disabled_extensions', [])
+    return config.get('disabledExtensions', [])
 
 
 def _get_core_extensions():

--- a/jupyterlab/index.app.js
+++ b/jupyterlab/index.app.js
@@ -21,7 +21,7 @@ function main() {
     if (version[0] === 'v') {
         version = version.slice(1);
     }
-    var disabled = Object.create(null);
+    var disabled = [];
     try {
         var option = PageConfig.getOption('disabledExtensions');
         disabled = JSON.parse(option);

--- a/jupyterlab/index.app.js
+++ b/jupyterlab/index.app.js
@@ -21,6 +21,13 @@ function main() {
     if (version[0] === 'v') {
         version = version.slice(1);
     }
+    var disabled = Object.create(null);
+    try {
+        var option = PageConfig.getOption('disabledExtensions');
+        disabled = JSON.parse(option);
+    } catch (e) {
+        // No-op
+    }
 
     lab = new app({
         namespace: namespace,
@@ -32,7 +39,9 @@ function main() {
     });
     {{#each jupyterlab_extensions}}
     try {
-        lab.registerPluginModule(require('{{this}}'));
+        if (disabled.indexOf('{{this}}') === -1) {
+            lab.registerPluginModule(require('{{this}}'));
+        }
     } catch (e) {
         console.error(e);
     }
@@ -42,7 +51,7 @@ function main() {
         var option = PageConfig.getOption('ignorePlugins');
         ignorePlugins = JSON.parse(option);
     } catch (e) {
-        console.error("Invalid ignorePlugins config:", option);
+        // No-op
     }
     lab.start({ "ignorePlugins": ignorePlugins });
 }

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -39,7 +39,7 @@ function main() {
     });
     {{#each jupyterlab_extensions}}
     try {
-        if (String(disabled['{{this}}']).toLowerCase() !== 'true') {
+        if (disabled.indexOf('{{this}}') === -1) {
             lab.registerPluginModule(require('{{this}}'));
         }
     } catch (e) {

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -21,6 +21,13 @@ function main() {
     if (version[0] === 'v') {
         version = version.slice(1);
     }
+    var disabled = Object.create(null);
+    try {
+        var option = PageConfig.getOption('disabledExtensions');
+        disabled = JSON.parse(option);
+    } catch (e) {
+        // No-op
+    }
 
     lab = new app({
         namespace: namespace,
@@ -32,7 +39,9 @@ function main() {
     });
     {{#each jupyterlab_extensions}}
     try {
-        lab.registerPluginModule(require('{{this}}'));
+        if (String(disabled['{{this}}']) !== 'true') {
+            lab.registerPluginModule(require('{{this}}'));
+        }
     } catch (e) {
         console.error(e);
     }
@@ -42,7 +51,7 @@ function main() {
         var option = PageConfig.getOption('ignorePlugins');
         ignorePlugins = JSON.parse(option);
     } catch (e) {
-        console.error("Invalid ignorePlugins config:", option);
+        // No-op
     }
     lab.start({ "ignorePlugins": ignorePlugins });
 }

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -21,7 +21,7 @@ function main() {
     if (version[0] === 'v') {
         version = version.slice(1);
     }
-    var disabled = Object.create(null);
+    var disabled = [];
     try {
         var option = PageConfig.getOption('disabledExtensions');
         disabled = JSON.parse(option);

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -39,7 +39,7 @@ function main() {
     });
     {{#each jupyterlab_extensions}}
     try {
-        if (String(disabled['{{this}}']) !== 'true') {
+        if (String(disabled['{{this}}']).toLowerCase() !== 'true') {
             lab.registerPluginModule(require('{{this}}'));
         }
     } catch (e) {

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -90,6 +90,7 @@ lab_flags['dev-mode'] = (
     "Start the app in dev mode for running from source."
 )
 
+
 class LabApp(NotebookApp):
     version = __version__
 

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -15,7 +15,7 @@ from traitlets import Bool, Unicode
 from ._version import __version__
 from .commands import (
     install_extension, uninstall_extension, list_extensions,
-    enable_extension, disable_extension,    
+    enable_extension, disable_extension,
     link_package, unlink_package, build, _get_linked_packages
 )
 

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -15,6 +15,7 @@ from traitlets import Bool, Unicode
 from ._version import __version__
 from .commands import (
     install_extension, uninstall_extension, list_extensions,
+    enable_extension, disable_extension,    
     link_package, unlink_package, build, _get_linked_packages
 )
 
@@ -37,12 +38,13 @@ class BaseExtensionApp(JupyterApp):
     app_dir = Unicode('', config=True,
         help="The app directory to target")
 
-    should_build = Bool(True, config=True,
+    should_build = Bool(False, config=True,
         help="Whether to build the app after the action")
 
 
 class InstallLabExtensionApp(BaseExtensionApp):
     description = "Install labextension(s)"
+    should_build = True
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
@@ -60,6 +62,7 @@ class LinkLabExtensionApp(BaseExtensionApp):
     package is manually re-installed from its source location when
     `jupyter lab build` is run.
     """
+    should_build = True
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
@@ -70,6 +73,7 @@ class LinkLabExtensionApp(BaseExtensionApp):
 
 class UnlinkLabExtensionApp(BaseExtensionApp):
     description = "Unlink labextension(s) or packages by name or path"
+    should_build = True
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
@@ -81,6 +85,7 @@ class UnlinkLabExtensionApp(BaseExtensionApp):
 
 class UninstallLabExtensionApp(BaseExtensionApp):
     description = "Uninstall labextension(s) by name"
+    should_build = True
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
@@ -92,19 +97,31 @@ class UninstallLabExtensionApp(BaseExtensionApp):
 
 class ListLabExtensionsApp(BaseExtensionApp):
     description = "List the installed labextensions"
-    should_build = False
 
     def start(self):
-        [print(ext) for ext in list_extensions(self.app_dir)]
+        list_extensions(self.app_dir)
 
 
 class ListLinkedLabExtensionsApp(BaseExtensionApp):
     description = "List the linked packages"
-    should_build = False
 
     def start(self):
         for path in _get_linked_packages(self.app_dir).values():
             print(path)
+
+
+class EnableLabExtensionsApp(BaseExtensionApp):
+    description = "Enable labextension(s) by name"
+
+    def start(self):
+        [enable_extension(arg, self.app_dir) for arg in self.extra_args]
+
+
+class DisableLabExtensionsApp(BaseExtensionApp):
+    description = "Disable labextension(s) by name"
+
+    def start(self):
+        [disable_extension(arg, self.app_dir) for arg in self.extra_args]
 
 
 _examples = """
@@ -127,7 +144,9 @@ class LabExtensionApp(JupyterApp):
         list=(ListLabExtensionsApp, "List labextensions"),
         link=(LinkLabExtensionApp, "Link labextension(s)"),
         unlink=(UnlinkLabExtensionApp, "Unlink labextension(s)"),
-        listlinked=(ListLinkedLabExtensionsApp, "List linked extensions")
+        listlinked=(ListLinkedLabExtensionsApp, "List linked extensions"),
+        enable=(EnableLabExtensionsApp, "Enable labextension(s)"),
+        disable=(DisableLabExtensionsApp, "Disable labextensions(s)")
     )
 
     def start(self):

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -27,8 +27,8 @@ from jupyterlab.extension import (
 )
 from jupyterlab.commands import (
     install_extension, uninstall_extension, list_extensions,
-    build, link_package, unlink_package, get_app_dir, should_build,
-    disable_extension, enable_extension,
+    build, link_package, unlink_package, should_build,
+    disable_extension, enable_extension, _get_extensions,
     _get_linked_packages, _ensure_package, _get_disabled
 )
 
@@ -104,15 +104,18 @@ class TestExtension(TestCase):
         self.assertEqual(commands.ENV_JUPYTER_PATH, [self.data_dir])
         self.assertEqual(commands.get_app_dir(), os.path.realpath(pjoin(self.data_dir, 'lab')))
 
+        self.app_dir = commands.get_app_dir()
+        print('****', self.app_dir)
+
     def tearDown(self):
         for modulename in self._mock_extensions:
             sys.modules.pop(modulename)
 
     def test_install_extension(self):
         install_extension(self.source_dir)
-        path = pjoin(get_app_dir(), 'extensions', '*python-tests*.tgz')
+        path = pjoin(self.app_dir, 'extensions', '*python-tests*.tgz')
         assert glob.glob(path)
-        assert '@jupyterlab/python-tests' in list_extensions()
+        assert '@jupyterlab/python-tests' in _get_extensions(self.app_dir)
 
     def test_install_failed(self):
         path = os.path.realpath(pjoin(here, '..'))
@@ -120,18 +123,18 @@ class TestExtension(TestCase):
             install_extension(path)
         with open(pjoin(path, 'package.json')) as fid:
             data = json.load(fid)
-        assert not data['name'] in list_extensions()
+        assert not data['name'] in _get_extensions(self.app_dir)
 
     def test_uninstall_extension(self):
         install_extension(self.source_dir)
         uninstall_extension('@jupyterlab/python-tests')
-        path = pjoin(get_app_dir(), 'extensions', '*python_tests*.tgz')
+        path = pjoin(self.app_dir, 'extensions', '*python_tests*.tgz')
         assert not glob.glob(path)
-        assert '@jupyterlab/python-tests' not in list_extensions()
+        assert '@jupyterlab/python-tests' not in _get_extensions(self.app_dir)
 
     def test_uninstall_core_extension(self):
         uninstall_extension('@jupyterlab/console-extension')
-        app_dir = get_app_dir()
+        app_dir = self.app_dir
         _ensure_package(app_dir)
         with open(pjoin(app_dir, 'staging', 'package.json')) as fid:
             data = json.load(fid)
@@ -142,7 +145,7 @@ class TestExtension(TestCase):
         link_package(self.source_dir)
         linked = _get_linked_packages().keys()
         assert '@jupyterlab/python-tests' in linked
-        assert '@jupyterlab/python-tests' in list_extensions()
+        assert '@jupyterlab/python-tests' in _get_extensions(self.app_dir)
 
     def test_link_package(self):
         path = os.path.realpath(pjoin(here, '..'))
@@ -151,7 +154,7 @@ class TestExtension(TestCase):
         with open(pjoin(path, 'package.json')) as fid:
             data = json.load(fid)
         assert data['name'] in linked
-        assert not data['name'] in list_extensions()
+        assert not data['name'] in _get_extensions(self.app_dir)
         unlink_package(path)
         linked = _get_linked_packages().keys()
         assert not data['name'] in linked
@@ -162,7 +165,7 @@ class TestExtension(TestCase):
         unlink_package(target)
         linked = _get_linked_packages().keys()
         assert '@jupyterlab/python-tests' not in linked
-        assert '@jupyterlab/python-tests' not in list_extensions()
+        assert '@jupyterlab/python-tests' not in _get_extensions(self.app_dir)
 
     def test_list_extensions(self):
         install_extension(self.source_dir)
@@ -174,12 +177,12 @@ class TestExtension(TestCase):
         install_extension(self.source_dir, app_dir)
         path = pjoin(app_dir, 'extensions', '*python-tests*.tgz')
         assert glob.glob(path)
-        assert '@jupyterlab/python-tests' in list_extensions(app_dir)
+        assert '@jupyterlab/python-tests' in _get_extensions(app_dir)
 
         uninstall_extension('@jupyterlab/python-tests', app_dir)
         path = pjoin(app_dir, 'extensions', '*python-tests*.tgz')
         assert not glob.glob(path)
-        assert '@jupyterlab/python-tests' not in list_extensions(app_dir)
+        assert '@jupyterlab/python-tests' not in _get_extensions(app_dir)
 
         link_package(self.source_dir, app_dir)
         linked = _get_linked_packages(app_dir).keys()
@@ -191,17 +194,17 @@ class TestExtension(TestCase):
 
     def test_app_dir_use_sys_prefix(self):
         app_dir = self.tempdir()
-        if os.path.exists(get_app_dir()):
-            os.removedirs(get_app_dir())
+        if os.path.exists(self.app_dir):
+            os.removedirs(self.app_dir)
 
         install_extension(self.source_dir)
         path = pjoin(app_dir, 'extensions', '*python-tests*.tgz')
         assert not glob.glob(path)
-        assert '@jupyterlab/python-tests' in list_extensions(app_dir)
+        assert '@jupyterlab/python-tests' in _get_extensions(app_dir)
 
     def test_app_dir_shadowing(self):
         app_dir = self.tempdir()
-        sys_dir = get_app_dir()
+        sys_dir = self.app_dir
         if os.path.exists(sys_dir):
             os.removedirs(sys_dir)
 
@@ -210,33 +213,33 @@ class TestExtension(TestCase):
         assert glob.glob(sys_path)
         app_path = pjoin(app_dir, 'extensions', '*python-tests*.tgz')
         assert not glob.glob(app_path)
-        assert '@jupyterlab/python-tests' in list_extensions(app_dir)
+        assert '@jupyterlab/python-tests' in _get_extensions(app_dir)
 
         install_extension(self.source_dir, app_dir)
         assert glob.glob(app_path)
-        assert '@jupyterlab/python-tests' in list_extensions(app_dir)
+        assert '@jupyterlab/python-tests' in _get_extensions(app_dir)
 
         uninstall_extension('@jupyterlab/python-tests', app_dir)
         assert not glob.glob(app_path)
         assert glob.glob(sys_path)
-        assert '@jupyterlab/python-tests' in list_extensions(app_dir)
+        assert '@jupyterlab/python-tests' in _get_extensions(app_dir)
 
         uninstall_extension('@jupyterlab/python-tests', app_dir)
         assert not glob.glob(app_path)
         assert not glob.glob(sys_path)
-        assert '@jupyterlab/python-tests' not in list_extensions(app_dir)
+        assert '@jupyterlab/python-tests' not in _get_extensions(app_dir)
 
     def test_build(self):
         install_extension(self.source_dir)
         build()
         # check staging directory.
-        entry = pjoin(get_app_dir(), 'staging', 'build', 'index.out.js')
+        entry = pjoin(self.app_dir, 'staging', 'build', 'index.out.js')
         with open(entry) as fid:
             data = fid.read()
         assert '@jupyterlab/python-tests' in data
 
         # check static directory.
-        entry = pjoin(get_app_dir(), 'static', 'index.out.js')
+        entry = pjoin(self.app_dir, 'static', 'index.out.js')
         with open(entry) as fid:
             data = fid.read()
         assert '@jupyterlab/python-tests' in data

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -257,10 +257,10 @@ class TestExtension(TestCase):
         install_extension(self.source_dir, app_dir)
         disable_extension('@jupyterlab/python-tests', app_dir)
         disabled = _get_disabled(app_dir)
-        assert disabled['@jupyterlab/python-tests']
+        assert '@jupyterlab/python-tests' in disabled
         disable_extension('@jupyterlab/notebook-extension', app_dir)
         disabled = _get_disabled(app_dir)
-        assert disabled['@jupyterlab/notebook-extension']
+        assert '@jupyterlab/notebook-extension' in disabled
 
     def test_enable_extension(self):
         app_dir = self.tempdir()
@@ -268,7 +268,7 @@ class TestExtension(TestCase):
         disable_extension('@jupyterlab/python-tests', app_dir)
         enable_extension('@jupyterlab/python-tests', app_dir)
         disabled = _get_disabled(app_dir)
-        assert not disabled['@jupyterlab/python-tests']
+        assert '@jupyterlab/python-tests' not in disabled
 
     def test_should_build(self):
         assert not should_build()[0]

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -105,7 +105,6 @@ class TestExtension(TestCase):
         self.assertEqual(commands.get_app_dir(), os.path.realpath(pjoin(self.data_dir, 'lab')))
 
         self.app_dir = commands.get_app_dir()
-        print('****', self.app_dir)
 
     def tearDown(self):
         for modulename in self._mock_extensions:

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -28,7 +28,8 @@ from jupyterlab.extension import (
 from jupyterlab.commands import (
     install_extension, uninstall_extension, list_extensions,
     build, link_package, unlink_package, get_app_dir, should_build,
-    _get_linked_packages, _ensure_package
+    disable_extension, enable_extension,
+    _get_linked_packages, _ensure_package, _get_disabled
 )
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -165,8 +166,7 @@ class TestExtension(TestCase):
 
     def test_list_extensions(self):
         install_extension(self.source_dir)
-        extensions = list_extensions()
-        assert '@jupyterlab/python-tests' in extensions
+        list_extensions()
 
     def test_app_dir(self):
         app_dir = self.tempdir()
@@ -248,6 +248,24 @@ class TestExtension(TestCase):
         app.initialize()
         sys.stderr = stderr
         load_jupyter_server_extension(app)
+
+    def test_disable_extension(self):
+        app_dir = self.tempdir()
+        install_extension(self.source_dir, app_dir)
+        disable_extension('@jupyterlab/python-tests', app_dir)
+        disabled = _get_disabled(app_dir)
+        assert disabled['@jupyterlab/python-tests']
+        disable_extension('@jupyterlab/notebook-extension', app_dir)
+        disabled = _get_disabled(app_dir)
+        assert disabled['@jupyterlab/notebook-extension']
+
+    def test_enable_extension(self):
+        app_dir = self.tempdir()
+        install_extension(self.source_dir, app_dir)
+        disable_extension('@jupyterlab/python-tests', app_dir)
+        enable_extension('@jupyterlab/python-tests', app_dir)
+        disabled = _get_disabled(app_dir)
+        assert not disabled['@jupyterlab/python-tests']
 
     def test_should_build(self):
         assert not should_build()[0]

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -79,10 +79,15 @@ if [[ $GROUP == cli ]]; then
     jupyter labextension link jupyterlab/tests/mockextension --no-build
     jupyter labextension unlink jupyterlab/tests/mockextension --no-build
     jupyter labextension link jupyterlab/tests/mockextension --no-build
+    jupyter labextension listlinked
     jupyter labextension unlink  @jupyterlab/python-tests --no-build
     jupyter labextension install jupyterlab/tests/mockextension  --no-build
     jupyter labextension list
-    jupyter labextension uninstall @jupyterlab/python-tests
+    jupyter labextension disable @jupyterlab/python-tests
+    jupyter labextension enable @jupyterlab/python-tests
+    jupyter labextension disable @jupyterlab/notebook-extension
+    jupyter labextension uninstall @jupyterlab/python-tests --no-build
+    jupyter labextension uninstall @jupyterlab/notebook-extension --no-build
 
     # Make sure we can call help on all the cli apps.
     jupyter lab -h 
@@ -94,4 +99,7 @@ if [[ $GROUP == cli ]]; then
     jupyter labextension install -h 
     jupyter labextension uninstall -h 
     jupyter labextension list -h
+    jupyter labextension listlinked -h
+    jupyter labextension enable -h
+    jupyter labextension disable -h
 fi


### PR DESCRIPTION
Fixes #2358  and #1192.

Also adds a more verbose output which includes uninstalled and disabled core extensions.

```
$ jupyter labextension list
JupyterLab v0.23.2
Known labextensions:
   app dir: /Users/ssilvester/anaconda/share/jupyter/lab
        jupyterlab-hub  enabled

Disabled core extensions:
    @jupyterlab/help-extension
```