### PR TITLE
Improvements to `all-packages` build when grafting in a sibling package.

### DIFF
--- a/packages/all-packages/tsconfig.json
+++ b/packages/all-packages/tsconfig.json
@@ -8,11 +8,17 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "./lib",
-    "lib": ["ES5", "ES2015.Collection", "ES2015.Promise", "DOM"],
-    "types": ["node", "text-encoding"],
+    "lib": [
+      "ES5",
+      "ES2015.Collection",
+      "ES2015.Promise",
+      "DOM"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@jupyterlab/*": ["../*/src"]
+      "@jupyterlab/*": [
+        "../*/src"
+      ]
     },
     "jsx": "react",
     "jsxFactory": "h"

--- a/scripts/add-sibling.js
+++ b/scripts/add-sibling.js
@@ -24,6 +24,7 @@ if (process.argv.length < 3) {
 // Extract the desired git repository and repository name.
 var target = process.argv[2];
 var basePath = path.resolve('.');
+var packageDirName;
 
 var packagePath = '';
 if (target[0] === '.' || target[0] === '/') {
@@ -39,7 +40,7 @@ if (target[0] === '.' || target[0] === '/') {
   fs.copySync(packagePath, newPackagePath);
 } else { 
   // Otherwise treat it as a git reposotory and try to add it.
-  var packageDirName = target.split('/').pop().split('.')[0];
+  packageDirName = target.split('/').pop().split('.')[0];
   var packagePath = path.join(basePath, 'packages', packageDirName);
   // Add the repository as a submodule.
   childProcess.execSync('git submodule add --force '+ target + ' ' + packagePath);
@@ -53,6 +54,12 @@ var allPackagesPath = path.join(basePath, 'packages', 'all-packages', 'package.j
 var allPackages = require(allPackagesPath);
 allPackages.dependencies[package.name] = '~'+String(package.version);
 fs.writeFileSync(allPackagesPath, JSON.stringify(allPackages, null, 2) + '\n');
+
+// Add the extension path to packages/all-packages/tsconfig.json
+var tsconfigPath = path.join(basePath, 'packages', 'all-packages', 'tsconfig.json');
+var tsconfig = require(tsconfigPath);
+tsconfig.compilerOptions.paths[package.name] = [path.join('..', packageDirName, 'src')];
+fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2) + '\n');
 
 // Add the extension to packages/all-packages/src/index.ts
 var indexPath = path.join(basePath, 'packages', 'all-packages', 'src', 'index.ts');

--- a/scripts/remove-sibling.js
+++ b/scripts/remove-sibling.js
@@ -38,6 +38,12 @@ var allPackages = require(allPackagesPath);
 allPackages.dependencies[package.name] = undefined;
 fs.writeFileSync(allPackagesPath, JSON.stringify(allPackages, null, 2) + '\n');
 
+// Remove the extension path from packages/all-packages/tsconfig.json
+var tsconfigPath = path.join(basePath, 'packages', 'all-packages', 'tsconfig.json');
+var tsconfig = require(tsconfigPath);
+tsconfig.compilerOptions.paths[package.name] = undefined;
+fs.writeFileSync(tsconfigPath, JSON.stringify(tsconfig, null, 2) + '\n');
+
 // Remove the extension from packages/all-packages/src/index.ts
 var indexPath = path.join(basePath, 'packages', 'all-packages', 'src', 'index.ts');
 var index = fs.readFileSync(indexPath, 'utf8');


### PR DESCRIPTION
This more reliably picks up sibling packages in the `all-packages` build, handling the case when the package directory name is not the same as the npm package name. It also removes the `types` field in `packages/all-packages/tsconfig.json`, which was preventing the inclusion of other types in the build.