### PR TITLE
Support Deprecated Sessions Model API

### DIFF
--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -351,13 +351,13 @@ class DefaultSession implements Session.ISession {
       if (response.xhr.status !== 200) {
         throw ServerConnection.makeError(response);
       }
-      let value = response.data as Session.IModel;
+      let value = response.data;
       try {
-        validate.validateModel(value);
+        let model = validate.validateModel(value);
+        return Private.updateFromServer(model, settings.baseUrl);
       } catch (err) {
         throw ServerConnection.makeError(response, err.message);
       }
-      return Private.updateFromServer(value, settings.baseUrl);
     }, error => {
       this._updating = false;
       return Private.onSessionError(error);

--- a/packages/services/src/session/validate.ts
+++ b/packages/services/src/session/validate.ts
@@ -43,12 +43,21 @@ function validateProperty(object: any, name: string, typeName?: string): void {
  */
 export
 function validateModel(data: any): Session.IModel {
+  // Support legacy session model.
+  let path = data.path;
+  let name = data.name;
+  let type = data.type;
+  if (path === undefined && data.notebook !== undefined) {
+    path = data.notebook.path;
+    type = 'notebook';
+    name = '';
+  }
   let model = {
     id: data.id,
-    path: data.notebook ? data.notebook.path : data.path,
-    type: data.notebook ? 'notebook' : data.type,
-    name: data.notebook ? '' : data.name,
-    kernel: data.kernel
+    kernel: data.kernel,
+    name,
+    path,
+    type
   };
   validateProperty(model, 'id', 'string');
   validateProperty(model, 'type', 'string');

--- a/packages/services/src/session/validate.ts
+++ b/packages/services/src/session/validate.ts
@@ -43,22 +43,19 @@ function validateProperty(object: any, name: string, typeName?: string): void {
  */
 export
 function validateModel(data: any): Session.IModel {
-  // Support legacy session model.
-  let path = data.path;
-  let name = data.name;
-  let type = data.type;
-  if (path === undefined && data.notebook !== undefined) {
-    path = data.notebook.path;
-    type = 'notebook';
-    name = '';
-  }
   let model = {
     id: data.id,
     kernel: data.kernel,
-    name,
-    path,
-    type
+    name: data.name,
+    path: data.path,
+    type: data.type
   };
+  // Support legacy session model.
+  if (data.path === undefined && data.notebook !== undefined) {
+    model.path = data.notebook.path;
+    model.type = 'notebook';
+    model.name = '';
+  }
   validateProperty(model, 'id', 'string');
   validateProperty(model, 'type', 'string');
   validateProperty(model, 'name', 'string');

--- a/packages/services/src/session/validate.ts
+++ b/packages/services/src/session/validate.ts
@@ -42,11 +42,19 @@ function validateProperty(object: any, name: string, typeName?: string): void {
  * Validate an `Session.IModel` object.
  */
 export
-function validateModel(model: Session.IModel): void {
+function validateModel(data: any): Session.IModel {
+  let model = {
+    id: data.id,
+    path: data.notebook ? data.notebook.path : data.path,
+    type: data.notebook ? 'notebook' : data.type,
+    name: data.notebook ? '' : data.name,
+    kernel: data.kernel
+  };
   validateProperty(model, 'id', 'string');
-  validateProperty(model, 'path', 'string');
   validateProperty(model, 'type', 'string');
   validateProperty(model, 'name', 'string');
+  validateProperty(model, 'path', 'string');
   validateProperty(model, 'kernel', 'object');
   validateKernelModel(model.kernel);
+  return model;
 }

--- a/packages/services/test/src/session/session.spec.ts
+++ b/packages/services/test/src/session/session.spec.ts
@@ -220,6 +220,24 @@ describe('session', () => {
       expectFailure(sessionPromise, done, msg);
     });
 
+    it('should handle a deprecated response model', (done) => {
+      let sessionModel = createSessionModel();
+      let data = {
+        id: '', kernel: { name: '', id: '' }, notebook: { path: '' }
+      };
+      tester.onRequest = request => {
+        if (request.method === 'POST') {
+          tester.respond(201, sessionModel);
+        } else {
+          tester.respond(200, data);
+        }
+      };
+      let options = createSessionOptions(sessionModel);
+      let sessionPromise = Session.startNew(options);
+      let msg = `Session failed to start: No running kernel with id: ${sessionModel.kernel.id}`;
+      expectFailure(sessionPromise, done, msg);
+    });
+
     it('should fail if the kernel is not running', (done) => {
       let sessionModel = createSessionModel();
       tester.onRequest = request => {

--- a/packages/services/test/src/session/validate.spec.ts
+++ b/packages/services/test/src/session/validate.spec.ts
@@ -27,6 +27,17 @@ describe('session/validate', () => {
       validateModel(model);
     });
 
+    it('should pass a deprecated model', () => {
+      let model = {
+        id: 'foo',
+        kernel: { name: 'foo', id: '123'},
+        notebook: {
+          path: 'bar'
+        }
+      };
+      validateModel(model);
+    });
+
     it('should fail on missing data', () => {
       let model: any = {
         id: 'foo',


### PR DESCRIPTION
Fixes #3030.  Verified by modifying the `node` services example to use [KernelGatewayApp](https://github.com/jupyter/kernel_gateway/blob/fc1d714eecacacc4447ec516578d9032c1f2b574/kernel_gateway/gatewayapp.py#L55) as follows:

```diff
diff --git a/packages/services/examples/node/main.py b/packages/services/examples/node/main.py
index 6754d9d21..aec94ecb0 100644
--- a/packages/services/examples/node/main.py
+++ b/packages/services/examples/node/main.py
@@ -13,7 +13,7 @@ from multiprocessing.pool import ThreadPool


 from tornado import ioloop
-from notebook.notebookapp import NotebookApp
+from kernel_gateway.gatewayapp import KernelGatewayApp
 from traitlets import Bool, Unicode

 root_dir = tempfile.mkdtemp(prefix='mock_contents')
@@ -34,23 +34,21 @@ def run_task(func, args=(), kwds={}):
     loop.call_later(1, start)


-class TestApp(NotebookApp):
+class TestApp(KernelGatewayApp):

     open_browser = Bool(False)
     notebook_dir = Unicode(root_dir)

     def start(self):
-        run_task(run_node, args=(self.connection_url, self.token))
+        run_task(run_node, args=(self.base_url))
         super(TestApp, self).start()


-def run_node(base_url, token):
+def run_node(base_url):
     # Run the node script with command arguments.
     node_command = ['node', 'index.js', '--jupyter-config-data=./config.json']

     config = dict(baseUrl=base_url)
-    if token:
-        config['token'] = token

     with open('config.json', 'w') as fid:
         json.dump(config, fid)
```