### PR TITLE
Handle wide prompts better

### DIFF
--- a/packages/cells/style/inputarea.css
+++ b/packages/cells/style/inputarea.css
@@ -34,11 +34,15 @@
   color: var(--jp-cell-inprompt-font-color);
   font-family: var(--jp-cell-prompt-font-family);
   padding: var(--jp-code-padding);
-  text-align: right;
   letter-spacing: var(--jp-cell-prompt-letter-spacing);
   opacity: var(--jp-cell-prompt-opacity);
   line-height: var(--jp-code-line-height);
   font-size: var(--jp-code-font-size);
   border: var(--jp-border-width) solid transparent;
   opacity: var(--jp-cell-prompt-opacity);
+  /* Right align prompt text, don't wrap to handle large prompt numbers */
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -35,12 +35,16 @@
   color: var(--jp-cell-outprompt-font-color);
   font-family: var(--jp-cell-prompt-font-family);
   padding: var(--jp-code-padding);
-  text-align: right;
   letter-spacing: var(--jp-cell-prompt-letter-spacing);
   line-height: var(--jp-code-line-height);
   font-size: var(--jp-code-font-size);
   border: var(--jp-border-width) solid transparent;
   opacity: var(--jp-cell-prompt-opacity);
+    /* Right align prompt text, don't wrap to handle large prompt numbers */
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -152,7 +152,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-active-background: var(--jp-layout-color0);
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
   --jp-cell-padding: 5px;
-  --jp-cell-prompt-width: 100px;
+  --jp-cell-prompt-width: 90px;
   --jp-cell-prompt-font-family: 'Roboto Mono', monospace;
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1.0;

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -152,7 +152,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-active-background: var(--jp-layout-color0);
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
   --jp-cell-padding: 5px;
-  --jp-cell-prompt-width: 100px;
+  --jp-cell-prompt-width: 90px;
   --jp-cell-prompt-font-family: 'Roboto Mono', monospace;
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1.0;


### PR DESCRIPTION
Previously, the prompt area was 100px wide. For small prompt numbers this seemed too generous, but for larger prompt numbers and larger font sizes, it was needed. This PR tries to improve the large prompt number and large font size handling while still narrowing the prompt area down to 90px through white space and text overflow handling.

This PR:

![screen shot 2017-12-19 at 5 52 39 pm](https://user-images.githubusercontent.com/27600/34187380-e95c9e30-e4e5-11e7-852a-2a77e3509748.png)

![screen shot 2017-12-19 at 5 53 07 pm](https://user-images.githubusercontent.com/27600/34187382-ef289558-e4e5-11e7-9f81-2ce2a5e3c279.png)

And with a big font size set in the browser:

![screen shot 2017-12-19 at 5 53 39 pm](https://user-images.githubusercontent.com/27600/34187389-f440b066-e4e5-11e7-98c8-3a78ea33b9f6.png)
