### PR TITLE
Icon refinements & disabled item fixes

### DIFF
--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -139,7 +139,7 @@
 
 
 .p-CommandPalette-item.p-mod-disabled {
-  color: rgba(0, 0, 0, 0.25);
+  color: var(--jp-ui-font-color3);
 }
 
 

--- a/packages/theming/style/icons/md/add.svg
+++ b/packages/theming/style/icons/md/add.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
+<svg fill="#616161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
     <path d="M15.3,9.9H9.9v5.4H8.1V9.9H2.7V8.1h5.4V2.7h1.8v5.4h5.4V9.9z"/>
     <path fill="none" d="M0,0h18v18H0V0z"/>
 </svg>

--- a/packages/theming/style/icons/md/book.svg
+++ b/packages/theming/style/icons/md/book.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
+<svg fill="#616161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
     <path d="M15.4,15.1c-0.5,0-0.9,0.4-1.1,0.9c0,0.1,0,0.2,0,0.3v0.9c0,0.1,0,0.2,0,0.3c0.1,0.5,0.5,0.9,1.1,0.9
         c0.8,0,1.3-0.6,1.3-1.7C16.7,15.8,16.3,15.1,15.4,15.1z"/>
     <path d="M18,2h-6v7L9.5,7.5L7,9V2H6C4.9,2,4,2.9,4,4v16c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2V4C20,2.9,19.1,2,18,2z M11,19.7H9.2

--- a/packages/theming/style/icons/md/circle.svg
+++ b/packages/theming/style/icons/md/circle.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
+<svg fill="#616161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
     <path fill="none" d="M0,0h18v18H0V0z"/>
     <circle cx="9" cy="9" r="8"/>
 </svg>

--- a/packages/theming/style/icons/md/close-black.svg
+++ b/packages/theming/style/icons/md/close-black.svg
@@ -1,6 +1,6 @@
 <svg fill="#ffffff" height="16" width="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <!-- The black circle background -->
-    <circle cx="12" cy="12" r="11" fill="#000000"/>
+    <circle cx="12" cy="12" r="11" fill="#616161"/>
     <!-- The cross (close icon) -->
     <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" fill="#fff"/>
 </svg>

--- a/packages/theming/style/icons/md/close.svg
+++ b/packages/theming/style/icons/md/close.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="16" viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="16" viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg">
     <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/packages/theming/style/icons/md/copy.svg
+++ b/packages/theming/style/icons/md/copy.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
+<svg fill="#616161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
     <path fill="none" d="M0,0h18v18H0V0z"/>
     <path d="M11.9,1H3.2C2.4,1,1.7,1.7,1.7,2.5v10.2h1.5V2.5h8.7V1z M14.1,3.9h-8c-0.8,0-1.5,0.7-1.5,1.5v10.2c0,0.8,0.7,1.5,1.5,1.5h8
         c0.8,0,1.5-0.7,1.5-1.5V5.4C15.5,4.6,14.9,3.9,14.1,3.9z M14.1,15.5h-8V5.4h8V15.5z"/>

--- a/packages/theming/style/icons/md/cut.svg
+++ b/packages/theming/style/icons/md/cut.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M0 0h24v24H0z" fill="none"/>
     <circle cx="6" cy="18" fill="none" r="2"/>
     <circle cx="12" cy="12" fill="none" r=".5"/>

--- a/packages/theming/style/icons/md/directory.svg
+++ b/packages/theming/style/icons/md/directory.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z"/>
 </svg>

--- a/packages/theming/style/icons/md/down_caret.svg
+++ b/packages/theming/style/icons/md/down_caret.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
+<svg fill="#616161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
     <path d="M5.2,5.9L9,9.7l3.8-3.8l1.2,1.2l-4.9,5l-4.9-5L5.2,5.9z"/>
     <path fill="none" d="M0-0.6h18v18H0V-0.6z"/>
 </svg>

--- a/packages/theming/style/icons/md/download.svg
+++ b/packages/theming/style/icons/md/download.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/packages/theming/style/icons/md/edit.svg
+++ b/packages/theming/style/icons/md/edit.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/packages/theming/style/icons/md/ellipses.svg
+++ b/packages/theming/style/icons/md/ellipses.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
+<svg fill="#616161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
 <g>
     <circle cx="12" cy="12" r="2"/>
     <g>

--- a/packages/theming/style/icons/md/file.svg
+++ b/packages/theming/style/icons/md/file.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/packages/theming/style/icons/md/home.svg
+++ b/packages/theming/style/icons/md/home.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
     <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/packages/theming/style/icons/md/lens.svg
+++ b/packages/theming/style/icons/md/lens.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<svg fill="#616161" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/>
 </svg>

--- a/packages/theming/style/icons/md/new-folder.svg
+++ b/packages/theming/style/icons/md/new-folder.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg fill="#616161" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 10 9" style="enable-background:new 0 0 10 9;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:none;}

--- a/packages/theming/style/icons/md/panorama_fish_eye.svg
+++ b/packages/theming/style/icons/md/panorama_fish_eye.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<svg fill="#616161" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/>
 </svg>

