### PR TITLE
Cleanup for 0.28 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Note: If installing using `pip install --user`, you must add the user-level
  `bin` directory to your `PATH` environment variable in order to launch
  `jupyter lab`.
 
+Note: If installing from source and not using the
+development installation (`pip install -e .`), you
+must run `jupyter lab build` after the install to
+get a working application directory.
+
+
 ### Running
 
 Start up JupyterLab using:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -825,26 +825,6 @@ def _ensure_package(app_dir, logger=None, name=None, version=None):
     with open(pkg_path, 'w') as fid:
         json.dump(data, fid, indent=4)
 
-    # Shim shortcuts and theme schemas until the 0.28 release.
-    if 'rc' in __version__:
-        raise ValueError('Remove this before final release')
-
-    base = os.path.realpath(pjoin(here, '..', 'packages'))
-    src = pjoin(base, 'shortcuts-extension', 'schema', 'plugin.json')
-    dest = pjoin(app_dir, 'schemas', 'jupyter.extensions.shortcuts.json')
-    shutil.copy(src, dest)
-
-    src = pjoin(base, 'apputils-extension', 'schema', 'themes.json')
-    dest = pjoin(app_dir, 'schemas', 'jupyter.services.theme-manager.json')
-    shutil.copy(src, dest)
-
-    src = pjoin(base, 'codemirror-extension', 'schema', 'commands.json')
-    dest = pjoin(app_dir, 'schemas', 'jupyter.services.codemirror-commands.json')
-    shutil.copy(src, dest)
-
-    src = pjoin(base, 'fileeditor-extension', 'schema', 'plugin.json')
-    dest = pjoin(app_dir, 'schemas', 'jupyter.services.editor-tracker.json')
-    shutil.copy(src, dest)
 
 def _ensure_app_dirs(app_dir, logger):
     """Ensure that the application directories exist"""

--- a/jupyterlab/tests/test_settings_api.py
+++ b/jupyterlab/tests/test_settings_api.py
@@ -26,10 +26,6 @@ class SettingsAPITest(LabTestBase):
 
     def test_get(self):
         id = '@jupyterlab/apputils-extension:shortcuts'
-        id = id.replace('@', '').replace('/', '').replace(':', '-')
-        if 'rc' in __version__:
-            raise ValueError('Remove this before final release')
-        id = 'jupyter.extensions.shortcuts'
         data = self.settings_api.get(id).json()
         assert data['id'] == id
         assert len(data['schema'])
@@ -41,8 +37,6 @@ class SettingsAPITest(LabTestBase):
 
     def test_patch(self):
         id = '@jupyterlab/apputils-extension:shortcuts'
-        id = id.replace('@', '').replace('/', '').replace(':', '-')
-        id = 'jupyter.extensions.shortcuts'
         resp = self.settings_api.patch(id, dict())
         assert resp.status_code == 204
 
@@ -52,8 +46,6 @@ class SettingsAPITest(LabTestBase):
 
     def test_patch_bad_data(self):
         id = '@jupyterlab/codemirror-extension:commands'
-        id = id.replace('@', '').replace('/', '').replace(':', '-')
-        id = 'jupyter.services.codemirror-commands'
         data = dict(keyMap=10)
         with assert_http_error(400):
             self.settings_api.patch(id, data)

--- a/jupyterlab/tests/test_settings_api.py
+++ b/jupyterlab/tests/test_settings_api.py
@@ -3,7 +3,6 @@ import json
 
 from jupyterlab.tests.utils import LabTestBase, APITester
 from notebook.tests.launchnotebook import assert_http_error
-from jupyterlab import __version__
 
 
 class SettingsAPI(APITester):
@@ -25,7 +24,7 @@ class SettingsAPITest(LabTestBase):
         self.settings_api = SettingsAPI(self.request)
 
     def test_get(self):
-        id = '@jupyterlab/apputils-extension:shortcuts'
+        id = '@jupyterlab/apputils-extension:themes'
         data = self.settings_api.get(id).json()
         assert data['id'] == id
         assert len(data['schema'])
@@ -36,7 +35,7 @@ class SettingsAPITest(LabTestBase):
             self.settings_api.get('foo')
 
     def test_patch(self):
