### PR TITLE
If document is not defined or if the document body is unavailable (w…

### DIFF
--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -174,7 +174,7 @@ namespace Private {
    */
   export
   function getBodyData(key: string): string {
-    if (typeof document === 'undefined') {
+    if (typeof document === 'undefined' || !document.body) {
       return '';
     }
     let val = document.body.dataset[key];


### PR DESCRIPTION
If document is not defined or if the document body is unavailable (when the page loads a script in a head tag, for example), bail.

Fixes https://github.com/jupyterlab/jupyterlab/issues/3716