### PR TITLE
Set code font-family using respective variable

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -22,6 +22,7 @@
 .CodeMirror {
   line-height: var(--jp-code-line-height);
   font-size: var(--jp-code-font-size);
+  font-family: var(--jp-code-font-family);
   height: auto;
   /* Changed to auto to autogrow */
   background: none;


### PR DESCRIPTION
The font family for code should be set by the variable `--jp-code-font-family`.