### PR TITLE
Upgrade to 1.6.0

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,4 @@
 yarn-path "./jupyterlab/staging/yarn.js"
 workspaces-experimental true
 registry "https://registry.npmjs.org"
+ignore-optional true


### PR DESCRIPTION
It appears that the ignore-optional option now works in yarn 1.6.0, so I turned that on as well to try to help prevent some errors we keep seeing in the build with optional dependencies.
