### PR TITLE
Feature redux

### DIFF
--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -352,7 +352,7 @@ namespace nbformat {
     /**
      * Type of cell output.
      */
-    output_type: string;
+    output_type: OutputType;
   }
 
   /**
@@ -526,5 +526,5 @@ namespace nbformat {
    * An output union type.
    */
   export
-  type IOutput = IUnrecognizedOutput | IExecuteResult | IDisplayData | IStream | IError;
+  type IOutput = IUnrecognizedOutput | IExecuteResult | IDisplayData | IDisplayUpdate | IStream | IError;
 }

--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -70,17 +70,17 @@ namespace nbformat {
   }
 
   /**
-   * A multiline string.
+   * A value in a mime bundle.
    */
   export
-  type MultilineString = string | string[];
+  type MimeValue = string | string[] | JSONObject;
 
   /**
    * A mime-type keyed dictionary of data.
    */
   export
-  interface IMimeBundle extends JSONObject {
-    [key: string]: MultilineString | JSONObject;
+  interface IMimeBundle {
+    [key: string]: MimeValue;
   }
 
   /**
@@ -113,7 +113,7 @@ namespace nbformat {
    * @returns Whether the type/value pair are valid.
    */
   export
-  function validateMimeValue(type: string, value: MultilineString | JSONObject): boolean {
+  function validateMimeValue(type: string, value: MimeValue): boolean {
     // Check if "application/json" or "application/foo+json"
     const jsonTest = /^application\/(.*?)+\+json$/;
     const isJSONType = type === 'application/json' || jsonTest.test(type);
@@ -197,7 +197,7 @@ namespace nbformat {
     /**
      * Contents of the cell, represented as an array of lines.
      */
-    source: MultilineString;
+    source: string | string[];
 
     /**
      * Cell-level metadata.
@@ -441,7 +441,7 @@ namespace nbformat {
     /**
      * The stream's text output.
      */
-    text: MultilineString;
+    text: string | string[];
   }
 
   /**

--- a/packages/outputarea/src/actions.ts
+++ b/packages/outputarea/src/actions.ts
@@ -3,127 +3,17 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 import {
-  Action, Table
+  Action
 } from '@phosphor/datastore';
 
 
 /**
- * An action for creating a new mime model.
+ * An enum of the output action type names.
  */
 export
-class CreateMimeModel extends Action<'@jupyterlab/outputarea/CREATE_MIME_MODEL'> {
-  /**
-   * Construct a new action.
-   *
-   * @param modelId - The unique id to use for the mime model.
-   *
-   * @param model - The initial state for the mime model.
-   */
-  constructor(
-    public readonly modelId: string,
-    public readonly model: IMimeModel) {
-    super('@jupyterlab/outputarea/CREATE_MIME_MODEL');
-  }
-}
-
-
-/**
- * An action for creating a new output item.
- */
-export
-class CreateOutputItem extends Action<'@jupyterlab/outputarea/CREATE_OUTPUT_ITEM'> {
-  /**
-   * Construct a new action.
-   *
-   * @param itemId - The unique id to use for the output item.
-   *
-   * @param item - The initial state for the output item.
-   */
-  constructor(
-    public readonly itemId: string,
-    public readonly item: IOutputItem) {
-    super('@jupyterlab/outputarea/CREATE_OUTPUT_ITEM');
-  }
-}
-
-
-/**
- * An action for creating a new output list.
- */
-export
-class CreateOutputList extends Action<'@jupyterlab/outputarea/CREATE_OUTPUT_LIST'> {
-  /**
-   * Construct a new action.
-   *
-   * @param listId - The unique id to use for the output list.
-   *
-   * @param list - The initial state for the output list.
-   */
-  constructor(
-    public readonly listId: string,
-    public readonly list: Table.List<string>) {
-    super('@jupyterlab/outputarea/CREATE_OUTPUT_LIST');
-  }
-}
-
-
-/**
- * An action for creating a new output area.
- */
-export
-class CreateOutputArea extends Action<'@jupyterlab/outputarea/CREATE_OUTPUT_AREA'> {
-  /**
-   * Construct a new action.
-   *
-   * @param areaId - The unique id to use for the output area.
-   *
-   * @param area - The initial state for the output area.
-   */
-  constructor(
-    public readonly areaId: string,
-    public readonly area: IOutputArea) {
-    super('@jupyterlab/outputarea/CREATE_OUTPUT_AREA');
-  }
-}
-
-
-/**
- * An action for adding an output item to an output list.
- */
-export
-class AddOutput extends Action<'@jupyterlab/outputarea/ADD_OUTPUT'> {
-  /**
-   * Construct a new action.
-   *
-   * @param listId - The id of the ouptut list to modify.
-   *
-   * @param itemId - The id of the output item to add to the list.
-   */
-  constructor(
-    public readonly listId: string,
-    public readonly itemId: string) {
-    super('@jupyterlab/outputarea/ADD_OUTPUT');
-  }
-}
-
-
-/**
- * An action for setting the contents of an output list.
- */
-export
-class SetOutputs extends Action<'@jupyterlab/outputarea/SET_OUTPUTS'> {
-  /**
-   * Construct a new action.
-   *
-   * @param listId - The id of the ouptut list to modify.
-   *
-   * @param list - The new state for the output list.
-   */
-  constructor(
-    public readonly listId: string
-    public readonly list: Table.List<string>) {
-    super('@jupyterlab/outputarea/SET_OUTPUTS');
-  }
+enum OutputActionType {
+  APPEND_OUTPUT = '@jupyterlab/outputarea/APPEND_OUTPUT',
+  CLEAR_OUTPUTS = '@jupyterlab/outputarea/CLEAR_OUTPUTS'
 }
 
 
@@ -132,10 +22,41 @@ class SetOutputs extends Action<'@jupyterlab/outputarea/SET_OUTPUTS'> {
  */
 export
 type OutputAction = (
-  CreateMimeModel |
-  CreateOutputItem |
-  CreateOutputList |
-  CreateOutputArea |
-  AddOutput |
-  SetOutputs
+  AppendOutputAction |
+  ClearOutputsAction
 );
+
+
+/**
+ * An action for appending output to an output area.
+ */
+export
+class AppendOutputAction extends Action<OutputActionType.APPEND_OUTPUT> {
+  /**
+   * @param areaId - The id of the output area.
+   *
+   * @param output - The output object to add to the area.
+   */
+  constructor(
+    public readonly areaId: string,
+    public readonly ouptut: nbformat.IOutput) {
+    super(OutputActionType.APPEND_OUTPUT);
+  }
+}
+
+
+/**
+ * An action for clearing the outputs of an output area.
+ */
+export
+class ClearOutputsAction extends Action<OutputActionType.CLEAR_OUTPUTS> {
+  /**
+   * @param areaId - The id of the output area.
+   *
+   * @param output - The output object to add to the area.
+   */
+  constructor(
+    public readonly areaId: string) {
+    super(OutputActionType.CLEAR_OUTPUTS);
+  }
+}

--- a/packages/outputarea/src/controllers.ts
+++ b/packages/outputarea/src/controllers.ts
@@ -1,0 +1,119 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+import {
+  nbformat
+} from '@jupyterlab/coreutils';
+
+import {
+  Kernel, KernelMessage
+} from '@jupyterlab/services';
+
+import {
+  AppendOutputAction
+} from './actions';
+
+import {
+  OutputArea, OutputStore
+} from './models';
+
+
+/**
+ * Execute code for an output area.
+ *
+ * @param code - The code to execute.
+ *
+ * @param kernel - The kernel to use for execution.
+ *
+ * @param outputAreaId - The id of the output area.
+ *
+ * @param store - The output data store to update with execution.
+ *
+ * @returns The kernel future for the execution request.
+ *
+ * #### Notes
+ * This function handles the iopub, reply, and stdin messages for
+ * the request. The caller should not handle those messages.
+ *
+ * The caller will typically be responsible for:
+ *   - Disposing of the future and clearing the output before
+ *     executing more code for the same output area.
+ *   - Using the `done` promise to perform any cleanup after
+ *     the execution is "finished".
+ */
+export
+function execute(code: string, kernel: Kernel.IKernelConnection, outputAreaId: string, store: OutputStore): Kernel.IFuture {
+  // Request execution from the kernel.
+  const future = kernel.requestExecute({ code, stop_on_error: true }, false);
+
+  // Set up the future handlers.
+  future.onIOPub = onIOPub;
+  future.onReply = onReply;
+  future.onStdin = onStdin;
+
+  // Return the future.
+  return future;
+
+  function getArea(): OutputArea | null {
+    // Fetch the area from the data store.
+    let area = store.state.outputAreaTable[outputAreaId] || null;
+
+    // If the area has been deleted, dispose the future.
+    if (!area) {
+      future.dispose();
+    }
+
+    // Return the area.
+    return area;
+  }
+
+  function onIOPub(msg: KernelMessage.IIOPubMessage): void {
+
+  }
+
+  function onReply(msg: KernelMessage.IExecuteReplyMsg): void {
+    // Bail if the output area has been deleted.
+    if (!getArea()) {
+      return;
+    }
+
+    // Ignore `error` and `abort` replies.
+    if (msg.content.status !== 'okay') {
+      return;
+    }
+
+    // Extract the payload from the message.
+    let payload = (msg.content as KernelMessage.IExecuteOkReply).payload;
+
+    // Bail early if there is no payload.
+    if (!payload || payload.length === 0) {
+      return;
+    }
+
+    // Find the first page in the payload.
+    let page = payload.find(item => item.source === 'page');
+
+    // Bail if there is no pager output.
+    if (!page) {
+      return;
+    }
+
+    // Extract the mime data bundle from the page.
+    let data = page.data as nbformat.IMimeBundle;
+
+    // Create the action to add the output.
+    let action = new AppendOutputAction(outputAreaId, {
+      output_type: 'display_data', data, metadata: {}
+    });
+
+    // Dispatch the action to the store.
+    store.dispatch(action);
+  }
+
+  function onStdin(msg: msg: KernelMessage.IStdinMessage): void {
+    // if (KernelMessage.isInputRequestMsg(msg)) {
+    //   this._onInputRequest(msg, value);
+    // }
+  }
+}

--- a/packages/outputarea/src/models.ts
+++ b/packages/outputarea/src/models.ts
@@ -7,78 +7,93 @@ import {
 } from '@phosphor/datastore';
 
 import {
-  IMimeModel
-} from '@jupyterlab/rendermime';
+  nbformat
+} from '@jupyterlab/coreutils';
 
 
 /**
- * The model for a single item in an output area.
+ * The type of an output item in an output area.
  */
 export
-interface IOutputItem {
+type OutputItem = {
   /**
-   * The output type.
+   * The nbformat type of the output.
    */
-  readonly type: string;
+  type: nbformat.OutputType;
 
   /**
-   * The execution count of the item.
+   * Whether the output is trusted.
+   */
+  readonly trusted: boolean;
+
+  /**
+   * The id of mime data bundle for the output.
+   */
+  readonly mimeDataId: string;
+
+  /**
+   * The id of the mime metadata bundle for the output.
+   */
+  readonly mimeMetadataId: string;
+
+  /**
+   * The stream type for 'stream' items.
+   */
+  readonly streamType: nbformat.StreamType | null;
+
+  /**
+   * The execution count of the output.
    */
   readonly executionCount: nbformat.ExecutionCount;
-
-  /**
-   * The id of the item's mime model.
-   */
-  readonly mimeModelId: string;
-}
+};
 
 
 /**
- * The model for an output area.
+ * The type of an output area.
  */
 export
-interface IOutputArea {
+type OutputArea = {
   /**
-   * Whether code is currently executing for the area.
+   * Whether the output area is trusted.
    */
-  readonly isExecuting: boolean;
+  readonly trusted: boolean;
 
   /**
    * The id for the area's output list.
    */
   readonly outputListId: string;
-}
+};
 
 
 /**
- * The data type for an output area store.
+ * The state type for an output area store.
  */
 export
-interface IOutputStoreState {
+type OutputState = {
   /**
-   * The table of mime models.
+   * The table of output item mime data bundles.
    */
-  readonly mimeModelTable: Table.RecordTable<IMimeModel>;
+  readonly mimeBundleTable: Table.JSONTable<JSONObject>;
 
   /**
    * The table of output items.
    */
-  readonly outputItemTable: Table.RecordTable<IOutputItem>;
+  readonly outputItemTable: Table.RecordTable<OutputItem>;
 
   /**
    * The table of output areas.
    */
-  readonly outputAreaTable: Table.RecordTable<IOutputArea>;
+  readonly outputAreaTable: Table.RecordTable<OutputArea>;
 
   /**
    * The table of output lists.
    */
   readonly outputListTable: Table.ListTable<string>;
-}
+};
 
 
 /**
  * A type alias for an output store.
  */
 export
-type OutputStore = DataStore<IOutputStoreState>;
+type OutputStore = DataStore<OutputState>;

--- a/packages/outputarea/src/reducers.ts
+++ b/packages/outputarea/src/reducers.ts
@@ -3,81 +3,260 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 import {
-  Table, combineReducers
+  JSONObject
+} from '@phosphor/coreutils';
+
+import {
+  Table, uuid4
 } from '@phosphor/datastore';
 
 import {
-  IMimeModel
-} from '@jupyterlab/rendermime';
+  AppendOutputAction, ClearOutputsAction, OutputAction, OutputActionType
+} from './actions';
 
 import {
-  IOutputArea, IOutputItem, IOutputStoreState
+  OutputState
 } from './models';
 
 
 /**
- * The root reducer for an output store.
+ * The mime type for stdout.
+ */
+const STDOUT = 'application/vnd.jupyter.stdout';
+
+/**
+ * The mime type for stderr.
+ */
+const STDERR = 'application/vnd.jupyter.stderr';
+
+
+/**
+ * The root reducer for the output area package.
  */
 export
-const reducer = combineReducers<IOutputStoreState>({
-  mimeModelTable,
-  outputItemTable,
-  outputAreaTable,
-  outputListTable
-});
-
-
-/**
- * A reducer which handles actions for the `mimeModelTable` branch.
- */
-function mimeModelTable(table: Table.RecordTable<IMimeModel>, action: OutputAction): Table.RecordTable<IMimeModel> {
+function outputReducer(state: OutputState, action: OutputAction): OutputState {
   switch (action.type) {
-  case '@jupyterlab/outputarea/CREATE_MIME_MODEL':
-    return Table.insert(table, action.modelId, action.model);
+  case OutputActionType.APPEND_OUTPUT:
+    return appendOutput(state, action);
+  case OutputActionType.CLEAR_OUTPUTS:
+    return clearOutputs(state, action);
   default:
-    return table;
+    return state;
   }
 }
 
 
 /**
- * A reducer which handles actions for the `outputItemTable` branch.
+ * Append an output item to an output area.
  */
-function outputItemTable(table: Table.RecordTable<IOutputItem>, action: OutputAction): Table.RecordTable<IOutputItem> {
-  switch (action.type) {
-  case '@jupyterlab/outputarea/CREATE_OUTPUT_ITEM':
-    return Table.insert(table, action.itemId, action.item);
-  default:
-    return table;
+function appendOutput(state: OutputState, action: AppendOutputAction): OutputState {
+  // Unpack the area id and output.
+  let { areaId, output } = action;
+
+  // Look up the output area object.
+  let area = state.outputAreaTable[areaId];
+
+  // Try to merge the output first, if possible.
+  let mergeState = mergeOutputs(state, area, output);
+
+  // Return the new state if the output was merged.
+  if (state !== mergeState) {
+    return mergeState;
   }
+
+  // Create the mime data for the output.
+  let mimeData = createMimeData(output);
+
+  // Create the mime metadata for the output.
+  let mimeMetadata = createMimeMetadata(output);
+
+  // Create the uuids needed for the tables.
+  let itemId = uuid4();
+  let mimeDataId = uuid4();
+  let mimeMetadataId = uuid4();
+
+  // Create the output item.
+  let item: OutputItem = {
+    type: output.output_type,
+    trusted: area.trusted,
+    mimeDataId,
+    mimeMetadataId,
+    streamType: getStreamType(output),
+    executionCount: getExecutionCount(output)
+  };
+
+  // Add the mime bundles to the table.
+  let mimeBundleTable = Table.apply(state.mimeBundleTable, [
+    Table.opInsert(mimeDataId, mimeData),
+    Table.opInsert(mimeMetadataId, mimeMetadata)
+  ]);
+
+  // Add the output item to the table.
+  let outputItemTable = Table.apply(state.outputItemTable,
+    Table.opInsert(itemId, item)
+  );
+
+  // Add the item id to the output list.
+  let outputListTable = Table.apply(state.outputListTable,
+    Table.opAppend(area.outputListId, [itemId])
+  );
+
+  // Return the updated state.
+  return { ...state, mimeBundleTable, outputItemTable, outputListTable };
 }
 
 
 /**
- * A reducer which handles actions for the `outputAreaTable` branch.
+ * Clear the outputs for an output area.
  */
-function outputAreaTable(table: Table.RecordTable<IOutputArea>, action: OutputAction): Table.RecordTable<IOutputArea> {
-  switch (action.type) {
-  case '@jupyterlab/outputarea/CREATE_OUTPUT_AREA':
-    return Table.insert(table, action.areaId, action.area);
-  default:
-    return table;
-  }
+function clearOutputs(state: OutputState, action: ClearOutputsAction): OutputState {
+  // Look up the output list id.
+  let outputListId = state.outputAreaTable[action.areaId].outputListId;
+
+  // Create the table operation to clear the list.
+  let op = Table.opReplace(outputListId, []);
+
+  // Apply the operation to the table.
+  let outputListTable = Table.apply(state.outputListTable, op);
+
+  // Return the updated state.
+  return { ...state, outputListTable };
 }
 
 
 /**
- * A reducer which handles actions for the `outputListTable` branch.
+ * Create the mime data for an output.
  */
-function outputListTable(table: Table.ListTable<string>, action: OutputAction): Table.ListTable<string> {
-  switch (action.type) {
-  case '@jupyterlab/outputarea/CREATE_OUTPUT_LIST':
-    return Table.insert(table, action.listId, action.list);
-  case '@jupyterlab/outputarea/ADD_OUTPUT':
-    return Table.push(table, action.listId, [action.itemId]);
-  case '@jupyterlab/outputarea/SET_OUTPUTS':
-    return Table.replace(table, action.listId, action.list);
+function createMimeData(output: nbformat.IOutput): JSONObject {
+  let data: JSONObject;
+  switch (true) {
+  case nbformat.isExecuteResult(output):
+  case nbformat.isDisplayUpdate(output):
+  case nbformat.isDisplayData(output):
+    data = normalizeMimeBundle(output.data);
+    break;
+  case nbformat.isStream(output):
+    data = { [getMimeType(output)]: output.text.join('\n') };
+    break;
+  case nbformat.isError(output):
+    data = { [stderr]: formatError(output) };
+    break;
   default:
-    return table;
+    data = {};
+    break;
   }
+  return data;
+}
+
+
+/**
+ * Create the mime metadata for an output.
+ */
+function createMimeMetadata(output: nbformat.IOutput): JSONObject {
+  let metadata: JSONObject;
+  switch (true) {
+  case nbformat.isExecuteResult(output):
+  case nbformat.isDisplayData(output):
+  case nbformat.isDisplayUpdate(output):
+    metadata = JSONExt.deepCopy(output.metadata);
+    break;
+  default:
+    metadata = {};
+    break;
+  }
+  return metadata;
+}
+
+
+/**
+ * Format the error text for an error output.
+ */
+function formatError(output: nbformat.IError): string {
+  return output.traceback.join('\n') || `${output.ename}: ${output.evalue}`;
+}
+
+
+/**
+ * Get the mimetype for an output stream.
+ */
+function getMimeType(output: nbformat.IStream): string {
+  return output.name === 'stdout' ? STDOUT : STDERR;
+}
+
+
+/**
+ * Get the stream type for an output.
+ */
+function getStreamType(output: nbformat.IOutput): string | null {
+  return nbformat.isStream(output) ? output.name : null;
+}
+
+
+/**
+ * Get the execution count for an output.
+ */
+function getExecutionCount(output: nbformat.IOutput): nbformat.ExecutionCount {
+  return nbformat.isExecuteResult(output) ? output.execution_count: null;
+}
+
+
+/**
+ * Create a normalized copy of a mime bundle.
+ *
+ * Top-level multiline strings (`string[]`) are joined with `\n`.
+ */
+function normalizeMimeBundle(bundle: IMimeBundle): JSONObject {
+  let result: JSONObject = {};
+  for (let key in bundle) {
+    let value = bundle[key];
+    if (Array.isArray(value)) {
+      result[key] = value.join('\n');
+    } else {
+      result[key] = JSONExt.deepCopy(value);
+    }
+  }
+  return result;
+}
+
+
+/**
+ * Merge an output with an existing output area, if possible.
+ *
+ * Returns the original state if no merge was performed.
+ */
+function mergeOutputs(state: OutputState, area: OutputArea, output: nbformat.IOutput): OutputState {
+  // Bail early if the output is not a stream.
+  if (!nbformat.isStream(output)) {
+    return state;
+  }
+
+  // Look up the output list for the area.
+  let outputList = state.outputListTable[area.outputListId];
+
+  // Bail early if the area has no outputs.
+  if (outputList.length === 0) {
+    return state;
+  }
+
+  // Look up the last output item for the area.
+  let lastItem = state.outputItemTable[outputList[outputList.length - 1]];
+
+  // Bail if the outputs cannot be merged.
+  if (lastItem.type !== 'stream' || lastItem.streamType !== output.name) {
+    return state;
+  }
+
+  // Shallow copy the mime data for the last stream item.
+  let mimeData = { ...state.mimeBundleTable[lastItem.mimeDataId] };
+
+  // Add the new output text to the existing text.
+  mimeData[getMimeType(output)] += output.text.join('\n');
+
+  // Replace the mime bundle in the table.
+  let mimeBundleTable = Table.apply(state.mimeBundleTable,
+    Table.opReplace(lastItem.mimeDataId, mimeData)
+  );
+
+  // Return the updated state.
+  return { ...state, mimeBundleTable };
 }

--- a/packages/outputarea/src/reducers.ts
+++ b/packages/outputarea/src/reducers.ts
@@ -113,11 +113,10 @@ function clearOutputs(state: OutputState, action: ClearOutputsAction): OutputSta
   // Look up the output list id.
   let outputListId = state.outputAreaTable[action.areaId].outputListId;
 
-  // Create the table operation to clear the list.
-  let op = Table.opReplace(outputListId, []);
-
-  // Apply the operation to the table.
-  let outputListTable = Table.apply(state.outputListTable, op);
+  // Clear the output list in the table.
+  let outputListTable = Table.apply(state.outputListTable,
+    Table.opReplace(outputListId, [])
+  );
 
   // Return the updated state.
   return { ...state, outputListTable };

--- a/packages/outputarea/src/reducers.ts
+++ b/packages/outputarea/src/reducers.ts
@@ -135,7 +135,7 @@ function createMimeData(output: nbformat.IOutput): JSONObject {
     data = normalizeMimeBundle(output.data);
     break;
   case nbformat.isStream(output):
-    data = { [getMimeType(output)]: output.text.join('\n') };
+    data = { [getMimeType(output)]: getStreamText(output) };
     break;
   case nbformat.isError(output):
     data = { [stderr]: formatError(output) };
@@ -182,6 +182,12 @@ function getMimeType(output: nbformat.IStream): string {
   return output.name === 'stdout' ? STDOUT : STDERR;
 }
 
+/**
+ * Get the normalized text for an output stream.
+ */
+function getStreamText({ text }: nbformat.IStream): string {
+  return typeof text === 'string' ? text : text.join('\n');
+}
 
 /**
  * Get the stream type for an output.
@@ -249,7 +255,7 @@ function mergeOutputs(state: OutputState, area: OutputArea, output: nbformat.IOu
   let mimeData = { ...state.mimeBundleTable[lastItem.mimeDataId] };
 
   // Add the new output text to the existing text.
-  mimeData[getMimeType(output)] += output.text.join('\n');
+  mimeData[getMimeType(output)] += getStreamText(output);
 
   // Replace the mime bundle in the table.
   let mimeBundleTable = Table.apply(state.mimeBundleTable,

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -596,6 +596,11 @@ namespace KernelMessage {
   export
   interface IExecuteOkReply extends IExecuteReply {
     /**
+     * The status code for the message.
+     */
+    status: 'ok';
+
+    /**
      * A list of payload objects.
      * Payloads are considered deprecated.
      * The only requirement of each payload object is that it have a 'source'
@@ -616,6 +621,11 @@ namespace KernelMessage {
    */
   export
   interface IExecuteErrorReply extends IExecuteReply {
+    /**
+     * The status code for the message.
+     */
+    status: 'error';
+
     /**
      * The exception name.
      */


### PR DESCRIPTION
Some more improvements. Mainly uses actions which cross-cut concerns in order to be more semantic. Uses updated Table `apply` in `@phosphor/datastore@0.5.0`.

Also fixes a few typings in nbformat and kernel messages.

There's still more to do, but this at least tracks the current pattern.