### PR TITLE
Fix #3335: add subcommand check to labextension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ mode, the page will have a red stripe at the top to indicate it is an unreleased
 
 ```bash
 jlpm run build:test
-jplm test
+jlpm test
 ```
 
 ### Build and run the stand-alone examples

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -232,7 +232,7 @@ def disable_extension(extension, app_dir=None, logger=None):
 
 
 def check_extension(extension, app_dir=None, installed=False, logger=None):
-    """Enable a JupyterLab extension.
+    """Check if a JupyterLab extension is enabled or disabled.
     """
     handler = _AppHandler(app_dir, logger)
     return handler.check_extension(extension, installed)
@@ -580,6 +580,22 @@ class _AppHandler(object):
             disabled.remove(extension)
         self._write_page_config(config)
 
+    def check_extension(self, extension, check_installed_only=False):
+        """Check if a lab extension is enabled or disabled
+        """
+        info = self.info
+
+        if extension in info["core_extensions"]:
+            return self._check_core_extension(
+                extension, info, check_installed_only)
+
+        if extension in info["linked_packages"]:
+            self.logger.info('%s:%s' % (extension, GREEN_ENABLED))
+            return True
+
+        return self._check_common_extension(
+            extension, info, check_installed_only)
+
     def _check_core_extension(self, extension, info, check_installed_only):
         """Check if a core extension is enabled or disabled
         """
@@ -596,7 +612,7 @@ class _AppHandler(object):
         return True
 
     def _check_common_extension(self, extension, info, check_installed_only):
-        """Check if a core extension is enabled or disabled
+        """Check if a common (non-core) extension is enabled or disabled
         """
         if extension not in info['extensions']:
             self.logger.info('%s:%s' % (extension, RED_X))
@@ -617,23 +633,6 @@ class _AppHandler(object):
 
         self.logger.info('%s:%s' % (extension, GREEN_ENABLED))
         return True
-
-    def check_extension(self, extension, check_installed_only=False):
-        """Check if a lab extension is enabled or disabled
-        """
-        config = self._read_page_config()
-        info = self.info
-
-        if extension in info["core_extensions"]:
-            return self._check_core_extension(
-                extension, info, check_installed_only)
-
-        if extension in info["linked_packages"]:
-            self.logger.info('%s:%s' % (extension, GREEN_ENABLED))
-            return True
-
-        return self._check_common_extension(
-            extension, info, check_installed_only)
 
     def _get_app_info(self):
         """Get information about the app.

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -231,6 +231,13 @@ def disable_extension(extension, app_dir=None, logger=None):
     return handler.toggle_extension(extension, True)
 
 
+def check_extension(extension, app_dir=None, installed=False, logger=None):
+    """Enable a JupyterLab extension.
+    """
+    handler = _AppHandler(app_dir, logger)
+    return handler.check_extension(extension, installed)
+
+
 def build_check(app_dir=None, logger=None):
     """Determine whether JupyterLab should be built.
 
@@ -572,6 +579,61 @@ class _AppHandler(object):
         if not value and extension in disabled:
             disabled.remove(extension)
         self._write_page_config(config)
+
+    def _check_core_extension(self, extension, info, check_installed_only):
+        """Check if a core extension is enabled or disabled
+        """
+        if extension in info['uninstalled_core']:
+            self.logger.info('%s:%s' % (extension, RED_X))
+            return False
+        if check_installed_only:
+            self.logger.info('%s: %s' % (extension, GREEN_OK))
+            return True
+        if extension in info['disabled_core']:
+            self.logger.info('%s: %s' % (extension, RED_DISABLED))
+            return False
+        self.logger.info('%s:%s' % (extension, GREEN_ENABLED))
+        return True
+
+    def _check_common_extension(self, extension, info, check_installed_only):
+        """Check if a core extension is enabled or disabled
+        """
+        if extension not in info['extensions']:
+            self.logger.info('%s:%s' % (extension, RED_X))
+            return False
+
+        errors = self._get_extension_compat()[extension]
+        if errors:
+            self.logger.info('%s:%s (compatibility errors)' % (extension, RED_X))
+            return False
+
+        if check_installed_only:
+            self.logger.info('%s: %s' % (extension, GREEN_OK))
+            return True
+
+        if _is_disabled(extension, info['disabled']):
+            self.logger.info('%s: %s' % (extension, RED_DISABLED))
+            return False
+
+        self.logger.info('%s:%s' % (extension, GREEN_ENABLED))
+        return True
+
+    def check_extension(self, extension, check_installed_only=False):
+        """Check if a lab extension is enabled or disabled
+        """
+        config = self._read_page_config()
+        info = self.info
+
+        if extension in info["core_extensions"]:
+            return self._check_core_extension(
+                extension, info, check_installed_only)
+
+        if extension in info["linked_packages"]:
+            self.logger.info('%s:%s' % (extension, GREEN_ENABLED))
+            return True
+
+        return self._check_common_extension(
+            extension, info, check_installed_only)
 
     def _get_app_info(self):
         """Get information about the app.


### PR DESCRIPTION
This pull request adds the subcommand `jupyter labextension check <extensions>` (Fixes #3335)

Usage examples:

1- Enabled extension
```
$ jupyter labextension check @jupyterlab/console-extension;  echo $?
@jupyterlab/console-extension: enabled
0
```

2- Disabled extension
```
$ jupyter labextension disable @jupyterlab/console-extension --no-build
$ jupyter labextension check @jupyterlab/console-extension;  echo $?
@jupyterlab/console-extension: disabled
1
```

3- Disabled extension, but checking only if it is installed
```
$ jupyter labextension check @jupyterlab/console-extension --installed; echo $?
@jupyterlab/console-extension: OK
0
```

4- Extension that is not installed or does not exist
```
$ jupyter labextension check @jupyter_dojo/labextension; echo $?
@jupyter_dojo/labextension: X
1
```

@jupyter_dojo/labextension;

5- Multiple extensions
```
$ jupyter labextension enable @jupyterlab/console-extension --no-build
$ jupyter labextension install @jupyter_dojo/labextension
$ jupyter labextension check @jupyterlab/console-extension @jupyter_dojo/labextension; echo $?
@jupyterlab/console-extension: enabled
@jupyter_dojo/labextension: enabled
0
```

6- Multiple extensions with a failure
```
$ jupyter labextension check @jupyterlab/console-extension invalid_extension; echo $?
@jupyterlab/console-extension: enabled
invalid_extension: X
1
```
