### PR TITLE
Rename open-tab command to open-browser-tab

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -60,7 +60,7 @@ namespace CommandIDs {
   const open = 'docmanager:open';
 
   export
-  const openTab = 'docmanager:open-tab';
+  const openBrowserTab = 'docmanager:open-browser-tab';
 
   export
   const openDirect = 'docmanager:open-direct';
@@ -260,7 +260,7 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     mnemonic: args => args['mnemonic'] as number || -1
   });
 
-  commands.addCommand(CommandIDs.openTab, {
+  commands.addCommand(CommandIDs.openBrowserTab, {
     execute: args => {
       const path = typeof args['path'] === 'undefined' ? ''
         : args['path'] as string;

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -81,7 +81,7 @@ namespace CommandIDs {
   const open = 'filebrowser:open';
 
   export
-  const openTab = 'filebrowser:open-tab';
+  const openBrowserTab = 'filebrowser:open-browser-tab';
 
   export
   const paste = 'filebrowser:paste';
@@ -350,7 +350,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, bro
     mnemonic: 0
   });
 
-  commands.addCommand(CommandIDs.openTab, {
+  commands.addCommand(CommandIDs.openBrowserTab, {
     execute: () => {
       const widget = tracker.currentWidget;
 
@@ -359,7 +359,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, bro
       }
 
       return Promise.all(toArray(map(widget.selectedItems(), item => {
-        return commands.execute('docmanager:open-tab', { path: item.path });
+        return commands.execute('docmanager:open-browser-tab', { path: item.path });
       })));
     },
     iconClass: 'jp-MaterialIcon jp-AddIcon',
@@ -460,7 +460,7 @@ function createContextMenu(model: Contents.IModel | undefined, commands: Command
 
   const path = model.path;
   if (model.type !== 'directory') {
-    menu.addItem({ command: CommandIDs.openTab });
+    menu.addItem({ command: CommandIDs.openBrowserTab });
     const factories = registry.preferredWidgetFactories(path).map(f => f.name);
     if (path && factories.length > 1) {
       const command =  'docmanager:open';


### PR DESCRIPTION
Rename the command `open-tab` to `open-browser-tab` to avoid confusion with JupyterLab tabs.

Follow-up of #4315.