### PR TITLE
setting baseUrl should set wsUrl

### DIFF
--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -2,11 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  PageConfig
-} from '@jupyterlab/coreutils';
-
-import {
-  URLExt
+  PageConfig, URLExt
 } from '@jupyterlab/coreutils';
 
 
@@ -209,8 +205,7 @@ namespace Private {
   function makeSettings(options: Partial<ServerConnection.ISettings> = {}): ServerConnection.ISettings {
     let extra: Partial<ServerConnection.ISettings> = {};
     if (options.baseUrl && !options.wsUrl) {
-      // setting baseUrl = https://host...
-      // sets wsUrl = wss://host...
+      // Setting baseUrl to https://host... sets wsUrl to wss://host...
       let baseUrl = options.baseUrl;
       if (baseUrl.indexOf('http') !== 0) {
         if (typeof location !== 'undefined') {
@@ -226,7 +221,7 @@ namespace Private {
     return {
       ...ServerConnection.defaultSettings,
       ...options,
-      ...extra,
+      ...extra
     };
   }
 

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -5,6 +5,10 @@ import {
   PageConfig
 } from '@jupyterlab/coreutils';
 
+import {
+  URLExt
+} from '@jupyterlab/coreutils';
+
 
 /**
  * Handle the default `fetch` and `WebSocket` providers.
@@ -203,9 +207,26 @@ namespace Private {
    */
   export
   function makeSettings(options: Partial<ServerConnection.ISettings> = {}): ServerConnection.ISettings {
+    let extra: Partial<ServerConnection.ISettings> = {};
+    if (options.baseUrl && !options.wsUrl) {
+      // setting baseUrl = https://host...
+      // sets wsUrl = wss://host...
+      let baseUrl = options.baseUrl;
+      if (baseUrl.indexOf('http') !== 0) {
+        if (typeof location !== 'undefined') {
+          baseUrl = URLExt.join(location.origin, baseUrl);
+        } else {
+          baseUrl = URLExt.join('http://localhost:8888/', baseUrl);
+        }
+      }
+      extra = {
+        wsUrl: 'ws' + baseUrl.slice(4),
+      };
+    }
     return {
       ...ServerConnection.defaultSettings,
-      ...options
+      ...options,
+      ...extra,
     };
   }
 

--- a/packages/services/test/src/serverconnection.spec.ts
+++ b/packages/services/test/src/serverconnection.spec.ts
@@ -43,6 +43,15 @@ describe('@jupyterlab/services', () => {
         expect(settings.token).to.be(PageConfig.getOption('token'));
       });
 
+      it('should use baseUrl for wsUrl', () => {
+        let conf: Partial<ServerConnection.ISettings> = {
+          baseUrl: 'https://host/path'
+        };
+        let settings = ServerConnection.makeSettings(conf);
+        expect(settings.baseUrl).to.be(conf.baseUrl);
+        expect(settings.wsUrl).to.be('wss://host/path');
+      });
+
       it('should handle overrides', () => {
         let defaults: Partial<ServerConnection.ISettings> = {
           baseUrl: 'foo',


### PR DESCRIPTION
`makeSettings({baseUrl})` behavior matches that of PageConfig when only baseUrl is specified. wsUrl deviating from baseUrl ~never happens, so should only need to be specified in the rare cases when wsUrl is not baseUrl.

This was the behavior in services 0.51, but got lost since then.

Regression test included.