### PR TITLE
Fix Typo in extension tutorial

### DIFF
--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -349,7 +349,7 @@ code:
 The first new block of code creates a ``Widget`` instance, assigns it a
 unique ID, gives it a label that will appear as its tab title, and makes
 the tab closable by the user. The second block of code add a new command
-labeled *Random xkcd comic* to JupyterLab. When the comm and executes,
+labeled *Random xkcd comic* to JupyterLab. When the command executes,
 it attaches the widget to the main display area if it is not already
 present and then makes it the active tab. The last new line of code adds
 the command to the command palette in a section called *Tutorial*.

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -376,7 +376,7 @@ carry on.
 .. code:: bash
 
     git add .
-    git commit -m 'Show xkcd panel on command'
+    git commit -m 'Show xkcd command on panel'
 
 Show a comic in the panel
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
There is a typo in `Line 352` of extension tutorial.

`labeled *Random xkcd comic* to JupyterLab. When the comm and executes,`

is now replaced to 

`labeled *Random xkcd comic* to JupyterLab. When the command executes,`

One commit message is also updated.
