### PR TITLE
Add __main__ section to jupyterlab.labextensions

### DIFF
--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -219,3 +219,6 @@ class LabExtensionApp(JupyterApp):
 
 
 main = LabExtensionApp.launch_instance
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This allows following usage:

    python3 -m jupyterlab.labextensions ...

To avoid the redundant second `lab` in there, I wanted to suggest to rename the folder `jupyterlab/labextensions` to `jupyterlabe/extensions`, but then I saw there is a file `jupyterlab/extension.py`, which would probably be quite confusing ...