### PR TITLE
Presentation mode

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -44,6 +44,9 @@ namespace CommandIDs {
   const toggleRightArea: string = 'application:toggle-right-area';
 
   export
+  const togglePresentationMode: string = 'application:toggle-presentation-mode';
+
+  export
   const tree: string = 'router:tree';
 
   export
@@ -283,6 +286,18 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     isVisible: () => !app.shell.isEmpty('right')
   });
   palette.addItem({ command, category });
+
+  command = CommandIDs.togglePresentationMode;
+  app.commands.addCommand(command, {
+    label: args => args['isPalette'] ?
+      'Toggle Presentation Mode' : 'Presentation Mode',
+    execute: () => {
+      app.shell.presentationMode = !app.shell.presentationMode;
+    },
+    isToggled: () => app.shell.presentationMode,
+    isVisible: () => true
+  });
+  palette.addItem({ command, category,  args: { 'isPalette': true } });
 
   command = CommandIDs.setMode;
   app.commands.addCommand(command, {

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -192,6 +192,20 @@ class ApplicationShell extends Widget {
   }
 
   /**
+   * Whether JupyterLab is in presentation mode with the `jp-mod-presentationMode` CSS class.
+   */
+  get presentationMode(): boolean {
+    return this.hasClass('jp-mod-presentationMode');
+  }
+
+  /**
+   * Enable/disable presentation mode (`jp-mod-presentationMode` CSS class) with a boolean.
+   */
+  set presentationMode(value: boolean) {
+    this.toggleClass('jp-mod-presentationMode', value);
+  }
+
+  /**
    * The main dock area's user interface mode.
    */
   get mode(): DockPanel.Mode {

--- a/packages/console/style/index.css
+++ b/packages/console/style/index.css
@@ -116,3 +116,20 @@
   box-shadow: var(--jp-input-box-shadow);
   background-color: var(--jp-cell-editor-active-background);
 }
+
+
+/*-----------------------------------------------------------------------------
+| Presentation Mode (.jp-mod-presentationMode)
+|----------------------------------------------------------------------------*/
+
+
+.jp-mod-presentationMode .jp-CodeConsole {
+  --jp-content-font-size1: var(--jp-content-presentation-font-size1);
+  --jp-code-font-size: var(--jp-code-presentation-font-size);
+}
+
+
+.jp-mod-presentationMode .jp-CodeConsole .jp-Cell .jp-InputPrompt,
+.jp-mod-presentationMode .jp-CodeConsole .jp-Cell .jp-OutputPrompt {
+  flex: 0 0 110px;
+}

--- a/packages/fileeditor/style/index.css
+++ b/packages/fileeditor/style/index.css
@@ -15,3 +15,13 @@
     box-shadow: var(--jp-toolbar-box-shadow);
     z-index: 10;
 }
+
+
+/*-----------------------------------------------------------------------------
+| Presentation Mode (.jp-mod-presentationMode)
+|----------------------------------------------------------------------------*/
+
+
+.jp-mod-presentationMode .jp-FileEditor {
+  --jp-code-font-size: var(--jp-code-presentation-font-size);
+}

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -361,7 +361,10 @@ function createViewMenu(app: JupyterLab, menu: ViewMenu): void {
   menu.addGroup(editorViewerGroup, 10);
 
   // Add the command for toggling single-document mode.
-  menu.addGroup([{ command: 'application:toggle-mode' }], 1000);
+  menu.addGroup([
+    { command: 'application:toggle-mode' },
+    { command: 'application:toggle-presentation-mode'}
+  ], 1000);
 }
 
 function createRunMenu(app: JupyterLab, menu: RunMenu): void {

--- a/packages/markdownviewer-extension/style/index.css
+++ b/packages/markdownviewer-extension/style/index.css
@@ -14,3 +14,14 @@
   padding-left: var(--jp-private-markdownviewer-padding);
   overflow: auto;
 }
+
+
+/*-----------------------------------------------------------------------------
+| Presentation Mode (.jp-mod-presentationMode)
+|----------------------------------------------------------------------------*/
+
+
+.jp-mod-presentationMode .jp-MimeDocument .jp-RenderedHTMLCommon {
+  --jp-content-font-size1: var(--jp-content-presentation-font-size1);
+  --jp-code-font-size: var(--jp-code-presentation-font-size);
+}

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -297,3 +297,20 @@
   height: var(--jp-toolbar-micro-height);
   z-index: 1;
 }
