### PR TITLE
Kernel banner

### DIFF
--- a/packages/help-extension/src/index.ts
+++ b/packages/help-extension/src/index.ts
@@ -208,6 +208,9 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
     // If a new session has been added, it is at the back
     // of the session list. If one has changed or stopped,
     // it does not hurt to check it.
+    if (!sessions.length) {
+      return;
+    }
     const sessionModel = sessions[sessions.length-1];
     if (kernelInfoCache.has(sessionModel.kernel.name)) {
       return;

--- a/packages/help-extension/src/index.ts
+++ b/packages/help-extension/src/index.ts
@@ -230,7 +230,9 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
             return result;
           }
           helpMenu.kernelUsers.forEach(u => {
-            if (u.tracker.has(widget) && u.getKernel(widget).name === name) {
+            if (u.tracker.has(widget) &&
+                u.getKernel(widget) &&
+                u.getKernel(widget).name === name) {
               result = true;
             }
           });

--- a/packages/help-extension/src/index.ts
+++ b/packages/help-extension/src/index.ts
@@ -224,7 +224,8 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
         }
         // Set the Kernel Info cache.
         const name = session.kernel.name;
-        kernelInfoCache.set(name, session.kernel.info);
+        const kernelInfo = session.kernel.info;
+        kernelInfoCache.set(name, kernelInfo);
 
         // Utility function to check if the current widget
         // has registered itself with the help menu.
@@ -264,7 +265,7 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
               headerLogo,
               h.div({className: 'jp-About-header-info'}, kernelName)
             );
-            const banner = h.pre({}, session.kernel.info.banner);
+            const banner = h.pre({}, kernelInfo.banner);
             let body = h.div({ className: 'jp-About-body' },
               banner
             );

--- a/packages/help-extension/src/index.ts
+++ b/packages/help-extension/src/index.ts
@@ -217,6 +217,11 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
     }
     serviceManager.sessions.connectTo(sessionModel.id).then((session) => {
       session.kernel.ready.then(() => {
+        // Check the cache second time so that, if two callbacks get scheduled,
+        // they don't try to add the same commands.
+        if (kernelInfoCache.has(sessionModel.kernel.name)) {
+          return;
+        }
         // Set the Kernel Info cache.
         const name = session.kernel.name;
         kernelInfoCache.set(name, session.kernel.info);

--- a/packages/help-extension/style/index.css
+++ b/packages/help-extension/style/index.css
@@ -107,6 +107,9 @@
   align-items: center;
 }
 
+.jp-About-body pre {
+  white-space: pre-wrap;
+}
 
 .jp-About-header-info {
   display: flex;

--- a/packages/mainmenu/src/help.ts
+++ b/packages/mainmenu/src/help.ts
@@ -62,6 +62,6 @@ namespace IHelpMenu {
     /**
      * A function to get the kernel for a widget.
      */
-    getKernel: (widget: T) => Kernel.IKernelConnection;
+    getKernel: (widget: T) => Kernel.IKernelConnection | null;
   }
 }


### PR DESCRIPTION
Fixes #3323 
![image](https://user-images.githubusercontent.com/5728311/33687228-61d43346-da8c-11e7-8def-0ed2172f7d37.png)
![image](https://user-images.githubusercontent.com/5728311/33687251-7379da6a-da8c-11e7-8323-7e55627609eb.png)
![image](https://user-images.githubusercontent.com/5728311/33687273-87d6ad30-da8c-11e7-890d-f09c890d932e.png)

I was talking withe @jasongrout about the possibility of having static (rather than dynamically populated) submenus for each kernel. This would aid discoverability, but the downside is that we would need to start and then stop test kernels in order to get the relevant information for those menus. Thoughts?

