### PR TITLE
Allow larger files uploads

### DIFF
--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -29,11 +29,12 @@ def load_jupyter_server_extension(nbapp):
     """Load the JupyterLab server extension.
     """
     # Delay imports to speed up jlpmapp
-    import json
+    from json import dumps
     from jupyterlab_launcher import add_handlers, LabConfig
     from notebook.utils import url_path_join as ujoin, url_escape
     from notebook._version import version_info
     from tornado.ioloop import IOLoop
+    from markupsafe import Markup
     from .build_handler import build_path, Builder, BuildHandler
     from .commands import (
         get_app_dir, get_user_settings_dir, watch, ensure_dev, watch_dev,
@@ -88,7 +89,14 @@ def load_jupyter_server_extension(nbapp):
     page_config['buildCheck'] = not core_mode and not dev_mode
     page_config['token'] = nbapp.token
     page_config['devMode'] = dev_mode
-    page_config['notebookVersion'] = json.dumps(version_info)
+    # Export the version info tuple to a JSON array. This get's printed
+    # inside double quote marks, so we render it to a JSON string of the
+    # JSON data (so that we can call JSON.parse on the frontend on it).
+    # We also have to wrap it in `Markup` so that it isn't escaped
+    # by Jinja. Otherwise, if the version has string parts these will be
+    # escaped and then will have to be unescaped on the frontend.
+    page_config['notebookVersion'] = Markup(dumps(dumps(version_info))[1:-1])
+
     if nbapp.file_to_run and type(nbapp).__name__ == "LabApp":
         relpath = os.path.relpath(nbapp.file_to_run, nbapp.notebook_dir)
         uri = url_escape(ujoin('/lab/tree', *relpath.split(os.sep)))

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -29,8 +29,10 @@ def load_jupyter_server_extension(nbapp):
     """Load the JupyterLab server extension.
     """
     # Delay imports to speed up jlpmapp
+    import json
     from jupyterlab_launcher import add_handlers, LabConfig
     from notebook.utils import url_path_join as ujoin, url_escape
+    from notebook._version import version_info
     from tornado.ioloop import IOLoop
     from .build_handler import build_path, Builder, BuildHandler
     from .commands import (
@@ -86,7 +88,7 @@ def load_jupyter_server_extension(nbapp):
     page_config['buildCheck'] = not core_mode and not dev_mode
     page_config['token'] = nbapp.token
     page_config['devMode'] = dev_mode
-
+    page_config['notebookVersion'] = json.dumps(version_info)
     if nbapp.file_to_run and type(nbapp).__name__ == "LabApp":
         relpath = os.path.relpath(nbapp.file_to_run, nbapp.notebook_dir)
         uri = url_escape(ujoin('/lab/tree', *relpath.split(os.sep)))

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -157,6 +157,19 @@ namespace PageConfig {
   }
 
   /**
+   * Get the Notebook version info [major, minor, patch].
+   */
+  export
+  function getNotebookVersion(): [number, number, number] {
+    const notebookVersion = getOption('notebookVersion');
+    if (notebookVersion === '') {
+      return [0, 0, 0];
+    }
+    return JSON.parse(notebookVersion);
+  }
+
+
+  /**
    * Private page config data for the Jupyter application.
    */
   let configData: { [key: string]: string } | null = null;

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -329,7 +329,7 @@ class FileBrowserModel implements IDisposable {
       throw new Error(msg);
     }
 
-    const err = new Error('File not uploaded');
+    const err = 'File not uploaded';
     if (largeFile && !await this._shouldUploadLarge(file)) {
       throw err;
     }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -46,8 +46,14 @@ const REFRESH_DURATION = 10000;
 const MIN_REFRESH = 1000;
 
 
+/**
+ * The maximum upload size (in bytes) for notebook version < 5.1.0
+ */
 export const LARGE_FILE_SIZE = 15 * 1024 * 1024;
 
+/**
+ * The size (in bytes) of the biggest chunk we should upload at once.
+ */
 export const CHUNK_SIZE = 1024 * 1024;
 
 

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -390,6 +390,7 @@ class FileBrowserModel implements IDisposable {
         } else {
           chunk++;
         }
+        console.log(`${Math.floor(100 * start / file.size)}% done`);
 
         reader.readAsArrayBuffer(file.slice(start, end));
       }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -101,6 +101,15 @@ class FileBrowserModel implements IDisposable {
     services.contents.fileChanged.connect(this._onFileChanged, this);
     services.sessions.runningChanged.connect(this._onRunningChanged, this);
 
+    this._unloadEventListener = (e: Event) => {
+      if (this._uploads.length > 0) {
+        const confirmationMessage = 'Files still uploading';
+
+        (e as any).returnValue = confirmationMessage;
+        return confirmationMessage;
+      }
+    };
+    window.addEventListener('beforeunload', this._unloadEventListener);
     this._scheduleUpdate();
     this._startTimer();
   }
@@ -187,6 +196,7 @@ class FileBrowserModel implements IDisposable {
     if (this.isDisposed) {
       return;
     }
+    window.removeEventListener('beforeunload', this._unloadEventListener);
     this._isDisposed = true;
     clearTimeout(this._timeoutId);
     this._sessions.length = 0;
@@ -593,7 +603,7 @@ class FileBrowserModel implements IDisposable {
   private _restored = new PromiseDelegate<void>();
   private _uploads: IUploadModel[] = [];
   private _uploadChanged = new Signal<this, IChangedArgs<IUploadModel>>(this);
-
+  private _unloadEventListener: (e: Event) => string;
 }
 
 

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -104,6 +104,11 @@ namespace Contents {
     readonly content: any;
 
     /**
+     * The chunk of the file upload.
+     */
+    readonly chunk?: number;
+
+    /**
      * The format of the file `content`.
      *
      * #### Notes

--- a/tests/test-filebrowser/package.json
+++ b/tests/test-filebrowser/package.json
@@ -20,6 +20,7 @@
     "@jupyterlab/docregistry": "^0.16.2",
     "@jupyterlab/filebrowser": "^0.16.2",
     "@jupyterlab/services": "^2.0.2",
+    "@phosphor/algorithm": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.5.0",

--- a/tests/test-filebrowser/src/model.spec.ts
+++ b/tests/test-filebrowser/src/model.spec.ts
@@ -4,7 +4,7 @@
 import expect = require('expect.js');
 
 import {
-  StateDB, uuid
+  StateDB, uuid, PageConfig
 } from '@jupyterlab/coreutils';
 
 import {
@@ -344,6 +344,30 @@ describe('filebrowser/model', () => {
         let file = new File(['<p>Hello world!</p>'], fname,
                             { type: 'text/html' });
         model.upload(file).catch(done);
+      });
+
+      describe('older notebook version', () => {
+        let prevNotebookVersion: string;
+
+        before(() => {
+          prevNotebookVersion = PageConfig.setOption('notebookVersion', JSON.stringify([5, 0, 0]));
+        });
+
+        after(() => {
+          PageConfig.setOption('notebookVersion', prevNotebookVersion);
+        });
+      });
+
+      describe('newer notebook version', () => {
+        let prevNotebookVersion: string;
+
+        before(() => {
+          prevNotebookVersion = PageConfig.setOption('notebookVersion', JSON.stringify([5, 1, 0]));
+        });
+
+        after(() => {
+          PageConfig.setOption('notebookVersion', prevNotebookVersion);
+        });
       });
 
     });


### PR DESCRIPTION
This fixes #1735 by allowing files larger than 15 MB to be uploaded, when you are running [notebook version >= 5.1](https://github.com/jupyterlab/jupyterlab/issues/1735#issuecomment-283998419).  If you are running older notebook versions, the old behavior is intact of denying the large upload. On newer versions, it ads a warning if you are over the 15 MB limit, which copies [the behavior of Jupyter Notebook](https://github.com/jupyter/notebook/pull/2162/files#diff-1bb6ee004561527c18aa1fbae3ea8fffR283).

- [x] add notebook version information to the client
- [x] disallow large uploads on old version