### PR TITLE
Clean up cell selection behavior

### DIFF
--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -592,20 +592,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     widget.mode = 'command';
-    let current = widget.activeCell;
-    let prev = widget.widgets[widget.activeCellIndex - 1];
-    if (widget.isSelected(prev)) {
-      widget.deselect(current);
-      if (widget.activeCellIndex > 1) {
-        let prevPrev = widget.widgets[widget.activeCellIndex - 2];
-        if (!widget.isSelected(prevPrev)) {
-          widget.deselect(prev);
-        }
-      }
-    } else {
-      widget.select(current);
-    }
-    widget.activeCellIndex -= 1;
+    widget.extendContiguousSelectionTo(widget.activeCellIndex - 1);
     Private.handleState(widget, state, true);
   }
 
@@ -629,20 +616,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     widget.mode = 'command';
-    let current = widget.activeCell;
-    let next = widget.widgets[widget.activeCellIndex + 1];
-    if (widget.isSelected(next)) {
-      widget.deselect(current);
-      if (widget.activeCellIndex < widget.model.cells.length - 2) {
-        let nextNext = widget.widgets[widget.activeCellIndex + 2];
-        if (!widget.isSelected(nextNext)) {
-          widget.deselect(next);
-        }
-      }
-    } else {
-      widget.select(current);
-    }
-    widget.activeCellIndex += 1;
+    widget.extendContiguousSelectionTo(widget.activeCellIndex + 1);
     Private.handleState(widget, state, true);
   }
 

