### PR TITLE
Styles prompt fonts

### DIFF
--- a/packages/theming/style/variables-light.css
+++ b/packages/theming/style/variables-light.css
@@ -152,9 +152,9 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-border-color: var(--md-grey-400);
   --jp-cell-editor-background-edit: var(--jp-ui-layout-color1);
   --jp-cell-editor-border-color-edit: var(--jp-brand-color1);
-  --jp-cell-prompt-width: 100px;
-  --jp-cell-prompt-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --jp-cell-prompt-letter-spacing: 2.4px;
+  --jp-cell-prompt-width: 68px;
+  --jp-cell-prompt-font-family: 'Roboto Mono', monospace;
+  --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1.0;
   --jp-cell-prompt-opacity-not-active: 0.56;
   --jp-cell-prompt-font-color-not-active: var(--md-grey-700);


### PR DESCRIPTION
This reverts prompt font styling done in e9d2d94e1feece7583b9ba2cb7a44c91d5305845 as part of #2583. This PR restyles the input prompt font as in @ellisonbg's work done in 560b66f9791e36adb68d844e630fe25e3acbd5cd as part of #2123.

| Before this PR | After this PR |
| :--: | :--: |
| <img width="366" alt="2 0" src="https://user-images.githubusercontent.com/1320475/27989864-70bf449e-6409-11e7-8bd3-3ff29f9ec3cf.png"> | <img width="374" alt="2mo" src="https://user-images.githubusercontent.com/1320475/27989872-acf3879a-6409-11e7-9f4e-e08a882d7239.png"> |

The monospaced font suggests `In` is available as a variable. I'd like to hear @cameronoelsen's  motivation for including the wide spacing. I've only been able to find part of a commit message: "changed the font family of the cell in and out prompt (still playing around with it)".

I got curious about small font spacing with variable width fonts, and generated a mockup.

<img width="369" alt="less-spacing smaller-width" src="https://user-images.githubusercontent.com/1320475/27989879-f302359c-6409-11e7-8feb-4e964806b07d.png">