### PR TITLE
Clean up handling of config data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ jupyterlab/themes
 jupyterlab/geckodriver
 dev_mode/schemas
 dev_mode/themes
+dev_mode/static
 
 node_modules
 .cache

--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -18,6 +18,7 @@ let data = utils.readJSONFile('./dev_mode/package.json');
 data['scripts']['build'] = 'webpack';
 data['scripts']['watch'] = 'webpack --watch';
 data['scripts']['build:prod'] = "webpack --define process.env.NODE_ENV=\"'production'\"";
+data['jupyterlab']['buildDir'] = './build';
 data['jupyterlab']['outputDir'] = '..';
 data['jupyterlab']['staticDir'] = '../static';
 data['jupyterlab']['linkedPackages'] = {};

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -126,6 +126,7 @@
       "@jupyterlab/vega2-extension": ""
     },
     "name": "JupyterLab",
+    "buildDir": "./static",
     "outputDir": ".",
     "singletonPackages": [
       "@jupyterlab/application",

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -110,7 +110,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(buildDir),
-    publicPath: 'lab/static/',
+    publicPath: jlab.publicUrl || 'lab/static/',
     filename: '[name].[chunkhash].js'
   },
   module: {
@@ -165,7 +165,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: path.join('templates', 'template.html'),
-      title: 'JupyterLab'
+      title: jlab.name || 'JupyterLab'
     }),
     new webpack.HashedModuleIdsPlugin(),
     new webpack.optimize.CommonsChunkPlugin({

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -12,13 +12,6 @@ var webpack = require('webpack');
 var Build = require('@jupyterlab/buildutils').Build;
 var package_data = require('./package.json');
 
-// Ensure a clear build directory.
-var buildDir = path.resolve('./build');
-if (fs.existsSync(buildDir)) {
-  fs.removeSync(buildDir);
-}
-fs.ensureDirSync(buildDir);
-
 // Handle the extensions.
 var jlab = package_data.jupyterlab;
 var extensions = jlab.extensions;
@@ -36,6 +29,13 @@ var data = {
   jupyterlab_mime_extensions: mimeExtensions,
 };
 var result = template(data);
+
+// Ensure a clear build directory.
+var buildDir = path.resolve(jlab.buildDir);
+if (fs.existsSync(buildDir)) {
+  fs.removeSync(buildDir);
+}
+fs.ensureDirSync(buildDir);
 
 fs.writeFileSync(path.join(buildDir, 'index.out.js'), result);
 fs.copySync('./package.json', path.join(buildDir, 'package.json'));

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -89,8 +89,23 @@ def ensure_dev(logger=None):
         yarn_proc = Process(['node', YARN_PATH], cwd=parent, logger=logger)
         yarn_proc.wait()
 
-    if not osp.exists(pjoin(parent, 'dev_mode', 'build')):
+    if not osp.exists(pjoin(parent, 'dev_mode', 'static')):
         yarn_proc = Process(['node', YARN_PATH, 'build'], cwd=parent,
+                            logger=logger)
+        yarn_proc.wait()
+
+
+def ensure_core(logger=None):
+    """Ensure that the core assets are available.
+    """
+    staging = pjoin(HERE, 'staging')
+
+    if not osp.exists(pjoin(staging, 'node_modules')):
+        yarn_proc = Process(['node', YARN_PATH], cwd=staging, logger=logger)
+        yarn_proc.wait()
+
+    if not osp.exists(pjoin(HERE, 'static')):
+        yarn_proc = Process(['node', YARN_PATH, 'build'], cwd=staging,
                             logger=logger)
         yarn_proc.wait()
 
@@ -282,8 +297,6 @@ def get_app_version(app_dir=None):
 class _AppHandler(object):
 
     def __init__(self, app_dir, logger=None, kill_event=None):
-        if app_dir and app_dir.startswith(HERE):
-            raise ValueError('Cannot run lab extension commands in core app')
         self.app_dir = app_dir or get_app_dir()
         self.sys_dir = get_app_dir()
         self.logger = logger or logging.getLogger('jupyterlab')
@@ -426,9 +439,7 @@ class _AppHandler(object):
         if not osp.exists(pkg_path):
             return ['No built application']
 
-        with open(pkg_path) as fid:
-            static_data = json.load(fid)
-
+        static_data = self.info['static_data']
         old_jlab = static_data['jupyterlab']
         old_deps = static_data.get('dependencies', dict())
 
@@ -658,7 +669,12 @@ class _AppHandler(object):
                 sys.append(name)
 
         info['uninstalled_core'] = self._get_uninstalled_core_extensions()
-        info['version'] = core_data['jupyterlab']['version']
+
+        info['static_data'] = _get_static_data(self.app_dir)
+        app_data = info['static_data'] or core_data
+        info['version'] = app_data['jupyterlab']['version']
+        info['publicUrl'] = app_data['jupyterlab'].get('publicUrl', '')
+
         info['sys_dir'] = self.sys_dir
         info['app_dir'] = self.app_dir
 
@@ -1211,6 +1227,17 @@ def _get_core_data():
     """
     with open(pjoin(HERE, 'staging', 'package.json')) as fid:
         return json.load(fid)
+
+
+def _get_static_data(app_dir):
+    """Get the data for the app static dir.
+    """
+    target = pjoin(app_dir, 'static', 'package.json')
+    if os.path.exists(target):
+        with open(target) as fid:
+            return json.load(fid)
+    else:
+        return None
 
 
 def _validate_compatibility(extension, deps, core_data):

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -35,7 +35,7 @@ def load_jupyter_server_extension(nbapp):
     from .build_handler import build_path, Builder, BuildHandler
     from .commands import (
         get_app_dir, get_user_settings_dir, watch, ensure_dev, watch_dev,
-        pjoin, DEV_DIR, HERE, get_app_version
+        pjoin, DEV_DIR, HERE, get_app_info
     )
     from ._version import __version__
 
@@ -86,7 +86,9 @@ def load_jupyter_server_extension(nbapp):
         config.schemas_dir = pjoin(HERE, 'schemas')
         config.app_settings_dir = ''
         config.themes_dir = pjoin(HERE, 'themes')
-        config.app_version = get_app_version()
+        info = get_app_info(app_dir)
+        config.app_version = info['version']
+        config.public_url = info['data']['jupyterlab']['publicUrl']
 
         logger.info(CORE_NOTE.strip())
         if not os.path.exists(config.static_dir):
@@ -109,7 +111,9 @@ def load_jupyter_server_extension(nbapp):
         config.schemas_dir = pjoin(app_dir, 'schemas')
         config.app_settings_dir = pjoin(app_dir, 'settings')
         config.themes_dir = pjoin(app_dir, 'themes')
-        config.app_version = get_app_version(app_dir)
+        info = get_app_info(app_dir)
+        config.app_version = info['version']
+        config.public_url = info['data']['jupyterlab']['publicUrl']
 
     page_config['devMode'] = dev_mode
     config.user_settings_dir = get_user_settings_dir()

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -35,7 +35,7 @@ def load_jupyter_server_extension(nbapp):
     from .build_handler import build_path, Builder, BuildHandler
     from .commands import (
         get_app_dir, get_user_settings_dir, watch, ensure_dev, watch_dev,
-        pjoin, DEV_DIR, HERE, get_app_info
+        pjoin, DEV_DIR, HERE, get_app_info, ensure_core
     )
     from ._version import __version__
 
@@ -80,48 +80,32 @@ def load_jupyter_server_extension(nbapp):
     page_config['buildAvailable'] = not core_mode and not dev_mode
     page_config['buildCheck'] = not core_mode and not dev_mode
     page_config['token'] = nbapp.token
+    page_config['devMode'] = dev_mode
 
     if core_mode:
-        config.static_dir = pjoin(HERE, 'static')
-        config.schemas_dir = pjoin(HERE, 'schemas')
-        config.app_settings_dir = ''
-        config.themes_dir = pjoin(HERE, 'themes')
-        info = get_app_info(app_dir)
-        config.app_version = info['version']
-        config.public_url = info['data']['jupyterlab']['publicUrl']
-
+        app_dir = HERE
         logger.info(CORE_NOTE.strip())
-        if not os.path.exists(config.static_dir):
-            msg = 'Static assets not built, please see CONTRIBUTING.md'
-            logger.error(msg)
+        ensure_core(logger)
 
     elif dev_mode:
-        config.static_dir = pjoin(DEV_DIR, 'build')
-        config.schemas_dir = pjoin(DEV_DIR, 'schemas')
-        config.app_settings_dir = ''
-        config.themes_dir = pjoin(DEV_DIR, 'themes')
-        config.app_version = __version__
-
+        app_dir = DEV_DIR
         ensure_dev(logger)
         if not watch_mode:
             logger.info(DEV_NOTE)
 
+    config.app_settings_dir = pjoin(app_dir, 'settings')
+    config.schemas_dir = pjoin(app_dir, 'schemas')
+    config.themes_dir = pjoin(app_dir, 'themes')
+    info = get_app_info(app_dir)
+    config.app_version = info['version']
+    public_url = info['publicUrl']
+    if public_url:
+        config.public_url = public_url
     else:
         config.static_dir = pjoin(app_dir, 'static')
-        config.schemas_dir = pjoin(app_dir, 'schemas')
-        config.app_settings_dir = pjoin(app_dir, 'settings')
-        config.themes_dir = pjoin(app_dir, 'themes')
-        info = get_app_info(app_dir)
-        config.app_version = info['version']
-        config.public_url = info['data']['jupyterlab']['publicUrl']
 
-    page_config['devMode'] = dev_mode
     config.user_settings_dir = get_user_settings_dir()
-    config.templates_dir = config.static_dir
-
-    page_config['themePath'] = '/lab/api/themes'
-    if 'rc' in __version__:
-        raise ValueError('remove the theme path shim')
+    config.templates_dir = pjoin(app_dir, 'static')
 
     if watch_mode:
         logger.info('Starting JupyterLab watch mode...')
@@ -142,5 +126,9 @@ def load_jupyter_server_extension(nbapp):
     build_url = ujoin(base_url, build_path)
     builder = Builder(logger, core_mode, app_dir)
     build_handler = (build_url, BuildHandler, {'builder': builder})
+
+    page_config['themePath'] = ujoin(base_url, '/lab/api/themes')
+    if 'rc' in __version__:
+        raise ValueError('remove the theme path shim')
 
     web_app.add_handlers(".*$", [build_handler])

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -109,7 +109,7 @@ def load_jupyter_server_extension(nbapp):
         config.schemas_dir = pjoin(app_dir, 'schemas')
         config.app_settings_dir = pjoin(app_dir, 'settings')
         config.themes_dir = pjoin(app_dir, 'themes')
-        config.app_version = get_app_version()
+        config.app_version = get_app_version(app_dir)
 
     page_config['devMode'] = dev_mode
     config.user_settings_dir = get_user_settings_dir()

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -18,7 +18,7 @@ from traitlets import Bool, Unicode
 from .commands import (
     install_extension, uninstall_extension, list_extensions,
     enable_extension, disable_extension, check_extension,
-    link_package, unlink_package, build, get_app_version
+    link_package, unlink_package, build, get_app_version, HERE
 )
 
 
@@ -58,6 +58,8 @@ class BaseExtensionApp(JupyterApp):
         help="Whether temporary files should be cleaned up after building jupyterlab")
 
     def start(self):
+        if self.app_dir and self.app_dir.startswith(HERE):
+            raise ValueError('Cannot run lab extension commands in core app')
         try:
             self.run_task()
         except Exception as ex:

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -123,6 +123,7 @@
       "@jupyterlab/vega2-extension": ""
     },
     "name": "JupyterLab",
+    "buildDir": "./build",
     "outputDir": "..",
     "singletonPackages": [
       "@jupyterlab/application",

--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -110,7 +110,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(buildDir),
-    publicPath: 'lab/static/',
+    publicPath: jlab.publicUrl || 'lab/static/',
     filename: '[name].[chunkhash].js'
   },
   module: {
@@ -165,7 +165,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: path.join('templates', 'template.html'),
-      title: 'JupyterLab'
+      title: jlab.name || 'JupyterLab'
     }),
     new webpack.HashedModuleIdsPlugin(),
     new webpack.optimize.CommonsChunkPlugin({

--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -12,13 +12,6 @@ var webpack = require('webpack');
 var Build = require('@jupyterlab/buildutils').Build;
 var package_data = require('./package.json');
 
-// Ensure a clear build directory.
-var buildDir = path.resolve('./build');
-if (fs.existsSync(buildDir)) {
-  fs.removeSync(buildDir);
-}
-fs.ensureDirSync(buildDir);
-
 // Handle the extensions.
 var jlab = package_data.jupyterlab;
 var extensions = jlab.extensions;
@@ -36,6 +29,13 @@ var data = {
   jupyterlab_mime_extensions: mimeExtensions,
 };
 var result = template(data);
+
+// Ensure a clear build directory.
+var buildDir = path.resolve(jlab.buildDir);
+if (fs.existsSync(buildDir)) {
+  fs.removeSync(buildDir);
+}
+fs.ensureDirSync(buildDir);
 
 fs.writeFileSync(path.join(buildDir, 'index.out.js'), result);
 fs.copySync('./package.json', path.join(buildDir, 'package.json'));

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -355,7 +355,7 @@ class TestExtension(TestCase):
 
     def test_build_custom(self):
         install_extension(self.mock_extension)
-        build(name='foo', version='1.0')
+        build(name='foo', version='1.0', public_url='bar')
 
         # check static directory.
         entry = pjoin(self.app_dir, 'static', 'index.out.js')
@@ -368,6 +368,7 @@ class TestExtension(TestCase):
             data = json.load(fid)
         assert data['jupyterlab']['name'] == 'foo'
         assert data['jupyterlab']['version'] == '1.0'
+        assert data['jupyterlab']['publicUrl'] == 'bar'
 
     def test_load_extension(self):
         app = NotebookApp()


### PR DESCRIPTION
- Use same directory layout for `dev` mode, `core` mode`, and `app` mode, which allows us to use  `_AppHandler` for all, and the same config data lookup
- Add handling of public url as a build parameter
- Fix handling of app version
