### PR TITLE
Fix link handler for renderers

### DIFF
--- a/packages/rendermime-extension/src/index.ts
+++ b/packages/rendermime-extension/src/index.ts
@@ -40,7 +40,7 @@ function activate(app: JupyterLab, latexTypesetter: ILatexTypesetter) {
     linkHandler: {
       handleLink: (node, path) => {
         app.commandLinker.connectNode(
-          node, 'file-operations:open', { path: path }
+          node, 'docmanager:open', { path: path }
         );
       }
     },


### PR DESCRIPTION
The link handler was using an old command name, preventing relative links in rendered markdown from working.