### PR TITLE
Dispose of docmanager widget if the inital load fails.

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -262,7 +262,10 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
         return this._populate();
       }
     }).catch(err => {
-      this._handleError(err, 'File Save Error');
+      const localPath = this._manager.contents.localPath(this._path);
+      const name = PathExt.basename(localPath);
+      this._handleError(err, `File Save Error for ${name}`);
+      throw err;
     });
   }
 
@@ -327,7 +330,10 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
         return this._populate();
       }
     }).catch(err => {
-      this._handleError(err, 'File Load Error');
+      const localPath = this._manager.contents.localPath(this._path);
+      const name = PathExt.basename(localPath);
+      this._handleError(err, `File Load Error for ${name}`);
+      throw err;
     });
   }
 

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -213,18 +213,15 @@ function activateBrowser(app: JupyterLab, factory: IFileBrowserFactory, restorer
   });
 
   Promise.all([app.restored, browser.model.restored]).then(() => {
-    const { model } = browser;
-
     function maybeCreate() {
       // Create a launcher if there are no open items.
       if (app.shell.isEmpty('main')) {
-        model.restored.then(() => createLauncher(commands, browser));
+        createLauncher(commands, browser);
       }
     }
 
     // When layout is modified, create a launcher if there are no open items.
     shell.layoutModified.connect(() => { maybeCreate(); });
-
     maybeCreate();
   });
 }


### PR DESCRIPTION
Fixes #3859 by not allowing invalid files to get cached in the stateDB. We should probably still handle the case for the state restoration failure, but I expect that to be changed in the upcoming context refactor.