### PR TITLE
small fix in extensions.rst

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -15,7 +15,7 @@ If you use ``conda``, you can get it with:
 
 .. code:: bash
 
-    conda -c conda-forge install nodejs
+    conda install -c conda-forge nodejs
 
 If you use `Homebrew <https://brew.sh/>`__ on Mac OS X:
 


### PR DESCRIPTION
conda install command was in the wrong order.
So I figured might as well fix it while I am looking at this.