### PR TITLE
Link to 'How to Extend the Notebook Plugin' from extensions_dev.

### DIFF
--- a/docs/extensions_dev.md
+++ b/docs/extensions_dev.md
@@ -168,6 +168,12 @@ for an example.  Ensure that the theme files are included in the
 an `embed.css` file that can be consumed outside of a JupyterLab application.
 See the JupyterLab Light Theme for an example.
 
+## Standard (General-Purpose) Extensions
+See the example,
+[How to Extend the Notebook Plugin](https://github.com/jupyterlab/jupyterlab/blob/master/docs/notebook.md#how-to-extend-the-notebook-plugin). Notice that the mime
+renderer and themes extensions above use a limited, simplified interface to
+JupyterLab's extension system. Modifying the notebook plugin requires the full,
+general-purpose interface to the extension system.
 
 ## Extension Settings
 An extension can specify user settings using a JSON Schema.  The schema


### PR DESCRIPTION
This should make the example more easily discoverable, addressing a request
from yesterday's tutorial.