### PR TITLE
New borders + UI Improvements

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -102,7 +102,7 @@
 
 
 .p-Menu-item.p-mod-disabled {
-  color: var(--jp-ui-font-color2);
+  color: var(--jp-ui-font-color3);
 }
 
 

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -31,13 +31,13 @@
 .p-CommandPalette-search {
   padding: 8px;
   background-color: var(--jp-layout-color2);
-  border-bottom: 1px solid var(--jp-border-color1);
+  border-bottom: 1px solid var(--jp-border-color0);
 }
 
 .p-CommandPalette-wrapper {
   overflow: overlay;
   padding: 0px 8px;
-  border: 1px solid var(--jp-border-color1);
+  border: 1px solid var(--jp-border-color0);
   background-color: var(--jp-input-background-color);
   height: 30px;
 }
@@ -107,7 +107,7 @@
   font-weight: 600;
   cursor: pointer;
   text-transform: uppercase;
-  border-bottom: solid var(--jp-border-width) var(--jp-border-color1);
+  border-bottom: solid var(--jp-border-width) var(--jp-border-color2);
   letter-spacing: 1px;
 }
 
@@ -139,7 +139,7 @@
 
 
 .p-CommandPalette-item.p-mod-disabled {
-  color: var(--jp-ui-font-color2);
+  color: var(--jp-ui-font-color3);
 }
 
 
@@ -177,14 +177,14 @@
 
 .p-CommandPalette-content::-webkit-scrollbar {
   background-color: var(--jp-layout-color1);
-  border-left: 1px solid var(--jp-border-color1);
+  border-left: 1px solid var(--jp-border-color2);
   width: var(--jp-scrollbar-width);
 }
 
 
 .p-CommandPalette-content::-webkit-scrollbar-thumb {
   background-color: var(--jp-layout-color2);
-  border-left: 1px solid var(--jp-border-color1);
+  border-left: 1px solid var(--jp-border-color2);
   border-radius: 0px;
 }
 

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -32,6 +32,8 @@
   padding: 8px;
   background-color: var(--jp-layout-color2);
   border-bottom: 1px solid var(--jp-border-color0);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  z-index: 2;
 }
 
 .p-CommandPalette-wrapper {
@@ -185,6 +187,8 @@
 .p-CommandPalette-content::-webkit-scrollbar-thumb {
   background-color: var(--jp-layout-color2);
   border-left: 1px solid var(--jp-border-color2);
+  padding-left: 1px;
+  padding-right: 1px;
   border-radius: 0px;
 }
 

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -25,6 +25,7 @@
   font-size: var(--jp-code-font-size);
   font-family: var(--jp-code-font-family);
   height: auto;
+  background: transparent;
   /* Changed to auto to autogrow */
 }
 

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -76,7 +76,7 @@
 
 
 .CodeMirror-gutters {
-  border-right: 1px solid var(--jp-border-color1);
+  border-right: 1px solid var(--jp-border-color2);
   background-color: var(--jp-layout-color2);
 }
 
@@ -127,11 +127,11 @@
 }
 
 .CodeMirror-vscrollbar::-webkit-scrollbar {
-  border-left: 1px solid var(--jp-border-color1);
+  border-left: 1px solid var(--jp-border-color2);
 }
 
 .CodeMirror-hscrollbar::-webkit-scrollbar {
-  border-top: 1px solid var(--jp-border-color1);
+  border-top: 1px solid var(--jp-border-color2);
 }
 
 .CodeMirror-vscrollbar::-webkit-scrollbar-thumb, .CodeMirror-hscrollbar::-webkit-scrollbar-thumb {
@@ -140,11 +140,11 @@
 }
 
 .CodeMirror-vscrollbar::-webkit-scrollbar-thumb {
-  border-left: 1px solid var(--jp-border-color1);
+  border-left: 1px solid var(--jp-border-color2);
 }
 
 .CodeMirror-hscrollbar::-webkit-scrollbar-thumb {
-  border-top: 1px solid var(--jp-border-color1);
+  border-top: 1px solid var(--jp-border-color2);
 }
 
 

--- a/packages/faq-extension/style/index.css
+++ b/packages/faq-extension/style/index.css
@@ -14,6 +14,8 @@
 
 .jp-FAQ-toolbar {
   min-height: var(--jp-toolbar-micro-height);
+  border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
+  box-shadow: var(--jp-toolbar-box-shadow);
 }
 
 

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -98,7 +98,9 @@
   flex-direction: row;
   overflow: hidden;
   border-top: var(--jp-border-width) solid var(--jp-border-color2);
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  z-index: 2;
 }
 
 

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -97,8 +97,8 @@
   display: flex;
   flex-direction: row;
   overflow: hidden;
