### PR TITLE
Properly indent in console after linebreak

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -543,6 +543,11 @@ namespace CodeEditor {
      *   contained in the editor.
      */
     getPositionForCoordinate(coordinate: ICoordinate): IPosition | null;
+
+    /**
+     * Inserts a new line at the cursor position and indents it.
+     */
+    newIndentedLine(): void;
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -483,6 +483,10 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     this.doc.setSelections(cmSelections, 0);
   }
 
+  newIndentedLine(): void {
+    this.execCommand('newlineAndIndent');
+  }
+
   /**
    * Execute a codemirror command on the editor.
    *

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -292,8 +292,6 @@ class CodeConsole extends Widget {
       return this._execute(promptCell);
     }
 
-    // Add a new line and indent it before seeing if we can execute
-    promptCell.editor.newIndentedLine();
     // Check whether we should execute.
     return this._shouldExecute(timeout).then(should => {
       if (this.isDisposed) {
@@ -303,6 +301,9 @@ class CodeConsole extends Widget {
         // Create a new prompt cell before kernel execution to allow typeahead.
         this.newPromptCell();
         return this._execute(promptCell);
+      } else {
+        // add a newline if we shouldn't execute
+        promptCell.editor.newIndentedLine();
       }
     });
   }

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -292,6 +292,8 @@ class CodeConsole extends Widget {
       return this._execute(promptCell);
     }
 
+    // Add a new line and indent it before seeing if we can execute
+    promptCell.editor.newIndentedLine();
     // Check whether we should execute.
     return this._shouldExecute(timeout).then(should => {
       if (this.isDisposed) {
@@ -573,7 +575,7 @@ class CodeConsole extends Widget {
       return Promise.resolve(false);
     }
     let model = promptCell.model;
-    let code = model.value.text + '\n';
+    let code = model.value.text;
     return new Promise<boolean>((resolve, reject) => {
       let timer = setTimeout(() => { resolve(true); }, timeout);
       let kernel = this.session.kernel;
@@ -589,12 +591,6 @@ class CodeConsole extends Widget {
         if (isComplete.content.status !== 'incomplete') {
           resolve(true);
           return;
-        }
-        model.value.text = code + isComplete.content.indent;
-        let editor = promptCell.editor;
-        let pos = editor.getPositionAt(model.value.text.length);
-        if (pos) {
-          editor.setCursorPosition(pos);
         }
         resolve(false);
       }).catch(() => { resolve(true); });

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -327,17 +327,7 @@ class CodeConsole extends Widget {
     if (!promptCell) {
       return;
     }
-    let model = promptCell.model;
-    let editor = promptCell.editor;
-    // Insert the line break at the cursor position, and move cursor forward.
-    let pos = editor.getCursorPosition();
-    let offset = editor.getOffsetAt(pos);
-    let text = model.value.text;
-    model.value.text = text.substr(0, offset) + '\n' + text.substr(offset);
-    pos = editor.getPositionAt(offset + 1) as CodeEditor.IPosition;
-    if (pos) {
-      editor.setCursorPosition(pos);
-    }
+    promptCell.editor.newIndentedLine();
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/3644 by indenting when inserting a linebreak in the console.

It does this by adding a `newIndentedLine` method to the Editor and implements in the Code Mirror editor. 

When/if we add a Monaka editor, [it will be possible to add a similar method to it](https://github.com/jupyterlab/jupyterlab/issues/3643#issuecomment-369373293).