### PR TITLE
Work on easy-configuring of the console execute shortcut.

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from '@jupyterlab/console';
 
 import {
-  PageConfig
+  ISettingRegistry, PageConfig
 } from '@jupyterlab/coreutils';
 
 import {
@@ -42,11 +42,11 @@ import {
 } from '@phosphor/algorithm';
 
 import {
-  ReadonlyJSONObject
+  JSONExt, ReadonlyJSONObject
 } from '@phosphor/coreutils';
 
 import {
-  DockLayout
+  DockLayout, Menu
 } from '@phosphor/widgets';
 
 
@@ -89,6 +89,12 @@ namespace CommandIDs {
 
   export
   const toggleShowAllActivity = 'console:toggle-show-all-kernel-activity';
+
+  export
+  const enterToExecute = 'console:enter-to-execute';
+
+  export
+  const shiftEnterToExecute = 'consol:shift-enter-to-execute';
 }
 
 
@@ -105,7 +111,8 @@ const tracker: JupyterLabPlugin<IConsoleTracker> = {
     IEditorServices,
     ILayoutRestorer,
     IFileBrowserFactory,
-    IRenderMimeRegistry
+    IRenderMimeRegistry,
+    ISettingRegistry
   ],
   optional: [ILauncher],
   activate: activateConsole,
@@ -138,7 +145,7 @@ export default plugins;
 /**
  * Activate the console extension.
  */
-function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: ILayoutRestorer, browserFactory: IFileBrowserFactory, rendermime: IRenderMimeRegistry, launcher: ILauncher | null): IConsoleTracker {
+function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommandPalette, contentFactory: ConsolePanel.IContentFactory,  editorServices: IEditorServices, restorer: ILayoutRestorer, browserFactory: IFileBrowserFactory, rendermime: IRenderMimeRegistry, settingRegistry: ISettingRegistry, launcher: ILauncher | null): IConsoleTracker {
   const manager = app.serviceManager;
   const { commands, shell } = app;
   const category = 'Console';
@@ -416,6 +423,81 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
                      false,
     isEnabled
   });
+
+  // Constants for setting the shortcuts for executing console cells.
+  const shortcutPlugin = '@jupyterlab/shortcuts-extension:plugin';
+  const selector = '.jp-CodeConsole-promptCell';
+
+  commands.addCommand(CommandIDs.shiftEnterToExecute, {
+    label: 'Execute with Shift+Enter',
+    isToggled: () => {
+      // Only show as toggled if the shortcuts are strictly
+      // The Shift+Enter ones.
+      const keyBindings = commands.keyBindings;
+      const linebreak = find(keyBindings,
+        kb => kb.command === CommandIDs.linebreak);
+      const runUnforced = find(keyBindings,
+        kb => kb.command === CommandIDs.runUnforced);
+      const runForced = find(keyBindings,
+        kb => kb.command === CommandIDs.runForced);
+      return linebreak && JSONExt.deepEqual(linebreak.keys, ['Enter']) &&
+             runUnforced === undefined &&
+             runForced && JSONExt.deepEqual(runForced.keys, ['Shift Enter']);
+    },
+    execute: () => {
+      const first = settingRegistry.set(shortcutPlugin, CommandIDs.linebreak, {
+        command: CommandIDs.linebreak,
+        keys: ['Enter'],
+        selector
+      });
+      const second = settingRegistry.remove(shortcutPlugin, CommandIDs.runUnforced);
+      const third = settingRegistry.set(shortcutPlugin, CommandIDs.runForced, {
+        command: CommandIDs.runForced,
+        keys: ['Shift Enter'],
+        selector
+      });
+
+      return Promise.all([first, second, third]);
+    }
+  });
+
+  commands.addCommand(CommandIDs.enterToExecute, {
+    label: 'Execute with Enter',
+    isToggled: () => {
+      // Only show as toggled if the shortcuts are strictly
+      // The Enter ones.
+      const keyBindings = commands.keyBindings;
+      const linebreak = find(keyBindings,
+        kb => kb.command === CommandIDs.linebreak);
+      const runUnforced = find(keyBindings,
+        kb => kb.command === CommandIDs.runUnforced);
+      const runForced = find(keyBindings,
+        kb => kb.command === CommandIDs.runForced);
+      return linebreak && JSONExt.deepEqual(linebreak.keys, ['Ctrl Enter']) &&
+             runUnforced && JSONExt.deepEqual(runUnforced.keys, ['Enter']) &&
+             runForced && JSONExt.deepEqual(runForced.keys, ['Shift Enter']);
+    },
+    execute: () => {
+      const first = settingRegistry.set(shortcutPlugin, CommandIDs.linebreak, {
+        command: CommandIDs.linebreak,
+        keys: ['Ctrl Enter'],
+        selector
+      });
+      const second = settingRegistry.set(shortcutPlugin, CommandIDs.runUnforced, {
+        command: CommandIDs.runUnforced,
+        keys: ['Enter'],
+        selector
+      });
+      const third = settingRegistry.set(shortcutPlugin, CommandIDs.runForced, {
+        command: CommandIDs.runForced,
+        keys: ['Shift Enter'],
+        selector
+      });
+
+      return Promise.all([first, second, third]);
+    }
+  });
+
   // Add command palette items
   [
     CommandIDs.create,
@@ -496,6 +578,15 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
     noun: 'Console Cells',
     clearCurrent: (current: ConsolePanel) => { return current.console.clear(); }
   } as IEditMenu.IClearer<ConsolePanel>);
