### PR TITLE
Refined notebook drag image

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -59,6 +59,9 @@ import {
   INotebookModel
 } from './model';
 
+import {
+  h, VirtualDOM
+} from '@phosphor/virtualdom';
 
 /**
  * The class name added to notebook widgets.
@@ -1317,10 +1320,23 @@ class Notebook extends StaticNotebook {
         toMove.push(widget);
       }
     });
-
-    // Create the drag image.
-    let dragImage = Private.createDragImage(selected.length, this.activeCell.model.executionCount, this.activeCell.model.value.text.split('\n')[0]);
-
+    let activeCell = this.activeCell;
+    let dragImage: HTMLElement = null;
+    if (activeCell.model.type === 'code') {
+      let executionCount = (activeCell.model as ICodeCellModel).executionCount;
+      let countString: string;
+      if (executionCount) {
+        countString = executionCount.toString();
+      } else {
+        countString = '';
+      }
+      // Create the drag image.
+      dragImage = Private.createDragImage(selected.length, countString, activeCell.model.value.text.split('\n')[0]);
+    }
+    else {
+      // Create the drag image.
+      dragImage = Private.createDragImage(selected.length, '', activeCell.model.value.text.split('\n')[0]);
+    }
     // Set up the drag event.
     this._drag = new Drag({
       mimeData: new MimeData(),
@@ -1531,16 +1547,14 @@ namespace Private {
    * Create a cell drag image.
    */
   export
