### PR TITLE
Fix Vega Action Rendering

### DIFF
--- a/packages/vega2-extension/README.md
+++ b/packages/vega2-extension/README.md
@@ -1,3 +1,30 @@
 # @jupyterlab/vega2-extension
 
 A mime-renderer extension for JupyterLab that provides support for rendering Vega and Vega-lite documents and mimebundles.
+
+
+Example in Python:
+
+
+```python
+from IPython.display import display
+
+display({
+    "application/vnd.vegalite.v1+json": {
+        "$schema": "https://vega.github.io/schema/vega-lite/v1.json",
+        "description": "A simple bar chart with embedded data.",
+        "data": {
+            "values": [
+                {"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43},
+                {"a": "D", "b": 91}, {"a": "E", "b": 81}, {"a": "F", "b": 53},
+                {"a": "G", "b": 19}, {"a": "H", "b": 87}, {"a": "I", "b": 52}
+            ]
+        },
+        "mark": "bar",
+        "encoding": {
+            "x": {"field": "a", "type": "ordinal"},
+            "y": {"field": "b", "type": "quantitative"}
+        }
+    }
+}, raw=True)
+```

--- a/packages/vega2-extension/src/index.ts
+++ b/packages/vega2-extension/src/index.ts
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import {
-  JSONObject, ReadonlyJSONObject, JSONValue
+  JSONObject, JSONValue, ReadonlyJSONObject
 } from '@phosphor/coreutils';
 
 import {
@@ -100,7 +100,7 @@ class RenderedVega extends Widget implements IRenderMime.IRenderer {
       spec: updatedData
     };
 
-    return this._ensureMod().then(embedFunc => {
+    return Private.ensureMod().then(embedFunc => {
       return new Promise<void>((resolve, reject) => {
         embedFunc(this.node, embedSpec, (error: any, result: any): any => {
           // Save png data in MIME bundle along with original MIME data.
@@ -112,22 +112,6 @@ class RenderedVega extends Widget implements IRenderMime.IRenderer {
           resolve(undefined);
         });
       });
-    });
-  }
-
-  /**
-   * Initialize the vega-embed module.
-   */
-  private _ensureMod(): Promise<typeof embed> {
-    return new Promise((resolve, reject) => {
-      (require as any).ensure(['vega-embed'], (require: NodeRequire) => {
-        resolve(require('vega-embed'));
-      },
-      (err: any) => {
-        reject(err);
-      },
-      'vega2'
-      );
     });
   }
 
@@ -198,6 +182,33 @@ namespace Private {
     'width': 400,
     'height': 400 / 1.5
   };
+
+  /**
+   * The embed module import.
+   */
+  let mod: typeof embed;
+
+  /**
+   * Initialize the vega-embed module.
+   */
+  export
+  function ensureMod(): Promise<typeof embed> {
+    return new Promise((resolve, reject) => {
+      if (mod !== undefined) {
+        resolve(mod);
+        return;
+      }
+      (require as any).ensure(['vega-embed'], (require: NodeRequire) => {
+        mod = require('vega-embed');
+        resolve(mod);
+      },
+      (err: any) => {
+        reject(err);
+      },
+      'vega2'
+      );
+    });
+  }
 
   /**
    * Apply the default cell config to the spec in place.


### PR DESCRIPTION
Fixes #3518.   Don't try and render the mime document while it is already rendering.  Also uses a local singleton for the vega module rather than relying on the loader to optimize the handling of the module.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/2096628/34564211-649540c0-f11b-11e7-8765-c06a1f9cf71b.png">
