### PR TITLE
Default drive name

### DIFF
--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -45,7 +45,7 @@ namespace PathExt {
   export
   function dirname(path: string): string {
     const drive = driveName(path);
-    let dir = removeSlash(posix.dirname(localPath(path)));
+    let dir = posix.dirname(localPath(path));
     dir = dir === '.' ? '' : dir;
     return drive ? `${drive}:${dir}` : dir;
   }
@@ -63,7 +63,7 @@ namespace PathExt {
     if (parts.length === 1) {
       return removeSlash(path);
     }
-    return removeSlash(join(...parts.slice(1)));
+    return removeSlash(parts.slice(1).join(':'));
   }
 
   /**

--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -33,7 +33,7 @@ namespace PathExt {
    */
   export
   function basename(path: string, ext?: string): string {
-    return posix.basename(path, ext);
+    return posix.basename(localPath(path), ext);
   }
 
   /**
@@ -44,8 +44,39 @@ namespace PathExt {
    */
   export
   function dirname(path: string): string {
-    let dir = removeSlash(posix.dirname(path));
-    return dir === '.' ? '' : dir;
+    const drive = driveName(path);
+    let dir = removeSlash(posix.dirname(localPath(path)));
+    dir = dir === '.' ? '' : dir;
+    return drive ? `${drive}:${dir}` : dir;
+  }
+
+  /**
+   * Given a path of the form `drive:path/to/file`, get the local part
+   * of the path (that is, removing the `drive:` component). If the
+   * path does not include a drive, it just returns the path.
+   *
+   * @param path - The file path.
+   */
+  export
+  function localPath(path: string): string {
+    const parts = path.split(':');
+    if (parts.length === 1) {
+      return removeSlash(path);
+    }
+    return removeSlash(join(...parts.slice(1)));
+  }
+
+  /**
+   * Given a path of the form `drive:path/to/file`, get the name of the
+   * drive for the path. If the  path does not include a drive,
+   * returns an empty string.
+   *
+   * @param path - The file path.
+   */
+  export
+  function driveName(path: string): string {
+    const parts = path.split(':');
+    return parts.length > 1 ? parts[0] : '';
   }
 
   /**

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -57,7 +57,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
 
     let dbFactory = options.modelDBFactory;
     if (dbFactory) {
-      this._modelDB = dbFactory.createNew(this._path.split(':').pop()!);
+      this._modelDB = dbFactory.createNew(PathExt.localPath(this._path));
       this._model = this._factory.createNew(lang, this._modelDB);
     } else {
       this._model = this._factory.createNew(lang);

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -160,7 +160,8 @@ function activateFactory(app: JupyterLab, docManager: IDocumentManager, state: I
 
     return widget;
   };
-  const defaultBrowser = createFileBrowser('filebrowser');
+  const defaultBrowser =
+    createFileBrowser('filebrowser', { driveName: 'Default' });
 
   return { createFileBrowser, defaultBrowser, tracker };
 }

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -340,7 +340,7 @@ namespace Private {
       node.removeChild(firstChild.nextSibling);
     }
 
-    let localPath = path.split(':').pop() as string;
+    const localPath = PathExt.localPath(path);
     let localParts = localPath.split('/');
     let parts = path.split('/');
     if (parts.length > 2) {

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -544,12 +544,9 @@ namespace Private {
    */
   export
   function normalizePath(root: string, path: string): string {
-    let parts = root.split(':');
-    if (parts.length === 1) {
-      return PathExt.resolve(root, path);
-    } else {
-      let resolved = PathExt.resolve(parts[1], path);
-      return parts[0] + ':' + resolved;
-    }
+    const driveName = PathExt.driveName(root);
+    const localPath = PathExt.localPath(root);
+    const resolved = PathExt.resolve(localPath, path);
+    return driveName ? `${driveName}:${resolved}` : resolved;
   }
 }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -287,7 +287,7 @@ class FileBrowserModel implements IDisposable {
       }
 
       const path = (cwd as ReadonlyJSONObject)['path'] as string;
