### PR TITLE
Update outdated CSS class reference

### DIFF
--- a/packages/console/style/index.css
+++ b/packages/console/style/index.css
@@ -83,7 +83,7 @@
 }
 
 
-.jp-CodeConsole-content .jp-CodeConsole-banner .jp-Cell-prompt {
+.jp-CodeConsole-content .jp-CodeConsole-banner .jp-InputPrompt {
   display: none;
 }
 


### PR DESCRIPTION
Came across this when grepping for the old class. This is just me blindly replacing it with the update name.