### PR TITLE
Adds a "Show in file browser" entry in tab context menu

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -82,6 +82,9 @@ namespace CommandIDs {
 
   export
   const toggleAutosave = 'docmanager:toggle-autosave';
+
+  export
+  const showInFileBrowser = 'docmanager:show-in-file-browser';
 }
 
 const pluginId = '@jupyterlab/docmanager-extension:plugin';
@@ -429,6 +432,19 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     }
   });
 
+  commands.addCommand(CommandIDs.showInFileBrowser, {
+      label: () => `Show in file browser`,
+      isEnabled,
+      execute: () => {
+        if (isEnabled()) {
+          let context = docManager.contextForWidget(app.shell.currentWidget);
+          // 'activate-main' is needed if this command is selected in the "open tabs" sidebar
+          commands.execute('filebrowser:activate-main');
+          commands.execute('filebrowser:navigate-main', {path: context.path});
+        }
+      }
+  });
+
   app.contextMenu.addItem({
     command: CommandIDs.rename,
     selector: '[data-type="document-title"]',
@@ -438,6 +454,11 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     command: CommandIDs.clone,
     selector: '[data-type="document-title"]',
     rank: 2
+  });
+  app.contextMenu.addItem({
+      command: CommandIDs.showInFileBrowser,
+      selector: '[data-type="document-title"]',
+      rank: 3
   });
 
   [

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -433,16 +433,18 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
   });
 
   commands.addCommand(CommandIDs.showInFileBrowser, {
-      label: () => `Show in file browser`,
-      isEnabled,
-      execute: () => {
-        if (isEnabled()) {
-          let context = docManager.contextForWidget(app.shell.currentWidget);
-          // 'activate-main' is needed if this command is selected in the "open tabs" sidebar
-          commands.execute('filebrowser:activate-main');
-          commands.execute('filebrowser:navigate-main', {path: context.path});
-        }
+    label: () => `Show in file browser`,
+    isEnabled,
+    execute: () => {
+      let context = docManager.contextForWidget(app.shell.currentWidget);
+      if (!context) {
+        return;
       }
+
+      // 'activate-main' is needed if this command is selected in the "open tabs" sidebar
+      commands.execute('filebrowser:activate-main');
+      commands.execute('filebrowser:navigate-main', {path: context.path});
+    }
   });
 
   app.contextMenu.addItem({
@@ -456,9 +458,9 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     rank: 2
   });
   app.contextMenu.addItem({
-      command: CommandIDs.showInFileBrowser,
-      selector: '[data-type="document-title"]',
-      rank: 3
+    command: CommandIDs.showInFileBrowser,
+    selector: '[data-type="document-title"]',
+    rank: 3
   });
 
   [


### PR DESCRIPTION
Fulfills the request made in #4472. Adds a "Show in file browser" entry to the context menu for tabs. Clicking on this menu item will activate the file browser pane and select the currently active file.

One weakness is that it will only work with the currently open file, even if you right click on another tab. However, this seems to be a flaw in the context menu itself (since the same thing happens when you select "Rename...") rather than my patch.

I'm not particularly familiar with JS or TS, so if there's anything basic (style, spacing, etc) I should fix, please let me know