### PR TITLE
Style refinements to collaborator hover.

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -82,8 +82,12 @@
   transform: translateX(-50%);
   color: white;
   border-radius: 3px;
-  padding: 1px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 1px;
+  padding-bottom: 1px;
   text-align: center;
+  font-size: var(--jp-ui-font-size1);
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Decreases the font size and adds some left-right padding.
Before:
![before_refine](https://user-images.githubusercontent.com/5728311/27932069-2f3a2be2-6251-11e7-809f-701f10e599d4.png)

After:
![refine_hover](https://user-images.githubusercontent.com/5728311/27931986-e54f79ba-6250-11e7-9219-87152047e891.png)
