### PR TITLE
Documentation updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,6 @@ jlpm install
 jlpm run build  # Build the dev mode assets (optional)
 jlpm run build:core  # Build the core mode assets (optional)
 jupyter lab build  # Build the app dir assets (optional)
-jupyter serverextension enable --py jupyterlab  # (optional)
 ```
 
 Notes:
@@ -101,7 +100,11 @@ jupyterlab_launcher` to get the latest version.
   Typescript code when debugging. However, it takes a bit longer to build the sources, so is used only to build for production
   by default.
 
-```
+If you are using a version of Jupyter Notebook earlier than 5.3, then
+you must also run the following command to enable the JupyterLab
+server extension:
+
+```bash
 jupyter serverextension enable --py --sys-prefix jupyterlab
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ If you use ``pip``, you can install it as:
 
 ```bash
 pip install jupyterlab
+```
+
+For all methods of installation, if you are using a version of Jupyter Notebook earlier than 5.3, then you must also run the following command
+after installation to enable the JupyterLab server extension:
+
+```bash
 jupyter serverextension enable --py jupyterlab --sys-prefix
 ```
 
@@ -58,7 +64,6 @@ JupyterLab can be installed from a git checkout using `pip`.  Example:
 
 ```bash
 pip install git+git://github.com/jupyterlab/jupyterlab.git
-jupyter serverextension enable --py jupyterlab --sys-prefix
 ```
 
 If you use ``pipenv``, you can install it as:
@@ -66,7 +71,6 @@ If you use ``pipenv``, you can install it as:
 ```bash
 pipenv install jupyterlab
 pipenv shell
-jupyter serverextension enable --py jupyterlab --sys-prefix
 ```
 
 or from a git checkout:
@@ -74,7 +78,6 @@ or from a git checkout:
 ```bash
 pipenv install git+git://github.com/jupyterlab/jupyterlab.git#egg=jupyterlab
 pipenv shell
-jupyter serverextension enable --py jupyterlab --sys-prefix
 ```
 
 When using ``pipenv``, in order to launch `jupyter lab`, you must activate the project's virtualenv. For example, in the directory where ``pipenv``'s `Pipfile` and `Pipfile.lock` live (i.e., where you ran the above commands):

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you use ``pip``, you can install it as:
 pip install jupyterlab
 ```
 
-For all methods of installation, if you are using a version of Jupyter Notebook earlier than 5.3, then you must also run the following command
+Note: For all methods of installation, if you are using a version of Jupyter Notebook earlier than 5.3, then you must also run the following command
 after installation to enable the JupyterLab server extension:
 
 ```bash

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -16,6 +16,13 @@ If you use ``pip``, you can install it with:
 .. code:: bash
 
     pip install jupyterlab
+
+If you are using a version of Jupyter Notebook earlier than 5.3, then
+you must also run the following command to enable the JupyterLab
+server extension:
+
+.. code:: bash
+
     jupyter serverextension enable --py jupyterlab --sys-prefix
 
 Prerequisites

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -119,8 +119,8 @@ JupyterLab Build Process
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 To rebuild the app directory, run ``jupyter lab build``. By default the
-``jupyter lab install`` command builds the application, so you typically
-do not need to call ``build`` directly.
+``jupyter labextension install`` command builds the application, so you
+typically do not need to call ``build`` directly.
 
 Building consists of:
 

--- a/docs/source/user/terminal.rst
+++ b/docs/source/user/terminal.rst
@@ -4,7 +4,7 @@ Terminals
 ---------
 
 JupyterLab terminals provide full support for system shells (bash, tsch,
-etc.) on Mac/Linux and command.exe on Windows. You can run anything in
+etc.) on Mac/Linux and PowerShell on Windows. You can run anything in
 your system shell with a terminal, including programs such as vim or
 emacs. The terminals run on the system where the Jupyter server is
 running, with the privileges of your user. Thus, if JupyterLab is


### PR DESCRIPTION
Adds a note about `serverextension enable` only being needed in Notebook < 5.3 and a bit of cleanup, based on a pass of the user docs.