### PR TITLE
Pin terminal version for now

### DIFF
--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -19,7 +19,7 @@
     "@phosphor/domutils": "^1.1.1",
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/widgets": "^1.3.0",
-    "xterm": "^2.8.0"
+    "xterm": "~2.8.0"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",


### PR DESCRIPTION
2.9.0 was causing a WebPack warning and 2.9.1 causes a test failure due to  https://github.com/sourcelair/xterm.js/issues/860.   Pinning to 2.8 for now.