### PR TITLE
Update notebook version req

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ You can also use the installer from the [Node.js](https://nodejs.org) website.
 
 ## Installing JupyterLab
 
-JupyterLab requires Jupyter Notebook version 4.2 or later.
+JupyterLab requires Jupyter Notebook version 4.3 or later.
 
 If you use ``conda``, you can install it as:
 
@@ -148,7 +148,7 @@ build tool.  The npm package source files are in the `packages/` subdirectory.
 **Prerequisites**
 
 - [node](http://nodejs.org/) (preferably version 5 or later)
-- Jupyter notebook server version 4.2 or later (to run examples)
+- Jupyter notebook server version 4.3 or later (to run examples)
 
 ```bash
 npm install --save jupyterlab
@@ -174,7 +174,7 @@ npm run build:packages
 
 The Jupyter server extension source files are in the `jupyterlab/`
 subdirectory. To use this extension, make sure the Jupyter notebook server
-version 4.2 or later is installed.
+version 4.3 or later is installed.
 
 ### Build the JupyterLab server extension
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We have a [roadmap](https://github.com/jupyter/roadmap/blob/master/jupyterlab.md
 
 ## Prerequisites
 
-Jupyter notebook version 4.2 or later. To check the notebook version:
+Jupyter notebook version 4.3 or later. To check the notebook version:
 
 ```bash
 jupyter notebook --version


### PR DESCRIPTION
I think the notebook version requirement is now 4.3 instead of 4.2? I just wanted to update the docs.