### PR TITLE
Expose validate functions in Contents namespace.

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -109,6 +109,14 @@ namespace Contents {
   }
 
   /**
+   * Validates an IModel, thowing an error if it does not pass.
+   */
+  export
+  function validateContentsModel(contents: IModel): void {
+    validate.validateContentsModel(contents);
+  }
+
+  /**
    * A contents file type.
    */
   export
@@ -182,6 +190,14 @@ namespace Contents {
      * Last modified timestamp.
      */
     readonly last_modified: string;
+  }
+
+  /**
+   * Validates an ICheckpointModel, thowing an error if it does not pass.
+   */
+  export
+  function validateCheckpointModel(checkpoint: ICheckpointModel): void {
+    validate.validateCheckpointModel(checkpoint);
   }
 
   /**


### PR DESCRIPTION
I was not able to figure out a way to expose these in `index.ts` without wrapping them in another function (Typescript apparently does not like re-exporting from within a namespace).