### PR TITLE
Make the output clone a simplified output widget without prompts.

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -40,7 +40,7 @@ import {
 } from '@jupyterlab/observables';
 
 import {
-  OutputArea, IOutputPrompt, OutputPrompt, IStdin, Stdin
+  OutputArea, SimplifiedOutputArea, IOutputPrompt, OutputPrompt, IStdin, Stdin
 } from '@jupyterlab/outputarea';
 
 import {
@@ -656,10 +656,10 @@ class CodeCell extends Cell {
   }
 
   /**
-   * Clone the OutputArea alone, using the same model.
+   * Clone the OutputArea alone, returning a simplified output area, using the same model.
    */
   cloneOutputArea(): OutputArea {
-    return new OutputArea({
+    return new SimplifiedOutputArea({
       model: this.model.outputs,
       contentFactory: this.contentFactory,
       rendermime: this._rendermime,

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -205,7 +205,7 @@ class OutputArea extends Widget {
     // Handle stdin.
     value.onStdin = msg => {
       if (KernelMessage.isInputRequestMsg(msg)) {
-        this._onInputRequest(msg, value);
+        this.onInputRequest(msg, value);
       }
     };
   }
@@ -291,7 +291,7 @@ class OutputArea extends Widget {
   /**
    * Handle an input request from a kernel.
    */
-  private _onInputRequest(msg: KernelMessage.IInputRequestMsg, future: Kernel.IFuture): void {
+  protected onInputRequest(msg: KernelMessage.IInputRequestMsg, future: Kernel.IFuture): void {
     // Add an output widget to the end.
     let factory = this.contentFactory;
     let stdinPrompt = msg.content.prompt;
@@ -326,7 +326,7 @@ class OutputArea extends Widget {
    * Render and insert a single output into the layout.
    */
   private _insertOutput(index: number, model: IOutputModel): void {
-    let output = this._createOutputItem(model);
+    let output = this.createOutputItem(model);
     output.toggleClass(EXECUTE_CLASS, model.executionCount !== null);
     let layout = this.layout as PanelLayout;
     layout.insertWidget(index, output);
@@ -354,7 +354,7 @@ class OutputArea extends Widget {
   /**
    * Create an output item with a prompt and actual output
    */
-  private _createOutputItem(model: IOutputModel): Widget {
+  protected createOutputItem(model: IOutputModel): Widget {
     let panel = new Panel();
     panel.addClass(OUTPUT_AREA_ITEM_CLASS);
 
@@ -363,6 +363,18 @@ class OutputArea extends Widget {
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
 
+    let output = this.createRenderedMimetype(model);
+    output.addClass(OUTPUT_AREA_OUTPUT_CLASS);
+    panel.addWidget(output);
+
+    return panel;
+  }
+
+  /**
+   * Render a mimetype
+   */
+  protected createRenderedMimetype(model: IOutputModel): Widget {
+    let widget: Widget;
     let mimeType = this.rendermime.preferredMimeType(
       model.data, !model.trusted
     );
@@ -383,11 +395,11 @@ class OutputArea extends Widget {
         output = new Private.IsolatedRenderer(output);
       }
       output.renderModel(model);
-      output.addClass(OUTPUT_AREA_OUTPUT_CLASS);
-      panel.addWidget(output);
+      widget = output;
+    } else {
+      widget = new Widget();
     }
-
-    return panel;
+    return widget;
   }
 
   /**
@@ -463,6 +475,25 @@ class OutputArea extends Widget {
   private _minHeightTimeout: number = null;
   private _future: Kernel.IFuture = null;
   private _displayIdMap = new Map<string, number[]>();
+}
+
+export
+class SimplifiedOutputArea extends OutputArea {
+  /**
+   * Handle an input request from a kernel by doing nothing.
+   */
+  protected onInputRequest(msg: KernelMessage.IInputRequestMsg, future: Kernel.IFuture): void {
+    return;
+  }
+
+  /**
+   * Create an output item without a prompt, just the output widgets
+   */
+  protected createOutputItem(model: IOutputModel): Widget {
+    let output = this.createRenderedMimetype(model);
+    output.addClass(OUTPUT_AREA_OUTPUT_CLASS);
+    return output;
+  }
 }
 
 

--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -20,6 +20,8 @@
 
 .jp-OutputArea {
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 
@@ -54,8 +56,6 @@
 
 
 .jp-OutputArea-output {
-  flex-grow: 1;
-  flex-shrink: 1;
   height: auto;
   overflow-x: auto;
   user-select: text;


### PR DESCRIPTION
When cloning an output area, we don’t want to handle input events because we want only one source for the input.

Also, we wanted to simplify the output area DOM structure so that individual rendered outputs could set themselves to grow (using flexbox), measure themselves after growing, so they could resize themselves to possibly take up the entire area. For example, we might have an ipywidget that wants to grow when in a separate tab, so it can listen to a resize event, set a flex-grow attribute, and measure the size to relayout.

CC @astrofrog @blink1073 