### PR TITLE
Fix file icon flicker

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1660,14 +1660,13 @@ namespace DirListing {
       let text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
       let modified = DOMUtils.findElement(node, ITEM_MODIFIED_CLASS);
 
-      let textContent = '';
-      let className = '';
       if (fileType) {
-        textContent = fileType.iconLabel || '';
-        className = `${ITEM_ICON_CLASS} ${fileType.iconClass || ''}`;
+        icon.textContent = fileType.iconLabel || '';
+        icon.className = `${ITEM_ICON_CLASS} ${fileType.iconClass || ''}`;
+      } else {
+        icon.textContent = '';
+        icon.className = ITEM_ICON_CLASS;
       }
-      icon.textContent = textContent;
-      icon.className = className;
 
       let modText = '';
       let modTitle = '';

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1660,14 +1660,14 @@ namespace DirListing {
       let text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
       let modified = DOMUtils.findElement(node, ITEM_MODIFIED_CLASS);
 
-      if (!fileType) {
-        icon.textContent = '';
-        icon.className = '';
-      } else {
-        icon.textContent = fileType.iconLabel || '';
-        icon.className = fileType.iconClass || '';
+      let textContent = '';
+      let className = '';
+      if (fileType) {
+        textContent = fileType.iconLabel || '';
+        className = `${ITEM_ICON_CLASS} ${fileType.iconClass || ''}`;
       }
-      icon.classList.add(ITEM_ICON_CLASS);
+      icon.textContent = textContent;
+      icon.className = className;
 
       let modText = '';
       let modTitle = '';


### PR DESCRIPTION
Fixes #3053 by setting the icon `className` in one step instead of two.