### PR TITLE
CI fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules
 .cache
 .vscode
 *.py[co]
+.pytest_cache
 __pycache__
 *.egg-info
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '5'
+- 'lts/*'
 dist: trusty
 sudo: required
 addons:

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -173,7 +173,7 @@ class TestExtension(TestCase):
             data = json.load(fid)
         extensions = get_app_info(self.app_dir)['extensions']
         name = data['name']
-        assert not name in extensions
+        assert name not in extensions
         assert not check_extension(name)
 
     def test_validation(self):
@@ -383,7 +383,7 @@ class TestExtension(TestCase):
         install_extension(self.mock_extension, app_dir)
         disable_extension(self.pkg_names['extension'], app_dir)
         info = get_app_info(app_dir)
-        name = self.pkg_names['extension'] 
+        name = self.pkg_names['extension']
         assert name in info['disabled']
         assert not check_extension(name, app_dir)
         assert check_extension(name, app_dir, True)
@@ -402,7 +402,7 @@ class TestExtension(TestCase):
         disable_extension(self.pkg_names['extension'], app_dir)
         enable_extension(self.pkg_names['extension'], app_dir)
         info = get_app_info(app_dir)
-        name = self.pkg_names['extension'] 
+        name = self.pkg_names['extension']
         assert name not in info['disabled']
         assert check_extension(name, app_dir)
         disable_extension('@jupyterlab/notebook-extension', app_dir)

--- a/packages/services/.travis.yml
+++ b/packages/services/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-- '0.12'
-- '5.1'
+- 'lts/*'
 sudo: false
 env:
   matrix:

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -13,7 +13,7 @@ source activate test
 
 if [[ $GROUP == py2 || $GROUP == py3 ]]; then
     # Run the python tests
-    py.test -v
+    py.test -v -s
 fi
 
 

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -13,7 +13,7 @@ source activate test
 
 if [[ $GROUP == py2 || $GROUP == py3 ]]; then
     # Run the python tests
-    py.test -v -s
+    py.test -v
 fi
 
 


### PR DESCRIPTION
Our Travis builds were using `node` version 5, which is pretty old. For some reason, the `webpack` command line executable was not working. I reproduced this by creating the same environment on my machine and running the tests with `node` 5. When I switch to `node` LTS, it works. I think that's a reasonable stance for us to take.