### PR TITLE
Clean up the enabled condition for run all above/below commands.

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -781,7 +781,12 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
         return NotebookActions.runAllAbove(notebook, context.session);
       }
     },
-    isEnabled: isEnabledAndSingleSelected
+    isEnabled: () => {
+      // Can't run above if there are multiple cells selected,
+      // or if we are at the top of the notebook.
+      return isEnabledAndSingleSelected() &&
+             tracker.currentWidget.notebook.activeCellIndex !== 0;
+    }
   });
   commands.addCommand(CommandIDs.runAllBelow, {
     label: 'Run Selected Cell and All Below',
@@ -794,7 +799,13 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
         return NotebookActions.runAllBelow(notebook, context.session);
       }
     },
-    isEnabled: isEnabledAndSingleSelected
+    isEnabled: () => {
+      // Can't run below if there are multiple cells selected,
+      // or if we are at the bottom of the notebook.
+      return isEnabledAndSingleSelected() &&
+             tracker.currentWidget.notebook.activeCellIndex !==
+             tracker.currentWidget.notebook.widgets.length - 1;
+    }
   });
   commands.addCommand(CommandIDs.restart, {
     label: 'Restart Kernel…',


### PR DESCRIPTION
Follow-up to #3785, to fix the enabled condition for `Run All Above` and `Run All Below`.