### PR TITLE
 Add labextension update entry point 

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -235,12 +235,12 @@ def uninstall_extension(name, app_dir=None, logger=None):
     return handler.uninstall_extension(name)
 
 
-def update_extension(name=None, all=False, app_dir=None, logger=None):
+def update_extension(name=None, all_=False, app_dir=None, logger=None):
     """Update an extension by name.
     """
     _node_check()
     handler = _AppHandler(app_dir, logger)
-    return handler.update_extension(name, all)
+    return handler.update_extension(name, all_)
 
 
 def clean(app_dir=None):

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -240,7 +240,9 @@ def update_extension(name=None, all_=False, app_dir=None, logger=None):
     """
     _node_check()
     handler = _AppHandler(app_dir, logger)
-    return handler.update_extension(name, all_)
+    if all_ is True:
+        return handler.update_all_extensions()
+    return handler.update_extension(name)
 
 
 def clean(app_dir=None):
@@ -579,17 +581,25 @@ class _AppHandler(object):
         self.logger.warn('No labextension named "%s" installed' % name)
         return False
 
-    def update_extension(self, name=None, all_ext=False):
-        if all_ext:
-            should_rebuild = False
-            for (extname, _) in self.info['extensions'].items():
-                if extname in self.info['local_extensions']:
-                    continue
-                updated = self._update_extension(extname)
-                # Rebuild if at least one update happens:
-                should_rebuild = should_rebuild or updated
-            return should_rebuild
+    def update_all_extensions(self):
+        """Update all non-local extensions.
 
+        Returns `True` if a rebuild is recommended, `False` otherwise.
+        """
+        should_rebuild = False
+        for (extname, _) in self.info['extensions'].items():
+            if extname in self.info['local_extensions']:
+                continue
+            updated = self._update_extension(extname)
+            # Rebuild if at least one update happens:
+            should_rebuild = should_rebuild or updated
+        return should_rebuild
+
+    def update_extension(self, name):
+        """Update an extension by name.
+
+        Returns `True` if a rebuild is recommended, `False` otherwise.
+        """
         if name not in self.info['extensions']:
             self.logger.warn('No labextension named "%s" installed' % name)
             return False

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -221,6 +221,8 @@ def install_extension(extension, app_dir=None, logger=None):
     """Install an extension package into JupyterLab.
 
     The extension is first validated.
+
+    Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     _node_check()
     handler = _AppHandler(app_dir, logger)
@@ -229,6 +231,8 @@ def install_extension(extension, app_dir=None, logger=None):
 
 def uninstall_extension(name, app_dir=None, logger=None):
     """Uninstall an extension by name or path.
+
+    Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     _node_check()
     handler = _AppHandler(app_dir, logger)
@@ -240,6 +244,8 @@ def update_extension(name=None, all_=False, app_dir=None, logger=None):
 
     Either `name` must be given as a string, or `all_` must be `True`.
     If `all_` is `True`, the value of `name` is ignored.
+
+    Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     _node_check()
     handler = _AppHandler(app_dir, logger)
@@ -281,6 +287,8 @@ def get_app_info(app_dir=None, logger=None):
 
 def enable_extension(extension, app_dir=None, logger=None):
     """Enable a JupyterLab extension.
+
+    Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     handler = _AppHandler(app_dir, logger)
     return handler.toggle_extension(extension, False)
@@ -288,6 +296,8 @@ def enable_extension(extension, app_dir=None, logger=None):
 
 def disable_extension(extension, app_dir=None, logger=None):
     """Disable a JupyterLab package.
+
+    Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     handler = _AppHandler(app_dir, logger)
     return handler.toggle_extension(extension, True)
@@ -318,13 +328,18 @@ def list_extensions(app_dir=None, logger=None):
 
 
 def link_package(path, app_dir=None, logger=None):
-    """Link a package against the JupyterLab build."""
+    """Link a package against the JupyterLab build.
+
+    Returns `True` if a rebuild is recommended, `False` otherwise.
+    """
     handler = _AppHandler(app_dir, logger)
     return handler.link_package(path)
 
 
 def unlink_package(package, app_dir=None, logger=None):
     """Unlink a package from JupyterLab by path or name.
+
+    Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     handler = _AppHandler(app_dir, logger)
     return handler.unlink_package(package)

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -694,14 +694,21 @@ class _AppHandler(object):
 
     def toggle_extension(self, extension, value):
         """Enable or disable a lab extension.
+
+        Returns `True` if a rebuild is recommended, `False` otherwise.
         """
         config = self._read_page_config()
         disabled = config.setdefault('disabledExtensions', [])
