### PR TITLE
Remove Search from Inline Editors

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -36,6 +36,8 @@ import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/edit/closebrackets.js';
 import 'codemirror/addon/comment/comment.js';
 import 'codemirror/addon/scroll/scrollpastend.js';
+import 'codemirror/addon/search/searchcursor';
+import 'codemirror/addon/search/search';
 import 'codemirror/keymap/emacs.js';
 import 'codemirror/keymap/sublime.js';
 import 'codemirror/keymap/vim.js';

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -35,9 +35,7 @@ import {
 import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/edit/closebrackets.js';
 import 'codemirror/addon/comment/comment.js';
-import 'codemirror/addon/scroll/scrollpastend.js'
-import 'codemirror/addon/search/searchcursor';
-import 'codemirror/addon/search/search';
+import 'codemirror/addon/scroll/scrollpastend.js';
 import 'codemirror/keymap/emacs.js';
 import 'codemirror/keymap/sublime.js';
 import 'codemirror/keymap/vim.js';

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -51,6 +51,7 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
    * Create a new editor for inline code.
    */
   newInlineEditor(options: CodeEditor.IOptions): CodeEditor.IEditor {
+    options.host.dataset.type = 'inline';
     return new CodeMirrorEditor({
       ...options,
       config: { ...this.inlineCodeMirrorConfig, ...options.config || {} }
@@ -61,6 +62,7 @@ class CodeMirrorEditorFactory implements IEditorFactoryService {
    * Create a new editor for a full document.
    */
   newDocumentEditor(options: CodeEditor.IOptions): CodeEditor.IEditor {
+    options.host.dataset.type = 'document';
     return new CodeMirrorEditor({
       ...options,
       config: { ...this.documentCodeMirrorConfig, ...options.config || {} }

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -58,6 +58,12 @@
 }
 
 
+/* Hide dialogs in inline editors due to poor UX with small editors. */
+.jp-CodeMirrorEditor[data-type="inline"] .CodeMirror-dialog {
+  display: none;
+}
+
+
 .CodeMirror-cursor {
   border-left: 1px solid var(--jp-editor-cursor-color);
 }


### PR DESCRIPTION
Fixes #3009. We can't use it in the notebook because it does not interact well with its modality.  The UX is poor for small editors (both in height and width), so we work around by disabling dialogs in inline editors.   Proper handling of search (for both editor and notebook) will have to wait for https://github.com/jupyterlab/jupyterlab/issues/1074.