### PR TITLE
Add ability to specify dev build and clean up build handling

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -356,6 +356,8 @@ class _AppHandler(object):
             if other['path'] != info['path'] and other['location'] == 'app':
                 os.remove(other['path'])
 
+        return True
+
     def build(self, name=None, version=None, public_url=None,
             command='build:prod', clean_staging=False):
         """Build the application.
@@ -566,6 +568,8 @@ class _AppHandler(object):
         linked = config.setdefault('linked_packages', dict())
         linked[info['name']] = info['source']
         self._write_build_config(config)
+
+        return True
 
     def unlink_package(self, path):
         """Link a package by name or at the given path.

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -22,6 +22,11 @@ build_aliases['app-dir'] = 'LabBuildApp.app_dir'
 build_aliases['name'] = 'LabBuildApp.name'
 build_aliases['version'] = 'LabBuildApp.version'
 
+build_flags = dict(flags)
+build_flags['dev'] = (
+    {'LabBuildApp': {'dev_build': True}},
+    "Build in Development mode"
+)
 
 version = __version__
 app_version = get_app_version()
@@ -39,6 +44,7 @@ class LabBuildApp(JupyterApp):
     directory, where it is used to serve the application.
     """
     aliases = build_aliases
+    flags = build_flags
 
     app_dir = Unicode('', config=True,
         help="The app directory to build in")
@@ -49,8 +55,13 @@ class LabBuildApp(JupyterApp):
     version = Unicode('', config=True,
         help="The version of the built application")
 
+    dev_build = Bool(False, config=True,
+        help="Whether to build in dev mode (defaults to production mode)")
+
     def start(self):
-        build(self.app_dir, self.name, self.version)
+        command = 'build:prod' if not self.dev_build else 'build'
+        build(app_dir=self.app_dir, name=self.name, version=self.version,
+              command=command, logger=self.log)
 
 
 clean_aliases = dict(base_aliases)

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -27,6 +27,10 @@ flags['no-build'] = (
     {'BaseExtensionApp': {'should_build': False}},
     "Defer building the app after the action."
 )
+flags['dev-build'] = (
+    {'BaseExtensionApp': {'dev_build': True}},
+    "Build in Development mode"
+)
 flags['clean'] = (
     {'BaseExtensionApp': {'should_clean': True}},
     "Cleanup intermediate files after the action."
@@ -51,8 +55,11 @@ class BaseExtensionApp(JupyterApp):
     app_dir = Unicode('', config=True,
         help="The app directory to target")
 
-    should_build = Bool(False, config=True,
+    should_build = Bool(True, config=True,
         help="Whether to build the app after the action")
+
+    dev_build = Bool(False, config=True,
+        help="Whether to build in dev mode (defaults to production mode)")
 
     should_clean = Bool(False, config=True,
         help="Whether temporary files should be cleaned up after building jupyterlab")
@@ -61,7 +68,11 @@ class BaseExtensionApp(JupyterApp):
         if self.app_dir and self.app_dir.startswith(HERE):
             raise ValueError('Cannot run lab extension commands in core app')
         try:
-            self.run_task()
+            ans = self.run_task()
+            if ans and self.should_build:
+                command = 'build:prod' if not self.dev_build else 'build'
+                build(app_dir=self.app_dir, clean_staging=self.should_clean,
+                      logger=self.log, command=command)
         except Exception as ex:
             _, _, exc_traceback = sys.exc_info()
             msg = traceback.format_exception(ex.__class__, ex, exc_traceback)
@@ -81,17 +92,13 @@ class BaseExtensionApp(JupyterApp):
 
 class InstallLabExtensionApp(BaseExtensionApp):
     description = "Install labextension(s)"
-    should_build = Bool(True, config=True,
-        help="Whether to build the app after the action")
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        [install_extension(arg, self.app_dir, logger=self.log) for
-         arg in self.extra_args]
-
-        if self.should_build:
-            build(self.app_dir, clean_staging=self.should_clean,
-                 logger=self.log)
+        return any(
+            install_extension(arg, self.app_dir, logger=self.log)
+            for arg in self.extra_args
+        )
 
 
 class LinkLabExtensionApp(BaseExtensionApp):
@@ -107,40 +114,32 @@ class LinkLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        [link_package(arg, self.app_dir, logger=self.log)
-         for arg in self.extra_args]
-
-        if self.should_build:
-            build(self.app_dir, clean_staging=self.should_clean,
-                  logger=self.log)
+        return any(
+            link_package(arg, self.app_dir, logger=self.log)
+            for arg in self.extra_args
+        )
 
 
 class UnlinkLabExtensionApp(BaseExtensionApp):
     description = "Unlink packages by name or path"
-    should_build = Bool(True, config=True,
-        help="Whether to build the app after the action")
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        ans = any([unlink_package(arg, self.app_dir, logger=self.log)
-                   for arg in self.extra_args])
-        if ans and self.should_build:
-            build(self.app_dir, clean_staging=self.should_clean,
-                  logger=self.log)
+        return any(
+            unlink_package(arg, self.app_dir, logger=self.log)
+            for arg in self.extra_args
+        )
 
 
 class UninstallLabExtensionApp(BaseExtensionApp):
     description = "Uninstall labextension(s) by name"
-    should_build = Bool(True, config=True,
-        help="Whether to build the app after the action")
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        ans = any([uninstall_extension(arg, self.app_dir, logger=self.log)
-                   for arg in self.extra_args])
-        if ans and self.should_build:
-            build(self.app_dir, clean_staging=self.should_clean,
-                  logger=self.log)
+        return any(
+            uninstall_extension(arg, self.app_dir, logger=self.log)
+            for arg in self.extra_args
+        )
 
 
 class ListLabExtensionsApp(BaseExtensionApp):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -95,10 +95,10 @@ class InstallLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        return any(
+        return any([
             install_extension(arg, self.app_dir, logger=self.log)
             for arg in self.extra_args
-        )
+        ])
 
 
 class LinkLabExtensionApp(BaseExtensionApp):
@@ -114,10 +114,10 @@ class LinkLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        return any(
+        return any([
             link_package(arg, self.app_dir, logger=self.log)
             for arg in self.extra_args
-        )
+        ])
 
 
 class UnlinkLabExtensionApp(BaseExtensionApp):
@@ -125,10 +125,10 @@ class UnlinkLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        return any(
+        return any([
             unlink_package(arg, self.app_dir, logger=self.log)
             for arg in self.extra_args
-        )
+        ])
 
 
 class UninstallLabExtensionApp(BaseExtensionApp):
@@ -136,10 +136,10 @@ class UninstallLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        return any(
+        return any([
             uninstall_extension(arg, self.app_dir, logger=self.log)
             for arg in self.extra_args
-        )
+        ])
 
 
 class ListLabExtensionsApp(BaseExtensionApp):


### PR DESCRIPTION
I saw this when debugging with @gnestor yesterday.  The production build takes a while (building source maps and uglifying), we should allow an override to use the dev build.  Adds:

```
jupyter lab build --dev
jupyter labextension install <foo> --dev-build
```
  