### PR TITLE
Console style work for beta

### DIFF
--- a/packages/console/style/index.css
+++ b/packages/console/style/index.css
@@ -33,15 +33,32 @@
 }
 
 
+.jp-CodeConsole .jp-Cell {
+  padding: var(--jp-cell-padding);
+}
+
+
+/*-----------------------------------------------------------------------------
+| Content (already run cells)
+|----------------------------------------------------------------------------*/
+
 .jp-CodeConsole-content {
-  background-color: var(--jp-console-background);
+  background: var(--jp-layout-color0);
   flex: 1 1 auto;
   overflow: auto;
   padding: var(--jp-console-padding);
 }
 
-.jp-CodeConsole .jp-Cell {
-  padding: var(--jp-cell-padding);
+
+.jp-CodeConsole-content .jp-Cell:not(.jp-mod-active) .jp-InputPrompt {
+  opacity: var(--jp-cell-prompt-not-active-opacity);
+  color: var(--jp-cell-prompt-not-active-font-color);
+}
+
+
+.jp-CodeConsole-content .jp-Cell:not(.jp-mod-active) .jp-OutputPrompt {
+  opacity: var(--jp-cell-prompt-not-active-opacity);
+  color: var(--jp-cell-prompt-not-active-font-color);
 }
 
 
@@ -49,6 +66,30 @@
 .jp-CodeConsole-content .jp-Cell.jp-CodeConsole-foreignCell {
 
 }
+
+
+.jp-CodeConsole-content .jp-InputArea-editor.jp-InputArea-editor {
+  background: transparent;
+  border: 1px solid transparent;
+}
+
+
+.jp-CodeConsole-content .jp-CodeConsole-banner .jp-InputPrompt {
+  display: none;
+}
+
+
+/* collapser is hovered */
+.jp-CodeConsole-content .jp-Cell .jp-Collapser:hover {
+  box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.25);
+  background: var(--jp-brand-color1);
+  opacity: var(--jp-cell-collapser-not-active-hover-opacity);
+}
+
+
+/*-----------------------------------------------------------------------------
+| Input/prompt cell
+|----------------------------------------------------------------------------*/
 
 
 .jp-CodeConsole-input {
@@ -70,27 +111,8 @@
 }
 
 
-.jp-CodeConsole-content .jp-CodeConsole-banner .jp-InputArea-editor.jp-InputArea-editor {
-  background: transparent;
-  border: none;
-}
-
-
-.jp-CodeConsole-content .jp-CodeConsole-banner .jp-InputPrompt {
-  display: none;
-}
-
-
 .jp-CodeConsole-promptCell .jp-InputArea-editor.jp-mod-focused {
   border: var(--jp-border-width) solid var(--jp-cell-editor-active-border-color);
   box-shadow: var(--jp-input-box-shadow);
   background-color: var(--jp-cell-editor-active-background);
-}
-
-
-/* collapser is hovered */
-.jp-CodeConsole-content .jp-Cell .jp-Collapser:hover {
-  box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.25);
-  background: var(--jp-brand-color1);
-  opacity: var(--jp-cell-collapser-not-active-hover-opacity);
 }

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -180,7 +180,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Console specific styles */
 
   --jp-console-padding: 10px;
-  --jp-console-background: var(--jp-layout-color0);
 
   /* Toolbar specific styles */
 

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -185,7 +185,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Console specific styles */
 
   --jp-console-padding: 10px;
-  --jp-console-background: var(--jp-layout-color0);
 
   /* Toolbar specific styles */
 


### PR DESCRIPTION
Talked with Jason and the Bloomberg design folks today about the console design. Here is a summary:

* When content is not editable (as in console cells that have been run) avoid using visual treatment of form fields (border + shaded bg).
* Using same background as notebook will ensure outputs looks the same in both. Some outputs (such as transparent images) are influenced by the background color. We can't prevent this, so at least make it the same in both.

Here is the state of this PR...

Light theme:

![screen shot 2017-12-18 at 7 12 36 pm](https://user-images.githubusercontent.com/27600/34139147-f4cc18cc-e427-11e7-8b21-a69a6684d912.png)

Dark theme using matplotlib `dark_background` style:

![screen shot 2017-12-18 at 7 13 01 pm](https://user-images.githubusercontent.com/27600/34139156-003f65ce-e428-11e7-989d-40faf3b5e791.png)

