### PR TITLE
Updatable Outputs

### DIFF
--- a/jupyterlab/make-release.js
+++ b/jupyterlab/make-release.js
@@ -32,7 +32,7 @@ function handlePackage(packagePath, data) {
   }
 
   var deps = package.dependencies || [];
-  for (let dep in deps) {
+  for (var dep in deps) {
     data.dependencies[dep] = deps[dep];
   }
 }

--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -342,7 +342,7 @@ namespace nbformat {
    * The valid output types.
    */
   export
-  type OutputType = 'execute_result' | 'display_data' | 'stream' | 'error';
+  type OutputType = 'execute_result' | 'display_data' | 'stream' | 'error' | 'update_display_data';
 
   /**
    * The base output type.
@@ -390,6 +390,27 @@ namespace nbformat {
      * Type of cell output.
      */
     output_type: 'display_data';
+
+    /**
+     * A mime-type keyed dictionary of data.
+     */
+    data: IMimeBundle;
+
+    /**
+     * Cell output metadata.
+     */
+    metadata: OutputMetadata;
+  }
+
+  /**
+   * Data displayed as an update to existing display data.
+   */
+  export
+  interface IDisplayUpdate extends IBaseOutput {
+    /**
+     * Type of cell output.
+     */
+    output_type: 'update_display_data';
 
     /**
      * A mime-type keyed dictionary of data.
@@ -475,6 +496,14 @@ namespace nbformat {
   export
   function isDisplayData(output: IOutput): output is IDisplayData {
     return output.output_type === 'display_data';
+  }
+
+  /**
+   * Test whether an output is from updated display data.
+   */
+  export
+  function isDisplayUpdate(output: IOutput): output is IDisplayUpdate {
+    return output.output_type === 'update_display_data';
   }
 
   /**

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -68,6 +68,11 @@ interface IOutputAreaModel extends IDisposable {
   add(output: nbformat.IOutput): number;
 
   /**
+   * Set the value at the specified index.
+   */
+  set(index: number, output: nbformat.IOutput): void;
+
+  /**
    * Clear all of the output.
    *
    * @param wait - Delay clearing the output until the next message is added.
@@ -253,6 +258,16 @@ class OutputAreaModel implements IOutputAreaModel {
   }
 
   /**
+   * Set the value at the specified index.
+   */
+  set(index: number, value: nbformat.IOutput): void {
+    // Normalize stream data.
+    this._normalize(value);
+    let item = this._createItem({ value, trusted: this._trusted });
+    this.list.set(index, item);
+  }
+
+  /**
    * Add an output, which may be combined with previous output.
    *
    * #### Notes
@@ -308,12 +323,8 @@ class OutputAreaModel implements IOutputAreaModel {
   private _add(value: nbformat.IOutput): number {
     let trusted = this._trusted;
 
-    // Normalize stream data.
-    if (nbformat.isStream(value)) {
-      if (Array.isArray(value.text)) {
-        value.text = (value.text as string[]).join('\n');
-      }
-    }
+    // Normalize the value.
+    this._normalize(value);
 
     // Consolidate outputs if they are stream outputs of the same kind.
     if (nbformat.isStream(value) && this._lastStream &&
@@ -344,6 +355,17 @@ class OutputAreaModel implements IOutputAreaModel {
 
     // Add the item to our list and return the new length.
     return this.list.push(item);
+  }
+
+  /**
+   * Normalize an output.
+   */
+  private _normalize(value: nbformat.IOutput): void {
+    if (nbformat.isStream(value)) {
+      if (Array.isArray(value.text)) {
+        value.text = (value.text as string[]).join('\n');
+      }
+    }
   }
 
   protected clearNext = false;

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -214,6 +214,7 @@ class OutputArea extends Widget {
       this._future.dispose();
     }
     this._future = null;
+    this._displayIdMap.clear();
     super.dispose();
   }
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -438,7 +438,7 @@ namespace OutputArea {
     if (!session.kernel) {
       return Promise.resolve(void 0);
     }
-    let future = session.kernel.requestExecute(content);
+    let future = session.kernel.requestExecute(content, false);
     output.future = future;
     return future.done;
   }

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  JSONObject
+} from '@phosphor/coreutils';
+
+import {
   Message
 } from '@phosphor/messaging';
 
