### PR TITLE
I3908 image rotation, flip and invert

### DIFF
--- a/docs/source/user/file_formats.rst
+++ b/docs/source/user/file_formats.rst
@@ -85,7 +85,9 @@ Images
 
 JupyterLab supports image data in cell output and as files in the above
 formats. In the image file viewer, you can use keyboard shortcuts such
-as ``+`` and ``-`` to zoom the image and ``0`` to reset the zoom level.
+as ``+`` and ``-`` to zoom the image, ``[`` and ``]`` to rotate the image, 
+and ``0`` to reset the image.
+
 To edit an SVG image as a text file, right-click on the SVG filename in
 the file browser and select the “Editor” item in the “Open With”
 submenu:

--- a/docs/source/user/file_formats.rst
+++ b/docs/source/user/file_formats.rst
@@ -86,7 +86,8 @@ Images
 JupyterLab supports image data in cell output and as files in the above
 formats. In the image file viewer, you can use keyboard shortcuts such
 as ``+`` and ``-`` to zoom the image, ``[`` and ``]`` to rotate the image, 
-and ``0`` to reset the image.
+and ``H`` and ``V`` to flip the image horizontally and vertically. Use 
+``I`` to invert the colors, and use ``0`` to reset the image.
 
 To edit an SVG image as a text file, right-click on the SVG filename in
 the file browser and select the “Editor” item in the “Open With”

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -27,10 +27,10 @@ namespace CommandIDs {
   const zoomOut = 'imageviewer:zoom-out';
 
   export
-  const rot90 = 'imageviewer:rotate-clockwise';
+  const rotateClockwise = 'imageviewer:rotate-clockwise';
 
   export
-  const rot270 = 'imageviewer:rotate-counterclockwise';
+  const rotateCounterclockwise = 'imageviewer:rotate-counterclockwise';
 }
 
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -27,10 +27,19 @@ namespace CommandIDs {
   const zoomOut = 'imageviewer:zoom-out';
 
   export
+  const flipHorizontal = 'imageviewer:flip-horizontal';
+
+  export
+  const flipVertical = 'imageviewer:flip-vertical';
+
+  export
   const rotateClockwise = 'imageviewer:rotate-clockwise';
 
   export
   const rotateCounterclockwise = 'imageviewer:rotate-counterclockwise';
+
+  export
+  const invertColors = 'imageviewer:invert-colors';
 }
 
 
@@ -104,7 +113,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 
   const category = 'Image Viewer';
 
-  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetImage, CommandIDs.rotateClockwise, CommandIDs.rotateCounterclockwise]
+  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetImage, CommandIDs.rotateClockwise, CommandIDs.rotateCounterclockwise, CommandIDs.flipHorizontal, CommandIDs.flipVertical, CommandIDs.invertColors]
     .forEach(command => { palette.addItem({ command, category }); });
 
   return tracker;
@@ -156,6 +165,24 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     isEnabled
   });
 
+  commands.addCommand('imageviewer:flip-horizontal', {
+    execute: flipHorizontal,
+    label: 'Flip image horizontally',
+    isEnabled
+  });
+
+  commands.addCommand('imageviewer:flip-vertical', {
+    execute: flipVertical,
+    label: 'Flip image vertically',
+    isEnabled
+  });
+
+  commands.addCommand('imageviewer:invert-colors', {
+    execute: invertColors,
+    label: 'Invert Colors',
+    isEnabled
+  });
+
   function zoomIn(): void {
     const widget = tracker.currentWidget;
 
@@ -178,6 +205,9 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     if (widget) {
       widget.scale = 1;
       widget.rotation = 0;
+      widget.horizontalflip = 1;
+      widget.verticalflip = 1;
+      widget.colorinversion = 0;
     }
   }
 
@@ -194,6 +224,31 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
 
     if (widget) {
       widget.rotation -= 90;
+    }
+  }
+
+  function flipHorizontal(): void {
+    const widget = tracker.currentWidget;
+
+    if (widget) {
+      widget.horizontalflip *= -1;
+    }
+  }
+
+  function flipVertical(): void {
+    const widget = tracker.currentWidget;
+
+    if (widget) {
+      widget.verticalflip *= -1;
+    }
+  }
+  
+  function invertColors(): void {
+    const widget = tracker.currentWidget;
+
+    if (widget) {
+      widget.colorinversion += 1;
+      widget.colorinversion %= 2;
     }
   }
 }

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -215,7 +215,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotation += 90;
+      widget.rotation -= 90;
     }
   }
 
@@ -223,7 +223,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotation -= 90;
+      widget.rotation += 90;
     }
   }
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -140,19 +140,19 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
 
   commands.addCommand('imageviewer:reset-zoom', {
     execute: resetZoom,
-    label: 'Reset Zoom',
+    label: 'Reset Image',
     isEnabled
   });
 
   commands.addCommand('imageviewer:rot90', {
     execute: rot90,
-    label: 'Rotate clockwise',
+    label: 'Rotate Clockwise',
     isEnabled
   });
     
   commands.addCommand('imageviewer:rot270', {
     execute: rot270,
-    label: 'Rotate counterclockwise',
+    label: 'Rotate Counterclockwise',
     isEnabled
   });
     
