### PR TITLE
Make notebook some context menus global

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -592,68 +592,48 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
     selector: '.jp-Notebook .jp-Cell',
     rank: 7
   });
+  app.contextMenu.addItem({
+    type: 'separator',
+    selector: '.jp-Notebook .jp-Cell',
+    rank: 8
+  });
 
   // CodeCell context menu groups
   app.contextMenu.addItem({
-    type: 'separator',
-    selector: '.jp-Notebook .jp-CodeCell',
-    rank: 8
-  });
-  app.contextMenu.addItem({
-    command: CommandIDs.clearOutputs,
+    command: CommandIDs.createOutputView,
     selector: '.jp-Notebook .jp-CodeCell',
     rank: 9
   });
   app.contextMenu.addItem({
-    command: CommandIDs.clearAllOutputs,
+    type: 'separator',
     selector: '.jp-Notebook .jp-CodeCell',
     rank: 10
   });
   app.contextMenu.addItem({
-    type: 'separator',
+    command: CommandIDs.clearOutputs,
     selector: '.jp-Notebook .jp-CodeCell',
     rank: 11
-  });
-  app.contextMenu.addItem({
-    command: CommandIDs.enableOutputScrolling,
-    selector: '.jp-Notebook .jp-CodeCell',
-    rank: 12
-  });
-  app.contextMenu.addItem({
-    command: CommandIDs.disableOutputScrolling,
-    selector: '.jp-Notebook .jp-CodeCell',
-    rank: 13
-  });
-  app.contextMenu.addItem({
-    type: 'separator',
-    selector: '.jp-Notebook .jp-CodeCell',
-    rank: 14
-  });
-  app.contextMenu.addItem({
-    command: CommandIDs.createOutputView,
-    selector: '.jp-Notebook .jp-CodeCell',
-    rank: 15
   });
 
 
   // Notebook context menu groups
   app.contextMenu.addItem({
-    type: 'separator',
+    command: CommandIDs.clearAllOutputs,
     selector: '.jp-Notebook',
     rank: 0
   });
   app.contextMenu.addItem({
-    command: CommandIDs.undoCellAction,
+    type: 'separator',
     selector: '.jp-Notebook',
     rank: 1
   });
   app.contextMenu.addItem({
-    command: CommandIDs.redoCellAction,
+    command: CommandIDs.enableOutputScrolling,
     selector: '.jp-Notebook',
     rank: 2
   });
   app.contextMenu.addItem({
-    command: CommandIDs.restart,
+    command: CommandIDs.disableOutputScrolling,
     selector: '.jp-Notebook',
     rank: 3
   });
@@ -663,12 +643,30 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
     rank: 4
   });
   app.contextMenu.addItem({
-    command: CommandIDs.createConsole,
+    command: CommandIDs.undoCellAction,
     selector: '.jp-Notebook',
     rank: 5
   });
-
-
+  app.contextMenu.addItem({
+    command: CommandIDs.redoCellAction,
+    selector: '.jp-Notebook',
+    rank: 6
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.restart,
+    selector: '.jp-Notebook',
+    rank: 7
+  });
+  app.contextMenu.addItem({
+    type: 'separator',
+    selector: '.jp-Notebook',
+    rank: 8
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.createConsole,
+    selector: '.jp-Notebook',
+    rank: 9
+  });
 
   return tracker;
 }


### PR DESCRIPTION
Addresses #3765

Currently, "Clear All Outputs", "Enable Scrolling for Outputs", and "Disable Scrolling for Outputs" context menus only show up when you right-click on a code cell. This changes them to show up when you right-click anywhere in the notebook.

It does this by making them global and re-ordering those options so that they show up between the existing global menu items and the current cell menu items. This preserves the grouping of "Clear Outputs" and "Clear All Outputs" when a code cell is selected.


## Code cell
### Old
![screen shot 2018-02-20 at 4 19 59 pm](https://user-images.githubusercontent.com/1186124/36449813-f22be944-1659-11e8-9ab4-efb1fbdb7b5e.png)

### New
![screen shot 2018-02-20 at 4 11 57 pm](https://user-images.githubusercontent.com/1186124/36449728-a956adda-1659-11e8-894e-680cf9ac590b.png)

## Other cell
### Old
![screen shot 2018-02-20 at 4 19 51 pm](https://user-images.githubusercontent.com/1186124/36449817-f7da1082-1659-11e8-8522-a80c84452139.png)

### New
![screen shot 2018-02-20 at 4 11 51 pm](https://user-images.githubusercontent.com/1186124/36449734-b0bb9ffe-1659-11e8-87d1-ea9eb2f30036.png)

## Outside of cells
### Old
![screen shot 2018-02-20 at 4 20 06 pm](https://user-images.githubusercontent.com/1186124/36449823-fc6e9492-1659-11e8-96b3-cbf548278371.png)

### New
![screen shot 2018-02-20 at 4 12 03 pm](https://user-images.githubusercontent.com/1186124/36449769-c8cb34ec-1659-11e8-9522-acc974f7ec5f.png)
