### PR TITLE
Improve handling of progress bars

### DIFF
--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -23,7 +23,7 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  PanelLayout, Widget
+  BoxLayout, Widget
 } from '@phosphor/widgets';
 
 import {
@@ -90,7 +90,7 @@ class NotebookPanel extends Widget implements DocumentRegistry.IReadyWidget {
       options.contentFactory || NotebookPanel.defaultContentFactory
     );
 
-    let layout = this.layout = new PanelLayout();
+    let layout = this.layout = new BoxLayout();
 
     // Toolbar
     let toolbar = new Toolbar();
@@ -109,6 +109,9 @@ class NotebookPanel extends Widget implements DocumentRegistry.IReadyWidget {
 
     layout.addWidget(toolbar);
     layout.addWidget(this.notebook);
+
+    BoxLayout.setStretch(toolbar, 0);
+    BoxLayout.setStretch(this.notebook, 1);
   }
 
   /**
@@ -158,7 +161,7 @@ class NotebookPanel extends Widget implements DocumentRegistry.IReadyWidget {
    * Get the toolbar used by the widget.
    */
   get toolbar(): Toolbar<Widget> {
-    return (this.layout as PanelLayout).widgets[0] as Toolbar<Widget>;
+    return (this.layout as BoxLayout).widgets[0] as Toolbar<Widget>;
   }
 
   /**

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -45,9 +45,6 @@
   background: var(--jp-layout-color0);
 }
 
-.jp-NotebookPanel > .jp-Notebook {
-  height: calc(100% - var(--jp-private-notebook-panel-toolbar-height));
-}
 
 .jp-Notebook::after {
   display: block;

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -395,14 +395,18 @@ class OutputAreaModel implements IOutputAreaModel {
    * carriage return characters.
    */
   private _fixCarriageReturn(txt: string): string {
-    txt = txt.replace(/\r+\n/gm, '\n'); // \r followed by \n --> newline
-    while (txt.search(/\r[^$]/g) > -1) {
-      let base = txt.match(/^(.*)\r+/m)[1];
-      let insert = txt.match(/\r+(.*)$/m)[1];
-      insert = insert + base.slice(insert.length, base.length);
-      txt = txt.replace(/\r+.*$/m, '\r').replace(/^.*\r/m, insert);
-    }
-    return txt;
+    let tmp = txt;
+    // Remove chunks that should be overridden by carriage returns
+    do {
+      // Remove any chunks preceding a carriage return unless carriage
+      // return followed by a newline
+      tmp = tmp.replace(/^[^\n]*(?:\r(?!\n))+/gm, '');
+    } while (tmp.search(/\r(?!\n)/) > -1);
+    do {
+      // Replace remaining \r\n characters with a newline
+      tmp = tmp.replace(/\r\n/gm, '\n');
+    } while (tmp.indexOf('\r\n') > -1);
+    return tmp;
   }
 
   /*

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -396,6 +396,8 @@ class OutputAreaModel implements IOutputAreaModel {
    */
   private _fixCarriageReturn(txt: string): string {
     let tmp = txt;
+    // Handle multiple carriage returns before a newline
+    tmp = tmp.replace(/\r\r+\n/gm, '\r\n');
     // Remove chunks that should be overridden by carriage returns
     do {
       // Remove any chunks preceding a carriage return unless carriage


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/3902.  

Reverts part of https://github.com/jupyterlab/jupyterlab/pull/3882 to the previous, more performant handling of carriage returns.  Also uses a box panel for the notebook panel to avoid browser calculations.

