### PR TITLE
Only change editor readonly status if needed in a cell update.

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -370,8 +370,10 @@ class Cell extends Widget {
       return;
     }
     // Handle read only state.
-    this.editor.setOption('readOnly', this._readOnly);
-    this.toggleClass(READONLY_CLASS, this._readOnly);
+    if (this.editor.getOption('readOnly') !== this._readOnly) {
+      this.editor.setOption('readOnly', this._readOnly);
+      this.toggleClass(READONLY_CLASS, this._readOnly);
+    }
   }
 
   private _readOnly = false;


### PR DESCRIPTION
@ellisonbg noticed that on current master, running the last cell of a notebook inserts a new cell, but we end up in command mode rather than edit mode. I traced this down to the delayed update message sent to the last cell, which ensures that the readonly status is set at https://github.com/jupyterlab/jupyterlab/compare/jupyterlab:3a6c62d...jasongrout:e32bcef#diff-901b6622e3beb3db23ab3289d24f5583L373 which in turn triggers an editor blur (the new focusout captures that and then changes the notebook to command mode). This PR fixes the symptom by changing the readonly option set to go through only if the readonly status is actually changed.

However, it seems odd that the editor blurs itself when it is set to be not readonly: https://github.com/jupyterlab/jupyterlab/blob/3a6c62d0d35fe9026ab54bfdb9affa000710e4e7/packages/codemirror/src/editor.ts#L1197

This blurring was introduced in https://github.com/jupyterlab/jupyterlab/pull/1850. Two things we could do to try to solve the deeper problem:

1. only actually change things in the editor setOption if the option actually changed, here: https://github.com/jupyterlab/jupyterlab/blob/3a6c62d0d35fe9026ab54bfdb9affa000710e4e7/packages/codemirror/src/editor.ts#L1191
2. don't blur the input at https://github.com/jupyterlab/jupyterlab/blob/3a6c62d0d35fe9026ab54bfdb9affa000710e4e7/packages/codemirror/src/editor.ts#L1197