### PR TITLE
Remove `direction: rtl` from `.jp-RunningSessions-itemLabel`

### DIFF
--- a/packages/running/style/index.css
+++ b/packages/running/style/index.css
@@ -148,7 +148,6 @@
   padding-left: 4px;
   text-overflow: ellipsis;
   overflow: hidden;
-  direction: rtl;
   white-space: nowrap;
   border-radius: 2px;
   transition: background-color 0.1s ease;


### PR DESCRIPTION
Fixes #3084