### PR TITLE
Catch error if there is an invalid state for instancetracker restoration

### DIFF
--- a/packages/apputils/src/instancetracker.ts
+++ b/packages/apputils/src/instancetracker.ts
@@ -316,7 +316,10 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
     return Promise.all(promises).then(([saved]) => {
       return Promise.all(saved.map(item => {
         const { id, value } = item;
-        const args = (value as any).data;
+        const args = value && (value as any).data;
+        if (args === undefined) {
+          return state.remove(item.id);
+        }
 
         // Execute the command and if it fails, delete the state restore data.
         return registry.execute(command, args).catch(() => state.remove(id));


### PR DESCRIPTION
Ran into this today with an invalid `IStateDB`. If `item.value` does not exist, this fails, and the application restoration hangs.

I don't know what the sequence of events are to get such a broken state, but I clearly got there, so we should handle it. One can reproduce it for testing purposes by nulling out the `value` field in `localStorage` for one of the open widgets.

cc @afshin 