### PR TITLE
Clean up websocket console print

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -642,9 +642,10 @@ class DefaultKernel implements Kernel.IKernel {
     let settings = this.serverSettings;
     let partialUrl = URLExt.join(settings.wsUrl, KERNEL_SERVICE_URL,
                                  encodeURIComponent(this._id));
+
     // Strip any authentication from the display string.
-    let parsed = URLExt.parse(partialUrl);
-    console.log('Starting websocket', parsed.host);
+    let display = partialUrl.replace(/^((?:\w+:)?\/\/)(?:[^@\/]+@)/, '$1');
+    console.log('Starting WebSocket:', display);
 
     let url = URLExt.join(
         partialUrl,


### PR DESCRIPTION
Use the method we had previously used in [services](https://github.com/jupyterlab/services/pull/184/files) to strip authorization, while getting the same output as the classic notebook, e.g. `Starting WebSocket: ws://localhost:8888/api/kernels/085d597a-5faa-4eb6-9727-d9ed7780eba6`.