### PR TITLE
Improved handling of initial launcher

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -76,9 +76,9 @@
     "glob": "^7.1.2",
     "handlebars": "^4.0.6",
     "json-loader": "^0.5.4",
+    "raw-loader": "^0.5.1",
     "sort-package-json": "^1.7.0",
     "style-loader": "^0.13.1",
-    "raw-loader": "^0.5.1",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1"
   },

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -197,6 +197,18 @@ function activateFileBrowser(app: JupyterLab, factory: IFileBrowserFactory, docM
     }
   });
 
+  // Create a launcher if there are no open items.
+  app.restored.then(() => {
+    if (app.shell.isEmpty('main')) {
+      // Make sure the model is restored.
+      fbWidget.model.restored.then(() => {
+        app.commands.execute('launcher:create', {
+          cwd: fbWidget.model.path
+        });
+      });
+    }
+  });
+
   let menu = createMenu(app);
 
   mainMenu.addMenu(menu, { rank: 1 });
@@ -363,15 +375,6 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, mai
     execute: () => {
       return commands.execute('launcher:create', {
         cwd: mainBrowser.model.path,
-      });
-    }
-  });
-
-  // Create a launcher with a banner if there are no open items.
-  app.restored.then(() => {
-    if (app.shell.isEmpty('main')) {
-      commands.execute('launcher:create', {
-        cwd: mainBrowser.model.path
       });
     }
   });

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -18,6 +18,10 @@ import {
 } from '@phosphor/algorithm';
 
 import {
+  PromiseDelegate
+} from '@phosphor/coreutils';
+
+import {
   IDisposable
 } from '@phosphor/disposable';
 
@@ -84,6 +88,13 @@ class FileBrowserModel implements IDisposable {
    */
   get connectionFailure(): ISignal<this, Error> {
     return this._connectionFailure;
+  }
+
+  /**
+   * A promise that resolves when the model is first restored.
+   */
+  get restored(): Promise<void> {
+    return this._restored.promise;
   }
 
   /**
@@ -263,6 +274,7 @@ class FileBrowserModel implements IDisposable {
     const ready = manager.services.ready;
     return Promise.all([state.fetch(key), ready]).then(([cwd]) => {
       if (!cwd) {
+        this._restored.resolve(void 0);
         return;
       }
 
@@ -272,7 +284,10 @@ class FileBrowserModel implements IDisposable {
         .then(() => this.cd(localPath))
         .catch(() => state.remove(key));
     }).catch(() => state.remove(key))
-      .then(() => { this._key = key; }); // Set key after restoration is done.
+      .then(() => {
+        this._key = key;
+        this._restored.resolve(void 0);
+      }); // Set key after restoration is done.
   }
 
   /**
@@ -454,6 +469,7 @@ class FileBrowserModel implements IDisposable {
   private _timeoutId = -1;
   private _driveName: string;
   private _isDisposed = false;
+  private _restored = new PromiseDelegate<void>();
 }
 
 


### PR DESCRIPTION
Fixes #2727.  Waits for the filebrowser model to restore itself before creating the initial launcher.