### PR TITLE
Make the filebrowser toolbar css more specific than the generic toolbar css

### DIFF
--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -31,7 +31,7 @@
 }
 
 
-.jp-FileBrowser-toolbar {
+.jp-FileBrowser-toolbar.jp-Toolbar {
   border-bottom: none;
   height: auto;
   margin: var(--jp-toolbar-header-margin);
@@ -65,7 +65,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.jp-FileBrowser-toolbar > .jp-Toolbar-button {
+.jp-FileBrowser-toolbar.jp-Toolbar > .jp-Toolbar-button {
   flex: 1 1 auto;
   height: var(--jp-private-filebrowser-button-height);
   line-height: var(--jp-private-filebrowser-button-height);
@@ -76,7 +76,7 @@
 }
 
 
-.jp-FileBrowser-toolbar > .jp-Toolbar-button:focus {
+.jp-FileBrowser-toolbar.jp-Toolbar > .jp-Toolbar-button:focus {
   box-shadow: var(--jp-toolbar-box-shadow);
   border-color: var(--jp-toolbar-border-color);
 }


### PR DESCRIPTION
I’ve seen at least one situation (when we installed the experimental drawio plugin) where the generic toolbar css was applied after the filebrowser toolbar css, so the filebrowser toolbar buttons were not spaced out.