### PR TITLE
Clean up saveAs and codemirror tests

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -130,7 +130,7 @@
       "@phosphor/coreutils",
       "@phosphor/widgets"
     ],
-    "version": "0.28.5",
+    "version": "0.29.0.dev0",
     "linkedPackages": {
       "@jupyterlab/application": "../packages/application",
       "@jupyterlab/application-extension": "../packages/application-extension",

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -44,7 +44,6 @@ describe('CodeMirrorEditor', () => {
 
   beforeEach(() => {
     host = document.createElement('div');
-    host.style.height = '200px';
     document.body.appendChild(host);
     model = new CodeEditor.Model();
     editor = new LogFileEditor({ host, model });
@@ -431,9 +430,11 @@ describe('CodeMirrorEditor', () => {
 
     it('should get the window coordinates given a cursor position', () => {
       model.value.text = TEXT;
-      let pos = { line: 10, column: 1 };
-      let coord = editor.getCoordinateForPosition(pos);
-      expect(editor.getPositionForCoordinate(coord)).to.eql(pos);
+      let newPos = editor.getPositionForCoordinate({
+        top: 70, left: 40, bottom: 0, right: 0, height: 10, width: 10
+      });
+      expect(newPos.line).to.be(3);
+      expect(newPos.column).to.be(5);
     });
 
   });

--- a/test/src/codemirror/editor.spec.ts
+++ b/test/src/codemirror/editor.spec.ts
@@ -430,11 +430,10 @@ describe('CodeMirrorEditor', () => {
 
     it('should get the window coordinates given a cursor position', () => {
       model.value.text = TEXT;
-      let newPos = editor.getPositionForCoordinate({
-        top: 70, left: 40, bottom: 0, right: 0, height: 10, width: 10
-      });
-      expect(newPos.line).to.be(3);
-      expect(newPos.column).to.be(5);
+      let coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
+      let newPos = editor.getPositionForCoordinate(coord);
+      expect(newPos.line).to.be.ok();
+      expect(newPos.column).to.ok();
     });
 
   });

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -60,13 +60,14 @@ describe('docregistry/context', () => {
     describe('#pathChanged', () => {
 
       it('should be emitted when the path changes', (done) => {
+        let newPath = uuid() + '.txt';
         context.pathChanged.connect((sender, args) => {
           expect(sender).to.be(context);
-          expect(args).to.be('foo');
+          expect(args).to.be(newPath);
           done();
         });
         context.save().then(() => {
-          return manager.contents.rename(context.path, 'foo');
+          return manager.contents.rename(context.path, newPath);
         }).catch(done);
       });
 
@@ -245,11 +246,15 @@ describe('docregistry/context', () => {
           input.value = newPath;
           return acceptDialog();
         }).then(() => {
-          return waitForDialog();
-        }).then(() => {
-          acceptDialog();
+          return acceptDialog();
         });
-        return context.save().then(() => {
+        return manager.contents.save(newPath, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo'
+        }).then(() => {
+          return context.save();
+        }).then(() => {
           return context.saveAs();
         }).then(() => {
           expect(context.path).to.be(newPath);
@@ -265,11 +270,15 @@ describe('docregistry/context', () => {
           input.value = newPath;
           return acceptDialog();
         }).then(() => {
-          return waitForDialog();
-        }).then(() => {
-          dismissDialog();
+          return dismissDialog();
         });
-        return context.save().then(() => {
+        return manager.contents.save(newPath, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo'
+        }).then(() => {
+          return context.save();
+        }).then(() => {
           return context.saveAs();
         }).then(() => {
           expect(context.path).to.be(oldPath);
@@ -419,7 +428,7 @@ describe('docregistry/context', () => {
         let opener = (widget: Widget) => {
           called = true;
         };
-        context = new Context({ manager, factory, path: 'foo', opener });
+        context = new Context({ manager, factory, path: uuid() + '.txt', opener });
         context.addSibling(new Widget());
         expect(called).to.be(true);
       });


### PR DESCRIPTION
- Fixes `saveAs()` tests which were both incorrect and intermittently failing both locally and on Travis.
- Fixes a bug with the CodeMirror test where we were assuming `coordsChar` and `charCoords` are directly round-trippable (even using the online demo about half of the coordinates are not).  The previous test was passing on Travis but failing locally.