### PR TITLE
Handle line separators in CodeMirror

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@jupyterlab/application-top",
   "version": "0.10.2",
+  "private": true,
   "scripts": {
     "build": "node update-core.js && webpack",
     "build:prod": "node update-core.js && webpack --devtool source-map",
@@ -86,7 +87,6 @@
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1"
   },
-  "private": true,
   "jupyterlab": {
     "extensions": {
       "@jupyterlab/application-extension": "",

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -716,6 +716,8 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
        doc.replaceRange('', from, to);
        break;
      case 'set':
+       // Detect the line endings in the text and update
+       // the editor accordingly.
        if (args.value.indexOf('\r\n') !== -1) {
           this.editor.setOption('lineSeparator', '\r\n');
        } else {

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -716,6 +716,11 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
        doc.replaceRange('', from, to);
        break;
      case 'set':
+       if (args.value.indexOf('\r\n') !== -1) {
+          this.editor.setOption('lineSeparator', '\r\n');
+       } else {
+          this.editor.setOption('lineSeparator', '\n');
+       }
        doc.setValue(args.value);
        break;
      default:

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -716,13 +716,6 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
        doc.replaceRange('', from, to);
        break;
      case 'set':
-       // Detect the line endings in the text and update
-       // the editor accordingly.
-       if (args.value.indexOf('\r\n') !== -1) {
-          this.editor.setOption('lineSeparator', '\r\n');
-       } else {
-          this.editor.setOption('lineSeparator', '\n');
-       }
        doc.setValue(args.value);
        break;
      default:

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -280,13 +280,22 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
       if (this.isDisposed) {
         return;
       }
+      let dirty = false;
       if (contents.format === 'json') {
         model.fromJSON(contents.content);
       } else {
-        model.fromString(contents.content);
+        let content = contents.content;
+        // Convert line endings if necessary, marking the file
+        // as dirty.
+        if (content.indexOf('\r') !== -1) {
+          dirty = true;
+          content = content.replace(/\r\n/g, '\n');
+          content = content.replace(/\r/g, '\n');
+        }
+        model.fromString(content);
       }
       this._updateContentsModel(contents);
-      model.dirty = false;
+      model.dirty = dirty;
       if (!this._isPopulated) {
         return this._populate();
       }

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -289,8 +289,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
         // as dirty.
         if (content.indexOf('\r') !== -1) {
           dirty = true;
-          content = content.replace(/\r\n/g, '\n');
-          content = content.replace(/\r/g, '\n');
+          content = content.replace(/\r\n|\r/g, '\n');
         }
         model.fromString(content);
       }


### PR DESCRIPTION
Addresses part of https://github.com/jupyterlab/jupyterlab/issues/2951.  Without this change, the CodeMirror buffer positions are incorrect, resulting in a mismatch between the buffer and our document model. 

We normalize `\r\n` and `\r` line endings to `\n`, and mark the file as dirty if we change the line endings.

Note that upon pasting text CodeMirror already normalizes line endings to `\n` by default.