### PR TITLE
Fixed exception when installing extension from incompatible tar

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1150,7 +1150,7 @@ class _AppHandler(object):
                 # Extend message to better guide the user what to do:
                 conflicts = '\n'.join(msg.splitlines()[2:])
                 msg = ''.join((
-                    self._format_no_compatible_package_version(extension),
+                    self._format_no_compatible_package_version(name),
                     "\n\n",
                     conflicts))
 


### PR DESCRIPTION
Previously, it would query npm with the full tar file path instead of the package name. This raised a 500 response error.