### PR TITLE
Toolbar adjust

### DIFF
--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -214,6 +214,7 @@ namespace Toolbar {
       tooltip: Private.commandTooltip(commands, id),
     });
     let oldClasses = Private.commandClassName(commands, id).split(/\s/);
+    (button.node as HTMLButtonElement).disabled = !commands.isEnabled(id);
     Private.setNodeContentFromCommand(button.node, commands, id);
 
     // Ensure that we pick up relevant changes to the command:
@@ -241,6 +242,7 @@ namespace Toolbar {
         oldClasses = newClasses;
         button.node.title = Private.commandTooltip(sender, id);
         Private.setNodeContentFromCommand(button.node, sender, id);
+        (button.node as HTMLButtonElement).disabled = !sender.isEnabled(id);
       }
     }
     commands.commandChanged.connect(onChange, button);
@@ -462,9 +464,6 @@ namespace Private {
   function commandClassName(commands: CommandRegistry, id: string): string {
     let name = commands.className(id);
     // Add the boolean state classes.
-    if (!commands.isEnabled(id)) {
-      name += ' p-mod-disabled';
-    }
     if (commands.isToggled(id)) {
       name += ' p-mod-toggled';
     }

--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -208,13 +208,12 @@ namespace Toolbar {
    */
   export
   function createFromCommand(commands: CommandRegistry, id: string): ToolbarButton {
-    let oldClass = Private.commandClassName(commands, id);
     let button = new ToolbarButton({
       onClick: () => { commands.execute(id); },
-      className: oldClass,
+      className: Private.commandClassName(commands, id),
       tooltip: Private.commandTooltip(commands, id),
     });
-
+    let oldClasses = Private.commandClassName(commands, id).split(/\s/);
     Private.setNodeContentFromCommand(button.node, commands, id);
 
     // Ensure that we pick up relevant changes to the command:
@@ -227,12 +226,19 @@ namespace Toolbar {
         button.dispose();
       } else if (args.type === 'changed') {
         // Update all fields (onClick is already indirected)
-        let newClass = Private.commandClassName(sender, id);
-        if (newClass !== oldClass) {
-          button.removeClass(oldClass);
-          button.addClass(newClass);
-          oldClass = newClass;
+        let newClasses = Private.commandClassName(sender, id).split(/\s/);
+
+        for (let cls of oldClasses) {
+          if (cls && newClasses.indexOf(cls) === -1) {
+            button.removeClass(cls);
+          }
         }
+        for (let cls of newClasses) {
+          if (cls && oldClasses.indexOf(cls) === -1) {
+            button.addClass(cls);
+          }
+        }
+        oldClasses = newClasses;
         button.node.title = Private.commandTooltip(sender, id);
         Private.setNodeContentFromCommand(button.node, sender, id);
       }
@@ -479,7 +485,7 @@ namespace Private {
     if (iconClass || iconLabel) {
       let icon = document.createElement('div');
       icon.innerText = commands.iconLabel(id);
-      icon.classList.add(...iconClass.split(/\s/));
+      icon.className += ` ${iconClass}`;
       node.appendChild(icon);
     } else {
       node.innerText = commands.label(id);

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -67,6 +67,15 @@
   box-shadow: var(--jp-toolbar-box-shadow);
 }
 
+.jp-Toolbar-button:disabled {
+  opacity: 0.4;
+}
+
+.jp-Toolbar-button.p-mod-toggled {
+  background-color: var(--jp-toolbar-active-background);
+  box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
+}
+
 .jp-Toolbar > .jp-Toolbar-item.jp-Toolbar-spacer {
   flex-grow: 1;
   flex-shrink: 1;

--- a/test/src/apputils/toolbar.spec.ts
+++ b/test/src/apputils/toolbar.spec.ts
@@ -179,14 +179,12 @@ describe('@jupyterlab/apputils', () => {
 
       it('should add main class', () => {
         let button = Toolbar.createFromCommand(commands, testLogCommandId);
-        console.log(button.node.className);
         expect(button.hasClass('test-log-class')).to.be(true);
         button.dispose();
       });
 
       it('should add an icon node with icon class and label', () => {
         let button = Toolbar.createFromCommand(commands, testLogCommandId);
-        console.log(button.node);
         let iconNode = button.node.children[0] as HTMLElement;
         expect(iconNode.classList.contains('test-icon-class')).to.be(true);
         expect(iconNode.innerText).to.equal('Test log icon label');
@@ -194,11 +192,32 @@ describe('@jupyterlab/apputils', () => {
       });
 
       it('should apply state classes', () => {
+        enabled = false;
+        toggled = true;
+        visible = false;
         let button = Toolbar.createFromCommand(commands, testLogCommandId);
-        console.log(button.node.className);
-        expect(button.hasClass('p-mod-disabled')).to.be(true);
+        expect((button.node as HTMLButtonElement).disabled).to.be(true);
         expect(button.hasClass('p-mod-toggled')).to.be(true);
         expect(button.hasClass('p-mod-hidden')).to.be(true);
+        button.dispose();
+      });
+
+      it('should update state classes', () => {
+        enabled = false;
+        toggled = true;
+        visible = false;
+        let button = Toolbar.createFromCommand(commands, testLogCommandId);
+        expect((button.node as HTMLButtonElement).disabled).to.be(true);
+        expect(button.hasClass('p-mod-toggled')).to.be(true);
+        expect(button.hasClass('p-mod-hidden')).to.be(true);
+        enabled = true;
+        visible = true;
+        commands.notifyCommandChanged(testLogCommandId);
+        expect((button.node as HTMLButtonElement).disabled).to.be(false);
+        expect(button.hasClass('p-mod-toggled')).to.be(true);
+        expect(button.hasClass('p-mod-hidden')).to.be(false);
+        enabled = false;
+        visible = false;
         button.dispose();
       });
 


### PR DESCRIPTION
After getting a successful live test of the features added in #2582, I found some minor bugs, and realized some styling was missing.

I currently made the "toggled" button have the same style as a depressed button (but without the outer hover shadowbox). Note that the pressed button gets its background color from 
`.jp-Toolbar-button:active` not `.jp-Toolbar-button.jp-mod-pressed`.