### PR TITLE
Prevent symlink recursion on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ from setupbase import (
     js_prerelease,
     CheckAssets,
     version_ns,
-    name
+    name,
+    custom_egg_info
 )
 
 
@@ -98,6 +99,7 @@ cmdclass = dict(
     sdist  = js_prerelease(sdist, strict=True),
     bdist_egg = bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
     jsdeps = CheckAssets,
+    egg_info = custom_egg_info
 )
 try:
     from wheel.bdist_wheel import bdist_wheel

--- a/setupbase.py
+++ b/setupbase.py
@@ -22,6 +22,7 @@ from os.path import join as pjoin
 from distutils import log
 from distutils.cmd import Command
 from distutils.version import LooseVersion
+from setuptools.command.egg_info import egg_info
 from setuptools.command.bdist_egg import bdist_egg
 from subprocess import check_call
 
@@ -208,3 +209,13 @@ class bdist_egg_disabled(bdist_egg):
     """
     def run(self):
         sys.exit("Aborting implicit building of eggs. Use `pip install .` to install from source.")
+
+
+class custom_egg_info(egg_info):
+    """Prune node_modules folders from egg_info to avoid symlink recursion
+    """
+    def run(self):
+        folders = glob.glob(pjoin(here, 'packages', '**', 'node_modules'))
+        for folder in folders:
+            shutil.rmtree(folder)
+        return egg_info.run(self)

--- a/setupbase.py
+++ b/setupbase.py
@@ -223,4 +223,3 @@ class custom_egg_info(egg_info):
         for folder in folders:
             shutil.rmtree(folder)
         return egg_info.run(self)
-        return egg_info.run(self)

--- a/setupbase.py
+++ b/setupbase.py
@@ -215,7 +215,12 @@ class custom_egg_info(egg_info):
     """Prune node_modules folders from egg_info to avoid symlink recursion
     """
     def run(self):
-        folders = glob.glob(pjoin(here, 'packages', '**', 'node_modules'))
+        folders = []
+        for dir, subdirs, files in os.walk(here):
+            if 'node_modules' in subdirs:
+                folders.append(pjoin(dir, 'node_modules'))
+                subdirs.remove('node_modules')
         for folder in folders:
             shutil.rmtree(folder)
+        return egg_info.run(self)
         return egg_info.run(self)


### PR DESCRIPTION
Allows the use of `pip install .` and `pip install -e .` after `npm install` on systems that would previously lock up.

Tested on Ubuntu 16.04 with the following:

```bash
npm install
sudo /usr/bin/pip install -v .
```

cf #3106 