### PR TITLE
Better handling of shut down for kernels, sessions, and terminals

### DIFF
--- a/packages/apputils/src/clientsession.ts
+++ b/packages/apputils/src/clientsession.ts
@@ -689,11 +689,15 @@ class ClientSession implements IClientSession {
    * Handle a session termination.
    */
   private _onTerminated(): void {
+    let kernel = this.kernel;
     if (this._session) {
       this._session.dispose();
     }
     this._session = null;
     this._terminated.emit(void 0);
+    if (kernel) {
+      this._kernelChanged.emit(null);
+    }
   }
 
   /**

--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -548,7 +548,7 @@ namespace Private {
     /**
      * Update the text of the kernel name item.
      */
-    _onKernelChanged(session: IClientSession): void {
+    private _onKernelChanged(session: IClientSession): void {
       this.node.textContent = session.kernelDisplayName;
     }
   }

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -80,14 +80,15 @@ class DefaultKernel implements Kernel.IKernel {
     this._commPromises = new Map<string, Promise<Kernel.IComm>>();
     this._comms = new Map<string, Kernel.IComm>();
     this._createSocket();
-    this.terminated = new Signal<this, void>(this);
     Private.runningKernels.push(this);
   }
 
   /**
    * A signal emitted when the kernel is shut down.
    */
-  readonly terminated: Signal<this, void>;
+  get terminated(): ISignal<this, void> {
+    return this._terminated;
+  }
 
   /**
    * The server settings for the kernel.
@@ -221,6 +222,7 @@ class DefaultKernel implements Kernel.IKernel {
     if (this.isDisposed) {
       return;
     }
+    this._terminated.emit(void 0);
     this._isDisposed = true;
     this._status = 'dead';
     this._clearSocket();
@@ -1038,6 +1040,7 @@ class DefaultKernel implements Kernel.IKernel {
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _displayIdToParentIds = new Map<string, string[]>();
   private _msgIdToDisplayIds = new Map<string, string[]>();
+  private _terminated = new Signal<this, void>(this);
   private _noOp = () => { /* no-op */};
 }
 
@@ -1275,7 +1278,6 @@ namespace Private {
       });
       // If kernel is no longer running on disk, emit dead signal.
       if (!updated && kernel.status !== 'dead') {
-        kernel.terminated.emit(void 0);
         kernel.dispose();
       }
     });
