### PR TITLE
Fix handling of codemirror focus and dialog in notebook

### DIFF
--- a/buildutils/src/add-sibling.ts
+++ b/buildutils/src/add-sibling.ts
@@ -38,7 +38,7 @@ if (fs.existsSync(packagePath)) {
 } else {
   // Otherwise treat it as a git reposotory and try to add it.
   packageDirName = target.split('/').pop().split('.')[0];
-  let packagePath = path.join(basePath, 'packages', packageDirName);
+  packagePath = path.join(basePath, 'packages', packageDirName);
   utils.run('git clone ' + target + ' ' + packagePath);
 }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "publish": "jlpm run clean:slate && jlpm run build:packages && lerna publish --force-publish=* -m \"Publish\" && jlpm run build:update",
     "remove:dependency": "node buildutils/lib/remove-dependency.js",
     "remove:package": "node buildutils/lib/remove-package.js",
+    "remove:sibling": "node buildutils/lib/remove-package.js",
     "test": "cd test && jlpm test",
     "test:chrome": "lerna run test:chrome --stream",
     "test:firefox": "lerna run test:firefox --stream",

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -40,9 +40,9 @@ import {
   Mode
 } from './mode';
 
+import 'codemirror/addon/comment/comment.js';
 import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/edit/closebrackets.js';
-import 'codemirror/addon/comment/comment.js';
 import 'codemirror/addon/scroll/scrollpastend.js';
 import 'codemirror/addon/search/searchcursor';
 import 'codemirror/addon/search/search';
@@ -327,7 +327,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    * Test whether the editor has keyboard focus.
    */
   hasFocus(): boolean {
-    return this._editor.hasFocus();
+    return this._editor.getWrapperElement().contains(document.activeElement);
   }
 
   /**

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -36,6 +36,11 @@
 }
 
 
+.CodeMirror-dialog {
+  background-color: var(--jp-layout-color0);
+}
+
+
 /* This causes https://github.com/jupyter/jupyterlab/issues/522 */
 /* May not cause it not because we changed it! */
 .CodeMirror-lines {
@@ -55,12 +60,6 @@
 
 .jp-CodeMirrorEditor, .jp-CodeMirrorEditor-static {
   cursor: text;
-}
-
-
-/* Hide dialogs in inline editors due to poor UX with small editors. */
-.jp-CodeMirrorEditor[data-type="inline"] .CodeMirror-dialog {
-  display: none;
 }
 
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1361,11 +1361,11 @@ class Notebook extends StaticNotebook {
 
     // Try to find the cell associated with the event.
     // `event.target` sometimes gives an orphaned node in Firefox 57.
-    let target = event.target;
+    let target = event.target as HTMLElement;
     if (!target.parentElement) {
-      target = document.elementFromPoint(event.clientX, event.clientY);
+      target = document.elementFromPoint(event.clientX, event.clientY) as HTMLElement;
     }
-    let index = this._findCell(target as HTMLElement);
+    let index = this._findCell(target);
     let widget = this.widgets[index];
 
     // Switch to command mode if the click is not in an editor.
@@ -1735,11 +1735,11 @@ class Notebook extends StaticNotebook {
     }
 
     // `event.target` sometimes gives an orphaned node in Firefox 57.
-    let target = event.target;
+    let target = event.target as HTMLElement;
     if (!target.parentElement) {
-      target = document.elementFromPoint(event.clientX, event.clientY);
+      target = document.elementFromPoint(event.clientX, event.clientY) as HTMLElement;
     }
-    let i = this._findCell(target as HTMLElement);
+    let i = this._findCell(target);
     if (i === -1) {
       return;
     }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1360,9 +1360,11 @@ class Notebook extends StaticNotebook {
     }
 
     // Try to find the cell associated with the event.
-    // We cannot use `event.target` because it sometimes gives an orphaned
-    // node in Firefox 57.
-    let target = document.elementFromPoint(event.clientX, event.clientY);
+    // `event.target` sometimes gives an orphaned node in Firefox 57.
+    let target = event.target;
+    if (!target.parentElement) {
+      target = document.elementFromPoint(event.clientX, event.clientY);
+    }
     let index = this._findCell(target as HTMLElement);
     let widget = this.widgets[index];
 
@@ -1732,9 +1734,11 @@ class Notebook extends StaticNotebook {
       return;
     }
 
-    // We cannot use `event.target` because it sometimes gives an orphaned
-    // node in Firefox 57.
-    let target = document.elementFromPoint(event.clientX, event.clientY);
+    // `event.target` sometimes gives an orphaned node in Firefox 57.
+    let target = event.target;
+    if (!target.parentElement) {
+      target = document.elementFromPoint(event.clientX, event.clientY);
+    }
     let i = this._findCell(target as HTMLElement);
     if (i === -1) {
       return;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1316,7 +1316,9 @@ class Notebook extends StaticNotebook {
   private _ensureFocus(force=false): void {
     let activeCell = this.activeCell;
     if (this.mode === 'edit' && activeCell) {
-      activeCell.editor.focus();
+      if (!activeCell.editor.hasFocus()) {
+        activeCell.editor.focus();
+      }
     } else if (activeCell) {
       activeCell.editor.blur();
     }
@@ -1418,8 +1420,9 @@ class Notebook extends StaticNotebook {
           this._mouseMode = 'couldDrag';
           document.addEventListener('mouseup', this, true);
           document.addEventListener('mousemove', this, true);
+          event.preventDefault();
         }
-        event.preventDefault();
+
       }
 
     }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1354,25 +1354,27 @@ class Notebook extends StaticNotebook {
    */
   private _evtMouseDown(event: MouseEvent): void {
 
-    // Mouse click should always ensure the notebook is focused.
-    this._ensureFocus(true);
-
     // We only handle main or secondary button actions.
     if (!(event.button === 0 || event.button === 2)) {
       return;
     }
 
     // Try to find the cell associated with the event.
-    let target = event.target as HTMLElement;
-    let index = this._findCell(target);
+    // We cannot use `event.target` because it sometimes gives an orphaned
+    // node in Firefox 57.
+    let target = document.elementFromPoint(event.clientX, event.clientY);
+    let index = this._findCell(target as HTMLElement);
     let widget = this.widgets[index];
-
 
     // Switch to command mode if the click is not in an editor.
     if (index === -1 || !widget.editorWidget.node.contains(target)) {
       this.mode = 'command';
+    } else if (index !== -1) {
+      this.mode = 'edit';
     }
 
+    // Mouse click should always ensure the notebook is focused.
+    this._ensureFocus(true);
 
     // Secondary click deselects cells and possibly changes the active cell.
     if (event.button === 2) {
@@ -1382,8 +1384,6 @@ class Notebook extends StaticNotebook {
       }
       return;
     }
-
-
 
     if (index !== -1) {
 
@@ -1731,8 +1731,11 @@ class Notebook extends StaticNotebook {
     if (!model) {
       return;
     }
-    let target = event.target as HTMLElement;
-    let i = this._findCell(target);
+
+    // We cannot use `event.target` because it sometimes gives an orphaned
+    // node in Firefox 57.
+    let target = document.elementFromPoint(event.clientX, event.clientY);
+    let i = this._findCell(target as HTMLElement);
     if (i === -1) {
       return;
     }


### PR DESCRIPTION
Fixes #3503.

cc @jwkvam 


<img width="232" alt="image" src="https://user-images.githubusercontent.com/2096628/34482158-ec493586-ef7b-11e7-800e-be2f32d7b17f.png">
