### PR TITLE
Fix cell tools select dropdown

### DIFF
--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -725,7 +725,7 @@ namespace Private {
     let optionNodes: VirtualNode[] = [];
     for (let label in options.optionsMap) {
       let value = JSON.stringify(options.optionsMap[label]);
-      optionNodes.push(h.option({ label, value }));
+      optionNodes.push(h.option({ value }, label));
     }
     let node = VirtualDOM.realize(
       h.div({},


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/2810.
Also validated other uses of `document.createElement('option')` and `h.option`.

<image src="https://user-images.githubusercontent.com/2096628/29138968-d56e9bd2-7d0a-11e7-8d2e-c233426205b1.png" width=300>
