### PR TITLE
Call closeFile during deleteFile in docmanager package. Closes #2865.

### DIFF
--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -230,6 +230,9 @@ class DocumentManager implements IDisposable {
   deleteFile(path: string): Promise<void> {
     return this.services.sessions.stopIfNeeded(path).then(() => {
       return this.services.contents.delete(path);
+    })
+    .then(() => {
+      return this.closeFile(path);
     });
   }
 

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -232,7 +232,11 @@ class DocumentManager implements IDisposable {
       return this.services.contents.delete(path);
     })
     .then(() => {
-      return this.closeFile(path);
+      let context = this._contextForPath(path);
+      if (context) {
+        return this._widgetManager.deleteWidgets(context);
+      }
+      return Promise.resolve(void 0);
     });
   }
 

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -209,6 +209,19 @@ class DocumentWidgetManager implements IDisposable {
   }
 
   /**
+   * Dispose of the widgets associated with a given context
+   * regardless of the widget's dirty state.
+   *
+   * @param context - The document context object.
+   */
+  deleteWidgets(context: DocumentRegistry.Context): Promise<void> {
+    let widgets = Private.widgetsProperty.get(context);
+    return Promise.all(
+      toArray(map(widgets, widget => this.onDelete(widget)))
+    ).then(() => undefined);
+  }
+
+  /**
    * Filter a message sent to a message handler.
    *
    * @param handler - The target handler of the message.
@@ -290,6 +303,16 @@ class DocumentWidgetManager implements IDisposable {
       widget.dispose();
       throw error;
     });
+  }
+
+  /**
+   * Dispose of widget regardless of widget's dirty state.
+   *
+   * @param widget - The target widget.
+   */
+  protected onDelete(widget: Widget): Promise<void> {
+    widget.dispose();
+    return Promise.resolve(void 0);
   }
 
   /**


### PR DESCRIPTION
Calling `closeFile` when a file is deleted to ensure any corresponding open tabs are closed. Let me know if there's more that needs to be considered for fixing this bug, thanks! 