### PR TITLE
Fix drag-to-main-area behavior.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -78,7 +78,7 @@ xckd repo
 
 
 ### Extension examples to update
-- https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/developer/notebook.md#adding-a-button-to-the-toolbar
+- https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/developer/notebook.rst#adding-a-button-to-the-toolbar
 
 
 ### Updating the xkcd tutorial

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  IChangedArgs, uuid
+  IChangedArgs
 } from '@jupyterlab/coreutils';
 
 import {
@@ -92,28 +92,18 @@ const plugin: JupyterLabPlugin<IDocumentManager> = {
           'type': 'document-title',
           ...widget.title.dataset
         };
-        if (!widget.isAttached && (widget as any).ready !== undefined) {
-          // Add a loading spinner, and remove it when the widget is ready.
-          let spinner = new Spinner();
-          spinner.id = uuid();
-          spinner.title.label = widget.title.label;
-          shell.addToMainArea(spinner, options || {});
-          shell.activateById(spinner.id);
+        if (!widget.isAttached) {
+          app.shell.addToMainArea(widget, options || {});
 
-          (widget as any).ready.then(() => {
-            const isCurrent = app.shell.currentWidget === spinner;
-            app.shell.addToMainArea(widget, {...options, ref: spinner.id });
+          // Add a loading spinner, and remove it when the widget is ready.
+          const spinner = new Spinner();
+          widget.node.appendChild(spinner.node);
+          widget.ready.then(() => {
+            widget.node.removeChild(spinner.node);
             spinner.dispose();
-            if (isCurrent) {
-              shell.activateById(widget.id);
-            }
           });
-        } else if (!widget.isAttached) {
-          shell.addToMainArea(widget, options || {});
-          shell.activateById(widget.id);
-        } else {
-          shell.activateById(widget.id);
         }
+        shell.activateById(widget.id);
 
         // Handle dirty state for open documents.
         let context = docManager.contextForWidget(widget);

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -96,12 +96,14 @@ const plugin: JupyterLabPlugin<IDocumentManager> = {
           app.shell.addToMainArea(widget, options || {});
 
           // Add a loading spinner, and remove it when the widget is ready.
-          const spinner = new Spinner();
-          widget.node.appendChild(spinner.node);
-          widget.ready.then(() => {
-            widget.node.removeChild(spinner.node);
-            spinner.dispose();
-          });
+          if (widget.ready !== undefined) {
+            const spinner = new Spinner();
+            widget.node.appendChild(spinner.node);
+            widget.ready.then(() => {
+              widget.node.removeChild(spinner.node);
+              spinner.dispose();
+            });
+          }
         }
         shell.activateById(widget.id);
 

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -378,7 +378,7 @@ class DocumentManager implements IDisposable {
    */
   private _createContext(path: string, factory: DocumentRegistry.ModelFactory, kernelPreference: IClientSession.IKernelPreference): Private.IContext {
     // Allow options to be passed when adding a sibling.
-    let adopter = (widget: Widget, options?: DocumentRegistry.IOpenOptions) => {
+    let adopter = (widget: DocumentRegistry.IReadyWidget, options?: DocumentRegistry.IOpenOptions) => {
       this._widgetManager.adoptWidget(context, widget);
       this._opener.open(widget, options);
     };
@@ -519,7 +519,7 @@ namespace DocumentManager {
     /**
      * Open the given widget.
      */
-    open(widget: Widget, options?: DocumentRegistry.IOpenOptions): void;
+    open(widget: DocumentRegistry.IReadyWidget, options?: DocumentRegistry.IOpenOptions): void;
   }
 }
 

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -125,7 +125,7 @@ class DocumentWidgetManager implements IDisposable {
    *
    * @param widget - The widget to adopt.
    */
-  adoptWidget(context: DocumentRegistry.Context, widget: Widget): void {
+  adoptWidget(context: DocumentRegistry.Context, widget: DocumentRegistry.IReadyWidget): void {
     let widgets = Private.widgetsProperty.get(context);
     widgets.push(widget);
     MessageLoop.installMessageHook(widget, this);
@@ -157,7 +157,7 @@ class DocumentWidgetManager implements IDisposable {
         return false;
       }
       return factory.name === widgetName;
-    }) as DocumentRegistry.IReadyWidget;
+    });
   }
 
   /**
@@ -448,7 +448,7 @@ namespace Private {
    * A private attached property for the widgets associated with a context.
    */
   export
-  const widgetsProperty = new AttachedProperty<DocumentRegistry.Context, Widget[]>({
+  const widgetsProperty = new AttachedProperty<DocumentRegistry.Context, DocumentRegistry.IReadyWidget[]>({
     name: 'widgets',
     create: () => []
   });

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1287,9 +1287,9 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
     isEnabled: isEnabledAndSingleSelected
   });
   commands.addCommand(CommandIDs.createConsole, {
-    label: 'Create Console for Notebook',
+    label: 'New Console for Notebook',
     execute: args => {
-      const current = getCurrent(args);
+      const current = getCurrent({ ...args, activate: false });
       const widget = tracker.currentWidget;
 
       if (!current || !widget) {
@@ -1653,7 +1653,10 @@ function populateMenus(app: JupyterLab, mainMenu: IMainMenu, tracker: INotebookT
     createConsole: current => {
       const options: ReadonlyJSONObject = {
         path: current.context.path,
-        preferredLanguage: current.context.model.defaultKernelLanguage
+        preferredLanguage: current.context.model.defaultKernelLanguage,
+        activate: true,
+        ref: current.id,
+        insertMode: 'split-bottom'
       };
       return commands.execute('console:create', options);
     }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1260,7 +1260,7 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
     label: 'Create New View for Output',
     execute: args => {
       // Clone the OutputArea
-      const current = getCurrent(args);
+      const current = getCurrent({ ...args, activate: false });
       const nb = current.notebook;
       const outputAreaView = (nb.activeCell as CodeCell).cloneOutputArea();
       // Create an empty toolbar


### PR DESCRIPTION
Fixes #3656. Partially reverts #3469.

This goes back to the previous behavior of the spinner, where it was used as an overlay on the document widget until the contents had been loaded (as opposed to making a separate main area widget and then swapping them). The current behavior suffers from a race condition when dragging files from the file browser to the main area, which makes reference to a the possibly-disposed spinner widget.

I was not able to reproduce the race condition referenced in #3469, and document activation seems to work correctly in my testing.