### PR TITLE
Build system cleanup

### DIFF
--- a/docs/extensions_dev.md
+++ b/docs/extensions_dev.md
@@ -84,13 +84,8 @@ jupyter labextension link <path>
 This causes the builder to re-install the source folder before building
 the application files.  You can re-build at any time using `jupyter lab build` and it will reinstall these packages.  You can also link other npm packages
 that you are working on simultaneously; they will be re-installed but not
-considered as extensions if they lack the metadata.
-
-You can see the list of linked extensions using:
-
-```
-jupyter labextension listlinked
-```
+considered as extensions if they lack the metadata.  Linked extensions and 
+packages are included in `jupyter labextension list`.
 
 You can also use `jupyter labextension install <path>`, but that will
 only copy the current contents of the source folder.

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -530,7 +530,7 @@ def _install_linked_package(staging, name, path, logger):
     if os.path.exists(target):
         shutil.rmtree(target)
 
-    linked = pjoin(staging, 'linked_pacakges')
+    linked = pjoin(staging, 'linked_packages')
 
     target = pjoin(linked, 'temp')
     if os.path.exists(target):
@@ -560,7 +560,7 @@ def _install_linked_package(staging, name, path, logger):
         os.remove(ext_path)
 
     # Move
-    shutil.move(pjoin(target, fname), pjoin(staging, 'linked_pakages'))
+    shutil.move(pjoin(target, fname), linked)
     shutil.rmtree(target)
 
     # Set the dependency in the package.

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -147,6 +147,8 @@ def install_extension(extension, app_dir=None, logger=None):
         with open(path, 'w') as fid:
             fid.write(value)
 
