### PR TITLE
Fix path logic if a package does not have the same name as its directory.

### DIFF
--- a/examples/app/extract-data.js
+++ b/examples/app/extract-data.js
@@ -6,6 +6,6 @@ var names = Object.keys(data.dependencies).filter(function(name) {
   return packageData.jupyterlab !== undefined;
 });
 Build.ensureAssets({
-  packageNames: names,
+  packageDirectories: names,
   output: './build'
 });

--- a/examples/app/extract-data.js
+++ b/examples/app/extract-data.js
@@ -1,11 +1,17 @@
+var path = require('path');
 var data = require('./package.json');
 var Build = require('@jupyterlab/buildutils').Build;
 
-var names = Object.keys(data.dependencies).filter(function(name) {
-  packageData = require(name + '/package.json');
-  return packageData.jupyterlab !== undefined;
+var basePath = path.resolve('.');
+var directories = [];
+Object.keys(data.dependencies).forEach(function(name) {
+  packagePath = path.join(basePath, 'node_modules', name);
+  packageData = require(path.join(packagePath, 'package.json'));
+  if (packageData.jupyterlab !== undefined) {
+    directories.push(packagePath);
+  }
 });
 Build.ensureAssets({
-  packageDirectories: names,
+  packageDirectories: directories,
   output: './build'
 });

--- a/jupyterlab/update-app.js
+++ b/jupyterlab/update-app.js
@@ -6,6 +6,6 @@ let names = Object.keys(data.jupyterlab.extensions).filter(function(name) {
   return packageData.jupyterlab !== undefined;
 });
 Build.ensureAssets({
-  packageNames: names,
+  packageDirectories: names,
   output: '..'
 });

--- a/jupyterlab/update-core.js
+++ b/jupyterlab/update-core.js
@@ -10,6 +10,8 @@ corePackage.jupyterlab.extensions = {};
 corePackage.jupyterlab.mimeExtensions = {};
 corePackage.dependencies = {};
 
+var packageDirectories = [];
+
 var basePath = path.resolve('..');
 var packages = glob.sync(path.join(basePath, 'packages/*'));
 packages.forEach(function(packagePath) {
@@ -49,11 +51,12 @@ packages.forEach(function(packagePath) {
       return;
     }
     corePackage.jupyterlab[item + 's'][data.name] = ext;
+    packageDirectories.push(packagePath);
   });
 });
 
 Build.ensureAssets({
-  packageNames: Object.keys(corePackage.jupyterlab.extensions),
+  packageDirectories: packageDirectories,
   output: '.'
 });
 

--- a/packages/buildutils/src/index.ts
+++ b/packages/buildutils/src/index.ts
@@ -32,7 +32,7 @@ namespace Build {
     /**
      * The names of the packages to ensure.
      */
-    packageNames: ReadonlyArray<string>;
+    packageDirectories: ReadonlyArray<string>;
   }
 
   /**
@@ -101,19 +101,19 @@ namespace Build {
    */
   export
   function ensureAssets(options: IEnsureOptions): void {
-    let { input, output, packageNames } = options;
+    let { input, output, packageDirectories } = options;
     input = input || '.';
 
-    packageNames.forEach(function(name) {
-      const packageDir = fs.realpathSync(path.join(input, 'node_modules', name));
+    packageDirectories.forEach(function(packageDir) {
       const packageData = require(path.join(packageDir, 'package.json'));
+      const packageName = packageData.name;
       const extension = normalizeExtension(packageData);
       const { schemaDir, themeDir } = extension;
 
       // Handle schemas.
       if (schemaDir) {
         const schemas = glob.sync(path.join(path.join(packageDir, schemaDir), '*'));
-        const destination = path.join(output, 'schemas', name);
+        const destination = path.join(output, 'schemas', packageName);
 
         // Remove the existing directory if necessary.
         if (fs.existsSync(destination)) {
@@ -146,7 +146,7 @@ namespace Build {
       // Handle themes.
       if (themeDir) {
         const from = path.join(packageDir, themeDir);
-        const destination = path.join(output, 'themes', name);
+        const destination = path.join(output, 'themes', packageName);
 
         // Remove the existing directory if necessary.
         if (fs.existsSync(destination)) {


### PR DESCRIPTION
Fixes #3066.

This makes `ensureAssets` take the path the the extension packages, rather than their name, which makes it work for packages whose directory names don't follow the same pattern as the core packages (i.e., `@jupyterlab/directoryname`)