### PR TITLE
Interface doc edits

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,9 +24,9 @@ JupyterLab Documentation
    user/notebook
    user/code_console
    user/terminal
-   user/documents_kernels
    user/running
    user/commands
+   user/documents_kernels
    user/file_formats
    user/extensions
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,10 +23,10 @@ JupyterLab Documentation
    user/file_editor
    user/notebook
    user/code_console
+   user/terminal
    user/documents_kernels
    user/running
    user/commands
-   user/terminal
    user/file_formats
    user/extensions
 

--- a/docs/source/user/code_console.md
+++ b/docs/source/user/code_console.md
@@ -1,27 +1,33 @@
 
 # Code Consoles
 
-Notebooks allow you to write and run code while you create a document. At times,
-it is helpful to write and run code in an exploratory manner, while not creating
-a document; a sort of transient playground for interactive code. The JupyterLab
-Code Console addresses this usage case, with full support for the rich output of
-Jupyter.
+Code consoles allow you to run code interactively in a kernel. The cells of a
+code console show the order in which code was executed in the kernel, as opposed
+to the explicit ordering of cells in a notebook document. Code consoles also
+display rich output, just like notebook cells.
 
-Create a code console by clicking the + button in the File Browser and selecting
-the kernel:
-
-[animation]
-
-Run code using `Shift Enter` and use the up and down arrows allow you to browse
-the history of previously run code:
+Create a new code console by clicking the `+` button in the file browser and
+selecting the kernel:
 
 [animation]
 
-Tab completion (`Tab`) and tooltips (`Shift Tab`) work as in the Notebook:
+Run code using `Shift Enter`. Use the up and down arrows to browse
+the history of previously-run code:
 
 [animation]
 
-You can clear the previous cells of the Code Console by right-clicking on the
-Code Console and selecting the “Clear Console Cells” item:
+Tab completion (`Tab`) and tooltips (`Shift Tab`) work as in the notebook:
+
+[animation]
+
+Clear the cells of the code console without restarting the kernel by
+right-clicking on the code console and selecting “Clear Console Cells”:
+
+[animation]
+
+Creating a code console from the File menu lets you select an existing kernel
+for the code console. The code console then acts as a log of computations in
+that kernel, and a place you can interactively inspect and run code in the
+kernel:
 
 [animation]

--- a/docs/source/user/commands.md
+++ b/docs/source/user/commands.md
@@ -2,9 +2,10 @@
 # Command Palette
 
 All user actions in JupyterLab are processed through a centralized command
-system. These commands are shared and used throughout JupyterLab (Menu Bar,
-Context Menus, etc.). The Command Palette provides a keyboard-driven way to
-search for and run any JupyterLab command:
+system. These commands are shared and used throughout JupyterLab (menu bar,
+context menus, keyboard shortcuts, etc.). The command palette in the left
+sidebar provides a keyboard-driven way to search for and run any JupyterLab
+command:
 
 [screenshot]
 

--- a/docs/source/user/documents_kernels.md
+++ b/docs/source/user/documents_kernels.md
@@ -1,24 +1,25 @@
 
 ## Kernel backed documents
 
-In the Jupyter architecture, Kernels are separate processes started by the
-server that run your code in different programming languages. JupyterLab allows
-you to connect any open text file to a code console/kernel. With this, you can
-run code from the text file in the kernel interactively.
+In the Jupyter architecture, kernels are separate processes started by the
+server that run your code in different programming languages and environments.
+JupyterLab allows you to connect any open text file to a code console and
+kernel. This means you can easily run code from the text file in the kernel
+interactively.
 
-Right-click on the document and select “Create Console for Editor”: 
-
-[animation]
-
-Once the code console is open, send a single line of code or a seletion of code
-to the code console by hitting `Shift Enter`:
+Right-click on a document and select “Create Console for Editor”: 
 
 [animation]
 
-In a markdown document, `Shift Enter` will automatically detect if the cursor is
-within a code block, and run the entire block:
+Once the code console is open, send a single line of code or select a block of
+code and send it to the code console by hitting `Shift Enter`:
 
 [animation]
 
-It is important to emphasize that any text file (markdown, python, R, LaTeX,
-C++, etc.) can be connected to a code console/kernel in this manner.
+In a Markdown document, `Shift Enter` will automatically detect if the cursor is
+within a code block, and run the entire block if there is no selection:
+
+[animation]
+
+*Any* text file (Markdown, Python, R, LaTeX, C++, etc.) in a text file editor
+can be connected to a code console and kernel in this manner.

--- a/docs/source/user/documents_kernels.md
+++ b/docs/source/user/documents_kernels.md
@@ -1,5 +1,5 @@
 
-## Kernel backed documents
+## Documents and kernels
 
 In the Jupyter architecture, kernels are separate processes started by the
 server that run your code in different programming languages and environments.

--- a/docs/source/user/file_editor.md
+++ b/docs/source/user/file_editor.md
@@ -1,23 +1,31 @@
-
 # File Editor
 
-The File Editor in JupyterLab enables you to edit text files in JupyterLab:
+The file editor in JupyterLab enables you to edit text files in JupyterLab:
 
 [screenshot]
 
