### PR TITLE
Include link to Angular extension guide in docs

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -21,6 +21,10 @@ JupyterLab can be extended in three ways via:
 
 See :ref:`xkcd_extension_tutorial` to learn how to make a simple JupyterLab extension.
 
+To understand how to wrap an **Angular** application as a JupyterLab extension,
+see the `"Create your own Angular JupyerLab extension" <https://github.com/SimonBiggs/scriptedforms/blob/master/scriptedforms/docs/create-your-own-angular-jupyterlab-extension.md#create-your-own-angular-jupyerlab-extension>`_ guide provided by 
+`Scripted Forms <https://github.com/SimonBiggs/scriptedforms>`_.
+
 A JupyterLab application is comprised of:
 
 -  A core Application object


### PR DESCRIPTION
Closes #4438 by providing a link to the Angular extension guide developed by @SimonBiggs.

I thought the docs and code examples were more likely to stay up to date if they were maintained in the ScriptedForms repo than if we included them here. 