### PR TITLE
JSON Editor and Console style fixes

### DIFF
--- a/packages/codeeditor/src/jsoneditor.ts
+++ b/packages/codeeditor/src/jsoneditor.ts
@@ -32,11 +32,6 @@ import {
 const JSONEDITOR_CLASS = 'jp-JSONEditor';
 
 /**
- * The class name added to a focused JSONEditor instance.
- */
-const FOCUSED_CLASS = 'jp-mod-focused';
-
-/**
  * The class name added when the Metadata editor contains invalid JSON.
  */
 const ERROR_CLASS = 'jp-mod-error';
@@ -216,8 +211,6 @@ class JSONEditor extends Widget {
       case 'click':
         this._evtClick(event as MouseEvent);
         break;
-      case 'focus':
-        this._toggleFocused();
       default:
         break;
     }
@@ -229,10 +222,17 @@ class JSONEditor extends Widget {
   protected onAfterAttach(msg: Message): void {
     let node = this.editorHostNode;
     node.addEventListener('blur', this, true);
-    node.addEventListener('focus', this, true);
+    node.addEventListener('click', this, true);
     this.revertButtonNode.hidden = true;
     this.commitButtonNode.hidden = true;
     this.headerNode.addEventListener('click', this);
+  }
+
+  /**
+   * Handle `after-show` messages for the widget.
+   */
+  protected onAfterShow(msg: Message): void {
+    this.editor.refresh();
   }
 
   /**
@@ -241,6 +241,7 @@ class JSONEditor extends Widget {
   protected onBeforeDetach(msg: Message): void {
     let node = this.editorHostNode;
     node.removeEventListener('blur', this, true);
+    node.removeEventListener('click', this, true);
     this.headerNode.removeEventListener('click', this);
   }
 
@@ -278,18 +279,6 @@ class JSONEditor extends Widget {
     this.commitButtonNode.hidden = !valid || !this._inputDirty;
   }
 
-
-  private _toggleFocused(): void {
-    let node = this.editorHostNode;
-    let codeMirror = node.getElementsByClassName('CodeMirror-wrap');
-    let focused = !codeMirror[0].classList.contains('CodeMirror-focused');
-    if (focused) {
-      node.classList.add(FOCUSED_CLASS);
-    } else {
-      node.classList.remove(FOCUSED_CLASS);
-    }
-  }
-
   /**
    * Handle blur events for the text area.
    */
@@ -298,7 +287,6 @@ class JSONEditor extends Widget {
     if (!this._inputDirty && this._dataDirty) {
       this._setValue();
     }
-    this._toggleFocused();
   }
 
   /**
@@ -330,6 +318,9 @@ class JSONEditor extends Widget {
           this.editorHostNode.classList.add(COLLAPSED_CLASS);
         }
       }
+      break;
+    case this.editorHostNode:
+      this.editor.focus();
       break;
     default:
       break;
@@ -387,6 +378,10 @@ class JSONEditor extends Widget {
       let value = JSON.stringify(content, null, 4);
       model.value.text = value;
       this._originalValue = content;
+      // Move the cursor to within the brace.
+      if (value.length > 1 && value[0] === '{') {
+        this.editor.setCursorPosition({ line: 0, column: 1 });
+      }
     }
     this.editor.refresh();
     this._changeGuard = false;

--- a/packages/codeeditor/style/index.css
+++ b/packages/codeeditor/style/index.css
@@ -17,10 +17,11 @@
   flex: 1 1 auto;
   border: var(--jp-border-width) solid var(--jp-input-border-color);
   border-radius: 0px;
-  background: var(--jp-input-background-color);
+  background: var(--jp-layout-color0);
   min-height: 50px;
   margin-left: 12px;
   margin-right: 12px;
+  padding: 1px;
 }
 
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -91,6 +91,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     host.classList.add(EDITOR_CLASS);
     host.classList.add('jp-Editor');
     host.addEventListener('focus', this, true);
+    host.addEventListener('blur', this, true);
     host.addEventListener('scroll', this, true);
 
     this._uuid = options.uuid || uuid();
@@ -243,6 +244,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     }
     this._isDisposed = true;
     this.host.removeEventListener('focus', this, true);
+    this.host.removeEventListener('blur', this, true);
     this.host.removeEventListener('scroll', this, true);
     this._keydownHandlers.length = 0;
     Signal.clearData(this);
@@ -761,6 +763,8 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     case 'focus':
       this._evtFocus(event as FocusEvent);
       break;
+    case 'blur':
+      this._evtBlur(event as FocusEvent);
     case 'scroll':
       this._evtScroll();
       break;
@@ -776,6 +780,14 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     if (this._needsRefresh) {
       this.refresh();
     }
+    this.host.classList.add('jp-mod-focused');
+  }
+
+  /**
+   * Handle `blur` events for the editor.
+   */
+  private _evtBlur(event: FocusEvent): void {
+    this.host.classList.remove('jp-mod-focused');
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -765,6 +765,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
       break;
     case 'blur':
       this._evtBlur(event as FocusEvent);
+      break;
     case 'scroll':
       this._evtScroll();
       break;

--- a/packages/console/style/index.css
+++ b/packages/console/style/index.css
@@ -69,9 +69,11 @@
 
 
 .jp-CodeConsole-content .jp-InputArea-editor.jp-InputArea-editor {
-  background: transparent;
-  border-color: transparent;
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color-active);
+  box-shadow: var(--jp-input-box-shadow);
+  background-color: var(--jp-cell-editor-background-active);
 }
+
 
 .jp-CodeConsole-input .jp-CodeConsole-prompt .jp-InputArea {
   height: 100%;
@@ -81,4 +83,11 @@
 
 .jp-CodeConsole-content .jp-CodeConsole-banner .jp-Cell-prompt {
   display: none;
+}
+
+
+.jp-CodeConsole-promptCell .jp-InputArea-editor.jp-mod-focused {
+  border: var(--jp-border-width) solid var(--jp-cell-editor-border-color-active);
+  box-shadow: var(--jp-input-box-shadow);
+  background-color: var(--jp-cell-editor-background-active);
 }

--- a/test/src/apputils/jsoneditor.spec.ts
+++ b/test/src/apputils/jsoneditor.spec.ts
@@ -393,7 +393,7 @@ describe('apputils', () => {
         simulate(editor.editorHostNode, 'blur');
         simulate(editor.revertButtonNode, 'click');
         simulate(editor.commitButtonNode, 'click');
-        expect(editor.events).to.eql(['focus', 'blur', 'click', 'click']);
+        expect(editor.events).to.eql(['blur', 'click', 'click']);
       });
 
     });

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -4,7 +4,7 @@
 import expect = require('expect.js');
 
 import {
-  generate
+  generate, simulate
 } from 'simulate-event';
 
 import {
@@ -314,6 +314,41 @@ describe('CodeMirrorEditor', () => {
       expect(editor.hasFocus()).to.be(false);
       editor.focus();
       expect(editor.hasFocus()).to.be(true);
+    });
+
+  });
+
+  describe('#blur()', () => {
+
+    it('should blur the editor', () => {
+      editor.focus();
+      expect(host.contains(document.activeElement)).to.be(true);
+      editor.blur();
+      expect(host.contains(document.activeElement)).to.be(false);
+    });
+
+  });
+
+  describe('#handleEvent', () => {
+
+    context('focus', () => {
+
+      it('should add the focus class to the host', () => {
+        simulate(editor.editor.getInputField(), 'focus');
+        expect(host.classList.contains('jp-mod-focused')).to.be(true);
+      });
+
+    });
+
+    context('blur', () => {
+
+      it('should remove the focus class from the host', () => {
+        simulate(editor.editor.getInputField(), 'focus');
+        expect(host.classList.contains('jp-mod-focused')).to.be(true);
+        simulate(editor.editor.getInputField(), 'blur');
+        expect(host.classList.contains('jp-mod-focused')).to.be(false);
+      });
+
     });
 
   });


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/2890.  Partially addresses https://github.com/jupyterlab/jupyterlab/issues/2888.

Light mode in Chrome:
<image src="https://user-images.githubusercontent.com/2096628/30298132-dc8946fa-970f-11e7-8ccd-023e26874eec.png" width=300>

<image src="https://user-images.githubusercontent.com/2096628/30298150-e8f58f16-970f-11e7-9b38-bd6a81f2264d.png" width=300>

Dark mode in Firefox:
<image src="https://user-images.githubusercontent.com/2096628/30298296-7fc2a370-9710-11e7-97f9-839d525b3fb4.png" width=300>

<image src="https://user-images.githubusercontent.com/2096628/30298329-93d39338-9710-11e7-811e-0eb202080033.png" width=300>
