### PR TITLE
Highlight the application *current* tab with a bar, not the application *active* tab

### DIFF
--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -77,8 +77,8 @@
 }
 
 
-/* This is the main application level active tab: only 1 exists. */
-.p-DockPanel-tabBar .p-TabBar-tab.jp-mod-active:before {
+/* This is the main application level current tab: only 1 exists. */
+.p-DockPanel-tabBar .p-TabBar-tab.jp-mod-current:before {
   position: absolute;
   top: calc(-1 * var(--jp-border-width));
   left: calc(-1 * var(--jp-border-width));


### PR DESCRIPTION
Fixes #3272

This corresponds more closely with the user’s semantic notion of the widget to which things will be done.

![focusfixed](https://user-images.githubusercontent.com/192614/33155302-5f5b61ea-cfa4-11e7-9e70-e804a33042f6.gif)
