### PR TITLE
Change single-document toggle shortcut to something more innocuous.

### DIFF
--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -26,7 +26,7 @@
       "default": { },
       "properties": {
         "command": { "default": "application:toggle-mode" },
-        "keys": { "default": ["Accel Shift Enter"] },
+        "keys": { "default": ["Accel Shift D"] },
         "selector": { "default": "body" }
       },
       "type": "object"


### PR DESCRIPTION
Because users sometimes land themselves in single-document mode with the current keyboard shortcut unintentionally, this PR changes the default to something less likely to be triggered accidentally.

Fixes https://github.com/jupyterlab/jupyterlab/issues/3695