### PR TITLE
Sort file names in numeric order

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1842,9 +1842,9 @@ namespace Private {
 
         // Compare by display name.
         if (state.direction === 'descending') {
-          return b.name.localeCompare(a.name);
+          return b.name.localeCompare(a.name, navigator.language, { numeric: true });
         }
-        return a.name.localeCompare(b.name);
+        return a.name.localeCompare(b.name, navigator.language, { numeric: true });
       });
     }
 


### PR DESCRIPTION
This is meant to fix #2845 😃 . Should I be modifying tests for this? Looking in `test/src/filebrowser/` it's not immediately clear to me where a test for this would live