### PR TITLE
Extension case insensitive

### DIFF
--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1239,25 +1239,6 @@ namespace DocumentRegistry {
  */
 namespace Private {
   /**
-   * Normalize a file extension to be of the type `'.foo'`.
-   *
-   * Adds a leading dot if not present and converts to lower case.
-   */
-  export
-  function normalizeExtension(extension: string): string {
-    if (extension === '*') {
-      return extension;
-    }
-    if (extension === '.*') {
-      return '*';
-    }
-    if (extension.indexOf('.') !== 0) {
-      extension = `.${extension}`;
-    }
-    return extension.toLowerCase();
-  }
-
-  /**
    * Get the extension name of a path.
    *
    * @param file - string.
@@ -1269,7 +1250,8 @@ namespace Private {
   function extname(path: string): string {
     let parts = PathExt.basename(path).split('.');
     parts.shift();
-    return '.' + parts.join('.');
+    let ext = '.' + parts.join('.');
+    return ext.toLowerCase();
   }
   /**
    * A no-op function.

--- a/test/src/docregistry/registry.spec.ts
+++ b/test/src/docregistry/registry.spec.ts
@@ -583,6 +583,53 @@ describe('docregistry/registry', () => {
         expect(ft.name).to.be('vega');
       });
 
+      it('should be case insensitive', () => {
+        let ft = registry.getFileTypeForModel({
+          name: 'foo.PY'
+        });
+        expect(ft.name).to.be('python');
+      });
+
+    });
+
+    describe('#getFileTypesForPath()', () => {
+
+      beforeEach(() => {
+        DocumentRegistry.defaultFileTypes.forEach(ft => {
+          registry.addFileType(ft);
+        });
+      });
+
+      it('should handle a notebook', () => {
+        let ft = registry.getFileTypesForPath('foo/bar/baz.ipynb');
+        expect(ft[0].name).to.be('notebook');
+      });
+
+      it('should handle a python file', () => {
+        let ft = registry.getFileTypesForPath('foo/bar/baz.py');
+        expect(ft[0].name).to.be('python');
+      });
+
+      it('should return an empty list for an unknown file', () => {
+        let ft = registry.getFileTypesForPath('foo/bar/baz.weird');
+        expect(ft.length).to.be(0);
+      });
+
+      it('should get the most specific extension first', () => {
+        [
+          { name: 'json', extensions: ['.json'] },
+          { name: 'vega', extensions: ['.vg.json'] }
+        ].forEach(ft => {registry.addFileType(ft); });
+        let ft = registry.getFileTypesForPath('foo/bar/baz.vg.json');
+        expect(ft[0].name).to.be('vega');
+        expect(ft[1].name).to.be('json');
+      });
+
+      it('should be case insensitive', () => {
+        let ft = registry.getFileTypesForPath('foo/bar/baz.PY');
+        expect(ft[0].name).to.be('python');
+      });
+
     });
 
   });


### PR DESCRIPTION
It is nice to have extension matching be case insensitive (especially for things like image formats, for whatever reason). We were previously doing this, but it got left behind in the `IFileTypes` refactor.