-        id = '@jupyterlab/apputils-extension:shortcuts'
+        id = '@jupyterlab/apputils-extension:themes'
         resp = self.settings_api.patch(id, dict())
         assert resp.status_code == 204
 

--- a/packages/all-packages/package.json
+++ b/packages/all-packages/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@jupyterlab/all-packages",
   "version": "0.11.0",
+  "private": true,
   "description": "JupyterLab - All Packages",
   "homepage": "https://github.com/jupyterlab/jupyterlab",
   "bugs": {
@@ -10,6 +11,7 @@
   "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
   "main": "lib/index.js",
@@ -83,6 +85,5 @@
     "rimraf": "^2.5.2",
     "typedoc": "^0.7.1",
     "typescript": "~2.4.1"
-  },
-  "private": true
+  }
 }

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/application-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Application Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -21,22 +37,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -2,15 +2,32 @@
   "name": "@jupyterlab/application",
   "version": "0.11.0",
   "description": "JupyterLab - Application",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
+    "lib/*.js.map",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -32,20 +49,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -2,17 +2,33 @@
   "name": "@jupyterlab/apputils-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Application Utilities Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
     "style/images/*.svg",
     "schema/*.json"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -28,23 +44,8 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/apputils",
   "version": "0.11.0",
   "description": "JupyterLab - Application Utilities",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^0.11.0",
@@ -31,20 +47,5 @@
     "@types/sanitize-html": "^1.13.31",
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/buildutils/package.json
+++ b/packages/buildutils/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/buildutils",
   "version": "0.1.1",
   "description": "JupyterLab - Build Utilities",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "fs-extra": "~4.0.2",
@@ -21,20 +37,5 @@
     "@types/node": "^8.0.31",
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/cells",
   "version": "0.11.0",
   "description": "JupyterLab - Notebook Cells",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -29,20 +45,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/codeeditor",
   "version": "0.11.0",
   "description": "JupyterLab - Abstract Code Editor",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/coreutils": "^0.11.0",