-  border-top: var(--jp-border-width) solid var(--jp-border-color1);
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  border-top: var(--jp-border-width) solid var(--jp-border-color2);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
 }
 
 
@@ -120,7 +120,7 @@
 
 .jp-DirListing-headerItem.jp-id-modified {
   flex: 0 0 112px;
-  border-left: var(--jp-border-width) solid var(--jp-border-color1);
+  border-left: var(--jp-border-width) solid var(--jp-border-color2);
   text-align: right;
 }
 
@@ -164,7 +164,7 @@
 /* Styling for the file browser content scroll bar */
 .jp-DirListing-content::-webkit-scrollbar {
   background-color: var(--jp-layout-color1);
-  border-left: 1px solid var(--jp-border-color1);
+  border-left: 1px solid var(--jp-border-color2);
   width: var(--jp-scrollbar-width);
 }
 
@@ -172,7 +172,7 @@
 .jp-DirListing-content::-webkit-scrollbar-thumb {
   background-color: var(--jp-layout-color2);
   border-radius: 0px;
-  border-left: 1px solid var(--jp-border-color1);
+  border-left: 1px solid var(--jp-border-color2);
 }
 
 

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -74,14 +74,14 @@
 
 .jp-Notebook::-webkit-scrollbar {
   background-color: var(--jp-layout-color0);
-  border-left: 1px solid var(--jp-border-color1);
+  border-left: 1px solid var(--jp-border-color2);
   width: var(--jp-scrollbar-width);
 }
 
 
 .jp-Notebook::-webkit-scrollbar-thumb {
   background-color: var(--jp-layout-color2);
-  border-left: 1px solid var(--jp-border-color1);
+  border-left: 1px solid var(--jp-border-color2);
 }
 
 

--- a/packages/running/style/index.css
+++ b/packages/running/style/index.css
@@ -80,7 +80,7 @@
   padding: 4px 12px;
   font-weight: 600;
   text-transform: uppercase;
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
   letter-spacing: 1px;
 }
 

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -39,7 +39,7 @@
 
 
 #setting-editor .p-SplitPanel-handle {
-  background-color: var(--jp-border-color1);
+  background-color: var(--jp-border-color2);
 }
 
 
@@ -100,6 +100,12 @@
 
 #setting-editor ul.jp-PluginList li.jp-mod-selected {
   background-color: var(--jp-brand-color1);
+  color: white;
+}
+
+
+#setting-editor ul.jp-PluginList li.jp-mod-selected {
+  border: 1px solid var(--jp-brand-color1);
 }
 
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -41,7 +41,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-border-width: 1px;
   --jp-border-color0: var(--md-grey-700);
   --jp-border-color1: var(--md-grey-800);
-  --jp-border-color2: var(--md-grey-900);
+  --jp-border-color2: var(--md-grey-800);
   --jp-border-color3: var(--md-grey-900);
 
   /* UI Fonts
@@ -180,7 +180,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Toolbar specific styles */
 
-  --jp-toolbar-border-color: var(--jp-border-color1);
+  --jp-toolbar-border-color: var(--jp-border-color2);
   --jp-toolbar-micro-height: 8px;
   --jp-toolbar-background: var(--jp-layout-color1);
   --jp-toolbar-box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -188,7 +188,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Toolbar specific styles */
 
-  --jp-toolbar-border-color: var(--md-grey-400);
+  --jp-toolbar-border-color: var(--jp-border-color2);
   --jp-toolbar-micro-height: 8px;
   --jp-toolbar-background: var(--jp-layout-color1);
   --jp-toolbar-box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -148,9 +148,9 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Window/plugin scroll bar styling */
 
-  --jp-scrollbar-thumb-color: var(--jp-layout-color1);
-  --jp-scrollbar-background-color: var(--jp-layout-color2);
-  --jp-scrollbar-border: 1px solid var(--jp-border-color1);
+  --jp-scrollbar-thumb-color: var(--jp-layout-color2);
+  --jp-scrollbar-background-color: var(--jp-layout-color0);
+  --jp-scrollbar-border: 1px solid var(--jp-border-color2);
 
   /* Cell specific styles */
 
@@ -188,7 +188,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Toolbar specific styles */
 
