### PR TITLE
Clean up handling of schema and theme files

### DIFF
--- a/jupyterlab/make-release.js
+++ b/jupyterlab/make-release.js
@@ -10,15 +10,8 @@ var cwd = path.resolve('..');
 var version = childProcess.execSync('python setup.py --version', { cwd: cwd });
 version = version.toString().trim();
 
-// Update our package.json files.
+// Update the package.app.json file.
 var data = require('./package.json');
-data['jupyterlab']['version'] = version;
-
-// Update our package.json files.
-var text = JSON.stringify(sortPackageJson(data), null, 2) + '\n';
-fs.writeFileSync('./package.json', text);
-
-// Update the build script.
 data['scripts']['build'] = 'webpack'
 text = JSON.stringify(sortPackageJson(data), null, 2) + '\n';
 fs.writeFileSync('./package.app.json', text);

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -28,6 +28,9 @@ mkdir ~/.jupyter
 
 # Install and enable the server extension
 pip install -v -e ".[test]"
+# Make sure the schema and theme files exist
+test -e jupyterlab/schemas/jupyter.extensions.shortcuts.json
+test -e jupyterlab/themes/jupyterlab-theme-light-extension/images/jupyterlab.svg
 npm install
 npm run build:main
 jupyter serverextension enable --py jupyterlab

--- a/setup.py
+++ b/setup.py
@@ -28,27 +28,30 @@ from distutils import log
 import json
 import os
 from glob import glob
+
+# BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
+# update it when the contents of directories change.
+if os.path.exists('MANIFEST'): os.remove('MANIFEST')
+
 from distutils.command.build_ext import build_ext
+from distutils.command.build_py import build_py
 from setuptools.command.sdist import sdist
 from setuptools import setup
 from setuptools.command.bdist_egg import bdist_egg
 
 
 # Our own imports
-
 from setupbase import (
     bdist_egg_disabled,
+    ensure_core_data,
     find_packages,
     find_package_data,
     js_prerelease,
     CheckAssets,
+    CoreDeps,
     version_ns,
     name
 )
-
-# BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
-# update it when the contents of directories change.
-if os.path.exists('MANIFEST'): os.remove('MANIFEST')
 
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -89,10 +92,12 @@ setup_args = dict(
 
 
 cmdclass = dict(
-    build_ext = build_ext,
+    build_py = ensure_core_data(build_py),
+    build_ext = ensure_core_data(build_ext),
     sdist  = js_prerelease(sdist, strict=True),
     bdist_egg = bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
-    jsdeps = CheckAssets
+    jsdeps = CheckAssets,
+    coredeps = CoreDeps,
 )
 try:
     from wheel.bdist_wheel import bdist_wheel


### PR DESCRIPTION
Make sure that `schema` and `theme` files are available without having to run npm locally in the repo, replaces https://github.com/jupyterlab/jupyterlab/pull/2806.

This allows users to get a working version of jupyterlab by installing it from source, and then building an app dir, without needing the local JavaScript sources.