### PR TITLE
Fix typo: CVS should be CSV

### DIFF
--- a/packages/faq-extension/faq.md
+++ b/packages/faq-extension/faq.md
@@ -28,7 +28,7 @@ interactive computing with data.
 In addition to the Jupyter Notebook, JupyterLab offers multiple models of
 interactive computing, including a scratchpad-like Code Console and the
 ability to attach kernels to any text file. JupyterLab has
-built-in support for many common file and output formats (CVS, PDF, Vega,
+built-in support for many common file and output formats (CSV, PDF, Vega,
 Vega-Lite, Markdown, JSON, VDOM, PNG, JPEG, HTML, etc.).
 
 The codebase and user-interface of JupyterLab is based on a flexible extension


### PR DESCRIPTION
Yes, minor change, I know - but it caught my eye 😄 