@@ -24,20 +40,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/codemirror-extension",
   "version": "0.11.0",
   "description": "JupyterLab - CodeMirror Provider Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "schema/*.json"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -26,23 +42,8 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/codemirror",
   "version": "0.11.0",
   "description": "JupyterLab - CodeMirror Editor Provider",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -26,20 +42,5 @@
     "@types/codemirror": "0.0.46",
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/completer-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Completer Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -22,22 +38,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/completer",
   "version": "0.11.0",
   "description": "JupyterLab - Completer",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -28,20 +44,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/console-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Code Console Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -26,22 +42,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/console",
   "version": "0.11.0",
   "description": "JupyterLab - Code Console",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -29,20 +45,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/coreutils",
   "version": "0.11.0",
   "description": "JupyterLab - Core Utilities",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@phosphor/algorithm": "^1.1.1",
@@ -28,20 +44,5 @@
     "@types/minimist": "^1.2.0",
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/csvviewer-extension",
   "version": "0.11.0",
   "description": "JupyterLab - CSV Widget Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -20,22 +36,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/csvviewer",
   "version": "0.11.0",
   "description": "JupyterLab - CSV Widget",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -28,20 +44,5 @@
     "@types/d3-dsv": "^1.0.30",
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/docmanager-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Document Manager Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -24,22 +40,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/docmanager",
   "version": "0.11.0",
   "description": "JupyterLab - Document Manager",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -27,20 +43,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/docregistry",
   "version": "0.11.0",
   "description": "JupyterLab - Document Registry",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/index.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -29,20 +45,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/faq-extension/package.json
+++ b/packages/faq-extension/package.json
@@ -2,16 +2,32 @@
   "name": "@jupyterlab/faq-extension",
   "version": "0.11.0",
   "description": "JupyterLab - FAQ Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
     "faq.md"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -27,20 +43,5 @@
   },
   "jupyterlab": {
     "extension": true
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/filebrowser-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Filebrowser Widget Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -27,22 +43,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/filebrowser",
   "version": "0.11.0",
   "description": "JupyterLab - FileBrowser Widget",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -31,20 +47,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/fileeditor-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Editor Widget Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "schema/*.json"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -24,23 +40,8 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/fileeditor",
   "version": "0.11.0",
   "description": "JupyterLab - Editor Widget",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -22,20 +38,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/help-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Help Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -24,22 +40,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/imageviewer-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Image Widget Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -21,22 +37,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/imageviewer",
   "version": "0.11.0",
   "description": "JupyterLab - Image Widget",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -23,20 +39,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/inspector-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Code Inspector Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -23,22 +39,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/inspector",
   "version": "0.11.0",
   "description": "JupyterLab - Code Inspector",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -27,20 +43,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/launcher-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Launcher Page Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -24,22 +40,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/launcher",
   "version": "0.11.0",
   "description": "JupyterLab - Launcher Panel",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -24,20 +40,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/markdownviewer-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Markdown Renderer Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -21,22 +37,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/notebook-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Notebook Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -27,22 +43,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/notebook",
   "version": "0.11.0",
   "description": "JupyterLab - Notebook",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -33,20 +49,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/outputarea",
   "version": "0.11.0",
   "description": "JupyterLab - Notebook Output Area",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -27,20 +43,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/pdf-extension",
   "version": "0.3.0",
   "description": "JupyterLab - PDF Viewer",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^0.4.0",
@@ -20,22 +36,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "mimeExtension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/rendermime-interfaces",
   "version": "0.4.0",
   "description": "JupyterLab - Interfaces for Mime Renderers",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@phosphor/coreutils": "^1.2.0",
@@ -18,20 +34,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/rendermime",
   "version": "0.11.0",
   "description": "JupyterLab - RenderMime",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -30,20 +46,5 @@
     "@types/mathjax": "0.0.31",
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/running-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Running Sessions Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -19,22 +35,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/running",
   "version": "0.11.0",
   "description": "JupyterLab - Running Sessions Panel",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -24,20 +40,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -2,8 +2,44 @@
   "name": "@jupyterlab/services",
   "version": "0.50.0",
   "description": "Client APIs for the Jupyter services REST APIs",
+  "keywords": [
+    "jupyter",
+    "notebook",
+    "services"
+  ],
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
+  "files": [
+    "lib/**/*.js",
+    "lib/*.js.map",
+    "lib/**/*.d.ts",
+    "lib/*.js",
+    "lib/*.d.ts",
+    "dist/*.js",
+    "dist/**/*.js"
+  ],
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab"
+  },
+  "scripts": {
+    "build": "npm run build:src",
+    "build:src": "tsc --project src",
+    "build:test": "tsc --project test/src",
+    "clean": "rimraf docs && rimraf lib && rimraf test/build && rimraf test/coverage",
+    "prepublishOnly": "npm run build:src && webpack",
+    "test": "mocha --retries 3 test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json",
+    "test:coverage": "istanbul cover --dir test/coverage _mocha -- --retries 3 test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json",
+    "test:debug": "mocha test/build/**/*.spec.js test/build/*.spec.js  --jupyter-config-data=./test/config.json --debug-brk",
+    "test:devtool": "devtool node_modules/.bin/_mocha -qc test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json --timeout=50000",
+    "test:integration": "cd test && python integration_test.py"
+  },
   "dependencies": {
     "@jupyterlab/coreutils": "^0.11.0",
     "@phosphor/algorithm": "^1.1.1",
@@ -26,40 +62,5 @@
     "webpack": "^2.2.1",
     "ws": "^1.1.1",
     "xmlhttprequest": "^1.8.0"
-  },
-  "scripts": {
-    "clean": "rimraf docs && rimraf lib && rimraf test/build && rimraf test/coverage",
-    "build:src": "tsc --project src",
-    "build:test": "tsc --project test/src",
-    "build": "npm run build:src",
-    "prepublishOnly": "npm run build:src && webpack",
-    "test:coverage": "istanbul cover --dir test/coverage _mocha -- --retries 3 test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json",
-    "test:integration": "cd test && python integration_test.py",
-    "test:devtool": "devtool node_modules/.bin/_mocha -qc test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json --timeout=50000",
-    "test:debug": "mocha test/build/**/*.spec.js test/build/*.spec.js  --jupyter-config-data=./test/config.json --debug-brk",
-    "test": "mocha --retries 3 test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab"
-  },
-  "keywords": [
-    "jupyter",
-    "services",
-    "notebook"
-  ],
-  "files": [
-    "lib/**/*.js",
-    "lib/**/*.d.ts",
-    "lib/*.js",
-    "lib/*.d.ts",
-    "dist/*.js",
-    "dist/**/*.js"
-  ],
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/settingeditor-extension",
   "version": "0.6.0",
   "description": "JupyterLab - Setting Editor Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -27,22 +43,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/shortcuts-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Shortcuts Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "schema/*.json"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -23,23 +39,8 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/tabmanager-extension/package.json
+++ b/packages/tabmanager-extension/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/tabmanager-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Tab Manager Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -21,22 +37,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/terminal-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Terminal Emulator Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -23,22 +39,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/terminal",
   "version": "0.11.0",
   "description": "JupyterLab - Terminal Emulator Widget",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -24,20 +40,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -2,18 +2,29 @@
   "name": "@jupyterlab/theme-dark-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Default Dark Theme",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
     "style/images/*.*",
     "style/icons/*.*",
     "style/icons/**/*.*"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -24,18 +35,8 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
   "jupyterlab": {
     "extension": true,
     "themeDir": "style"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -1,20 +1,36 @@
 {
   "name": "@jupyterlab/theme-light-extension",
   "version": "0.11.0",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "description": "JupyterLab - Default Light Theme",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css",
     "style/images/*.*",
     "style/icons/*.*",
     "style/icons/**/*.*"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
   },
-  "description": "JupyterLab - Default Light Theme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
+  },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
     "@jupyterlab/apputils": "^0.11.0",
