### PR TITLE
Force Travis to use Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '5'
+dist: precise
 sudo: false
 addons:
   firefox: latest


### PR DESCRIPTION
It seems that the move to Trusty is breaking our builds, reverting to Precise for now.