### PR TITLE
Fix link syntax on cookiecutter projects

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -46,8 +46,8 @@ A plugin adds a core functionality to the application:
    the default export.
 
    We provide two cookie cutters to create JuptyerLab plugin extensions in
-   `CommonJS <https://github.com/jupyterlab/extension-cookiecutter-js>`_ and
-   `TypeScript <https://github.com/jupyterlab/extension-cookiecutter-ts>`_.
+   `CommonJS <https://github.com/jupyterlab/extension-cookiecutter-js>`__ and
+   `TypeScript <https://github.com/jupyterlab/extension-cookiecutter-ts>`__.
 
 The default plugins in the JupyterLab application include:
 


### PR DESCRIPTION
This is rendering incorrectly on readthedocs: https://jupyterlab.readthedocs.io/en/stable/developer/extension_dev.html#plugins