### PR TITLE
Editor submit unselected line to console

### DIFF
--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -316,6 +316,15 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, editorServices: IE
             break;
           }
         }
+      } else {
+        // no selection, submit whole line and advance
+        code = editor.getLine(selection.start.line);
+        const cursor = editor.getCursorPosition();
+        if (cursor.line + 1 == editor.lineCount) {
+          let text = editor.model.value.text;
+          editor.model.value.text = text + '\n';
+        }
+        editor.setCursorPosition({ line: cursor.line + 1, column: cursor.column });
       }
 
       const activate = false;


### PR DESCRIPTION
Allows submitting an entire line to the console with `Shift + Enter` if nothing is selected  and not in markdown.  If in markdown, instead select the code block (#2270)

redo of #2191, #2197 - it looks like this got factored out as part of #2270  but don't think it was intentional?

close #1356