--- a/packages/theming/style/icons/md/paste.svg
+++ b/packages/theming/style/icons/md/paste.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M19 2h-4.18C14.4.84 13.3 0 12 0c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm7 18H5V4h2v3h10V4h2v16z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/packages/theming/style/icons/md/refresh.svg
+++ b/packages/theming/style/icons/md/refresh.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
+<svg fill="#616161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18 18">
     <path d="M13.7,4.3C12.5,3.1,10.8,2.4,9,2.4c-3.6,0-6.6,3-6.6,6.6s2.9,6.6,6.6,6.6c3.1,0,5.6-2.1,6.4-5h-1.7
         c-0.7,1.9-2.5,3.3-4.7,3.3c-2.7,0-5-2.2-5-4.9s2.2-4.9,5-4.9c1.4,0,2.6,0.6,3.5,1.5L9.8,8.2h5.8V2.4L13.7,4.3z"/>
     <path fill="none" d="M0,0h18v18H0V0z"/>

--- a/packages/theming/style/icons/md/run.svg
+++ b/packages/theming/style/icons/md/run.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M8 5v14l11-7z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>

--- a/packages/theming/style/icons/md/save.svg
+++ b/packages/theming/style/icons/md/save.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"/>
 </svg>

--- a/packages/theming/style/icons/md/stop.svg
+++ b/packages/theming/style/icons/md/stop.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#616161" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M6 6h12v12H6z"/>
 </svg>

--- a/packages/theming/style/icons/md/terminal.svg
+++ b/packages/theming/style/icons/md/terminal.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
+<svg fill="#616161" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
     <path d="M5,3C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5c0-1.1-0.9-2-2-2H5z M7.4,5.7l4.6,4.6l-4.6,4.6L6,13.5
         l3.2-3.2L6,7.1 M18.2,18.3H5.8v-1.9h12.3v1.9H18.2z"/>
 </svg>

--- a/packages/theming/style/icons/md/upload.svg
+++ b/packages/theming/style/icons/md/upload.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg fill="#616161" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 18 18" style="enable-background:new 0 0 18 18;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:none;}

--- a/packages/theming/style/menus.css
+++ b/packages/theming/style/menus.css
@@ -55,7 +55,7 @@
 
 
 .p-MenuBar-item.p-mod-disabled {
-  color: var(--jp-ui-font-color2);
+  color: var(--jp-ui-font-color3);
 }
 
 
@@ -102,7 +102,7 @@
 
 
 .p-Menu-item.p-mod-disabled {
-  color: var(--jp-ui-font-color2);
+  color: var(--jp-ui-font-color3);
 }
 
 

--- a/packages/theming/style/tabs.css
+++ b/packages/theming/style/tabs.css
@@ -91,6 +91,7 @@
 
 /* This is the left tab bar current tab: only 1 exists. */
 .p-TabBar-tab.p-mod-current {
+  color: var(--jp-ui-font-color0);
   background: var(--jp-layout-color0);
 }
 

--- a/packages/theming/style/variables-light.css
+++ b/packages/theming/style/variables-light.css
@@ -63,9 +63,9 @@ all of MD as it is not optimized for dense, information rich UIs.
   */
 
   --jp-ui-font-color0: rgba(0,0,0,1.0);
-  --jp-ui-font-color1: rgba(0,0,0,0.87);
-  --jp-ui-font-color2: rgba(0,0,0,0.54);
-  --jp-ui-font-color3: rgba(0,0,0,0.38);
+  --jp-ui-font-color1: rgba(0,0,0,0.8);
+  --jp-ui-font-color2: rgba(0,0,0,0.5);
+  --jp-ui-font-color3: rgba(0,0,0,0.3);
 
   /* Use these against the brand/accent/warn/error colors.
      These will typically go from light to darker, in both a dark and light theme


### PR DESCRIPTION
Restyled icons to be lighter in color to make the interface less stark. Also changed the font color variables in the light theme to match these color changes in the icons. Replaced the hard-coded values for disabled items in the command palette and top-level menu items.

### File browser example
#### Before
<img width="302" alt="screen shot 2017-06-21 at 3 03 53 pm" src="https://user-images.githubusercontent.com/6437976/27408770-2daf11bc-5693-11e7-9b18-3bd911c1aab2.png">

#### After
<img width="302" alt="screen shot 2017-06-21 at 3 04 11 pm" src="https://user-images.githubusercontent.com/6437976/27408776-32b3743c-5693-11e7-8c62-509871a3da31.png">

### Notebook toolbar example
#### Before
<img width="676" alt="screen shot 2017-06-21 at 3 05 11 pm" src="https://user-images.githubusercontent.com/6437976/27408784-39f16de4-5693-11e7-8eb8-3480016393a4.png">

#### After
<img width="668" alt="screen shot 2017-06-21 at 3 04 57 pm" src="https://user-images.githubusercontent.com/6437976/27408788-3e5dc418-5693-11e7-957d-c167d1de42b1.png">

### Command pallete & disabled top-level menu items
#### Before
<img width="302" alt="screen shot 2017-06-21 at 3 05 39 pm" src="https://user-images.githubusercontent.com/6437976/27408841-737938bc-5693-11e7-8958-e7be4d8db225.png">

#### After
<img width="302" alt="screen shot 2017-06-21 at 3 05 52 pm" src="https://user-images.githubusercontent.com/6437976/27408844-760e20c4-5693-11e7-8689-fe08c4bdf029.png">
