### PR TITLE
Toolbar style refinements, file browser new file icon

### DIFF
--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -41,6 +41,12 @@
 }
 
 
+.jp-Toolbar-item.jp-Toolbar-button:focus {
+  box-shadow: var(--jp-toolbar-box-shadow);
+  border: 1px solid var(--jp-toolbar-border-color);
+}
+
+
 .jp-Toolbar-button.jp-mod-pressed {
   background-color: var(--jp-layout-color3);
   box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -5,7 +5,7 @@
 |----------------------------------------------------------------------------*/
 
 :root {
-  --jp-private-toolbar-height: 32px;
+  --jp-private-toolbar-height: 28px;
 }
 
 
@@ -56,9 +56,9 @@
 
 
 .jp-Toolbar-button:active {
-  border: 1px solid #BDBDBD;
-  background-color: #E0E0E0;
-  box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);
+  border: 1px solid var(--jp-toolbar-border-color);
+  background-color: var(--jp-toolbar-active-background);
+  box-shadow: var(--jp-toolbar-box-shadow);
 }
 
 .jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-spacer {
@@ -73,7 +73,7 @@
   letter-spacing: normal;
   text-align: left;
   font-size: var(--jp-ui-font-size1);
-  line-height: calc( var(--jp-private-toolbar-height) + 1px );
+  line-height: 22px;
 }
 
 

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -5,7 +5,7 @@
 |----------------------------------------------------------------------------*/
 
 :root {
-  --jp-private-toolbar-height: 24px;
+  --jp-private-toolbar-height: 32px;
 }
 
 
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: row;
   border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
-  height: calc(var(--jp-private-toolbar-height) + var(--jp-border-width));
+  height: var(--jp-private-toolbar-height);
 }
 
 
@@ -31,11 +31,13 @@
 
 .jp-Toolbar-item.jp-Toolbar-button {
   display: inline-block;
+  height: 24px;
   width: 32px;
   background-color: white;
   background-repeat: no-repeat;
   background-position: center;
   background-size: 16px;
+  border: 1px solid var(--jp-layout-color0);
 }
 
 
@@ -46,10 +48,18 @@
 
 
 .jp-Toolbar-button:hover {
-  background-color: var(--jp-layout-color2);
-  box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
+  border: 1px solid #BDBDBD;
+  background-color: var(--jp-layout-color0);
+  box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);
+
 }
 
+
+.jp-Toolbar-button:active {
+  border: 1px solid #BDBDBD;
+  background-color: #E0E0E0;
+  box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);
+}
 
 .jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-spacer {
   flex-grow: 1;
@@ -74,4 +84,3 @@
   background-position: center;
   background-size: 16px;
 }
