### PR TITLE
Fix jlpm run build on Windows, following pattern used elsewhere in pa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:packages": "cd packages/metapackage && jlpm run build",
     "build:src": "lerna run build --scope \"@jupyterlab/!(test-|example-)*\"",
     "build:test": "lerna run build:test",
-    "build:themes": "lerna run build:webpack --scope \"@jupyterlab/theme-*-extension\"",
+    "build:themes": "lerna run build:webpack --scope \"@jupyterlab/theme-*\"",
     "build:update": "node buildutils/lib/update-core-mode.js",
     "build:utils": "cd buildutils && jlpm run build",
     "clean": "jlpm run clean:dev",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:packages": "cd packages/metapackage && jlpm run build",
     "build:src": "lerna run build --scope \"@jupyterlab/!(test-|example-)*\"",
     "build:test": "lerna run build:test",
-    "build:themes": "lerna run build:webpack --scope '@jupyterlab/theme-*-extension'",
+    "build:themes": "lerna run build:webpack --scope \"@jupyterlab/theme-*-extension\"",
     "build:update": "node buildutils/lib/update-core-mode.js",
     "build:utils": "cd buildutils && jlpm run build",
     "clean": "jlpm run clean:dev",


### PR DESCRIPTION
Using single quotes on Windows results in:

Error: No packages found that match scope ''@jupyterlab/theme-*-extension''

Elsewhere escaped double quotes are used, so I'm assuming this is more x-plat friendly.