### PR TITLE
Don't use flexbox for Notebook panel, as it has peformance issues on Firefox

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -29,8 +29,8 @@
 
 
 .jp-NotebookPanel {
-  display: flex;
-  flex-direction: column;
+  display: block;
+  overflow: scroll;
   height: 100%;
 }
 
@@ -40,7 +40,6 @@
 }
 
 .jp-Notebook {
-  flex: 1 1 auto;
   padding: var(--jp-notebook-padding);
   outline: none;
   overflow: auto;


### PR DESCRIPTION
Potential short-term fix for #1639.

This has a *huge* effect on the loading of large notebooks using Firefox (at least on my machine). It also seems to have a minimal effect on the layout, since it doesn't touch the notebook document css at all (just the layout of the toolbar vs notebook widget).

Do others see the same effect? Is there a downside that I am missing?