### PR TITLE
Add rendermime-interfaces to singleton packages

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -124,6 +124,7 @@
       "@jupyterlab/launcher",
       "@jupyterlab/notebook",
       "@jupyterlab/rendermime",
+      "@jupyterlab/rendermime-interfaces",
       "@jupyterlab/services",
       "@jupyterlab/terminal",
       "@jupyterlab/tooltip",


### PR DESCRIPTION
Otherwise mime extensions that don't depend on any of our other singleton packages won't be flagged as incompatible. 