### PR TITLE
Clean up toolbar CSS so that it shows as active, remove superfluous jp-mod-pressed class.

### DIFF
--- a/packages/apputils/src/toolbar.ts
+++ b/packages/apputils/src/toolbar.ts
@@ -46,11 +46,6 @@ const TOOLBAR_ITEM_CLASS = 'jp-Toolbar-item';
 const TOOLBAR_BUTTON_CLASS = 'jp-Toolbar-button';
 
 /**
- * The class name added to a pressed button.
- */
-const TOOLBAR_PRESSED_CLASS = 'jp-mod-pressed';
-
-/**
  * The class name added to toolbar interrupt button.
  */
 const TOOLBAR_INTERRUPT_CLASS = 'jp-StopIcon';
@@ -386,13 +381,6 @@ class ToolbarButton extends Widget {
         this._onClick();
       }
       break;
-    case 'mousedown':
-      this.addClass(TOOLBAR_PRESSED_CLASS);
-      break;
-    case 'mouseup':
-    case 'mouseout':
-      this.removeClass(TOOLBAR_PRESSED_CLASS);
-      break;
     default:
       break;
     }
@@ -403,9 +391,6 @@ class ToolbarButton extends Widget {
    */
   protected onAfterAttach(msg: Message): void {
     this.node.addEventListener('click', this);
-    this.node.addEventListener('mousedown', this);
-    this.node.addEventListener('mouseup', this);
-    this.node.addEventListener('mouseout', this);
   }
 
   /**
@@ -413,9 +398,6 @@ class ToolbarButton extends Widget {
    */
   protected onBeforeDetach(msg: Message): void {
     this.node.removeEventListener('click', this);
-    this.node.removeEventListener('mousedown', this);
-    this.node.removeEventListener('mouseup', this);
-    this.node.removeEventListener('mouseout', this);
   }
 
   private _onClick: () => void;

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -47,21 +47,13 @@
 }
 
 
-.jp-Toolbar-button.jp-mod-pressed {
-  background-color: var(--jp-layout-color3);
-  box-shadow: inset 0 0px 1px rgba(0, 0, 0, 0.5);
-}
-
-
 .jp-Toolbar-button:enabled:hover {
-  border: 1px solid var(--jp-border-color1);
-  background-color: var(--jp-layout-color1);
+  border: 1px solid var(--jp-toolbar-border-color);
   box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.24);
-
 }
 
 
-.jp-Toolbar-button:active {
+.jp-Toolbar-button:enabled:active {
   border: 1px solid var(--jp-toolbar-border-color);
   background-color: var(--jp-toolbar-active-background);
   box-shadow: var(--jp-toolbar-box-shadow);

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -76,11 +76,6 @@
 }
 
 
-.jp-FileBrowser-toolbar.jp-Toolbar > .jp-Toolbar-button:focus {
-  box-shadow: var(--jp-toolbar-box-shadow);
-  border-color: var(--jp-toolbar-border-color);
-}
-
 /*-----------------------------------------------------------------------------
 | DirListing
 |----------------------------------------------------------------------------*/

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -404,53 +404,6 @@ describe('@jupyterlab/apputils', () => {
 
       });
 
-      context('mousedown', () => {
-
-        it('should add the `jp-mod-pressed` class', (done) => {
-          let button = new ToolbarButton();
-          Widget.attach(button, document.body);
-          requestAnimationFrame(() => {
-            simulate(button.node, 'mousedown');
-            expect(button.hasClass('jp-mod-pressed')).to.be(true);
-            button.dispose();
-            done();
-          });
-        });
-
-      });
-
-      context('mouseup', () => {
-
-        it('should remove the `jp-mod-pressed` class', (done) => {
-          let button = new ToolbarButton();
-          Widget.attach(button, document.body);
-          requestAnimationFrame(() => {
-            simulate(button.node, 'mousedown');
-            simulate(button.node, 'mouseup');
-            expect(button.hasClass('jp-mod-pressed')).to.be(false);
-            button.dispose();
-            done();
-          });
-        });
-
-      });
-
-      context('mouseout', () => {
-
-        it('should remove the `jp-mod-pressed` class', (done) => {
-          let button = new ToolbarButton();
-          Widget.attach(button, document.body);
-          requestAnimationFrame(() => {
-            simulate(button.node, 'mousedown');
-            simulate(button.node, 'mouseout');
-            expect(button.hasClass('jp-mod-pressed')).to.be(false);
-            button.dispose();
-            done();
-          });
-        });
-
-      });
-
     });
 
     describe('#onAfterAttach()', () => {
@@ -459,12 +412,8 @@ describe('@jupyterlab/apputils', () => {
         let button = new LogToolbarButton();
         Widget.attach(button, document.body);
         expect(button.methods).to.contain('onAfterAttach');
-        simulate(button.node, 'mousedown');
-        simulate(button.node, 'mouseup');
-        simulate(button.node, 'mouseout');
-        expect(button.events).to.contain('mousedown');
-        expect(button.events).to.contain('mouseup');
-        expect(button.events).to.contain('mouseout');
+        simulate(button.node, 'click');
+        expect(button.events).to.contain('click');
         button.dispose();
       });
 
@@ -478,12 +427,8 @@ describe('@jupyterlab/apputils', () => {
         requestAnimationFrame(() => {
           Widget.detach(button);
           expect(button.methods).to.contain('onBeforeDetach');
-          simulate(button.node, 'mousedown');
-          simulate(button.node, 'mouseup');
-          simulate(button.node, 'mouseout');
-          expect(button.events).to.not.contain('mousedown');
-          expect(button.events).to.not.contain('mouseup');
-          expect(button.events).to.not.contain('mouseout');
+          simulate(button.node, 'click');
+          expect(button.events).to.not.contain('click');
           button.dispose();
           done();
         });


### PR DESCRIPTION
Fixes #4094.

Cleans up some of the toolbar button styling which had some redundancy and conflicting rules.