### PR TITLE
Apply text color more generally to allow vim dialog theming.

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -41,7 +41,7 @@
 }
 
 
-.CodeMirror.cm-s-jupyter pre {
+.CodeMirror.cm-s-jupyter {
   color: var(--jp-mirror-editor-pre-color);
 }
 


### PR DESCRIPTION
Only applying the jupyter theme to `<pre>` tags was missing the Codemirror dialog entry box, which is used in vim-mode, making it illegible in the jupyter theme.

Is this relaxing of the selector a problem anywhere else? cc @ellisonbg @cameronoelsen 