### PR TITLE
Update default terminal theme when changing in the menu

### DIFF
--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -245,6 +245,8 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Instanc
     isToggled: () => terminalTheme === 'dark',
     execute: () => {
       terminalTheme = terminalTheme === 'dark' ? 'light' : 'dark';
+      let options = Terminal.defaultOptions;
+      options.theme = terminalTheme
       tracker.forEach(widget => {
         if (widget.theme !== terminalTheme) {
           widget.theme = terminalTheme;

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -246,7 +246,7 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Instanc
     execute: () => {
       terminalTheme = terminalTheme === 'dark' ? 'light' : 'dark';
       let options = Terminal.defaultOptions;
-      options.theme = terminalTheme
+      options.theme = terminalTheme;
       tracker.forEach(widget => {
         if (widget.theme !== terminalTheme) {
           widget.theme = terminalTheme;


### PR DESCRIPTION
Hi JupyterLab people,

I've just started using the beta version, and I have to say it is an amazing piece of work, I am really enjoying it .

A small annoyance that I've noticed is that when using the "Use Dark Terminal Theme" option in the View menu it was reflected in existing terminals, but the newly created terminals would always use the default dark one (which I am not a fan of).

Code-wise, the fix seems to be trivial. The added code is consistent with the terminal font size code, which maintains the font size for new terminals. I've done some simple testing on my machine and I get the expected behavior.

Thanks for your effort.