### PR TITLE
Clean up webpack builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,6 +173,26 @@ To run a specific example, change to the examples directory (i.e.
 python main.py
 ```
 
+## Debugging
+
+All methods of building JupyterLab produce source maps.  The source maps
+should be available in the source files view of your browser's development
+tools under the `webpack://` header.
+
+When running JupyterLab normally, expand the `~` header to see the source maps for individual packages.
+
+When running in `--dev-mode`, the core packages are available under
+`packages/`, while the third party libraries are available under `~`.
+Note: it is recommended to use `jupyter lab --watch --dev-mode` while
+debugging.
+
+When running a test, the packages will be available at the top level
+(e.g. `application/src`), and the current set of test files available under
+`/src`.  Note: it is recommended to use `jlpm run watch` in the test folder
+while debugging (see [above](#Build and run the tests) for more info) on
+test options.
+
+
 ----
 
 ## High level Architecture
@@ -228,9 +248,6 @@ To have the system build after each source file change, run:
 ```bash
 jupyter lab --dev-mode --watch
 ```
-
-You can also run `jupyter lab --dev-mode --fast-watch` to skip
-the initial build if the assets are already built.
 
 
 ## Build Utilities

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -160,7 +160,7 @@ module.exports = {
     fs: 'empty'
   },
   bail: true,
-  devtool: 'cheap-module-eval-sourcemap',
+  devtool: 'source-map',
   plugins: [
     new HtmlWebpackPlugin({
       template: path.join('templates', 'template.html'),

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -160,7 +160,7 @@ module.exports = {
     fs: 'empty'
   },
   bail: true,
-  devtool: 'cheap-source-map',
+  devtool: 'cheap-module-eval-sourcemap',
   plugins: [
     new HtmlWebpackPlugin({
       template: path.join('templates', 'template.html'),

--- a/dev_mode/webpack.prod.config.js
+++ b/dev_mode/webpack.prod.config.js
@@ -2,8 +2,6 @@
 var UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 var merge = require('webpack-merge');
 var webpack = require('webpack');
-var os = require('os');
-
 var common = require('./webpack.config');
 
 module.exports = merge(common, {
@@ -11,11 +9,12 @@ module.exports = merge(common, {
   plugins: [
     new UglifyJSPlugin({
       sourceMap: true,
-      parallel: os.cpus().length,
+      parallel: true,
       uglifyOptions: {
         beautify: false,
         ecma: 6,
-        compress: true,
+        mangle: true,
+        compress: false,
         comments: false,
       }
     }),

--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -160,7 +160,7 @@ module.exports = {
     fs: 'empty'
   },
   bail: true,
-  devtool: 'cheap-source-map',
+  devtool: 'source-map',
   plugins: [
     new HtmlWebpackPlugin({
       template: path.join('templates', 'template.html'),

--- a/tests/webpack.config.js
+++ b/tests/webpack.config.js
@@ -1,8 +1,25 @@
+var path = require('path');
+// `CheckerPlugin` is optional. Use it if you want async error reporting.
+// We need this plugin to detect a `--watch` mode. It may be removed later
+// after https://github.com/webpack/webpack/issues/3460 will be resolved.
+var CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin;
+
+
+// Use sourcemaps if in watch mode;
+var devtool = 'eval';
+if (process.argv.indexOf('--watch') !== -1) {
+  devtool = 'cheap-module-eval-sourcemap';
+}
+
 module.exports = {
   resolve: {
     extensions: ['.ts', '.js']
   },
   bail: true,
+  devtool: devtool,
+  plugins: [
+    new CheckerPlugin(),
+  ],
   module: {
     rules: [
       {
@@ -19,6 +36,12 @@ module.exports = {
             }
           }
         ]
+      },
+      { test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+        // eslint-disable-next-line no-undef
+        exclude: path.join(process.cwd(), 'node_modules')
       },
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
       { test: /\.(json|ipynb)$/, use: 'json-loader' },


### PR DESCRIPTION
- Adds TypeScript source map support to dev mode and tests when in watch mode.  Adds ~2 secs to dev build but gives us TypeScript source maps.
 "In most cases `cheap-module-eval-source-map` is the best option." - https://webpack.js.org/guides/build-performance/

- "It's not well known, but whitespace removal and symbol mangling accounts for 95% of the size reduction in minified code for most JavaScript - not elaborate code transforms." - [uglify readme](https://github.com/mishoo/UglifyJS2/tree/7c0c92943f08e89118ed32019c014a44192f9dfc#uglify-fast-minify-mode)

  Production build takes ~1/2 the time and is ~10% bigger with `compress: false`.

- I tried the recommended method to speed up [TypeScript loading](https://webpack.js.org/guides/build-performance/#typescript) in the tests, but it actually slowed the tests down.

- Also updates docs around debugging