### PR TITLE
Add production mode handling

### DIFF
--- a/buildutils/src/make-release.ts
+++ b/buildutils/src/make-release.ts
@@ -20,6 +20,7 @@ utils.run('npm run build:prod');
 let data = utils.readJSONFile('./package.json');
 data['scripts']['build'] = 'webpack';
 data['scripts']['watch'] = 'webpack --watch';
+data['scripts']['build:prod'] = "webpack --define process.env.NODE_ENV=\"'production'\"";
 data['jupyterlab']['outputDir'] = '..';
 data['jupyterlab']['linkedPackages'] = {};
 utils.ensurePackageData(data, './package.app.json');

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -599,11 +599,11 @@ def clean(app_dir=None):
             shutil.rmtree(target)
 
 
-def build(app_dir=None, name=None, version=None, logger=None):
+def build(app_dir=None, name=None, version=None, logger=None, command='build:prod'):
     """Build the JupyterLab application.
     """
     func = partial(build_async, app_dir=app_dir, name=name, version=version,
-                   logger=logger)
+                   logger=logger, command=command)
     return IOLoop.instance().run_sync(func)
 
 def is_disabled(name, disabled=[]):
@@ -615,7 +615,7 @@ def is_disabled(name, disabled=[]):
     return False
 
 @gen.coroutine
-def build_async(app_dir=None, name=None, version=None, logger=None, abort_callback=None):
+def build_async(app_dir=None, name=None, version=None, logger=None, abort_callback=None, command='build:prod'):
     """Build the JupyterLab application.
     """
     # Set up the build directory.