+
+
+/*-----------------------------------------------------------------------------
+| Presentation Mode (.jp-mod-presentationMode)
+|----------------------------------------------------------------------------*/
+
+
+.jp-mod-presentationMode .jp-Notebook {
+  --jp-content-font-size1: var(--jp-content-presentation-font-size1);
+  --jp-code-font-size: var(--jp-code-presentation-font-size);
+}
+
+.jp-mod-presentationMode .jp-Notebook .jp-Cell .jp-InputPrompt,
+.jp-mod-presentationMode .jp-Notebook .jp-Cell .jp-OutputPrompt {
+  flex: 0 0 110px;
+}
+

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -89,10 +89,10 @@ all of MD as it is not optimized for dense, information rich UIs.
    */
 
   --jp-ui-font-scale-factor: 1.2;
-  --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));
+  --jp-ui-font-size0: 0.83333em;
   --jp-ui-font-size1: 13px; /* Base font size */
-  --jp-ui-font-size2: calc(var(--jp-ui-font-size1)*var(--jp-ui-font-scale-factor));
-  --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
+  --jp-ui-font-size2: 1.2em;
+  --jp-ui-font-size3: 1.44em;
 
   --jp-ui-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
@@ -120,16 +120,23 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Content Fonts
    *
    * Content font variables are used for typography of user generated content.
+   *
+   * The font sizing here is done assuming that the body font size of --jp-content-font-size1
+   * is applied to a parent element. When children elements, such as headings, are sized
+   * in em all things will be computed relative to that body size.
    */
 
   --jp-content-line-height: 1.6;
   --jp-content-font-scale-factor: 1.2;
-  --jp-content-font-size0: calc( var(--jp-content-font-size1)/var(--jp-content-font-scale-factor) );
+  --jp-content-font-size0: 0.83333em;
   --jp-content-font-size1: 14px; /* Base font size */
-  --jp-content-font-size2: calc( var(--jp-content-font-size1)*var(--jp-content-font-scale-factor) );
-  --jp-content-font-size3: calc( var(--jp-content-font-size2)*var(--jp-content-font-scale-factor) );
-  --jp-content-font-size4: calc( var(--jp-content-font-size3)*var(--jp-content-font-scale-factor) );
-  --jp-content-font-size5: calc( var(--jp-content-font-size4)*var(--jp-content-font-scale-factor) );
+  --jp-content-font-size2: 1.2em;
+  --jp-content-font-size3: 1.44em;
+  --jp-content-font-size4: 1.728em;
+  --jp-content-font-size5: 2.0736em;
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-content-presentation-font-size1: 17px;
 
   --jp-content-heading-line-height: 1.0;
   --jp-content-heading-margin-top: 1.2em;
@@ -154,9 +161,12 @@ all of MD as it is not optimized for dense, information rich UIs.
    */
 
   --jp-code-font-size: 13px;
-  --jp-code-line-height: 17px;
-  --jp-code-padding: 5px;
+  --jp-code-line-height: 1.3077; /* 17px for 13px base */
+  --jp-code-padding: 0.385em; /* 5px for 13px base */
   --jp-code-font-family: 'Source Code Pro', monospace;
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-code-presentation-font-size: 16px;
 
   /* Layout
    *

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -87,10 +87,10 @@ all of MD as it is not optimized for dense, information rich UIs.
    */
 
   --jp-ui-font-scale-factor: 1.2;
-  --jp-ui-font-size0: calc(var(--jp-ui-font-size1)/var(--jp-ui-font-scale-factor));
+  --jp-ui-font-size0: 0.83333em;
   --jp-ui-font-size1: 13px; /* Base font size */
