### PR TITLE
Bust local cache

### DIFF
--- a/packages/codemirror/src/mimetype.ts
+++ b/packages/codemirror/src/mimetype.ts
@@ -40,8 +40,11 @@ class CodeMirrorMimeTypeService implements IEditorMimeTypeService {
    * If a mime type cannot be found returns the default mime type `text/plain`, never `null`.
    */
   getMimeTypeByFilePath(path: string): string {
-    if (PathExt.extname(path) === '.ipy') {
+    const ext = PathExt.extname(path);
+    if (ext === '.ipy') {
       return 'text/x-python';
+    } else if (ext === '.md') {
+      return 'text/x-ipythongfm';
     }
     let mode = Mode.findByFileName(path) || Mode.findBest('');
     return mode.mime;

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -732,6 +732,9 @@ namespace Private {
     return resolver.resolveUrl(source).then(path => {
       return resolver.getDownloadUrl(path);
     }).then(url => {
+      // Bust caching for local src attrs.
+      // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache
+      url += ((/\?/).test(url) ? '&' : '?') + (new Date()).getTime();
       node.setAttribute(name, url);
     }).catch(err => {
       // If there was an error getting the url,


### PR DESCRIPTION
A couple of small improvements after working with a markdown document with a code console attached.
(For more discussion see #3221)

1. If we want to embed images that are the result computations, it would be nice to be able to update them upon re-render. Currently the browser caches image loads, so they usually do not update properly. This adds cache-busting for local links.
2. Currently, the text editor doesn't choose the `text/x-ipythongfm` mode by default for markdown documents. The primary difference is (so far as I can tell) that code fences are not syntax highlighted. This fixes that.

Overall, it was a very positive experience, as a more lightweight alternative to a notebook.