### PR TITLE
Solving "Console history should respect current text"

### DIFF
--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -165,7 +165,7 @@ class ConsoleHistory implements IConsoleHistory {
       this._placeholder = placeholder;
       // Filter the history with the placeholder string.
       this.setFilter(placeholder);
-      this._cursor = this._filtered.length;
+      this._cursor = this._filtered.length - 1;
     }
 
     --this._cursor;
@@ -325,6 +325,8 @@ class ConsoleHistory implements IConsoleHistory {
         this._filtered.push(last = current);
       }
     }
+
+    this._filtered.push(filterStr);
   }
 
   private _cursor = 0;

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -312,7 +312,13 @@ class ConsoleHistory implements IConsoleHistory {
     });
   }
 
-  protected setFilter(filterStr: string = ""): void {
+  /**
+   * Set the filter data.
+   *
+   * @param filterStr - The string to use when filtering the data.
+  */
+  protected setFilter(filterStr: string = ''): void {
+    
     // Apply the new filter and remove contiguous duplicates.
     this._filtered.length = 0;
     

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -163,10 +163,14 @@ class ConsoleHistory implements IConsoleHistory {
     if (!this._hasSession) {
       this._hasSession = true;
       this._placeholder = placeholder;
+      // Filter the history with the placeholder string.
+      this.setFilter(placeholder);
+      this._cursor = this._filtered.length;
     }
 
-    let content = this._history[--this._cursor];
+    --this._cursor;
     this._cursor = Math.max(0, this._cursor);
+    let content = this._filtered[this._cursor];
     return Promise.resolve(content);
   }
 
@@ -183,10 +187,14 @@ class ConsoleHistory implements IConsoleHistory {
     if (!this._hasSession) {
       this._hasSession = true;
       this._placeholder = placeholder;
+      // Filter the history with the placeholder string.
+      this.setFilter(placeholder);
+      this._cursor = this._filtered.length;
     }
 
-    let content = this._history[++this._cursor];
-    this._cursor = Math.min(this._history.length, this._cursor);
+    ++this._cursor;
+    this._cursor = Math.min(this._filtered.length - 1, this._cursor);
+    let content = this._filtered[this._cursor];
     return Promise.resolve(content);
   }
 
@@ -304,6 +312,21 @@ class ConsoleHistory implements IConsoleHistory {
     });
   }
 
+  protected setFilter(filterStr: string = ""): void {
+    // Apply the new filter and remove contiguous duplicates.
+    this._filtered.length = 0;
+    
+    let last = '';
+    let current = '';
+
+    for (let i = 0; i < this._history.length; i++) {
+      current = this._history[i];
+      if (current !== last && filterStr == current.slice(0, filterStr.length)) {
+        this._filtered.push(last = current);
+      }
+    }
+  }
+
   private _cursor = 0;
   private _hasSession = false;
   private _history: string[] = [];
@@ -311,6 +334,7 @@ class ConsoleHistory implements IConsoleHistory {
   private _setByHistory = false;
   private _isDisposed = false;
   private _editor: CodeEditor.IEditor | null = null;
+  private _filtered: string[] = [];
 }
 
 

--- a/test/src/console/history.spec.ts
+++ b/test/src/console/history.spec.ts
@@ -132,11 +132,10 @@ describe('console/history', () => {
 
     describe('#back()', () => {
 
-      it('should return void promise if no history exists', (done) => {
+      it('should return an empty string if no history exists', () => {
         let history = new ConsoleHistory({ session });
-        history.back('').then(result => {
-          expect(result).to.be(void 0);
-          done();
+        return history.back('').then(result => {
+          expect(result).to.be('');
         });
       });
 
@@ -155,11 +154,10 @@ describe('console/history', () => {
 
     describe('#forward()', () => {
 
-      it('should return void promise if no history exists', (done) => {
+      it('should return an emptry string if no history exists', () => {
         let history = new ConsoleHistory({ session });
-        history.forward('').then(result => {
-          expect(result).to.be(void 0);
-          done();
+        return history.forward('').then(result => {
+          expect(result).to.be('');
         });
       });
 


### PR DESCRIPTION
Hi there!
I've added some lines to solve issue #1285, "Console history should respect current text".
If you now enter, say, "import", and then press up to go through history, you only see lines starting with "import". If you press down to go forward through history, at the end you get your original text, e.g. "import".