### PR TITLE
Fix cancellation of time-conflict-saving.

### DIFF
--- a/packages/docmanager/src/savehandler.ts
+++ b/packages/docmanager/src/savehandler.ts
@@ -134,6 +134,11 @@ class SaveHandler implements IDisposable {
       // Restart the update to pick up the new interval.
       this._setTimer();
     }).catch(err => {
+      // If the user canceled the save, do nothing.
+      if (err.message === 'Cancel') {
+        return;
+      }
+      // Otherwise, log the error.
       console.error('Error in Auto-Save', err.message);
     });
   }

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -262,9 +262,14 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
         return this._populate();
       }
     }).catch(err => {
-      if (err === 'Cancel') {
-        return;
+      // If the save has been canceled by the user,
+      // throw the error so that whoever called save()
+      // can decide what to do.
+      if (err.message === 'Cancel') {
+        throw err;
       }
+
+      // Otherwise show an error message and throw the error.
       const localPath = this._manager.contents.localPath(this._path);
       const name = PathExt.basename(localPath);
       this._handleError(err, `File Save Error for ${name}`);
@@ -504,7 +509,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
     let promise = this._manager.contents.get(path, { content: false });
     return promise.then(model => {
       if (this.isDisposed) {
-        return Promise.reject('Disposed');
+        return Promise.reject(new Error('Disposed'));
       }
       // We want to check last_modified (disk) > last_modified (client)
       // (our last save)
@@ -595,7 +600,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
       buttons: [Dialog.cancelButton(), revertBtn, overwriteBtn]
     }).then(result => {
       if (this.isDisposed) {
-        return Promise.reject('Disposed');
+        return Promise.reject(new Error('Disposed'));
       }
       if (result.button.label === 'OVERWRITE') {
         return this._manager.contents.save(this._path, options);
@@ -603,7 +608,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
       if (result.button.label === 'REVERT') {
         return this.revert().then(() => { return model; });
       }
-      return Promise.reject('Cancel'); // Otherwise cancel the save.
+      return Promise.reject(new Error('Cancel')); // Otherwise cancel the save.
     });
   }
 
@@ -618,7 +623,7 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
       buttons: [Dialog.cancelButton(), overwriteBtn]
     }).then(result => {
       if (this.isDisposed) {
-        return Promise.reject('Disposed');
+        return Promise.reject(new Error('Disposed'));
       }
       if (result.button.label === 'OVERWRITE') {
         return this._manager.contents.delete(path).then(() => {

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -599,11 +599,11 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
       }
       if (result.button.label === 'OVERWRITE') {
         return this._manager.contents.save(this._path, options);
-      } else if (result.button.label === 'REVERT') {
-        return this.revert().then(() => { return model; });
-      } else if (result.button.label === 'CANCEL') {
-        return Promise.reject('Cancel');
       }
+      if (result.button.label === 'REVERT') {
+        return this.revert().then(() => { return model; });
+      }
+      return Promise.reject('Cancel'); // Otherwise cancel the save.
     });
   }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -262,6 +262,9 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
         return this._populate();
       }
     }).catch(err => {
+      if (err === 'Cancel') {
+        return;
+      }
       const localPath = this._manager.contents.localPath(this._path);
       const name = PathExt.basename(localPath);
       this._handleError(err, `File Save Error for ${name}`);
@@ -598,6 +601,8 @@ class Context<T extends DocumentRegistry.IModel> implements DocumentRegistry.ICo
         return this._manager.contents.save(this._path, options);
       } else if (result.button.label === 'REVERT') {
         return this.revert().then(() => { return model; });
+      } else if (result.button.label === 'CANCEL') {
+        return Promise.reject('Cancel');
       }
     });
   }


### PR DESCRIPTION
We were not correctly handling the case of the user selecting `CANCEL` when the time-conflict dialog was shown. 