### PR TITLE
Running `npm install` on lab extensions can cause duplicate npm modules.

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -122,10 +122,6 @@ def install_extension(extension, app_dir=None, logger=None):
     shutil.move(pjoin(target, fname), pjoin(app_dir, 'extensions'))
     shutil.rmtree(target)
 
-    staging = pjoin(app_dir, 'staging')
-    run(['npm', 'install', pjoin(app_dir, 'extensions', fname)],
-        cwd=staging, logger=logger)
-
 
 def link_package(path, app_dir=None, logger=None):
     """Link a package against the JupyterLab build.


### PR DESCRIPTION
It was reported by @ktong in jupyterlab/jupyterlab-google-drive#19 that fresh installs of the extension cause some conflict in node modules. This can be fixed by running `jupyter lab clean && jupyter lab build`.

I am not as steeped in the build system as @blink1073 , but it seems that duplicate modules are coming in due to an unnecessary (?) `npm install` in the extension directory when running `jupyter labextension install`