### PR TITLE
Fixing rendermime styles

### DIFF
--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -66,7 +66,7 @@
 
 
 .jp-RenderedText[data-mime-type="application/vnd.jupyter.stderr"] {
-  background: var(--jp-notebook-error-background-color);
+  background: var(--jp-rendermime-error-background);
 }
 
 
@@ -292,7 +292,6 @@ margin-top = 14, 14, 14, 14, 8, 8
 
 
 .jp-RenderedHTMLCommon table {
-  border: 1px solid var(--jp-border-color1);
   border-collapse: collapse;
   border-spacing: 0;
   color: var(--jp-ui-font-color1);
@@ -328,7 +327,6 @@ margin-top = 14, 14, 14, 14, 8, 8
 
 
 .jp-RenderedHTMLCommon th {
-  background-color: var(--jp-layout-color2);
   font-weight: bold;
 }
 
@@ -339,12 +337,12 @@ margin-top = 14, 14, 14, 14, 8, 8
 
 
 .jp-RenderedHTMLCommon tbody tr:nth-child(even) {
-  background: var(--jp-layout-color1);
+  background: var(  --jp-rendermime-row-background);
 }
 
 
 .jp-RenderedHTMLCommon tbody tr:hover {
-  background: var(--jp-notebook-tr-hover-background-color);
+  background: var( --jp-rendermime-row-hover-background);
 }
 
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -170,8 +170,12 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-notebook-scroll-padding: 100px;
   --jp-notebook-select-background-color: var(--jp-layout-color1);
   --jp-notebook-multiselected-color: rgba(33,150,243,.24);
-  --jp-notebook-error-background-color: rgba(244,67,54,.28);
-  --jp-notebook-tr-hover-background-color: rgba(3,169,244,.2);
+  --jp-rendermime-error-background: rgba(244,67,54,.28);
+
+  /* Rendermime styles */
+
+  --jp-rendermime-row-background: var(--md-grey-900);
+  --jp-rendermime-row-hover-background: rgba(3,169,244,.2);
 
   /* Dialog specific styles */
   --jp-dialog-background: rgba(0,0,0,.6);

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -173,10 +173,15 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-notebook-padding: 10px;
   --jp-notebook-scroll-padding: 100px;
   --jp-notebook-multiselected-color: var(--md-blue-50);
-  --jp-notebook-error-background-color: #fdd;
-  --jp-notebook-tr-hover-background-color: var(--md-light-blue-50);
+
+  /* Rendermime styles */
+
+  --jp-rendermime-error-background: #fdd;
+  --jp-rendermime-row-background: var(--md-grey-100);
+  --jp-rendermime-row-hover-background: var(--md-light-blue-50);
 
   /* Dialog specific styles */
+  
   --jp-dialog-background: rgba(0,0,0,.25);
 
   /* Console specific styles */


### PR DESCRIPTION
This fixes #2848 and brings the table style back in line with that of the classic notebook. It also applies that same design to the dark theme. This looks like:

<img width="844" alt="screen shot 2017-08-20 at 7 23 46 pm" src="https://user-images.githubusercontent.com/27600/29499362-41274916-85dd-11e7-8587-ee63fc5831a7.png">

<img width="896" alt="screen shot 2017-08-20 at 7 24 00 pm" src="https://user-images.githubusercontent.com/27600/29499364-4423bdb6-85dd-11e7-8b0b-2c11263258c2.png">

@cameronoelsen 