### PR TITLE
Don’t scroll on the run cell command.

### DIFF
--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -344,7 +344,7 @@ namespace NotebookActions {
    * @param session - The optional client session object.
    *
    * #### Notes
-   * The last selected cell will be activated.
+   * The last selected cell will be activated, but not scrolled into view.
    * The existing selection will be cleared.
    * An execution error will prevent the remaining code cells from executing.
    * All markdown cells will be rendered.
@@ -356,7 +356,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let promise = Private.runSelected(widget, session);
-    Private.handleRunState(widget, state);
+    Private.handleRunState(widget, state, false);
     return promise;
   }
 
@@ -369,7 +369,7 @@ namespace NotebookActions {
    *
    * #### Notes
    * The existing selection will be cleared.
-   * The cell after the last selected cell will be activated.
+   * The cell after the last selected cell will be activated and scrolled into view.
    * An execution error will prevent the remaining code cells from executing.
    * All markdown cells will be rendered.
    * If the last selected cell is the last cell, a new code cell
@@ -391,7 +391,7 @@ namespace NotebookActions {
     } else {
       widget.activeCellIndex++;
     }
-    Private.handleRunState(widget, state);
+    Private.handleRunState(widget, state, true);
     return promise;
   }
 
@@ -408,6 +408,7 @@ namespace NotebookActions {
    * The widget mode will be set to `'edit'` after running.
    * The existing selection will be cleared.
    * The cell insert can be undone.
+   * The new cell will be scrolled into view.
    */
   export
   function runAndInsert(widget: Notebook, session?: IClientSession): Promise<boolean> {
@@ -421,7 +422,7 @@ namespace NotebookActions {
     model.cells.insert(widget.activeCellIndex + 1, cell);
     widget.activeCellIndex++;
     widget.mode = 'edit';
-    Private.handleRunState(widget, state);
+    Private.handleRunState(widget, state, true);
     return promise;
   }
 
@@ -436,7 +437,7 @@ namespace NotebookActions {
    * The existing selection will be cleared.
    * An execution error will prevent the remaining code cells from executing.
    * All markdown cells will be rendered.
-   * The last cell in the notebook will be activated.
+   * The last cell in the notebook will be activated and scrolled into view.
    */
   export
   function runAll(widget: Notebook, session?: IClientSession): Promise<boolean> {
@@ -448,7 +449,7 @@ namespace NotebookActions {
       widget.select(child);
     });
     let promise = Private.runSelected(widget, session);
-    Private.handleRunState(widget, state);
+    Private.handleRunState(widget, state, true);
     return promise;
   }
 
@@ -1081,13 +1082,15 @@ namespace Private {
    * Handle the state of a widget after running a run action.
    */
   export
-  function handleRunState(widget: Notebook, state: IState): void {
+  function handleRunState(widget: Notebook, state: IState, scroll = false): void {
     if (state.wasFocused || widget.mode === 'edit') {
       widget.activate();
     }
-    // Scroll to the top of the previous active cell output.
-    let er = state.activeCell.inputArea.node.getBoundingClientRect();
-    widget.scrollToPosition(er.bottom);
+    if (scroll) {
+      // Scroll to the top of the previous active cell output.
+      let er = state.activeCell.inputArea.node.getBoundingClientRect();
+      widget.scrollToPosition(er.bottom);
+    }
   }
 
   /**


### PR DESCRIPTION
This fixes a regression compared to the classic notebook, which also didn’t scroll on the run cell command.

CC @dmadeka, who pointed this out.