### PR TITLE
Separate shutdown all buttons for terminals/notebooks (closes #3764)

### DIFF
--- a/packages/running/src/index.ts
+++ b/packages/running/src/index.ts
@@ -47,9 +47,19 @@ const HEADER_CLASS = 'jp-RunningSessions-header';
 const REFRESH_CLASS = 'jp-RunningSessions-headerRefresh';
 
 /**
- * The class name added to a shutdown all button.
+ * The class name added to shutdown all buttons.
  */
-const SHUTDOWN_CLASS = 'jp-RunningSessions-headerShutdownAll';
+const SHUTDOWN_CLASS = 'jp-RunningSessions-shutdownAll';
+
+/**
+ * The class name added to a shutdown all terminals button.
+ */
+const SHUTDOWN_TERMINALS_CLASS = 'jp-RunningSessions-terminalShutdownAll';
+
+/**
+ * The class name added to a shutdown all sessions button.
+ */
+const SHUTDOWN_SESSIONS_CLASS = 'jp-RunningSessions-sessionShutdownAll';
 
 /**
  * The class name added to the running terminal sessions section.
@@ -299,7 +309,8 @@ class RunningSessions extends Widget {
     let sessionSection = DOMUtils.findElement(this.node, SESSIONS_CLASS);
     let sessionList = DOMUtils.findElement(sessionSection, LIST_CLASS);
     let refresh = DOMUtils.findElement(this.node, REFRESH_CLASS);
-    let shutdown = DOMUtils.findElement(this.node, SHUTDOWN_CLASS);
+    let shutdownTerms = DOMUtils.findElement(this.node, SHUTDOWN_TERMINALS_CLASS);
+    let shutdownSessions = DOMUtils.findElement(this.node, SHUTDOWN_SESSIONS_CLASS);
     let renderer = this._renderer;
     let clientX = event.clientX;
     let clientY = event.clientY;
@@ -310,18 +321,32 @@ class RunningSessions extends Widget {
       return;
     }
 
-    // Check for a shutdown.
-    if (ElementExt.hitTest(shutdown, clientX, clientY)) {
+    // Check for terminals shutdown.
+    if (ElementExt.hitTest(shutdownTerms, clientX, clientY)) {
       showDialog({
-        title: 'Shutdown All?',
-        body: 'Shut down all kernels and terminals?',
+        title: 'Shutdown All Terminals?',
+        body: 'Shut down all terminals?',
+        buttons: [
+          Dialog.cancelButton(), Dialog.warnButton({ label: 'SHUTDOWN' })
+        ]
+      }).then(result => {
+        if (result.button.accept) {
+          this._manager.terminals.shutdownAll();
+        }
+      });
+    }
+
+    // Check for sessions shutdown.
+    if (ElementExt.hitTest(shutdownSessions, clientX, clientY)) {
+      showDialog({
+        title: 'Shutdown All Sessions?',
+        body: 'Shut down all sessions?',
         buttons: [
           Dialog.cancelButton(), Dialog.warnButton({ label: 'SHUTDOWN' })
         ]
       }).then(result => {
         if (result.button.accept) {
           this._manager.sessions.shutdownAll();
-          this._manager.terminals.shutdownAll();
         }
       });
     }
@@ -538,11 +563,6 @@ namespace RunningSessions {
       refresh.className = REFRESH_CLASS;
       header.appendChild(refresh);
 
-      let shutdown = document.createElement('button');
-      shutdown.title = 'Shutdown All Kernels…';
-      shutdown.className = SHUTDOWN_CLASS;
-      header.appendChild(shutdown);
-
       node.appendChild(header);
       node.appendChild(terminals);
       node.appendChild(sessions);
@@ -557,6 +577,12 @@ namespace RunningSessions {
     createTerminalHeaderNode(): HTMLElement {
       let node = document.createElement('div');
       node.textContent = 'Terminal Sessions';
+
+      let shutdown = document.createElement('button');
+      shutdown.title = 'Shutdown All Terminal Sessions…';
+      shutdown.className = `${SHUTDOWN_CLASS} ${SHUTDOWN_TERMINALS_CLASS}`;
+      node.appendChild(shutdown);
+
       return node;
     }
 
@@ -568,6 +594,12 @@ namespace RunningSessions {
     createSessionHeaderNode(): HTMLElement {
       let node = document.createElement('div');
       node.textContent = 'Kernel Sessions';
+
+      let shutdown = document.createElement('button');
+      shutdown.title = 'Shutdown All Kernel Sessions…';
+      shutdown.className = `${SHUTDOWN_CLASS} ${SHUTDOWN_SESSIONS_CLASS}`;
+      node.appendChild(shutdown);
+
       return node;
     }
 

--- a/packages/running/style/index.css
+++ b/packages/running/style/index.css
@@ -56,7 +56,7 @@
 }
 
 
-.jp-RunningSessions-headerShutdownAll {
+.jp-RunningSessions-shutdownAll {
   flex: 1 1 auto;
   height: var(--jp-private-running-button-height);
   width: var(--jp-private-running-button-width);
@@ -69,7 +69,6 @@
   outline: 0;
   background-image: var(--jp-icon-close);
   background-size: 16px;
-  display: block;
   vertical-align: middle;
   background-repeat: no-repeat;
   background-position: center;
@@ -84,7 +83,7 @@
 
 
 .jp-RunningSessions-headerRefresh:hover,
-.jp-RunningSessions-headerShutdownAll:hover {
+.jp-RunningSessions-shutdownAll:hover {
   background-color: var(--jp-layout-color0);
   box-shadow: var(--jp-toolbar-box-shadow);
   border: 1px solid var(--jp-toolbar-border-color);
@@ -93,7 +92,7 @@
 
 
 .jp-RunningSessions-headerRefresh:active,
-.jp-RunningSessions-headerShutdownAll:active  {
+.jp-RunningSessions-shutdownAll:active  {
   border: 1px solid var(--jp-toolbar-border-color);
   background-color: var(--jp-toolbar-active-background);
   box-shadow: var(--jp-toolbar-box-shadow);


### PR DESCRIPTION
I split the shutdown all button into two different buttons, one to shutdown all terminals and the other to shutdown all kernels. I moved these buttons to the respective headers and kept the styling intact, as you can see below:

![screen shot 2018-02-20 at 3 47 50 pm](https://user-images.githubusercontent.com/1186124/36448450-ad1d22f4-1655-11e8-9555-7c89745de7ae.png)

At the least, these should probably be right aligned so that they appear over the individual "SHUTDOWN" buttons. Also, the reload button looks a bit more lonely now at the top.