### PR TITLE
Update document links

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -77,7 +77,7 @@ xckd repo
 
 
 ### Extension examples to update
-- https://github.com/jupyterlab/jupyterlab/blob/master/docs/notebook.md#adding-a-button-to-the-toolbar
+- https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/developer/notebook.md#adding-a-button-to-the-toolbar
 
 
 ### Updating the xkcd tutorial

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,5 +5,4 @@ dependencies:
 - python=3.5
 - sphinx>=1.6
 - sphinx_rtd_theme
-- pip:
-  - recommonmark==0.4.0
+- recommonmark

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,4 +5,5 @@ dependencies:
 - python=3.5
 - sphinx>=1.6
 - sphinx_rtd_theme
-- recommonmark
+- pip:
+  - recommonmark==0.4.0

--- a/docs/source/developer/extension_dev.md
+++ b/docs/source/developer/extension_dev.md
@@ -199,7 +199,7 @@ The theme extension is installed the same as a regular extension (see
 
 ## Standard (General-Purpose) Extensions
 See the example,
-[How to Extend the Notebook Plugin](https://github.com/jupyterlab/jupyterlab/blob/master/docs/notebook.md#how-to-extend-the-notebook-plugin). Notice that the mime
+[How to Extend the Notebook Plugin](./notebook.md#how-to-extend-the-notebook-plugin). Notice that the mime
 renderer and themes extensions above use a limited, simplified interface to
 JupyterLab's extension system. Modifying the notebook plugin requires the full,
 general-purpose interface to the extension system.


### PR DESCRIPTION
Fixes #3573.  We are already building the docs [here](https://github.com/jupyterlab/jupyterlab/blob/cd2aa2caf79de628aa37f87111a656393e677449/scripts/travis_script.sh#L65) and deploying them [here](https://github.com/jupyterlab/jupyterlab/blob/cd2aa2caf79de628aa37f87111a656393e677449/scripts/travis_after_success.sh#L8).

I tried to use the `recommonmark` package from `conda-forge` following https://github.com/jupyter-widgets/ipywidgets/pull/1890 but I got the error: `ImportError: No module named 'CommonMark'` on the CI build.

  