@@ -654,7 +654,7 @@ def build_async(app_dir=None, name=None, version=None, logger=None, abort_callba
 
     # Build the app.
     yield run([npm, 'run', 'clean'], cwd=staging, logger=logger, abort_callback= abort_callback)
-    yield run([npm, 'run', 'build'], cwd=staging, logger=logger, abort_callback= abort_callback)
+    yield run([npm, 'run', command], cwd=staging, logger=logger, abort_callback= abort_callback)
 
     # Move the app to the static dir.
     static = pjoin(app_dir, 'static')

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -107,8 +107,7 @@ def load_jupyter_server_extension(nbapp):
             watch(os.path.dirname(here), nbapp.log)
         else:
             config.assets_dir = os.path.join(app_dir, 'staging', 'build')
-            if build_check(app_dir=app_dir, logger=nbapp.log)[0]:
-                build(app_dir=app_dir, logger=nbapp.log)
+            build(app_dir=app_dir, logger=nbapp.log, command='build')
             watch(os.path.join(app_dir, 'staging'), nbapp.log)
             page_config['buildAvailable'] = False
 

--- a/jupyterlab/package.app.json
+++ b/jupyterlab/package.app.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "webpack",
-    "build:prod": "rimraf build && webpack --define process.env.NODE_ENV=\"'production'\" --devtool source-map",
+    "build:prod": "webpack --define process.env.NODE_ENV=\"'production'\" --devtool source-map",
     "build:static": "node make-release.js",
     "clean": "rimraf build",
     "watch": "webpack --watch"

--- a/jupyterlab/package.app.json
+++ b/jupyterlab/package.app.json
@@ -4,8 +4,7 @@
   "private": true,
   "scripts": {
     "build": "webpack",
-    "build:prod": "node update-core.js && webpack --devtool source-map",
-    "build:static": "node make-release.js",
+    "build:prod": "rimraf build && webpack --define process.env.NODE_ENV=\"'production'\" --devtool source-map",
     "clean": "rimraf build",
     "watch": "webpack --watch"
   },
@@ -14,10 +13,9 @@
     "@jupyterlab/application-extension": "^0.11.1",
     "@jupyterlab/apputils": "^0.11.1",
     "@jupyterlab/apputils-extension": "^0.11.1",
-    "@jupyterlab/buildutils": "^0.1.2",
     "@jupyterlab/cells": "^0.11.1",
     "@jupyterlab/codeeditor": "^0.11.1",
-    "@jupyterlab/codemirror": "^0.11.2",
+    "@jupyterlab/codemirror": "^0.11.3",
     "@jupyterlab/codemirror-extension": "^0.11.1",
     "@jupyterlab/completer": "^0.11.1",
     "@jupyterlab/completer-extension": "^0.11.1",
@@ -34,7 +32,6 @@
     "@jupyterlab/filebrowser-extension": "^0.11.1",
     "@jupyterlab/fileeditor": "^0.11.1",
     "@jupyterlab/fileeditor-extension": "^0.11.1",
-    "@jupyterlab/geojson-extension": "^0.11.0",
     "@jupyterlab/help-extension": "^0.11.1",
     "@jupyterlab/imageviewer": "^0.11.1",
     "@jupyterlab/imageviewer-extension": "^0.11.1",
@@ -64,23 +61,24 @@
     "@jupyterlab/tooltip-extension": "^0.11.1",
     "@jupyterlab/vdom-extension": "^0.11.0",
     "@jupyterlab/vega2-extension": "^0.11.1",
-    "@phosphor/coreutils": "^1.2.0",
-    "@phosphor/widgets": "^1.3.0"
+    "@phosphor/coreutils": "^1.3.0",
+    "@phosphor/widgets": "^1.5.0"
   },
   "devDependencies": {
-    "css-loader": "^0.28.5",
-    "file-loader": "^0.10.1",
+    "@jupyterlab/buildutils": "^0.1.2",
+    "css-loader": "~0.28.7",
+    "file-loader": "~0.10.1",
     "fs-extra": "~4.0.2",
     "glob": "~7.1.2",
-    "handlebars": "^4.0.6",
-    "json-loader": "^0.5.4",
-    "raw-loader": "^0.5.1",
-    "rimraf": "^2.6.1",
-    "sort-package-json": "^1.7.0",
-    "source-map-loader": "0.2.1",
-    "style-loader": "^0.13.1",
-    "url-loader": "^0.5.7",
-    "webpack": "^2.2.1"
+    "handlebars": "~4.0.11",
+    "json-loader": "~0.5.7",
+    "raw-loader": "~0.5.1",
+    "rimraf": "~2.6.2",
+    "sort-package-json": "~1.7.1",
+    "source-map-loader": "~0.2.1",
+    "style-loader": "~0.13.2",
+    "url-loader": "~0.5.9",
+    "webpack": "~2.7.0"
   },
   "jupyterlab": {
     "extensions": {
@@ -110,7 +108,6 @@
       "@jupyterlab/tooltip-extension": ""
     },
     "mimeExtensions": {
-      "@jupyterlab/geojson-extension": "",
       "@jupyterlab/json-extension": "",
       "@jupyterlab/pdf-extension": "",
       "@jupyterlab/vdom-extension": "",
@@ -137,7 +134,7 @@
       "@phosphor/coreutils",
       "@phosphor/widgets"
     ],
-    "version": "0.28.11",
+    "version": "0.29.0.dev0",
     "linkedPackages": {}
   }
 }

--- a/jupyterlab/package.app.json
+++ b/jupyterlab/package.app.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "webpack",
     "build:prod": "rimraf build && webpack --define process.env.NODE_ENV=\"'production'\" --devtool source-map",
+    "build:static": "node make-release.js",
     "clean": "rimraf build",
     "watch": "webpack --watch"
   },
@@ -13,9 +14,10 @@
     "@jupyterlab/application-extension": "^0.11.1",
     "@jupyterlab/apputils": "^0.11.1",
     "@jupyterlab/apputils-extension": "^0.11.1",
+    "@jupyterlab/buildutils": "^0.1.2",
     "@jupyterlab/cells": "^0.11.1",
     "@jupyterlab/codeeditor": "^0.11.1",
