### PR TITLE
Make semver.py do proper unicode checking in python 2.

### DIFF
--- a/jupyterlab/semver.py
+++ b/jupyterlab/semver.py
@@ -32,6 +32,10 @@ import re
 
 SEMVER_SPEC_VERSION = '2.0.0'
 
+try:
+    string_type = basestring # Python 2
+except NameError:
+    string_type = str # Python 3
 
 class _R(object):
     def __init__(self, i):
@@ -311,7 +315,7 @@ def semver(version, loose):
             return version
         else:
             version = version.version
-    elif not isinstance(version, str):  # xxx:
+    elif not isinstance(version, string_type):  # xxx:
         raise ValueError("Invalid Version: {}".format(version))
 
     """

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -127,8 +127,9 @@ class TestExtension(TestCase):
         assert '@jupyterlab/python-tests' in _get_extensions(self.app_dir)
 
     def test_install_incompatible(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as excinfo:
             install_extension(self.incompat_dir)
+        assert 'Conflicting Dependencies' in str(excinfo.value)
 
     def test_install_failed(self):
         path = self.mock_package
@@ -180,8 +181,9 @@ class TestExtension(TestCase):
         assert not data['name'] in linked
 
     def test_link_incompatible(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as excinfo:
             install_extension(self.incompat_dir)
+        assert 'Conflicting Dependencies' in str(excinfo.value)
 
     def test_unlink_package(self):
         target = self.source_dir


### PR DESCRIPTION
Not having this leads to https://github.com/jupyter-widgets/ipywidgets/issues/1435 - the semver module doesn't recognize a unicode string as a valid version number in python 2.