### PR TITLE
Add Slides to the slides exportation label and correct reveal.js name

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -272,7 +272,7 @@ const EXPORT_TO_FORMATS = [
   { 'format': 'pdf', 'label': 'PDF' },
   { 'format': 'rst', 'label': 'ReStructured Text' },
   { 'format': 'script', 'label': 'Executable Script' },
-  { 'format': 'slides', 'label': 'Reveal JS' }
+  { 'format': 'slides', 'label': 'Reveal.js Slides' }
 ];
 
 


### PR DESCRIPTION
Hey folks, just a minor thing I realized the other day...

We can not expect that everyone knows the relationship between the "Reveal JS" label and the HTML slides. In fact, reveal.js is a kind of implementation detail for the static slides produced by nbconvert. This is why I am proposing to make a tiny change here adding the `Slides` word after the corrected name of the framework (it is Reveal.js, not Reveal JS).