### PR TITLE
Fix markdownviewer CSS

### DIFF
--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -14,6 +14,8 @@ import {
 } from '@jupyterlab/docregistry';
 
 
+import '../style/index.css';
+
 /**
  * The class name for the text editor icon from the default theme.
  */

--- a/packages/markdownviewer-extension/style/index.css
+++ b/packages/markdownviewer-extension/style/index.css
@@ -1,0 +1,16 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+:root {
+  --jp-private-markdownviewer-padding: 16px;
+}
+
+.jp-Document.jp-MimeRenderer .jp-RenderedMarkdown {
+  padding-top: var(--jp-private-markdownviewer-padding);
+  padding-right: var(--jp-private-markdownviewer-padding);
+  padding-bottom: var(--jp-private-markdownviewer-padding);
+  padding-left: var(--jp-private-markdownviewer-padding);
+  overflow: auto;
+}


### PR DESCRIPTION
This CSS got left behind in the refactor of #2555.