@@ -177,6 +177,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
 
     if (widget) {
       widget.scale = 1;
+      widget.rotation = 0;
     }
   }
     

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -215,7 +215,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotation -= 90;
+      widget.rotation += 90;
     }
   }
 
@@ -223,7 +223,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotation += 90;
+      widget.rotation -= 90;
     }
   }
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -242,7 +242,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
       widget.verticalflip *= -1;
     }
   }
-  
+
   function invertColors(): void {
     const widget = tracker.currentWidget;
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -18,7 +18,7 @@ import {
  */
 namespace CommandIDs {
   export
-  const resetZoom = 'imageviewer:reset-zoom';
+  const resetImage = 'imageviewer:reset-image';
 
   export
   const zoomIn = 'imageviewer:zoom-in';
@@ -27,10 +27,10 @@ namespace CommandIDs {
   const zoomOut = 'imageviewer:zoom-out';
 
   export
-  const rot90 = 'imageviewer:rot90';
+  const rot90 = 'imageviewer:rotate-clockwise';
 
   export
-  const rot270 = 'imageviewer:rot270';
+  const rot270 = 'imageviewer:rotate-counterclockwise';
 }
 
 
@@ -104,7 +104,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 
   const category = 'Image Viewer';
 
-  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetZoom, CommandIDs.rot90, CommandIDs.rot270]
+  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetImage, CommandIDs.rotateClockwise, CommandIDs.rotateCounterclockwise]
     .forEach(command => { palette.addItem({ command, category }); });
 
   return tracker;
@@ -138,20 +138,20 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     isEnabled
   });
 
-  commands.addCommand('imageviewer:reset-zoom', {
-    execute: resetZoom,
+  commands.addCommand('imageviewer:reset-image', {
+    execute: resetImage,
     label: 'Reset Image',
     isEnabled
   });
 
-  commands.addCommand('imageviewer:rot90', {
-    execute: rot90,
+  commands.addCommand('imageviewer:rotate-clockwise', {
+    execute: rotateClockwise,
     label: 'Rotate Clockwise',
     isEnabled
   });
 
-  commands.addCommand('imageviewer:rot270', {
-    execute: rot270,
+  commands.addCommand('imageviewer:rotate-counterclockwise', {
+    execute: rotateCounterclockwise,
     label: 'Rotate Counterclockwise',
     isEnabled
   });
@@ -172,7 +172,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     }
   }
 
-  function resetZoom(): void {
+  function resetImage(): void {
     const widget = tracker.currentWidget;
 
     if (widget) {
@@ -181,7 +181,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     }
   }
 
-  function rot90(): void {
+  function rotateClockwise(): void {
     const widget = tracker.currentWidget;
 
     if (widget) {
@@ -189,11 +189,11 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     }
   }
 
-  function rot270(): void {
+  function rotateCounterclockwise(): void {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotation += 270;
+      widget.rotation -= 90;
     }
   }
 }

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -33,10 +33,10 @@ namespace CommandIDs {
   const flipVertical = 'imageviewer:flip-vertical';
 
   export
-  const rotateClockwise = 'imageviewer:rotate-clockwise';
+  const rotateRight = 'imageviewer:rotate-right';
 
   export
-  const rotateCounterclockwise = 'imageviewer:rotate-counterclockwise';
+  const rotateLeft = 'imageviewer:rotate-left';
 
   export
   const invertColors = 'imageviewer:invert-colors';
@@ -113,7 +113,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 
   const category = 'Image Viewer';
 
-  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetImage, CommandIDs.rotateClockwise, CommandIDs.rotateCounterclockwise, CommandIDs.flipHorizontal, CommandIDs.flipVertical, CommandIDs.invertColors]
+  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetImage, CommandIDs.rotateRight, CommandIDs.rotateLeft, CommandIDs.flipHorizontal, CommandIDs.flipVertical, CommandIDs.invertColors]
     .forEach(command => { palette.addItem({ command, category }); });
 
   return tracker;
@@ -153,15 +153,15 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     isEnabled
   });
 
-  commands.addCommand('imageviewer:rotate-clockwise', {
-    execute: rotateClockwise,
-    label: 'Rotate Clockwise',
+  commands.addCommand('imageviewer:rotate-right', {
+    execute: rotateRight,
+    label: 'Rotate Right (CW)',
     isEnabled
   });
 
-  commands.addCommand('imageviewer:rotate-counterclockwise', {
-    execute: rotateCounterclockwise,
-    label: 'Rotate Counterclockwise',
+  commands.addCommand('imageviewer:rotate-left', {
+    execute: rotateLeft,
+    label: 'Rotate Left (CCW)',
     isEnabled
   });
 
@@ -204,26 +204,24 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
 
     if (widget) {
       widget.scale = 1;
-      widget.rotation = 0;
-      widget.horizontalflip = 1;
-      widget.verticalflip = 1;
       widget.colorinversion = 0;
+      widget.resetRotationFlip();
     }
   }
 
-  function rotateClockwise(): void {
+  function rotateRight(): void {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotation += 90;
+      widget.rotateRight();
     }
   }
 
-  function rotateCounterclockwise(): void {
+  function rotateLeft(): void {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotation -= 90;
+      widget.rotateLeft();
     }
   }
 
@@ -231,7 +229,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.horizontalflip *= -1;
+      widget.flipHorizontal();
     }
   }
 
@@ -239,7 +237,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.verticalflip *= -1;
+      widget.flipVertical();
     }
   }
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -180,7 +180,7 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
       widget.rotation = 0;
     }
   }
