### PR TITLE
Pass through resize messages for mime documents

### DIFF
--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -22,7 +22,7 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  PanelLayout, Widget
+  BoxLayout, Widget
 } from '@phosphor/widgets';
 
 import {
@@ -413,10 +413,11 @@ class MimeDocument extends Widget implements DocumentRegistry.IReadyWidget {
   constructor(options: MimeDocument.IOptions) {
     super();
     this.addClass('jp-MimeDocument');
-    let layout = this.layout = new PanelLayout();
+    let layout = this.layout = new BoxLayout();
     let toolbar = new Widget();
     toolbar.addClass('jp-Toolbar');
     layout.addWidget(toolbar);
+    BoxLayout.setStretch(toolbar, 0);
     let context = options.context;
     this.title.label = PathExt.basename(context.path);
     this.rendermime = options.rendermime.clone({ resolver: context });
@@ -504,7 +505,8 @@ class MimeDocument extends Widget implements DocumentRegistry.IReadyWidget {
     let mimeModel = new MimeModel({ data });
     if (!this._renderer) {
       this._renderer = this.rendermime.createRenderer(this._mimeType);
-      (this.layout as PanelLayout).addWidget(this._renderer);
+      (this.layout as BoxLayout).addWidget(this._renderer);
+      BoxLayout.setStretch(this._renderer, 1);
     }
     return this._renderer.renderModel(mimeModel);
   }

--- a/packages/docregistry/style/index.css
+++ b/packages/docregistry/style/index.css
@@ -4,9 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 .jp-MimeDocument {
-  border-top: var(--jp-border-width) solid var(--jp-border-color2);
   outline: none;
-  margin-top: -1px;
 }
 
 

--- a/packages/docregistry/style/index.css
+++ b/packages/docregistry/style/index.css
@@ -8,14 +8,12 @@
   outline: none;
   overflow: hidden;
   margin-top: -1px;
-  display: flex;
-  flex-direction: column;
 }
 
 
 .jp-MimeDocument .jp-Toolbar {
     display: block;
-    height: var(--jp-toolbar-micro-height);
+    min-height: var(--jp-toolbar-micro-height);
     background: var(--jp-toolbar-background);
     border-bottom: 1px solid var(--jp-toolbar-border-color);
     box-shadow: var(--jp-toolbar-box-shadow);

--- a/packages/docregistry/style/index.css
+++ b/packages/docregistry/style/index.css
@@ -6,12 +6,11 @@
 .jp-MimeDocument {
   border-top: var(--jp-border-width) solid var(--jp-border-color2);
   outline: none;
-  overflow: hidden;
   margin-top: -1px;
 }
 
 
-.jp-MimeDocument .jp-Toolbar {
+.jp-MimeDocument > .jp-Toolbar {
     display: block;
     min-height: var(--jp-toolbar-micro-height);
     background: var(--jp-toolbar-background);


### PR DESCRIPTION
Uses a box layout for the `MimeDocument` so proper `resize` messages are passed to the renderer.

cc @jasongrout who wanted this for the fasta-viewer.