### PR TITLE
Add an application splash screen

### DIFF
--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -6,7 +6,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib/*.d.ts",
-    "lib/*.js"
+    "lib/*.js",
+    "style/*.css"
   ],
   "directories": {
     "lib": "lib/"

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -8,7 +8,8 @@ import {
 } from '@jupyterlab/application';
 
 import {
-  ICommandPalette, IMainMenu, MainMenu, IThemeManager, ThemeManager
+  ICommandPalette, IMainMenu, MainMenu, IThemeManager, ThemeManager,
+  ISplashScreen
 } from '@jupyterlab/apputils';
 
 import {
@@ -30,6 +31,8 @@ import {
 import {
   activatePalette
 } from './palette';
+
+import '../style/index.css';
 
 
 /**
@@ -146,15 +149,42 @@ const settingPlugin: JupyterLabPlugin<ISettingRegistry> = {
  */
 const themePlugin: JupyterLabPlugin<IThemeManager> = {
   id: 'jupyter.services.theme-manger',
-  requires: [ISettingRegistry],
-  activate: (app: JupyterLab, settingRegistry: ISettingRegistry): IThemeManager => {
+  requires: [ISettingRegistry, ISplashScreen],
+  activate: (app: JupyterLab, settingRegistry: ISettingRegistry, splash: ISplashScreen): IThemeManager => {
     let baseUrl = app.serviceManager.serverSettings.baseUrl;
     let host = app.shell;
     let when = app.started;
-    return new ThemeManager({ baseUrl,  settingRegistry, host, when });
+    let manager = new ThemeManager({ baseUrl,  settingRegistry, host, when });
+    splash.show();
+    manager.ready.then(() => {
+      splash.hide();
+    }, () => {
+      splash.hide();
+    });
+    return manager;
   },
   autoStart: true,
   provides: IThemeManager
+};
+
+
+/**
+ * The default splash screen provider.
+ */
+const splashPlugin: JupyterLabPlugin<ISplashScreen> = {
+  id: 'jupyter.services.splash-screen',
+  autoStart: true,
+  provides: ISplashScreen,
+  activate: () => {
+    return {
+      show: () => {
+        Private.showSplash();
+      },
+      hide: () => {
+        Private.hideSplash();
+      }
+    };
+  }
 };
 
 
@@ -200,7 +230,51 @@ const plugins: JupyterLabPlugin<any>[] = [
   palettePlugin,
   settingPlugin,
   stateDBPlugin,
+  splashPlugin,
   themePlugin
 ];
 export default plugins;
+
+
+
+/**
+ * The namespace for module private data.
+ */
+namespace Private {
+  /**
+   * The splash element.
+   */
+  let splash: HTMLElement | null;
+
+  /**
+   * The splash screen counter.
+   */
+  let splashCount = 0;
+
+  /**
+   * Show the splash element.
+   */
+  export
+  function showSplash(): void {
+    if (!splash) {
+      splash = document.createElement('div');
+      splash.id = 'jupyterlab-splash';
+      let child = document.createElement('div');
+      splash.appendChild(child);
+      document.body.appendChild(splash);
+    }
+    splashCount++;
+  }
+
+  /**
+   * Hide the splash element.
+   */
+  export
+  function hideSplash(): void {
+    splashCount = Math.max(splashCount - 1, 0);
+    if (splashCount === 0 && splash) {
+      document.body.removeChild(splash);
+    }
+  }
+}
 

--- a/packages/apputils-extension/style/index.css
+++ b/packages/apputils-extension/style/index.css
@@ -1,0 +1,7 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2017, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+@import './splash.css';

--- a/packages/apputils-extension/style/splash.css
+++ b/packages/apputils-extension/style/splash.css
@@ -1,0 +1,97 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+#jupyterlab-splash {
+  position:fixed;
+  padding:0;
+  margin:0;
+
+  top:0;
+  left:0;
+
+  width: 100%;
+  height: 100%;
+  background: white;
+
+  z-index: 1000;
+}
+
+
+#jupyterlab-splash > div {
+  color: var(--md-grey-500);
+  font-size: 20px;
+  margin: 100px auto;
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  position: relative;
+  text-indent: -9999em;
+  -webkit-animation: loadsplash4 1.3s infinite linear;
+  animation: loadsplash4 1.3s infinite linear;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+
+  z-index: 1001;
+}
+
+
+@-webkit-keyframes loadsplash4 {
+  0%,
+  100% {
+    box-shadow: 0 -3em 0 0.2em, 2em -2em 0 0em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 0;
+  }
+  12.5% {
+    box-shadow: 0 -3em 0 0, 2em -2em 0 0.2em, 3em 0 0 0, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  25% {
+    box-shadow: 0 -3em 0 -0.5em, 2em -2em 0 0, 3em 0 0 0.2em, 2em 2em 0 0, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  37.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 0, 2em 2em 0 0.2em, 0 3em 0 0em, -2em 2em 0 -1em, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  50% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 0em, 0 3em 0 0.2em, -2em 2em 0 0, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  62.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 0, -2em 2em 0 0.2em, -3em 0 0 0, -2em -2em 0 -1em;
+  }
+  75% {
+    box-shadow: 0em -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0.2em, -2em -2em 0 0;
+  }
+  87.5% {
+    box-shadow: 0em -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0, -2em -2em 0 0.2em;
+  }
+}
+
+
+@keyframes loadsplash4 {
+  0%,
+  100% {
+    box-shadow: 0 -3em 0 0.2em, 2em -2em 0 0em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 0;
+  }
+  12.5% {
+    box-shadow: 0 -3em 0 0, 2em -2em 0 0.2em, 3em 0 0 0, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  25% {
+    box-shadow: 0 -3em 0 -0.5em, 2em -2em 0 0, 3em 0 0 0.2em, 2em 2em 0 0, 0 3em 0 -1em, -2em 2em 0 -1em, -3em 0 0 -1em, -2em -2em 0 -1em;
+  }
+  37.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 0, 2em 2em 0 0.2em, 0 3em 0 0em, -2em 2em 0 -1em, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  50% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 0em, 0 3em 0 0.2em, -2em 2em 0 0, -3em 0em 0 -1em, -2em -2em 0 -1em;
+  }
+  62.5% {
+    box-shadow: 0 -3em 0 -1em, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 0, -2em 2em 0 0.2em, -3em 0 0 0, -2em -2em 0 -1em;
+  }
+  75% {
+    box-shadow: 0em -3em 0 -1em, 2em -2em 0 -1em, 3em 0em 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0.2em, -2em -2em 0 0;
+  }
+  87.5% {
+    box-shadow: 0em -3em 0 0, 2em -2em 0 -1em, 3em 0 0 -1em, 2em 2em 0 -1em, 0 3em 0 -1em, -2em 2em 0 0, -3em 0em 0 0, -2em -2em 0 0.2em;
+  }
+}

--- a/packages/apputils/src/index.ts
+++ b/packages/apputils/src/index.ts
@@ -14,6 +14,7 @@ export * from './iframe';
 export * from './instancetracker';
 export * from './mainmenu';
 export * from './sanitizer';
+export * from './splash';
 export * from './styling';
 export * from './thememanager';
 export * from './toolbar';

--- a/packages/apputils/src/splash.ts
+++ b/packages/apputils/src/splash.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Token
+} from '@phosphor/coreutils';
+
+
+/* tslint:disable */
+/**
+ * The main menu token.
+ */
+export
+const ISplashScreen = new Token<ISplashScreen>('jupyter.services.splash-screen');
+/* tslint:enable */
+
+
+/**
+ * The interface for an application splash screen.
+ */
+export
+interface ISplashScreen {
+  /**
+   * Show the application splash screen.
+   */
+  show(): void;
+
+
+  /**
+   * Hide the application splash screen.
+   */
+  hide(): void;
+}

--- a/packages/apputils/src/splash.ts
+++ b/packages/apputils/src/splash.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  IDisposable
+} from '@phosphor/disposable';
+
+import {
   Token
 } from '@phosphor/coreutils';
 
@@ -22,12 +26,8 @@ export
 interface ISplashScreen {
   /**
    * Show the application splash screen.
+   *
+   * @returns A disposable used to clear the splash screen.
    */
-  show(): void;
-
-
-  /**
-   * Hide the application splash screen.
-   */
-  hide(): void;
+  show(): IDisposable;
 }


### PR DESCRIPTION
Adds an interface to show an application splash screen, and a default CSS-only spinner implementation.

Invokes the splash screen when initially loading the theme.

I looked into porting the splash screen used in the electron app, but since it is a React component it would need quite a bit of refactoring, so I left that for a future PR.

![splash-screen](https://user-images.githubusercontent.com/2096628/29045894-c2d557e4-7b8a-11e7-80ea-c349548546b3.gif)
