### PR TITLE
Allow disabling of extensions

### DIFF
--- a/docs/extensions_user.md
+++ b/docs/extensions_user.md
@@ -22,8 +22,8 @@ brew install node
 
 ### Installing Extensions
 
-The base JupyterLab application comes with core set of extensions, which 
-provide the Notebook, Terminal, Text Editor, etc.  New extensions can be 
+The base JupyterLab application comes with core set of extensions, which
+provide the Notebook, Terminal, Text Editor, etc.  New extensions can be
 installed into the application using the command:
 
 ```
@@ -46,7 +46,7 @@ jupyter labextension uninstall <bar>
 ```
 
 Where `<bar>` is the name of the extension, as printed in the extension
-list.  Core extensions can also be uninstalled this way (and can later be 
+list.  Core extensions can also be uninstalled this way (and can later be
 re-installed).
 
 Extensions can be disabled by running the command:
@@ -55,7 +55,7 @@ Extensions can be disabled by running the command:
 jupyter labextension disable <foo>
 ```
 
-Where `<foo>` is the name of the extension.  This will prevent the 
+Where `<foo>` is the name of the extension.  This will prevent the
 extension from loading on the front end, but does not require a rebuild.
 The extension can be re-enabled using the command:
 
@@ -71,12 +71,12 @@ Core plugins can also be disabled (and then re-enabled).
 The JupyterLab application directory (where the application assets are
 built and the settings reside) can be overridden using `--app-dir` in
 any of the JupyterLab commands, or by setting the `JUPYTERLAB_DIR` environment
-variable.  If not specified, it will default to 
-`<sys-prefix/share/jupyter/lab`, where `sys-prefix` is the 
+variable.  If not specified, it will default to
+`<sys-prefix/share/jupyter/lab`, where `sys-prefix` is the
 site-specific directory prefix of the current Python environment.  You can
-query the current application path using `jupyter lab path`.  
+query the current application path using `jupyter lab path`.
 
-To create the app directory without installing any extensions, run `jupyter lab build`.  
+To create the app directory without installing any extensions, run `jupyter lab build`.
 The `install` and `link` commands already run the build, so it typically
 does not need to be called directly.
 
@@ -90,8 +90,27 @@ Building consists of:
 
 The `settings` directory contains `page_config.json` and `build_config.json`
 files.
+
+### `page_config.json`
+
 The `page_config.json` data is used to provide config data to the application
-environment.  For example, the `ignoredPlugins` data is used to ignore registered plugins by the name of the token they provide.
+environment.
+
+Two important fields in the `page_config.json` file allow control of which plugins load:
+
+1. `disabledExtensions` for extensions that should not load at all.
+2. `deferredExtensions` for extensions that do not load until they are required
+by something, irrespective of whether they set `autostart` to `true`.
+
+The values for each are an array of strings. The following sequence of checks are performed against the patterns in `disabledExtensions` and `deferredExtensions`.
+
+* If an identical string match occurs between a config value and a package name (*e.g.*, `"@jupyterlab/apputils-extension"`), then the entire package is disabled (or deferred).
+* If the string value is compiled as a regular expression and tests positive against a package name (*e.g.*, `"disabledExtensions": ["@jupyterlab/apputils*$"]`), then the entire package is disabled (or deferred).
+* If an identical string match occurs between a config value and an individual plugin ID within a larger package (*e.g.*, `"disabledExtensions": ["@jupyterlab/apputils-extension:settings"]`), then that specific plugin is disabled (or deferred).
+* If the string value is compiled as a regular expression and tests positive against an individual plugin ID within a larger package (*e.g.*, `"disabledExtensions": ["^@jupyterlab/apputils-extension:set.*$"]`), then that specific plugin is disabled (or deferred).
+
+### `build_config.json`
+
 The `build_config.json` file is used to track the folders that have been
 added using `jupyter labextension link <folder>`, as well as core extensions
 that have been explicitly uninstalled.  e.g.
@@ -120,9 +139,9 @@ if called again.  If the `sys-prefix` version cannot be uninstalled, its
 plugins can still be ignored using `ignoredPackages` metadata in `settings`.
 
 The `static` folder contains the assets that will be loaded by the JuptyerLab
-application.  The `staging` folder is used to create the build and then 
+application.  The `staging` folder is used to create the build and then
 populate the `static` folder.
 
-Running `jupyter lab` will attempt to run the `static` assets in the 
+Running `jupyter lab` will attempt to run the `static` assets in the
 application folder if they exist.  You can run `jupyter lab --core-mode`
 to load the core JupyterLab application instead.

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -753,6 +753,7 @@ def _toggle_extension(extension, value, app_dir=None, logger=None):
     """
     app_dir = get_app_dir(app_dir)
     extensions = _get_extensions(app_dir)
+    config = _get_build_config(app_dir)
     disabled = config.get('disabledExtensions', [])
     if value and extension not in disabled:
         disabled.append(extension)

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -4,26 +4,25 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 from __future__ import print_function
-from distutils.version import LooseVersion
 import errno
+import glob
 import json
 import logging
 import pipes
 import os
-import glob
-from functools import partial
-from os import path as osp
-from os.path import join as pjoin
-from tornado import gen
-from tornado.ioloop import IOLoop
-from subprocess import CalledProcessError, Popen, STDOUT
+import re
 import shutil
 import sys
 import tarfile
+from distutils.version import LooseVersion
+from functools import partial
 from jupyter_core.paths import ENV_JUPYTER_PATH, jupyter_config_path
-from notebook.nbextensions import (
-    GREEN_ENABLED, GREEN_OK, RED_DISABLED, RED_X
-)
+from notebook.nbextensions import GREEN_ENABLED, GREEN_OK, RED_DISABLED, RED_X
+from os import path as osp
+from os.path import join as pjoin
+from subprocess import CalledProcessError, Popen, STDOUT
+from tornado import gen
+from tornado.ioloop import IOLoop
 
 from .semver import Range, gte, lt, lte, gt
 from ._version import __version__
@@ -440,9 +439,10 @@ def list_extensions(app_dir=None, logger=None):
     if app:
         logger.info('   app dir: %s' % app_dir)
         for item in sorted(app):
+            logger.info(item)
             version = extensions[item]['version']
             extra = ''
-            if item in disabled:
+            if is_disabled(item, disabled):
                 extra += ' %s' % RED_DISABLED
             else:
                 extra += ' %s' % GREEN_ENABLED
@@ -450,7 +450,7 @@ def list_extensions(app_dir=None, logger=None):
                 extra += ' %s' % RED_X
             else:
                 extra += ' %s' % GREEN_OK
-            logger.info('        %s@%s%s' % (item, version, extra))
+            logger.info('        %s v%s%s' % (item, version, extra))
             if errors[item]:
                 msg = _format_compatibility_errors(item, version, errors[item])
                 logger.warn(msg + '\n')
@@ -471,7 +471,7 @@ def list_extensions(app_dir=None, logger=None):
                 extra += ' %s' % GREEN_OK
             if item in linked:
                 extra += '*'
-            logger.info('        %s@%s%s' % (item, version, extra))
+            logger.info('        %s v%s%s' % (item, version, extra))
             if errors[item]:
                 msg = _format_compatibility_errors(item, version, errors[item])
                 logger.warn(msg + '\n')
@@ -524,6 +524,13 @@ def build(app_dir=None, name=None, version=None, logger=None):
                    logger=logger)
     return IOLoop.instance().run_sync(func)
 
+def is_disabled(name, disabled=[]):
+    for pattern in disabled:
+        if name == pattern:
+            return True
+        if re.compile(pattern).match(name) != None:
+            return True
+    return False
 
 @gen.coroutine
 def build_async(app_dir=None, name=None, version=None, logger=None, abort_callback=None):

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -753,10 +753,14 @@ def _toggle_extension(extension, value, app_dir=None, logger=None):
     """
     app_dir = get_app_dir(app_dir)
     extensions = _get_extensions(app_dir)
-    core_extensions = _get_core_extensions()
+    disabled = config.get('disabledExtensions', [])
+    if value and extension not in disabled:
+        disabled.append(extension)
+    if not value and extension in disabled:
+        disabled.remove(extension)
+    config['disabledExtensions'] = disabled
+    _write_page_config(config, app_dir, logger=logger)
 
-    if extension not in extensions and extension not in core_extensions:
-        raise ValueError('Extension %s is not installed' % extension)
 
 
 def _write_build_config(config, app_dir, logger):

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -129,7 +129,7 @@ def install_extension_async(extension, app_dir=None, logger=None, abort_callback
         return
 
     _ensure_app_dirs(app_dir, logger)
-    
+
     target = pjoin(app_dir, 'extensions', 'temp')
     if os.path.exists(target):
         shutil.rmtree(target)
@@ -745,23 +745,11 @@ def _toggle_extension(extension, value, app_dir=None, logger=None):
     """Enable or disable a lab extension.
     """
     app_dir = get_app_dir(app_dir)
-    config = _get_page_config(app_dir)
     extensions = _get_extensions(app_dir)
     core_extensions = _get_core_extensions()
 
     if extension not in extensions and extension not in core_extensions:
         raise ValueError('Extension %s is not installed' % extension)
-    disabled = config.get('disabledExtensions', [])
-    if value and extension not in disabled:
-        disabled.append(extension)
-    if not value and extension in disabled:
-        disabled.remove(extension)
-
-    # Prune extensions that are not installed.
-    disabled = [ext for ext in disabled
-                if (ext in extensions or ext in core_extensions)]
-    config['disabledExtensions'] = disabled
-    _write_page_config(config, app_dir, logger=logger)
 
 
 def _write_build_config(config, app_dir, logger):

--- a/jupyterlab/index.app.js
+++ b/jupyterlab/index.app.js
@@ -38,9 +38,9 @@ function main() {
         })
     }
 
-    function isDisabled() {
+    function isDisabled(value) {
         return disabled.some(function(pattern) {
-            return pattern.raw === '{{@key}}' || pattern.rule.test('{{@key}}')
+            return pattern.raw === value || pattern.rule.test(value)
         });
     }
 
@@ -64,13 +64,13 @@ function main() {
         }
         if (!isDisabled('{{@key}}')) {
             var module = require('{{@key}}/{{this}}');
-            if (Array.isArray(module)) {
-                module.forEach(function(plugin) {
+            if (Array.isArray(module.default)) {
+                module.default.forEach(function(plugin) {
                     if (isDeferred(plugin.id)) {
                         ignorePlugins.push(plugin.id);
                     }
                     if (!isDisabled(plugin.id)) {
-                        mimeExtensions.push(plugin.id);
+                        mimeExtensions.push(plugin);
                     }
                 });
             } else {
@@ -100,13 +100,13 @@ function main() {
         }
         if (!isDisabled('{{@key}}')) {
             var module = require('{{@key}}/{{this}}');
-            if (Array.isArray(module)) {
-                module.forEach(function(plugin) {
+            if (Array.isArray(module.default)) {
+                module.default.forEach(function(plugin) {
                     if (isDeferred(plugin.id)) {
                         ignorePlugins.push(plugin.id);
                     }
                     if (!isDisabled(plugin.id)) {
-                        lab.registerPluginModule(plugin.id);
+                        lab.registerPluginModule(plugin);
                     }
                 });
             } else {

--- a/jupyterlab/index.app.js
+++ b/jupyterlab/index.app.js
@@ -64,8 +64,15 @@ function main() {
         }
         if (!isDisabled('{{@key}}')) {
             var module = require('{{@key}}/{{this}}');
-            if (Array.isArray(module.default)) {
-                module.default.forEach(function(plugin) {
+            var extension = module.default;
+
+            // Handle CommonJS exports.
+            if (!module.hasOwnProperty('__esModule')) {
+              extension = module;
+            }
+
+            if (Array.isArray(extension)) {
+                extension.forEach(function(plugin) {
                     if (isDeferred(plugin.id)) {
                         ignorePlugins.push(plugin.id);
                     }
@@ -74,7 +81,7 @@ function main() {
                     }
                 });
             } else {
-                mimeExtensions.push(module);
+                mimeExtensions.push(extension);
             }
         }
     } catch (e) {
@@ -100,8 +107,15 @@ function main() {
         }
         if (!isDisabled('{{@key}}')) {
             var module = require('{{@key}}/{{this}}');
-            if (Array.isArray(module.default)) {
-                module.default.forEach(function(plugin) {
+            var extension = module.default;
+
+            // Handle CommonJS exports.
+            if (!module.hasOwnProperty('__esModule')) {
+              extension = module;
+            }
+
+            if (Array.isArray(extension)) {
+                extension.forEach(function(plugin) {
                     if (isDeferred(plugin.id)) {
                         ignorePlugins.push(plugin.id);
                     }
@@ -110,7 +124,7 @@ function main() {
                     }
                 });
             } else {
-                lab.registerPluginModule(module);
+                lab.registerPluginModule(extension);
             }
         }
     } catch (e) {

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -24,7 +24,9 @@ function main() {
     var disabled = [];
     try {
         var option = PageConfig.getOption('disabledExtensions');
-        disabled = JSON.parse(option);
+        disabled = JSON.parse(option).map(function(pattern) {
+            return { raw: pattern, rule: new RegExp(pattern) };
+        });
     } catch (e) {
         // No-op
     }

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -38,9 +38,9 @@ function main() {
         })
     }
 
-    function isDisabled() {
+    function isDisabled(value) {
         return disabled.some(function(pattern) {
-            return pattern.raw === '{{@key}}' || pattern.rule.test('{{@key}}')
+            return pattern.raw === value || pattern.rule.test(value)
         });
     }
 
@@ -64,13 +64,13 @@ function main() {
         }
         if (!isDisabled('{{@key}}')) {
             var module = require('{{@key}}/{{this}}');
-            if (Array.isArray(module)) {
-                module.forEach(function(plugin) {
+            if (Array.isArray(module.default)) {
+                module.default.forEach(function(plugin) {
                     if (isDeferred(plugin.id)) {
                         ignorePlugins.push(plugin.id);
                     }
                     if (!isDisabled(plugin.id)) {
-                        mimeExtensions.push(plugin.id);
+                        mimeExtensions.push(plugin);
                     }
                 });
             } else {
@@ -100,13 +100,13 @@ function main() {
         }
         if (!isDisabled('{{@key}}')) {
             var module = require('{{@key}}/{{this}}');
-            if (Array.isArray(module)) {
-                module.forEach(function(plugin) {
+            if (Array.isArray(module.default)) {
+                module.default.forEach(function(plugin) {
                     if (isDeferred(plugin.id)) {
                         ignorePlugins.push(plugin.id);
                     }
                     if (!isDisabled(plugin.id)) {
-                        lab.registerPluginModule(plugin.id);
+                        lab.registerPluginModule(plugin);
                     }
                 });
             } else {

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -64,8 +64,15 @@ function main() {
         }
         if (!isDisabled('{{@key}}')) {
             var module = require('{{@key}}/{{this}}');
-            if (Array.isArray(module.default)) {
-                module.default.forEach(function(plugin) {
+            var extension = module.default;
+
+            // Handle CommonJS exports.
+            if (!module.hasOwnProperty('__esModule')) {
+              extension = module;
+            }
+
+            if (Array.isArray(extension)) {
+                extension.forEach(function(plugin) {
                     if (isDeferred(plugin.id)) {
                         ignorePlugins.push(plugin.id);
                     }
@@ -74,7 +81,7 @@ function main() {
                     }
                 });
             } else {
-                mimeExtensions.push(module);
+                mimeExtensions.push(extension);
             }
         }
     } catch (e) {
@@ -100,8 +107,15 @@ function main() {
         }
         if (!isDisabled('{{@key}}')) {
             var module = require('{{@key}}/{{this}}');
-            if (Array.isArray(module.default)) {
-                module.default.forEach(function(plugin) {
+            var extension = module.default;
+
+            // Handle CommonJS exports.
+            if (!module.hasOwnProperty('__esModule')) {
+              extension = module;
+            }
+
+            if (Array.isArray(extension)) {
+                extension.forEach(function(plugin) {
                     if (isDeferred(plugin.id)) {
                         ignorePlugins.push(plugin.id);
                     }
@@ -110,7 +124,7 @@ function main() {
                     }
                 });
             } else {
-                lab.registerPluginModule(module);
+                lab.registerPluginModule(extension);
             }
         }
     } catch (e) {

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -33,7 +33,11 @@ function main() {
     var mimeExtensions = [];
     {{#each jupyterlab_mime_extensions}}
     try {
-        if (disabled.indexOf('{{@key}}') === -1) {
+        var enabled = !disabled.some(function(pattern) {
+            return pattern.raw === '{{@key}}' || pattern.test('{{@key}}')
+        });
+
+        if (enabled) {
             mimeExtensions.push(require('{{@key}}/{{this}}'));
         }
     } catch (e) {
@@ -54,7 +58,11 @@ function main() {
     // Handled the registered standard extensions.
     {{#each jupyterlab_extensions}}
     try {
-        if (disabled.indexOf('{{@key}}') === -1) {
+        var enabled = !disabled.some(function(pattern) {
+            return pattern.raw === '{{@key}}' || pattern.test('{{@key}}')
+        });
+
+        if (enabled) {
             lab.registerPluginModule(require('{{@key}}/{{this}}'));
         }
     } catch (e) {
@@ -70,7 +78,7 @@ function main() {
     } catch (e) {
         // No-op
     }
-    lab.start({ "ignorePlugins": ignorePlugins });
+    lab.start({ 'ignorePlugins': ignorePlugins });
 
     // Handle a selenium test.
     var seleniumTest = PageConfig.getOption('seleniumTest');

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -29,14 +29,32 @@ function main() {
         // No-op
     }
 
+    // Get the deferred extensions.
+    var deferredExtensions = [];
+    var ignorePlugins = [];
+    try {
+        var option = PageConfig.getOption('deferredExtensions');
+        deferredExtensions = JSON.parse(option).map(function(pattern) {
+            return { raw: pattern, rule: new RegExp(pattern) };
+        });
+    } catch (e) {
+        // No-op
+    }
+
     // Handle the registered mime extensions.
     var mimeExtensions = [];
     {{#each jupyterlab_mime_extensions}}
     try {
+        var deferred = !deferredExtensions.some(function(pattern) {
+            return pattern.raw === '{{@key}}' || pattern.rule.test('{{@key}}')
+        });
         var enabled = !disabled.some(function(pattern) {
-            return pattern.raw === '{{@key}}' || pattern.test('{{@key}}')
+            return pattern.raw === '{{@key}}' || pattern.rule.test('{{@key}}')
         });
 
+        if (deferred) {
+            ignorePlugins.push('{{key}}');
+        }
         if (enabled) {
             mimeExtensions.push(require('{{@key}}/{{this}}'));
         }
@@ -58,10 +76,16 @@ function main() {
     // Handled the registered standard extensions.
     {{#each jupyterlab_extensions}}
     try {
+        var deferred = !deferredExtensions.some(function(pattern) {
+            return pattern.raw === '{{@key}}' || pattern.rule.test('{{@key}}')
+        });
         var enabled = !disabled.some(function(pattern) {
-            return pattern.raw === '{{@key}}' || pattern.test('{{@key}}')
+            return pattern.raw === '{{@key}}' || pattern.rule.test('{{@key}}')
         });
 
+        if (deferred) {
+            ignorePlugins.push('{{key}}');
+        }
         if (enabled) {
             lab.registerPluginModule(require('{{@key}}/{{this}}'));
         }
@@ -70,15 +94,7 @@ function main() {
     }
     {{/each}}
 
-    // Handle the ignored plugins.
-    var ignorePlugins = [];
-    try {
-        var option = PageConfig.getOption('ignorePlugins');
-        ignorePlugins = JSON.parse(option);
-    } catch (e) {
-        // No-op
-    }
-    lab.start({ 'ignorePlugins': ignorePlugins });
+    lab.start({ ignorePlugins: ignorePlugins });
 
     // Handle a selenium test.
     var seleniumTest = PageConfig.getOption('seleniumTest');

--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -53,7 +53,7 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
 export
 function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<void> {
   return {
-    id: `@jupyterlab/application:mimerenderer-${item.name}`,
+    id: item.id,
     requires: [ILayoutRestorer],
     autoStart: true,
     activate: (app: JupyterLab, restorer: ILayoutRestorer) => {

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -51,21 +51,27 @@ namespace PageConfig {
 
     // Use script tag if available.
     if (typeof document !== 'undefined') {
-      let el = document.getElementById('jupyter-config-data');
+      const el = document.getElementById('jupyter-config-data');
+
       if (el) {
-        configData = JSON.parse(el.textContent || '') as { [key: string]: string };
+        configData = JSON.parse(el.textContent || '') as {
+          [key: string]: string
+        };
         found = true;
       }
     }
     // Otherwise use CLI if given.
     if (!found && typeof process !== 'undefined') {
       try {
-        let cli = minimist(process.argv.slice(2));
+        const cli = minimist(process.argv.slice(2));
         if ('jupyter-config-data' in cli) {
-          let path: any = require('path');
-          let fullPath = path.resolve(cli['jupyter-config-data']);
+          const path: any = require('path');
+          const fullPath = path.resolve(cli['jupyter-config-data']);
+
+          /* tslint:disable */
           // Force Webpack to ignore this require.
           configData = eval('require')(fullPath) as { [key: string]: string };
+          /* tslint:enable */
         }
       } catch (e) {
         console.error(e);
@@ -93,7 +99,8 @@ namespace PageConfig {
    */
   export
   function setOption(name: string, value: string): string {
-    let last = getOption(name);
+    const last = getOption(name);
+
     configData![name] = value;
     return last;
   }

--- a/packages/pdf-extension/src/index.ts
+++ b/packages/pdf-extension/src/index.ts
@@ -51,7 +51,7 @@ class RenderedPDF extends Widget implements IRenderMime.IRenderer {
     if (oldUrl) {
       try {
         URL.revokeObjectURL(oldUrl);
-      } catch(err) { /* no-op */ }
+      } catch (error) { /* no-op */ }
     }
     return Promise.resolve(void 0);
   }
@@ -62,7 +62,7 @@ class RenderedPDF extends Widget implements IRenderMime.IRenderer {
   dispose() {
     try {
       URL.revokeObjectURL(this._objectUrl);
-    } catch(err) { /* no-op */ }
+    } catch (error) { /* no-op */ }
     super.dispose();
   }
 
@@ -83,7 +83,7 @@ const rendererFactory: IRenderMime.IRendererFactory = {
 
 const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
   {
-    name: 'PDF',
+    id: '@jupyterlab/pdf-extension:factory',
     rendererFactory,
     rank: 0,
     dataType: 'string',

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -151,9 +151,14 @@ namespace IRenderMime {
   export
   interface IExtension {
     /**
-     * The name of the extension.
+     * The ID of the extension.
+     *
+     * #### Notes
+     * The convention for extension IDs in JupyterLab is the full NPM package
+     * name followed by a colon and a unique string token, e.g.
+     * `'@jupyterlab/apputils-extension:settings'` or `'foo-extension:bar'`.
      */
-    readonly name: string;
+    readonly id: string;
 
     /**
      * A renderer factory to be registered to render the MIME type.

--- a/packages/vega2-extension/src/index.ts
+++ b/packages/vega2-extension/src/index.ts
@@ -127,7 +127,7 @@ const rendererFactory: IRenderMime.IRendererFactory = {
 };
 
 const extension: IRenderMime.IExtension = {
-  name: 'vega',
+  id: '@jupyterlab/vega2-extension:factory',
   rendererFactory,
   rank: 0,
   dataType: 'json',


### PR DESCRIPTION
There are two fields in the `page_config.json` file that can allow control of which plugins load:

1. `disabledExtensions` for extensions that should not load at all.
2. `deferredExtensions` for extensions that do not load until they are required by something, irrespective of whether they set `autostart` to `true`.

The values for each are an array of strings.

* If an identical string match occurs between a config value and a package name (*e.g.*, `"@jupyterlab/apputils-extension"`), then the entire package is disabled (or deferred).
* If the string value is compiled as a regular expression and tests positive against a package name (*e.g.*, `"disabledExtensions": ["@jupyterlab/apputils*$"]`), then the entire package is disabled (or deferred).
* If an identical string match occurs between a config value and an individual plugin ID within a larger package (*e.g.*, `"disabledExtensions": ["@jupyterlab/apputils-extension:settings"]`), then that specific plugin is disabled (or deferred). CC: @ivanov @ellisonbg 
* If the string value is compiled as a regular expression and tests positive against an individual plugin ID within a larger package (*e.g.*, `"disabledExtensions": ["^@jupyterlab/apputils-extension:set.*$"]`), then that specific plugin is disabled (or deferred).

## Backward-incompatible API change

The MIME renderer extension interface no longer has a `name` field. Instead, it has an `id` field that follows the same semantic conventions as our other plugins. So for example, the `name` field of the Vega renderer has changed from `name: 'vega'` to `id: '@jupyterlab/vega2-extension:factory'`