### PR TITLE
Fix FileBrowser items alignment with header

### DIFF
--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -219,7 +219,7 @@
 
 
 .jp-DirListing-itemModified {
-  flex: 0 0 108px;
+  flex: 0 0 125px;
   text-align: right;
 }
 


### PR DESCRIPTION
Hi,

I noticed there was a misalignment of the file browser items text relative to the headers, as seen on the following screenshot:

![](http://drop.yapok.org/2018-03-20T10:02:23.png)

This was due to the `flex-basis` property on `.jp-DirListing-itemModified` being wrongly computed (I assume that the flex values were summed up to match those of the header, but this was done without taking the padding of the header element into account)

Here's how it looks after this fix (without the funky outlines of course :grinning:):

![](http://drop.yapok.org/2018-03-20T10:02:44.png)