### PR TITLE
Add a signal for any kernel message sent/received

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -109,17 +109,20 @@ class DefaultKernel implements Kernel.IKernel {
   }
 
   /**
-   * A signal emitted for any kernel messages sent or received.
-   */
-  get anyMessage(): ISignal<this, DefaultKernel.IAnyMessageArgs> {
-    return this._anyMessage;
-  }
-
-  /**
    * A signal emitted for unhandled kernel message.
    */
   get unhandledMessage(): ISignal<this, KernelMessage.IMessage> {
     return this._unhandledMessage;
+  }
+
+  /**
+   * A signal emitted for any kernel message.
+   *
+   * Note: The behavior is undefined if the message is modified
+   * during message handling. As such, it should be treated as read-only.
+   */
+  get anyMessage(): ISignal<this, DefaultKernel.IAnyMessageArgs> {
+    return this._anyMessage;
   }
 
   /**

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -111,7 +111,7 @@ class DefaultKernel implements Kernel.IKernel {
   /**
    * A signal emitted for any kernel messages sent or received.
    */
-  get anyMessage(): ISignal<this, KernelMessage.IMessage> {
+  get anyMessage(): ISignal<this, DefaultKernel.IAnyMessageArgs> {
     return this._anyMessage;
   }
 
@@ -273,7 +273,7 @@ class DefaultKernel implements Kernel.IKernel {
     } else {
       this._ws.send(serialize.serialize(msg));
     }
-    this._anyMessage.emit(msg);
+    this._anyMessage.emit({msg, direction: 'send'});
     let future = new KernelFutureHandler(() => {
       let msgId = msg.header.msg_id;
       this._futures.delete(msgId);
@@ -563,7 +563,7 @@ class DefaultKernel implements Kernel.IKernel {
     } else {
       this._ws.send(serialize.serialize(msg));
     }
-    this._anyMessage.emit(msg);
+    this._anyMessage.emit({msg, direction: 'send'});
   }
 
   /**
@@ -995,7 +995,7 @@ class DefaultKernel implements Kernel.IKernel {
       }
       this._iopubMessage.emit(msg as KernelMessage.IIOPubMessage);
     }
-    this._anyMessage.emit(msg);
+    this._anyMessage.emit({msg, direction: 'recv'});
   }
 
   /**
@@ -1042,7 +1042,7 @@ class DefaultKernel implements Kernel.IKernel {
   private _specPromise: Promise<Kernel.ISpecModel>;
   private _statusChanged = new Signal<this, Kernel.Status>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
-  private _anyMessage = new Signal<this, KernelMessage.IMessage>(this);
+  private _anyMessage = new Signal<this, DefaultKernel.IAnyMessageArgs>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _displayIdToParentIds = new Map<string, string[]>();
   private _msgIdToDisplayIds = new Map<string, string[]>();
@@ -1174,6 +1174,22 @@ namespace DefaultKernel {
   export
   function shutdownAll(settings?: ServerConnection.ISettings): Promise<void> {
     return Private.shutdownAll(settings);
+  }
+
+  /**
+   * Arguments interface for the anyMessage signal.
+   */
+  export
+  interface IAnyMessageArgs {
+    /**
+     * The message that is being signaled.
+     */
+    msg: KernelMessage.IMessage;
+
+    /**
+     * The direction of the message.
+     */
+    direction: 'send' | 'recv';
   }
 }
 

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -109,6 +109,13 @@ class DefaultKernel implements Kernel.IKernel {
   }
 
   /**
+   * A signal emitted for any kernel messages sent or received.
+   */
+  get anyMessage(): ISignal<this, KernelMessage.IMessage> {
+    return this._anyMessage;
+  }
+
+  /**
    * A signal emitted for unhandled kernel message.
    */
   get unhandledMessage(): ISignal<this, KernelMessage.IMessage> {
@@ -266,6 +273,7 @@ class DefaultKernel implements Kernel.IKernel {
     } else {
       this._ws.send(serialize.serialize(msg));
     }
+    this._anyMessage.emit(msg);
     let future = new KernelFutureHandler(() => {
       let msgId = msg.header.msg_id;
       this._futures.delete(msgId);
@@ -555,6 +563,7 @@ class DefaultKernel implements Kernel.IKernel {
     } else {
       this._ws.send(serialize.serialize(msg));
     }
+    this._anyMessage.emit(msg);
   }
 
   /**
@@ -986,6 +995,7 @@ class DefaultKernel implements Kernel.IKernel {
       }
       this._iopubMessage.emit(msg as KernelMessage.IIOPubMessage);
     }
+    this._anyMessage.emit(msg);
   }
 
   /**
@@ -1032,6 +1042,7 @@ class DefaultKernel implements Kernel.IKernel {
   private _specPromise: Promise<Kernel.ISpecModel>;
   private _statusChanged = new Signal<this, Kernel.Status>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
+  private _anyMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _displayIdToParentIds = new Map<string, string[]>();
   private _msgIdToDisplayIds = new Map<string, string[]>();

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -121,7 +121,7 @@ class DefaultKernel implements Kernel.IKernel {
    * Note: The behavior is undefined if the message is modified
    * during message handling. As such, it should be treated as read-only.
    */
-  get anyMessage(): ISignal<this, DefaultKernel.IAnyMessageArgs> {
+  get anyMessage(): ISignal<this, Kernel.IAnyMessageArgs> {
     return this._anyMessage;
   }
 
@@ -1045,7 +1045,7 @@ class DefaultKernel implements Kernel.IKernel {
   private _specPromise: Promise<Kernel.ISpecModel>;
   private _statusChanged = new Signal<this, Kernel.Status>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
-  private _anyMessage = new Signal<this, DefaultKernel.IAnyMessageArgs>(this);
+  private _anyMessage = new Signal<this, Kernel.IAnyMessageArgs>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _displayIdToParentIds = new Map<string, string[]>();
   private _msgIdToDisplayIds = new Map<string, string[]>();
@@ -1177,22 +1177,6 @@ namespace DefaultKernel {
   export
   function shutdownAll(settings?: ServerConnection.ISettings): Promise<void> {
     return Private.shutdownAll(settings);
-  }
-
-  /**
-   * Arguments interface for the anyMessage signal.
-   */
-  export
-  interface IAnyMessageArgs {
-    /**
-     * The message that is being signaled.
-     */
-    msg: KernelMessage.IMessage;
-
-    /**
-     * The direction of the message.
-     */
-    direction: 'send' | 'recv';
   }
 }
 

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -373,6 +373,14 @@ namespace Kernel {
     unhandledMessage: ISignal<this, KernelMessage.IMessage>;
 
     /**
+     * A signal emitted for any kernel message.
+     *
+     * Note: The behavior is undefined if the message is modified
+     * during message handling. As such, it should be treated as read-only.
+     */
+    anyMessage: ISignal<this, DefaultKernel.IAnyMessageArgs>;
+
+    /**
      * The server settings for the kernel.
      */
     readonly serverSettings: ServerConnection.ISettings;

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -378,7 +378,7 @@ namespace Kernel {
      * Note: The behavior is undefined if the message is modified
      * during message handling. As such, it should be treated as read-only.
      */
-    anyMessage: ISignal<this, DefaultKernel.IAnyMessageArgs>;
+    anyMessage: ISignal<this, IAnyMessageArgs>;
 
     /**
      * The server settings for the kernel.
@@ -898,5 +898,21 @@ namespace Kernel {
      * A mapping of kernel spec name to spec.
      */
     readonly kernelspecs: { [key: string]: ISpecModel };
+  }
+
+  /**
+   * Arguments interface for the anyMessage signal.
+   */
+  export
+  interface IAnyMessageArgs {
+    /**
+     * The message that is being signaled.
+     */
+    msg: KernelMessage.IMessage;
+
+    /**
+     * The direction of the message.
+     */
+    direction: 'send' | 'recv';
   }
 }

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -18,6 +18,10 @@ import {
 } from '../kernel';
 
 import {
+  DefaultKernel
+} from '../kernel/default';
+
+import {
   ServerConnection
 } from '..';
 
@@ -88,6 +92,16 @@ class DefaultSession implements Session.ISession {
    */
   get unhandledMessage(): ISignal<this, KernelMessage.IMessage> {
     return this._unhandledMessage;
+  }
+
+  /**
+   * A signal emitted for any kernel message.
+   *
+   * Note: The behavior is undefined if the message is modified
+   * during message handling. As such, it should be treated as read-only.
+   */
+  get anyMessage(): ISignal<this, DefaultKernel.IAnyMessageArgs> {
+    return this._anyMessage;
   }
 
   /**
@@ -311,6 +325,7 @@ class DefaultSession implements Session.ISession {
     kernel.statusChanged.connect(this.onKernelStatus, this);
     kernel.unhandledMessage.connect(this.onUnhandledMessage, this);
     kernel.iopubMessage.connect(this.onIOPubMessage, this);
+    kernel.anyMessage.connect(this.onAnyMessage, this);
   }
 
   /**
@@ -332,6 +347,13 @@ class DefaultSession implements Session.ISession {
    */
   protected onUnhandledMessage(sender: Kernel.IKernel, msg: KernelMessage.IMessage) {
     this._unhandledMessage.emit(msg);
+  }
+
+  /**
+   * Handle any kernel messages.
+   */
+  protected onAnyMessage(sender: Kernel.IKernel, args: DefaultKernel.IAnyMessageArgs) {
+    this._anyMessage.emit(args);
   }
 
   /**
@@ -386,6 +408,7 @@ class DefaultSession implements Session.ISession {
   private _statusChanged = new Signal<this, Kernel.Status>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
+  private _anyMessage = new Signal<this, DefaultKernel.IAnyMessageArgs>(this);
   private _propertyChanged = new Signal<this, 'path' | 'name' | 'type'>(this);
   private _terminated = new Signal<this, void>(this);
 }

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -18,10 +18,6 @@ import {
 } from '../kernel';
 
 import {
-  DefaultKernel
-} from '../kernel/default';
-
-import {
   ServerConnection
 } from '..';
 
@@ -100,7 +96,7 @@ class DefaultSession implements Session.ISession {
    * Note: The behavior is undefined if the message is modified
    * during message handling. As such, it should be treated as read-only.
    */
-  get anyMessage(): ISignal<this, DefaultKernel.IAnyMessageArgs> {
+  get anyMessage(): ISignal<this, Kernel.IAnyMessageArgs> {
     return this._anyMessage;
   }
 
@@ -352,7 +348,7 @@ class DefaultSession implements Session.ISession {
   /**
    * Handle any kernel messages.
    */
-  protected onAnyMessage(sender: Kernel.IKernel, args: DefaultKernel.IAnyMessageArgs) {
+  protected onAnyMessage(sender: Kernel.IKernel, args: Kernel.IAnyMessageArgs) {
     this._anyMessage.emit(args);
   }
 
@@ -408,7 +404,7 @@ class DefaultSession implements Session.ISession {
   private _statusChanged = new Signal<this, Kernel.Status>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
-  private _anyMessage = new Signal<this, DefaultKernel.IAnyMessageArgs>(this);
+  private _anyMessage = new Signal<this, Kernel.IAnyMessageArgs>(this);
   private _propertyChanged = new Signal<this, 'path' | 'name' | 'type'>(this);
   private _terminated = new Signal<this, void>(this);
 }

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -22,6 +22,10 @@ import {
 } from '../kernel';
 
 import {
+  DefaultKernel
+} from '../kernel/default';
+
+import {
   ServerConnection
 } from '..';
 
@@ -69,6 +73,14 @@ namespace Session {
      * A signal emitted for unhandled kernel message.
      */
     unhandledMessage: ISignal<this, KernelMessage.IMessage>;
+
+    /**
+     * A signal emitted for any kernel message.
+     *
+     * Note: The behavior is undefined if the message is modified
+     * during message handling. As such, it should be treated as read-only.
+     */
+    anyMessage: ISignal<this, DefaultKernel.IAnyMessageArgs>;
 
     /**
      * Unique id of the session.

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -22,10 +22,6 @@ import {
 } from '../kernel';
 
 import {
-  DefaultKernel
-} from '../kernel/default';
-
-import {
   ServerConnection
 } from '..';
 
@@ -80,7 +76,7 @@ namespace Session {
      * Note: The behavior is undefined if the message is modified
      * during message handling. As such, it should be treated as read-only.
      */
-    anyMessage: ISignal<this, DefaultKernel.IAnyMessageArgs>;
+    anyMessage: ISignal<this, Kernel.IAnyMessageArgs>;
 
     /**
      * Unique id of the session.


### PR DESCRIPTION
A low-level hook for those interested in monitoring messages to/from the kernel.

Needed for #4423.