### PR TITLE
Make kernel icon URLs absolute

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -15,6 +15,10 @@ import {
 } from '@jupyterlab/codeeditor';
 
 import {
+  PageConfig, PathExt
+} from '@jupyterlab/coreutils';
+
+import {
   IConsoleTracker, ConsolePanel
 } from '@jupyterlab/console';
 
@@ -162,6 +166,7 @@ function activateConsole(app: JupyterLab, manager: IServiceManager, mainMenu: IM
   if (launcher) {
     manager.ready.then(() => {
       let specs = manager.specs;
+      let baseUrl = PageConfig.getBaseUrl();
       for (let name in specs.kernelspecs) {
         let displayName = specs.kernelspecs[name].display_name;
         let rank = name === specs.default ? 0 : Infinity;
@@ -172,7 +177,7 @@ function activateConsole(app: JupyterLab, manager: IServiceManager, mainMenu: IM
           iconClass: 'jp-CodeConsoleIcon',
           callback,
           rank,
-          kernelIconUrl: specs.kernelspecs[name].resources["logo-64x64"]
+          kernelIconUrl: baseUrl + PathExt.removeSlash(specs.kernelspecs[name].resources["logo-64x64"])
         });
       }
     });

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from '@jupyterlab/codeeditor';
 
 import {
-  IStateDB
+  IStateDB, PageConfig, PathExt
 } from '@jupyterlab/coreutils';
 
 import {
@@ -442,6 +442,7 @@ function activateNotebookHandler(app: JupyterLab, services: IServiceManager, mai
   if (launcher) {
     services.ready.then(() => {
       let specs = services.specs;
+      let baseUrl = PageConfig.getBaseUrl();
       for (let name in specs.kernelspecs) {
         let displayName = specs.kernelspecs[name].display_name;
         let rank = name === specs.default ? 0 : Infinity;
@@ -452,7 +453,7 @@ function activateNotebookHandler(app: JupyterLab, services: IServiceManager, mai
           iconClass: 'jp-NotebookRunningIcon',
           callback,
           rank,
-          kernelIconUrl: specs.kernelspecs[name].resources["logo-64x64"]
+          kernelIconUrl: baseUrl + PathExt.removeSlash(specs.kernelspecs[name].resources["logo-64x64"])
         });
       }
     });


### PR DESCRIPTION
This change forces kernel icon requests to go to the Jupyter server instead of the current context. This is needed in the [electron app](https://github.com/jupyterlab/jupyterlab_app), where the JavaScript is served by the electron app instead of the Jupyter server, but kernel icon requests still need to be directed to the Jupyter server.