### PR TITLE
Add a padding on launcher card labels

### DIFF
--- a/packages/launcher/style/index.css
+++ b/packages/launcher/style/index.css
@@ -177,6 +177,7 @@
   height: var(--jp-private-launcher-card-label-height);
   line-height: var(--jp-private-launcher-card-label-height);
   font-size: var(--jp-ui-font-size1);
+  padding: 0 8px;
   color: var(--jp-ui-font-color1);
   box-sizing: border-box;
   overflow: hidden;


### PR DESCRIPTION
This avoids the text touching the border of the card if the label is long enough