### PR TITLE
Launcher wrapping fix

### DIFF
--- a/packages/launcher/style/index.css
+++ b/packages/launcher/style/index.css
@@ -8,7 +8,6 @@
   background: var(--md-grey-50);
   display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
   align-items: center;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
-Removed the flex-wrap class from the launcher to allow content to be viewed in the launcher when the area is not large enough for the launcher items

### Before
![screen shot 2017-06-30 at 9 30 13 am](https://user-images.githubusercontent.com/6437976/27745070-d3e4d21c-5d76-11e7-8fa0-4820cb08545f.png)

### After
![screen shot 2017-06-30 at 9 29 01 am](https://user-images.githubusercontent.com/6437976/27745081-d92964e0-5d76-11e7-9928-30d672e75460.png)

