### PR TITLE
Display the splash screen only until the theme manager is ready.

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -169,7 +169,7 @@ const themes: JupyterLabPlugin<IThemeManager> = {
     const disposable = splash.show();
     const dispose = () => { disposable.dispose(); };
 
-    manager.ready.then(() => { setTimeout(dispose, 2500); }, dispose);
+    manager.ready.then(dispose, dispose);
 
     return manager;
   },

--- a/packages/apputils-extension/style/splash.css
+++ b/packages/apputils-extension/style/splash.css
@@ -18,7 +18,7 @@
 
 
 .splash-fade {
-  animation: .2s fade-out forwards;
+  animation: .5s fade-out forwards;
 }
 
 
@@ -37,7 +37,7 @@
   width: 100%;
   height: 100%;
   z-index: 1;
-  animation: 1.5s fade-in linear forwards;
+  animation: .3s fade-in linear forwards;
 }
 
 .planet {

--- a/packages/apputils-extension/style/splash.css
+++ b/packages/apputils-extension/style/splash.css
@@ -18,7 +18,7 @@
 
 
 .splash-fade {
-  animation: .5s fade-out forwards;
+  animation: .2s fade-out forwards;
 }
 
 


### PR DESCRIPTION
The full animation was awesome the first several times, then started getting repetitive every single time the page was refreshed.

In reality, the splash screen should probably be a *very* lightweight piece of js/css/svg embedded directly in the index.html. As it is, it doesn't start running until the entire megabytes-big jlab javascript is loaded, so there still is a long blank time, especially over a slow connection.

However, I think this is still an improvement once you start using JupyterLab a lot. Thoughts?