### PR TITLE
Add the boxshadow that we used to have on various toolbars to the main toolbar class

### DIFF
--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -15,7 +15,10 @@
   display: flex;
   flex-direction: row;
   border-bottom: var(--jp-border-width) solid var(--jp-toolbar-border-color);
+  box-shadow: var(--jp-toolbar-box-shadow);
+  background: var(--jp-toolbar-background);
   min-height: var(--jp-toolbar-micro-height);
+  z-index: 1;
 }
 
 


### PR DESCRIPTION
@ian-r-rose requested this in #3499.

CC @tgeorgeux, @ellisonbg

before:

<img width="904" alt="screen shot 2018-04-27 at 1 02 25 pm" src="https://user-images.githubusercontent.com/192614/39382721-531b0f24-4a1b-11e8-8cbd-91cbe102ea42.png">


after (notice toolbar shadow for launcher):
<img width="901" alt="screen shot 2018-04-27 at 1 00 41 pm" src="https://user-images.githubusercontent.com/192614/39382653-0c08a984-4a1b-11e8-8455-e7b05e6095e3.png">
