### PR TITLE
Add helper to create toolbar button from command

### DIFF
--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -323,7 +323,9 @@ class ToolbarButton extends Widget {
     this.addClass(TOOLBAR_BUTTON_CLASS);
     this._onClick = options.onClick;
     if (options.className) {
-      this.addClass(options.className);
+      for (let extra of options.className.split(/\s/)) {
+        this.addClass(extra);
+      }
     }
     this.node.title = options.tooltip || '';
   }

--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -449,6 +449,9 @@ namespace Private {
     return commands.caption(id);
   }
 
+  /**
+   * Get the class names for a command based ToolBarButton
+   */
   export
   function commandClassName(commands: CommandRegistry, id: string): string {
     let name = commands.className(id);
@@ -465,6 +468,9 @@ namespace Private {
     return name;
   }
 
+  /**
+   * Fill the node of a command based ToolBarButton.
+   */
   export
   function setNodeContentFromCommand(node: HTMLElement, commands: CommandRegistry, id: string): void {
     let iconClass = commands.iconClass(id);

--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -203,7 +203,7 @@ namespace Toolbar {
    */
   export
   function toolbarButtonFromCommand(commands: CommandRegistry, id: string): ToolbarButton {
-    let oldClass = commands.className(id)
+    let oldClass = commands.className(id);
     let button = new ToolbarButton({
       onClick: () => { commands.execute(id); },
       className: oldClass,
@@ -228,10 +228,7 @@ namespace Toolbar {
         button.node.title = Private.commandTooltip(commands, id);
       }
     }
-    commands.commandChanged.connect(onChange);
-    button.disposed.connect(() => {
-      commands.commandChanged.disconnect(onChange);
-    });
+    commands.commandChanged.connect(onChange, button);
     return button;
   }
 

--- a/test/src/apputils/toolbar.spec.ts
+++ b/test/src/apputils/toolbar.spec.ts
@@ -8,6 +8,14 @@ import {
 } from '@phosphor/algorithm';
 
 import {
+  CommandRegistry
+} from '@phosphor/commands';
+
+import {
+  ReadonlyJSONObject
+} from '@phosphor/coreutils';
+
+import {
   Message
 } from '@phosphor/messaging';
 
@@ -130,6 +138,103 @@ describe('@jupyterlab/apputils', () => {
         widget.addItem('b', new Widget());
         widget.insertItem(10, 'c', new Widget());
         expect(toArray(widget.names())).to.eql(['a', 'b', 'c']);
+      });
+
+    });
+
+    describe('.createFromCommand', () => {
+
+      let commands = new CommandRegistry();
+      let testLogCommandId = 'test:toolbar-log';
+      let logArgs: ReadonlyJSONObject[] = [];
+      let enabled = false;
+      let toggled = true;
+      let visible = false;
+      commands.addCommand(testLogCommandId, {
+        execute: (args) => { logArgs.push(args); },
+        label: 'Test log command label',
+        caption: 'Test log command caption',
+        usage: 'Test log command usage',
+        iconClass: 'test-icon-class',
+        iconLabel: 'Test log icon label',
+        className: 'test-log-class',
+        isEnabled: (args) => { return enabled; },
+        isToggled: (args) => { return toggled; },
+        isVisible: (args) => { return visible; },
+      });
+
+      it('should create a button', () => {
+        let button = Toolbar.createFromCommand(commands, testLogCommandId);
+        expect(button).to.be.a(ToolbarButton);
+        button.dispose();
+      });
+
+      it('should dispose the button if the action is removed', () => {
+        let id = 'to-be-removed';
+        let cmd = commands.addCommand(id, { execute: () => { return; } });
+        let button = Toolbar.createFromCommand(commands, id);
+        cmd.dispose();
+        expect(button.isDisposed).to.be(true);
+      });
+
+      it('should add main class', () => {
+        let button = Toolbar.createFromCommand(commands, testLogCommandId);
+        console.log(button.node.className);
+        expect(button.hasClass('test-log-class')).to.be(true);
+        button.dispose();
+      });
+
+      it('should add an icon node with icon class and label', () => {
+        let button = Toolbar.createFromCommand(commands, testLogCommandId);
+        console.log(button.node);
+        let iconNode = button.node.children[0] as HTMLElement;
+        expect(iconNode.classList.contains('test-icon-class')).to.be(true);
+        expect(iconNode.innerText).to.equal('Test log icon label');
+        button.dispose();
+      });
+
+      it('should apply state classes', () => {
+        let button = Toolbar.createFromCommand(commands, testLogCommandId);
+        console.log(button.node.className);
+        expect(button.hasClass('p-mod-disabled')).to.be(true);
+        expect(button.hasClass('p-mod-toggled')).to.be(true);
+        expect(button.hasClass('p-mod-hidden')).to.be(true);
+        button.dispose();
+      });
+
+      it('should add use the command label if no icon class/label', () => {
+        let id = 'to-be-removed';
+        let cmd = commands.addCommand(id, {
+          execute: () => { return; },
+          label: 'Label-only button',
+        });
+        let button = Toolbar.createFromCommand(commands, id);
+        expect(button.node.childElementCount).to.be(0);
+        expect(button.node.innerText).to.equal('Label-only button');
+        cmd.dispose();
+      });
+
+      it('should update the node content on command change event', () => {
+        let id = 'to-be-removed';
+        let iconClassValue: string | null = null;
+        let cmd = commands.addCommand(id, {
+          execute: () => { return; },
+          label: 'Label-only button',
+          iconClass: (args) => { return iconClassValue; }
+        });
+        let button = Toolbar.createFromCommand(commands, id);
+        expect(button.node.childElementCount).to.be(0);
+        expect(button.node.innerText).to.equal('Label-only button');
+
+        iconClassValue = 'updated-icon-class';
+        commands.notifyCommandChanged(id);
+
+        expect(button.node.innerText).to.equal('');
+        expect(button.node.childElementCount).to.be(1);
+        let iconNode = button.node.children[0] as HTMLElement;
+        expect(iconNode.classList.contains(iconClassValue)).to.be(true);
+
+        cmd.dispose();
       });
 
     });


### PR DESCRIPTION
Creates a toolbar button from a command, and listens for changes.

### TODO
 - [x] Add unit tests
 - [x] ~~Use for existing toolbar buttons with a corresponding command~~ (cannot use commands internally, to support use as library)