### PR TITLE
Solarized themes for text editor

### DIFF
--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -275,8 +275,8 @@ function activateEditorCommands(app: JupyterLab, tracker: IEditorTracker, mainMe
 
   [
    'jupyter', 'default', 'abcdef', 'base16-dark', 'base16-light',
-   'hopscotch', 'material', 'mbo', 'mdn-like', 'seti', 'the-matrix',
-   'xq-light', 'zenburn'
+   'hopscotch', 'material', 'mbo', 'mdn-like', 'seti', 'solarized dark',
+   'solarized light', 'the-matrix', 'xq-light', 'zenburn'
   ].forEach(name => themeMenu.addItem({
     command: CommandIDs.changeTheme,
     args: { theme: name }

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -16,6 +16,7 @@
 @import url('~codemirror/theme/mbo.css');
 @import url('~codemirror/theme/mdn-like.css');
 @import url('~codemirror/theme/seti.css');
+@import url('~codemirror/theme/solarized.css');
 @import url('~codemirror/theme/the-matrix.css');
 @import url('~codemirror/theme/xq-light.css');
 


### PR DESCRIPTION
Adding solarized themes already present in codemirror package. A small step towards issue #1082.

## screenshots
* [solarized dark](https://screenshots.firefox.com/8cHObMImztx7FIWz/localhost)
* [solarized light](https://screenshots.firefox.com/t4rSOvL6egDJR0wy/localhost)
