### PR TITLE
Internal/External Linking Check on Docs

### DIFF
--- a/docs/source/developer/documentation.rst
+++ b/docs/source/developer/documentation.rst
@@ -1,10 +1,10 @@
-Writing documentation
+Writing Documentation
 ---------------------
 
 This section provide information about writing documentation for
 JupyterLab.
 
-Writing style
+Writing Style
 ~~~~~~~~~~~~~
 
 -  The documentation should be written in the second person, referring
@@ -20,7 +20,7 @@ Writing style
 -  The beginning of each section should begin with a short (1-2
    sentence) high-level description of the topic, feature or component.
 
-Proper nouns
+Proper Nouns
 ~~~~~~~~~~~~
 
 The main parts of JupyterLab should be treated as proper nouns and
@@ -37,7 +37,7 @@ capitalized:
 -  Code Console
 -  Terminal
 
-Keyboard shortcuts
+Keyboard Shortcuts
 ~~~~~~~~~~~~~~~~~~
 
 Typeset keyboard shortcuts as follows:
@@ -50,7 +50,7 @@ Typeset keyboard shortcuts as follows:
 -  Don’t use platform specific icons for modifier keys, as they are
    difficult to display in a platform specific way on Sphinx/RTD.
 
-Screenshots and animations
+Screenshots and Animations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Our documentation should contain screenshots and animations that

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -1,3 +1,5 @@
+.. _developer_extensions:
+
 Extension Developer Guide
 -------------------------
 
@@ -11,6 +13,8 @@ JupyterLab can be extended in three ways via:
 -  document widget extensions (lower level): Document widget extensions
    extend the functionality of document widgets added to the
    application, and we cover them in the "Documents" tutorial.
+
+See :ref:`xkcd_extension_tutorial` to learn how to make a simple JupyterLab extension.
 
 A JupyterLab application is comprised of:
 
@@ -31,6 +35,8 @@ A plugin adds a core functionality to the application:
    `JupyterLab.IPluginModule <http://jupyterlab.github.io/jupyterlab/interfaces/_application_src_index_.jupyterlab.ipluginmodule.html>`__
    interface, by exporting a plugin object or array of plugin objects as
    the default export.
+
+   We provide two cookie cutters to create JuptyerLab plugin extensions in `CommonJS <https://github.com/jupyterlab/extension-cookiecutter-js>` and `TypeScript <https://github.com/jupyterlab/extension-cookiecutter-ts>`
 
 The default plugins in the JupyterLab application include:
 
@@ -185,6 +191,9 @@ Mime Renderer Extensions
 
 Mime Renderer extensions are a convenience for creating an extension
 that can render mime data and potentially render files of a given type.
+We provide cookiecutters for Mime render extensions in
+`JavaScript <https://github.com/jupyterlab/mimerender-cookiecutter>`__ and
+`TypeScript <https://github.com/jupyterlab/mimerender-cookiecutter-ts>`__.
 
 Mime renderer extensions are more declarative than standard extensions.
 The extension is treated the same from the command line perspective
@@ -353,4 +362,3 @@ This would look something like the following in a ``Widget`` subclass:
       event.stopPropagation();
 
 .. |dependencies| image:: dependency-graph.svg
-

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -1,3 +1,5 @@
+.. _xkcd_extension_tutorial:
+
 Let's Make an xkcd JupyterLab Extension
 ---------------------------------------
 
@@ -863,4 +865,3 @@ learning, here are some suggestions about what to try next:
 .. |Single xkcd extension panel| image:: xkcd_tutorial_single.png
 .. |Styled xkcd panel with attribution| image:: xkcd_tutorial_complete.png
 .. |Extension page on npmjs.com| image:: xkcd_tutorial_npm.png
-

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -1,3 +1,5 @@
+.. _installation:
+
 Installation
 ------------
 

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -1,13 +1,15 @@
+.. _overview:
+
 Overview
 --------
 
 *JupyterLab is the next generation user interface for Project Jupyter*
 
 JupyterLab goes beyond the classic Jupyter Notebook by providing a
-flexible and extensible web application with a set of reusable
+flexible and :ref:`extensible <user_extensions>` web application with a set of reusable
 components. You can arrange multiple notebooks, text editors, terminals,
 output areas, and custom components using tabs/panels and collapsible
-sidebars. These components are carefully designed to enable you to use
+sidebars. These :ref:`components <interface>` are carefully designed to enable you to use
 them together or on their own to support new workflows (for example, you
 can send code from a file to a code console with a keystroke, or move
 cells around a notebook or between notebooks with drag-and-drop).
