### PR TITLE
Allow an initial command to be passed to a terminal

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -76,9 +76,9 @@
     "glob": "^7.1.2",
     "handlebars": "^4.0.6",
     "json-loader": "^0.5.4",
+    "raw-loader": "^0.5.1",
     "sort-package-json": "^1.7.0",
     "style-loader": "^0.13.1",
-    "raw-loader": "^0.5.1",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1"
   },

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -164,8 +164,9 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Instanc
     label: 'New Terminal',
     caption: 'Start a new terminal session',
     execute: args => {
-      let name = args ? args['name'] as string : '';
-      let term = new Terminal();
+      let name = args['name'] as string;
+      let initialCommand = args['initialCommand'] as string;
+      let term = new Terminal({ initialCommand });
       term.title.closable = true;
       term.title.icon = TERMINAL_ICON_CLASS;
       term.title.label = '...';

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -74,6 +74,7 @@ class Terminal extends Widget {
     // Initialize settings.
     let defaults = Terminal.defaultOptions;
     this._fontSize = options.fontSize || defaults.fontSize;
+    this._initialCommand = options.initialCommand || defaults.initialCommand;
     this.theme = options.theme || defaults.theme;
     this.id = `jp-Terminal-${Private.id++}`;
     this.title.label = 'Terminal';
@@ -100,6 +101,12 @@ class Terminal extends Widget {
       value.messageReceived.connect(this._onMessage, this);
       this.title.label = `Terminal ${value.name}`;
       this._setSessionSize();
+      if (this._initialCommand) {
+        this._session.send({
+          type: 'stdin',
+          content: [this._initialCommand + '\n']
+        });
+      }
     });
   }
 
@@ -341,6 +348,7 @@ class Terminal extends Widget {
   private _theme: Terminal.Theme = 'dark';
   private _box: ElementExt.IBoxSizing | null = null;
   private _session: TerminalSession.ISession | null = null;
+  private _initialCommand: string;
 }
 
 
@@ -368,6 +376,11 @@ namespace Terminal {
      * Whether to blink the cursor.  Can only be set at startup.
      */
     cursorBlink: boolean;
+
+    /**
+     * Initial command.
+     */
+    initialCommand: string;
   }
 
   /**
@@ -377,7 +390,8 @@ namespace Terminal {
   const defaultOptions: IOptions = {
     theme: 'dark',
     fontSize: 13,
-    cursorBlink: true
+    cursorBlink: true,
+    initialCommand: ''
   };
 
   /**

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -378,7 +378,7 @@ namespace Terminal {
     cursorBlink: boolean;
 
     /**
-     * Initial command.
+     * An optional command to run when the session starts.
      */
     initialCommand: string;
   }


### PR DESCRIPTION
Fixes #2855.   Allows an `initialCommand` to be passed to the `terminal:create-new` command.

<image src="https://user-images.githubusercontent.com/2096628/29425384-af98d82a-8348-11e7-9d5f-381c33622dea.png" width=400>
