### PR TITLE
Build Script Fixes

### DIFF
--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -103,8 +103,7 @@ function ensurePackage(options: IEnsurePackageOptions): string[] {
     }
     if (names.indexOf(name) === -1) {
       let version = data.dependencies[name];
-      delete data.dependencies[name];
-      messages.push(`Removed dependency: ${name}@${version}`);
+      messages.push(`Unused dependency: ${name}@${version}: remove or add to list of known unused packages`);
     }
   });
 

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -103,7 +103,7 @@ function ensurePackage(options: IEnsurePackageOptions): string[] {
     }
     if (names.indexOf(name) === -1) {
       let version = data.dependencies[name];
-      messages.push(`Unused dependency: ${name}@${version}: remove or add to list of known unused packages`);
+      messages.push(`Unused dependency: ${name}@${version}: remove or add to list of known unused dependencies for this package`);
     }
   });
 

--- a/buildutils/src/remove-dependency.ts
+++ b/buildutils/src/remove-dependency.ts
@@ -39,7 +39,7 @@ function handlePackage(packagePath: string): void {
   }
 
   // Update dependencies as appropriate.
-  for (let dtype in ['dependencies', 'devDependencies']) {
+  for (let dtype of ['dependencies', 'devDependencies']) {
     let deps = data[dtype] || {};
     delete deps[name];
   }

--- a/buildutils/src/update-dependency.ts
+++ b/buildutils/src/update-dependency.ts
@@ -50,10 +50,10 @@ function handlePackage(packagePath: string): void {
   }
 
   // Update dependencies as appropriate.
-  for (let dtype in ['dependencies', 'devDependencies']) {
+  for (let dtype of ['dependencies', 'devDependencies']) {
     let deps = data[dtype] || {};
     if (name in deps) {
-      deps[dtype] = specifier;
+      deps[name] = specifier;
     }
   }
 


### PR DESCRIPTION
- Fix the `update:dependency` and `remove:dependency` scripts
- Do not automatically remove an used dep, it could be a global or a type that is needed.  Prompt the developer instead.