### PR TITLE
Fix isLocal() to only return true if a local path is given.

### DIFF
--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -96,7 +96,7 @@ namespace URLExt {
    * Test whether the url is a local url.
    *
    * #### Notes
-   * This function returns `false` for any fully qualified URL, including
+   * This function returns `false` for any fully qualified url, including
    * `data:`, `file:`, and `//` protocol URLs.
    */
   export

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -102,9 +102,8 @@ namespace URLExt {
   export
   function isLocal(url: string): boolean {
     const { protocol } = parse(url);
-    const lower = url.toLowerCase();
 
-    return lower.indexOf(protocol) !== 0 && lower.indexOf('//') !== 0;
+    return url.toLowerCase().indexOf(protocol) !== 0 && url.indexOf('//') !== 0;
   }
 
   /**

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -94,12 +94,17 @@ namespace URLExt {
 
   /**
    * Test whether the url is a local url.
+   *
+   * #### Notes
+   * This function returns `false` for any fully qualified URL, including
+   * `data:`, `file:`, and `//` protocol URLs.
    */
   export
   function isLocal(url: string): boolean {
-    const { host, protocol } = parse(url);
+    const { protocol } = parse(url);
+    const lower = url.toLowerCase();
 
-    return protocol !== 'data:' && (host === location.host || host === '');
+    return lower.indexOf(protocol) !== 0 && lower.indexOf('//') !== 0;
   }
 
   /**

--- a/tests/test-coreutils/src/url.spec.ts
+++ b/tests/test-coreutils/src/url.spec.ts
@@ -84,10 +84,15 @@ describe('@jupyterlab/coreutils', () => {
     describe('.isLocal()', () => {
 
       it('should test whether the url is a local url', () => {
-        expect(URLExt.isLocal('//foo')).to.equal(false);
-        expect(URLExt.isLocal('http://foo')).to.equal(false);
-        expect(URLExt.isLocal('/foo/bar')).to.equal(true);
-        expect(URLExt.isLocal('foo.txt')).to.equal(true);
+        expect(URLExt.isLocal('https://foo/bar.txt')).to.equal(false);
+        expect(URLExt.isLocal('http://foo/bar.txt')).to.equal(false);
+        expect(URLExt.isLocal('//foo/bar.txt')).to.equal(false);
+        expect(URLExt.isLocal('../foo/bar.txt')).to.equal(true);
+        expect(URLExt.isLocal('./foo/bar.txt')).to.equal(true);
+        expect(URLExt.isLocal('/foo/bar.txt')).to.equal(true);
+        expect(URLExt.isLocal('foo/bar.txt')).to.equal(true);
+        expect(URLExt.isLocal('bar.txt')).to.equal(true);
+        expect(URLExt.isLocal('file://foo/bar.txt')).to.equal(false);
         expect(URLExt.isLocal('data:text/plain,123ABC')).to.equal(false);
       });
 


### PR DESCRIPTION
 Any fully qualified URL of any protocol should return `false`.

Fixes https://github.com/jupyterlab/jupyterlab/issues/3862