### PR TITLE
Handle theme loading errors

### DIFF
--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -120,11 +120,13 @@ class ThemeManager {
     const link = document.createElement('link');
     const baseUrl = PageConfig.getOption('themePath');
     const delegate = new PromiseDelegate<void>();
+    const href = URLExt.join(baseUrl, path);
 
     link.rel = 'stylesheet';
     link.type = 'text/css';
-    link.href = URLExt.join(baseUrl, path);
+    link.href = href;
     link.onload = () => { delegate.resolve(void 0); };
+    link.onerror = () => { delegate.reject(`Stylesheet failed to load: ${href}`); };
     document.body.appendChild(link);
     this._links.push(link);
 

--- a/packages/theme-dark-extension/src/index.ts
+++ b/packages/theme-dark-extension/src/index.ts
@@ -20,6 +20,8 @@ const plugin: JupyterLabPlugin<void> = {
     manager.register({
       name: 'JupyterLab Dark',
       load: function() {
+        // Load the optional monospace font for the input/output prompt.
+        manager.loadCSS('https://fonts.googleapis.com/css?family=Roboto+Mono');
         return manager.loadCSS('@jupyterlab/theme-dark-extension/index.css');
       },
       unload: function() {

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -25,12 +25,6 @@ all of MD as it is not optimized for dense, information rich UIs.
 */
 
 
-/*
- * Optional monospace font for input/output prompt.
- */
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono');
-
-
 :root {
 
   /* Borders

--- a/packages/theme-light-extension/src/index.ts
+++ b/packages/theme-light-extension/src/index.ts
@@ -20,6 +20,8 @@ const plugin: JupyterLabPlugin<void> = {
     manager.register({
       name: 'JupyterLab Light',
       load: function() {
+        // Load the optional monospace font for the input/output prompt.
+        manager.loadCSS('https://fonts.googleapis.com/css?family=Roboto+Mono');
         return manager.loadCSS('@jupyterlab/theme-light-extension/index.css');
       },
       unload: function() {

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -25,12 +25,6 @@ all of MD as it is not optimized for dense, information rich UIs.
 */
 
 
-/*
- * Optional monospace font for input/output prompt.
- */
-@import url('https://fonts.googleapis.com/css?family=Roboto+Mono');
-
-
 :root {
 
   /* Borders


### PR DESCRIPTION
Fixes #3295.

We do two things here:

1. Properly return an error if a theme css file doesn't load, and
2. Load the optional google font optionally (i.e., an error is not returned if it doesn't load)