+        did_something = False
         if value and extension not in disabled:
             disabled.append(extension)
-        if not value and extension in disabled:
+            did_something = True
+        elif not value and extension in disabled:
             disabled.remove(extension)
-        self._write_page_config(config)
+            did_something = True
+        if did_something:
+            self._write_page_config(config)
+        return did_something
 
     def check_extension(self, extension, check_installed_only=False):
         """Check if a lab extension is enabled or disabled

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -356,7 +356,7 @@ class _AppHandler(object):
                 uninstalled.remove(extension)
                 config['uninstalled_core_extensions'] = uninstalled
                 self._write_build_config(config)
-            return
+            return False
 
         # Create the app dirs if needed.
         self._ensure_app_dirs()

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1166,15 +1166,15 @@ class _AppHandler(object):
         info['path'] = target
         return info
 
-    def _extract_package(self, source, tempdir):
+    def _extract_package(self, source, tempdir, quiet=False):
         # npm pack the extension
         is_dir = osp.exists(source) and osp.isdir(source)
         if is_dir and not osp.exists(pjoin(source, 'node_modules')):
-            self._run(['node', YARN_PATH, 'install'], cwd=source)
+            self._run(['node', YARN_PATH, 'install'], cwd=source, quiet=quiet)
 
         info = dict(source=source, is_dir=is_dir)
 
-        ret = self._run([which('npm'), 'pack', source], cwd=tempdir)
+        ret = self._run([which('npm'), 'pack', source], cwd=tempdir, quiet=quiet)
         if ret != 0:
             msg = '"%s" is not a valid npm package'
             raise ValueError(msg % source)
@@ -1215,7 +1215,8 @@ class _AppHandler(object):
                 # Found a compatible version
                 # Verify that the version is a valid extension.
                 with TemporaryDirectory() as tempdir:
-                    info = self._extract_package('%s@%s' % (name, version), tempdir)
+                    info = self._extract_package(
+                        '%s@%s' % (name, version), tempdir, quiet=True)
                 if _validate_extension(info['data']):
                     # Invalid, do not consider other versions
                     return

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -662,7 +662,9 @@ class _AppHandler(object):
         return True
 
     def unlink_package(self, path):
-        """Link a package by name or at the given path.
+        """Unlink a package by name or at the given path.
+
+        A ValueError is raised if the path is not an unlinkable package.
 
         Returns `True` if a rebuild is recommended, `False` otherwise.
         """
@@ -691,6 +693,7 @@ class _AppHandler(object):
             raise ValueError('No linked package for %s' % path)
 
         self._write_build_config(config)
