### PR TITLE
Fix shown version

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -339,8 +339,6 @@ def should_build(app_dir=None, logger=None):
     with open(pkg_path) as fid:
         static_data = json.load(fid)
 
-    core_data = _get_core_data()
-
     # Look for mismatched version.
     static_version = static_data['jupyterlab'].get('version', '')
     core_version = static_data['jupyterlab']['version']
@@ -694,6 +692,10 @@ def _get_core_data():
     """
     with open(pjoin(here, 'package.app.json')) as fid:
         return json.load(fid)
+
+
+# Provide the application version.
+app_version = _get_core_data()['jupyterlab']['version']
 
 
 def _test_overlap(spec1, spec2):

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -26,8 +26,6 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 
 from .semver import Range, gte, lt, lte, gt
-from ._version import __version__
-
 
 if sys.platform == 'win32':
     from subprocess import list2cmdline
@@ -341,11 +339,14 @@ def should_build(app_dir=None, logger=None):
     with open(pkg_path) as fid:
         static_data = json.load(fid)
 
+    core_data = _get_core_data()
+
     # Look for mismatched version.
-    version = static_data['jupyterlab'].get('version', '')
-    if LooseVersion(version) != LooseVersion(__version__):
+    static_version = static_data['jupyterlab'].get('version', '')
+    core_version = static_data['jupyterlab']['version']
+    if LooseVersion(static_version) != LooseVersion(core_version):
         msg = 'Version mismatch: %s (built), %s (current)'
-        return True, msg % (version, __version__)
+        return True, msg % (static_version, core_version)
 
     # Look for mismatched extensions.
     template_data = _get_package_template(app_dir, logger)
@@ -457,7 +458,7 @@ def list_extensions(app_dir=None, logger=None):
             continue
         app.append(key)
 
-    logger.info('JupyterLab v%s' % __version__)
+    logger.info('JupyterLab v%s' % core_data['jupyterlab']['version'])
     logger.info('Known labextensions:')
     if app:
         logger.info('   app dir: %s' % app_dir)
@@ -810,7 +811,6 @@ def _ensure_package(app_dir, logger=None, name=None, version=None):
     """Make sure the build dir is set up.
     """
     logger = logger or logging
-    version = version or __version__
     _ensure_app_dirs(app_dir, logger)
 
     # Look for mismatched version.

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -11,7 +11,9 @@ from traitlets import Bool, Unicode
 
 from ._version import __version__
 from .extension import load_jupyter_server_extension
-from .commands import build, clean, get_app_dir, get_user_settings_dir
+from .commands import (
+    build, clean, get_app_dir, get_user_settings_dir, app_version
+)
 
 
 build_aliases = dict(base_aliases)
@@ -20,8 +22,13 @@ build_aliases['name'] = 'LabBuildApp.name'
 build_aliases['version'] = 'LabBuildApp.version'
 
 
+version = __version__
+if version != app_version:
+    version = '%s (dev), %s (app)' % (__version__, app_version)
+
+
 class LabBuildApp(JupyterApp):
-    version = __version__
+    version = version
     description = """
     Build the JupyterLab application
 
@@ -49,7 +56,7 @@ clean_aliases['app-dir'] = 'LabCleanApp.app_dir'
 
 
 class LabCleanApp(JupyterApp):
-    version = __version__
+    version = version
     description = """
     Clean the JupyterLab application
 
@@ -66,7 +73,7 @@ class LabCleanApp(JupyterApp):
 
 
 class LabPathApp(JupyterApp):
-    version = __version__
+    version = version
     description = """
     Print the configured paths for the JupyterLab application
 
@@ -100,7 +107,7 @@ lab_flags['watch'] = (
 
 
 class LabApp(NotebookApp):
-    version = __version__
+    version = version
 
     description = """
     JupyterLab - An extensible computational environment for Jupyter.

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -5,6 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 from __future__ import print_function
 
+import json
 import os
 import sys
 from tornado.ioloop import IOLoop
@@ -13,7 +14,6 @@ from jupyter_core.application import JupyterApp, base_flags, base_aliases
 
 from traitlets import Bool, Unicode
 
-from ._version import __version__
 from .commands import (
     install_extension, uninstall_extension, list_extensions,
     enable_extension, disable_extension,
@@ -31,8 +31,14 @@ aliases = dict(base_aliases)
 aliases['app-dir'] = 'BaseExtensionApp.app_dir'
 
 
+here = os.path.dirname(__file__)
+with open(os.path.join(here, 'package.app.json')) as fid:
+    data = json.load(fid)
+VERSION = data['jupyterlab']['version']
+
+
 class BaseExtensionApp(JupyterApp):
-    version = __version__
+    version = VERSION
     flags = flags
     aliases = aliases
 
@@ -149,7 +155,7 @@ jupyter labextension uninstall <extension name>  # uninstall a labextension
 class LabExtensionApp(JupyterApp):
     """Base jupyter labextension command entry point"""
     name = "jupyter labextension"
-    version = __version__
+    version = VERSION
     description = "Work with JupyterLab extensions"
     examples = _examples
 


### PR DESCRIPTION
If on a dev version, we see the following (otherwise you just see the app version):

```bash
$ jupyter lab --version
0.29.0.dev0 (dev), 0.28.7 (app)
$ jupyter labextension list
JupyterLab v0.28.7
Known labextensions:
...
```