### PR TITLE
Add ready Promise for documents and renderer widgets

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -156,7 +156,7 @@ const RENDER_TIMEOUT = 1000;
  * A base cell widget.
  */
 export
-class Cell extends Widget {
+class Cell extends Widget implements RenderMime.IReadyWidget {
   /**
    * Construct a new base cell widget.
    */
@@ -243,6 +243,13 @@ class Cell extends Widget {
     }
     this._readOnly = value;
     this.update();
+  }
+
+  /**
+   * A promise that resolves when the widget renders for the first time.
+   */
+  get ready(): Promise<void> {
+    return Promise.resolve(undefined);
   }
 
   /**

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -4,6 +4,10 @@
 import * as dsv from 'd3-dsv';
 
 import {
+  PromiseDelegate
+} from '@phosphor/coreutils';
+
+import {
   DataGrid, JSONModel
 } from '@phosphor/datagrid';
 
@@ -12,11 +16,7 @@ import {
 } from '@phosphor/messaging';
 
 import {
-  PanelLayout
-} from '@phosphor/widgets';
-
-import {
-  Widget
+  PanelLayout, Widget
 } from '@phosphor/widgets';
 
 import {
@@ -57,7 +57,7 @@ const RENDER_TIMEOUT = 1000;
  * A viewer for CSV tables.
  */
 export
-class CSVViewer extends Widget {
+class CSVViewer extends Widget implements DocumentRegistry.IWidget {
   /**
    * Construct a new CSV viewer.
    */
@@ -81,12 +81,17 @@ class CSVViewer extends Widget {
     layout.addWidget(this._grid);
 
     context.pathChanged.connect(this._onPathChanged, this);
-    // Throttle the rendering rate of the widget.
-    this._monitor = new ActivityMonitor({
-      signal: context.model.contentChanged,
-      timeout: RENDER_TIMEOUT
+
+    this._context.ready.then(() => {
+      this._updateGrid();
+      this._ready.resolve(undefined);
+      // Throttle the rendering rate of the widget.
+      this._monitor = new ActivityMonitor({
+        signal: context.model.contentChanged,
+        timeout: RENDER_TIMEOUT
+      });
+      this._monitor.activityStopped.connect(this._updateGrid, this);
     });
-    this._monitor.activityStopped.connect(this._updateGrid, this);
   }
 
   /**
@@ -94,6 +99,13 @@ class CSVViewer extends Widget {
    */
   get context(): DocumentRegistry.Context {
     return this._context;
+  }
+
+  /**
+   * A promise that resolves when the csv viewer is ready.
+   */
+  get ready() {
+    return this._ready.promise;
   }
 
   /**
@@ -160,6 +172,7 @@ class CSVViewer extends Widget {
   private _toolbar: CSVToolbar = null;
   private _monitor: ActivityMonitor<any, any> = null;
   private _delimiter = ',';
+  private _ready = new PromiseDelegate<void>();
 }
 
 

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -115,16 +115,14 @@ class CSVViewer extends Widget implements DocumentRegistry.IWidget {
     if (this._grid === null) {
       return;
     }
-    let grid = this._grid;
-    let toolbar = this._toolbar;
     let monitor = this._monitor;
     this._grid = null;
     this._toolbar = null;
     this._monitor = null;
 
-    grid.dispose();
-    toolbar.dispose();
-    monitor.dispose();
+    if (monitor) {
+      monitor.dispose();
+    }
 
     super.dispose();
   }

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -57,7 +57,7 @@ const RENDER_TIMEOUT = 1000;
  * A viewer for CSV tables.
  */
 export
-class CSVViewer extends Widget implements DocumentRegistry.IWidget {
+class CSVViewer extends Widget implements DocumentRegistry.IReadyWidget {
   /**
    * Construct a new CSV viewer.
    */

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -16,6 +16,7 @@
     "@jupyterlab/codeeditor": "^0.7.0",
     "@jupyterlab/codemirror": "^0.7.0",
     "@jupyterlab/coreutils": "^0.7.0",
+    "@jupyterlab/rendermime": "^0.7.0",
     "@jupyterlab/services": "^0.46.0",
     "@phosphor/algorithm": "^1.1.1",
     "@phosphor/coreutils": "^1.1.1",

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -14,10 +14,6 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  Widget
-} from '@phosphor/widgets';
-
-import {
   CodeEditor
 } from '@jupyterlab/codeeditor';
 
@@ -276,7 +272,7 @@ class Base64ModelFactory extends TextModelFactory {
  * The default implemetation of a widget factory.
  */
 export
-abstract class ABCWidgetFactory<T extends Widget, U extends DocumentRegistry.IModel> implements DocumentRegistry.IWidgetFactory<T, U> {
+abstract class ABCWidgetFactory<T extends DocumentRegistry.IWidget, U extends DocumentRegistry.IModel> implements DocumentRegistry.IWidgetFactory<T, U> {
   /**
    * Construct a new `ABCWidgetFactory`.
    */

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -272,7 +272,7 @@ class Base64ModelFactory extends TextModelFactory {
  * The default implemetation of a widget factory.
  */
 export
-abstract class ABCWidgetFactory<T extends DocumentRegistry.IWidget, U extends DocumentRegistry.IModel> implements DocumentRegistry.IWidgetFactory<T, U> {
+abstract class ABCWidgetFactory<T extends DocumentRegistry.IReadyWidget, U extends DocumentRegistry.IModel> implements DocumentRegistry.IWidgetFactory<T, U> {
   /**
    * Construct a new `ABCWidgetFactory`.
    */

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -37,6 +37,11 @@ import {
   IChangedArgs as IChangedArgsGeneric, PathExt, IModelDB
 } from '@jupyterlab/coreutils';
 
+import {
+  RenderMime
+} from '@jupyterlab/rendermime';
+
+
 /* tslint:disable */
 /**
  * The document registry token.
@@ -822,18 +827,13 @@ namespace DocumentRegistry {
    * A widget for a document.
    */
   export
-  interface IWidget extends Widget {
-    /**
-     * A promise that resolves when the document is ready.
-     */
-    ready: Promise<void>;
-  }
+  interface IReadyWidget extends RenderMime.IReadyWidget { }
 
   /**
    * The interface for a widget factory.
    */
   export
-  interface IWidgetFactory<T extends IWidget, U extends IModel> extends IDisposable, IWidgetFactoryOptions {
+  interface IWidgetFactory<T extends IReadyWidget, U extends IModel> extends IDisposable, IWidgetFactoryOptions {
     /**
      * A signal emitted when a widget is created.
      */
@@ -852,7 +852,7 @@ namespace DocumentRegistry {
    * A type alias for a standard widget factory.
    */
   export
-  type WidgetFactory = IWidgetFactory<IWidget, IModel>;
+  type WidgetFactory = IWidgetFactory<IReadyWidget, IModel>;
 
   /**
    * An interface for a widget extension.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -819,10 +819,21 @@ namespace DocumentRegistry {
   }
 
   /**
+   * A widget for a document.
+   */
+  export
+  interface IWidget extends Widget {
+    /**
+     * A promise that resolves when the document is ready.
+     */
+    ready: Promise<void>;
+  }
+
+  /**
    * The interface for a widget factory.
    */
   export
-  interface IWidgetFactory<T extends Widget, U extends IModel> extends IDisposable, IWidgetFactoryOptions {
+  interface IWidgetFactory<T extends IWidget, U extends IModel> extends IDisposable, IWidgetFactoryOptions {
     /**
      * A signal emitted when a widget is created.
      */
@@ -841,7 +852,7 @@ namespace DocumentRegistry {
    * A type alias for a standard widget factory.
    */
   export
-  type WidgetFactory = IWidgetFactory<Widget, IModel>;
+  type WidgetFactory = IWidgetFactory<IWidget, IModel>;
 
   /**
    * An interface for a widget extension.

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -29,7 +29,7 @@ const EDITOR_CLASS = 'jp-FileEditor';
  * A document widget for editors.
  */
 export
-class FileEditor extends CodeEditorWrapper {
+class FileEditor extends CodeEditorWrapper implements DocumentRegistry.IWidget {
   /**
    * Construct a new editor widget.
    */
@@ -71,6 +71,13 @@ class FileEditor extends CodeEditorWrapper {
    */
   get context(): DocumentRegistry.Context {
     return this._context;
+  }
+
+  /**
+   * A promise that resolves when the file editor is ready.
+   */
+  get ready(): Promise<void> {
+    return this._context.ready;
   }
 
   /**

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -13,6 +13,10 @@ import {
   CodeEditor, IEditorServices, IEditorMimeTypeService, CodeEditorWrapper
 } from '@jupyterlab/codeeditor';
 
+import {
+  PromiseDelegate
+} from '@phosphor/coreutils';
+
 
 /**
  * The class name added to a dirty widget.
@@ -29,7 +33,7 @@ const EDITOR_CLASS = 'jp-FileEditor';
  * A document widget for editors.
  */
 export
-class FileEditor extends CodeEditorWrapper implements DocumentRegistry.IWidget {
+class FileEditor extends CodeEditorWrapper implements DocumentRegistry.IReadyWidget {
   /**
    * Construct a new editor widget.
    */
@@ -77,7 +81,7 @@ class FileEditor extends CodeEditorWrapper implements DocumentRegistry.IWidget {
    * A promise that resolves when the file editor is ready.
    */
   get ready(): Promise<void> {
-    return this._context.ready;
+    return this._ready.promise;
   }
 
   /**
@@ -101,6 +105,9 @@ class FileEditor extends CodeEditorWrapper implements DocumentRegistry.IWidget {
     // Wire signal connections.
     contextModel.stateChanged.connect(this._onModelStateChanged, this);
     contextModel.contentChanged.connect(this._onContentChanged, this);
+
+    // Resolve the ready promise.
+    this._ready.resolve(undefined);
   }
 
   /**
@@ -163,6 +170,7 @@ class FileEditor extends CodeEditorWrapper implements DocumentRegistry.IWidget {
 
   protected _context: DocumentRegistry.Context;
   private _mimeTypeService: IEditorMimeTypeService;
+  private _ready = new PromiseDelegate<void>();
 }
 
 

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -24,7 +24,7 @@ const IMAGE_CLASS = 'jp-ImageViewer';
  * A widget for images.
  */
 export
-class ImageViewer extends Widget {
+class ImageViewer extends Widget implements DocumentRegistry.IWidget {
   /**
    * Construct a new image widget.
    */
@@ -49,6 +49,13 @@ class ImageViewer extends Widget {
    */
   get context(): DocumentRegistry.Context {
     return this._context;
+  }
+
+  /**
+   * A promise that resolves when the image viewer is ready.
+   */
+  get ready(): Promise<void> {
+    return this._context.ready;
   }
 
   /**

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -41,7 +41,7 @@ const RENDER_TIMEOUT = 1000;
  * A widget for rendered markdown.
  */
 export
-class MarkdownViewer extends Widget {
+class MarkdownViewer extends Widget implements DocumentRegistry.IWidget {
   /**
    * Construct a new markdown widget.
    */
@@ -59,12 +59,17 @@ class MarkdownViewer extends Widget {
 
     context.pathChanged.connect(this._onPathChanged, this);
 
-    // Throttle the rendering rate of the widget.
-    this._monitor = new ActivityMonitor({
-      signal: context.model.contentChanged,
-      timeout: RENDER_TIMEOUT
+    this._context.ready.then(() => {
+      // Throttle the rendering rate of the widget.
+      this._monitor = new ActivityMonitor({
+        signal: context.model.contentChanged,
+        timeout: RENDER_TIMEOUT
+      });
+      this._monitor.activityStopped.connect(this.update, this);
+      if (this.isAttached) {
+        this.update();
+      }
     });
-    this._monitor.activityStopped.connect(this.update, this);
   }
 
   /**
@@ -72,6 +77,13 @@ class MarkdownViewer extends Widget {
    */
   get context(): DocumentRegistry.Context {
     return this._context;
+  }
+
+  /**
+   * A promise that resolves when the markdown viewer is ready.
+   */
+  get ready(): Promise<void> {
+    return this._context.ready;
   }
 
   /**

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -45,7 +45,7 @@ const RENDER_TIMEOUT = 1000;
  * A widget for rendered markdown.
  */
 export
-class MarkdownViewer extends Widget implements DocumentRegistry.IWidget {
+class MarkdownViewer extends Widget implements DocumentRegistry.IReadyWidget {
   /**
    * Construct a new markdown widget.
    */
@@ -122,7 +122,7 @@ class MarkdownViewer extends Widget implements DocumentRegistry.IWidget {
   /**
    * Render the markdown content.
    */
-  private _render(): RenderMime.IWidget {
+  private _render(): RenderMime.IReadyWidget {
     let context = this._context;
     let model = context.model;
     let layout = this.layout as PanelLayout;

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -98,7 +98,9 @@ class MarkdownViewer extends Widget implements DocumentRegistry.IWidget {
     if (this.isDisposed) {
       return;
     }
-    this._monitor.dispose();
+    if (this._monitor) {
+      this._monitor.dispose();
+    }
     super.dispose();
   }
 

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -78,7 +78,7 @@ const DIRTY_CLASS = 'jp-mod-dirty';
  * kernel on the context.
  */
 export
-class NotebookPanel extends Widget {
+class NotebookPanel extends Widget implements DocumentRegistry.IWidget {
   /**
    * Construct a new notebook panel.
    */
@@ -129,6 +129,13 @@ class NotebookPanel extends Widget {
    */
   get session(): IClientSession {
     return this._context ? this._context.session : null;
+  }
+
+  /**
+   * A promise that resolves when the notebook panel is ready.
+   */
+  get ready(): Promise<void> {
+    return this._context.ready;
   }
 
   /**

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -31,6 +31,10 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
+  MarkdownCell
+} from '@jupyterlab/cells';
+
+import {
   IEditorMimeTypeService
 } from '@jupyterlab/codeeditor';
 
@@ -135,7 +139,15 @@ class NotebookPanel extends Widget implements DocumentRegistry.IWidget {
    * A promise that resolves when the notebook panel is ready.
    */
   get ready(): Promise<void> {
-    return this._context.ready;
+    return this._context.ready.then(() => {
+      let promises: Promise<void>[] = [];
+      each(this.notebook.widgets, widget => {
+        if (widget instanceof MarkdownCell) {
+          promises.push(widget.ready);
+        }
+      });
+      return Promise.all(promises).then(() => undefined);
+    });
   }
 
   /**

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -31,10 +31,6 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  MarkdownCell
-} from '@jupyterlab/cells';
-
-import {
   IEditorMimeTypeService
 } from '@jupyterlab/codeeditor';
 
@@ -82,7 +78,7 @@ const DIRTY_CLASS = 'jp-mod-dirty';
  * kernel on the context.
  */
 export
-class NotebookPanel extends Widget implements DocumentRegistry.IWidget {
+class NotebookPanel extends Widget implements DocumentRegistry.IReadyWidget {
   /**
    * Construct a new notebook panel.
    */
@@ -142,9 +138,7 @@ class NotebookPanel extends Widget implements DocumentRegistry.IWidget {
     return this._context.ready.then(() => {
       let promises: Promise<void>[] = [];
       each(this.notebook.widgets, widget => {
-        if (widget instanceof MarkdownCell) {
-          promises.push(widget.ready);
-        }
+        promises.push(widget.ready);
       });
       return Promise.all(promises).then(() => undefined);
     });

--- a/packages/rendermime/src/mimemodel.ts
+++ b/packages/rendermime/src/mimemodel.ts
@@ -2,12 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  JSONObject
+  JSONObject, JSONValue
 } from '@phosphor/coreutils';
-
-import {
-  IObservableJSON, ObservableJSON
-} from '@jupyterlab/coreutils';
 
 import {
   RenderMime
@@ -24,50 +20,24 @@ class MimeModel implements RenderMime.IMimeModel {
    */
   constructor(options: MimeModel.IOptions = {}) {
     this.trusted = !!options.trusted;
-    this.data = new ObservableJSON({ values: options.data });
-    this.metadata = new ObservableJSON({ values: options.metadata });
+    this.data = new Private.Bundle(options.data || {});
+    this.metadata = new Private.Bundle(options.metadata || {});
   }
 
   /**
    * The data associated with the model.
    */
-  readonly data: IObservableJSON;
+  readonly data: RenderMime.IBundle;
 
   /**
    * The metadata associated with the model.
    */
-  readonly metadata: IObservableJSON;
+  readonly metadata: RenderMime.IBundle;
 
   /**
    * Whether the model is trusted.
    */
   readonly trusted: boolean;
-
-  /**
-   * Test whether the model is disposed.
-   */
-  get isDisposed(): boolean {
-    return this.data.isDisposed;
-  }
-
-  /**
-   * Dispose of the resources used by the mime model.
-   */
-  dispose(): void {
-    this.data.dispose();
-    this.metadata.dispose();
-  }
-
-  /**
-   * Serialize the model as JSON data.
-   */
-  toJSON(): JSONObject {
-    return {
-      trusted: this.trusted,
-      data: this.data.toJSON(),
-      metadata: this.metadata.toJSON()
-    };
-  }
 }
 
 
@@ -98,3 +68,61 @@ namespace MimeModel {
   }
 }
 
+
+/**
+ * A namespace for module private data.
+ */
+namespace Private {
+  /**
+   * The default implementation of an ibundle.
+   */
+  export
+  class Bundle implements RenderMime.IBundle {
+    /**
+     * Create a new bundle.
+     */
+    constructor(values: JSONObject) {
+      this._values = values;
+    }
+
+    /**
+     * Get a value for a given key.
+     *
+     * @param key - the key.
+     *
+     * @returns the value for that key.
+     */
+    get(key: string): JSONValue {
+      return this._values[key];
+    }
+
+    /**
+     * Check whether the bundle has a key.
+     *
+     * @param key - the key to check.
+     *
+     * @returns `true` if the bundle has the key, `false` otherwise.
+     */
+    has(key: string): boolean {
+      return Object.keys(this._values).indexOf(key) !== -1;
+    }
+
+    /**
+     * Set a key-value pair in the bundle.
+     *
+     * @param key - The key to set.
+     *
+     * @param value - The value for the key.
+     *
+     * @returns the old value for the key, or undefined
+     *   if that did not exist.
+     */
+    set(key: string, value: JSONValue): JSONValue {
+      let old = this._values[key];
+      this._values[key] = value;
+      return old;
+    }
+
+    private _values: JSONObject;
+  }
+}

--- a/packages/rendermime/src/mimemodel.ts
+++ b/packages/rendermime/src/mimemodel.ts
@@ -20,8 +20,8 @@ class MimeModel implements RenderMime.IMimeModel {
    */
   constructor(options: MimeModel.IOptions = {}) {
     this.trusted = !!options.trusted;
-    this.data = new Private.Bundle(options.data || {});
-    this.metadata = new Private.Bundle(options.metadata || {});
+    this.data = new MimeModel.Bundle(options.data || {});
+    this.metadata = new MimeModel.Bundle(options.metadata || {});
   }
 
   /**
@@ -66,13 +66,7 @@ namespace MimeModel {
      */
     metadata?: JSONObject;
   }
-}
 
-
-/**
- * A namespace for module private data.
- */
-namespace Private {
   /**
    * The default implementation of an ibundle.
    */
@@ -120,6 +114,29 @@ namespace Private {
     set(key: string, value: JSONValue): JSONValue {
       let old = this._values[key];
       this._values[key] = value;
+      return old;
+    }
+
+    /**
+     * Get a list of the keys in the bundle.
+     *
+     * @returns - a list of keys.
+     */
+    keys(): string[] {
+      return Object.keys(this._values);
+    }
+
+    /**
+     * Remove a key from the bundle.
+     *
+     * @param key - the key to remove.
+     *
+     * @returns the value of the given key,
+     *   or undefined if that does not exist.
+     */
+    delete(key: string): JSONValue {
+      let old = this._values[key];
+      delete this._values[key];
       return old;
     }
 

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -6,7 +6,7 @@ import {
 } from '@phosphor/coreutils';
 
 import {
-  nbformat
+  IObservableJSON, ObservableJSON, nbformat
 } from '@jupyterlab/coreutils';
 
 import {
@@ -67,12 +67,15 @@ namespace IOutputModel {
  * The default implementation of a notebook output model.
  */
 export
-class OutputModel extends MimeModel implements IOutputModel {
+class OutputModel implements IOutputModel {
   /**
    * Construct a new output model.
    */
   constructor(options: IOutputModel.IOptions) {
-    super(Private.getBundleOptions(options));
+    let { trusted, data, metadata } = Private.getBundleOptions(options);
+    this.trusted = trusted;
+    this.data = new ObservableJSON({ values: data });
+    this.metadata = new ObservableJSON({ values: metadata });
     // Make a copy of the data.
     let value = options.value;
     for (let key in value) {
@@ -102,6 +105,21 @@ class OutputModel extends MimeModel implements IOutputModel {
    * The execution count.
    */
   readonly executionCount: nbformat.ExecutionCount;
+
+  /**
+   * The data associated with the model.
+   */
+  readonly data: IObservableJSON;
+
+  /**
+   * The metadata associated with the model.
+   */
+  readonly metadata: IObservableJSON;
+
+  /**
+   * Whether the model is trusted.
+   */
+  readonly trusted: boolean;
 
   /**
    * Serialize the model to JSON.

--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -34,6 +34,21 @@ interface IOutputModel extends RenderMime.IMimeModel {
   readonly executionCount: nbformat.ExecutionCount;
 
   /**
+   * The data associated with the model.
+   */
+  readonly data: IObservableJSON;
+
+  /**
+   * The metadata associated with the model.
+   */
+  readonly metadata: IObservableJSON;
+
+  /**
+   * Dispose of the resources used by the output model.
+   */
+  dispose(): void;
+
+  /**
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.IOutput;
@@ -120,6 +135,14 @@ class OutputModel implements IOutputModel {
    * Whether the model is trusted.
    */
   readonly trusted: boolean;
+
+  /**
+   * Dispose of the resources used by the output model.
+   */
+  dispose(): void {
+    this.data.dispose();
+    this.metadata.dispose();
+  }
 
   /**
    * Serialize the model to JSON.

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -27,7 +27,7 @@ class HTMLRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
     return new RenderedHTML(options);
   }
 
@@ -60,7 +60,7 @@ class ImageRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
     return new RenderedImage(options);
   }
 
@@ -94,7 +94,7 @@ class TextRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
     return new RenderedText(options);
   }
 
@@ -130,7 +130,7 @@ class JavaScriptRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
     return new RenderedJavaScript(options);
   }
 
@@ -166,7 +166,7 @@ class SVGRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
     return new RenderedSVG(options);
   }
 
@@ -202,7 +202,7 @@ class PDFRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
     return new RenderedPDF(options);
   }
 
@@ -235,7 +235,7 @@ class LatexRenderer implements RenderMime.IRenderer  {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
     return new RenderedLatex(options);
   }
 
@@ -268,7 +268,7 @@ class MarkdownRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
     return new RenderedMarkdown(options);
   }
 

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Widget
-} from '@phosphor/widgets';
-
-import {
   RenderMime, RenderedHTML, RenderedMarkdown, RenderedText, RenderedImage,
   RenderedJavaScript, RenderedSVG, RenderedPDF, RenderedLatex
 } from '.';
@@ -31,7 +27,7 @@ class HTMLRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
     return new RenderedHTML(options);
   }
 
@@ -64,7 +60,7 @@ class ImageRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
     return new RenderedImage(options);
   }
 
@@ -98,7 +94,7 @@ class TextRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
     return new RenderedText(options);
   }
 
@@ -134,7 +130,7 @@ class JavaScriptRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
     return new RenderedJavaScript(options);
   }
 
@@ -170,7 +166,7 @@ class SVGRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
     return new RenderedSVG(options);
   }
 
@@ -206,7 +202,7 @@ class PDFRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
     return new RenderedPDF(options);
   }
 
@@ -239,7 +235,7 @@ class LatexRenderer implements RenderMime.IRenderer  {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
     return new RenderedLatex(options);
   }
 
@@ -272,7 +268,7 @@ class MarkdownRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
     return new RenderedMarkdown(options);
   }
 

--- a/packages/rendermime/src/rendermime.ts
+++ b/packages/rendermime/src/rendermime.ts
@@ -336,6 +336,17 @@ namespace RenderMime {
   }
 
   /**
+   * A rendered widget.
+   */
+  export
+  interface IWidget extends Widget {
+    /**
+     * A promise that resolves when the widget is ready.
+     */
+    ready: Promise<void>;
+  }
+
+  /**
    * The interface for a renderer.
    */
   export
@@ -357,7 +368,7 @@ namespace RenderMime {
      *
      * @param options - The options used to render the data.
      */
-    render(options: IRenderOptions): Widget;
+    render(options: IRenderOptions): IWidget;
 
     /**
      * Whether the renderer will sanitize the data given the render options.

--- a/packages/rendermime/src/rendermime.ts
+++ b/packages/rendermime/src/rendermime.ts
@@ -300,15 +300,6 @@ namespace RenderMime {
     get(key: string): JSONValue;
 
     /**
-     * Check whether the bundle has a key.
-     *
-     * @param key - the key to check.
-     *
-     * @returns `true` if the bundle has the key, `false` otherwise.
-     */
-    has(key: string): boolean;
-
-    /**
      * Set a key-value pair in the bundle.
      *
      * @param key - The key to set.
@@ -319,6 +310,32 @@ namespace RenderMime {
      *   if that did not exist.
      */
     set(key: string, value: JSONValue): JSONValue;
+
+    /**
+     * Check whether the bundle has a key.
+     *
+     * @param key - the key to check.
+     *
+     * @returns `true` if the bundle has the key, `false` otherwise.
+     */
+    has(key: string): boolean;
+
+    /**
+     * Get a list of the keys in the bundle.
+     *
+     * @returns - a list of keys.
+     */
+    keys(): string[];
+
+    /**
+     * Remove a key from the bundle.
+     *
+     * @param key - the key to remove.
+     *
+     * @returns the value of the given key,
+     *   or undefined if that does not exist.
+     */
+    delete(key: string): JSONValue;
   }
 
   /**

--- a/packages/rendermime/src/rendermime.ts
+++ b/packages/rendermime/src/rendermime.ts
@@ -106,7 +106,7 @@ class RenderMime {
    * Renders the model using the preferred mime type.  See
    * [[preferredMimeType]].
    */
-  render(model: RenderMime.IMimeModel): Widget {
+  render(model: RenderMime.IMimeModel): RenderMime.IWidget {
     let mimeType = this.preferredMimeType(model);
     if (!mimeType) {
       return this._handleError(model);
@@ -215,7 +215,7 @@ class RenderMime {
   /**
    * Return a widget for an error.
    */
-  private _handleError(model: RenderMime.IMimeModel): Widget {
+  private _handleError(model: RenderMime.IMimeModel): RenderMime.IWidget {
    let errModel = new MimeModel({
       data: {
         'application/vnd.jupyter.stderr': 'Unable to render data'

--- a/packages/rendermime/src/rendermime.ts
+++ b/packages/rendermime/src/rendermime.ts
@@ -102,7 +102,7 @@ class RenderMime {
    * Renders the model using the preferred mime type.  See
    * [[preferredMimeType]].
    */
-  render(model: RenderMime.IMimeModel): RenderMime.IWidget {
+  render(model: RenderMime.IMimeModel): RenderMime.IReadyWidget {
     let mimeType = this.preferredMimeType(model);
     if (!mimeType) {
       return this._handleError(model);
@@ -211,7 +211,7 @@ class RenderMime {
   /**
    * Return a widget for an error.
    */
-  private _handleError(model: RenderMime.IMimeModel): RenderMime.IWidget {
+  private _handleError(model: RenderMime.IMimeModel): RenderMime.IReadyWidget {
    let errModel = new MimeModel({
       data: {
         'application/vnd.jupyter.stderr': 'Unable to render data'
@@ -366,7 +366,7 @@ namespace RenderMime {
    * A rendered widget.
    */
   export
-  interface IWidget extends Widget {
+  interface IReadyWidget extends Widget {
     /**
      * A promise that resolves when the widget is ready.
      */
@@ -395,7 +395,7 @@ namespace RenderMime {
      *
      * @param options - The options used to render the data.
      */
-    render(options: IRenderOptions): IWidget;
+    render(options: IRenderOptions): IReadyWidget;
 
     /**
      * Whether the renderer will sanitize the data given the render options.

--- a/packages/rendermime/src/rendermime.ts
+++ b/packages/rendermime/src/rendermime.ts
@@ -10,19 +10,15 @@ import {
 } from '@phosphor/algorithm';
 
 import {
-  JSONObject
+  JSONValue
 } from '@phosphor/coreutils';
-
-import {
-  IDisposable
-} from '@phosphor/disposable';
 
 import {
   Widget
 } from '@phosphor/widgets';
 
 import {
-  IObservableJSON, PathExt, URLExt
+  PathExt, URLExt
 } from '@jupyterlab/coreutils';
 
 import {
@@ -290,10 +286,46 @@ namespace RenderMime {
   }
 
   /**
+   * A bundle for mime data.
+   */
+  export
+  interface IBundle {
+    /**
+     * Get a value for a given key.
+     *
+     * @param key - the key.
+     *
+     * @returns the value for that key.
+     */
+    get(key: string): JSONValue;
+
+    /**
+     * Check whether the bundle has a key.
+     *
+     * @param key - the key to check.
+     *
+     * @returns `true` if the bundle has the key, `false` otherwise.
+     */
+    has(key: string): boolean;
+
+    /**
+     * Set a key-value pair in the bundle.
+     *
+     * @param key - The key to set.
+     *
+     * @param value - The value for the key.
+     *
+     * @returns the old value for the key, or undefined
+     *   if that did not exist.
+     */
+    set(key: string, value: JSONValue): JSONValue;
+  }
+
+  /**
    * An observable model for mime data.
    */
   export
-  interface IMimeModel extends IDisposable {
+  interface IMimeModel {
     /**
      * Whether the model is trusted.
      */
@@ -302,17 +334,12 @@ namespace RenderMime {
     /**
      * The data associated with the model.
      */
-    readonly data: IObservableJSON;
+    readonly data: IBundle;
 
     /**
      * The metadata associated with the model.
      */
-    readonly metadata: IObservableJSON;
-
-    /**
-     * Serialize the model as JSON data.
-     */
-    toJSON(): JSONObject;
+    readonly metadata: IBundle;
   }
 
   /**

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -88,7 +88,7 @@ const PDF_CLASS = 'jp-RenderedPDF';
  * A widget for displaying any widget whoes representation is rendered HTML
  * */
 export
-class RenderedHTMLCommon extends Widget implements RenderMime.IWidget {
+class RenderedHTMLCommon extends Widget implements RenderMime.IReadyWidget {
   /* Construct a new rendered HTML common widget.*/
   constructor(options: RenderMime.IRenderOptions) {
     super();

--- a/test/src/docmanager/manager.spec.ts
+++ b/test/src/docmanager/manager.spec.ts
@@ -24,10 +24,17 @@ import {
 } from '../utils';
 
 
-class WidgetFactory extends ABCWidgetFactory<Widget, DocumentRegistry.IModel> {
+class DocWidget extends Widget implements DocumentRegistry.IWidget {
+  get ready(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}
 
-  protected createNewWidget(context: DocumentRegistry.Context): Widget {
-    let widget = new Widget();
+
+class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IWidget, DocumentRegistry.IModel> {
+
+  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IWidget {
+    let widget = new DocWidget();
     widget.addClass('WidgetFactory');
     return widget;
   }

--- a/test/src/docmanager/manager.spec.ts
+++ b/test/src/docmanager/manager.spec.ts
@@ -24,16 +24,16 @@ import {
 } from '../utils';
 
 
-class DocWidget extends Widget implements DocumentRegistry.IWidget {
+class DocWidget extends Widget implements DocumentRegistry.IReadyWidget {
   get ready(): Promise<void> {
     return Promise.resolve(undefined);
   }
 }
 
 
-class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IWidget, DocumentRegistry.IModel> {
+class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IReadyWidget, DocumentRegistry.IModel> {
 
-  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IWidget {
+  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IReadyWidget {
     let widget = new DocWidget();
     widget.addClass('WidgetFactory');
     return widget;

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -33,16 +33,16 @@ import {
 
 
 
-class DocWidget extends Widget implements DocumentRegistry.IWidget {
+class DocWidget extends Widget implements DocumentRegistry.IReadyWidget {
   get ready(): Promise<void> {
     return Promise.resolve(undefined);
   }
 }
 
 
-class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IWidget, DocumentRegistry.IModel> {
+class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IReadyWidget, DocumentRegistry.IModel> {
 
-  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IWidget {
+  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IReadyWidget {
     let widget = new DocWidget();
     widget.addClass('WidgetFactory');
     return widget;

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -32,10 +32,18 @@ import {
 } from '../utils';
 
 
-class WidgetFactory extends ABCWidgetFactory<Widget, DocumentRegistry.IModel> {
 
-  protected createNewWidget(context: DocumentRegistry.Context): Widget {
-    let widget = new Widget();
+class DocWidget extends Widget implements DocumentRegistry.IWidget {
+  get ready(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}
+
+
+class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IWidget, DocumentRegistry.IModel> {
+
+  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IWidget {
+    let widget = new DocWidget();
     widget.addClass('WidgetFactory');
     return widget;
   }

--- a/test/src/docregistry/default.spec.ts
+++ b/test/src/docregistry/default.spec.ts
@@ -17,10 +17,19 @@ import {
 } from '../utils';
 
 
-class WidgetFactory extends ABCWidgetFactory<Widget, DocumentRegistry.IModel> {
+class DocWidget extends Widget implements DocumentRegistry.IWidget {
+  get ready(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}
 
-  createNewWidget(context: DocumentRegistry.Context): Widget {
-    return new Widget();
+
+class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IWidget, DocumentRegistry.IModel> {
+
+  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IWidget {
+    let widget = new DocWidget();
+    widget.addClass('WidgetFactory');
+    return widget;
   }
 }
 

--- a/test/src/docregistry/default.spec.ts
+++ b/test/src/docregistry/default.spec.ts
@@ -17,16 +17,16 @@ import {
 } from '../utils';
 
 
-class DocWidget extends Widget implements DocumentRegistry.IWidget {
+class DocWidget extends Widget implements DocumentRegistry.IReadyWidget {
   get ready(): Promise<void> {
     return Promise.resolve(undefined);
   }
 }
 
 
-class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IWidget, DocumentRegistry.IModel> {
+class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IReadyWidget, DocumentRegistry.IModel> {
 
-  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IWidget {
+  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IReadyWidget {
     let widget = new DocWidget();
     widget.addClass('WidgetFactory');
     return widget;

--- a/test/src/docregistry/registry.spec.ts
+++ b/test/src/docregistry/registry.spec.ts
@@ -24,16 +24,16 @@ import {
 } from '@jupyterlab/docregistry';
 
 
-class DocWidget extends Widget implements DocumentRegistry.IWidget {
+class DocWidget extends Widget implements DocumentRegistry.IReadyWidget {
   get ready(): Promise<void> {
     return Promise.resolve(undefined);
   }
 }
 
 
-class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IWidget, DocumentRegistry.IModel> {
+class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IReadyWidget, DocumentRegistry.IModel> {
 
-  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IWidget {
+  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IReadyWidget {
     let widget = new DocWidget();
     widget.addClass('WidgetFactory');
     return widget;

--- a/test/src/docregistry/registry.spec.ts
+++ b/test/src/docregistry/registry.spec.ts
@@ -24,10 +24,19 @@ import {
 } from '@jupyterlab/docregistry';
 
 
-class WidgetFactory extends ABCWidgetFactory<Widget, DocumentRegistry.IModel> {
+class DocWidget extends Widget implements DocumentRegistry.IWidget {
+  get ready(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+}
 
-  createNewWidget(context: DocumentRegistry.Context): Widget {
-    return new Widget();
+
+class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IWidget, DocumentRegistry.IModel> {
+
+  protected createNewWidget(context: DocumentRegistry.Context): DocumentRegistry.IWidget {
+    let widget = new DocWidget();
+    widget.addClass('WidgetFactory');
+    return widget;
   }
 }
 

--- a/test/src/imageviewer/widget.spec.ts
+++ b/test/src/imageviewer/widget.spec.ts
@@ -165,15 +165,13 @@ describe('ImageViewer', () => {
 
   describe('#onUpdateRequest()', () => {
 
-    it('should add the image', (done) => {
+    it('should render the image', () => {
       let img: HTMLImageElement = widget.node.querySelector('img');
-      expect(img.src).to.be('');
-      context.ready.then(() => {
+      return widget.ready.then(() => {
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
         expect(widget.methods).to.contain('onUpdateRequest');
         expect(img.src).to.contain(IMAGE.content);
-        done();
-      }).catch(done);
+      });
     });
 
   });

--- a/test/src/markdownviewer/widget.spec.ts
+++ b/test/src/markdownviewer/widget.spec.ts
@@ -85,14 +85,15 @@ describe('markdownviewer/widget', () => {
 
     });
 
-    describe('#onAfterAttach()', () => {
+    describe('#ready', () => {
 
-      it('should update the widget', () => {
-        let widget = new LogWidget(context, RENDERMIME);
-        expect(widget.methods).to.not.contain('onAfterAttach');
-        Widget.attach(widget, document.body);
-        expect(widget.methods).to.contain('onAfterAttach');
-        widget.dispose();
+      it('should be fulfilled when the widget is done rendering', () => {
+        let widget = new MarkdownViewer(context, RENDERMIME);
+        context.save();
+        return widget.ready.then(() => {
+          let layout = widget.layout as PanelLayout;
+          expect(layout.widgets.length).to.be(2);
+        });
       });
 
     });

--- a/test/src/renderers/renderers.spec.ts
+++ b/test/src/renderers/renderers.spec.ts
@@ -294,63 +294,45 @@ describe('renderers', () => {
 
     describe('#render()', () => {
 
-      it('should set the inner html', (done) => {
+      it('should set the inner html', () => {
         let r = new MarkdownRenderer();
         let source = '<p>hello</p>';
         let mimeType = 'text/markdown';
         let model = createModel(mimeType, source);
         let widget = r.render({ mimeType, model, sanitizer });
-        let loop = () => {
-          if ((widget as any)._rendered) {
-            expect(widget.node.innerHTML).to.be(source);
-            done();
-            return;
-          }
-          setTimeout(loop, 100);
-        };
-        setTimeout(loop, 100);
+        return widget.ready.then(() => {
+          expect(widget.node.innerHTML).to.be(source);
+        });
       });
 
-      it('should add header anchors', (done) => {
+      it('should add header anchors', () => {
         let source = require('../../../examples/filebrowser/sample.md') as string;
         let r = new MarkdownRenderer();
         let mimeType = 'text/markdown';
         let model = createModel(mimeType, source);
         let widget = r.render({ mimeType, model, sanitizer });
-        let loop = () => {
-          if ((widget as any)._rendered) {
-            Widget.attach(widget, document.body);
-            let node = document.getElementById('Title-third-level');
-            expect(node.localName).to.be('h3');
-            let anchor = node.firstChild.nextSibling as HTMLAnchorElement;
-            expect(anchor.href).to.contain('#Title-third-level');
-            expect(anchor.target).to.be('_self');
-            expect(anchor.className).to.contain('jp-InternalAnchorLink');
-            expect(anchor.textContent).to.be('¶');
-            Widget.detach(widget);
-            done();
-            return;
-          }
-          setTimeout(loop, 100);
-        };
-        setTimeout(loop, 100);
+        return widget.ready.then(() => {
+          Widget.attach(widget, document.body);
+          let node = document.getElementById('Title-third-level');
+          expect(node.localName).to.be('h3');
+          let anchor = node.firstChild.nextSibling as HTMLAnchorElement;
+          expect(anchor.href).to.contain('#Title-third-level');
+          expect(anchor.target).to.be('_self');
+          expect(anchor.className).to.contain('jp-InternalAnchorLink');
+          expect(anchor.textContent).to.be('¶');
+          Widget.detach(widget);
+        });
       });
 
-      it('should sanitize the html', (done) => {
+      it('should sanitize the html', () => {
         let r = new MarkdownRenderer();
         let source = '<p>hello</p><script>alert("foo")</script>';
         let mimeType = 'text/markdown';
         let model = createModel(mimeType, source);
         let widget = r.render({ mimeType, model, sanitizer });
-        let loop = () => {
-          if ((widget as any)._rendered) {
-            expect(widget.node.innerHTML).to.not.contain('script');
-            done();
-            return;
-          }
-          setTimeout(loop, 100);
-        };
-        setTimeout(loop, 100);
+        return widget.ready.then(() => {
+          expect(widget.node.innerHTML).to.not.contain('script');
+        });
       });
 
     });

--- a/test/src/rendermime/mimemodel.spec.ts
+++ b/test/src/rendermime/mimemodel.spec.ts
@@ -4,10 +4,6 @@
 import expect = require('expect.js');
 
 import {
-  JSONExt
-} from '@phosphor/coreutils';
-
-import {
   MimeModel
 } from '@jupyterlab/rendermime';
 
@@ -18,10 +14,6 @@ describe('rendermime/mimemodel', () => {
 
   beforeEach(() => {
     model = new MimeModel();
-  });
-
-  afterEach(() => {
-    model.dispose();
   });
 
   describe('MimeModel', () => {

--- a/test/src/rendermime/mimemodel.spec.ts
+++ b/test/src/rendermime/mimemodel.spec.ts
@@ -77,21 +77,6 @@ describe('rendermime/mimemodel', () => {
 
     });
 
-    describe('#toJSON()', () => {
-
-      it('should return the raw JSON values', () => {
-        let model = new MimeModel();
-        model.data.set('foo', 1);
-        model.metadata.set('bar', 'baz');
-        expect(JSONExt.deepEqual(model.toJSON(), {
-          trusted: false,
-          data: {'foo': 1 },
-          metadata: {'bar': 'baz'}
-        })).to.be(true);
-      });
-
-    });
-
   });
 
 });

--- a/test/src/rendermime/mimemodel.spec.ts
+++ b/test/src/rendermime/mimemodel.spec.ts
@@ -55,18 +55,6 @@ describe('rendermime/mimemodel', () => {
 
     });
 
-    describe('#dispose()', () => {
-
-      it('should dispose of the resources used by the model', () => {
-        let model = new MimeModel();
-        model.dispose();
-        expect(model.isDisposed).to.be(true);
-        model.dispose();
-        expect(model.isDisposed).to.be(true);
-      });
-
-    });
-
     describe('#data', () => {
 
       it('should be the data observable map', () => {

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -152,14 +152,9 @@ describe('rendermime/index', () => {
       });
 
       it('should handle an injection', () => {
-        let called = false;
         let model = createModel({ 'test/injector': 'foo' });
-        model.data.changed.connect((sender, args) => {
-          expect(args.key).to.be('application/json');
-          called = true;
-        });
         r.render(model);
-        expect(called).to.be(true);
+        expect(model.data.get('test/injector')).to.be('foo');
       });
 
       it('should send a url resolver', (done) => {

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -164,7 +164,7 @@ namespace Private {
       return Promise.resolve(undefined);
     }
 
-    render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+    render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
       let source = options.model.data.get(options.mimeType);
       options.model.data.set(options.mimeType, json2html(source));
       return super.render(options);
@@ -180,7 +180,7 @@ namespace Private {
       return Promise.resolve(undefined);
     }
 
-    render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
+    render(options: RenderMime.IRenderOptions): RenderMime.IReadyWidget {
       options.model.data.set('application/json', { 'foo': 1 } );
       return super.render(options);
     }

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -160,7 +160,11 @@ namespace Private {
 
     mimeTypes = ['application/json'];
 
-    render(options: RenderMime.IRenderOptions): Widget {
+    get ready(): Promise<void> {
+      return Promise.resolve(undefined);
+    }
+
+    render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
       let source = options.model.data.get(options.mimeType);
       options.model.data.set(options.mimeType, json2html(source));
       return super.render(options);
@@ -172,7 +176,11 @@ namespace Private {
 
     mimeTypes = ['test/injector'];
 
-    render(options: RenderMime.IRenderOptions): Widget {
+    get ready(): Promise<void> {
+      return Promise.resolve(undefined);
+    }
+
+    render(options: RenderMime.IRenderOptions): RenderMime.IWidget {
       options.model.data.set('application/json', { 'foo': 1 } );
       return super.render(options);
     }


### PR DESCRIPTION
First part of  https://github.com/jupyterlab/jupyterlab/issues/2354.

Adds a `ready` Promise to document widgets and rendermime widgets, which is a known API change that will be needed to support linking to anchors in other documents.

Simplifies the interface for `IMimeModel` to not include any observable state, removing the ambiguity about whether a mime renderer can update.