### PR TITLE
Fix handling of REST cache

### DIFF
--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -179,7 +179,7 @@ namespace ServerConnection {
     baseUrl: PageConfig.getBaseUrl(),
     wsUrl: PageConfig.getWsUrl(),
     token: PageConfig.getToken(),
-    init: { 'cache': 'no-cache', 'credentials': 'same-origin' },
+    init: { 'cache': 'no-store', 'credentials': 'same-origin' },
     fetch: FETCH,
     Headers: HEADERS,
     Request: REQUEST,


### PR DESCRIPTION
Fixes #3388 by forcing the browser to skip the cache.  cf https://developer.mozilla.org/en-US/docs/Web/API/Request/cache