### PR TITLE
Fix documentation link to direct people to jupyterlab readthedocs docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 **[Installation](#installation)** |
-**[Documentation](#documentation)** |
+**[Documentation](http://jupyterlab.readthedocs.io/en/latest/)** |
 **[Contributing](#contributing)** |
 **[License](#license)** |
 **[Team](#team)** |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 **[Installation](#installation)** |
-**[Documentation](http://jupyterlab.readthedocs.io/en/latest/)** |
+**[Documentation](http://jupyterlab.readthedocs.io)** |
 **[Contributing](#contributing)** |
 **[License](#license)** |
 **[Team](#team)** |


### PR DESCRIPTION
Noticed that the Documentation link was pointing to a local header that did not exist. Since the docs have an official home, I figured that redirecting to that would be more useful.