@@ -15,7 +17,7 @@ cells around a notebook or between notebooks with drag-and-drop).
 **JupyterLab has full support for Jupyter Notebook documents.** In
 addition, it enables other models of interactive computing, such as:
 
--  :ref:`code-consoles` provide transient scratchpads for running code
+-  :ref:`code_console` provide transient scratchpads for running code
    interactively, with full support for rich output.
 -  :ref:`Kernel-backed documents <kernel-backed-documents>` allow code in any text file (Markdown,
    Python, R, LaTeX, etc.) to be run interactively in any Jupyter

--- a/docs/source/getting_started/starting.rst
+++ b/docs/source/getting_started/starting.rst
@@ -1,3 +1,5 @@
+.. _starting:
+
 Starting JupyterLab
 -------------------
 

--- a/docs/source/user/code_console.rst
+++ b/docs/source/user/code_console.rst
@@ -1,4 +1,4 @@
-.. _code-consoles:
+.. _code_console:
 
 Code Consoles
 -------------
@@ -9,8 +9,8 @@ kernel, as opposed to the explicit ordering of cells in a notebook
 document. Code consoles also display rich output, just like notebook
 cells.
 
-Create a new code console by clicking the ``+`` button in the file
-browser and selecting the kernel:
+Create a new code console by clicking the ``+`` button in the :ref:`file
+browser <left_sidebar>` and selecting the kernel:
 
 [animation]
 
@@ -29,7 +29,7 @@ right-clicking on the code console and selecting “Clear Console Cells”:
 
 [animation]
 
-Creating a code console from the File menu lets you select an existing
+Creating a code console from the :ref:`file menu <menu_bar>` lets you select an existing
 kernel for the code console. The code console then acts as a log of
 computations in that kernel, and a place you can interactively inspect
 and run code in the kernel:

--- a/docs/source/user/commands.rst
+++ b/docs/source/user/commands.rst
@@ -1,3 +1,5 @@
+.. _commands:
+
 Command Palette
 ---------------
 

--- a/docs/source/user/documents_kernels.rst
+++ b/docs/source/user/documents_kernels.rst
@@ -6,7 +6,7 @@ Documents and kernels
 In the Jupyter architecture, kernels are separate processes started by
 the server that run your code in different programming languages and
 environments. JupyterLab allows you to connect any open text file to a
-code console and kernel. This means you can easily run code from the
+:ref:`code console and kernel <code_console>`. This means you can easily run code from the
 text file in the kernel interactively.
 
 Right-click on a document and select “Create Console for Editor”:

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -1,3 +1,5 @@
+.. _user_extensions:
+
 Extensions
 ----------
 
@@ -6,7 +8,7 @@ They can provide new file viewer types, launcher activities, and output
 renderers, among many other things. JupyterLab extensions are
 `npm <https://www.npmjs.com/>`__ packages (the standard package format
 in Javascript development). For information about developing extensions,
-see the :ref:`developer documentation <developer-guide>`.
+see the :ref:`developer documentation <developer_extensions>`.
 
 In order to install JupyterLab extensions, you need to have Node.js
 version 4+ installed.
@@ -50,7 +52,7 @@ tarball, or a URL to a gzipped tarball.
 We encourage extension authors to add the ``jupyterlab-extensions``
 GitHub topic to any repository with a JupyterLab extension to facilitate
 discovery. You can see a list of extensions by searching Github for the
-`jupyterlab-extensions <https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extensions&type=Repositories>`__
+`jupyterlab-extension <https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extension&type=Repositories>`__
 topic.
 
 You can list the currently installed extensions by running the command:
@@ -168,7 +170,7 @@ The ``settings`` directory contains ``page_config.json`` and
 .. _page_configjson:
 
 page_config.json
-                
+
 
 The ``page_config.json`` data is used to provide config data to the
 application environment.
@@ -204,7 +206,7 @@ and ``deferredExtensions``.
 .. _build_configjson:
 
 build_config.json
-                 
+
 
 The ``build_config.json`` file is used to track the local directories
 that have been installed using

--- a/docs/source/user/file_editor.rst
+++ b/docs/source/user/file_editor.rst
@@ -1,3 +1,5 @@
+.. _file_editor:
+
 File Editor
 -----------
 

--- a/docs/source/user/file_formats.rst
+++ b/docs/source/user/file_formats.rst
@@ -1,6 +1,6 @@
 .. _file-and-output-formats:
 
-File and output formats
+File and Output Formats
 -----------------------
 
 JupyterLab provides a unified architecture for viewing and editing data
@@ -45,6 +45,7 @@ Other Jupyter kernels offer similar APIs.
 
 The rest of this section highlights some of the common data formats that
 JupyterLab supports.
