### PR TITLE
Select kernel response

### DIFF
--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -609,6 +609,8 @@ class ClientSession implements IClientSession {
       if (model) {
         return this._changeKernel(model).then(() => true);
       }
+      // The case of the user selecting "No Kernel"
+      return true;
     }).then(selected => {
       this._dialog = null;
       return selected;

--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -554,10 +554,7 @@ class ClientSession implements IClientSession {
     }
     // Try to use an existing kernel.
     if (preference.id) {
-      return this._changeKernel({ id: preference.id }).then(
-        () => void 0,
-        () => this._selectKernel()
-      );
+      return this._changeKernel({ id: preference.id }).then(() => void 0);
     }
     let name = ClientSession.getDefaultKernel({
       specs: this.manager.specs,
@@ -565,12 +562,8 @@ class ClientSession implements IClientSession {
       preference
     });
     if (name) {
-      return this._changeKernel({ name }).then(
-        () => void 0,
-        () => this._selectKernel()
-      );
+      return this._changeKernel({ name }).then(() => void 0);
     }
-    return this._selectKernel().then(() => void 0);
   }
 
   /**

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -196,7 +196,7 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
   /**
    * Create a console for a given path.
    */
-  function createConsole(options: ICreateOptions): Promise<ConsolePanel> {
+  function createConsole(options: ICreateOptions): Promise<ConsolePanel | undefined> {
     let panel: ConsolePanel;
     return manager.ready.then(() => {
       panel = new ConsolePanel({
@@ -217,7 +217,22 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
         }
       );
       shell.activateById(panel.id);
-      return panel;
+
+      // If we don't have a kernel preference, bring up the selection dialog.
+      if (!options.kernelPreference) {
+        return panel.session.selectKernel().then(selected => {
+          // If the user canceled the selection, consider it
+          // canceling the new console, and close it.
+          if (!selected) {
+            panel.close();
+            return void 0;
+          } else {
+            return panel;
+          }
+        });
+      } else {
+        return panel;
+      }
     });
   }
 

--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -111,7 +111,7 @@ interface ILauncherItem {
    * The callback must return the widget that was created so the launcher
    * can replace itself with the created widget.
    */
-  callback: (cwd: string, name: string) => Widget | Promise<Widget>;
+  callback: (cwd: string, name: string) => Widget | Promise<Widget> | undefined | Promise<void>;
 
   /**
    * The icon class for the launcher item.
@@ -394,10 +394,9 @@ function Card(kernel: boolean, item: ILauncherItem, launcher: Launcher, launcher
     let callback = item.callback as any;
     let value = callback(launcher.cwd, item.name);
     Promise.resolve(value).then(widget => {
-      if (!widget) {
-        throw new Error('Launcher callbacks must resolve with a widget');
+      if (widget) {
+        launcherCallback(widget);
       }
-      launcherCallback(widget);
       launcher.dispose();
     }).catch(err => {
       launcher.pending = false;

--- a/packages/mainmenu/src/kernel.ts
+++ b/packages/mainmenu/src/kernel.ts
@@ -81,7 +81,7 @@ namespace IKernelMenu {
     /**
      * A function to change the kernel.
      */
-    changeKernel?: (widget: T) => Promise<void>;
+    changeKernel?: (widget: T) => Promise<boolean>;
 
     /**
      * A function to shut down the kernel.


### PR DESCRIPTION
Fixes #4157.
1. The "Select new kernel" dialog is now not created by the client session initialization: that is the responsibility of the creator.
1. `IClientSession.selectKernel` now resolves with a boolean, indicating whether a kernel was selected, or the operation was canceled.
1. The notebook and console now dispose of newly created widgets if the user selects `CANCEL` in the kernel selection dialog. The notebook also deletes the newly-created file.