### PR TITLE
Move link color into a theme variable, and carefully scope it.

### DIFF
--- a/packages/apputils/style/styling.css
+++ b/packages/apputils/style/styling.css
@@ -97,8 +97,3 @@ select.jp-mod-styled {
   -webkit-appearance: none;
   -moz-appearance: none;
 }
-
-
-a:-webkit-any-link {
-  color: var(--md-blue-600);
-}

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -74,11 +74,6 @@
 }
 
 
-.jp-Notebook a:-webkit-any-link {
-  color: var(--md-blue-500);
-}
-
-
 /*-----------------------------------------------------------------------------
 | Notebook state related styling
 |

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -113,13 +113,15 @@
 }
 
 
-.jp-RenderedHTMLCommon:link {
+.jp-RenderedHTMLCommon a:link {
   text-decoration: underline;
+  color: var(--jp-content-link-color1);
 }
 
 
-.jp-RenderedHTMLCommon:visited {
+.jp-RenderedHTMLCommon a:visited {
   text-decoration: underline;
+  color: var(--jp-content-link-color1);
 }
 
 /*For a 14px base font size this goes as:

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -115,13 +115,13 @@
 
 .jp-RenderedHTMLCommon a:link {
   text-decoration: underline;
-  color: var(--jp-content-link-color1);
+  color: var(--jp-content-link-color);
 }
 
 
 .jp-RenderedHTMLCommon a:visited {
   text-decoration: underline;
-  color: var(--jp-content-link-color1);
+  color: var(--jp-content-link-color);
 }
 
 /*For a 14px base font size this goes as:

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -87,10 +87,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-content-font-color2: var(--md-grey-500);
   --jp-content-font-color3: var(--md-grey-700);
 
-  --jp-content-link-color0: var(--md-blue-800);
-  --jp-content-link-color1: var(--md-blue-600);
-  --jp-content-link-color2: var(--md-blue-400);
-  --jp-content-link-color3: var(--md-blue-200);
+  --jp-content-link-color: var(--md-blue-600);
 
   --jp-ui-font-scale-factor: 1.2;
   --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -87,6 +87,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-content-font-color2: var(--md-grey-500);
   --jp-content-font-color3: var(--md-grey-700);
 
+  --jp-content-link-color0: var(--md-blue-800);
+  --jp-content-link-color1: var(--md-blue-600);
+  --jp-content-link-color2: var(--md-blue-400);
+  --jp-content-link-color3: var(--md-blue-200);
+
   --jp-ui-font-scale-factor: 1.2;
   --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));
   --jp-ui-font-size1: 13px; /* Base font size */

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -87,6 +87,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-content-font-color2: var(--md-grey-700);
   --jp-content-font-color3: var(--md-grey-500);
 
+  --jp-content-link-color0: var(--md-blue-800);
+  --jp-content-link-color1: var(--md-blue-600);
+  --jp-content-link-color2: var(--md-blue-400);
+  --jp-content-link-color3: var(--md-blue-200);
+
   --jp-ui-font-scale-factor: 1.2;
   --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));
   --jp-ui-font-size1: 13px; /* Base font size */

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -87,10 +87,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-content-font-color2: var(--md-grey-700);
   --jp-content-font-color3: var(--md-grey-500);
 
-  --jp-content-link-color0: var(--md-blue-800);
-  --jp-content-link-color1: var(--md-blue-600);
-  --jp-content-link-color2: var(--md-blue-400);
-  --jp-content-link-color3: var(--md-blue-200);
+  --jp-content-link-color: var(--md-blue-600);
 
   --jp-ui-font-scale-factor: 1.2;
   --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));


### PR DESCRIPTION
Turns out we had two different link colors (one for the notebook, one for everywhere else). I chose the slightly darker one (md-600)

Fixes #3257