### PR TITLE
Workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ jupyterlab/schemas
 jupyterlab/themes
 jupyterlab/geckodriver
 dev_mode/schemas
-dev_mode/themes
 dev_mode/static
+dev_mode/themes
+dev_mode/workspaces
 
 node_modules
 .cache

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -4,9 +4,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Module globals
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 import os
 
 DEV_NOTE = """You're running JupyterLab from source.
@@ -37,7 +37,6 @@ def load_jupyter_server_extension(nbapp):
         get_app_dir, get_user_settings_dir, watch, ensure_dev, watch_dev,
         pjoin, DEV_DIR, HERE, get_app_info, ensure_core
     )
-    from ._version import __version__
 
     web_app = nbapp.web_app
     logger = nbapp.log
@@ -101,6 +100,7 @@ def load_jupyter_server_extension(nbapp):
 
     config.app_settings_dir = pjoin(app_dir, 'settings')
     config.schemas_dir = pjoin(app_dir, 'schemas')
+    config.sessions_dir = pjoin(app_dir, 'sessions')
     config.themes_dir = pjoin(app_dir, 'themes')
     info = get_app_info(app_dir)
     config.app_version = info['version']
@@ -132,6 +132,6 @@ def load_jupyter_server_extension(nbapp):
     build_handler = (build_url, BuildHandler, {'builder': builder})
 
     # Must add before the launcher handlers to avoid shadowing.
-    web_app.add_handlers(".*$", [build_handler])
+    web_app.add_handlers('.*$', [build_handler])
 
     add_handlers(web_app, config)

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -100,8 +100,8 @@ def load_jupyter_server_extension(nbapp):
 
     config.app_settings_dir = pjoin(app_dir, 'settings')
     config.schemas_dir = pjoin(app_dir, 'schemas')
-    config.sessions_dir = pjoin(app_dir, 'sessions')
     config.themes_dir = pjoin(app_dir, 'themes')
+    config.workspaces_dir = pjoin(app_dir, 'workspaces')
     info = get_app_info(app_dir)
     config.app_version = info['version']
     public_url = info['publicUrl']

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -191,8 +191,8 @@ const router: JupyterLabPlugin<IRouter> = {
     commands.addCommand(CommandIDs.url, {
       execute: args => URLExt.join(tree, (args.path as string))
     });
-    app.started.then(() => { router.route(window.location.href); });
     router.register({ command: CommandIDs.tree, pattern: /^\/tree\/.+/ });
+    app.started.then(() => { router.route(window.location.href); });
 
     return router;
   },

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -48,9 +48,6 @@ namespace CommandIDs {
 
   export
   const tree: string = 'router:tree';
-
-  export
-  const url: string = 'router:tree-url';
 }
 
 
@@ -172,13 +169,13 @@ const router: JupyterLabPlugin<IRouter> = {
       PageConfig.getBaseUrl(),
       PageConfig.getOption('pageUrl')
     );
-    const tree = PageConfig.getTreeUrl();
     const router = new Router({ base, commands });
+    const pattern = /^\/tree\/(.*)/;
 
     commands.addCommand(CommandIDs.tree, {
       execute: (args: IRouter.ICommandArgs) => {
         return app.restored.then(() => {
-          const path = (args.path as string).replace('/tree', '');
+          const path = decodeURIComponent((args.path.match(pattern)[1]));
 
           // Change the URL back to the base application URL.
           window.history.replaceState({ }, '', base);
@@ -188,10 +185,7 @@ const router: JupyterLabPlugin<IRouter> = {
       }
     });
 
-    commands.addCommand(CommandIDs.url, {
-      execute: args => URLExt.join(tree, (args.path as string))
-    });
-    router.register({ command: CommandIDs.tree, pattern: /^\/tree\/.+/ });
+    router.register({ command: CommandIDs.tree, pattern });
     app.started.then(() => { router.route(window.location.href); });
 
     return router;

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -177,20 +177,21 @@ const router: JupyterLabPlugin<IRouter> = {
 
     commands.addCommand(CommandIDs.tree, {
       execute: (args: IRouter.ICommandArgs) => {
-        const path = (args.path as string).replace('/tree', '');
+        return app.restored.then(() => {
+          const path = (args.path as string).replace('/tree', '');
 
-        // Change the URL back to the base application URL.
-        window.history.replaceState({ }, '', base);
+          // Change the URL back to the base application URL.
+          window.history.replaceState({ }, '', base);
 
-        return commands.execute('filebrowser:navigate-main', { path });
+          return commands.execute('filebrowser:navigate-main', { path });
+        });
       }
     });
 
     commands.addCommand(CommandIDs.url, {
       execute: args => URLExt.join(tree, (args.path as string))
     });
-
-    app.restored.then(() => { router.route(window.location.href); });
+    app.started.then(() => { router.route(window.location.href); });
     router.register(/^\/tree\/.+/, CommandIDs.tree);
 
     return router;

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -192,7 +192,7 @@ const router: JupyterLabPlugin<IRouter> = {
       execute: args => URLExt.join(tree, (args.path as string))
     });
     app.started.then(() => { router.route(window.location.href); });
-    router.register(/^\/tree\/.+/, CommandIDs.tree);
+    router.register({ command: CommandIDs.tree, pattern: /^\/tree\/.+/ });
 
     return router;
   },

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -16,8 +16,12 @@ import {
 } from '@phosphor/coreutils';
 
 import {
-  IDisposable, DisposableDelegate
+  DisposableDelegate, IDisposable
 } from '@phosphor/disposable';
+
+import {
+  ISignal, Signal
+} from '@phosphor/signaling';
 
 
 /* tslint:disable */
@@ -45,15 +49,18 @@ interface IRouter {
   readonly commands: CommandRegistry;
 
   /**
+   * A signal emitted when the router routes a route.
+   */
+  readonly routed: ISignal<IRouter, IRouter.ICommandArgs>;
+
+  /**
    * Register to route a path pattern to a command.
    *
-   * @param pattern - The regular expression that will be matched against URLs.
-   *
-   * @param command - The command string that will be invoked upon matching.
+   * @param options - The route registration options.
    *
    * @returns A disposable that removes the registered rul from the router.
    */
-  register(pattern: RegExp, command: string): IDisposable;
+  register(options: IRouter.IRegisterArgs): IDisposable;
 
   /**
    * Route a specific path to an action.
@@ -89,6 +96,28 @@ namespace IRouter {
      */
     search: string;
   }
+
+  /**
+   * The specification for registering a route with the router.
+   */
+  export
+  interface IRegisterArgs {
+    /**
+     * The command string that will be invoked upon matching.
+     */
+    command: string;
+
+    /**
+     * The regular expression that will be matched against URLs.
+     */
+    pattern: RegExp;
+
+    /**
+     * The rank order of the registered rule. A lower rank denotes a higher
+     * priority. The default rank is `100`.
+     */
+    rank?: number;
+  }
 }
 
 
@@ -116,18 +145,25 @@ class Router implements IRouter {
   readonly commands: CommandRegistry;
 
   /**
+   * A signal emitted when the router routes a route.
+   */
+  get routed(): ISignal<this, IRouter.ICommandArgs> {
+    return this._routed;
+  }
+
+  /**
    * Register to route a path pattern to a command.
    *
-   * @param pattern - The regular expression that will be matched against URLs.
-   *
-   * @param command - The command string that will be invoked upon matching.
+   * @param options - The route registration options.
    *
    * @returns A disposable that removes the registered rul from the router.
    */
-  register(pattern: RegExp, command: string): IDisposable {
+  register(options: IRouter.IRegisterArgs): IDisposable {
+    const { command, pattern } = options;
+    const rank = 'rank' in options ? options.rank : 100;
     const rules = this._rules;
 
-    rules.set(pattern, command);
+    rules.set(pattern, { command, rank });
 
     return new DisposableDelegate(() => { rules.delete(pattern); });
   }
@@ -142,20 +178,29 @@ class Router implements IRouter {
    * match the `IRouter.ICommandArgs` interface.
    */
   route(url: string): void {
-    const { base } = this;
-    const parsed = URLExt.parse(url.replace(base, ''));
-    const path = parsed.pathname;
-    const search = parsed.search;
-    const rules = this._rules;
+    const parsed = URLExt.parse(url.replace(this.base, ''));
+    const args = { path: parsed.pathname, search: parsed.search };
+    const matches: Private.Rule[] = [];
 
-    rules.forEach((command, pattern) => {
-      if (path.match(pattern)) {
-        this.commands.execute(command, { path, search });
+    // Collect all rules that match the URL.
+    this._rules.forEach((rule, pattern) => {
+      if (parsed.pathname.match(pattern)) {
+        matches.push(rule);
       }
     });
+
+    // Order the rules by rank and collect the promises their commands return.
+    const promises = matches.sort((a, b) => a.rank - b.rank)
+      .map(rule => this.commands.execute(rule.command, args));
+
+    // After all the promises (if any) resolve, emit the routed signal.
+    Promise.all(promises)
+      .catch(reason => { console.warn(`Routing ${url} failed:`, reason); })
+      .then(() => { this._routed.emit(args); });
   }
 
-  private _rules = new Map<RegExp, string>();
+  private _routed = new Signal<this, IRouter.ICommandArgs>(this);
+  private _rules = new Map<RegExp, Private.Rule>();
 }
 
 
@@ -179,4 +224,16 @@ namespace Router {
      */
     commands: CommandRegistry;
   }
+}
+
+
+/**
+ * A namespace for private module data.
+ */
+namespace Private {
+  /**
+   * The internal representation of a routing rule.
+   */
+  export
+  type Rule = { command: string; rank: number };
 }

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -189,14 +189,15 @@ class Router implements IRouter {
       }
     });
 
-    // Order the rules by rank and collect the promises their commands return.
-    const promises = matches.sort((a, b) => a.rank - b.rank)
-      .map(rule => this.commands.execute(rule.command, args));
+    // Order the matching rules by rank and execute them.
+    matches.sort((a, b) => a.rank - b.rank).forEach(rule => {
+      // Ignore the results of each executed promise.
+      this.commands.execute(rule.command, args).catch(reason => {
+        console.warn(`Routing ${url} using ${rule.command} failed:`, reason);
+      });
+    });
 
-    // After all the promises (if any) resolve, emit the routed signal.
-    Promise.all(promises)
-      .catch(reason => { console.warn(`Routing ${url} failed:`, reason); })
-      .then(() => { this._routed.emit(args); });
+    this._routed.emit(args);
   }
 
   private _routed = new Signal<this, IRouter.ICommandArgs>(this);

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -37,7 +37,6 @@
     "@jupyterlab/coreutils": "^1.0.1",
     "@jupyterlab/mainmenu": "^0.3.1",
     "@jupyterlab/services": "^1.0.1",
-    "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/widgets": "^1.5.0",

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -43,6 +43,14 @@ import '../style/index.css';
 
 
 /**
+ * The interval in milliseconds that calls to save a workspace are debounced
+ * to allow for multiple quickly executed state changes to result in a single
+ * workspace save operation.
+ */
+const WORKSPACE_SAVE_DEBOUNCE_INTERVAL = 2000;
+
+
+/**
  * The command IDs used by the apputils plugin.
  */
 namespace CommandIDs {
@@ -267,7 +275,7 @@ const state: JupyterLabPlugin<IStateDB> = {
             .catch(reason => {
               console.warn(`Saving workspace (${id}) failed.`, reason);
             });
-        }, 2000);
+        }, WORKSPACE_SAVE_DEBOUNCE_INTERVAL);
       }
     });
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -12,7 +12,8 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  DataConnector, ISettingRegistry, IStateDB, SettingRegistry, StateDB
+  DataConnector, ISettingRegistry, IStateDB, PageConfig, SettingRegistry,
+  StateDB, URLExt
 } from '@jupyterlab/coreutils';
 
 import {
@@ -248,6 +249,13 @@ const state: JupyterLabPlugin<IStateDB> = {
     disposables.add(commands.addCommand(command, {
       execute: (args: IRouter.ICommandArgs) => {
         const workspace = (args.path || '').match(pattern)[1];
+        const base = URLExt.join(
+          PageConfig.getBaseUrl(),
+          PageConfig.getOption('pageUrl')
+        );
+
+        // Change the URL back to the base application URL.
+        window.history.replaceState({ }, '', base);
 
         // If there is no workspace, leave the state database intact.
         if (!workspace) {

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -51,10 +51,13 @@ import '../style/index.css';
  */
 namespace CommandIDs {
   export
+  const changeTheme = 'apputils:change-theme';
+
+  export
   const clearStateDB = 'apputils:clear-statedb';
 
   export
-  const changeTheme = 'apputils:change-theme';
+  const loadState = 'apputils:load-statedb';
 }
 
 
@@ -201,13 +204,7 @@ const splash: JupyterLabPlugin<ISplashScreen> = {
   id: '@jupyterlab/apputils-extension:splash',
   autoStart: true,
   provides: ISplashScreen,
-  activate: () => {
-    return {
-      show: () => {
-        return Private.showSplash();
-      }
-    };
-  }
+  activate: () => ({ show: () => Private.showSplash() })
 };
 
 
@@ -218,12 +215,14 @@ const state: JupyterLabPlugin<IStateDB> = {
   id: '@jupyterlab/apputils-extension:state',
   autoStart: true,
   provides: IStateDB,
-  activate: (app: JupyterLab) => {
+  requires: [IRouter],
+  activate: (app: JupyterLab, router: IRouter) => {
+    const { commands, info, restored } = app;
     const state = new StateDB({
-      namespace: app.info.namespace,
-      when: app.restored.then(() => { /* no-op */ })
+      namespace: info.namespace,
+      when: restored.then(() => { /* no-op */ })
     });
-    const version = app.info.version;
+    const version = info.version;
     const key = 'statedb:version';
     const fetch = state.fetch(key);
     const save = () => state.save(key, { version });

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -265,7 +265,7 @@ const state: JupyterLabPlugin<IStateDB> = {
           state.toJSON()
             .then(data => workspaces.save(id, { data, metadata }))
             .catch(reason => {
-              console.warn('Saving workspace failed.', reason);
+              console.warn(`Saving workspace (${id}) failed.`, reason);
             });
         }, 2000);
       }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -260,7 +260,6 @@ const state: JupyterLabPlugin<IStateDB> = {
 
         return state.toJSON()
           .then(data => workspaces.save(id, { data, metadata }))
-          .then(() => { console.log('boom!'); })
           .catch(reason => {
             console.warn('Saving workspace failed.', reason);
           });

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -25,10 +25,6 @@ import {
 } from '@jupyterlab/services';
 
 import {
-  each
-} from '@phosphor/algorithm';
-
-import {
   PromiseDelegate
 } from '@phosphor/coreutils';
 
@@ -55,7 +51,7 @@ namespace CommandIDs {
   const changeTheme = 'apputils:change-theme';
 
   export
-  const clearStateDB = 'apputils:clear-statedb';
+  const clearState = 'apputils:clear-statedb';
 
   export
   const loadState = 'apputils:load-statedb';
@@ -164,11 +160,11 @@ const themes: JupyterLabPlugin<IThemeManager> = {
       const themeMenu = new Menu({ commands });
       themeMenu.title.label = 'JupyterLab Theme';
       manager.ready.then(() => {
-        each(manager.themes, theme => {
-          themeMenu.addItem({
-            command: CommandIDs.changeTheme,
-            args: { isPalette: false, theme: theme }
-          });
+        const command = CommandIDs.changeTheme;
+        const isPalette = false;
+
+        manager.themes.forEach(theme => {
+          themeMenu.addItem({ command, args: { isPalette, theme } });
         });
       });
       mainMenu.settingsMenu.addGroup([{
@@ -176,17 +172,15 @@ const themes: JupyterLabPlugin<IThemeManager> = {
       }], 0);
     }
 
-    // If we have a command palette, add theme
-    // switching options to it.
+    // If we have a command palette, add theme switching options to it.
     if (palette) {
-      const category = 'Settings';
       manager.ready.then(() => {
-        each(manager.themes, theme => {
-          palette.addItem({
-            command: CommandIDs.changeTheme,
-            args: { isPalette: true, theme: theme },
-            category
-          });
+        const category = 'Settings';
+        const command = CommandIDs.changeTheme;
+        const isPalette = true;
+
+        manager.themes.forEach(theme => {
+          palette.addItem({ command, args: { isPalette, theme }, category });
         });
       });
     }
@@ -242,7 +236,7 @@ const state: JupyterLabPlugin<IStateDB> = {
       }
     };
 
-    command = CommandIDs.clearStateDB;
+    command = CommandIDs.clearState;
     commands.addCommand(command, {
       label: 'Clear Application Restore State',
       execute: () => state.clear()
@@ -365,9 +359,7 @@ namespace Private {
       splashCount = Math.max(splashCount - 1, 0);
       if (splashCount === 0 && splash) {
         splash.classList.add('splash-fade');
-        setTimeout(() => {
-          document.body.removeChild(splash);
-        }, 500);
+        setTimeout(() => { document.body.removeChild(splash); }, 500);
       }
     });
   }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -201,7 +201,7 @@ const splash: JupyterLabPlugin<ISplashScreen> = {
   id: '@jupyterlab/apputils-extension:splash',
   autoStart: true,
   provides: ISplashScreen,
-  activate: () => ({ show: () => Private.showSplash() })
+  activate: app => ({ show: () => Private.showSplash(app.restored) })
 };
 
 
@@ -343,7 +343,7 @@ namespace Private {
    * Show the splash element.
    */
   export
-  function showSplash(): IDisposable {
+  function showSplash(ready: Promise<any>): IDisposable {
     if (!splash) {
       splash = document.createElement('div');
       splash.id = 'jupyterlab-splash';
@@ -386,11 +386,13 @@ namespace Private {
     document.body.appendChild(splash);
     splashCount++;
     return new DisposableDelegate(() => {
-      splashCount = Math.max(splashCount - 1, 0);
-      if (splashCount === 0 && splash) {
-        splash.classList.add('splash-fade');
-        setTimeout(() => { document.body.removeChild(splash); }, 500);
-      }
+      ready.then(() => {
+        splashCount = Math.max(splashCount - 1, 0);
+        if (splashCount === 0 && splash) {
+          splash.classList.add('splash-fade');
+          setTimeout(() => { document.body.removeChild(splash); }, 500);
+        }
+      });
     });
   }
 }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -225,7 +225,7 @@ const state: JupyterLabPlugin<IStateDB> = {
     const transform = new PromiseDelegate<StateDB.DataTransform>();
     const state = new StateDB({
       namespace: info.namespace,
-      load: transform.promise
+      transform: transform.promise
     });
     const disposables = new DisposableSet();
     const pattern = /^\/workspaces\/(.+)/;

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -68,7 +68,7 @@ class Palette implements ICommandPalette {
    */
   addItem(options: IPaletteItem): IDisposable {
     let item = this._palette.addItem(options as CommandPalette.IItemOptions);
-    return new DisposableDelegate(() => this._palette.removeItem(item));
+    return new DisposableDelegate(() => { this._palette.removeItem(item); });
   }
 
   private _palette: CommandPalette;

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -129,6 +129,14 @@ namespace PageConfig {
   }
 
   /**
+   * Get the workspaces url for a JupyterLab application.
+   */
+  export
+  function getWorkspacesUrl(): string {
+    return URLExt.join(getBaseUrl(), getOption('pageUrl'), 'workspaces');
+  }
+
+  /**
    * Get the base websocket url for a Jupyter application.
    */
   export

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -129,14 +129,6 @@ namespace PageConfig {
   }
 
   /**
-   * Get the workspaces url for a JupyterLab application.
-   */
-  export
-  function getWorkspacesUrl(): string {
-    return URLExt.join(getBaseUrl(), getOption('pageUrl'), 'workspaces');
-  }
-
-  /**
    * Get the base websocket url for a Jupyter application.
    */
   export

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -75,6 +75,20 @@ interface IStateDB extends IDataConnector<ReadonlyJSONValue> {
   fetchNamespace(namespace: string): Promise<IStateItem[]>;
 
   /**
+   * Overwrite all the data in the state database with new contents.
+   *
+   * @param contents - The new contents of the state database.
+   *
+   * @returns A promise that resolves on success.
+   *
+   * #### Notes
+   * Each top-level key in the `contents` object will be stored as an individual
+   * value in the state database. This method accepts JSON in the same format
+   * this is returned by the `toJSON` method.
+   */
+  fromJSON(contents: ReadonlyJSONObject): Promise<void>;
+
+  /**
    * Return a serialized copy of the state database's entire contents.
    *
    * @returns A promise that bears the database contents as JSON.
@@ -201,6 +215,30 @@ class StateDB implements IStateDB {
     }
 
     return Promise.resolve(items);
+  }
+
+  /**
+   * Overwrite all the data in the state database with new contents.
+   *
+   * @param contents - The new contents of the state database.
+   *
+   * @returns A promise that resolves on success.
+   *
+   * #### Notes
+   * Each top-level key in the `contents` object will be stored as an individual
+   * value in the state database. This method accepts JSON in the same format
+   * this is returned by the `toJSON` method.
+   */
+  fromJSON(contents: ReadonlyJSONObject): Promise<void> {
+    this._clear();
+
+    try {
+      Object.keys(contents).forEach(key => { this._save(key, contents[key]); });
+    } catch (error) {
+      return Promise.reject(error);
+    }
+
+    return Promise.resolve(undefined);
   }
 
   /**

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -352,6 +352,12 @@ class StateDB implements IStateDB {
  */
 export
 namespace StateDB {
+  export
+  type DataChange = {
+    type: 'cancel' | 'clear' | 'merge' | 'overwrite',
+    contents: ReadonlyJSONObject | null
+  };
+
   /**
    * The instantiation options for a state database.
    */
@@ -371,7 +377,7 @@ namespace StateDB {
      * be cleared, merged with the `contents` data, or if it should be
      * overwritten with the `contents` data.
      */
-    load?: Promise<{ type: 'clear' | 'merge' | 'overwrite', contents?: ReadonlyJSONObject}>;
+    load?: Promise<DataChange>;
   }
 }
 

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -177,7 +177,6 @@ class StateDB implements IStateDB {
   fetchNamespace(namespace: string): Promise<IStateItem[]> {
     const { localStorage } = window;
     const prefix = `${this.namespace}:${namespace}:`;
-    const regex = new RegExp(`^${this.namespace}\:`);
     let items: IStateItem[] = [];
     let i = localStorage.length;
 
@@ -191,7 +190,7 @@ class StateDB implements IStateDB {
           let envelope = JSON.parse(value) as Private.Envelope;
 
           items.push({
-            id: key.replace(regex, ''),
+            id: key.replace(`${this.namespace}:`, ''),
             value: envelope ? envelope.v : undefined
           });
         } catch (error) {
@@ -224,21 +223,21 @@ class StateDB implements IStateDB {
    */
   toJSON(): Promise<ReadonlyJSONObject> {
     const { localStorage } = window;
-    const regex = new RegExp(`^${this.namespace}\:`);
+    const prefix = `${this.namespace}:`;
     const contents: Partial<ReadonlyJSONObject> =  { };
     let i = localStorage.length;
 
     while (i) {
       let key = localStorage.key(--i);
 
-      if (key && key.match(regex)) {
+      if (key && key.indexOf(prefix) === 0) {
         let value = localStorage.getItem(key);
 
         try {
           let envelope = JSON.parse(value) as Private.Envelope;
 
           if (envelope) {
-            contents[key.replace(regex, '')] = envelope.v;
+            contents[key.replace(prefix, '')] = envelope.v;
           }
         } catch (error) {
           console.warn(error);

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -107,6 +107,8 @@ class StateDB implements IStateDB {
       const { contents, type } = initial;
 
       switch (type) {
+        case 'cancel':
+          return;
         case 'clear':
           this._clear();
           return;
@@ -352,9 +354,19 @@ class StateDB implements IStateDB {
  */
 export
 namespace StateDB {
+  /**
+   * A data transformation that can be applied to a state database.
+   */
   export
   type DataChange = {
+    /*
+     * The change operation being applied.
+     */
     type: 'cancel' | 'clear' | 'merge' | 'overwrite',
+
+    /**
+     * The contents of the change operation.
+     */
     contents: ReadonlyJSONObject | null
   };
 
@@ -371,11 +383,6 @@ namespace StateDB {
     /**
      * An optional promise that resolves with the contents that should reside
      * in the state database.
-     *
-     * #### Notes
-     * The `type` field indicates whether the data in the state database should
-     * be cleared, merged with the `contents` data, or if it should be
-     * overwritten with the `contents` data.
      */
     load?: Promise<DataChange>;
   }

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -358,7 +358,7 @@ namespace StateDB {
    * A data transformation that can be applied to a state database.
    */
   export
-  type DataChange = {
+  type DataTransform = {
     /*
      * The change operation being applied.
      */
@@ -384,7 +384,7 @@ namespace StateDB {
      * An optional promise that resolves with the contents that should reside
      * in the state database.
      */
-    load?: Promise<DataChange>;
+    load?: Promise<DataTransform>;
   }
 }
 

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -94,17 +94,17 @@ class StateDB implements IStateDB {
    * @param options - The instantiation options for a state database.
    */
   constructor(options: StateDB.IOptions) {
-    const { load, namespace } = options;
+    const { namespace, transform } = options;
 
     this.namespace = namespace;
 
-    if (!load) {
+    if (!transform) {
       this._ready = Promise.resolve(undefined);
       return;
     }
 
-    this._ready = load.then(initial => {
-      const { contents, type } = initial;
+    this._ready = transform.then(transformation => {
+      const { contents, type } = transformation;
 
       switch (type) {
         case 'cancel':
@@ -381,10 +381,11 @@ namespace StateDB {
     namespace: string;
 
     /**
-     * An optional promise that resolves with the contents that should reside
-     * in the state database.
+     * An optional promise that resolves with a data transformation that is
+     * applied to the database contents before the database begins resolving
+     * client requests.
      */
-    load?: Promise<DataTransform>;
+    transform?: Promise<DataTransform>;
   }
 }
 

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -380,10 +380,10 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, bro
 
   commands.addCommand(CommandIDs.share, {
     execute: () => {
-      const path = browser.selectedItems().next().path;
+      const path = encodeURIComponent(browser.selectedItems().next().path);
       const tree = PageConfig.getTreeUrl();
 
-      Clipboard.copyToSystem(URLExt.join(tree, (path as string)));
+      Clipboard.copyToSystem(URLExt.join(tree, path));
     },
     isVisible: () => toArray(browser.selectedItems()).length === 1,
     iconClass: 'jp-MaterialIcon jp-LinkIcon',

--- a/packages/help-extension/src/index.ts
+++ b/packages/help-extension/src/index.ts
@@ -198,8 +198,8 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
     CommandIDs.launchClassic
   ].map(command => { return { command }; });
   helpMenu.addGroup(labGroup, 0);
-  const resourcesGroup =
-    RESOURCES.map(args => { return { args, command: CommandIDs.open }; });
+  const resourcesGroup = RESOURCES
+    .map(args => ({ args, command: CommandIDs.open }));
   helpMenu.addGroup(resourcesGroup, 10);
 
   // Generate a cache of the kernel help links.
@@ -273,7 +273,12 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
             showDialog({
               title,
               body,
-              buttons: [Dialog.createButton({label: 'DISMISS', className: 'jp-About-button jp-mod-reject jp-mod-styled'})]
+              buttons: [
+                Dialog.createButton({
+                  label: 'DISMISS',
+                  className: 'jp-About-button jp-mod-reject jp-mod-styled'
+                })
+              ]
             });
           }
         });
@@ -321,10 +326,20 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
       let jupyterURL = 'https://jupyter.org/about.html';
       let contributorsURL = 'https://github.com/jupyterlab/jupyterlab/graphs/contributors';
       let externalLinks = h.span({className: 'jp-About-externalLinks'},
-        h.a({href: contributorsURL, target: '_blank', className: 'jp-Button-flat'}, 'CONTRIBUTOR LIST'),
-        h.a({href: jupyterURL, target: '_blank', className: 'jp-Button-flat'}, 'ABOUT PROJECT JUPYTER')
+        h.a({
+          href: contributorsURL,
+          target: '_blank',
+          className: 'jp-Button-flat'
+        }, 'CONTRIBUTOR LIST'),
+        h.a({
+          href: jupyterURL,
+          target: '_blank',
+          className: 'jp-Button-flat'
+        }, 'ABOUT PROJECT JUPYTER')
       );
-      let copyright = h.span({className: 'jp-About-copyright'}, '© 2017 Project Jupyter');
+      let copyright = h.span({
+        className: 'jp-About-copyright'
+      }, '© 2017 Project Jupyter');
       let body = h.div({ className: 'jp-About-body' },
         externalLinks,
         copyright
@@ -333,7 +348,12 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
       showDialog({
         title,
         body,
-        buttons: [Dialog.createButton({label: 'DISMISS', className: 'jp-About-button jp-mod-reject jp-mod-styled'})]
+        buttons: [
+          Dialog.createButton({
+            label: 'DISMISS',
+            className: 'jp-About-button jp-mod-reject jp-mod-styled'
+          })
+        ]
       });
     }
   });

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -9,3 +9,4 @@ export * from './serverconnection';
 export * from './session';
 export * from './setting';
 export * from './terminal';
+export * from './workspace';

--- a/packages/services/src/manager.ts
+++ b/packages/services/src/manager.ts
@@ -37,6 +37,10 @@ import {
   ServerConnection
 } from './serverconnection';
 
+import {
+  WorkspaceManager
+} from './workspace';
+
 
 /**
  * A Jupyter services manager.
@@ -56,6 +60,7 @@ class ServiceManager implements ServiceManager.IManager {
     this.settings = new SettingManager(options);
     this.terminals = new TerminalManager(options);
     this.builder = new BuildManager(options);
+    this.workspaces = new WorkspaceManager(options);
 
     this.sessions.specsChanged.connect((sender, specs) => {
       this._specsChanged.emit(specs);
@@ -134,6 +139,11 @@ class ServiceManager implements ServiceManager.IManager {
    * Get the terminal manager instance.
    */
   readonly terminals: TerminalManager;
+
+  /**
+   * Get the workspace manager instance.
+   */
+  readonly workspaces: WorkspaceManager;
 
   /**
    * Test whether the manager is ready.

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -17,7 +17,7 @@ const SERVICE_SETTINGS_URL = 'api/settings';
 
 
 /**
- * The static namespace for `SettingManager`.
+ * The settings API service manager.
  */
 export
 class SettingManager {
@@ -47,7 +47,7 @@ class SettingManager {
     const { baseUrl, pageUrl } = serverSettings;
     const base = baseUrl + pageUrl;
     const url = Private.url(base, id);
-    const promise = ServerConnection.makeRequest(url, {}, serverSettings);
+    const promise = ServerConnection.makeRequest(url, { }, serverSettings);
 
     return promise.then(response => {
       if (response.status !== 200) {
@@ -84,7 +84,7 @@ class SettingManager {
         throw new ServerConnection.ResponseError(response);
       }
 
-      return void 0;
+      return undefined;
     });
   }
 }

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -65,8 +65,8 @@ class SettingManager {
    *
    * @param raw - The user setting values as a raw string of JSON with comments.
    *
-   * @returns A promise that resolves when saving is complete or rejects
-   * with a `ServerConnection.IError`.
+   * @returns A promise that resolves when saving is complete or rejects with
+   * a `ServerConnection.IError`.
    */
   save(id: string, raw: string): Promise<void> {
     const { serverSettings } = this;

--- a/packages/services/src/workspace/index.ts
+++ b/packages/services/src/workspace/index.ts
@@ -61,6 +61,36 @@ class WorkspaceManager {
       return response.json();
     });
   }
+
+  /**
+   * Save a workspace.
+   *
+   * @param id - The workspace's ID.
+   *
+   * @param workspace - The workspace being saved.
+   *
+   * @returns A promise that resolves when saving is complete or rejects with
+   * a `ServerConnection.IError`.
+   */
+  save(id: string, workspace: Workspace.IWorkspace): Promise<void> {
+    const { serverSettings } = this;
+    const { baseUrl, pageUrl } = serverSettings;
+    const base = baseUrl + pageUrl;
+    const url = Private.url(base, id);
+    const init = {
+      body: JSON.stringify(workspace),
+      method: 'PUT'
+    };
+    const promise = ServerConnection.makeRequest(url, init, serverSettings);
+
+    return promise.then(response => {
+      if (response.status !== 204) {
+        throw new ServerConnection.ResponseError(response);
+      }
+
+      return undefined;
+    });
+  }
 }
 
 

--- a/packages/services/src/workspace/index.ts
+++ b/packages/services/src/workspace/index.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  URLExt
+} from '@jupyterlab/coreutils';
+
+import {
+  ReadonlyJSONObject
+} from '@phosphor/coreutils';
+
+import {
+  ServerConnection
+} from '../serverconnection';
+
+
+/**
+ * The url for the lab workspaces service.
+ */
+const SERVICE_WORKSPACES_URL = 'api/workspaces';
+
+
+/**
+ * The workspaces API service manager.
+ */
+export
+class WorkspaceManager {
+  /**
+   * Create a new workspace manager.
+   */
+  constructor(options: WorkspaceManager.IOptions = { }) {
+    this.serverSettings = options.serverSettings ||
+      ServerConnection.makeSettings();
+  }
+
+  /**
+   * The server settings used to make API requests.
+   */
+  readonly serverSettings: ServerConnection.ISettings;
+
+  /**
+   * Fetch a workspace.
+   *
+   * @param id - The workspaces's ID.
+   *
+   * @returns A promise that resolves with the workspace or rejects with a
+   * `ServerConnection.IError`.
+   */
+  fetch(id: string): Promise<Workspace.IWorkspace> {
+    const { serverSettings } = this;
+    const { baseUrl, pageUrl } = serverSettings;
+    const base = baseUrl + pageUrl;
+    const url = Private.url(base, id);
+    const promise = ServerConnection.makeRequest(url, { }, serverSettings);
+
+    return promise.then(response => {
+      if (response.status !== 200) {
+        throw new ServerConnection.ResponseError(response);
+      }
+
+      return response.json();
+    });
+  }
+}
+
+
+/**
+ * A namespace for `WorkspaceManager` statics.
+ */
+export
+namespace WorkspaceManager {
+  /**
+   * The instantiation options for a workspace manager.
+   */
+  export
+  interface IOptions {
+    /**
+     * The server settings used to make API requests.
+     */
+    serverSettings?: ServerConnection.ISettings;
+  }
+}
+
+
+/**
+ * A namespace for workspace API interfaces.
+ */
+export
+namespace Workspace {
+  /**
+   * The interface for the workspace API manager.
+   */
+  export
+  interface IManager extends WorkspaceManager { }
+
+  /**
+   * The interface describing a workspace API response.
+   */
+  export
+  interface IWorkspace {
+    /**
+     * The workspace data.
+     */
+    data: ReadonlyJSONObject;
+
+    /**
+     * The metadata for a workspace.
+     */
+    metadata: {
+      /**
+       * The workspace ID.
+       */
+      id: string;
+    };
+  }
+}
+
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+  /**
+   * Get the url for a workspace.
+   */
+  export
+  function url(base: string, id: string): string {
+    return URLExt.join(base, SERVICE_WORKSPACES_URL, id);
+  }
+}

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -86,7 +86,7 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, registry: ISetting
   commands.addCommand(CommandIDs.debug, {
     execute: () => { tracker.currentWidget.toggleDebug(); },
     iconClass: 'jp-MaterialIcon jp-BugIcon',
-    label: 'Debug user settings in inspector',
+    label: 'Debug User Settings In Inspector',
     isToggled: () => tracker.currentWidget.isDebugVisible
   });
 
@@ -132,14 +132,14 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, registry: ISetting
   commands.addCommand(CommandIDs.revert, {
     execute: () => { tracker.currentWidget.revert(); },
     iconClass: 'jp-MaterialIcon jp-RefreshIcon',
-    label: 'Revert user settings',
+    label: 'Revert User Settings',
     isEnabled: () => tracker.currentWidget.canRevertRaw
   });
 
   commands.addCommand(CommandIDs.save, {
     execute: () => tracker.currentWidget.save(),
     iconClass: 'jp-MaterialIcon jp-SaveIcon',
-    label: 'Save user settings',
+    label: 'Save User Settings',
     isEnabled: () => tracker.currentWidget.canSaveRaw
   });
 

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -143,6 +143,8 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, registry: ISetting
     isEnabled: () => tracker.currentWidget.canSaveRaw
   });
 
+  palette.addItem({ category: 'Settings', command: 'apputils:save-statedb' });
+
   return tracker;
 }
 export default plugin;

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -143,8 +143,6 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, registry: ISetting
     isEnabled: () => tracker.currentWidget.canSaveRaw
   });
 
-  palette.addItem({ category: 'Settings', command: 'apputils:save-statedb' });
-
   return tracker;
 }
 export default plugin;

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -40,7 +40,7 @@
       },
       "type": "object"
     },
-    "command-palette:activate": {
+    "apputils:activate-command-palette": {
       "default": { },
       "properties": {
         "command": { "default": "apputils:activate-command-palette" },

--- a/test/src/application/layoutrestorer.spec.ts
+++ b/test/src/application/layoutrestorer.spec.ts
@@ -163,14 +163,15 @@ describe('apputils', () => {
           execute: () => { called = true; }
         });
         state.save(key, { data: null }).then(() => {
+          ready.resolve(undefined);
           return restorer.restore(tracker, {
             args: () => null,
             name: () => tracker.namespace,
             command: tracker.namespace
           });
         }).catch(done);
-        ready.resolve(void 0);
-        restorer.restored.then(() => { expect(called).to.be(true); })
+        restorer.restored
+          .then(() => { expect(called).to.be(true); })
           .then(() => state.remove(key))
           .then(() => { done(); })
           .catch(done);

--- a/test/src/coreutils/statedb.spec.ts
+++ b/test/src/coreutils/statedb.spec.ts
@@ -25,6 +25,33 @@ describe('StateDB', () => {
 
   });
 
+  describe('#changed', () => {
+
+    it('should emit changes when the database is updated', done => {
+      let namespace = 'test-namespace';
+      let db = new StateDB({ namespace });
+      let changes: StateDB.Change[] = [
+        { id: 'foo', type: 'save' },
+        { id: 'foo', type: 'remove' },
+        { id: 'bar', type: 'save' },
+        { id: 'bar', type: 'remove' }
+      ];
+      let recorded: StateDB.Change[] = [];
+
+      db.changed.connect((sender, change) => { recorded.push(change); });
+
+      db.save('foo', 0)
+        .then(() => db.remove('foo'))
+        .then(() => db.save('bar', 1))
+        .then(() => db.remove('bar'))
+        .then(() => { expect(recorded).to.eql(changes); })
+        .then(() => db.clear())
+        .then(done)
+        .catch(done);
+    });
+
+  });
+
   describe('#maxLength', () => {
 
     it('should enforce the maximum length of a stored item', done => {

--- a/test/src/coreutils/statedb.spec.ts
+++ b/test/src/coreutils/statedb.spec.ts
@@ -8,47 +8,19 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  PromiseDelegate, ReadonlyJSONObject
+  ReadonlyJSONObject
 } from '@phosphor/coreutils';
 
 
 describe('StateDB', () => {
 
-  beforeEach(() => {
-    window.localStorage.clear();
-  });
+  beforeEach(() => { window.localStorage.clear(); });
 
   describe('#constructor()', () => {
 
     it('should create a state database', () => {
       let db = new StateDB({ namespace: 'test' });
       expect(db).to.be.a(StateDB);
-    });
-
-    it('should take an optional when promise', () => {
-      let { localStorage } = window;
-      let promise = new PromiseDelegate<void>();
-      let db = new StateDB({ namespace: 'test', when: promise.promise });
-      let key = 'foo:bar';
-      let value = { baz: 'qux' };
-      promise.resolve(void 0);
-      return promise.promise.then(() => {
-        expect(localStorage.length).to.be(0);
-        return db.save(key, value);
-      }).then(() => db.fetch(key))
-      .then(fetched => { expect(fetched).to.eql(value); });
-    });
-
-    it('should clear the namespace if the sentinel is set', () => {
-      let { localStorage } = window;
-      let key = 'test:statedb:sentinel';
-      localStorage.setItem(key, 'sentinel');
-      localStorage.setItem('test:foo', 'bar');
-      let promise = new PromiseDelegate<void>();
-      let db = new StateDB({ namespace: 'test', when: promise.promise });
-      expect(db).to.be.a(StateDB);
-      expect(localStorage.length).to.be(1);
-      expect(localStorage.getItem('test:foo')).to.be(null);
     });
 
   });
@@ -188,37 +160,6 @@ describe('StateDB', () => {
           expect(sorted[1].id).to.be(keys[4]);
           expect(sorted[2].id).to.be(keys[5]);
         })
-        .then(() => db.clear())
-        .then(done)
-        .catch(done);
-    });
-
-  });
-
-  describe('#fromJSON()', () => {
-
-    it('overwrites the full contents of a state database', done => {
-      let { localStorage } = window;
-
-      let db = new StateDB({ namespace: 'test-namespace' });
-      let key = 'abc';
-      let value = '123';
-      let contents: ReadonlyJSONObject = {
-        [key]: 'def',
-        ghi: 'jkl',
-        mno: 1,
-        pqr: {
-          foo: { bar: { baz: 'qux' } }
-        }
-      };
-
-      expect(localStorage.length).to.be(0);
-      db.save(key, value)
-        .then(() => db.fetch(key))
-        .then(result => { expect(result).to.be(value); })
-        .then(() => db.fromJSON(contents))
-        .then(() => db.fetch(key))
-        .then(result => { expect(result).to.be(contents[key]); })
         .then(() => db.clear())
         .then(done)
         .catch(done);

--- a/test/src/coreutils/statedb.spec.ts
+++ b/test/src/coreutils/statedb.spec.ts
@@ -195,6 +195,37 @@ describe('StateDB', () => {
 
   });
 
+  describe('#fromJSON()', () => {
+
+    it('overwrites the full contents of a state database', done => {
+      let { localStorage } = window;
+
+      let db = new StateDB({ namespace: 'test-namespace' });
+      let key = 'abc';
+      let value = '123';
+      let contents: ReadonlyJSONObject = {
+        [key]: 'def',
+        ghi: 'jkl',
+        mno: 1,
+        pqr: {
+          foo: { bar: { baz: 'qux' } }
+        }
+      };
+
+      expect(localStorage.length).to.be(0);
+      db.save(key, value)
+        .then(() => db.fetch(key))
+        .then(result => { expect(result).to.be(value); })
+        .then(() => db.fromJSON(contents))
+        .then(() => db.fetch(key))
+        .then(result => { expect(result).to.be(contents[key]); })
+        .then(() => db.clear())
+        .then(done)
+        .catch(done);
+    });
+
+  });
+
   describe('#remove()', () => {
 
     it('should remove a stored key', done => {

--- a/test/src/coreutils/statedb.spec.ts
+++ b/test/src/coreutils/statedb.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  PromiseDelegate
+  PromiseDelegate, ReadonlyJSONObject
 } from '@phosphor/coreutils';
 
 
@@ -230,6 +230,32 @@ describe('StateDB', () => {
         .then(fetched => { expect(fetched).to.eql(value); })
         .then(() => db.remove(key))
         .then(() => { expect(localStorage).to.be.empty(); })
+        .then(done)
+        .catch(done);
+    });
+
+  });
+
+  describe('#toJSON()', () => {
+
+    it('return the full contents of a state database', done => {
+      let { localStorage } = window;
+
+      let db = new StateDB({ namespace: 'test-namespace' });
+      let contents: ReadonlyJSONObject = {
+        abc: 'def',
+        ghi: 'jkl',
+        mno: 1,
+        pqr: {
+          foo: { bar: { baz: 'qux' } }
+        }
+      };
+
+      expect(localStorage.length).to.be(0);
+      Promise.all(Object.keys(contents).map(key => db.save(key, contents[key])))
+        .then(() => db.toJSON())
+        .then(serialized => { expect(serialized).to.eql(contents); })
+        .then(() => db.clear())
         .then(done)
         .catch(done);
     });


### PR DESCRIPTION
This PR adds the concept of named sessions that are saved on the server, these are called **workspaces**. This is a new feature and is not prominently exposed while we consider what the best user interface and experience should be.

To use this feature:
* A user navigates to a workspace URL at `/lab/workspaces/<workspace_name>`
* If `<workspace_name>` exists on the back-end, the workspace data will load the saved layout and open files in the JupyterLab interface. If it does not exist, it will be created.
* The workspace will be automatically saved as the user changes the state of the application.

Depends on https://github.com/jupyterlab/jupyterlab_launcher/pull/34
  
  