### PR TITLE
Use full production mode

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "webpack",
-    "build:prod": "webpack --define process.env.NODE_ENV=\"'production'\" --devtool source-map",
+    "build:prod": "webpack -p --devtool source-map",
     "clean": "rimraf build",
     "prepublishOnly": "npm run build",
     "watch": "webpack --watch"


### PR DESCRIPTION
Fixes #3187 

Brings our total bundle size down to ~3MB for vendor and main, compared to ~2MB for the classic notebook `main.min.js` for a notebook page.  Note that the files are each ~1.5Mb and can be loaded in parallel.