### PR TITLE
disable package lock use on top-level package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false


### PR DESCRIPTION
Installed dev mode, recalled @blink1073's comment in a lerna thread, figured y'all would like this. :smile:

Ok it's selfishly because I hate having an unclean git workspace. ;)