### PR TITLE
enable dragging multiple selected files within & out of filebrowser

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -26,7 +26,7 @@ import {
 } from '@phosphor/algorithm';
 
 import {
-  MimeData
+  MimeData, PromiseDelegate
 } from '@phosphor/coreutils';
 
 import {
@@ -1153,6 +1153,7 @@ class DirListing extends Widget {
     }));
     this._drag.mimeData.setData(CONTENTS_MIME, paths);
     if (item && item.type !== 'directory') {
+      const otherPaths = paths.slice(1).reverse();
       this._drag.mimeData.setData(FACTORY_MIME, () => {
         if (!item) {
           return;
@@ -1161,6 +1162,21 @@ class DirListing extends Widget {
         let widget = this._manager.findWidget(path);
         if (!widget) {
           widget = this._manager.open(item.path);
+        }
+        if (otherPaths.length) {
+          const firstWidgetPlaced = new PromiseDelegate<void>();
+          firstWidgetPlaced.promise.then(() => {
+            let prevWidget = widget;
+            otherPaths.forEach(path => {
+              const options: DocumentRegistry.IOpenOptions = {
+                ref: prevWidget.id,
+                mode: 'tab-after'
+              };
+              prevWidget = this._manager.openOrReveal(path, void 0, void 0, options);
+              this._manager.openOrReveal(item.path);
+            });
+          });
+          firstWidgetPlaced.resolve(void 0);
         }
         return widget;
       });

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1127,7 +1127,7 @@ class DirListing extends Widget {
     if (!source.classList.contains(SELECTED_CLASS)) {
       item = items[index];
       selectedNames = [item.name];
-    } else if (selectedNames.length === 1) {
+    } else {
       let name = selectedNames[0];
       item = find(items, value => value.name === name);
     }


### PR DESCRIPTION
Noticed that multi-select did not work for moving files around inside the file browser… it just appeared that the selection did not have an effect. 

@ian-r-rose and I sat down to figure out why.

This PR removes condition that resulted in aborting attempts to start drags with multiple files.

It seems like the functionality was intended to be present at some point, so we weren't sure if this had existed and was deprecated. Most of the operations other than dragging a file into the main area were already operating on an array and not specifically on a single item (e.g., an array of paths). 

Edit: we now handle opening multiple files, which gets around the expectation that a drop target has a single widget. We use a promise delegate and immediately resolve to put the open commands for the other files on the async stack so that they only trigger after the original drop event is resolved. 

<details>
<summary> An somewhat unaddressed issue: relocating multiple files via drag to main area</summary>
Because the DockPanel expects to receive a single widget, we couldn't implement a way to move multiple files to the drop location. The current promise delegate solution is fragile (it relies on no async work messing with the layout in between when the first widget is placed and when the others can be placed.

**NB**: the openOrReveal command does not appear to successfully move files according to their layout options if those files are already open . 
</details>