### PR TITLE
Dialog button style fixes

### DIFF
--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -83,12 +83,14 @@
 button.jp-mod-styled.jp-mod-accept {
   background: var(--jp-brand-color1);
   color: var(--jp-inverse-ui-font-color0);
+  border: 1px solid var(--jp-brand-color1);
 }
 
 
 button.jp-mod-styled.jp-mod-reject {
-  background: #9E9E9E;
+  background: var(--md-grey-500);
   margin-right: 12px;
+  border: 1px solid var(--md-grey-500);
   color: var(--jp-inverse-ui-font-color0);
 }
 
@@ -96,6 +98,7 @@ button.jp-mod-styled.jp-mod-reject {
 button.jp-mod-styled.jp-mod-warn {
   background: var(--jp-error-color1);
   color: var(--jp-inverse-ui-font-color0);
+  border: 1px solid var(--jp-error-color1);
 }
 
 
@@ -117,4 +120,3 @@ button.jp-mod-styled.jp-mod-warn {
   font-size: var(--jp-ui-font-size1);
   color: var(--md-grey-700);
 }
-

--- a/packages/apputils/style/styling.css
+++ b/packages/apputils/style/styling.css
@@ -14,7 +14,7 @@ button.jp-mod-styled {
   text-align: center;
   line-height: 32px;
   height: 32px;
-  padding: 0px 8px;
+  padding: 0px 12px;
   letter-spacing: .8px;
   outline: none;
   appearance: none;


### PR DESCRIPTION
Added more space to the padding of the dialog buttons:

#### Before
![screen shot 2017-06-19 at 9 21 15 am](https://user-images.githubusercontent.com/6437976/27295197-dfd09d94-54d0-11e7-9551-e37af22347b3.png)

#### After
![screen shot 2017-06-19 at 9 22 29 am](https://user-images.githubusercontent.com/6437976/27295207-e343e94a-54d0-11e7-827d-cbe55e4182fd.png)

Added css borders to all of the dialog buttons so that when the buttons are in focus, they do not shift in position:

#### Before
![ezgif-1-8070245705](https://user-images.githubusercontent.com/6437976/27295269-28635af6-54d1-11e7-82d8-14821fcd0b31.gif)

#### After
![ezgif-1-8c3014dd7b](https://user-images.githubusercontent.com/6437976/27295282-37c0eff4-54d1-11e7-9d5e-a1f043e24e54.gif)
