### PR TITLE
Allow MimeRenderDocuments to use base64 encoded files.

### DIFF
--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -6,7 +6,7 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  MimeDocument, MimeDocumentFactory
+  MimeDocument, MimeDocumentFactory, DocumentRegistry
 } from '@jupyterlab/docregistry';
 
 import {
@@ -80,7 +80,7 @@ function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<
 
       if (item.fileTypes) {
         item.fileTypes.forEach(ft => {
-          app.docRegistry.addFileType(ft);
+          app.docRegistry.addFileType(ft as DocumentRegistry.IFileType);
         });
       }
 
@@ -89,6 +89,7 @@ function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<
           renderTimeout: item.renderTimeout,
           dataType: item.dataType,
           rendermime: app.rendermime,
+          modelName: option.modelName,
           name: option.name,
           primaryFileType: registry.getFileType(option.primaryFileType),
           fileTypes: option.fileTypes,

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -83,6 +83,11 @@ namespace IRenderMime {
     readonly name: string;
 
     /**
+     * The name of the document model type.
+     */
+    readonly modelName: string;
+
+    /**
      * The primary file type of the widget.
      */
     readonly primaryFileType: string;
@@ -133,6 +138,11 @@ namespace IRenderMime {
      * The icon label for the file type.
      */
     readonly iconLabel?: string;
+
+    /**
+     * The file format for the file type ('text', 'base64', or 'json').
+     */
+    readonly fileFormat: string;
   }
 
   /**

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -85,7 +85,7 @@ namespace IRenderMime {
     /**
      * The name of the document model type.
      */
-    readonly modelName: string;
+    readonly modelName?: string;
 
     /**
      * The primary file type of the widget.
@@ -142,7 +142,7 @@ namespace IRenderMime {
     /**
      * The file format for the file type ('text', 'base64', or 'json').
      */
-    readonly fileFormat: string;
+    readonly fileFormat?: string;
   }
 
   /**

--- a/packages/vega2-extension/src/index.ts
+++ b/packages/vega2-extension/src/index.ts
@@ -133,12 +133,14 @@ const extension: IRenderMime.IExtension = {
   dataType: 'json',
   documentWidgetFactoryOptions: [{
     name: 'Vega',
+    modelName: 'text',
     primaryFileType: 'vega',
     fileTypes: ['vega', 'json'],
     defaultFor: ['vega']
   },
   {
     name: 'Vega Lite',
+    modelName: 'text',
     primaryFileType: 'vega-lite',
     fileTypes: ['vega-lite', 'json'],
     defaultFor: ['vega-lite']
@@ -146,12 +148,14 @@ const extension: IRenderMime.IExtension = {
   fileTypes: [{
     mimeTypes: [VEGA_MIME_TYPE],
     name: 'vega',
+    fileFormat: 'text',
     extensions: ['.vg', '.vg.json'],
     iconClass: 'jp-MaterialIcon jp-VegaIcon',
   },
   {
     mimeTypes: [VEGALITE_MIME_TYPE],
     name: 'vega-lite',
+    fileFormat: 'text',
     extensions: ['.vl', '.vl.json'],
     iconClass: 'jp-MaterialIcon jp-VegaIcon',
   }]


### PR DESCRIPTION
This extends the `rendermime-interface` to be able to use other file formats than plain text (e.g., base64 encoded files).

My understanding of the `rendermime-interface` package is that it should have as few dependencies as possible, so I have typed `fileFormat` as a string rather than a `Contents.FileFormat`. If this is in error, happy to change it.