### PR TITLE
Fix jarring visual effect when settings load.

### DIFF
--- a/packages/settingeditor-extension/src/settingeditor.ts
+++ b/packages/settingeditor-extension/src/settingeditor.ts
@@ -234,8 +234,13 @@ class SettingEditor extends Widget {
     // Allow the message queue (which includes fit requests that might disrupt
     // setting relative sizes) to clear before setting sizes.
     requestAnimationFrame(() => {
-      this._fetchState().then(() => { this._setPresets(); }).catch(reason => {
+      this._panel.hide();
+      this._fetchState().then(() => {
+        this._panel.show();
+        this._setPresets();
+      }).catch(reason => {
         console.error('Fetching setting editor state failed', reason);
+        this._panel.show();
         this._setPresets();
       });
     });


### PR DESCRIPTION
Hides the panel until its state restoration data has been retrieved.

**before:**
![before](https://user-images.githubusercontent.com/159529/28876741-19f49f3c-7792-11e7-99f0-596ff93b4b55.gif)

**after:**
![after](https://user-images.githubusercontent.com/159529/28876750-22c0a84a-7792-11e7-85a7-b5fe2f6e13a1.gif)
