### PR TITLE
Docs tweaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Eventually, JupyterLab will replace the classic Jupyter Notebook.
 
 **JupyterLab is currently in beta.** The beta releases are suitable for general
 usage. For JupyterLab extension developers, the extension APIs will continue to
-change and iterate until the 1.0 release.
+evolve until the 1.0 release.
 
 For a good overview of JupyterLab, please see [this link](https://channel9.msdn.com/Events/PyData/Seattle2017/BRK11) to a recent talk we gave about JupyterLab at PyData Seattle (2017).
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@
 An extensible environment for interactive and reproducible computing, based on the
 Jupyter Notebook and Architecture.
 
-JupyterLab is the next generation user interface for Project Jupyter. It offers all the
-familiar building blocks of the classic Jupyter Notebook (notebook, terminal, text editor,
-file browser, rich outputs, etc.) in a flexible and powerful user inteface that can be
-extended through third party extensions that access our public APIs. Eventually, JupyterLab
-will replace the classic Jupyter Notebook.
+JupyterLab is the next-generation user interface for Project Jupyter. It offers
+all the familiar building blocks of the classic Jupyter Notebook (notebook,
+terminal, text editor, file browser, rich outputs, etc.) in a flexible and
+powerful user inteface that can be extended through third party extensions.
+Eventually, JupyterLab will replace the classic Jupyter Notebook.
 
-**JupyterLab is approaching its beta release in 2018. During our pre-beta series of releases, we encourage users and developers to try out JupyterLab and give us feedback.
-For users, the upcoming beta will be suitable for general usage.  For developers, our
-APIs will continue to change significantly up until the 1.0 release.**
+**JupyterLab is currently in beta.** The beta releases are suitable for general
+usage. For JupyterLab extension developers, the extension APIs will continue to
+change and iterate until the 1.0 release.
 
 For a good overview of JupyterLab, please see [this link](https://channel9.msdn.com/Events/PyData/Seattle2017/BRK11) to a recent talk we gave about JupyterLab at PyData Seattle (2017).
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ JupyterLab is the next-generation user interface for Project Jupyter. It offers
 all the familiar building blocks of the classic Jupyter Notebook (notebook,
 terminal, text editor, file browser, rich outputs, etc.) in a flexible and
 powerful user inteface that can be extended through third party extensions.
-Eventually, JupyterLab will replace the classic Jupyter Notebook.
+Eventually, JupyterLab will replace the classic Jupyter Notebook after
+JupyterLab reaches 1.0.
 
 **JupyterLab is currently in beta.** The beta releases are suitable for general
 usage. For JupyterLab extension developers, the extension APIs will continue to

--- a/docs/source/developer/css.rst
+++ b/docs/source/developer/css.rst
@@ -16,7 +16,7 @@ CSS checklist
 -  The JupyterLab default CSS variables in the ``theme-light-extension``
    and ``theme-dark-extension`` packages are used to style packages
    where ever possible. Individual packages should not npm-depend on
-   these packages though, to allow the theme to be swapped out.
+   these packages though, to enable the theme to be swapped out.
 -  Additional public/private CSS variables are defined by plugins
    sparingly and in accordance with the conventions described below.
 
@@ -147,7 +147,7 @@ CSS class name that gives a semantic naming of the component, such as:
 In general, the parent ``MyWidget`` should add these classes to the
 children. This applies when the children are plain DOM nodes or
 ``Widget`` instances/subclasses themselves. Thus, the general naming of
-CSS classes is of the form ``jp-WidgetName-semanticChild``. This allows
+CSS classes is of the form ``jp-WidgetName-semanticChild``. This enables
 the styling of these children in a manner that is independent of the
 children implementation or CSS classes they have themselves.
 

--- a/docs/source/developer/documentation.rst
+++ b/docs/source/developer/documentation.rst
@@ -53,7 +53,7 @@ Element Names
   more specific name, such as “File browser.” Tab bars have tabs which toggle
   panels.
 - The menu bar contains menu items, which have their own submenus.
-- The main work area can be referred to as work area when the name is unambiguous.
+- The main work area can be referred to as the work area when the name is unambiguous.
 - When describing elements in the UI, colloquial names are preferred
   (e.g., “File browser” instead of “Files panel”).
   

--- a/docs/source/developer/documents.rst
+++ b/docs/source/developer/documents.rst
@@ -59,7 +59,7 @@ fetch the model (e.g. text, base64, notebook).
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Adds additional functionality to a widget type. An extension instance is
-created for each widget instance, allowing the extension to add
+created for each widget instance, enabling the extension to add
 functionality to each widget or observe the widget and/or its context.
 
 *Examples*

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -83,7 +83,7 @@ application consists of:
 
 -  A top area for things like top level menus and toolbars
 -  Left and right side bar areas for collapsible content
--  A main area for user activity.
+-  A main work area for user activity.
 -  A bottom area for things like status bars
 
 Phosphor

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -97,9 +97,9 @@ as patterns and objects for writing clean, well-abstracted code. The
 widgets in the application are primarily **Phosphor widgets**, and
 Phosphor concepts, like message passing and signals, are used
 throughout. **Phosphor messages** are a *many-to-one* interaction that
-allows information like resize events to flow through the widget
+enables information like resize events to flow through the widget
 hierarchy in the application. **Phosphor signals** are a *one-to-many*
-interaction that allow listeners to react to changes in an observed
+interaction that enable listeners to react to changes in an observed
 object.
 
 Extension Authoring
@@ -300,7 +300,7 @@ Storing Extension Data
 In addition to the file system that is accessed by using the
 ``@jupyterlab/services`` package, JupyterLab offers two ways for
 extensions to store data: a client-side state database that is built on
-top of ``localStorage`` and a plugin settings system that allows for
+top of ``localStorage`` and a plugin settings system that provides for
 default setting values and user overrides.
 
 State Database

--- a/docs/source/developer/patterns.rst
+++ b/docs/source/developer/patterns.rst
@@ -17,7 +17,7 @@ Initialization Options
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Objects will typically have an ``IOptions`` interface for initializing
-the widget. The use of this interface allows options to be later added
+the widget. The use of this interface enables options to be later added
 while preserving backward compatibility.
 
 ContentFactory Option
@@ -44,7 +44,7 @@ The "Private" module namespace is used to group variables and functions
 that are not intended to be exported and may have otherwise existed as
 module-level variables and functions. The use of the namespace also
 makes it clear when a variable access is to an imported name or from the
-module itself. Finally, the namespace allows the entire section to be
+module itself. Finally, the namespace enables the entire section to be
 collapsed in an editor if desired.
 
 Disposables
@@ -81,11 +81,11 @@ Signals are intended for one-to-many communication where outside objects
 react to changes on another object. Signals are always emitted with the
 sender as the first argument, and contain a single second argument with
 the payload. Signals should generally not be used to trigger the
-"default" behavior for an action, but to allow others to trigger
+"default" behavior for an action, but to enable others to trigger
 additional behavior. If a "default" behavior is intended to be provided
 by another object, then a callback should be provided by that object.
 Wherever possible as signal connection should be made with the pattern
-``.connect(this._onFoo, this)``. Providing the ``this`` context allows
+``.connect(this._onFoo, this)``. Providing the ``this`` context enables
 the connection to be properly cleared by ``clearSignalData(this)``.
 Using a private method avoids allocating a closure for each connection.
 
@@ -96,8 +96,8 @@ Some of the more advanced widgets have a model associated with them. The
 common pattern used is that the model is settable and must be set
 outside of the constructor. This means that any consumer of the widget
 must account for a model that may be ``null``, and may change at any
-time. The widget should emit a ``modelChanged`` signal to allow
-consumers to handle a change in model. The reason to allow a model to
+time. The widget should emit a ``modelChanged`` signal to enable
+consumers to handle a change in model. The reason to enable a model to
 swap is that the same widget could be used to display different model
 content while preserving the widget's location in the application. The
 reason the model cannot be provided in the constructor is the

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -334,7 +334,7 @@ code:
           label: 'Random xkcd comic',
           execute: () => {
             if (!widget.isAttached) {
-              // Attach the widget to the main area if it's not there
+              // Attach the widget to the main work area if it's not there
               app.shell.addToMainArea(widget);
             }
             // Activate the widget
@@ -612,7 +612,7 @@ these changes:
         label: 'Random xkcd comic',
         execute: () => {
           if (!widget.isAttached) {
-            // Attach the widget to the main area if it's not there
+            // Attach the widget to the main work area if it's not there
             app.shell.addToMainArea(widget);
           }
           // Refresh the comic in the widget
@@ -736,7 +736,7 @@ Finally, rewrite the ``activate`` function so that it:
             tracker.add(widget);
           }
           if (!widget.isAttached) {
-            // Attach the widget to the main area if it's not there
+            // Attach the widget to the main work area if it's not there
             app.shell.addToMainArea(widget);
           } else {
             // Refresh the comic in the widget

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -3,7 +3,7 @@
 Overview
 --------
 
-*JupyterLab is the next generation user interface for Project Jupyter*
+*JupyterLab is the next-generation user interface for Project Jupyter*
 
 JupyterLab goes beyond the classic Jupyter Notebook by providing a
 flexible and :ref:`extensible <user_extensions>` web application with a set of reusable

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -3,15 +3,20 @@
 Overview
 --------
 
-JupyterLab is the next-generation user interface for Project Jupyter.
+JupyterLab is the next-generation web-based user interface for Project Jupyter.
 JupyterLab will eventually replace the classic Jupyter Notebook.
 
-JupyterLab is an extensible open-source web-based interface for Project Jupyter.
-In JupyterLab, you can arrange multiple notebooks, text editors, terminals,
-output areas, and custom components, using tabs, adjustable splitters, and
-collapsible sidebars. JupyterLab extensions can customize or enhance any part of
-the JupyterLab, including providing custom components, themes, and new file
-viewers and editors.
+JupyterLab enables you to work with documents and activities such as notebooks,
+text editors, terminals, and custom components in a flexible, integrated, and
+extensible manner. You can arrange multiple documents and activities in the work
+area using tabs, adjustable splitters, and collapsible sidebars, and then save
+layouts as custom named workspaces. Documents and activites integrate with each
+other (for example, you can send a code chunk from a text editor to a console to
+execute with a keystroke, you can open a live preview of a Markdown, CSV, or
+Vega document you are editing, and you can drag cells between notebooks).
+JupyterLab extensions can customize or enhance any part of the JupyterLab,
+including extending existing components or providing new activities, themes, and
+file viewers and editors.
 
 :ref:`JupyterLab has full support for Jupyter Notebook documents. <notebook>`
 JupyterLab also enables other models of interactive computing:

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -3,8 +3,8 @@
 Overview
 --------
 
-*JupyterLab is the next-generation user interface for Project Jupyter.
-JupyterLab will eventually replace the classic Jupyter Notebook.*
+JupyterLab is the next-generation user interface for Project Jupyter.
+JupyterLab will eventually replace the classic Jupyter Notebook.
 
 JupyterLab is an extensible open-source web-based interface for Project Jupyter.
 In JupyterLab, you can arrange multiple notebooks, text editors, terminals,
@@ -31,11 +31,10 @@ JupyterLab also enables other models of interactive computing:
    have live preview of Markdown documents, or edit GeoJSON files with live
    updates of an adjoining map.
 
-JupyterLab also offers a unified model for viewing and handling data
-formats. This enables data in many formats (images, CSV, JSON, Markdown,
-PDF, Vega, Vega-Lite, etc.) to be opened as a file or returned by a
-kernel as rich output. See :ref:`file-and-output-formats` for more
-information.
+JupyterLab also offers a unified model for viewing and handling data formats.
+JupyterLab understands many file formats (images, CSV, JSON, Markdown, PDF,
+Vega, Vega-Lite, etc.) and can also display rich kernel output in these formats.
+See :ref:`file-and-output-formats` for more information.
 
 To navigate the user interface, JupyterLab offers :ref:`customizable keyboard shortcuts <shortcuts>`
 and the ability to use key maps from vim, emacs, and Sublime Text.

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -3,7 +3,8 @@
 Overview
 --------
 
-*JupyterLab is the next-generation user interface for Project Jupyter, and will eventually replace the classic Jupyter Notebook.*
+*JupyterLab is the next-generation user interface for Project Jupyter.
+JupyterLab will eventually replace the classic Jupyter Notebook.*
 
 JupyterLab is an extensible open-source web-based interface for Project Jupyter.
 In JupyterLab, you can arrange multiple notebooks, text editors, terminals,

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -47,4 +47,4 @@ JupyterLab is served from the same `server
 <https://jupyter-notebook.readthedocs.io/en/stable/>`__ and uses the same
 `notebook document format <http://nbformat.readthedocs.io/en/latest/>`__ as the
 classic Jupyter Notebook. JupyterLab will eventually replace the classic Jupyter
-Notebook after it reaches 1.0 and we have a transition period.
+Notebook after it reaches 1.0.

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -47,4 +47,4 @@ JupyterLab is served from the same `server
 <https://jupyter-notebook.readthedocs.io/en/stable/>`__ and uses the same
 `notebook document format <http://nbformat.readthedocs.io/en/latest/>`__ as the
 classic Jupyter Notebook. JupyterLab will eventually replace the classic Jupyter
-Notebook after it reaches 1.0.
+Notebook after JupyterLab reaches 1.0.

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -19,12 +19,12 @@ addition, it enables other models of interactive computing, such as:
 
 -  :ref:`code_console` provide transient scratchpads for running code
    interactively, with full support for rich output.
--  :ref:`Kernel-backed documents <kernel-backed-documents>` allow code in any text file (Markdown,
+-  :ref:`Kernel-backed documents <kernel-backed-documents>` enable code in any text file (Markdown,
    Python, R, LaTeX, etc.) to be run interactively in any Jupyter
    kernel.
 
 JupyterLab also offers a unified model for viewing and handling data
-formats. This allows data in many formats (images, CSV, JSON, Markdown,
+formats. This enables data in many formats (images, CSV, JSON, Markdown,
 PDF, Vega, Vega-Lite, etc.) to be opened as a file or returned by a
 kernel as rich output. See :ref:`file-and-output-formats` for more
 information.

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -4,7 +4,6 @@ Overview
 --------
 
 JupyterLab is the next-generation web-based user interface for Project Jupyter.
-JupyterLab will eventually replace the classic Jupyter Notebook.
 
 JupyterLab enables you to work with documents and activities such as notebooks,
 text editors, terminals, and custom components in a flexible, integrated, and
@@ -44,8 +43,8 @@ See :ref:`file-and-output-formats` for more information.
 To navigate the user interface, JupyterLab offers :ref:`customizable keyboard shortcuts <shortcuts>`
 and the ability to use key maps from vim, emacs, and Sublime Text.
 
-JupyterLab is served from the same
-`server <https://jupyter-notebook.readthedocs.io/en/stable/>`__ and uses
-the same `notebook document
-format <http://nbformat.readthedocs.io/en/latest/>`__ as the classic
-Jupyter Notebook.
+JupyterLab is served from the same `server
+<https://jupyter-notebook.readthedocs.io/en/stable/>`__ and uses the same
+`notebook document format <http://nbformat.readthedocs.io/en/latest/>`__ as the
+classic Jupyter Notebook. JupyterLab will eventually replace the classic Jupyter
+Notebook after it reaches 1.0 and we have a transition period.

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -3,25 +3,32 @@
 Overview
 --------
 
-*JupyterLab is the next-generation user interface for Project Jupyter*
+*JupyterLab is the next-generation user interface for Project Jupyter, and will eventually replace the classic Jupyter Notebook.*
 
-JupyterLab goes beyond the classic Jupyter Notebook by providing a
-flexible and :ref:`extensible <user_extensions>` web application with a set of reusable
-components. You can arrange multiple notebooks, text editors, terminals,
-output areas, and custom components using tabs/panels and collapsible
-sidebars. These :ref:`components <interface>` are carefully designed to enable you to use
-them together or on their own to support new workflows (for example, you
-can send code from a file to a :ref:`code console <code_console>` with a keystroke, or move
-cells around a :ref:`notebook <notebook>` or between notebooks with drag-and-drop).
+JupyterLab is an extensible open-source web-based interface for Project Jupyter.
+In JupyterLab, you can arrange multiple notebooks, text editors, terminals,
+output areas, and custom components, using tabs, adjustable splitters, and
+collapsible sidebars. JupyterLab extensions can customize or enhance any part of
+the JupyterLab, including providing custom components, themes, and new file
+viewers and editors.
 
-:ref:`JupyterLab has full support for Jupyter Notebook documents. <notebook>` In
-addition, it enables other models of interactive computing, such as:
+:ref:`JupyterLab has full support for Jupyter Notebook documents. <notebook>`
+JupyterLab also enables other models of interactive computing:
 
 -  :ref:`code_console` provide transient scratchpads for running code
-   interactively, with full support for rich output.
--  :ref:`Kernel-backed documents <kernel-backed-documents>` enable code in any text file (Markdown,
-   Python, R, LaTeX, etc.) to be run interactively in any Jupyter
-   kernel.
+   interactively, with full support for rich output. A code console can be
+   linked to a notebook kernel as a computation log from the notebook, for
+   example.
+-  :ref:`Kernel-backed documents <kernel-backed-documents>` enable code in any
+   text file (Markdown, Python, R, LaTeX, etc.) to be run interactively in any
+   Jupyter kernel.
+-  Notebook cell outputs can be pulled into their own tab, side-by-side with
+   the notebook, enabling simple dashboards with interactive controls backed by
+   a kernel.
+-  Multiple views of documents with different editors or viewers enable live
+   editing of documents reflected in other viewers. For example, it is easy to
+   have live preview of Markdown documents, or edit GeoJSON files with live
+   updates of an adjoining map.
 
 JupyterLab also offers a unified model for viewing and handling data
 formats. This enables data in many formats (images, CSV, JSON, Markdown,

--- a/docs/source/user/code_console.rst
+++ b/docs/source/user/code_console.rst
@@ -3,7 +3,7 @@
 Code Consoles
 -------------
 
-Code consoles allow you to run code interactively in a kernel. The cells
+Code consoles enable you to run code interactively in a kernel. The cells
 of a code console show the order in which code was executed in the
 kernel, as opposed to the explicit ordering of cells in a notebook
 document. Code consoles also display rich output, just like notebook

--- a/docs/source/user/commands.rst
+++ b/docs/source/user/commands.rst
@@ -7,7 +7,7 @@ All user actions in JupyterLab are processed through a centralized
 command system. These commands are shared and used throughout JupyterLab
 (menu bar, context menus, keyboard shortcuts, etc.). The command palette
 in the left sidebar provides a keyboard-driven way to search for and run
-any JupyterLab command:
+JupyterLab commands:
 
 .. image:: images/command_palette.png
    :align: center

--- a/docs/source/user/documents_kernels.rst
+++ b/docs/source/user/documents_kernels.rst
@@ -5,7 +5,7 @@ Documents and kernels
 
 In the Jupyter architecture, kernels are separate processes started by
 the server that run your code in different programming languages and
-environments. JupyterLab allows you to connect any open text file to a
+environments. JupyterLab enables you to connect any open text file to a
 :ref:`code console and kernel <code_console>`. This means you can easily run code from the
 text file in the kernel interactively.
 

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -10,8 +10,8 @@ renderers, among many other things. JupyterLab extensions are
 in Javascript development). For information about developing extensions,
 see the :ref:`developer documentation <developer_extensions>`.
 
-In order to install JupyterLab extensions, you need to have Node.js
-version 4+ installed.
+In order to install JupyterLab extensions, you need to have `Node.js
+<https://nodejs.org/>`__ version 4 or later installed.
 
 If you use ``conda``, you can get it with:
 
@@ -25,6 +25,9 @@ If you use `Homebrew <https://brew.sh/>`__ on Mac OS X:
 
     brew install node
 
+You can also download Node.js from the `Node.js website <https://nodejs.org/>`__ and
+install it directly.
+
 Installing Extensions
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -35,21 +38,21 @@ using the command:
 
 .. code:: bash
 
-    jupyter labextension install <foo>
+    jupyter labextension install my-extension
 
-where ``<foo>`` is the name of a valid JupyterLab extension npm package
-on `npm <https://www.npmjs.com>`__. Use the ``<foo>@<foo version>``
+where ``my-extension`` is the name of a valid JupyterLab extension npm package
+on `npm <https://www.npmjs.com>`__. Use the ``my-extension@version``
 syntax to install a specific version of an extension, for example:
 
 .. code:: bash
 
-    jupyter labextension install <foo>@1.2.3
+    jupyter labextension install my-extension@1.2.3
 
 You can also install an extension that is not uploaded to npm, i.e.,
-``<foo>`` can be a local directory containing the extension, a gzipped
+``my-extension`` can be a local directory containing the extension, a gzipped
 tarball, or a URL to a gzipped tarball.
 
-We encourage extension authors to add the ``jupyterlab-extensions``
+We encourage extension authors to add the ``jupyterlab-extension``
 GitHub topic to any repository with a JupyterLab extension to facilitate
 discovery. You can see a list of extensions by searching GitHub for the
 `jupyterlab-extension <https://github.com/search?utf8=%E2%9C%93&q=topic%3Ajupyterlab-extension&type=Repositories>`__
@@ -65,11 +68,11 @@ Uninstall an extension by running the command:
 
 .. code:: bash
 
-    jupyter labextension uninstall <bar>
+    jupyter labextension uninstall my-extension
 
-where ``<bar>`` is the name of the extension, as printed in the
+where ``my-extension`` is the name of the extension, as printed in the
 extension list. You can also uninstall core extensions using this
-command (which can later be re-installed).
+command (you can always re-install core extensions later).
 
 Installing and uninstalling extensions can take some time, as they are
 downloaded, bundled with the core extensions, and the whole application
@@ -93,16 +96,16 @@ extensions) without rebuilding the application by running the command:
 
 .. code:: bash
 
-    jupyter labextension disable <bar>
+    jupyter labextension disable my-extension
 
-where ``<bar>`` is the name of the extension. This will prevent the
-extension from loading in the browser, but does not require a rebuild.
+This will prevent the extension from loading in the browser, but does not
+require a rebuild.
 
 You can re-enable an extension using the command:
 
 .. code:: bash
 
-    jupyter labextension enable <foo>
+    jupyter labextension enable my-extension
 
 Advanced Usage
 ~~~~~~~~~~~~~~
@@ -118,7 +121,7 @@ can query the current application path by running ``jupyter lab path``.
 JupyterLab Build Process
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-To rebuild the app directory, run ``jupyter lab build``. By default the
+To rebuild the app directory, run ``jupyter lab build``. By default, the
 ``jupyter labextension install`` command builds the application, so you
 typically do not need to call ``build`` directly.
 
@@ -128,7 +131,7 @@ Building consists of:
 -  Handling any locally installed packages
 -  Ensuring all installed assets are available
 -  Bundling the assets
--  Copying the assets to the ``static`` directory
+-  Copying the bundled assets to the ``static`` directory
 
 JupyterLab Application Directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -175,7 +175,7 @@ page_config.json
 The ``page_config.json`` data is used to provide config data to the
 application environment.
 
-Two important fields in the ``page_config.json`` file allow control of
+Two important fields in the ``page_config.json`` file enable control of
 which plugins load:
 
 1. ``disabledExtensions`` for extensions that should not load at all.

--- a/docs/source/user/file_editor.rst
+++ b/docs/source/user/file_editor.rst
@@ -19,7 +19,7 @@ basic theming. These settings can be found in the Settings menu:
    :class: jp-screenshot
 
 To edit an existing text file, double-click on its name in the file
-browser or drag it into the main area:
+browser or drag it into the main work area:
 
 .. raw:: html
 

--- a/docs/source/user/file_editor.rst
+++ b/docs/source/user/file_editor.rst
@@ -24,7 +24,7 @@ browser or drag it into the main work area:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/IuqmxkHsS7o?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/IuqmxkHsS7o?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 To create a new text file in the current directory of the file browser,
@@ -34,7 +34,7 @@ Launcher tab, and click the “Text Editor” card in the Launcher:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/T1XVz-rjW8I?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/T1XVz-rjW8I?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 You can also create a new text file with the File menu:
@@ -42,7 +42,7 @@ You can also create a new text file with the File menu:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/ssFCduQAF48?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/ssFCduQAF48?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 A new file is created with a default name. Rename a file by
@@ -52,5 +52,5 @@ from the context menu:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/pQR0RV9ObnQ?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/pQR0RV9ObnQ?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>

--- a/docs/source/user/file_formats.rst
+++ b/docs/source/user/file_formats.rst
@@ -191,7 +191,7 @@ Vega-Lite:
 -  File extensions: ``.vl``, ``.vl.json``
 -  MIME type: ``application/vnd.vegalite.v1+json``
 
-Vega and Vega-Lite are declarative visualization grammars that allow
+Vega and Vega-Lite are declarative visualization grammars that enable
 visualizations to be encoded as JSON data. For more information, see the
 documentation of Vega or Vega-Lite. JupyterLab supports rendering Vega
 2.x and Vega-Lite 1.x data in files and cell output.
@@ -215,7 +215,7 @@ the “Open With…” submenu in the file browser content menu:
   </div>
 
 As with other files in JupyterLab, multiple views of a single file
-remain synchronized, allowing you to interactively edit and render
+remain synchronized, enabling you to interactively edit and render
 Vega/Vega-Lite visualizations:
 
 .. raw:: html

--- a/docs/source/user/file_formats.rst
+++ b/docs/source/user/file_formats.rst
@@ -66,7 +66,7 @@ Markdown documents can be edited as text files or rendered inline:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/eQsRlqK-z1c?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/eQsRlqK-z1c?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 The Markdown syntax supported in this mode is the same syntax used in
@@ -92,7 +92,7 @@ submenu:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/y_ydmAmVdCA?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/y_ydmAmVdCA?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 CSV
@@ -109,7 +109,7 @@ semicolon-separated values):
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/z6xuZ9H3Imo?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/z6xuZ9H3Imo?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 To edit a CSV file as a text file, right-click on the file in the file
@@ -118,7 +118,7 @@ browser and select the “Editor” item in the “Open With” submenu:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/b5oAoVB3Wd4?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/b5oAoVB3Wd4?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 JSON
@@ -134,7 +134,7 @@ JSON file using a searchable tree view:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/FRj1r7-7kiQ?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/FRj1r7-7kiQ?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 To edit the JSON as a text file, right-click on the filename in the file
@@ -143,7 +143,7 @@ browser and select the “Editor” item in the “Open With” submenu:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/HKcJAGZngzw?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/HKcJAGZngzw?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 HTML
@@ -176,7 +176,7 @@ in JupyterLab, double-click on the file in the file browser:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/vLAEzD5dxQw?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/vLAEzD5dxQw?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 Vega/Vega-Lite
@@ -203,7 +203,7 @@ be opened by double-clicking the file in the file browser:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Dddtyz5fWkU?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/Dddtyz5fWkU?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 The files can also be opened in the JSON viewer or file editor through
@@ -212,7 +212,7 @@ the “Open With…” submenu in the file browser content menu:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/qaiGRXh4jxc?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/qaiGRXh4jxc?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 As with other files in JupyterLab, multiple views of a single file
@@ -222,7 +222,7 @@ Vega/Vega-Lite visualizations:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/4Me4rCeS8To?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/4Me4rCeS8To?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 
@@ -260,7 +260,7 @@ interactively:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/fObR8xeKCJU?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/fObR8xeKCJU?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 The `nteract/vdom <https://github.com/nteract/vdom>`__ library provides

--- a/docs/source/user/file_formats.rst
+++ b/docs/source/user/file_formats.rst
@@ -48,7 +48,8 @@ message from a dictionary of keys (MIME types) and values (MIME data):
 Other Jupyter kernels offer similar APIs.
 
 The rest of this section highlights some of the common data formats that
-JupyterLab supports.
+JupyterLab supports by default. JupyterLab extensions can also add support for
+other file formats.
 
 
 Markdown

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -59,7 +59,7 @@ they will remain in sync:
      <iframe src="https://www.youtube-nocookie.com/embed/87ALbxm1Y3I?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
-The file system can be navigated by double clicking on folders in the
+The file system can be navigated by double-clicking on folders in the
 listing or clicking on the folders at the top of the directory listing:
 
 .. raw:: html

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -6,7 +6,7 @@ Working with Files
 Opening Files
 ~~~~~~~~~~~~~
 
-The file browser and File menu allow you to work with files and
+The file browser and File menu enable you to work with files and
 directories on your system. This includes opening, creating, deleting,
 renaming, downloading, copying, and sharing files and directories.
 
@@ -80,8 +80,8 @@ Creating Files and Activities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create new files or activities by clicking the ``+`` button at the top
-of the file browser. This will open a new Launcher tab in the main area,
-which allows you to pick an activity and kernel:
+of the file browser. This will open a new Launcher tab in the main work area,
+which enables you to pick an activity and kernel:
 
 .. raw:: html
 

--- a/docs/source/user/files.rst
+++ b/docs/source/user/files.rst
@@ -30,7 +30,7 @@ To open any file, double-click on its name in the file browser:
      <iframe src="https://www.youtube-nocookie.com/embed/Rh-vwjTwBTI?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
-You can also drag a file into the main area to create a new tab:
+You can also drag a file into the main work area to create a new tab:
 
 .. raw:: html
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -80,7 +80,7 @@ the left, right, top, or bottom of the panel:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ka8qS7CO1XQ?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/Ka8qS7CO1XQ?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 The work area has a single current activity. The tab for the current activity is
@@ -112,7 +112,7 @@ Toggle single-document mode using the View menu:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/DO7NOenMQC0?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/DO7NOenMQC0?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 When you leave single-document mode, the original layout of the main
@@ -128,7 +128,7 @@ the element:
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/y30fs6kg6fc?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/y30fs6kg6fc?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 The browser’s native context menu can be accessed by holding down
@@ -137,7 +137,7 @@ The browser’s native context menu can be accessed by holding down
 .. raw:: html
 
   <div class="jp-youtube-video">
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/XPPWW-7WJ40?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+    <iframe src="https://www.youtube-nocookie.com/embed/XPPWW-7WJ40?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
 .. _shortcuts:

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -55,7 +55,7 @@ and a list of tabs in the main work area:
    :align: center
    :class: jp-screenshot
 
-The left sidebar can be collapsed or expanded by selecting "Show Left Sidebar"
+The left sidebar can be collapsed or expanded by selecting "Show Left Area"
 in the View menu or by clicking on the active sidebar tab:
 
 .. raw:: html

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -55,8 +55,8 @@ and a list of tabs in the main work area:
    :align: center
    :class: jp-screenshot
 
-The left sidebar can be collapsed or expanded by clicking on the active
-sidebar tab:
+The left sidebar can be collapsed or expanded by selecting "Show Left Sidebar"
+in the View menu or by clicking on the active sidebar tab:
 
 .. raw:: html
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -49,7 +49,7 @@ Left Sidebar
 
 The left sidebar contains a number of commonly-used tabs, such as a file
 browser, a list of running kernels and terminals, the command palette,
-and a list of tabs in the main area:
+and a list of tabs in the main work area:
 
 .. image:: images/interface_left.png
    :align: center
@@ -90,7 +90,7 @@ Tabs and Single-Document Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Tabs panel in the left sidebar lists the open documents or
-activities in the main area:
+activities in the main work area:
 
 .. image:: images/interface_tabs.png
    :align: center
@@ -103,7 +103,7 @@ The same information is also available in the Tabs menu:
    :class: jp-screenshot
 
 It is often useful to focus on a single document or activity without closing
-other tabs in the main area. Single-document mode enable this, while making
+other tabs in the main work area. Single-document mode enable this, while making
 it simple to return to your multi-activity layout in the main work area.
 Toggle single-document mode using the View menu:
 

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -71,9 +71,11 @@ JupyterLab extensions can add additional panels to the left sidebar.
 Main Work Area
 ~~~~~~~~~~~~~~
 
-The main work area in JupyterLab allows you to arrange documents
-(notebooks, text files, etc.) and other activities (terminals, code
-consoles, etc.) into panels of tabs that can be resized or subdivided:
+The main work area in JupyterLab enables you to arrange documents (notebooks,
+text files, etc.) and other activities (terminals, code consoles, etc.) into
+panels of tabs that can be resized or subdivided. Drag a tab to the center of a
+tab panel to move the tab to the panel. Subdivide a tab panel by dragging a tab to
+the left, right, top, or bottom of the panel:
 
 .. raw:: html
 
@@ -81,8 +83,8 @@ consoles, etc.) into panels of tabs that can be resized or subdivided:
     <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ka8qS7CO1XQ?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
-The work area has a single current activity. The tab for this activity
-is marked with a colored top border (blue by default).
+The work area has a single current activity. The tab for the current activity is
+marked with a colored top border (blue by default).
 
 .. _tabs:
 
@@ -120,7 +122,7 @@ Context Menus
 ~~~~~~~~~~~~~
 
 Many parts of JupyterLab, such as notebooks, text files, code consoles,
-and tabs have context menus that can be accessed by right-clicking on
+and tabs, have context menus that can be accessed by right-clicking on
 the element:
 
 .. raw:: html

--- a/docs/source/user/notebook.rst
+++ b/docs/source/user/notebook.rst
@@ -94,11 +94,7 @@ Create a new synchronized view of a cell’s output:
 Tab completion (activated with the ``Tab`` key) now includes additional
 information about the types of the matched items:
 
-.. raw:: html
-
-  <div class="jp-youtube-video">
-     <iframe src="https://www.youtube-nocookie.com/embed/XXX NEED TODO?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-  </div>
+.. todo:: Make a screencast video of this?
 
 The tooltip (activated with ``Shift Tab``) contains additional
 information about objects:

--- a/docs/source/user/notebook.rst
+++ b/docs/source/user/notebook.rst
@@ -94,7 +94,12 @@ Create a new synchronized view of a cell’s output:
 Tab completion (activated with the ``Tab`` key) now includes additional
 information about the types of the matched items:
 
-.. todo:: Make a screencast video of this?
+.. raw:: html
+
+  <div class="jp-youtube-video">
+     <iframe src="https://www.youtube-nocookie.com/embed/MuNr0i8LgpM?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  </div>
+
 
 The tooltip (activated with ``Shift Tab``) contains additional
 information about objects:

--- a/docs/source/user/notebook.rst
+++ b/docs/source/user/notebook.rst
@@ -3,7 +3,7 @@
 Notebooks
 ---------
 
-Jupyter Notebooks are documents that combine live runnable code with
+Jupyter notebooks are documents that combine live runnable code with
 narrative text (Markdown), equations (LaTeX), images, interactive
 visualizations and other rich output:
 
@@ -11,13 +11,11 @@ visualizations and other rich output:
    :align: center
    :class: jp-screenshot
 
-**Jupyter Notebook (.ipynb files) are fully supported in JupyterLab.**
-Furthermore, the `notebook document
-format <http://nbformat.readthedocs.io/en/latest/>`__ used in JupyterLab
-is the same as in the classic notebook. Your existing notebooks should
-open correctly in JupyterLab. If they don’t, please open an issue on our
-`GitHub issues <https://github.com/jupyterlab/jupyterlab/issues>`__
-page.
+**Jupyter notebooks (.ipynb files) are fully supported in JupyterLab.** The
+`notebook document format <http://nbformat.readthedocs.io/en/latest/>`__ used in
+JupyterLab is the same as in the classic Jupyter Notebook. Your existing notebooks
+should open correctly in JupyterLab. If they don’t, please open an issue on our
+`GitHub issues <https://github.com/jupyterlab/jupyterlab/issues>`__ page.
 
 Create a notebook by clicking the ``+`` button in the file browser and
 then selecting a kernel in the new Launcher tab:

--- a/docs/source/user/running.rst
+++ b/docs/source/user/running.rst
@@ -13,8 +13,8 @@ directories:
 
 As with the classic Jupyter Notebook, when you close a notebook
 document, code console, or terminal, the underlying kernel or terminal
-running on the server continues to run. This allows you to perform
-long-running actions and return later. The Running tab allows you to
+running on the server continues to run. This enables you to perform
+long-running actions and return later. The Running tab enables you to
 re-open or focus the document linked to a given kernel or terminal:
 
 .. raw:: html

--- a/docs/source/user/running.rst
+++ b/docs/source/user/running.rst
@@ -3,7 +3,7 @@
 Managing Kernels and Terminals
 ------------------------------
 
-The Running tab in the left sidebar shows a list of all the kernels and
+The Running panel in the left sidebar shows a list of all the kernels and
 terminals currently running across all notebooks, code consoles, and
 directories:
 
@@ -14,7 +14,7 @@ directories:
 As with the classic Jupyter Notebook, when you close a notebook
 document, code console, or terminal, the underlying kernel or terminal
 running on the server continues to run. This enables you to perform
-long-running actions and return later. The Running tab enables you to
+long-running actions and return later. The Running panel enables you to
 re-open or focus the document linked to a given kernel or terminal:
 
 .. raw:: html
@@ -23,7 +23,7 @@ re-open or focus the document linked to a given kernel or terminal:
      <iframe src="https://www.youtube-nocookie.com/embed/gDM5lwU6Dmo?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
-Kernels or terminals can be shut down from the Running tab:
+Kernels or terminals can be shut down from the Running panel:
 
 .. raw:: html
 

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -255,7 +255,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   command = CommandIDs.toggleLeftArea;
   app.commands.addCommand(command, {
     label: args => args['isPalette'] ?
-    'Toggle Left Sidebar' : 'Show Left Sidebar',
+    'Toggle Left Area' : 'Show Left Area',
     execute: () => {
       if (app.shell.leftCollapsed) {
         app.shell.expandLeft();
@@ -272,7 +272,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   command = CommandIDs.toggleRightArea;
   app.commands.addCommand(command, {
     label: args => args['isPalette'] ?
-    'Toggle Right Sidebar' : 'Show Right Sidebar',
+    'Toggle Right Area' : 'Show Right Area',
     execute: () => {
       if (app.shell.rightCollapsed) {
         app.shell.expandRight();

--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -255,7 +255,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   command = CommandIDs.toggleLeftArea;
   app.commands.addCommand(command, {
     label: args => args['isPalette'] ?
-    'Toggle Left Area' : 'Show Left Area',
+    'Toggle Left Sidebar' : 'Show Left Sidebar',
     execute: () => {
       if (app.shell.leftCollapsed) {
         app.shell.expandLeft();
@@ -272,7 +272,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   command = CommandIDs.toggleRightArea;
   app.commands.addCommand(command, {
     label: args => args['isPalette'] ?
-    'Toggle Right Area' : 'Show Right Area',
+    'Toggle Right Sidebar' : 'Show Right Sidebar',
     execute: () => {
       if (app.shell.rightCollapsed) {
         app.shell.expandRight();


### PR DESCRIPTION
I'm making one more pass through the docs, tweaking wording, etc. I also noticed that the menu/command palette items for the left/right area said "area", so I changed them to say "sidebar".

I think this is ready for review.

Discussion items:
- [x] The wording of the second paragraph in overview.rst (the one starting with "JupyterLab is an extensible open-source web-based interface for Project Jupyter.")