### PR TITLE
Switch the docs environment recommonmark to the conda-forge package

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,5 +5,4 @@ dependencies:
 - python=3.5
 - sphinx>=1.6
 - sphinx_rtd_theme
-- pip:
-  - recommonmark==0.4.0
+- recommonmark


### PR DESCRIPTION
A few minutes ago, we finally built recommonmark (and its dependencies) on conda-forge (see https://github.com/conda-forge/commonmark-feedstock/pull/8, for example).