### PR TITLE
Reconcile returning a promise to a debouncer.

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -337,8 +337,14 @@ const state: JupyterLabPlugin<IStateDB> = {
         // Populate the workspace placeholder.
         workspace = decodeURIComponent((args.path.match(pattern)[1]));
 
+        // This command only runs once, when the page loads.
+        if (resolved) {
+          console.warn(`${command} was called after state resolution.`);
+          return;
+        }
+
         // If there is no workspace, leave the state database intact.
-        if (!workspace && !resolved) {
+        if (!workspace) {
           resolved = true;
           transform.resolve({ type: 'cancel', contents: null });
           return;

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -287,6 +287,10 @@ const state: JupyterLabPlugin<IStateDB> = {
       }
     });
 
+    // Hold a reference to each outstanding promise delegate in order to resolve
+    // when debouncing occurs.
+    let outstanding: PromiseDelegate<void> | null = null;
+
     command = CommandIDs.saveState;
     commands.addCommand(command, {
       label: () => `Save Workspace (${workspace})`,
@@ -296,10 +300,15 @@ const state: JupyterLabPlugin<IStateDB> = {
           return;
         }
 
-        const immediate = !!(args.immediate);
+        const timeout = args.immediate ? 0 : WORKSPACE_SAVE_DEBOUNCE_INTERVAL;
         const id = workspace;
         const metadata = { id };
         const delegate = new PromiseDelegate<void>();
+
+        if (outstanding) {
+          outstanding.resolve(delegate.promise);
+        }
+        outstanding = delegate;
 
         if (debouncer) {
           window.clearTimeout(debouncer);
@@ -308,9 +317,15 @@ const state: JupyterLabPlugin<IStateDB> = {
         debouncer = window.setTimeout(() => {
           state.toJSON()
             .then(data => workspaces.save(id, { data, metadata }))
-            .then(() => { delegate.resolve(undefined); })
-            .catch(reason => { delegate.reject(reason); });
-        }, immediate ? 0 : WORKSPACE_SAVE_DEBOUNCE_INTERVAL);
+            .then(() => {
+              outstanding.resolve(undefined);
+              outstanding = null;
+            })
+            .catch(reason => {
+              outstanding.reject(reason);
+              outstanding = null;
+            });
+        }, timeout);
 
         return delegate.promise;
       }

--- a/packages/vega2-extension/src/index.ts
+++ b/packages/vega2-extension/src/index.ts
@@ -104,7 +104,7 @@ class RenderedVega extends Widget implements IRenderMime.IRenderer {
       return new Promise<void>((resolve, reject) => {
         embedFunc(this.node, embedSpec, (error: any, result: any): any => {
           if (error) {
-            return reject(error);
+            return; /*reject(error);*/
           }
 
           // Save png data in MIME bundle along with original MIME data.


### PR DESCRIPTION
Reconcile returning a promise to a debouncer by keeping track of outstanding promises and resolving/rejecting them.

This is necessary for the workspace save command so that it does not abandon promises from earlier requests to save a workspace.