### PR TITLE
Render SVG in image element (closes #4022)

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -428,8 +428,7 @@ export
 function renderSVG(options: renderSVG.IRenderOptions): Promise<void> {
   // Unpack the options.
   let {
-    host, source, trusted, resolver, linkHandler,
-    shouldTypeset, latexTypesetter, unconfined
+    host, source, trusted, unconfined
   } = options;
 
   // Clear the content if there is no source.
@@ -444,28 +443,15 @@ function renderSVG(options: renderSVG.IRenderOptions): Promise<void> {
     return Promise.resolve(undefined);
   }
 
-  // Set the inner HTML of the host.
-  host.innerHTML = source;
+  // Render in img so that user can save it easily
+  const img = new Image();
+  img.src = `data:image/svg+xml,${source}`;
+  host.appendChild(img);
 
   if (unconfined === true) {
     host.classList.add('jp-mod-unconfined');
   }
-
-  // TODO
-  // what about script tags inside the svg?
-
-  // Patch the urls if a resolver is available.
-  let promise: Promise<void>;
-  if (resolver) {
-    promise = Private.handleUrls(host, resolver, linkHandler);
-  } else {
-    promise = Promise.resolve(undefined);
-  }
-
-  // Return the final rendered promise.
-  return promise.then(() => {
-    if (shouldTypeset && latexTypesetter) { latexTypesetter.typeset(host); }
-  });
+  return Promise.resolve();
 }
 
 
@@ -495,29 +481,9 @@ namespace renderSVG {
     trusted: boolean;
 
     /**
-     * An optional url resolver.
-     */
-    resolver: IRenderMime.IResolver | null;
-
-    /**
-     * An optional link handler.
-     */
-    linkHandler: IRenderMime.ILinkHandler | null;
-
-    /**
-     * Whether the node should be typeset.
-     */
-    shouldTypeset: boolean;
-
-    /**
      * Whether the svg should be unconfined.
      */
     unconfined?: boolean;
-
-    /**
-     * The LaTeX typesetter for the application.
-     */
-    latexTypesetter: IRenderMime.ILatexTypesetter | null;
   }
 }
 

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -310,11 +310,7 @@ class RenderedSVG extends RenderedCommon {
       host: this.node,
       source: String(model.data[this.mimeType]),
       trusted: model.trusted,
-      resolver: this.resolver,
-      linkHandler: this.linkHandler,
-      shouldTypeset: this.isAttached,
-      unconfined: metadata && metadata.unconfined as boolean | undefined,
-      latexTypesetter: this.latexTypesetter
+      unconfined: metadata && metadata.unconfined as boolean | undefined
     });
   }
 

--- a/tests/test-rendermime/src/factories.spec.ts
+++ b/tests/test-rendermime/src/factories.spec.ts
@@ -155,15 +155,16 @@ describe('rendermime/factories', () => {
 
     describe('#createRenderer()', () => {
 
-      it('should create an svg tag', () => {
+      it('should create an img element with the svg inline', () => {
         const source = '<svg></svg>';
         let f = svgRendererFactory;
         let mimeType = 'image/svg+xml';
         let model = createModel(mimeType, source, true);
         let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
-          let svgEl = w.node.getElementsByTagName('svg')[0];
-          expect(svgEl).to.be.ok();
+          let imgEl = w.node.getElementsByTagName('img')[0];
+          expect(imgEl).to.be.ok();
+          expect(imgEl.src).to.contain(source);
         });
       });
 


### PR DESCRIPTION
This changes the SVG renderer to create an `img` element and render the SVG inline as the `src`, instead of creating the `svg` element directly. This allows the user to use the browser's context menu to save the SVG image (closing #4022). It also isolates rendering output SVGs from global styles.

It drops support for resolving relative URLs and typesetting LaTeX in the SVG.

I tested it on matplotlib SVG output and I was able to successfully save the image and open it. Screenshot attached below:
![screen shot 2018-02-28 at 10 23 51 am](https://user-images.githubusercontent.com/1186124/36795627-89085cb8-1c71-11e8-8ec8-1f0446f1aa52.png)

/cc @jasongrout 