### PR TITLE
Add support for types in the completer

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -405,10 +405,10 @@ class CompletionHandler implements IDisposable {
         // For some reason the _jupyter_types_experimental list has two entries for each
         // match, with one having a type of "<unknown>". Discard those and use undefined
         // to indicate an unknown type.
-        if (matches.indexOf(item.text as string) !== -1 && item.type !== "<unknown>") {
+        if (matches.indexOf(item.text as string) !== -1 && item.type !== '<unknown>') {
           typeMap[item.text as string] = item.type;
         }
-      })
+      });
     }
 
     // Update the options, including the type map.

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  each, iter, toArray
-} from '@phosphor/algorithm';
-
-import {
   CodeEditor
 } from '@jupyterlab/codeeditor';
 
@@ -396,17 +392,21 @@ class CompletionHandler implements IDisposable {
       });
     }
 
-    // Extract the optional typeMap. The current implementation uses _jupyter_types_experimental
-    // which provide string type names. We make no assumptions about the names of the types, so
-    // other kernels can provide their own types.
+    // Extract the optional typeMap. The current implementation uses
+    // _jupyter_types_experimental which provide string type names. We make no
+    // assumptions about the names of the types, so other kernels can provide
+    // their own types.
     let typeMap: JSONObject = {};
     if (reply.metadata._jupyter_types_experimental) {
-      each(iter(toArray(reply.metadata._jupyter_types_experimental as JSONArray)), (item: JSONObject) => {
-        // For some reason the _jupyter_types_experimental list has two entries for each
-        // match, with one having a type of "<unknown>". Discard those and use undefined
-        // to indicate an unknown type.
-        if (matches.indexOf(item.text as string) !== -1 && item.type !== '<unknown>') {
-          typeMap[item.text as string] = item.type;
+      let types = (reply.metadata._jupyter_types_experimental as JSONArray);
+      types.forEach((item: JSONObject) => {
+        // For some reason the _jupyter_types_experimental list has two entries
+        // for each match, with one having a type of "<unknown>". Discard those
+        // and use undefined to indicate an unknown type.
+        let text = item.text as string;
+        let type = item.type as string;
+        if (matches.indexOf(text) !== -1 && type !== '<unknown>') {
+          typeMap[text] = item.type;
         }
       });
     }

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  each, iter, toArray
+} from '@phosphor/algorithm';
+
+import {
   CodeEditor
 } from '@jupyterlab/codeeditor';
 
@@ -10,7 +14,7 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  ReadonlyJSONObject
+  ReadonlyJSONObject, JSONObject, JSONArray
 } from '@phosphor/coreutils';
 
 import {
@@ -392,8 +396,23 @@ class CompletionHandler implements IDisposable {
       });
     }
 
