### PR TITLE
Update codemirror from 5.35.0 to 5.37.0

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -83,7 +83,7 @@
     "@phosphor/widgets": "^1.5.0",
     "ajv": "~5.1.6",
     "ansi_up": "^3.0.0",
-    "codemirror": "~5.35.0",
+    "codemirror": "~5.37.0",
     "comment-json": "^1.1.3",
     "es6-promise": "~4.1.1",
     "marked": "~0.3.9",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/fileeditor": "^0.16.2",
     "@jupyterlab/mainmenu": "^0.5.2",
     "@phosphor/widgets": "^1.5.0",
-    "codemirror": "~5.35.0"
+    "codemirror": "~5.37.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -38,7 +38,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "codemirror": "~5.35.0"
+    "codemirror": "~5.37.0"
   },
   "devDependencies": {
     "@types/codemirror": "~0.0.46",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,9 +1531,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror@~5.35.0:
-  version "5.35.0"
-  resolved "https://registry.npmjs.org/codemirror/-/codemirror-5.35.0.tgz#280653d495455bc66aa87e6284292b02775ba878"
+codemirror@~5.37.0:
+  version "5.37.0"
+  resolved "https://registry.npmjs.org/codemirror/-/codemirror-5.37.0.tgz#c349b584e158f590277f26d37c2469a6bc538036"
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
to allow syntax highlighting of python f-string

![image](https://user-images.githubusercontent.com/9889312/39074712-22d6b650-44b8-11e8-936a-9b1737105795.png)
