### PR TITLE
Fix notebook toolbar height

### DIFF
--- a/packages/notebook/style/toolbar.css
+++ b/packages/notebook/style/toolbar.css
@@ -20,7 +20,7 @@
 
 .jp-NotebookPanel-toolbar {
   padding: 2px;
-  height: var(--jp-private-notebook-panel-toolbar-height);
+  min-height: var(--jp-private-notebook-panel-toolbar-height);
   box-shadow: var(--jp-toolbar-box-shadow);
   background: var(--jp-toolbar-background);
   z-index: 1;


### PR DESCRIPTION
Follow up to #4045; I had inadvertently collapsed the notebook toolbars.