### PR TITLE
Blur the previous editor when changing cells

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -837,6 +837,7 @@ class Notebook extends StaticNotebook {
       newValue = Math.max(newValue, 0);
       newValue = Math.min(newValue, this.model.cells.length - 1);
     }
+    let prev = this.activeCell;
     this._activeCellIndex = newValue;
     let cell = this.widgets[newValue];
     if (cell !== this._activeCell) {
@@ -851,6 +852,10 @@ class Notebook extends StaticNotebook {
     this._ensureFocus();
     if (newValue === oldValue) {
       return;
+    }
+    // Ensure that the previous cell's editor is blurred.
+    if (prev && prev !== this.activeCell) {
+      prev.editor.blur();
     }
     this._trimSelections();
     this._stateChanged.emit({ name: 'activeCellIndex', oldValue, newValue });

--- a/tests/test-completer/package.json
+++ b/tests/test-completer/package.json
@@ -20,6 +20,7 @@
     "@jupyterlab/codemirror": "^0.14.1",
     "@jupyterlab/completer": "^0.14.1",
     "@phosphor/algorithm": "^1.1.2",
+    "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.5.0",
     "expect.js": "~0.3.1",


### PR DESCRIPTION
Fixes #3531.  Tested on Firefox and Chrome.