### PR TITLE
Change order of `CodeMirror.multiplexingMode` arguments

### DIFF
--- a/packages/codemirror/src/codemirror-ipythongfm.ts
+++ b/packages/codemirror/src/codemirror-ipythongfm.ts
@@ -25,13 +25,12 @@ CodeMirror.defineMode('ipythongfm', (config: CodeMirror.EditorConfiguration, mod
   return CodeMirror.multiplexingMode(
     gfmMode,
     {
-      open: '$', close: '$',
+      open: '$$', close: '$$',
       mode: texMode,
       delimStyle: 'delimit'
     },
     {
-      // not sure this works as $$ is interpreted at (opening $, closing $, as defined just above)
-      open: '$$', close: '$$',
+      open: '$', close: '$',
       mode: texMode,
       delimStyle: 'delimit'
     },


### PR DESCRIPTION
This PR intends to fix issue #4387.
It changes order of `CodeMirror.multiplexingMode` arguments so that double dollars are no longer interpreted as an opening single dollar followed by a closing single dollar.