@@ -1418,7 +1420,6 @@ namespace Private {
   function killKernels(id: string): void {
     each(toArray(runningKernels), kernel => {
       if (kernel.id === id) {
-        kernel.terminated.emit(void 0);
         kernel.dispose();
       }
     });

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -222,8 +222,8 @@ class DefaultKernel implements Kernel.IKernel {
     if (this.isDisposed) {
       return;
     }
-    this._terminated.emit(void 0);
     this._isDisposed = true;
+    this._terminated.emit(void 0);
     this._status = 'dead';
     this._clearSocket();
     this._futures.forEach((future, key) => {

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -230,14 +230,14 @@ class KernelManager implements Kernel.IManager {
    */
   shutdownAll(): Promise<void> {
     // Proactively remove all models.
-    let previous = this._models.length;
-    if (previous) {
+    let models = this._models;
+    if (models.length > 0) {
       this._models = [];
       this._runningChanged.emit([]);
     }
 
     return this._refreshRunning().then(() => {
-      return Promise.all(this._models.map(model => {
+      return Promise.all(models.map(model => {
         return Kernel.shutdown(model.id, this.serverSettings).then(() => {
           let toRemove: Kernel.IKernel[] = [];
           this._kernels.forEach(k => {

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -53,13 +53,14 @@ class DefaultSession implements Session.ISession {
     this.serverSettings = options.serverSettings || ServerConnection.makeSettings();
     Private.addRunning(this);
     this.setupKernel(kernel);
-    this.terminated = new Signal<this, void>(this);
   }
 
   /**
    * A signal emitted when the session is shut down.
    */
-  readonly terminated: Signal<this, void>;
+  get terminated(): ISignal<this, void> {
+    return this._terminated;
+  }
 
   /**
    * A signal emitted when the kernel changes.
@@ -217,6 +218,8 @@ class DefaultSession implements Session.ISession {
     }
     this._isDisposed = true;
     this._kernel.dispose();
+    this._statusChanged.emit('dead');
+    this._terminated.emit(void 0);
     Private.removeRunning(this);
     Signal.clearData(this);
   }
@@ -386,6 +389,7 @@ class DefaultSession implements Session.ISession {
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _propertyChanged = new Signal<this, 'path' | 'name' | 'type'>(this);
+  private _terminated = new Signal<this, void>(this);
 }
 
 
@@ -593,7 +597,6 @@ namespace Private {
     let running = runningSessions.get(baseUrl) || [];
     each(running.slice(), session => {
       if (session.id === id) {
-        session.terminated.emit(void 0);
         session.dispose();
       }
     });
@@ -736,7 +739,7 @@ namespace Private {
       });
       // If session is no longer running on disk, emit dead signal.
       if (!updated && session.status !== 'dead') {
-        session.terminated.emit(void 0);
+        session.dispose();
       }
     });
     return Promise.all(promises).then(() => { return sessions; });

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -238,14 +238,14 @@ class SessionManager implements Session.IManager {
    */
   shutdownAll(): Promise<void> {
     // Proactively remove all models.
-    let previous = this._models.length;
-    if (previous) {
+    let models = this._models;
+    if (models.length > 0) {
       this._models = [];
       this._runningChanged.emit([]);
     }
 
     return this._refreshRunning().then(() => {
-      return Promise.all(this._models.map(model => {
+      return Promise.all(models.map(model => {
         return Session.shutdown(model.id, this.serverSettings).then(() => {
           let toRemove: Session.ISession[] = [];
           this._sessions.forEach(s => {

--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -44,13 +44,14 @@ class DefaultTerminalSession implements TerminalSession.ISession {
     this._name = name;
     this.serverSettings = options.serverSettings || ServerConnection.makeSettings();
     this._readyPromise = this._initializeSocket();
-    this.terminated = new Signal<this, void>(this);
   }
 
   /**
    * A signal emitted when the session is shut down.
    */
-  readonly terminated: Signal<this, void>;
+  get terminated(): Signal<this, void> {
+    return this._terminated;
+  }
 
   /**
    * A signal emitted when a message is received from the server.
@@ -107,6 +108,7 @@ class DefaultTerminalSession implements TerminalSession.ISession {
       return;
     }
 
+    this.terminated.emit(void 0);
     this._isDisposed = true;
     if (this._ws) {
       this._ws.close();
@@ -231,6 +233,7 @@ class DefaultTerminalSession implements TerminalSession.ISession {
   private _isDisposed = false;
   private _isReady = false;
   private _messageReceived = new Signal<this, TerminalSession.IMessage>(this);
+  private _terminated = new Signal<this, void>(this);
   private _name: string;
   private _readyPromise: Promise<void>;
   private _url: string;
@@ -349,7 +352,6 @@ namespace DefaultTerminalSession {
       each(Object.keys(Private.running), runningUrl => {
         if (urls.indexOf(runningUrl) === -1) {
           let session = Private.running[runningUrl];
-          session.terminated.emit(void 0);
           session.dispose();
         }
       });
@@ -447,7 +449,6 @@ namespace Private {
     // Update the local data store.
     if (Private.running[url]) {
       let session = Private.running[url];
-      session.terminated.emit(void 0);
       session.dispose();
     }
   }

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -177,14 +177,14 @@ class TerminalManager implements TerminalSession.IManager {
    */
   shutdownAll(): Promise<void> {
     // Proactively remove all models.
-    let previous = this._models.length;
-    if (previous) {
+    let models = this._models;
+    if (models.length > 0) {
       this._models = [];
       this._runningChanged.emit([]);
     }
 
     return this._refreshRunning().then(() => {
-      return Promise.all(this._models.map(model => {
+      return Promise.all(models.map(model => {
         return TerminalSession.shutdown(model.name, this.serverSettings).then(() => {
           let toRemove: TerminalSession.ISession[] = [];
           this._sessions.forEach(s => {

--- a/packages/services/test/src/kernel/manager.spec.ts
+++ b/packages/services/test/src/kernel/manager.spec.ts
@@ -245,7 +245,7 @@ describe('kernel/manager', () => {
         let called = false;
         return manager.startNew().then(k => {
           manager.runningChanged.connect((sender, args) => {
-            expect(k.isDisposed).to.be(true);
+            expect(k.isDisposed).to.be(false);
             called = true;
           });
           return manager.shutdown(k.id);

--- a/packages/services/test/src/terminal/manager.spec.ts
+++ b/packages/services/test/src/terminal/manager.spec.ts
@@ -155,7 +155,7 @@ describe('terminal', () => {
         let called = false;
         return manager.startNew().then(s => {
           manager.runningChanged.connect((sender, args) => {
-            expect(s.isDisposed).to.be(true);
+            expect(s.isDisposed).to.be(false);
             called = true;
           });
           return manager.shutdown(s.name);


### PR DESCRIPTION
Fixes #3466.  Fixes #3301.  Synchronously update the list of running models, but only terminate the client on a server response.  Improve handling of `terminate` signals.