### PR TITLE
Handle error on getting download URL in renderers.

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -721,6 +721,10 @@ namespace Private {
       return resolver.getDownloadUrl(path);
     }).then(url => {
       node.setAttribute(name, url);
+    }).catch(err => {
+      // If there was an error getting the url,
+      // just make it an empty link.
+      node.setAttribute(name, '');
     });
   }
 
@@ -757,6 +761,10 @@ namespace Private {
     }).then(url => {
       // Set the visible anchor.
       anchor.href = url + hash;
+    }).catch(err => {
+      // If there was an error getting the url,
+      // just make it an empty link.
+      anchor.href = '';
     });
   }
 


### PR DESCRIPTION
Fixes an issue we saw in the collaborative meeting notes on Friday. If link resolving in a rendered markdown file fails, it should not bring down the whole renderer.