-

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -104,7 +104,7 @@ class FileBrowser extends Widget {
     this._crumbs = new BreadCrumbs({ model });
     this.toolbar = new Toolbar<Widget>();
     let newFolder = new ToolbarButton({
-      className: 'jp-FolderIcon',
+      className: 'jp-newFolderIcon',
       onClick: () => {
         this._manager.newUntitled({
           path: model.path,

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -29,6 +29,12 @@
 }
 
 
+.jp-FileBrowser-toolbar {
+  border-bottom: none;
+  height: auto;
+}
+
+
 .jp-BreadCrumbs {
   flex: 0 0 auto;
   margin: 4px 12px;

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -74,6 +74,11 @@
 }
 
 
+.jp-FileBrowser-toolbar > .jp-Toolbar-button:focus {
+  box-shadow: var(--jp-toolbar-box-shadow);
+  border-color: var(--jp-toolbar-border-color);
+}
+
 /*-----------------------------------------------------------------------------
 | DirListing
 |----------------------------------------------------------------------------*/

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -32,6 +32,7 @@
 .jp-FileBrowser-toolbar {
   border-bottom: none;
   height: auto;
+  margin: 4px 4px 0px 4px;
 }
 
 
@@ -67,9 +68,9 @@
   height: var(--jp-private-filebrowser-button-height);
   line-height: var(--jp-private-filebrowser-button-height);
   color: var(--jp-ui-font-color1);
-  border: none;
   font-size: var(--jp-ui-icon-font-size);
   outline: 0;
+  margin-bottom: 4px;
 }
 
 

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -32,7 +32,7 @@
 .jp-FileBrowser-toolbar {
   border-bottom: none;
   height: auto;
-  margin: 4px 4px 0px 4px;
+  margin: var(--jp-toolbar-header-margin);
 }
 
 

--- a/packages/notebook/style/toolbar.css
+++ b/packages/notebook/style/toolbar.css
@@ -14,6 +14,7 @@
 
 
 .jp-NotebookPanel-toolbar {
+  padding: 4px;
   box-shadow: var(--jp-toolbar-box-shadow);
   background: var(--jp-toolbar-background);
   z-index: 1;

--- a/packages/notebook/style/toolbar.css
+++ b/packages/notebook/style/toolbar.css
@@ -14,7 +14,8 @@
 
 
 .jp-NotebookPanel-toolbar {
-  padding: 4px;
+  padding: 2px;
+  height: 28px;
   box-shadow: var(--jp-toolbar-box-shadow);
   background: var(--jp-toolbar-background);
   z-index: 1;

--- a/packages/running/style/index.css
+++ b/packages/running/style/index.css
@@ -28,6 +28,7 @@
   flex: 0 0 auto;
   display: flex;
   flex-direction: row;
+  margin: var(--jp-toolbar-header-margin);
 }
 
 
@@ -57,9 +58,19 @@
   flex-direction: column;
 }
 
+
 .jp-RunningSessions-headerRefresh:hover {
-  background-color: var(--jp-layout-color2);
+  background-color: var(--jp-layout-color0);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  border: 1px solid var(--jp-toolbar-border-color);
   z-index: 1; /* raise overlapping border */
+}
+
+
+.jp-RunningSessions-headerRefresh:active {
+  border: 1px solid var(--jp-toolbar-border-color);
+  background-color: var(--jp-toolbar-active-background);
+  box-shadow: var(--jp-toolbar-box-shadow);
 }
 
 

--- a/packages/theming/style/icons.css
+++ b/packages/theming/style/icons.css
@@ -74,6 +74,11 @@
 }
 
 
+.jp-newFolderIcon {
+  background-image: url(icons/md/new-folder.svg);
+}
+
+
 .jp-HomeIcon {
   background-image: url(icons/md/home.svg);
   min-width: 14px;

--- a/packages/theming/style/icons/md/new-folder.svg
+++ b/packages/theming/style/icons/md/new-folder.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 10 9" style="enable-background:new 0 0 10 9;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-miterlimit:10;}
+</style>
+<g transform="translate(-1.000000, -1.148148)">
+	<path id="Shape" d="M5,2H2C1.5,2,1,2.5,1,3v6c0,0.6,0.5,1,1,1h8c0.6,0,1-0.4,1-1V4c0-0.5-0.4-1-1-1H6L5,2L5,2z"/>
+	<polygon id="Shape_1_" class="st0" points="0,0 12,0 12,12 0,12 	"/>
+</g>
+<g>
+	<line class="st1" x1="5" y1="3.3" x2="5" y2="7.7"/>
+	<line class="st1" x1="7.2" y1="5.5" x2="2.8" y2="5.5"/>
+</g>
+</svg>

--- a/packages/theming/style/icons/md/upload.svg
+++ b/packages/theming/style/icons/md/upload.svg
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
-    <path fill="none" d="M0,0h18v18H0V0z"/>
-    <path d="M6.8,11.8h4.5V7.2h3L9,2L3.8,7.2h3V11.8z M3.8,14h10.5v2H3.8V14z"/>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 18 18" style="enable-background:new 0 0 18 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<path class="st0" d="M0,0h18v18H0V0z"/>
+<path d="M6.8,9.8h4.5V5.2h3L9,0L3.8,5.2h3V9.8z M3.8,12h10.5v2H3.8V12z"/>
 </svg>

--- a/packages/theming/style/variables-light.css
+++ b/packages/theming/style/variables-light.css
@@ -174,6 +174,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-toolbar-border-color: var(--md-grey-400);
   --jp-toolbar-micro-height: 8px;
   --jp-toolbar-background: var(--jp-layout-color0);
-  --jp-toolbar-box-shadow: 0px 0.4px 6px 0px rgba(0,0,0,0.1);
+  --jp-toolbar-box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);
 
 }

--- a/packages/theming/style/variables-light.css
+++ b/packages/theming/style/variables-light.css
@@ -175,5 +175,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-toolbar-micro-height: 8px;
   --jp-toolbar-background: var(--jp-layout-color0);
   --jp-toolbar-box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);
-
+  --jp-toolbar-header-margin: 4px 4px 0px 4px;
+  --jp-toolbar-active-background: var(--md-grey-300);
 }


### PR DESCRIPTION
In this PR, I focused on reviewing the design buttons in the toolbars of both side panes as well as the notebook toolbar. The toolbar header inside of side panels now have a margin that allows the toolbar buttons to look like standalone buttons on hover. Instead of having a depressed look for toolbar buttons on hover, the buttons now feel like they are hovering off the page. I also added an active state for the buttons when you click on them. The user experience of these buttons feels a lot more refined.

#### Before (File browser toolbar buttons)
![ezgif-1-1451da7f2a](https://user-images.githubusercontent.com/6437976/27199318-6d12ca9c-51ca-11e7-935c-6e7a1c6ed78b.gif)

#### After 
![ezgif-1-f4bd4d481c](https://user-images.githubusercontent.com/6437976/27199174-edc00854-51c9-11e7-90e0-6fbfbd2fc6c7.gif)

#### Before (Running sessions browser toolbar buttons)
![ezgif-1-cbf19785f3](https://user-images.githubusercontent.com/6437976/27199366-9ad14c38-51ca-11e7-8b2e-a45162a5eceb.gif)

#### After
![ezgif-1-01dcaee8c5](https://user-images.githubusercontent.com/6437976/27199224-160d6b58-51ca-11e7-825a-1998e3312a12.gif)

#### Before (Notebook toolbar buttons)
![ezgif-1-1fb7a2abba](https://user-images.githubusercontent.com/6437976/27199436-c611ff78-51ca-11e7-8318-6eb862368c85.gif)

#### After
![ezgif-1-e5dae39eb9](https://user-images.githubusercontent.com/6437976/27199263-36ecbcb6-51ca-11e7-81a1-746950302492.gif)
