### PR TITLE
Allow FileEditor widget to take focus.

### DIFF
--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -35,6 +35,7 @@
     "@jupyterlab/coreutils": "^0.12.0",
     "@jupyterlab/docregistry": "^0.12.0",
     "@phosphor/coreutils": "^1.3.0",
+    "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.5.0"
   },
   "devDependencies": {

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -21,6 +21,9 @@ import {
   PromiseDelegate
 } from '@phosphor/coreutils';
 
+import {
+  Message
+} from '@phosphor/messaging';
 
 /**
  * The class name added to a dirty widget.
@@ -185,6 +188,7 @@ class FileEditor extends Widget implements DocumentRegistry.IReadyWidget {
    */
   constructor(options: FileEditor.IOptions) {
     super();
+    this.node.tabIndex = -1;
 
     const context = this._context = options.context;
     this._mimeTypeService = options.mimeTypeService;
@@ -219,6 +223,13 @@ class FileEditor extends Widget implements DocumentRegistry.IReadyWidget {
    */
   get ready(): Promise<void> {
     return this.editorWidget.ready;
+  }
+
+  /**
+   * Handle `'activate-request'` messages.
+   */
+  protected onActivateRequest(msg: Message): void {
+    this.node.focus();
   }
 
   /**


### PR DESCRIPTION
Fixes #3276.
cc @jasongrout 