### PR TITLE
Updating the README with Pipenv installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ pip install git+git://github.com/jupyterlab/jupyterlab.git
 jupyter serverextension enable --py jupyterlab --sys-prefix
 ```
 
+If you use ``pipenv``, you can install it as:
+
+```bash
+pipenv install jupyterlab
+pipenv shell
+jupyter serverextension enable --py jupyterlab --sys-prefix
+```
+
+or from a git checkout:
+
+```bash
+pipenv install git+git://github.com/jupyterlab/jupyterlab.git#egg=jupyterlab
+pipenv shell
+jupyter serverextension enable --py jupyterlab --sys-prefix
+```
+
+When using ``pipenv``, in order to launch `jupyter lab`, you must activate the project's virtualenv. For example, in the directory where ``pipenv``'s `Pipfile` and `Pipfile.lock` live (i.e., where you ran the above commands):
+
+```bash
+pipenv shell
+jupyter lab
+```
+
 ### Running
 
 Start up JupyterLab using:


### PR DESCRIPTION
An update to the documentation on installing JupyterLab using Pipenv as mentioned in #3679.