### PR TITLE
Make IFrames take up the whole space available.

### DIFF
--- a/packages/apputils/style/iframe.css
+++ b/packages/apputils/style/iframe.css
@@ -2,6 +2,12 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
+
+.jp-IFrame {
+  width: 100%;
+  height: 100%;
+}
+
 /*
 When drag events occur, `p-mod-override-cursor` is added to the body.
 Because iframes steal all cursor events, the following two rules are necessary
@@ -11,7 +17,6 @@ better solution to this problem.
 body.p-mod-override-cursor .jp-IFrame {
   position: relative;
 }
-
 
 body.p-mod-override-cursor .jp-IFrame:before {
   content: '';


### PR DESCRIPTION
The help widget was not taking up the whole space available to it.