### PR TITLE
Handle file types in document registry

### DIFF
--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -32,7 +32,7 @@ import {
 } from '@jupyterlab/docmanager';
 
 import {
-  DocumentRegistry, TextModelFactory
+  DocumentRegistry
 } from '@jupyterlab/docregistry';
 
 import {
@@ -76,9 +76,7 @@ function createApp(manager: ServiceManager.IManager): void {
     }
   };
 
-  let docRegistry = new DocumentRegistry({
-    textModelFactory: new TextModelFactory()
-  });
+  let docRegistry = new DocumentRegistry();
   let docManager = new DocumentManager({
     registry: docRegistry,
     manager,
@@ -93,7 +91,7 @@ function createApp(manager: ServiceManager.IManager): void {
     factoryOptions: {
       name: 'Editor',
       modelName: 'text',
-      fileExtensions: ['*'],
+      fileTypes: ['*'],
       defaultFor: ['*'],
       preferKernel: false,
       canStartKernel: true

--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -76,13 +76,14 @@ function createApp(manager: ServiceManager.IManager): void {
     }
   };
 
-  let docRegistry = new DocumentRegistry();
+  let docRegistry = new DocumentRegistry({
+    textModelFactory: new TextModelFactory()
+  });
   let docManager = new DocumentManager({
     registry: docRegistry,
     manager,
     opener
   });
-  let mFactory = new TextModelFactory();
   let editorServices = {
     factoryService: new CodeMirrorEditorFactory(),
     mimeTypeService: new CodeMirrorMimeTypeService()
@@ -98,7 +99,6 @@ function createApp(manager: ServiceManager.IManager): void {
       canStartKernel: true
     }
   });
-  docRegistry.addModelFactory(mFactory);
   docRegistry.addWidgetFactory(wFactory);
 
   let commands = new CommandRegistry();

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -33,7 +33,7 @@ import {
 } from '@jupyterlab/docmanager';
 
 import {
-  DocumentRegistry
+  DocumentRegistry, TextModelFactory
 } from '@jupyterlab/docregistry';
 
 import {
@@ -104,7 +104,9 @@ function createApp(manager: ServiceManager.IManager): void {
     }
   };
 
-  let docRegistry = new DocumentRegistry();
+  let docRegistry = new DocumentRegistry({
+    textModelFactory: new TextModelFactory()
+  });
   let docManager = new DocumentManager({
     registry: docRegistry,
     manager,

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -105,9 +105,6 @@ function createApp(manager: ServiceManager.IManager): void {
   };
 
   let docRegistry = new DocumentRegistry();
-  DocumentRegistry.defaultFileTypes.forEach(ft => {
-    docRegistry.addFileType(ft);
-  });
   let docManager = new DocumentManager({
     registry: docRegistry,
     manager,

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -33,7 +33,7 @@ import {
 } from '@jupyterlab/docmanager';
 
 import {
-  DocumentRegistry, TextModelFactory
+  DocumentRegistry
 } from '@jupyterlab/docregistry';
 
 import {
@@ -104,8 +104,9 @@ function createApp(manager: ServiceManager.IManager): void {
     }
   };
 
-  let docRegistry = new DocumentRegistry({
-    textModelFactory: new TextModelFactory()
+  let docRegistry = new DocumentRegistry();
+  DocumentRegistry.defaultFileTypes.forEach(ft => {
+    docRegistry.addFileType(ft);
   });
   let docManager = new DocumentManager({
     registry: docRegistry,
@@ -120,8 +121,8 @@ function createApp(manager: ServiceManager.IManager): void {
   let wFactory = new NotebookWidgetFactory({
     name: 'Notebook',
     modelName: 'notebook',
-    fileExtensions: ['.ipynb'],
-    defaultFor: ['.ipynb'],
+    fileTypes: ['notebook'],
+    defaultFor: ['notebook'],
     preferKernel: true,
     canStartKernel: true,
     rendermime, contentFactory,

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  Base64ModelFactory, DocumentRegistry, TextModelFactory
+  Base64ModelFactory, DocumentRegistry
 } from '@jupyterlab/docregistry';
 
 import {
@@ -69,9 +69,7 @@ class JupyterLab extends Application<ApplicationShell> {
     let initialFactories = defaultRendererFactories;
     this.rendermime = new RenderMime({ initialFactories, linkHandler });
 
-    let registry = this.docRegistry = new DocumentRegistry({
-      textModelFactory: new TextModelFactory()
-    });
+    let registry = this.docRegistry = new DocumentRegistry();
     DocumentRegistry.defaultFileTypes.forEach(ft => {
       registry.addFileType(ft);
     });

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -70,9 +70,6 @@ class JupyterLab extends Application<ApplicationShell> {
     this.rendermime = new RenderMime({ initialFactories, linkHandler });
 
     let registry = this.docRegistry = new DocumentRegistry();
-    DocumentRegistry.defaultFileTypes.forEach(ft => {
-      registry.addFileType(ft);
-    });
     registry.addModelFactory(new Base64ModelFactory());
 
     if (options.mimeExtensions) {

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -70,15 +70,11 @@ class JupyterLab extends Application<ApplicationShell> {
     this.rendermime = new RenderMime({ initialFactories, linkHandler });
 
     let registry = this.docRegistry = new DocumentRegistry();
+    DocumentRegistry.defaultFileTypes.forEach(ft => {
+      registry.addFileType(ft);
+    });
     registry.addModelFactory(new TextModelFactory());
     registry.addModelFactory(new Base64ModelFactory());
-    registry.addFileType({
-      name: 'Text',
-      extension: '.txt',
-      contentType: 'file',
-      fileFormat: 'text'
-    });
-    registry.addCreator({ name: 'Text File', fileType: 'Text', });
 
     if (options.mimeExtensions) {
       let plugins = createRendermimePlugins(options.mimeExtensions);

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -69,11 +69,12 @@ class JupyterLab extends Application<ApplicationShell> {
     let initialFactories = defaultRendererFactories;
     this.rendermime = new RenderMime({ initialFactories, linkHandler });
 
-    let registry = this.docRegistry = new DocumentRegistry();
+    let registry = this.docRegistry = new DocumentRegistry({
+      textModelFactory: new TextModelFactory()
+    });
     DocumentRegistry.defaultFileTypes.forEach(ft => {
       registry.addFileType(ft);
     });
-    registry.addModelFactory(new TextModelFactory());
     registry.addModelFactory(new Base64ModelFactory());
 
     if (options.mimeExtensions) {

--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -75,9 +75,20 @@ function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<
         renderTimeout: item.renderTimeout,
         dataType: item.dataType,
         rendermime: app.rendermime,
+        iconClass: item.iconClass,
+        iconLabel: item.iconLabel,
         ...item.documentWidgetFactoryOptions,
       });
       app.docRegistry.addWidgetFactory(factory);
+
+      if (item.fileType) {
+        app.docRegistry.addFileType({
+          ...item.fileType,
+          mimeTypes: [item.mimeType],
+          iconClass: item.iconClass,
+          iconLabel: item.iconLabel
+        });
+      }
 
       const factoryName = factory.name;
       const namespace = `${factoryName}-renderer`;

--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -52,7 +52,7 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
 export
 function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<void> {
   return {
-    id: `jupyter.services.mimerenderer-${item.mimeType}`,
+    id: `jupyter.services.mimerenderer-${item.name}`,
     requires: [ILayoutRestorer],
     autoStart: true,
     activate: (app: JupyterLab, restorer: ILayoutRestorer) => {
@@ -71,22 +71,17 @@ function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<
       }
 
       let factory = new MimeDocumentFactory({
-        mimeType: item.mimeType,
+        registry: app.docRegistry,
         renderTimeout: item.renderTimeout,
         dataType: item.dataType,
         rendermime: app.rendermime,
-        iconClass: item.iconClass,
-        iconLabel: item.iconLabel,
         ...item.documentWidgetFactoryOptions,
       });
       app.docRegistry.addWidgetFactory(factory);
 
-      if (item.fileType) {
-        app.docRegistry.addFileType({
-          ...item.fileType,
-          mimeTypes: [item.mimeType],
-          iconClass: item.iconClass,
-          iconLabel: item.iconLabel
+      if (item.fileTypes) {
+        item.fileTypes.forEach(ft => {
+          app.docRegistry.addFileType(ft);
         });
       }
 

--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -43,8 +43,8 @@ export default plugin;
 function activate(app: JupyterLab, restorer: ILayoutRestorer): void {
   const factory = new CSVViewerFactory({
     name: FACTORY,
-    fileExtensions: ['.csv'],
-    defaultFor: ['.csv'],
+    fileTypes: ['csv'],
+    defaultFor: ['csv'],
     readOnly: true
   });
   const tracker = new InstanceTracker<CSVViewer>({ namespace: 'csvviewer' });

--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -57,10 +57,16 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer): void {
   });
 
   app.docRegistry.addWidgetFactory(factory);
+  let ft = app.docRegistry.getFileType('csv');
   factory.widgetCreated.connect((sender, widget) => {
     // Track the widget.
     tracker.add(widget);
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => { tracker.save(widget); });
+
+    if (ft) {
+      widget.title.iconClass = ft.iconClass;
+      widget.title.iconLabel = ft.iconLabel;
+    }
   });
 }

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -434,7 +434,8 @@ class DocumentManager implements IDisposable {
     if (!widgetFactory) {
       return undefined;
     }
-    let factory = this.registry.getModelFactory(widgetFactory.modelName || 'text');
+    let modelName = widgetFactory.modelName || 'text';
+    let factory = this.registry.getModelFactory(modelName);
     if (!factory) {
       return undefined;
     }

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -248,8 +248,7 @@ class DocumentManager implements IDisposable {
    */
   findWidget(path: string, widgetName='default'): Widget | undefined {
     if (widgetName === 'default') {
-      let extname = DocumentRegistry.extname(path);
-      let factory = this.registry.defaultWidgetFactory(extname);
+      let factory = this.registry.defaultWidgetFactory(path);
       if (!factory) {
         return undefined;
       }
@@ -411,8 +410,7 @@ class DocumentManager implements IDisposable {
   private _widgetFactoryFor(path: string, widgetName: string): DocumentRegistry.WidgetFactory | undefined {
     let { registry } = this;
     if (widgetName === 'default') {
-      let extname = DocumentRegistry.extname(path);
-      let factory = registry.defaultWidgetFactory(extname);
+      let factory = registry.defaultWidgetFactory(path);
       if (!factory) {
         return undefined;
       }
@@ -441,9 +439,8 @@ class DocumentManager implements IDisposable {
     }
 
     // Handle the kernel pereference.
-    let ext = DocumentRegistry.extname(path);
     let preference = this.registry.getKernelPreference(
-      ext, widgetFactory.name, kernel
+      path, widgetFactory.name, kernel
     );
 
     let context: Private.IContext | null = null;

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -49,8 +49,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     this._factory = options.factory;
     this._opener = options.opener || Private.noOp;
     this._path = options.path;
-    let ext = DocumentRegistry.extname(this._path);
-    let lang = this._factory.preferredLanguage(ext);
+    let lang = this._factory.preferredLanguage(PathExt.basename(this._path));
 
     let dbFactory = options.modelDBFactory;
     if (dbFactory) {
@@ -63,11 +62,13 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     this._readyPromise = manager.ready.then(() => {
       return this._populatedPromise.promise;
     });
+
+    let ext = PathExt.extname(this._path);
     this.session = new ClientSession({
       manager: manager.sessions,
       path: this._path,
       type: ext === '.ipynb' ? 'notebook' : 'file',
-      name: this._path.split('/').pop(),
+      name: PathExt.basename(this._path),
       kernelPreference: options.kernelPreference || { shouldStart: false }
     });
     this.session.propertyChanged.connect(this._onSessionChanged, this);

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -573,18 +573,18 @@ class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument, DocumentRegistr
    */
   constructor(options: MimeDocumentFactory.IOptions) {
     super(Private.createRegistryOptions(options));
-    this._registry = options.registry;
     this._rendermime = options.rendermime;
     this._renderTimeout = options.renderTimeout || 1000;
     this._dataType = options.dataType || 'string';
+    this._fileType = options.primaryFileType;
   }
 
   /**
    * Create a new widget given a context.
    */
   protected createNewWidget(context: DocumentRegistry.Context): MimeDocument {
-    let ft = this._registry.getFileTypeForModel({ name: context.path });
-    let mimeType = ft.mimeTypes.length > 0 ? ft.mimeTypes[0] : 'text/plain';
+    let ft = this._fileType;
+    let mimeType = ft.mimeTypes.length ? ft.mimeTypes[0] : 'text/plain';
     let widget = new MimeDocument({
       context,
       mimeType,
@@ -601,7 +601,7 @@ class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument, DocumentRegistr
   private _rendermime: RenderMime;
   private _renderTimeout: number;
   private _dataType: 'string' | 'json';
-  private _registry: DocumentRegistry;
+  private _fileType: DocumentRegistry.IFileType;
 }
 
 
@@ -616,9 +616,9 @@ namespace MimeDocumentFactory {
   export
   interface IOptions extends DocumentRegistry.IWidgetFactoryOptions {
     /**
-     * The parent document registry.
+     * The primary file type associated with the document.
      */
-    registry: DocumentRegistry;
+    primaryFileType: DocumentRegistry.IFileType;
 
     /**
      * The rendermime instance.

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -347,7 +347,7 @@ abstract class ABCWidgetFactory<T extends DocumentRegistry.IReadyWidget, U exten
   /**
    * The registered name of the model type used to create the widgets.
    */
-  get modelName(): string {
+  get modelName(): string | undefined {
     return this._modelName;
   }
 

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -347,7 +347,7 @@ abstract class ABCWidgetFactory<T extends DocumentRegistry.IReadyWidget, U exten
   /**
    * The registered name of the model type used to create the widgets.
    */
-  get modelName(): string | undefined {
+  get modelName(): string {
     return this._modelName;
   }
 

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -37,10 +37,6 @@ import {
   IChangedArgs as IChangedArgsGeneric, PathExt, IModelDB
 } from '@jupyterlab/coreutils';
 
-import {
-  IRenderMime
-} from '@jupyterlab/rendermime';
-
 
 /**
  * The document registry.
@@ -826,7 +822,22 @@ namespace DocumentRegistry {
    * The options used to initialize a widget factory.
    */
   export
-  interface IWidgetFactoryOptions extends IRenderMime.IDocumentWidgetFactoryOptions {
+  interface IWidgetFactoryOptions {
+    /**
+     * The name of the widget to display in dialogs.
+     */
+    readonly name: string;
+
+    /**
+     * The file types the widget can view.
+     */
+    readonly fileTypes: ReadonlyArray<string>;
+
+    /**
+     * The file types for which the factory should be the default.
+     */
+    readonly defaultFor?: ReadonlyArray<string>;
+
     /**
      * Whether the widget factory is read only.
      */
@@ -952,7 +963,38 @@ namespace DocumentRegistry {
    * An interface for a file type.
    */
   export
-  interface IFileType extends IRenderMime.IFileType {
+  interface IFileType {
+    /**
+     * The name of the file type.
+     */
+    readonly name: string;
+
+    /**
+     * The mime types associated the file type.
+     */
+    readonly mimeTypes: ReadonlyArray<string>;
+
+    /**
+     * The extensions of the file type (e.g. `".txt"`).  Can be a compound
+     * extension (e.g. `".table.json`).
+     */
+    readonly extensions: ReadonlyArray<string>;
+
+    /**
+     * An optional pattern for a file name (e.g. `^Dockerfile$`).
+     */
+    readonly pattern?: string;
+
+    /**
+     * The icon class name for the file type.
+     */
+    readonly iconClass?: string;
+
+    /**
+     * The icon label for the file type.
+     */
+    readonly iconLabel?: string;
+
     /**
      * The content type of the new file.
      */

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -529,7 +529,7 @@ class DocumentRegistry implements IDisposable {
    *
    * @returns The best matching file type.
    */
-  getFileTypeForModel(model: Contents.IModel): DocumentRegistry.IFileType {
+  getFileTypeForModel(model: Partial<Contents.IModel>): DocumentRegistry.IFileType {
     switch (model.type) {
     case 'directory':
       return find(this._fileTypes, ft => ft.contentType === 'directory') || DocumentRegistry.defaultDirectoryFileType;
@@ -537,7 +537,7 @@ class DocumentRegistry implements IDisposable {
       return find(this._fileTypes, ft => ft.contentType === 'notebook') ||
         DocumentRegistry.defaultNotebookFileType;
     default:
-      let ext = PathExt.extname(model.path);
+      let ext = PathExt.extname(model.path || '');
       let ft = find(this._fileTypes, ft => ft.extensions.indexOf(ext) !== -1);
       return ft || this.getFileType('text') || DocumentRegistry.defaultTextFileType;
     }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -56,6 +56,14 @@ class DocumentRegistry implements IDisposable {
       throw new Error('Text model factory must have the name `text`');
     }
     this._modelFactories['text'] = factory || new TextModelFactory();
+
+    let fts = options.initialFileTypes || DocumentRegistry.defaultFileTypes;
+    fts.forEach(ft => {
+      let value: DocumentRegistry.IFileType = {
+        ...DocumentRegistry.fileTypeDefaults, ...ft
+      };
+      this._fileTypes.push(value);
+    });
   }
 
   /**
@@ -595,9 +603,16 @@ namespace DocumentRegistry {
   export
   interface IOptions {
     /**
-     * The text model factory for the registry.
+     * The text model factory for the registry.  A default instance will
+     * be used if not given.
      */
     textModelFactory?: ModelFactory;
+
+    /**
+     * The initial file types for the registry.
+     * The [[DocumentRegistry.defaultFileTypes]] will be used if not given.
+     */
+    initialFileTypes?: DocumentRegistry.IFileType[];
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -543,7 +543,6 @@ class DocumentRegistry implements IDisposable {
     }
   }
 
-
   private _modelFactories: { [key: string]: DocumentRegistry.ModelFactory } = Object.create(null);
   private _widgetFactories: { [key: string]: DocumentRegistry.WidgetFactory } = Object.create(null);
   private _defaultWidgetFactory = '';

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -870,15 +870,15 @@ namespace DocumentRegistry {
     readonly name: string;
 
     /**
-     * The extension of the file type (e.g. `".txt"`).  Can be a compound
+     * The extensions of the file type (e.g. `".txt"`).  Can be a compound
      * extension (e.g. `".table.json:`).
      */
-    readonly extension: string;
+    readonly extensions: ReadonlyArray<string>;
 
     /**
-     * The optional mimetype of the file type.
+     * The optional mime type of the file type.
      */
-    readonly mimetype?: string;
+    readonly mimeTypes?: ReadonlyArray<string>;
 
     /**
      * The optional icon class to use for the file type.
@@ -962,6 +962,101 @@ namespace DocumentRegistry {
     parts.shift();
     return '.' + parts.join('.');
   }
+
+  /**
+   * The default file types used by the document registry.
+   */
+  export
+  const defaultFileTypes: ReadonlyArray<IFileType> = [
+    {
+      name: 'markdown',
+      extensions: ['.md'],
+      mimeTypes: ['text/markdown'],
+      iconClass: 'jp-MaterialIcon jp-MarkdownIcon',
+    },
+    {
+      name: 'python',
+      extensions: ['.py'],
+      mimeTypes: ['text/x-python'],
+      iconClass: 'jp-MaterialIcon jp-PythonIcon'
+    },
+    {
+      name: 'json',
+      extensions: ['.json'],
+      mimeTypes: ['application/json', 'application/x-json'],
+      iconClass: 'jp-MaterialIcon jp-JSONIcon'
+    },
+    {
+      name: 'csv',
+      extensions: ['.csv'],
+      mimeTypes: ['text/csv'],
+      iconClass: 'jp-MaterialIcon jp-SpreadsheetIcon'
+    },
+    {
+      name: 'xls',
+      extensions: ['.xls'],
+      iconClass: 'jp-MaterialIcon jp-SpreadsheetIcon'
+    },
+    {
+      name: 'r',
+      mimeTypes: ['text/x-rsrc'],
+      extensions: ['.r'],
+      iconClass: 'jp-MaterialIcon jp-RKernelIcon'
+    },
+    {
+      name: 'yaml',
+      mimeTypes: ['text/x-yaml', 'text/yaml'],
+      extensions: ['.yaml', '.yml'],
+      iconClass: 'jp-MaterialIcon jp-YamlIcon'
+    },
+    {
+      name: 'svg',
+      mimeTypes: ['image/svg+xml'],
+      extensions: ['.svg'],
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
+      fileFormat: 'base64'
+    },
+    {
+      name: 'tiff',
+      mimeTypes: ['image/tiff'],
+      extensions: ['.tif', '.tiff'],
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
+      fileFormat: 'base64'
+    },
+    {
+      name: 'jpeg',
+      mimeTypes: ['image/jpeg'],
+      extensions: ['.jpg', '.jpeg'],
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
+      fileFormat: 'base64'
+    },
+    {
+      name: 'gif',
+      mimeTypes: ['image/gif'],
+      extensions: ['.gif'],
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
+      fileFormat: 'base64'
+    },
+    {
+      name: 'png',
+      mimeTypes: ['image/png'],
+      extensions: ['.png'],
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
+      fileFormat: 'base64'
+    },
+    {
+      name: 'raw',
+      extensions: ['.raw'],
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
+      fileFormat: 'base64'
+    },
+    {
+      name: 'text',
+      mimeTypes: ['text/plain'],
+      extensions: ['.txt'],
+      iconClass: 'jp-MaterialIcon jp-FileIcon'
+    }
+  ];
 }
 
 

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -37,6 +37,10 @@ import {
   IChangedArgs as IChangedArgsGeneric, PathExt, IModelDB
 } from '@jupyterlab/coreutils';
 
+import {
+  TextModelFactory
+} from './default';
+
 
 /**
  * The document registry.
@@ -46,11 +50,13 @@ class DocumentRegistry implements IDisposable {
   /**
    * Construct a new document registry.
    */
-  constructor(options: DocumentRegistry.IOptions) {
+  constructor(options: DocumentRegistry.IOptions = {}) {
     if (options.textModelFactory.name !== 'text') {
       throw new Error('Text model factory must have the name `text`');
     }
-    this._modelFactories['text'] = options.textModelFactory;
+    this._modelFactories['text'] = (
+      options.textModelFactory || new TextModelFactory()
+    );
   }
 
   /**
@@ -592,7 +598,7 @@ namespace DocumentRegistry {
     /**
      * The text model factory for the registry.
      */
-    textModelFactory: ModelFactory;
+    textModelFactory?: ModelFactory;
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -512,6 +512,25 @@ class DocumentRegistry implements IDisposable {
     };
   }
 
+  /**
+   * Get the best file type given a contents model.
+   */
+  getFileTypeForModel(model: Contents.IModel): DocumentRegistry.IFileType | undefined {
+    switch (model.type) {
+    case 'directory':
+      return find(this._fileTypes, ft => ft.contentType === 'directory');
+    case 'notebook':
+      return find(this._fileTypes, ft => ft.contentType === 'notebook');
+    case 'file':
+      let ext = PathExt.extname(model.path);
+      let ft = find(this._fileTypes, ft => ft.extensions.indexOf(ext) !== -1);
+      return ft || this.getFileType('text');
+    default:
+      return undefined;
+    }
+  }
+
+
   private _modelFactories: { [key: string]: DocumentRegistry.ModelFactory } = Object.create(null);
   private _widgetFactories: { [key: string]: DocumentRegistry.WidgetFactory } = Object.create(null);
   private _defaultWidgetFactory = '';
@@ -1055,6 +1074,20 @@ namespace DocumentRegistry {
       mimeTypes: ['text/plain'],
       extensions: ['.txt'],
       iconClass: 'jp-MaterialIcon jp-FileIcon'
+    },
+    {
+      name: 'notebook',
+      extensions: ['.ipynb'],
+      contentType: 'notebook',
+      fileFormat: 'json',
+      iconClass: 'jp-MaterialIcon jp-NotebookIcon'
+    },
+    {
+      name: 'directory',
+      extensions: [],
+      mimeTypes: ['text/directory'],
+      contentType: 'directory',
+      iconClass: 'jp-MaterialIcon jp-OpenFolderIcon'
     }
   ];
 }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -51,12 +51,11 @@ class DocumentRegistry implements IDisposable {
    * Construct a new document registry.
    */
   constructor(options: DocumentRegistry.IOptions = {}) {
-    if (options.textModelFactory.name !== 'text') {
+    let factory = options.textModelFactory;
+    if (factory && factory.name !== 'text') {
       throw new Error('Text model factory must have the name `text`');
     }
-    this._modelFactories['text'] = (
-      options.textModelFactory || new TextModelFactory()
-    );
+    this._modelFactories['text'] = factory || new TextModelFactory();
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -538,8 +538,9 @@ class DocumentRegistry implements IDisposable {
         DocumentRegistry.defaultNotebookFileType;
     default:
       // Find the best matching extension.
-      if (model.name) {
-        let fts = this.getFileTypesForPath(model.name);
+      if (model.name || model.path) {
+        let name = model.name || PathExt.basename(model.path);
+        let fts = this.getFileTypesForPath(name);
         if (fts.length > 0) {
           return fts[0];
         }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -247,16 +247,18 @@ class DocumentRegistry implements IDisposable {
    * These are used to populate the "Create New" dialog.
    */
   addFileType(fileType: Partial<DocumentRegistry.IFileType>): IDisposable {
-    this._fileTypes.push({
+    let value: DocumentRegistry.IFileType = {
       ...DocumentRegistry.fileTypeDefaults, ...fileType
-    });
+    };
+    this._fileTypes.push(value);
+
     this._changed.emit({
       type: 'fileType',
-      name: fileType.name,
+      name: value.name,
       change: 'added'
     });
     return new DisposableDelegate(() => {
-      ArrayExt.removeFirstOf(this._fileTypes, fileType);
+      ArrayExt.removeFirstOf(this._fileTypes, value);
       this._changed.emit({
         type: 'fileType',
         name: fileType.name,

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -415,8 +415,7 @@ function createContextMenu(path: string, commands: CommandRegistry, registry: Do
 
   menu.addItem({ command: CommandIDs.open });
 
-  const ext = DocumentRegistry.extname(path);
-  const factories = registry.preferredWidgetFactories(ext).map(f => f.name);
+  const factories = registry.preferredWidgetFactories(path).map(f => f.name);
   if (path && factories.length > 1) {
     const command =  'docmanager:open';
     const openWith = new Menu({ commands });

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -102,7 +102,7 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, editorServices: IE
   const namespace = 'editor';
   const factory = new FileEditorFactory({
     editorServices,
-    factoryOptions: { name: FACTORY, fileExtensions: ['*'], defaultFor: ['*'] }
+    factoryOptions: { name: FACTORY, fileTypes: ['*'], defaultFor: ['*'] }
   });
   const { commands, restored } = app;
   const tracker = new InstanceTracker<FileEditor>({ namespace });

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -34,10 +34,11 @@ namespace CommandIDs {
 
 
 /**
- * The list of file extensions for images.
+ * The list of file types for images.
  */
-const EXTENSIONS = ['.png', '.gif', '.jpeg', '.jpg', '.svg', '.bmp', '.ico',
-  '.xbm', '.tiff', '.tif'];
+const FILE_TYPES = [
+  'png', 'gif', 'jpeg', 'svg', 'bmp', 'ico', 'xbm', 'tiff'
+];
 
 /**
  * The name of the factory that creates image widgets.
@@ -70,8 +71,8 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
   const factory = new ImageViewerFactory({
     name: FACTORY,
     modelName: 'base64',
-    fileExtensions: EXTENSIONS,
-    defaultFor: EXTENSIONS,
+    fileTypes: FILE_TYPES,
+    defaultFor: FILE_TYPES,
     readOnly: true
   });
   const tracker = new InstanceTracker<ImageViewer>({ namespace });

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -90,6 +90,13 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => { tracker.save(widget); });
     tracker.add(widget);
+
+    let fts = app.docRegistry.getFileTypesForPath(widget.context.path);
+    if (fts.length > 0) {
+      widget.title.iconClass = fts[0].iconClass;
+      widget.title.iconLabel = fts[0].iconLabel;
+    }
+
   });
 
   addCommands(tracker, app.commands);

--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -17,11 +17,6 @@ import {
 import '../style/index.css';
 
 /**
- * The class name for the text editor icon from the default theme.
- */
-const TEXTEDITOR_ICON_CLASS = 'jp-TextEditorIcon';
-
-/**
  * The name of the factory that creates markdown widgets.
  */
 const FACTORY = 'Markdown Preview';
@@ -51,10 +46,11 @@ const plugin: JupyterLabPlugin<void> = {
  * Activate the markdown plugin.
  */
 function activate(app: JupyterLab, restorer: ILayoutRestorer) {
+    const primaryFileType = app.docRegistry.getFileType('markdown');
     const factory = new MimeDocumentFactory({
       name: FACTORY,
+      primaryFileType,
       fileTypes: ['markdown'],
-      registry: app.docRegistry,
       rendermime: app.rendermime
     });
     app.docRegistry.addWidgetFactory(factory);
@@ -71,7 +67,6 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer) {
     });
 
     factory.widgetCreated.connect((sender, widget) => {
-      widget.title.icon = TEXTEDITOR_ICON_CLASS;
       // Notify the instance tracker if restore data needs to update.
       widget.context.pathChanged.connect(() => { tracker.save(widget); });
       tracker.add(widget);

--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -53,8 +53,8 @@ const plugin: JupyterLabPlugin<void> = {
 function activate(app: JupyterLab, restorer: ILayoutRestorer) {
     const factory = new MimeDocumentFactory({
       name: FACTORY,
-      fileExtensions: ['.md'],
-      mimeType: 'text/markdown',
+      fileTypes: ['markdown'],
+      registry: app.docRegistry,
       rendermime: app.rendermime
     });
     app.docRegistry.addWidgetFactory(factory);

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -397,7 +397,7 @@ function activateNotebookHandler(app: JupyterLab, services: IServiceManager, mai
   registry.addWidgetFactory(factory);
   registry.addFileType({
     name: 'Notebook',
-    extension: '.ipynb',
+    extensions: ['.ipynb'],
     contentType: 'notebook',
     fileFormat: 'json'
   });

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -365,7 +365,7 @@ function activateNotebookHandler(app: JupyterLab, services: IServiceManager, mai
 
   const factory = new NotebookWidgetFactory({
     name: FACTORY,
-    fileExtensions: ['.ipynb'],
+    fileTypes: ['notebook'],
     modelName: 'notebook',
     defaultFor: ['.ipynb'],
     preferKernel: true,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -367,7 +367,7 @@ function activateNotebookHandler(app: JupyterLab, services: IServiceManager, mai
     name: FACTORY,
     fileTypes: ['notebook'],
     modelName: 'notebook',
-    defaultFor: ['.ipynb'],
+    defaultFor: ['notebook'],
     preferKernel: true,
     canStartKernel: true,
     rendermime: app.rendermime,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -395,12 +395,6 @@ function activateNotebookHandler(app: JupyterLab, services: IServiceManager, mai
   let registry = app.docRegistry;
   registry.addModelFactory(new NotebookModelFactory({}));
   registry.addWidgetFactory(factory);
-  registry.addFileType({
-    name: 'Notebook',
-    extensions: ['.ipynb'],
-    contentType: 'notebook',
-    fileFormat: 'json'
-  });
   registry.addCreator({
     name: 'Notebook',
     fileType: 'Notebook',

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -168,7 +168,7 @@ namespace IRenderMime {
     /**
      * The options used to open a document with the renderer factory.
      */
-    readonly documentWidgetFactoryOptions?: IDocumentWidgetFactoryOptions |ReadonlyArray<IDocumentWidgetFactoryOptions>;
+    readonly documentWidgetFactoryOptions?: IDocumentWidgetFactoryOptions | ReadonlyArray<IDocumentWidgetFactoryOptions>;
 
     /**
      * The optional file type associated with the extension.

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -78,6 +78,11 @@ namespace IRenderMime {
   export
   interface IDocumentWidgetFactoryOptions {
     /**
+     * The name of the widget to display in dialogs.
+     */
+    readonly name: string;
+
+    /**
      * The file extensions the widget can view.
      *
      * #### Notes
@@ -86,11 +91,6 @@ namespace IRenderMime {
      * period (e.g. .table.json).
      */
     readonly fileExtensions: ReadonlyArray<string>;
-
-    /**
-     * The name of the widget to display in dialogs.
-     */
-    readonly name: string;
 
     /**
      * The file extensions for which the factory should be the default.
@@ -104,26 +104,23 @@ namespace IRenderMime {
      * **See also:** [[fileExtensions]].
      */
     readonly defaultFor?: ReadonlyArray<string>;
+  }
+
+  /**
+   * A file type to associate with the renderer.
+   */
+  export
+  interface IFileType {
+    /**
+     * The name of the file type.
+     */
+    readonly name: string;
 
     /**
-     * Whether the widget factory is read only.
+     * The extensions of the file type (e.g. `".txt"`).  Can be a compound
+     * extension (e.g. `".table.json`).
      */
-    readonly readOnly?: boolean;
-
-    /**
-     * The registered name of the model type used to create the widgets.
-     */
-    readonly modelName?: string;
-
-    /**
-     * Whether the widgets prefer having a kernel started.
-     */
-    readonly preferKernel?: boolean;
-
-    /**
-     * Whether the widgets can start a kernel when opened.
-     */
-    readonly canStartKernel?: boolean;
+    readonly extensions: ReadonlyArray<string>;
   }
 
   /**
@@ -170,6 +167,11 @@ namespace IRenderMime {
      * The options used to open a document with the renderer factory.
      */
     readonly documentWidgetFactoryOptions?: IDocumentWidgetFactoryOptions;
+
+    /**
+     * The optional name for a fileType associated with the extension.
+     */
+    readonly fileType?: IFileType;
   }
 
   /**

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -83,25 +83,12 @@ namespace IRenderMime {
     readonly name: string;
 
     /**
-     * The file extensions the widget can view.
-     *
-     * #### Notes
-     * Use "*" to denote all files. Specific file extensions must be preceded
-     * with '.', like '.png', '.txt', etc.  They may themselves contain a
-     * period (e.g. .table.json).
+     * The file types the widget can view.
      */
-    readonly fileExtensions: ReadonlyArray<string>;
+    readonly fileTypes: ReadonlyArray<string>;
 
     /**
-     * The file extensions for which the factory should be the default.
-     *
-     * #### Notes
-     * Use "*" to denote all files. Specific file extensions must be preceded
-     * with '.', like '.png', '.txt', etc. Entries in this attribute must also
-     * be included in the fileExtensions attribute.
-     * The default is an empty array.
-     *
-     * **See also:** [[fileExtensions]].
+     * The file types for which the factory should be the default.
      */
     readonly defaultFor?: ReadonlyArray<string>;
   }
@@ -117,10 +104,30 @@ namespace IRenderMime {
     readonly name: string;
 
     /**
+     * The mime types associated the file type.
+     */
+    readonly mimeTypes: ReadonlyArray<string>;
+
+    /**
      * The extensions of the file type (e.g. `".txt"`).  Can be a compound
      * extension (e.g. `".table.json`).
      */
     readonly extensions: ReadonlyArray<string>;
+
+    /**
+     * An optional pattern for a file name (e.g. `^Dockerfile$`).
+     */
+    readonly pattern?: string;
+
+    /**
+     * The icon class name for the file type.
+     */
+    readonly iconClass?: string;
+
+    /**
+     * The icon label for the file type.
+     */
+    readonly iconLabel?: string;
   }
 
   /**
@@ -129,9 +136,9 @@ namespace IRenderMime {
   export
   interface IExtension {
     /**
-     * The MIME type for the renderer, which is the output MIME type it will handle.
+     * The name of the extension.
      */
-    readonly mimeType: string;
+    readonly name: string;
 
     /**
      * A renderer factory to be registered to render the MIME type.
@@ -154,24 +161,14 @@ namespace IRenderMime {
     readonly dataType?: 'string' | 'json';
 
     /**
-     * The icon class name for the widget.
-     */
-    readonly iconClass?: string;
-
-    /**
-     * The icon label for the widget.
-     */
-    readonly iconLabel?: string;
-
-    /**
      * The options used to open a document with the renderer factory.
      */
     readonly documentWidgetFactoryOptions?: IDocumentWidgetFactoryOptions;
 
     /**
-     * The optional name for a fileType associated with the extension.
+     * The optional file type associated with the extension.
      */
-    readonly fileType?: IFileType;
+    readonly fileTypes?: ReadonlyArray<IFileType>;
   }
 
   /**

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -83,6 +83,11 @@ namespace IRenderMime {
     readonly name: string;
 
     /**
+     * The primary file type of the widget.
+     */
+    readonly primaryFileType: string;
+
+    /**
      * The file types the widget can view.
      */
     readonly fileTypes: ReadonlyArray<string>;
@@ -163,7 +168,7 @@ namespace IRenderMime {
     /**
      * The options used to open a document with the renderer factory.
      */
-    readonly documentWidgetFactoryOptions?: IDocumentWidgetFactoryOptions;
+    readonly documentWidgetFactoryOptions?: IDocumentWidgetFactoryOptions |ReadonlyArray<IDocumentWidgetFactoryOptions>;
 
     /**
      * The optional file type associated with the extension.

--- a/packages/theming/style/icons.css
+++ b/packages/theming/style/icons.css
@@ -238,6 +238,11 @@
 }
 
 
+.jp-VegaIcon {
+  background-image: url(icons/jupyter/vega.svg);
+}
+
+
 .jp-QuestionMarkIcon {
   background-image: url(icons/jupyter/questionmark.svg);
 }

--- a/packages/vega2-extension/src/index.ts
+++ b/packages/vega2-extension/src/index.ts
@@ -126,44 +126,31 @@ const rendererFactory: IRenderMime.IRendererFactory = {
   createRenderer: options => new RenderedVega(options)
 };
 
-const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
-  // Vega
-  {
-    mimeType: VEGA_MIME_TYPE,
-    rendererFactory,
-    rank: 0,
-    dataType: 'json',
-    iconClass: 'jp-MaterialIcon jp-VegaIcon',
-    documentWidgetFactoryOptions: {
-      name: 'Vega',
-      fileExtensions: ['.vg', '.vg.json', '.json'],
-      defaultFor: ['.vg', '.vg.json']
-    },
-    fileType: {
-      name: 'vega',
-      extensions: ['.vg', '.vg.json']
-    }
+const extension: IRenderMime.IExtension = {
+  name: 'vega',
+  rendererFactory,
+  rank: 0,
+  dataType: 'json',
+  documentWidgetFactoryOptions: {
+    name: 'Vega',
+    fileTypes: ['vega', 'vega-lite', 'json'],
+    defaultFor: ['vega', 'vega-lite']
   },
-  // Vega-Lite
-  {
-    mimeType: VEGALITE_MIME_TYPE,
-    rendererFactory,
-    rank: 0,
-    dataType: 'json',
+  fileTypes: [{
+    mimeTypes: [VEGA_MIME_TYPE],
+    name: 'vega',
+    extensions: ['.vg', '.vg.json'],
     iconClass: 'jp-MaterialIcon jp-VegaIcon',
-    documentWidgetFactoryOptions: {
-      name: 'Vega-Lite',
-      fileExtensions: ['.vl', '.vl.json', '.json'],
-      defaultFor: ['.vl', '.vl.json']
-    },
-    fileType: {
-      name: 'vega-lite',
-      extensions: ['.vl', '.vl.json']
-    }
-  }
-];
+  },
+  {
+    mimeTypes: [VEGALITE_MIME_TYPE],
+    name: 'vega-lite',
+    extensions: ['.vl', '.vl.json'],
+    iconClass: 'jp-MaterialIcon jp-VegaIcon',
+  }]
+};
 
-export default extensions;
+export default extension;
 
 
 /**

--- a/packages/vega2-extension/src/index.ts
+++ b/packages/vega2-extension/src/index.ts
@@ -131,11 +131,18 @@ const extension: IRenderMime.IExtension = {
   rendererFactory,
   rank: 0,
   dataType: 'json',
-  documentWidgetFactoryOptions: {
+  documentWidgetFactoryOptions: [{
     name: 'Vega',
-    fileTypes: ['vega', 'vega-lite', 'json'],
-    defaultFor: ['vega', 'vega-lite']
+    primaryFileType: 'vega',
+    fileTypes: ['vega', 'json'],
+    defaultFor: ['vega']
   },
+  {
+    name: 'Vega Lite',
+    primaryFileType: 'vega-lite',
+    fileTypes: ['vega-lite', 'json'],
+    defaultFor: ['vega-lite']
+  }],
   fileTypes: [{
     mimeTypes: [VEGA_MIME_TYPE],
     name: 'vega',

--- a/packages/vega2-extension/src/index.ts
+++ b/packages/vega2-extension/src/index.ts
@@ -133,11 +133,15 @@ const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
     rendererFactory,
     rank: 0,
     dataType: 'json',
+    iconClass: 'jp-MaterialIcon jp-VegaIcon',
     documentWidgetFactoryOptions: {
       name: 'Vega',
       fileExtensions: ['.vg', '.vg.json', '.json'],
-      defaultFor: ['.vg', '.vg.json'],
-      readOnly: true
+      defaultFor: ['.vg', '.vg.json']
+    },
+    fileType: {
+      name: 'vega',
+      extensions: ['.vg', '.vg.json']
     }
   },
   // Vega-Lite
@@ -146,11 +150,15 @@ const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
     rendererFactory,
     rank: 0,
     dataType: 'json',
+    iconClass: 'jp-MaterialIcon jp-VegaIcon',
     documentWidgetFactoryOptions: {
       name: 'Vega-Lite',
       fileExtensions: ['.vl', '.vl.json', '.json'],
-      defaultFor: ['.vl', '.vl.json'],
-      readOnly: true
+      defaultFor: ['.vl', '.vl.json']
+    },
+    fileType: {
+      name: 'vega-lite',
+      extensions: ['.vl', '.vl.json']
     }
   }
 ];
@@ -173,7 +181,7 @@ namespace Private {
 
   /**
    * Apply the default cell config to the spec in place.
-   * 
+   *
    * #### Notes
    * This carefully does a shallow copy to avoid copying the potentially
    * large data.

--- a/test/src/docmanager/manager.spec.ts
+++ b/test/src/docmanager/manager.spec.ts
@@ -50,7 +50,7 @@ describe('@jupyterlab/docmanager', () => {
   let textModelFactory = new TextModelFactory();
   let widgetFactory = new WidgetFactory({
     name: 'test',
-    fileExtensions: ['.txt'],
+    fileTypes: ['text'],
     canStartKernel: true,
     preferKernel: true
   });
@@ -172,7 +172,7 @@ describe('@jupyterlab/docmanager', () => {
         let widgetFactory2 = new WidgetFactory({
           name: 'test',
           modelName: 'foo',
-          fileExtensions: ['.txt']
+          fileTypes: ['text']
         });
         manager.registry.addWidgetFactory(widgetFactory2);
         return services.contents.newUntitled({ type: 'file', ext: '.txt'}).then(model => {
@@ -229,7 +229,7 @@ describe('@jupyterlab/docmanager', () => {
         let widgetFactory2 = new WidgetFactory({
           name: 'test',
           modelName: 'foo',
-          fileExtensions: ['.txt']
+          fileTypes: ['text']
         });
         manager.registry.addWidgetFactory(widgetFactory2);
         return services.contents.newUntitled({ type: 'file', ext: '.txt'}).then(model => {

--- a/test/src/docmanager/manager.spec.ts
+++ b/test/src/docmanager/manager.spec.ts
@@ -47,7 +47,7 @@ describe('@jupyterlab/docmanager', () => {
   let services: ServiceManager.IManager;
   let context: DocumentRegistry.Context;
   let widget: Widget;
-  let modelFactory = new TextModelFactory();
+  let textModelFactory = new TextModelFactory();
   let widgetFactory = new WidgetFactory({
     name: 'test',
     fileExtensions: ['.txt'],
@@ -62,8 +62,7 @@ describe('@jupyterlab/docmanager', () => {
   });
 
   beforeEach(() => {
-    let registry = new DocumentRegistry();
-    registry.addModelFactory(modelFactory);
+    let registry = new DocumentRegistry({ textModelFactory });
     registry.addWidgetFactory(widgetFactory);
     manager = new DocumentManager({
       registry,

--- a/test/src/docmanager/manager.spec.ts
+++ b/test/src/docmanager/manager.spec.ts
@@ -64,6 +64,9 @@ describe('@jupyterlab/docmanager', () => {
   beforeEach(() => {
     let registry = new DocumentRegistry({ textModelFactory });
     registry.addWidgetFactory(widgetFactory);
+    DocumentRegistry.defaultFileTypes.forEach(ft => {
+      registry.addFileType(ft);
+    });
     manager = new DocumentManager({
       registry,
       manager: services,
@@ -131,6 +134,7 @@ describe('@jupyterlab/docmanager', () => {
 
       it('should open a file and return the widget used to view it', () => {
         return services.contents.newUntitled({ type: 'file', ext: '.txt'}).then(model => {
+          debugger;
           widget = manager.open(model.path);
           expect(widget.hasClass('WidgetFactory')).to.be(true);
           return dismissDialog();

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -79,11 +79,11 @@ describe('@jupyterlab/docmanager', () => {
   let context: Context<DocumentRegistry.IModel>;
   let widgetFactory = new WidgetFactory({
     name: 'test',
-    fileExtensions: ['.txt']
+    fileTypes: ['text']
   });
   let readOnlyFactory = new WidgetFactory({
     name: 'readonly',
-    fileExtensions: ['.txt'],
+    fileTypes: ['text'],
     readOnly: true
   });
 

--- a/test/src/docmanager/widgetmanager.spec.ts
+++ b/test/src/docmanager/widgetmanager.spec.ts
@@ -75,7 +75,7 @@ describe('@jupyterlab/docmanager', () => {
 
   let manager: LoggingManager;
   let services: ServiceManager.IManager;
-  let modelFactory = new TextModelFactory();
+  let textModelFactory = new TextModelFactory();
   let context: Context<DocumentRegistry.IModel>;
   let widgetFactory = new WidgetFactory({
     name: 'test',
@@ -92,13 +92,12 @@ describe('@jupyterlab/docmanager', () => {
   });
 
   beforeEach(() => {
-    let registry = new DocumentRegistry();
-    registry.addModelFactory(modelFactory);
+    let registry = new DocumentRegistry({ textModelFactory });
     registry.addWidgetFactory(widgetFactory);
     manager = new LoggingManager({ registry });
     context = new Context({
       manager: services,
-      factory: modelFactory,
+      factory: textModelFactory,
       path: uuid()
     });
   });

--- a/test/src/docregistry/default.spec.ts
+++ b/test/src/docregistry/default.spec.ts
@@ -59,12 +59,12 @@ class WidgetFactory extends ABCWidgetFactory<DocumentRegistry.IReadyWidget, Docu
 function createFactory(): WidgetFactory {
   return new WidgetFactory({
     name: 'test',
-    fileExtensions: ['.txt']
+    fileTypes: ['text']
   });
 }
 
 
-describe('docmanager/default', () => {
+describe('docregistry/default', () => {
 
   let context: Context<DocumentRegistry.IModel>;
 
@@ -78,14 +78,14 @@ describe('docmanager/default', () => {
 
   describe('ABCWidgetFactory', () => {
 
-    describe('#fileExtensions', () => {
+    describe('#fileTypes', () => {
 
       it('should be the value passed in', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
         });
-        expect(factory.fileExtensions).to.eql(['.txt']);
+        expect(factory.fileTypes).to.eql(['text']);
       });
 
     });
@@ -95,7 +95,7 @@ describe('docmanager/default', () => {
       it('should be the value passed in', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
         });
         expect(factory.name).to.be('test');
       });
@@ -107,7 +107,7 @@ describe('docmanager/default', () => {
       it('should default to an empty array', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
         });
         expect(factory.defaultFor).to.eql([]);
       });
@@ -115,10 +115,10 @@ describe('docmanager/default', () => {
       it('should be the value passed in', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
-          defaultFor: ['.md']
+          fileTypes: ['text'],
+          defaultFor: ['text']
         });
-        expect(factory.defaultFor).to.eql(['.md']);
+        expect(factory.defaultFor).to.eql(['text']);
       });
 
     });
@@ -128,7 +128,7 @@ describe('docmanager/default', () => {
       it('should default to false', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
         });
         expect(factory.readOnly).to.be(false);
       });
@@ -136,7 +136,7 @@ describe('docmanager/default', () => {
       it('should be the value passed in', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
           readOnly: true
         });
         expect(factory.readOnly).to.be(true);
@@ -149,7 +149,7 @@ describe('docmanager/default', () => {
       it('should default to `text`', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
         });
         expect(factory.modelName).to.be('text');
       });
@@ -157,7 +157,7 @@ describe('docmanager/default', () => {
       it('should be the value passed in', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
           modelName: 'notebook'
         });
         expect(factory.modelName).to.be('notebook');
@@ -169,7 +169,7 @@ describe('docmanager/default', () => {
       it('should default to false', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
         });
         expect(factory.preferKernel).to.be(false);
       });
@@ -177,7 +177,7 @@ describe('docmanager/default', () => {
       it('should be the value passed in', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
           preferKernel: true
         });
         expect(factory.preferKernel).to.be(true);
@@ -190,7 +190,7 @@ describe('docmanager/default', () => {
       it('should default to false', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
         });
         expect(factory.canStartKernel).to.be(false);
       });
@@ -198,7 +198,7 @@ describe('docmanager/default', () => {
       it('should be the value passed in', () => {
         let factory = new WidgetFactory({
           name: 'test',
-          fileExtensions: ['.txt'],
+          fileTypes: ['text'],
           canStartKernel: true
         });
         expect(factory.canStartKernel).to.be(true);
@@ -591,9 +591,9 @@ describe('docmanager/default', () => {
       it('should require a context parameter', () => {
         let widgetFactory = new MimeDocumentFactory({
           name: 'markdown',
-          fileExtensions: ['.md'],
+          fileTypes: ['markdown'],
           rendermime: RENDERMIME,
-          mimeType: 'text/markdown'
+          primaryFileType: DocumentRegistry.defaultTextFileType
         });
         expect(widgetFactory.createNew(context)).to.be.a(MimeDocument);
       });

--- a/test/src/docregistry/registry.spec.ts
+++ b/test/src/docregistry/registry.spec.ts
@@ -209,7 +209,7 @@ describe('docregistry/registry', () => {
       it('should add a file type to the document registry', () => {
         let fileType = { name: 'notebook', extensions: ['.ipynb'] };
         registry.addFileType(fileType);
-        expect(registry.fileTypes().next()).to.be(fileType);
+        expect(registry.fileTypes().next().name).to.be(fileType.name);
       });
 
       it('should be removed from the registry when disposed', () => {
@@ -224,7 +224,7 @@ describe('docregistry/registry', () => {
         registry.addFileType(fileType);
         let disposable = registry.addFileType(fileType);
         disposable.dispose();
-        expect(registry.fileTypes().next()).to.be(fileType);
+        expect(registry.fileTypes().next().name).to.be(fileType.name);
       });
 
     });
@@ -396,9 +396,9 @@ describe('docregistry/registry', () => {
         registry.addFileType(fileTypes[1]);
         registry.addFileType(fileTypes[2]);
         let values = registry.fileTypes();
-        expect(values.next()).to.be(fileTypes[0]);
-        expect(values.next()).to.be(fileTypes[1]);
-        expect(values.next()).to.be(fileTypes[2]);
+        expect(values.next().name).to.be(fileTypes[0].name);
+        expect(values.next().name).to.be(fileTypes[1].name);
+        expect(values.next().name).to.be(fileTypes[2].name);
       });
 
     });
@@ -430,8 +430,8 @@ describe('docregistry/registry', () => {
         ];
         registry.addFileType(fileTypes[0]);
         registry.addFileType(fileTypes[1]);
-        expect(registry.getFileType('notebook')).to.be(fileTypes[0]);
-        expect(registry.getFileType('python')).to.be(fileTypes[1]);
+        expect(registry.getFileType('notebook').name).to.be(fileTypes[0].name);
+        expect(registry.getFileType('python').name).to.be(fileTypes[1].name);
         expect(registry.getFileType('r')).to.be(void 0);
       });
     });
@@ -559,16 +559,27 @@ describe('docregistry/registry', () => {
 
       it('should handle a python file', () => {
         let ft = registry.getFileTypeForModel({
-          path: 'foo.py'
+          name: 'foo.py'
         });
         expect(ft.name).to.be('python');
       });
 
       it('should handle an unknown file', () => {
         let ft = registry.getFileTypeForModel({
-          path: 'foo.bar'
+          name: 'foo.bar'
         });
         expect(ft.name).to.be('text');
+      });
+
+      it('should get the most specific extension', () => {
+        [
+          { name: 'json', extensions: ['.json'] },
+          { name: 'vega', extensions: ['.vg.json'] }
+        ].forEach(ft => {registry.addFileType(ft); });
+        let ft = registry.getFileTypeForModel({
+          name: 'foo.vg.json'
+        });
+        expect(ft.name).to.be('vega');
       });
 
     });

--- a/test/src/docregistry/registry.spec.ts
+++ b/test/src/docregistry/registry.spec.ts
@@ -20,7 +20,7 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  ABCWidgetFactory, DocumentRegistry, TextModelFactory
+  ABCWidgetFactory, Base64ModelFactory, DocumentRegistry, TextModelFactory
 } from '@jupyterlab/docregistry';
 
 
@@ -65,7 +65,9 @@ describe('docregistry/registry', () => {
     let registry: DocumentRegistry;
 
     beforeEach(() => {
-      registry = new DocumentRegistry();
+      registry = new DocumentRegistry({
+        textModelFactory: new TextModelFactory()
+      });
     });
 
     afterEach(() => {
@@ -85,7 +87,7 @@ describe('docregistry/registry', () => {
     describe('#dispose()', () => {
 
       it('should dispose of the resources held by the registry', () => {
-        registry.addFileType({ name: 'notebook', extension: '.ipynb' });
+        registry.addFileType({ name: 'notebook', extensions: ['.ipynb'] });
         registry.dispose();
         expect(registry.isDisposed).to.be(true);
       });
@@ -108,7 +110,6 @@ describe('docregistry/registry', () => {
       });
 
       it('should become the global default if `*` is given as a defaultFor', () => {
-        registry.addModelFactory(new TextModelFactory());
         let factory = new WidgetFactory({
           name: 'global',
           fileExtensions: ['*'],
@@ -119,7 +120,6 @@ describe('docregistry/registry', () => {
       });
 
       it('should override an existing global default', () => {
-        registry.addModelFactory(new TextModelFactory());
         registry.addWidgetFactory(new WidgetFactory({
           name: 'global',
           fileExtensions: ['*'],
@@ -135,7 +135,6 @@ describe('docregistry/registry', () => {
       });
 
       it('should override an existing extension default', () => {
-        registry.addModelFactory(new TextModelFactory());
         registry.addWidgetFactory(createFactory());
         let factory = createFactory();
         registry.addWidgetFactory(factory);
@@ -143,7 +142,6 @@ describe('docregistry/registry', () => {
       });
 
       it('should be removed from the registry when disposed', () => {
-        registry.addModelFactory(new TextModelFactory());
         let factory = createFactory();
         let disposable = registry.addWidgetFactory(factory);
         disposable.dispose();
@@ -155,26 +153,26 @@ describe('docregistry/registry', () => {
     describe('#addModelFactory()', () => {
 
       it('should add the model factory to the registry', () => {
-        let factory = new TextModelFactory();
+        let factory = new Base64ModelFactory();
         registry.addModelFactory(factory);
       });
 
       it('should be a no-op a factory with the given `name` is already registered', () => {
-        let factory = new TextModelFactory();
+        let factory = new Base64ModelFactory();
         registry.addModelFactory(factory);
-        let disposable = registry.addModelFactory(new TextModelFactory());
+        let disposable = registry.addModelFactory(new Base64ModelFactory());
         disposable.dispose();
       });
 
       it('should be a no-op if the same factory is already registered', () => {
-        let factory = new TextModelFactory();
+        let factory = new Base64ModelFactory();
         registry.addModelFactory(factory);
         let disposable = registry.addModelFactory(factory);
         disposable.dispose();
       });
 
       it('should be removed from the registry when disposed', () => {
-        let factory = new TextModelFactory();
+        let factory = new Base64ModelFactory();
         let disposable = registry.addModelFactory(factory);
         disposable.dispose();
       });
@@ -209,20 +207,20 @@ describe('docregistry/registry', () => {
     describe('#addFileType()', () => {
 
       it('should add a file type to the document registry', () => {
-        let fileType = { name: 'notebook', extension: '.ipynb' };
+        let fileType = { name: 'notebook', extensions: ['.ipynb'] };
         registry.addFileType(fileType);
         expect(registry.fileTypes().next()).to.be(fileType);
       });
 
       it('should be removed from the registry when disposed', () => {
-        let fileType = { name: 'notebook', extension: '.ipynb' };
+        let fileType = { name: 'notebook', extensions: ['.ipynb'] };
         let disposable = registry.addFileType(fileType);
         disposable.dispose();
         expect(toArray(registry.fileTypes()).length).to.be(0);
       });
 
       it('should be a no-op if a file type of the same name is registered', () => {
-        let fileType = { name: 'notebook', extension: '.ipynb' };
+        let fileType = { name: 'notebook', extensions: ['.ipynb'] };
         registry.addFileType(fileType);
         let disposable = registry.addFileType(fileType);
         disposable.dispose();
@@ -390,9 +388,9 @@ describe('docregistry/registry', () => {
       it('should get the registered file types', () => {
         expect(toArray(registry.fileTypes()).length).to.be(0);
         let fileTypes = [
-          { name: 'notebook', extension: '.ipynb' },
-          { name: 'python', extension: '.py' },
-          { name: 'table', extension: '.table.json' }
+          { name: 'notebook', extensions: ['.ipynb'] },
+          { name: 'python', extensions: ['.py'] },
+          { name: 'table', extensions: ['.table.json'] }
         ];
         registry.addFileType(fileTypes[0]);
         registry.addFileType(fileTypes[1]);
@@ -427,8 +425,8 @@ describe('docregistry/registry', () => {
 
       it('should get a file type by name', () => {
         let fileTypes = [
-          { name: 'notebook', extension: '.ipynb' },
-          { name: 'python', extension: '.py' }
+          { name: 'notebook', extensions: ['.ipynb'] },
+          { name: 'python', extensions: ['.py'] }
         ];
         registry.addFileType(fileTypes[0]);
         registry.addFileType(fileTypes[1]);
@@ -492,9 +490,9 @@ describe('docregistry/registry', () => {
     describe('#getModelFactory()', () => {
 
       it('should get a registered model factory by name', () => {
-        let mFactory = new TextModelFactory();
+        let mFactory = new Base64ModelFactory();
         registry.addModelFactory(mFactory);
-        expect(registry.getModelFactory('text')).to.be(mFactory);
+        expect(registry.getModelFactory('base64')).to.be(mFactory);
       });
 
     });
@@ -502,7 +500,7 @@ describe('docregistry/registry', () => {
     describe('#getWidgetFactory()', () => {
 
       it('should get a widget factory by name', () => {
-        registry.addModelFactory(new TextModelFactory());
+        registry.addModelFactory(new Base64ModelFactory());
         let factory = createFactory();
         registry.addWidgetFactory(factory);
         let mdFactory = new WidgetFactory({
@@ -533,6 +531,44 @@ describe('docregistry/registry', () => {
         expect(buzz[0]).to.be(foo);
         expect(toArray(buzz).length).to.be(1);
         expect(registry.widgetExtensions('baz').next()).to.be(void 0);
+      });
+
+    });
+
+    describe('#getFileTypeForModel()', () => {
+
+      beforeEach(() => {
+        DocumentRegistry.defaultFileTypes.forEach(ft => {
+          registry.addFileType(ft);
+        });
+      });
+
+      it('should handle a directory', () => {
+        let ft = registry.getFileTypeForModel({
+          type: 'directory'
+        });
+        expect(ft.name).to.be('directory');
+      });
+
+      it('should handle a notebook', () => {
+        let ft = registry.getFileTypeForModel({
+          type: 'notebook'
+        });
+        expect(ft.name).to.be('notebook');
+      });
+
+      it('should handle a python file', () => {
+        let ft = registry.getFileTypeForModel({
+          path: 'foo.py'
+        });
+        expect(ft.name).to.be('python');
+      });
+
+      it('should handle an unknown file', () => {
+        let ft = registry.getFileTypeForModel({
+          path: 'foo.bar'
+        });
+        expect(ft.name).to.be('text');
       });
 
     });

--- a/test/src/docregistry/registry.spec.ts
+++ b/test/src/docregistry/registry.spec.ts
@@ -20,7 +20,7 @@ import {
 } from '@phosphor/widgets';
 
 import {
-  ABCWidgetFactory, Base64ModelFactory, DocumentRegistry, TextModelFactory
+  ABCWidgetFactory, Base64ModelFactory, DocumentRegistry
 } from '@jupyterlab/docregistry';
 
 
@@ -66,15 +66,10 @@ describe('docregistry/registry', () => {
     let registry: DocumentRegistry;
 
     beforeEach(() => {
-      registry = new DocumentRegistry({
-        textModelFactory: new TextModelFactory()
-      });
+      registry = new DocumentRegistry();
       registry.addFileType({
         name: 'foobar',
         extensions: ['.foo.bar']
-      });
-      DocumentRegistry.defaultFileTypes.forEach(ft => {
-        registry.addFileType(ft);
       });
     });
 
@@ -215,14 +210,14 @@ describe('docregistry/registry', () => {
     describe('#addFileType()', () => {
 
       it('should add a file type to the document registry', () => {
-        registry = new DocumentRegistry();
+        registry = new DocumentRegistry({ initialFileTypes: [] });
         let fileType = { name: 'notebook', extensions: ['.ipynb'] };
         registry.addFileType(fileType);
         expect(registry.fileTypes().next().name).to.be(fileType.name);
       });
 
       it('should be removed from the registry when disposed', () => {
-        registry = new DocumentRegistry();
+        registry = new DocumentRegistry({ initialFileTypes: [] });
         let fileType = { name: 'notebook', extensions: ['.ipynb'] };
         let disposable = registry.addFileType(fileType);
         disposable.dispose();
@@ -230,7 +225,7 @@ describe('docregistry/registry', () => {
       });
 
       it('should be a no-op if a file type of the same name is registered', () => {
-        registry = new DocumentRegistry();
+        registry = new DocumentRegistry({ initialFileTypes: [] });
         let fileType = { name: 'notebook', extensions: ['.ipynb'] };
         registry.addFileType(fileType);
         let disposable = registry.addFileType(fileType);
@@ -398,7 +393,7 @@ describe('docregistry/registry', () => {
     describe('#fileTypes()', () => {
 
       it('should get the registered file types', () => {
-        registry = new DocumentRegistry();
+        registry = new DocumentRegistry({ initialFileTypes: [] });
         expect(toArray(registry.fileTypes()).length).to.be(0);
         let fileTypes = [
           { name: 'notebook', extensions: ['.ipynb'] },

--- a/test/src/filebrowser/crumbs.spec.ts
+++ b/test/src/filebrowser/crumbs.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@jupyterlab/docmanager';
 
 import {
-  DocumentRegistry
+  DocumentRegistry, TextModelFactory
 } from '@jupyterlab/docregistry';
 
 import {
@@ -79,7 +79,9 @@ describe('filebrowser/model', () => {
       open: widget => { /* no op */ }
     };
 
-    registry = new DocumentRegistry();
+    registry = new DocumentRegistry({
+      textModelFactory: new TextModelFactory()
+    });
     serviceManager = new ServiceManager();
     manager = new DocumentManager({
       registry, opener,

--- a/test/src/filebrowser/model.spec.ts
+++ b/test/src/filebrowser/model.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '@jupyterlab/docmanager';
 
 import {
-  DocumentRegistry
+  DocumentRegistry, TextModelFactory
 } from '@jupyterlab/docregistry';
 
 import {
@@ -38,7 +38,9 @@ describe('filebrowser/model', () => {
       open: widget => { /* no op */ }
     };
 
-    registry = new DocumentRegistry();
+    registry = new DocumentRegistry({
+      textModelFactory: new TextModelFactory()
+    });
     serviceManager = new ServiceManager();
     manager = new DocumentManager({
       registry, opener,

--- a/test/src/fileeditor/widget.spec.ts
+++ b/test/src/fileeditor/widget.spec.ts
@@ -127,7 +127,7 @@ describe('fileeditor', () => {
       },
       factoryOptions: {
         name: 'editor',
-        fileExtensions: ['*'],
+        fileTypes: ['*'],
         defaultFor: ['*']
       }
     });

--- a/test/src/imageviewer/widget.spec.ts
+++ b/test/src/imageviewer/widget.spec.ts
@@ -198,8 +198,8 @@ describe('ImageViewerFactory', () => {
       let factory = new ImageViewerFactory({
         name: 'Image',
         modelName: 'base64',
-        fileExtensions: ['.png'],
-        defaultFor: ['.png']
+        fileTypes: ['png'],
+        defaultFor: ['png']
       });
       let context = createFileContext(IMAGE.path);
       expect(factory.createNew(context)).to.be.an(ImageViewer);

--- a/test/src/notebook/widgetfactory.spec.ts
+++ b/test/src/notebook/widgetfactory.spec.ts
@@ -38,7 +38,7 @@ const contentFactory = createNotebookPanelFactory();
 function createFactory(): NotebookWidgetFactory {
   return new NotebookWidgetFactory({
     name: 'notebook',
-    fileExtensions: ['.ipynb'],
+    fileTypes: ['notebook'],
     rendermime,
     contentFactory,
     mimeTypeService


### PR DESCRIPTION
Fixes #2594.  

Adds better utilization of `IFileType` across the application.

- Used by widget factories instead of raw file extensions
- Used by mime  extensions to establish new file types
- Used by the file listing to choose a file icon
- Adds support for `pattern` in `IFileType` for matching file names 

Also cleans up the handling of the default `text` model factory for the registry.

<image src="https://user-images.githubusercontent.com/2096628/28334483-ebaa08f6-6bc0-11e7-8bf1-18a52d35ecb6.png" width=300>


<image src="https://user-images.githubusercontent.com/2096628/28384210-77d4f61a-6c89-11e7-863b-da3919d80d49.png" width=500>