-    
+
   function rot90(): void {
     const widget = tracker.currentWidget;
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -25,6 +25,12 @@ namespace CommandIDs {
 
   export
   const zoomOut = 'imageviewer:zoom-out';
+
+  export
+  const rot90 = 'imageviewer:rot90';
+
+  export
+  const rot270 = 'imageviewer:rot270';
 }
 
 
@@ -98,7 +104,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 
   const category = 'Image Viewer';
 
-  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetZoom]
+  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetZoom, CommandIDs.rot90, CommandIDs.rot270]
     .forEach(command => { palette.addItem({ command, category }); });
 
   return tracker;
@@ -138,6 +144,18 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     isEnabled
   });
 
+  commands.addCommand('imageviewer:rot90', {
+    execute: rot90,
+    label: 'Rotate clockwise',
+    isEnabled
+  });
+    
+  commands.addCommand('imageviewer:rot270', {
+    execute: rot270,
+    label: 'Rotate counterclockwise',
+    isEnabled
+  });
+    
   function zoomIn(): void {
     const widget = tracker.currentWidget;
 
@@ -159,6 +177,22 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
 
     if (widget) {
       widget.scale = 1;
+    }
+  }
+    
+  function rot90(): void {
+    const widget = tracker.currentWidget;
+
+    if (widget) {
+      widget.rotation += 90;
+    }
+  }
+
+  function rot270(): void {
+    const widget = tracker.currentWidget;
+
+    if (widget) {
+      widget.rotation += 270;
     }
   }
 }

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -33,10 +33,10 @@ namespace CommandIDs {
   const flipVertical = 'imageviewer:flip-vertical';
 
   export
-  const rotateRight = 'imageviewer:rotate-right';
+  const rotateClockwise = 'imageviewer:rotate-clockwise';
 
   export
-  const rotateLeft = 'imageviewer:rotate-left';
+  const rotateCounterclockwise = 'imageviewer:rotate-counterclockwise';
 
   export
   const invertColors = 'imageviewer:invert-colors';
@@ -113,7 +113,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 
   const category = 'Image Viewer';
 
-  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetImage, CommandIDs.rotateRight, CommandIDs.rotateLeft, CommandIDs.flipHorizontal, CommandIDs.flipVertical, CommandIDs.invertColors]
+  [CommandIDs.zoomIn, CommandIDs.zoomOut, CommandIDs.resetImage, CommandIDs.rotateClockwise, CommandIDs.rotateCounterclockwise, CommandIDs.flipHorizontal, CommandIDs.flipVertical, CommandIDs.invertColors]
     .forEach(command => { palette.addItem({ command, category }); });
 
   return tracker;
@@ -153,15 +153,15 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     isEnabled
   });
 
-  commands.addCommand('imageviewer:rotate-right', {
-    execute: rotateRight,
-    label: 'Rotate Right (CW)',
+  commands.addCommand('imageviewer:rotate-clockwise', {
+    execute: rotateClockwise,
+    label: 'Rotate Clockwise',
     isEnabled
   });
 
-  commands.addCommand('imageviewer:rotate-left', {
-    execute: rotateLeft,
-    label: 'Rotate Left (CCW)',
+  commands.addCommand('imageviewer:rotate-counterclockwise', {
+    execute: rotateCounterclockwise,
+    label: 'Rotate Counterclockwise',
     isEnabled
   });
 
@@ -209,19 +209,19 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     }
   }
 
-  function rotateRight(): void {
+  function rotateClockwise(): void {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotateRight();
+      widget.rotateClockwise();
     }
   }
 
-  function rotateLeft(): void {
+  function rotateCounterclockwise(): void {
     const widget = tracker.currentWidget;
 
     if (widget) {
-      widget.rotateLeft();
+      widget.rotateCounterclockwise();
     }
   }
 

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -149,13 +149,13 @@ function addCommands(app: JupyterLab, tracker: IImageTracker) {
     label: 'Rotate Clockwise',
     isEnabled
   });
-    
+
   commands.addCommand('imageviewer:rot270', {
     execute: rot270,
     label: 'Rotate Counterclockwise',
     isEnabled
   });
-    
+
   function zoomIn(): void {
     const widget = tracker.currentWidget;
 

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -42,11 +42,6 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this.node.tabIndex = -1;
     this.addClass(IMAGE_CLASS);
 
-    this._orientation = document.createElement('div');
-    this._orientation.textContent = '↸';
-    this._orientation.classList.add('jp-ImageViewer-orientation')
-    this.node.appendChild(this._orientation);
-
     this._img = document.createElement('img');
     this.node.appendChild(this._img);
 
@@ -186,8 +181,6 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     let [tX, tY] = Private.prodVec(this._matrix, [1, 1]);
     let transform = `matrix(${a}, ${b}, ${c}, ${d}, 0, 0) translate(${tX < 0 ? -100 : 0}%, ${tY < 0 ? -100 : 0}%) `;
     this._img.style.transform = `scale(${this._scale}) ${transform}`;
-    this._orientation.style.transform = transform;
-
     this._img.style.filter = `invert(${this._colorinversion})`;
   }
 
@@ -196,7 +189,6 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
   private _colorinversion = 0;
   private _ready = new PromiseDelegate<void>();
   private _img: HTMLImageElement;
-  private _orientation: HTMLDivElement;
 }
 
 

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -82,7 +82,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
       return;
     }
     this._scale = value;
