### PR TITLE
Build system improvements

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -52,7 +52,8 @@ def get_app_dir(app_dir=None):
     app_dir = pjoin(sys.prefix, 'share', 'jupyter', 'lab')
 
     # Check for a user level install.
-    if hasattr(site, 'getuserbase') and here.startswith(site.getuserbase()):
+    userbase = getattr(site, 'userbase', '')
+    if here.startswith(userbase) and not app_dir.startswith(userbase):
         app_dir = pjoin(site.getuserbase(), 'share', 'jupyter', 'lab')
 
     # Check for a system install in '/usr/local/share'.
@@ -154,6 +155,7 @@ def install_extension_async(extension, app_dir=None, logger=None, abort_callback
 
     # Run npm install if needed
     if (os.path.exists(extension) and
+            os.path.isdir(extension) and
             not os.path.exists(pjoin(extension, 'node_modules'))):
         yield run([get_npm_name(), 'install'], cwd=extension, logger=logger,
                   abort_callback=abort_callback)
@@ -208,6 +210,10 @@ def install_extension_async(extension, app_dir=None, logger=None, abort_callback
 
     shutil.move(pjoin(target, fname), pjoin(app_dir, 'extensions'))
     shutil.rmtree(target)
+
+    # Remove any existing package from staging/node_modules to force
+    # npm to re-install it from the tarball.
+    target = pjoin(app_dir, 'staging', 'node_modules', data['name'])
 
 
 def link_package(path, app_dir=None, logger=None):
@@ -901,6 +907,8 @@ def _get_package_template(app_dir, logger):
             data['jupyterlab']['extensions'].pop(item)
         else:
             data['jupyterlab']['mimeExtensions'].pop(item)
+        # Remove from dependencies as well.
+        data['dependencies'].pop(item)
 
     return data
 

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -54,7 +54,7 @@ def get_app_dir(app_dir=None):
     # Check for a user level install.
     userbase = getattr(site, 'userbase', '')
     if here.startswith(userbase) and not app_dir.startswith(userbase):
-        app_dir = pjoin(site.getuserbase(), 'share', 'jupyter', 'lab')
+        app_dir = pjoin(userbase, 'share', 'jupyter', 'lab')
 
     # Check for a system install in '/usr/local/share'.
     elif (sys.prefix.startswith('/usr') and not


### PR DESCRIPTION
- Handle an app_dir that is contained within the user site dir.  https://groups.google.com/d/msg/jupyter/K3-QWeioDfk/nEYKo88BCAAJ
- Remove a package from `staging/node_modules` on install, otherwise npm doesn't re-read the tarball.
- Allow installing from local tarball files
- Remove an uninstalled core extension from `dependencies`.  This allows us to completely remove `vega2` packages in favor of `vega3` packages from the `node_modules` tree.