### PR TITLE
Render RenderedJavascript in white when using the Dark Theme

### DIFF
--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -19,6 +19,7 @@
 
 
 .jp-RenderedText pre,
+.jp-RenderedJavaScript pre,
 .jp-RenderedHTMLCommon pre {
   color: var(--jp-content-font-color1);
   border: none;


### PR DESCRIPTION
Tried to run arbitrary JavaScript code in a notebook cell, but couldn't really see what was happening when using the Dark Theme (black text on black background)!

Before:

![before](https://user-images.githubusercontent.com/591645/36449820-44e8ee20-168c-11e8-9537-7f0e850feada.gif)

After:

![after](https://user-images.githubusercontent.com/591645/36449831-51983676-168c-11e8-9bbf-c71fb305aee7.gif)
