### PR TITLE
Adding forceBelow and forceAbove options to HoverBox privilege

### DIFF
--- a/packages/apputils/src/hoverbox.ts
+++ b/packages/apputils/src/hoverbox.ts
@@ -135,8 +135,8 @@ namespace HoverBox {
       renderBelow = true;
     } else {
       renderBelow = options.privilege === 'above' ?
-      spaceAbove < maxHeight && spaceAbove < spaceBelow
-        : spaceBelow >= maxHeight || spaceBelow >= spaceAbove;
+        spaceAbove < maxHeight && spaceAbove < spaceBelow
+          : spaceBelow >= maxHeight || spaceBelow >= spaceAbove;
     }
 
     if (renderBelow) {

--- a/packages/apputils/src/hoverbox.ts
+++ b/packages/apputils/src/hoverbox.ts
@@ -79,12 +79,13 @@ namespace HoverBox {
 
     /**
      * If space is available both above and below the anchor, denote which
-     * location is privileged.
+     * location is privileged. Use forceBelow and forceAbove to mandate where
+     * hover box should render relative to anchor.
      *
      * #### Notes
      * The default value is `'below'`.
      */
-    privilege?: 'above' | 'below';
+    privilege?: 'above' | 'below' | 'forceBelow' | 'forceAbove';
   }
 
 
@@ -127,9 +128,16 @@ namespace HoverBox {
     let maxHeight = parseInt(style.maxHeight, 10) || options.maxHeight;
 
     // Determine whether to render above or below; check privilege.
-    const renderBelow = options.privilege === 'above' ?
+    let renderBelow = true;
+    if (options.privilege === 'forceAbove') {
+      renderBelow = false;
+    } else if (options.privilege === 'forceBelow') {
+      renderBelow = true;
+    } else {
+      renderBelow = options.privilege === 'above' ?
       spaceAbove < maxHeight && spaceAbove < spaceBelow
         : spaceBelow >= maxHeight || spaceBelow >= spaceAbove;
+    }
 
     if (renderBelow) {
       maxHeight = Math.min(spaceBelow - marginTop, maxHeight);


### PR DESCRIPTION
This PR adds the option to hoverbox to force content to display below or above (analogous to forceX and forceY on Menu.IItemOptions).