@@ -24,23 +40,8 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
   "jupyterlab": {
     "extension": true,
     "themeDir": "style"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -2,14 +2,30 @@
   "name": "@jupyterlab/tooltip-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Tooltip Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.11.0",
@@ -26,22 +42,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
   "jupyterlab": {
     "extension": true
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -2,15 +2,31 @@
   "name": "@jupyterlab/tooltip",
   "version": "0.11.0",
   "description": "JupyterLab - Tooltip Widget",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.11.0",
@@ -24,20 +40,5 @@
   "devDependencies": {
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
-  },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  }
 }

--- a/packages/vega2-extension/package.json
+++ b/packages/vega2-extension/package.json
@@ -2,18 +2,31 @@
   "name": "@jupyterlab/vega2-extension",
   "version": "0.11.0",
   "description": "JupyterLab - Vega 2 Mime Renderer Extension",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
   "files": [
     "lib/*.d.ts",
+    "lib/*.js.map",
     "lib/*.js",
     "style/*.css"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "directories": {
     "lib": "lib/"
   },
-  "jupyterlab": {
-    "mimeExtension": true
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^0.4.0",
@@ -28,19 +41,7 @@
     "rimraf": "^2.5.2",
     "typescript": "~2.4.1"
   },
-  "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jupyterlab/jupyterlab.git"
-  },
-  "author": "Project Jupyter",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterlab/jupyterlab/issues"
-  },
-  "homepage": "https://github.com/jupyterlab/jupyterlab"
+  "jupyterlab": {
+    "mimeExtension": true
+  }
 }

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -73,6 +73,15 @@ if [[ $GROUP == cli ]]; then
     python -m jupyterlab.selenium_check 
     jupyter labextension list
 
+    # Make sure we can non-dev install.
+    conda env create -n test_install notebook
+    source activate test_install
+    pip install .
+    jupyter lab build
+    pip install selenium
+    python -m jupyterlab.selenium_check
+    source deactivate
+
     # Test the cli apps.
     jupyter lab clean
     jupyter lab build


### PR DESCRIPTION
- Cleans up tests and removes schema shim after release of JavaScript packages
- Adds test and docs for `pip install .` 
- Adds sourcemaps to released packages using the following script (which is causing the large diffs):

```javascript
var sortPackageJson = require('sort-package-json');
var fs = require('fs');
var glob = require('glob');

glob.sync('*/package.json').forEach(function (filePath) {
    var data = require('./' + filePath);
    if (!data.files) {
        return;
    }
    if (!glob.sync(filePath + '/lib/*.js.map')) {
        return;
    }
    var files = data.files;
    files.splice(1, 0, 'lib/*.js.map');
    var text = JSON.stringify(sortPackageJson(data), null, 2) + '\n';
    fs.writeFileSync('./' + filePath, text);
});
```