### PR TITLE
Clarify the scrollToPosition parameters and update scrolling behavior

### DIFF
--- a/packages/notebook/src/actions.ts
+++ b/packages/notebook/src/actions.ts
@@ -1218,7 +1218,7 @@ namespace Private {
     if (scroll) {
       // Scroll to the top of the previous active cell output.
       let er = state.activeCell.inputArea.node.getBoundingClientRect();
-      widget.scrollToPosition(er.bottom);
+      widget.scrollToPosition(er.bottom, 45);
     }
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1079,12 +1079,19 @@ class Notebook extends StaticNotebook {
   }
 
   /**
-   * Scroll so that the given position is visible.
+   * Scroll so that the given position is centered.
    *
    * @param position - The vertical position in the notebook widget.
    *
-   * @param threshold - An optional threshold for the scroll.  Defaults to 25
-   *   percent of the widget height.
+   * @param threshold - An optional threshold for the scroll (0-50, defaults to
+   * 25).
+   *
+   * #### Notes
+   * If the position is within the threshold percentage of the widget height,
+   * measured from the center of the widget, the scroll position will not be
+   * changed. A threshold of 0 means we will always scroll so the position is
+   * centered, and a threshold of 50 means scrolling only happens if position is
+   * outside the current window.
    */
   scrollToPosition(position: number, threshold=25): void {
     let node = this.node;


### PR DESCRIPTION
The delta is calculated as the position from the node’s center position, so a threshold of 50 means scroll if you’re outside of 50% either side of the center, i.e., if you're outside of the window.

Also adjust the scrolling after running to only happen if the output was within 5% of the top or bottom, instead of 25%.

Addresses #3682