### PR TITLE
Wrap text.

### DIFF
--- a/packages/launcher/src/index.ts
+++ b/packages/launcher/src/index.ts
@@ -264,7 +264,8 @@ class LauncherWidget extends VDomRenderer<LauncherModel> {
       let icon = h.div({ className: imageClass, onclick }, item.iconLabel);
       let title = item.displayName;
       let text = h.span({className: TEXT_CLASS, onclick, title }, title);
-      let category = h.span({className: TEXT_CLASS, onclick }, item.category);
+      let activityType = item.category ? ' ' + item.category : '';
+      let category = h.span({className: TEXT_CLASS, onclick }, activityType);
       return h.div({
         className: ITEM_CLASS,
       }, [icon, text, category]);

--- a/packages/launcher/style/index.css
+++ b/packages/launcher/style/index.css
@@ -70,9 +70,6 @@
 
 .jp-LauncherWidget-item {
   width: 100px;
-  height: 100px;
-  display: flex;
-  flex-direction: column;
 }
 
 
@@ -91,7 +88,6 @@
 .jp-LauncherWidget-text {
   flex: 0 0 auto;
   text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 


### PR DESCRIPTION
Wrapping text for launcher items seems to work better when there are longer activity names. Is there a reason to use `white-space: nowrap` here?

![nowrap](https://user-images.githubusercontent.com/5728311/27013712-4479b41c-4e9e-11e7-9b5a-daadd716b8cf.png)
![wrap](https://user-images.githubusercontent.com/5728311/27013713-47dd3ea8-4e9e-11e7-817a-43e58e44427c.png)