-  --jp-ui-font-size2: calc(var(--jp-ui-font-size1)*var(--jp-ui-font-scale-factor));
-  --jp-ui-font-size3: calc(var(--jp-ui-font-size2)*var(--jp-ui-font-scale-factor));
+  --jp-ui-font-size2: 1.2em;
+  --jp-ui-font-size3: 1.44em;
 
   --jp-ui-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
@@ -118,16 +118,23 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Content Fonts
    *
    * Content font variables are used for typography of user generated content.
+   *
+   * The font sizing here is done assuming that the body font size of --jp-content-font-size1
+   * is applied to a parent element. When children elements, such as headings, are sized
+   * in em all things will be computed relative to that body size.
    */
 
   --jp-content-line-height: 1.6;
   --jp-content-font-scale-factor: 1.2;
-  --jp-content-font-size0: calc( var(--jp-content-font-size1)/var(--jp-content-font-scale-factor) );
+  --jp-content-font-size0: 0.83333em;
   --jp-content-font-size1: 14px; /* Base font size */
-  --jp-content-font-size2: calc( var(--jp-content-font-size1)*var(--jp-content-font-scale-factor) );
-  --jp-content-font-size3: calc( var(--jp-content-font-size2)*var(--jp-content-font-scale-factor) );
-  --jp-content-font-size4: calc( var(--jp-content-font-size3)*var(--jp-content-font-scale-factor) );
-  --jp-content-font-size5: calc( var(--jp-content-font-size4)*var(--jp-content-font-scale-factor) );
+  --jp-content-font-size2: 1.2em;
+  --jp-content-font-size3: 1.44em;
+  --jp-content-font-size4: 1.728em;
+  --jp-content-font-size5: 2.0736em;
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-content-presentation-font-size1: 17px;
 
   --jp-content-heading-line-height: 1.0;
   --jp-content-heading-margin-top: 1.2em;
@@ -151,9 +158,12 @@ all of MD as it is not optimized for dense, information rich UIs.
    */
 
   --jp-code-font-size: 13px;
-  --jp-code-line-height: 17px;
-  --jp-code-padding: 5px;
+  --jp-code-line-height: 1.3077; /* 17px for 13px base */
+  --jp-code-padding: 0.385em; /* 5px for 13px base */
   --jp-code-font-family: 'Source Code Pro', monospace;
+
+  /* This gives a magnification of about 125% in presentation mode over normal. */
+  --jp-code-presentation-font-size: 16px;
 
   /* Layout
    *


### PR DESCRIPTION
This is an initial implementation of a presentation mode for JupyterLab:

* `app.shell.presentationMode` is a `boolean` to switch into presentation mode.
* It simply toggles a `jp-mod-presentationMode` CSS class on the application Widget.
* A View menu and Command Palette item have been added for the user to switch.
* Theme variables refactored to allow the base font size CSS variables to be changed in particular selectors.
* Initial styling for notebook, console, rendered markdown and file editor.
* The styling only affects content and code, not the surrounding UI.
* The font size, and leading increase is equivalent to about a 125% screen zoom, which is a common browser zoom to use when presenting notebooks.

Non-presentation mode:

![screen shot 2018-01-01 at 8 45 31 pm](https://user-images.githubusercontent.com/27600/34474571-92569afa-ef35-11e7-8bea-52df2036190c.png)

Presentation mode for a notebook with lots of markdown:

![screen shot 2018-01-01 at 8 45 45 pm](https://user-images.githubusercontent.com/27600/34474576-9bb8d0d6-ef35-11e7-8807-984c0c8a587c.png)

Lots of code in presentation mode:

![screen shot 2018-01-01 at 8 46 07 pm](https://user-images.githubusercontent.com/27600/34474579-a9238c0c-ef35-11e7-9c79-22b7d083f92b.png)

View menu and command palette items:

![screen shot 2018-01-01 at 8 47 43 pm](https://user-images.githubusercontent.com/27600/34474586-b637e10e-ef35-11e7-8fda-32081147ae9c.png)

Fixes #3139 