@@ -255,6 +259,9 @@ class OutputArea extends Widget {
       widget.dispose();
     }
 
+    // Clear the display id map.
+    this._displayIdMap.clear();
+
     // When an output area is cleared and then quickly replaced with new
     // content (as happens with @interact in widgets, for example), the
     // quickly changing height can make the page jitter.
@@ -279,12 +286,17 @@ class OutputArea extends Widget {
   private _onIOPub(msg: KernelMessage.IIOPubMessage): void {
     let model = this.model;
     let msgType = msg.header.msg_type;
+    let output: nbformat.IOutput;
+    let transient = (msg.content.transient || {}) as JSONObject;
+    let displayId = transient['display_id'] as string;
+    let targets: number[];
+
     switch (msgType) {
     case 'execute_result':
     case 'display_data':
     case 'stream':
     case 'error':
-      let output = msg.content as nbformat.IOutput;
+      output = msg.content as nbformat.IOutput;
       output.output_type = msgType as nbformat.OutputType;
       model.add(output);
       break;
@@ -292,8 +304,23 @@ class OutputArea extends Widget {
       let wait = (msg as KernelMessage.IClearOutputMsg).content.wait;
       model.clear(wait);
       break;
+    case 'update_display_data':
+      output = msg.content as nbformat.IOutput;
+      output.output_type = msgType as nbformat.OutputType;
+      targets = this._displayIdMap.get(displayId);
+      if (targets) {
+        for (let index of targets) {
+          model.set(index, output);
+        }
+      }
+      break;
     default:
       break;
+    }
+    if (displayId && msgType === 'display_data') {
+       targets = this._displayIdMap.get(displayId) || [];
+       targets.push(model.length - 1);
+       this._displayIdMap.set(displayId, targets);
     }
   }
 
@@ -395,6 +422,7 @@ class OutputArea extends Widget {
 
   private _minHeightTimeout: number = null;
   private _future: Kernel.IFuture = null;
+  private _displayIdMap = new Map<string, number[]>();
 }
 
 

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -114,6 +114,7 @@ class OutputModel extends MimeModel implements IOutputModel {
     switch (this.type) {
     case 'display_data':
     case 'execute_result':
+    case 'update_display_data':
       output['data'] = this.data.toJSON();
       output['metadata'] = this.metadata.toJSON();
       break;
@@ -170,7 +171,7 @@ namespace OutputModel {
   export
   function getData(output: nbformat.IOutput): JSONObject {
     let bundle: nbformat.IMimeBundle = {};
-    if (nbformat.isExecuteResult(output) || nbformat.isDisplayData(output)) {
+    if (nbformat.isExecuteResult(output) || nbformat.isDisplayData(output) || nbformat.isDisplayUpdate(output)) {
       bundle = (output as nbformat.IExecuteResult).data;
     } else if (nbformat.isStream(output)) {
       if (output.name === 'stderr') {

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -776,7 +776,7 @@ class DefaultKernel implements Kernel.IKernel {
       parentIds.map((parentId) => {
         let future = this._futures && this._futures.get(parentId);
         if (future) {
-          future.handleMsg(msg);
+          future.handleMsg(updateMsg);
         }
       });
     }

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -229,6 +229,8 @@ class DefaultKernel implements Kernel.IKernel {
     this._comms.forEach((comm, key) => {
       comm.dispose();
     });
+    this._displayIdToParentIds.clear();
+    this._msgIdToDisplayIds.clear();
     this._futures = null;
     this._commPromises = null;
     this._comms = null;
@@ -902,6 +904,8 @@ class DefaultKernel implements Kernel.IKernel {
     this._futures = new Map<string, KernelFutureHandler>();
     this._commPromises = new Map<string, Promise<Kernel.IComm>>();
     this._comms = new Map<string, Kernel.IComm>();
+    this._displayIdToParentIds.clear();
+    this._msgIdToDisplayIds.clear();
   }
 
   /**

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -708,7 +708,7 @@ class DefaultKernel implements Kernel.IKernel {
       case 'display_data':
       case 'update_display_data':
       case 'execute_result':
-        // display_data messages may re-route based on their display_id
+        // display_data messages may re-route based on their display_id.
         let transient = (msg.content.transient || {}) as JSONObject;
         let displayId = transient['display_id'] as string;
         if (displayId) {
@@ -764,7 +764,7 @@ class DefaultKernel implements Kernel.IKernel {
     let parentIds = this._displayIdToParentIds.get(displayId);
     if (parentIds) {
       // We've seen it before, update existing outputs with same display_id
-      // by handling display_data as update_display_data
+      // by handling display_data as update_display_data.
       let updateMsg: KernelMessage.IMessage = {
         header: JSONExt.deepCopy(msg.header) as KernelMessage.IHeader,
         parent_header: JSONExt.deepCopy(msg.parent_header)  as KernelMessage.IHeader,
@@ -789,8 +789,8 @@ class DefaultKernel implements Kernel.IKernel {
       return true;
     }
 
-    // regular display_data with id, record it for future updating
-    // in _display_id_to_parent_ids for future lookup
+    // Regular display_data with id, record it for future updating
+    // in _displayIdToParentIds for future lookup.
     parentIds = this._displayIdToParentIds.get(displayId) || [];
     if (parentIds.indexOf(msgId) === -1) {
       parentIds.push(msgId);

--- a/packages/services/test/src/kernel/kernel.spec.ts
+++ b/packages/services/test/src/kernel/kernel.spec.ts
@@ -1071,48 +1071,6 @@ describe('kernel', () => {
         });
       });
 
-      it('should handle display_id messages', () => {
-        let options: KernelMessage.IExecuteRequest = {
-          code: 'test',
-          silent: false,
-          store_history: true,
-          user_expressions: {},
-          allow_stdin: false,
-          stop_on_error: false
-        };
-        let called0 = false;
-        let called1 = false;
-        let future0 = kernel.requestExecute(options, false);
-
-        tester.onMessage((msg) => {
-          if (msg.channel === 'shell') {
-            // send a reply
-            msg.parent_header = msg.header;
-            msg.channel = 'shell';
-            tester.send(msg);
-        }
-
-        future0.onReply = () => {
-          // trigger onIOPub with a 'display_data' message
-          msg.channel = 'iopub';
-          msg.header.msg_type = 'stream';
-          msg.content = { 'name': 'stdout', 'text': 'foo' };
-          tester.send(msg);
-        };
-
-        future0.onIOPub = () => {
-          if (msg.header.msg_type === 'display_data') {
-            called0 = true;
-          } else if (msg.header.msg_type === 'update_display_data') {
-            // trigger onDone
-            msg.header.msg_type = 'status';
-            (msg as KernelMessage.IStatusMsg).content.execution_state = 'idle';
-            tester.send(msg);
-          }
-        };
-
-      });
-
     });
 
     context('#registerMessageHook()', () => {


### PR DESCRIPTION
Fixes #1227.  Fixes #629.

Verified using Min's [notebook](https://nbviewer.jupyter.org/gist/minrk/1a1e56a611f1ff1e2645f733bdd0e381):

<image src="https://user-images.githubusercontent.com/2096628/27156977-161fc726-5125-11e7-812c-92160877c59a.png" width=300>

Now that futures are kept alive until the next execution, we get threaded messages (#629):

<image src="https://user-images.githubusercontent.com/2096628/27153577-9e2854f2-5117-11e7-8333-d79497be235c.png" width=300>
