### PR TITLE
Added save functionality to CodeMirror

### DIFF
--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -36,7 +36,8 @@
     "@jupyterlab/coreutils": "^1.0.3",
     "@jupyterlab/fileeditor": "^0.15.1",
     "@jupyterlab/mainmenu": "^0.4.1",
-    "@phosphor/widgets": "^1.5.0"
+    "@phosphor/widgets": "^1.5.0",
+    "codemirror": "~5.24.2"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import * as CodeMirror from 'codemirror';
+
 import {
   Menu
 } from '@phosphor/widgets';
@@ -294,4 +296,9 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
       editor.execCommand('replace');
     }
   } as IEditMenu.IFindReplacer<FileEditor>);
+
+  // Add save functionality to CodeMirror
+  CodeMirror.prototype.save = () => {
+    commands.execute('docmanager:save');
+  }
 }

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -100,7 +100,7 @@ const id = commands.id;
 function activateEditorServices(app: JupyterLab): IEditorServices {
   CodeMirror.prototype.save = () => {
     app.commands.execute('docmanager:save');
-  }
+  };
   return editorServices;
 }
 

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import * as CodeMirror from 'codemirror';
+import * as CodeMirror
+  from 'codemirror';
 
 import {
   Menu
@@ -59,8 +60,9 @@ namespace CommandIDs {
 const services: JupyterLabPlugin<IEditorServices> = {
   id: '@jupyterlab/codemirror-extension:services',
   provides: IEditorServices,
-  activate: (): IEditorServices => editorServices
+  activate: activateEditorServices
 };
+
 
 
 /**
@@ -90,6 +92,18 @@ export default plugins;
  * The plugin ID used as the key in the setting registry.
  */
 const id = commands.id;
+
+
+/**
+ * Set up the editor services.
+ */
+function activateEditorServices(app: JupyterLab): IEditorServices {
+  CodeMirror.prototype.save = () => {
+    app.commands.execute('docmanager:save');
+  }
+  return editorServices;
+}
+
 
 /**
  * Set up the editor widget menu and commands.
@@ -296,9 +310,4 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
       editor.execCommand('replace');
     }
   } as IEditMenu.IFindReplacer<FileEditor>);
-
-  // Add save functionality to CodeMirror
-  CodeMirror.prototype.save = () => {
-    commands.execute('docmanager:save');
-  }
 }


### PR DESCRIPTION
This is a replica of an accidentally deleted pull request (https://github.com/jupyterlab/jupyterlab/pull/3666).

It addresses issue #3239.

The changes add save functionality to CodeMirror to allow the vim binding `:w` to save files in the text editor.