### PR TITLE
Add missing output styles

### DIFF
--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -70,13 +70,6 @@
 }
 
 
-/* html */
-
-.jp-OutputArea-executeResult.jp-RenderedHTMLCommon {
-  padding-top: 0px;
-}
-
-
 /* tables */
 
 .jp-OutputArea-output.jp-RenderedHTMLCommon table {

--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -29,6 +29,7 @@
 }
 
 
+
 .jp-OutputPrompt {
   flex: 0 0 var(--jp-cell-prompt-width);
   color: var(--jp-cell-outprompt-font-color);
@@ -48,6 +49,39 @@
   flex-shrink: 1;
   height: auto;
   overflow-x: auto;
+  user-select: text;
+  -moz-user-select: text;
+  -webkit-user-select: text;
+  -ms-user-select: text;
+}
+
+
+/* pre */
+
+.jp-OutputArea-output pre {
+  border: none;
+  margin: 0px;
+  padding: 0px;
+  overflow-x: auto;
+  overflow-y: auto;
+  word-break: break-all;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+
+/* html */
+
+.jp-OutputArea-executeResult.jp-RenderedHTMLCommon {
+  padding-top: 0px;
+}
+
+
+/* tables */
+
+.jp-OutputArea-output.jp-RenderedHTMLCommon table {
+  margin-left: 0;
+  margin-right: 0;
 }
 
 


### PR DESCRIPTION
cf #2074.  

Brings forward missing styles from https://github.com/jupyterlab/jupyterlab/blob/v0.16.0/src/outputarea/index.css.