### PR TITLE
Move CSS imports to the extensions.

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -13,6 +13,7 @@ import {
   IStateDB, PageConfig
 } from '@jupyterlab/coreutils';
 
+import '@jupyterlab/application/style/index.css';
 
 /**
  * The command IDs used by the application plugin.

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -12,8 +12,6 @@ import {
 export { ApplicationShell } from './shell';
 export { ILayoutRestorer, LayoutRestorer } from './layoutrestorer';
 
-import '../style/index.css';
-
 /**
  * The type for all JupyterLab plugins.
  */

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -28,6 +28,7 @@ import {
   activatePalette
 } from './palette';
 
+import '@jupyterlab/apputils/style/index.css';
 
 /**
  * The command IDs used by the apputils plugin.

--- a/packages/apputils/src/index.ts
+++ b/packages/apputils/src/index.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './clientsession';
 export * from './clipboard';
 export * from './commandlinker';

--- a/packages/cells/src/index.ts
+++ b/packages/cells/src/index.ts
@@ -3,8 +3,6 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import '../style/index.css';
-
 export * from './collapser';
 export * from './headerfooter';
 export * from './inputarea';

--- a/packages/chatbox-extension/src/index.ts
+++ b/packages/chatbox-extension/src/index.ts
@@ -25,6 +25,8 @@ import {
   IRenderMime
 } from '@jupyterlab/rendermime';
 
+import '@jupyterlab/chatbox/style/index.css';
+
 
 /**
  * The command IDs used by the chatbox plugin.

--- a/packages/chatbox/src/index.ts
+++ b/packages/chatbox/src/index.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './panel';
 export * from './chatbox';
 export * from './entry'

--- a/packages/codeeditor/src/index.ts
+++ b/packages/codeeditor/src/index.ts
@@ -13,8 +13,6 @@ import {
   IEditorMimeTypeService
 } from './mimetype';
 
-import '../style/index.css';
-
 export * from './editor';
 export * from './jsoneditor';
 export * from './widget';

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -33,6 +33,8 @@ import {
   IEditorTracker
 } from '@jupyterlab/fileeditor';
 
+import '@jupyterlab/codemirror/style/index.css';
+
 
 /**
  * The command IDs used by the codemirror plugin.

--- a/packages/codemirror/src/index.ts
+++ b/packages/codemirror/src/index.ts
@@ -13,8 +13,6 @@ import {
   CodeMirrorMimeTypeService
 } from './mimetype';
 
-import '../style/index.css';
-
 export * from './mode';
 export * from './editor';
 export * from './factory';

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -21,6 +21,7 @@ import {
   INotebookTracker
 } from '@jupyterlab/notebook';
 
+import '@jupyterlab/completer/style/index.css';
 
 
 /**

--- a/packages/completer/src/index.ts
+++ b/packages/completer/src/index.ts
@@ -17,8 +17,6 @@ import {
   Widget
 } from '@phosphor/widgets';
 
-import '../style/index.css';
-
 export * from './handler';
 export * from './model';
 export * from './widget';

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -42,6 +42,8 @@ import {
   Menu
 } from '@phosphor/widgets';
 
+import '@jupyterlab/console/style/index.css';
+
 
 /**
  * The command IDs used by the console plugin.

--- a/packages/console/src/index.ts
+++ b/packages/console/src/index.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './foreign';
 export * from './history';
 export * from './panel';

--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -17,6 +17,8 @@ import {
   IDocumentRegistry
 } from '@jupyterlab/docregistry';
 
+import '@jupyterlab/csvviewer/style/index.css';
+
 
 /**
  * The name of the factory that creates CSV widgets.

--- a/packages/csvviewer/src/index.ts
+++ b/packages/csvviewer/src/index.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './toolbar';
 export * from './widget';

--- a/packages/docregistry-extension/src/index.ts
+++ b/packages/docregistry-extension/src/index.ts
@@ -9,6 +9,8 @@ import {
   DocumentRegistry, IDocumentRegistry, TextModelFactory, Base64ModelFactory
 } from '@jupyterlab/docregistry';
 
+import '@jupyterlab/docregistry/style/index.css';
+
 
 /**
  * The default document registry provider.

--- a/packages/docregistry/src/index.ts
+++ b/packages/docregistry/src/index.ts
@@ -4,5 +4,3 @@
 export * from './context';
 export * from './default';
 export * from './registry';
-
-import '../style/index.css';

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -37,6 +37,8 @@ import {
   Menu
 } from '@phosphor/widgets';
 
+import '@jupyterlab/filebrowser/style/index.css';
+
 
 /**
  * The command IDs used by the file browser plugin.

--- a/packages/filebrowser/src/index.ts
+++ b/packages/filebrowser/src/index.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './browser';
 export * from './crumbs';
 export * from './factory';

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -33,6 +33,8 @@ import {
   ILauncher
 } from '@jupyterlab/launcher';
 
+import '@jupyterlab/fileeditor/style/index.css';
+
 
 /**
  * The class name for the text editor icon from the default theme.

--- a/packages/fileeditor/src/index.ts
+++ b/packages/fileeditor/src/index.ts
@@ -13,8 +13,6 @@ import {
   FileEditor
 } from './widget';
 
-import '../style/index.css';
-
 export * from './widget';
 
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -21,6 +21,8 @@ import {
   CommandRegistry
 } from '@phosphor/commands';
 
+import '@jupyterlab/imageviewer/style/index.css';
+
 
 /**
  * The command IDs used by the image widget plugin.

--- a/packages/imageviewer/src/index.ts
+++ b/packages/imageviewer/src/index.ts
@@ -13,8 +13,6 @@ import {
   ImageViewer
 } from './widget';
 
-import '../style/index.css';
-
 export * from './widget';
 
 

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -25,6 +25,8 @@ import {
   InspectorManager
 } from './manager';
 
+import '@jupyterlab/inspector/style/index.css';
+
 
 /**
  * The command IDs used by the inspector plugin.

--- a/packages/inspector/src/index.ts
+++ b/packages/inspector/src/index.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './handler';
 export * from './inspector';

--- a/packages/launcher-extension/src/index.ts
+++ b/packages/launcher-extension/src/index.ts
@@ -27,6 +27,8 @@ import {
 } from '@phosphor/widgets';
 
 import '../style/index.css';
+import '@jupyterlab/launcher/style/index.css';
+
 
 
 /**

--- a/packages/launcher/src/index.ts
+++ b/packages/launcher/src/index.ts
@@ -29,8 +29,6 @@ import {
   VDomModel, VDomRenderer
 } from '@jupyterlab/apputils';
 
-import '../style/index.css';
-
 /**
  * The command IDs used by the launcher plugin.
  */

