### PR TITLE
Add scroll past end for codemirror documents

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -35,6 +35,7 @@ import {
 import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/edit/closebrackets.js';
 import 'codemirror/addon/comment/comment.js';
+import 'codemirror/addon/scroll/scrollpastend.js'
 import 'codemirror/addon/search/searchcursor';
 import 'codemirror/addon/search/search';
 import 'codemirror/keymap/emacs.js';
@@ -977,6 +978,11 @@ namespace CodeMirrorEditor {
      * selection will copy or cut the whole lines that have cursors on them.
      */
     lineWiseCopyCut?: boolean;
+
+    /**
+     * Whether to scroll past the end of the buffer.
+     */
+    scrollPastEnd?: boolean;
   }
 
   /**
@@ -999,6 +1005,7 @@ namespace CodeMirrorEditor {
     lineSeparator: null,
     scrollbarStyle: 'native',
     lineWiseCopyCut: true,
+    scrollPastEnd: false
   };
 
   /**

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -42,6 +42,7 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
         'Shift-Enter': () => { /* no-op */ }
       },
       lineNumbers: true,
+      scrollPastEnd: true,
       ...defaults
     };
   }


### PR DESCRIPTION
Fixes #813.  Fixes #2993.

<image src="https://user-images.githubusercontent.com/2096628/30494744-fa94215e-9a0e-11e7-8d99-5aeb30baaf86.png" width=400>
