### PR TITLE
Collapser style refinements

### DIFF
--- a/packages/cells/style/collapser.css
+++ b/packages/cells/style/collapser.css
@@ -48,6 +48,12 @@
 }
 
 
+.jp-Cell .jp-Collapser .jp-Collapser-icon.jp-ExpandLessIcon {
+  position: relative;
+  bottom: -3px;
+}
+
+
 .jp-Cell.jp-mod-active .jp-Collapser-child .jp-Collapser-icon {
   display: block;
 }

--- a/packages/cells/style/placeholder.css
+++ b/packages/cells/style/placeholder.css
@@ -31,6 +31,12 @@
   background-position: center;
   background-size: 32px;
   width: 32px;
-  height: 100%;
-  margin-left: 4px;
+  height: 16px;
+  border: 1px solid transparent;
+}
+
+.jp-Placeholder-content .jp-MoreHorizIcon:hover {
+  border: 1px solid var(--md-grey-400);
+  box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);
+  background-color: var(--jp-layout-color0);
 }

--- a/packages/theming/style/icons/md/expand-less.svg
+++ b/packages/theming/style/icons/md/expand-less.svg
@@ -1,4 +1,11 @@
-<svg fill="#2196F3" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-    <path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/>
-    <path d="M0 0h24v24H0z" fill="none"/>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#2196F3;}
+	.st1{fill:none;}
+</style>
+<path class="st0" d="M12,9l-6,6l1.4,1.4l4.6-4.6l4.6,4.6L18,15L12,9z"/>
+<path class="st1" d="M0,0h24v24H0V0z"/>
 </svg>


### PR DESCRIPTION
In collapsers, the expand/collapse blue arrow positioning was fixed to be at the very bottom of the collapser bracket. This problem was apparent in small, one line-outputs seen here:

#### Before
<img width="274" alt="screen shot 2017-06-28 at 4 37 51 pm" src="https://user-images.githubusercontent.com/6437976/27665126-40ff44b6-5c20-11e7-84b8-88d8d5ff349c.png">

#### After
![screen shot 2017-06-28 at 4 25 47 pm](https://user-images.githubusercontent.com/6437976/27665131-475a356e-5c20-11e7-9fc8-f357a3bd2f23.png)


Another usability issue was related to the horizontal "more" that is added in place of collapsed cells. When testing and asking users how they would re-expand the cell, they typically wanted to press on the three dots but were unsure if it was a button to re-expand. I have fixed this by adding a visual cue to the three dots when a user hovers over them. This styling is similar to what users would see with a navigation bar button:

#### Before (hover state)
![screen shot 2017-06-28 at 4 26 25 pm](https://user-images.githubusercontent.com/6437976/27665139-50e3e008-5c20-11e7-8d4b-dbadfd95faac.png)

#### After (hover state)
![screen shot 2017-06-28 at 4 26 13 pm](https://user-images.githubusercontent.com/6437976/27665140-54d48cd0-5c20-11e7-9eb6-da898c998dc0.png)

