### PR TITLE
Don't show scroll while a document is loading.

### DIFF
--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -12,6 +12,7 @@
     "lib/*.d.ts",
     "lib/*.js.map",
     "lib/*.js",
+    "style/*.css",
     "schema/*.json"
   ],
   "main": "lib/index.js",

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -33,6 +33,8 @@ import {
   IDisposable
 } from '@phosphor/disposable';
 
+import '../style/index.css';
+
 
 /**
  * The command IDs used by the document manager plugin.
@@ -106,9 +108,11 @@ const plugin: JupyterLabPlugin<IDocumentManager> = {
           // Add a loading spinner, and remove it when the widget is ready.
           if (widget.ready !== undefined) {
             const spinner = new Spinner();
+            widget.addClass('jp-mod-loading');
             widget.node.appendChild(spinner.node);
             widget.ready.then(() => {
               widget.node.removeChild(spinner.node);
+              widget.removeClass('jp-mod-loading');
               spinner.dispose();
             });
           }

--- a/packages/docmanager-extension/style/index.css
+++ b/packages/docmanager-extension/style/index.css
@@ -1,0 +1,9 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2018, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-mod-loading {
+  overflow: hidden;
+}


### PR DESCRIPTION
The CSS changes in #3805 made the loading spinner look a little funky as a scrolled document starts to be rendered under the overlay. This is a temporary fix for that (I expect the upcoming context refactor to make it obselete).