### PR TITLE
Add Open In New Browser Tab option to the file browser

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -60,6 +60,9 @@ namespace CommandIDs {
   const open = 'docmanager:open';
 
   export
+  const openTab = 'docmanager:open-tab';
+
+  export
   const openDirect = 'docmanager:open-direct';
 
   export
@@ -255,6 +258,18 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     icon: args => args['icon'] as string || '',
     label: args => (args['label'] || args['factory']) as string,
     mnemonic: args => args['mnemonic'] as number || -1
+  });
+
+  commands.addCommand(CommandIDs.openTab, {
+    execute: args => {
+      const path = typeof args['path'] === 'undefined' ? ''
+        : args['path'] as string;
+      return docManager.services.contents.getDownloadUrl(path).then((url) => {
+        window.open(url, '_blank');
+      });
+    },
+    icon: args => args['icon'] as string || '',
+    label: () => 'Open in New Tab'
   });
 
   commands.addCommand(CommandIDs.openDirect, {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -264,7 +264,7 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     execute: args => {
       const path = typeof args['path'] === 'undefined' ? ''
         : args['path'] as string;
-      return docManager.services.contents.getDownloadUrl(path).then((url) => {
+      return docManager.services.contents.getDownloadUrl(path).then(url => {
         window.open(url, '_blank');
       });
     },

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -264,6 +264,11 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     execute: args => {
       const path = typeof args['path'] === 'undefined' ? ''
         : args['path'] as string;
+
+        if (!path) {
+          return;
+        }
+
       return docManager.services.contents.getDownloadUrl(path).then(url => {
         window.open(url, '_blank');
       });

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -265,9 +265,9 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
       const path = typeof args['path'] === 'undefined' ? ''
         : args['path'] as string;
 
-        if (!path) {
-          return;
-        }
+      if (!path) {
+        return;
+      }
 
       return docManager.services.contents.getDownloadUrl(path).then(url => {
         window.open(url, '_blank');

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -269,7 +269,7 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
       });
     },
     icon: args => args['icon'] as string || '',
-    label: () => 'Open in New Tab'
+    label: () => 'Open in New Browser Tab'
   });
 
   commands.addCommand(CommandIDs.openDirect, {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -363,7 +363,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, bro
       })));
     },
     iconClass: 'jp-MaterialIcon jp-AddIcon',
-    label: 'Open in New Tab',
+    label: 'Open in New Browser Tab',
     mnemonic: 0
   });
 

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -81,6 +81,9 @@ namespace CommandIDs {
   const open = 'filebrowser:open';
 
   export
+  const openTab = 'filebrowser:open-tab';
+
+  export
   const paste = 'filebrowser:paste';
 
   export
@@ -347,6 +350,23 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, bro
     mnemonic: 0
   });
 
+  commands.addCommand(CommandIDs.openTab, {
+    execute: () => {
+      const widget = tracker.currentWidget;
+
+      if (!widget) {
+        return;
+      }
+
+      return Promise.all(toArray(map(widget.selectedItems(), item => {
+        return commands.execute('docmanager:open-tab', { path: item.path });
+      })));
+    },
+    iconClass: 'jp-MaterialIcon jp-AddIcon',
+    label: 'Open in New Tab',
+    mnemonic: 0
+  });
+
   commands.addCommand(CommandIDs.paste, {
     execute: () => {
       const widget = tracker.currentWidget;
@@ -440,6 +460,7 @@ function createContextMenu(model: Contents.IModel | undefined, commands: Command
 
   const path = model.path;
   if (model.type !== 'directory') {
+    menu.addItem({ command: CommandIDs.openTab });
     const factories = registry.preferredWidgetFactories(path).map(f => f.name);
     if (path && factories.length > 1) {
       const command =  'docmanager:open';


### PR DESCRIPTION
Add the "Open in New Tab" option to the `filebrowser` right-click menu to cover the use case discussed in https://github.com/jupyterlab/jupyterlab/issues/4137.

It is not only limited to `html` files so images can also be opened in a new browser tab.

## Flow

![new-tab](https://user-images.githubusercontent.com/591645/38268170-b9af6b50-377d-11e8-9838-fd0562538cf5.gif)