### PR TITLE
Clean up CodeMirror Option handling

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -301,7 +301,7 @@ class Cell extends Widget {
       return;
     }
     // Handle read only state.
-    this.editor.readOnly = this._readOnly;
+    this.editor.setOption('readOnly', this._readOnly);
     this.toggleClass(READONLY_CLASS, this._readOnly);
   }
 
@@ -480,7 +480,7 @@ class CodeCell extends Cell {
     let model = this.model;
 
     // Code cells should not wrap lines.
-    this.editor.wordWrap = false;
+    this.editor.setOption('wordWrap', false);
 
     // Insert the output before the cell footer.
     let outputWrapper = this._outputWrapper = new Panel();
@@ -670,7 +670,7 @@ class MarkdownCell extends Cell {
     super(options);
     this.addClass(MARKDOWN_CELL_CLASS);
     this._rendermime = options.rendermime;
-    this.editor.wordWrap = true;
+    this.editor.setOption('wordWrap', true);
 
     // Throttle the rendering rate of the widget.
     this._monitor = new ActivityMonitor({

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -480,7 +480,7 @@ class CodeCell extends Cell {
     let model = this.model;
 
     // Code cells should not wrap lines.
-    this.editor.setOption('wordWrap', false);
+    this.editor.setOption('lineWrap', false);
 
     // Insert the output before the cell footer.
     let outputWrapper = this._outputWrapper = new Panel();
@@ -670,7 +670,6 @@ class MarkdownCell extends Cell {
     super(options);
     this.addClass(MARKDOWN_CELL_CLASS);
     this._rendermime = options.rendermime;
-    this.editor.setOption('wordWrap', true);
 
     // Throttle the rendering rate of the widget.
     this._monitor = new ActivityMonitor({

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -583,7 +583,7 @@ namespace CodeEditor {
    */
   export
   let defaultConfig: IConfig = {
-    lineNumbers: true,
+    lineNumbers: false,
     wordWrap: true,
     readOnly: false,
     tabSize: 4,

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -395,12 +395,12 @@ namespace CodeEditor {
     /**
      * Get a config option for the editor.
      */
-    setOption(option: keyof IConfig): void;
+    getOption<K extends keyof IConfig>(option: K): IConfig[K];
 
     /**
      * Set a config option for the editor.
      */
-    setOption(option: keyof IConfig, value: ): void;
+    setOption<K extends keyof IConfig>(option: K, value: IConfig[K]): void;
 
     /**
      * Returns the content for the given line number.
@@ -583,7 +583,7 @@ namespace CodeEditor {
    */
   export
   let defaultConfig: IConfig = {
-    lineNumbers: true
+    lineNumbers: true,
     wordWrap: true,
     readOnly: false,
     tabSize: 4,

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -367,21 +367,6 @@ namespace CodeEditor {
     selectionStyle: CodeEditor.ISelectionStyle;
 
     /**
-     * Whether line numbers should be displayed. Defaults to false.
-     */
-    lineNumbers: boolean;
-
-    /**
-     * Set to false for horizontal scrolling. Defaults to true.
-     */
-    wordWrap: boolean;
-
-    /**
-     * Whether the editor is read-only.  Defaults to false.
-     */
-    readOnly: boolean;
-
-    /**
      * The DOM node that hosts the editor.
      */
     readonly host: HTMLElement;
@@ -406,6 +391,16 @@ namespace CodeEditor {
      * Get the number of lines in the eidtor.
      */
     readonly lineCount: number;
+
+    /**
+     * Get a config option for the editor.
+     */
+    setOption(option: keyof IConfig): void;
+
+    /**
+     * Set a config option for the editor.
+     */
+    setOption(option: keyof IConfig, value: ): void;
 
     /**
      * Returns the content for the given line number.
@@ -472,7 +467,7 @@ namespace CodeEditor {
 
     /**
      * Repaint the editor.
-     * 
+     *
      * #### Notes
      * A repainted editor should fit to its host node.
      */
@@ -543,6 +538,61 @@ namespace CodeEditor {
   type Factory = (options: IOptions) => CodeEditor.IEditor;
 
   /**
+   * The configuration options for an editor.
+   */
+  export
+  interface IConfig {
+    /**
+     * Whether line numbers should be displayed.
+     */
+    lineNumbers: boolean;
+
+    /**
+     * Set to false for horizontal scrolling.
+     */
+    wordWrap: boolean;
+
+    /**
+     * Whether the editor is read-only.
+     */
+    readOnly: boolean;
+
+    /**
+     * The number of spaces a tab is equal to.
+     */
+    tabSize: number;
+
+    /**
+     * Whether to insert spaces when pressing Tab.
+     */
+    insertSpaces: boolean;
+
+    /**
+     * Whether to highlight matching brackets when one of them is selected.
+     */
+    matchBrackets: boolean;
+
+    /**
+     * Whether to automatically close brackets after opening them.
+     */
+    autoClosingBrackets: boolean;
+  }
+
+  /**
+   * The default configuration options for an editor.
+   */
+  export
+  let defaultConfig: IConfig = {
+    lineNumbers: true
+    wordWrap: true,
+    readOnly: false,
+    tabSize: 4,
+    insertSpaces: true,
+    matchBrackets: true,
+    autoClosingBrackets: true
+  };
+
+  /**
    * The options used to initialize an editor.
    */
   export
@@ -563,24 +613,14 @@ namespace CodeEditor {
     uuid?: string;
 
     /**
-     * Whether line numbers should be displayed. Defaults to `false`.
+     * The default selection style for the editor.
      */
-    lineNumbers?: boolean;
-
-    /**
-     * Set to false for horizontal scrolling. Defaults to `true`.
-     */
-    wordWrap?: boolean;
-
-    /**
-     * Whether the editor is read-only. Defaults to `false`.
-     */
-    readOnly?: boolean;
-
-   /**
-    * The default selection style for the editor.
-    */
     selectionStyle?: CodeEditor.ISelectionStyle;
+
+    /**
+     * The configuration options for the editor.
+     */
+    config?: Partial<IConfig>;
   }
 
   export

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -550,7 +550,7 @@ namespace CodeEditor {
     /**
      * Set to false for horizontal scrolling.
      */
-    wordWrap: boolean;
+    lineWrap: boolean;
 
     /**
      * Whether the editor is read-only.
@@ -584,7 +584,7 @@ namespace CodeEditor {
   export
   let defaultConfig: IConfig = {
     lineNumbers: false,
-    wordWrap: true,
+    lineWrap: true,
     readOnly: false,
     tabSize: 4,
     insertSpaces: true,

--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -94,7 +94,7 @@ class JSONEditor extends Widget {
     model.value.changed.connect(this._onValueChanged, this);
     this.model = model;
     this.editor = options.editorFactory({ host, model });
-    this.editor.readOnly = true;
+    this.editor.setOption('readOnly', true);
     this.collapsible = !!options.collapsible;
   }
 
@@ -179,7 +179,7 @@ class JSONEditor extends Widget {
       this._source.changed.disconnect(this._onSourceChanged, this);
     }
     this._source = value;
-    this.editor.readOnly = !value;
+    this.editor.setOption('readOnly', !this.editor.getOption('readOnly'));
     if (value) {
       value.changed.connect(this._onSourceChanged, this);
     }

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -34,8 +34,7 @@ class CodeEditorWrapper extends Widget {
       host: this.node,
       model: options.model,
       uuid: options.uuid,
-      wordWrap: options.wordWrap,
-      readOnly: options.readOnly,
+      config: options.config,
       selectionStyle: options.selectionStyle
     });
     editor.model.selections.changed.connect(this._onSelectionsChanged, this);
@@ -149,19 +148,9 @@ namespace CodeEditorWrapper {
     uuid?: string;
 
     /**
-     * Whether line numbers should be displayed. Defaults to `false`.
+     * The configuration options for the editor.
      */
-    lineNumbers?: boolean;
-
-    /**
-     * Set to false for horizontal scrolling. Defaults to `true`.
-     */
-    wordWrap?: boolean;
-
-    /**
-     * Whether the editor is read-only. Defaults to `false`.
-     */
-    readOnly?: boolean;
+    config?: Partial<CodeEditor.IConfig>;
 
    /**
     * The default selection style for the editor.

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -244,14 +244,16 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
       });
     });
 
-    let args: JSONObject = { tabs: true, size: 4, name: 'Indent with Tab' };
+    let args: JSONObject = {
+      insertSpaces: false, size: 4, name: 'Indent with Tab'
+    };
     let command = 'editor:change-tabs';
     tabMenu.addItem({ command, args });
     palette.addItem({ command, args, category: 'Editor' });
 
     for (let size of [1, 2, 4, 8]) {
       let args: JSONObject = {
-        tabs: false, size, name: `Spaces: ${size} `
+        insertSpaces: true, size, name: `Spaces: ${size} `
       };
       tabMenu.addItem({ command, args });
       palette.addItem({ command, args, category: 'Editor' });
@@ -261,7 +263,7 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
     menu.addItem({ type: 'submenu', submenu: tabMenu });
     menu.addItem({ type: 'separator' });
     menu.addItem({ command: 'editor:line-numbers' });
-    menu.addItem({ command: 'editor:word-wrap' });
+    menu.addItem({ command: 'editor:line-wrap' });
     menu.addItem({ command: 'editor:match-brackets' });
     menu.addItem({ command: 'editor:autoclosing-brackets' });
     menu.addItem({ type: 'submenu', submenu: keyMapMenu });

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -91,9 +91,7 @@ export default plugins;
 function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMenu: IMainMenu, palette: ICommandPalette, state: IStateDB, settingRegistry: ISettingRegistry): void {
   const { commands, restored } = app;
   const { id } = commandsPlugin;
-  let theme: string = CodeMirrorEditor.DEFAULT_THEME;
-  let keyMap: string = 'default';
-  let matchBrackets = false;
+  let { theme, keyMap, matchBrackets } = CodeMirrorEditor.defaultConfig;
 
   // Annotate the plugin settings.
   settingRegistry.annotate(id, '', {
@@ -184,7 +182,7 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
     commands.addCommand(CommandIDs.changeTheme, {
       label: args => args['theme'] as string,
       execute: args => {
-        theme = args['theme'] as string || CodeMirrorEditor.DEFAULT_THEME;
+        theme = args['theme'] as string || theme;
         tracker.forEach(widget => {
           if (widget.editor instanceof CodeMirrorEditor) {
             let cm = widget.editor.editor;
@@ -203,7 +201,7 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
         return title === 'sublime' ? 'Sublime Text' : title;
       },
       execute: args => {
-        keyMap = args['keyMap'] as string || 'default';
+        keyMap = args['keyMap'] as string || keyMap;
         tracker.forEach(widget => {
           if (widget.editor instanceof CodeMirrorEditor) {
             let cm = widget.editor.editor;
@@ -251,8 +249,8 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
         let editor = widget.editor as CodeMirrorEditor;
         let size = args['size'] as number || 4;
         let tabs = !!args['tabs'];
-        editor.editor.setOption('indentWithTabs', tabs);
-        editor.editor.setOption('indentUnit', size);
+        editor.setOption('insertSpaces', !tabs);
+        editor.setOption('tabSize', size);
       },
       isEnabled: hasWidget,
       isToggled: args => {
@@ -263,10 +261,10 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
         let tabs = !!args['tabs'];
         let size = args['size'] as number || 4;
         let editor = widget.editor as CodeMirrorEditor;
-        if (editor.editor.getOption('indentWithTabs') !== tabs) {
+        if (editor.getOption('insertSpaces') === tabs) {
           return false;
         }
-        return editor.editor.getOption('indentUnit') === size;
+        return editor.getOption('tabSize') === size;
       }
     });
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1103,36 +1103,22 @@ namespace Private {
    */
   export
   function handleOptions(options: CodeMirrorEditor.IOptions): CodeMirror.EditorConfiguration {
-    return {
+    let config = {
+      ...options,
       readOnly: options.readOnly !== undefined ? options.readOnly : false,
       lineNumbers: options.lineNumbers !== undefined ? options.lineNumbers : false,
       lineWrapping: options.wordWrap !== undefined ? options.wordWrap : true,
-      mode: options.mode,
-      theme: options.theme || CodeMirrorEditor.DEFAULT_THEME,
-      indentUnit: options.indentUnit,
-      smartIndent: options.smartIndent,
-      tabSize: options.tabSize,
-      indentWithTabs: options.indentWithTabs,
-      electricChars: options.electricChars,
-      rtlMoveVisually: options.rtlMoveVisually,
-      keyMap: options.keyMap,
-      extraKeys: options.extraKeys,
-      firstLineNumber: options.firstLineNumber,
-      gutters: options.gutters,
-      showCursorWhenSelecting: options.showCursorWhenSelecting,
-      undoDepth: options.undoDepth,
-      historyEventDelay: options.historyEventDelay,
-      tabindex: options.tabindex,
-      autofocus: options.autofocus,
-      dragDrop: options.dragDrop,
-      cursorHeight: options.cursorHeight,
-      workTime: options.workTime,
-      workDelay: options.workDelay,
-      pollInterval: options.pollInterval,
-      flattenSpans: options.flattenSpans,
-      maxHighlightLength: options.maxHighlightLength,
-      viewportMargin: options.viewportMargin
-    };
+      theme: options.theme || CodeMirrorEditor.DEFAULT_THEME
+    } as CodeMirror.EditorConfiguration;
+
+    // Remove extra keys.
+    for (let key of ['host', 'model', 'uuid', 'wordWrap', 'selectionStyle']) {
+      if (config.hasOwnProperty(key)) {
+        delete (config as any)[key];
+      }
+    }
+
+    return config;
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1088,7 +1088,7 @@ namespace Private {
       editor.setOption('indentWithTabs', !value);
       break;
     case 'autoClosingBrackets':
-      editor.setOption('autoCloseBrackets', !value);
+      editor.setOption('autoCloseBrackets', value);
       break;
     case 'readOnly':
       let el = editor.getWrapperElement();

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -84,7 +84,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   /**
    * Construct a CodeMirror editor.
    */
-  constructor(options: CodeEditor.IOptions, config: CodeMirror.EditorConfiguration={}) {
+  constructor(options: CodeMirrorEditor.IOptions) {
     let host = this.host = options.host;
     host.classList.add(EDITOR_CLASS);
     host.addEventListener('focus', this, true);
@@ -93,7 +93,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     this._uuid = options.uuid || uuid();
     this._selectionStyle = options.selectionStyle || {};
 
-    Private.updateConfig(options, config);
+    let config = Private.handleOptions(options);
 
     let model = this._model = options.model;
     let editor = this._editor = CodeMirror(host, config);
@@ -871,6 +871,210 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
 export
 namespace CodeMirrorEditor {
   /**
+   * The options used to initialize a code mirror editor.
+   */
+  export
+  interface IOptions extends CodeEditor.IOptions {
+    /**
+     * The mode to use. When not given, this will default to the first mode
+     * that was loaded.
+     */
+    mode?: string | Mode.ISpec;
+
+    /**
+     * The theme to style the editor with.
+     * You must make sure the CSS file defining the corresponding
+     * .cm-s-[name] styles is loaded.
+     * The default is "jupyter".
+     */
+    theme?: string;
+
+    /**
+     * How many spaces a block (whatever that means in the edited language)
+     * should be indented. The default is 2.
+     */
+    indentUnit?: number;
+
+    /**
+     * Whether to use the context-sensitive indentation that the mode provides
+     * (or just indent the same as the line before). Defaults to true.
+     */
+    smartIndent?: boolean;
+
+    /**
+     * The width of a tab character. Defaults to 4.
+     */
+    tabSize?: number;
+
+    /**
+     * Whether, when indenting, the first N*tabSize spaces should be replaced
+     * by N tabs. Default is false.
+     */
+    indentWithTabs?: boolean;
+
+    /**
+     * Configures whether the editor should re-indent the current line when a
+     * character is typed that might change its proper indentation
+     * (only works if the mode supports indentation). Default is true.
+     */
+    electricChars?: boolean;
+
+    /**
+     * Determines whether horizontal cursor movement through right-to-left
+     * (Arabic, Hebrew) text is visual (pressing the left arrow moves the
+     * cursor left)
+     * or logical (pressing the left arrow moves to the next lower index in
+     * the string, which is visually right in right-to-left text).
+     * The default is false on Windows, and true on other platforms.
+     */
+    rtlMoveVisually?: boolean;
+
+    /**
+     * Configures the keymap to use. The default is "default", which is the
+     * only keymap defined in codemirror.js itself.
+     * Extra keymaps are found in the CodeMirror keymap directory.
+     */
+    keyMap?: string;
+
+    /**
+     * Can be used to specify extra keybindings for the editor, alongside the
+     * ones defined by keyMap. Should be either null, or a valid keymap value.
+     */
+    extraKeys?: any;
+
+    /**
+     * At which number to start counting lines. Default is 1.
+     */
+    firstLineNumber?: number;
+
+    /**
+     * Can be used to add extra gutters (beyond or instead of the line number
+     * gutter).
+     * Should be an array of CSS class names, each of which defines a width
+     * (and optionally a background),
+     * and which will be used to draw the background of the gutters.
+     * May include the CodeMirror-linenumbers class, in order to explicitly
+     * set the position of the line number gutter
+     * (it will default to be to the right of all other gutters).
+     * These class names are the keys passed to setGutterMarker.
+     */
+    gutters?: string[];
+
+    /**
+     * Determines whether the gutter scrolls along with the content
+     * horizontally (false)
+     * or whether it stays fixed during horizontal scrolling (true,
+     * the default).
+     */
+    fixedGutter?: boolean;
+
+    /**
+     * Whether the cursor should be drawn when a selection is active.
+     * Defaults to false.
+     */
+    showCursorWhenSelecting?: boolean;
+
+    /**
+     * The maximum number of undo levels that the editor stores.
+     * Defaults to 40.
+     */
+    undoDepth?: number;
+
+    /**
+     * The period of inactivity (in milliseconds) that will cause a new
+     * history event to be started when typing or deleting. Defaults to 500.
+     */
+    historyEventDelay?: number;
+
+    /**
+     * The tab index to assign to the editor. If not given, no tab index will
+     * be assigned.
+     */
+    tabindex?: number;
+
+    /**
+     * Can be used to make CodeMirror focus itself on initialization.
+     * Defaults to off.
+     */
+    autofocus?: boolean;
+
+    /**
+     * Controls whether drag-and - drop is enabled. On by default.
+     */
+    dragDrop?: boolean;
+
+    /**
+     * Half - period in milliseconds used for cursor blinking.
+     * The default blink rate is 530ms.
+     */
+    cursorBlinkRate?: number;
+
+    /**
+     * Determines the height of the cursor. Default is 1, meaning it spans
+     * the whole height of the line.
+     * For some fonts (and by some tastes) a smaller height (for example 0.85),
+     * which causes the cursor to not reach all the way to the bottom of the
+     * line, looks better
+     */
+    cursorHeight?: number;
+
+    /**
+     * Highlighting is done by a pseudo background - thread that will work for
+     * workTime milliseconds,
+     * and then use timeout to sleep for workDelay milliseconds.
+     * The defaults are 200 and 300, you can change these options to make the
+     * highlighting more or less aggressive.
+     */
+    workTime?: number;
+
+    /**
+     * See workTime.
+     */
+    workDelay?: number;
+
+    /**
+     * Indicates how quickly CodeMirror should poll its input textarea for
+     * changes(when focused).
+     * Most input is captured by events, but some things, like IME input on
+     * some browsers, don't generate events that allow CodeMirror to properly
+     * detect it.
+     * Thus, it polls. Default is 100 milliseconds.
+     */
+    pollInterval?: number;
+
+    /**
+     * By default, CodeMirror will combine adjacent tokens into a single span
+     * if they have the same class.
+     * This will result in a simpler DOM tree, and thus perform better. With
+     * some kinds of styling(such as rounded corners),
+     * this will change the way the document looks. You can set this option to
+     * false to disable this behavior.
+     */
+    flattenSpans?: boolean;
+
+    /**
+     * When highlighting long lines, in order to stay responsive, the editor
+     * will give up and simply style
+     * the rest of the line as plain text when it reaches a certain position.
+     * The default is 10000.
+     * You can set this to Infinity to turn off this behavior.
+     */
+    maxHighlightLength?: number;
+
+    /**
+     * Specifies the amount of lines that are rendered above and below the
+     * part of the document that's currently scrolled into view.
+     * This affects the amount of updates needed when scrolling, and the
+     * amount of work that such an update does.
+     * You should usually leave it at its default, 10. Can be set to Infinity
+     * to make sure the whole document is always rendered,
+     * and thus the browser's text search works on it. This will have bad
+     * effects on performance of big documents.
+     */
+    viewportMargin?: number;
+  }
+
+  /**
    * The name of the default CodeMirror theme
    */
   export
@@ -898,24 +1102,37 @@ namespace Private {
    * Handle extra codemirror config from codeeditor options.
    */
   export
-  function updateConfig(options: CodeEditor.IOptions, config: CodeMirror.EditorConfiguration): void {
-    if (options.readOnly !== undefined) {
-      config.readOnly = options.readOnly;
-    } else {
-      config.readOnly = false;
-    }
-    if (options.lineNumbers !== undefined) {
-      config.lineNumbers = options.lineNumbers;
-    } else {
-      config.lineNumbers = false;
-    }
-    if (options.wordWrap !== undefined) {
-      config.lineWrapping = options.wordWrap;
-    } else {
-      config.lineWrapping = true;
-    }
-    config.theme = (config.theme || CodeMirrorEditor.DEFAULT_THEME);
-    config.indentUnit = config.indentUnit || 4;
+  function handleOptions(options: CodeMirrorEditor.IOptions): CodeMirror.EditorConfiguration {
+    return {
+      readOnly: options.readOnly !== undefined ? options.readOnly : false,
+      lineNumbers: options.lineNumbers !== undefined ? options.lineNumbers : false,
+      lineWrapping: options.wordWrap !== undefined ? options.wordWrap : true,
+      mode: options.mode,
+      theme: options.theme || CodeMirrorEditor.DEFAULT_THEME,
+      indentUnit: options.indentUnit,
+      smartIndent: options.smartIndent,
+      tabSize: options.tabSize,
+      indentWithTabs: options.indentWithTabs,
+      electricChars: options.electricChars,
+      rtlMoveVisually: options.rtlMoveVisually,
+      keyMap: options.keyMap,
+      extraKeys: options.extraKeys,
+      firstLineNumber: options.firstLineNumber,
+      gutters: options.gutters,
+      showCursorWhenSelecting: options.showCursorWhenSelecting,
+      undoDepth: options.undoDepth,
+      historyEventDelay: options.historyEventDelay,
+      tabindex: options.tabindex,
+      autofocus: options.autofocus,
+      dragDrop: options.dragDrop,
+      cursorHeight: options.cursorHeight,
+      workTime: options.workTime,
+      workDelay: options.workDelay,
+      pollInterval: options.pollInterval,
+      flattenSpans: options.flattenSpans,
+      maxHighlightLength: options.maxHighlightLength,
+      viewportMargin: options.viewportMargin
+    };
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -197,42 +197,6 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   }
 
   /**
-   * Control the rendering of line numbers.
-   */
-  get lineNumbers(): boolean {
-    return this._editor.getOption('lineNumbers');
-  }
-  set lineNumbers(value: boolean) {
-    this._editor.setOption('lineNumbers', value);
-  }
-
-  /**
-   * Set to false for horizontal scrolling. Defaults to true.
-   */
-  get wordWrap(): boolean {
-    return this._editor.getOption('lineWrapping');
-  }
-  set wordWrap(value: boolean) {
-    this._editor.setOption('lineWrapping', value);
-  }
-
-  /**
-   * Should the editor be read only.
-   */
-  get readOnly(): boolean {
-    return this._editor.getOption('readOnly') !== false;
-  }
-  set readOnly(readOnly: boolean) {
-    this._editor.setOption('readOnly', readOnly);
-    if (readOnly) {
-      this.host.classList.add(READ_ONLY_CLASS);
-    } else {
-      this.host.classList.remove(READ_ONLY_CLASS);
-      this.blur();
-    }
-  }
-
-  /**
    * Returns a model for this editor.
    */
   get model(): CodeEditor.IModel {
@@ -1125,6 +1089,16 @@ namespace Private {
       break;
     case 'autoClosingBrackets':
       editor.setOption('autoCloseBrackets', !value);
+      break;
+    case 'readOnly':
+      let el = editor.getWrapperElement();
+      if (value) {
+        el.classList.add(READ_ONLY_CLASS);
+      } else {
+        el.classList.remove(READ_ONLY_CLASS);
+        editor.getInputField().blur();
+      }
+      editor.setOption(option, value);
       break;
     default:
       editor.setOption(option, value);

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -934,7 +934,7 @@ namespace CodeMirrorEditor {
      * option is set to true, it will be covered by an element with class
      * CodeMirror-gutter-filler.
      */
-    coverGutterNextToScrollbar: boolean;
+    coverGutterNextToScrollbar?: boolean;
 
     /**
      * Explicitly set the line separator for the editor.
@@ -944,7 +944,7 @@ namespace CodeMirrorEditor {
      * only be split on that string, and output will, by default, use that
      * same separator.
      */
-    lineSeparator: string;
+    lineSeparator?: string;
 
     /**
      * Chooses a scrollbar implementation. The default is "native", showing
@@ -952,13 +952,13 @@ namespace CodeMirrorEditor {
      * which completely hides the scrollbars. Addons can implement additional
      * scrollbar models.
      */
-    scrollbarStyle: string;
+    scrollbarStyle?: string;
 
     /**
      * When enabled, which is the default, doing copy or cut when there is no
      * selection will copy or cut the whole lines that have cursors on them.
      */
-    lineWiseCopyCut: boolean;
+    lineWiseCopyCut?: boolean;
   }
 
   /**
@@ -969,8 +969,8 @@ namespace CodeMirrorEditor {
     ...CodeEditor.defaultConfig,
     mode: 'null',
     theme: 'jupyter',
-    smartIndent: true,
-    electricChars: true,
+    smartIndent: false,
+    electricChars: false,
     keyMap: 'default',
     extraKeys: null,
     gutters: Object.freeze([]),
@@ -1060,10 +1060,12 @@ namespace Private {
   export
   function getOption<K extends keyof CodeMirrorEditor.IConfig>(editor: CodeMirror.Editor, option: K): CodeMirrorEditor.IConfig[K] {
     switch (option) {
-    case 'wordWrap':
+    case 'lineWrap':
       return editor.getOption('lineWrapping');
     case 'insertSpaces':
       return !editor.getOption('indentWithTabs');
+    case 'tabSize':
+      return editor.getOption('indentUnit');
     case 'autoClosingBrackets':
       return editor.getOption('autoCloseBrackets');
     default:
@@ -1077,12 +1079,11 @@ namespace Private {
   export
   function setOption<K extends keyof CodeMirrorEditor.IConfig>(editor: CodeMirror.Editor, option: K, value: CodeMirrorEditor.IConfig[K]): void {
     switch (option) {
-    case 'wordWrap':
+    case 'lineWrap':
       editor.setOption('lineWrapping', value);
       break;
     case 'tabSize':
-      editor.setOption('indentSize', value);
-      editor.setOption('tabSize', value);
+      editor.setOption('indentUnit', value);
       break;
     case 'insertSpaces':
       editor.setOption('indentWithTabs', !value);

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import * as CodeMirror
-  from 'codemirror';
-
 import {
   CodeEditor, IEditorFactoryService
 } from '@jupyterlab/codeeditor';
@@ -18,11 +15,10 @@ import {
  */
 export
 class CodeMirrorEditorFactory implements IEditorFactoryService {
-
   /**
    * Construct an IEditorFactoryService for CodeMirrorEditors.
    */
-  constructor(codeMirrorOptions?: CodeMirror.EditorConfiguration) {
+  constructor(defaults: Partial<CodeMirrorEditor.IOptions> = {}) {
     this.inlineCodeMirrorOptions = {
       extraKeys: {
         'Cmd-Right': 'goLineRight',
@@ -34,7 +30,8 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Ctrl-Alt-[': 'indentAuto',
         'Cmd-/': 'toggleComment',
         'Ctrl-/': 'toggleComment',
-      }
+      },
+      ...defaults
     };
     this.documentCodeMirrorOptions = {
       extraKeys: {
@@ -42,48 +39,26 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Shift-Enter': () => { /* no-op */ }
       },
       lineNumbers: true,
-      lineWrapping: true
+      lineWrapping: true,
+      ...defaults
     };
-    if (codeMirrorOptions !== undefined) {
-      // Note: If codeMirrorOptions include `extraKeys`,
-      // existing option will be overwritten.
-      Private.assign(this.inlineCodeMirrorOptions, codeMirrorOptions);
-      Private.assign(this.documentCodeMirrorOptions, codeMirrorOptions);
-    }
   }
 
   /**
    * Create a new editor for inline code.
    */
   newInlineEditor(options: CodeEditor.IOptions): CodeEditor.IEditor {
-    return new CodeMirrorEditor(options, this.inlineCodeMirrorOptions);
+    return new CodeMirrorEditor({...this.inlineCodeMirrorOptions, ...options});
   }
 
   /**
    * Create a new editor for a full document.
    */
   newDocumentEditor(options: CodeEditor.IOptions): CodeEditor.IEditor {
-    return new CodeMirrorEditor(options, this.documentCodeMirrorOptions);
+    return new CodeMirrorEditor({...this.documentCodeMirrorOptions, ...options});
   }
 
-  protected inlineCodeMirrorOptions: CodeMirror.EditorConfiguration;
-  protected documentCodeMirrorOptions: CodeMirror.EditorConfiguration;
+  protected inlineCodeMirrorOptions: Partial<CodeMirrorEditor.IOptions>;
+  protected documentCodeMirrorOptions: Partial<CodeMirrorEditor.IOptions>;
 
-}
-
-
-namespace Private {
-  // Replace with Object.assign when available.
-  export
-  function assign<T>(target: T, ...configs: any[]): T {
-    for (const source of configs) {
-      if (source) {
-        Object.keys(source).forEach(key => {
-          (target as any)[key] = (source as any)[key];
-        });
-      }
-    }
-
-    return target;
-  }
 }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -32,7 +32,6 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Cmd-/': 'toggleComment',
         'Ctrl-/': 'toggleComment',
       },
-      lineNumbers: false,
       ...defaults
     };
     this.documentCodeMirrorOptions = {
@@ -41,6 +40,7 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Tab': 'indentMore',
         'Shift-Enter': () => { /* no-op */ }
       },
+      lineNumbers: true,
       ...defaults
     };
   }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -19,7 +19,7 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
    * Construct an IEditorFactoryService for CodeMirrorEditors.
    */
   constructor(defaults: Partial<CodeMirrorEditor.IConfig> = {}) {
-    this.inlineCodeMirrorOptions = {
+    this.inlineCodeMirrorConfig = {
       ...CodeMirrorEditor.defaultConfig,
       extraKeys: {
         'Cmd-Right': 'goLineRight',
@@ -34,7 +34,7 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
       },
       ...defaults
     };
-    this.documentCodeMirrorOptions = {
+    this.documentCodeMirrorConfig = {
       ...CodeMirrorEditor.defaultConfig,
       extraKeys: {
         'Tab': 'indentMore',
@@ -49,17 +49,23 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
    * Create a new editor for inline code.
    */
   newInlineEditor(options: CodeEditor.IOptions): CodeEditor.IEditor {
-    return new CodeMirrorEditor({...this.inlineCodeMirrorOptions, ...options});
+    return new CodeMirrorEditor({
+      ...options,
+      config: { ...this.inlineCodeMirrorConfig, ...options.config || {} }
+    });
   }
 
   /**
    * Create a new editor for a full document.
    */
   newDocumentEditor(options: CodeEditor.IOptions): CodeEditor.IEditor {
-    return new CodeMirrorEditor({...this.documentCodeMirrorOptions, ...options});
+    return new CodeMirrorEditor({
+      ...options,
+      config: { ...this.documentCodeMirrorConfig, ...options.config || {} }
+    });
   }
 
-  protected inlineCodeMirrorOptions: Partial<CodeMirrorEditor.IConfig>;
-  protected documentCodeMirrorOptions: Partial<CodeMirrorEditor.IConfig>;
+  protected inlineCodeMirrorConfig: Partial<CodeMirrorEditor.IConfig>;
+  protected documentCodeMirrorConfig: Partial<CodeMirrorEditor.IConfig>;
 
 }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -18,8 +18,9 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
   /**
    * Construct an IEditorFactoryService for CodeMirrorEditors.
    */
-  constructor(defaults: Partial<CodeMirrorEditor.IOptions> = {}) {
+  constructor(defaults: Partial<CodeMirrorEditor.IConfig> = {}) {
     this.inlineCodeMirrorOptions = {
+      ...CodeMirrorEditor.defaultConfig,
       extraKeys: {
         'Cmd-Right': 'goLineRight',
         'End': 'goLineRight',
@@ -31,15 +32,15 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Cmd-/': 'toggleComment',
         'Ctrl-/': 'toggleComment',
       },
+      lineNumbers: false,
       ...defaults
     };
     this.documentCodeMirrorOptions = {
+      ...CodeMirrorEditor.defaultConfig,
       extraKeys: {
         'Tab': 'indentMore',
         'Shift-Enter': () => { /* no-op */ }
       },
-      lineNumbers: true,
-      lineWrapping: true,
       ...defaults
     };
   }
@@ -58,7 +59,7 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
     return new CodeMirrorEditor({...this.documentCodeMirrorOptions, ...options});
   }
 
-  protected inlineCodeMirrorOptions: Partial<CodeMirrorEditor.IOptions>;
-  protected documentCodeMirrorOptions: Partial<CodeMirrorEditor.IOptions>;
+  protected inlineCodeMirrorOptions: Partial<CodeMirrorEditor.IConfig>;
+  protected documentCodeMirrorOptions: Partial<CodeMirrorEditor.IConfig>;
 
 }

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -57,7 +57,7 @@
 }
 
 
-.jp-CodeMirrorEditor.jp-mod-readOnly .CodeMirror-cursor {
+.CodeMirror.jp-mod-readOnly .CodeMirror-cursor {
   display: none;
 }
 

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -123,8 +123,8 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
    */
   function updateTracker(): void {
     tracker.forEach(widget => {
-      widget.editor.lineNumbers = lineNumbers;
-      widget.editor.wordWrap = wordWrap;
+      widget.editor.setOption('lineNumbers', lineNumbers);
+      widget.editor.setOption('wordWrap', wordWrap);
     });
   }
 
@@ -144,22 +144,24 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => { tracker.save(widget); });
     tracker.add(widget);
-    widget.editor.lineNumbers = lineNumbers;
-    widget.editor.wordWrap = wordWrap;
+    widget.editor.setOption('lineNumbers', lineNumbers);
+    widget.editor.setOption('wordWrap', wordWrap);
   });
   registry.addWidgetFactory(factory);
 
   // Handle the settings of new widgets.
   tracker.widgetAdded.connect((sender, widget) => {
     const editor = widget.editor;
-    editor.lineNumbers = lineNumbers;
-    editor.wordWrap = wordWrap;
+    editor.setOption('lineNumbers', lineNumbers);
+    editor.setOption('wordWrap', wordWrap);
   });
 
   commands.addCommand(CommandIDs.lineNumbers, {
     execute: () => {
       lineNumbers = !lineNumbers;
-      tracker.forEach(widget => { widget.editor.lineNumbers = lineNumbers; });
+      tracker.forEach(widget => {
+        widget.editor.setOption('lineNumbers', lineNumbers);
+      });
       return settingRegistry.set(id, 'lineNumbers', lineNumbers);
     },
     isEnabled: hasWidget,
@@ -170,7 +172,9 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
   commands.addCommand(CommandIDs.wordWrap, {
     execute: () => {
       wordWrap = !wordWrap;
-      tracker.forEach(widget => { widget.editor.wordWrap = wordWrap; });
+      tracker.forEach(widget => {
+        widget.editor.setOption('wordWrap', wordWrap);
+      });
       return settingRegistry.set(id, 'wordWrap', wordWrap);
     },
     isEnabled: hasWidget,

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -53,7 +53,7 @@ namespace CommandIDs {
   const lineNumbers = 'editor:line-numbers';
 
   export
-  const wordWrap = 'editor:word-wrap';
+  const lineWrap = 'editor:line-wrap';
 
   export
   const changeTabs = 'editor:change-tabs';
@@ -108,7 +108,7 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
   const hasWidget = () => tracker.currentWidget !== null;
 
   let {
-    lineNumbers, wordWrap, matchBrackets, autoClosingBrackets
+    lineNumbers, lineWrap, matchBrackets, autoClosingBrackets
   } = CodeEditor.defaultConfig;
 
   // Handle state restoration.
@@ -128,8 +128,8 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
     matchBrackets = cached === null ? matchBrackets : !!cached;
     cached = settings.get('autoClosingBrackets') as boolean | null;
     autoClosingBrackets = cached === null ? autoClosingBrackets : !!cached;
-    cached = settings.get('wordWrap') as boolean | null;
-    wordWrap = cached === null ? wordWrap : !!cached;
+    cached = settings.get('lineWrap') as boolean | null;
+    lineWrap = cached === null ? lineWrap : !!cached;
   }
 
   /**
@@ -147,7 +147,7 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
   function updateWidget(widget: FileEditor): void {
     let editor = widget.editor;
     editor.setOption('lineNumbers', lineNumbers);
-    editor.setOption('wordWrap', wordWrap);
+    editor.setOption('lineWrap', lineWrap);
     editor.setOption('matchBrackets', matchBrackets);
     editor.setOption('autoClosingBrackets', autoClosingBrackets);
   }
@@ -190,16 +190,16 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
     label: 'Line Numbers'
   });
 
-  commands.addCommand(CommandIDs.wordWrap, {
+  commands.addCommand(CommandIDs.lineWrap, {
     execute: () => {
-      wordWrap = !wordWrap;
+      lineWrap = !lineWrap;
       tracker.forEach(widget => {
-        widget.editor.setOption('wordWrap', wordWrap);
+        widget.editor.setOption('lineWrap', lineWrap);
       });
-      return settingRegistry.set(id, 'wordWrap', wordWrap);
+      return settingRegistry.set(id, 'lineWrap', lineWrap);
     },
     isEnabled: hasWidget,
-    isToggled: () => wordWrap,
+    isToggled: () => lineWrap,
     label: 'Word Wrap'
   });
 
@@ -212,8 +212,8 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
       }
       let editor = widget.editor;
       let size = args['size'] as number || 4;
-      let tabs = !!args['tabs'];
-      editor.setOption('insertSpaces', !tabs);
+      let insertSpaces = !!args['insertSpaces'];
+      editor.setOption('insertSpaces', insertSpaces);
       editor.setOption('tabSize', size);
     },
     isEnabled: hasWidget,
@@ -222,10 +222,10 @@ function activate(app: JupyterLab, registry: IDocumentRegistry, restorer: ILayou
       if (!widget) {
         return false;
       }
-      let tabs = !!args['tabs'];
+      let insertSpaces = !!args['insertSpaces'];
       let size = args['size'] as number || 4;
       let editor = widget.editor;
-      if (editor.getOption('insertSpaces') === tabs) {
+      if (editor.getOption('insertSpaces') !== insertSpaces) {
         return false;
       }
       return editor.getOption('tabSize') === size;

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -207,9 +207,6 @@ class FileEditorFactory extends ABCWidgetFactory<FileEditor, DocumentRegistry.IC
     let func = this._services.factoryService.newDocumentEditor.bind(
       this._services.factoryService);
     let factory: CodeEditor.Factory = options => {
-      options.lineNumbers = true;
-      options.readOnly = false;
-      options.wordWrap = true;
       return func(options);
     };
     return new FileEditor({

--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -702,10 +702,10 @@ namespace NotebookActions {
       return;
     }
     let state = Private.getState(widget);
-    let lineNumbers = widget.activeCell.editor.lineNumbers;
+    let lineNumbers = widget.activeCell.editor.getOption('lineNumbers');
     each(widget.widgets, child => {
       if (widget.isSelected(child)) {
-        child.editor.lineNumbers = !lineNumbers;
+        child.editor.setOption('lineNumbers', !lineNumbers);
       }
     });
     Private.handleState(widget, state);
@@ -726,9 +726,9 @@ namespace NotebookActions {
       return;
     }
     let state = Private.getState(widget);
-    let lineNumbers = widget.activeCell.editor.lineNumbers;
+    let lineNumbers = widget.activeCell.editor.getOption('lineNumbers');
     each(widget.widgets, child => {
-      child.editor.lineNumbers = !lineNumbers;
+      child.editor.setOption('lineNumbers', !lineNumbers);
     });
     Private.handleState(widget, state);
   }

--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -363,7 +363,7 @@ namespace CellTools {
       let editorWidget = new CodeEditorWrapper({ model, factory });
       editorWidget.addClass('jp-InputArea-editor');
       editorWidget.addClass('jp-InputArea-editor');
-      editorWidget.editor.readOnly = true;
+      editorWidget.editor.setOption('readOnly', true);
       layout.addWidget(prompt);
       layout.addWidget(editorWidget);
     }

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -489,7 +489,7 @@ namespace Private {
       sanitize: false,
       tables: true,
       // breaks: true; We can't use GFM breaks as it causes problems with tables
-      langPrefix: `cm-s-${CodeMirrorEditor.DEFAULT_THEME} language-`,
+      langPrefix: `cm-s-${CodeMirrorEditor.defaultConfig.theme} language-`,
       highlight: (code, lang, callback) => {
         if (!lang) {
             // no language, no highlight

--- a/test/src/codeeditor/widget.spec.ts
+++ b/test/src/codeeditor/widget.spec.ts
@@ -112,7 +112,7 @@ describe('CodeEditorWrapper', () => {
   describe('#editor', () => {
 
     it('should be a a code editor', () => {
-      expect(widget.editor.lineNumbers).to.be(false);
+      expect(widget.editor.getOption('lineNumbers')).to.be(false);
     });
 
   });

--- a/test/src/codeeditor/widget.spec.ts
+++ b/test/src/codeeditor/widget.spec.ts
@@ -82,7 +82,7 @@ describe('CodeEditorWrapper', () => {
   let widget: LogWidget;
   let editorFactory = (options: CodeEditor.IOptions) => {
     options.uuid = 'foo';
-    return new LogEditor(options, {});
+    return new LogEditor(options);
   };
 
   beforeEach(() => {

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -150,7 +150,7 @@ describe('CodeMirrorEditor', () => {
     });
 
     it('should get whether horizontally scrolling should be used', () => {
-      expect(editor.getOption('wordWrap')).to.be(true);
+      expect(editor.getOption('lineWrap')).to.be(true);
     });
 
     it('should get whether the editor is readonly', () => {
@@ -167,8 +167,8 @@ describe('CodeMirrorEditor', () => {
     });
 
     it('should set whether horizontally scrolling should be used', () => {
-      editor.setOption('wordWrap', false);
-      expect(editor.getOption('wordWrap')).to.be(false);
+      editor.setOption('lineWrap', false);
+      expect(editor.getOption('lineWrap')).to.be(false);
     });
 
     it('should set whether the editor is readonly', () => {

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -143,41 +143,37 @@ describe('CodeMirrorEditor', () => {
 
   });
 
-  describe('#lineNumbers', () => {
+  describe('#getOption()', () => {
 
     it('should get whether line numbers should be shown', () => {
-      expect(editor.lineNumbers).to.be(false);
+      expect(editor.getOption('lineNumbers')).to.be(false);
     });
 
-    it('should set whether line numbers should be shown', () => {
-      editor.lineNumbers = true;
-      expect(editor.lineNumbers).to.be(true);
+    it('should get whether horizontally scrolling should be used', () => {
+      expect(editor.getOption('wordWrap')).to.be(true);
+    });
+
+    it('should get whether the editor is readonly', () => {
+      expect(editor.getOption('readOnly')).to.be(false);
     });
 
   });
 
-  describe('#wordWrap', () => {
+  describe('#setOption()', () => {
 
-    it('should get whether horizontally scrolling should be used', () => {
-      expect(editor.wordWrap).to.be(true);
+    it('should set whether line numbers should be shown', () => {
+      editor.setOption('lineNumbers', true);
+      expect(editor.getOption('lineNumbers')).to.be(true);
     });
 
     it('should set whether horizontally scrolling should be used', () => {
-      editor.wordWrap = false;
-      expect(editor.wordWrap).to.be(false);
-    });
-
-  });
-
-  describe('#readOnly', () => {
-
-    it('should get whether the editor is readonly', () => {
-      expect(editor.readOnly).to.be(false);
+      editor.setOption('wordWrap', false);
+      expect(editor.getOption('wordWrap')).to.be(false);
     });
 
     it('should set whether the editor is readonly', () => {
-      editor.readOnly = true;
-      expect(editor.readOnly).to.be(true);
+      editor.setOption('readOnly', true);
+      expect(editor.getOption('readOnly')).to.be(true);
     });
 
   });

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -47,7 +47,7 @@ describe('CodeMirrorEditor', () => {
     host.style.height = '200px';
     document.body.appendChild(host);
     model = new CodeEditor.Model();
-    editor = new LogFileEditor({ host, model }, {});
+    editor = new LogFileEditor({ host, model });
   });
 
   afterEach(() => {

--- a/test/src/codemirror/factory.spec.ts
+++ b/test/src/codemirror/factory.spec.ts
@@ -24,7 +24,7 @@ describe('CodeMirrorEditorFactory', () => {
 
   const options: Partial<CodeMirrorEditor.IConfig> = {
     lineNumbers: false,
-    wordWrap: true,
+    lineWrap: true,
     extraKeys: {
       'Ctrl-Tab': 'indentAuto',
     }

--- a/test/src/codemirror/factory.spec.ts
+++ b/test/src/codemirror/factory.spec.ts
@@ -13,8 +13,8 @@ import {
 
 
 class ExposeCodeMirrorEditorFactory extends CodeMirrorEditorFactory {
-  public inlineCodeMirrorOptions: CodeMirror.EditorConfiguration;
-  public documentCodeMirrorOptions: CodeMirror.EditorConfiguration;
+  public inlineCodeMirrorOptions: CodeMirrorEditor.IConfig;
+  public documentCodeMirrorOptions: CodeMirrorEditor.IConfig;
 }
 
 
@@ -22,13 +22,12 @@ describe('CodeMirrorEditorFactory', () => {
   let host: HTMLElement;
   let model: CodeEditor.IModel;
 
-  const options: CodeMirror.EditorConfiguration = {
+  const options: Partial<CodeMirrorEditor.IConfig> = {
     lineNumbers: false,
-    lineWrapping: true,
+    wordWrap: true,
     extraKeys: {
       'Ctrl-Tab': 'indentAuto',
-    },
-    undoDepth: 5,
+    }
   };
 
   beforeEach(() => {
@@ -52,8 +51,8 @@ describe('CodeMirrorEditorFactory', () => {
 
       let factory = new ExposeCodeMirrorEditorFactory(options);
       expect(factory).to.be.a(CodeMirrorEditorFactory);
-      expect(factory.inlineCodeMirrorOptions).to.eql(options);
-      expect(factory.documentCodeMirrorOptions).to.eql(options);
+      expect(factory.inlineCodeMirrorOptions.extraKeys).to.eql(options.extraKeys);
+      expect(factory.documentCodeMirrorOptions.extraKeys).to.eql(options.extraKeys);
     });
 
   });
@@ -69,11 +68,11 @@ describe('CodeMirrorEditorFactory', () => {
 
     it('should create a new editor with given options', () => {
       let factory = new CodeMirrorEditorFactory(options);
-      let editor = factory.newInlineEditor({host, model});
+      let editor = factory.newInlineEditor({host, model}) as CodeMirrorEditor;
       expect(editor).to.be.a(CodeMirrorEditor);
-      let inner = (editor as CodeMirrorEditor).editor;
-      for (let key of Object.keys(options)) {
-        expect(inner.getOption(key)).to.equal((options as any)[key]);
+      for (let key in Object.keys(options)) {
+        let option = key as keyof CodeMirrorEditor.IConfig;
+        expect(editor.getOption(option)).to.equal(options[option]);
       }
       editor.dispose();
     });
@@ -91,11 +90,11 @@ describe('CodeMirrorEditorFactory', () => {
 
     it('should create a new editor with given options', () => {
       let factory = new CodeMirrorEditorFactory(options);
-      let editor = factory.newDocumentEditor({host, model});
+      let editor = factory.newDocumentEditor({host, model}) as CodeMirrorEditor;
       expect(editor).to.be.a(CodeMirrorEditor);
-      let inner = (editor as CodeMirrorEditor).editor;
-      for (let key of Object.keys(options)) {
-        expect(inner.getOption(key)).to.equal((options as any)[key]);
+      for (let key in Object.keys(options)) {
+        let option = key as keyof CodeMirrorEditor.IConfig;
+        expect(editor.getOption(option)).to.equal(options[option]);
       }
       editor.dispose();
     });

--- a/test/src/codemirror/factory.spec.ts
+++ b/test/src/codemirror/factory.spec.ts
@@ -13,8 +13,8 @@ import {
 
 
 class ExposeCodeMirrorEditorFactory extends CodeMirrorEditorFactory {
-  public inlineCodeMirrorOptions: CodeMirrorEditor.IConfig;
-  public documentCodeMirrorOptions: CodeMirrorEditor.IConfig;
+  public inlineCodeMirrorConfig: CodeMirrorEditor.IConfig;
+  public documentCodeMirrorConfig: CodeMirrorEditor.IConfig;
 }
 
 
@@ -51,8 +51,8 @@ describe('CodeMirrorEditorFactory', () => {
 
       let factory = new ExposeCodeMirrorEditorFactory(options);
       expect(factory).to.be.a(CodeMirrorEditorFactory);
-      expect(factory.inlineCodeMirrorOptions.extraKeys).to.eql(options.extraKeys);
-      expect(factory.documentCodeMirrorOptions.extraKeys).to.eql(options.extraKeys);
+      expect(factory.inlineCodeMirrorConfig.extraKeys).to.eql(options.extraKeys);
+      expect(factory.documentCodeMirrorConfig.extraKeys).to.eql(options.extraKeys);
     });
 
   });

--- a/test/src/console/history.spec.ts
+++ b/test/src/console/history.spec.ts
@@ -199,7 +199,7 @@ describe('console/history', () => {
         expect(history.methods).to.not.contain('onTextChange');
         let model = new CodeEditor.Model();
         let host = document.createElement('div');
-        let editor = new CodeMirrorEditor({ model, host }, {});
+        let editor = new CodeMirrorEditor({ model, host });
         history.editor = editor;
         model.value.text = 'foo';
         expect(history.methods).to.contain('onTextChange');
@@ -214,7 +214,7 @@ describe('console/history', () => {
         expect(history.methods).to.not.contain('onEdgeRequest');
         let host = document.createElement('div');
         let model = new CodeEditor.Model();
-        let editor = new CodeMirrorEditor({ model, host }, {});
+        let editor = new CodeMirrorEditor({ model, host });
         history.editor = editor;
         history.push('foo');
         editor.model.value.changed.connect(() => {

--- a/test/src/notebook/actions.spec.ts
+++ b/test/src/notebook/actions.spec.ts
@@ -52,6 +52,7 @@ describe('@jupyterlab/notebook', () => {
     before(() => {
       return createClientSession().then(s => {
         session = s;
+        return session.initialize();
       });
     });
 
@@ -468,66 +469,62 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#run()', () => {
 
-      beforeEach(() => {
-        return session.initialize();
-      });
-
-      it('should run the selected cells', function (done) {
+      it('should run the selected cells', function () {
         let next = widget.widgets[1] as MarkdownCell;
         widget.select(next);
         let cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
         next.rendered = false;
-        NotebookActions.run(widget, session).then(result => {
+        return NotebookActions.run(widget, session).then(result => {
           expect(result).to.be(true);
           expect(cell.model.outputs.length).to.be.above(0);
           expect(next.rendered).to.be(true);
-        }).then(done, done);
+        });
       });
 
-      it('should be a no-op if there is no model', (done) => {
+      it('should be a no-op if there is no model', () => {
         widget.model = null;
-        NotebookActions.run(widget, session).then(result => {
+        return NotebookActions.run(widget, session).then(result => {
           expect(result).to.be(false);
-        }).then(done, done);
+        });
       });
 
-      it('should activate the last selected cell', (done) => {
+      it('should activate the last selected cell', () => {
         let other = widget.widgets[2];
         widget.select(other);
         other.model.value.text = 'a = 1';
-        NotebookActions.run(widget, session).then(result => {
+        return NotebookActions.run(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.activeCell).to.be(other);
-        }).then(done, done);
+        });
       });
 
-      it('should clear the selection', (done) => {
+      it('should clear the selection', () => {
         let next = widget.widgets[1];
         widget.select(next);
-        NotebookActions.run(widget, session).then(result => {
+        return NotebookActions.run(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.isSelected(widget.widgets[0])).to.be(false);
-        }).then(done, done);
+        });
       });
 
-      it('should change to command mode', (done) => {
+      it('should change to command mode', () => {
         widget.mode = 'edit';
-        NotebookActions.run(widget, session).then(result => {
+        return NotebookActions.run(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.mode).to.be('command');
-        }).then(done, done);
+        });
       });
 
-      it('should handle no session', (done) => {
-        NotebookActions.run(widget, null).then(result => {
+      it('should handle no session', () => {
+        return NotebookActions.run(widget, null).then(result => {
           expect(result).to.be(true);
           let cell = widget.activeCell as CodeCell;
           expect(cell.model.executionCount).to.be(null);
-        }).then(done, done);
+        });
       });
 
-      it('should stop executing code cells on an error', (done) => {
+      it('should stop executing code cells on an error', () => {
         let cell = widget.model.contentFactory.createCodeCell({});
         cell.value.text = ERROR_INPUT;
         widget.model.cells.insert(2, cell);
@@ -535,206 +532,198 @@ describe('@jupyterlab/notebook', () => {
         cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
         widget.select(widget.widgets[widget.widgets.length - 1]);
-        NotebookActions.run(widget, session).then(result => {
+        return NotebookActions.run(widget, session).then(result => {
           expect(result).to.be(false);
           expect(cell.executionCount).to.be(null);
-        }).then(done, done);
+        });
       });
 
-      it('should render all markdown cells on an error', (done) => {
+      it('should render all markdown cells on an error', () => {
         let cell = widget.model.contentFactory.createMarkdownCell({});
         widget.model.cells.push(cell);
         let child = widget.widgets[widget.widgets.length - 1] as MarkdownCell;
         child.rendered = false;
         widget.select(child);
         widget.activeCell.model.value.text = ERROR_INPUT;
-        NotebookActions.run(widget, session).then(result => {
+        return NotebookActions.run(widget, session).then(result => {
           expect(result).to.be(false);
           expect(child.rendered).to.be(true);
-        }).then(done, done);
+        });
       });
 
     });
 
     describe('#runAndAdvance()', () => {
 
-      beforeEach(() => {
-        return session;
-      });
-
-      it('should run the selected cells ', (done) => {
+      it('should run the selected cells ', () => {
         let next = widget.widgets[1] as MarkdownCell;
         widget.select(next);
         let cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
         next.rendered = false;
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(true);
           expect(cell.model.outputs.length).to.be.above(0);
           expect(next.rendered).to.be(true);
-        }).then(done, done);
+        });
       });
 
-      it('should be a no-op if there is no model', (done) => {
+      it('should be a no-op if there is no model', () => {
         widget.model = null;
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(false);
-        }).then(done, done);
+        });
       });
 
-      it('should clear the existing selection', (done) => {
+      it('should clear the existing selection', () => {
         let next = widget.widgets[2];
         widget.select(next);
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(false);
           expect(widget.isSelected(widget.widgets[0])).to.be(false);
-        }).then(done, done);
+        });
       });
 
-      it('should change to command mode', (done) => {
+      it('should change to command mode', () => {
         widget.mode = 'edit';
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.mode).to.be('command');
-        }).then(done, done);
+        });
       });
 
-      it('should activate the cell after the last selected cell', (done) => {
+      it('should activate the cell after the last selected cell', () => {
         let next = widget.widgets[3] as MarkdownCell;
         widget.select(next);
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.activeCellIndex).to.be(4);
-        }).then(done, done);
+        });
       });
 
-      it('should create a new code cell in edit mode if necessary', (done) => {
+      it('should create a new code cell in edit mode if necessary', () => {
         let count = widget.widgets.length;
         widget.activeCellIndex = count - 1;
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.widgets.length).to.be(count + 1);
           expect(widget.activeCell).to.be.a(CodeCell);
           expect(widget.mode).to.be('edit');
-        }).then(done, done);
+        });
       });
 
-      it('should allow an undo of the new cell', (done) => {
+      it('should allow an undo of the new cell', () => {
         let count = widget.widgets.length;
         widget.activeCellIndex = count - 1;
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(true);
           NotebookActions.undo(widget);
           expect(widget.widgets.length).to.be(count);
-        }).then(done, done);
+        });
       });
 
-      it('should stop executing code cells on an error', (done) => {
+      it('should stop executing code cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
         let cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
         widget.select(widget.widgets[widget.widgets.length - 1]);
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(false);
           expect(cell.executionCount).to.be(null);
-        }).then(done, done);
+        });
       });
 
-      it('should render all markdown cells on an error', (done) => {
+      it('should render all markdown cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
         let cell = widget.widgets[1] as MarkdownCell;
         cell.rendered = false;
         widget.select(cell);
-        NotebookActions.runAndAdvance(widget, session).then(result => {
+        return NotebookActions.runAndAdvance(widget, session).then(result => {
           expect(result).to.be(false);
           expect(cell.rendered).to.be(true);
           expect(widget.activeCellIndex).to.be(2);
-        }).then(done, done);
+        });
       });
 
     });
 
     describe('#runAndInsert()', () => {
 
-      beforeEach(() => {
-        return session.initialize();
-      });
-
-      it('should run the selected cells ', (done) => {
+      it('should run the selected cells ', () => {
         let next = widget.widgets[1] as MarkdownCell;
         widget.select(next);
         let cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
         next.rendered = false;
-        NotebookActions.runAndInsert(widget, session).then(result => {
+        return NotebookActions.runAndInsert(widget, session).then(result => {
           expect(result).to.be(true);
           expect(cell.model.outputs.length).to.be.above(0);
           expect(next.rendered).to.be(true);
-        }).then(done, done);
+        });
       });
 
-      it('should be a no-op if there is no model', (done) => {
+      it('should be a no-op if there is no model', () => {
         widget.model = null;
-        NotebookActions.runAndInsert(widget, session).then(result => {
+        return NotebookActions.runAndInsert(widget, session).then(result => {
           expect(result).to.be(false);
-        }).then(done, done);
+        });
       });
 
-      it('should clear the existing selection', (done) => {
+      it('should clear the existing selection', () => {
         let next = widget.widgets[1];
         widget.select(next);
-        NotebookActions.runAndInsert(widget, session).then(result => {
+        return NotebookActions.runAndInsert(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.isSelected(widget.widgets[0])).to.be(false);
-        }).then(done, done);
+        });
       });
 
-      it('should insert a new code cell in edit mode after the last selected cell', (done) => {
+      it('should insert a new code cell in edit mode after the last selected cell', () => {
         let next = widget.widgets[2];
         widget.select(next);
         next.model.value.text = 'a = 1';
         let count = widget.widgets.length;
-        NotebookActions.runAndInsert(widget, session).then(result => {
+        return NotebookActions.runAndInsert(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.activeCell).to.be.a(CodeCell);
           expect(widget.mode).to.be('edit');
           expect(widget.widgets.length).to.be(count + 1);
-        }).then(done, done);
+        });
       });
 
-      it('should allow an undo of the cell insert', (done) => {
+      it('should allow an undo of the cell insert', () => {
         let next = widget.widgets[2];
         widget.select(next);
         next.model.value.text = 'a = 1';
         let count = widget.widgets.length;
-        NotebookActions.runAndInsert(widget, session).then(result => {
+        return NotebookActions.runAndInsert(widget, session).then(result => {
           expect(result).to.be(true);
           NotebookActions.undo(widget);
           expect(widget.widgets.length).to.be(count);
-        }).then(done, done);
+        });
       });
 
-      it('should stop executing code cells on an error', (done) => {
+      it('should stop executing code cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
         let cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
         widget.select(widget.widgets[widget.widgets.length - 1]);
-        NotebookActions.runAndInsert(widget, session).then(result => {
+        return NotebookActions.runAndInsert(widget, session).then(result => {
           expect(result).to.be(false);
           expect(cell.executionCount).to.be(null);
-        }).then(done, done);
+        });
       });
 
-      it('should render all markdown cells on an error', (done) => {
+      it('should render all markdown cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
         let cell = widget.widgets[1] as MarkdownCell;
         cell.rendered = false;
         widget.select(cell);
-        NotebookActions.runAndInsert(widget, session).then(result => {
+        return NotebookActions.runAndInsert(widget, session).then(result => {
           expect(result).to.be(false);
           expect(cell.rendered).to.be(true);
           expect(widget.activeCellIndex).to.be(2);
-        }).then(done, done);
+        });
       });
 
     });
@@ -744,76 +733,74 @@ describe('@jupyterlab/notebook', () => {
       beforeEach(() => {
         // Make sure all cells have valid code.
         widget.widgets[2].model.value.text = 'a = 1';
-
-        return session.initialize();
       });
 
-      it('should run all of the cells in the notebok', (done) => {
+      it('should run all of the cells in the notebok', () => {
         let next = widget.widgets[1] as MarkdownCell;
         let cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
         next.rendered = false;
-        NotebookActions.runAll(widget, session).then(result => {
+        return NotebookActions.runAll(widget, session).then(result => {
           expect(result).to.be(true);
           expect(cell.model.outputs.length).to.be.above(0);
           expect(next.rendered).to.be(true);
-        }).then(done, done);
+        });
       });
 
-      it('should be a no-op if there is no model', (done) => {
+      it('should be a no-op if there is no model', () => {
         widget.model = null;
-        NotebookActions.runAll(widget, session).then(result => {
+        return NotebookActions.runAll(widget, session).then(result => {
           expect(result).to.be(false);
-        }).then(done, done);
+        });
       });
 
-      it('should change to command mode', (done) => {
+      it('should change to command mode', () => {
         widget.mode = 'edit';
-        NotebookActions.runAll(widget, session).then(result => {
+        return NotebookActions.runAll(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.mode).to.be('command');
-        }).then(done, done);
+        });
       });
 
-      it('should clear the existing selection', (done) => {
+      it('should clear the existing selection', () => {
         let next = widget.widgets[2];
         widget.select(next);
-        NotebookActions.runAll(widget, session).then(result => {
+        return NotebookActions.runAll(widget, session).then(result => {
           expect(result).to.be(true);
           expect(widget.isSelected(widget.widgets[2])).to.be(false);
-        }).then(done, done);
+        });
       });
 
-      it('should activate the last cell', (done) => {
-        NotebookActions.runAll(widget, session).then(result => {
+      it('should activate the last cell', () => {
+        return NotebookActions.runAll(widget, session).then(result => {
           expect(widget.activeCellIndex).to.be(widget.widgets.length - 1);
-        }).then(done, done);
+        });
       });
 
-      it('should stop executing code cells on an error', (done) => {
+      it('should stop executing code cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
         let cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
-        NotebookActions.runAll(widget, session).then(result => {
+        return NotebookActions.runAll(widget, session).then(result => {
           expect(result).to.be(false);
           expect(cell.executionCount).to.be(null);
           expect(widget.activeCellIndex).to.be(widget.widgets.length - 1);
-        }).then(done, done);
+        });
       });
 
-      it('should render all markdown cells on an error', (done) => {
+      it('should render all markdown cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
         let cell = widget.widgets[1] as MarkdownCell;
         cell.rendered = false;
-        NotebookActions.runAll(widget, session).then(result => {
+        return NotebookActions.runAll(widget, session).then(result => {
           expect(result).to.be(false);
           expect(cell.rendered).to.be(true);
-        }).then(done, done);
+        });
       });
 
     });
 
-    describe('#selectAbove()', () => {
+    describe('#selectAbove(`)', () => {
 
       it('should select the cell above the active cell', () => {
         widget.activeCellIndex = 1;

--- a/test/src/notebook/actions.spec.ts
+++ b/test/src/notebook/actions.spec.ts
@@ -1234,19 +1234,19 @@ describe('@jupyterlab/notebook', () => {
     describe('#toggleLineNumbers()', () => {
 
       it('should toggle line numbers on the selected cells', () => {
-        let state = widget.activeCell.editor.lineNumbers;
+        let state = widget.activeCell.editor.getOption('lineNumbers');
         NotebookActions.toggleLineNumbers(widget);
-        expect(widget.activeCell.editor.lineNumbers).to.be(!state);
+        expect(widget.activeCell.editor.getOption('lineNumbers')).to.be(!state);
       });
 
       it('should be based on the state of the active cell', () => {
-        let state = widget.activeCell.editor.lineNumbers;
+        let state = widget.activeCell.editor.getOption('lineNumbers');
         let next = widget.widgets[1];
-        next.editor.lineNumbers = !state;
+        next.editor.setOption('lineNumbers', !state);
         widget.select(next);
         NotebookActions.toggleLineNumbers(widget);
-        expect(widget.widgets[0].editor.lineNumbers).to.be(!state);
-        expect(widget.widgets[1].editor.lineNumbers).to.be(!state);
+        expect(widget.widgets[0].editor.getOption('lineNumbers')).to.be(!state);
+        expect(widget.widgets[1].editor.getOption('lineNumbers')).to.be(!state);
       });
 
       it('should preserve the widget mode', () => {
@@ -1268,21 +1268,23 @@ describe('@jupyterlab/notebook', () => {
     describe('#toggleAllLineNumbers()', () => {
 
       it('should toggle line numbers on all cells', () => {
-        let state = widget.activeCell.editor.lineNumbers;
+        let state = widget.activeCell.editor.getOption('lineNumbers');
         NotebookActions.toggleAllLineNumbers(widget);
         for (let i = 0; i < widget.widgets.length; i++) {
-          expect(widget.widgets[i].editor.lineNumbers).to.be(!state);
+          let lineNumbers = widget.widgets[i].editor.getOption('lineNumbers');
+          expect(lineNumbers).to.be(!state);
         }
       });
 
       it('should be based on the state of the active cell', () => {
-        let state = widget.activeCell.editor.lineNumbers;
+        let state = widget.activeCell.editor.getOption('lineNumbers');
         for (let i = 1; i < widget.widgets.length; i++) {
-          widget.widgets[i].editor.lineNumbers = !state;
+          widget.widgets[i].editor.setOption('lineNumbers', !state);
         }
         NotebookActions.toggleAllLineNumbers(widget);
         for (let i = 0; i < widget.widgets.length; i++) {
-          expect(widget.widgets[i].editor.lineNumbers).to.be(!state);
+          let lineNumbers = widget.widgets[i].editor.getOption('lineNumbers');
+          expect(lineNumbers).to.be(!state);
         }
       });
 


### PR DESCRIPTION
- [x] Add default configuration to editor with more options.
- [x] Avoid overwriting passed in options.  
- [x] Give a unified interface for codemirror editor options. 
- [x] Update tests
- [x] Move settings to code editor extension and add the matchbrackets to menu

Fixes https://github.com/jupyterlab/jupyterlab/issues/2394.