### PR TITLE
Handle missing kernel info help links

### DIFF
--- a/packages/help-extension/src/index.ts
+++ b/packages/help-extension/src/index.ts
@@ -286,7 +286,7 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
 
         // Add the kernel info help_links to the Help menu.
         const kernelGroup: Menu.IItemOptions[] = [];
-        session.kernel.info.help_links.forEach((link) => {
+        (session.kernel.info.help_links || []).forEach((link) => {
           const commandId = `help-menu-${name}:${link.text}`;
           commands.addCommand(commandId, {
             label: link.text,


### PR DESCRIPTION
They are optional, cf. http://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-info