### PR TITLE
Fixed an issue preventing installation of labextensions.

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -98,7 +98,7 @@ def ensure_dev(logger=None):
         yarn_proc = Process(['node', YARN_PATH], cwd=parent, logger=logger)
         yarn_proc.wait()
 
-    theme_packages = ['theme-light-extension', 'theme-dark-extension'] 
+    theme_packages = ['theme-light-extension', 'theme-dark-extension']
     for theme in theme_packages:
         base_path = pjoin(parent, 'packages', theme)
         if not osp.exists(pjoin(base_path, 'static')):
@@ -1195,7 +1195,7 @@ def _normalize_path(extension):
 def _read_package(target):
     """Read the package data in a given target tarball.
     """
-    tar = tarfile.open(target, "r:gz")
+    tar = tarfile.open(target, "r")
     f = tar.extractfile('package/package.json')
     data = json.loads(f.read().decode('utf8'))
     data['jupyterlab_extracted_files'] = [
@@ -1262,7 +1262,7 @@ def _tarsum(input_file):
     """
     Compute the recursive sha sum of a tar file.
     """
-    tar = tarfile.open(input_file, "r:gz")
+    tar = tarfile.open(input_file, "r")
     chunk_size = 100 * 1024
     h = hashlib.new("sha1")
 


### PR DESCRIPTION
Installing jupyterlab extensions was failing on my mac due to the specification of `"r:gz"` in the [`tarfile.open`](https://github.com/jupyterlab/jupyterlab/blob/master/jupyterlab/commands.py#L1198) command.

I have provided some context here:
https://gist.github.com/mjmdavis/b00708c33fbcdc5f4e8dccba1e655d31

The exception is coming from [`tarfile` handling the gzip strictly](https://github.com/python/cpython/blob/18fd89246333bfa1b76c1623df689214f3ce2bf3/Lib/tarfile.py#L1639).

The changes herein allow me to install the plugins successfully.