### PR TITLE
Update services readme

### DIFF
--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -3,7 +3,7 @@ JupyterLab Services
 
 Javascript client for the Jupyter services REST APIs
 
-[API Docs](http://jupyterlab.github.io/services/)
+[API Docs](http://jupyterlab.github.io/jupyterlab/)
 
 [REST API Docs](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml)
 
@@ -16,7 +16,7 @@ Package Install
 
 **Prerequisites**
 - [node](http://nodejs.org/)
-- [python](https://www.continuum.io/downloads)
+- [python](https://www.anaconda.com/download)
 
 ```bash
 npm install --save @jupyterlab/services
@@ -30,11 +30,11 @@ Source Build
 **Prerequisites**
 - [git](http://git-scm.com/)
 - [node 0.12+](http://nodejs.org/)
-- [python](https://www.continuum.io/downloads)
+- [python](https://www.anaconda.com/download)
 
 ```bash
-git clone https://github.com/jupyterlab/services.git
-cd services
+git clone https://github.com/jupyterlab/jupyterlab.git
+cd packages/services
 npm install
 npm run build
 conda install notebook  # notebook 4.3+ required

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -89,7 +89,7 @@ if [[ $GROUP == other ]]; then
 
     # Run the link check
     pip install -q pytest-check-links
-    py.test --check-links -k .md .
+    travis_retry py.test --check-links -k .md .
 
     # Build the api docs
     npm run docs

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -87,9 +87,9 @@ if [[ $GROUP == other ]]; then
     # Make sure the examples build
     npm run build:examples
 
-    # Run the link check
+    # Run the link check - allow for a link to fail once
     pip install -q pytest-check-links
-    travis_retry py.test --check-links -k .md .
+    py.test --check-links -k .md . || py.test --check-links -k .md . 
 
     # Build the api docs
     npm run docs


### PR DESCRIPTION
It was pointing to the deprecated services repo, which we moved to the `jupyter-attic`, causing our Travis builds to start failing.