### PR TITLE
Completer bug fix: magics were not showing up

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -272,7 +272,7 @@ class CompletionHandler implements IDisposable {
     }
 
     // If the part of the line before the cursor is white space, return.
-    if (line.slice(0, position.column).match(/^\W*$/)) {
+    if (line.slice(0, position.column).match(/^\s*$/)) {
       this._enabled = false;
       model.reset(true);
       host.classList.remove(COMPLETER_ENABLED_CLASS);


### PR DESCRIPTION
If the part of the line before the cursor is white space, disable completion in an editor. Otherwise, enabled it. The regular expression here was incorrect.

Fixes https://github.com/jupyterlab/jupyterlab/issues/3725