### PR TITLE
Make lerna use "yarn" since it has hardcoded checks

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,12 @@
 {
   "lerna": "2.4.0",
   "version": "independent",
-  "npmClient": "jlpm",
+  "npmClient": "yarn",
   "registry": "https://registry.npmjs.org/",
-  "useWorkspaces": true
+  "useWorkspaces": true,
+  "command": {
+    "publish": {
+      "npmClientArgs": ["--non-interactive"]
+    }
+  }
 }


### PR DESCRIPTION
We switch away from lerna thinking the package manager is jlpm since lerna has some hardcoded logic to deal with “yarn”. Yarn should be in the path by the time it runs.

This also attempts to do the same as https://github.com/lerna/lerna/commit/07d080db6cb77f3d1b28abce5bde7c732523a091