-    this.updateStyle();
+    this._updateStyle();
   }
 
   /**
@@ -96,7 +96,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
         return;
     }
     this._colorinversion = value;
-    this.updateStyle();
+    this._updateStyle();
   }
 
   /**
@@ -104,7 +104,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
    */
   resetRotationFlip(): void {
     this._matrix = [1, 0, 0, 1];
-    this.updateStyle();
+    this._updateStyle();
   }
 
   /**
@@ -112,7 +112,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
    */
   rotateLeft(): void {
     this._matrix = Private.prod(this._matrix, Private.rotateLeftMatrix);
-    this.updateStyle();
+    this._updateStyle();
   }
 
   /**
@@ -120,7 +120,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
    */
   rotateRight(): void {
     this._matrix = Private.prod(this._matrix, Private.rotateRightMatrix);
-    this.updateStyle();
+    this._updateStyle();
   }
 
   /**
@@ -128,7 +128,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
    */
   flipHorizontal(): void {
     this._matrix = Private.prod(this._matrix, Private.flipHMatrix);
-    this.updateStyle();
+    this._updateStyle();
   }
 
   /**
@@ -136,7 +136,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
    */
   flipVertical(): void {
     this._matrix = Private.prod(this._matrix, Private.flipVMatrix);
-    this.updateStyle();
+    this._updateStyle();
   }
 
   /**
@@ -176,7 +176,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this._img.src = `data:${cm.mimetype};${cm.format},${content}`;
   }
 
-  private updateStyle(): void {
+  private _updateStyle(): void {
     let [a, b, c, d] = this._matrix;
     let [tX, tY] = Private.prodVec(this._matrix, [1, 1]);
     let transform = `matrix(${a}, ${b}, ${c}, ${d}, 0, 0) translate(${tX < 0 ? -100 : 0}%, ${tY < 0 ? -100 : 0}%) `;

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -108,17 +108,17 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   /**
-   * Rotate the image left (counter-clockwise).
+   * Rotate the image counter-clockwise (left).
    */
-  rotateLeft(): void {
+  rotateCounterclockwise(): void {
     this._matrix = Private.prod(this._matrix, Private.rotateLeftMatrix);
     this._updateStyle();
   }
 
   /**
-   * Rotate the image right (clockwise).
+   * Rotate the image clockwise (right).
    */
-  rotateRight(): void {
+  rotateClockwise(): void {
     this._matrix = Private.prod(this._matrix, Private.rotateRightMatrix);
     this._updateStyle();
   }

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -79,10 +79,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
       return;
     }
     this._scale = value;
-    let scaleNode = this.node.querySelector('div') as HTMLElement;
-    let transform: string;
-    transform = `translate(-50%,-50%) scale(${value}) rotate(${this._rotation}deg)`;
-    scaleNode.style.transform = transform;
+    this.updateStyle();
   }
 
   /**
@@ -96,12 +93,51 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
         return;
     }
     this._rotation = value % 360;
-    let rotNode = this.node.querySelector('div') as HTMLElement;
-    let transform: string;
-    transform = `translate(-50%,-50%) scale(${this._scale}) rotate(${value}deg)`;
-    rotNode.style.transform = transform;
+    this.updateStyle();
+  }
+  
+  /**
+   * The horizontal flip of the image.
+   */
+  get horizontalflip(): number {
+    return this._horizontalflip;
+  }
+  set horizontalflip(value: number) {
+    if (value === this._horizontalflip) {
+        return;
+    }
+    this._horizontalflip = value;
+    this.updateStyle();
   }
 
+  /**
+   * The vertical flip of the image.
+   */
+  get verticalflip(): number {
+    return this._verticalflip;
+  }
+  set verticalflip(value: number) {
+    if (value === this._verticalflip) {
+        return;
+    }
+    this._verticalflip = value;
+    this.updateStyle();
+  }
+
+  /**
+   * The color inversion of the image.
+   */
+  get colorinversion(): number {
+    return this._colorinversion;
+  }
+  set colorinversion(value: number) {
+    if (value === this._colorinversion) {
+        return;
+    }
+    this._colorinversion = value;
+    this.updateStyle();
+  }
+  
   /**
    * Handle `update-request` messages for the widget.
    */
@@ -141,8 +177,25 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     node.setAttribute('src', src);
   }
 
+  private updateStyle(): void {
+      let transformString: string;
+      let filterString: string;
+  
+      transformString = `translate(-50%,-50%) `;
+      transformString += `scale(${this._scale*this._horizontalflip},${this._scale*this._verticalflip}) `;
+      transformString += `rotate(${this._rotation}deg)`;
+      filterString = `invert(${this._colorinversion})`;
+
+      let rotNode = this.node.querySelector('div') as HTMLElement;
+      rotNode.style.transform = transformString;
+      rotNode.style.filter = filterString;
+  }
+
   private _scale = 1;
   private _rotation = 0;