--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -21,6 +21,8 @@ import {
   MarkdownViewer, MarkdownViewerFactory
 } from '@jupyterlab/markdownviewer';
 
+import '@jupyterlab/markdownviewer/style/index.css';
+
 
 /**
  * The class name for the text editor icon from the default theme.

--- a/packages/markdownviewer/src/index.ts
+++ b/packages/markdownviewer/src/index.ts
@@ -1,6 +1,4 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './widget';

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -54,6 +54,13 @@ import {
   URLExt
 } from '@jupyterlab/coreutils';
 
+// TODO: Should we presume webpack semantics for @import in CSS files
+// and load the dependency CSS in dependencies (e.g., load the outputarea
+// CSS in the cell CSS file, and the cell CSS file in the notebook CSS file)?
+import '@jupyterlab/cells/style/index.css';
+import '@jupyterlab/codeeditor/style/index.css';
+import '@jupyterlab/notebook/style/index.css';
+import '@jupyterlab/outputarea/style/index.css';
 
 
 /**

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -54,13 +54,8 @@ import {
   URLExt
 } from '@jupyterlab/coreutils';
 
-// TODO: Should we presume webpack semantics for @import in CSS files
-// and load the dependency CSS in dependencies (e.g., load the outputarea
-// CSS in the cell CSS file, and the cell CSS file in the notebook CSS file)?
-import '@jupyterlab/cells/style/index.css';
-import '@jupyterlab/codeeditor/style/index.css';
-import '@jupyterlab/notebook/style/index.css';
-import '@jupyterlab/outputarea/style/index.css';
+// Import the style file that includes dependency style files
+import '@jupyterlab/notebook/style/module.css';
 
 
 /**

--- a/packages/notebook/src/index.ts
+++ b/packages/notebook/src/index.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './actions';
 export * from './celltools';
 export * from './default-toolbar';

--- a/packages/notebook/style/module.css
+++ b/packages/notebook/style/module.css
@@ -1,0 +1,11 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* This CSS file imports dependency CSS files. */
+
+@import '~@jupyterlab/cells/style/index.css';
+@import '~@jupyterlab/codeeditor/style/index.css';
+@import '~@jupyterlab/outputarea/style/index.css';
+@import './index.css';

