### PR TITLE
add `--clean` flag to labextension commands

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -599,11 +599,12 @@ def clean(app_dir=None):
             shutil.rmtree(target)
 
 
-def build(app_dir=None, name=None, version=None, logger=None, command='build:prod'):
+def build(app_dir=None, name=None, version=None, logger=None, command='build:prod',
+          clean_staging=False):
     """Build the JupyterLab application.
     """
     func = partial(build_async, app_dir=app_dir, name=name, version=version,
-                   logger=logger, command=command)
+                   logger=logger, command=command, clean_staging=clean_staging)
     return IOLoop.instance().run_sync(func)
 
 def is_disabled(name, disabled=[]):
@@ -615,7 +616,9 @@ def is_disabled(name, disabled=[]):
     return False
 
 @gen.coroutine
-def build_async(app_dir=None, name=None, version=None, logger=None, abort_callback=None, command='build:prod'):
+def build_async(app_dir=None, name=None, version=None, logger=None,
+                abort_callback=None, command='build:prod',
+                clean_staging=False):
     """Build the JupyterLab application.
     """
     # Set up the build directory.
@@ -661,6 +664,11 @@ def build_async(app_dir=None, name=None, version=None, logger=None, abort_callba
     if os.path.exists(static):
         shutil.rmtree(static)
     shutil.copytree(pjoin(app_dir, 'staging', 'build'), static)
+    if clean_staging:
+        staging = pjoin(app_dir, 'staging')
+        if logger:
+            logger.info("Cleaning %s", staging)
+        shutil.rmtree(staging)
 
 
 @gen.coroutine

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -26,6 +26,10 @@ flags['no-build'] = (
     {'BaseExtensionApp': {'should_build': False}},
     "Defer building the app after the action."
 )
+flags['clean'] = (
+    {'BaseExtensionApp': {'should_clean': True}},
+    "Cleanup intermediate files after the action."
+)
 
 aliases = dict(base_aliases)
 aliases['app-dir'] = 'BaseExtensionApp.app_dir'
@@ -48,6 +52,9 @@ class BaseExtensionApp(JupyterApp):
     should_build = Bool(False, config=True,
         help="Whether to build the app after the action")
 
+    should_clean = Bool(False, config=True,
+        help="Whether temporary files should be cleaned up after building jupyterlab")
+
     def _log_format_default(self):
         """A default format for messages"""
         return "%(message)s"
@@ -64,7 +71,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
          for arg in self.extra_args]
         if self.should_build:
             try:
-                build(self.app_dir, logger=self.log)
+                build(self.app_dir, clean_staging=self.should_clean, logger=self.log)
             except Exception as e:
                 for arg in self.extra_args:
                     uninstall_extension(arg, self.app_dir, logger=self.log)
@@ -89,7 +96,7 @@ class LinkLabExtensionApp(BaseExtensionApp):
          for arg in self.extra_args]
         if self.should_build:
             try:
-                build(self.app_dir, logger=self.log)
+                build(self.app_dir, clean_staging=self.should_clean, logger=self.log)
             except Exception as e:
                 for arg in self.extra_args:
                     unlink_package(arg, self.app_dir, logger=self.log)
@@ -106,7 +113,7 @@ class UnlinkLabExtensionApp(BaseExtensionApp):
         ans = any([unlink_package(arg, self.app_dir, logger=self.log)
                    for arg in self.extra_args])
         if ans and self.should_build:
-            build(self.app_dir, logger=self.log)
+            build(self.app_dir, clean_staging=self.should_clean, logger=self.log)
 
 
 class UninstallLabExtensionApp(BaseExtensionApp):
@@ -119,7 +126,7 @@ class UninstallLabExtensionApp(BaseExtensionApp):
         ans = any([uninstall_extension(arg, self.app_dir, logger=self.log)
                    for arg in self.extra_args])
         if ans and self.should_build:
-            build(self.app_dir, logger=self.log)
+            build(self.app_dir, clean_staging=self.should_clean, logger=self.log)
 
 
 class ListLabExtensionsApp(BaseExtensionApp):
@@ -166,7 +173,7 @@ class LabExtensionApp(JupyterApp):
         link=(LinkLabExtensionApp, "Link labextension(s)"),
         unlink=(UnlinkLabExtensionApp, "Unlink labextension(s)"),
         enable=(EnableLabExtensionsApp, "Enable labextension(s)"),
-        disable=(DisableLabExtensionsApp, "Disable labextensions(s)")
+        disable=(DisableLabExtensionsApp, "Disable labextension(s)"),
     )
 
     def start(self):


### PR DESCRIPTION
cleans up staging directory after build to avoid leaving intermediate files around.

I mainly want this for Docker, so eliminating as much as possible other than the built result is what I'm after. Is there any other cache that I should clear other than `staging`?