### PR TITLE
Alert user for duplicate plugin ids 

### DIFF
--- a/packages/application-extension/src/index.ts
+++ b/packages/application-extension/src/index.ts
@@ -67,6 +67,18 @@ const main: JupyterLabPlugin<void> = {
   id: '@jupyterlab/application-extension:main',
   requires: [ICommandPalette],
   activate: (app: JupyterLab, palette: ICommandPalette) => {
+    // If there were errors registering plugins, tell the user.
+    if (app.registerPluginErrors.length !== 0) {
+      const body = h.pre(app.registerPluginErrors.map(e => e.message).join('\n'));
+      let options = {
+        title: 'Error Registering Plugins',
+        body,
+        buttons: [Dialog.okButton()],
+        okText: 'DISMISS'
+      };
+      showDialog(options).then(() => { /* no-op */ });
+    }
+
     addCommands(app, palette);
 
     // If the currently active widget changes,

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -154,7 +154,6 @@ class JupyterLab extends Application<ApplicationShell> {
     data.forEach(item => {
       try {
         this.registerPlugin(item);
-        this.registerPlugin(item);
       } catch (error) {
         this.registerPluginErrors.push(error);
       }

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -99,7 +99,7 @@ class JupyterLab extends Application<ApplicationShell> {
   /**
    * A list of all errors encountered when registering plugins.
    */
-  public readonly registerPluginErrors: Array<Error> = [];
+  readonly registerPluginErrors: Array<Error> = [];
 
   /**
    * Whether the application is dirty.

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -97,6 +97,11 @@ class JupyterLab extends Application<ApplicationShell> {
   readonly serviceManager: ServiceManager;
 
   /**
+   * A list of all errors encountered when registering plugins.
+   */
+  public readonly registerPluginErrors: Array<Error> = [];
+
+  /**
    * Whether the application is dirty.
    */
   get isDirty(): boolean {
@@ -149,8 +154,9 @@ class JupyterLab extends Application<ApplicationShell> {
     data.forEach(item => {
       try {
         this.registerPlugin(item);
+        this.registerPlugin(item);
       } catch (error) {
-        window.alert(error);
+        this.registerPluginErrors.push(error);
       }
     });
   }

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -146,7 +146,13 @@ class JupyterLab extends Application<ApplicationShell> {
     if (!Array.isArray(data)) {
       data = [data];
     }
-    data.forEach(item => { this.registerPlugin(item); });
+    data.forEach(item => {
+      try {
+        this.registerPlugin(item);
+      } catch (error) {
+        window.alert(error);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
This addresses #3720 by popping up an alert to the user if two plugins are loaded with the same name and continuing to load. Here is a screenshot of it in action:


<img width="1143" alt="screen shot 2018-02-27 at 1 43 18 pm" src="https://user-images.githubusercontent.com/1186124/36749148-e6df847e-1bc7-11e8-8288-d3a102815bc2.png">


This could also be addressed by just logging the error the console, [which is what happens if a plugin fails to activate](https://github.com/saulshanabrook/phosphor/blob/4d787b32136861adae4ebadc6c877a130d0cb216/packages/application/src/index.ts#L404), or by showing some sort of dialog to the user within the jupyterlab UI.

As implemented, one alert is shown per error, which gets annoying if there are many duplicate plugin ids. 