+    return fname
+
 
 def link_package(path, app_dir=None, logger=None):
     """Link a package against the JupyterLab build.
@@ -175,11 +177,12 @@ def link_package(path, app_dir=None, logger=None):
 
     is_extension = _is_extension(data)
     if is_extension:
-        install_extension(path, app_dir)
+        fname = install_extension(path, app_dir)
     else:
         msg = ('*** Note: Linking non-extension package "%s" (lacks ' +
                '`jupyterlab.extension` metadata)')
         logger.info(msg % data['name'])
+        fname = path
 
     core_data = _get_core_data()
     deps = data.get('dependencies', dict())
@@ -193,6 +196,8 @@ def link_package(path, app_dir=None, logger=None):
     config.setdefault('linked_packages', dict())
     config['linked_packages'][data['name']] = path
     _write_build_config(config, app_dir, logger=logger)
+
+    return fname
 
 
 def unlink_package(package, app_dir=None, logger=None):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -53,10 +53,17 @@ class InstallLabExtensionApp(BaseExtensionApp):
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        [install_extension(arg, self.app_dir, logger=self.log)
-         for arg in self.extra_args]
+        paths = [
+            install_extension(arg, self.app_dir, logger=self.log)
+            for arg in self.extra_args
+        ]
         if self.should_build:
-            build(self.app_dir, logger=self.log)
+            try:
+                build(self.app_dir, logger=self.log)
+            except Exception as e:
+                for path in paths:
+                    os.remove(path)
+                raise e
 
 
 class LinkLabExtensionApp(BaseExtensionApp):
@@ -73,10 +80,17 @@ class LinkLabExtensionApp(BaseExtensionApp):
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        [link_package(arg, self.app_dir, logger=self.log)
-         for arg in self.extra_args]
+        paths = [
+            link_package(arg, self.app_dir, logger=self.log)
+            for arg in self.extra_args
+        ]
         if self.should_build:
-            build(self.app_dir, logger=self.log)
+            try:
+                build(self.app_dir, logger=self.log)
+            except Exception as e:
+                for path in paths:
+                    os.remove(path)
+                raise e
 
 
 class UnlinkLabExtensionApp(BaseExtensionApp):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -53,16 +53,14 @@ class InstallLabExtensionApp(BaseExtensionApp):
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        paths = [
-            install_extension(arg, self.app_dir, logger=self.log)
-            for arg in self.extra_args
-        ]
+        [install_extension(arg, self.app_dir, logger=self.log)
+         for arg in self.extra_args]
         if self.should_build:
             try:
                 build(self.app_dir, logger=self.log)
             except Exception as e:
-                for path in paths:
-                    os.remove(path)
+                for arg in self.extra_args:
+                    uninstall_extension(arg, self.app_dir, logger=self.log)
                 raise e
 
 
@@ -80,16 +78,14 @@ class LinkLabExtensionApp(BaseExtensionApp):
 
     def start(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        paths = [
-            link_package(arg, self.app_dir, logger=self.log)
-            for arg in self.extra_args
-        ]
+        [link_package(arg, self.app_dir, logger=self.log)
+         for arg in self.extra_args]
         if self.should_build:
             try:
                 build(self.app_dir, logger=self.log)
             except Exception as e:
-                for path in paths:
-                    os.remove(path)
+                for arg in self.extra_args:
+                    unlink_package(arg, self.app_dir, logger=self.log)
                 raise e
 
 
@@ -124,15 +120,6 @@ class ListLabExtensionsApp(BaseExtensionApp):
 
     def start(self):
         list_extensions(self.app_dir, logger=self.log)
-
-
-class ListLinkedLabExtensionsApp(BaseExtensionApp):
-    description = "List the linked packages"
-
-    def start(self):
-        linked = _get_linked_packages(self.app_dir, logger=self.log)
-        for path in linked.values():
-            print(path)
 
 
 class EnableLabExtensionsApp(BaseExtensionApp):
@@ -171,7 +158,6 @@ class LabExtensionApp(JupyterApp):
         list=(ListLabExtensionsApp, "List labextensions"),
         link=(LinkLabExtensionApp, "Link labextension(s)"),
         unlink=(UnlinkLabExtensionApp, "Unlink labextension(s)"),
-        listlinked=(ListLinkedLabExtensionsApp, "List linked extensions"),
         enable=(EnableLabExtensionsApp, "Enable labextension(s)"),
         disable=(DisableLabExtensionsApp, "Disable labextensions(s)")
     )

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -79,7 +79,6 @@ if [[ $GROUP == cli ]]; then
     jupyter labextension link jupyterlab/tests/mockextension --no-build
     jupyter labextension unlink jupyterlab/tests/mockextension --no-build
     jupyter labextension link jupyterlab/tests/mockextension --no-build
-    jupyter labextension listlinked
     jupyter labextension unlink  @jupyterlab/python-tests --no-build
     jupyter labextension install jupyterlab/tests/mockextension  --no-build
     jupyter labextension list
@@ -99,7 +98,6 @@ if [[ $GROUP == cli ]]; then
     jupyter labextension install -h 
     jupyter labextension uninstall -h 
     jupyter labextension list -h
-    jupyter labextension listlinked -h
     jupyter labextension enable -h
     jupyter labextension disable -h
 fi


### PR DESCRIPTION
Fixes #2711. Fixes #2713.
Fixes https://github.com/jupyterlab/jupyterlab-fasta/issues/5

- Removes any installed/linked packages if an associated build attempt fails
- Enforces the use of tarballs for linked packages instead of symlinks for `npm@5` compatibility
- Adds the package version to `labextensions list`
- Adds linked extension and package info to `labextensions list` and removes `listlinked` command
- Fixes the handling of the npm executable on Windows.


```bash
$ jupyter labextension list
JupyterLab v0.25.2
Known labextensions:
   app dir: /Users/ssilvester/anaconda/share/jupyter/lab
        jupyterlab_myextension@0.1.0  enabled  OK
   linked extensions:
        jupyterlab_myextension: /Users/ssilvester/workspace/test/jupyterlab_myextension
   linked packages:
        @jupyterlab/python-tests: /Users/ssilvester/workspace/jupyter/lab/jupyterlab/tests/mockextension
```