### PR TITLE
Pin sphinx to <=1.6 for docs and pip install

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 - python==3.5
-- sphinx>1.4,<1.6
 - pip:
+  - sphinx<=1.6
   - recommonmark==0.4.0
   - jupyter_alabaster_theme


### PR DESCRIPTION
The docs on RTD have been failing to build recently. This PR moves sphinx to a pip dependency to correct the build.