### PR TITLE
Add a default file browser

### DIFF
--- a/packages/filebrowser/src/factory.ts
+++ b/packages/filebrowser/src/factory.ts
@@ -60,6 +60,11 @@ interface IFileBrowserFactory {
    * The instance tracker used by the factory to track file browsers.
    */
   readonly tracker: InstanceTracker<FileBrowser>;
+
+  /**
+   * The default file browser for the application.
+   */
+  defaultBrowser: FileBrowser;
 }
 
 


### PR DESCRIPTION
Fixes #2575.  Tracking the path of the default file browser would look like:


```typescript
import {
  JupyterLab, JupyterLabPlugin
} from '@jupyterlab/application';

import {
   IFileBrowserFactory
} from '@jupyterlab/filebrowser';

const myPlugin: JupyterLabPlugin<void> = {
  id: 'foo',
  requires: [IFileBrowserFactory],
  autoStart: true,
  activate: (app: JupyterLab, factory: IFileBrowserFactory) => {
      let model = factory.defaultBrowser.model;
      console.log(model.path);
      model.pathChanged.connect(...);
  }
};
```