### PR TITLE
Allow execution of a single line in markdown-like files

### DIFF
--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -285,7 +285,7 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, editorServices: IE
 
   commands.addCommand(CommandIDs.runCode, {
     execute: () => {
-      // This will run the current selection or the entire ```fenced``` code block.
+      // Run the appropriate code, taking into account a ```fenced``` code block.
       const widget = tracker.currentWidget;
 
       if (!widget) {
@@ -313,10 +313,10 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, editorServices: IE
         for (let block of blocks) {
           if (block.startLine <= start.line && start.line <= block.endLine) {
             code = block.code;
+            selected = true;
             break;
           }
         }
-        selected = blocks.length > 0;
       }
 
       if (!selected) {

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -298,7 +298,7 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, editorServices: IE
       const extension = PathExt.extname(path);
       const selection = editor.getSelection();
       const { start, end } = selection;
-      const selected = start.column !== end.column || start.line !== end.line;
+      let selected = start.column !== end.column || start.line !== end.line;
 
       if (selected) {
         // Get the selected code from the editor.
@@ -316,11 +316,14 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, editorServices: IE
             break;
           }
         }
-      } else {
+        selected = blocks.length > 0;
+      }
+
+      if (!selected) {
         // no selection, submit whole line and advance
         code = editor.getLine(selection.start.line);
         const cursor = editor.getCursorPosition();
-        if (cursor.line + 1 == editor.lineCount) {
+        if (cursor.line + 1 === editor.lineCount) {
           let text = editor.model.value.text;
           editor.model.value.text = text + '\n';
         }


### PR DESCRIPTION
Previously, when editing a markdown-like file (which includes `.txt`), we would do nothing if there was no selection or we were not in a code block.  This change runs the current line, matching the behavior in non-markdown-like files.

cf https://github.com/jupyterlab/jupyterlab/pull/2947#issuecomment-329206948