-  --jp-toolbar-border-color: var(--jp-border-color2);
+  --jp-toolbar-border-color: var(--jp-border-color1);
   --jp-toolbar-micro-height: 8px;
   --jp-toolbar-background: var(--jp-layout-color1);
   --jp-toolbar-box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);


### PR DESCRIPTION
## Refined the styling of the borders in the application to be less stark and have clearer hierarchy across views. 

### Before
![screen shot 2017-08-11 at 4 25 52 pm](https://user-images.githubusercontent.com/6437976/29235222-e8569c38-7eb1-11e7-8184-2937fad58290.png)

### After 
![screen shot 2017-08-11 at 4 23 12 pm](https://user-images.githubusercontent.com/6437976/29235226-ee6e5692-7eb1-11e7-9066-a3976c6a601c.png)

## Changed border variables on the dark theme to be consistent with the light theme. 

## Fixed hover styling of active item within the settings pane. 

### Before 
<img width="169" alt="screen shot 2017-08-11 at 4 38 51 pm" src="https://user-images.githubusercontent.com/6437976/29235433-9cde6126-7eb3-11e7-84cb-1b608bcd065f.png">

### After
<img width="160" alt="screen shot 2017-08-11 at 4 38 19 pm" src="https://user-images.githubusercontent.com/6437976/29235436-a0c75b6c-7eb3-11e7-84d7-2055ff400ed3.png">

## Fixed a styling issue with CodeMirror that was causing it to always have a white background (more apparent in the dark theme, but was affecting everything that was using CodeMirror for text). 

### Before
<img width="545" alt="screen shot 2017-08-11 at 4 41 02 pm" src="https://user-images.githubusercontent.com/6437976/29235477-018e550e-7eb4-11e7-8276-4cda8e09f1c7.png">

<img width="544" alt="screen shot 2017-08-11 at 4 41 16 pm" src="https://user-images.githubusercontent.com/6437976/29235479-053c5b38-7eb4-11e7-9d55-03cc55863a01.png">

<img width="207" alt="screen shot 2017-08-11 at 4 42 33 pm" src="https://user-images.githubusercontent.com/6437976/29235489-25568c22-7eb4-11e7-9ea2-b695f2715c66.png">


### After
<img width="528" alt="screen shot 2017-08-11 at 4 40 06 pm" src="https://user-images.githubusercontent.com/6437976/29235483-0e225284-7eb4-11e7-9668-4b33a42b2cf3.png">

<img width="529" alt="screen shot 2017-08-11 at 4 40 40 pm" src="https://user-images.githubusercontent.com/6437976/29235485-112ea018-7eb4-11e7-88fb-90920fda3a46.png">

<img width="432" alt="screen shot 2017-08-11 at 4 42 42 pm" src="https://user-images.githubusercontent.com/6437976/29235491-29217e84-7eb4-11e7-9f0a-e0eb7b927b67.png">

## Added styling to the FAQ extensions to match the rest of the application. 

### Before
<img width="543" alt="screen shot 2017-08-11 at 4 44 19 pm" src="https://user-images.githubusercontent.com/6437976/29235520-5ee411a8-7eb4-11e7-8fef-3ccbf83d6e2c.png">

### After
<img width="526" alt="screen shot 2017-08-11 at 4 44 53 pm" src="https://user-images.githubusercontent.com/6437976/29235531-6f67acec-7eb4-11e7-99f2-8a07cbd7e72e.png">

## Added a box shadow to toolbars that are being used in the side panel to stay consistent across the application. This addition really helps to make the application less flat. It is really subtle but definitely improves the overall experience.

### Before
<img width="300" alt="screen shot 2017-08-11 at 4 46 45 pm" src="https://user-images.githubusercontent.com/6437976/29235606-010e8e90-7eb5-11e7-89c2-0e7f1a20cecb.png">

<img width="300" alt="screen shot 2017-08-11 at 4 46 55 pm" src="https://user-images.githubusercontent.com/6437976/29235608-049c4b7e-7eb5-11e7-86b2-d2c53fd7d588.png">

### After
<img width="300" alt="screen shot 2017-08-11 at 4 46 24 pm" src="https://user-images.githubusercontent.com/6437976/29235610-09d3a6b4-7eb5-11e7-91dd-2b69e0080644.png">

<img width="300" alt="screen shot 2017-08-11 at 4 46 34 pm" src="https://user-images.githubusercontent.com/6437976/29235612-0d2b27a6-7eb5-11e7-9ab1-53c7a090d2f3.png">


