### PR TITLE
Minor change to link color in dark theme

### DIFF
--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -82,7 +82,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-content-font-color2: var(--md-grey-500);
   --jp-content-font-color3: var(--md-grey-700);
 
-  --jp-content-link-color: var(--md-blue-600);
+  --jp-content-link-color: var(--md-blue-400);
 
   --jp-ui-font-scale-factor: 1.2;
   --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));


### PR DESCRIPTION
Was a bit dark/intense before (MD Blue 600):

![screen shot 2017-12-19 at 5 14 56 pm](https://user-images.githubusercontent.com/27600/34186429-516b788a-e4e0-11e7-943a-129883354ea1.png)

After (MD Blue 400):

![screen shot 2017-12-19 at 5 15 04 pm](https://user-images.githubusercontent.com/27600/34186442-5f9e5c24-e4e0-11e7-8a94-011713af62ec.png)

I left MD Blue 600 for the light theme where it worked well.

