### PR TITLE
Fix invalid css comment.

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -68,7 +68,7 @@
 }
 
 
-// When zoomed out 67% and 33% on a screen of 1440 width x 900 height
+/* When zoomed out 67% and 33% on a screen of 1440 width x 900 height */
 @media screen and (min-width: 2138px) and (max-width: 4319px)  {
     .CodeMirror-cursor {
         border-left: 2px solid var(--jp-editor-cursor-color);
@@ -76,7 +76,7 @@
 }
 
 
-// When zoomed out less than 33%
+/* When zoomed out less than 33% */
 @media screen and (min-width: 4320px)  {
     .CodeMirror-cursor {
         border-left: 4px solid var(--jp-editor-cursor-color);


### PR DESCRIPTION
There were comments of the form // in the stylesheet found at packages/codemirror/style/index.css. I changed them to be valid css comments as the css styles below that point were more than likely being ignored by the browser.

pkg:codemirror
type:Bug

Fixes #3814 