### PR TITLE
Fixed multiple cell drag image in notebook

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -190,7 +190,7 @@
   z-index: -1;
   position: absolute;
   height: 32px;
-  width: 276px;
+  width: 300px;
   top: 8px;
   left: 8px;
   background: #EEEEEE;


### PR DESCRIPTION
The multiple cell drag image in the notebook somehow got it's styling messed up. This fixes the width of the "multipleBack" cell that is generated for the multiple cell drag image.