### PR TITLE
Pin the version of launcher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup_args['cmdclass'] = cmdclass
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'notebook>=4.3.1',
-    'jupyterlab_launcher>=0.5.2'
+    'jupyterlab_launcher>=0.5.2,<0.6.0'
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
We are going to make in incompatible release of `jupyterlab_launcher`, so we need to release a new version of 0.28 that locks down the compatible version ranges.  I'll make the same patch and release to 0.27 as well.