### PR TITLE
Fix scrolling for outputs.

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -285,12 +285,12 @@
 }
 
 .jp-LinkedOutputView .jp-OutputArea {
-  height: 100%;
+  height: calc(100% - var(--jp-toolbar-micro-height));
   display: block;
 }
 
 .jp-LinkedOutputView .jp-OutputArea-child:only-child {
-  height: 100%;
+  height: calc(100% - var(--jp-toolbar-micro-height));
 }
 
 .jp-LinkedOutputView-toolbar {

--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -20,8 +20,6 @@
 
 .jp-OutputArea {
   overflow-y: auto;
-  display: flex;
-  flex-direction: column;
 }
 
 


### PR DESCRIPTION
Fixes #4434

We still have a problem with “new view of output” cutting off the bottom bit, since the toolbar takes up a bit of room at the top of the panel and the height 100% output is pushed down.