### PR TITLE
Strict null Cleanup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,4 +14,3 @@ include jupyterlab/node-version-check.js
 include jupyterlab/released_packages.txt
 
 prune jupyterlab/tests
-prune node_modules

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,4 @@ include jupyterlab/node-version-check.js
 include jupyterlab/released_packages.txt
 
 prune jupyterlab/tests
+prune node_modules

--- a/packages/apputils/src/clientsession.ts
+++ b/packages/apputils/src/clientsession.ts
@@ -372,7 +372,7 @@ class ClientSession implements IClientSession {
   /**
    * Change the current kernel associated with the document.
    */
-  changeKernel(options: Kernel.IModel): Promise<Kernel.IKernelConnection> {
+  changeKernel(options: Partial<Kernel.IModel>): Promise<Kernel.IKernelConnection> {
     return this.ready.then(() => {
       if (this.isDisposed) {
         return;
@@ -561,7 +561,7 @@ class ClientSession implements IClientSession {
   /**
    * Change the kernel.
    */
-  private _changeKernel(options: Kernel.IModel): Promise<Kernel.IKernelConnection> {
+  private _changeKernel(options: Partial<Kernel.IModel>): Promise<Kernel.IKernelConnection> {
     if (this.isDisposed) {
       return Promise.resolve(void 0);
     }
@@ -594,7 +594,7 @@ class ClientSession implements IClientSession {
   /**
    * Start a session and set up its signals.
    */
-  private _startSession(model: Kernel.IModel): Promise<Kernel.IKernelConnection> {
+  private _startSession(model: Partial<Kernel.IModel>): Promise<Kernel.IKernelConnection> {
     if (this.isDisposed) {
       return Promise.reject('Session is disposed.');
     }

--- a/packages/coreutils/src/activitymonitor.ts
+++ b/packages/coreutils/src/activitymonitor.ts
@@ -73,15 +73,13 @@ class ActivityMonitor<Sender, Args> implements IDisposable {
         sender: this._sender,
         args: this._args
       });
-      this._sender = null;
-      this._args = null;
     }, this._timeout);
   }
 
   private _timer = -1;
   private _timeout = -1;
-  private _sender: Sender = null;
-  private _args: Args = null;
+  private _sender: Sender;
+  private _args: Args;
   private _isDisposed = false;
   private _activityStopped = new Signal<this, ActivityMonitor.IArguments<Sender, Args>>(this);
 }

--- a/packages/coreutils/src/markdowncodeblocks.ts
+++ b/packages/coreutils/src/markdowncodeblocks.ts
@@ -79,22 +79,22 @@ namespace MarkdownCodeBlocks {
         // Check whether this is a single line code block of the form ```a = 10```.
         const firstIndex = line.indexOf(CODE_BLOCK_MARKER);
         const lastIndex = line.lastIndexOf(CODE_BLOCK_MARKER);
-        const isSingleLine = firstIndex != lastIndex
+        const isSingleLine = firstIndex !== lastIndex;
         if (isSingleLine) {
           currentBlock.code = line.substring(firstIndex + CODE_BLOCK_MARKER.length, lastIndex);
           currentBlock.endLine = lineIndex;
           codeBlocks.push(currentBlock);
           currentBlock = null;
         }
-      } else {
+      } else if (currentBlock) {
         if (lineContainsMarker) {
           // End of block, finish it up.
-          currentBlock.endLine = lineIndex-1;
+          currentBlock.endLine = lineIndex - 1;
           codeBlocks.push(currentBlock);
           currentBlock = null;
         } else {
           // Append the current line.
-          currentBlock.code += line + "\n";
+          currentBlock.code += line + '\n';
         }
       }
     }

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -182,7 +182,7 @@ interface IModelDB extends IDisposable {
    *
    * @returns an `IObservable`.
    */
-  get(path: string): IObservable;
+  get(path: string): IObservable | undefined;
 
   /**
    * Whether the `IModelDB` has an object at this path.
@@ -426,7 +426,7 @@ class ModelDB implements IModelDB {
    *
    * @returns an `IObservable`.
    */
-  get(path: string): IObservable {
+  get(path: string): IObservable | undefined {
     return this._db.get(this._resolvePath(path));
   }
 
@@ -514,8 +514,8 @@ class ModelDB implements IModelDB {
    */
   getValue(path: string): JSONValue {
     let val = this.get(path);
-    if (val.type !== 'Value') {
-        throw Error('Can only call getValue for an ObservableValue');
+    if (!val || val.type !== 'Value') {
+      throw Error('Can only call getValue for an ObservableValue');
     }
     return (val as ObservableValue).get();
   }
@@ -530,8 +530,8 @@ class ModelDB implements IModelDB {
    */
   setValue(path: string, value: JSONValue): void {
     let val = this.get(path);
-    if (val.type !== 'Value') {
-        throw Error('Can only call setValue on an ObservableValue');
+    if (!val || val.type !== 'Value') {
+      throw Error('Can only call setValue on an ObservableValue');
     }
     (val as ObservableValue).set(value);
   }

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -117,7 +117,7 @@ interface ICollaborator extends JSONObject {
    * use in places where the full `displayName` would take
    * too much space.
    */
-  readonly shortName?: string;
+  readonly shortName: string;
 }
 
 
@@ -282,7 +282,7 @@ class ObservableValue implements IObservableValue {
    *
    * @param initialValue: the starting value for the `ObservableValue`.
    */
-  constructor(initialValue?: JSONValue) {
+  constructor(initialValue: JSONValue = {}) {
     this._value = initialValue;
   }
 
@@ -571,11 +571,8 @@ class ModelDB implements IModelDB {
     if (this.isDisposed) {
       return;
     }
-    let db = this._db;
-    this._db = null;
-
     if (this._toDispose) {
-      db.dispose();
+      this._db.dispose();
     }
     this._disposables.dispose();
   }
@@ -591,7 +588,7 @@ class ModelDB implements IModelDB {
   }
 
   private _basePath: string;
-  private _db: ModelDB | ObservableMap<IObservable> = null;
+  private _db: ModelDB | ObservableMap<IObservable>;
   private _toDispose = false;
   private _disposables = new DisposableSet();
 }

--- a/packages/coreutils/src/modeldb.ts
+++ b/packages/coreutils/src/modeldb.ts
@@ -282,7 +282,7 @@ class ObservableValue implements IObservableValue {
    *
    * @param initialValue: the starting value for the `ObservableValue`.
    */
-  constructor(initialValue: JSONValue = {}) {
+  constructor(initialValue: JSONValue = null) {
     this._value = initialValue;
   }
 
@@ -398,7 +398,7 @@ class ModelDB implements IModelDB {
    * Whether the database is disposed.
    */
   get isDisposed(): boolean {
-    return this._db === null;
+    return this._isDisposed;
   }
 
   /**
@@ -571,6 +571,7 @@ class ModelDB implements IModelDB {
     if (this.isDisposed) {
       return;
     }
+    this._isDisposed = true;
     if (this._toDispose) {
       this._db.dispose();
     }
@@ -590,6 +591,7 @@ class ModelDB implements IModelDB {
   private _basePath: string;
   private _db: ModelDB | ObservableMap<IObservable>;
   private _toDispose = false;
+  private _isDisposed = false;
   private _disposables = new DisposableSet();
 }
 

--- a/packages/coreutils/src/observablejson.ts
+++ b/packages/coreutils/src/observablejson.ts
@@ -61,6 +61,9 @@ class ObservableJSON extends ObservableMap<JSONValue> {
     let out: JSONObject = Object.create(null);
     for (let key of this.keys()) {
       let value = this.get(key);
+      if (!value) {
+        continue;
+      }
       if (JSONExt.isPrimitive(value)) {
         out[key] = value;
       } else {

--- a/packages/coreutils/src/observablelist.ts
+++ b/packages/coreutils/src/observablelist.ts
@@ -71,7 +71,7 @@ interface IObservableList<T> extends IDisposable {
    * #### Undefined Behavior
    * An `index` which is non-integral or out of range.
    */
-  get(index: number): T;
+  get(index: number): T | undefined;
 
   /**
    * Insert a value into the list at a specific index.
@@ -181,7 +181,7 @@ interface IObservableList<T> extends IDisposable {
    * #### Undefined Behavior
    * An `index` which is non-integral.
    */
-  remove(index: number): T;
+  remove(index: number): T | undefined;
 
   /**
    * Remove a range of items from the list.
@@ -389,7 +389,7 @@ class ObservableList<T> implements IObservableList<T> {
    * #### Undefined Behavior
    * An `index` which is non-integral or out of range.
    */
-  get(index: number): T {
+  get(index: number): T | undefined {
     return this._array[index];
   }
 
@@ -412,7 +412,7 @@ class ObservableList<T> implements IObservableList<T> {
   set(index: number, value: T): void {
     let oldValue = this._array[index];
     if (value === undefined) {
-      value = null;
+      throw new Error('Cannot set an undefined item');
     }
     // Bail if the value does not change.
     let itemCmp = this._itemCmp;
@@ -524,8 +524,11 @@ class ObservableList<T> implements IObservableList<T> {
    * #### Undefined Behavior
    * An `index` which is non-integral.
    */
-  remove(index: number): T {
+  remove(index: number): T | undefined {
     let value = ArrayExt.removeAt(this._array, index);
+    if (value === undefined) {
+      return;
+    }
     this._changed.emit({
       type: 'remove',
       oldIndex: index,

--- a/packages/coreutils/src/observablemap.ts
+++ b/packages/coreutils/src/observablemap.ts
@@ -44,7 +44,7 @@ interface IObservableMap<T> extends IDisposable, IObservable {
    * @returns the old value for the key, or undefined
    *   if that did not exist.
    */
-  set(key: string, value: T): T;
+  set(key: string, value: T): T | undefined;
 
   /**
    * Get a value for a given key.
@@ -53,7 +53,7 @@ interface IObservableMap<T> extends IDisposable, IObservable {
    *
    * @returns the value for that key.
    */
-  get(key: string): T;
+  get(key: string): T | undefined;
 
   /**
    * Check whether the map has a key.
@@ -86,7 +86,7 @@ interface IObservableMap<T> extends IDisposable, IObservable {
    * @returns the value of the given key,
    *   or undefined if that does not exist.
    */
-  delete(key: string): T;
+  delete(key: string): T | undefined;
 
   /**
    * Set the ObservableMap to an empty map.
@@ -143,12 +143,12 @@ namespace IObservableMap {
     /**
      * The old value of the change.
      */
-    oldValue: T;
+    oldValue: T | undefined;
 
     /**
      * The new value of the change.
      */
-    newValue: T;
+    newValue: T | undefined;
   }
 }
 
@@ -214,7 +214,7 @@ class ObservableMap<T> implements IObservableMap<T> {
    * #### Notes
    * This is a no-op if the value does not change.
    */
-  set(key: string, value: T): T {
+  set(key: string, value: T): T | undefined {
     let oldVal = this._map.get(key);
     if (value === undefined) {
       throw Error('Cannot set an undefined value, use remove');
@@ -222,7 +222,7 @@ class ObservableMap<T> implements IObservableMap<T> {
     // Bail if the value does not change.
     let itemCmp = this._itemCmp;
     if (oldVal !== undefined && itemCmp(oldVal, value)) {
-      return;
+      return oldVal;
     }
     this._map.set(key, value);
     this._changed.emit({
@@ -241,7 +241,7 @@ class ObservableMap<T> implements IObservableMap<T> {
    *
    * @returns the value for that key.
    */
-  get(key: string): T {
+  get(key: string): T | undefined {
     return this._map.get(key);
   }
 
@@ -291,7 +291,7 @@ class ObservableMap<T> implements IObservableMap<T> {
    * @returns the value of the given key,
    *   or undefined if that does not exist.
    */
-  delete(key: string): T {
+  delete(key: string): T | undefined {
     let oldVal = this._map.get(key);
     this._map.delete(key);
     this._changed.emit({
@@ -323,7 +323,6 @@ class ObservableMap<T> implements IObservableMap<T> {
     }
     Signal.clearData(this);
     this._map.clear();
-    this._map = null;
   }
 
   private _map: Map<string, T> = new Map<string, T>();

--- a/packages/coreutils/src/observablemap.ts
+++ b/packages/coreutils/src/observablemap.ts
@@ -189,7 +189,7 @@ class ObservableMap<T> implements IObservableMap<T> {
    * Whether this map has been disposed.
    */
   get isDisposed(): boolean {
-    return this._map === null;
+    return this._isDisposed;
   }
 
   /**
@@ -318,9 +318,10 @@ class ObservableMap<T> implements IObservableMap<T> {
    * Dispose of the resources held by the map.
    */
   dispose(): void {
-    if (this._map === null) {
+    if (this.isDisposed) {
       return;
     }
+    this._isDisposed = true;
     Signal.clearData(this);
     this._map.clear();
   }
@@ -328,6 +329,7 @@ class ObservableMap<T> implements IObservableMap<T> {
   private _map: Map<string, T> = new Map<string, T>();
   private _itemCmp: (first: T, second: T) => boolean;
   private _changed = new Signal<this, IObservableMap.IChangedArgs<T>>(this);
+  private _isDisposed = false;
 }
 
 

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -80,9 +80,9 @@ namespace PageConfig {
         configData[key] = String(configData[key]).split('&#39;').join('"');
       }
     }
-    return configData[name] || '';
+    return configData![name] || '';
   }
-  
+
   /**
    * Set global configuration data for the Jupyter application.
    *
@@ -94,7 +94,7 @@ namespace PageConfig {
   export
   function setOption(name: string, value: string): string {
     let last = getOption(name);
-    configData[name] = value;
+    configData![name] = value;
     return last;
   }
 

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -636,7 +636,7 @@ class SettingRegistry {
   private _pluginChanged = new Signal<this, string>(this);
   private _plugins: { [name: string]: ISettingRegistry.IPlugin } = Object.create(null);
   private _preload: (plugin: string, schema: ISettingRegistry.ISchema) => void;
-  private _validator: ISchemaValidator | null = null;
+  private _validator: ISchemaValidator;
 }
 
 
@@ -715,10 +715,6 @@ class Settings implements ISettingRegistry.ISettings {
     }
 
     this._isDisposed = true;
-    this._composite = null;
-    this._schema = null;
-    this._user = null;
-
     Signal.clearData(this);
   }
 

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -113,7 +113,7 @@ class StateDB implements IStateDB {
     let i = window.localStorage.length;
     while (i) {
       let key = window.localStorage.key(--i);
-      if (key.indexOf(prefix) === 0) {
+      if (key && key.indexOf(prefix) === 0) {
         window.localStorage.removeItem(key);
       }
     }
@@ -137,10 +137,14 @@ class StateDB implements IStateDB {
    * The promise returned by this method may be rejected if an error occurs in
    * retrieving the data. Non-existence of an `id` will succeed with `null`.
    */
-  fetch(id: string): Promise<JSONObject | null> {
+  fetch(id: string): Promise<JSONObject | undefined> {
     const key = `${this.namespace}:${id}`;
+    const value = window.localStorage.getItem(key);
+    if (!value) {
+      return Promise.resolve(undefined);
+    }
     try {
-      return Promise.resolve(JSON.parse(window.localStorage.getItem(key)));
+      return Promise.resolve(JSON.parse(value));
     } catch (error) {
       return Promise.reject(error);
     }
@@ -169,11 +173,12 @@ class StateDB implements IStateDB {
     let i = window.localStorage.length;
     while (i) {
       let key = window.localStorage.key(--i);
-      if (key.indexOf(prefix) === 0) {
+      if (key && key.indexOf(prefix) === 0) {
+        let value = window.localStorage.getItem(key);
         try {
           items.push({
             id: key.replace(regex, ''),
-            value: JSON.parse(window.localStorage.getItem(key))
+            value: value ? JSON.parse(value) : undefined
           });
         } catch (error) {
           console.warn(error);

--- a/packages/coreutils/src/undoablelist.ts
+++ b/packages/coreutils/src/undoablelist.ts
@@ -106,15 +106,6 @@ class ObservableUndoableList<T> extends ObservableList<T> implements IObservable
   }
 
   /**
-   * Dispose of the resources held by the model.
-   */
-  dispose(): void {
-    this._serializer = null;
-    this._stack = null;
-    super.dispose();
-  }
-
-  /**
    * Begin a compound operation.
    *
    * @param isUndoAble - Whether the operation is undoable.
@@ -294,7 +285,7 @@ class ObservableUndoableList<T> extends ObservableList<T> implements IObservable
   private _madeCompoundChange = false;
   private _index = -1;
   private _stack: IObservableList.IChangedArgs<JSONValue>[][] = [];
-  private _serializer: ISerializer<T> = null;
+  private _serializer: ISerializer<T>;
 }
 
 /**

--- a/packages/coreutils/tsconfig.json
+++ b/packages/coreutils/tsconfig.json
@@ -4,6 +4,7 @@
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,
+    "strictNullChecks": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES5",

--- a/packages/coreutils/tsconfig.json
+++ b/packages/coreutils/tsconfig.json
@@ -4,7 +4,6 @@
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,
-    "strictNullChecks": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES5",

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -214,7 +214,7 @@ class DocumentManager implements IDisposable {
    * This function will return `undefined` if a valid widget factory
    * cannot be found.
    */
-  createNew(path: string, widgetName='default', kernel?: Kernel.IModel): Widget {
+  createNew(path: string, widgetName='default', kernel?: Partial<Kernel.IModel>): Widget {
     return this._createOrOpenDocument('create', path, widgetName, kernel);
   }
 
@@ -290,7 +290,7 @@ class DocumentManager implements IDisposable {
    * This function will return `undefined` if a valid widget factory
    * cannot be found.
    */
-  open(path: string, widgetName='default', kernel?: Kernel.IModel): Widget {
+  open(path: string, widgetName='default', kernel?: Partial<Kernel.IModel>): Widget {
     return this._createOrOpenDocument('open', path, widgetName, kernel);
   }
 
@@ -310,7 +310,7 @@ class DocumentManager implements IDisposable {
    * This function will return `undefined` if a valid widget factory
    * cannot be found.
    */
-  openOrReveal(path: string, widgetName='default', kernel?: Kernel.IModel): Widget {
+  openOrReveal(path: string, widgetName='default', kernel?: Partial<Kernel.IModel>): Widget {
     let widget = this.findWidget(path, widgetName);
     if (widget) {
       this._opener.open(widget);
@@ -430,7 +430,7 @@ class DocumentManager implements IDisposable {
    * The two cases differ in how the document context is handled, but the creation
    * of the widget and launching of the kernel are identical.
    */
-  private _createOrOpenDocument(which: 'open'|'create', path: string, widgetName='default', kernel?: Kernel.IModel): Widget {
+  private _createOrOpenDocument(which: 'open'|'create', path: string, widgetName='default', kernel?: Partial<Kernel.IModel>): Widget {
     let widgetFactory = this._widgetFactoryFor(path, widgetName);
     if (!widgetFactory) {
       return;

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -387,7 +387,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
       this.session.setPath(newPath);
       this.session.setName(newPath.split('/').pop());
       this._path = newPath;
-      this._updateContentsModel(change.newValue);
+      this._updateContentsModel(change.newValue as Contents.IModel);
       this._pathChanged.emit(this._path);
     }
   }
@@ -411,6 +411,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
       path: model.path,
       name: model.name,
       type: model.type,
+      content: undefined,
       writable: model.writable,
       created: model.created,
       last_modified: model.last_modified,

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -490,7 +490,7 @@ class DocumentRegistry implements IDisposable {
    *
    * @returns A kernel preference.
    */
-  getKernelPreference(ext: string, widgetName: string, kernel?: Kernel.IModel): IClientSession.IKernelPreference {
+  getKernelPreference(ext: string, widgetName: string, kernel?: Partial<Kernel.IModel>): IClientSession.IKernelPreference {
     ext = Private.normalizeExtension(ext);
     widgetName = widgetName.toLowerCase();
     let widgetFactory = this._widgetFactories[widgetName];

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -53,7 +53,17 @@ class FileBrowserModel implements IDisposable {
     this.manager = options.manager;
     this._driveName = options.driveName || '';
     let rootPath = this._driveName ? this._driveName + ':' : '';
-    this._model = { path: rootPath, name: '/', type: 'directory' };
+    this._model = {
+      path: rootPath,
+      name: PathExt.basename(rootPath),
+      type: 'directory',
+      content: undefined,
+      writable: false,
+      created: 'unknown',
+      last_modified: 'unknown',
+      mimetype: 'text/plain',
+      format: 'text'
+    };
     this._state = options.state || null;
 
     const { services } = options.manager;
@@ -326,7 +336,7 @@ class FileBrowserModel implements IDisposable {
 
     return new Promise<Contents.IModel>((resolve, reject) => {
       reader.onload = (event: Event) => {
-        let model: Contents.IModel = {
+        let model: Partial<Contents.IModel> = {
           type: type,
           format,
           name,
@@ -354,6 +364,7 @@ class FileBrowserModel implements IDisposable {
       name: contents.name,
       path: contents.path,
       type: contents.type,
+      content: undefined,
       writable: contents.writable,
       created: contents.created,
       last_modified: contents.last_modified,

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -160,7 +160,7 @@ class DefaultConfigSection implements IConfigSection {
   }
 
   private _url = 'unknown';
-  private _data: JSONObject = null;
+  private _data: JSONObject;
 }
 
 
@@ -223,8 +223,8 @@ class ConfigWithDefaults {
     return data;
   }
 
-  private _section: IConfigSection = null;
-  private _defaults: JSONObject = null;
+  private _section: IConfigSection;
+  private _defaults: JSONObject;
   private _className = '';
 }
 

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  JSONExt, JSONObject
+  JSONObject
 } from '@phosphor/coreutils';
 
 import {
@@ -56,7 +56,7 @@ namespace Contents {
      * #### Notes
      *  Equivalent to the last part of the `path` field.
      */
-    readonly name?: string;
+    readonly name: string;
 
     /**
      * The full file path.
@@ -64,27 +64,27 @@ namespace Contents {
      * #### Notes
      * It will *not* start with `/`, and it will be `/`-delimited.
      */
-    readonly path?: string;
+    readonly path: string;
 
     /**
      * The type of file.
      */
-    readonly type?: ContentType;
+    readonly type: ContentType;
 
     /**
      * Whether the requester has permission to edit the file.
      */
-    readonly writable?: boolean;
+    readonly writable: boolean;
 
     /**
      * File creation timestamp.
      */
-    readonly created?: string;
+    readonly created: string;
 
     /**
      * Last modified timestamp.
      */
-    readonly last_modified?: string;
+    readonly last_modified: string;
 
     /**
      * Specify the mime-type of file contents.
@@ -92,12 +92,12 @@ namespace Contents {
      * #### Notes
      * Only non-`null` when `content` is present and `type` is `"file"`.
      */
-    readonly mimetype?: string;
+    readonly mimetype: string;
 
     /**
      * The optional file content.
      */
-    readonly content?: any;
+    readonly content: any;
 
     /**
      * The format of the file `content`.
@@ -105,7 +105,7 @@ namespace Contents {
      * #### Notes
      * Only relevant for type: 'file'
      */
-    readonly format?: FileFormat;
+    readonly format: FileFormat;
   }
 
   /**
@@ -125,7 +125,7 @@ namespace Contents {
    * The options used to fetch a file.
    */
   export
-  interface IFetchOptions extends JSONObject {
+  interface IFetchOptions {
     /**
      * The override file type for the request.
      */
@@ -148,7 +148,7 @@ namespace Contents {
    * The options used to create a file.
    */
   export
-  interface ICreateOptions extends JSONObject {
+  interface ICreateOptions {
     /**
      * The directory in which to create the file.
      */
@@ -197,12 +197,12 @@ namespace Contents {
     /**
      * The new contents.
      */
-    oldValue: IModel | null;
+    oldValue: Partial<IModel> | null;
 
     /**
      * The old contents.
      */
-    newValue: IModel | null;
+    newValue: Partial<IModel> | null;
   }
 
   /**
@@ -225,7 +225,7 @@ namespace Contents {
      * relevant backend. Returns `null` if the backend
      * does not provide one.
      */
-    getModelDBFactory(path: string): ModelDB.IFactory;
+    getModelDBFactory(path: string): ModelDB.IFactory | null;
 
     /**
      * Get a file or directory.
@@ -287,7 +287,7 @@ namespace Contents {
      * @returns A promise which resolves with the file content model when the
      *   file is saved.
      */
-    save(path: string, options?: IModel): Promise<IModel>;
+    save(path: string, options?: Partial<IModel>): Promise<IModel>;
 
     /**
      * Copy a file into a given directory.
@@ -432,7 +432,7 @@ namespace Contents {
      * @returns A promise which resolves with the file content model when the
      *   file is saved.
      */
-    save(localPath: string, options?: IModel): Promise<IModel>;
+    save(localPath: string, options?: Partial<IModel>): Promise<IModel>;
 
     /**
      * Copy a file into a given directory.
@@ -549,9 +549,9 @@ class ContentsManager implements Contents.IManager {
    * relevant backend. Returns `null` if the backend
    * does not provide one.
    */
-  getModelDBFactory(path: string): ModelDB.IFactory {
-    let [drive,] = this._driveForPath(path);
-    return drive.modelDBFactory || null;
+  getModelDBFactory(path: string): ModelDB.IFactory | null {
+    let [drive, ] = this._driveForPath(path);
+    return drive && drive.modelDBFactory || null;
   }
 
   /**
@@ -565,6 +565,9 @@ class ContentsManager implements Contents.IManager {
    */
   get(path: string, options?: Contents.IFetchOptions): Promise<Contents.IModel> {
     let [drive, localPath] = this._driveForPath(path);
+    if (!drive) {
+      return Promise.reject(`No valid drive for path: ${path}`);
+    }
     return drive.get(localPath, options).then( contentsModel => {
       let listing: Contents.IModel[] = [];
       if (contentsModel.type === 'directory') {
@@ -613,6 +616,9 @@ class ContentsManager implements Contents.IManager {
     if (options.path) {
       let globalPath = Private.normalize(options.path);
       let [drive, localPath] = this._driveForPath(globalPath);
+      if (!drive) {
+        return Promise.reject(`No valid drive for path: ${globalPath}`);
+      }
       return drive.newUntitled({ ...options, path: localPath }).then( contentsModel => {
         return {
           ...contentsModel,
@@ -673,7 +679,7 @@ class ContentsManager implements Contents.IManager {
    * #### Notes
    * Ensure that `model.content` is populated for the file.
    */
-  save(path: string, options: Contents.IModel = {}): Promise<Contents.IModel> {
+  save(path: string, options: Partial<Contents.IModel> = {}): Promise<Contents.IModel> {
     let [drive, localPath] = this._driveForPath(path);
     return drive.save(localPath, { ...options, path: localPath }).then(contentsModel => {
       return { ...contentsModel, path: Private.normalize(path) } as Contents.IModel;
@@ -814,15 +820,15 @@ class ContentsManager implements Contents.IManager {
     if (sender === this._defaultDrive) {
       this._fileChanged.emit(args);
     } else {
-      let newValue: Contents.IModel = null;
-      let oldValue: Contents.IModel = null;
-      if (args.newValue) {
+      let newValue: Partial<Contents.IModel> | null = null;
+      let oldValue: Partial<Contents.IModel> | null = null;
+      if (args.newValue && args.newValue.path) {
         newValue = {
           ...args.newValue,
           path: this._toGlobalPath(sender, args.newValue.path)
         };
       }
-      if (args.oldValue) {
+      if (args.oldValue && args.oldValue.path) {
         oldValue = {
           ...args.oldValue,
           path: this._toGlobalPath(sender, args.oldValue.path)
@@ -838,7 +844,7 @@ class ContentsManager implements Contents.IManager {
 
   private _isDisposed = false;
   private _additionalDrives = new Map<string, Contents.IDrive>();
-  private _defaultDrive: Contents.IDrive = null;
+  private _defaultDrive: Contents.IDrive;
   private _fileChanged = new Signal<this, Contents.IChangedArgs>(this);
 }
 
@@ -914,8 +920,8 @@ class Drive implements Contents.IDrive {
       if (options.type === 'notebook') {
         delete options['format'];
       }
-      let params: any = JSONExt.deepCopy(options);
-      params.content = options.content ? '1' : '0';
+      let content = options.content ? '1' : '0';
+      let params: JSONObject = { ...options, content };
       url += URLExt.objectToQueryString(params);
     }
 
@@ -1086,7 +1092,7 @@ class Drive implements Contents.IDrive {
    *
    * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/contents) and validates the response model.
    */
-  save(localPath: string, options: Contents.IModel = {}): Promise<Contents.IModel> {
+  save(localPath: string, options: Partial<Contents.IModel> = {}): Promise<Contents.IModel> {
     let request = {
       url: this._getUrl(localPath),
       method: 'PUT',

--- a/packages/services/src/kernel/comm.ts
+++ b/packages/services/src/kernel/comm.ts
@@ -88,13 +88,6 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
   }
 
   /**
-   * Test whether the comm has been disposed.
-   */
-  get isDisposed(): boolean {
-    return (this._kernel === null);
-  }
-
-  /**
    * Open a comm with optional data and metadata.
    *
    * #### Notes
@@ -104,7 +97,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
    */
   open(data?: JSONValue, metadata?: JSONObject): Kernel.IFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
-      throw 'Cannot open';
+      throw new Error('Cannot open');
     }
     let options: KernelMessage.IOptions = {
       msgType: 'comm_open',
@@ -131,7 +124,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
    */
   send(data: JSONValue, metadata?: JSONObject, buffers: (ArrayBuffer | ArrayBufferView)[] = [], disposeOnDone: boolean = true): Kernel.IFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
-      throw 'Cannot send';
+      throw new Error('Cannot send');
     }
     let options: KernelMessage.IOptions = {
       msgType: 'comm_msg',
@@ -160,7 +153,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
    */
   close(data?: JSONValue, metadata?: JSONObject): Kernel.IFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
-      throw 'Cannot close';
+      throw new Error('Cannot close');
     }
     let options: KernelMessage.IOptions = {
       msgType: 'comm_msg',

--- a/packages/services/src/kernel/comm.ts
+++ b/packages/services/src/kernel/comm.ts
@@ -104,7 +104,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
    */
   open(data?: JSONValue, metadata?: JSONObject): Kernel.IFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
-      return;
+      throw 'Cannot open';
     }
     let options: KernelMessage.IOptions = {
       msgType: 'comm_open',
@@ -131,7 +131,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
    */
   send(data: JSONValue, metadata?: JSONObject, buffers: (ArrayBuffer | ArrayBufferView)[] = [], disposeOnDone: boolean = true): Kernel.IFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
-      return;
+      throw 'Cannot send';
     }
     let options: KernelMessage.IOptions = {
       msgType: 'comm_msg',
@@ -160,7 +160,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
    */
   close(data?: JSONValue, metadata?: JSONObject): Kernel.IFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
-      return;
+      throw 'Cannot close';
     }
     let options: KernelMessage.IOptions = {
       msgType: 'comm_msg',
@@ -184,22 +184,9 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
     return future;
   }
 
-  /**
-   * Dispose of the resources held by the comm.
-   */
-  dispose(): void {
-    if (this.isDisposed) {
-      return;
-    }
-    this._onClose = null;
-    this._onMsg = null;
-    this._kernel = null;
-    super.dispose();
-  }
-
   private _target = '';
   private _id = '';
-  private _kernel: Kernel.IKernel = null;
-  private _onClose: (msg: KernelMessage.ICommCloseMsg) => void = null;
-  private _onMsg: (msg: KernelMessage.ICommMsgMsg) => void = null;
+  private _kernel: Kernel.IKernel;
+  private _onClose: (msg: KernelMessage.ICommCloseMsg) => void;
+  private _onMsg: (msg: KernelMessage.ICommMsgMsg) => void;
 }

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -161,7 +161,7 @@ class DefaultKernel implements Kernel.IKernel {
    * Test whether the kernel has been disposed.
    */
   get isDisposed(): boolean {
-    return this._futures === null;
+    return this._isDisposed;
   }
 
   /**
@@ -221,6 +221,7 @@ class DefaultKernel implements Kernel.IKernel {
     if (this.isDisposed) {
       return;
     }
+    this._isDisposed = true;
     this._status = 'dead';
     this._clearSocket();
     this._futures.forEach((future, key) => {
@@ -1013,6 +1014,7 @@ class DefaultKernel implements Kernel.IKernel {
   private _name = '';
   private _status: Kernel.Status = 'unknown';
   private _clientId = '';
+  private _isDisposed = false;
   private _wsStopped = false;
   private _ws: WebSocket | null = null;
   private _username = '';

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -469,7 +469,7 @@ namespace Kernel {
    * when the kernel is started by the server, otherwise the promise is rejected.
    */
   export
-  function startNew(options?: Kernel.IOptions): Promise<IKernel> {
+  function startNew(options: Kernel.IOptions): Promise<IKernel> {
     options = options || {};
     return DefaultKernel.startNew(options);
   }
@@ -522,7 +522,7 @@ namespace Kernel {
     /**
      * The kernel type (e.g. python3).
      */
-    name?: string;
+    name: string;
 
     /**
      * The server settings for the kernel.
@@ -818,12 +818,12 @@ namespace Kernel {
     /**
      * Unique identifier of the kernel server session.
      */
-    readonly id?: string;
+    readonly id: string;
 
     /**
      * The name of the kernel.
      */
-    readonly name?: string;
+    readonly name: string;
   }
 
   /**

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -469,7 +469,7 @@ namespace Kernel {
    * when the kernel is started by the server, otherwise the promise is rejected.
    */
   export
-  function startNew(options: Kernel.IOptions): Promise<IKernel> {
+  function startNew(options: Kernel.IOptions = {}): Promise<IKernel> {
     return DefaultKernel.startNew(options);
   }
 
@@ -521,7 +521,7 @@ namespace Kernel {
     /**
      * The kernel type (e.g. python3).
      */
-    name: string;
+    name?: string;
 
     /**
      * The server settings for the kernel.

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -470,7 +470,6 @@ namespace Kernel {
    */
   export
   function startNew(options: Kernel.IOptions): Promise<IKernel> {
-    options = options || {};
     return DefaultKernel.startNew(options);
   }
 

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -83,7 +83,6 @@ class KernelManager implements Kernel.IManager {
     clearInterval(this._runningTimer);
     clearInterval(this._specsTimer);
     Signal.clearData(this);
-    this._specs = null;
     this._running = [];
   }
 
@@ -158,7 +157,7 @@ class KernelManager implements Kernel.IManager {
    * #### Notes
    * The manager `serverSettings` will be always be used.
    */
-  startNew(options: Kernel.IOptions = {}): Promise<Kernel.IKernel> {
+  startNew(options: Kernel.IOptions): Promise<Kernel.IKernel> {
     let newOptions = { ...options, serverSettings: this.serverSettings };
     return Kernel.startNew(newOptions).then(kernel => {
       this._onStarted(kernel);
@@ -260,7 +259,7 @@ class KernelManager implements Kernel.IManager {
   }
 
   private _running: Kernel.IModel[] = [];
-  private _specs: Kernel.ISpecModels = null;
+  private _specs: Kernel.ISpecModels;
   private _isDisposed = false;
   private _runningTimer = -1;
   private _specsTimer = -1;

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -259,7 +259,7 @@ class KernelManager implements Kernel.IManager {
   }
 
   private _running: Kernel.IModel[] = [];
-  private _specs: Kernel.ISpecModels;
+  private _specs: Kernel.ISpecModels | null = null;
   private _isDisposed = false;
   private _runningTimer = -1;
   private _specsTimer = -1;

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -157,7 +157,7 @@ class KernelManager implements Kernel.IManager {
    * #### Notes
    * The manager `serverSettings` will be always be used.
    */
-  startNew(options: Kernel.IOptions): Promise<Kernel.IKernel> {
+  startNew(options: Kernel.IOptions = {}): Promise<Kernel.IKernel> {
     let newOptions = { ...options, serverSettings: this.serverSettings };
     return Kernel.startNew(newOptions).then(kernel => {
       this._onStarted(kernel);

--- a/packages/services/src/manager.ts
+++ b/packages/services/src/manager.ts
@@ -130,9 +130,9 @@ class ServiceManager implements ServiceManager.IManager {
     return this._readyPromise;
   }
 
-  private _sessionManager: SessionManager = null;
-  private _contentsManager: ContentsManager = null;
-  private _terminalManager: TerminalManager = null;
+  private _sessionManager: SessionManager;
+  private _contentsManager: ContentsManager;
+  private _terminalManager: TerminalManager;
   private _isDisposed = false;
   private _readyPromise: Promise<void>;
   private _specsChanged = new Signal<this, Kernel.ISpecModels>(this);

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -240,7 +240,7 @@ namespace ServerConnection {
  */
 namespace Private {
   export
-  let defaultSettings: ServerConnection.ISettings = null;
+  let defaultSettings: ServerConnection.ISettings;
 
   /**
    * Handle the server connection settings, returning a new value.

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -313,6 +313,7 @@ namespace Private {
       if (xhr.status >= 300) {
         let message = xhr.statusText || `Invalid Status: ${xhr.status}`;
         delegate.reject({ event, xhr, request, settings, message });
+        return;
       }
       let data = xhr.responseText;
       if (request.dataType === 'json' || request.dataType === undefined) {

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -49,7 +49,7 @@ namespace ServerConnection {
   function makeSettings(options?: Partial<ISettings>) {
     // Use the singleton default settings if no options are given.
     if (options === void 0) {
-      if (Private.defaultSettings === null) {
+      if (Private.defaultSettings === void 0) {
         Private.defaultSettings = Private.makeSettings();
       }
       return Private.defaultSettings;

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -272,7 +272,7 @@ class DefaultSession implements Session.ISession {
    * This shuts down the existing kernel and creates a new kernel,
    * keeping the existing session ID and session path.
    */
-  changeKernel(options: Kernel.IModel): Promise<Kernel.IKernelConnection> {
+  changeKernel(options: Partial<Kernel.IModel>): Promise<Kernel.IKernelConnection> {
     if (this.isDisposed) {
       return Promise.reject(new Error('Session is disposed'));
     }

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -48,8 +48,8 @@ class DefaultSession implements Session.ISession {
   constructor(options: Session.IOptions, id: string, kernel: Kernel.IKernel) {
     this._id = id;
     this._path = options.path;
-    this._type = options.type;
-    this._name = options.name;
+    this._type = options.type || 'file';
+    this._name = options.name || '';
     this.serverSettings = options.serverSettings || ServerConnection.makeSettings();
     this._uuid = uuid();
     Private.addRunning(this);
@@ -217,11 +217,8 @@ class DefaultSession implements Session.ISession {
       return;
     }
     this._isDisposed = true;
-    if (this._kernel) {
-      this._kernel.dispose();
-    }
+    this._kernel.dispose();
     Private.removeRunning(this);
-    this._kernel = null;
     Signal.clearData(this);
   }
 
@@ -385,7 +382,7 @@ class DefaultSession implements Session.ISession {
   private _path = '';
   private _name = '';
   private _type = '';
-  private _kernel: Kernel.IKernel = null;
+  private _kernel: Kernel.IKernel;
   private _uuid = '';
   private _isDisposed = false;
   private _updating = false;
@@ -479,7 +476,9 @@ namespace Private {
   export
   function removeRunning(session: DefaultSession): void {
     let running = runningSessions.get(session.serverSettings.baseUrl);
-    ArrayExt.removeFirstOf(running, session);
+    if (running) {
+      ArrayExt.removeFirstOf(running, session);
+    }
   }
 
   /**
@@ -582,9 +581,9 @@ namespace Private {
       try {
         validate.validateModel(data);
       } catch (err) {
-        throw ServerConnection.makeError(response, err.message);
+        throw ServerConnection.makeError(response, err.message || String(err));
       }
-      return updateFromServer(data, settings.baseUrl);
+      return updateFromServer(data, settings!.baseUrl);
     }, Private.onSessionError);
   }
 
@@ -635,7 +634,7 @@ namespace Private {
           throw ServerConnection.makeError(response, err.message);
         }
       }
-      return updateRunningSessions(data, settings.baseUrl);
+      return updateRunningSessions(data, settings!.baseUrl);
     }, Private.onSessionError);
   }
 
@@ -668,12 +667,12 @@ namespace Private {
       if (response.xhr.status !== 204) {
         throw ServerConnection.makeError(response);
       }
-      killSessions(id, settings.baseUrl);
+      killSessions(id, settings!.baseUrl);
     }, err => {
       if (err.xhr.status === 404) {
         let response = JSON.parse(err.xhr.responseText) as any;
         console.warn(response['message']);
-        killSessions(id, settings.baseUrl);
+        killSessions(id, settings!.baseUrl);
         return;
       }
       if (err.xhr.status === 410) {
@@ -765,6 +764,7 @@ namespace Private {
           promises.push(session.update(sId));
           return true;
         }
+        return false;
       });
       // If session is no longer running on disk, emit dead signal.
       if (!updated && session.status !== 'dead') {

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -285,7 +285,7 @@ class SessionManager implements Session.IManager {
 
   private _isDisposed = false;
   private _running: Session.IModel[] = [];
-  private _specs: Kernel.ISpecModels;
+  private _specs: Kernel.ISpecModels | null = null;
   private _runningTimer = -1;
   private _specsTimer = -1;
   private _readyPromise: Promise<void>;

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -36,7 +36,7 @@ class SessionManager implements Session.IManager {
    *
    * @param options - The default options for each session.
    */
-  constructor(options: Session.IOptions = {}) {
+  constructor(options: SessionManager.IOptions = {}) {
     this.serverSettings = (
       options.serverSettings || ServerConnection.makeSettings()
     );
@@ -285,10 +285,29 @@ class SessionManager implements Session.IManager {
 
   private _isDisposed = false;
   private _running: Session.IModel[] = [];
-  private _specs: Kernel.ISpecModels = null;
+  private _specs: Kernel.ISpecModels;
   private _runningTimer = -1;
   private _specsTimer = -1;
   private _readyPromise: Promise<void>;
   private _specsChanged = new Signal<this, Kernel.ISpecModels>(this);
   private _runningChanged = new Signal<this, Session.IModel[]>(this);
+}
+
+
+
+/**
+ * The namespace for `SessionManager` class statics.
+ */
+export
+namespace SessionManager {
+  /**
+   * The options used to initialize a SessionManager.
+   */
+  export
+  interface IOptions {
+    /**
+     * The server settings for the manager.
+     */
+    serverSettings?: ServerConnection.ISettings;
+  }
 }

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -304,7 +304,7 @@ namespace Session {
     /**
      * The path (not including name) to the session.
      */
-    path?: string;
+    path: string;
 
     /**
      * The name of the session.
@@ -489,6 +489,6 @@ namespace Session {
     readonly name: string;
     readonly path: string;
     readonly type: string;
-    readonly kernel?: Kernel.IModel;
+    readonly kernel: Kernel.IModel;
   }
 }

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -150,7 +150,7 @@ namespace Session {
      * This shuts down the existing kernel and creates a new kernel,
      * keeping the existing session ID and path.
      */
-    changeKernel(options: Kernel.IModel): Promise<Kernel.IKernelConnection>;
+    changeKernel(options: Partial<Kernel.IModel>): Promise<Kernel.IKernelConnection>;
 
     /**
      * Kill the kernel and shutdown the session.

--- a/packages/services/src/session/validate.ts
+++ b/packages/services/src/session/validate.ts
@@ -48,6 +48,7 @@ function validateModel(model: Session.IModel): void {
   validateProperty(model, 'type', 'string');
   validateProperty(model, 'name', 'string');
   validateProperty(model, 'kernel', 'object');
-  validateKernelModel(model.kernel);
-
+  if (model.kernel) {
+    validateKernelModel(model.kernel);
+  }
 }

--- a/packages/services/src/session/validate.ts
+++ b/packages/services/src/session/validate.ts
@@ -48,7 +48,5 @@ function validateModel(model: Session.IModel): void {
   validateProperty(model, 'type', 'string');
   validateProperty(model, 'name', 'string');
   validateProperty(model, 'kernel', 'object');
-  if (model.kernel) {
-    validateKernelModel(model.kernel);
-  }
+  validateKernelModel(model.kernel);
 }

--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -112,7 +112,6 @@ class DefaultTerminalSession implements TerminalSession.ISession {
       this._ws = null;
     }
     delete Private.running[this._url];
-    this._readyPromise = null;
     Signal.clearData(this);
   }
 
@@ -120,19 +119,21 @@ class DefaultTerminalSession implements TerminalSession.ISession {
    * Send a message to the terminal session.
    */
   send(message: TerminalSession.IMessage): void {
-    if (this._isDisposed) {
+    if (this._isDisposed || !message.content) {
       return;
     }
 
     let msg: JSONPrimitive[] = [message.type];
     msg.push(...message.content);
     let value = JSON.stringify(msg);
-    if (this._isReady) {
+    if (this._isReady && this._ws) {
       this._ws.send(value);
       return;
     }
     this.ready.then(() => {
-      this._ws.send(value);
+      if (this._ws) {
+        this._ws.send(value);
+      }
     });
   }
 
@@ -185,6 +186,9 @@ class DefaultTerminalSession implements TerminalSession.ISession {
     };
 
     return new Promise<void>((resolve, reject) => {
+      if (!this._ws) {
+        return;
+      }
       this._ws.onopen = (event: MessageEvent) => {
         if (this._isDisposed) {
           return;
@@ -203,7 +207,7 @@ class DefaultTerminalSession implements TerminalSession.ISession {
 
   private _name: string;
   private _url: string;
-  private _ws: WebSocket = null;
+  private _ws: WebSocket | null = null;
   private _isDisposed = false;
   private _readyPromise: Promise<void>;
   private _isReady = false;
@@ -357,17 +361,16 @@ namespace DefaultTerminalSession {
         throw ServerConnection.makeError(response);
       }
       Private.killTerminal(url);
-    }, err => {
+    }).catch(err => {
       if (err.xhr.status === 404) {
         let response = JSON.parse(err.xhr.responseText) as any;
         console.warn(response['message']);
         Private.killTerminal(url);
         return;
       }
-      return Promise.reject(err);
+      return Promise.reject(err) as Promise<void>;
     });
   }
-
 }
 
 

--- a/packages/services/test/src/contents/index.spec.ts
+++ b/packages/services/test/src/contents/index.spec.ts
@@ -314,7 +314,7 @@ describe('contents', () => {
         expect(args.newValue.path).to.be(DEFAULT_FILE.path);
         done();
       });
-      contents.newUntitled({ type: 'file', name: 'test' }).catch(done);
+      contents.newUntitled({ type: 'file', ext: 'test' }).catch(done);
     });
 
     it('should fail for an incorrect model', (done) => {
@@ -995,7 +995,7 @@ describe('drive', () => {
         expect(args.newValue.path).to.be(DEFAULT_FILE.path);
         done();
       });
-      drive.newUntitled({ type: 'file', name: 'test' }).catch(done);
+      drive.newUntitled({ type: 'file', ext: 'test' }).catch(done);
     });
 
     it('should accept server settings', (done) => {

--- a/packages/services/test/src/integration.ts
+++ b/packages/services/test/src/integration.ts
@@ -330,7 +330,7 @@ describe('jupyter.services - Integration', () => {
 
     it('should create a file by name and delete it', () => {
       let contents = new ContentsManager();
-      let options: Contents.IModel = {
+      let options: Partial<Contents.IModel> = {
         type: 'file', content: '', format: 'text'
       };
       return contents.save('baz.txt', options).then(model0 => {
@@ -340,7 +340,7 @@ describe('jupyter.services - Integration', () => {
 
     it('should exercise the checkpoint API', () => {
       let contents = new ContentsManager();
-      let options: Contents.IModel = {
+      let options: Partial<Contents.IModel> = {
         type: 'file', format: 'text', content: 'foo'
       };
       let checkpoint: Contents.ICheckpointModel;

--- a/packages/services/test/src/kernel/comm.spec.ts
+++ b/packages/services/test/src/kernel/comm.spec.ts
@@ -23,7 +23,6 @@ describe('jupyter.services - Comm', () => {
 
   beforeEach(() => {
     tester = new KernelTester();
-    debugger;
     return Kernel.startNew().then(k => {
       kernel = k;
       return kernel.ready;
@@ -384,13 +383,13 @@ describe('jupyter.services - Comm', () => {
       it('should not send subsequent messages', () => {
         let comm = kernel.connectToComm('test');
         comm.close({ foo: 'bar' });
-        expect(comm.send('test')).to.be(void 0);
+        expect(() => { comm.send('test'); }).to.throwError();
       });
 
-      it('should be a no-op if already closed', () => {
+      it('should throw if already closed', () => {
         let comm = kernel.connectToComm('test');
         comm.close({ foo: 'bar' });
-        comm.close();
+        expect(() => { comm.close(); }).to.throwError();
       });
 
       it('should yield a future', (done) => {

--- a/packages/services/test/src/kernel/kernel.spec.ts
+++ b/packages/services/test/src/kernel/kernel.spec.ts
@@ -968,9 +968,6 @@ describe('kernel', () => {
           stop_on_error: false
         };
         let future = kernel.requestExecute(content);
-        expect(future.onStdin).to.be(null);
-        expect(future.onReply).to.be(null);
-        expect(future.onIOPub).to.be(null);
 
         let options: KernelMessage.IOptions = {
           msgType: 'custom',
@@ -1032,9 +1029,6 @@ describe('kernel', () => {
           stop_on_error: false
         };
         let future = kernel.requestExecute(options, false);
-        expect(future.onStdin).to.be(null);
-        expect(future.onReply).to.be(null);
-        expect(future.onIOPub).to.be(null);
 
         tester.onMessage((msg) => {
           expect(msg.channel).to.be('shell');
@@ -1064,9 +1058,7 @@ describe('kernel', () => {
 
         return future.done.then(() => {
           expect(future.isDisposed).to.be(false);
-          expect(future.onIOPub).to.not.be(null);
           future.dispose();
-          expect(future.onIOPub).to.be(null);
           expect(future.isDisposed).to.be(true);
         });
       });

--- a/packages/services/test/src/kernel/validate.spec.ts
+++ b/packages/services/test/src/kernel/validate.spec.ts
@@ -109,11 +109,6 @@ describe('kernel/validate', () => {
       validateModel(id);
     });
 
-    it('should fail on missing data', () => {
-      expect(() => validateModel({ name: 'foo' })).to.throwError();
-      expect(() => validateModel({ id: 'foo' })).to.throwError();
-    });
-
   });
 
   describe('#validateSpecModel', () => {

--- a/packages/services/test/src/session/session.spec.ts
+++ b/packages/services/test/src/session/session.spec.ts
@@ -522,22 +522,20 @@ describe('session', () => {
 
       it('should dispose of the resources held by the session', () => {
         session.dispose();
-        expect(session.kernel).to.be(null);
+        expect(session.isDisposed).to.be(true);
       });
 
       it('should be safe to call twice', () => {
         session.dispose();
         expect(session.isDisposed).to.be(true);
-        expect(session.kernel).to.be(null);
         session.dispose();
         expect(session.isDisposed).to.be(true);
-        expect(session.kernel).to.be(null);
       });
 
       it('should be safe to call if the kernel is disposed', () => {
         session.kernel.dispose();
         session.dispose();
-        expect(session.kernel).to.be(null);
+        expect(session.isDisposed).to.be(true);
       });
 
     });

--- a/test/src/apputils/statedb.spec.ts
+++ b/test/src/apputils/statedb.spec.ts
@@ -103,7 +103,7 @@ describe('StateDB', () => {
         .catch(done);
     });
 
-    it('should resolve a nonexistent key fetch with null', done => {
+    it('should resolve a nonexistent key fetch with undefined', done => {
       let { localStorage } = window;
       localStorage.clear();
 
@@ -112,7 +112,7 @@ describe('StateDB', () => {
 
       expect(localStorage.length).to.be(0);
       db.fetch(key)
-        .then(fetched => { expect(fetched).to.be(null); })
+        .then(fetched => { expect(fetched).to.be(undefined); })
         .then(done)
         .catch(done);
     });

--- a/test/src/coreutils/modeldb.spec.ts
+++ b/test/src/coreutils/modeldb.spec.ts
@@ -22,7 +22,7 @@ describe('@jupyterlab/coreutils', () => {
       it('should accept no arguments', () => {
         let value = new ObservableValue();
         expect(value instanceof ObservableValue).to.be(true);
-        expect(value.get()).to.be(undefined);
+        expect(value.get()).to.be(null);
       });
 
       it('should accept an initial JSON value', () => {
@@ -69,7 +69,7 @@ describe('@jupyterlab/coreutils', () => {
         value.changed.connect((sender, args) => {
           expect(sender).to.be(value);
           expect(args.newValue).to.be('set');
-          expect(args.oldValue).to.be(undefined);
+          expect(args.oldValue).to.be(null);
           called = true;
         });
         value.set('set');

--- a/test/src/imageviewer/widget.spec.ts
+++ b/test/src/imageviewer/widget.spec.ts
@@ -51,7 +51,7 @@ class LogImage extends ImageViewer {
 /**
  * The common image model.
  */
-const IMAGE: Contents.IModel = {
+const IMAGE: Partial<Contents.IModel> = {
   path: uuid() + '.png',
   type: 'file',
   mimetype: 'image/png',


### PR DESCRIPTION
Used `strictNullChecks` to clean up `coreutils` and `services`.  We could not leave the check on in `tsconfig` yet because `JSONObject` cannot yet take an optional key.

This effort caught some bugs where we were not properly handling `null` or `undefined` and helped clarify the `services` interfaces.