### PR TITLE
Fixup mirrored output padding and output height

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -287,12 +287,14 @@
   display: none;
 }
 
-
 .jp-LinkedOutputView .jp-OutputArea {
   height: 100%;
-  padding: var(--jp-notebook-padding) 0px var(--jp-notebook-padding) var(--jp-notebook-padding);
+  padding: 0;
 }
 
+.jp-LinkedOutputView .jp-OutputArea-child:only-child {
+  height: 100%;
+}
 
 .jp-LinkedOutputView-toolbar {
   box-shadow: var(--jp-toolbar-box-shadow);
@@ -300,7 +302,6 @@
   height: var(--jp-toolbar-micro-height);
   z-index: 1;
 }
-
 
 /*-----------------------------------------------------------------------------
 | Presentation Mode (.jp-mod-presentationMode)


### PR DESCRIPTION
The goal is to enable mirrored output to have content that expand on the entire tab like here:

<img width="1140" alt="screen shot 2018-02-15 at 12 59 55 am" src="https://user-images.githubusercontent.com/2397974/36234499-a43ab778-11eb-11e8-8a7a-158f0393b727.png">

 - set the `.jp-OutputArea-child` height to 100%
 - remove the weird padding that only is set on the top, bottom and left sides but not the right side.


