### PR TITLE
Change hub config file to jupyterhub_config.py

### DIFF
--- a/docs/source/user/jupyterhub.rst
+++ b/docs/source/user/jupyterhub.rst
@@ -13,7 +13,7 @@ If you install JupyterLab on a system running JupyterHub, it will immediately be
 available at the ``/lab`` URL, but users will still be directed to the classic
 Notebook (``/tree``) by default. To change the user's default user interface to
 JupyterLab, set the following configuration option in your
-:file:`jupyterlab_config.py` file::
+:file:`jupyterhub_config.py` file::
 
     c.Spawner.default_url = '/lab'
 


### PR DESCRIPTION
Most hub users will name their hub config file named `jupyterhub_config.py` , since the Hub installation tutorial  ( http://jupyterhub.readthedocs.io/en/latest/getting-started/config-basics.html ) recommends that name for the file.