### PR TITLE
Fix handling of extension type

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -686,7 +686,7 @@ def _ensure_package(app_dir, name=None, version=None, logger=None):
             continue
         data['dependencies'][key] = value['path']
         jlab_data = value['jupyterlab']
-        if jlab_data.get('extension', True):
+        if jlab_data.get('extension', False):
             data['jupyterlab']['extensions'].append(key)
         else:
             data['jupyterlab']['mimeExtensions'].append(key)


### PR DESCRIPTION
Fixes #2626.  This change along with fixing a typo [here](https://github.com/jupyterlab/jupyter-renderers/blob/fb04613c36fde515aca106167426e47b28fd916a/packages/geojson-extension/package.json#L15) enables geojson rendering.

This will cause a 0.25.1 release.