### PR TITLE
Fix handling of kernel change

### DIFF
--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -281,10 +281,8 @@ class DefaultSession implements Session.ISession {
       return Promise.reject(new Error('Session is disposed'));
     }
     let data = JSON.stringify({ kernel: options });
-    if (this._kernel) {
-      this._kernel.dispose();
-      this._statusChanged.emit('restarting');
-    }
+    this._kernel.dispose();
+    this._statusChanged.emit('restarting');
     return this._patch(data).then(() => this.kernel);
   }
 

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -282,10 +282,8 @@ class DefaultSession implements Session.ISession {
     }
     let data = JSON.stringify({ kernel: options });
     if (this._kernel) {
-      return this._kernel.ready.then(() => {
-        this._kernel.dispose();
-        return this._patch(data);
-      }).then(() => this.kernel);
+      this._kernel.dispose();
+      this._statusChanged.emit('restarting');
     }
     return this._patch(data).then(() => this.kernel);
   }

--- a/packages/services/test/src/session/manager.spec.ts
+++ b/packages/services/test/src/session/manager.spec.ts
@@ -131,8 +131,9 @@ describe('session/manager', () => {
         handleRequest(manager, 200, specs);
         manager.specsChanged.connect((sender, args) => {
           expect(sender).to.be(manager);
-          expect(args.default).to.be(specs.default);
-          done();
+          if (args.default === specs.default) {
+            done();
+          }
         });
         manager.refreshSpecs();
       });
@@ -185,6 +186,8 @@ describe('session/manager', () => {
           called = true;
         });
         return session.changeKernel({ name: session.kernel.name }).then(() => {
+          return manager.refreshRunning();
+        }).then(() => {
           expect(called).to.be(true);
         });
       });
@@ -286,8 +289,9 @@ describe('session/manager', () => {
         let called = false;
         return startNew(manager).then(s => {
           manager.runningChanged.connect((sender, args) => {
-            expect(s.isDisposed).to.be(true);
-            called = true;
+            if (s.isDisposed) {
+              called = true;
+            }
           });
           return manager.shutdown(s.id);
         }).then(() => {

--- a/packages/services/test/src/terminal/terminal.spec.ts
+++ b/packages/services/test/src/terminal/terminal.spec.ts
@@ -8,6 +8,10 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
+  Signal
+} from '@phosphor/signaling';
+
+import {
   TerminalSession
 } from '../../../lib/terminal';
 
@@ -120,14 +124,16 @@ describe('terminal', () => {
     describe('#messageReceived', () => {
 
       it('should be emitted when a message is received', (done) => {
+        const object = {};
         TerminalSession.startNew().then(s => {
           session = s;
           session.messageReceived.connect((sender, msg) => {
             expect(sender).to.be(session);
             if (msg.type === 'stdout') {
+              Signal.disconnectReceiver(object);
               done();
             }
-          });
+          }, object);
         }).catch(done);
       });
 


### PR DESCRIPTION
Fixes a bug seen at the Jupyter Widgets Workshop where if a kernel failed to start then you could never switch to a different kernel.  The offending kernel was my local Octave kernel, because I had not yet properly set up the path to they Octave executable on my machine.