### PR TITLE
Add package readmes

### DIFF
--- a/packages/all-packages/README.md
+++ b/packages/all-packages/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/all-packages
+
+A private package for JupyterLab which aids in building the final bundled distribution of the application.

--- a/packages/all-packages/README.md
+++ b/packages/all-packages/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/all-packages

--- a/packages/application-extension/README.md
+++ b/packages/application-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/application-extension
+
+An extension for JupyterLab which provides some top-level commands and services for the [@jupyterlab/application](../application) package.

--- a/packages/application-extension/README.md
+++ b/packages/application-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/application-extension

--- a/packages/application/README.md
+++ b/packages/application/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/application

--- a/packages/application/README.md
+++ b/packages/application/README.md
@@ -1,1 +1,4 @@
 # @jupyterlab/application
+
+A JupyterLab package that provides the top-level application object,
+with which JupyterLab plugins may be registered.

--- a/packages/apputils-extension/README.md
+++ b/packages/apputils-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/apputils-extension

--- a/packages/apputils-extension/README.md
+++ b/packages/apputils-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/apputils-extension
+
+A JupyterLab extension which provides an entry point for several of the UI elements and utilities in [@jupyterlab/apputils](../apputils).

--- a/packages/apputils/README.md
+++ b/packages/apputils/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/apputils

--- a/packages/apputils/README.md
+++ b/packages/apputils/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/apputils
+
+A JupyterLab package which provides a collection of utilities and UI elements for building an application and manipulating the DOM.

--- a/packages/cells/README.md
+++ b/packages/cells/README.md
@@ -1,1 +1,6 @@
 # @jupyterlab/cells
+
+A JupyterLab package which provides an implementation of a Jupyter notebook cell.
+These cells are used in both the [notebook](../notebook) and the [code console](../console).
+The result of cell execution is shown in an output area,
+which is implemented in [@jupyterlab/outputarea](../outputarea).

--- a/packages/cells/README.md
+++ b/packages/cells/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/cells

--- a/packages/codeeditor/README.md
+++ b/packages/codeeditor/README.md
@@ -1,1 +1,5 @@
 # @jupyterlab/codeeditor
+
+A JupyterLab package which defines an abstract interface to a code editor,
+which is used in many places in the application, including [cells](../cells)
+and the [file editor](../fileeditor).

--- a/packages/codeeditor/README.md
+++ b/packages/codeeditor/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/codeeditor

--- a/packages/codemirror-extension/README.md
+++ b/packages/codemirror-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/codemirror-extension
+
+A JupyterLab package which provides an entry point, commands, and keyboard shortcuts for the [@jupyterlab/codemirror](../codemirror) package.

--- a/packages/codemirror-extension/README.md
+++ b/packages/codemirror-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/codemirror-extension

--- a/packages/codemirror/README.md
+++ b/packages/codemirror/README.md
@@ -1,1 +1,4 @@
 # @jupyterlab/codemirror
