### PR TITLE
Reuse existing node when rendering update_display outputs

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -318,8 +318,14 @@ class OutputArea extends Widget {
    */
   private _setOutput(index: number, model: IOutputModel): void {
     let layout = this.layout as PanelLayout;
-    layout.widgets[index].dispose();
-    this._insertOutput(index, model);
+    let panel = layout.widgets[index] as Panel;
+    let renderer = panel.widgets[1] as IRenderMime.IRenderer;
+    if (renderer.renderModel) {
+      renderer.renderModel(model);
+    } else {
+      layout.widgets[index].dispose();
+      this._insertOutput(index, model);
+    }
   }
 
   /**


### PR DESCRIPTION
Addresses https://github.com/jupyterlab/jupyterlab/issues/3118#issuecomment-372474650

When rendering an output that originates from an `update_display_data` message, it will check if the renderer widget is an instance of IRenderer and if so, call `renderModel` on it with the new model vs. disposing of the original widget and creating a new one.

Before:

![before](https://user-images.githubusercontent.com/512354/38342544-e6551bee-3833-11e8-8972-d00758175836.gif)

After:

![after](https://user-images.githubusercontent.com/512354/38342547-eaa585e4-3833-11e8-94cc-ba01ed463f34.gif)
