### PR TITLE
services: Handle undefined error event

### DIFF
--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -328,8 +328,8 @@ namespace Private {
       delegate.reject({ xhr, event, request, settings, message: 'Aborted' });
     };
 
-    xhr.onerror = (event: ErrorEvent) => {
-      delegate.reject({ xhr, event, request, settings, message: event.message });
+    xhr.onerror = (event?: ErrorEvent) => {
+      delegate.reject({ xhr, event, request, settings, message: event ? event.message : 'Errored' });
     };
 
     xhr.ontimeout = (event: ProgressEvent) => {


### PR DESCRIPTION
When trying to connect to an address where no server is running it seams that the error event can be undefined. This will result in an internal error since `event.message` cannot be accessed.

Noticed while upgrading to the latest version of `@jupyterlab/services`: https://github.com/nteract/hydrogen/pull/908