### PR TITLE
Typings should not be in dependencies.

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -24,7 +24,6 @@ let MISSING: { [key: string]: string[] } = {
 };
 
 let UNUSED: { [key: string]: string[] } = {
-  '@jupyterlab/apputils': ['@types/react'],
   '@jupyterlab/apputils-extension': ['es6-promise'],
   '@jupyterlab/theme-dark-extension': ['font-awesome'],
   '@jupyterlab/theme-light-extension': ['font-awesome'],

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -42,12 +42,12 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.5.0",
-    "@types/react": "~16.0.19",
     "react": "~16.2.0",
     "react-dom": "~16.2.0",
     "sanitize-html": "~1.14.3"
   },
   "devDependencies": {
+    "@types/react": "~16.0.19",
     "@types/react-dom": "~16.0.2",
     "@types/sanitize-html": "~1.14.0",
     "rimraf": "~2.6.2",


### PR DESCRIPTION
This will need to be in 0.32. I think this can cause problems when dependencies that rely on `@jupyterlab/apputils` also depend on `@types/react`.