### PR TITLE
Add prepublishOnly scripts

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/buildutils/src/create-package.ts
+++ b/buildutils/src/create-package.ts
@@ -36,6 +36,6 @@ inquirer.prompt(questions).then(answers => {
   }
   data.name = name;
   data.description = description;
-  utils.ensurePackageData(data, jsonPath);
+  utils.writePackageData(jsonPath, data);
   utils.run('npm run integrity');
 });

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -55,7 +55,7 @@ function ensurePackage(options: IEnsurePackageOptions): string[] {
   filenames = filenames.concat(glob.sync(path.join(pkgPath, 'src/**/*.ts*')));
 
   if (filenames.length === 0) {
-    if (utils.ensurePackageData(data, path.join(pkgPath, 'package.json'))) {
+    if (utils.writePackageData(path.join(pkgPath, 'package.json'), data)) {
       messages.push('Updated package.json');
     }
     return messages;
@@ -107,7 +107,7 @@ function ensurePackage(options: IEnsurePackageOptions): string[] {
     }
   });
 
-  if (utils.ensurePackageData(data, path.join(pkgPath, 'package.json'))) {
+  if (utils.writePackageData(path.join(pkgPath, 'package.json'), data)) {
     messages.push('Updated package.json');
   }
   return messages;

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -92,7 +92,7 @@ function ensureMetaPackage(): string[] {
 
   // Write the files.
   if (messages.length > 0) {
-    utils.ensurePackageData(metaPackageData, metaPackageJson);
+    utils.writePackageData(metaPackageJson, metaPackageData);
   }
   let newIndex = lines.join('\n');
   if (newIndex !== index) {
@@ -168,7 +168,7 @@ function ensureJupyterlab(): string[] {
   });
 
   // Write the package.json back to disk.
-  if (utils.ensurePackageData(corePackage, corePath)) {
+  if (utils.writePackageData(corePath, corePackage)) {
     return ['Updated core'];
   }
   return [];
@@ -214,7 +214,7 @@ function ensureIntegrity(): void {
   // Handle the top level package.
   let corePath = path.resolve('.', 'package.json');
   let coreData: any = utils.readJSONFile(corePath);
-  if (utils.ensurePackageData(coreData, corePath)) {
+  if (utils.writePackageData(corePath, coreData)) {
     messages['top'] = ['Update package.json'];
   }
 

--- a/buildutils/src/make-release.ts
+++ b/buildutils/src/make-release.ts
@@ -23,7 +23,7 @@ data['scripts']['watch'] = 'webpack --watch';
 data['scripts']['build:prod'] = "webpack --define process.env.NODE_ENV=\"'production'\"";
 data['jupyterlab']['outputDir'] = '..';
 data['jupyterlab']['linkedPackages'] = {};
-utils.ensurePackageData(data, './package.app.json');
+utils.writePackageData('./package.app.json', data);
 
 // Update our app index file.
 fs.copySync('./index.js', './index.app.js');

--- a/buildutils/src/remove-dependency.ts
+++ b/buildutils/src/remove-dependency.ts
@@ -45,5 +45,5 @@ function handlePackage(packagePath: string): void {
   }
 
   // Write the file back to disk.
-  utils.ensurePackageData(data, packagePath);
+  utils.writePackageData(packagePath, data);
 }

--- a/buildutils/src/update-dependency.ts
+++ b/buildutils/src/update-dependency.ts
@@ -58,5 +58,5 @@ function handlePackage(packagePath: string): void {
   }
 
   // Write the file back to disk.
-  utils.ensurePackageData(data, packagePath);
+  utils.writePackageData(packagePath, data);
 }

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -16,7 +16,9 @@ function getLernaPaths(): string[] {
   for (let config of lernaConfig.packages) {
     paths = paths.concat(glob.sync(path.join(basePath, config)));
   }
-  return paths;
+  return paths.filter(pkgPath => {
+    return fs.existsSync(path.join(pkgPath, 'package.json'));
+  });
 }
 
 
@@ -40,7 +42,7 @@ function getCorePaths(): string[] {
  * @returns Whether the file has changed.
  */
 export
-function ensurePackageData(data: any, pkgJsonPath: string): boolean {
+function writePackageData(pkgJsonPath: string, data: any): boolean {
   let text = JSON.stringify(sortPackageJson(data), null, 2) + '\n';
   let orig = fs.readFileSync(pkgJsonPath, 'utf8').split('\r\n').join('\n');
   if (text !== orig) {

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "devDependencies": {

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "node extract-data && webpack",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@jupyterlab/application": "^0.12.0",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc && webpack",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.12.4",

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc && webpack",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@jupyterlab/codemirror": "^0.12.0",

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc && webpack",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^0.12.4",

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc && webpack",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@jupyterlab/codemirror": "^0.12.0",

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc --project src && webpack --config webpack.conf.js",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@jupyterlab/services": "^0.51.0",

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -6,6 +6,7 @@
     "build": "rimraf build && webpack",
     "build:prod": "rimraf build && webpack --define process.env.NODE_ENV=\"'production'\" --devtool source-map",
     "clean": "rimraf build",
+    "prepublishOnly": "npm run build",
     "watch": "webpack --watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "install": "lerna bootstrap --hoist && npm run build:utils",
     "integrity": "node buildutils/lib/ensure-repo.js",
     "patch:release": "node buildutils/lib/patch-release.js",
-    "publish": "npm run clean:slate && lerna publish --force-publish=* -m \"Publish\"",
+    "publish": "git clean -dfx && npm install && lerna publish --force-publish=* -m \"Publish\"",
     "remove:dependency": "node buildutils/lib/remove-dependency.js",
     "remove:package": "node buildutils/lib/remove-package.js",
     "test": "cd test && npm test",

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/faq-extension/package.json
+++ b/packages/faq-extension/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -27,6 +27,7 @@
     "build": "tsc && node build.js",
     "clean": "rimraf lib",
     "docs": "typedoc --mode modules --module commonjs --excludeNotExported --target es5 --moduleResolution node --name JupyterLab --out ../../docs/api .",
+    "prepublishOnly": "npm run build",
     "watch": "npm run clean && run-p watch:*",
     "watch:files": "node watch-files.js",
     "watch:tsc": "tsc -w"

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc && webpack",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@jupyterlab/services": "^0.51.0",

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc && webpack",
-    "clean": "rimraf build"
+    "clean": "rimraf build",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@jupyterlab/outputarea": "^0.12.0",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -34,7 +34,7 @@
     "build:src": "tsc --project src",
     "build:test": "tsc --project test/src",
     "clean": "rimraf docs && rimraf lib && rimraf test/build && rimraf test/coverage",
-    "prepublishOnly": "npm run build:src && webpack",
+    "prepublishOnly": "npm run build",
     "test": "mocha --retries 3 test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json",
     "test:coverage": "istanbul cover --dir test/coverage _mocha -- --retries 3 test/build/**/*.spec.js test/build/*.spec.js --jupyter-config-data=./test/config.json",
     "test:debug": "mocha test/build/**/*.spec.js test/build/*.spec.js  --jupyter-config-data=./test/config.json --debug-brk",

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/tabmanager-extension/package.json
+++ b/packages/tabmanager-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/vdom-extension/package.json
+++ b/packages/vdom-extension/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {

--- a/packages/vega2-extension/package.json
+++ b/packages/vega2-extension/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rimraf lib",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {


### PR DESCRIPTION
This command is only run when actually publishing to npm, and it ensures that we always have self-contained built packages.
This will also be helpful if we switch to using ES6 module imports and the [dynamic import](https://github.com/tc39/proposal-dynamic-import) in all but the `coreutils` and `services` packages.
Also cleans up the `ensurePackageData` util to more closely match [fs.writeFile](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback).