### PR TITLE
Use notebook style keyboards shortcuts for console

### DIFF
--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -62,15 +62,6 @@
       "default": { },
       "properties": {
         "command": { "default": "console:linebreak" },
-        "keys": { "default": ["Ctrl Enter"] },
-        "selector": { "default": ".jp-CodeConsole-promptCell" }
-      },
-      "type": "object"
-    },
-    "console:run-unforced": {
-      "default": { },
-      "properties": {
-        "command": { "default": "console:run-unforced" },
         "keys": { "default": ["Enter"] },
         "selector": { "default": ".jp-CodeConsole-promptCell" }
       },


### PR DESCRIPTION
@jasongrout @ian-r-rose @blink1073 @afshin 

In a recent conversation Ian and I talked about switching to use notebook style keyboard shortcuts in the console. This PR implements that, namely:

* Enter = always newline
* Shift + Enter = always run code

The previous version tried to be smart about Enter alone either running code or inserting a newline, but it was different enough from the notebooks behavior, that it was pretty painful to adjust to the different interactions.

Our user testing at JupyterCon 2017 suggests that most users are using shift+enter to run code - I think we should keep to that idea throughout JupyterLab. 