### PR TITLE
Make min-height and min-width more uniformly applied for main area widgets

### DIFF
--- a/packages/console/style/index.css
+++ b/packages/console/style/index.css
@@ -14,6 +14,8 @@
   flex: 1 1 auto;
   flex-direction: column;
   margin-top: -1px;
+  min-width: 240px;
+  min-height: 120px;
 }
 
 

--- a/packages/faq-extension/style/index.css
+++ b/packages/faq-extension/style/index.css
@@ -9,6 +9,8 @@
   outline: none;
   display: flex;
   flex-direction: column;
+  min-width: 240px;
+  min-height: 120px;
 }
 
 

--- a/packages/help-extension/style/index.css
+++ b/packages/help-extension/style/index.css
@@ -5,7 +5,8 @@
 
 
 .jp-Help {
-  min-width: 480px;
+  min-width: 240px;
+  min-height: 240px;
   background: white;
   outline: none;
 }

--- a/packages/inspector/style/index.css
+++ b/packages/inspector/style/index.css
@@ -19,6 +19,8 @@
 
 .jp-Inspector {
   outline: none;
+  min-width: 120px;
+  min-height: 120px;
 }
 
 

--- a/packages/launcher/style/index.css
+++ b/packages/launcher/style/index.css
@@ -26,6 +26,8 @@
   outline: none;
   background: var(--jp-layout-color0);
   box-sizing: border-box;
+  min-width: 120px;
+  min-height: 120px;
 }
 
 

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -32,10 +32,12 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  min-width: 240px !important;
-  min-height: 120px !important;
 }
 
+.jp-NotebookPanel.jp-Document {
+  min-width: 240px;
+  min-height: 120px;
+}
 
 .jp-Notebook {
   flex: 1 1 auto;

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -32,14 +32,14 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-width: 240px !important;
+  min-height: 120px !important;
 }
 
 
 .jp-Notebook {
   flex: 1 1 auto;
   padding: var(--jp-notebook-padding);
-  min-width: 50px;
-  min-height: 50px;
   outline: none;
   overflow: auto;
   background: var(--jp-layout-color0);

--- a/packages/settingeditor-extension/style/settingeditor.css
+++ b/packages/settingeditor-extension/style/settingeditor.css
@@ -15,6 +15,8 @@
 
 
 #setting-editor {
+  min-width: 360px;
+  min-height: 240px;
   background-color: var(--jp-layout-color0);
   border-top: var(--jp-border-width) solid var(--jp-border-color1);
   margin-top: -1px;
@@ -76,8 +78,8 @@
 
 
 #setting-editor .jp-PluginList {
-  min-width: 150px;
-  width: 150px;
+  min-width: 120px;
+  width: 120px;
 }
 
 

--- a/packages/terminal/style/index.css
+++ b/packages/terminal/style/index.css
@@ -12,8 +12,8 @@
 
 
 .jp-Terminal {
-  min-width: 200px;
-  min-height: 200px;
+  min-width: 240px;
+  min-height: 120px;
   padding: 8px;
   margin: 0;
 }


### PR DESCRIPTION
Addresses #3099.

1. Make sure that all widgets added to the main area have a `min-width` and `min-height` CSS property. This prevents them from being squeezed away.
2. All `min-width` and `min-height`  properties are multiples of `120px`. I did not put a ton of thought into this particular value, it just seemed reasonable.
3. The particular multiples of `120px` were judgement calls about the absolute smallest these widgets could be while still having some visible content.