-      const localPath = path.split(':').pop();
+      const localPath = PathExt.localPath(path);
       return manager.services.contents.get(path)
         .then(() => this.cd(localPath))
         .catch(() => state.remove(key));

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -300,7 +300,7 @@ class FileEditor extends Widget implements DocumentRegistry.IReadyWidget {
     const path = this._context.path;
 
     editor.model.mimeType = this._mimeTypeService.getMimeTypeByFilePath(path);
-    this.title.label = PathExt.basename(path.split(':').pop()!);
+    this.title.label = PathExt.basename(path);
   }
 
   private editorWidget: FileEditorCodeWrapper;

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -35,7 +35,7 @@ import {
 } from '@jupyterlab/codeeditor';
 
 import {
-  IChangedArgs
+  IChangedArgs, PathExt
 } from '@jupyterlab/coreutils';
 
 import {
@@ -284,7 +284,7 @@ class NotebookPanel extends Widget implements DocumentRegistry.IReadyWidget {
    * Handle a change to the document path.
    */
   protected onPathChanged(sender: DocumentRegistry.IContext<INotebookModel>, path: string): void {
-    this.title.label = path.split('/').pop();
+    this.title.label = PathExt.basename(path);
   }
 
   /**

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -829,15 +829,16 @@ class ContentsManager implements Contents.IManager {
    */
   private _driveForPath(path: string): [Contents.IDrive, string] {
     // Split the path at ':'
-    let parts = path.split(':')
-    if (parts.length === 1) {
+    const driveName = PathExt.driveName(path);
+    const localPath = PathExt.localPath(path);
+    if (!driveName) {
       throw Error('ContentsManager: drive not specified');
     } else {
-      let drive = this._drives.get(parts[0]);
+      let drive = this._drives.get(driveName);
       if (!drive) {
         throw Error('ContentsManager: cannot find requested drive');
       }
-      return [drive, Private.normalize(parts[1])];
+      return [drive, Private.normalize(localPath)];
     }
   }
 
@@ -1357,16 +1358,8 @@ namespace Private {
    */
   export
   function normalize(path: string): string {
-    const parts = path.split(':');
-
-    if (parts.length === 1) {
-      return PathExt.normalize(path);
-    }
-
-    if (parts.length === 2) {
-      return parts[0] + ':' + PathExt.normalize(parts[1]);
-    }
-
-    throw new Error('Malformed path: ' + path);
+    const driveName = PathExt.driveName(path);
+    const localPath = PathExt.normalize(PathExt.localPath(path));
+    return driveName ? `${driveName}:${localPath}` : localPath;
   }
 }

--- a/test/src/coreutils/path.spec.ts
+++ b/test/src/coreutils/path.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '@jupyterlab/coreutils';
 
 
-const TESTPATH = 'foo/test/simple/test-path.js';
+const TESTPATH = 'drive:foo/test/simple/test-path.js';
 
 
 describe('@jupyterlab/coreutils', () => {
@@ -32,12 +32,21 @@ describe('@jupyterlab/coreutils', () => {
         expect(PathExt.basename(TESTPATH)).to.equal('test-path.js');
       });
 
+      it('should not return the drive name for a file in the root directory', () => {
+        expect(PathExt.basename('drive:test.js')).to.equal('test.js');
+      });
+
+      it('should work for local paths that include a ":"', () => {
+        expect(PathExt.basename('drive:foo/test:directory/test:file.json'))
+        .to.equal('test:file.json');
+      });
+
     });
 
     describe('.dirname()', () => {
 
       it('should get the directory name of a path', () => {
-        expect(PathExt.dirname(TESTPATH)).to.equal('foo/test/simple');
+        expect(PathExt.dirname(TESTPATH)).to.equal('drive:foo/test/simple');
       });
 
       it('should not return "." for an empty path', () => {
@@ -48,6 +57,42 @@ describe('@jupyterlab/coreutils', () => {
       it('should not return "." for a path in the root directory', () => {
         let path = PathExt.dirname('foo.txt');
         expect(path).to.equal('');
+      });
+
+      it('should return the drive name for a path in the root of a drive', () => {
+        expect(PathExt.dirname('drive:test.js')).to.equal('drive:');
+      });
+
+      it('should work for local paths that include a ":"', () => {
+        expect(PathExt.dirname('drive:foo/test:directory/test:file.json'))
+        .to.equal('drive:foo/test:directory');
+      });
+    });
+
+    describe('.localPath()', () => {
+
+      it('should return the portion of the path after a drive name', () => {
+        expect(PathExt.localPath(TESTPATH))
+        .to.equal('foo/test/simple/test-path.js');
+      });
+
+      it('should return the path if it does not include a drive name', () => {
+        expect(PathExt.localPath('foo/test/simple/test-path.js'))
+        .to.equal('foo/test/simple/test-path.js');
+      });
+
+    });
+
+    describe('.driveName()', () => {
+
+      it('should return the drive name for a path', () => {
+        expect(PathExt.driveName(TESTPATH))
+        .to.equal('drive');
+      });
+
+      it('should return empty string if it does not include a drive name', () => {
+        expect(PathExt.driveName('foo/test/simple/test-path.js'))
+        .to.equal('');
       });
 
     });


### PR DESCRIPTION
Potential fix for #3351.
This requires that all mounted `Contents.IDrive`s have a name, so we can always distinguish the drive name. Subsequent `:` characters in the path can then be valid characters in file and directory names. This would be a breaking change for downstream users of `@jupyterlab/services`, since it would require a name from the default drive.