### PR TITLE
Add buffers argument to comm.open/close

### DIFF
--- a/packages/services/src/kernel/comm.ts
+++ b/packages/services/src/kernel/comm.ts
@@ -95,7 +95,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
    *
    * **See also:** [[ICommOpen]]
    */
-  open(data?: JSONValue, metadata?: JSONObject): Kernel.IFuture {
+  open(data?: JSONValue, metadata?: JSONObject, buffers: (ArrayBuffer | ArrayBufferView)[] = []): Kernel.IFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
       throw new Error('Cannot open');
     }
@@ -110,7 +110,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
       target_name: this._target,
       data: data || {}
     };
-    let msg = KernelMessage.createShellMessage(options, content, metadata);
+    let msg = KernelMessage.createShellMessage(options, content, metadata, buffers);
     return this._kernel.sendShellMessage(msg, false, true);
   }
 
@@ -151,7 +151,7 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
    *
    * **See also:** [[ICommClose]], [[onClose]]
    */
-  close(data?: JSONValue, metadata?: JSONObject): Kernel.IFuture {
+  close(data?: JSONValue, metadata?: JSONObject, buffers: (ArrayBuffer | ArrayBufferView)[] = []): Kernel.IFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
       throw new Error('Cannot close');
     }
@@ -165,12 +165,12 @@ class CommHandler extends DisposableDelegate implements Kernel.IComm {
       comm_id: this._id,
       data: data || {}
     };
-    let msg = KernelMessage.createShellMessage(options, content, metadata);
+    let msg = KernelMessage.createShellMessage(options, content, metadata, buffers);
     let future = this._kernel.sendShellMessage(msg, false, true);
     options.channel = 'iopub';
-    let ioMsg = KernelMessage.createMessage(options, content, metadata);
     let onClose = this._onClose;
     if (onClose) {
+      let ioMsg = KernelMessage.createMessage(options, content, metadata, buffers);
       onClose(ioMsg as KernelMessage.ICommCloseMsg);
     }
     this.dispose();

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -762,7 +762,7 @@ namespace Kernel {
      * #### Notes
      * This sends a `comm_open` message to the server.
      */
-    open(data?: JSONValue, metadata?: JSONObject): IFuture;
+    open(data?: JSONValue, metadata?: JSONObject, buffers?: (ArrayBuffer | ArrayBufferView)[]): IFuture;
 
     /**
      * Send a `comm_msg` message to the kernel.
@@ -797,7 +797,7 @@ namespace Kernel {
      *
      * This is a no-op if the comm is already closed.
      */
-    close(data?: JSONValue, metadata?: JSONObject): IFuture;
+    close(data?: JSONValue, metadata?: JSONObject, buffers?: (ArrayBuffer | ArrayBufferView)[]): IFuture;
   }
 
   /**

--- a/packages/services/test/src/kernel/comm.spec.ts
+++ b/packages/services/test/src/kernel/comm.spec.ts
@@ -300,9 +300,14 @@ describe('jupyter.services - Comm', () => {
         let comm = kernel.connectToComm('test');
         tester.onMessage((msg: KernelMessage.ICommOpenMsg) => {
           expect(msg.content.data).to.eql({ foo: 'bar' });
+          let decoder = new TextDecoder('utf8');
+          let item = msg.buffers[0] as DataView;
+          expect(decoder.decode(item)).to.be('hello');
           done();
         });
-        comm.open({ foo: 'bar' }, { fizz: 'buzz' });
+        let encoder = new TextEncoder('utf8');
+        let data = encoder.encode('hello');
+        comm.open({ foo: 'bar' }, { fizz: 'buzz' }, [data, data.buffer]);
       });
 
       it('should yield a future', (done) => {
@@ -366,9 +371,14 @@ describe('jupyter.services - Comm', () => {
         let comm = kernel.connectToComm('test');
         tester.onMessage((msg: KernelMessage.ICommCloseMsg) => {
           expect(msg.content.data).to.eql({ foo: 'bar' });
+          let decoder = new TextDecoder('utf8');
+          let item = msg.buffers[0] as DataView;
+          expect(decoder.decode(item)).to.be('hello');
           done();
         });
-        comm.close({ foo: 'bar' }, { });
+        let encoder = new TextEncoder('utf8');
+        let data = encoder.encode('hello');
+        comm.close({ foo: 'bar' }, { }, [data, data.buffer]);
       });
 
       it('should trigger an onClose', (done) => {


### PR DESCRIPTION
Adds a `buffers` argument to services.kernel.Comm.open/close.

I'm a little unsure about the `ioMsg` create for `onClose` in the close method, but other than that it should be straight forward since it uses the same internal methods as the `send` method.

Fixes #2556.