### PR TITLE
Improved incompatibility warning

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -720,12 +720,27 @@ def _test_overlap(spec1, spec2):
 def _format_compatibility_errors(name, version, errors):
     """Format a message for compatibility errors.
     """
+    msgs = []
+    l0 = 10
+    l1 = 10
+    for error in errors:
+        pkg, jlab, ext = error
+        jlab = str(Range(jlab, True))
+        ext = str(Range(ext, True))
+        msgs.append((pkg, jlab, ext))
+        l0 = max(l0, len(pkg) + 1)
+        l1 = max(l1, len(jlab) + 1)
+
     msg = '\n"%s@%s" is not compatible with the current JupyterLab'
     msg = msg % (name, version)
-    msg += '\nConflicting Dependencies:'
-    msg += '\nRequired\tActual\tPackage'
-    for error in errors:
-        msg += '\n%s  \t%s\t%s' % (error[1], error[2], error[0])
+    msg += '\nConflicting Dependencies:\n'
+    msg += 'JupyterLab'.ljust(l0)
+    msg += 'Extension'.ljust(l1)
+    msg += 'Package\n'
+
+    for (pkg, jlab, ext) in msgs:
+        msg += jlab.ljust(l0) + ext.ljust(l1) + pkg + '\n'
+
     return msg
 
 


### PR DESCRIPTION
Better titles and more explicit version ranges.  Fixes #2811.


```
"@jupyterlab/google-drive@0.4.0" is not compatible with the current JupyterLab
Conflicting Dependencies:
JupyterLab              Extension            Package
>=0.9.0-0 <0.10.0-0     >=0.8.0-0 <0.9.0-0   @jupyterlab/filebrowser
>=0.9.0-0 <0.10.0-0     >=0.8.0-0 <0.9.0-0   @jupyterlab/apputils
>=0.48.0-0 <0.49.0-0    >=0.47.0-0 <0.48.0-0 @jupyterlab/services
>=0.9.0-0 <0.10.0-0     >=0.8.0-0 <0.9.0-0   @jupyterlab/docmanager
>=0.9.0-0 <0.10.0-0     >=0.8.0-0 <0.9.0-0   @jupyterlab/coreutils
>=0.9.0-0 <0.10.0-0     >=0.8.0-0 <0.9.0-0   @jupyterlab/application
```