### PR TITLE
Focus behavior fixes

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -370,8 +370,10 @@ class Cell extends Widget {
       return;
     }
     // Handle read only state.
-    this.editor.setOption('readOnly', this._readOnly);
-    this.toggleClass(READONLY_CLASS, this._readOnly);
+    if (this.editor.getOption('readOnly') !== this._readOnly) {
+      this.editor.setOption('readOnly', this._readOnly);
+      this.toggleClass(READONLY_CLASS, this._readOnly);
+    }
   }
 
   private _readOnly = false;

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1190,12 +1190,7 @@ namespace Private {
       break;
     case 'readOnly':
       let el = editor.getWrapperElement();
-      if (value) {
-        el.classList.add(READ_ONLY_CLASS);
-      } else {
-        el.classList.remove(READ_ONLY_CLASS);
-        editor.getInputField().blur();
-      }
+      el.classList.toggle(READ_ONLY_CLASS, value);
       editor.setOption(option, value);
       break;
     default:

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -813,11 +813,8 @@ class Notebook extends StaticNotebook {
       }
       activeCell.inputHidden = false;
     } else {
-      // Blur the active cell.
-      let activeCell = this.activeCell;
-      if (activeCell) {
-        activeCell.editor.blur();
-      }
+      // Focus on the notebook document, which blurs the active cell.
+      this.node.focus();
     }
     this._stateChanged.emit({ name: 'mode', oldValue, newValue });
     this._ensureFocus();
@@ -849,9 +846,6 @@ class Notebook extends StaticNotebook {
     if (cell !== this._activeCell) {
       // Post an update request.
       this.update();
-      if (this._activeCell) {
-        this._activeCell.editor.blur();
-      }
       this._activeCell = cell;
       this._activeCellChanged.emit(cell);
     }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1831,9 +1831,9 @@ class Notebook extends StaticNotebook {
   private _evtFocusOut(event: MouseEvent): void {
     let relatedTarget = event.relatedTarget as HTMLElement;
 
-    // Bail if focus is leaving the notebook.
-    if (!this.node.contains(relatedTarget)) {
-      this.mode = 'command';
+    // Bail if the window is losing focus, to preserve edit mode. This test
+    // assumes that we explicitly focus things rather than calling blur()
+    if (!relatedTarget) {
       return;
     }
 
@@ -1846,6 +1846,7 @@ class Notebook extends StaticNotebook {
         return;
       }
     }
+
     // Otherwise enter command mode.
     this.mode = 'command';
   }

--- a/tests/test-notebook/src/widget.spec.ts
+++ b/tests/test-notebook/src/widget.spec.ts
@@ -1289,8 +1289,9 @@ describe('notebook/widget', () => {
         it('should switch to command mode', () => {
           simulate(widget.node, 'focusin');
           widget.mode = 'edit';
-          let other = document.createElement('div');
-          simulate(widget.node, 'focusout', { relatedTarget: other });
+          let event = generate('focusout');
+          (event as any).relatedTarget = document.body;
+          widget.node.dispatchEvent(event);
           expect(widget.mode).to.be('command');
           MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
           expect(widget.mode).to.be('command');


### PR DESCRIPTION
Here is a followup to #3617:

- Don't blur an editor, but rather focus something else
- This lets us distinguish between switching focus in the same browser tab (where we want to switch to command mode), and switching to another browser tab (where we want to preserve the mode), thereby making it possible to fix #1737 again.

- [x] Fix failing test