### PR TITLE
Pass cwd into notebook launcher.

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -413,7 +413,7 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
   // The launcher callback.
   let callback = (cwd: string, name: string) => {
     return commands.execute(
-      'file-operations:new-untitled', { type: 'notebook' }
+      'file-operations:new-untitled', { path: cwd, type: 'notebook' }
     ).then(model => {
       return commands.execute('file-operations:open', {
         path: model.path, factory: FACTORY,


### PR DESCRIPTION
Fix for creating notebooks in directories other than the CWD of the primary file browser.