### PR TITLE
Add validation for file renaming.

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -14,7 +14,7 @@ import {
 } from '@jupyterlab/docregistry';
 
 import {
-  IDocumentManager, renameFile
+  IDocumentManager, isValidFileName, renameFile
 } from '@jupyterlab/docmanager';
 
 import {
@@ -1331,6 +1331,16 @@ class DirListing extends Widget {
         this._inRename = false;
         return original;
       }
+      if (!isValidFileName(newName)) {
+        showErrorMessage('Rename Error', Error(
+            `"${newName}" is not a valid name for a file. ` +
+            `Names must have nonzero length, ` +
+            `and cannot include "/", "\\", or ":"`
+        ));
+        this._inRename = false;
+        return original;
+      }
+
       if (this.isDisposed) {
         this._inRename = false;
         return Promise.reject('Disposed') as Promise<string>;


### PR DESCRIPTION
Fixes #4216.
This disallows `/`, `\`, and `:` characters in file names, and shows an error if a user tries to rename a file to those. I am not sure why `:` is on the list, but I have retained it for compatibility with classic notebook, which also disallows those three characters. 