### PR TITLE
Remove auto content type

### DIFF
--- a/packages/services/src/builder/index.ts
+++ b/packages/services/src/builder/index.ts
@@ -69,7 +69,7 @@ class BuildManager {
   build(): Promise<void> {
     const base = this.serverSettings.baseUrl;
     const url = URLExt.join(base, BUILD_SETTINGS_URL);
-    const request = { method: 'POST', url };
+    const request = { method: 'POST', url, contentType: 'application/json' };
     const { serverSettings } = this;
     const promise = ServerConnection.makeRequest(request, serverSettings);
 

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -148,7 +148,8 @@ class DefaultConfigSection implements IConfigSection {
     let request = {
       url: this._url,
       method: 'PATCH',
-      data: JSON.stringify(newdata)
+      data: JSON.stringify(newdata),
+      contentType: 'application/json'
     };
     return ServerConnection.makeRequest(request, this.serverSettings).then(response => {
       if (response.xhr.status !== 200) {

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -980,6 +980,7 @@ class Drive implements Contents.IDrive {
       url: this._getUrl(options.path || ''),
       method: 'POST',
       data,
+      contentType: 'application/json'
     };
     return ServerConnection.makeRequest(request, this.serverSettings).then(response => {
       if (response.xhr.status !== 201) {

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1299,6 +1299,7 @@ namespace Private {
       url: URLExt.join(settings.baseUrl, KERNEL_SERVICE_URL),
       method: 'POST',
       data: JSON.stringify({ name: options.name }),
+      contentType: 'application/json',
       cache: false
     };
     return ServerConnection.makeRequest(request, settings).then(response => {

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -267,6 +267,9 @@ namespace Private {
    */
   export
   function populateRequest(xhr: XMLHttpRequest, request: ServerConnection.IRequest, settings: ServerConnection.ISettings): void {
+    if (request.contentType !== void 0) {
+      xhr.setRequestHeader('Content-Type', request.contentType);
+    }
 
     xhr.timeout = settings.timeout;
     if (settings.withCredentials) {

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -93,14 +93,14 @@ namespace ServerConnection {
     dataType?: string;
 
     /**
-     * The outgoing content type, used to set the `Content-Type` header.  Defaults to `'application/json'` when there is sent data.
+     * The outgoing content type, used to set the `Content-Type` header.
      */
     contentType?: string;
 
     /**
      * The request data.
      */
-    data?: any;
+    data?: Blob | BufferSource | FormData | URLSearchParams | ReadableStream | string;
 
     /**
      * Whether to cache the response. Defaults to `false`.

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -100,7 +100,7 @@ namespace ServerConnection {
     /**
      * The request data.
      */
-    data?: JSONValue;
+    data?: any;
 
     /**
      * Whether to cache the response. Defaults to `false`.

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -267,11 +267,6 @@ namespace Private {
    */
   export
   function populateRequest(xhr: XMLHttpRequest, request: ServerConnection.IRequest, settings: ServerConnection.ISettings): void {
-    if (request.contentType !== void 0) {
-      xhr.setRequestHeader('Content-Type', request.contentType);
-    } else if (request.data) {
-      xhr.setRequestHeader('Content-Type', 'application/json');
-    }
 
     xhr.timeout = settings.timeout;
     if (settings.withCredentials) {

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -6,7 +6,7 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  JSONValue, PromiseDelegate
+  PromiseDelegate
 } from '@phosphor/coreutils';
 
 

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -343,6 +343,7 @@ class DefaultSession implements Session.ISession {
       url: Private.getSessionUrl(settings.baseUrl, this._id),
       method: 'PATCH',
       data,
+      contentType: 'application/json',
       cache: false
     };
     return ServerConnection.makeRequest(request, settings).then(response => {
@@ -712,7 +713,8 @@ namespace Private {
       url: URLExt.join(settings.baseUrl, SESSION_SERVICE_URL),
       method: 'POST',
       cache: false,
-      data: JSON.stringify(model)
+      data: JSON.stringify(model),
+      contentType: 'application/json'
     };
     return ServerConnection.makeRequest(request, settings).then(response => {
       if (response.xhr.status !== 201) {

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -77,6 +77,7 @@ class SettingManager {
     const base = this.serverSettings.baseUrl;
     const request = {
       data: JSON.stringify(user),
+      contentType: 'application/json',
       method: 'PATCH',
       url: Private.url(base, id)
     };

--- a/packages/services/test/src/serverconnection.spec.ts
+++ b/packages/services/test/src/serverconnection.spec.ts
@@ -62,7 +62,7 @@ describe('@jupyterlab/services', () => {
         MockXMLHttpRequest.onRequest = request => {
           expect(request.method).to.be('POST');
           expect(request.password).to.be('password');
-          expect(Object.keys(request.requestHeaders)).to.eql(['Content-Type', 'foo']);
+          expect(Object.keys(request.requestHeaders)).to.eql(['foo']);
           let url = request.url;
           expect(url.indexOf('hello?')).to.be(-1);
           expect(url.indexOf('hello')).to.be(0);

--- a/packages/services/test/src/serverconnection.spec.ts
+++ b/packages/services/test/src/serverconnection.spec.ts
@@ -62,7 +62,7 @@ describe('@jupyterlab/services', () => {
         MockXMLHttpRequest.onRequest = request => {
           expect(request.method).to.be('POST');
           expect(request.password).to.be('password');
-          expect(Object.keys(request.requestHeaders)).to.eql(['foo']);
+          expect(Object.keys(request.requestHeaders)).to.eql(['Content-Type', 'foo']);
           let url = request.url;
           expect(url.indexOf('hello?')).to.be(-1);
           expect(url.indexOf('hello')).to.be(0);


### PR DESCRIPTION
Fixes #2817.  Updates our handling of XHR data to match the spec: https://fetch.spec.whatwg.org/#bodyinit.  We explicitly set the `contentType` where we are sending JSON data.