### PR TITLE
Update doc build and turn off autodoc_ref

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ copyright = '2017, Project Jupyter'
 author = 'Project Jupyter'
 
 # TODO determine if this should be the current repo or recommonmark's repo
-github_doc_root = 'https://github.com/rtfd/recommonmark/tree/master/docs/'
+github_doc_root = 'https://github.com/willingc/jupyterlab/tree/master/docs/'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -359,6 +359,6 @@ def setup(app):
         'url_resolver': lambda url: github_doc_root + url,
         'auto_toc_tree_section': 'Contents',
         'enable_eval_rst': True,
-        'enable_auto_doc_ref': True,
+        'enable_auto_doc_ref': False,
     }, True)
     app.add_transform(AutoStructify)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,9 +57,6 @@ project = 'JupyterLab Tutorial'
 copyright = '2017, Project Jupyter'
 author = 'Project Jupyter'
 
-# TODO determine if this should be the current repo or recommonmark's repo
-github_doc_root = 'https://github.com/willingc/jupyterlab/tree/master/docs/'
-
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
@@ -347,13 +344,12 @@ texinfo_documents = [
 #
 # texinfo_no_detailmenu = False
 
+# autodoc configuration with AutoStructify
+#
 # See http://recommonmark.readthedocs.io/en/latest/auto_structify.html
-# def setup(app):
-#     app.add_config_value('recommonmark_config', {
-#         'enable_auto_doc_ref': True
-#     }, True)
-#     app.add_transform(AutoStructify)
-
+# See the setup function in current conf.py file in the recommonmark repo
+# https://github.com/rtfd/recommonmark/blob/master/docs/conf.py#L296
+github_doc_root = 'https://github.com/jupyterlab/jupyterlab/tree/master/docs/'
 def setup(app):
     app.add_config_value('recommonmark_config', {
         'url_resolver': lambda url: github_doc_root + url,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,9 @@ project = 'JupyterLab Tutorial'
 copyright = '2017, Project Jupyter'
 author = 'Project Jupyter'
 
+# TODO determine if this should be the current repo or recommonmark's repo
+github_doc_root = 'https://github.com/rtfd/recommonmark/tree/master/docs/'
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
@@ -345,8 +348,17 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 # See http://recommonmark.readthedocs.io/en/latest/auto_structify.html
+# def setup(app):
+#     app.add_config_value('recommonmark_config', {
+#         'enable_auto_doc_ref': True
+#     }, True)
+#     app.add_transform(AutoStructify)
+
 def setup(app):
     app.add_config_value('recommonmark_config', {
-        'enable_auto_doc_ref': True
+        'url_resolver': lambda url: github_doc_root + url,
+        'auto_toc_tree_section': 'Contents',
+        'enable_eval_rst': True,
+        'enable_auto_doc_ref': True,
     }, True)
     app.add_transform(AutoStructify)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,8 +2,10 @@ name: lab_tutorial
 channels:
   - conda-forge
 dependencies:
-- python==3.5
+- nodejs
+- python=3.5
+- sphinx>=1.4, !=1.5.4
+- sphinx_rtd_theme
 - pip:
-  - sphinx==1.5.4
-  - recommonmark==0.4.0
   - jupyter_alabaster_theme
+  - recommonmark==0.4.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,9 +2,8 @@ name: lab_tutorial
 channels:
   - conda-forge
 dependencies:
-- nodejs
 - python=3.5
-- sphinx>=1.4, !=1.5.4
+- sphinx>=1.6
 - sphinx_rtd_theme
 - pip:
   - jupyter_alabaster_theme

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,6 +4,6 @@ channels:
 dependencies:
 - python==3.5
 - pip:
-  - sphinx<=1.6
+  - sphinx==1.5.4
   - recommonmark==0.4.0
   - jupyter_alabaster_theme


### PR DESCRIPTION
This PR fixes the currently failing doc build by:
- updating the dependencies for Sphinx and installing it via conda not pip (`environment.yml`)
- update the `setup(app)` in `conf.py` to current recommendation in recommonmark docs
- disable autodoc_ref in `setup(app)` since it appears to be the root cause of the error messages

Here is the rendered build on my test system on rtd. Please verify that turning off autodoc_ref didn't remove anything important ;-)

http://jlab.readthedocs.io/en/debug-rtd/index.html

cc/ @blink1073 @jzf2101 