### PR TITLE
Allow Object type for option mode in CodeMirrorEditor.IOption

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -934,7 +934,7 @@ namespace CodeMirrorEditor {
     /**
      * The mode to use.
      */
-    mode?: string | Mode.ISpec;
+    mode?: string | Object | Mode.ISpec;
 
     /**
      * The theme to style the editor with.

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -934,7 +934,7 @@ namespace CodeMirrorEditor {
     /**
      * The mode to use.
      */
-    mode?: string | Object | Mode.ISpec;
+    mode?: string | Mode.IMode;
 
     /**
      * The theme to style the editor with.
@@ -1225,4 +1225,3 @@ CodeMirrorEditor.addCommand(
 CodeMirrorEditor.addCommand(
   'indentMoreOrinsertTab', Private.indentMoreOrinsertTab
 );
-

--- a/packages/codemirror/src/mode.ts
+++ b/packages/codemirror/src/mode.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  JSONValue
+} from '@phosphor/coreutils';
+
+import {
   IEditorMimeTypeService
 } from '@jupyterlab/codeeditor';
 
@@ -38,7 +42,7 @@ declare var require: any;
 export
 namespace Mode {
   /**
-   * The interface of a codemirror mode spec.
+   * The interface of a codemirror modeInfo spec.
    */
   export
   interface ISpec {
@@ -46,6 +50,15 @@ namespace Mode {
     name?: string;
     mode: string;
     mime: string;
+  }
+
+  /**
+   * The interface of a codemirror mode spec.
+   */
+  export
+  interface IMode {
+    name: string;
+    [key: string]: JSONValue;
   }
 
   /**


### PR DESCRIPTION
The `mode` option of [`CodeMirrorEditor.IOption`](https://github.com/jupyterlab/jupyterlab/blob/master/packages/codemirror/src/editor.ts#L937) is passed to [editor.setOption(option, value)](https://github.com/jupyterlab/jupyterlab/blob/master/packages/codemirror/src/editor.ts#L1206) and calls [`codemirror.setOption`](https://codemirror.net/doc/manual.html#setOption) where the [`mode` option](https://codemirror.net/doc/manual.html#config) accepts both a string (e.g. `python`) and an object (e.g. `{name: 'python', version: 3}`). 

Existing definition of [`mode`](https://github.com/jupyterlab/jupyterlab/blob/master/packages/codemirror/src/editor.ts#L937)

```
mode?: string | Mode.ISpec;
```
does not accept the latter case. This PR adds `Object` to the type definition and allows the specification of complete codemirror mode.