### PR TITLE
Launcher callback improvements

### DIFF
--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -106,6 +106,10 @@ interface ILauncherItem {
    * The callback is invoked with a current working directory and the
    * name of the selected launcher item.  When the function returns
    * the launcher will close.
+   *
+   * #### Notes
+   * The callback must return the widget that was created so the launcher
+   * can replace itself with the created widget.
    */
   callback: (cwd: string, name: string) => Widget | Promise<Widget>;
 
@@ -390,6 +394,9 @@ function Card(kernel: boolean, item: ILauncherItem, launcher: Launcher, launcher
     let callback = item.callback as any;
     let value = callback(launcher.cwd, item.name);
     Promise.resolve(value).then(widget => {
+      if (!widget) {
+        console.error('Launcher callbacks must resolve with a widget');
+      }
       launcherCallback(widget);
       launcher.dispose();
     }).catch(err => {

--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -395,7 +395,7 @@ function Card(kernel: boolean, item: ILauncherItem, launcher: Launcher, launcher
     let value = callback(launcher.cwd, item.name);
     Promise.resolve(value).then(widget => {
       if (!widget) {
-        console.error('Launcher callbacks must resolve with a widget');
+        throw new Error('Launcher callbacks must resolve with a widget');
       }
       launcherCallback(widget);
       launcher.dispose();


### PR DESCRIPTION
Fixes #3183.

Adds more documentation and shows an error dialog if the launcher item does not return a widget.