### PR TITLE
Dedupe the completion responses

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -384,8 +384,12 @@ class CompletionHandler implements IDisposable {
     // Update the original request.
     model.original = state;
 
+    // Dedupe the matches.
+    let matches = reply.matches || [];
+    matches = Array.from(new Set(matches) as any);
+
     // Update the options.
-    model.setOptions(reply.matches || []);
+    model.setOptions(matches);
 
     // Update the cursor.
     model.cursor = {

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -385,8 +385,12 @@ class CompletionHandler implements IDisposable {
     model.original = state;
 
     // Dedupe the matches.
-    let matches = reply.matches || [];
-    matches = Array.from(new Set(matches) as any);
+    let matches: string[] = [];
+    if (reply.matches) {
+      (new Set(reply.matches)).forEach(match => {
+        matches.push(match);
+      });
+    }
 
     // Update the options.
     model.setOptions(matches);

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -181,7 +181,7 @@ class CompleterModel implements Completer.IModel {
   }
 
   /**
-   * Set the avilable options in the completer menu.
+   * Set the available options in the completer menu.
    */
   setOptions(newValue: IterableOrArrayLike<string>) {
     const values = toArray(newValue || []);

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -585,7 +585,7 @@ namespace Completer {
     options(): IIterator<string>;
 
     /**
-     * Set the avilable options in the completer menu.
+     * Set the available options in the completer menu.
      */
     setOptions(options: IterableOrArrayLike<string>): void;
 


### PR DESCRIPTION
Fixes #3365.  I believe the root cause is `ipython` giving back both static and dynamic matches.