### PR TITLE
Improve handling of code mirror sync check

### DIFF
--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -13,6 +13,7 @@
     "lib": "lib/"
   },
   "dependencies": {
+    "@jupyterlab/apputils": "^0.10.0",
     "@jupyterlab/codeeditor": "^0.10.0",
     "@jupyterlab/coreutils": "^0.10.1",
     "@phosphor/algorithm": "^1.1.1",

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -861,7 +861,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   private _scheduleCheck(): void {
     window.clearTimeout(this._checkTimer);
     this._checkTimer = window.setTimeout(() => {
-      let doc =this._editor.getDoc();
+      let doc = this._editor.getDoc();
       if (doc.getValue() === this._model.value.text) {
         this._handleSyncError();
       }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -248,7 +248,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     this.host.removeEventListener('blur', this, true);
     this.host.removeEventListener('scroll', this, true);
     this._keydownHandlers.length = 0;
-    window.clearTimeout(this._timer);
+    window.clearInterval(this._timer);
     Signal.clearData(this);
   }
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -862,7 +862,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     window.clearTimeout(this._checkTimer);
     this._checkTimer = window.setTimeout(() => {
       let doc = this._editor.getDoc();
-      if (doc.getValue() === this._model.value.text) {
+      if (doc.getValue() !== this._model.value.text) {
         this._handleSyncError();
       }
     }, 3000);

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -860,7 +860,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    */
   private _scheduleCheck(): void {
     window.clearTimeout(this._checkTimer);
-    window.setTimeout(() => {
+    this._checkTimer = window.setTimeout(() => {
       let doc =this._editor.getDoc();
       if (doc.getValue() === this._model.value.text) {
         this._handleSyncError();


### PR DESCRIPTION
cf https://github.com/jupyterlab/jupyterlab/issues/2951.  Make it more obvious when there is an error, and do not check after every keystroke.