### PR TITLE
Whitelist audio video

### DIFF
--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -25,7 +25,7 @@ class Sanitizer implements ISanitizer {
 
   private _options: sanitize.IOptions = {
     allowedTags: sanitize.defaults.allowedTags
-      .concat('h1', 'h2', 'img', 'span'),
+      .concat('h1', 'h2', 'img', 'span', 'audio', 'video'),
     allowedAttributes: {
       // Allow the "rel" attribute for <a> tags.
       'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),
@@ -34,7 +34,12 @@ class Sanitizer implements ISanitizer {
       // Allow "class" attribute for <code> tags.
       'code': ['class'],
       // Allow "class" attribute for <span> tags.
-      'span': ['class']
+      'span': ['class'],
+      // Allow the "src" attribute for <audio> tags.
+      'audio': ['src', 'autoplay', 'loop', 'muted', 'controls'],
+      // Allow the "src" attribute for <video> tags.
+      'video': ['src', 'height', 'width', 'autoplay',
+                'loop', 'muted', 'controls']
     },
     transformTags: {
       // Set the "rel" attribute for <a> tags to "nofollow".

--- a/test/src/apputils/sanitizer.spec.ts
+++ b/test/src/apputils/sanitizer.spec.ts
@@ -63,6 +63,18 @@ describe('defaultSanitizer', () => {
       expect(defaultSanitizer.sanitize(div)).to.be(div);
     });
 
+    it('should allow video tags with some attributes', () => {
+      let video = '<video src="my/video.mp4" height="42" width="42"' +
+                  ' autoplay controls loop muted></video>';
+      expect(defaultSanitizer.sanitize(video)).to.be(video);
+    });
+
+    it('should allow audio tags with some attributes', () => {
+      let audio = '<audio src="my/audio.ogg autoplay loop ' +
+                  'controls muted"></audio>';
+      expect(defaultSanitizer.sanitize(audio)).to.be(audio);
+    });
+
   });
 
 });


### PR DESCRIPTION
Whitelists audio and video tags for the sanitizer in rendered HTML.
Specifically avoids vulnerabilities listed [here](https://html5sec.org/), namely:
* A `<source>` tag encapsulated in an `<audio>` or `<video>` tags.
* The `poster` attribute
* Error handlers (i.e. `onerror`) in the `<audio>` or `<video>` tags.
* `onratechange` handlers in the `<video>` tag.

If there are other things to investigate security-wise, happy to try to chase them down.