### PR TITLE
Notebook drag image refinement

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -9,7 +9,7 @@
 
 
 :root {
-  --jp-private-notebook-dragImage-width: 280px;
+  --jp-private-notebook-dragImage-width: 304px;
   --jp-private-notebook-dragImage-height: 36px;
   --jp-private-notebook-selected-color: var(--md-blue-400);
   --jp-private-notebook-multiselected-color: var(--md-blue-50);


### PR DESCRIPTION
Changed the width of the notebook cell's drag image. The drag image didnt seem to be wide enough to fit all text inputs, as pointed out by @ellisonbg in issue #2473