### PR TITLE
Support state nullification with a URL parameter.

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -182,13 +182,13 @@ const router: JupyterLabPlugin<IRouter> = {
         const path = decodeURIComponent((args.path.match(Patterns.tree)[1]));
 
         // File browser navigation waits for the application to be restored.
-        // As a result, this command cannot return a promise because the it
-        // would create a circular dependency on the restored promise that would
-        // cause the router to hang on page load.
+        // As a result, this command cannot return a promise because it would
+        // create a circular dependency on the restored promise that would
+        // cause the application to never restore.
         const opened = commands.execute('filebrowser:navigate-main', { path });
 
-        // Change the URL back to the base application URL without triggering
-        // further routing events.
+        // Change the URL back to the base application URL without adding the
+        // URL change to the browser history.
         opened.then(() => { router.navigate('', { silent: true }); });
       }
     });
@@ -222,8 +222,8 @@ const notfound: JupyterLabPlugin<void> = {
       return;
     }
 
-    // Change the URL back to the base application URL without triggering
-    // further routing events.
+    // Change the URL back to the base application URL without adding the
+    // URL change to the browser history.
     router.navigate('', { silent: true });
 
     showDialog({

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -170,22 +170,21 @@ const router: JupyterLabPlugin<IRouter> = {
       PageConfig.getOption('pageUrl')
     );
     const router = new Router({ base, commands });
-    const pattern = /^\/tree\/(.*)/;
+    const pattern = /^\/tree\/([^\?]+)/;
 
     commands.addCommand(CommandIDs.tree, {
       execute: (args: IRouter.ICommandArgs) => {
-        // Tree handling waits for the application to be restored. As a result,
-        // it cannot return a promise, otherwise the router would hang waiting
-        // for a restoration that cannot finish.
-        app.restored.then(() => {
-          const path = decodeURIComponent((args.path.match(pattern)[1]));
+        const path = decodeURIComponent((args.path.match(pattern)[1]));
 
-          // Change the URL back to the base application URL without triggering
-          // further routing events.
-          router.navigate('', { silent: true });
+        // Change the URL back to the base application URL without triggering
+        // further routing events.
+        router.navigate('', { silent: true });
 
-          commands.execute('filebrowser:navigate-main', { path });
-        });
+        // File browser navigation waits for the application to be restored.
+        // As a result, this command cannot return a promise because the it
+        // would create a circular dependency on the restored promise that would
+        // cause the router to hang on page load.
+        commands.execute('filebrowser:navigate-main', { path });
       }
     });
 

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -203,20 +203,17 @@ const router: JupyterLabPlugin<IRouter> = {
  */
 const notfound: JupyterLabPlugin<void> = {
   id: '@jupyterlab/application-extension:notfound',
-  activate: (app: JupyterLab) => {
+  activate: (app: JupyterLab, router: IRouter) => {
     const bad = PageConfig.getOption('notFoundUrl');
+    const base = router.base;
 
     if (!bad) {
       return;
     }
 
-    const base = URLExt.join(
-      PageConfig.getBaseUrl(),
-      PageConfig.getOption('pageUrl')
-    );
-
-    // Change the URL back to the base application URL.
-    window.history.replaceState({ }, '', base);
+    // Change the URL back to the base application URL without triggering
+    // further routing events.
+    router.navigate('', { silent: true });
 
     showDialog({
       title: 'Path Not Found',
@@ -224,6 +221,7 @@ const notfound: JupyterLabPlugin<void> = {
       buttons: [Dialog.okButton()]
     });
   },
+  requires: [IRouter],
   autoStart: true
 };
 

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -189,7 +189,7 @@ const router: JupyterLabPlugin<IRouter> = {
 
         // Change the URL back to the base application URL without triggering
         // further routing events.
-        router.navigate('', { silent: true, when: opened });
+        opened.then(() => { router.navigate('', { silent: true }); });
       }
     });
 

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -174,13 +174,17 @@ const router: JupyterLabPlugin<IRouter> = {
 
     commands.addCommand(CommandIDs.tree, {
       execute: (args: IRouter.ICommandArgs) => {
-        return app.restored.then(() => {
+        // Tree handling waits for the application to be restored. As a result,
+        // it cannot return a promise, otherwise the router would hang waiting
+        // for a restoration that cannot finish.
+        app.restored.then(() => {
           const path = decodeURIComponent((args.path.match(pattern)[1]));
 
-          // Change the URL back to the base application URL.
-          window.history.replaceState({ }, '', base);
+          // Change the URL back to the base application URL without triggering
+          // further routing events.
+          router.navigate('', { silent: true });
 
-          return commands.execute('filebrowser:navigate-main', { path });
+          commands.execute('filebrowser:navigate-main', { path });
         });
       }
     });

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -131,11 +131,6 @@ namespace IRouter {
      * Whether the navigation should generate an HTML history `popstate` event.
      */
     silent?: boolean;
-
-    /**
-     * An optional promise that must resolve before navigation happens.
-     */
-    when?: Promise<any>;
   }
 
   /**
@@ -221,15 +216,15 @@ class Router implements IRouter {
   navigate(path: string, options: IRouter.INavigateOptions = { }): void {
     const url = path ? URLExt.join(this.base, path) : this.base;
     const { history } = window;
-    const { silent, when} = options;
+    const { silent } = options;
 
-    (when || Promise.resolve(undefined)).then(() => {
-      if (silent) {
-        history.replaceState({ }, '', url);
-      } else {
-        history.pushState({ }, '', url);
-      }
-    });
+    if (silent) {
+      history.replaceState({ }, '', url);
+    } else {
+      history.pushState({ }, '', url);
+    }
+
+    requestAnimationFrame(() => { this.route(); });
   }
 
   /**

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -255,10 +255,11 @@ class Router implements IRouter {
     const { commands, stop } = this;
     const current = this.current();
     const { request } = current;
+    const rules = this._rules;
     const matches: Private.Rule[] = [];
 
     // Collect all rules that match the URL.
-    this._rules.forEach((rule, pattern) => {
+    rules.forEach((rule, pattern) => {
       if (request.match(pattern)) {
         matches.push(rule);
       }

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -128,7 +128,7 @@ namespace IRouter {
   export
   interface INavigateOptions {
     /**
-     * Whether the navigation should generate an HTML history `popstate` event.
+     * Whether the navigation should be added to the browser's history.
      */
     silent?: boolean;
   }
@@ -203,7 +203,7 @@ class Router implements IRouter {
     const path = parsed.pathname.replace(base, '');
     const request = path + search;
 
-    return { path, request,  search };
+    return { path, request, search };
   }
 
   /**

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -60,6 +60,15 @@ interface IRouter {
   readonly stop: Token<void>;
 
   /**
+   * Navigate to a new path within the application.
+   *
+   * @param path - The new path or empty string if redirecting to root.
+   *
+   * @param options - The navigation options.
+   */
+  navigate(path: string, options: IRouter.INavigateOptions): void;
+
+  /**
    * Register a rule that maps a path pattern to a command.
    *
    * @param options - The route registration options.
@@ -103,8 +112,14 @@ namespace IRouter {
     search: string;
   }
 
+  /**
+   * The options passed into a navigation request.
+   */
   export
   interface INavigateOptions {
+    /**
+     * Whether the navigation should generate an HTML history `popstate` event.
+     */
     silent: boolean;
   }
 
@@ -168,10 +183,15 @@ class Router implements IRouter {
     return this._routed;
   }
 
+  /**
+   * Navigate to a new path within the application.
+   *
+   * @param path - The new path or empty string if redirecting to root.
+   *
+   * @param options - The navigation options.
+   */
   navigate(path: string, options: IRouter.INavigateOptions = { silent: false }): void {
-    const url = URLExt.join(this.base, path);
-
-    console.log('navigate to', url);
+    const url = path ? URLExt.join(this.base, path) : this.base;
 
     if (options.silent) {
       window.history.replaceState({ }, '', url);

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -130,7 +130,12 @@ namespace IRouter {
     /**
      * Whether the navigation should generate an HTML history `popstate` event.
      */
-    silent: boolean;
+    silent?: boolean;
+
+    /**
+     * An optional promise that must resolve before navigation happens.
+     */
+    when?: Promise<any>;
   }
 
   /**
@@ -213,15 +218,18 @@ class Router implements IRouter {
    *
    * @param options - The navigation options.
    */
-  navigate(path: string, options: IRouter.INavigateOptions = { silent: false }): void {
+  navigate(path: string, options: IRouter.INavigateOptions = { }): void {
     const url = path ? URLExt.join(this.base, path) : this.base;
     const { history } = window;
+    const { silent, when} = options;
 
-    if (options.silent) {
-      requestAnimationFrame(() => { history.replaceState({ }, '', url); });
-    } else {
-      requestAnimationFrame(() => { history.pushState({ }, '', url); });
-    }
+    (when || Promise.resolve(undefined)).then(() => {
+      if (silent) {
+        history.replaceState({ }, '', url);
+      } else {
+        history.pushState({ }, '', url);
+      }
+    });
   }
 
   /**

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -232,6 +232,8 @@ class Router implements IRouter {
       history.pushState({ }, '', url);
     }
 
+    // Because a `route()` call may still be in the stack after having received
+    // a `stop` token, wait for the next stack frame before calling `route()`.
     requestAnimationFrame(() => { this.route(); });
   }
 

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -71,7 +71,7 @@ interface IRouter {
    *
    * @param options - The navigation options.
    */
-  navigate(path: string, options?: IRouter.INavigateOptions): void;
+  navigate(path: string, options?: IRouter.INavOptions): void;
 
   /**
    * Register a rule that maps a path pattern to a command.
@@ -126,7 +126,7 @@ namespace IRouter {
    * The options passed into a navigation request.
    */
   export
-  interface INavigateOptions {
+  interface INavOptions {
     /**
      * Whether the navigation should be added to the browser's history.
      */
@@ -213,7 +213,7 @@ class Router implements IRouter {
    *
    * @param options - The navigation options.
    */
-  navigate(path: string, options: IRouter.INavigateOptions = { }): void {
+  navigate(path: string, options: IRouter.INavOptions = { }): void {
     const url = path ? URLExt.join(this.base, path) : this.base;
     const { history } = window;
     const { silent } = options;

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -242,7 +242,7 @@ class Router implements IRouter {
    *
    * @param options - The route registration options.
    *
-   * @returns A disposable that removes the registered rul from the router.
+   * @returns A disposable that removes the registered rule from the router.
    */
   register(options: IRouter.IRegisterOptions): IDisposable {
     const { command, pattern } = options;

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -293,9 +293,11 @@ class Router implements IRouter {
           queue.length = 0;
           console.log(`Routing ${request} was short-circuited by ${command}`);
         }
+        next();
       }).catch(reason => {
         console.warn(`Routing ${request} to ${command} failed`, reason);
-      }).then(() => { next(); });
+        next();
+      });
     })();
   }
 

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -106,12 +106,20 @@ namespace IRouter {
   export
   interface ILocation extends ReadonlyJSONObject {
     /**
+     * The location hash.
+     */
+    hash: string;
+
+    /**
      * The path that matched a routing pattern.
      */
     path: string;
 
     /**
      * The request being routed with the router `base` omitted.
+     *
+     * #### Notes
+     * This field includes the query string and hash, if they exist.
      */
     request: string;
 
@@ -186,11 +194,11 @@ class Router implements IRouter {
   get current(): IRouter.ILocation {
     const { base } = this;
     const parsed = URLExt.parse(window.location.href);
-    const { search } = parsed;
+    const { search, hash } = parsed;
     const path = parsed.pathname.replace(base, '');
-    const request = path + search;
+    const request = path + search + hash;
 
-    return { path, request, search };
+    return { hash, path, request, search };
   }
 
   /**

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -403,7 +403,7 @@ const state: JupyterLabPlugin<IStateDB> = {
           .then(() => router.stop); // Stop routing before new route navigation.
 
         // After the state has been recovered, navigate to the URL.
-        router.navigate(url, { when: recovered });
+        recovered.then(() => { router.navigate(url); });
 
         return recovered;
       }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -403,7 +403,7 @@ const state: JupyterLabPlugin<IStateDB> = {
           .then(() => router.stop); // Stop routing before new route navigation.
 
         // After the state has been reset, navigate to the URL.
-        cleared.then(() => { router.navigate(url); });
+        cleared.then(() => { router.navigate(url, { silent: true }); });
 
         return cleared;
       }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@jupyterlab/application';
 
 import {
-  Dialog, ICommandPalette, IThemeManager, ThemeManager, ISplashScreen
+  Dialog, ICommandPalette, ISplashScreen, IThemeManager, ThemeManager
 } from '@jupyterlab/apputils';
 
 import {
@@ -221,7 +221,11 @@ const splash: JupyterLabPlugin<ISplashScreen> = {
     return {
       show: () => {
         const { commands, restored } = app;
-        const recovery = () => { commands.execute(CommandIDs.recoverState); };
+        const recovery = () => {
+          commands.execute(CommandIDs.recoverState)
+            .then(() => { document.location.reload(); })
+            .catch(() => { document.location.reload(); });
+        };
 
         return Private.showSplash(restored, recovery);
       }
@@ -277,13 +281,10 @@ const state: JupyterLabPlugin<IStateDB> = {
         const immediate = true;
         const silent = true;
 
-        // Clear the state silenty so that the state changed signal listener
-        // will not be triggered as it causes a save state, but the save state
-        // promise is lost and cannot be used to reload the application.
+        // Clear the state silently so that the state changed signal listener
+        // will not be triggered as it causes a save state.
         return state.clear(silent)
-          .then(() => commands.execute(CommandIDs.saveState, { immediate }))
-          .then(() => { document.location.reload(); })
-          .catch(() => { document.location.reload(); });
+          .then(() => commands.execute(CommandIDs.saveState, { immediate }));
       }
     });
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -344,7 +344,6 @@ const state: JupyterLabPlugin<IStateDB> = {
         }
 
         // Any time the local state database changes, save the workspace.
-        state.changed.disconnect(listener, state);
         state.changed.connect(listener, state);
 
         // Fetch the workspace and overwrite the state database.

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -63,13 +63,13 @@ namespace CommandIDs {
   const changeTheme = 'apputils:change-theme';
 
   export
-  const clearState = 'apputils:clear-statedb';
-
-  export
   const loadState = 'apputils:load-statedb';
 
   export
   const recoverState = 'apputils:recover-statedb';
+
+  export
+  const reset = 'apputils:reset';
 
   export
   const resetOnLoad = 'apputils:reset-on-load';
@@ -236,11 +236,7 @@ const splash: JupyterLabPlugin<ISplashScreen> = {
     return {
       show: () => {
         const { commands, restored } = app;
-        const recovery = () => {
-          commands.execute(CommandIDs.recoverState)
-            .then(() => { document.location.reload(); })
-            .catch(() => { document.location.reload(); });
-        };
+        const recovery = () => { commands.execute(CommandIDs.reset); };
 
         return Private.showSplash(restored, recovery);
       }
@@ -267,11 +263,6 @@ const state: JupyterLabPlugin<IStateDB> = {
     const state = new StateDB({
       namespace: info.namespace,
       transform: transform.promise
-    });
-
-    commands.addCommand(CommandIDs.clearState, {
-      label: 'Clear Application Restore State',
-      execute: () => state.clear()
     });
 
     commands.addCommand(CommandIDs.recoverState, {
@@ -373,6 +364,14 @@ const state: JupyterLabPlugin<IStateDB> = {
       pattern: Patterns.loadState
     });
 
+    commands.addCommand(CommandIDs.reset, {
+      label: 'Reset Application State',
+      execute: () => {
+        commands.execute(CommandIDs.recoverState)
+          .then(() => { document.location.reload(); })
+          .catch(() => { document.location.reload(); });
+      }
+    });
 
     commands.addCommand(CommandIDs.resetOnLoad, {
       execute: (args: IRouter.ILocation) => {

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -376,7 +376,7 @@ const state: JupyterLabPlugin<IStateDB> = {
 
     commands.addCommand(CommandIDs.resetOnLoad, {
       execute: (args: IRouter.ILocation) => {
-        const { path, search } = args;
+        const { hash, path, search } = args;
         const query = URLExt.queryStringToObject(search || '');
         const reset = 'reset' in query;
 
@@ -397,7 +397,7 @@ const state: JupyterLabPlugin<IStateDB> = {
         // Maintain the query string parameters but remove `reset`.
         delete query['reset'];
 
-        const url = path + URLExt.objectToQueryString(query);
+        const url = path + URLExt.objectToQueryString(query) + hash;
         const cleared = commands.execute(CommandIDs.recoverState)
           .then(() => router.stop); // Stop routing before new route navigation.
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -448,7 +448,7 @@ namespace Private {
    */
   export
   function getWorkspace(router: IRouter): string {
-    const match = router.current().path.match(Patterns.loadState);
+    const match = router.current.path.match(Patterns.loadState);
 
     return match && decodeURIComponent(match[1]) || '';
   }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -69,10 +69,10 @@ namespace CommandIDs {
   const loadState = 'apputils:load-statedb';
 
   export
-  const resetOnLoad = 'apputils:reset-on-load';
+  const recoverState = 'apputils:recover-statedb';
 
   export
-  const recoverState = 'apputils:recover-statedb';
+  const resetOnLoad = 'apputils:reset-on-load';
 
   export
   const saveState = 'apputils:save-statedb';

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -83,7 +83,7 @@ namespace URLExt {
    * @returns an encoded url query.
    *
    * #### Notes
-   * From [stackoverflow](http://stackoverflow.com/a/30707423).
+   * Modified version of [stackoverflow](http://stackoverflow.com/a/30707423).
    */
   export
   function objectToQueryString(value: JSONObject): string {

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -87,9 +87,31 @@ namespace URLExt {
    */
   export
   function objectToQueryString(value: JSONObject): string {
-    return '?' + Object.keys(value).map(key =>
-      encodeURIComponent(key) + '=' + encodeURIComponent(String(value[key]))
-    ).join('&');
+    const keys = Object.keys(value);
+
+    if (!keys.length) {
+      return '';
+    }
+
+    return '?' + keys.map(key => {
+      const content = encodeURIComponent(String(value[key]));
+
+      return key + (content ? '=' + content : '');
+    }).join('&');
+  }
+
+  /**
+   * Return a parsed object that represents the values in a query string.
+   */
+  export
+  function queryStringToObject(value: string): JSONObject {
+    return value.replace(/^\?/, '').split('&').reduce((acc, val) => {
+      const [key, value] = val.split('=');
+
+      acc[key] = decodeURIComponent(value || '');
+
+      return acc;
+    }, { } as { [key: string]: string });
   }
 
   /**

--- a/packages/help-extension/src/index.ts
+++ b/packages/help-extension/src/index.ts
@@ -201,6 +201,7 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
   const resourcesGroup = RESOURCES
     .map(args => ({ args, command: CommandIDs.open }));
   helpMenu.addGroup(resourcesGroup, 10);
+  helpMenu.addGroup([{ command: 'apputils:reset' }], 20);
 
   // Generate a cache of the kernel help links.
   const kernelInfoCache = new Map<string, KernelMessage.IInfoReply>();
@@ -388,7 +389,7 @@ function activate(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette
   RESOURCES.forEach(args => {
     palette.addItem({ args, command: CommandIDs.open, category });
   });
-  palette.addItem({ command: 'apputils:clear-statedb', category });
+  palette.addItem({ command: 'apputils:reset', category });
   palette.addItem({ command: CommandIDs.launchClassic, category });
 
 }

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  Router
+} from '@jupyterlab/application';
+
+import {
+  CommandRegistry
+} from '@phosphor/commands';
+
+import {
+  Token
+} from '@phosphor/coreutils';
+
+
+const base = '/';
+
+
+describe('apputils', () => {
+
+  describe('Router', () => {
+
+    let commands: CommandRegistry;
+    let router: Router;
+
+    beforeEach(() => {
+      commands = new CommandRegistry();
+      router = new Router({ base, commands });
+    });
+
+    describe('#constructor()', () => {
+
+      it('should construct a new router', () => {
+        expect(router).to.be.a(Router);
+      });
+
+    });
+
+    describe('#base', () => {
+
+      it('should be the base URL of the application', () => {
+        expect(router.base).to.be(base);
+      });
+
+    });
+
+    describe('#commands', () => {
+
+      it('should be the command registry used by the router', () => {
+        expect(router.commands).to.be(commands);
+      });
+
+    });
+
+    describe('#stop', () => {
+
+      it('should be a unique token', () => {
+        expect(router.stop).to.be.a(Token);
+      });
+
+      it('should stop routing if returned by a routed command', done => {
+        const wanted = ['a', 'b'];
+        let recorded: string[] = [];
+
+        commands.addCommand('a', { execute: () => { recorded.push('a'); } });
+        commands.addCommand('b', { execute: () => { recorded.push('b'); } });
+        commands.addCommand('c', { execute: () => router.stop });
+        commands.addCommand('d', { execute: () => { recorded.push('d'); } });
+
+        router.register({ command: 'a', pattern: /.*/, rank: 10 });
+        router.register({ command: 'b', pattern: /.*/, rank: 20 });
+        router.register({ command: 'c', pattern: /.*/, rank: 30 });
+        router.register({ command: 'd', pattern: /.*/, rank: 40 });
+
+        router.route();
+
+        router.routed.connect(() => {
+          expect(recorded).to.eql(wanted);
+          done();
+        });
+      });
+
+    });
+
+  });
+
+});

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -77,12 +77,12 @@ describe('apputils', () => {
 
         commands.addCommand('a', { execute: () => { routed = true; } });
         router.register({ command: 'a', pattern: /.*/, rank: 10 });
-        router.route();
 
         router.routed.connect(() => {
           expect(routed).to.be(true);
           done();
         });
+        router.route();
       });
 
     });
@@ -107,12 +107,11 @@ describe('apputils', () => {
         router.register({ command: 'c', pattern: /.*/, rank: 30 });
         router.register({ command: 'd', pattern: /.*/, rank: 40 });
 
-        router.route();
-
         router.routed.connect(() => {
           expect(recorded).to.eql(wanted);
           done();
         });
+        router.route();
       });
 
     });
@@ -134,11 +133,12 @@ describe('apputils', () => {
 
         commands.addCommand('a', { execute: () => { recorded.push('a'); } });
         router.register({ command: 'a', pattern: /.*/ });
-        router.route();
+
         router.routed.connect(() => {
           expect(recorded).to.eql(wanted);
           done();
         });
+        router.route();
       });
 
     });
@@ -152,13 +152,16 @@ describe('apputils', () => {
         commands.addCommand('a', { execute: () => { recorded.push('a'); } });
         router.register({ command: 'a', pattern: /#a/, rank: 10 });
         expect(recorded).to.be.empty();
+
+        // Change the hash because changing location is a security error.
         window.location.hash = 'a';
-        router.route();
+
         router.routed.connect(() => {
           expect(recorded).to.eql(wanted);
           window.location.hash = '';
           done();
         });
+        router.route();
       });
 
     });

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -59,12 +59,13 @@ describe('apputils', () => {
 
       it('should return the current window location as an object', () => {
         // The karma test window location is a file called `context.html`
-        // without any query string parameters.
+        // without any query string parameters or hash.
         const path = 'context.html';
         const request = path;
         const search = '';
+        const hash = '';
 
-        expect(router.current).to.eql({ path, request, search });
+        expect(router.current).to.eql({ hash, path, request, search });
       });
 
     });
@@ -110,6 +111,52 @@ describe('apputils', () => {
 
         router.routed.connect(() => {
           expect(recorded).to.eql(wanted);
+          done();
+        });
+      });
+
+    });
+
+    describe('#navigate()', () => {
+
+      it('cannot be tested since changing location is a security risk', () => {
+        // Router#navigate() changes window.location.href but karma tests
+        // disallow changing the window location.
+      });
+
+    });
+
+    describe('#register()', () => {
+
+      it('should register a command with a route pattern', done => {
+        const wanted = ['a'];
+        let recorded: string[] = [];
+
+        commands.addCommand('a', { execute: () => { recorded.push('a'); } });
+        router.register({ command: 'a', pattern: /.*/ });
+        router.route();
+        router.routed.connect(() => {
+          expect(recorded).to.eql(wanted);
+          done();
+        });
+      });
+
+    });
+
+    describe('#route()', () => {
+
+      it('should route the location to a command', done => {
+        const wanted = ['a'];
+        let recorded: string[] = [];
+
+        commands.addCommand('a', { execute: () => { recorded.push('a'); } });
+        router.register({ command: 'a', pattern: /#a/, rank: 10 });
+        expect(recorded).to.be.empty();
+        window.location.hash = 'a';
+        router.route();
+        router.routed.connect(() => {
+          expect(recorded).to.eql(wanted);
+          window.location.hash = '';
           done();
         });
       });

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -55,6 +55,37 @@ describe('apputils', () => {
 
     });
 
+    describe('#current', () => {
+
+      it('should return the current window location as an object', () => {
+        // The karma test window location is a file called `context.html`
+        // without any query string parameters.
+        const path = 'context.html';
+        const request = path;
+        const search = '';
+
+        expect(router.current).to.eql({ path, request, search });
+      });
+
+    });
+
+    describe('#routed', () => {
+
+      it('should emit a signal when a path is routed', done => {
+        let routed = false;
+
+        commands.addCommand('a', { execute: () => { routed = true; } });
+        router.register({ command: 'a', pattern: /.*/, rank: 10 });
+        router.route();
+
+        router.routed.connect(() => {
+          expect(routed).to.be(true);
+          done();
+        });
+      });
+
+    });
+
     describe('#stop', () => {
 
       it('should be a unique token', () => {


### PR DESCRIPTION
When the query string parameter `?reset` is added to a lab URL (*e.g.*, `/lab?reset` or `/lab/workspaces/foo?reset` or `/lab?one=two&reset`), the state database and workspace (if any) are cleared.

This PR also creates a command for the user to reset the application state and reload the page.
*cf.*, https://github.com/jupyterlab/jupyterlab/issues/3700 (cc: @gnestor)

<img width="375" alt="reset application state" src="https://user-images.githubusercontent.com/159529/36348627-daab8206-146b-11e8-8fce-af6a4e11a09d.png">


NB: The workspace saving interval has been shortened to 1.5 seconds.

This PR is dependent on: https://github.com/jupyterlab/jupyterlab_launcher/pull/38

*cf.*, https://github.com/jupyterlab/jupyterlab_launcher/pull/40