### PR TITLE
Load CSS to make vim mode work correctly.

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -4,6 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 @import url('~codemirror/lib/codemirror.css');
+@import url('~codemirror/addon/dialog/dialog.css');
 
 @import url('~codemirror/theme/material.css');
 @import url('~codemirror/theme/zenburn.css');
@@ -25,7 +26,6 @@
   font-family: var(--jp-code-font-family);
   height: auto;
   /* Changed to auto to autogrow */
-  background: none;
 }
 
 


### PR DESCRIPTION
We were missing some CSS to render vim-mode correctly in the editor.