### PR TITLE
Simplify node version check

### DIFF
--- a/jupyterlab/node-version-check.js
+++ b/jupyterlab/node-version-check.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-var semver = require('semver');
-
-if (!semver.satisfies(semver(process.version), '>=5')) {
+var version = parseInt(process.version.replace('v', ''));
+if (version < 5) {
   process.exit(1);
 }


### PR DESCRIPTION
Turns out `semver` package is not built in to `node`...