+  private _horizontalflip = 1;
+  private _verticalflip = 1;
+  private _colorinversion = 0;
   private _ready = new PromiseDelegate<void>();
 }
 

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -95,7 +95,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     if (value === this._rotation) {
         return;
     }
-    this._rotation = value;
+    this._rotation = value % 360;
     let rotNode = this.node.querySelector('div') as HTMLElement;
     let transform: string;
     transform = `translate(-50%,-50%) scale(${this._scale}) rotate(${value}deg)`;

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -111,7 +111,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
    * Rotate the image counter-clockwise (left).
    */
   rotateCounterclockwise(): void {
-    this._matrix = Private.prod(this._matrix, Private.rotateLeftMatrix);
+    this._matrix = Private.prod(this._matrix, Private.rotateCounterclockwiseMatrix);
     this._updateStyle();
   }
 
@@ -119,7 +119,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
    * Rotate the image clockwise (right).
    */
   rotateClockwise(): void {
-    this._matrix = Private.prod(this._matrix, Private.rotateRightMatrix);
+    this._matrix = Private.prod(this._matrix, Private.rotateClockwiseMatrix);
     this._updateStyle();
   }
 
@@ -233,13 +233,13 @@ namespace Private {
    * Clockwise rotation transformation matrix.
    */
   export
-  const rotateRightMatrix = [0, 1, -1, 0];
+  const rotateClockwiseMatrix = [0, 1, -1, 0];
 
   /**
    * Counter-clockwise rotation transformation matrix.
    */
   export
-  const rotateLeftMatrix = [0, -1, 1, 0];
+  const rotateCounterclockwiseMatrix = [0, -1, 1, 0];
 
   /**
    * Horizontal flip transformation matrix.

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -96,10 +96,10 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
         return;
     }
     this._rotation = value;
-    let scaleNode = this.node.querySelector('div') as HTMLElement;
+    let rotNode = this.node.querySelector('div') as HTMLElement;
     let transform: string;
-      transform = `rotate(${value}deg)`;
-    scaleNode.style.transform = transform;
+      transform = `translate(-50%,-50%) rotate(${value}deg)`;
+    rotNode.style.transform = transform;
   }
 
   /**

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -81,7 +81,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this._scale = value;
     let scaleNode = this.node.querySelector('div') as HTMLElement;
     let transform: string;
-    transform = `scale(${value})`;
+      transform = `translate(-50%,-50%) scale(${value}) rotate(${this._rotation}deg)`;
     scaleNode.style.transform = transform;
   }
 
@@ -98,7 +98,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this._rotation = value;
     let rotNode = this.node.querySelector('div') as HTMLElement;
     let transform: string;
-      transform = `translate(-50%,-50%) rotate(${value}deg)`;
+      transform = `translate(-50%,-50%) scale(${this._scale}) rotate(${value}deg)`;
     rotNode.style.transform = transform;
   }
 

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -95,7 +95,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this._rotation = value % 360;
     this.updateStyle();
   }
-  
+
   /**
    * The horizontal flip of the image.
    */
@@ -137,7 +137,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this._colorinversion = value;
     this.updateStyle();
   }
-  
+
   /**
    * Handle `update-request` messages for the widget.
    */
@@ -180,9 +180,9 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
   private updateStyle(): void {
       let transformString: string;
       let filterString: string;
-  
+
       transformString = `translate(-50%,-50%) `;
-      transformString += `scale(${this._scale*this._horizontalflip},${this._scale*this._verticalflip}) `;
+      transformString += `scale(${this._scale * this._horizontalflip},${this._scale * this._verticalflip}) `;
       transformString += `rotate(${this._rotation}deg)`;
       filterString = `invert(${this._colorinversion})`;
 

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -81,14 +81,14 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this._scale = value;
     let scaleNode = this.node.querySelector('div') as HTMLElement;
     let transform: string;
-      transform = `translate(-50%,-50%) scale(${value}) rotate(${this._rotation}deg)`;
+    transform = `translate(-50%,-50%) scale(${value}) rotate(${this._rotation}deg)`;
     scaleNode.style.transform = transform;
   }
 
   /**
    * The rotation of the image.
    */
