### PR TITLE
Add word wrapping for tooltip

### DIFF
--- a/packages/tooltip/style/index.css
+++ b/packages/tooltip/style/index.css
@@ -25,5 +25,6 @@
 }
 
 .jp-Tooltip pre {
+  white-space: pre-wrap;
   margin: 0;
 }


### PR DESCRIPTION
This should resolve the word wrapping issue in tooltips, as reported in #4244.