### PR TITLE
Remove troublesome context menu handling logic

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -76,9 +76,9 @@
     "glob": "^7.1.2",
     "handlebars": "^4.0.6",
     "json-loader": "^0.5.4",
+    "raw-loader": "^0.5.1",
     "sort-package-json": "^1.7.0",
     "style-loader": "^0.13.1",
-    "raw-loader": "^0.5.1",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1"
   },

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -615,9 +615,6 @@ class DirListing extends Widget {
     case 'dblclick':
       this._evtDblClick(event as MouseEvent);
       break;
-    case 'contextmenu':
-      this._evtContextMenu(event as MouseEvent);
-      break;
     case 'dragenter':
     case 'dragover':
       event.preventDefault();
@@ -656,7 +653,6 @@ class DirListing extends Widget {
     node.addEventListener('keydown', this);
     node.addEventListener('click', this);
     node.addEventListener('dblclick', this);
-    node.addEventListener('contextmenu', this);
     content.addEventListener('dragenter', this);
     content.addEventListener('dragover', this);
     content.addEventListener('drop', this);
@@ -678,7 +674,6 @@ class DirListing extends Widget {
     node.removeEventListener('keydown', this);
     node.removeEventListener('click', this);
     node.removeEventListener('dblclick', this);
-    node.removeEventListener('contextmenu', this);
     content.removeEventListener('scroll', this);
     content.removeEventListener('dragover', this);
     content.removeEventListener('dragover', this);
@@ -789,13 +784,6 @@ class DirListing extends Widget {
   }
 
   /**
-   * Handle the `'contextmenu'` event for the widget.
-   */
-  private _evtContextMenu(event: MouseEvent): void {
-    this._inContext = true;
-  }
-
-  /**
    * Handle the `'mousedown'` event for the widget.
    */
   private _evtMousedown(event: MouseEvent): void {
@@ -817,11 +805,9 @@ class DirListing extends Widget {
 
     // Check for clearing a context menu.
     let newContext = (IS_MAC && event.ctrlKey) || (event.button === 2);
-    if (this._inContext && !newContext) {
-      this._inContext = false;
+    if (newContext) {
       return;
     }
-    this._inContext = false;
 
     let index = Private.hitTestNodes(this._items, event.clientX, event.clientY);
     if (index === -1) {
@@ -1428,7 +1414,6 @@ class DirListing extends Widget {
   private _clipboard: string[] = [];
   private _manager: IDocumentManager;
   private _softSelection = '';
-  private _inContext = false;
   private _selection: { [key: string]: boolean; } = Object.create(null);
   private _renderer: DirListing.IRenderer;
   private _searchPrefix: string = '';


### PR DESCRIPTION
Fixes #1006.  I had added logic to track whether a context menu was open so that when you clicked out of it it would preserve the selection.  However, the logic to detect when the context menu was closed relied a new `mousedown` event, preventing the next selection from working.