### PR TITLE
Clear the application state automatically if needed

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -164,7 +164,10 @@ const state: JupyterLabPlugin<IStateDB> = {
   autoStart: true,
   provides: IStateDB,
   activate: (app: JupyterLab) => {
-    const state = new StateDB({ namespace: app.info.namespace });
+    const state = new StateDB({
+      namespace: app.info.namespace,
+      when: app.restored.then(() => { /* no-op */ })
+    });
     const version = app.info.version;
     const key = 'statedb:version';
     const fetch = state.fetch(key);

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -88,17 +88,9 @@ class StateDB implements IStateDB {
    */
   constructor(options: StateDB.IOptions) {
     this.namespace = options.namespace;
-    let key = `${this.namespace}:stateDb:sentinel`;
-    let sentinel = window.localStorage.getItem(key);
-    // Clear state if the sentinel was not properly cleared on last page load.
-    if (sentinel) {
-      this._clear();
+    if (options.when) {
+      this._handleSentinel(options.when);
     }
-    // Set the sentinel value and clear it when the statedb is initialized.
-    window.localStorage.setItem(key, 'sentinel');
-    options.when.then(() => {
-      window.localStorage.removeItem(key);
-    });
   }
 
   /**
@@ -268,6 +260,23 @@ class StateDB implements IStateDB {
 
     return Promise.resolve(undefined);
   }
+
+  /**
+   * Handle the startup sentinel.
+   */
+  private _handleSentinel(when: Promise<void>): void {
+    let key = `${this.namespace}:stateDb:sentinel`;
+    let sentinel = window.localStorage.getItem(key);
+    // Clear state if the sentinel was not properly cleared on last page load.
+    if (sentinel) {
+      this._clear();
+    }
+    // Set the sentinel value and clear it when the statedb is initialized.
+    window.localStorage.setItem(key, 'sentinel');
+    when.then(() => {
+      window.localStorage.removeItem(key);
+    });
+  }
 }
 
 /**
@@ -286,10 +295,10 @@ namespace StateDB {
     namespace: string;
 
     /**
-     * The Promise for when the state database should be considered
+     * An optional Promise for when the state database should be considered
      * initialized.
      */
-    when: Promise<void>;
+    when?: Promise<void>;
   }
 }
 

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -88,6 +88,14 @@ class StateDB implements IStateDB {
    */
   constructor(options: StateDB.IOptions) {
     this.namespace = options.namespace;
+    let key = `${this.namespace}:stateDb:sentinel`;
+    let sentinel = window.localStorage.getItem(key);
+    if (sentinel) {
+      this._clear();
+    }
+    options.when.then(() => {
+      window.localStorage.removeItem(key);
+    });
   }
 
   /**
@@ -109,18 +117,7 @@ class StateDB implements IStateDB {
    * Clear the entire database.
    */
   clear(): Promise<void> {
-    const prefix = `${this.namespace}:`;
-    let i = window.localStorage.length;
-
-    while (i) {
-      let key = window.localStorage.key(--i);
-
-      if (key && key.indexOf(prefix) === 0) {
-        window.localStorage.removeItem(key);
-      }
-    }
-
-    return Promise.resolve(undefined);
+    return this._clear();
   }
 
   /**
@@ -250,6 +247,24 @@ class StateDB implements IStateDB {
       return Promise.reject(error);
     }
   }
+
+  /**
+   * Clear the entire database.
+   */
+  private _clear(): Promise<void> {
+    const prefix = `${this.namespace}:`;
+    let i = window.localStorage.length;
+
+    while (i) {
+      let key = window.localStorage.key(--i);
+
+      if (key && key.indexOf(prefix) === 0) {
+        window.localStorage.removeItem(key);
+      }
+    }
+
+    return Promise.resolve(undefined);
+  }
 }
 
 /**
@@ -266,6 +281,12 @@ namespace StateDB {
      * The namespace prefix for all state database entries.
      */
     namespace: string;
+
+    /**
+     * The Promise for when the state database should be considered
+     * initialized.
+     */
+    when: Promise<void>;
   }
 }
 

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -94,6 +94,8 @@ class StateDB implements IStateDB {
     if (sentinel) {
       this._clear();
     }
+    // Set the sentinel value and clear it when the statedb is initialized.
+    window.localStorage.setItem(key, 'sentinel');
     options.when.then(() => {
       window.localStorage.removeItem(key);
     });

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -90,7 +90,7 @@ class StateDB implements IStateDB {
     this.namespace = options.namespace;
     let key = `${this.namespace}:stateDb:sentinel`;
     let sentinel = window.localStorage.getItem(key);
-    // Check if the sentinel was not properly cleared on last page load.
+    // Clear state if the sentinel was not properly cleared on last page load.
     if (sentinel) {
       this._clear();
     }

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -90,6 +90,7 @@ class StateDB implements IStateDB {
     this.namespace = options.namespace;
     let key = `${this.namespace}:stateDb:sentinel`;
     let sentinel = window.localStorage.getItem(key);
+    // Check if the sentinel was not properly cleared on last page load.
     if (sentinel) {
       this._clear();
     }

--- a/test/src/coreutils/statedb.spec.ts
+++ b/test/src/coreutils/statedb.spec.ts
@@ -41,7 +41,7 @@ describe('StateDB', () => {
 
     it('should clear the namespace if the sentinel is set', () => {
       let { localStorage } = window;
-      let key = 'test:stateDb:sentinel';
+      let key = 'test:statedb:sentinel';
       localStorage.setItem(key, 'sentinel');
       localStorage.setItem('test:foo', 'bar');
       let promise = new PromiseDelegate<void>();

--- a/test/src/coreutils/statedb.spec.ts
+++ b/test/src/coreutils/statedb.spec.ts
@@ -7,14 +7,48 @@ import {
   StateDB
 } from '@jupyterlab/coreutils';
 
+import {
+  PromiseDelegate
+} from '@phosphor/coreutils';
+
 
 describe('StateDB', () => {
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
 
   describe('#constructor()', () => {
 
     it('should create a state database', () => {
       let db = new StateDB({ namespace: 'test' });
       expect(db).to.be.a(StateDB);
+    });
+
+    it('should take an optional when promise', () => {
+      let { localStorage } = window;
+      let promise = new PromiseDelegate<void>();
+      let db = new StateDB({ namespace: 'test', when: promise.promise });
+      let key = 'foo:bar';
+      let value = { baz: 'qux' };
+      promise.resolve(void 0);
+      return promise.promise.then(() => {
+        expect(localStorage.length).to.be(0);
+        return db.save(key, value);
+      }).then(() => db.fetch(key))
+      .then(fetched => { expect(fetched).to.eql(value); });
+    });
+
+    it('should clear the namespace if the sentinel is set', () => {
+      let { localStorage } = window;
+      let key = 'test:stateDb:sentinel';
+      localStorage.setItem(key, 'sentinel');
+      localStorage.setItem('test:foo', 'bar');
+      let promise = new PromiseDelegate<void>();
+      let db = new StateDB({ namespace: 'test', when: promise.promise });
+      expect(db).to.be.a(StateDB);
+      expect(localStorage.length).to.be(1);
+      expect(localStorage.getItem('test:foo')).to.be(null);
     });
 
   });
@@ -46,7 +80,6 @@ describe('StateDB', () => {
 
     it('should empty the items in a state database', done => {
       let { localStorage } = window;
-      localStorage.clear();
 
       let db = new StateDB({ namespace: 'test-namespace' });
       let key = 'foo:bar';
@@ -63,7 +96,6 @@ describe('StateDB', () => {
 
     it('should only clear its own namespace', done => {
       let { localStorage } = window;
-      localStorage.clear();
 
       let db1 = new StateDB({ namespace: 'test-namespace-1' });
       let db2 = new StateDB({ namespace: 'test-namespace-2' });
@@ -87,7 +119,6 @@ describe('StateDB', () => {
 
     it('should fetch a stored key', done => {
       let { localStorage } = window;
-      localStorage.clear();
 
       let db = new StateDB({ namespace: 'test-namespace' });
       let key = 'foo:bar';
@@ -105,7 +136,6 @@ describe('StateDB', () => {
 
     it('should resolve a nonexistent key fetch with undefined', done => {
       let { localStorage } = window;
-      localStorage.clear();
 
       let db = new StateDB({ namespace: 'test-namespace' });
       let key = 'foo:bar';
@@ -123,7 +153,6 @@ describe('StateDB', () => {
 
     it('should fetch a stored namespace', done => {
       let { localStorage } = window;
-      localStorage.clear();
 
       let db = new StateDB({ namespace: 'test-namespace' });
       let keys = [
@@ -170,7 +199,6 @@ describe('StateDB', () => {
 
     it('should remove a stored key', done => {
       let { localStorage } = window;
-      localStorage.clear();
 
       let db = new StateDB({ namespace: 'test-namespace' });
       let key = 'foo:bar';
@@ -191,7 +219,6 @@ describe('StateDB', () => {
 
     it('should save a key and a value', done => {
       let { localStorage } = window;
-      localStorage.clear();
 
       let db = new StateDB({ namespace: 'test-namespace' });
       let key = 'foo:bar';

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -10,7 +10,6 @@ import './apputils/dialog.spec';
 import './apputils/iframe.spec';
 import './apputils/instancetracker.spec';
 import './apputils/sanitizer.spec';
-import './apputils/statedb.spec';
 import './apputils/styling.spec';
 import './apputils/toolbar.spec';
 import './apputils/vdom.spec';
@@ -36,14 +35,15 @@ import './console/panel.spec';
 import './console/widget.spec';
 
 import './coreutils/activitymonitor.spec';
+import './coreutils/markdowncodeblocks.spec';
 import './coreutils/nbformat.spec';
 import './coreutils/pageconfig.spec';
 import './coreutils/path.spec';
 import './coreutils/settingregistry.spec';
+import './coreutils/statedb.spec';
 import './coreutils/time.spec';
 import './coreutils/url.spec';
 import './coreutils/uuid.spec';
-import './coreutils/markdowncodeblocks.spec';
 
 import './csvviewer/toolbar.spec';
 import './csvviewer/widget.spec';


### PR DESCRIPTION
Fixes #2945.

Clears the application state if the application failed to complete its initial layout on the previous load.