### PR TITLE
Add more loaders to the webpack config

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -113,6 +113,9 @@ module.exports = {
   },
   module: {
     rules: [
+      { test: /^JUPYTERLAB_RAW_LOADER_/, use: 'raw-loader' },
+      { test: /^JUPYTERLAB_URL_LOADER_/, use: 'url-loader?limit=10000' },
+      { test: /^JUPYTERLAB_FILE_LOADER_/, use: 'file-loader' },
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
       { test: /\.json$/, use: 'json-loader' },
       { test: /\.md$/, use: 'raw-loader' },

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -116,6 +116,7 @@ module.exports = {
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
       { test: /\.json$/, use: 'json-loader' },
       { test: /\.md$/, use: 'raw-loader' },
+      { test: /\.txt$/, use: 'raw-loader' },
       { test: /\.js$/, use: ['source-map-loader'], enforce: 'pre',
         // eslint-disable-next-line no-undef
         exclude: path.join(process.cwd(), 'node_modules')

--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -113,6 +113,9 @@ module.exports = {
   },
   module: {
     rules: [
+      { test: /^JUPYTERLAB_RAW_LOADER_/, use: 'raw-loader' },
+      { test: /^JUPYTERLAB_URL_LOADER_/, use: 'url-loader?limit=10000' },
+      { test: /^JUPYTERLAB_FILE_LOADER_/, use: 'file-loader' },
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
       { test: /\.json$/, use: 'json-loader' },
       { test: /\.md$/, use: 'raw-loader' },

--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -116,6 +116,7 @@ module.exports = {
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
       { test: /\.json$/, use: 'json-loader' },
       { test: /\.md$/, use: 'raw-loader' },
+      { test: /\.txt$/, use: 'raw-loader' },
       { test: /\.js$/, use: ['source-map-loader'], enforce: 'pre',
         // eslint-disable-next-line no-undef
         exclude: path.join(process.cwd(), 'node_modules')


### PR DESCRIPTION
This adds the ability to load `.txt` files inline. 

It also adds an escape hatch of sorts to use the webpack raw, file, and url loaders by prefixing a filename with `JUPYTERLAB_{RAW|FILE|URL}_LOADER_`, e.g., `require('JUPYTERLAB_RAW_LOADER_myfile.myext')` returns the string content of the file. Of course, since this is adding a webpack-specific feature for extensions, it is up for discussion. There have been cases recently where people have wanted to load custom resources that did not have the same filename extensions as what we provided. 

One way to accomplish the loading is to use webpack loaders with the syntax `require('file-loader!myfile.myext')`, but this doesn't work in Typescript because ts doesn't understand the loader syntax. Also note that Rollup has a corresponding concept for the url and raw loaders, so there's precedence that this is a cross-bundler concept.
