### PR TITLE
Fix theme building issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:packages": "cd packages/metapackage && jlpm run build",
     "build:src": "lerna run build --scope \"@jupyterlab/!(test-|example-)*\"",
     "build:test": "lerna run build:test",
-    "build:themes": "lerna run build:webpack --scope \"@jupyterlab/theme-*-extension\"",
+    "build:themes": "lerna run build:webpack --npm-client jlpm --scope \"@jupyterlab/theme-*-extension\"",
     "build:update": "node buildutils/lib/update-core-mode.js",
     "build:utils": "cd buildutils && jlpm run build",
     "clean": "jlpm run clean:dev",


### PR DESCRIPTION
This fixes #4459 by using telling `lerna` to call `jlpm` instead of `yarn` when building the themes. I still have no idea why it fails when using yarn on some setups. 

Instead of changing the `npm-client` for just this command, we could instead add `"npmClient": "jlpm",` to the `lerna.json` config, which I tested also fixes this command.

The fix here is smaller, but the other might make more sense if we don't want this problem to crop up other places. Is there any reason not to use `jlpm` as the global npm client in lerna?