### PR TITLE
Remove the sdist command that was failing on Travis

### DIFF
--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -112,6 +112,5 @@ if [[ $GROUP == other ]]; then
     if [ ! -f ./build/release_data.json ]; then
         echo "npm publish in jupyterlab unsucessful!"
     fi
-    python setup.py sdist
     python setup.py bdist_wheel --universal
 fi


### PR DESCRIPTION
We were getting a BlockingIOError when trying to run the sdist command on Travis.  I'm going to make sure the wheel build isn't also flaky before calling this done.