### PR TITLE
Upgrade to yarn 1.5.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-jupyterlab/yarn.js binary
+jupyterlab/staging/yarn.js binary


### PR DESCRIPTION
Fixes #4049.  We still can't use `--ignore-optional`, unfortunately.  cf https://github.com/yarnpkg/yarn/issues/5054