### PR TITLE
Focusin/out instead of focus/blur for notebook cells to allow events to bubble

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1361,7 +1361,7 @@ class Notebook extends StaticNotebook {
 
     // `event.target` sometimes gives an orphaned node in Firefox 57, which
     // can have `null` anywhere in its parent tree. If we fail to find a
-    // cell using `event.taget`, try again using a `target reconstructed from
+    // cell using `event.target`, try again using a target reconstructed from
     // the position of the click event.
     let target = event.target as HTMLElement;
     let index = this._findCell(target);
@@ -1754,7 +1754,7 @@ class Notebook extends StaticNotebook {
 
     // `event.target` sometimes gives an orphaned node in Firefox 57, which
     // can have `null` anywhere in its parent tree. If we fail to find a
-    // cell using `event.taget`, try again using a `target reconstructed from
+    // cell using `event.target`, try again using a target reconstructed from
     // the position of the click event.
     let target = event.target as HTMLElement;
     let i = this._findCell(target);

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1125,11 +1125,11 @@ class Notebook extends StaticNotebook {
     case 'dblclick':
       this._evtDblClick(event as MouseEvent);
       break;
-    case 'focus':
-      this._evtFocus(event as MouseEvent);
+    case 'focusin':
+      this._evtFocusIn(event as MouseEvent);
       break;
-    case 'blur':
-      this._evtBlur(event as MouseEvent);
+    case 'focusout':
+      this._evtFocusOut(event as MouseEvent);
       break;
     case 'p-dragenter':
       this._evtDragEnter(event as IDragEvent);
@@ -1157,8 +1157,8 @@ class Notebook extends StaticNotebook {
     node.addEventListener('mousedown', this);
     node.addEventListener('keydown', this);
     node.addEventListener('dblclick', this);
-    node.addEventListener('focus', this, true);
-    node.addEventListener('blur', this, true);
+    node.addEventListener('focusin', this, true);
+    node.addEventListener('focusout', this, true);
     node.addEventListener('p-dragenter', this);
     node.addEventListener('p-dragleave', this);
     node.addEventListener('p-dragover', this);
@@ -1173,8 +1173,8 @@ class Notebook extends StaticNotebook {
     node.removeEventListener('mousedown', this);
     node.removeEventListener('keydown', this);
     node.removeEventListener('dblclick', this);
-    node.removeEventListener('focus', this, true);
-    node.removeEventListener('blur', this, true);
+    node.removeEventListener('focusin', this, true);
+    node.removeEventListener('focusout', this, true);
     node.removeEventListener('p-dragenter', this);
     node.removeEventListener('p-dragleave', this);
     node.removeEventListener('p-dragover', this);
@@ -1696,7 +1696,7 @@ class Notebook extends StaticNotebook {
   /**
    * Handle `focus` events for the widget.
    */
-  private _evtFocus(event: MouseEvent): void {
+  private _evtFocusIn(event: MouseEvent): void {
     let target = event.target as HTMLElement;
     let i = this._findCell(target);
     if (i !== -1) {
@@ -1718,9 +1718,9 @@ class Notebook extends StaticNotebook {
   }
 
   /**
-   * Handle `blur` events for the notebook.
+   * Handle `focusout` events for the notebook.
    */
-  private _evtBlur(event: MouseEvent): void {
+  private _evtFocusOut(event: MouseEvent): void {
     let relatedTarget = event.relatedTarget as HTMLElement;
     // Bail if focus is leaving the notebook.
     if (!this.node.contains(relatedTarget)) {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1157,8 +1157,8 @@ class Notebook extends StaticNotebook {
     node.addEventListener('mousedown', this);
     node.addEventListener('keydown', this);
     node.addEventListener('dblclick', this);
-    node.addEventListener('focusin', this, true);
-    node.addEventListener('focusout', this, true);
+    node.addEventListener('focusin', this);
+    node.addEventListener('focusout', this);
     node.addEventListener('p-dragenter', this);
     node.addEventListener('p-dragleave', this);
     node.addEventListener('p-dragover', this);
@@ -1173,8 +1173,8 @@ class Notebook extends StaticNotebook {
     node.removeEventListener('mousedown', this);
     node.removeEventListener('keydown', this);
     node.removeEventListener('dblclick', this);
-    node.removeEventListener('focusin', this, true);
-    node.removeEventListener('focusout', this, true);
+    node.removeEventListener('focusin', this);
+    node.removeEventListener('focusout', this);
     node.removeEventListener('p-dragenter', this);
     node.removeEventListener('p-dragleave', this);
     node.removeEventListener('p-dragover', this);

--- a/tests/test-notebook/src/widget.spec.ts
+++ b/tests/test-notebook/src/widget.spec.ts
@@ -1206,35 +1206,35 @@ describe('notebook/widget', () => {
 
       });
 
-      context('focus', () => {
+      context('focusin', () => {
 
         it('should change to edit mode if a child cell takes focus', () => {
           let child = widget.widgets[0];
-          simulate(child.editorWidget.node, 'focus');
-          expect(widget.events).to.contain('focus');
+          simulate(child.editorWidget.node, 'focusin');
+          expect(widget.events).to.contain('focusin');
           expect(widget.mode).to.be('edit');
         });
 
         it('should change to command mode if the widget takes focus', () => {
           let child = widget.widgets[0];
-          simulate(child.editorWidget.node, 'focus');
-          expect(widget.events).to.contain('focus');
+          simulate(child.editorWidget.node, 'focusin');
+          expect(widget.events).to.contain('focusin');
           expect(widget.mode).to.be('edit');
           widget.events = [];
-          simulate(widget.node, 'focus');
-          expect(widget.events).to.contain('focus');
+          simulate(widget.node, 'focusin');
+          expect(widget.events).to.contain('focusin');
           expect(widget.mode).to.be('command');
         });
 
       });
 
-      context('blur', () => {
+      context('focusout', () => {
 
         it('should preserve the mode', () => {
-          simulate(widget.node, 'focus');
+          simulate(widget.node, 'focusin');
           widget.mode = 'edit';
           let other = document.createElement('div');
-          simulate(widget.node, 'blur', { relatedTarget: other });
+          simulate(widget.node, 'focusout', { relatedTarget: other });
           expect(widget.mode).to.be('edit');
           MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
           expect(widget.mode).to.be('edit');
@@ -1242,9 +1242,9 @@ describe('notebook/widget', () => {
         });
 
         it('should set command mode', () => {
-          simulate(widget.node, 'focus');
+          simulate(widget.node, 'focusin');
           widget.mode = 'edit';
-          let evt = generate('blur');
+          let evt = generate('focusout');
           (evt as any).relatedTarget = widget.activeCell.node;
           widget.node.dispatchEvent(evt);
           expect(widget.mode).to.be('command');
@@ -1267,8 +1267,8 @@ describe('notebook/widget', () => {
           expect(widget.events).to.contain('mousedown');
           simulate(widget.node, 'dblclick');
           expect(widget.events).to.contain('dblclick');
-          simulate(child.node, 'focus');
-          expect(widget.events).to.contain('focus');
+          simulate(child.node, 'focusin');
+          expect(widget.events).to.contain('focusin');
           widget.dispose();
           done();
         });
@@ -1305,8 +1305,8 @@ describe('notebook/widget', () => {
           expect(widget.events).to.not.contain('mousedown');
           simulate(widget.node, 'dblclick');
           expect(widget.events).to.not.contain('dblclick');
-          simulate(child.node, 'focus');
-          expect(widget.events).to.not.contain('focus');
+          simulate(child.node, 'focusin');
+          expect(widget.events).to.not.contain('focusin');
           widget.dispose();
           done();
         });


### PR DESCRIPTION
Fixes #3531. Alternative to #3537.

I still find this puzzling, but having a broader event listener for focus/blur (`focusin`/`focusout` bubbles, while `focus`/`blur` does not) allows us to catch some events in the event handlers that were not being caught before, and correctly blurs the CodeMirror instances.

@jasongrout, should we plan to have a post-beta-sit-down where we try to simplify, clean up, and write tests for cell focus and selection logic?