### PR TITLE
Context menu item for scrolling output

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -722,6 +722,10 @@ class CodeCell extends Cell {
   private _outputLengthHandler(sender: OutputArea, args: number) {
     let force = args === 0 ? true : false;
     this.toggleClass(NO_OUTPUTS_CLASS, force);
+    /* Turn of scrolling outputs if there are none */
+    if (force) {
+      this.outputsScrolled = false;
+    }
   }
 
   private _rendermime: RenderMimeRegistry = null;

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -614,6 +614,13 @@ class CodeCell extends Cell {
     this._outputHidden = value;
   }
 
+  get outputScrolled(): boolean {
+    return this._outputScrolled;
+  }
+  set outputScrolled(value: boolean) {
+    this.toggleClass('jp-mod-outputScrolled', value);
+  }
+
   /**
    * Handle the input being hidden.
    *
@@ -718,6 +725,7 @@ class CodeCell extends Cell {
 
   private _rendermime: RenderMimeRegistry = null;
   private _outputHidden = false;
+  private _outputScrolled = false;
   private _outputWrapper: Widget = null;
   private _outputCollapser: OutputCollapser = null;
   private _outputPlaceholder: OutputPlaceholder = null;

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -614,11 +614,12 @@ class CodeCell extends Cell {
     this._outputHidden = value;
   }
 
-  get outputScrolled(): boolean {
-    return this._outputScrolled;
+  get outputsScrolled(): boolean {
+    return this._outputsScrolled;
   }
-  set outputScrolled(value: boolean) {
-    this.toggleClass('jp-mod-outputScrolled', value);
+  set outputsScrolled(value: boolean) {
+    this.toggleClass('jp-mod-outputsScrolled', value);
+    this._outputsScrolled = value;
   }
 
   /**
@@ -725,7 +726,7 @@ class CodeCell extends Cell {
 
   private _rendermime: RenderMimeRegistry = null;
   private _outputHidden = false;
-  private _outputScrolled = false;
+  private _outputsScrolled = false;
   private _outputWrapper: Widget = null;
   private _outputCollapser: OutputCollapser = null;
   private _outputPlaceholder: OutputPlaceholder = null;

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -614,6 +614,9 @@ class CodeCell extends Cell {
     this._outputHidden = value;
   }
 
+  /**
+   * Whether the output is in a scrolled state?
+   */
   get outputsScrolled(): boolean {
     return this._outputsScrolled;
   }
@@ -722,7 +725,7 @@ class CodeCell extends Cell {
   private _outputLengthHandler(sender: OutputArea, args: number) {
     let force = args === 0 ? true : false;
     this.toggleClass(NO_OUTPUTS_CLASS, force);
-    /* Turn of scrolling outputs if there are none */
+    /* Turn off scrolling outputs if there are none */
     if (force) {
       this.outputsScrolled = false;
     }

--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -87,6 +87,14 @@
 }
 
 
+.jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
+  overflow-y: auto;
+  max-height: 200px;
+  box-shadow: inset 0 0 6px 2px rgba(0,0,0,0.3);
+  margin-left: 5px;
+}
+
+
 /*-----------------------------------------------------------------------------
 | CodeCell
 |----------------------------------------------------------------------------*/

--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -10,6 +10,7 @@
 
 
 :root {
+  --jp-private-cell-scrolling-output-offset: 5px;
 }
 
 
@@ -91,7 +92,12 @@
   overflow-y: auto;
   max-height: 200px;
   box-shadow: inset 0 0 6px 2px rgba(0,0,0,0.3);
-  margin-left: 5px;
+  margin-left: var(--jp-private-cell-scrolling-output-offset);
+}
+
+
+.jp-CodeCell.jp-mod-outputsScrolled .jp-OutputArea-prompt {
+  flex: 0 0 calc( var(--jp-cell-prompt-width) - var(--jp-private-cell-scrolling-output-offset) );
 }
 
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -246,7 +246,10 @@ namespace CommandIDs {
   const showAllOutputs = 'notebook:show-all-cell-outputs';
 
   export
-  const toggleOutputsScrolled = 'notebook:toggle-cell-outputs-scrolled';
+  const enableOutputScrolling = 'notebook:enable-output-scrolling';
+
+  export
+  const disableOutputScrolling = 'notebook:disable-output-scrolling';
 }
 
 
