### PR TITLE
Don't stringify random objects in error message.

### DIFF
--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -52,7 +52,7 @@ function showErrorMessage(title: string, error: any): Promise<void> {
   console.error(error);
   let options = {
     title: title,
-    body: error.message || String(error),
+    body: error.message || title,
     buttons: [Dialog.okButton()],
     okText: 'DISMISS'
   };


### PR DESCRIPTION
Fixes #3067.

This is not a perfect solution, since the error messages are still somewhat uninformative.

Another option (though with the same problem) would be to revert 2a81feb7dac2ef6c1169e8c75094e1befe2964d2