### PR TITLE
Allow the cwd of the launcher to be updated

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@jupyterlab/application-top",
   "version": "0.10.2",
+  "private": true,
   "scripts": {
     "build": "node update-core.js && webpack",
     "build:prod": "node update-core.js && webpack --devtool source-map",
@@ -86,7 +87,6 @@
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1"
   },
-  "private": true,
   "jupyterlab": {
     "extensions": {
       "@jupyterlab/application-extension": "",

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -18,6 +18,7 @@
     "@jupyterlab/docmanager": "^0.10.0",
     "@jupyterlab/docregistry": "^0.10.0",
     "@jupyterlab/filebrowser": "^0.10.0",
+    "@jupyterlab/launcher": "^0.10.0",
     "@phosphor/algorithm": "^1.1.1",
     "@phosphor/commands": "^1.3.0",
     "@phosphor/widgets": "^1.3.0"

--- a/packages/launcher-extension/src/index.ts
+++ b/packages/launcher-extension/src/index.ts
@@ -81,6 +81,7 @@ function activate(app: JupyterLab, palette: ICommandPalette): ILauncher {
       if (args['activate'] !== false) {
         shell.activateById(widget.id);
       }
+      return widget;
     }
   });
 

--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -232,7 +232,7 @@ class Launcher extends VDomRenderer<LauncherModel> {
    */
   constructor(options: Launcher.IOptions) {
     super();
-    this.cwd = options.cwd;
+    this._cwd = options.cwd;
     this._callback = options.callback;
     this.addClass(LAUNCHER_CLASS);
   }
@@ -240,7 +240,13 @@ class Launcher extends VDomRenderer<LauncherModel> {
   /**
    * The cwd of the launcher.
    */
-  readonly cwd: string;
+  get cwd(): string {
+    return this._cwd;
+  }
+  set cwd(value: string) {
+    this._cwd = value;
+    this.update();
+  }
 
   /**
    * Whether there is a pending item being launched.
@@ -337,6 +343,7 @@ class Launcher extends VDomRenderer<LauncherModel> {
 
   private _callback: (widget: Widget) => void;
   private _pending = false;
+  private _cwd = '';
 }
 
 
@@ -359,7 +366,6 @@ namespace Launcher {
      * The callback used when an item is launched.
      */
     callback: (widget: Widget) => void;
-
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/2893.  We can't pass a signal to the launch command because it is not a JSON object, so we return the launcher widget and update its `cwd` as needed.