-  get rotation(): number{
+  get rotation(): number {
     return this._rotation;
   }
   set rotation(value: number) {
@@ -98,7 +98,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this._rotation = value;
     let rotNode = this.node.querySelector('div') as HTMLElement;
     let transform: string;
-      transform = `translate(-50%,-50%) scale(${this._scale}) rotate(${value}deg)`;
+    transform = `translate(-50%,-50%) scale(${this._scale}) rotate(${value}deg)`;
     rotNode.style.transform = transform;
   }
 

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -37,10 +37,18 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
    * Construct a new image widget.
    */
   constructor(context: DocumentRegistry.Context) {
-    super({ node: Private.createNode() });
+    super();
     this.context = context;
     this.node.tabIndex = -1;
     this.addClass(IMAGE_CLASS);
+
+    this._orientation = document.createElement('div');
+    this._orientation.textContent = '↸';
+    this._orientation.classList.add('jp-ImageViewer-orientation')
+    this.node.appendChild(this._orientation);
+
+    this._img = document.createElement('img');
+    this.node.appendChild(this._img);
 
     this._onTitleChanged();
     context.pathChanged.connect(this._onTitleChanged, this);
@@ -83,48 +91,6 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   /**
-   * The rotation of the image.
-   */
-  get rotation(): number {
-    return this._rotation;
-  }
-  set rotation(value: number) {
-    if (value === this._rotation) {
-        return;
-    }
-    this._rotation = value % 360;
-    this.updateStyle();
-  }
-
-  /**
-   * The horizontal flip of the image.
-   */
-  get horizontalflip(): number {
-    return this._horizontalflip;
-  }
-  set horizontalflip(value: number) {
-    if (value === this._horizontalflip) {
-        return;
-    }
-    this._horizontalflip = value;
-    this.updateStyle();
-  }
-
-  /**
-   * The vertical flip of the image.
-   */
-  get verticalflip(): number {
-    return this._verticalflip;
-  }
-  set verticalflip(value: number) {
-    if (value === this._verticalflip) {
-        return;
-    }
-    this._verticalflip = value;
-    this.updateStyle();
-  }
-
-  /**
    * The color inversion of the image.
    */
   get colorinversion(): number {
@@ -135,6 +101,46 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
         return;
     }
     this._colorinversion = value;
+    this.updateStyle();
+  }
+
+  /**
+   * Reset rotation and flip transformations.
+   */
+  resetRotationFlip(): void {
+    this._matrix = [1, 0, 0, 1];
+    this.updateStyle();
+  }
+
+  /**
+   * Rotate the image left (counter-clockwise).
+   */
+  rotateLeft(): void {
+    this._matrix = Private.prod(this._matrix, Private.rotateLeftMatrix);
+    this.updateStyle();
+  }
+
+  /**
+   * Rotate the image right (clockwise).
+   */
+  rotateRight(): void {
+    this._matrix = Private.prod(this._matrix, Private.rotateRightMatrix);
+    this.updateStyle();
+  }
+
+  /**
+   * Flip the image horizontally.
+   */
+  flipHorizontal(): void {
+    this._matrix = Private.prod(this._matrix, Private.flipHMatrix);
+    this.updateStyle();
+  }
+
+  /**
+   * Flip the image vertically.
+   */
+  flipVertical(): void {
+    this._matrix = Private.prod(this._matrix, Private.flipVMatrix);
     this.updateStyle();
   }
 
@@ -172,31 +178,25 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
       return;
     }
     let content = context.model.toString();
-    let src = `data:${cm.mimetype};${cm.format},${content}`;
-    let node = this.node.querySelector('img') as HTMLImageElement;
-    node.setAttribute('src', src);
+    this._img.src = `data:${cm.mimetype};${cm.format},${content}`;
   }
 
   private updateStyle(): void {
-      let transformString: string;
-      let filterString: string;
+    let [a, b, c, d] = this._matrix;
+    let [tX, tY] = Private.prodVec(this._matrix, [1, 1]);
+    let transform = `matrix(${a}, ${b}, ${c}, ${d}, 0, 0) translate(${tX < 0 ? -100 : 0}%, ${tY < 0 ? -100 : 0}%) `;
+    this._img.style.transform = `scale(${this._scale}) ${transform}`;
+    this._orientation.style.transform = transform;
 
-      transformString = `translate(-50%,-50%) `;
-      transformString += `scale(${this._scale * this._horizontalflip},${this._scale * this._verticalflip}) `;
-      transformString += `rotate(${this._rotation}deg)`;
-      filterString = `invert(${this._colorinversion})`;
-
-      let rotNode = this.node.querySelector('div') as HTMLElement;
-      rotNode.style.transform = transformString;
-      rotNode.style.filter = filterString;
+    this._img.style.filter = `invert(${this._colorinversion})`;
   }
 
   private _scale = 1;
-  private _rotation = 0;
-  private _horizontalflip = 1;
-  private _verticalflip = 1;
+  private _matrix = [1, 0, 0, 1];
   private _colorinversion = 0;
   private _ready = new PromiseDelegate<void>();
+  private _img: HTMLImageElement;
+  private _orientation: HTMLDivElement;
 }
 
 
@@ -218,15 +218,43 @@ class ImageViewerFactory extends ABCWidgetFactory<ImageViewer, DocumentRegistry.
  */
 namespace Private {
   /**
-   * Create the node for the image widget.
+   * Multiply 2x2 matrices.
    */
   export
-  function createNode(): HTMLElement {
-    let node = document.createElement('div');
-    let innerNode = document.createElement('div');
-    let image = document.createElement('img');
-    node.appendChild(innerNode);
-    innerNode.appendChild(image);
-    return node;
+  function prod([a11, a12, a21, a22]: number[], [b11, b12, b21, b22]: number[]): number[] {
+    return [a11 * b11 + a12 * b21, a11 * b12 + a12 * b22,
+            a21 * b11 + a22 * b21, a21 * b12 + a22 * b22];
   }
+
+  /**
+   * Multiply a 2x2 matrix and a 2x1 vector.
+   */
+  export
+  function prodVec([a11, a12, a21, a22]: number[], [b1, b2]: number[]): number[] {
+    return [a11 * b1 + a12 * b2, a21 * b1 + a22 * b2];
+  }
+
+  /**
+   * Clockwise rotation transformation matrix.
+   */
+  export
+  const rotateRightMatrix = [0, 1, -1, 0];
+
+  /**
+   * Counter-clockwise rotation transformation matrix.
+   */
+  export
+  const rotateLeftMatrix = [0, -1, 1, 0];
+
+  /**
+   * Horizontal flip transformation matrix.
+   */
+  export
+  const flipHMatrix = [-1, 0, 0, 1];
+
+  /**
+   * Vertical flip transformation matrix.
+   */
+  export
+  const flipVMatrix = [1, 0, 0, -1];
 }

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -176,6 +176,9 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
     this._img.src = `data:${cm.mimetype};${cm.format},${content}`;
   }
 
