### PR TITLE
Populate kernel help links

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -30,7 +30,7 @@ import {
 } from '@jupyterlab/launcher';
 
 import {
-  IEditMenu, IFileMenu, IKernelMenu, IMainMenu, IRunMenu
+  IEditMenu, IFileMenu, IHelpMenu, IKernelMenu, IMainMenu, IRunMenu
 } from '@jupyterlab/mainmenu';
 
 import {
@@ -451,6 +451,12 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
     noun: 'Console',
     clear: (current: ConsolePanel) => { return current.console.clear() }
   } as IEditMenu.IClearer<ConsolePanel>);
+
+  // Add kernel information to the application help menu.
+  mainMenu.helpMenu.kernelUsers.add({
+    tracker,
+    getKernel: current => current.session.kernel
+  } as IHelpMenu.IKernelUser<ConsolePanel>);
 
   app.contextMenu.addItem({command: CommandIDs.clear, selector: '.jp-CodeConsole'});
   app.contextMenu.addItem({command: CommandIDs.restart, selector: '.jp-CodeConsole'});

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -34,6 +34,7 @@
     "@jupyterlab/apputils": "^0.13.0",
     "@jupyterlab/coreutils": "^0.13.0",
     "@jupyterlab/mainmenu": "^0.2.0",
+    "@jupyterlab/services": "^0.52.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.5.0"

--- a/packages/help-extension/src/index.ts
+++ b/packages/help-extension/src/index.ts
@@ -242,11 +242,12 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
           });
           return result;
         }
-        const links  = info.help_links;
+        const links = info.help_links;
         const kernelGroup: Menu.IItemOptions[] = [];
-        links.forEach((link: any) => {
+        links.forEach((link) => {
           const commandId = `help-menu-${name}:${link.text}`;
           commands.addCommand(commandId, {
+            label: link.text,
             isVisible: usesKernel,
             isEnabled: usesKernel,
             execute: () => { commands.execute(CommandIDs.open, link) }

--- a/packages/mainmenu/src/help.ts
+++ b/packages/mainmenu/src/help.ts
@@ -2,11 +2,15 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Menu
+  Kernel
+} from '@jupyterlab/services';
+
+import {
+  Menu, Widget
 } from '@phosphor/widgets';
 
 import {
-  IJupyterLabMenu, JupyterLabMenu
+  IJupyterLabMenu, IMenuExtender, JupyterLabMenu
 } from './labmenu';
 
 /**
@@ -14,6 +18,12 @@ import {
  */
 export
 interface IHelpMenu extends IJupyterLabMenu {
+  /**
+   * A set of kernel users for the help menu.
+   * This is used to populate additional help
+   * links provided by the kernel of a widget.
+   */
+  readonly kernelUsers: Set<IHelpMenu.IKernelUser<Widget>>;
 }
 
 /**
@@ -27,5 +37,31 @@ class HelpMenu extends JupyterLabMenu implements IHelpMenu {
   constructor(options: Menu.IOptions) {
     super(options);
     this.menu.title.label = 'Help';
+    this.kernelUsers = new Set<IHelpMenu.IKernelUser<Widget>>();
+  }
+
+  /**
+   * A set of kernel users for the help menu.
+   * This is used to populate additional help
+   * links provided by the kernel of a widget.
+   */
+  readonly kernelUsers: Set<IHelpMenu.IKernelUser<Widget>>;
+}
+
+/**
+ * Namespace for IHelpMenu
+ */
+export
+namespace IHelpMenu {
+  /**
+   * Interface for a Kernel user to register itself
+   * with the IHelpMenu's semantic extension points.
+   */
+  export
+  interface IKernelUser<T extends Widget> extends IMenuExtender<T> {
+    /**
+     * A function to get the kernel for a widget.
+     */
+    getKernel: (widget: T) => Kernel.IKernel;
   }
 }

--- a/packages/mainmenu/src/help.ts
+++ b/packages/mainmenu/src/help.ts
@@ -62,6 +62,6 @@ namespace IHelpMenu {
     /**
      * A function to get the kernel for a widget.
      */
-    getKernel: (widget: T) => Kernel.IKernel;
+    getKernel: (widget: T) => Kernel.IKernelConnection;
   }
 }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -26,7 +26,7 @@ import {
 } from '@jupyterlab/launcher';
 
 import {
-  IMainMenu, IEditMenu, IFileMenu, IKernelMenu, IRunMenu, IViewMenu
+  IMainMenu, IEditMenu, IFileMenu, IHelpMenu, IKernelMenu, IRunMenu, IViewMenu
 } from '@jupyterlab/mainmenu';
 
 import {
@@ -1441,4 +1441,10 @@ function populateMenus(app: JupyterLab, mainMenu: IMainMenu, tracker: INotebookT
   ].map(command => { return { command }; });
   mainMenu.editMenu.addGroup(undoCellActionGroup, 4);
   mainMenu.editMenu.addGroup(editGroup, 5);
+
+  // Add kernel information to the application help menu.
+  mainMenu.helpMenu.kernelUsers.add({
+    tracker,
+    getKernel: current => current.session.kernel
+  } as IHelpMenu.IKernelUser<NotebookPanel>);
 }

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -371,7 +371,7 @@ namespace KernelMessage {
     implementation_version: string;
     language_info: ILanguageInfo;
     banner: string;
-    help_links: { [key: string]: string; };
+    help_links: { text: string; url: string }[];
   }
 
   /**

--- a/packages/services/test/src/utils.ts
+++ b/packages/services/test/src/utils.ts
@@ -75,8 +75,10 @@ const EXAMPLE_KERNEL_INFO: KernelMessage.IInfoReply = {
     nbconverter_exporter: ''
   },
   banner: '',
-  help_links: {
-  }
+  help_links: [{
+    text: 'A very helpful link',
+    url: 'https://very.helpful.website'
+  }]
 };
 
 


### PR DESCRIPTION
Adds a new semantic extension point for the `Help` menu, and populates a portion of the `Help` menu according to the kernel info links. Fixes #3177, Addresses #3103 