### PR TITLE
Add tooltip to New Launcher button and Home icon

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -145,7 +145,8 @@ function activateFactory(app: JupyterLab, docManager: IDocumentManager, state: I
       className: 'jp-AddIcon',
       onClick: () => {
         return createLauncher(commands, widget);
-      }
+      },
+      tooltip: 'New Launcher'
     });
     launcher.addClass('jp-MaterialIcon');
     widget.toolbar.insertItem(0, 'launch', launcher);

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -373,6 +373,7 @@ namespace Private {
   function createCrumbs(): ReadonlyArray<HTMLElement> {
     let home = document.createElement('span');
     home.className = MATERIAL_CLASS + ' ' + BREADCRUMB_HOME + ' ' + BREADCRUMB_ITEM_CLASS;
+    home.title = 'Home';
     let ellipsis = document.createElement('span');
     ellipsis.className = MATERIAL_CLASS + ' ' + BREADCRUMB_ELLIPSES + ' ' + BREADCRUMB_ITEM_CLASS;
     let parent = document.createElement('span');


### PR DESCRIPTION
This PR fixes https://github.com/jupyterlab/jupyterlab/issues/3459

- [x] Add tooltip text to New Launcher button
- [x] Add tooltip text to Home icon