@@ -597,14 +600,29 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
     rank: 9
   });
   app.contextMenu.addItem({
-    command: CommandIDs.toggleOutputsScrolled,
-    selector: '.jp-Notebook:focus .jp-CodeCell',
+    type: 'separator',
+    selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
     rank: 10
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.enableOutputScrolling,
+    selector: '.jp-Notebook:focus .jp-CodeCell',
+    rank: 11
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.disableOutputScrolling,
+    selector: '.jp-Notebook:focus .jp-CodeCell',
+    rank: 12
+  });
+  app.contextMenu.addItem({
+    type: 'separator',
+    selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
+    rank: 13
   });
   app.contextMenu.addItem({
     command: CommandIDs.createOutputView,
     selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
-    rank: 12
+    rank: 14
   });
 
 
@@ -896,7 +914,7 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
     isEnabled
   });
   commands.addCommand(CommandIDs.clearOutputs, {
-    label: 'Clear Selected Outputs',
+    label: 'Clear Outputs',
     execute: args => {
       const current = getCurrent(args);
 
@@ -1449,13 +1467,24 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
     },
     isEnabled
   });
-  commands.addCommand(CommandIDs.toggleOutputsScrolled, {
-    label: 'Scroll Selected Outputs',
+  commands.addCommand(CommandIDs.enableOutputScrolling, {
+    label: 'Enable Scrolling for Outputs',
     execute: args => {
       const current = getCurrent(args);
 
       if (current) {
-        return NotebookActions.toggleOutputsScrolled(current.notebook);
+        return NotebookActions.enableOutputScrolling(current.notebook);
+      }
+    },
+    isEnabled
+  });
+  commands.addCommand(CommandIDs.disableOutputScrolling, {
+    label: 'Disable Scrolling for Outputs',
+    execute: args => {
+      const current = getCurrent(args);
+
+      if (current) {
+        return NotebookActions.disableOutputScrolling(current.notebook);
       }
     },
     isEnabled
@@ -1535,7 +1564,8 @@ function populatePalette(palette: ICommandPalette): void {
     CommandIDs.showOutput,
     CommandIDs.hideAllOutputs,
     CommandIDs.showAllOutputs,
-    CommandIDs.toggleOutputsScrolled
+    CommandIDs.enableOutputScrolling,
+    CommandIDs.disableOutputScrolling
   ].forEach(command => { palette.addItem({ command, category }); });
 }
 
@@ -1556,7 +1586,7 @@ function populateMenus(app: JupyterLab, mainMenu: IMainMenu, tracker: INotebookT
   // Add a clearer to the edit menu
   mainMenu.editMenu.clearers.add({
     tracker,
-    noun: 'Selected Outputs',
+    noun: 'Outputs',
     pluralNoun: 'Outputs',
     clearCurrent: (current: NotebookPanel) => {
       return NotebookActions.clearOutputs(current.notebook);

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -245,6 +245,8 @@ namespace CommandIDs {
   export
   const showAllOutputs = 'notebook:show-all-cell-outputs';
 
+  export
+  const toggleOutputScrolled = 'notebook:toggle-cell-outputs-scrolled';
 }
 
 
@@ -1396,6 +1398,17 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
     },
     isEnabled
   });
+  commands.addCommand(CommandIDs.showAllOutputs, {
+    label: 'Scroll Selected Output',
+    execute: args => {
+      const current = getCurrent(args);
+
+      if (current) {
+        return NotebookActions.toggleOutputScrolled(current.notebook);
+      }
+    },
+    isEnabled
+  });
 }
 
 
@@ -1471,6 +1484,7 @@ function populatePalette(palette: ICommandPalette): void {
     CommandIDs.showOutput,
     CommandIDs.hideAllOutputs,
     CommandIDs.showAllOutputs,
+    CommandIDs.toggleOutputScrolled
   ].forEach(command => { palette.addItem({ command, category }); });
 }
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -246,7 +246,7 @@ namespace CommandIDs {
   const showAllOutputs = 'notebook:show-all-cell-outputs';
 
   export
-  const toggleOutputScrolled = 'notebook:toggle-cell-outputs-scrolled';
+  const toggleOutputsScrolled = 'notebook:toggle-cell-outputs-scrolled';
 }
 
 
@@ -544,6 +544,26 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
   }
 
   app.contextMenu.addItem({
+    type: 'separator',
+    selector: '.jp-Notebook.jp-mod-focus  .jp-Cell',
+    rank: 0
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.deleteCell,
+    selector: '.jp-Notebook.jp-mod-focus .jp-Cell',
+    rank: 1
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.split,
+    selector: '.jp-Notebook:focus .jp-Cell'
+  });
+  app.contextMenu.addItem({
+    type: 'separator',
+    selector: '.jp-Notebook.jp-mod-focus',
+    rank: 0
+  });
+  app.contextMenu.addItem({
     command: CommandIDs.clearOutputs,
     selector: '.jp-Notebook.jp-mod-focus .jp-Cell'
   });
@@ -554,6 +574,19 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
   app.contextMenu.addItem({
     command: CommandIDs.createOutputView,
     selector: '.jp-Notebook.jp-mod-focus .jp-Cell'
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.clearOutputs,
+    selector: '.jp-Notebook:focus .jp-CodeCell'
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.createOutputView,
+    selector: '.jp-Notebook:focus .jp-CodeCell'
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.toggleOutputsScrolled,
+    selector: '.jp-Notebook:focus .jp-CodeCell',
   });
   app.contextMenu.addItem({
     type: 'separator',
@@ -585,6 +618,7 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
     selector: '.jp-Notebook.jp-mod-focus',
     rank: 3
   });
+
 
   return tracker;
 }