+        return True
 
     def toggle_extension(self, extension, value):
         """Enable or disable a lab extension.

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -121,7 +121,7 @@ class UpdateLabExtensionApp(BaseExtensionApp):
             self.log.warn('Specify an extension to update, or use --all to update all extensions')
             return False
         if self.all:
-            return update_extension(all=True, app_dir=self.app_dir, logger=self.log)
+            return update_extension(all_=True, app_dir=self.app_dir, logger=self.log)
         return any([
             update_extension(name=arg, app_dir=self.app_dir, logger=self.log)
             for arg in self.extra_args

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -18,7 +18,8 @@ from traitlets import Bool, Unicode
 from .commands import (
     install_extension, uninstall_extension, list_extensions,
     enable_extension, disable_extension, check_extension,
-    link_package, unlink_package, build, get_app_version, HERE
+    link_package, unlink_package, build, get_app_version, HERE,
+    update_extension,
 )
 
 
@@ -41,6 +42,13 @@ check_flags['installed'] = (
     {'CheckLabExtensionsApp': {'should_check_installed_only': True}},
     "Check only if the extension is installed."
 )
+
+update_flags = copy(flags)
+update_flags['all'] = (
+    {'UpdateLabExtensionApp': {'all': True}},
+    "Update all extensions"
+)
+
 aliases = dict(base_aliases)
 aliases['app-dir'] = 'BaseExtensionApp.app_dir'
 
@@ -97,6 +105,25 @@ class InstallLabExtensionApp(BaseExtensionApp):
         self.extra_args = self.extra_args or [os.getcwd()]
         return any([
             install_extension(arg, self.app_dir, logger=self.log)
+            for arg in self.extra_args
+        ])
+
+
+class UpdateLabExtensionApp(BaseExtensionApp):
+    description = "Update labextension(s)"
+    flags = update_flags
+
+    all = Bool(False, config=True,
+        help="Whether to update all extensions")
+
+    def run_task(self):
+        if not self.all and not self.extra_args:
+            self.log.warn('Specify an extension to update, or use --all to update all extensions')
+            return False
+        if self.all:
+            return update_extension(all=True, app_dir=self.app_dir, logger=self.log)
+        return any([
+            update_extension(name=arg, app_dir=self.app_dir, logger=self.log)
             for arg in self.extra_args
         ])
 
@@ -199,6 +226,7 @@ class LabExtensionApp(JupyterApp):
 
     subcommands = dict(
         install=(InstallLabExtensionApp, "Install labextension(s)"),
+        update=(UpdateLabExtensionApp, "Update labextension(s)"),
         uninstall=(UninstallLabExtensionApp, "Uninstall labextension(s)"),
         list=(ListLabExtensionsApp, "List labextensions"),
         link=(LinkLabExtensionApp, "Link labextension(s)"),

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -132,7 +132,7 @@ class TestExtension(TestCase):
         self.app_dir = commands.get_app_dir()
 
     def test_install_extension(self):
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         path = pjoin(self.app_dir, 'extensions', '*.tgz')
         assert glob.glob(path)
         extensions = get_app_info(self.app_dir)['extensions']
@@ -141,9 +141,9 @@ class TestExtension(TestCase):
         assert check_extension(name)
 
     def test_install_twice(self):
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         path = pjoin(commands.get_app_dir(), 'extensions', '*.tgz')
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         assert glob.glob(path)
         extensions = get_app_info(self.app_dir)['extensions']
         name = self.pkg_names['extension']
@@ -156,7 +156,7 @@ class TestExtension(TestCase):
         assert name in get_app_info(self.app_dir)['extensions']
         assert check_extension(name)
 
-        uninstall_extension(name)
+        assert uninstall_extension(name) is True
         assert name not in get_app_info(self.app_dir)['extensions']
         assert not check_extension(name)
 
@@ -191,10 +191,10 @@ class TestExtension(TestCase):
         assert not check_extension(self.pkg_names["mimeextension"])
 
     def test_uninstall_extension(self):
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         name = self.pkg_names['extension']
         assert check_extension(name)
-        uninstall_extension(self.pkg_names['extension'])
+        assert uninstall_extension(self.pkg_names['extension']) is True
         path = pjoin(self.app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
         extensions = get_app_info(self.app_dir)['extensions']
@@ -202,7 +202,7 @@ class TestExtension(TestCase):
         assert not check_extension(name)
 
     def test_uninstall_core_extension(self):
-        uninstall_extension('@jupyterlab/console-extension')
+        assert uninstall_extension('@jupyterlab/console-extension') is True
         app_dir = self.app_dir
         build(app_dir)
         with open(pjoin(app_dir, 'staging', 'package.json')) as fid:
@@ -211,7 +211,7 @@ class TestExtension(TestCase):
         assert '@jupyterlab/console-extension' not in extensions
         assert not check_extension('@jupyterlab/console-extension')
 
-        install_extension('@jupyterlab/console-extension')
+        assert install_extension('@jupyterlab/console-extension') is True
         build(app_dir)
         with open(pjoin(app_dir, 'staging', 'package.json')) as fid:
             data = json.load(fid)
@@ -228,7 +228,7 @@ class TestExtension(TestCase):
         assert name not in linked
         assert name in get_app_info(app_dir)['extensions']
         assert check_extension(name)
-        unlink_package(path)
+        assert unlink_package(path) is True
         linked = get_app_info(app_dir)['linked_packages']
         assert name not in linked
         assert name not in get_app_info(app_dir)['extensions']
@@ -237,34 +237,34 @@ class TestExtension(TestCase):
     def test_link_package(self):
         path = self.mock_package
         name = self.pkg_names['package']
-        link_package(path)
+        assert link_package(path) is True
         app_dir = self.app_dir
         linked = get_app_info(app_dir)['linked_packages']
         assert name in linked
         assert name not in get_app_info(app_dir)['extensions']
         assert check_extension(name)
-        unlink_package(path)
+        assert unlink_package(path)
         linked = get_app_info(app_dir)['linked_packages']
         assert name not in linked
         assert not check_extension(name)
 
     def test_unlink_package(self):
         target = self.mock_package
-        link_package(target)
-        unlink_package(target)
+        assert link_package(target) is True
+        assert unlink_package(target) is True
         linked = get_app_info(self.app_dir)['linked_packages']
         name = self.pkg_names['package']
         assert name not in linked
         assert not check_extension(name)
 
     def test_list_extensions(self):
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         list_extensions()
 
     def test_app_dir(self):
         app_dir = self.tempdir()
 
-        install_extension(self.mock_extension, app_dir)
+        assert install_extension(self.mock_extension, app_dir) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert glob.glob(path)
         extensions = get_app_info(app_dir)['extensions']
@@ -272,20 +272,20 @@ class TestExtension(TestCase):
         assert ext_name in extensions
         assert check_extension(ext_name, app_dir)
 
-        uninstall_extension(self.pkg_names['extension'], app_dir)
+        assert uninstall_extension(self.pkg_names['extension'], app_dir) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
         extensions = get_app_info(app_dir)['extensions']
         assert ext_name not in extensions
         assert not check_extension(ext_name, app_dir)
 
-        link_package(self.mock_package, app_dir)
+        assert link_package(self.mock_package, app_dir) is True
         linked = get_app_info(app_dir)['linked_packages']
         pkg_name = self.pkg_names['package']
         assert pkg_name in linked
         assert check_extension(pkg_name, app_dir)
 
-        unlink_package(self.mock_package, app_dir)
+        assert unlink_package(self.mock_package, app_dir) is True
         linked = get_app_info(app_dir)['linked_packages']
         assert pkg_name not in linked
         assert not check_extension(pkg_name, app_dir)
@@ -295,7 +295,7 @@ class TestExtension(TestCase):
         if os.path.exists(self.app_dir):
             os.removedirs(self.app_dir)
 
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
         extensions = get_app_info(app_dir)['extensions']
@@ -309,7 +309,7 @@ class TestExtension(TestCase):
         if os.path.exists(sys_dir):
             os.removedirs(sys_dir)
 
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         sys_path = pjoin(sys_dir, 'extensions', '*.tgz')
         assert glob.glob(sys_path)
         app_path = pjoin(app_dir, 'extensions', '*.tgz')
@@ -319,20 +319,20 @@ class TestExtension(TestCase):
         assert ext_name in extensions
         assert check_extension(ext_name, app_dir)
 
-        install_extension(self.mock_extension, app_dir)
+        assert install_extension(self.mock_extension, app_dir) is True
         assert glob.glob(app_path)
         extensions = get_app_info(app_dir)['extensions']
         assert ext_name in extensions
         assert check_extension(ext_name, app_dir)
 
-        uninstall_extension(self.pkg_names['extension'], app_dir)
+        assert uninstall_extension(self.pkg_names['extension'], app_dir) is True
         assert not glob.glob(app_path)
         assert glob.glob(sys_path)
         extensions = get_app_info(app_dir)['extensions']
         assert ext_name in extensions
         assert check_extension(ext_name, app_dir)
 
-        uninstall_extension(self.pkg_names['extension'], app_dir)
+        assert uninstall_extension(self.pkg_names['extension'], app_dir) is True
         assert not glob.glob(app_path)
         assert not glob.glob(sys_path)
         extensions = get_app_info(app_dir)['extensions']
@@ -340,7 +340,7 @@ class TestExtension(TestCase):
         assert not check_extension(ext_name, app_dir)
 
     def test_build(self):
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         build()
         # check staging directory.
         entry = pjoin(self.app_dir, 'staging', 'build', 'index.out.js')
@@ -355,7 +355,7 @@ class TestExtension(TestCase):
         assert self.pkg_names['extension'] in data
 
     def test_build_custom(self):
-        install_extension(self.mock_extension)
+        assert install_extension(self.mock_extension) is True
         build(name='foo', version='1.0', public_url='bar')
 
         # check static directory.
@@ -381,14 +381,14 @@ class TestExtension(TestCase):
 
     def test_disable_extension(self):
         app_dir = self.tempdir()
-        install_extension(self.mock_extension, app_dir)
-        disable_extension(self.pkg_names['extension'], app_dir)
+        assert install_extension(self.mock_extension, app_dir) is True
+        assert disable_extension(self.pkg_names['extension'], app_dir) is True
         info = get_app_info(app_dir)
         name = self.pkg_names['extension']
         assert name in info['disabled']
         assert not check_extension(name, app_dir)
         assert check_extension(name, app_dir, True)
-        disable_extension('@jupyterlab/notebook-extension', app_dir)
+        assert disable_extension('@jupyterlab/notebook-extension', app_dir) is True
         info = get_app_info(app_dir)
         assert '@jupyterlab/notebook-extension' in info['disabled']
         assert not check_extension('@jupyterlab/notebook-extension', app_dir)
@@ -399,14 +399,14 @@ class TestExtension(TestCase):
 
     def test_enable_extension(self):
         app_dir = self.tempdir()
-        install_extension(self.mock_extension, app_dir)
-        disable_extension(self.pkg_names['extension'], app_dir)
-        enable_extension(self.pkg_names['extension'], app_dir)
+        assert install_extension(self.mock_extension, app_dir) is True
+        assert disable_extension(self.pkg_names['extension'], app_dir) is True
+        assert enable_extension(self.pkg_names['extension'], app_dir) is True
         info = get_app_info(app_dir)
         name = self.pkg_names['extension']
         assert name not in info['disabled']
         assert check_extension(name, app_dir)
-        disable_extension('@jupyterlab/notebook-extension', app_dir)
+        assert disable_extension('@jupyterlab/notebook-extension', app_dir) is True
         assert name not in info['disabled']
         assert check_extension(name, app_dir)
         assert '@jupyterlab/notebook-extension' not in info['disabled']
@@ -415,15 +415,15 @@ class TestExtension(TestCase):
     def test_build_check(self):
         # Do the initial build.
         assert build_check()
-        install_extension(self.mock_extension)
-        link_package(self.mock_package)
+        assert install_extension(self.mock_extension) is True
+        assert link_package(self.mock_package) is True
         build()
         assert not build_check()
 
         # Check installed extensions.
-        install_extension(self.mock_mimeextension)
+        assert install_extension(self.mock_mimeextension) is True
         assert build_check()
-        uninstall_extension(self.pkg_names['mimeextension'])
+        assert uninstall_extension(self.pkg_names['mimeextension']) is True
         assert not build_check()
 
         # Check local extensions.
@@ -529,7 +529,7 @@ class TestExtension(TestCase):
         with p1, p2:
             orig_install = commands._AppHandler._install_extension
             with p3, pytest.raises(Success):
-                install_extension('mockextension')
+                assert install_extension('mockextension') is True
 
 
     def test_update_single(self):
@@ -550,11 +550,11 @@ class TestExtension(TestCase):
             '_latest_compatible_package_version',
             _mock_latest)
 
-        install_extension(self.mock_extension)
-        install_extension(self.mock_mimeextension)
+        assert install_extension(self.mock_extension) is True
+        assert install_extension(self.mock_mimeextension) is True
 
         with p1, p2:
-            assert True == update_extension(self.pkg_names['extension'])
+            assert update_extension(self.pkg_names['extension']) is True
         assert installed == [self.pkg_names['extension']]
 
 
@@ -584,8 +584,8 @@ class TestExtension(TestCase):
         install_extension(self.mock_mimeextension)
 
         with p1, p2:
-            assert True == update_extension(self.pkg_names['extension'])
-            assert True == update_extension(self.pkg_names['mimeextension'])
+            assert update_extension(self.pkg_names['extension']) is True
+            assert update_extension(self.pkg_names['mimeextension']) is True
         assert installed == [self.pkg_names['extension'], self.pkg_names['mimeextension']]
 
     def test_update_all(self):
@@ -601,8 +601,8 @@ class TestExtension(TestCase):
             return info
 
 
-        install_extension(self.mock_extension)
-        install_extension(self.mock_mimeextension)
+        assert install_extension(self.mock_extension) is True
+        assert install_extension(self.mock_mimeextension) is True
 
         p1 = patch.object(
             commands._AppHandler,
@@ -617,5 +617,5 @@ class TestExtension(TestCase):
         )
 
         with p1, p2:
-            assert True == update_extension(None, all_=True)
+            assert update_extension(None, all_=True) is True
         assert sorted(updated) == [self.pkg_names['extension'], self.pkg_names['mimeextension']]

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -617,5 +617,5 @@ class TestExtension(TestCase):
         )
 
         with p1, p2:
-            assert True == update_extension(None, all=True)
+            assert True == update_extension(None, all_=True)
         assert sorted(updated) == [self.pkg_names['extension'], self.pkg_names['mimeextension']]


### PR DESCRIPTION
Adds a CLI entry point `jupyter labextension update`. Can be used with one or more package names, or the flag `--all` to update all extensions (except core and local extensions). The command will look for the latest version of the extensions that are compatible with the current install of jupyterlab, and install that version if it is newer than the currently installed version.

I'm assuming that it is best to use the python package to manage the core extensions(?).

Open question: When users update jupyterlab, they might need to update their extensions. What would be a good way to help the user through:
- Updating those packages that can be updated.
- Letting the user know about packages which currently do not have a compatible version.

Fixes #3740.
Xref #4408. 