### PR TITLE
Typographical design for the beta

### DIFF
--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -100,8 +100,8 @@
 
 .jp-MarkdownOutput {
   flex: 1 1 auto;
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+  margin-top: 0;
+  margin-bottom: 0;
   padding-left: var(--jp-code-padding);
 }
 

--- a/packages/faq-extension/style/index.css
+++ b/packages/faq-extension/style/index.css
@@ -5,7 +5,10 @@
 
 
 .jp-FAQ {
-  font-family: var(--jp-ui-font-family);
+  font-family: var(--jp-content-font-family);
+  line-height: var(--jp-content-line-height);
+  font-size: var(--jp-content-font-size1);
+  color: var(--jp-content-font-color1);
   outline: none;
   display: flex;
   flex-direction: column;
@@ -28,17 +31,34 @@
 }
 
 
+.jp-FAQ-content h1 {
+  font-size: var(--jp-content-font-size5);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
+}
+
+
 .jp-FAQ-content h2 {
-  font-size: 20px;
-  font-weight: 500;
+  font-size: var(--jp-content-font-size4);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-FAQ-content h3 {
-  font-weight: 500;
+  font-size: var(--jp-content-font-size3);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
+
 .jp-FAQ-content a {
-  color: var(--jp-brand-color1);
+  color: var(--jp-content-link-color);
 }

--- a/packages/faq-extension/style/index.css
+++ b/packages/faq-extension/style/index.css
@@ -27,38 +27,5 @@
 
 .jp-FAQ-content {
   overflow-y: auto;
-  padding: 16px 32px;
-}
-
-
-.jp-FAQ-content h1 {
-  font-size: var(--jp-content-font-size5);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
-}
-
-
-.jp-FAQ-content h2 {
-  font-size: var(--jp-content-font-size4);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
-}
-
-
-.jp-FAQ-content h3 {
-  font-size: var(--jp-content-font-size3);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
-}
-
-
-
-.jp-FAQ-content a {
-  color: var(--jp-content-link-color);
+  padding: 32px;
 }

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -237,11 +237,11 @@
 .jp-DirListing-item.jp-mod-running .jp-DirListing-itemIcon:before {
   color: limegreen;
   content: "\25CF";
-  font-size: 13px;
+  font-size: 8px;
   position: relative;
   width: 100%;
   height: 100%;
-  top: 0px;
+  top: -2px;
   left: -8px;
 }
 

--- a/packages/markdownviewer-extension/style/index.css
+++ b/packages/markdownviewer-extension/style/index.css
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 :root {
-  --jp-private-markdownviewer-padding: 16px;
+  --jp-private-markdownviewer-padding: 32px;
 }
 
 .jp-Document.jp-MimeDocument .jp-RenderedMarkdown {

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -14,6 +14,7 @@
   padding-left: var(--jp-code-padding);
   font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
+  font-family: var(--jp-code-font-family);
 }
 
 
@@ -76,7 +77,7 @@
 
 .jp-RenderedLatex {
   color: var(--jp-content-font-color1);
-  font-size: var(--jp-content-font-size);
+  font-size: var(--jp-content-font-size1);
   line-height: var(--jp-content-line-height);
 }
 
@@ -88,7 +89,7 @@
 
 .jp-RenderedHTMLCommon {
   color: var(--jp-content-font-color1);
-  font-size: var(--jp-content-font-size);
+  font-size: var(--jp-content-font-size1);
   line-height: var(--jp-content-line-height);
 }
 
@@ -124,88 +125,60 @@
   color: var(--jp-content-link-color);
 }
 
-/*For a 14px base font size this goes as:
-font-size = 26, 22, 18, 14, 12, 12
-margin-top = 14, 14, 14, 14, 8, 8
-*/
+/* Headings */
 
 .jp-RenderedHTMLCommon h1 {
-  font-size: 185.7%;
-  margin: 1.08em 0 0 0;
-  font-weight: bold;
-  line-height: 1.0;
+  font-size: var(--jp-content-font-size5);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-RenderedHTMLCommon h2 {
-  font-size: 157.1%;
-  margin: 1.27em 0 0 0;
-  font-weight: bold;
-  line-height: 1.0;
+  font-size: var(--jp-content-font-size4);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-RenderedHTMLCommon h3 {
-  font-size: 128.6%;
-  margin: 1.55em 0 0 0;
-  font-weight: bold;
-  line-height: 1.0;
+  font-size: var(--jp-content-font-size3);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
+
 .jp-RenderedHTMLCommon h4 {
-  font-size: 100%;
-  margin: 2em 0 0 0;
-  font-weight: bold;
-  line-height: 1.0;
+  font-size: var(--jp-content-font-size2);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-RenderedHTMLCommon h5 {
-  font-size: 100%;
-  margin: 2em 0 0 0;
-  font-weight: bold;
-  line-height: 1.0;
-  font-style: italic;
+  font-size: var(--jp-content-font-size1);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-RenderedHTMLCommon h6 {
-  font-size: 100%;
-  margin: 2em 0 0 0;
-  font-weight: bold;
-  line-height: 1.0;
-  font-style: italic;
-}
-
-
-.jp-RenderedHTMLCommon h1:first-child {
-  margin-top: 0.538em;
-}
-
-
-.jp-RenderedHTMLCommon h2:first-child {
-  margin-top: 0.636em;
-}
-
-
-.jp-RenderedHTMLCommon h3:first-child {
-  margin-top: 0.777em;
-}
-
-
-.jp-RenderedHTMLCommon h4:first-child {
-  margin-top: 1em;
-}
-
-
-.jp-RenderedHTMLCommon h5:first-child {
-  margin-top: 1em;
-}
-
-
-.jp-RenderedHTMLCommon h6:first-child {
-  margin-top: 1em;
+  font-size: var(--jp-content-font-size0);
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: 400;
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -91,6 +91,8 @@
   color: var(--jp-content-font-color1);
   font-size: var(--jp-content-font-size1);
   line-height: var(--jp-content-line-height);
+  /* Give a bit more R padding on Markdown text to keep line lengths reasonable */
+  padding-right: 20px;
 }
 
 
@@ -115,72 +117,88 @@
 
 
 .jp-RenderedHTMLCommon a:link {
+  text-decoration: none;
+  color: var(--jp-content-link-color);
+}
+
+
+.jp-RenderedHTMLCommon a:hover {
   text-decoration: underline;
   color: var(--jp-content-link-color);
 }
 
 
 .jp-RenderedHTMLCommon a:visited {
-  text-decoration: underline;
+  text-decoration: none;
   color: var(--jp-content-link-color);
 }
 
+
 /* Headings */
+
+.jp-RenderedHTMLCommon h1,
+.jp-RenderedHTMLCommon h2,
+.jp-RenderedHTMLCommon h3,
+.jp-RenderedHTMLCommon h4,
+.jp-RenderedHTMLCommon h5,
+.jp-RenderedHTMLCommon h6 {
+  line-height: var(--jp-content-heading-line-height);
+  font-weight: var(--jp-content-heading-font-weight);
+  font-style: normal;
+  margin: var(--jp-content-heading-margin-top) 0 var(--jp-content-heading-margin-bottom) 0;
+}
+
+
+.jp-RenderedHTMLCommon h1:first-child,
+.jp-RenderedHTMLCommon h2:first-child,
+.jp-RenderedHTMLCommon h3:first-child,
+.jp-RenderedHTMLCommon h4:first-child,
+.jp-RenderedHTMLCommon h5:first-child,
+.jp-RenderedHTMLCommon h6:first-child {
+  margin-top: calc( 0.5 * var(--jp-content-heading-margin-top) );
+}
+
+
+.jp-RenderedHTMLCommon h1:last-child,
+.jp-RenderedHTMLCommon h2:last-child,
+.jp-RenderedHTMLCommon h3:last-child,
+.jp-RenderedHTMLCommon h4:last-child,
+.jp-RenderedHTMLCommon h5:last-child,
+.jp-RenderedHTMLCommon h6:last-child {
+  margin-bottom: calc( 0.5 * var(--jp-content-heading-margin-bottom) );
+}
+
 
 .jp-RenderedHTMLCommon h1 {
   font-size: var(--jp-content-font-size5);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-RenderedHTMLCommon h2 {
   font-size: var(--jp-content-font-size4);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-RenderedHTMLCommon h3 {
   font-size: var(--jp-content-font-size3);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
-
 
 
 .jp-RenderedHTMLCommon h4 {
   font-size: var(--jp-content-font-size2);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-RenderedHTMLCommon h5 {
   font-size: var(--jp-content-font-size1);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
 
 .jp-RenderedHTMLCommon h6 {
   font-size: var(--jp-content-font-size0);
-  line-height: var(--jp-content-heading-line-height);
-  font-weight: 400;
-  font-style: normal;
-  margin: var(--jp-content-heading-margin-top) 0 0 0;
 }
 
+/* Lists */
 
 .jp-RenderedHTMLCommon ul:not(.list-inline),
 .jp-RenderedHTMLCommon ol:not(.list-inline) {
@@ -228,42 +246,45 @@
 }
 
 
-.jp-RenderedHTMLCommon * + ol,
-.jp-RenderedHTMLCommon * + ul {
-  margin-top: 1em;
+.jp-RenderedHTMLCommon ol,
+.jp-RenderedHTMLCommon ul {
+  margin-bottom: 1em;
 }
 
 
-.jp-RenderedHTMLCommon ul * + ul,
-.jp-RenderedHTMLCommon ul * + ol,
-.jp-RenderedHTMLCommon ol * + ul,
-.jp-RenderedHTMLCommon ol * + ol {
-  margin-top: 0em;
+.jp-RenderedHTMLCommon ul ul,
+.jp-RenderedHTMLCommon ul ol,
+.jp-RenderedHTMLCommon ol ul,
+.jp-RenderedHTMLCommon ol ol {
+  margin-bottom: 0em;
 }
 
 
 .jp-RenderedHTMLCommon hr {
-  color: var(--jp-border-color1);
+  color: var(--jp-border-color2);
   background-color: var(--jp-border-color1);
   margin-top: 1em;
   margin-bottom: 1em;
 }
 
 
-.jp-RenderedHTMLCommon pre {
-  margin: 1em 2em;
+.jp-RenderedHTMLCommon > pre {
+  margin: 1.5em 2em;
 }
 
 
 .jp-RenderedHTMLCommon pre,
 .jp-RenderedHTMLCommon code {
   border: 0;
-  background-color: var(--jp-layout-color1);
+  background-color: var(--jp-layout-color0);
   color: var(--jp-content-font-color1);
-  font-size: 100%;
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-size);
+  line-height: var(--jp-code-line-height);
   padding: 0px;
 }
 
+/* Tables */
 
 .jp-RenderedHTMLCommon table {
   border-collapse: collapse;
@@ -313,17 +334,17 @@
 
 
 .jp-RenderedHTMLCommon tbody tr:nth-child(even) {
-  background: var(  --jp-rendermime-row-background);
+  background: var(  --jp-rendermime-table-row-background);
 }
 
 
 .jp-RenderedHTMLCommon tbody tr:hover {
-  background: var( --jp-rendermime-row-hover-background);
+  background: var( --jp-rendermime-table-row-hover-background);
 }
 
 
-.jp-RenderedHTMLCommon * + table {
-  margin-top: 1em;
+.jp-RenderedHTMLCommon table {
+  margin-bottom: 1em;
 }
 
 
@@ -333,21 +354,22 @@
 }
 
 
-.jp-RenderedHTMLCommon * + p {
-  margin-top: 1em;
+.jp-RenderedHTMLCommon p {
+  margin-bottom: 1em;
 }
 
 
 .jp-RenderedHTMLCommon img {
-  -moz-force-broken-image-icon: 1;
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
+    -moz-force-broken-image-icon: 1;
 }
 
 
-.jp-RenderedHTMLCommon * + img {
-  margin-top: 1em;
+/* Restrict to direct children as other images could be nested in other content. */
+.jp-RenderedHTMLCommon > img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 1em;
 }
 
 
@@ -369,12 +391,7 @@
 
 
 .jp-RenderedHTMLCommon .alert {
-  margin-bottom: initial;
-}
-
-
-.jp-RenderedHTMLCommon * + .alert {
-  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 
@@ -397,6 +414,16 @@ h4:hover .jp-InternalAnchorLink,
 h5:hover .jp-InternalAnchorLink,
 h6:hover .jp-InternalAnchorLink {
   visibility: visible;
+}
+
+
+/* Most direct children of .jp-RenderedHTMLCommon have a margin-bottom of 1.0.
+ * At the bottom of cells this is a bit too much as there is also spacing
+ * between cells. Going all the way to 0 gets too tight between markdown and
+ * code cells.
+ */
+.jp-RenderedHTMLCommon > *:last-child {
+  margin-bottom: 0.5em;
 }
 
 

--- a/packages/theme-dark-extension/style/index.css
+++ b/packages/theme-dark-extension/style/index.css
@@ -5,3 +5,11 @@
 
 @import './variables.css';
 @import './urls.css';
+
+
+/* Set the default typography for monospace elements */
+tt, code, kbd, samp, pre {
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-size);
+  line-height: var(--jp-code-line-height);
+}

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -93,15 +93,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-content-heading-margin-bottom: 0.8em;
   --jp-content-heading-font-weight: 500;
 
-<<<<<<< HEAD
-  --jp-content-link-color: var(--md-blue-400);
-=======
   /* Defaults use Material Design specification */
   --jp-content-font-color0: rgba(255,255,255,1.0);
   --jp-content-font-color1: rgba(255,255,255,1.0);
   --jp-content-font-color2: rgba(0,0,0,0.7);
   --jp-content-font-color3: rgba(0,0,0,0.5);
->>>>>>> Significant redesign of typography.
 
   --jp-content-link-color: var(--md-blue-700);
 
@@ -178,15 +174,9 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-box-shadow: inset 0 0 2px var(--md-blue-300);
   --jp-cell-editor-active-background: var(--jp-layout-color0);
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
-<<<<<<< HEAD
-  --jp-cell-padding: 5px;
-  --jp-cell-prompt-width: 90px;
-  --jp-cell-prompt-font-family: 'Roboto Mono', monospace;
-=======
 
-  --jp-cell-prompt-width: 100px;
+  --jp-cell-prompt-width: 90px;
   --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
->>>>>>> Significant redesign of typography.
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1.0;
   --jp-cell-prompt-not-active-opacity: 0.5;

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -28,8 +28,8 @@ all of MD as it is not optimized for dense, information rich UIs.
 :root {
 
   /* Borders
-
-  The following variables, specify the visual styling of borders in JupyterLab.
+   *
+   * The following variables, specify the visual styling of borders in JupyterLab.
    */
 
   --jp-border-width: 1px;
@@ -40,29 +40,33 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-button-border-radius: 2px;
 
   /* UI Fonts
-
-  The UI font CSS variables are used for the typography all of the JupyterLab
-  user interface elements that are not directly user generated content.
-  */
+   *
+   * The UI font CSS variables are used for the typography all of the JupyterLab
+   * user interface elements that are not directly user generated content.
+   */
 
   --jp-ui-font-scale-factor: 1.2;
   --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));
   --jp-ui-font-size1: 13px; /* Base font size */
   --jp-ui-font-size2: calc(var(--jp-ui-font-size1)*var(--jp-ui-font-scale-factor));
   --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
-  --jp-ui-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 
-  /* Use these font colors against the corresponding main layout colors.
-     In a light theme, these go from dark to light.
-  */
+  --jp-ui-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
+  /*
+   * Use these font colors against the corresponding main layout colors.
+   * In a light theme, these go from dark to light.
+   */
+
+  /* Defaults use Material Design specification */
   --jp-ui-font-color0: white;
   --jp-ui-font-color1: var(--md-grey-300);
   --jp-ui-font-color2: var(--md-grey-500);
   --jp-ui-font-color3: var(--md-grey-700);
 
-  /* Use these against the brand/accent/warn/error colors.
-     These will typically go from light to darker, in both a dark and light theme
+  /*
+   * Use these against the brand/accent/warn/error colors.
+   * These will typically go from light to darker, in both a dark and light theme.
    */
 
   --jp-ui-inverse-font-color0: rgba(0,0,0,1.0);
@@ -71,35 +75,55 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-ui-inverse-font-color3: rgba(0,0,0,0.3);
 
   /* Content Fonts
+   *
+   * Content font variables are used for typography of user generated content.
+   */
 
-  Content font variables are used for typography of user generated content.
-  */
+  --jp-content-line-height: 1.6;
+  --jp-content-font-scale-factor: 1.2;
+  --jp-content-font-size0: calc( var(--jp-content-font-size1)/var(--jp-content-font-scale-factor) );
+  --jp-content-font-size1: 14px; /* Base font size */
+  --jp-content-font-size2: calc( var(--jp-content-font-size1)*var(--jp-content-font-scale-factor) );
+  --jp-content-font-size3: calc( var(--jp-content-font-size2)*var(--jp-content-font-scale-factor) );
+  --jp-content-font-size4: calc( var(--jp-content-font-size3)*var(--jp-content-font-scale-factor) );
+  --jp-content-font-size5: calc( var(--jp-content-font-size4)*var(--jp-content-font-scale-factor) );
 
-  --jp-content-font-size: 13px;
-  --jp-content-line-height: 1.5;
-  --jp-content-font-color0: white;
-  --jp-content-font-color1: var(--md-grey-300);
-  --jp-content-font-color2: var(--md-grey-500);
-  --jp-content-font-color3: var(--md-grey-700);
+  --jp-content-heading-line-height: 1.0;
+  --jp-content-heading-margin-top: 1.2em;
+  --jp-content-heading-margin-bottom: 0.8em;
+  --jp-content-heading-font-weight: 500;
 
+<<<<<<< HEAD
   --jp-content-link-color: var(--md-blue-400);
+=======
+  /* Defaults use Material Design specification */
+  --jp-content-font-color0: rgba(255,255,255,1.0);
+  --jp-content-font-color1: rgba(255,255,255,1.0);
+  --jp-content-font-color2: rgba(0,0,0,0.7);
+  --jp-content-font-color3: rgba(0,0,0,0.5);
+>>>>>>> Significant redesign of typography.
 
-  --jp-ui-font-scale-factor: 1.2;
-  --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));
-  --jp-ui-font-size1: 13px; /* Base font size */
-  --jp-ui-font-size2: calc(var(--jp-ui-font-size1)*var(--jp-ui-font-scale-factor));
-  --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
+  --jp-content-link-color: var(--md-blue-700);
+
+  --jp-content-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+
+  /* 
+   * Code Fonts
+   * 
+   * Code font variables are used for typography of code and other monospaces content.
+   */
 
   --jp-code-font-size: 13px;
   --jp-code-line-height: 17px;
   --jp-code-padding: 5px;
-  --jp-code-font-family: monospace;
+  --jp-code-font-family: 'Source Code Pro', monospace;
 
   /* Layout
-
-  The following are the main layout colors use in JupyterLab. In a light
-  theme these would go from light to dark.
-  */
+   *
+   * The following are the main layout colors use in JupyterLab. In a light
+   * theme these would go from light to dark.
+   */
 
   --jp-layout-color0: #111111;
   --jp-layout-color1: var(--md-grey-900);
@@ -143,17 +167,26 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Cell specific styles */
 
+  --jp-cell-padding: 5px;
+
   --jp-cell-collapser-width: 8px;
   --jp-cell-collapser-min-height: 20px;
   --jp-cell-collapser-not-active-hover-opacity: 0.6;
+
   --jp-cell-editor-background: var(--jp-layout-color1);
   --jp-cell-editor-border-color: var(--md-grey-700);
   --jp-cell-editor-box-shadow: inset 0 0 2px var(--md-blue-300);
   --jp-cell-editor-active-background: var(--jp-layout-color0);
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
+<<<<<<< HEAD
   --jp-cell-padding: 5px;
   --jp-cell-prompt-width: 90px;
   --jp-cell-prompt-font-family: 'Roboto Mono', monospace;
+=======
+
+  --jp-cell-prompt-width: 100px;
+  --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
+>>>>>>> Significant redesign of typography.
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1.0;
   --jp-cell-prompt-not-active-opacity: 0.5;
@@ -171,10 +204,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Rendermime styles */
 
   --jp-rendermime-error-background: rgba(244,67,54,.28);
-  --jp-rendermime-row-background: var(--md-grey-900);
-  --jp-rendermime-row-hover-background: rgba(3,169,244,.2);
+  --jp-rendermime-table-row-background: var(--md-grey-900);
+  --jp-rendermime-table-row-hover-background: rgba(3,169,244,.2);
 
   /* Dialog specific styles */
+  
   --jp-dialog-background: rgba(0,0,0,.6);
 
   /* Console specific styles */

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -99,7 +99,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-content-font-color2: rgba(0,0,0,0.7);
   --jp-content-font-color3: rgba(0,0,0,0.5);
 
-  --jp-content-link-color: var(--md-blue-700);
+  --jp-content-link-color: var(--md-blue-300);
 
   --jp-content-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 

--- a/packages/theme-light-extension/src/index.ts
+++ b/packages/theme-light-extension/src/index.ts
@@ -21,7 +21,7 @@ const plugin: JupyterLabPlugin<void> = {
       name: 'JupyterLab Light',
       load: function() {
         // Load the optional monospace font for the input/output prompt.
-        manager.loadCSS('https://fonts.googleapis.com/css?family=Roboto+Mono');
+        manager.loadCSS('https://fonts.googleapis.com/css?family=Roboto|Source+Code+Pro');
         return manager.loadCSS('@jupyterlab/theme-light-extension/index.css');
       },
       unload: function() {

--- a/packages/theme-light-extension/style/index.css
+++ b/packages/theme-light-extension/style/index.css
@@ -5,3 +5,11 @@
 
 @import './variables.css';
 @import './urls.css';
+
+
+/* Set the default typography for monospace elements */
+tt, code, kbd, samp, pre {
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-family);
+  line-height: var(--jp-code-line-height);
+}

--- a/packages/theme-light-extension/style/index.css
+++ b/packages/theme-light-extension/style/index.css
@@ -10,6 +10,6 @@
 /* Set the default typography for monospace elements */
 tt, code, kbd, samp, pre {
   font-family: var(--jp-code-font-family);
-  font-size: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -51,24 +51,25 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-ui-font-size2: calc(var(--jp-ui-font-size1)*var(--jp-ui-font-scale-factor));
   --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
 
-  --jp-ui-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --jp-ui-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
   /*
    * Use these font colors against the corresponding main layout colors.
    * In a light theme, these go from dark to light.
    */
 
+  /* Defaults use Material Design specification */
   --jp-ui-font-color0: rgba(0,0,0,1.0);
-  --jp-ui-font-color1: rgba(0,0,0,0.8);
-  --jp-ui-font-color2: rgba(0,0,0,0.5);
-  --jp-ui-font-color3: rgba(0,0,0,0.3);
+  --jp-ui-font-color1: rgba(0,0,0,0.87);
+  --jp-ui-font-color2: rgba(0,0,0,0.54);
+  --jp-ui-font-color3: rgba(0,0,0,0.38);
 
   /*
    * Use these against the brand/accent/warn/error colors.
    * These will typically go from light to darker, in both a dark and light theme.
    */
 
-  --jp-ui-inverse-font-color0: rgba(255,255,255,1);
+  --jp-ui-inverse-font-color0: rgba(255,255,255,1.0);
   --jp-ui-inverse-font-color1: rgba(255,255,255,1.0);
   --jp-ui-inverse-font-color2: rgba(255,255,255,0.7);
   --jp-ui-inverse-font-color3: rgba(255,255,255,0.5);
@@ -79,33 +80,38 @@ all of MD as it is not optimized for dense, information rich UIs.
    */
 
   --jp-content-line-height: 1.6;
-  --jp-content-heading-line-height: 1.0;
-  --jp-content-heading-margin-top: 1.2em;
   --jp-content-font-scale-factor: 1.2;
   --jp-content-font-size0: calc( var(--jp-content-font-size1)/var(--jp-content-font-scale-factor) );
-  --jp-content-font-size1: 13px; /* Base font size */
+  --jp-content-font-size1: 14px; /* Base font size */
   --jp-content-font-size2: calc( var(--jp-content-font-size1)*var(--jp-content-font-scale-factor) );
   --jp-content-font-size3: calc( var(--jp-content-font-size2)*var(--jp-content-font-scale-factor) );
   --jp-content-font-size4: calc( var(--jp-content-font-size3)*var(--jp-content-font-scale-factor) );
   --jp-content-font-size5: calc( var(--jp-content-font-size4)*var(--jp-content-font-scale-factor) );
 
-  --jp-content-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --jp-content-heading-line-height: 1.0;
+  --jp-content-heading-margin-top: 1.2em;
+  --jp-content-heading-margin-bottom: 0.8em;
+  --jp-content-heading-font-weight: 500;
 
+  /* Defaults use Material Design specification */
   --jp-content-font-color0: rgba(0,0,0,1.0);
-  --jp-content-font-color1: rgba(0,0,0,0.8);
-  --jp-content-font-color2: rgba(0,0,0,0.5);
-  --jp-content-font-color3: rgba(0,0,0,0.3);
+  --jp-content-font-color1: rgba(0,0,0,0.87);
+  --jp-content-font-color2: rgba(0,0,0,0.54);
+  --jp-content-font-color3: rgba(0,0,0,0.38);
 
-  --jp-content-link-color: var(--md-blue-600);
+  /* This needs to be fairly light to maintain contrast against dark backgrounds */
+  --jp-content-link-color: var(--md-blue-300);
+
+  --jp-content-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
   /* 
    * Code Fonts
    * 
-   * Cocde font variables are used for typography of code and other monospaces content.
+   * Code font variables are used for typography of code and other monospaces content.
    */
 
   --jp-code-font-size: 13px;
-  --jp-code-line-height: 1.307;
+  --jp-code-line-height: 17px;
   --jp-code-padding: 5px;
   --jp-code-font-family: 'Source Code Pro', monospace;
 
@@ -192,8 +198,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Rendermime styles */
 
   --jp-rendermime-error-background: #fdd;
-  --jp-rendermime-row-background: var(--md-grey-100);
-  --jp-rendermime-row-hover-background: var(--md-light-blue-50);
+  --jp-rendermime-table-row-background: var(--md-grey-100);
+  --jp-rendermime-table-row-hover-background: var(--md-light-blue-50);
 
   /* Dialog specific styles */
   

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -28,8 +28,8 @@ all of MD as it is not optimized for dense, information rich UIs.
 :root {
 
   /* Borders
-
-  The following variables, specify the visual styling of borders in JupyterLab.
+   *
+   * The following variables, specify the visual styling of borders in JupyterLab.
    */
 
   --jp-border-width: 1px;
@@ -40,29 +40,32 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-button-border-radius: 2px;
 
   /* UI Fonts
-
-  The UI font CSS variables are used for the typography all of the JupyterLab
-  user interface elements that are not directly user generated content.
-  */
+   *
+   * The UI font CSS variables are used for the typography all of the JupyterLab
+   * user interface elements that are not directly user generated content.
+   */
 
   --jp-ui-font-scale-factor: 1.2;
   --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));
   --jp-ui-font-size1: 13px; /* Base font size */
   --jp-ui-font-size2: calc(var(--jp-ui-font-size1)*var(--jp-ui-font-scale-factor));
   --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
-  --jp-ui-font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 
-  /* Use these font colors against the corresponding main layout colors.
-     In a light theme, these go from dark to light.
-  */
+  --jp-ui-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+
+  /*
+   * Use these font colors against the corresponding main layout colors.
+   * In a light theme, these go from dark to light.
+   */
 
   --jp-ui-font-color0: rgba(0,0,0,1.0);
   --jp-ui-font-color1: rgba(0,0,0,0.8);
   --jp-ui-font-color2: rgba(0,0,0,0.5);
   --jp-ui-font-color3: rgba(0,0,0,0.3);
 
-  /* Use these against the brand/accent/warn/error colors.
-     These will typically go from light to darker, in both a dark and light theme
+  /*
+   * Use these against the brand/accent/warn/error colors.
+   * These will typically go from light to darker, in both a dark and light theme.
    */
 
   --jp-ui-inverse-font-color0: rgba(255,255,255,1);
@@ -71,35 +74,46 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-ui-inverse-font-color3: rgba(255,255,255,0.5);
 
   /* Content Fonts
+   *
+   * Content font variables are used for typography of user generated content.
+   */
 
-  Content font variables are used for typography of user generated content.
-  */
+  --jp-content-line-height: 1.6;
+  --jp-content-heading-line-height: 1.0;
+  --jp-content-heading-margin-top: 1.2em;
+  --jp-content-font-scale-factor: 1.2;
+  --jp-content-font-size0: calc( var(--jp-content-font-size1)/var(--jp-content-font-scale-factor) );
+  --jp-content-font-size1: 13px; /* Base font size */
+  --jp-content-font-size2: calc( var(--jp-content-font-size1)*var(--jp-content-font-scale-factor) );
+  --jp-content-font-size3: calc( var(--jp-content-font-size2)*var(--jp-content-font-scale-factor) );
+  --jp-content-font-size4: calc( var(--jp-content-font-size3)*var(--jp-content-font-scale-factor) );
+  --jp-content-font-size5: calc( var(--jp-content-font-size4)*var(--jp-content-font-scale-factor) );
 
-  --jp-content-font-size: 13px;
-  --jp-content-line-height: 1.5;
-  --jp-content-font-color0: black;
-  --jp-content-font-color1: black;
-  --jp-content-font-color2: var(--md-grey-700);
-  --jp-content-font-color3: var(--md-grey-500);
+  --jp-content-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+
+  --jp-content-font-color0: rgba(0,0,0,1.0);
+  --jp-content-font-color1: rgba(0,0,0,0.8);
+  --jp-content-font-color2: rgba(0,0,0,0.5);
+  --jp-content-font-color3: rgba(0,0,0,0.3);
 
   --jp-content-link-color: var(--md-blue-600);
 
-  --jp-ui-font-scale-factor: 1.2;
-  --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));
-  --jp-ui-font-size1: 13px; /* Base font size */
-  --jp-ui-font-size2: calc(var(--jp-ui-font-size1)*var(--jp-ui-font-scale-factor));
-  --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
+  /* 
+   * Code Fonts
+   * 
+   * Cocde font variables are used for typography of code and other monospaces content.
+   */
 
   --jp-code-font-size: 13px;
   --jp-code-line-height: 1.307;
   --jp-code-padding: 5px;
-  --jp-code-font-family: monospace;
+  --jp-code-font-family: 'Source Code Pro', monospace;
 
   /* Layout
-
-  The following are the main layout colors use in JupyterLab. In a light
-  theme these would go from light to dark.
-  */
+   *
+   * The following are the main layout colors use in JupyterLab. In a light
+   * theme these would go from light to dark.
+   */
 
   --jp-layout-color0: white;
   --jp-layout-color1: white;
@@ -143,17 +157,20 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Cell specific styles */
 
+  --jp-cell-padding: 5px;
+
   --jp-cell-collapser-width: 8px;
   --jp-cell-collapser-min-height: 20px;
   --jp-cell-collapser-not-active-hover-opacity: 0.6;
+
   --jp-cell-editor-background: var(--md-grey-100);	
   --jp-cell-editor-border-color: var(--md-grey-300);
   --jp-cell-editor-box-shadow: inset 0 0 2px var(--md-blue-300);
   --jp-cell-editor-active-background: var(--jp-layout-color0);
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
-  --jp-cell-padding: 5px;
+
   --jp-cell-prompt-width: 90px;
-  --jp-cell-prompt-font-family: 'Roboto Mono', monospace;
+  --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1.0;
   --jp-cell-prompt-not-active-opacity: 0.5;

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -99,8 +99,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-content-font-color2: rgba(0,0,0,0.54);
   --jp-content-font-color3: rgba(0,0,0,0.38);
 
-  /* This needs to be fairly light to maintain contrast against dark backgrounds */
-  --jp-content-link-color: var(--md-blue-300);
+  --jp-content-link-color: var(--md-blue-700);
 
   --jp-content-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 


### PR DESCRIPTION
* Better separation of ui, content and code typography.
* Unified font scales for content and headings.
* Careful consistency checks between markdown docuemnt and notebooks to amek sure that headings look similar - that cells don't add too much margin above and below.
* Lots of small fixes to various things in rendered HTML.
* fine tuning font colors.
* Use system fonts if available (SF on Mac, Segoe on Win, Helvetica, Arial)

Current PR light:

![screen shot 2017-12-20 at 7 00 48 pm](https://user-images.githubusercontent.com/27600/34238902-116c83a8-e5b9-11e7-9958-4d382d7f5641.png)

Current PR dark:

![screen shot 2017-12-20 at 7 01 37 pm](https://user-images.githubusercontent.com/27600/34238910-16d70fb6-e5b9-11e7-9a90-f5315994be4f.png)

Master:

![screen shot 2017-12-20 at 7 11 53 pm](https://user-images.githubusercontent.com/27600/34239023-ac17a310-e5b9-11e7-84a2-b2233344ca64.png)
