### PR TITLE
Add the notebook mime type to the default file type

### DIFF
--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1106,6 +1106,7 @@ namespace DocumentRegistry {
   const defaultNotebookFileType: IFileType = {
     ...fileTypeDefaults,
     name: 'notebook',
+    mimeTypes: ['application/x-ipynb+json'],
     extensions: ['.ipynb'],
     contentType: 'notebook',
     fileFormat: 'json',


### PR DESCRIPTION
cf http://jupyter.readthedocs.io/en/latest/reference/mimetype.html#custom-mimetypes-used-in-jupyter-and-ipython-projects