### PR TITLE
taking out the dash in "key map"

### DIFF
--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -30,7 +30,7 @@ kernel as rich output. See :ref:`file-and-output-formats` for more
 information.
 
 To navigate the user interface, JupyterLab offers :ref:`customizable keyboard shortcuts <shortcuts>`
-and the ability to use key-maps from vim, emacs, and Sublime Text.
+and the ability to use key maps from vim, emacs, and Sublime Text.
 
 JupyterLab is served from the same
 `server <https://jupyter-notebook.readthedocs.io/en/stable/>`__ and uses


### PR DESCRIPTION
I realize we could use a dash here, and probably should, but we don't in the UI for now