### PR TITLE
Always enable the scroll bar for the completer.

### DIFF
--- a/packages/completer/style/index.css
+++ b/packages/completer/style/index.css
@@ -18,7 +18,8 @@
   color: var(--jp-content-font-color1);
   border: var(--jp-border-width) solid var(--jp-border-color1);
   list-style-type: none;
-  overflow: auto;
+  overflow-y: scroll;
+  overflow-x: auto;
   padding: 0;
   /* Position the completer relative to the text editor, align the '.' */
   margin: 4px 0 0 -30px;


### PR DESCRIPTION
This works around a firefox issue we are seeing, documented at https://github.com/jupyterlab/jupyterlab/issues/3543 and https://github.com/jupyterlab/jupyterlab/issues/3543#issuecomment-355697550.

Fixes #3543.