### PR TITLE
Call update-core.js before installing so that package.json is up-to-date.

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -2,7 +2,7 @@
   "name": "@jupyterlab/application-top",
   "version": "0.9.0",
   "scripts": {
-    "build": "webpack",
+    "build": "node update-core.js && webpack",
     "publish": "node make-release.js"
   },
   "dependencies": {

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -2,7 +2,7 @@
   "name": "@jupyterlab/application-top",
   "version": "0.9.0",
   "scripts": {
-    "build": "node update-core.js && webpack",
+    "build": "webpack",
     "publish": "node make-release.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "install": "lerna bootstrap --hoist",
+    "install": "npm run update:core && lerna bootstrap --hoist",
     "build:packages": "cd packages/all-packages && npm run build",
     "build:examples": "lerna run build --scope \"@jupyterlab/example-*\"",
     "build": "npm run build:packages && cd jupyterlab && npm run build",
@@ -24,6 +24,7 @@
     "test:firefox": "lerna run test:firefox --stream",
     "test:ie": "lerna run test:ie --concurrency 1 --stream",
     "update:dependency": "node scripts/update-dependency.js",
+    "update:core": "cd jupyterlab && node update-core.js",
     "watch:packages": "watch \"npm run build:packages\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
     "watch": "watch \"npm run build\" ./packages/** --wait 10 --filter=scripts/watch-filter.js --ignoreDotFiles",
     "watch:main": "npm run watch",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "install": "npm run update:core && lerna bootstrap --hoist",
+    "install": "lerna bootstrap --hoist",
     "build:packages": "cd packages/all-packages && npm run build",
     "build:examples": "lerna run build --scope \"@jupyterlab/example-*\"",
     "build": "npm run build:packages && cd jupyterlab && npm run build",

--- a/scripts/add-sibling.js
+++ b/scripts/add-sibling.js
@@ -68,3 +68,6 @@ var indexPath = path.join(basePath, 'packages', 'all-packages', 'src', 'index.ts
 var index = fs.readFileSync(indexPath, 'utf8');
 index = index + 'import "' + package.name + '";\n';
 fs.writeFileSync(indexPath, index);
+
+// Update the core jupyterlab build dependencies.
+childProcess.execSync('npm run update:core');


### PR DESCRIPTION
The autogeneration of `jupyterlab/package.json` was happening too late for an `addsibling`-based workflow, since the new dependencies are not added pre-install.