### PR TITLE
Allow other CodeMirror themes to set background and color

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -76,9 +76,9 @@
     "glob": "^7.1.2",
     "handlebars": "^4.0.6",
     "json-loader": "^0.5.4",
+    "raw-loader": "^0.5.1",
     "sort-package-json": "^1.7.0",
     "style-loader": "^0.13.1",
-    "raw-loader": "^0.5.1",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1"
   },

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -25,21 +25,32 @@
   font-size: var(--jp-code-font-size);
   font-family: var(--jp-code-font-family);
   height: auto;
-  background: transparent;
   /* Changed to auto to autogrow */
 }
 
 
 .CodeMirror pre {
-  color: var(--jp-mirror-editor-pre-color);
   padding: 0;
   border: 0;
   border-radius: 0;
 }
 
+
+.CodeMirror.cm-s-jupyter {
+  background: var(--jp-layout-color0);
+}
+
+
+.CodeMirror.cm-s-jupyter pre {
+  color: var(--jp-mirror-editor-pre-color);
+}
+
+
 .jp-OutputArea-output pre {
   color: var(--jp-mirror-editor-pre-color);
 }
+
+
 
 
 /* This causes https://github.com/jupyter/jupyterlab/issues/522 */

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -51,8 +51,6 @@
 }
 
 
-
-
 /* This causes https://github.com/jupyter/jupyterlab/issues/522 */
 /* May not cause it not because we changed it! */
 .CodeMirror-lines {


### PR DESCRIPTION
Only provide overrides for the `jupyter` theme.

jupyter (dark):
<image src="https://user-images.githubusercontent.com/2096628/29377756-60a8464a-8282-11e7-88e4-ebee0130ac20.png" width=400>

jupyter (light):
<image src="https://user-images.githubusercontent.com/2096628/29377825-9b83c032-8282-11e7-9f66-af4c1c848761.png" width=400>

base16-light (dark):
<image src="https://user-images.githubusercontent.com/2096628/29377939-f9c1c662-8282-11e7-8ffb-dff2bd37a8c9.png" width=400>

base16-light (light):
<image src="https://user-images.githubusercontent.com/2096628/29377802-8cabe238-8282-11e7-8fe8-c244e7715bbe.png" width=400>

