### PR TITLE
Only allow output to scroll if a cell is active

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -68,6 +68,10 @@
   max-height: 1000px;
 }
 
+.jp-Notebook .jp-Cell:not(.jp-mod-active) .jp-OutputArea {
+  overflow-y: hidden;
+}
+
 
 /*-----------------------------------------------------------------------------
 | Notebook state related styling


### PR DESCRIPTION
Fixes #1445 

Output has a max height and will scroll if longer, but only if the cell is active.