### PR TITLE
Show the latest kernel banner in console on restart.

### DIFF
--- a/tests/test-console/src/widget.spec.ts
+++ b/tests/test-console/src/widget.spec.ts
@@ -286,8 +286,8 @@ describe('console/widget', () => {
         widget.promptCell.model.value.text = 'foo';
 
         let serialized = widget.serialize();
-        expect(serialized).to.have.length(2);
-        expect(serialized[1].source).to.be('foo');
+        expect(serialized).to.have.length(1);
+        expect(serialized[0].source).to.be('foo');
       });
 
     });


### PR DESCRIPTION
This PR refactors the banner code in the console to:

1. Display the banner every time the kernel is connected (i.e., restarted, reconnected, started)
2. keep track of the latest banner and keep it around when clearing the cells

There still is a possible race condition, where a kernel might be restarted and then quickly changed - the banner updated might be the wrong one. But this existed before, and I think this PR makes the usability better.

![console](https://user-images.githubusercontent.com/192614/35025106-41acfb3e-faf8-11e7-9f4e-6c09859ad2b3.gif)

Fixes #3653.