### PR TITLE
Whitelist class attribute for p, div, and pre.

### DIFF
--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -35,6 +35,12 @@ class Sanitizer implements ISanitizer {
       'code': ['class'],
       // Allow "class" attribute for <span> tags.
       'span': ['class'],
+      // Allow "class" attribute for <div> tags.
+      'div': ['class'],
+      // Allow "class" attribute for <p> tags.
+      'p': ['class'],
+      // Allow "class" attribute for <pre> tags.
+      'pre': ['class'],
       // Allow the "src" attribute for <audio> tags.
       'audio': ['src', 'autoplay', 'loop', 'muted', 'controls'],
       // Allow the "src" attribute for <video> tags.

--- a/test/src/apputils/sanitizer.spec.ts
+++ b/test/src/apputils/sanitizer.spec.ts
@@ -48,6 +48,21 @@ describe('defaultSanitizer', () => {
       expect(defaultSanitizer.sanitize(code)).to.be(code);
     });
 
+    it('should allow the class attribute for div tags', () => {
+      let div = '<div class="foo">bar</div>';
+      expect(defaultSanitizer.sanitize(div)).to.be(div);
+    });
+
+    it('should allow the class attribute for p tags', () => {
+      let p = '<p class="foo">bar</p>';
+      expect(defaultSanitizer.sanitize(p)).to.be(p);
+    });
+
+    it('should allow the class attribute for pre tags', () => {
+      let pre = '<pre class="foo">bar</pre>';
+      expect(defaultSanitizer.sanitize(pre)).to.be(pre);
+    });
+
     it('should strip script tags', () => {
       let script = '<script>alert("foo")</script>';
       expect(defaultSanitizer.sanitize(script)).to.be('');


### PR DESCRIPTION
Working with @fperez today, we realized that the sanitizer was stripping out class attributes for `div`, `p`, and `pre` tags, which makes a lot of custom markup in notebooks break.