@@ -1398,13 +1432,13 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
     },
     isEnabled
   });
-  commands.addCommand(CommandIDs.showAllOutputs, {
-    label: 'Scroll Selected Output',
+  commands.addCommand(CommandIDs.toggleOutputsScrolled, {
+    label: 'Scroll Selected Outputs',
     execute: args => {
       const current = getCurrent(args);
 
       if (current) {
-        return NotebookActions.toggleOutputScrolled(current.notebook);
+        return NotebookActions.toggleOutputsScrolled(current.notebook);
       }
     },
     isEnabled
@@ -1484,7 +1518,7 @@ function populatePalette(palette: ICommandPalette): void {
     CommandIDs.showOutput,
     CommandIDs.hideAllOutputs,
     CommandIDs.showAllOutputs,
-    CommandIDs.toggleOutputScrolled
+    CommandIDs.toggleOutputsScrolled
   ].forEach(command => { palette.addItem({ command, category }); });
 }
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -543,51 +543,72 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
     });
   }
 
+  // Cell context menu groups
   app.contextMenu.addItem({
     type: 'separator',
     selector: '.jp-Notebook.jp-mod-focus  .jp-Cell',
     rank: 0
   });
   app.contextMenu.addItem({
-    command: CommandIDs.deleteCell,
+    command: CommandIDs.cut,
     selector: '.jp-Notebook.jp-mod-focus .jp-Cell',
     rank: 1
   });
-
   app.contextMenu.addItem({
-    command: CommandIDs.split,
-    selector: '.jp-Notebook:focus .jp-Cell'
+    command: CommandIDs.copy,
+    selector: '.jp-Notebook.jp-mod-focus .jp-Cell',
+    rank: 2
   });
   app.contextMenu.addItem({
     type: 'separator',
-    selector: '.jp-Notebook.jp-mod-focus',
-    rank: 0
+    selector: '.jp-Notebook.jp-mod-focus  .jp-Cell',
+    rank: 3
   });
   app.contextMenu.addItem({
-    command: CommandIDs.clearOutputs,
-    selector: '.jp-Notebook.jp-mod-focus .jp-Cell'
+    command: CommandIDs.deleteCell,
+    selector: '.jp-Notebook.jp-mod-focus .jp-Cell',
+    rank: 4
+  });
+  app.contextMenu.addItem({
+    type: 'separator',
+    selector: '.jp-Notebook.jp-mod-focus .jp-Cell',
+    rank: 5
   });
   app.contextMenu.addItem({
     command: CommandIDs.split,
-    selector: '.jp-Notebook.jp-mod-focus .jp-Cell'
-  });
-  app.contextMenu.addItem({
-    command: CommandIDs.createOutputView,
-    selector: '.jp-Notebook.jp-mod-focus .jp-Cell'
+    selector: '.jp-Notebook.jp-mod-focus .jp-Cell',
+    rank: 6
   });
 
+  // CodeCell context menu groups
   app.contextMenu.addItem({
-    command: CommandIDs.clearOutputs,
-    selector: '.jp-Notebook:focus .jp-CodeCell'
+    type: 'separator',
+    selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
+    rank: 7
   });
   app.contextMenu.addItem({
-    command: CommandIDs.createOutputView,
-    selector: '.jp-Notebook:focus .jp-CodeCell'
+    command: CommandIDs.clearOutputs,
+    selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
+    rank: 8
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.clearAllOutputs,
+    selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
+    rank: 9
   });
   app.contextMenu.addItem({
     command: CommandIDs.toggleOutputsScrolled,
     selector: '.jp-Notebook:focus .jp-CodeCell',
+    rank: 10
   });
