### PR TITLE
Deselect cells when click events happen outside of selection, or when there is a double-click.

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1424,9 +1424,13 @@ class Notebook extends StaticNotebook {
           document.addEventListener('mousemove', this, true);
           event.preventDefault();
         }
-
       }
-
+    } else {
+      // If there is a click event in the notebook, but not on any cells,
+      // deselect any current selection.
+      this.deselectAll();
+      event.preventDefault();
+      event.stopPropagation();
     }
   }
 
@@ -1733,6 +1737,7 @@ class Notebook extends StaticNotebook {
     if (!model) {
       return;
     }
+    this.deselectAll();
 
     // `event.target` sometimes gives an orphaned node in Firefox 57.
     let target = event.target as HTMLElement;


### PR DESCRIPTION
Fixes two small issues with cell selection:
1. When there is a click in the notebook, but not on any cells, it should deselect the current cell selection.
2. A double-click on the interior of a cell selection should not make an interior cell active (the active cell should be one of the ends of the selection).

cc @jasongrout 