### PR TITLE
Less noise upon using add/removesibling.

### DIFF
--- a/packages/all-packages/package.json
+++ b/packages/all-packages/package.json
@@ -1,16 +1,31 @@
 {
   "name": "@jupyterlab/all-packages",
-  "private": true,
   "version": "0.9.0",
   "description": "JupyterLab - All Packages",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc && node build.js",
+    "clean": "rimraf lib",
+    "docs": "typedoc --mode modules --module commonjs --excludeNotExported --target es5 --moduleResolution node --name JupyterLab --out ../../docs/api .",
+    "watch": "watch \"npm run build\" .. --wait 10 --filter=../../scripts/watch-filter.js"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.9.0",
@@ -67,20 +82,5 @@
     "typedoc": "^0.7.1",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc && node build.js",
-    "clean": "rimraf lib",
-    "docs": "typedoc --mode modules --module commonjs --excludeNotExported --target es5 --moduleResolution node --name JupyterLab --out ../../docs/api .",
-    "watch": "watch \"npm run build\" .. --wait 10 --filter=../../scripts/watch-filter.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  "private": true
 }


### PR DESCRIPTION
The `package.json` sorting introduced in #2759 can introduce some diff-noise. This just sorts this `package.json` to prevent it.