### PR TITLE
Improved support for equation labeling

### DIFF
--- a/packages/rendermime/src/latex.ts
+++ b/packages/rendermime/src/latex.ts
@@ -189,7 +189,6 @@ function init() {
       processEscapes: true,
       processEnvironments: true
     },
-    TeX: { equationNumbers: { autoNumber: 'AMS' } },
     // Center justify equations in code and markdown cells. Elsewhere
     // we use CSS to left justify single line equations in code cells.
     displayAlign: 'center',

--- a/packages/rendermime/src/latex.ts
+++ b/packages/rendermime/src/latex.ts
@@ -167,7 +167,10 @@ function typeset(node: HTMLElement): void {
     initialized = true;
   }
   if ((window as any).MathJax) {
-    MathJax.Hub.Queue(['Typeset', MathJax.Hub, node]);
+    MathJax.Hub.Queue(
+      ['Typeset', MathJax.Hub, node,
+      ['resetEquationNumbers', MathJax.InputJax.TeX]]
+    );
   }
 }
 
@@ -186,6 +189,7 @@ function init() {
       processEscapes: true,
       processEnvironments: true
     },
+    TeX: { equationNumbers: { autoNumber: 'AMS' } },
     // Center justify equations in code and markdown cells. Elsewhere
     // we use CSS to left justify single line equations in code cells.
     displayAlign: 'center',


### PR DESCRIPTION
cf https://github.com/jupyter/notebook/pull/2677.  The screenshot below is three markdown cells with the same content.

Before:

<image src="https://user-images.githubusercontent.com/2096628/28532052-3db97568-705e-11e7-9cf6-ac1354be9b09.png" width=400>


After:
<image src="https://user-images.githubusercontent.com/2096628/28530993-0e3e92bc-705b-11e7-847e-d1e20845606a.png" width=500>
