### PR TITLE
Improve filebrowser rendering performance

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1676,8 +1676,8 @@ namespace DirListing {
       let modText = '';
       let modTitle = '';
       if (model.last_modified) {
-        modText = Time.formatHuman(model.last_modified);
-        modTitle = Time.format(model.last_modified);
+        modText = Time.formatHuman(new Date(model.last_modified));
+        modTitle = Time.format(new Date(model.last_modified));
       }
 
       // If an item is being edited currently, its text node is unavailable.


### PR DESCRIPTION
I found that the call to `Time.formatHuman` was taking the bulk of the time refreshing the file listing.  This simple change cuts the rendering time from ~100ms to ~50ms for a directory with ~400 items. 

cf https://github.com/moment/moment/issues/731#issuecomment-16454386