### PR TITLE
Focus the text editor intelligently.

### DIFF
--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -200,7 +200,6 @@ class FileEditor extends Widget implements DocumentRegistry.IReadyWidget {
    */
   constructor(options: FileEditor.IOptions) {
     super();
-    this.node.tabIndex = -1;
 
     const context = this._context = options.context;
     this._mimeTypeService = options.mimeTypeService;
@@ -238,10 +237,59 @@ class FileEditor extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   /**
+   * Handle the DOM events for the widget.
+   *
+   * @param event - The DOM event sent to the widget.
+   *
+   * #### Notes
+   * This method implements the DOM `EventListener` interface and is
+   * called in response to events on the widget's node. It should
+   * not be called directly by user code.
+   */
+  handleEvent(event: Event): void {
+    if (!this.model) {
+      return;
+    }
+    switch (event.type) {
+    case 'mousedown':
+      this._ensureFocus();
+      break;
+    default:
+      break;
+    }
+  }
+
+  /**
+   * Handle `after-attach` messages for the widget.
+   */
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg);
+    let node = this.node;
+    node.addEventListener('mousedown', this);
+  }
+
+  /**
+   * Handle `before-detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    let node = this.node;
+    node.removeEventListener('mousedown', this);
+  }
+
+  /**
    * Handle `'activate-request'` messages.
    */
   protected onActivateRequest(msg: Message): void {
-    this.node.focus();
+    this._ensureFocus();
+  }
+
+  /**
+   * Ensure that the widget has focus.
+   */
+  private _ensureFocus(): void {
+    if (!this.editor.hasFocus()) {
+      this.editor.focus();
+    }
   }
 
   /**


### PR DESCRIPTION
We focus the actual text editor when the tab is clicked, or when there is a mouse click anywhere in the entire widget when the text editor isn’t focused already. This lets us do things like switch tabs back and forth with keyboard shortcuts or clicking on tabs to pick up the cursor where we left off, or click on the line number portion of the editor to get the cursor focused in the chosen editor.

This extends the work done in #3278.