-    // Update the options.
-    model.setOptions(matches);
+    // Extract the optional typeMap. The current implementation uses _jupyter_types_experimental
+    // which provide string type names. We make no assumptions about the names of the types, so
+    // other kernels can provide their own types.
+    let typeMap: JSONObject = {};
+    if (reply.metadata._jupyter_types_experimental) {
+      each(iter(toArray(reply.metadata._jupyter_types_experimental as JSONArray)), (item: JSONObject) => {
+        // For some reason the _jupyter_types_experimental list has two entries for each
+        // match, with one having a type of "<unknown>". Discard those and use undefined
+        // to indicate an unknown type.
+        if (matches.indexOf(item.text as string) !== -1 && item.type !== "<unknown>") {
+          typeMap[item.text as string] = item.type;
+        }
+      })
+    }
+
+    // Update the options, including the type map.
+    model.setOptions(matches, typeMap as Completer.ITypeMap);
 
     // Update the cursor.
     model.cursor = {

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -182,11 +182,11 @@ class CompleterModel implements Completer.IModel {
 
   /**
    * The map from identifiers (a.b) to types (function, module, class, instance, etc.).
-   * 
+   *
    * #### Notes
    * A type map is currently only provided by the latest IPython kernel using the
    * completer reply metadata field `_jupyter_types_experimental`. The values are completely up to the kernel.
-   * 
+   *
    */
   typeMap(): ReadonlyJSONObject {
     return this._typeMap;
@@ -194,7 +194,7 @@ class CompleterModel implements Completer.IModel {
 
   /**
    * An ordered list of all the known types in the typeMap.
-   * 
+   *
    * #### Notes
    * To visually encode the types of the completer matches, we assemble an ordered list. This list begin
    * with ['function', 'instance', 'class', 'module', 'keyword'] and then has any remaining types
@@ -443,7 +443,7 @@ namespace Private {
 
   /**
    * Compute a reliably ordered list of types.
-   * 
+   *
    * #### Notes
    * The resulting list always begins with the known types
    * ['function', 'instance', 'class', 'module', 'keyword'], followed by other types in alphabetical

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -210,7 +210,7 @@ class CompleterModel implements Completer.IModel {
    */
   setOptions(newValue: IterableOrArrayLike<string>, typeMap: JSONObject) {
     const values = toArray(newValue || []);
-    if (JSONExt.deepEqual(values, this._options)) {
+    if (JSONExt.deepEqual(values, this._options) && JSONExt.deepEqual(typeMap, this._typeMap)) {
       return;
     }
     if (values.length) {
@@ -220,6 +220,8 @@ class CompleterModel implements Completer.IModel {
       this._subsetMatch = true;
     } else {
       this._options = [];
+      this._typeMap = {};
+      this._orderedTypes = [];
     }
     this._stateChanged.emit(void 0);
   }

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  IIterator, IterableOrArrayLike, iter, map, toArray, filter
+  IIterator, IterableOrArrayLike, iter, map, toArray
 } from '@phosphor/algorithm';
 
 import {
@@ -181,11 +181,13 @@ class CompleterModel implements Completer.IModel {
   }
 
   /**
-   * The map from identifiers (a.b) to types (function, module, class, instance, etc.).
+   * The map from identifiers (a.b) to types (function, module, class, instance,
+   * etc.).
    *
    * #### Notes
-   * A type map is currently only provided by the latest IPython kernel using the
-   * completer reply metadata field `_jupyter_types_experimental`. The values are completely up to the kernel.
+   * A type map is currently only provided by the latest IPython kernel using
+   * the completer reply metadata field `_jupyter_types_experimental`. The
+   * values are completely up to the kernel.
    *
    */
   typeMap(): ReadonlyJSONObject {
@@ -196,10 +198,14 @@ class CompleterModel implements Completer.IModel {
    * An ordered list of all the known types in the typeMap.
    *
    * #### Notes
-   * To visually encode the types of the completer matches, we assemble an ordered list. This list begin
-   * with ['function', 'instance', 'class', 'module', 'keyword'] and then has any remaining types
-   * listed alphebetically. This will give reliable visual encoding for these known types, but allow
-   * kernels to provide new types.
+   * To visually encode the types of the completer matches, we assemble an
+   * ordered list. This list begins with:
+   * ```
+   * ['function', 'instance', 'class', 'module', 'keyword']
+   * ```
+   * and then has any remaining types listed alphebetically. This will give
+   * reliable visual encoding for these known types, but allow kernels to
+   * provide new types.
    */
   orderedTypes(): string[] {
     return this._orderedTypes;
@@ -211,7 +217,8 @@ class CompleterModel implements Completer.IModel {
   setOptions(newValue: IterableOrArrayLike<string>, typeMap?: JSONObject) {
     const values = toArray(newValue || []);
     const types = typeMap || {};
-    if (JSONExt.deepEqual(values, this._options) && JSONExt.deepEqual(types, this._typeMap)) {
+    if (JSONExt.deepEqual(values, this._options) &&
+        JSONExt.deepEqual(types, this._typeMap)) {
       return;
     }
     if (values.length) {
@@ -448,18 +455,21 @@ namespace Private {
    * Compute a reliably ordered list of types.
    *
    * #### Notes
-   * The resulting list always begins with the known types
-   * ['function', 'instance', 'class', 'module', 'keyword'], followed by other types in alphabetical
-   * order.
+   * The resulting list always begins with the known types:
+   * ```
+   * ['function', 'instance', 'class', 'module', 'keyword']
+   * ```
+   * followed by other types in alphabetical order.
    */
   export
   function findOrderedTypes(typeMap: ReadonlyJSONObject): string[] {
     const knownTypes = ['function', 'instance', 'class', 'module', 'keyword'];
-    let allTypes: string[] = toArray(map(Object.keys(typeMap), key => typeMap[key].toString()));
-    let newTypes = toArray(filter(allTypes, value => knownTypes.indexOf(value) === -1));
-    newTypes.sort();
-    let finalTypes = knownTypes.concat(newTypes);
-    return finalTypes;
+    let allTypes: string[] = Object.keys(typeMap)
+      .map(key => typeMap[key].toString());
+    let newTypes = allTypes
+      .filter(value => knownTypes.indexOf(value) === -1).sort();
+
+    return knownTypes.concat(newTypes);
   }
 
 }

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -208,15 +208,16 @@ class CompleterModel implements Completer.IModel {
   /**
    * Set the available options in the completer menu.
    */
-  setOptions(newValue: IterableOrArrayLike<string>, typeMap: JSONObject) {
+  setOptions(newValue: IterableOrArrayLike<string>, typeMap?: JSONObject) {
     const values = toArray(newValue || []);
-    if (JSONExt.deepEqual(values, this._options) && JSONExt.deepEqual(typeMap, this._typeMap)) {
+    const types = typeMap || {};
+    if (JSONExt.deepEqual(values, this._options) && JSONExt.deepEqual(types, this._typeMap)) {
       return;
     }
     if (values.length) {
       this._options = values;
-      this._typeMap = typeMap;
-      this._orderedTypes = Private.findOrderedTypes(typeMap);
+      this._typeMap = types;
+      this._orderedTypes = Private.findOrderedTypes(types);
       this._subsetMatch = true;
     } else {
       this._options = [];

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -2,11 +2,11 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  IIterator, IterableOrArrayLike, iter, map, toArray
+  IIterator, IterableOrArrayLike, iter, map, toArray, filter
 } from '@phosphor/algorithm';
 
 import {
-  JSONExt
+  JSONExt, JSONObject, ReadonlyJSONObject
 } from '@phosphor/coreutils';
 
 import {
@@ -181,15 +181,42 @@ class CompleterModel implements Completer.IModel {
   }
 
   /**
+   * The map from identifiers (a.b) to types (function, module, class, instance, etc.).
+   * 
+   * #### Notes
+   * A type map is currently only provided by the latest IPython kernel using the
+   * completer reply metadata field `_jupyter_types_experimental`. The values are completely up to the kernel.
+   * 
+   */
+  typeMap(): ReadonlyJSONObject {
+    return this._typeMap;
+  }
+
+  /**
+   * An ordered list of all the known types in the typeMap.
+   * 
+   * #### Notes
+   * To visually encode the types of the completer matches, we assemble an ordered list. This list begin
+   * with ['function', 'instance', 'class', 'module', 'keyword'] and then has any remaining types
+   * listed alphebetically. This will give reliable visual encoding for these known types, but allow
+   * kernels to provide new types.
+   */
+  orderedTypes(): string[] {
+    return this._orderedTypes;
+  }
+
+  /**
    * Set the available options in the completer menu.
    */
-  setOptions(newValue: IterableOrArrayLike<string>) {
+  setOptions(newValue: IterableOrArrayLike<string>, typeMap: JSONObject) {
     const values = toArray(newValue || []);
     if (JSONExt.deepEqual(values, this._options)) {
       return;
     }
     if (values.length) {
       this._options = values;
+      this._typeMap = typeMap;
+      this._orderedTypes = Private.findOrderedTypes(typeMap);
       this._subsetMatch = true;
     } else {
       this._options = [];
@@ -346,6 +373,8 @@ class CompleterModel implements Completer.IModel {
     this._original = null;
     this._query = '';
     this._subsetMatch = false;
+    this._typeMap = {};
+    this._orderedTypes = [];
   }
 
   private _current: Completer.ITextState | null = null;
@@ -355,6 +384,8 @@ class CompleterModel implements Completer.IModel {
   private _original: Completer.ITextState | null = null;
   private _query = '';
   private _subsetMatch = false;
+  private _typeMap: ReadonlyJSONObject = {};
+  private _orderedTypes: string[] = [];
   private _stateChanged = new Signal<this, void>(this);
 }
 
@@ -409,4 +440,23 @@ namespace Private {
     }
     return a.raw.localeCompare(b.raw);
   }
+
+  /**
+   * Compute a reliably ordered list of types.
+   * 
+   * #### Notes
+   * The resulting list always begins with the known types
+   * ['function', 'instance', 'class', 'module', 'keyword'], followed by other types in alphabetical
+   * order.
+   */
+  export
+  function findOrderedTypes(typeMap: ReadonlyJSONObject): string[] {
+    const knownTypes = ['function', 'instance', 'class', 'module', 'keyword'];
+    let allTypes: string[] = toArray(map(Object.keys(typeMap), key => typeMap[key].toString()));
+    let newTypes = toArray(filter(allTypes, value => knownTypes.indexOf(value) === -1));
+    newTypes.sort();
+    let finalTypes = knownTypes.concat(newTypes);
+    return finalTypes;
+  }
+
 }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -594,7 +594,7 @@ namespace Completer {
     /**
      * Set the available options in the completer menu.
      */
-    setOptions(options: IterableOrArrayLike<string>, typeMap: JSONObject): void;
+    setOptions(options: IterableOrArrayLike<string>, typeMap?: JSONObject): void;
 
     /**
      * Handle a cursor change.
@@ -714,11 +714,16 @@ namespace Completer {
         let colorIndex: number = orderedTypes.indexOf(type) + 1;
         typeNode.className = 'jp-Completer-type';
         typeNode.setAttribute(`data-color-index`, colorIndex.toString());
-        li.appendChild(typeNode);
         li.title = type;
+        let typeExtendedNode = document.createElement('code');
+        typeExtendedNode.className = 'jp-Completer-typeExtended';
+        typeExtendedNode.textContent = type.toLocaleLowerCase();
+        li.appendChild(typeNode);
+        li.appendChild(matchNode);
+        li.appendChild(typeExtendedNode);
+      } else {
+        li.appendChild(matchNode);
       }
-
-      li.appendChild(matchNode);
       return li;
     }
   }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -257,7 +257,7 @@ class Completer extends Widget {
     let node = this.node;
     node.textContent = '';
 
-    // Compute an ordered list of all the types in the typeMap, this is computed once by the 
+    // Compute an ordered list of all the types in the typeMap, this is computed once by the
     // model each time new data arrives for efficiency.
     let orderedTypes = model.orderedTypes();
 
@@ -672,7 +672,7 @@ namespace Completer {
 
   export
   interface  ITypeMap {
-    [index: string]: string
+    [index: string]: string;
   }
 
 
@@ -711,7 +711,7 @@ namespace Completer {
         let typeNode = document.createElement('span');
         let type = typeMap[item.raw] || '';
         typeNode.textContent = (type[0] || '').toLowerCase();
-        let colorIndex: number = orderedTypes.indexOf(type) + 1
+        let colorIndex: number = orderedTypes.indexOf(type) + 1;
         typeNode.className = 'jp-Completer-type';
         typeNode.setAttribute(`data-color-index`, colorIndex.toString());
         li.appendChild(typeNode);

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -257,13 +257,14 @@ class Completer extends Widget {
     let node = this.node;
     node.textContent = '';
 
-    // Compute an ordered list of all the types in the typeMap, this is computed once by the
-    // model each time new data arrives for efficiency.
+    // Compute an ordered list of all the types in the typeMap, this is computed
+    // once by the model each time new data arrives for efficiency.
     let orderedTypes = model.orderedTypes();
 
     // Populate the completer items.
     for (let item of items) {
-      let li = this._renderer.createItemNode(item!, model.typeMap(), orderedTypes);
+      let li = this._renderer
+        .createItemNode(item!, model.typeMap(), orderedTypes);
       node.appendChild(li);
     }
 
@@ -453,7 +454,8 @@ class Completer extends Widget {
       return;
     }
 
-    const position = editor.getPositionAt(model.cursor.start) as CodeEditor.IPosition;
+    const start = model.cursor.start;
+    const position = editor.getPositionAt(start) as CodeEditor.IPosition;
     const anchor = editor.getCoordinateForPosition(position) as ClientRect;
     const style = window.getComputedStyle(this.node);
     const borderLeft = parseInt(style.borderLeftWidth!, 10) || 0;
@@ -582,7 +584,8 @@ namespace Completer {
     options(): IIterator<string>;
 
     /**
-     * The map from identifiers (`a.b`) to their types (function, module, class, instance, etc.).
+     * The map from identifiers (`a.b`) to their types (function, module, class,
+     * instance, etc.).
      */
     typeMap(): ReadonlyJSONObject;
 
@@ -770,7 +773,7 @@ namespace Private {
   function itemValues(items: NodeList): string[] {
     let values: string[] = [];
     for (let i = 0, len = items.length; i < len; i++) {
-      values.push((items[i] as HTMLElement).getAttribute('data-value') as string);
+      values.push((items[i] as HTMLElement).getAttribute('data-value'));
     }
     return values;
   }

--- a/packages/completer/style/index.css
+++ b/packages/completer/style/index.css
@@ -12,10 +12,10 @@
 
 
 .jp-Completer {
+  box-shadow: var(--jp-elevation-z6);
   background: var(--jp-layout-color1);
   color: var(--jp-content-font-color1);
   border: var(--jp-border-width) solid var(--jp-border-color1);
-  box-shadow: var(--jp-elevation-z6);
   list-style-type: none;
   overflow: auto;
   padding: 0;
@@ -27,27 +27,105 @@
 
 
 .jp-Completer-item {
+  display: table-row;
+  box-sizing: border-box;
   margin: 0;
+  padding: 0;
+  height: var(--jp-private-completer-item-height);
   min-width: 150px;
-  padding: 0 2px;
+  font-size: var(--jp-private-completer-code-font-size);
+}
+
+
+.jp-Completer-item .jp-Completer-match {
+  display: table-cell;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0 8px 0 6px;
+  height: var(--jp-private-completer-item-height);
+  vertical-align: middle;
+}
+
+
+.jp-Completer-item .jp-Completer-type {
+  display: table-cell;
+  box-sizing: border-box;
+  height: var(--jp-private-completer-item-height);
+  text-align: center;
+  vertical-align: middle;
+  background: var(--jp-layout-color4);
+  color: white;
+  width: 24px;
+  font-family: var(-jp-ui-font-family);
 }
 
 
 .jp-Completer-item:hover, .jp-Completer-item.jp-mod-active {
-  background: var(--jp-layout-color2);
+  background: var(--jp-brand-color3);
+  opacity: 0.8;
 }
 
 
-.jp-Completer-item code {
-  font-size: var(--jp-private-completer-code-font-size);
-  height: var(--jp-private-completer-item-height);
-  padding: 0;
-  margin: 0;
-}
-
-
-.jp-Completer-item mark {
+.jp-Completer-item .jp-Completer-match mark {
   font-weight: bold;
   background: inherit;
   color: inherit;
 }
+
+
+.jp-Completer-type[data-color-index='0'] {
+  background: transparent;
+}
+
+
+.jp-Completer-type[data-color-index='1'] {
+  background: #1f77b4;
+}
+
+
+.jp-Completer-type[data-color-index='2'] {
+  background: #ff7f0e;
+}
+
+
+.jp-Completer-type[data-color-index='3'] {
+  background: #2ca02c;
+}
+
+
+.jp-Completer-type[data-color-index='4'] {
+  background: #d62728;
+}
+
+
+.jp-Completer-type[data-color-index='5'] {
+  background: #9467bd;
+}
+
+
+.jp-Completer-type[data-color-index='6'] {
+  background: #8c564b;
+}
+
+
+.jp-Completer-type[data-color-index='7'] {
+  background: #e377c2;
+}
+
+
+.jp-Completer-type[data-color-index='8'] {
+  background: #7f7f7f;
+}
+
+
+.jp-Completer-type[data-color-index='9'] {
+  background: #bcbd22;
+}
+
+
+.jp-Completer-type[data-color-index='10'] {
+  background: #17becf;
+}
+
+
+

--- a/packages/completer/style/index.css
+++ b/packages/completer/style/index.css
@@ -64,6 +64,20 @@
 }
 
 
+.jp-Completer-item .jp-Completer-typeExtended {
+  display: table-cell;
+  box-sizing: border-box;
+  height: var(--jp-private-completer-item-height);
+  text-align: right;
+  background: transparent;
+  color: var(--jp-ui-font-color2);
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-size);
+  line-height: var(--jp-private-completer-item-height);
+  padding-right: 8px;
+}
+
+
 .jp-Completer-item:hover {
   background: var(--jp-layout-color2);
   opacity: 0.8;

--- a/packages/completer/style/index.css
+++ b/packages/completer/style/index.css
@@ -6,8 +6,9 @@
 
 
 :root {
-  --jp-private-completer-code-font-size: 14px;
-  --jp-private-completer-item-height: 24px;
+  --jp-private-completer-item-height: 22px;
+  /* Shift the baseline of the type character to align with the match text */
+  --jp-private-completer-type-offset: 2px;
 }
 
 
@@ -33,7 +34,6 @@
   padding: 0;
   height: var(--jp-private-completer-item-height);
   min-width: 150px;
-  font-size: var(--jp-private-completer-code-font-size);
 }
 
 
@@ -43,7 +43,9 @@
   margin: 0;
   padding: 0 8px 0 6px;
   height: var(--jp-private-completer-item-height);
-  vertical-align: middle;
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-size);
+  line-height: var(--jp-private-completer-item-height);
 }
 
 
@@ -52,15 +54,23 @@
   box-sizing: border-box;
   height: var(--jp-private-completer-item-height);
   text-align: center;
-  vertical-align: middle;
-  background: var(--jp-layout-color4);
+  background: transparent;
   color: white;
-  width: 24px;
-  font-family: var(-jp-ui-font-family);
+  width: var(--jp-private-completer-item-height);
+  font-family: var(--jp-ui-font-family);
+  font-size: var(--jp-ui-font-size1);
+  line-height: calc( var(--jp-private-completer-item-height) - var(--jp-private-completer-type-offset) );
+  padding-bottom: var(--jp-private-completer-type-offset);
 }
 
 
-.jp-Completer-item:hover, .jp-Completer-item.jp-mod-active {
+.jp-Completer-item:hover {
+  background: var(--jp-layout-color2);
+  opacity: 0.8;
+}
+
+
+.jp-Completer-item.jp-mod-active {
   background: var(--jp-brand-color3);
   opacity: 0.8;
 }

--- a/packages/completer/style/index.css
+++ b/packages/completer/style/index.css
@@ -20,7 +20,8 @@
   list-style-type: none;
   overflow: auto;
   padding: 0;
-  margin: 4px 0 0 -4px;
+  /* Position the completer relative to the text editor, align the '.' */
+  margin: 4px 0 0 -30px;
   max-height: calc((10 * var(--jp-private-completer-item-height)) + (2 * var(--jp-border-width)));
   min-height: calc(var(--jp-private-completer-item-height) + (2 * var(--jp-border-width)));
   z-index: 10001;

--- a/test/src/completer/model.spec.ts
+++ b/test/src/completer/model.spec.ts
@@ -8,6 +8,10 @@ import {
 } from '@phosphor/algorithm';
 
 import {
+  JSONExt
+} from '@phosphor/coreutils';
+
+import {
   CodeEditor
 } from '@jupyterlab/codeeditor';
 
@@ -49,9 +53,9 @@ describe('completer/model', () => {
         let listener = (sender: any, args: void) => { called++; };
         model.stateChanged.connect(listener);
         expect(called).to.be(0);
-        model.setOptions(['foo']);
+        model.setOptions(['foo'], {});
         expect(called).to.be(1);
-        model.setOptions([]);
+        model.setOptions(['foo'], {foo: 'instance'});
         expect(called).to.be(2);
       });
 
@@ -61,12 +65,15 @@ describe('completer/model', () => {
         let listener = (sender: any, args: void) => { called++; };
         model.stateChanged.connect(listener);
         expect(called).to.be(0);
-        model.setOptions(['foo']);
-        model.setOptions(['foo']);
+        model.setOptions(['foo'], {});
+        model.setOptions(['foo'], {});
         expect(called).to.be(1);
-        model.setOptions([]);
-        model.setOptions([]);
+        model.setOptions(['foo'], {foo: 'instance'});
+        model.setOptions(['foo'], {foo: 'instance'});
         expect(called).to.be(2);
+        model.setOptions([], {});
+        model.setOptions([], {});
+        expect(called).to.be(3);
       });
 
       it('should signal when original request changes', () => {
@@ -148,7 +155,7 @@ describe('completer/model', () => {
           { raw: 'bar', text: 'bar' },
           { raw: 'baz', text: 'baz' }
         ];
-        model.setOptions(['foo', 'bar', 'baz']);
+        model.setOptions(['foo', 'bar', 'baz'], {});
         expect(toArray(model.items())).to.eql(want);
       });
 
@@ -157,7 +164,7 @@ describe('completer/model', () => {
         let want: Completer.IItem[] = [
           { raw: 'foo', text: '<mark>f</mark>oo' }
         ];
-        model.setOptions(['foo', 'bar', 'baz']);
+        model.setOptions(['foo', 'bar', 'baz'], {});
         model.query = 'f';
         expect(toArray(model.items())).to.eql(want);
       });
@@ -168,7 +175,7 @@ describe('completer/model', () => {
           { raw: 'qux', text: '<mark>qux</mark>' },
           { raw: 'quux', text: '<mark>qu</mark>u<mark>x</mark>' }
         ];
-        model.setOptions(['foo', 'bar', 'baz', 'quux', 'qux']);
+        model.setOptions(['foo', 'bar', 'baz', 'quux', 'qux'], {});
         model.query = 'qux';
         expect(toArray(model.items())).to.eql(want);
       });
@@ -179,7 +186,7 @@ describe('completer/model', () => {
           { raw: 'quux', text: '<mark>qu</mark>ux' },
           { raw: 'qux', text: '<mark>qu</mark>x' }
         ];
-        model.setOptions(['foo', 'bar', 'baz', 'qux', 'quux']);
+        model.setOptions(['foo', 'bar', 'baz', 'qux', 'quux'], {});
         model.query = 'qu';
         expect(toArray(model.items())).to.eql(want);
       });
@@ -196,9 +203,17 @@ describe('completer/model', () => {
       it('should return model options', () => {
         let model = new CompleterModel();
         let options = ['foo'];
-        model.setOptions(options);
+        model.setOptions(options, {});
         expect(toArray(model.options())).to.not.equal(options);
         expect(toArray(model.options())).to.eql(options);
+      });
+
+      it('should return the typeMap', () => {
+        let model = new CompleterModel();
+        let options = ['foo'];
+        let typeMap = {foo: 'instance'};
+        model.setOptions(options, typeMap);
+        expect(JSONExt.deepEqual(model.typeMap(), typeMap)).to.be.ok();
       });
 
     });
@@ -308,7 +323,7 @@ describe('completer/model', () => {
 
       it('should dispose of the model resources', () => {
         let model = new CompleterModel();
-        model.setOptions(['foo']);
+        model.setOptions(['foo'], {foo: 'instance'});
         expect(model.isDisposed).to.be(false);
         model.dispose();
         expect(model.isDisposed).to.be(true);

--- a/test/src/completer/model.spec.ts
+++ b/test/src/completer/model.spec.ts
@@ -53,7 +53,7 @@ describe('completer/model', () => {
         let listener = (sender: any, args: void) => { called++; };
         model.stateChanged.connect(listener);
         expect(called).to.be(0);
-        model.setOptions(['foo'], {});
+        model.setOptions(['foo']);
         expect(called).to.be(1);
         model.setOptions(['foo'], {foo: 'instance'});
         expect(called).to.be(2);
@@ -65,8 +65,8 @@ describe('completer/model', () => {
         let listener = (sender: any, args: void) => { called++; };
         model.stateChanged.connect(listener);
         expect(called).to.be(0);
-        model.setOptions(['foo'], {});
-        model.setOptions(['foo'], {});
+        model.setOptions(['foo']);
+        model.setOptions(['foo']);
         expect(called).to.be(1);
         model.setOptions(['foo'], {foo: 'instance'});
         model.setOptions(['foo'], {foo: 'instance'});
@@ -155,7 +155,7 @@ describe('completer/model', () => {
           { raw: 'bar', text: 'bar' },
           { raw: 'baz', text: 'baz' }
         ];
-        model.setOptions(['foo', 'bar', 'baz'], {});
+        model.setOptions(['foo', 'bar', 'baz']);
         expect(toArray(model.items())).to.eql(want);
       });
 
@@ -164,7 +164,7 @@ describe('completer/model', () => {
         let want: Completer.IItem[] = [
           { raw: 'foo', text: '<mark>f</mark>oo' }
         ];
-        model.setOptions(['foo', 'bar', 'baz'], {});
+        model.setOptions(['foo', 'bar', 'baz']);
         model.query = 'f';
         expect(toArray(model.items())).to.eql(want);
       });
@@ -175,7 +175,7 @@ describe('completer/model', () => {
           { raw: 'qux', text: '<mark>qux</mark>' },
           { raw: 'quux', text: '<mark>qu</mark>u<mark>x</mark>' }
         ];
-        model.setOptions(['foo', 'bar', 'baz', 'quux', 'qux'], {});
+        model.setOptions(['foo', 'bar', 'baz', 'quux', 'qux']);
         model.query = 'qux';
         expect(toArray(model.items())).to.eql(want);
       });
@@ -186,7 +186,7 @@ describe('completer/model', () => {
           { raw: 'quux', text: '<mark>qu</mark>ux' },
           { raw: 'qux', text: '<mark>qu</mark>x' }
         ];
-        model.setOptions(['foo', 'bar', 'baz', 'qux', 'quux'], {});
+        model.setOptions(['foo', 'bar', 'baz', 'qux', 'quux']);
         model.query = 'qu';
         expect(toArray(model.items())).to.eql(want);
       });

--- a/test/src/completer/widget.spec.ts
+++ b/test/src/completer/widget.spec.ts
@@ -49,8 +49,8 @@ function createEditorWidget(): CodeEditorWrapper {
 
 
 class CustomRenderer extends Completer.Renderer {
-  createItemNode(item: Completer.IItem): HTMLLIElement {
-    let li = super.createItemNode(item);
+  createItemNode(item: Completer.IItem, typeMap: Completer.ITypeMap, orderedTypes: string[]): HTMLLIElement {
+    let li = super.createItemNode(item, typeMap, orderedTypes);
     li.classList.add(TEST_ITEM_CLASS);
     return li;
   }
@@ -107,7 +107,7 @@ describe('completer/widget', () => {
           model: new CompleterModel(),
           renderer: new CustomRenderer()
         };
-        options.model.setOptions(['foo', 'bar']);
+        options.model.setOptions(['foo', 'bar'], {});
 
         let widget = new Completer(options);
         expect(widget).to.be.a(Completer);
@@ -130,7 +130,7 @@ describe('completer/widget', () => {
         };
         let value = '';
         let listener = (sender: any, selected: string) => { value = selected; };
-        options.model.setOptions(['foo', 'bar']);
+        options.model.setOptions(['foo', 'bar'], {});
         Widget.attach(anchor, document.body);
 
         let widget = new Completer(options);
@@ -181,7 +181,7 @@ describe('completer/widget', () => {
 
           model.original = request;
           model.cursor = { start: 0, end: 1 };
-          model.setOptions(['abc', 'abd', 'abe', 'abi']);
+          model.setOptions(['abc', 'abd', 'abe', 'abi'], {});
 
           let widget = new Completer({ model, editor: code.editor });
           widget.hide();
@@ -278,7 +278,7 @@ describe('completer/widget', () => {
         let options: Completer.IOptions = {
           editor: anchor.editor, model
         };
-        model.setOptions(['foo', 'bar']);
+        model.setOptions(['foo', 'bar'], {foo: 'instance', bar: 'function'});
         Widget.attach(anchor, document.body);
 
         let widget = new Completer(options);
@@ -320,7 +320,7 @@ describe('completer/widget', () => {
           let options: Completer.IOptions = {
             editor: anchor.editor, model
           };
-          model.setOptions(['foo', 'bar']);
+          model.setOptions(['foo', 'bar'], {foo: 'instance', bar: 'function'});
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -343,7 +343,7 @@ describe('completer/widget', () => {
           let options: Completer.IOptions = {
             editor: anchor.editor, model
           };
-          model.setOptions(['foo', 'bar', 'baz']);
+          model.setOptions(['foo', 'bar', 'baz'], {foo: 'instance', bar: 'function'});
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -380,7 +380,7 @@ describe('completer/widget', () => {
           let options: Completer.IOptions = {
             editor: anchor.editor, model
           };
-          model.setOptions(['foo', 'bar', 'baz']);
+          model.setOptions(['foo', 'bar', 'baz'], {foo: 'instance', bar: 'function'});
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -427,7 +427,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setOptions(['fo', 'foo', 'foo', 'fooo']);
+          model.setOptions(['fo', 'foo', 'foo', 'fooo'], {foo: 'instance', bar: 'function'});
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -466,7 +466,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setOptions(['foo', 'bar', 'baz']);
+          model.setOptions(['foo', 'bar', 'baz'], {foo: 'instance', bar: 'function'});
           model.query = 'b';
           Widget.attach(anchor, document.body);
 
@@ -495,7 +495,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setOptions(['foo', 'bar']);
+          model.setOptions(['foo', 'bar'], {});
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -520,7 +520,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setOptions(['foo', 'bar']);
+          model.setOptions(['foo', 'bar'], {});
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -544,7 +544,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             // no op
           };
-          model.setOptions(['foo', 'bar']);
+          model.setOptions(['foo', 'bar'], {});
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -605,7 +605,7 @@ describe('completer/widget', () => {
 
           model.original = request;
           model.cursor = { start: text.length - 1, end: text.length };
-          model.setOptions(['abc', 'abd', 'abe', 'abi']);
+          model.setOptions(['abc', 'abd', 'abe', 'abi'], {});
 
           let widget = new Completer({ model, editor: code.editor });
           Widget.attach(widget, document.body);
@@ -650,7 +650,7 @@ describe('completer/widget', () => {
 
         Widget.attach(anchor, document.body);
         model.original = request;
-        model.setOptions(['foo']);
+        model.setOptions(['foo'], {});
 
         let widget = new Completer(options);
         widget.selected.connect(listener);
@@ -688,7 +688,7 @@ describe('completer/widget', () => {
 
         Widget.attach(anchor, document.body);
         model.original = request;
-        model.setOptions(['foo', 'bar', 'baz']);
+        model.setOptions(['foo', 'bar', 'baz'], {});
 
         let widget = new Completer(options);
         widget.hide();

--- a/test/src/completer/widget.spec.ts
+++ b/test/src/completer/widget.spec.ts
@@ -107,7 +107,7 @@ describe('completer/widget', () => {
           model: new CompleterModel(),
           renderer: new CustomRenderer()
         };
-        options.model.setOptions(['foo', 'bar'], {});
+        options.model.setOptions(['foo', 'bar']);
 
         let widget = new Completer(options);
         expect(widget).to.be.a(Completer);
@@ -130,7 +130,7 @@ describe('completer/widget', () => {
         };
         let value = '';
         let listener = (sender: any, selected: string) => { value = selected; };
-        options.model.setOptions(['foo', 'bar'], {});
+        options.model.setOptions(['foo', 'bar']);
         Widget.attach(anchor, document.body);
 
         let widget = new Completer(options);
@@ -181,7 +181,7 @@ describe('completer/widget', () => {
 
           model.original = request;
           model.cursor = { start: 0, end: 1 };
-          model.setOptions(['abc', 'abd', 'abe', 'abi'], {});
+          model.setOptions(['abc', 'abd', 'abe', 'abi']);
 
           let widget = new Completer({ model, editor: code.editor });
           widget.hide();
@@ -495,7 +495,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setOptions(['foo', 'bar'], {});
+          model.setOptions(['foo', 'bar']);
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -520,7 +520,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
-          model.setOptions(['foo', 'bar'], {});
+          model.setOptions(['foo', 'bar']);
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -544,7 +544,7 @@ describe('completer/widget', () => {
           let listener = (sender: any, selected: string) => {
             // no op
           };
-          model.setOptions(['foo', 'bar'], {});
+          model.setOptions(['foo', 'bar']);
           Widget.attach(anchor, document.body);
 
           let widget = new Completer(options);
@@ -605,7 +605,7 @@ describe('completer/widget', () => {
 
           model.original = request;
           model.cursor = { start: text.length - 1, end: text.length };
-          model.setOptions(['abc', 'abd', 'abe', 'abi'], {});
+          model.setOptions(['abc', 'abd', 'abe', 'abi']);
 
           let widget = new Completer({ model, editor: code.editor });
           Widget.attach(widget, document.body);
@@ -650,7 +650,7 @@ describe('completer/widget', () => {
 
         Widget.attach(anchor, document.body);
         model.original = request;
-        model.setOptions(['foo'], {});
+        model.setOptions(['foo']);
 
         let widget = new Completer(options);
         widget.selected.connect(listener);
@@ -688,7 +688,7 @@ describe('completer/widget', () => {
 
         Widget.attach(anchor, document.body);
         model.original = request;
-        model.setOptions(['foo', 'bar', 'baz'], {});
+        model.setOptions(['foo', 'bar', 'baz']);
 
         let widget = new Completer(options);
         widget.hide();


### PR DESCRIPTION
Recent versions of IPython add experimental support for adding type data to the list of completions. This is provided by the `reply.metadata._jupyter_types_experimental` field of the completer reply. Some of the main points of the PR:

* If the type data is provided by `_jupyter_types_experimental` render the types visually.
* Don't make any assumption about the values provided by the kernel. This is done to allow each kernel to provide their own unique type names.
* Visually encode the types using the category10 colormap of vega (https://github.com/vega/vega/wiki/Scales#scale-range-literals) and a lowercase first letter of the type name (so `function` becomes `f`).
* A bit of style cleanup of the completer.

This work uncovered some refactoring of the completer that we should probably do post-beta. I will open a separate PR describing that work.