+  /**
+   * Update the image CSS style, including the transform and filter.
+   */
   private _updateStyle(): void {
     let [a, b, c, d] = this._matrix;
     let [tX, tY] = Private.prodVec(this._matrix, [1, 1]);

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -86,6 +86,23 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   /**
+   * The rotation of the image.
+   */
+  get rotation(): number{
+    return this._rotation;
+  }
+  set rotation(value: number) {
+    if (value === this._rotation) {
+        return;
+    }
+    this._rotation = value;
+    let scaleNode = this.node.querySelector('div') as HTMLElement;
+    let transform: string;
+      transform = `rotate(${value}deg)`;
+    scaleNode.style.transform = transform;
+  }
+
+  /**
    * Handle `update-request` messages for the widget.
    */
   protected onUpdateRequest(msg: Message): void {
@@ -125,6 +142,7 @@ class ImageViewer extends Widget implements DocumentRegistry.IReadyWidget {
   }
 
   private _scale = 1;
+  private _rotation = 0;
   private _ready = new PromiseDelegate<void>();
 }
 

--- a/packages/imageviewer/style/index.css
+++ b/packages/imageviewer/style/index.css
@@ -15,6 +15,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  z-index: -1;
 }
 
 

--- a/packages/imageviewer/style/index.css
+++ b/packages/imageviewer/style/index.css
@@ -15,18 +15,6 @@
   max-height:100%;
 }
 
