### PR TITLE
Collapser style revision

### DIFF
--- a/packages/cells/style/collapser.css
+++ b/packages/cells/style/collapser.css
@@ -3,9 +3,12 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+:root {
+  --jp-private-collapser-width: 16px;
+}
 
 .jp-Collapser {
-  flex: 0 0 16px;
+  flex: 0 0 var(--jp-private-collapser-width);
   padding: 0px;
   margin: 0px;
   border: none;
@@ -15,13 +18,14 @@
 
 
 .jp-Collapser-child {
+  display: block;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
 }
 
 
-.jp-Collapser-child:hover {
+.jp-Cell .jp-Collapser .jp-Collapser-child:hover {
   opacity: .2;
   border-left: 2px solid var(--jp-brand-color1);
   border-top: 2px solid var(--jp-brand-color1);
@@ -29,21 +33,29 @@
 }
 
 
-.jp-mod-active .jp-Collapser-child:hover {
+.jp-Cell.jp-mod-active .jp-Collapser-child:hover {
   opacity: 1;
   border: none;
 }
 
 
-.jp-Cell.jp-mod-active .jp-Collapser .jp-Collapser-icon {
-  /* Haven't finished the styling, hide for now */
-  display: block;
+.jp-Cell .jp-Collapser .jp-Collapser-icon {
+  display: none;
   height: 100%;
   background-repeat: no-repeat;
   background-position: -3px 100%;
   background-size: 20px;
 }
 
+
+.jp-Cell.jp-mod-active .jp-Collapser-child .jp-Collapser-icon {
+  display: block;
+}
+
+
+.jp-Collapser-child:hover .jp-Collapser-icon {
+  display: block;
+}
 
 .jp-Collapser-child.jp-mod-collapsed .jp-Collapser-icon {
   background-position: -3px center !important;

--- a/packages/cells/style/collapser.css
+++ b/packages/cells/style/collapser.css
@@ -5,7 +5,7 @@
 
 
 .jp-Collapser {
-  flex: 0 0 12px;
+  flex: 0 0 16px;
   padding: 0px;
   margin: 0px;
   border: none;
@@ -22,11 +22,29 @@
 
 
 .jp-Collapser-child:hover {
-  background: var(--jp-brand-color1);
+  opacity: .2;
+  border-left: 2px solid var(--jp-brand-color1);
+  border-top: 2px solid var(--jp-brand-color1);
+  border-bottom: 2px solid var(--jp-brand-color1);
 }
 
 
-.jp-Collapser .jp-Collapser-icon {
+.jp-mod-active .jp-Collapser-child:hover {
+  opacity: 1;
+  border: none;
+}
+
+
+.jp-Cell.jp-mod-active .jp-Collapser .jp-Collapser-icon {
   /* Haven't finished the styling, hide for now */
-  display: none;
+  display: block;
+  height: 100%;
+  background-repeat: no-repeat;
+  background-position: -3px 100%;
+  background-size: 20px;
+}
+
+
+.jp-Collapser-child.jp-mod-collapsed .jp-Collapser-icon {
+  background-position: -3px center !important;
 }

--- a/packages/theming/style/icons.css
+++ b/packages/theming/style/icons.css
@@ -171,3 +171,8 @@
 .jp-ExpandLessIcon {
   background-image: url(icons/md/expand-less.svg);
 }
+
+
+.jp-ExpandMoreIcon {
+  background-image: url(icons/md/expand-more.svg);
+}

--- a/packages/theming/style/icons/md/expand-more.svg
+++ b/packages/theming/style/icons/md/expand-more.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#2196F3;}
+	.st1{fill:none;}
+</style>
+<path class="st0" d="M12,16l6-6l-1.4-1.4L12,13.2L7.4,8.6L6,10L12,16z"/>
+<path class="st1" d="M24,24H0L0,0l24,0V24z"/>
+</svg>


### PR DESCRIPTION
- Revised the size of collapser from 12px to 16px
- Created hover state for collapser that is active and inactive
- Styled and added collapser expand and collapse arrows to collapser items
- Added expand collapser icon to file and css

#### Collapser expanded state
![screen shot 2017-06-20 at 5 56 06 pm](https://user-images.githubusercontent.com/6437976/27362235-d93163d0-55e1-11e7-959e-feb8ba3c34fe.png)

#### Collapser collapsed state
![screen shot 2017-06-20 at 5 56 18 pm](https://user-images.githubusercontent.com/6437976/27362241-e41a3b64-55e1-11e7-9f96-35f4876f47f4.png)

#### Collapser hover state
![screen shot 2017-06-20 at 5 56 28 pm](https://user-images.githubusercontent.com/6437976/27362244-e95af94c-55e1-11e7-9f44-8155920e71db.png)


For the hover state, I am hoping to figure out how I can include the arrows in the hover state so that users make the connection that if they click on the hover state, it will do the given action (collapse/expand)