--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -146,7 +146,7 @@ namespace NotebookActions {
 
     // Get the cells to merge.
     each(widget.widgets, (child, i) => {
-      if (widget.isSelected(child)) {
+      if (widget.isSelectedOrActive(child)) {
         toMerge.push(child.model.value.text);
         if (i !== index) {
           toDelete.push(child.model);
@@ -281,8 +281,8 @@ namespace NotebookActions {
     let widgets = widget.widgets;
     cells.beginCompoundOperation();
     for (let i = cells.length - 2; i > -1; i--) {
-      if (widget.isSelected(widgets[i])) {
-        if (!widget.isSelected(widgets[i + 1])) {
+      if (widget.isSelectedOrActive(widgets[i])) {
+        if (!widget.isSelectedOrActive(widgets[i + 1])) {
           cells.move(i, i + 1);
           if (widget.activeCellIndex === i) {
             widget.activeCellIndex++;
@@ -311,8 +311,8 @@ namespace NotebookActions {
     let widgets = widget.widgets;
     cells.beginCompoundOperation();
     for (let i = 1; i < cells.length; i++) {
-      if (widget.isSelected(widgets[i])) {
-        if (!widget.isSelected(widgets[i - 1])) {
+      if (widget.isSelectedOrActive(widgets[i])) {
+        if (!widget.isSelectedOrActive(widgets[i - 1])) {
           cells.move(i, i - 1);
           if (widget.activeCellIndex === i) {
             widget.activeCellIndex--;
@@ -760,7 +760,7 @@ namespace NotebookActions {
         const toDelete: number[] = [];
         each(widget.widgets, (child, i) => {
           let deletable = child.model.metadata.get('deletable');
-          if (widget.isSelected(child) && deletable !== false) {
+          if (widget.isSelectedOrActive(child) && deletable !== false) {
             toDelete.push(i);
           }
         });
@@ -872,7 +872,7 @@ namespace NotebookActions {
     let i = 0;
     each(cells, (cell: ICodeCellModel) => {
       let child = widget.widgets[i];
-      if (widget.isSelected(child) && cell.type === 'code') {
+      if (widget.isSelectedOrActive(child) && cell.type === 'code') {
         cell.outputs.clear();
         (child as CodeCell).outputHidden = false;
         cell.executionCount = null;
@@ -922,7 +922,7 @@ namespace NotebookActions {
     let state = Private.getState(widget);
     let cells = widget.widgets;
     each(cells, (cell: Cell) => {
-      if (widget.isSelected(cell) && cell.model.type === 'code') {
+      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         cell.inputHidden = true;
       }
     });
@@ -942,7 +942,7 @@ namespace NotebookActions {
     let state = Private.getState(widget);
     let cells = widget.widgets;
     each(cells, (cell: Cell) => {
-      if (widget.isSelected(cell) && cell.model.type === 'code') {
+      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         cell.inputHidden = false;
       }
     });
@@ -1002,7 +1002,7 @@ namespace NotebookActions {
     let state = Private.getState(widget);
     let cells = widget.widgets;
     each(cells, (cell: Cell) => {
-      if (widget.isSelected(cell) && cell.model.type === 'code') {
+      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).inputHidden = true;
       }
     });
@@ -1022,7 +1022,7 @@ namespace NotebookActions {
     let state = Private.getState(widget);
     let cells = widget.widgets;
     each(cells, (cell: Cell) => {
-      if (widget.isSelected(cell) && cell.model.type === 'code') {
+      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).inputHidden = false;
       }
     });
@@ -1093,7 +1093,7 @@ namespace NotebookActions {
     let cells = widget.model.cells;
     let i = 0;
     each(widget.widgets, (child: MarkdownCell) => {
-      if (widget.isSelected(child)) {
+      if (widget.isSelectedOrActive(child)) {
         Private.setMarkdownHeader(cells.get(i), level);
       }
       i++;
@@ -1235,7 +1235,7 @@ namespace Private {
     let lastIndex = widget.activeCellIndex;
     let i = 0;
     each(widget.widgets, child => {
-      if (widget.isSelected(child)) {
+      if (widget.isSelectedOrActive(child)) {
         selected.push(child);
         lastIndex = i;
       }
@@ -1355,7 +1355,7 @@ namespace Private {
     clipboard.clear();
     let data: nbformat.IBaseCell[] = [];
     each(widget.widgets, child => {
-      if (widget.isSelected(child)) {
+      if (widget.isSelectedOrActive(child)) {
         data.push(child.model.toJSON());
       }
     });
@@ -1388,7 +1388,7 @@ namespace Private {
 
     cells.beginCompoundOperation();
     each(widget.widgets, (child, i) => {
-      if (!widget.isSelected(child)) {
+      if (!widget.isSelectedOrActive(child)) {
         return;
       }
       if (child.model.type !== value) {
@@ -1442,7 +1442,7 @@ namespace Private {
     // Find the cells to delete.
     each(widget.widgets, (child, i) => {
       let deletable = child.model.metadata.get('deletable');
-      if (widget.isSelected(child) && deletable !== false) {
+      if (widget.isSelectedOrActive(child) && deletable !== false) {
         toDelete.push(i);
       }
     });

--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -124,7 +124,7 @@ class CellTools extends Widget {
       return selected;
     }
     each(panel.notebook.widgets, widget => {
-      if (panel.notebook.isSelected(widget)) {
+      if (panel.notebook.isSelectedOrActive(widget)) {
         selected.push(widget);
       }
     });

--- a/packages/notebook/src/default-toolbar.ts
+++ b/packages/notebook/src/default-toolbar.ts
@@ -315,7 +315,7 @@ class CellTypeSwitcher extends Widget {
     let mType: string = widget.activeCell.model.type;
     for (let i = 0; i < widget.widgets.length; i++) {
       let child = widget.widgets[i];
-      if (widget.isSelected(child)) {
+      if (widget.isSelectedOrActive(child)) {
         if (child.model.type !== mType) {
           mType = '-';
           select.appendChild(this._wildCard);

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1362,15 +1362,11 @@ class Notebook extends StaticNotebook {
       }
       if (event.shiftKey) {
         shouldDrag = false;
-        this.extendContiguousSelectionTo(i);
 
         // Prevent text select behavior.
         event.preventDefault();
         event.stopPropagation();
       }
-      // Set the cell as the active one.
-      // This must be done *after* setting the mode above.
-      this.activeCellIndex = i;
     }
 
     this._ensureFocus(true);
@@ -1388,8 +1384,16 @@ class Notebook extends StaticNotebook {
    * Handle the `'mouseup'` event for the widget.
    */
   private _evtMouseup(event: MouseEvent): void {
-    if (!this._drag) {
+    if (this._drag) {
+      return;
+    }
+    let target = event.target as HTMLElement;
+    let i = this._findCell(target);
+    if (event.shiftKey) {
+      this.extendContiguousSelectionTo(i);
+    } else {
       this.deselectAll();
+      this.activeCellIndex = i;
     }
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1266,7 +1266,7 @@ class Notebook extends StaticNotebook {
     // cell index, otherwise it stays the same.
     this.activeCellIndex = index <= this.activeCellIndex ?
       this.activeCellIndex - 1 : this.activeCellIndex ;
-    if (this.isSelectedOrActive(cell)) {
+    if (this.isSelected(cell)) {
       this._selectionChanged.emit(void 0);
     }
   }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1368,16 +1368,22 @@ class Notebook extends StaticNotebook {
       }
 
       if (event.shiftKey) {
-        this.extendContiguousSelectionTo(index);
+        // Prevent text select behavior.
+        event.preventDefault();
+        event.stopPropagation();
 
+        try {
+          this.extendContiguousSelectionTo(index);
+        } catch (e) {
+          console.error(e);
+          this.deselectAll();
+          return;
+        }
         // Enter selecting mode
         this._mouseMode = 'select';
         document.addEventListener('mouseup', this, true);
         document.addEventListener('mousemove', this, true);
 
-        // Prevent text select behavior.
-        event.preventDefault();
-        event.stopPropagation();
       } else {
         // Check if we need to change the active cell.
         if (!this.isSelectedOrActive(widget)) {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -945,10 +945,15 @@ class Notebook extends StaticNotebook {
   /**
    * Move the head of an existing contiguous selection to extend the selection.
    *
-   * If the new selection is a single cell, that becomes the active cell and all
-   * cells are deselected.
+   * @param index - The new head of the existing selection.
    *
-   * #### Note
+   * #### Notes
+   * If there is no existing selection, the active cell is considered an
+   * existing one-cell selection.
+   *
+   * If the new selection is a single cell, that cell becomes the active cell
+   * and all cells are deselected.
+   *
    * There is no change if there are no cells (i.e., activeCellIndex is -1).
    */
   extendContiguousSelectionTo(index: number): void {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1451,6 +1451,8 @@ class Notebook extends StaticNotebook {
         this._startDrag(data.index, event.clientX, event.clientY);
       }
       break;
+    default:
+      break;
     }
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -970,9 +970,8 @@ class Notebook extends StaticNotebook {
     // Move the active cell. We do this before the collapsing shortcut below.
     this.activeCellIndex = index;
 
-    // Make sure the index is valid, according to the rules for setting the
-    // active cell. This may change the index, based on the rules for clipping
-    // the active cell index.
+    // Make sure the index is valid, according to the rules for setting and clipping the
+    // active cell index. This may change the index.
     index = this.activeCellIndex;
 
     // Collapse the selection if it is only the active cell.

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -907,9 +907,16 @@ class Notebook extends StaticNotebook {
   }
 
   /**
-   * Whether a cell is selected or is the active cell.
+   * Whether a cell is selected.
    */
   isSelected(widget: Cell): boolean {
+    return Private.selectedProperty.get(widget);
+  }
+
+  /**
+   * Whether a cell is selected or is the active cell.
+   */
+  isSelectedOrActive(widget: Cell): boolean {
     if (widget === this._activeCell) {
       return true;
     }
@@ -1071,7 +1078,7 @@ class Notebook extends StaticNotebook {
         widget.removeClass(ACTIVE_CLASS);
       }
       widget.removeClass(OTHER_SELECTED_CLASS);
-      if (this.isSelected(widget)) {
+      if (this.isSelectedOrActive(widget)) {
         widget.addClass(SELECTED_CLASS);
         count++;
       } else {
@@ -1125,7 +1132,7 @@ class Notebook extends StaticNotebook {
     // cell index, otherwise it stays the same.
     this.activeCellIndex = index <= this.activeCellIndex ?
       this.activeCellIndex - 1 : this.activeCellIndex ;
-    if (this.isSelected(cell)) {
+    if (this.isSelectedOrActive(cell)) {
       this._selectionChanged.emit(void 0);
     }
   }
@@ -1440,7 +1447,7 @@ class Notebook extends StaticNotebook {
 
     each(this.widgets, (widget, i) => {
       let cell = cells.get(i);
-      if (this.isSelected(widget)) {
+      if (this.isSelectedOrActive(widget)) {
         widget.addClass(DROP_SOURCE_CLASS);
         selected.push(cell.toJSON());
         toMove.push(widget);

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1110,13 +1110,14 @@ class Notebook extends StaticNotebook {
       this._evtMouseDown(event as MouseEvent);
       break;
     case 'mouseup':
-      this._evtMouseup(event as MouseEvent);
-      if (event.target === document) {
+      if (event.currentTarget === this.node) {
+        this._evtMouseup(event as MouseEvent);
+      } else if (event.currentTarget === document) {
         this._evtDocumentMouseup(event as MouseEvent);
       }
       break;
     case 'mousemove':
-      if (event.target === document) {
+      if (event.currentTarget === document) {
         this._evtDocumentMousemove(event as MouseEvent);
       }
       break;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1390,6 +1390,10 @@ class Notebook extends StaticNotebook {
     }
     let target = event.target as HTMLElement;
     let i = this._findCell(target);
+    if (i == -1) {
+      this.deselectAll();
+      return;
+    }
     if (event.shiftKey) {
       this.extendContiguousSelectionTo(i);
     } else {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1007,7 +1007,7 @@ class Notebook extends StaticNotebook {
         selectionChanged = true;
       }
 
-      // Toggle everything strictly between head and index except anchor.
+      // Toggle everything strictly between index and head except anchor.
       for (i = index + 1; i < head; i++) {
         if (i !== anchor) {
           Private.selectedProperty.set(this.widgets[i], !Private.selectedProperty.get(this.widgets[i]));

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1255,8 +1255,13 @@ class Notebook extends StaticNotebook {
    * Handle a cell being moved.
    */
   protected onCellMoved(fromIndex: number, toIndex: number): void {
-    if (fromIndex === this.activeCellIndex) {
+    let i = this.activeCellIndex;
+    if (fromIndex === i) {
       this.activeCellIndex = toIndex;
+    } else if (fromIndex < i && i <= toIndex) {
+      this.activeCellIndex--;
+    } else if (toIndex <= i && i < fromIndex) {
+      this.activeCellIndex++;
     }
   }
 
@@ -1552,10 +1557,8 @@ class Notebook extends StaticNotebook {
       if (toIndex >= fromIndex && toIndex < fromIndex + toMove.length) {
         return;
       }
-      let relativeActiveIndex = this.activeCellIndex - fromIndex;
 
       // Move the cells one by one
-      let start = toIndex;
       this.model.cells.beginCompoundOperation();
       if (fromIndex < toIndex) {
         each(toMove, (cellWidget) => {
@@ -1567,8 +1570,6 @@ class Notebook extends StaticNotebook {
         });
       }
       this.model.cells.endCompoundOperation();
-
-      this.activeCellIndex = start + relativeActiveIndex;
     } else {
       // Handle the case where we are copying cells between
       // notebooks.

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -965,11 +965,11 @@ class Notebook extends StaticNotebook {
       if (index === this.activeCellIndex) {
         // Already collapsed selection, nothing more to do.
         return;
-      } else {
-        // We will start a new selection below.
-        head = this.activeCellIndex;
-        anchor = this.activeCellIndex;
       }
+
+      // We will start a new selection below.
+      head = this.activeCellIndex;
+      anchor = this.activeCellIndex;
     }
 
     // Move the active cell. We do this before the collapsing shortcut below.

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1562,6 +1562,7 @@ class Notebook extends StaticNotebook {
       if (index === -1) {
         index = this.widgets.length;
       }
+      let start = index;
       let model = this.model;
       let values = event.mimeData.getData(JUPYTER_CELL_MIME);
       let factory = model.contentFactory;
@@ -1584,8 +1585,10 @@ class Notebook extends StaticNotebook {
         model.cells.insert(index++, value);
       });
       model.cells.endCompoundOperation();
-      // Activate the last cell.
-      this.activeCellIndex = index - 1;
+      // Select the inserted cells.
+      this.deselectAll();
+      this.activeCellIndex = start;
+      this.extendContiguousSelectionTo(index - 1);
     }
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -980,36 +980,51 @@ class Notebook extends StaticNotebook {
       return;
     }
 
+    let selectionChanged = false;
+
     if (head < index) {
       if (head < anchor) {
         Private.selectedProperty.set(this.widgets[head], false);
+        selectionChanged = true;
       }
 
       // Toggle everything strictly between head and index except anchor.
       for (i = head + 1; i < index; i++) {
         if (i !== anchor) {
           Private.selectedProperty.set(this.widgets[i], !Private.selectedProperty.get(this.widgets[i]));
+          selectionChanged = true;
         }
       }
 
     } else if (index < head) {
       if (anchor < head) {
         Private.selectedProperty.set(this.widgets[head], false);
+        selectionChanged = true;
       }
 
       // Toggle everything strictly between head and index except anchor.
       for (i = index + 1; i < head; i++) {
         if (i !== anchor) {
           Private.selectedProperty.set(this.widgets[i], !Private.selectedProperty.get(this.widgets[i]));
+          selectionChanged = true;
         }
       }
     }
 
     // Anchor and index should *always* be selected.
+    if (!Private.selectedProperty.get(this.widgets[anchor])) {
+      selectionChanged = true;
+    }
     Private.selectedProperty.set(this.widgets[anchor], true);
+
+    if (!Private.selectedProperty.get(this.widgets[index])) {
+      selectionChanged = true;
+    }
     Private.selectedProperty.set(this.widgets[index], true);
 
-    this._selectionChanged.emit(void 0);
+    if (selectionChanged) {
+      this._selectionChanged.emit(void 0);
+    }
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1092,9 +1092,14 @@ class Notebook extends StaticNotebook {
       break;
     case 'mouseup':
       this._evtMouseup(event as MouseEvent);
+      if (event.target === document) {
+        this._evtDocumentMouseup(event as MouseEvent);
+      }
       break;
     case 'mousemove':
-      this._evtMousemove(event as MouseEvent);
+      if (event.target === document) {
+        this._evtDocumentMousemove(event as MouseEvent);
+      }
       break;
     case 'keydown':
       this._ensureFocus(true);
@@ -1132,6 +1137,7 @@ class Notebook extends StaticNotebook {
     super.onAfterAttach(msg);
     let node = this.node;
     node.addEventListener('mousedown', this);
+    node.addEventListener('mouseup', this);
     node.addEventListener('keydown', this);
     node.addEventListener('dblclick', this);
     node.addEventListener('focus', this, true);
@@ -1148,6 +1154,7 @@ class Notebook extends StaticNotebook {
   protected onBeforeDetach(msg: Message): void {
     let node = this.node;
     node.removeEventListener('mousedown', this);
+    node.removeEventListener('mouseup', this);
     node.removeEventListener('keydown', this);
     node.removeEventListener('dblclick', this);
     node.removeEventListener('focus', this, true);
@@ -1336,15 +1343,11 @@ class Notebook extends StaticNotebook {
       }
       if (event.shiftKey) {
         shouldDrag = false;
-        this._extendSelectionTo(i);
+        this.extendContiguousSelectionTo(i);
 
         // Prevent text select behavior.
         event.preventDefault();
         event.stopPropagation();
-      } else {
-        if (!this.isSelected(widget)) {
-          this.deselectAll();
-        }
       }
       // Set the cell as the active one.
       // This must be done *after* setting the mode above.
@@ -1362,11 +1365,19 @@ class Notebook extends StaticNotebook {
     }
   }
 
-
   /**
    * Handle the `'mouseup'` event for the widget.
    */
   private _evtMouseup(event: MouseEvent): void {
+    if (!this._drag) {
+      this.deselectAll();
+    }
+  }
+
+  /**
+   * Handle the `'mouseup'` event for the drag.
+   */
+  private _evtDocumentMouseup(event: MouseEvent): void {
     if (event.button !== 0 || !this._drag) {
       document.removeEventListener('mousemove', this, true);
       document.removeEventListener('mouseup', this, true);
@@ -1379,7 +1390,7 @@ class Notebook extends StaticNotebook {
   /**
    * Handle the `'mousemove'` event for the widget.
    */
-  private _evtMousemove(event: MouseEvent): void {
+  private _evtDocumentMousemove(event: MouseEvent): void {
     event.preventDefault();
     event.stopPropagation();
 

--- a/test/src/notebook/actions.spec.ts
+++ b/test/src/notebook/actions.spec.ts
@@ -887,7 +887,7 @@ describe('@jupyterlab/notebook', () => {
         expect(widget.activeCellIndex).to.be(-1);
       });
 
-      it('should change to command mode', () => {
+      it('should change to command mode if there is a selection', () => {
         widget.mode = 'edit';
         widget.activeCellIndex = 1;
         NotebookActions.extendSelectionAbove(widget);
@@ -895,10 +895,12 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should not wrap around to the bottom', () => {
+        widget.mode = 'edit';
         NotebookActions.extendSelectionAbove(widget);
         expect(widget.activeCellIndex).to.be(0);
         let last = widget.widgets[widget.widgets.length - 1];
         expect(widget.isSelected(last)).to.be(false);
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should deselect the current cell if the cell above is selected', () => {
@@ -939,18 +941,20 @@ describe('@jupyterlab/notebook', () => {
         expect(widget.activeCellIndex).to.be(-1);
       });
 
-      it('should change to command mode', () => {
+      it('should change to command mode if there is a selection', () => {
         widget.mode = 'edit';
         NotebookActions.extendSelectionBelow(widget);
         expect(widget.mode).to.be('command');
       });
 
-      it('should not wrap around to the bottom', () => {
+      it('should not wrap around to the top', () => {
         let last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
+        widget.mode = 'edit';
         NotebookActions.extendSelectionBelow(widget);
         expect(widget.activeCellIndex).to.be(last);
         expect(widget.isSelected(widget.widgets[0])).to.be(false);
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should deselect the current cell if the cell below is selected', () => {

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -912,6 +912,12 @@ describe('notebook/widget', () => {
           widget.select(widget.widgets[0]);
           widget.select(widget.widgets[1]);
           widget.select(widget.widgets[2]);
+
+          // mousedown doesn't deselect
+          simulate(widget.widgets[0].node, 'mousedown');
+          expect(selected(widget)).to.eql([0, 1, 2]);
+
+          // mouseup does deselect when we aren't dragging
           simulate(widget.widgets[0].node, 'mouseup');
           expect(selected(widget)).to.eql([0]);
         });

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -1191,24 +1191,6 @@ describe('notebook/widget', () => {
 
       });
 
-      context('mouseup', () => {
-
-        it('should deselect cells if not dragging', () => {
-          widget.select(widget.widgets[0]);
-          widget.select(widget.widgets[1]);
-          widget.select(widget.widgets[2]);
-
-          // mousedown doesn't deselect
-          simulate(widget.widgets[0].node, 'mousedown');
-          expect(selected(widget)).to.eql([0, 1, 2]);
-
-          // mouseup does deselect when we aren't dragging
-          simulate(widget.widgets[0].node, 'mouseup');
-          expect(selected(widget)).to.eql([]);
-        });
-
-      });
-
       context('dblclick', () => {
 
         it('should unrender a markdown cell', () => {

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -878,7 +878,7 @@ describe('notebook/widget', () => {
         widget.dispose();
       });
 
-      it('should work in each distinct permutation of head, anchor, and index', () => {
+      it('should work in each permutation of anchor, head, and index', () => {
         let checkSelection = (anchor: number, head: number, index: number, select = true) => {
           // Set up the test by pre-selecting appropriate cells if select is true.
           if (select) {
@@ -940,9 +940,9 @@ describe('notebook/widget', () => {
         };
 
 
-        // Lists are of the form [head, anchor, index].
+        // Lists are of the form [anchor, head, index].
         let permutations = [
-          // Head, anchor, and index are distinct
+          // Anchor, head, and index are distinct
           [1, 3, 5],
           [1, 5, 3],
           [3, 1, 5],
@@ -950,12 +950,12 @@ describe('notebook/widget', () => {
           [5, 1, 3],
           [5, 3, 1],
 
-          // Two of head, anchor, and index are equal
+          // Two of anchor, head, and index are equal
           [1, 3, 3],
           [3, 1, 3],
           [3, 3, 1],
 
-          // Head, anchor, and index all equal
+          // Anchor, head, and index all equal
           [3, 3, 3]
 
         ];
@@ -967,7 +967,7 @@ describe('notebook/widget', () => {
           checkSelection(p[0], p[1], Number.MAX_SAFE_INTEGER);
           checkSelection(p[0], p[1], -10);
 
-          // If head and anchor are the same, also check when we only have an
+          // If anchor and head are the same, also check when we only have an
           // active cell, with no selection.
           if (p[0] === p[1]) {
             checkSelection(p[0], p[1], p[2], false);

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -890,6 +890,12 @@ describe('notebook/widget', () => {
           // Set the active cell to indicate the head of the selection.
           widget.activeCellIndex = head;
 
+          // Set up a selection event listener.
+          let selectionChanged = 0;
+          widget.selectionChanged.connect((sender, args) => {
+            selectionChanged += 1;
+          })
+
           // Check the contiguous selection.
           let selection = widget.getContiguousSelection();
           if (select) {
@@ -911,6 +917,14 @@ describe('notebook/widget', () => {
 
           // Check the contiguous selection.
           selection = widget.getContiguousSelection();
+
+
+          // Check the selection changed signal was emitted once if necessary.
+          if (head === index) {
+            expect(selectionChanged).to.be(0);
+          } else {
+            expect(selectionChanged).to.be(1);
+          }
 
           if (anchor !== index) {
             expect(selection.anchor).to.be.equal(anchor);
@@ -967,8 +981,18 @@ describe('notebook/widget', () => {
 
       it.only('handles the case of no cells', () => {
         widget.model.cells.clear();
+
+        // Set up a selection event listener.
+        let selectionChanged = 0;
+        widget.selectionChanged.connect((sender, args) => {
+          selectionChanged += 1;
+        })
+
         widget.extendContiguousSelectionTo(3);
+
         expect(widget.activeCellIndex).to.be(-1);
+        expect(selectionChanged).to.be(0);
+
       });
 
     });

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -844,7 +844,7 @@ describe('notebook/widget', () => {
         expect(selected(widget)).to.eql([]);
         widget.select(widget.activeCell);
         expect(selected(widget)).to.eql([widget.activeCellIndex]);
-      })
+      });
 
     });
 
@@ -1033,7 +1033,6 @@ describe('notebook/widget', () => {
 
         expect(widget.activeCellIndex).to.be(-1);
         expect(selectionChanged).to.be(0);
-
       });
 
     });
@@ -1066,7 +1065,6 @@ describe('notebook/widget', () => {
         // Check if active cell is inside selection.
         widget.activeCellIndex = 2;
         expect(() => widget.getContiguousSelection()).to.throwError(/Active cell not at endpoint of selection/);
-
       });
 
       it('returns null values if there is no selection', () => {

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -1038,6 +1038,93 @@ describe('notebook/widget', () => {
 
     });
 
+    describe('#getContiguousSelection()', () => {
+
+      it('throws an error when the selection is not contiguous', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+
+        widget.select(widget.widgets[1]);
+        widget.select(widget.widgets[3]);
+        widget.activeCellIndex = 3;
+
+        expect(() => widget.getContiguousSelection()).to.throwError(/Selection not contiguous/);
+      });
+
+      it('throws an error if the active cell is not at an endpoint', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+
+        widget.select(widget.widgets[1]);
+        widget.select(widget.widgets[2]);
+        widget.select(widget.widgets[3]);
+
+        // Check if active cell is outside selection.
+        widget.activeCellIndex = 0;
+        expect(() => widget.getContiguousSelection()).to.throwError(/Active cell not at endpoint of selection/);
+
+        // Check if active cell is inside selection.
+        widget.activeCellIndex = 2;
+        expect(() => widget.getContiguousSelection()).to.throwError(/Active cell not at endpoint of selection/);
+
+      });
+
+      it('returns null values if there is no selection', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+
+        let selection = widget.getContiguousSelection();
+        expect(selection).to.eql({head: null, anchor: null});
+      });
+
+      it('handles the case of no cells', () => {
+        let widget = createActiveWidget();
+        widget.model.cells.clear();
+        expect(widget.widgets.length).to.be(0);
+
+        let selection = widget.getContiguousSelection();
+        expect(selection).to.eql({head: null, anchor: null});
+      });
+
+      it('works if head is before the anchor', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+
+        widget.select(widget.widgets[1]);
+        widget.select(widget.widgets[2]);
+        widget.select(widget.widgets[3]);
+        widget.activeCellIndex = 1;
+
+        let selection = widget.getContiguousSelection();
+        expect(selection).to.eql({head: 1, anchor: 3});
+      });
+
+      it('works if head is after the anchor', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+
+        widget.select(widget.widgets[1]);
+        widget.select(widget.widgets[2]);
+        widget.select(widget.widgets[3]);
+        widget.activeCellIndex = 3;
+
+        let selection = widget.getContiguousSelection();
+        expect(selection).to.eql({head: 3, anchor: 1});
+      });
+
+      it('works if head and anchor are the same', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+
+        widget.select(widget.widgets[3]);
+        widget.activeCellIndex = 3;
+
+        let selection = widget.getContiguousSelection();
+        expect(selection).to.eql({head: 3, anchor: 3});
+      });
+
+    });
+
     describe('#handleEvent()', () => {
 
       let widget: LogNotebook;

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -681,10 +681,11 @@ describe('notebook/widget', () => {
         widget.model.fromJSON(DEFAULT_CONTENT);
         Widget.attach(widget, document.body);
         requestAnimationFrame(() => {
+          widget.extendContiguousSelectionTo(widget.widgets.length - 1);
           let selectedRange = Array.from(Array(widget.widgets.length).keys());
           expect(selected(widget)).to.eql(selectedRange);
           widget.mode = 'edit';
-          expect(selected(widget)).to.eql([widget.activeCellIndex]);
+          expect(selected(widget)).to.eql([]);
           widget.dispose();
           done();
         });
@@ -806,9 +807,6 @@ describe('notebook/widget', () => {
         let widget = createActiveWidget();
         widget.model.fromJSON(DEFAULT_CONTENT);
         for (let i = 0; i < widget.widgets.length; i++) {
-          if (i === widget.activeCellIndex) {
-            continue;
-          }
           let cell = widget.widgets[i];
           widget.select(cell);
           expect(widget.isSelected(cell)).to.be(true);
@@ -817,14 +815,16 @@ describe('notebook/widget', () => {
         }
       });
 
-      it('should have no effect on the active cell', () => {
+      it('should let the active cell be deselected', () => {
         let widget = createActiveWidget();
         widget.model.fromJSON(DEFAULT_CONTENT);
-        let cell = widget.widgets[widget.activeCellIndex];
+        let cell = widget.activeCell;
+        widget.select(cell);
         expect(widget.isSelected(cell)).to.be(true);
         widget.deselect(cell);
-        expect(widget.isSelected(cell)).to.be(true);
+        expect(widget.isSelected(cell)).to.be(false);
       });
+
 
     });
 
@@ -833,8 +833,18 @@ describe('notebook/widget', () => {
       it('should get whether the cell is selected', () => {
         let widget = createActiveWidget();
         widget.model.fromJSON(DEFAULT_CONTENT);
-        expect(selected(widget)).to.eql([widget.activeCellIndex]);
+        widget.select(widget.widgets[0]);
+        widget.select(widget.widgets[2]);
+        expect(selected(widget)).to.eql([0, 2]);
       });
+
+      it('reports selection whether or not cell is active', () => {
+        let widget = createActiveWidget();
+        widget.model.fromJSON(DEFAULT_CONTENT);
+        expect(selected(widget)).to.eql([]);
+        widget.select(widget.activeCell);
+        expect(selected(widget)).to.eql([widget.activeCellIndex]);
+      })
 
     });
 
@@ -919,7 +929,7 @@ describe('notebook/widget', () => {
 
           // mouseup does deselect when we aren't dragging
           simulate(widget.widgets[0].node, 'mouseup');
-          expect(selected(widget)).to.eql([0]);
+          expect(selected(widget)).to.eql([]);
         });
 
       });

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -140,6 +140,18 @@ function createActiveWidget(): LogNotebook {
 }
 
 
+function selected(nb: Notebook): number[] {
+    const selected = [];
+    const cells = nb.widgets;
+    for (let i = 0; i < cells.length; i++) {
+      if (nb.isSelected(cells[i])) {
+        selected.push(i);
+      }
+    }
+    return selected;
+}
+
+
 describe('notebook/widget', () => {
 
   describe('StaticNotebook', () => {
@@ -669,19 +681,10 @@ describe('notebook/widget', () => {
         widget.model.fromJSON(DEFAULT_CONTENT);
         Widget.attach(widget, document.body);
         requestAnimationFrame(() => {
-          for (let i = 0; i < widget.widgets.length; i++) {
-            let cell = widget.widgets[i];
-            widget.select(cell);
-            expect(widget.isSelected(cell)).to.be(true);
-          }
+          let selectedRange = Array.from(Array(widget.widgets.length).keys());
+          expect(selected(widget)).to.eql(selectedRange);
           widget.mode = 'edit';
-          for (let i = 0; i < widget.widgets.length; i++) {
-            if (i === widget.activeCellIndex) {
-              continue;
-            }
-            let cell = widget.widgets[i];
-            expect(widget.isSelected(cell)).to.be(false);
-          }
+          expect(selected(widget)).to.eql([widget.activeCellIndex]);
           widget.dispose();
           done();
         });
@@ -790,11 +793,9 @@ describe('notebook/widget', () => {
       it('should allow multiple widgets to be selected', () => {
         let widget = createActiveWidget();
         widget.model.fromJSON(DEFAULT_CONTENT);
-        for (let i = 0; i < widget.widgets.length; i++) {
-          let cell = widget.widgets[i];
-          widget.select(cell);
-          expect(widget.isSelected(cell)).to.be(true);
-        }
+        widget.widgets.forEach(cell => { widget.select(cell); });
+        let expectSelected = Array.from(Array(widget.widgets.length).keys());
+        expect(selected(widget)).to.eql(expectSelected);
       });
 
     });
@@ -832,14 +833,7 @@ describe('notebook/widget', () => {
       it('should get whether the cell is selected', () => {
         let widget = createActiveWidget();
         widget.model.fromJSON(DEFAULT_CONTENT);
-        for (let i = 0; i < widget.widgets.length; i++) {
-          let cell = widget.widgets[i];
-          if (i === widget.activeCellIndex) {
-            expect(widget.isSelected(cell)).to.be(true);
-          } else {
-            expect(widget.isSelected(cell)).to.be(false);
-          }
-        }
+        expect(selected(widget)).to.eql([widget.activeCellIndex]);
       });
 
     });
@@ -887,17 +881,6 @@ describe('notebook/widget', () => {
         });
 
         it('should extend selection if invoked with shift', () => {
-          const selected = (nb: Notebook) => {
-            const selected = [];
-            const cells = nb.widgets;
-            for (let i = 0; i < cells.length; i++) {
-              if (nb.isSelected(cells[i])) {
-                selected.push(i);
-              }
-            }
-            return selected;
-          };
-
           widget.activeCellIndex = 3;
 
           // shift click below

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -1027,7 +1027,7 @@ describe('notebook/widget', () => {
         let selectionChanged = 0;
         widget.selectionChanged.connect((sender, args) => {
           selectionChanged += 1;
-        })
+        });
 
         widget.extendContiguousSelectionTo(3);
 

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -865,6 +865,7 @@ describe('notebook/widget', () => {
           let child = widget.widgets[1];
           simulate(child.node, 'mousedown');
           expect(widget.events).to.contain('mousedown');
+          expect(widget.isSelected(widget.widgets[0])).to.be(false);
           expect(widget.activeCellIndex).to.be(1);
         });
 
@@ -883,6 +884,42 @@ describe('notebook/widget', () => {
           simulate(child.node, 'mousedown');
           expect(child.rendered).to.be(true);
           expect(widget.activeCell).to.be(child);
+        });
+
+        it('should extend selection if invoked with shift', () => {
+          const selected = (nb: Notebook) => {
+            const selected = [];
+            const cells = nb.widgets;
+            for (let i = 0; i < cells.length; i++) {
+              if (nb.isSelected(cells[i])) {
+                selected.push(i);
+              }
+            }
+            return selected;
+          };
+
+          widget.activeCellIndex = 3;
+
+          // shift click below
+          simulate(widget.widgets[4].node, 'mousedown', {shiftKey: true});
+          expect(widget.activeCellIndex).to.be(4);
+          expect(selected(widget)).to.eql([3, 4]);
+
+          // shift click above
+          simulate(widget.widgets[1].node, 'mousedown', {shiftKey: true});
+          expect(widget.activeCellIndex).to.be(1);
+          expect(selected(widget)).to.eql([1, 2, 3]);
+
+          // shift click expand
+          simulate(widget.widgets[0].node, 'mousedown', {shiftKey: true});
+          expect(widget.activeCellIndex).to.be(0);
+          expect(selected(widget)).to.eql([0, 1, 2, 3]);
+
+          // shift click contract
+          simulate(widget.widgets[2].node, 'mousedown', {shiftKey: true});
+          expect(widget.activeCellIndex).to.be(2);
+          expect(selected(widget)).to.eql([2, 3]);
+
         });
 
       });

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -902,7 +902,18 @@ describe('notebook/widget', () => {
           simulate(widget.widgets[2].node, 'mousedown', {shiftKey: true});
           expect(widget.activeCellIndex).to.be(2);
           expect(selected(widget)).to.eql([2, 3]);
+        });
 
+      });
+
+      context('mouseup', () => {
+
+        it('should deselect cells if not dragging', () => {
+          widget.select(widget.widgets[0]);
+          widget.select(widget.widgets[1]);
+          widget.select(widget.widgets[2]);
+          simulate(widget.widgets[0].node, 'mouseup');
+          expect(selected(widget)).to.eql([0]);
         });
 
       });

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -1472,7 +1472,7 @@ describe('notebook/widget', () => {
           widget.model.cells.move(fromIndex, toIndex);
           expect(widget.activeCellIndex).to.be(activeIndex);
           expect(widget.widgets[activeIndex]).to.be(cell);
-        })
+        });
       });
 
     });

--- a/test/src/notebook/widget.spec.ts
+++ b/test/src/notebook/widget.spec.ts
@@ -1468,9 +1468,29 @@ describe('notebook/widget', () => {
 
       it('should update the active cell index if necessary', () => {
         let widget = createActiveWidget();
-        widget.model.fromJSON(DEFAULT_CONTENT);
-        widget.model.cells.move(1, 0);
-        expect(widget.activeCellIndex).to.be(0);
+
+        // [fromIndex, toIndex, activeIndex], starting with activeIndex=3.
+        let moves = [
+          [0, 2, 3],
+          [0, 3, 2],
+          [0, 4, 2],
+          [3, 2, 2],
+          [3, 3, 3],
+          [3, 4, 4],
+          [4, 2, 4],
+          [4, 3, 4],
+          [4, 5, 3]
+        ];
+
+        moves.forEach((m) => {
+          let [fromIndex, toIndex, activeIndex] = m;
+          widget.model.fromJSON(DEFAULT_CONTENT);
+          let cell = widget.widgets[3];
+          widget.activeCellIndex = 3;
+          widget.model.cells.move(fromIndex, toIndex);
+          expect(widget.activeCellIndex).to.be(activeIndex);
+          expect(widget.widgets[activeIndex]).to.be(cell);
+        })
       });
 
     });


### PR DESCRIPTION
This PR:

* disambiguates *selected* from *active* at the notebook widget level. There is a new function `isSelectedOrActive` that is the equivalent of the previous `isSelected`, and now `isSelected` and friends only refer to the selected property of a cell.
* introduces a contiguous cell selection framework on the notebook widget. A contiguous selection is a single contiguous sequence of selected cells with the active cell at one end of the selection. The `head` of the selection is the active cell, and the `anchor` is the other end of the selection. Comprehensive tests are included for this framework.
* Converts all selection UX to use the contiguous selection framework
* Enhances the user interaction for selection so that it behaves more like text selection - shift-click and shift-drag updates a selection, clicking outside deselects all, etc.
* Fixes a bug in updating the active cell index when a cell is moved
* Other refactoring as necessary.

Fixes #3373.

Another PR should create comprehensive tests for the UX around selection, particularly with keyboard handling and mouse events.