### PR TITLE
Fix docs links

### DIFF
--- a/docs/extensions_dev.md
+++ b/docs/extensions_dev.md
@@ -37,7 +37,7 @@ The default plugins in the JupyterLab application include:
 interactive kernel console sessions.
 - [Services](https://github.com/jupyterlab/jupyterlab/blob/master/packages/services-extension/src/index.ts) - An application-specific interface to `@jupyterlab/services`.
 - [RenderMime](https://github.com/jupyterlab/jupyterlab/blob/master/packages/rendermime-extension/src/index.ts) - The registry for adding kernel `display_data` renderers.
-- [Document Registry](https://github.com/jupyterlab/jupyterlab/blob/master/packages/docregistry-extension/src/index.ts) - Used to add functionality around widgets backed by files.
+- [Document Registry](https://github.com/jupyterlab/jupyterlab/tree/master/packages/docregistry/src) - Used to add functionality around widgets backed by files.
 
 ## Application Object
 The JupyterLab Application object is given to each plugin in

--- a/docs/extensions_dev.md
+++ b/docs/extensions_dev.md
@@ -36,7 +36,7 @@ The default plugins in the JupyterLab application include:
 - [Console](https://github.com/jupyterlab/jupyterlab/blob/master/packages/console-extension/src/index.ts) - Adds the ability to launch Jupyter Console instances for
 interactive kernel console sessions.
 - [Services](https://github.com/jupyterlab/jupyterlab/blob/master/packages/services-extension/src/index.ts) - An application-specific interface to `@jupyterlab/services`.
-- [RenderMime](https://github.com/jupyterlab/jupyterlab/blob/master/packages/rendermime-extension/src/index.ts) - The registry for adding kernel `display_data` renderers.
+- [RenderMime](https://github.com/jupyterlab/jupyterlab/blob/master/packages/rendermime/src) - The registry for adding kernel `display_data` renderers.
 - [Document Registry](https://github.com/jupyterlab/jupyterlab/tree/master/packages/docregistry/src) - Used to add functionality around widgets backed by files.
 
 ## Application Object


### PR DESCRIPTION
This doc build issue showed up in the previous rendermime refactor. Let's see if this fixes the doc build on travis.