### PR TITLE
Improved UX for cell output view.

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -633,6 +633,17 @@ class CodeCell extends Cell {
   }
 
   /**
+   * Clone the OutputArea alone, using the same model.
+   */
+  cloneOutputArea(): OutputArea {
+    return new OutputArea({
+      model: this.model.outputs,
+      contentFactory: this.contentFactory,
+      rendermime: this._rendermime,
+    });
+  }
+
+  /**
    * Dispose of the resources used by the widget.
    */
   dispose(): void {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -95,9 +95,11 @@ const plugin: JupyterLabPlugin<IDocumentManager> = {
           app.shell.addToMainArea(widget);
 
           // Add a loading spinner, and remove it when the widget is ready.
-          let spinner = new Spinner();
-          widget.node.appendChild(spinner.node);
-          widget.ready.then(() => { widget.node.removeChild(spinner.node); });
+          if (widget.ready !== undefined) {
+            let spinner = new Spinner();
+            widget.node.appendChild(spinner.node);
+            widget.ready.then(() => { widget.node.removeChild(spinner.node); });
+          }
         }
         app.shell.activateById(widget.id);
 

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@jupyterlab/application": "^0.13.1",
     "@jupyterlab/apputils": "^0.13.1",
+    "@jupyterlab/cells": "^0.13.0",
     "@jupyterlab/codeeditor": "^0.13.0",
     "@jupyterlab/coreutils": "^0.13.0",
     "@jupyterlab/filebrowser": "^0.13.2",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1166,7 +1166,9 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
       layout.addWidget(outputAreaView);
       shell.addToMainArea(widget);
       // Remove the output view if the parent notebook is closed.
-      nb.disposed.connect(() => {widget.dispose();})
+      nb.disposed.connect(
+        () => { widget.dispose(); }
+      );
     },
     isEnabled
   });

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1153,18 +1153,15 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
       toolbar.addClass('jp-LinkedOutputView-toolbar');
       // Create a MainAreaWidget
       const layout = new PanelLayout();
-      const widget = new MainAreaWidget({layout: layout});
+      const widget = new MainAreaWidget({ layout });
       widget.id = `LinkedOutputView-${uuid()}`;
-      widget.title.closable = true;
       widget.title.label = 'Output View';
       widget.title.icon = NOTEBOOK_ICON_CLASS;
       widget.title.caption = current.title.label ? `For Notebook: ${current.title.label}` : 'For Notebook:';
       widget.addClass('jp-LinkedOutputView');
-      // Allow the widget to take focus if needed, helpful for working with jupyter widgets.
-      widget.node.tabIndex = -1;
       layout.addWidget(toolbar);
       layout.addWidget(outputAreaView);
-      shell.addToMainArea(widget);
+      current.context.addSibling(widget);
       // Remove the output view if the parent notebook is closed.
       nb.disposed.connect(
         () => { widget.dispose(); }

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -282,3 +282,27 @@
 .jp-KeySelector label {
   line-height: 1.4;
 }
+
+
+/*-----------------------------------------------------------------------------
+| Output Area View
+|----------------------------------------------------------------------------*/
+
+
+.jp-LinkedOutputView .jp-OutputArea-prompt {
+  display: none;
+}
+
+
+.jp-LinkedOutputView .jp-OutputArea {
+  height: 100%;
+  padding: var(--jp-notebook-padding) 0px var(--jp-notebook-padding) var(--jp-notebook-padding);
+}
+
+
+.jp-LinkedOutputView-toolbar {
+  box-shadow: var(--jp-toolbar-box-shadow);
+  background: var(--jp-toolbar-background);
+  height: var(--jp-toolbar-micro-height);
+  z-index: 1;
+}


### PR DESCRIPTION
Fixes #3406 

This replaces the "New View for Cell" with "New View for Output"

* Removed prompt area
* No input shown
* micro toolbar, and appropriate padding
* auto-dispose if parent notebook is closed
* Hover over the tab shows the notebook name
* Output view scrolls in y as needed

The idea here is to focus (for now) on the simple case of getting a new view on the output for exploring jupyter widgets in micro-dashboard settings.

@jasongrout @SylvainCorlay 

Here are two examples:

![screen shot 2017-12-18 at 5 59 01 pm](https://user-images.githubusercontent.com/27600/34137030-877ecbf2-e41d-11e7-81a2-70d3a2c376c3.png)
