### PR TITLE
Refined notebook cell active state & collapser

### DIFF
--- a/packages/cells/src/collapser.tsx
+++ b/packages/cells/src/collapser.tsx
@@ -27,11 +27,6 @@ const COLLAPSER_CLASS = 'jp-Collapser';
 const COLLAPSER_CHILD_CLASS = 'jp-Collapser-child';
 
 /**
- * The CSS class added to the collapser icon.
- */
-const COLLAPSER_ICON_CLASS = 'jp-Collapser-icon';
-
-/**
  * The CSS class added to input collapsers.
  */
 const INPUT_COLLAPSER = 'jp-InputCollapser';
@@ -40,16 +35,6 @@ const INPUT_COLLAPSER = 'jp-InputCollapser';
  * The CSS class added to output collapsers.
  */
 const OUTPUT_COLLAPSER = 'jp-OutputCollapser';
-
-/**
- * The CSS class added the collapser icon in the collapsed state.
- */
-const COLLAPSED_ICON_CLASS = 'jp-ExpandMoreIcon';
-
-/**
- * The CSS class added the collapser icon in the expanded state.
- */
-const EXPANDED_ICON_CLASS = 'jp-ExpandLessIcon';
 
 /**
  * The CSS class added the collapser child when collapsed.
@@ -87,16 +72,11 @@ abstract class Collapser extends VDomRenderer<null> {
    */
   protected render(): VirtualNode | ReadonlyArray<VirtualNode> {
     let childClass = COLLAPSER_CHILD_CLASS;
-    let iconClass = COLLAPSER_ICON_CLASS;
     if (this.collapsed) {
       childClass += ` ${MOD_COLLAPSED_CLASS}`;
-      iconClass += ` ${COLLAPSED_ICON_CLASS}`;
-    } else {
-      iconClass += ` ${EXPANDED_ICON_CLASS}`;
     }
     return (
       <div className={childClass}  onclick={ (e) => this.handleClick(e) } >
-        <div className={iconClass} />
       </div>
     );
   }

--- a/packages/cells/src/inputarea.ts
+++ b/packages/cells/src/inputarea.ts
@@ -319,7 +319,7 @@ class InputPrompt extends Widget implements IInputPrompt {
     if (value === null) {
       this.node.textContent = ' ';
     } else {
-        this.node.textContent = `In [${value || ' '}]:`;
+        this.node.textContent = `[${value || ' '}]:`;
     }
   }
 

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -43,7 +43,7 @@
   min-height: 50px;
   outline: none;
   overflow: auto;
-  background: var(--jp-layout-color1);
+  background: var(--md-grey-50);
 }
 
 
@@ -55,7 +55,7 @@
 
 
 .jp-Notebook .jp-Cell {
-  overflow: visible
+  overflow: visible;
 }
 
 
@@ -101,13 +101,17 @@
   color: var(--jp-cell-prompt-font-color-not-active);
 }
 
-.jp-Notebook .jp-Cell.jp-mod-active .jp-Cell-inputCollapser,
-.jp-Notebook .jp-Cell.jp-mod-active .jp-Cell-outputCollapser {
-  border-left: 2px solid var(--jp-brand-color1);
-  border-top: 2px solid var(--jp-brand-color1);
-  border-bottom: 2px solid var(--jp-brand-color1);
+.jp-Notebook .jp-Cell.jp-mod-active .jp-Cell-inputCollapser .jp-Collapser-child,
+.jp-Notebook .jp-Cell.jp-mod-active .jp-Cell-outputCollapser .jp-Collapser-child {
+  border-left: 4px solid var(--jp-brand-color1);
+  transition: .16s border-left;
 }
 
+
+.jp-Notebook .jp-Cell .jp-Cell-inputCollapser:hover .jp-Collapser-child,
+.jp-Notebook .jp-Cell .jp-Cell-outputCollapser:hover .jp-Collapser-child {
+  border-left: 20px solid var(--jp-brand-color1);
+}
 
 /* Command mode */
 
@@ -126,6 +130,13 @@
   border: var(--jp-border-width) solid var(--jp-cell-editor-border-color-edit);
   background: var(--jp-cell-editor-background-edit);
   box-shadow: inset 0 0 2px var(--md-blue-300);
+}
+
+
+/* Active mode */
+
+.jp-Notebook .jp-Cell.jp-mod-active {
+  box-shadow: 0px 1px 4px 1px rgba(0,0,0,.32);
 }
 
 

--- a/packages/theming/style/variables-light.css
+++ b/packages/theming/style/variables-light.css
@@ -147,12 +147,12 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Cell specific styles */
 
-  --jp-cell-padding: 5px;
+  --jp-cell-padding: 8px;
   --jp-cell-editor-background: var(--md-grey-50);
   --jp-cell-editor-border-color: var(--md-grey-400);
   --jp-cell-editor-background-edit: var(--jp-ui-layout-color1);
   --jp-cell-editor-border-color-edit: var(--jp-brand-color1);
-  --jp-cell-prompt-width: 100px;
+  --jp-cell-prompt-width: 68px;
   --jp-cell-prompt-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   --jp-cell-prompt-letter-spacing: 2.4px;
   --jp-cell-prompt-opacity: 1.0;
@@ -167,7 +167,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Notebook specific styles */
 
-  --jp-notebook-padding: 10px;
+  --jp-notebook-padding: 16px;
   --jp-notebook-scroll-padding: 100px;
 
   /* Console specific styles */


### PR DESCRIPTION
After hearing back from users from Pydata (@ellisonbg), we have refined the look of the collapser and active state in the notebook. These are both still in progress, but the changes were made:

## Collapser changes
![ezgif-2-9fa29737eb](https://user-images.githubusercontent.com/6437976/28190817-a8d19fb8-67e1-11e7-9670-df97891687e1.gif)

- Removed the collapse/expand icon entirely. This is because users would think that the collapser is only clickable from that arrow. Refined the styling to instead just be a larger left border that animates when you hover over it. This is more generic, and since collapsing cells is not a top level action that _every_ user is going to use, I think this is a nice implementation. When testing this with users, I found that the more advanced users that have coded before connected with the singular line on the left since most text editors / code editors have their code block collapse tools on the left.

## Notebook cell active state
<img width="946" alt="screen shot 2017-07-13 at 3 37 16 pm" src="https://user-images.githubusercontent.com/6437976/28190723-363c1104-67e1-11e7-8a7a-29c8ab68c69e.png">

- While the current collapser does a nice job at indicating the height of the currently selected cell (by using the visual indication of a bracket), it does not associate outputs and inputs together. It is also harder to simply look at a document and to see the active cell clearly. For this, I added a box shadow to make the active cell jump off of the notebook document. This makes it easier to associate code blocks together while also making it easy to see the active/selected cell.