### PR TITLE
Fix documentation domain to jupyterlab.readthedocs.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ The JupyterLab application is made up of two major parts:
 - an npm package
 - a Jupyter server extension (Python package)
 
-Each part is named `jupyterlab`. The [developer tutorial documentation](https://jupyterlab-tutorial.readthedocs.io/en/latest/index.html)
+Each part is named `jupyterlab`. The [developer tutorial documentation](https://jupyterlab.readthedocs.io/en/latest/index.html)
 provides additional architecture information.
 
 ## The NPM Packages
@@ -316,7 +316,7 @@ run `jupyter lab --core-mode`.  This is the core application that will
 be shipped.
 
 - If working with extensions, see the extension documentation on
-https://jupyterlab-tutorial.readthedocs.io/en/latest/index.html.
+https://jupyterlab.readthedocs.io/en/latest/index.html.
 
 - The npm modules are fully compatible with Node/Babel/ES6/ES5. Simply
 omit the type declarations when using a language other than TypeScript.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ A tool like [postcss](http://postcss.org/) can be used to convert the CSS files 
 
 ## Documentation
 
-Read our documentation on [ReadTheDocs](http://jupyterlab-tutorial.readthedocs.io/en/latest/).
+Read our documentation on [ReadTheDocs](http://jupyterlab.readthedocs.io/en/latest/).
 
 ----
 
@@ -143,7 +143,7 @@ JupyterLab follows the official [Jupyter Code of Conduct](https://github.com/jup
 
 JupyterLab can be extended using extensions that are [npm](https://www.npmjs.com/) packages
 and use our public APIs. See our documentation
-for [users](https://jupyterlab-tutorial.readthedocs.io/en/latest/user/extensions.html) and [developers](https://jupyterlab-tutorial.readthedocs.io/en/latest/developer/extension_dev.html).
+for [users](https://jupyterlab.readthedocs.io/en/latest/user/extensions.html) and [developers](https://jupyterlab.readthedocs.io/en/latest/developer/extension_dev.html).
 
 ### License
 
@@ -185,7 +185,7 @@ and you may participate in development discussions or get live help on [Gitter](
 ## Resources
 
 - [Reporting Issues](https://github.com/jupyterlab/jupyterlab/issues)
-- [Architecture tutorial](https://jupyterlab-tutorial.readthedocs.io/en/latest/index.html)
+- [Architecture tutorial](https://jupyterlab.readthedocs.io/en/latest/index.html)
 - [API Docs](http://jupyterlab.github.io/jupyterlab/)
 - [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
 - [Project Jupyter website](https://jupyter.org)


### PR DESCRIPTION
Closes #2956 once and for all, as I've also deactivated
jupyterlab-tutorial.readthedocs.io which now will return 404.