+
+  // Add the execute keystroke setting submenu.
+  const executeMenu = new Menu({ commands });
+  executeMenu.title.label = 'Console Run Keystroke';
+  executeMenu.addItem({ command: CommandIDs.enterToExecute });
+  executeMenu.addItem({ command: CommandIDs.shiftEnterToExecute });
+  mainMenu.settingsMenu.addGroup([{
+    type: 'submenu' as Menu.ItemType, submenu: executeMenu
+  }], 10);
 
   // Add kernel information to the application help menu.
   mainMenu.helpMenu.kernelUsers.add({

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -428,18 +428,33 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
   const shortcutPlugin = '@jupyterlab/shortcuts-extension:plugin';
   const selector = '.jp-CodeConsole-promptCell';
 
+  // Keep updated keybindings for the console commands related to execution.
+  let linebreak = find(commands.keyBindings,
+    kb => kb.command === CommandIDs.linebreak);
+  let runUnforced = find(commands.keyBindings,
+    kb => kb.command === CommandIDs.runUnforced);
+  let runForced = find(commands.keyBindings,
+    kb => kb.command === CommandIDs.runForced);
+  commands.keyBindingChanged.connect((s, args) => {
+    if (args.binding.command === CommandIDs.linebreak) {
+      linebreak = args.type === 'added' ? args.binding : undefined;
+      return;
+    }
+    if (args.binding.command === CommandIDs.runUnforced) {
+      runUnforced = args.type === 'added' ? args.binding : undefined;
+      return;
+    }
+    if (args.binding.command === CommandIDs.runForced) {
+      runForced = args.type === 'added' ? args.binding : undefined;
+      return;
+    }
+  });
+
   commands.addCommand(CommandIDs.shiftEnterToExecute, {
     label: 'Execute with Shift+Enter',
     isToggled: () => {
       // Only show as toggled if the shortcuts are strictly
       // The Shift+Enter ones.
-      const keyBindings = commands.keyBindings;
-      const linebreak = find(keyBindings,
-        kb => kb.command === CommandIDs.linebreak);
-      const runUnforced = find(keyBindings,
-        kb => kb.command === CommandIDs.runUnforced);
-      const runForced = find(keyBindings,
-        kb => kb.command === CommandIDs.runForced);
       return linebreak && JSONExt.deepEqual(linebreak.keys, ['Enter']) &&
              runUnforced === undefined &&
              runForced && JSONExt.deepEqual(runForced.keys, ['Shift Enter']);
@@ -466,13 +481,6 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
     isToggled: () => {
       // Only show as toggled if the shortcuts are strictly
       // The Enter ones.
-      const keyBindings = commands.keyBindings;
-      const linebreak = find(keyBindings,
-        kb => kb.command === CommandIDs.linebreak);
-      const runUnforced = find(keyBindings,
-        kb => kb.command === CommandIDs.runUnforced);
-      const runForced = find(keyBindings,
-        kb => kb.command === CommandIDs.runForced);
       return linebreak && JSONExt.deepEqual(linebreak.keys, ['Ctrl Enter']) &&
              runUnforced && JSONExt.deepEqual(runUnforced.keys, ['Enter']) &&
              runForced && JSONExt.deepEqual(runForced.keys, ['Shift Enter']);

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -94,7 +94,7 @@ namespace CommandIDs {
   const enterToExecute = 'console:enter-to-execute';
 
   export
-  const shiftEnterToExecute = 'consol:shift-enter-to-execute';
+  const shiftEnterToExecute = 'console:shift-enter-to-execute';
 }
 
 


### PR DESCRIPTION
Fixes #3643.

This makes the keyboard stroke to execute a console cell more easily configurable. It allows easy toggling/setting of `Enter` vs `Shift-Enter` to execute. Other shortcuts may still be set using the Settings Editor if the user desires.