### PR TITLE
Enhance settings UI.

### DIFF
--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -320,7 +320,7 @@ class JSONEditor extends Widget {
    */
   private _mergeContent(): void {
     let model = this.editor.model;
-    let current = this._getContent();
+    let current = this._source ? this._source.toJSON() : { };
     let old = this._originalValue;
     let user = JSON.parse(model.value.text) as JSONObject;
     let source = this.source;
@@ -348,21 +348,6 @@ class JSONEditor extends Widget {
   }
 
   /**
-   * Get the metadata from the owner.
-   */
-  private _getContent(): JSONObject {
-    let source = this._source;
-    if (!source) {
-      return {};
-    }
-    let content: JSONObject = {};
-    for (let key of source.keys()) {
-      content[key] = source.get(key) || null;
-    }
-    return content;
-  }
-
-  /**
    * Set the value given the owner contents.
    */
   private _setValue(): void {
@@ -372,7 +357,7 @@ class JSONEditor extends Widget {
     this.commitButtonNode.hidden = true;
     this.removeClass(ERROR_CLASS);
     let model = this.editor.model;
-    let content = this._getContent();
+    let content = this._source ? this._source.toJSON() : { };
     this._changeGuard = true;
     if (content === void 0) {
       model.value.text = 'No data!';

--- a/packages/coreutils/src/observablejson.ts
+++ b/packages/coreutils/src/observablejson.ts
@@ -65,7 +65,7 @@ class ObservableJSON extends ObservableMap<JSONValue> {
       const value = this.get(key);
 
       if (value !== undefined) {
-        out[key] = JSONExt.isPrimitive(value) ? value : JSONExt.deepCopy(value);
+        out[key] = JSONExt.deepCopy(value);
       }
     }
     return out;

--- a/packages/coreutils/src/observablejson.ts
+++ b/packages/coreutils/src/observablejson.ts
@@ -58,16 +58,14 @@ class ObservableJSON extends ObservableMap<JSONValue> {
    * Serialize the model to JSON.
    */
   toJSON(): JSONObject {
-    let out: JSONObject = Object.create(null);
-    for (let key of this.keys()) {
-      let value = this.get(key);
-      if (!value) {
-        continue;
-      }
-      if (JSONExt.isPrimitive(value)) {
-        out[key] = value;
-      } else {
-        out[key] = JSON.parse(JSON.stringify(value));
+    const out: JSONObject = Object.create(null);
+    const keys = this.keys();
+
+    for (let key of keys) {
+      const value = this.get(key);
+
+      if (value !== undefined) {
+        out[key] = JSONExt.isPrimitive(value) ? value : JSONExt.deepCopy(value);
       }
     }
     return out;

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -904,7 +904,7 @@ namespace Private {
     // If the root level is not an object or is not further defined downward
     // return its default value, which may be `undefined`.
     if (schema.type !== 'object' || !schema.properties) {
-      return schema.default;
+      return schema.default && JSONExt.deepCopy(schema.default);
     }
 
     // If the property is at the root level, traverse its schema.
@@ -913,11 +913,11 @@ namespace Private {
     // If the property is not an object or is not further defined downward
     // return its default value, which may be `undefined`.
     if (schema.type !== 'object' || !schema.properties || !schema.default) {
-      return schema.default;
+      return schema.default && JSONExt.deepCopy(schema.default);
     }
 
     const properties = schema.properties;
-    const result: JSONObject = schema.default;
+    const result: JSONObject = JSONExt.deepCopy(schema.default);
 
     // Iterate through the schema's properties and populate the default values
     // for each property definition.

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -902,7 +902,7 @@ namespace Private {
   export
   function reifyDefault(schema: ISettingRegistry.ISchema, root?: string): JSONValue | undefined {
     // If the property is at the root level, traverse its schema.
-    schema = root ? schema.properties[root] : schema;
+    schema = (root ? schema.properties[root] : schema) || { };
 
     // If the property has no default or is a primitive, return.
     if (!('default' in schema) || schema.type !== 'object') {

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -260,7 +260,7 @@ namespace ISettingRegistry {
      *
      * @returns A calculated default JSON value for a specific setting.
      */
-    default(key: string): JSONValue;
+    default(key: string): JSONValue | undefined;
 
     /**
      * Get an individual setting.
@@ -721,7 +721,7 @@ class Settings implements ISettingRegistry.ISettings {
    *
    * @returns A calculated default JSON value for a specific setting.
    */
-  default(key: string): JSONValue {
+  default(key: string): JSONValue | undefined {
     return Private.reifyDefault(this.schema, key);
   }
 

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -907,28 +907,27 @@ namespace Private {
       return schema.default;
     }
 
-    const property = root ? schema.properties[root] : schema;
+    // If the property is at the root level, traverse its schema.
+    schema = root ? schema.properties[root] : schema;
 
     // If the property is not an object or is not further defined downward
     // return its default value, which may be `undefined`.
-    if (property.type !== 'object' || !property.properties) {
-      return property.default;
+    if (schema.type !== 'object' || !schema.properties || !schema.default) {
+      return schema.default;
     }
 
-    const properties = property.properties;
-    const result: JSONObject = property.default || { };
+    const properties = schema.properties;
+    const result: JSONObject = schema.default;
 
-    // Iterate through the schema and populate the default values for each
-    // property that is defined in the schema.
-    for (let prop in properties) {
-      if ('default' in properties[prop]) {
-        const reified = reifyDefault(properties[prop]);
+    // Iterate through the schema's properties and populate the default values
+    // for each property definition.
+    for (let property in properties) {
+      if ('default' in properties[property]) {
+        const reified = reifyDefault(properties[property]);
 
-        if (reified === undefined) {
-          continue;
+        if (reified !== undefined) {
+          result[property] = reified;
         }
-
-        result[prop] = reified;
       }
     }
 

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -16,7 +16,7 @@
     "@jupyterlab/application": "^0.9.0",
     "@jupyterlab/apputils": "^0.9.0",
     "@jupyterlab/codeeditor": "^0.9.0",
-    "@phosphor/coreutils": "^1.2.0",
+    "@jupyterlab/coreutils": "^0.9.0",
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/signaling": "^1.2.1",
     "@phosphor/virtualdom": "^1.1.1",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -17,6 +17,7 @@
     "@jupyterlab/apputils": "^0.9.0",
     "@jupyterlab/codeeditor": "^0.9.0",
     "@jupyterlab/coreutils": "^0.9.0",
+    "@phosphor/datagrid": "^0.1.1",
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/signaling": "^1.2.1",
     "@phosphor/virtualdom": "^1.1.1",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -16,7 +16,6 @@
     "@jupyterlab/application": "^0.9.0",
     "@jupyterlab/apputils": "^0.9.0",
     "@jupyterlab/codeeditor": "^0.9.0",
-    "@jupyterlab/coreutils": "^0.9.0",
     "@phosphor/coreutils": "^1.2.0",
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/signaling": "^1.2.1",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -17,6 +17,7 @@
     "@jupyterlab/apputils": "^0.9.0",
     "@jupyterlab/codeeditor": "^0.9.0",
     "@jupyterlab/coreutils": "^0.9.0",
+    "@phosphor/coreutils": "^1.2.0",
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/signaling": "^1.2.1",
     "@phosphor/virtualdom": "^1.1.1",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -17,7 +17,6 @@
     "@jupyterlab/apputils": "^0.9.0",
     "@jupyterlab/codeeditor": "^0.9.0",
     "@jupyterlab/coreutils": "^0.9.0",
-    "@phosphor/datagrid": "^0.1.1",
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/signaling": "^1.2.1",
     "@phosphor/virtualdom": "^1.1.1",

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -61,8 +61,9 @@ const plugin: JupyterLabPlugin<void> = {
         }
 
         const key = plugin.id;
+        const when = app.restored;
         const editor = new SettingEditor({
-          editorFactory, key, registry, state
+          editorFactory, key, registry, state, when
         });
 
         tracker.add(editor);

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -58,6 +58,16 @@ const PLUGIN_LIST_CLASS = 'jp-PluginList';
 const PLUGIN_ICON_CLASS = 'jp-PluginList-icon';
 
 /**
+ * The class name added to the fieldset table.
+ */
+const FIELDSET_TABLE_CLASS = 'jp-PluginFieldset-table';
+
+/**
+ * The class name for the add icon used to add individual preferences.
+ */
+const FIELDSET_ADD_ICON_CLASS = 'jp-AddIcon';
+
+/**
  * The class name added to selected items.
  */
 const SELECTED_CLASS = 'jp-mod-selected';
@@ -800,7 +810,7 @@ class PluginFieldset extends Widget {
 
     // Populate if possible.
     if (settings) {
-      Private.populateFieldset(this.node, settings.plugin, settings.schema);
+      Private.populateFieldset(this.node, settings);
     }
   }
 
@@ -880,23 +890,27 @@ namespace Private {
    * Populate the fieldset with a specific plugin's metadata.
    */
   export
-  function populateFieldset(node: HTMLElement, id: string, schema: ISettingRegistry.ISchema): void {
+  function populateFieldset(node: HTMLElement, settings: ISettingRegistry.ISettings): void {
+    const { plugin, schema, user } = settings;
     const fields: { [key: string]: VirtualElement } = Object.create(null);
     const properties = schema.properties || { };
-    const title = `(${id}) ${schema.description}`;
-    const label = `Fields - ${schema.title || id}`;
-    const headers = h.tr(
-      h.th('Key'),
-      h.th('Type'),
-      h.th('Default'));
+    const title = `(${plugin}) ${schema.description}`;
+    const label = `Fields - ${schema.title || plugin}`;
+    const headers = h.div(
+      h.div(''),
+      h.div('Key'),
+      h.div('Type'),
+      h.div('Default'));
 
     Object.keys(properties).forEach(key => {
       const field = properties[key];
       const { title, type } = field;
-      fields[key] = h.tr(
-        h.td(h.code({ title }, key)),
-        h.td(h.code(type || '')),
-        h.td('default' in field ? h.code(JSON.stringify(field.default)) : ''));
+
+      fields[key] = h.div(
+        h.div({ className: key in user ? FIELDSET_ADD_ICON_CLASS : undefined }),
+        h.div(h.code({ title }, key)),
+        h.div(h.code(type)),
+        h.div('default' in field ? h.code(JSON.stringify(field.default)) : ''));
     });
 
     const rows: VirtualElement[] = Object.keys(fields)
@@ -904,7 +918,9 @@ namespace Private {
 
     node.appendChild(VirtualDOM.realize(h.legend({ title }, label)));
     if (rows.length) {
-      node.appendChild(VirtualDOM.realize(h.table(headers, rows)));
+      const table = h.div({ className: FIELDSET_TABLE_CLASS }, headers, rows);
+
+      node.appendChild(VirtualDOM.realize(table));
     }
   }
 

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -77,19 +77,9 @@ const PLUGIN_ICON_CLASS = 'jp-PluginList-icon';
 const FIELDSET_TABLE_CLASS = 'jp-PluginFieldset-table';
 
 /**
- * The class name added to the fieldset header.
+ * The class name added to the fieldset table default value cells.
  */
-const FIELDSET_HEADER_CLASS = 'jp-PluginFieldset-header';
-
-/**
- * The class name added to the fieldset table rows.
- */
-const FIELDSET_ROW_CLASS = 'jp-PluginFieldset-row';
-
-/**
- * The class name added to the fieldset table cells.
- */
-const FIELDSET_CELL_CLASS = 'jp-PluginFieldset-cell';
+const FIELDSET_VALUE_CLASS = 'jp-PluginFieldset-value';
 
 /**
  * The class name added to fieldset buttons.
@@ -943,22 +933,25 @@ namespace Private {
     const title = `(${plugin}) ${schema.description}`;
     const label = `Fields - ${schema.title || plugin}`;
     const addClass = `${FIELDSET_BUTTON_CLASS} ${FIELDSET_ADD_ICON_CLASS}`;
-    const mainCellClass = `${FIELDSET_CELL_CLASS} jp-mod-main`;
-    const headers = h.div({ className: FIELDSET_ROW_CLASS },
-      h.div({ className: FIELDSET_HEADER_CLASS }, ''),
-      h.div({ className: FIELDSET_HEADER_CLASS }, 'Key'),
-      h.div({ className: FIELDSET_HEADER_CLASS }, 'Type'));
+    const headers = h.tr(
+      h.th(''),
+      h.th('Key'),
+      h.th('Default'),
+      h.th('Type'));
 
     Object.keys(properties).forEach(key => {
       const field = properties[key];
       const { title, type } = field;
       const exists = key in user;
+      const value = JSON.stringify(reifyDefault(schema, key));
+      const valueClass = FIELDSET_VALUE_CLASS;
 
-      fields[key] = h.div({ className: FIELDSET_ROW_CLASS },
-        h.div({ className: FIELDSET_CELL_CLASS }, exists ?
-          h.div({ className: addClass }) : undefined),
-        h.div({ className: mainCellClass }, h.code({ title }, key)),
-        h.div({ className: FIELDSET_CELL_CLASS }, h.code(type)));
+
+      fields[key] = h.tr(
+        h.td(exists ? h.div({ className: addClass }) : undefined),
+        h.td(h.code({ title }, key)),
+        h.td({ className: valueClass }, h.code({ title: value }, value)),
+        h.td(h.code(type)));
     });
 
     const rows: VirtualElement[] = Object.keys(fields)
@@ -966,7 +959,7 @@ namespace Private {
 
     node.appendChild(VirtualDOM.realize(h.legend({ title }, label)));
     if (rows.length) {
-      const table = h.div({ className: FIELDSET_TABLE_CLASS }, headers, rows);
+      const table = h.table({ className: FIELDSET_TABLE_CLASS }, headers, rows);
 
       node.appendChild(VirtualDOM.realize(table));
     }

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -77,6 +77,11 @@ const PLUGIN_ICON_CLASS = 'jp-PluginList-icon';
 const FIELDSET_TABLE_CLASS = 'jp-PluginFieldset-table';
 
 /**
+ * The class name added to the fieldset table add button cells.
+ */
+const FIELDSET_ADD_CLASS = 'jp-PluginFieldset-add';
+
+/**
  * The class name added to the fieldset table key cells.
  */
 const FIELDSET_KEY_CLASS = 'jp-PluginFieldset-key';
@@ -85,6 +90,11 @@ const FIELDSET_KEY_CLASS = 'jp-PluginFieldset-key';
  * The class name added to the fieldset table default value cells.
  */
 const FIELDSET_VALUE_CLASS = 'jp-PluginFieldset-value';
+
+/**
+ * The class name added to the fieldset table type cells.
+ */
+const FIELDSET_TYPE_CLASS = 'jp-PluginFieldset-type';
 
 /**
  * The class name added to fieldset buttons.
@@ -939,10 +949,10 @@ namespace Private {
     const label = `Fields - ${schema.title || plugin}`;
     const addClass = `${FIELDSET_BUTTON_CLASS} ${FIELDSET_ADD_ICON_CLASS}`;
     const headers = h.tr(
-      h.th(''),
-      h.th('Key'),
-      h.th('Default'),
-      h.th('Type'));
+      h.th({ className: FIELDSET_ADD_CLASS }, ''),
+      h.th({ className: FIELDSET_KEY_CLASS }, 'Key'),
+      h.th({ className: FIELDSET_VALUE_CLASS }, 'Default'),
+      h.th({ className: FIELDSET_TYPE_CLASS }, 'Type'));
 
     Object.keys(properties).forEach(key => {
       const field = properties[key];
@@ -954,8 +964,8 @@ namespace Private {
 
       fields[key] = h.tr(
         h.td(exists ? undefined : h.div({ className: addClass })),
-        h.td({ className: FIELDSET_KEY_CLASS, title: field.title },
-          h.code({ title: field.title }, key)),
+        h.td({ className: FIELDSET_KEY_CLASS, title: field.title || key },
+          h.code({ title: field.title || key }, key)),
         h.td({ className: FIELDSET_VALUE_CLASS, title: valueTitle },
           h.code({ title: valueTitle }, value)),
         h.td(h.code(type)));

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -503,7 +503,7 @@ class PluginList extends Widget {
    *
    * #### Notes
    * This method implements the DOM `EventListener` interface and is
-   * called in response to events on the dock panel's node. It should
+   * called in response to events on the plugin list's node. It should
    * not be called directly by user code.
    */
   handleEvent(event: Event): void {
@@ -563,7 +563,7 @@ class PluginList extends Widget {
    *
    * @param event - The DOM event sent to the widget
    */
-  protected _evtClick(event: MouseEvent): void {
+  private _evtClick(event: MouseEvent): void {
     let target = event.target as HTMLElement;
     let id = target.getAttribute('data-id');
 
@@ -851,6 +851,40 @@ class PluginFieldset extends Widget {
   }
 
   /**
+   * Handle the DOM events for the plugin fieldset class.
+   *
+   * @param event - The DOM event sent to the class.
+   *
+   * #### Notes
+   * This method implements the DOM `EventListener` interface and is
+   * called in response to events on the fieldset's DOM node. It should
+   * not be called directly by user code.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+    case 'click':
+      this._evtClick(event as MouseEvent);
+      break;
+    default:
+      return;
+    }
+  }
+
+  /**
+   * Handle `'after-attach'` messages.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this.node.addEventListener('click', this);
+  }
+
+  /**
+   * Handle `before-detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    this.node.removeEventListener('click', this);
+  }
+
+  /**
    * Handle `'update-request'` messages.
    */
   protected onUpdateRequest(msg: Message): void {
@@ -863,6 +897,16 @@ class PluginFieldset extends Widget {
     if (settings) {
       Private.populateFieldset(this.node, settings);
     }
+  }
+
+  /**
+   * Handle the `'click'` event for the plugin fieldset.
+   *
+   * @param event - The DOM event sent to the widget
+   */
+  private _evtClick(event: MouseEvent): void {
+    let target = event.target as HTMLElement;
+    console.log('clicked', target);
   }
 
   private _settings: ISettingRegistry.ISettings | null = null;
@@ -944,7 +988,7 @@ namespace Private {
   export
   function populateFieldset(node: HTMLElement, settings: ISettingRegistry.ISettings): void {
     const { plugin, schema, user } = settings;
-    const fields: { [key: string]: VirtualElement } = Object.create(null);
+    const fields: { [property: string]: VirtualElement } = Object.create(null);
     const properties = schema.properties || { };
     const title = `(${plugin}) ${schema.description}`;
     const label = `Fields - ${schema.title || plugin}`;

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -16,10 +16,6 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  JSONObject, JSONValue
-} from '@phosphor/coreutils';
-
-import {
   Message
 } from '@phosphor/messaging';
 
@@ -958,9 +954,9 @@ namespace Private {
       const field = properties[key];
       const { type } = field;
       const exists = key in user;
-      const reified = reifyDefault(schema, key);
-      const value = JSON.stringify(reified) || '';
-      const valueTitle = JSON.stringify(reified, null, 4);
+      const defaultValue = settings.default(key);
+      const value = JSON.stringify(defaultValue) || '';
+      const valueTitle = JSON.stringify(defaultValue, null, 4);
 
       fields[key] = h.tr(
         h.td({ className: FIELDSET_ADD_CLASS },
@@ -981,44 +977,6 @@ namespace Private {
 
       node.appendChild(VirtualDOM.realize(table));
     }
-  }
-
-  /**
-   * Create a fully extrapolated default value for a root key in a schema.
-   */
-  function reifyDefault(schema: ISettingRegistry.ISchema, root?: string): JSONValue | undefined {
-    // If the root level is not an object or is not further defined downward
-    // return its default value, which may be `undefined`.
-    if (schema.type !== 'object' || !schema.properties) {
-      return schema.default;
-    }
-
-    const property = root ? schema.properties[root] : schema;
-
-    // If the property is not an object or is not further defined downward
-    // return its default value, which may be `undefined`.
-    if (property.type !== 'object' || !property.properties) {
-      return property.default;
-    }
-
-    const properties = property.properties;
-    const result: JSONObject = property.default || { };
-
-    // Iterate through the schema and populate the default values for each
-    // property that is defined in the schema.
-    for (let prop in properties) {
-      if ('default' in properties[prop]) {
-        const reified = reifyDefault(properties[prop]);
-
-        if (reified === undefined) {
-          continue;
-        }
-
-        result[prop] = reified;
-      }
-    }
-
-    return result;
   }
 
   /**

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -33,6 +33,16 @@ import {
 
 
 /**
+ * The ratio panes in the plugin editor.
+ */
+const DEFAULT_INNER = [5, 2];
+
+/**
+ * The ratio panes in the setting editor.
+ */
+const DEFAULT_OUTER = [1, 3];
+
+/**
  * The class name added to all setting editors.
  */
 const SETTING_EDITOR_CLASS = 'jp-SettingEditor';
@@ -216,7 +226,6 @@ class SettingEditor extends Widget {
 
     const { key, state } = this;
     const editor = this._editor;
-    const panel = this._panel;
 
     return this._fetching = state.fetch(key).then(saved => {
       this._fetching = null;
@@ -225,8 +234,8 @@ class SettingEditor extends Widget {
         return;
       }
 
-      const inner = editor.sizes;
-      const outer = panel.relativeSizes();
+      const inner = DEFAULT_INNER;
+      const outer = DEFAULT_OUTER;
       const plugin = editor.settings ? editor.settings.plugin : '';
 
       if (!saved) {
@@ -346,7 +355,7 @@ class SettingEditor extends Widget {
   private _instructions: Widget;
   private _list: PluginList;
   private _panel: SplitPanel;
-  private _presets = { inner: [5, 2], outer: [1, 3], plugin: '' };
+  private _presets = { inner: DEFAULT_INNER, outer: DEFAULT_OUTER, plugin: '' };
   private _saving = false;
 }
 

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -844,6 +844,7 @@ class PluginFieldset extends Widget {
  */
 namespace Private {
   /**
+   * Create the instructions text node.
    */
   export
   function createInstructionsNode(): HTMLElement {

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -103,6 +103,11 @@ const FIELDSET_BUTTON_CLASS = 'jp-PluginFieldset-button';
 const FIELDSET_ADD_ICON_CLASS = 'jp-AddIcon';
 
 /**
+ * The class name added to active items.
+ */
+const ACTIVE_CLASS = 'jp-mod-active';
+
+/**
  * The class name added to selected items.
  */
 const SELECTED_CLASS = 'jp-mod-selected';
@@ -943,40 +948,41 @@ namespace Private {
     const properties = schema.properties || { };
     const title = `(${plugin}) ${schema.description}`;
     const label = `Fields - ${schema.title || plugin}`;
-    const addClass = `${FIELDSET_BUTTON_CLASS} ${FIELDSET_ADD_ICON_CLASS}`;
     const headers = h.tr(
       h.th({ className: FIELDSET_ADD_CLASS }, ''),
       h.th({ className: FIELDSET_KEY_CLASS }, 'Key'),
       h.th({ className: FIELDSET_VALUE_CLASS }, 'Default'),
       h.th({ className: FIELDSET_TYPE_CLASS }, 'Type'));
 
-    Object.keys(properties).forEach(key => {
-      const field = properties[key];
+    Object.keys(properties).forEach(property => {
+      const field = properties[property];
       const { type } = field;
-      const exists = key in user;
-      const defaultValue = settings.default(key);
+      const exists = property in user;
+      const defaultValue = settings.default(property);
       const value = JSON.stringify(defaultValue) || '';
       const valueTitle = JSON.stringify(defaultValue, null, 4);
+      const addClass = exists ? FIELDSET_ADD_CLASS
+        : `${FIELDSET_ADD_CLASS} ${ACTIVE_CLASS}`;
+      const addButton = h.div({
+        className: `${FIELDSET_BUTTON_CLASS} ${FIELDSET_ADD_ICON_CLASS}`
+      });
 
-      fields[key] = h.tr(
-        h.td({ className: FIELDSET_ADD_CLASS },
-          exists ? undefined : h.div({ className: addClass })),
-        h.td({ className: FIELDSET_KEY_CLASS, title: field.title || key },
-          h.code({ title: field.title || key }, key)),
+      fields[property] = h.tr(
+        h.td({ className: addClass }, exists ? undefined : addButton),
+        h.td({ className: FIELDSET_KEY_CLASS, title: field.title || property },
+          h.code({ title: field.title || property }, property)),
         h.td({ className: FIELDSET_VALUE_CLASS, title: valueTitle },
           h.code({ title: valueTitle }, value)),
         h.td({ className: FIELDSET_TYPE_CLASS }, type));
     });
 
     const rows: VirtualElement[] = Object.keys(fields)
-      .sort((a, b) => a.localeCompare(b)).map(key => fields[key]);
+      .sort((a, b) => a.localeCompare(b)).map(property => fields[property]);
 
     node.appendChild(VirtualDOM.realize(h.legend({ title }, label)));
-    if (rows.length) {
-      const table = h.table({ className: FIELDSET_TABLE_CLASS }, headers, rows);
-
-      node.appendChild(VirtualDOM.realize(table));
-    }
+    node.appendChild(VirtualDOM.realize(h.table({
+      className: FIELDSET_TABLE_CLASS
+    }, headers, rows.length ? rows : undefined)));
   }
 
   /**

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -907,9 +907,12 @@ class PluginFieldset extends Widget {
     let target = event.target as HTMLElement;
 
     while (target && target.parentElement !== root) {
-      if (target.hasAttribute(attribute)) {
+      const active = target.classList.contains(ACTIVE_CLASS);
+
+      if (active && target.hasAttribute(attribute)) {
         event.preventDefault();
         this._onPropertyAdded(target.getAttribute(attribute));
+        target.classList.remove(ACTIVE_CLASS);
         return;
       }
       target = target.parentElement;

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -142,6 +142,11 @@ class SettingEditor extends Widget {
     const editor = this._editor = new PluginEditor({ editorFactory });
     const confirm = () => editor.confirm();
     const list = this._list = new PluginList({ confirm, registry });
+    const when = options.when;
+
+    if (when) {
+      this._when = Array.isArray(when) ? Promise.all(when) : when;
+    }
 
     layout.addWidget(panel);
     panel.addWidget(list);
@@ -226,8 +231,9 @@ class SettingEditor extends Widget {
 
     const { key, state } = this;
     const editor = this._editor;
+    const promises = [state.fetch(key), this._when];
 
-    return this._fetching = state.fetch(key).then(saved => {
+    return this._fetching = Promise.all(promises).then(([saved]) => {
       this._fetching = null;
 
       if (this._saving) {
@@ -357,6 +363,7 @@ class SettingEditor extends Widget {
   private _panel: SplitPanel;
   private _presets = { inner: DEFAULT_INNER, outer: DEFAULT_OUTER, plugin: '' };
   private _saving = false;
+  private _when: Promise<any>;
 }
 
 
@@ -389,6 +396,11 @@ namespace SettingEditor {
      * The state database used to store layout.
      */
     state: IStateDB;
+
+    /**
+     * The point after which the editor should restore its state.
+     */
+    when?: Promise<any> | Array<Promise<any>>;
   }
 }
 

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -73,6 +73,26 @@ const PLUGIN_ICON_CLASS = 'jp-PluginList-icon';
 const FIELDSET_TABLE_CLASS = 'jp-PluginFieldset-table';
 
 /**
+ * The class name added to the fieldset header.
+ */
+const FIELDSET_HEADER_CLASS = 'jp-PluginFieldset-header';
+
+/**
+ * The class name added to the fieldset table rows.
+ */
+const FIELDSET_ROW_CLASS = 'jp-PluginFieldset-row';
+
+/**
+ * The class name added to the fieldset table cells.
+ */
+const FIELDSET_CELL_CLASS = 'jp-PluginFieldset-cell';
+
+/**
+ * The class name added to fieldset buttons.
+ */
+const FIELDSET_BUTTON_CLASS = 'jp-PluginFieldset-button';
+
+/**
  * The class name for the add icon used to add individual preferences.
  */
 const FIELDSET_ADD_ICON_CLASS = 'jp-AddIcon';
@@ -918,21 +938,23 @@ namespace Private {
     const properties = schema.properties || { };
     const title = `(${plugin}) ${schema.description}`;
     const label = `Fields - ${schema.title || plugin}`;
-    const headers = h.div(
-      h.div(''),
-      h.div('Key'),
-      h.div('Type'),
-      h.div('Default'));
+    const addClass = `${FIELDSET_BUTTON_CLASS} ${FIELDSET_ADD_ICON_CLASS}`;
+    const mainCellClass = `${FIELDSET_CELL_CLASS} jp-mod-main`;
+    const headers = h.div({ className: FIELDSET_ROW_CLASS },
+      h.div({ className: FIELDSET_HEADER_CLASS }, ''),
+      h.div({ className: FIELDSET_HEADER_CLASS }, 'Key'),
+      h.div({ className: FIELDSET_HEADER_CLASS }, 'Type'));
 
     Object.keys(properties).forEach(key => {
       const field = properties[key];
       const { title, type } = field;
+      const exists = key in user;
 
-      fields[key] = h.div(
-        h.div({ className: key in user ? FIELDSET_ADD_ICON_CLASS : undefined }),
-        h.div(h.code({ title }, key)),
-        h.div(h.code(type)),
-        h.div('default' in field ? h.code(JSON.stringify(field.default)) : ''));
+      fields[key] = h.div({ className: FIELDSET_ROW_CLASS },
+        h.div({ className: FIELDSET_CELL_CLASS }, exists ?
+          h.div({ className: addClass }) : undefined),
+        h.div({ className: mainCellClass }, h.code({ title }, key)),
+        h.div({ className: FIELDSET_CELL_CLASS }, h.code(type)));
     });
 
     const rows: VirtualElement[] = Object.keys(fields)

--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -179,11 +179,7 @@ class SettingEditor extends Widget {
     // Allow the message queue (which includes fit requests that might disrupt
     // setting relative sizes) to clear before setting sizes.
     requestAnimationFrame(() => {
-      // Set the original (default) outer dimensions.
-      this._panel.setRelativeSizes(this._presets.outer);
-      this._fetchState().then(() => {
-        this._setPresets();
-      }).catch(reason => {
+      this._fetchState().then(() => { this._setPresets(); }).catch(reason => {
         console.error('Fetching setting editor state failed', reason);
         this._setPresets();
       });
@@ -289,18 +285,17 @@ class SettingEditor extends Widget {
     const editor = this._editor;
     const list = this._list;
     const panel = this._panel;
-    const { inner, outer, plugin } = this._presets;
-
-    panel.setRelativeSizes(outer);
-    editor.sizes = inner;
+    const { plugin } = this._presets;
 
     if (!plugin) {
       editor.settings = null;
       list.selection = '';
+      this._setSizes();
       return;
     }
 
     if (editor.settings && editor.settings.plugin === plugin) {
+      this._setSizes();
       return;
     }
 
@@ -315,11 +310,25 @@ class SettingEditor extends Widget {
       }
       editor.settings = settings;
       list.selection = plugin;
+      this._setSizes();
     }).catch((reason: Error) => {
       console.error(`Loading settings failed: ${reason.message}`);
       list.selection = this._presets.plugin = '';
       editor.settings = null;
+      this._setSizes();
     });
+  }
+
+  /**
+   * Set the layout sizes.
+   */
+  private _setSizes(): void {
+    const { inner, outer } = this._presets;
+    const editor = this._editor;
+    const panel = this._panel;
+
+    editor.sizes = inner;
+    panel.setRelativeSizes(outer);
   }
 
   private _editor: PluginEditor;

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -199,7 +199,7 @@
 }
 
 
-#setting-editor .jp-PluginEditor td.jp-PluginFieldset-add:hover {
+#setting-editor .jp-PluginEditor td.jp-PluginFieldset-add.jp-mod-active:hover {
   border: 1px solid var(--jp-toolbar-border-color);
 }
 
@@ -232,5 +232,5 @@
   border-radius: 8px;
   width: 8px;
   height: 8px;
-  margin: 3px 0 0 1px;
+  margin-top: 3px;
 }

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -5,7 +5,8 @@
 
 
 :root {
-  --jp-private-settingeditor-add-width: 15px;
+  --jp-private-settingeditor-row-height: 16px;
+  --jp-private-settingeditor-add-width: 16px;
   --jp-private-settingeditor-key-width: 150px;
   --jp-private-settingeditor-type-width: 75px;
   --jp-private-settingeditor-value-width: calc(
@@ -164,14 +165,22 @@
 
 #setting-editor .jp-PluginEditor tr {
   color: var(--jp-ui-font-color2);
-  height: 16px;
+  height: var( --jp-private-settingeditor-row-height);
   overflow: hidden;
 }
 
 
 #setting-editor .jp-PluginEditor th {
   background-color: var(--jp-layout-color3);
+  border: 1px solid transparent;
   font-weight: bold;
+  height: var( --jp-private-settingeditor-row-height);
+}
+
+
+#setting-editor .jp-PluginEditor td {
+  border: 1px solid transparent;
+  height: var( --jp-private-settingeditor-row-height);
 }
 
 
@@ -196,7 +205,6 @@
 
 
 #setting-editor .jp-PluginEditor td.jp-PluginFieldset-add {
-  border: 1px solid transparent;
   cursor: pointer;
   text-align: center;
 }
@@ -235,4 +243,5 @@
   border-radius: 8px;
   width: 8px;
   height: 8px;
+  margin: 3px 0 0 1px;
 }

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-#setting-editor.jp-SettingEditor {
+#setting-editor {
   background-color: var(--jp-layout-color0);
   border-top: var(--jp-border-width) solid var(--jp-border-color1);
   margin-top: -1px;
@@ -11,7 +11,7 @@
 }
 
 
-#setting-editor.jp-SettingEditor::before {
+#setting-editor::before {
   content: '';
   display: block;
   height: var(--jp-toolbar-micro-height);
@@ -22,22 +22,23 @@
 }
 
 
-#setting-editor.jp-SettingEditor .p-SplitPanel {
+#setting-editor .p-SplitPanel {
   height: 100%;
   width: 100%;
 }
 
-#setting-editor.jp-SettingEditor .p-SplitPanel-handle {
+
+#setting-editor .p-SplitPanel-handle {
   background-color: var(--jp-border-color1);
 }
 
 
-#setting-editor.jp-SettingEditor .jp-SettingEditorInstructions {
+#setting-editor .jp-SettingEditorInstructions {
   text-align: center;
 }
 
 
-#setting-editor.jp-SettingEditor .jp-SettingEditorInstructions-icon {
+#setting-editor .jp-SettingEditorInstructions-icon {
   display: inline-block;
   background-size: 60px;
   width: 60px;
@@ -47,7 +48,7 @@
 }
 
 
-#setting-editor.jp-SettingEditor .jp-SettingEditorInstructions-title {
+#setting-editor .jp-SettingEditorInstructions-title {
   font-size: 32px;
   font-weight: 200;
   line-height: 78px;
@@ -55,12 +56,12 @@
 }
 
 
-#setting-editor.jp-SettingEditor .jp-SettingEditorInstructions-text {
+#setting-editor .jp-SettingEditorInstructions-text {
   font-size: var(--jp-ui-font-size2);
 }
 
 
-#setting-editor.jp-SettingEditor ul.jp-PluginList {
+#setting-editor ul.jp-PluginList {
   background-color: var(--jp-layout-color1);
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
@@ -72,7 +73,7 @@
 }
 
 
-#setting-editor.jp-SettingEditor ul.jp-PluginList li {
+#setting-editor ul.jp-PluginList li {
   border: 1px solid transparent;
   overflow: hidden;
   padding: 2px 0 5px 5px;
@@ -81,17 +82,18 @@
 }
 
 
-#setting-editor.jp-SettingEditor ul.jp-PluginList li:hover {
+#setting-editor ul.jp-PluginList li:hover {
   background-color: var(--jp-layout-color2);
+  border: 1px solid var(--md-grey-300);
 }
 
 
-#setting-editor.jp-SettingEditor ul.jp-PluginList li.jp-mod-selected {
+#setting-editor ul.jp-PluginList li.jp-mod-selected {
   background-color: var(--jp-brand-color1);
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginList-icon {
+#setting-editor .jp-PluginList-icon {
   display: inline-block;
   height: 20px;
   width: 20px;
@@ -101,26 +103,26 @@
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor {
+#setting-editor .jp-PluginEditor {
   padding: 10px;
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-JSONEditor-host {
+#setting-editor .jp-PluginEditor .jp-JSONEditor-host {
   height: 100%;
   margin-left: 0;
   margin-right: 0;
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-JSONEditor-header {
+#setting-editor .jp-PluginEditor .jp-JSONEditor-header {
   position: absolute;
   right: 0;
   z-index: 9999;
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset {
+#setting-editor .jp-PluginEditor .jp-PluginFieldset {
   border: 1px solid var(--jp-brand-color1);
   margin: 0;
   overflow-y: auto;
@@ -128,7 +130,7 @@
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset legend {
+#setting-editor .jp-PluginEditor .jp-PluginFieldset legend {
   color: var(--jp-brand-color1);
   font-size: 70%;
   font-weight: bold;
@@ -136,29 +138,49 @@
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset-table {
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-table {
   display: table;
-  border-collapse: collapse;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
+  padding: 2px;
+  width: calc(100% - 4px);
+}
+
+
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-header {
+  display: table-cell;
+  background-color: var(--md-grey-400);
+  font-weight: bold;
+}
+
+
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-row {
+  display: table-row;
+  color: var(--jp-ui-font-color2);
+  height: 16px;
+}
+
+
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-cell {
+  display: table-cell;
+}
+
+
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-cell.jp-mod-main {
   width: 100%;
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset-table > div {
-  border: 1px solid var(--jp-border-color0);
-  background-color: var(--md-grey-400);
-  color: var(--jp-ui-font-color2);
-  display: table-row;
-  margin: 3px;
-  padding: 3px;
-}
-
-
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset-table > div > div {
-  background-color: var(--md-grey-400);
-  color: var(--jp-ui-font-color2);
-  display: table-cell;
-  margin: 3px;
-  padding: 3px;
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-button {
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 8px;
+  border: 1px solid var(--jp-layout-color3);
+  border-radius: 8px;
+  cursor: pointer;
+  width: 8px;
+  height: 8px;
+  position: relative;
+  top: 1px;
+  right: 1px;
 }

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -121,6 +121,7 @@
   height: 100%;
   margin-left: 0;
   margin-right: 0;
+  overflow: auto;
 }
 
 

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -98,7 +98,7 @@
 
 #setting-editor ul.jp-PluginList li:hover {
   background-color: var(--jp-layout-color2);
-  border: 1px solid var(--md-grey-300);
+  border: 1px solid var(--jp-border-color2);
 }
 
 
@@ -170,7 +170,7 @@
 
 
 #setting-editor .jp-PluginEditor th {
-  background-color: var(--md-grey-400);
+  background-color: var(--jp-layout-color3);
   font-weight: bold;
 }
 

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -9,12 +9,6 @@
   --jp-private-settingeditor-add-width: 16px;
   --jp-private-settingeditor-key-width: 150px;
   --jp-private-settingeditor-type-width: 75px;
-  --jp-private-settingeditor-value-width: calc(
-    100% -
-    var(--jp-private-settingeditor-add-width) -
-    var(--jp-private-settingeditor-key-width) -
-    var(--jp-private-settingeditor-type-width)
-  );
 }
 
 
@@ -191,11 +185,6 @@
 
 #setting-editor .jp-PluginEditor th.jp-PluginFieldset-key {
   width: var(--jp-private-settingeditor-key-width);
-}
-
-
-#setting-editor .jp-PluginEditor th.jp-PluginFieldset-value {
-  width: var(--jp-private-settingeditor-value-width);
 }
 
 

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -138,8 +138,7 @@
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-table {
-  display: table;
+#setting-editor .jp-PluginEditor table.jp-PluginFieldset-table {
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   padding: 2px;
@@ -147,27 +146,25 @@
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-header {
-  display: table-cell;
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-table tr {
+  color: var(--jp-ui-font-color2);
+  height: 16px;
+  overflow: hidden;
+}
+
+
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th {
   background-color: var(--md-grey-400);
   font-weight: bold;
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-row {
-  display: table-row;
-  color: var(--jp-ui-font-color2);
-  height: 16px;
-}
-
-
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-cell {
-  display: table-cell;
-}
-
-
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-cell.jp-mod-main {
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-value {
   width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -136,23 +136,29 @@
 }
 
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset table{
+#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset-table {
+  display: table;
   border-collapse: collapse;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   width: 100%;
 }
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset table,
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset th,
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset td {
-  border: 1px solid var(--jp-border-color0);
-}
 
-#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset li {
+#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset-table > div {
+  border: 1px solid var(--jp-border-color0);
   background-color: var(--md-grey-400);
   color: var(--jp-ui-font-color2);
-  display: inline-block;
+  display: table-row;
+  margin: 3px;
+  padding: 3px;
+}
+
+
+#setting-editor.jp-SettingEditor .jp-PluginEditor .jp-PluginFieldset-table > div > div {
+  background-color: var(--md-grey-400);
+  color: var(--jp-ui-font-color2);
+  display: table-cell;
   margin: 3px;
   padding: 3px;
 }

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -3,6 +3,20 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+
+:root {
+  --jp-private-settingeditor-add-width: 15px;
+  --jp-private-settingeditor-key-width: 150px;
+  --jp-private-settingeditor-type-width: 75px;
+  --jp-private-settingeditor-value-width: calc(
+    100% -
+    var(--jp-private-settingeditor-add-width) -
+    var(--jp-private-settingeditor-key-width) -
+    var(--jp-private-settingeditor-type-width)
+  );
+}
+
+
 #setting-editor {
   background-color: var(--jp-layout-color0);
   border-top: var(--jp-border-width) solid var(--jp-border-color1);
@@ -139,10 +153,12 @@
 
 
 #setting-editor .jp-PluginEditor table.jp-PluginFieldset-table {
+  table-layout: fixed;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   padding: 2px;
   width: calc(100% - 4px);
+  overflow: hidden;
 }
 
 
@@ -159,9 +175,34 @@
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-value {
-  width: 100%;
-  max-width: 100%;
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th.jp-PluginFieldset-add {
+  width: var(--jp-private-settingeditor-add-width);
+}
+
+
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th.jp-PluginFieldset-key {
+  width: var(--jp-private-settingeditor-key-width);
+}
+
+
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th.jp-PluginFieldset-value {
+  width: var(--jp-private-settingeditor-value-width);
+}
+
+
+#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th.jp-PluginFieldset-type {
+  width: var(--jp-private-settingeditor-type-width);
+}
+
+
+#setting-editor .jp-PluginEditor td.jp-PluginFieldset-key {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+
+#setting-editor .jp-PluginEditor td.jp-PluginFieldset-value {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -162,36 +162,48 @@
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-table tr {
+#setting-editor .jp-PluginEditor tr {
   color: var(--jp-ui-font-color2);
   height: 16px;
   overflow: hidden;
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th {
+#setting-editor .jp-PluginEditor th {
   background-color: var(--md-grey-400);
   font-weight: bold;
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th.jp-PluginFieldset-add {
+#setting-editor .jp-PluginEditor th.jp-PluginFieldset-add {
   width: var(--jp-private-settingeditor-add-width);
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th.jp-PluginFieldset-key {
+#setting-editor .jp-PluginEditor th.jp-PluginFieldset-key {
   width: var(--jp-private-settingeditor-key-width);
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th.jp-PluginFieldset-value {
+#setting-editor .jp-PluginEditor th.jp-PluginFieldset-value {
   width: var(--jp-private-settingeditor-value-width);
 }
 
 
-#setting-editor .jp-PluginEditor .jp-PluginFieldset-table th.jp-PluginFieldset-type {
+#setting-editor .jp-PluginEditor th.jp-PluginFieldset-type {
   width: var(--jp-private-settingeditor-type-width);
+}
+
+
+#setting-editor .jp-PluginEditor td.jp-PluginFieldset-add {
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-align: center;
+}
+
+
+#setting-editor .jp-PluginEditor td.jp-PluginFieldset-add:hover {
+  border: 1px solid var(--jp-toolbar-border-color);
 }
 
 
@@ -209,16 +221,18 @@
 }
 
 
+#setting-editor .jp-PluginEditor td.jp-PluginFieldset-type {
+  text-align: right;
+}
+
+
 #setting-editor .jp-PluginEditor .jp-PluginFieldset-button {
+  display: inline-block;
   background-position: center;
   background-repeat: no-repeat;
   background-size: 8px;
   border: 1px solid var(--jp-layout-color3);
   border-radius: 8px;
-  cursor: pointer;
   width: 8px;
   height: 8px;
-  position: relative;
-  top: 1px;
-  right: 1px;
 }

--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from '@phosphor/commands';
 
 import {
-  JSONValue
+  JSONObject, JSONValue
 } from '@phosphor/coreutils';
 
 import {
@@ -57,9 +57,9 @@ const plugin: JupyterLabPlugin<void> = {
     const { commands } = app;
 
     settingReqistry.load(plugin.id).then(settings => {
-      Private.loadShortcuts(commands, settings);
+      Private.loadShortcuts(commands, settings.composite);
       settings.changed.connect(() => {
-        Private.loadShortcuts(commands, settings);
+        Private.loadShortcuts(commands, settings.composite);
       });
     }).catch((reason: Error) => {
       console.error('Loading shortcut settings failed.', reason.message);
@@ -88,15 +88,11 @@ namespace Private {
    * Load the keyboard shortcuts from settings.
    */
   export
-  function loadShortcuts(commands: CommandRegistry, settings: ISettingRegistry.ISettings): void {
+  function loadShortcuts(commands: CommandRegistry, composite: JSONObject): void {
     if (disposables) {
       disposables.dispose();
     }
-
-    const { composite } = settings;
-    const keys = Object.keys(composite);
-
-    disposables = keys.reduce((acc, val): DisposableSet => {
+    disposables = Object.keys(composite).reduce((acc, val): DisposableSet => {
       const options = normalizeOptions(composite[val]);
 
       if (options) {

--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -54,12 +54,12 @@ const plugin: JupyterLabPlugin<void> = {
   id: 'jupyter.extensions.shortcuts',
   requires: [ISettingRegistry],
   activate: (app: JupyterLab, settingReqistry: ISettingRegistry): void => {
-    settingReqistry.load(plugin.id).then(settings => {
-      let disposables = Private.loadShortcuts(app, settings);
+    const { commands } = app;
 
+    settingReqistry.load(plugin.id).then(settings => {
+      Private.loadShortcuts(commands, settings);
       settings.changed.connect(() => {
-        disposables.dispose();
-        disposables = Private.loadShortcuts(app, settings);
+        Private.loadShortcuts(commands, settings);
       });
     }).catch((reason: Error) => {
       console.error('Loading shortcut settings failed.', reason.message);
@@ -80,18 +80,27 @@ export default plugin;
  */
 namespace Private {
   /**
+   * The internal collection of currently loaded shortcuts.
+   */
+  let disposables: IDisposable;
+
+  /**
    * Load the keyboard shortcuts from settings.
    */
   export
-  function loadShortcuts(app: JupyterLab, settings: ISettingRegistry.ISettings): IDisposable {
+  function loadShortcuts(commands: CommandRegistry, settings: ISettingRegistry.ISettings): void {
+    if (disposables) {
+      disposables.dispose();
+    }
+
     const { composite } = settings;
     const keys = Object.keys(composite);
 
-    return keys.reduce((acc, val): DisposableSet => {
+    disposables = keys.reduce((acc, val): DisposableSet => {
       const options = normalizeOptions(composite[val]);
 
       if (options) {
-        acc.add(app.commands.addKeyBinding(options));
+        acc.add(commands.addKeyBinding(options));
       }
 
       return acc;

--- a/test/src/coreutils/settingregistry.spec.ts
+++ b/test/src/coreutils/settingregistry.spec.ts
@@ -543,6 +543,65 @@ describe('@jupyterlab/coreutils', () => {
 
     });
 
+    describe('#default()', () => {
+
+      it('should return a fully extrapolated schema default', done => {
+        const id = 'omicron';
+        const defaults = {
+          foo: 'one',
+          bar: 100,
+          baz: {
+            qux: 'two',
+            quux: 'three',
+            quuz: {
+              corge: { grault: 200 }
+            }
+          }
+        };
+
+        connector.schemas[id] = {
+          type: 'object',
+          properties: {
+            foo: { type: 'string', default: defaults.foo },
+            bar: { type: 'number', default: defaults.bar },
+            baz: {
+              type: 'object',
+              default: { },
+              properties: {
+                qux: { type: 'string', default: defaults.baz.qux },
+                quux: { type: 'string', default: defaults.baz.quux },
+                quuz: {
+                  type: 'object',
+                  default: { },
+                  properties: {
+                    corge: {
+                      type: 'object',
+                      default: { },
+                      properties: {
+                        grault: {
+                          type: 'number',
+                          default: defaults.baz.quuz.corge.grault
+                        }
+                      }
+                    },
+                  }
+                },
+              }
+            },
+            'nonexistent-default': { type: 'string' }
+          }
+        };
+        registry.load(id).then(settings => {
+          expect(settings.default('nonexistent-key')).to.be(undefined);
+          expect(settings.default('foo')).to.be(defaults.foo);
+          expect(settings.default('bar')).to.be(defaults.bar);
+          expect(settings.default('baz')).to.eql(defaults.baz);
+          expect(settings.default('nonexistent-default')).to.be(undefined);
+        }).then(done).catch(done);
+      });
+
+    });
+
     describe('#get()', () => {
 
       it('should get a setting item', done => {


### PR DESCRIPTION
**Default values of nested objects are constructed for the user to see.
Before, most objects just appeared as `{ }`.**
<img width="662" alt="default object value" src="https://user-images.githubusercontent.com/159529/28734187-a44bebe0-73d7-11e7-96d5-59da56055e36.png">

**Plugin field set allows adding individual properties to user settings so the user can discover/modify them:**
![setting-editor](https://user-images.githubusercontent.com/159529/28733936-5ff3d36e-73d6-11e7-997c-a621daa5c814.gif)

**Makes it easy to duplicate and rename existing keyboard shortcuts to create new ones dynamically at run-time (or simply to override the default shortcut):**

![setting-editor-custom-shortcut](https://user-images.githubusercontent.com/159529/28755480-eb7d8a5a-7553-11e7-94f5-11febc28361c.gif)

cc: @ellisonbg @cameronoelsen @mpacer @jasongrout 
