### PR TITLE
Allow using DockLayout mode options to open and openOrReveal

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -102,7 +102,7 @@ const plugin: JupyterLabPlugin<IDocumentManager> = {
 
           (widget as any).ready.then(() => {
             const isCurrent = app.shell.currentWidget === spinner;
-            app.shell.addToMainArea(widget, { ref: spinner.id });
+            app.shell.addToMainArea(widget, {...options, ref: spinner.id });
             spinner.dispose();
             if (isCurrent) {
               shell.activateById(widget.id);
@@ -227,8 +227,9 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
         : args['path'] as string;
       const factory = args['factory'] as string || void 0;
       const kernel = args['kernel'] as Kernel.IModel || void 0;
+      const options = args['options'] as DocumentRegistry.IOpenOptions || void 0;
       return docManager.services.contents.get(path, { content: false })
-        .then(() => docManager.openOrReveal(path, factory, kernel))
+        .then(() => docManager.openOrReveal(path, factory, kernel, options))
         .then(widget => {
           return widget.ready.then(() => { return widget; });
         });
@@ -329,15 +330,16 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
   commands.addCommand(CommandIDs.clone, {
     label: () => `New View for ${fileType()}`,
     isEnabled,
-    execute: () => {
+    execute: (args) => {
       const widget = app.shell.currentWidget;
+      const options = args['options'] as DocumentRegistry.IOpenOptions || void 0;
       if (!widget) {
         return;
       }
       // Clone the widget.
       let child = docManager.cloneWidget(widget);
       if (child) {
-        opener.open(child);
+        opener.open(child, options);
       }
     },
   });

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -294,8 +294,8 @@ class DocumentManager implements IDisposable {
    * This function will return `undefined` if a valid widget factory
    * cannot be found.
    */
-  open(path: string, widgetName='default', kernel?: Partial<Kernel.IModel>): DocumentRegistry.IReadyWidget | undefined {
-    return this._createOrOpenDocument('open', path, widgetName, kernel);
+  open(path: string, widgetName='default', kernel?: Partial<Kernel.IModel>, options?: DocumentRegistry.IOpenOptions ): DocumentRegistry.IReadyWidget | undefined {
+    return this._createOrOpenDocument('open', path, widgetName, kernel, options);
   }
 
   /**
@@ -314,13 +314,13 @@ class DocumentManager implements IDisposable {
    * This function will return `undefined` if a valid widget factory
    * cannot be found.
    */
-  openOrReveal(path: string, widgetName='default', kernel?: Partial<Kernel.IModel>): DocumentRegistry.IReadyWidget | undefined {
+  openOrReveal(path: string, widgetName='default', kernel?: Partial<Kernel.IModel>, options?: DocumentRegistry.IOpenOptions ): DocumentRegistry.IReadyWidget | undefined {
     let widget = this.findWidget(path, widgetName);
     if (widget) {
-      this._opener.open(widget);
+      this._opener.open(widget, options || {});
       return widget;
     }
-    return this.open(path, widgetName, kernel);
+    return this.open(path, widgetName, kernel, options || {});
   }
 
   /**
@@ -431,7 +431,7 @@ class DocumentManager implements IDisposable {
    * The two cases differ in how the document context is handled, but the creation
    * of the widget and launching of the kernel are identical.
    */
-  private _createOrOpenDocument(which: 'open'|'create', path: string, widgetName='default', kernel?: Partial<Kernel.IModel>): DocumentRegistry.IReadyWidget | undefined {
+  private _createOrOpenDocument(which: 'open'|'create', path: string, widgetName='default', kernel?: Partial<Kernel.IModel>, options?: DocumentRegistry.IOpenOptions): DocumentRegistry.IReadyWidget | undefined {
     let widgetFactory = this._widgetFactoryFor(path, widgetName);
     if (!widgetFactory) {
       return undefined;
@@ -466,7 +466,7 @@ class DocumentManager implements IDisposable {
     }
 
     let widget = this._widgetManager.createWidget(widgetFactory, context!);
-    this._opener.open(widget);
+    this._opener.open(widget, options || {});
     return widget;
   }
 


### PR DESCRIPTION
This is in the vein of #3484, primarily allowing us to open arbitrary widgets using different dockLayout insert modes. 

This change is necessary for the jupyterlab-latex extension to include https://github.com/mpacer/jupyterlab-latex/pull/31, which opens the pdf preview along-side the TeX document (as opposed to in a tab following it).
  