-.jp-ImageViewer-orientation {
-  box-sizing: border-box;
-  position: absolute;
-  transform-origin: top left;
-  top: 10px;
-  left: 10px;
-  font-size: 30px;
-  font-weight: 900;
-  z-index: 1;
-  background-color: rgba(255, 255, 255, 0.8);
-}
-
 .jp-ImageViewer::before {
     content: '';
     display: block;

--- a/packages/imageviewer/style/index.css
+++ b/packages/imageviewer/style/index.css
@@ -12,10 +12,16 @@
 .jp-ImageViewer > div {
   position: absolute;
   transform-origin: center center;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 
 .jp-ImageViewer img {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
   max-width: 100%;
   max-height: 100%;
   margin: auto;

--- a/packages/imageviewer/style/index.css
+++ b/packages/imageviewer/style/index.css
@@ -22,8 +22,6 @@
   display: table-cell;
   vertical-align: middle;
   text-align: center;
-  max-width: 100%;
-  max-height: 100%;
   margin: auto;
 }
 

--- a/packages/imageviewer/style/index.css
+++ b/packages/imageviewer/style/index.css
@@ -10,7 +10,8 @@
 
 
 .jp-ImageViewer > div {
-  transform-origin: top left;
+  position: absolute;
+  transform-origin: center center;
 }
 
 

--- a/packages/imageviewer/style/index.css
+++ b/packages/imageviewer/style/index.css
@@ -11,8 +11,6 @@
 .jp-ImageViewer > img {
   box-sizing: border-box;
   transform-origin: top left;
-  max-width:100%;
-  max-height:100%;
 }
 
 .jp-ImageViewer::before {

--- a/packages/imageviewer/style/index.css
+++ b/packages/imageviewer/style/index.css
@@ -19,9 +19,6 @@
 
 
 .jp-ImageViewer img {
-  display: table-cell;
-  vertical-align: middle;
-  text-align: center;
   margin: auto;
 }
 

--- a/packages/imageviewer/style/index.css
+++ b/packages/imageviewer/style/index.css
@@ -8,21 +8,24 @@
   overflow: auto;
 }
 
+.jp-ImageViewer > img {
+  box-sizing: border-box;
+  transform-origin: top left;
+  max-width:100%;
+  max-height:100%;
+}
 
-.jp-ImageViewer > div {
+.jp-ImageViewer-orientation {
+  box-sizing: border-box;
   position: absolute;
-  transform-origin: center center;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: -1;
+  transform-origin: top left;
+  top: 10px;
+  left: 10px;
+  font-size: 30px;
+  font-weight: 900;
+  z-index: 1;
+  background-color: rgba(255, 255, 255, 0.8);
 }
-
-
-.jp-ImageViewer img {
-  margin: auto;
-}
-
 
 .jp-ImageViewer::before {
     content: '';

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -179,7 +179,7 @@
       "default": { },
       "properties": {
         "command": { "default": "imageviewer:rotate-clockwise" },
-        "keys": { "default": ["["] },
+        "keys": { "default": ["]"] },
         "selector": { "default": ".jp-ImageViewer" }
       },
       "type": "object"
@@ -188,7 +188,7 @@
       "default": { },
       "properties": {
         "command": { "default": "imageviewer:rotate-counterclockwise" },
-        "keys": { "default": ["]"] },
+        "keys": { "default": ["["] },
         "selector": { "default": ".jp-ImageViewer" }
       },
       "type": "object"

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -175,6 +175,24 @@
       },
       "type": "object"
     },
+    "imageviewer:rot90": {
+      "default": { },
+      "properties": {
+        "command": { "default": "imageviewer:rot90" },
+        "keys": { "default": ["["] },
+        "selector": { "default": ".jp-ImageViewer" }
+      },
+      "type": "object"
+    },
+    "imageviewer:rot270": {
+      "default": { },
+      "properties": {
+        "command": { "default": "imageviewer:rot270" },
+        "keys": { "default": ["]"] },
+        "selector": { "default": ".jp-ImageViewer" }
+      },
+      "type": "object"
+    },
     "inspector:open": {
       "default": { },
       "properties": {

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -148,10 +148,10 @@
       },
       "type": "object"
     },
-    "imageviewer:reset-zoom": {
+    "imageviewer:reset-image": {
       "default": { },
       "properties": {
-        "command": { "default": "imageviewer:reset-zoom" },
+        "command": { "default": "imageviewer:reset-image" },
         "keys": { "default": ["0"] },
         "selector": { "default": ".jp-ImageViewer" }
       },
@@ -175,20 +175,47 @@
       },
       "type": "object"
     },
-    "imageviewer:rot90": {
+    "imageviewer:rotate-clockwise": {
       "default": { },
       "properties": {
-        "command": { "default": "imageviewer:rot90" },
+        "command": { "default": "imageviewer:rotate-clockwise" },
         "keys": { "default": ["["] },
         "selector": { "default": ".jp-ImageViewer" }
       },
       "type": "object"
     },
-    "imageviewer:rot270": {
+    "imageviewer:rotate-counterclockwise": {
       "default": { },
       "properties": {
-        "command": { "default": "imageviewer:rot270" },
+        "command": { "default": "imageviewer:rotate-counterclockwise" },
         "keys": { "default": ["]"] },
+        "selector": { "default": ".jp-ImageViewer" }
+      },
+      "type": "object"
+    },
+    "imageviewer:flip-vertical": {
+      "default": { },
+      "properties": {
+        "command": { "default": "imageviewer:flip-vertical" },
+        "keys": { "default": ["V"] },
+        "selector": { "default": ".jp-ImageViewer" }
+      },
+      "type": "object"
+    },
+    "imageviewer:flip-horizontal": {
+      "default": { },
+      "properties": {
+        "command": { "default": "imageviewer:flip-horizontal" },
+        "keys": { "default": ["H"] },
+        "selector": { "default": ".jp-ImageViewer" }
+      },
+      "type": "object"
+    },
+    "imageviewer:invert-colors": {
+      "default": { },
+      "properties": {
+        "command": { "default": "imageviewer:invert-colors" },
+        "keys": { "default": ["I"] },
         "selector": { "default": ".jp-ImageViewer" }
       },
       "type": "object"

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -175,19 +175,19 @@
       },
       "type": "object"
     },
-    "imageviewer:rotate-right": {
+    "imageviewer:rotate-clockwise": {
       "default": { },
       "properties": {
-        "command": { "default": "imageviewer:rotate-right" },
+        "command": { "default": "imageviewer:rotate-clockwise" },
         "keys": { "default": ["]"] },
         "selector": { "default": ".jp-ImageViewer" }
       },
       "type": "object"
     },
-    "imageviewer:rotate-left": {
+    "imageviewer:rotate-counterclockwise": {
       "default": { },
       "properties": {
-        "command": { "default": "imageviewer:rotate-left" },
+        "command": { "default": "imageviewer:rotate-counterclockwise" },
         "keys": { "default": ["["] },
         "selector": { "default": ".jp-ImageViewer" }
       },

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -175,19 +175,19 @@
       },
       "type": "object"
     },
-    "imageviewer:rotate-clockwise": {
+    "imageviewer:rotate-right": {
       "default": { },
       "properties": {
-        "command": { "default": "imageviewer:rotate-clockwise" },
+        "command": { "default": "imageviewer:rotate-right" },
         "keys": { "default": ["]"] },
         "selector": { "default": ".jp-ImageViewer" }
       },
       "type": "object"
     },
-    "imageviewer:rotate-counterclockwise": {
+    "imageviewer:rotate-left": {
       "default": { },
       "properties": {
-        "command": { "default": "imageviewer:rotate-counterclockwise" },
+        "command": { "default": "imageviewer:rotate-left" },
         "keys": { "default": ["["] },
         "selector": { "default": ".jp-ImageViewer" }
       },


### PR DESCRIPTION
This PR addresses the image widget rotation issue #3908. This adds css to center the image on the page so that the rotation transformation origin can be set to the image center. It also assigns "[" and "]" as keyboard shortcuts.