### PR TITLE
Proof extension documentation.

### DIFF
--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -93,13 +93,13 @@ environment.  You can query the current application path by running `jupyter
 lab path`.
 
 To create the app directory without installing any extensions, run `jupyter lab
-build`. By default, the `install` and `link` commands already run the build,
+build`. By default the `install` command already builds the application,
 so you typically do not need to call `build` directly.
 
 Building consists of:
 
 - Populating the `staging/` directory using template files
-- Handling any linked packages (see `jupyter labextension link`)
+- Handling any locally installed packages
 - Ensuring all installed assets are available
 - Bundling the assets
 - Copying the assets to the `static` directory
@@ -141,8 +141,8 @@ are performed against the patterns in `disabledExtensions` and
 
 ### `build_config.json`
 
-The `build_config.json` file is used to track the folders that have been added
-using `jupyter labextension link <folder>`, as well as core extensions that have
+The `build_config.json` file is used to track the local folders that have been installed
+using `jupyter labextension install <folder>`, as well as core extensions that have
 been explicitly uninstalled.  e.g.
 
 ```bash
@@ -151,7 +151,7 @@ $ cat settings/build_config.json
     "uninstalled_core_extensions": [
         "@jupyterlab/markdownwidget-extension"
     ],
-    "linked_packages": {
+    "local_extensions": {
         "@jupyterlab/python-tests": "/path/to/my/extension"
     }
 }

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -88,7 +88,7 @@ jupyter labextension enable <foo>
 Core plugins can also be disabled (and then re-enabled).
 
 
-## Advanced usage
+## Advanced Usage
 
 The JupyterLab application directory (where the application assets are built and
 the settings reside) can be overridden using `--app-dir` in any of the

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -67,7 +67,10 @@ install/uninstall step. Once you are ready to rebuild, you can run the command:
 jupyter lab build
 ```
 
-You can disable an extension (without unistalilng it) by running the command:
+## Disabling Extensions
+
+You may want to disable specific JupyterLab extensions without rebuilding
+the application. You can disable an extension by running the command:
 
 ```
 jupyter labextension disable <bar>

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -31,9 +31,17 @@ You can install new extensions into the application using the command:
 jupyter labextension install <foo>
 ```
 
-where `<foo>` is the name of a valid JupyterLab extension on
-[npm](https://www.npmjs.com). If the extension is not published there,
-`<foo>` can also refer to a local directory containing the extension.
+where `<foo>` is the name of a valid JupyterLab extension npm package on
+[npm](https://www.npmjs.com). Use the `<foo>@<foo version>` syntax to install a
+specific version of an extension, for example:
+
+```
+jupyter labextension install <foo>@1.2.3
+```
+
+You can also install an extension that is not uploaded to npm, i.e., `<foo>` can
+be a local directory containing the extension, a gzipped tarball, or a URL to a
+gzipped tarball.
 
 We encourage extension authors to add the `jupyterlab-extensions` GitHub topic to
 any repository with a JupyterLab extension to facilitate discovery.

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -81,8 +81,8 @@ jupyter lab build
 
 ## Disabling Extensions
 
-You may want to disable specific JupyterLab extensions without rebuilding
-the application. You can disable an extension by running the command:
+You can disable specific JupyterLab extensions (including core extensions)
+without rebuilding the application by running the command:
 
 ```bash
 jupyter labextension disable <bar>
@@ -91,14 +91,11 @@ jupyter labextension disable <bar>
 where `<bar>` is the name of the extension.  This will prevent the extension
 from loading in the browser, but does not require a rebuild.
 
-You can re-enable the extension later using the command:
+You can re-enable an extension using the command:
 
 ```bash
 jupyter labextension enable <foo>
 ```
-
-Core plugins can also be disabled (and then re-enabled).
-
 
 ## Advanced Usage
 
