### PR TITLE
Sidebar focus and title fixes

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -254,7 +254,8 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
 
   command = CommandIDs.toggleLeftArea;
   app.commands.addCommand(command, {
-    label: 'Show Left Area',
+    label: args => args['isPalette'] ?
+    'Toggle Left Area' : 'Show Left Area',
     execute: () => {
       if (app.shell.leftCollapsed) {
         app.shell.expandLeft();
@@ -265,11 +266,12 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     isToggled: () => !app.shell.leftCollapsed,
     isVisible: () => !app.shell.isEmpty('left')
   });
-  palette.addItem({ command, category });
+  palette.addItem({ command, category, args: { 'isPalette': true } });
 
   command = CommandIDs.toggleRightArea;
   app.commands.addCommand(command, {
-    label: 'Show Right Area',
+    label: args => args['isPalette'] ?
+    'Toggle Right Area' : 'Show Right Area',
     execute: () => {
       if (app.shell.rightCollapsed) {
         app.shell.expandRight();
@@ -280,7 +282,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     isToggled: () => !app.shell.rightCollapsed,
     isVisible: () => !app.shell.isEmpty('right')
   });
-  palette.addItem({ command, category });
+  palette.addItem({ command, category, args: { 'isPalette': true } });
 
   command = CommandIDs.togglePresentationMode;
   app.commands.addCommand(command, {

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -261,6 +261,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
         app.shell.expandLeft();
       } else {
         app.shell.collapseLeft();
+        app.shell.activateById(app.shell.currentWidget.id);
       }
     },
     isToggled: () => !app.shell.leftCollapsed,
@@ -277,6 +278,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
         app.shell.expandRight();
       } else {
         app.shell.collapseRight();
+        app.shell.activateById(app.shell.currentWidget.id);
       }
     },
     isToggled: () => !app.shell.rightCollapsed,


### PR DESCRIPTION
Fixes the big issues of #3630.

This PR makes it so that closing a sidebar automatically activates the current widget in the dock area, and also changes the command name in the palette to be "Toggle" instead of "Show", in the same pattern that the single-document mode says "Toggle" when the isToggled state is not shown.