-The File Editor includes syntax highlighting, configurable indentation (tabs,
+The file editor includes syntax highlighting, configurable indentation (tabs or
 spaces), different key maps (vim, emacs, Sublime Text) and basic theming. These
 settings can be found in the Settings menu:
 
 [screenshot]
 
-To edit an existing text file, double-click on the file in the File Browser or
-drag it into the Dock Panel:
+To edit an existing text file, double-click on its name in the file browser or
+drag it into the main area:
 
 [animation]
 
-To create a new text file in the current directory of the File Browser, click
-the + button at the top of the File Browser and click the “Text Editor” card in
+To create a new text file in the current directory of the file browser, click
+the `+` button at the top of the file browser to create a new Launcher tab, and click the “Text Editor” card in
 the Launcher:
+
+[animation]
+
+You can also create a new text file with the File menu:
+
+[animation]
+
+A new file is created with a default name. Rename a file by right-clicking on
+its name in the file browser and selecting “Rename” from the context menu:
 
 [animation]

--- a/docs/source/user/file_formats.md
+++ b/docs/source/user/file_formats.md
@@ -4,11 +4,12 @@ JupyterLab provides a unified architecture for viewing and editing data in a
 wide variety of formats. This model applies whether the data is in a file or is
 provided by a kernel as rich cell output in a notebook or code console.
 
-For files, the data format is detected by the extension of the file. A single
-file extension may have multiple editors or viewers registered. For example a
-Markdown file (`.md`) can be edited in the file editor or rendered and displayed
-as HTML. You can open different editors and viewers for a file by right-clicking
-on the filename in the file browser and using the "Open With..." submenu:
+For files, the data format is detected by the extension of the file (or the
+whole filename if there is no extension). A single file extension may have
+multiple editors or viewers registered. For example a Markdown file (`.md`) can
+be edited in the file editor or rendered and displayed as HTML. You can open
+different editors and viewers for a file by right-clicking on the filename in
+the file browser and using the "Open With..." submenu:
 
 [screenshot]
 
@@ -69,8 +70,10 @@ JupyterLab supports image data in cell output and as files in the above formats.
 * File extension: `.csv`
 * MIME type: None
 
-Files with rows of comma-separated values (CSV files) are a common
-format for tabular data. The default viewer for CSV files in JupyterLab is a high-performance data grid viewer:
+Files with rows of comma-separated values (CSV files) are a common format for
+tabular data. The default viewer for CSV files in JupyterLab is a
+high-performance data grid viewer (which can also handle tab- and
+semicolon-separated values):
 
 [animation]
 
@@ -105,7 +108,7 @@ JupyterLab supports rendering HTML in cell output and editing HTML files as text
 * File extension: `.tex`
 * MIME type: `text/latex`
 
-JupyterLab supports rendering LaTeX in cell output and editing LaTeX files as text in the file editor.
+JupyterLab supports rendering LaTeX equations in cell output and editing LaTeX files as text in the file editor.
 
 
 ## PDF

--- a/docs/source/user/file_formats.md
+++ b/docs/source/user/file_formats.md
@@ -1,43 +1,48 @@
-
 # File and output formats
 
 ## Overview
 
-When working with code and data, you will encounter data and files in a wide
-variety of formats. JupyterLab provides a unified architecture for viewing and editing
-data. This model applies whether the data is in a file or is provided by a
-kernel as rich output in a notebook or code console.
+JupyterLab provides a unified architecture for viewing and editing data in a
+wide variety of formats. This model applies whether the data is in a file or is
+provided by a kernel as rich cell output in a notebook or code console.
 
 For files, the data format is detected by the extension of the file. A single
 file extension may have multiple editors or viewers registered. For example a
 Markdown file (`.md`) can be edited in the file editor or rendered and displayed
-as HTML.
-
-You can open different editors and viewers for a file by right-clicking on
-the filename in the file browser and using the "Open With..." submenu:
+as HTML. You can open different editors and viewers for a file by right-clicking
+on the filename in the file browser and using the "Open With..." submenu:
 
 [screenshot]
 
-To use these different data formats as output in a notebook or code console,
-you can use the relevant display API for the kernel you are using. For example,
-the IPython kernel provides a `display` function that takes a `dict` of keys
-(MIME types) and values (MIME data):
+To use these different data formats as output in a notebook or code console, you
+can use the relevant display API for the kernel you are using. For example, the
+IPython kernel provides a variety of convenience classes for displaying rich output:
+
+```python
+from IPython.display import display, HTML
+display(HTML('<h1>Hello World</h1>'))
+```
+
+Running this code will display the HTML in the output of a notebook or code
+console cell:
+
+[screenshot]
+
+The IPython display function can also construct a raw rich output message from a
+dictionary of keys (MIME types) and values (MIME data):
 
 ```python
 from IPython.display import display
-display({'text/html': '<h1>Hello World</h1>'}, raw=True)
+display({'text/html': '<h1>Hello World</h1>', 'text/plain': 'Hello World'}, raw=True)
 ```
-
-Running this code will display the HTML in the output of the notebook or code
-console:
-
-[screenshot]
 
 Other Jupyter kernels offer similar APIs.
 
-## Markdown
+## Formats
 
-* File format: `.md`
+### Markdown
+
+* File extension: `.md`
 * MIME type: `text/markdown`
 
 Markdown is a simple and popular markup language used for text cells in the
@@ -45,69 +50,56 @@ Jupyter Notebook.
 
 Markdown documents can be edited as text files or rendered inline:
 
+[animation showing opening a markdown document editor and renderer side-by-side, and changes in the editor being reflected in the renderer]
+
+The Markdown syntax supported in this mode is the same syntax used in the
+Jupyter Notebook (for example, LaTeX equations work). As seen in the animation,
+edits to the Markdown source are immediately reflected in the rendered version.
+
+### Images
+
+* File extensions: `.bmp`, `.gif`, `.jpeg`, `.jpg`, `.png`, `.svg`
+* MIME types: `image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/svg+xml`
+
+JupyterLab supports image data in cell output and as files in the above formats. In the image file viewer, you can use keyboard shortcuts such as `+` and `-` to zoom the image and `0` to reset the zoom level. To edit an SVG image as a text file, right-click on the SVG filename in the file browser and select the “Editor” item in the “Open With…” submenu:
+
 [animation]
 
-The markdown syntax supported in this mode is the same as that in the Jupyter
-Notebook (LaTeX equations work). As seen in the animation, edits to the Markdown
-source are immediately reflected in the rendered version.
+### HTML
 
-## Images
-
-* File format: `.png`, `.jpeg`, `.gif`
-* MIME type: `image/png`, `image/jpeg`, `image/gif`
-
-JupyterLab supports image data as files and output in the above formats. In the image file viewer, you can use keyboard shortcuts such as `+` and `-` to zoom the image and `0` to reset the zoom level.
-
-## HTML
-
-* File format: `.html`
+* File extension: `.html`
 * MIME type: `text/html`
 
-JupyterLab supports rendered HTML in output. HTML files can be edited as text
-files in the file editor.
+JupyterLab supports rendering HTML in cell output and editing HTML files as text in the file editor.
 
-## SVG
+### LaTeX
 
-* File format: `.svg`
-* MIME type: `image/svg+xml`
-
-JupyterLab will render Scalable Vector Graphics (SVG) in files and output. SVG
-files can slso be edited as text files in the file editor.
-
-## LaTeX
-
-* File format: `.tex`
+* File extension: `.tex`
 * MIME type: `text/latex`
 
-JupyterLab will render LaTeX questions in output, and LaTeX files (`.tex`) can
-be edited as text files in the file editor.
+JupyterLab supports rendering LaTeX in cell output and editing LaTeX files as text in the file editor.
 
-## JSON
+### JSON
 
-* File format: `.json`
-* MIME type: `application/binary+json`
+* File extension: `.json`
+* MIME type: `application/json`
 
-JavaScript Object Notation (JSON) files are common in data science.
+JavaScript Object Notation (JSON) files are common in data science. JupyterLab supports displaying JSON data in cell output or viewing a JSON file using a searchable tree view:
 
-The default viewer for JSON files is a searchable tree view:
+[animation showing both rendering JSON as cell output and viewing a JSON file]
 
-[animation]
-
-To edit the JSON as a text file, right-click on the file in the file browser and
-select the “Editor” item in the “Open With…” submenu:
+To edit the JSON as a text file, right-click on the filename in the file browser
+and select the “Editor” item in the “Open With…” submenu:
 
 [animation]
 
-## CSV
+### CSV
 
-* File format: `.csv`
+* File extension: `.csv`
 * MIME type: None
 
-Files with rows of Comma-Separated Values (with a `.csv` extension) are a common
-format for tabular data.
-
-The default viewer for CSV files in JupyterLab is a high performance data grid
-viewer:
+Files with rows of comma-separated values (CSV files) are a common
+format for tabular data. The default viewer for CSV files in JupyterLab is a high-performance data grid viewer:
 
 [animation]
 
@@ -116,35 +108,32 @@ and select the “Editor” item in the “Open With…” submenu:
 
 [animation]
 
-## PDF
+### PDF
 
-* File format: `.pdf`
+* File extension: `.pdf`
 * MIME type: `application/pdf`
 
-PDF files are a common standard file format for
-documents. To view a PDF file in JupyterLab, double-click on the file in the
-file browser:
+PDF is a common standard file format for documents. To view a PDF file in
+JupyterLab, double-click on the file in the file browser:
 
 [animation]
 
-
-## Vega/Vega-Lite
+### Vega/Vega-Lite
 
 Vega:
 
-* File format: `.vg`, `.vg.json`
+* File extension: `.vg`, `.vg.json`
 * MIME type: `application/vnd.vega.v2+json`
 
 Vega-Lite:
 
-* File format: `.vl`, `.vl.json`
+* File extension: `.vl`, `.vl.json`
 * MIME type: `application/vnd.vegalite.v1+json`
 
 Vega and Vega-Lite are declarative visualization grammars that allow
 visualizations to be encoded as JSON data. For more information, see the
-documentation of Vega or Vega-Lite. JupyterLab has built-in rendering support
-for Vega 2.x and Vega-Lite 1.x data. This support works for both files and
-output in the Notebook and Code Console.
+documentation of Vega or Vega-Lite. JupyterLab supports rendering
+Vega 2.x and Vega-Lite 1.x data in files and cell output.
 
 Vega-Lite 1.x files, with a `.vl` or `.vl.json` file extension, can be opened by
 double-clicking the file in the File Browser:
@@ -166,7 +155,7 @@ The same workflow also works for Vega 2.x files, with a `.vg` or `.vg.json` file
 extension.
 
 Output support for Vega/Vega-Lite in a notebook or code console is provided
-through third party libraries such as Altair (Python), the vegalite R package,
+through third-party libraries such as Altair (Python), the vegalite R package,
 or Vegas (Scala/Spark).
 
 [screenshot]
@@ -174,9 +163,9 @@ or Vegas (Scala/Spark).
 A JupyterLab extension that supports Vega 3.x and Vega-Lite 2.x can be found
 [here](https://github.com/jupyterlab/jupyter-renderers).
 
-## Virtual DOM
+### Virtual DOM
 
-* File format: `.vdom`, `.json`
+* File extension: `.vdom`, `.json`
 * MIME type: `application/vdom.v1+json`
 
 Virtual DOM libraries such as [react.js](https://reactjs.org/) have greatly
@@ -186,7 +175,7 @@ project, which collaborates closely with Project Jupyter, has created a
 JupyterLab can render this data using react.js. This works for both VDOM files
 with the `.vdom` extension, or within notebook output.
 
-Here is an example of a `.vdom` files being edited and rendered interactively:
+Here is an example of a `.vdom` file being edited and rendered interactively:
 
 [animation]
 

--- a/docs/source/user/file_formats.md
+++ b/docs/source/user/file_formats.md
@@ -4,23 +4,24 @@
 ## Overview
 
 When working with code and data, you will encounter data and files in a wide
-variety of formats. JupyterLab provides a unified architecture for working with
-data. This model applies whether the data is in a file, or is provided by a
-Kernel as output in a notebook or code console.
+variety of formats. JupyterLab provides a unified architecture for viewing and editing
+data. This model applies whether the data is in a file or is provided by a
+kernel as rich output in a notebook or code console.
 
 For files, the data format is detected by the extension of the file. A single
 file extension may have multiple editors or viewers registered. For example a
-Markdown file (`.md`) can be edited in the File Editor, or rendered inline.
+Markdown file (`.md`) can be edited in the file editor or rendered and displayed
+as HTML.
 
-You can access different editors and viewers for a file, by right-clicking on
-the filename in the File Browser and using the "Open With..." submenu:
+You can open different editors and viewers for a file by right-clicking on
+the filename in the file browser and using the "Open With..." submenu:
 
 [screenshot]
 
-To use these different data formats as output in the Notebook or Code Console,
+To use these different data formats as output in a notebook or code console,
 you can use the relevant display API for the kernel you are using. For example,
 the IPython kernel provides a `display` function that takes a `dict` of keys
-(MIME types) and value (MIME data):
+(MIME types) and values (MIME data):
 
 ```python
 from IPython.display import display
@@ -32,7 +33,7 @@ console:
 
 [screenshot]
 
-Other Jupyter Kernels offer similar APIs.
+Other Jupyter kernels offer similar APIs.
 
 ## Markdown
 
@@ -47,23 +48,23 @@ Markdown documents can be edited as text files or rendered inline:
 [animation]
 
 The markdown syntax supported in this mode is the same as that in the Jupyter
-Notebook (LaTeX equations work). As seen in the animation, edits to the markdown
-source are immediately reflected in the rendered version:
+Notebook (LaTeX equations work). As seen in the animation, edits to the Markdown
+source are immediately reflected in the rendered version.
 
 ## Images
 
 * File format: `.png`, `.jpeg`, `.gif`
 * MIME type: `image/png`, `image/jpeg`, `image/gif`
 
-JupyterLab supports image data as files and output in the above formats.
+JupyterLab supports image data as files and output in the above formats. In the image file viewer, you can use keyboard shortcuts such as `+` and `-` to zoom the image and `0` to reset the zoom level.
 
 ## HTML
 
-* File format: edit as text file
+* File format: `.html`
 * MIME type: `text/html`
 
 JupyterLab supports rendered HTML in output. HTML files can be edited as text
-files in the File Editor.
+files in the file editor.
 
 ## SVG
 
@@ -71,20 +72,20 @@ files in the File Editor.
 * MIME type: `image/svg+xml`
 
 JupyterLab will render Scalable Vector Graphics (SVG) in files and output. SVG
-files can slso be edited as text files in the File Editor.
+files can slso be edited as text files in the file editor.
 
 ## LaTeX
 
-* File format: edit as text file
+* File format: `.tex`
 * MIME type: `text/latex`
 
 JupyterLab will render LaTeX questions in output, and LaTeX files (`.tex`) can
-be edited as text files in the File Editor.
+be edited as text files in the file editor.
 
 ## JSON
 
 * File format: `.json`
-* MIME type: `application+json`
+* MIME type: `application/binary+json`
 
 JavaScript Object Notation (JSON) files are common in data science.
 
@@ -92,7 +93,7 @@ The default viewer for JSON files is a searchable tree view:
 
 [animation]
 
-To edit the JSON as a text file, right-click on the file in the File Browser and
+To edit the JSON as a text file, right-click on the file in the file browser and
 select the “Editor” item in the “Open With…” submenu:
 
 [animation]
@@ -102,16 +103,15 @@ select the “Editor” item in the “Open With…” submenu:
 * File format: `.csv`
 * MIME type: None
 
-Files with rows of Comma Separate Values (with a `.csv` extension) are a common
+Files with rows of Comma-Separated Values (with a `.csv` extension) are a common
 format for tabular data.
 
 The default viewer for CSV files in JupyterLab is a high performance data grid
-viewer. To view a CSV file in the interactive Data Grid, double-click on the
-file in the File Browser:
+viewer:
 
 [animation]
 
-To edit a CSV file as a text file, right-click on the file in the File Browser
+To edit a CSV file as a text file, right-click on the file in the file browser
 and select the “Editor” item in the “Open With…” submenu:
 
 [animation]
@@ -121,9 +121,9 @@ and select the “Editor” item in the “Open With…” submenu:
 * File format: `.pdf`
 * MIME type: `application/pdf`
 
-PDF files (`.pdf` extension) are a common and standard file format for
+PDF files are a common standard file format for
 documents. To view a PDF file in JupyterLab, double-click on the file in the
-File Browser:
+file browser:
 
 [animation]
 
@@ -141,22 +141,22 @@ Vega-Lite:
 * MIME type: `application/vnd.vegalite.v1+json`
 
 Vega and Vega-Lite are declarative visualization grammars that allow
-visualizations to be encoded as JSON data. Fro more information see the
+visualizations to be encoded as JSON data. For more information, see the
 documentation of Vega or Vega-Lite. JupyterLab has built-in rendering support
 for Vega 2.x and Vega-Lite 1.x data. This support works for both files and
 output in the Notebook and Code Console.
 
 Vega-Lite 1.x files, with a `.vl` or `.vl.json` file extension, can be opened by
-double-clicking he file in the File Browser:
+double-clicking the file in the File Browser:
 
 [animation]
 
-The files can also be opened in the JSON viewer or File Editor through the “Open
-With…” submenu in the File Browser content menu:
+The files can also be opened in the JSON viewer or file editor through the “Open
+With…” submenu in the file browser content menu:
 
 [animation]
 
-As with other files in JupyterLab multiple views of a single file remain
+As with other files in JupyterLab, multiple views of a single file remain
 synchronized, allowing you to interactively edit and render Vega-Lite/Vega
 visualizations:
 
@@ -165,7 +165,7 @@ visualizations:
 The same workflow also works for Vega 2.x files, with a `.vg` or `.vg.json` file
 extension.
 
-Output support for Vega/Vega-Lite in the Notebook or Code Console is provided
+Output support for Vega/Vega-Lite in a notebook or code console is provided
 through third party libraries such as Altair (Python), the vegalite R package,
 or Vegas (Scala/Spark).
 

--- a/docs/source/user/file_formats.md
+++ b/docs/source/user/file_formats.md
@@ -1,7 +1,5 @@
 # File and output formats
 
-## Overview
-
 JupyterLab provides a unified architecture for viewing and editing data in a
 wide variety of formats. This model applies whether the data is in a file or is
 provided by a kernel as rich cell output in a notebook or code console.
@@ -38,9 +36,10 @@ display({'text/html': '<h1>Hello World</h1>', 'text/plain': 'Hello World'}, raw=
 
 Other Jupyter kernels offer similar APIs.
 
-## Formats
+The rest of this section highlights some of the common data formats that
+JupyterLab supports.
 
-### Markdown
+## Markdown
 
 * File extension: `.md`
 * MIME type: `text/markdown`
@@ -56,7 +55,7 @@ The Markdown syntax supported in this mode is the same syntax used in the
 Jupyter Notebook (for example, LaTeX equations work). As seen in the animation,
 edits to the Markdown source are immediately reflected in the rendered version.
 
-### Images
+## Images
 
 * File extensions: `.bmp`, `.gif`, `.jpeg`, `.jpg`, `.png`, `.svg`
 * MIME types: `image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/svg+xml`
@@ -65,35 +64,7 @@ JupyterLab supports image data in cell output and as files in the above formats.
 
 [animation]
 
-### HTML
-
-* File extension: `.html`
-* MIME type: `text/html`
-
-JupyterLab supports rendering HTML in cell output and editing HTML files as text in the file editor.
-
-### LaTeX
-
-* File extension: `.tex`
-* MIME type: `text/latex`
-
-JupyterLab supports rendering LaTeX in cell output and editing LaTeX files as text in the file editor.
-
-### JSON
-
-* File extension: `.json`
-* MIME type: `application/json`
-
-JavaScript Object Notation (JSON) files are common in data science. JupyterLab supports displaying JSON data in cell output or viewing a JSON file using a searchable tree view:
-
-[animation showing both rendering JSON as cell output and viewing a JSON file]
-
-To edit the JSON as a text file, right-click on the filename in the file browser
-and select the “Editor” item in the “Open With…” submenu:
-
-[animation]
-
-### CSV
+## CSV
 
 * File extension: `.csv`
 * MIME type: None
@@ -108,7 +79,36 @@ and select the “Editor” item in the “Open With…” submenu:
 
 [animation]
 
-### PDF
+## JSON
+
+* File extension: `.json`
+* MIME type: `application/json`
+
+JavaScript Object Notation (JSON) files are common in data science. JupyterLab supports displaying JSON data in cell output or viewing a JSON file using a searchable tree view:
+
+[animation showing both rendering JSON as cell output and viewing a JSON file]
+
+To edit the JSON as a text file, right-click on the filename in the file browser
+and select the “Editor” item in the “Open With…” submenu:
+
+[animation]
+
+## HTML
+
+* File extension: `.html`
+* MIME type: `text/html`
+
+JupyterLab supports rendering HTML in cell output and editing HTML files as text in the file editor.
+
+## LaTeX
+
+* File extension: `.tex`
+* MIME type: `text/latex`
+
+JupyterLab supports rendering LaTeX in cell output and editing LaTeX files as text in the file editor.
+
+
+## PDF
 
 * File extension: `.pdf`
 * MIME type: `application/pdf`
@@ -118,7 +118,7 @@ JupyterLab, double-click on the file in the file browser:
 
 [animation]
 
-### Vega/Vega-Lite
+## Vega/Vega-Lite
 
 Vega:
 
@@ -163,7 +163,7 @@ or Vegas (Scala/Spark).
 A JupyterLab extension that supports Vega 3.x and Vega-Lite 2.x can be found
 [here](https://github.com/jupyterlab/jupyter-renderers).
 
-### Virtual DOM
+## Virtual DOM
 
 * File extension: `.vdom`, `.json`
 * MIME type: `application/vdom.v1+json`

--- a/docs/source/user/file_formats.md
+++ b/docs/source/user/file_formats.md
@@ -133,12 +133,12 @@ JupyterLab, double-click on the file in the file browser:
 
 Vega:
 
-* File extension: `.vg`, `.vg.json`
+* File extensions: `.vg`, `.vg.json`
 * MIME type: `application/vnd.vega.v2+json`
 
 Vega-Lite:
 
-* File extension: `.vl`, `.vl.json`
+* File extensions: `.vl`, `.vl.json`
 * MIME type: `application/vnd.vegalite.v1+json`
 
 Vega and Vega-Lite are declarative visualization grammars that allow
@@ -176,7 +176,7 @@ A JupyterLab extension that supports Vega 3.x and Vega-Lite 2.x can be found
 
 ## Virtual DOM
 
-* File extension: `.vdom`, `.json`
+* File extensions: `.vdom`, `.json`
 * MIME type: `application/vdom.v1+json`
 
 Virtual DOM libraries such as [react.js](https://reactjs.org/) have greatly

--- a/docs/source/user/file_formats.md
+++ b/docs/source/user/file_formats.md
@@ -9,7 +9,7 @@ whole filename if there is no extension). A single file extension may have
 multiple editors or viewers registered. For example a Markdown file (`.md`) can
 be edited in the file editor or rendered and displayed as HTML. You can open
 different editors and viewers for a file by right-clicking on the filename in
-the file browser and using the "Open With..." submenu:
+the file browser and using the “Open With” submenu:
 
 [screenshot]
 
@@ -61,7 +61,11 @@ edits to the Markdown source are immediately reflected in the rendered version.
 * File extensions: `.bmp`, `.gif`, `.jpeg`, `.jpg`, `.png`, `.svg`
 * MIME types: `image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/svg+xml`
 
-JupyterLab supports image data in cell output and as files in the above formats. In the image file viewer, you can use keyboard shortcuts such as `+` and `-` to zoom the image and `0` to reset the zoom level. To edit an SVG image as a text file, right-click on the SVG filename in the file browser and select the “Editor” item in the “Open With…” submenu:
+JupyterLab supports image data in cell output and as files in the above formats.
+In the image file viewer, you can use keyboard shortcuts such as `+` and `-` to
+zoom the image and `0` to reset the zoom level. To edit an SVG image as a text
+file, right-click on the SVG filename in the file browser and select the
+“Editor” item in the “Open With” submenu:
 
 [animation]
 
@@ -78,7 +82,7 @@ semicolon-separated values):
 [animation]
 
 To edit a CSV file as a text file, right-click on the file in the file browser
-and select the “Editor” item in the “Open With…” submenu:
+and select the “Editor” item in the “Open With” submenu:
 
 [animation]
 
@@ -92,7 +96,7 @@ JavaScript Object Notation (JSON) files are common in data science. JupyterLab s
 [animation showing both rendering JSON as cell output and viewing a JSON file]
 
 To edit the JSON as a text file, right-click on the filename in the file browser
-and select the “Editor” item in the “Open With…” submenu:
+and select the “Editor” item in the “Open With” submenu:
 
 [animation]
 

--- a/docs/source/user/file_formats.md
+++ b/docs/source/user/file_formats.md
@@ -91,7 +91,9 @@ and select the “Editor” item in the “Open With” submenu:
 * File extension: `.json`
 * MIME type: `application/json`
 
-JavaScript Object Notation (JSON) files are common in data science. JupyterLab supports displaying JSON data in cell output or viewing a JSON file using a searchable tree view:
+JavaScript Object Notation (JSON) files are common in data science. JupyterLab
+supports displaying JSON data in cell output or viewing a JSON file using a
+searchable tree view:
 
 [animation showing both rendering JSON as cell output and viewing a JSON file]
 
@@ -105,14 +107,16 @@ and select the “Editor” item in the “Open With” submenu:
 * File extension: `.html`
 * MIME type: `text/html`
 
-JupyterLab supports rendering HTML in cell output and editing HTML files as text in the file editor.
+JupyterLab supports rendering HTML in cell output and editing HTML files as text
+in the file editor.
 
 ## LaTeX
 
 * File extension: `.tex`
 * MIME type: `text/latex`
 
-JupyterLab supports rendering LaTeX equations in cell output and editing LaTeX files as text in the file editor.
+JupyterLab supports rendering LaTeX equations in cell output and editing LaTeX
+files as text in the file editor.
 
 
 ## PDF

--- a/docs/source/user/files.md
+++ b/docs/source/user/files.md
@@ -1,13 +1,13 @@
 
 # Working with files
 
-## Overview
+## Opening files
 
-The File Browser and File menu allow you to work with files and directories on
-your system. This includes opening, creating, deleting, renaming, downloading,
-copying and sharing files and directories.
+The file browser and File menu allow you to work with
+files and directories on your system. This includes opening, creating, deleting,
+renaming, downloading, copying, and sharing files and directories.
 
-The File Browser is in the Left Panel (the Files tab):
+The file browser is in the left sidebar Files tab:
 
 [screenshot]
 
@@ -15,18 +15,19 @@ Many actions on files can also be carried out in the File menu:
 
 [screenshot]
 
-To open any file double-click on its name in the File Browser:
+To open any file, double-click on its name in the file browser:
 
 [animation]
 
-You can also drag a file into the Dock Panel:
+You can also drag a file into the main area to create a new tab:
 
 [animation]
 
-Many files types have multiple viewers/editors. For example, you can open a
-markdown file in the text editor, or as rendered markdown. To open a file in a
-non-default viewer/editor, right-click on its name in the File Browser, and use
-the "Open With..." submenu to select the viewer/editor:
+Many files types have multiple viewers/editors. For example, you can open a Markdown file in
+a text editor or as rendered HTML. A JupyterLab extension can also
+add new viewers/editors for files. To open a file in a non-default
+viewer/editor, right-click on its name in the file browser and use the "Open
+With..." submenu to select the viewer/editor:
 
 [animation]
 
@@ -35,42 +36,41 @@ will remain in sync:
 
 [animation]
 
-The file system can be navigated by double clicking on folders, or on the
-directories at the top of the directory listing:
+The file system can be navigated by double clicking on folders in the listing or
+clicking on the folders at the top of the directory listing:
 
 [animation]
 
-Each file or directory in JupyterLab also has a URL that can used to open
-JupyterLab with that file or directory open. To get the shareable link,
-right-click on the file or directory and select the "Copy Shareable Link" item:
+Right-click on a file or directory and select "Copy Shareable Link" to copy a
+URL that can be used to open JupyterLab with that file or directory open.
 
 [screenshot]
 
 ## Creating files and activities
 
-Create new files or activities by clicking the + button at the top of the File
-Browser. This will open the Launcher in the Dock Panel, which allows you to pick
+Create new files or activities by clicking the `+` button at the top of the file
+browser. This will open a new Launcher tab in the main area, which allows you to pick
 an activity and kernel:
 
 [animation]
 
-You can also create new documents or activities using the File Menu:
+You can also create new documents or activities using the File menu:
 
 [screenshot]
 
-The current working directory of the Launcher will follow that of the File
-Browser:
+The current working directory of a new activity or document will be the directory listed in the file browser (except for a terminal, which always starts in the root directory of the file browser):
 
 [animation]
 
 ## Uploading and downloading
 
-Files can be uploaded to the current directory of the File Browser by dragging
-and dropping files onto the File Browser:
+Files can be uploaded to the current directory of the file browser by dragging
+and dropping files onto the file browser, or by clicking the "Upload Files"
+button at the top of the file browser:
 
 [animation]
 
-Any file in JupyterLab can be downloaded by clicking on the “Download” button at
-the top of the File Browser:
+Any file in JupyterLab can be downloaded by right-clicking its name in the file
+browser and selecting “Download” from the context menu:
 
 [animation]

--- a/docs/source/user/files.md
+++ b/docs/source/user/files.md
@@ -58,9 +58,17 @@ You can also create new documents or activities using the File menu:
 
 [screenshot]
 
-The current working directory of a new activity or document will be the directory listed in the file browser (except for a terminal, which always starts in the root directory of the file browser):
+The current working directory of a new activity or document will be the
+directory listed in the file browser (except for a terminal, which always starts
+in the root directory of the file browser):
 
 [animation]
+
+A new file is created with a default name. Rename a file by right-clicking on
+its name in the file browser and selecting “Rename” from the context menu:
+
+[animation]
+
 
 ## Uploading and downloading
 

--- a/docs/source/user/interface.md
+++ b/docs/source/user/interface.md
@@ -1,92 +1,86 @@
+# The JupyterLab Interface
 
-# The Interface
-
-The JupyterLab provides the flexible building blocks for interactive,
+JupyterLab provides flexible building blocks for interactive,
 exploratory computing. While JupyterLab has many features found in traditional
-IDEs (Integrated Development Environments), it remains focused on interactive,
+integrated development environments (IDEs), it remains focused on interactive,
 exploratory computing.
 
-The JupyterLab Interface consists of a Menu Bar at the top, with a Left Panel
-and Dock Panel below. The Left Panel contains the File Browser, the Running
-List, the Command Palette, the Cell Tools Inspector and the Tabs List. The main
-work area for documents in JupyterLab is called the Dock Panel.
+The JupyterLab interface consists of a main work area containing tabs of
+documents and activities, a collapsible left sidebar, and a menu bar. The left sidebar
+contains a file browser, the list of running kernels and terminals, the command
+palette, the notebook cell tools inspector, and the tabs list.
 
 [screenshot]
 
 ## Menu Bar
 
-The Menu Bar at the top of JupyterLab has top-level menus that expose all of the
-actions available in JupyterLab, along with showing their keyboard shortcuts.
-The default menus are:
-
+The menu bar at the top of JupyterLab has top-level menus that expose actions
+available in JupyterLab with their keyboard shortcuts. The default menus are:
 
 - File: actions related to files and directories
 - Edit: actions related to editing documents and other activities
-- View: actions that reversibly alter the appearance of JupyterLab
+- View: actions that alter the appearance of JupyterLab
 - Run: actions for running code in different activities such as Notebooks and
   Code Consoles
-- Kernel: actions for managing Kernels, which are separately processes which run
+- Kernel: actions for managing kernels, which are separate processes for running
   code
-- Tabs: a list of the open documents and activities in the Dock Panel
-- Settings: common settings and an advanced Settings Editor
-- Help: a list of JupyterLab and Kernel related help links
+- Tabs: a list of the open documents and activities in the dock panel
+- Settings: common settings and an advanced settings editor
+- Help: a list of JupyterLab and kernel help links
 
-JupyterLab extensions can also create new top-level menus in the Menu Bar.
+JupyterLab extensions can also create new top-level menus in the menu bar.
 
-## Left Panel
+## Left Sidebar
 
-The Left Panel contains a number of commonly used panels, such as the File
-Browser, Running List, Command Palette and Tabs List:
+The left sidebar contains a number of commonly-used tabs, such as a file browser, a list of running kernels and terminals, the command palette, and a list of tabs in the main area:
 
 [screenshot]
 
-The Left Panel can be collapsed or expanded by clicking on the active tab:
+The left sidebar can be collapsed or expanded by clicking on the active sidebar tab:
 
 [animation]
 
-JupyterLab extensions can add additional panels to the Left Panel.
+JupyterLab extensions can add additional panels to the left sidebar.
 
-## Dock Panel
+## Main area
 
-The Dock Panel is the main work area in JupyterLab and allows you to arrange
-documents (notebooks, text files, etc.) and other activities (terminals, code
-consoles, etc.) into panels and tabs that can be resized or subdivided:
-
-[animation]
-
-The Dock Panel has a single active document or activity that receives keyboard
-focus and whose tab is marked with a colored top border (blue by default):
-
-[screenshot]
-
-## Tabs and single-document view
-
-The Tabs List gives you access to the open documents and activities in the Dock
-Panel:
-
-[screenshot]
-
-The same information is also available in the Tab Menu:
-
-[screenshot]
-
-It is often useful to focus your work on a single document, while not closing
-other documents. Single Document Mode toggles the view of the Dock Panel to show
-only a single document at a time:
+The main work area in JupyterLab allows you to arrange documents (notebooks,
+text files, etc.) and other activities (terminals, code consoles, etc.) into
+panels of tabs that can be resized or subdivided:
 
 [animation]
 
-When you leave Single Document Mode, the original layout of the Dock Panel is
+The main area has a single current activity. The tab for this activity is
+marked with a colored top border (blue by default).
+
+[screenshot]
+
+## Tabs and Single Document Mode
+
+The Tabs panel in the left sidebar lists the open documents or activities in the
+main area:
+
+[screenshot]
+
+The same information is also available in the Tabs Menu:
+
+[screenshot]
+
+It is often useful to focus on a single document or activity without closing
+other tabs in the main area. Single Document Mode toggles the view of the main
+area to show only a single tab at a time:
+
+[animation]
+
+When you leave Single Document Mode, the original layout of the main area is
 restored:
 
 [animation]
 
-
 ## Context Menus
 
-Many parts of JupyterLab, such as notebooks, text files, code consoles, Dock
-Panel tabs, etc. have context menus that can be accessed by right-clicking on
-the element:
+Many parts of JupyterLab, such as notebooks, text files, code consoles, and tabs
+have context menus that can be accessed by right-clicking on the element:
 
 [animation]
 

--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -64,3 +64,10 @@ The tooltip (activated with `Shift Tab`) contains additional information about
 objects:
 
 [animation]
+
+You can connect a code console to a notebook kernel to have a log of computations done
+in the kernel, in the order in which they were done. The attached code console
+also provides a place to interactively inspect kernel state without changing the
+notebook. Right-click on a notebook and select “Create Console for Notebook”:
+
+[animation]

--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -1,8 +1,8 @@
 
 # Notebooks
 
-Jupyter Notebooks are documents that combine live runnable code, with narrative
-text (markdown), equations (LaTeX), images, interactive visualizations and other
+Jupyter Notebooks are documents that combine live runnable code with narrative
+text (Markdown), equations (LaTeX), images, interactive visualizations and other
 rich output:
 
 [screenshot]
@@ -14,8 +14,15 @@ same as the classic notebook. Thus, your existing notebooks should work fine in
 JupyterLab. If they don’t, please open an issue on our [GitHub
 issues](https://github.com/jupyterlab/jupyterlab/issues) page.
 
-Create a notebook by clicking the + button in the File Browser and then
-selecting a kernel:
+Create a notebook by clicking the `+` button in the file browser and then
+selecting a kernel in the new Launcher tab:
+
+[animation]
+
+A new file is created with a default name. Rename a file by right-clicking on
+its name in the file browser and selecting “Rename” from the context menu:
+
+[animation]
 
 The user interface for Notebooks in JupyterLab closely follows that of the
 classic Jupyter Notebook. The keyboard shortcuts of the classic Notebook
@@ -30,7 +37,7 @@ Drag cells between notebooks to quickly copy content:
 
 [animation]
 
-Create multiple, synchronized views of a single notebook:
+Create multiple synchronized views of a single notebook:
 
 [animation]
 
@@ -39,7 +46,7 @@ button on left of each cell:
 
 [animation]
 
-Create a new, synchronized view of a cell’s output:
+Create a new synchronized view of a cell’s output:
 
 [animation]
 
@@ -52,4 +59,3 @@ The tooltip (activated with `Shift Tab`) contains additional information about
 objects:
 
 [animation]
-

--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -10,7 +10,7 @@ rich output:
 **Jupyter Notebook (.ipynb files) are fully supported in JupyterLab.**
 Furthermore, the [notebook document
 format](http://nbformat.readthedocs.io/en/latest/) used in JupyterLab is the
-same as in the classic notebook. Your existing notebooks should work fine in
+same as in the classic notebook. Your existing notebooks should open correctly in
 JupyterLab. If they don’t, please open an issue on our [GitHub
 issues](https://github.com/jupyterlab/jupyterlab/issues) page.
 

--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -10,7 +10,7 @@ rich output:
 **Jupyter Notebook (.ipynb files) are fully supported in JupyterLab.**
 Furthermore, the [notebook document
 format](http://nbformat.readthedocs.io/en/latest/) used in JupyterLab is the
-same as the classic notebook. Thus, your existing notebooks should work fine in
+same as in the classic notebook. Your existing notebooks should work fine in
 JupyterLab. If they don’t, please open an issue on our [GitHub
 issues](https://github.com/jupyterlab/jupyterlab/issues) page.
 

--- a/docs/source/user/notebook.md
+++ b/docs/source/user/notebook.md
@@ -46,6 +46,11 @@ button on left of each cell:
 
 [animation]
 
+Enable scrolling for long outputs by right-clicking on a cell and selecting
+“Enable Scrolling for Outputs”:
+
+[animation]
+
 Create a new synchronized view of a cell’s output:
 
 [animation]

--- a/docs/source/user/running.md
+++ b/docs/source/user/running.md
@@ -1,19 +1,23 @@
-# Running kernels and terminals
+# Managing kernels and terminals
 
-The Running List (Running tab in the Left Panel) shows a list of all the
-notebooks, code consoles and terminals that are currently running across all
+The Running tab in the left sidebar shows a list of all the kernels and
+terminals currently running across all notebooks, code consoles, and
 directories:
 
 [screenshot]
 
 As with the classic Jupyter Notebook, when you close a notebook document, code
-console or terminal, the underlying kernel or terminal running on the server
-continues to run. This allows you to perform long running actions and return
-later. The Running List allows you to re-open, or focus, the document linked to
-a given Kernel or Terminal:
+console, or terminal, the underlying kernel or terminal running on the server
+continues to run. This allows you to perform long-running actions and return
+later. The Running tab allows you to re-open or focus the document linked to
+a given kernel or terminal:
 
 [animation]
 
-Kernels or Terminals can be shutdown from the Running list:
+Kernels or terminals can be shut down from the Running tab:
+
+[animation]
+
+You can shut down all kernels and terminals by clicking the `X` button:
 
 [animation]

--- a/docs/source/user/terminal.md
+++ b/docs/source/user/terminal.md
@@ -1,21 +1,21 @@
 
 # Terminals
 
-JupyterLab Terminals provide full support for system shells (bash, tsch, etc.)
-on Mac/Linux and Command.exe on Windows. With the Terminal, you can run anything
-in your system shell, including programs such as vim or emacs. The Terminals run
-on the system where the Jupyter server is running, with the permissions of your
-user. Thus, if JupyterLab is installed on your local machine, the JupyterLab
-terminals will run there.
+JupyterLab terminals provide full support for system shells (bash, tsch, etc.)
+on Mac/Linux and command.exe on Windows. You can run anything in your system
+shell with a terminal, including programs such as vim or emacs. The terminals
+run on the system where the Jupyter server is running, with the privileges of
+your user. Thus, if JupyterLab is installed on your local machine, the
+JupyterLab terminals will run there.
 
 [screenshot]
 
-To open a new Terminal click the + button in the File Browser and select the
-Terminal in the Launcher:
+To open a new terminal, click the `+` button in the file browser and select the
+terminal in the new Launcher tab:
 
 [animation]
 
-Closing a terminal will leave it running on the server, but you can re-open it
-using the Running Tab:
+Closing a terminal tab will leave it running on the server, but you can re-open it
+using the Running tab in the left sidebar:
 
 [animation]

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1191,21 +1191,6 @@ namespace DocumentRegistry {
       iconClass: 'jp-MaterialIcon jp-ImageIcon',
       fileFormat: 'base64'
     },
-    {
-      name: 'xbm',
-      displayName: 'Image',
-      mimeTypes: ['image/xbm'],
-      extensions: ['.xbm'],
-      iconClass: 'jp-MaterialIcon jp-ImageIcon',
-      fileFormat: 'base64'
-    },
-    {
-      name: 'raw',
-      displayName: 'Image',
-      extensions: ['.raw'],
-      iconClass: 'jp-MaterialIcon jp-ImageIcon',
-      fileFormat: 'base64'
-    }
   ];
 }
 

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1113,7 +1113,7 @@ namespace DocumentRegistry {
       name: 'json',
       displayName: 'JSON File',
       extensions: ['.json'],
-      mimeTypes: ['application/json', 'application/x-json'],
+      mimeTypes: ['application/json'],
       iconClass: 'jp-MaterialIcon jp-JSONIcon'
     },
     {

--- a/packages/faq-extension/faq.md
+++ b/packages/faq-extension/faq.md
@@ -43,7 +43,7 @@ Notebook. Here are a few of them you may want to try out:
   application using drag and drop.
 * Run code interactively outside of a notebook in the Code Console, and
   connect one to a text file.
-* Right click on a markdown file and "Open with..." a live markdown viewer.
+* Right click on a markdown file and “Open with” a live markdown viewer.
 * Double click on CSV files to view them as a nicely formatted table.
 * Drag and drop notebook cells within a notebook or between notebooks.
 

--- a/packages/rendermime/src/factories.ts
+++ b/packages/rendermime/src/factories.ts
@@ -28,7 +28,7 @@ const htmlRendererFactory: IRenderMime.IRendererFactory = {
 export
 const imageRendererFactory: IRenderMime.IRendererFactory = {
   safe: true,
-  mimeTypes: ['image/png', 'image/jpeg', 'image/gif'],
+  mimeTypes: ['image/bmp', 'image/png', 'image/jpeg', 'image/gif'],
   defaultRank: 90,
   createRenderer: options => new widgets.RenderedImage(options)
 };

--- a/tests/test-rendermime/src/factories.spec.ts
+++ b/tests/test-rendermime/src/factories.spec.ts
@@ -312,7 +312,7 @@ describe('rendermime/factories', () => {
     describe('#mimeTypes', () => {
 
       it('should support multiple mimeTypes', () => {
-        expect(imageRendererFactory.mimeTypes).to.eql(['image/png', 'image/jpeg', 'image/gif']);
+        expect(imageRendererFactory.mimeTypes).to.eql(['image/bmp', 'image/png', 'image/jpeg', 'image/gif']);
       });
 
     });


### PR DESCRIPTION
More documentation edits in the interface section. This PR also makes some minor changes to the supported mimetypes/formats:

* adds `.bmp` to the supported mimetypes
* removes `application/x-json` from the file mimetypes
* removes xbm and raw image support as browsers typically don't support those.
