### PR TITLE
Use resolutions key in package.json  to resolve all react and react-doc versions

### DIFF
--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -204,5 +204,9 @@
     "version": "0.32.0.dev0",
     "linkedPackages": {},
     "staticDir": "../static"
+  },
+  "resolutions": {
+    "react": "~16.2.0",
+    "react-dom": "~16.2.0"
   }
 }


### PR DESCRIPTION
This should prevent issues arising from multiple versions of react being loaded