+  app.contextMenu.addItem({
+    command: CommandIDs.createOutputView,
+    selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
+    rank: 12
+  });
+
+
+  // Notebook context menu groups
   app.contextMenu.addItem({
     type: 'separator',
     selector: '.jp-Notebook.jp-mod-focus',
@@ -606,18 +627,14 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
   app.contextMenu.addItem({
     type: 'separator',
     selector: '.jp-Notebook.jp-mod-focus',
-    rank: 0
+    rank: 3
   });
   app.contextMenu.addItem({
     command: CommandIDs.createConsole,
     selector: '.jp-Notebook.jp-mod-focus',
-    rank: 3
+    rank: 4
   });
-  app.contextMenu.addItem({
-    command: CommandIDs.clearAllOutputs,
-    selector: '.jp-Notebook.jp-mod-focus',
-    rank: 3
-  });
+
 
 
   return tracker;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -610,12 +610,12 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
   });
   app.contextMenu.addItem({
     command: CommandIDs.enableOutputScrolling,
-    selector: '.jp-Notebook:focus .jp-CodeCell',
+    selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
     rank: 12
   });
   app.contextMenu.addItem({
     command: CommandIDs.disableOutputScrolling,
-    selector: '.jp-Notebook:focus .jp-CodeCell',
+    selector: '.jp-Notebook.jp-mod-focus .jp-CodeCell',
     rank: 13
   });
   app.contextMenu.addItem({

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -690,6 +690,9 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
            tracker.currentWidget === app.shell.currentWidget;
   }
 
+  /**
+   * Whether there is an notebook active, with a single selected cell.
+   */
   function isEnabledAndSingleSelected(): boolean {
     if (!isEnabled()) { return false; }
     const { notebook } = tracker.currentWidget;

--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -1044,7 +1044,7 @@ namespace NotebookActions {
   }
 
   export
-  function toggleOutputScrolled(widget: Notebook): void {
+  function toggleOutputsScrolled(widget: Notebook): void {
     if (!widget.model || !widget.activeCell) {
       return;
     }
@@ -1053,7 +1053,7 @@ namespace NotebookActions {
     each(cells, (cell: Cell) => {
       if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         const codeCell: CodeCell = (cell as CodeCell);
-        codeCell.outputScrolled = !codeCell.outputScrolled;
+        codeCell.outputsScrolled = !codeCell.outputsScrolled;
       }
     });
     Private.handleState(widget, state);

--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -1043,6 +1043,11 @@ namespace NotebookActions {
     Private.handleState(widget, state);
   }
 
+  /**
+   * Enable output scrolling for all selected cells.
+   *
+   * @param widget - The target notebook widget.
+   */
   export
   function enableOutputScrolling(widget: Notebook): void {
     if (!widget.model || !widget.activeCell) {
@@ -1058,7 +1063,11 @@ namespace NotebookActions {
     Private.handleState(widget, state);
   }
 
-
+  /**
+   * Disable output scrolling for all selected cells.
+   *
+   * @param widget - The target notebook widget.
+   */
   export
   function disableOutputScrolling(widget: Notebook): void {
     if (!widget.model || !widget.activeCell) {

--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -1044,7 +1044,7 @@ namespace NotebookActions {
   }
 
   export
-  function toggleOutputsScrolled(widget: Notebook): void {
+  function enableOutputScrolling(widget: Notebook): void {
     if (!widget.model || !widget.activeCell) {
       return;
     }
@@ -1052,12 +1052,28 @@ namespace NotebookActions {
     let cells = widget.widgets;
     each(cells, (cell: Cell) => {
       if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
-        const codeCell: CodeCell = (cell as CodeCell);
-        codeCell.outputsScrolled = !codeCell.outputsScrolled;
+        (cell as CodeCell).outputsScrolled = true;
       }
     });
     Private.handleState(widget, state);
   }
+
+
+  export
+  function disableOutputScrolling(widget: Notebook): void {
+    if (!widget.model || !widget.activeCell) {
+      return;
+    }
+    let state = Private.getState(widget);
+    let cells = widget.widgets;
+    each(cells, (cell: Cell) => {
+      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
+        (cell as CodeCell).outputsScrolled = false;
+      }
+    });
+    Private.handleState(widget, state);
+  }
+
 
   /**
    * Set the markdown header level.

--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -1043,6 +1043,22 @@ namespace NotebookActions {
     Private.handleState(widget, state);
   }
 
+  export
+  function toggleOutputScrolled(widget: Notebook): void {
+    if (!widget.model || !widget.activeCell) {
+      return;
+    }
+    let state = Private.getState(widget);
+    let cells = widget.widgets;
+    each(cells, (cell: Cell) => {
+      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
+        const codeCell: CodeCell = (cell as CodeCell);
+        codeCell.outputScrolled = !codeCell.outputScrolled;
+      }
+    });
+    Private.handleState(widget, state);
+  }
+
   /**
    * Set the markdown header level.
    *


### PR DESCRIPTION
This add a context menu item for scrolling output in a code cell. It isn't our final solution to this design challenge, but it more functional for the beta. Output remains non-scrolled by default. Fixes #3541 



