### PR TITLE
Enforce sort order in the file browser

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -530,7 +530,7 @@ class DirListing extends Widget {
     let items = this._sortedItems;
 
     let index = ArrayExt.findFirstIndex(items, value => {
-      return value.name.toLowerCase().substr(0, prefix.length) === prefix
+      return value.name.toLowerCase().substr(0, prefix.length) === prefix;
     });
 
     if (index !== -1) {
@@ -1784,18 +1784,35 @@ namespace Private {
    */
   export
   function sort(items: IIterator<Contents.IModel>, state: DirListing.ISortState) : Contents.IModel[] {
-    // Shortcut for unmodified.
-    if (state.key !== 'last_modified' && state.direction === 'ascending') {
-      return toArray(items);
-    }
 
     let copy = toArray(items);
 
     if (state.key === 'last_modified') {
+      // Sort by type and then by last modified.
       copy.sort((a, b) => {
+        // Compare based on type.
+        let t1 = typeWeight(a);
+        let t2 = typeWeight(b);
+        if (t1 !== t2) {
+          return t1 < t2 ? -1 : 1;  // Infinity safe
+        }
+
         let valA = new Date(a.last_modified).getTime();
         let valB = new Date(b.last_modified).getTime();
         return valB - valA;
+      });
+    } else {
+      // Sort by type and then by name.
+      copy.sort((a, b) => {
+        // Compare based on type.
+        let t1 = typeWeight(a);
+        let t2 = typeWeight(b);
+        if (t1 !== t2) {
+          return t1 < t2 ? -1 : 1;  // Infinity safe
+        }
+
+        // Compare by display name.
+        return a.name.localeCompare(b.name);
       });
     }
 
@@ -1813,5 +1830,21 @@ namespace Private {
   export
   function hitTestNodes(nodes: HTMLElement[], x: number, y: number): number {
     return ArrayExt.findFirstIndex(nodes, node => ElementExt.hitTest(node, x, y));
+  }
+
+  /**
+   * Weight a contents model by type.
+   */
+  function typeWeight(model: Contents.IModel): number {
+    switch (model.type) {
+    case 'directory':
+      return 0;
+    case 'notebook':
+      return 1;
+    case 'file':
+      return 2;
+    default:
+      return Infinity;
+    }
   }
 }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1799,6 +1799,10 @@ namespace Private {
 
         let valA = new Date(a.last_modified).getTime();
         let valB = new Date(b.last_modified).getTime();
+
+        if (state.direction === 'descending') {
+          return valA - valB;
+        }
         return valB - valA;
       });
     } else {
@@ -1812,13 +1816,11 @@ namespace Private {
         }
 
         // Compare by display name.
+        if (state.direction === 'descending') {
+          return b.name.localeCompare(a.name);
+        }
         return a.name.localeCompare(b.name);
       });
-    }
-
-    // Reverse the order if descending.
-    if (state.direction === 'descending') {
-      copy.reverse();
     }
 
     return copy;


### PR DESCRIPTION
Fixes #2403.  Items are uniformly sorted by type and then by either name or last_modified.

<image src="https://user-images.githubusercontent.com/2096628/27102780-181f6966-504c-11e7-8482-e6b61dd9723e.png" width=300>

<image src="https://user-images.githubusercontent.com/2096628/27106890-f80097c2-505a-11e7-8194-528326f4b0e1.png" width=300>

<image src="https://user-images.githubusercontent.com/2096628/27102790-1ee3dcdc-504c-11e7-9a5a-c9707ba8404b.png" width=300>
