### PR TITLE
Handle missing directory

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -226,7 +226,15 @@ class FileBrowserModel implements IDisposable {
       this._refreshed.emit(void 0);
     }).catch(error => {
       this._pendingPath = null;
-      this._connectionFailure.emit(error);
+      if (error.message === 'Not Found') {
+        let path = this._model.path;
+        error.message = `Directory not found: "${path}"`;
+        this._connectionFailure.emit(error);
+        let parent = PathExt.dirname(path);
+        if (parent !== path) {
+          this.cd('..');
+        }
+      }
     });
     return this._pending;
   }


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/3003.  Handles a removed directory by alerting the user and changing to the parent directory.


<image src="https://user-images.githubusercontent.com/2096628/30503508-25c1c5cc-9a30-11e7-8994-84e706503b69.png" width=300>