@@ -113,7 +110,7 @@ lab path`.
 ### JupyterLab Build Process
 
 To rebuild the app directory, run `jupyter lab build`.
-By default the `jupyter lab install` command already builds the application,
+By default the `jupyter lab install` command builds the application,
 so you typically do not need to call `build` directly.
 
 Building consists of:
@@ -129,9 +126,9 @@ Building consists of:
 The JupyterLab application directory contains the subdirectories
 `extensions`, `schemas`, `settings`, `staging`, `static`, and `themes`.
 
-#### `extensions`
+#### extensions
 
-The `extensions` folder has the packed tarballs for each of the
+The `extensions` directory has the packed tarballs for each of the
 installed extensions for the app.  If the application directory is not the same
 as the `sys-prefix` directory, the extensions installed in the `sys-prefix`
 directory will be used in the app directory.  If an extension is installed in
@@ -141,18 +138,18 @@ shadowed extension, and then attempt to uninstall the `sys-prefix` version if
 called again.  If the `sys-prefix` version cannot be uninstalled, its plugins
 can still be ignored using `ignoredPackages` metadata in `settings`.
 
-#### `schemas`
+#### schemas
 
 The `schemas` directory contains [JSON Schemas](http://json-schema.org/) that
 describe the settings used by individual extensions. Users may edit these
 settings using the JupyterLab Settings Editor.
 
-#### `settings`
+#### settings
 
 The `settings` directory contains `page_config.json` and `build_config.json`
 files.
 
-##### `page_config.json`
+##### page_config.json
 
 The `page_config.json` data is used to provide config data to the application
 environment.
@@ -164,34 +161,33 @@ plugins load:
 2. `deferredExtensions` for extensions that do not load until they are required
    by something, irrespective of whether they set `autostart` to `true`.
 
-The values for each are an array of strings. The following sequence of checks
+The value for each field is an array of strings. The following sequence of checks
 are performed against the patterns in `disabledExtensions` and
 `deferredExtensions`.
 
 * If an identical string match occurs between a config value and a package name
-  (*e.g.*, `"@jupyterlab/apputils-extension"`), then the entire package is
+  (e.g., `"@jupyterlab/apputils-extension"`), then the entire package is
   disabled (or deferred).
 * If the string value is compiled as a regular expression and tests positive
-  against a package name (*e.g.*, `"disabledExtensions":
+  against a package name (e.g., `"disabledExtensions":
   ["@jupyterlab/apputils*$"]`), then the entire package is disabled (or
   deferred).
 * If an identical string match occurs between a config value and an individual
