### PR TITLE
Codemirror theming tweaks

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -63,15 +63,14 @@
   cursor: text;
 }
 
-
-.CodeMirror-cursor {
+.jp-CodeMirrorEditor[data-type="inline"] .CodeMirror-cursor {
   border-left: 1.4px solid var(--jp-editor-cursor-color);
 }
 
 
 /* When zoomed out 67% and 33% on a screen of 1440 width x 900 height */
 @media screen and (min-width: 2138px) and (max-width: 4319px)  {
-    .CodeMirror-cursor {
+    .jp-CodeMirrorEditor[data-type="inline"] .CodeMirror-cursor {
         border-left: 2px solid var(--jp-editor-cursor-color);
     }
 }
@@ -79,7 +78,7 @@
 
 /* When zoomed out less than 33% */
 @media screen and (min-width: 4320px)  {
-    .CodeMirror-cursor {
+    .jp-CodeMirrorEditor[data-type="inline"] .CodeMirror-cursor {
         border-left: 4px solid var(--jp-editor-cursor-color);
     }
 }

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -36,8 +36,9 @@
 }
 
 
-.CodeMirror-dialog {
+.jp-CodeMirrorEditor[data-type="inline"] .CodeMirror-dialog {
   background-color: var(--jp-layout-color0);
+  color: var(--jp-content-font-color1);
 }
 
 


### PR DESCRIPTION
Only override some Codemirror colors for the notebook, and leave them alone in the text editor. Fixes #3847. Fixes #3960