### PR TITLE
Properly scope notebook context menus

### DIFF
--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -209,7 +209,7 @@ const notebooks: JupyterLabPlugin<void> = {
 
     app.contextMenu.addItem({
       command: CommandIDs.open,
-      selector: '.jp-NotebookPanel'
+      selector: '.jp-Notebook:focus'
     });
   }
 };

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -543,44 +543,44 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
 
   app.contextMenu.addItem({
     command: CommandIDs.clearOutputs,
-    selector: '.jp-Notebook .jp-Cell'
+    selector: '.jp-Notebook:focus .jp-Cell'
   });
   app.contextMenu.addItem({
     command: CommandIDs.split,
-    selector: '.jp-Notebook .jp-Cell'
+    selector: '.jp-Notebook:focus .jp-Cell'
   });
   app.contextMenu.addItem({
     command: CommandIDs.createOutputView,
-    selector: '.jp-Notebook .jp-Cell'
+    selector: '.jp-Notebook:focus .jp-Cell'
   });
   app.contextMenu.addItem({
     type: 'separator',
-    selector: '.jp-Notebook',
+    selector: '.jp-Notebook:focus',
     rank: 0
   });
   app.contextMenu.addItem({
     command: CommandIDs.undoCellAction,
-    selector: '.jp-Notebook',
+    selector: '.jp-Notebook:focus',
     rank: 1
   });
   app.contextMenu.addItem({
     command: CommandIDs.redoCellAction,
-    selector: '.jp-Notebook',
+    selector: '.jp-Notebook:focus',
     rank: 2
   });
   app.contextMenu.addItem({
     type: 'separator',
-    selector: '.jp-Notebook',
+    selector: '.jp-Notebook:focus',
     rank: 0
   });
   app.contextMenu.addItem({
     command: CommandIDs.createConsole,
-    selector: '.jp-Notebook',
+    selector: '.jp-Notebook:focus',
     rank: 3
   });
   app.contextMenu.addItem({
     command: CommandIDs.clearAllOutputs,
-    selector: '.jp-Notebook',
+    selector: '.jp-Notebook:focus',
     rank: 3
   });
 


### PR DESCRIPTION
Fixes #3521 

Output has focus:

<img width="346" alt="image" src="https://user-images.githubusercontent.com/2096628/34562098-833c58c8-f112-11e7-92b2-c029a734e942.png">

 Notebook has focus:

<img width="324" alt="image" src="https://user-images.githubusercontent.com/2096628/34562119-9d8abdbe-f112-11e7-99ba-7dc6708ab125.png">

Editor has focus:

<img width="360" alt="image" src="https://user-images.githubusercontent.com/2096628/34562146-b4ddd5b4-f112-11e7-847e-f44823008a09.png">