-  plugin ID within a larger package (*e.g.*, `"disabledExtensions":
+  plugin ID within a package (e.g., `"disabledExtensions":
   ["@jupyterlab/apputils-extension:settings"]`), then that specific plugin is
   disabled (or deferred).
 * If the string value is compiled as a regular expression and tests positive
-  against an individual plugin ID within a larger package (*e.g.*,
+  against an individual plugin ID within a package (e.g.,
   `"disabledExtensions": ["^@jupyterlab/apputils-extension:set.*$"]`), then that
   specific plugin is disabled (or deferred).
 
-##### `build_config.json`
+##### build_config.json
 
-The `build_config.json` file is used to track the local folders that have been installed
-using `jupyter labextension install <folder>`, as well as core extensions that have
-been explicitly uninstalled.  e.g.
+The `build_config.json` file is used to track the local directories that have been installed
+using `jupyter labextension install <directory>`, as well as core extensions that have
+been explicitly uninstalled.  An example of a `build_config.json` file is:
 
-```bash
-$ cat settings/build_config.json
+```json
 {
     "uninstalled_core_extensions": [
         "@jupyterlab/markdownwidget-extension"
@@ -202,17 +198,17 @@ $ cat settings/build_config.json
 }
 ```
 
-#### `staging` and `static`
+#### staging and static
 
 The `static` directory contains the assets that will be loaded by the JuptyerLab
-application.  The `staging` folder is used to create the build and then populate
-the `static` folder.
+application.  The `staging` directory is used to create the build and then populate
+the `static` directory.
 
 Running `jupyter lab` will attempt to run the `static` assets in the application
-folder if they exist.  You can run `jupyter lab --core-mode` to load the core
+directory if they exist.  You can run `jupyter lab --core-mode` to load the core
 JupyterLab application (i.e., the application without any extensions) instead.
 
-#### `themes`
+#### themes
 
 The `themes` directory contains assets (such as CSS and icons)
 for JupyterLab theme extensions.

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -4,6 +4,7 @@ JupyterLab extensions add functionality to the JupyterLab application. They can
 provide new file viewer types, launcher activities, and output renderers, among
 many other things. JupyterLab extensions are [npm](https://www.npmjs.com/) packages
 (the standard package format in Javascript development).
+For information about developing extensions, see the [developer documentation]().
 
 In order to install JupyterLab extensions you need to have Node.js version 4+
 installed.
@@ -53,14 +54,18 @@ jupyter labextension uninstall <bar>
 ```
 
 where `<bar>` is the name of the extension, as printed in the extension list.
-You can also uninstall core extensions uninstalled this way (which can later be
+You can also uninstall core extensions using this command (which can later be
 re-installed).
 
 Installing and uninstalling extensions can take some time, as they are
 downloaded, bundled with the core extensions, and the whole application is rebuilt.
-If you are installing/uninstalling several extensions, you may want to defer
-rebuilding the application by including the flag `--no-build` in the
-install/uninstall step. Once you are ready to rebuild, you can run the command:
+You can install/uninstall more than one extension in the same command by listing
+their names after the `install` command.
+
+If you are installing/uninstalling several extensions in several stages,
+you may want to defer rebuilding the application by including the flag
+`--no-build` in the install/uninstall step.
+Once you are ready to rebuild, you can run the command:
 
 ```
 jupyter lab build

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -6,7 +6,7 @@ many other things. JupyterLab extensions are [npm](https://www.npmjs.com/) packa
 (the standard package format in Javascript development).
 For information about developing extensions, see the [developer documentation]().
 
-In order to install JupyterLab extensions you need to have Node.js version 4+
+In order to install JupyterLab extensions, you need to have Node.js version 4+
 installed.
 
 If you use ``conda``, you can get it with:

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -27,7 +27,7 @@ The base JupyterLab application includes a core set of extensions, which provide
 the features described in this User Guide (Notebook, Terminal, Text Editor, etc.)
 You can install new extensions into the application using the command:
 
-```
+```bash
 jupyter labextension install <foo>
 ```
 
@@ -35,7 +35,7 @@ where `<foo>` is the name of a valid JupyterLab extension npm package on
 [npm](https://www.npmjs.com). Use the `<foo>@<foo version>` syntax to install a
 specific version of an extension, for example:
 
-```
+```bash
 jupyter labextension install <foo>@1.2.3
 ```
 
@@ -51,13 +51,13 @@ topic.
 
 You can list the currently installed extensions by running the command:
 
-```
+```bash
 jupyter labextension list
 ```
 
 Uninstall an extension by running the command:
 
-```
+```bash
 jupyter labextension uninstall <bar>
 ```
 
@@ -75,7 +75,7 @@ you may want to defer rebuilding the application by including the flag
 `--no-build` in the install/uninstall step.
 Once you are ready to rebuild, you can run the command:
 
-```
+```bash
 jupyter lab build
 ```
 
@@ -84,7 +84,7 @@ jupyter lab build
 You may want to disable specific JupyterLab extensions without rebuilding
 the application. You can disable an extension by running the command:
 
-```
+```bash
 jupyter labextension disable <bar>
 ```
 
@@ -93,7 +93,7 @@ from loading in the browser, but does not require a rebuild.
 
 You can re-enable the extension later using the command:
 
-```
+```bash
 jupyter labextension enable <foo>
 ```
 

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -34,10 +34,12 @@ jupyter labextension install <foo>
 where `<foo>` is the name of a valid JupyterLab extension on
 [npm](https://www.npmjs.com). If the extension is not published there,
 `<foo>` can also refer to a local directory containing the extension.
+
 We encourage extension authors to add the `jupyterlab-extensions` GitHub topic to
 any repository with a JupyterLab extension to facilitate discovery.
-You can see a list of extensions by [searching Github for the
-juputerlab-extensions topic](https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extensions&type=Repositories)
+You can see a list of extensions by searching Github for the
+[jupyterlab-extensions](https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extensions&type=Repositories)
+topic.
 
 You can list the currently installed extensions by running the command:
 
@@ -72,8 +74,9 @@ jupyter labextension disable <bar>
 ```
 
 where `<bar>` is the name of the extension.  This will prevent the extension
-from loading in the browser, but does not require a rebuild. You can re-enable
-the extension later using the command:
+from loading in the browser, but does not require a rebuild.
+
+You can re-enable the extension later using the command:
 
 ```
 jupyter labextension enable <foo>

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -5,11 +5,10 @@ provide new file viewer types, launcher activities, and output renderers, among
 many other things. JupyterLab extensions are [npm](https://www.npmjs.com/) packages
 (the standard package format in Javascript development).
 
-## Installing Node.js
+In order to install JupyterLab extensions you need to have Node.js version 4+
+installed.
 
-Installing JupyterLab extensions requires Node.js version 4+.
-
-If you use ``conda``, you can get them with:
+If you use ``conda``, you can get it with:
 
 ```bash
 conda -c conda-forge install nodejs
@@ -98,8 +97,10 @@ If not specified, it will default to `<sys-prefix>/share/jupyter/lab`, where
 environment.  You can query the current application path by running `jupyter
 lab path`.
 
-To create the app directory without installing any extensions, run `jupyter lab
-build`. By default the `install` command already builds the application,
+### JupyterLab Build Process
+
+To rebuild the app directory, run `jupyter lab build`.
+By default the `jupyter lab install` command already builds the application,
 so you typically do not need to call `build` directly.
 
 Building consists of:
@@ -110,10 +111,35 @@ Building consists of:
 - Bundling the assets
 - Copying the assets to the `static` directory
 
+### JupyterLab Application Directory
+
+The JupyterLab application directory contains the subdirectories
+`extensions`, `schemas`, `settings`, `staging`, `static`, and `themes`.
+
+#### `extensions`
+
+The `extensions` folder has the packed tarballs for each of the
+installed extensions for the app.  If the application directory is not the same
+as the `sys-prefix` directory, the extensions installed in the `sys-prefix`
+directory will be used in the app directory.  If an extension is installed in
+the app directory that exists in the `sys-prefix` directory, it will shadow the
+`sys-prefix` version.  Uninstalling an extension will first uninstall the
+shadowed extension, and then attempt to uninstall the `sys-prefix` version if
+called again.  If the `sys-prefix` version cannot be uninstalled, its plugins
+can still be ignored using `ignoredPackages` metadata in `settings`.
+
+#### `schemas`
+
+The `schemas` directory contains [JSON Schemas](http://json-schema.org/) that
+describe the settings used by individual extensions. Users may edit these
+settings using the JupyterLab Settings Editor.
+
+#### `settings`
+
 The `settings` directory contains `page_config.json` and `build_config.json`
 files.
 
-### `page_config.json`
+##### `page_config.json`
 
 The `page_config.json` data is used to provide config data to the application
 environment.
@@ -145,7 +171,7 @@ are performed against the patterns in `disabledExtensions` and
   `"disabledExtensions": ["^@jupyterlab/apputils-extension:set.*$"]`), then that
   specific plugin is disabled (or deferred).
 
-### `build_config.json`
+##### `build_config.json`
 
 The `build_config.json` file is used to track the local folders that have been installed
 using `jupyter labextension install <folder>`, as well as core extensions that have
@@ -163,21 +189,17 @@ $ cat settings/build_config.json
 }
 ```
 
-The other folders in the app directory are: `extensions`, `static`, and
-`staging`.  The `extensions` folder has the packed tarballs for each of the
-installed extensions for the app.  If the application directory is not the same
-as the `sys-prefix` directory, the extensions installed in the `sys-prefix`
-directory will be used in the app directory.  If an extension is installed in
-the app directory that exists in the `sys-prefix` directory, it will shadow the
-`sys-prefix` version.  Uninstalling an extension will first uninstall the
-shadowed extension, and then attempt to uninstall the `sys-prefix` version if
-called again.  If the `sys-prefix` version cannot be uninstalled, its plugins
-can still be ignored using `ignoredPackages` metadata in `settings`.
+#### `staging` and `static`
 
-The `static` folder contains the assets that will be loaded by the JuptyerLab
+The `static` directory contains the assets that will be loaded by the JuptyerLab
 application.  The `staging` folder is used to create the build and then populate
 the `static` folder.
 
 Running `jupyter lab` will attempt to run the `static` assets in the application
 folder if they exist.  You can run `jupyter lab --core-mode` to load the core
 JupyterLab application (i.e., the application without any extensions) instead.
+
+#### `themes`
+
+The `themes` directory contains assets (such as CSS and icons)
+for JupyterLab theme extensions.

--- a/docs/source/user/extensions.md
+++ b/docs/source/user/extensions.md
@@ -1,8 +1,9 @@
 # Extensions
 
 JupyterLab extensions add functionality to the JupyterLab application. They can
-provide new file viewer types, launcher activities, and output renderers for
-example. JupyterLab extensions are [NPM](https://www.npmjs.com/) packages.
+provide new file viewer types, launcher activities, and output renderers, among
+many other things. JupyterLab extensions are [npm](https://www.npmjs.com/) packages
+(the standard package format in Javascript development).
 
 ## Installing Node.js
 
@@ -23,45 +24,56 @@ brew install node
 ## Installing Extensions
 
 The base JupyterLab application includes a core set of extensions, which provide
-the features described in this User Guide (Notebook, Terminal, Text Editor,
-etc.)  New extensions can be installed into the application using the command:
+the features described in this User Guide (Notebook, Terminal, Text Editor, etc.)
+You can install new extensions into the application using the command:
 
 ```
 jupyter labextension install <foo>
 ```
 
-Where `<foo>` is a valid JupyterLab extension specifier.  This specifier is
-defined by the extension author in their installation instructions. We are
-encouraging extension authors to add the `jupyterlab-extensions` GitHub topic to
-any repository with a JupyterLab extension. You can see a list of extensions by
-[searching Github for the juputerlab-extensions
-topic](https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extensions&type=Repositories)
+where `<foo>` is the name of a valid JupyterLab extension on
+[npm](https://www.npmjs.com). If the extension is not published there,
+`<foo>` can also refer to a local directory containing the extension.
+We encourage extension authors to add the `jupyterlab-extensions` GitHub topic to
+any repository with a JupyterLab extension to facilitate discovery.
+You can see a list of extensions by [searching Github for the
+juputerlab-extensions topic](https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extensions&type=Repositories)
 
-List the currently installed extensions by running the command:
+You can list the currently installed extensions by running the command:
 
 ```
 jupyter labextension list
 ```
 
-Uninstalled an extension by running the command:
+Uninstall an extension by running the command:
 
 ```
 jupyter labextension uninstall <bar>
 ```
 
-Where `<bar>` is the name of the extension, as printed in the extension list.
-Core extensions can also be uninstalled this way (and can later be
+where `<bar>` is the name of the extension, as printed in the extension list.
+You can also uninstall core extensions uninstalled this way (which can later be
 re-installed).
 
-Disable an extension (without unistalilng it) by running the command:
+Installing and uninstalling extensions can take some time, as they are
+downloaded, bundled with the core extensions, and the whole application is rebuilt.
+If you are installing/uninstalling several extensions, you may want to defer
+rebuilding the application by including the flag `--no-build` in the
+install/uninstall step. Once you are ready to rebuild, you can run the command:
 
 ```
-jupyter labextension disable <foo>
+jupyter lab build
 ```
 
-Where `<foo>` is the name of the extension.  This will prevent the extension
-from loading on the front end, but does not require a rebuild. Re-enabled the
-extension later using the command:
+You can disable an extension (without unistalilng it) by running the command:
+
+```
+jupyter labextension disable <bar>
+```
+
+where `<bar>` is the name of the extension.  This will prevent the extension
+from loading in the browser, but does not require a rebuild. You can re-enable
+the extension later using the command:
 
 ```
 jupyter labextension enable <foo>
@@ -75,21 +87,21 @@ Core plugins can also be disabled (and then re-enabled).
 The JupyterLab application directory (where the application assets are built and
 the settings reside) can be overridden using `--app-dir` in any of the
 JupyterLab commands, or by setting the `JUPYTERLAB_DIR` environment variable.
-If not specified, it will default to `<sys-prefix/share/jupyter/lab`, where
-`sys-prefix` is the site-specific directory prefix of the current Python
-environment.  You can query the current application path using `jupyter lab
-path`.
+If not specified, it will default to `<sys-prefix>/share/jupyter/lab`, where
+`<sys-prefix>` is the site-specific directory prefix of the current Python
+environment.  You can query the current application path by running `jupyter
+lab path`.
 
 To create the app directory without installing any extensions, run `jupyter lab
-build`. The `install` and `link` commands already run the build, so it typically
-does not need to be called directly.
+build`. By default, the `install` and `link` commands already run the build,
+so you typically do not need to call `build` directly.
 
 Building consists of:
 
 - Populating the `staging/` directory using template files
 - Handling any linked packages (see `jupyter labextension link`)
-- Ensuring all install assets are available
-- Building the assets
+- Ensuring all installed assets are available
+- Bundling the assets
 - Copying the assets to the `static` directory
 
 The `settings` directory contains `page_config.json` and `build_config.json`
@@ -162,4 +174,4 @@ the `static` folder.
 
 Running `jupyter lab` will attempt to run the `static` assets in the application
 folder if they exist.  You can run `jupyter lab --core-mode` to load the core
-JupyterLab application instead.
+JupyterLab application (i.e., the application without any extensions) instead.


### PR DESCRIPTION
Fixes #3585.

There a few things that I did not edit much, as I found them confusing myself:
1. Locally installed extensions are linked by default. How does this interact with `jupyter labextension link`? `commands.py` has references to `local_extensions` and `linked_packages`. How are they different? If I run `jupyter labextension install` and `jupyter labextension link` on the same local package, it appears twice in the list given by `jupyter labextension list`.
2. What does the `*` after some extensions mean when doing `jupyter labextension list`?
3. The discussion of different app directories shadowing each other is confusing, and I didn't feel confident enough in what it was saying to try to clarify it.