### PR TITLE
Do not cache the local node_modules in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
   firefox: latest
 cache:
   directories:
-    - node_modules
     - $HOME/.npm
 env:
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
 
 # build cache to preserve files/folders between builds
 cache:
-  - node_modules # NPM packages
+  - '%APPDATA%\npm-cache'  # npm cache
 
 # scripts that run after cloning repository
 install:


### PR DESCRIPTION
Use the global cache but not the local one to avoid bugs when we add/remove deps.