### PR TITLE
Clean up handling of broken images

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -651,6 +651,14 @@ namespace Private {
         anchors[i].target = '_blank';
       }
     }
+
+    // Handle image elements.
+    let imgs = node.getElementsByTagName('img');
+    for (let i = 0; i < imgs.length; i++) {
+      if (!imgs[i].alt) {
+        imgs[i].alt = 'Image';
+      }
+    }
   }
 
   /**

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -366,6 +366,7 @@ margin-top = 14, 14, 14, 14, 8, 8
 
 
 .jp-RenderedHTMLCommon img {
+  -moz-force-broken-image-icon: 1;
   display: block;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
Fixes #2296.  Chrome does not show anything unless there is an `alt` set.  Sometimes it shows an empty square and sometimes it shows the broken image icon.

Chrome:

<image src="https://user-images.githubusercontent.com/2096628/34205484-3678964e-e548-11e7-90bc-08739d50306c.png" width=300>

Firefox:

<image src="https://user-images.githubusercontent.com/2096628/34205505-47a1f37a-e548-11e7-80c8-055e5e27838c.png" width=300>