+
+A JupyterLab package which provides the default implementation of the [@jupyterlab/codeeditor](../codeeditor)
+interface, using the [CodeMirror](https://codemirror.net) editor.

--- a/packages/codemirror/README.md
+++ b/packages/codemirror/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/codemirror

--- a/packages/completer-extension/README.md
+++ b/packages/completer-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/completer-extension
+
+An extension for JupyterLab which provides an entry point, commands, and keyboard shortcuts for the [@jupyterlab/completer](../completer) package.

--- a/packages/completer-extension/README.md
+++ b/packages/completer-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/completer-extension

--- a/packages/completer/README.md
+++ b/packages/completer/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/completer
+
+A JupyterLab package which provides a text completer for editing code in the Jupyter [notebook](../notebook) and [code console](../console).

--- a/packages/completer/README.md
+++ b/packages/completer/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/completer

--- a/packages/console-extension/README.md
+++ b/packages/console-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/console-extension
+
+An extension for JupyterLab which provides an entry point, commands, and keyboard shortcuts for the [@jupyterlab/console](../console) package.

--- a/packages/console-extension/README.md
+++ b/packages/console-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/console-extension

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/console

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -1,1 +1,6 @@
 # @jupyterlab/console
+
+A JupyterLab package which implements an interactive console for Jupyter kernels.
+It is designed to be similar to the [Jupyter QtConsole](https://github.com/jupyter/qtconsole),
+and can act as a more temporary scratch space for computation using the [notebook](../notebook)
+and the [file editor](../fileeditor).

--- a/packages/coreutils/README.md
+++ b/packages/coreutils/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/coreutils

--- a/packages/coreutils/README.md
+++ b/packages/coreutils/README.md
@@ -1,1 +1,4 @@
 # @jupyterlab/coreutils
+
+A JupyterLab package which provides utility functions and data structures that are widely used across many
+of the `@jupyterlab` packages. This includes (among other things) functions for manipulating paths, urls, strings, lists, and maps.

--- a/packages/csvviewer-extension/README.md
+++ b/packages/csvviewer-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/csvviewer-extension

--- a/packages/csvviewer-extension/README.md
+++ b/packages/csvviewer-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/csvviewer-extension
+
+An extension for JupyterLab which provides an entry point for the [@jupyterlab/csvviewer](../csvviewer) package.

--- a/packages/csvviewer/README.md
+++ b/packages/csvviewer/README.md
@@ -1,1 +1,4 @@
 # @jupyterlab/csvviewer
+
+A JupyterLab package that provides a viewer for CSV files,
+based upon the [@phosphor/datagrid](https://github.com/phosphorjs/phosphor/tree/master/packages/datagrid) package.

--- a/packages/csvviewer/README.md
+++ b/packages/csvviewer/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/csvviewer

--- a/packages/docmanager-extension/README.md
+++ b/packages/docmanager-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/docmanager-extension

--- a/packages/docmanager-extension/README.md
+++ b/packages/docmanager-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/docmanager-extension
+
+An extension for JupyterLab which provides an entry point and commands for the [@jupyterlab/docmanager](../docmanager) package.

--- a/packages/docmanager/README.md
+++ b/packages/docmanager/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/docmanager

--- a/packages/docmanager/README.md
+++ b/packages/docmanager/README.md
@@ -1,1 +1,6 @@
 # @jupyterlab/docmanager
+
+A JupyterLab package which handles interactions with documents and the file system.
+It opens and closes files, creates new views onto files, and keeps track of open documents.
+
+The `DocumentManager` should be considered a singleton for the application.

--- a/packages/docregistry/README.md
+++ b/packages/docregistry/README.md
@@ -1,1 +1,9 @@
 # @jupyterlab/docregistry
+
+A JupyterLab package which tracks the different types of documents that the application is able to interact with.
+This includes notebooks, text files, and base64 encoded documents.
+
+Extensions may register new document types with the document registry to allow them to be opened with JupyterLab.
+An example of this may be found in the [@jupyterlab/notebook](../notebook) package.
+
+The document registry is a singleton on the [application](../application).

--- a/packages/docregistry/README.md
+++ b/packages/docregistry/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/docregistry

--- a/packages/faq-extension/README.md
+++ b/packages/faq-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/faq-extension

--- a/packages/faq-extension/README.md
+++ b/packages/faq-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/faq-extension
+
+A JupyterLab extension which provides a frequently-asked-questions window for the application.

--- a/packages/filebrowser-extension/README.md
+++ b/packages/filebrowser-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/filebrowser-extension
+
+An extension for JupyterLab which provides an entry point, commands, and keyboard shortcuts for the [@jupyterlab/filebrowser](../filebrowser) package.

--- a/packages/filebrowser-extension/README.md
+++ b/packages/filebrowser-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/filebrowser-extension

--- a/packages/filebrowser/README.md
+++ b/packages/filebrowser/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/filebrowser

--- a/packages/filebrowser/README.md
+++ b/packages/filebrowser/README.md
@@ -1,1 +1,5 @@
 # @jupyterlab/filebrowser
+
+A JupyterLab package which provides a file browser to the application.
+Document operations (such as opening, closing, renaming and moving),
+are delegated to the [document manager](../docmanager).

--- a/packages/fileeditor-extension/README.md
+++ b/packages/fileeditor-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/fileeditor-extension

--- a/packages/fileeditor-extension/README.md
+++ b/packages/fileeditor-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/fileeditor-extension
+
+An extension for JupyterLab which provides an entry point, commands, and keyboard shortcuts for the [@jupyterlab/fileeditor](../fileeditor) package.

--- a/packages/fileeditor/README.md
+++ b/packages/fileeditor/README.md
@@ -1,1 +1,5 @@
 # @jupyterlab/fileeditor
+
+A JupyterLab package which provides a text editor. The default text editor wraps
+a [codemirror](../codemirror) instance, but others may be substituted by
+implementing the [@jupyterlab/codeeditor](../codeeditor) interface.

--- a/packages/fileeditor/README.md
+++ b/packages/fileeditor/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/fileeditor

--- a/packages/help-extension/README.md
+++ b/packages/help-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/help-extension
+
+A JupyterLab extension that provides a help menu, including links to documentation.

--- a/packages/help-extension/README.md
+++ b/packages/help-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/help-extension

--- a/packages/imageviewer-extension/README.md
+++ b/packages/imageviewer-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/imageviewer-extension
+
+An extension for JupyterLab which provides an entry point, commands, and keyboard shortcuts for the [@jupyterlab/imageviewer](../imageviewer) package.

--- a/packages/imageviewer-extension/README.md
+++ b/packages/imageviewer-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/imageviewer-extension

--- a/packages/imageviewer/README.md
+++ b/packages/imageviewer/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/imageviewer
+
+A JupyterLab package which provides an image viewer.

--- a/packages/imageviewer/README.md
+++ b/packages/imageviewer/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/imageviewer

--- a/packages/inspector-extension/README.md
+++ b/packages/inspector-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/inspector-extension

--- a/packages/inspector-extension/README.md
+++ b/packages/inspector-extension/README.md
@@ -1,1 +1,5 @@
 # @jupyterlab/inspector-extension
+
+An extension for JupyterLab which provides an entry point, commands, and keyboard shortcuts for the [@jupyterlab/inspector](../inspector) package.
+
+It is used in both the [@jupyterlab/notebook](../notebook) and [@jupyterlab/console](../console) packages.

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/inspector
+
+A JupyterLab package which provides a variable inspector.

--- a/packages/inspector/README.md
+++ b/packages/inspector/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/inspector

--- a/packages/launcher-extension/README.md
+++ b/packages/launcher-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/launcher-extension

--- a/packages/launcher-extension/README.md
+++ b/packages/launcher-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/launcher-extension
+
+An extension for JupyterLab which provides an entry point for the [@jupyterlab/launcher](../launcher) package.

--- a/packages/launcher/README.md
+++ b/packages/launcher/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/launcher

--- a/packages/launcher/README.md
+++ b/packages/launcher/README.md
@@ -1,1 +1,6 @@
 # @jupyterlab/launcher
+
+A JupyterLab package that provides a launcher for various activities,
+including notebooks, consoles, text editors, and terminals.
+
+JupyterLab extensions may register themselves with the launcher in order to show up as an activity when the application starts.

--- a/packages/markdownviewer-extension/README.md
+++ b/packages/markdownviewer-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/markdownviewer-extension

--- a/packages/markdownviewer-extension/README.md
+++ b/packages/markdownviewer-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/markdownviewer-extension
+
+A JupyterLab extension which provides a renderer for markdown files.

--- a/packages/notebook-extension/README.md
+++ b/packages/notebook-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/notebook-extension

--- a/packages/notebook-extension/README.md
+++ b/packages/notebook-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/notebook-extension
+
+An extension for JupyterLab which provides an entry point, commands, and keyboard shortcuts for the [@jupyterlab/notebook](../notebook) package.

--- a/packages/notebook/README.md
+++ b/packages/notebook/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/notebook

--- a/packages/notebook/README.md
+++ b/packages/notebook/README.md
@@ -1,1 +1,5 @@
 # @jupyterlab/notebook
+
+A JupyterLab package which implements the primary interface to the Jupyter notebook.
+
+Notebook cells are implemented in [@jupyterlab/cells](../cells).

--- a/packages/outputarea/README.md
+++ b/packages/outputarea/README.md
@@ -1,1 +1,9 @@
 # @jupyterlab/outputarea
+
+A JupyterLab package which provides an implementation of the Jupyter notebook output area.
+Execution results from both the [notebook](../notebook) and the [code console](../console)
+are placed in the output area.
+
+Output areas are able to render results of several different mime types, which are implemented
+in the [rendermime](../rendermime) package. This list of mime types may be extended via
+the simplified mime-extension interface defined in [@jupyterlab/rendermime-interfaces](../rendermime-interfaces).

--- a/packages/outputarea/README.md
+++ b/packages/outputarea/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/outputarea

--- a/packages/pdf-extension/README.md
+++ b/packages/pdf-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/pdf-extension
+
+A mime-renderer extension for JupyterLab that provides support for rendering PDF documents and mime bundles.

--- a/packages/pdf-extension/README.md
+++ b/packages/pdf-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/pdf-extension

--- a/packages/rendermime-interfaces/README.md
+++ b/packages/rendermime-interfaces/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/rendermime-interfaces

--- a/packages/rendermime-interfaces/README.md
+++ b/packages/rendermime-interfaces/README.md
@@ -1,1 +1,14 @@
 # @jupyterlab/rendermime-interfaces
+
+A package for JupyterLab which provides interfaces for implementing mime renderer extensions.
+
+A general JupyterLab plugin involves a certain amount of boilerplate code
+that can be annoying for authors of relatively extensions.
+The interfaces in this package are meant to give an easier way for extension authors
+to provide a plugin that renders mime bundles and documents of a specific mime type.
+
+When using these interfaces, extensions only need to provide some metadata about
+wht kind of mime bundle they are able to render, and a `Widget` with
+a `renderModel` method that renders the mime bundle.
+
+Examples can be found in [@jupyterlab/vega2-extension](../vega2-extension) and [@jupyterlab/pdf-extension](../pdf-extension).

--- a/packages/rendermime/README.md
+++ b/packages/rendermime/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/rendermime

--- a/packages/rendermime/README.md
+++ b/packages/rendermime/README.md
@@ -1,1 +1,8 @@
 # @jupyterlab/rendermime
+
+A JupyterLab package which manages mime bundle renderers for the application,
+and provides default renderers for a number of formats, such as markdown,
+HTML, images, and LaTeX. 
+
+A simplified interface for adding new mime renderers to the application
+can be found in [@jupyterlab/rendermime-interfaces](../rendermime-interfaces).

--- a/packages/rendermime/README.md
+++ b/packages/rendermime/README.md
@@ -6,3 +6,5 @@ HTML, images, and LaTeX.
 
 A simplified interface for adding new mime renderers to the application
 can be found in [@jupyterlab/rendermime-interfaces](../rendermime-interfaces).
+
+The rendermime is a singleton on the [application](../application).

--- a/packages/running-extension/README.md
+++ b/packages/running-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/running-extension
+
+An extension for JupyterLab which provides an entry point and commands for the [@jupyterlab/running](../running) package.

--- a/packages/running-extension/README.md
+++ b/packages/running-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/running-extension

--- a/packages/running/README.md
+++ b/packages/running/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/running

--- a/packages/running/README.md
+++ b/packages/running/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/running
+
+A JupyterLab package which provides a listing of currently running kernel sessions and information about them.

--- a/packages/settingeditor-extension/README.md
+++ b/packages/settingeditor-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/settingeditor-extension

--- a/packages/settingeditor-extension/README.md
+++ b/packages/settingeditor-extension/README.md
@@ -1,3 +1,3 @@
 # @jupyterlab/settingeditor-extension
 
-An extension for JupyterLab which provides a user-editable interface for the JupyterLab [settings registry](../apputils/src).
+An extension for JupyterLab which provides a user-editable interface for the JupyterLab [settings registry](../coreutils/src/settingregistry.ts).

--- a/packages/settingeditor-extension/README.md
+++ b/packages/settingeditor-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/settingeditor-extension
+
+An extension for JupyterLab which provides a user-editable interface for the JupyterLab [settings registry](../apputils/src).

--- a/packages/shortcuts-extension/README.md
+++ b/packages/shortcuts-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/shortcuts-extension
+
+An extension for JupyterLab which registers keyboard shortcuts for the application.

--- a/packages/shortcuts-extension/README.md
+++ b/packages/shortcuts-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/shortcuts-extension

--- a/packages/tabmanager-extension/README.md
+++ b/packages/tabmanager-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/tabmanager-extension
+
+An extension for JupyterLab which provides a listing in the left area for all the currently open documents and widgets in the dock panel.

--- a/packages/tabmanager-extension/README.md
+++ b/packages/tabmanager-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/tabmanager-extension

--- a/packages/terminal-extension/README.md
+++ b/packages/terminal-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/terminal-extension

--- a/packages/terminal-extension/README.md
+++ b/packages/terminal-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/terminal-extension
+
+An extension for JupyterLab which provides an entry point and commands for the [@jupyterlab/terminal](../terminal) package.

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/terminal

--- a/packages/terminal/README.md
+++ b/packages/terminal/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/terminal
+
+A JupyterLab package which provides a bash terminal for the user to access and send commands to the underlying server.

--- a/packages/theme-dark-extension/README.md
+++ b/packages/theme-dark-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/theme-dark-extension

--- a/packages/theme-dark-extension/README.md
+++ b/packages/theme-dark-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/theme-dark-extension
+
+A JupyterLab theme extension which provides the default dark-colored theme.

--- a/packages/theme-light-extension/README.md
+++ b/packages/theme-light-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/theme-light-extension
+
+A JupyterLab theme extension which provides the default light-colored theme.

--- a/packages/theme-light-extension/README.md
+++ b/packages/theme-light-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/theme-light-extension

--- a/packages/tooltip-extension/README.md
+++ b/packages/tooltip-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/tooltip-extension
+
+A JupyterLab extension which provides an entry-point, commands, and keyboard shortcuts for the [@jupyterlab/tooltip](../tooltip) package.

--- a/packages/tooltip-extension/README.md
+++ b/packages/tooltip-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/tooltip-extension

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/tooltip

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/tooltip
+
+An package for JupyterLab which renders tooltip information from a kernel, for use in Jupyter notebooks and consoles.

--- a/packages/vega2-extension/README.md
+++ b/packages/vega2-extension/README.md
@@ -1,1 +1,3 @@
 # @jupyterlab/vega2-extension
+
+A mime-renderer extension for JupyterLab that provides support for rendering Vega and Vega-lite documents and mimebundles.

--- a/packages/vega2-extension/README.md
+++ b/packages/vega2-extension/README.md
@@ -1,0 +1,1 @@
+# @jupyterlab/vega2-extension


### PR DESCRIPTION
Adds 1-2 sentence `README.md`s at the npm package level to provide better signposting and documentation for extension authors as to how the application fits together.