### PR TITLE
Guarantee that the create/open ready promise is never null.

### DIFF
--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -468,7 +468,7 @@ class DocumentManager implements IDisposable {
     );
 
     let context: Private.IContext | null = null;
-    let ready: Promise<void> | null = null;
+    let ready: Promise<void> = Promise.resolve(undefined);
 
     // Handle the load-from-disk case
     if (which === 'open') {


### PR DESCRIPTION
Otherwise the error handling causes an error when it tries to `catch` on a `null`:
```typescript
// If the initial opening of the context fails, dispose of the widget.
ready.catch(err => { widget.close(); });
```