+
 
 Markdown
 ~~~~~~~~

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -1,7 +1,9 @@
-Working with files
+.. _working_with_files:
+
+Working with Files
 ------------------
 
-Opening files
+Opening Files
 ~~~~~~~~~~~~~
 
 The file browser and File menu allow you to work with files and
@@ -24,11 +26,11 @@ You can also drag a file into the main area to create a new tab:
 
 [animation]
 
-Many files types have multiple viewers/editors. For example, you can
-open a Markdown file in a text editor or as rendered HTML. A JupyterLab
-extension can also add new viewers/editors for files. To open a file in
-a non-default viewer/editor, right-click on its name in the file browser
-and use the "Open With..." submenu to select the viewer/editor:
+Many files types have :ref:`multiple viewers/editors <file-and-output-formats>`.
+For example, you can open a Markdown file in a text editor or as rendered HTML.
+A JupyterLab extension can also add new viewers/editors for files.
+To open a file in a non-default viewer/editor, right-click on its name in the
+file browser and use the "Open With..." submenu to select the viewer/editor:
 
 [animation]
 
@@ -48,7 +50,7 @@ directory open.
 
 [screenshot]
 
-Creating files and activities
+Creating Files and Activities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create new files or activities by clicking the ``+`` button at the top

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -1,3 +1,5 @@
+.. _interface:
+
 The JupyterLab Interface
 ------------------------
 
@@ -6,13 +8,15 @@ exploratory computing. While JupyterLab has many features found in
 traditional integrated development environments (IDEs), it remains
 focused on interactive, exploratory computing.
 
-The JupyterLab interface consists of a main work area containing tabs of
-documents and activities, a collapsible left sidebar, and a menu bar.
-The left sidebar contains a file browser, the list of running kernels
-and terminals, the command palette, the notebook cell tools inspector,
-and the tabs list.
+The JupyterLab interface consists of a :ref:`main work area <main_area>` containing tabs of
+documents and activities, a collapsible :ref:`left sidebar <left_sidebar>`, and a :ref:`menu bar <menu_bar>`.
+The left sidebar contains a :ref:`file browser <working_with_files>`, the :ref:`list of running kernels
+and terminals <running>`, the :ref:`command palette <commands>`, the :ref:`notebook cell tools inspector <notebook>`,
+and the :ref:`tabs list <tabs>`.
 
 [screenshot]
+
+.. _menu_bar:
 
 Menu Bar
 ~~~~~~~~
@@ -32,8 +36,10 @@ default menus are:
 -  Settings: common settings and an advanced settings editor
 -  Help: a list of JupyterLab and kernel help links
 
-JupyterLab extensions can also create new top-level menus in the menu
+:ref:`JupyterLab extensions <user_extensions>` can also create new top-level menus in the menu
 bar.
+
+.. _left_sidebar:
 
 Left Sidebar
 ~~~~~~~~~~~~
@@ -51,6 +57,8 @@ sidebar tab:
 
 JupyterLab extensions can add additional panels to the left sidebar.
 
+.. _main_area:
+
 Main area
 ~~~~~~~~~
 
@@ -64,6 +72,8 @@ The main area has a single current activity. The tab for this activity
 is marked with a colored top border (blue by default).
 
 [screenshot]
+
+.. _tabs:
 
 Tabs and Single Document Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user/notebook.rst
+++ b/docs/source/user/notebook.rst
@@ -1,3 +1,5 @@
+.. _notebook:
+
 Notebooks
 ---------
 
@@ -67,7 +69,7 @@ information about objects:
 
 [animation]
 
-You can connect a code console to a notebook kernel to have a log of
+You can connect a :ref:`code console <code_console>` to a notebook kernel to have a log of
 computations done in the kernel, in the order in which they were done.
 The attached code console also provides a place to interactively inspect
 kernel state without changing the notebook. Right-click on a notebook

--- a/docs/source/user/running.rst
+++ b/docs/source/user/running.rst
@@ -1,4 +1,6 @@
-Managing kernels and terminals
+.. _running:
+
+Managing Kernels and Terminals
 ------------------------------
 
 The Running tab in the left sidebar shows a list of all the kernels and

--- a/docs/source/user/terminal.rst
+++ b/docs/source/user/terminal.rst
@@ -1,3 +1,5 @@
+.. _terminal:
+
 Terminals
 ---------
 


### PR DESCRIPTION
In my opinion, the external linking on all these pages look ok.   I also added language referencing the existence of our cookie cutters for which I would like extra help in making the language precise.

With respect to internal links, I've mostly focused on the user side of the docs. I have also included a link the xkcd walkthrough in the dev docs for extensions. 

We still need to confirm the naming conventions for this language to be accurate. 

I've also made the title naming consistent across the user side of the docs.

closes #3650