### PR TITLE
Context contains a url resolver instead of being one

### DIFF
--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -36,6 +36,7 @@
     "@jupyterlab/coreutils": "^0.13.0",
     "@jupyterlab/observables": "^0.2.0",
     "@jupyterlab/rendermime": "^0.13.0",
+    "@jupyterlab/rendermime-interfaces": "^0.4.3",
     "@jupyterlab/services": "^0.52.0",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -34,7 +34,7 @@ import {
 } from '@jupyterlab/observables';
 
 import {
-  RenderMime
+  RenderMimeRegistry
 } from '@jupyterlab/rendermime';
 
 import {
@@ -88,7 +88,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     this.session.propertyChanged.connect(this._onSessionChanged, this);
     manager.contents.fileChanged.connect(this._onFileChanged, this);
 
-    this.urlResolver = new RenderMime.UrlResolver({
+    this.urlResolver = new RenderMimeRegistry.UrlResolver({
       session: this.session,
       contents: manager.contents
     });

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -26,12 +26,20 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  PathExt, URLExt
+  PathExt
 } from '@jupyterlab/coreutils';
 
 import {
   IModelDB, ModelDB
 } from '@jupyterlab/observables';
+
+import {
+  RenderMime
+} from '@jupyterlab/rendermime';
+
+import {
+  IRenderMime
+} from '@jupyterlab/rendermime-interfaces';
 
 import {
   DocumentRegistry
@@ -79,6 +87,11 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     });
     this.session.propertyChanged.connect(this._onSessionChanged, this);
     manager.contents.fileChanged.connect(this._onFileChanged, this);
+
+    this.urlResolver = new RenderMime.UrlResolver({
+      session: this.session,
+      contents: manager.contents
+    });
   }
 
   /**
@@ -188,6 +201,11 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
   get ready(): Promise<void> {
     return this._readyPromise;
   }
+
+  /**
+   * The url resolver for the context.
+   */
+  readonly urlResolver: IRenderMime.IResolver;
 
   /**
    * Populate the contents of the model, either from
@@ -361,28 +379,6 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     return this._manager.ready.then(() => {
       return contents.listCheckpoints(this._path);
     });
-  }
-
-  /**
-   * Resolve a relative url to a correct server path.
-   */
-  resolveUrl(url: string): Promise<string> {
-    if (URLExt.isLocal(url)) {
-      let cwd = PathExt.dirname(this._path);
-      url = PathExt.resolve(cwd, url);
-    }
-    return Promise.resolve(url);
-  }
-
-  /**
-   * Get the download url of a given absolute server path.
-   */
-  getDownloadUrl(path: string): Promise<string> {
-    let contents = this._manager.contents;
-    if (URLExt.isLocal(path)) {
-      return this._manager.ready.then(() => contents.getDownloadUrl(path));
-    }
-    return Promise.resolve(path);
   }
 
   /**

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -48,7 +48,9 @@ class MimeDocument extends Widget implements DocumentRegistry.IReadyWidget {
     layout.addWidget(toolbar);
     BoxLayout.setStretch(toolbar, 0);
     let context = options.context;
-    this.rendermime = options.rendermime.clone({ resolver: context });
+    this.rendermime = options.rendermime.clone({
+      resolver: context.urlResolver
+    });
 
     this._context = context;
     this._mimeType = options.mimeType;

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -42,6 +42,10 @@ import {
 } from '@jupyterlab/observables';
 
 import {
+  IRenderMime
+} from '@jupyterlab/rendermime-interfaces';
+
+import {
   TextModelFactory
 } from './default';
 
@@ -702,6 +706,11 @@ namespace DocumentRegistry {
     readonly contentsModel: Contents.IModel | null;
 
     /**
+     * The url resolver for the context.
+     */
+    readonly urlResolver: IRenderMime.IResolver;
+
+    /**
      * Whether the context is ready.
      */
     readonly isReady: boolean;
@@ -760,16 +769,6 @@ namespace DocumentRegistry {
      *    the file.
      */
     listCheckpoints(): Promise<Contents.ICheckpointModel[]>;
-
-    /**
-     * Resolve a relative url to a correct server path.
-     */
-    resolveUrl(url: string): Promise<string>;
-
-    /**
-     * Get the download url of a given absolute server path.
-     */
-    getDownloadUrl(path: string): Promise<string>;
 
     /**
      * Add a sibling widget to the document manager.

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -66,7 +66,7 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
    * the default toolbar items using `ToolbarItems.populateDefaults`.
    */
   protected createNewWidget(context: DocumentRegistry.IContext<INotebookModel>): NotebookPanel {
-    let rendermime = this.rendermime.clone({ resolver: context });
+    let rendermime = this.rendermime.clone({ resolver: context.urlResolver });
     let panel = new NotebookPanel({
       rendermime,
       contentFactory: this.contentFactory,

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -20,6 +20,10 @@ import {
 } from '@jupyterlab/docregistry';
 
 import {
+  RenderMime
+} from '@jupyterlab/rendermime';
+
+import {
   waitForDialog, acceptDialog, dismissDialog
 } from '../utils';
 
@@ -386,37 +390,10 @@ describe('docregistry/context', () => {
 
     });
 
-    describe('#resolveUrl()', () => {
+    describe('#urlResolver', () => {
 
-      it('should resolve a relative url to a correct server path', () => {
-        return context.resolveUrl('./foo').then(path => {
-          expect(path).to.be('foo');
-        });
-      });
-
-      it('should ignore urls that have a protocol', () => {
-        return context.resolveUrl('http://foo').then(path => {
-          expect(path).to.be('http://foo');
-        });
-      });
-
-    });
-
-    describe('#getDownloadUrl()', () => {
-
-      it('should resolve an absolute server url to a download url', () => {
-        let contextPromise = context.getDownloadUrl('foo');
-        let contentsPromise = manager.contents.getDownloadUrl('foo');
-        return Promise.all([contextPromise, contentsPromise])
-        .then(values => {
-          expect(values[0]).to.be(values[1]);
-        });
-      });
-
-      it('should ignore urls that have a protocol', () => {
-        return context.getDownloadUrl('http://foo').then(path => {
-          expect(path).to.be('http://foo');
-        });
+      it('should be a url resolver', () => {
+        expect(context.urlResolver).to.be.a(RenderMime.UrlResolver);
       });
 
     });

--- a/test/src/docregistry/context.spec.ts
+++ b/test/src/docregistry/context.spec.ts
@@ -20,7 +20,7 @@ import {
 } from '@jupyterlab/docregistry';
 
 import {
-  RenderMime
+  RenderMimeRegistry
 } from '@jupyterlab/rendermime';
 
 import {
@@ -393,7 +393,7 @@ describe('docregistry/context', () => {
     describe('#urlResolver', () => {
 
       it('should be a url resolver', () => {
-        expect(context.urlResolver).to.be.a(RenderMime.UrlResolver);
+        expect(context.urlResolver).to.be.a(RenderMimeRegistry.UrlResolver);
       });
 
     });

--- a/test/src/rendermime/registry.spec.ts
+++ b/test/src/rendermime/registry.spec.ts
@@ -36,7 +36,7 @@ import {
 } from '../utils';
 
 
-const RESOLVER: IRenderMime.IResolver = createFileContext();
+const RESOLVER: IRenderMime.IResolver = createFileContext().urlResolver;
 
 
 function createModel(data: JSONObject): IRenderMime.IMimeModel {


### PR DESCRIPTION
Avoids duplication of logic and avoids handing out an object to a mime renderer that contains more information than we intended to hand out (if casting as `any` or using JavaScript).