### PR TITLE
Restore typings to apputils dependencies.

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -24,6 +24,7 @@ let MISSING: { [key: string]: string[] } = {
 };
 
 let UNUSED: { [key: string]: string[] } = {
+  '@jupyterlab/apputils': ['@types/react'],
   '@jupyterlab/apputils-extension': ['es6-promise'],
   '@jupyterlab/theme-dark-extension': ['font-awesome'],
   '@jupyterlab/theme-light-extension': ['font-awesome'],

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -42,12 +42,12 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.5.0",
+    "@types/react": "^16.0.19",
     "react": "~16.2.0",
     "react-dom": "~16.2.0",
     "sanitize-html": "~1.14.3"
   },
   "devDependencies": {
-    "@types/react": "~16.0.19",
     "@types/react-dom": "~16.0.2",
     "@types/sanitize-html": "~1.14.0",
     "rimraf": "~2.6.2",

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -42,7 +42,7 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.5.0",
-    "@types/react": "^16.0.19",
+    "@types/react": "~16.0.19",
     "react": "~16.2.0",
     "react-dom": "~16.2.0",
     "sanitize-html": "~1.14.3"


### PR DESCRIPTION
Reverts #4367.

I am unsatisfied with this solution, since different versions of `@types/react` are mutually incompatible, and it makes this a very brittle dependency to include. I see this as the lesser of two evils, though.