### PR TITLE
Deconflict shortcuts

### DIFF
--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -58,7 +58,7 @@ const SHORTCUTS = [
   {
     command: 'command-palette:activate',
     selector: 'body',
-    keys: ['Accel Shift P']
+    keys: ['Accel Shift C']
   },
   {
     command: 'completer:invoke-console',
@@ -111,14 +111,9 @@ const SHORTCUTS = [
     keys: ['Ctrl Q']
   },
   {
-    command: 'file-operations:close-all-files',
-    selector: 'body',
-    keys: ['Ctrl Shift Q']
-  },
-  {
     command: 'help-jupyterlab:toggle',
     selector: 'body',
-    keys: ['Accel Shift H']
+    keys: ['Ctrl Shift H']
   },
   {
     command: 'imageviewer:reset-zoom',


### PR DESCRIPTION
Fixes #2390.  Removes the default shortcut for close all files since `Ctrl + Shift + Q` quits the application on Windows and Linux in Chrome, and de-conflicts the command palette and help toggles.