### PR TITLE
Use more explicit typescript version

### DIFF
--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -20,7 +20,7 @@
     "file-loader": "^0.10.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
-    "typescript": "^2.2.1",
+    "typescript": "~2.3.1",
     "url-loader": "^0.5.7",
     "watch": "^1.0.2",
     "webpack": "^2.2.1"

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -25,7 +25,7 @@
     "json-loader": "^0.5.4",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
-    "typescript": "^2.2.1",
+    "typescript": "~2.3.1",
     "url-loader": "^0.5.7",
     "watch": "^1.0.2",
     "webpack": "^1.13.0"

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -24,7 +24,7 @@
     "file-loader": "^0.10.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
-    "typescript": "^2.2.1",
+    "typescript": "~2.3.1",
     "url-loader": "^0.5.7",
     "watch": "^1.0.2",
     "webpack": "^2.2.1"

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -19,7 +19,7 @@
     "json-loader": "^0.5.4",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
-    "typescript": "^2.2.1",
+    "typescript": "~2.3.1",
     "url-loader": "^0.5.7",
     "watch": "^1.0.2",
     "webpack": "^1.13.0"

--- a/packages/all-packages/package.json
+++ b/packages/all-packages/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typedoc": "^0.7.1",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc && node build.js",

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/chatbox-extension/package.json
+++ b/packages/chatbox-extension/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/chatbox/package.json
+++ b/packages/chatbox/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@types/minimist": "^1.2.0",
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/docregistry-extension/package.json
+++ b/packages/docregistry-extension/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/faq-extension/package.json
+++ b/packages/faq-extension/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/services-extension/package.json
+++ b/packages/services-extension/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -22,7 +22,7 @@
     "requirejs": "^2.2.0",
     "rimraf": "^2.5.2",
     "text-encoding": "^0.5.2",
-    "typescript": "^2.2.1",
+    "typescript": "~2.3.1",
     "webpack": "^2.2.1",
     "ws": "^1.1.1",
     "xmlhttprequest": "^1.8.0"

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/tabmanager-extension/package.json
+++ b/packages/tabmanager-extension/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "repository": {
     "type": "git",

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "repository": {
     "type": "git",

--- a/packages/theming/package.json
+++ b/packages/theming/package.json
@@ -18,7 +18,7 @@
   "dependencies": {},
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "repository": {
     "type": "git",

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.5.2",
-    "typescript": "^2.2.1"
+    "typescript": "~2.3.1"
   },
   "scripts": {
     "build": "tsc",

--- a/test/package.json
+++ b/test/package.json
@@ -78,7 +78,7 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.2",
     "style-loader": "^0.13.1",
-    "typescript": "^2.2.1",
+    "typescript": "~2.3.1",
     "url-loader": "^0.5.7",
     "watch": "^1.0.2",
     "webpack": "^2.2.1"


### PR DESCRIPTION
Fixes #2479 by running `npm run update:dependency typescript ~2.3.1`.