### PR TITLE
Fix handling of missing directory

### DIFF
--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -270,7 +270,11 @@ class FileBrowser extends Widget {
       return;
     }
     this._showingError = true;
-    showErrorMessage('Server Connection Error', args).then(() => {
+    let title = 'Server Connection Error';
+    if (args.message.indexOf('Directory not found') === 0) {
+      title = 'Directory not found';
+    }
+    showErrorMessage(title, args).then(() => {
       this._showingError = false;
     });
   }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -227,13 +227,9 @@ class FileBrowserModel implements IDisposable {
     }).catch(error => {
       this._pendingPath = null;
       if (error.message === 'Not Found') {
-        let path = this._model.path;
-        error.message = `Directory not found: "${path}"`;
+        error.message = `Directory not found: "${this._model.path}"`;
         this._connectionFailure.emit(error);
-        let parent = PathExt.dirname(path);
-        if (parent !== path) {
-          this.cd('..');
-        }
+        this.cd('/');
       }
     });
     return this._pending;


### PR DESCRIPTION
Fixes #3324.   Fixes #3327.  Moves to straight to the home path if the directory is not found.

<img width="252" alt="image" src="https://user-images.githubusercontent.com/2096628/33658662-247d04e4-da43-11e7-9b90-cb69c86e8782.png">
