### PR TITLE
Fix handling of kernel urls

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@jupyterlab/codeeditor';
 
 import {
-  PageConfig, PathExt
+  PageConfig
 } from '@jupyterlab/coreutils';
 
 import {
@@ -170,6 +170,11 @@ function activateConsole(app: JupyterLab, manager: IServiceManager, mainMenu: IM
       for (let name in specs.kernelspecs) {
         let displayName = specs.kernelspecs[name].display_name;
         let rank = name === specs.default ? 0 : Infinity;
+        let kernelIconUrl = specs.kernelspecs[name].resources['logo-64x64'];
+        if (kernelIconUrl) {
+          let index = kernelIconUrl.indexOf('kernelspecs');
+          kernelIconUrl = baseUrl + kernelIconUrl.slice(index);
+        }
         launcher.add({
           displayName,
           category: 'Console',
@@ -177,7 +182,7 @@ function activateConsole(app: JupyterLab, manager: IServiceManager, mainMenu: IM
           iconClass: 'jp-CodeConsoleIcon',
           callback,
           rank,
-          kernelIconUrl: baseUrl + PathExt.removeSlash(specs.kernelspecs[name].resources["logo-64x64"])
+          kernelIconUrl
         });
       }
     });

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from '@jupyterlab/codeeditor';
 
 import {
-  IStateDB, PageConfig, PathExt
+  IStateDB, PageConfig, URLExt
 } from '@jupyterlab/coreutils';
 
 import {
@@ -41,10 +41,6 @@ import {
 import {
   Menu, Widget
 } from '@phosphor/widgets';
-
-import {
-  URLExt
-} from '@jupyterlab/coreutils';
 
 
 
@@ -449,6 +445,11 @@ function activateNotebookHandler(app: JupyterLab, services: IServiceManager, mai
       for (let name in specs.kernelspecs) {
         let displayName = specs.kernelspecs[name].display_name;
         let rank = name === specs.default ? 0 : Infinity;
+        let kernelIconUrl = specs.kernelspecs[name].resources['logo-64x64'];
+        if (kernelIconUrl) {
+          let index = kernelIconUrl.indexOf('kernelspecs');
+          kernelIconUrl = baseUrl + kernelIconUrl.slice(index);
+        }
         launcher.add({
           displayName,
           category: 'Notebook',
@@ -456,7 +457,7 @@ function activateNotebookHandler(app: JupyterLab, services: IServiceManager, mai
           iconClass: 'jp-NotebookRunningIcon',
           callback,
           rank,
-          kernelIconUrl: baseUrl + PathExt.removeSlash(specs.kernelspecs[name].resources["logo-64x64"])
+          kernelIconUrl
         });
       }
     });


### PR DESCRIPTION
Handles missing resources and urls that contain a `pathname` (e.g `0.0.0.0/users/foo`).