-  function createDragImage(count: number, promptNumber: number, cellContent: string): HTMLElement {
-    console.log("promptNumber = " + `${promptNumber}`);
+  function createDragImage(count: number, promptNumber: string, cellContent: string): HTMLElement {
+    console.log("promptNumber = " + promptNumber);
     console.log("CellContent = " + cellContent);
-    let node = document.createElement('div');
-    let span = document.createElement('span');
-    span.textContent = `${count}`;
-    span.className = FILLED_CIRCLE_CLASS;
-    node.appendChild(span);
-    node.className = DRAG_IMAGE_CLASS;
-    return node;
+    return VirtualDOM.realize(
+      h.div({className: DRAG_IMAGE_CLASS},
+        h.span({className: FILLED_CIRCLE_CLASS, title: `${count}`})
+      )
+    );
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1319,7 +1319,7 @@ class Notebook extends StaticNotebook {
     });
 
     // Create the drag image.
-    let dragImage = Private.createDragImage(selected.length);
+    let dragImage = Private.createDragImage(selected.length, this.activeCell.model.executionCount, this.activeCell.model.value.text.split('\n')[0]);
 
     // Set up the drag event.
     this._drag = new Drag({
@@ -1531,7 +1531,9 @@ namespace Private {
    * Create a cell drag image.
    */
   export
-  function createDragImage(count: number): HTMLElement {
+  function createDragImage(count: number, promptNumber: number, cellContent: string): HTMLElement {
+    console.log("promptNumber = " + `${promptNumber}`);
+    console.log("CellContent = " + cellContent);
     let node = document.createElement('div');
     let span = document.createElement('span');
     span.textContent = `${count}`;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -119,9 +119,19 @@ const DROP_SOURCE_CLASS = 'jp-mod-dropSource';
 const DRAG_IMAGE_CLASS = 'jp-dragImage';
 
 /**
- * The class name added to a filled circle.
+ * The class name added to the drag image cell content.
  */
-const FILLED_CIRCLE_CLASS = 'jp-filledCircle';
+const CELL_DRAG_CONTENT_CLASS = 'jp-cellDragContent';
+
+/**
+ * The class name added to the drag image cell content.
+ */
+const CELL_DRAG_PROMPT_CLASS = 'jp-cellDragPrompt';
+
+/**
+ * The class name added to the drag image cell content.
+ */
+const CELL_DRAG_MULTIPLE_BACK = 'jp-cellDragMultipleBack';
 
 /**
  * The mimetype used for Jupyter cell data.
@@ -1548,13 +1558,22 @@ namespace Private {
    */
   export
   function createDragImage(count: number, promptNumber: string, cellContent: string): HTMLElement {
-    console.log("promptNumber = " + promptNumber);
-    console.log("CellContent = " + cellContent);
-    return VirtualDOM.realize(
-      h.div({className: DRAG_IMAGE_CLASS},
-        h.span({className: FILLED_CIRCLE_CLASS, title: `${count}`})
-      )
-    );
+    if (count > 1) {
+      return VirtualDOM.realize(
+        h.div(
+          h.div({className: DRAG_IMAGE_CLASS},
+            h.span({className: CELL_DRAG_PROMPT_CLASS}, "[" + promptNumber + "]:"),
+            h.span({className: CELL_DRAG_CONTENT_CLASS}, cellContent)),
+          h.div({className: CELL_DRAG_MULTIPLE_BACK}, "")
+        )
+      );
+    } else {
+      return VirtualDOM.realize(
+        h.div({className: DRAG_IMAGE_CLASS},
+          h.span({className: CELL_DRAG_CONTENT_CLASS, title: `${count}`})
+        )
+      );
+    }
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -121,22 +121,22 @@ const DRAG_IMAGE_CLASS = 'jp-dragImage';
 /**
  * The class name added to singular drag images
  */
-const SINGLE_DRAG_IMAGE_CLASS = 'jp-dragImageSinglePrompt';
+const SINGLE_DRAG_IMAGE_CLASS = 'jp-dragImage-singlePrompt';
 
 /**
  * The class name added to the drag image cell content.
  */
-const CELL_DRAG_CONTENT_CLASS = 'jp-cellDragContent';
+const CELL_DRAG_CONTENT_CLASS = 'jp-dragImage-content';
 
 /**
  * The class name added to the drag image cell content.
  */
-const CELL_DRAG_PROMPT_CLASS = 'jp-cellDragPrompt';
+const CELL_DRAG_PROMPT_CLASS = 'jp-dragImage-prompt';
 
 /**
  * The class name added to the drag image cell content.
  */
-const CELL_DRAG_MULTIPLE_BACK = 'jp-cellDragMultipleBack';
+const CELL_DRAG_MULTIPLE_BACK = 'jp-dragImage-multipleBack';
 
 /**
  * The mimetype used for Jupyter cell data.
@@ -1337,21 +1337,20 @@ class Notebook extends StaticNotebook {
     });
     let activeCell = this.activeCell;
     let dragImage: HTMLElement = null;
+    let countString: string;
     if (activeCell.model.type === 'code') {
       let executionCount = (activeCell.model as ICodeCellModel).executionCount;
-      let countString: string;
+      countString = ' ';
       if (executionCount) {
         countString = executionCount.toString();
-      } else {
-        countString = '';
       }
-      // Create the drag image.
-      dragImage = Private.createDragImage(selected.length, countString, activeCell.model.value.text.split('\n')[0].slice(0,26));
     }
     else {
-      // Create the drag image.
-      dragImage = Private.createDragImage(selected.length, '', activeCell.model.value.text.split('\n')[0].slice(0,26));
+      countString = '';
     }
+    // Create the drag image.
+    dragImage = Private.createDragImage(selected.length, countString, activeCell.model.value.text.split('\n')[0].slice(0,26));
+
     // Set up the drag event.
     this._drag = new Drag({
       mimeData: new MimeData(),

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -119,6 +119,11 @@ const DROP_SOURCE_CLASS = 'jp-mod-dropSource';
 const DRAG_IMAGE_CLASS = 'jp-dragImage';
 
 /**
+ * The class name added to singular drag images
+ */
+const SINGLE_DRAG_IMAGE_CLASS = 'jp-dragImageSinglePrompt';
+
+/**
  * The class name added to the drag image cell content.
  */
 const CELL_DRAG_CONTENT_CLASS = 'jp-cellDragContent';
@@ -1341,11 +1346,11 @@ class Notebook extends StaticNotebook {
         countString = '';
       }
       // Create the drag image.
-      dragImage = Private.createDragImage(selected.length, countString, activeCell.model.value.text.split('\n')[0]);
+      dragImage = Private.createDragImage(selected.length, countString, activeCell.model.value.text.split('\n')[0].slice(0,26));
     }
     else {
       // Create the drag image.
-      dragImage = Private.createDragImage(selected.length, '', activeCell.model.value.text.split('\n')[0]);
+      dragImage = Private.createDragImage(selected.length, '', activeCell.model.value.text.split('\n')[0].slice(0,26));
     }
     // Set up the drag event.
     this._drag = new Drag({
@@ -1559,20 +1564,45 @@ namespace Private {
   export
   function createDragImage(count: number, promptNumber: string, cellContent: string): HTMLElement {
     if (count > 1) {
-      return VirtualDOM.realize(
-        h.div(
-          h.div({className: DRAG_IMAGE_CLASS},
-            h.span({className: CELL_DRAG_PROMPT_CLASS}, "[" + promptNumber + "]:"),
-            h.span({className: CELL_DRAG_CONTENT_CLASS}, cellContent)),
-          h.div({className: CELL_DRAG_MULTIPLE_BACK}, "")
-        )
-      );
+      if (promptNumber !== '') {
+        return VirtualDOM.realize(
+          h.div(
+            h.div({className: DRAG_IMAGE_CLASS},
+              h.span({className: CELL_DRAG_PROMPT_CLASS}, "[" + promptNumber + "]:"),
+              h.span({className: CELL_DRAG_CONTENT_CLASS}, cellContent)),
+            h.div({className: CELL_DRAG_MULTIPLE_BACK}, "")
+          )
+        );
+      } else {
+        return VirtualDOM.realize(
+          h.div(
+            h.div({className: DRAG_IMAGE_CLASS},
+              h.span({className: CELL_DRAG_PROMPT_CLASS}),
+              h.span({className: CELL_DRAG_CONTENT_CLASS}, cellContent)),
+            h.div({className: CELL_DRAG_MULTIPLE_BACK}, "")
+          )
+        );
+      }
     } else {
-      return VirtualDOM.realize(
-        h.div({className: DRAG_IMAGE_CLASS},
-          h.span({className: CELL_DRAG_CONTENT_CLASS, title: `${count}`})
-        )
-      );
+      if (promptNumber !== '') {
+        return VirtualDOM.realize(
+          h.div(
+            h.div({className: `${DRAG_IMAGE_CLASS} ${SINGLE_DRAG_IMAGE_CLASS}`},
+              h.span({className: CELL_DRAG_PROMPT_CLASS}, "[" + promptNumber + "]:"),
+              h.span({className: CELL_DRAG_CONTENT_CLASS}, cellContent)
+            )
+          )
+        );
+      } else {
+        return VirtualDOM.realize(
+          h.div(
+            h.div({className: `${DRAG_IMAGE_CLASS} ${SINGLE_DRAG_IMAGE_CLASS}`},
+              h.span({className: CELL_DRAG_PROMPT_CLASS}),
+              h.span({className: CELL_DRAG_CONTENT_CLASS}, cellContent)
+            )
+          )
+        );
+      }
     }
   }
 

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -9,9 +9,8 @@
 
 
 :root {
-  --jp-private-notebook-dragImage-width: var(--jp-cell-prompt-width);
-  --jp-private-notebook-dragImage-height: 39px;
-  --jp-private-notebook-dragImage-circleRadius: 20px;
+  --jp-private-notebook-dragImage-width: 276px;
+  --jp-private-notebook-dragImage-height: 38px;
   --jp-private-notebook-selected-color: var(--md-blue-400);
   --jp-private-notebook-multiselected-color: var(--md-blue-50);
   --jp-private-notebook-left-border-width: 5px;
@@ -158,27 +157,53 @@
   position: absolute;
   width: var(--jp-private-notebook-dragImage-width);
   height: var(--jp-private-notebook-dragImage-height);
-  border: var(--jp-border-width) solid black;
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
   background: var(--jp-layout-color1);
   overflow: visible;
 }
 
 
-.jp-dragImage .jp-filledCircle {
+.jp-dragImage .jp-cellDragContent {
+    z-index: 2;
     position: absolute;
-    left: calc( ( var(--jp-private-notebook-dragImage-width) - var(--jp-private-notebook-dragImage-circleRadius) ) / 2 );
-    top: calc( ( var(--jp-private-notebook-dragImage-height) - var(--jp-private-notebook-dragImage-circleRadius) ) / 2 );
-    border-radius: 50%;
-
-    width: var(--jp-private-notebook-dragImage-circleRadius);
-    height: var(--jp-private-notebook-dragImage-circleRadius);
-
-    background: var(--jp-accent-color1);
-    color: white;
-    text-align: center;
-    line-height: var(--jp-private-notebook-dragImage-circleRadius);
+    left: 52px;
+    top: 4px;
+    width: 208px;
+    height: 18px;
+    font-size: var(--jp-code-font-size);
+    font-family: monospace;
+    line-height: var(--jp-code-line-height);
+    padding: var(--jp-code-padding);
+    border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+    background: var(--jp-cell-editor-background);
+    color: var(--jp-content-font-color3);
+    text-align: left;
 }
 
+.jp-dragImage .jp-cellDragPrompt {
+  position: absolute;
+  top: 4px;
+  left: 10px;
+  color: var(--jp-content-font-color2);
+  padding: var(--jp-code-padding);
+  font-family: 'Roboto Mono', monospace;
+  letter-spacing: var(--jp-cell-prompt-letter-spacing);
+  line-height: var(--jp-code-line-height);
+  font-size: var(--jp-code-font-size);
+  border: var(--jp-border-width) solid transparent;
+}
+
+.jp-cellDragMultipleBack {
+  z-index: -1;
+  position: absolute;
+  height: 34px;
+  width: 272px;
+  top: 8px;
+  left: 8px;
+  background: var(--jp-cell-editor-background);
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
+  box-shadow: 2px 2px 4px 0px rgba(0,0,0,0.12);
+}
 
 /*-----------------------------------------------------------------------------
 | Cell toolbar

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -163,12 +163,12 @@
 }
 
 
-.jp-dragImageSinglePrompt {
+.jp-dragImage-singlePrompt {
   box-shadow: 2px 2px 4px 0px rgba(0,0,0,0.12);
 }
 
 
-.jp-dragImage .jp-cellDragContent {
+.jp-dragImage .jp-dragImage-content {
     z-index: 2;
     position: absolute;
     left: 52px;
@@ -185,7 +185,7 @@
     text-align: left;
 }
 
-.jp-dragImage .jp-cellDragPrompt {
+.jp-dragImage .jp-dragImage-prompt {
   position: absolute;
   top: 4px;
   left: 10px;
@@ -198,7 +198,7 @@
   border: var(--jp-border-width) solid transparent;
 }
 
-.jp-cellDragMultipleBack {
+.jp-dragImage-multipleBack {
   z-index: -1;
   position: absolute;
   height: 34px;

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -163,6 +163,11 @@
 }
 
 
+.jp-dragImageSinglePrompt {
+  box-shadow: 2px 2px 4px 0px rgba(0,0,0,0.12);
+}
+
+
 .jp-dragImage .jp-cellDragContent {
     z-index: 2;
     position: absolute;
@@ -200,7 +205,7 @@
   width: 272px;
   top: 8px;
   left: 8px;
-  background: var(--jp-cell-editor-background);
+  background: #EEEEEE;
   border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
   box-shadow: 2px 2px 4px 0px rgba(0,0,0,0.12);
 }


### PR DESCRIPTION
Fixes #1616.

Before this pull request, the drag image of the notebook cells was hard to use and hard to tell which cells you were actually dragging and moving. I changed the design to reflect the look of a cell and took a small snippet of the code from each cell and put it into the drag image. The result of this is a much cleaner experience, check it out below!

#### Before (Single cell drag)
![single-move-before](https://user-images.githubusercontent.com/6437976/27148358-d3e04668-50f4-11e7-878f-63113dd01d48.gif)

#### After (Single cell drag - code cell)
![single-drag-code](https://user-images.githubusercontent.com/6437976/27148391-f870eb4a-50f4-11e7-9a15-a608781a6d98.gif)

#### After (Single cell drag - markdown & raw)
![single-drag-md](https://user-images.githubusercontent.com/6437976/27148421-16f13b74-50f5-11e7-9c65-901c7a1b0bac.gif)

#### Before (Multiple cell drag)
![multiple-drag-before](https://user-images.githubusercontent.com/6437976/27148471-4e050b0e-50f5-11e7-8965-02de2c366204.gif)

#### After (Multiple cell drag - code cell)
![multiple-drag-code](https://user-images.githubusercontent.com/6437976/27148505-687cb34c-50f5-11e7-9189-829e7b7a39e1.gif)

#### After (Multiple cell drag - markdown/raw)
![multiple-md-after](https://user-images.githubusercontent.com/6437976/27148544-8205360e-50f5-11e7-93c0-6aae84c6bcab.gif)