--- a/packages/outputarea/src/index.ts
+++ b/packages/outputarea/src/index.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from './model';
 export * from './widget';

--- a/packages/rendermime-extension/src/index.ts
+++ b/packages/rendermime-extension/src/index.ts
@@ -21,6 +21,7 @@ import {
   IRenderMime, RenderMime
 } from '@jupyterlab/rendermime';
 
+import '@jupyterlab/rendermime/style/index.css';
 
 /**
  * The default rendermime provider.

--- a/packages/rendermime/src/index.ts
+++ b/packages/rendermime/src/index.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '../style/index.css';
-
 export * from '@jupyterlab/rendermime-interfaces';
 export * from './latex';
 export * from './mimemodel';

--- a/packages/running-extension/src/index.ts
+++ b/packages/running-extension/src/index.ts
@@ -13,6 +13,8 @@ import {
   RunningSessions
 } from '@jupyterlab/running';
 
+import '@jupyterlab/running/style/index.css';
+
 
 /**
  * The default running sessions extension.

--- a/packages/running/src/index.ts
+++ b/packages/running/src/index.ts
@@ -25,8 +25,6 @@ import {
   DOMUtils
 } from '@jupyterlab/apputils';
 
-import '../style/index.css';
-
 /**
  * The class name added to a running widget.
  */

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -25,6 +25,8 @@ import {
   Menu
 } from '@phosphor/widgets';
 
+import '@jupyterlab/terminal/style/index.css';
+
 
 /**
  * The command IDs used by the terminal plugin.

--- a/packages/terminal/src/index.ts
+++ b/packages/terminal/src/index.ts
@@ -13,8 +13,6 @@ import {
   Terminal
 } from './widget';
 
-import '../style/index.css';
-
 export * from './widget';
 
 /**

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -37,6 +37,8 @@ import {
   ITooltipManager, Tooltip
 } from '@jupyterlab/tooltip';
 
+import '@jupyterlab/tooltip/style/index.css';
+
 
 /**
  * The command IDs used by the tooltip plugin.

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -21,8 +21,6 @@ import {
   IRenderMime
 } from '@jupyterlab/rendermime';
 
-import '../style/index.css';
-
 export * from './widget';
 
 


### PR DESCRIPTION
We do this so that others can import and use the base packages without having to deal with the CSS. They would responsible for somehow loading the CSS on the page when they need it.

The status quo is causing problems, for example in the ipywidgets html manager, which imports rendermime. There, postcss complains that the rendermime css is using css variables that have not been declared. What we'd like to do instead is consolidate all of the needed css in one place and include it on the page, rather than having dependencies each include snippets of CSS not under our control.

- [ ] Test