-    "@jupyterlab/codemirror": "^0.11.3",
+    "@jupyterlab/codemirror": "^0.11.2",
     "@jupyterlab/codemirror-extension": "^0.11.1",
     "@jupyterlab/completer": "^0.11.1",
     "@jupyterlab/completer-extension": "^0.11.1",
@@ -32,6 +34,7 @@
     "@jupyterlab/filebrowser-extension": "^0.11.1",
     "@jupyterlab/fileeditor": "^0.11.1",
     "@jupyterlab/fileeditor-extension": "^0.11.1",
+    "@jupyterlab/geojson-extension": "^0.11.0",
     "@jupyterlab/help-extension": "^0.11.1",
     "@jupyterlab/imageviewer": "^0.11.1",
     "@jupyterlab/imageviewer-extension": "^0.11.1",
@@ -61,24 +64,23 @@
     "@jupyterlab/tooltip-extension": "^0.11.1",
     "@jupyterlab/vdom-extension": "^0.11.0",
     "@jupyterlab/vega2-extension": "^0.11.1",
-    "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.5.0"
+    "@phosphor/coreutils": "^1.2.0",
+    "@phosphor/widgets": "^1.3.0"
   },
   "devDependencies": {
-    "@jupyterlab/buildutils": "^0.1.2",
-    "css-loader": "~0.28.7",
-    "file-loader": "~0.10.1",
+    "css-loader": "^0.28.5",
+    "file-loader": "^0.10.1",
     "fs-extra": "~4.0.2",
     "glob": "~7.1.2",
-    "handlebars": "~4.0.11",
-    "json-loader": "~0.5.7",
-    "raw-loader": "~0.5.1",
-    "rimraf": "~2.6.2",
-    "sort-package-json": "~1.7.1",
-    "source-map-loader": "~0.2.1",
-    "style-loader": "~0.13.2",
-    "url-loader": "~0.5.9",
-    "webpack": "~2.7.0"
+    "handlebars": "^4.0.6",
+    "json-loader": "^0.5.4",
+    "raw-loader": "^0.5.1",
+    "rimraf": "^2.6.1",
+    "sort-package-json": "^1.7.0",
+    "source-map-loader": "0.2.1",
+    "style-loader": "^0.13.1",
+    "url-loader": "^0.5.7",
+    "webpack": "^2.2.1"
   },
   "jupyterlab": {
     "extensions": {
@@ -108,6 +110,7 @@
       "@jupyterlab/tooltip-extension": ""
     },
     "mimeExtensions": {
+      "@jupyterlab/geojson-extension": "",
       "@jupyterlab/json-extension": "",
       "@jupyterlab/pdf-extension": "",
       "@jupyterlab/vdom-extension": "",
@@ -134,7 +137,7 @@
       "@phosphor/coreutils",
       "@phosphor/widgets"
     ],
-    "version": "0.29.0.dev0",
+    "version": "0.28.11",
     "linkedPackages": {}
   }
 }

--- a/jupyterlab/package.app.json
+++ b/jupyterlab/package.app.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "webpack",
-    "build:prod": "webpack --define process.env.NODE_ENV=\"'production'\" --devtool source-map",
+    "build:prod": "webpack --define process.env.NODE_ENV=\"'production'\"",
     "build:static": "node make-release.js",
     "clean": "rimraf build",
     "watch": "webpack --watch"

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "rimraf build && webpack",
-    "build:prod": "rimraf build && webpack --devtool source-map",
+    "build:prod": "rimraf build && webpack --define process.env.NODE_ENV=\"'production'\" --devtool source-map",
     "clean": "rimraf build",
     "watch": "webpack --watch"
   },


### PR DESCRIPTION
Takes the bundle from 8MB -> 7.31MB and speeds up React.  I didn't include the uglify plugin yet because I couldn't get source mapping to work the way I'd like.