### PR TITLE
Only keep completer type annotations if they are not null.

### DIFF
--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -494,7 +494,7 @@ namespace Private {
   function findOrderedTypes(typeMap: Completer.TypeMap): string[] {
     const filtered = Object.keys(typeMap)
       .map(key => typeMap[key])
-      .filter(value => !(value in KNOWN_MAP))
+      .filter(value => value && !(value in KNOWN_MAP))
       .sort((a, b) => a.localeCompare(b));
 
     return KNOWN_TYPES.concat(filtered);


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/3678