### PR TITLE
Disable ForeignHandler by default and add command console:toggle-echo to enable ForeighHandler through context menu

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -86,6 +86,9 @@ namespace CommandIDs {
 
   export
   const changeKernel = 'console:change-kernel';
+
+  export
+  const toggleEcho = 'console:toggle-echo';
 }
 
 
@@ -399,6 +402,17 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
     isEnabled
   });
 
+  commands.addCommand(CommandIDs.toggleEcho, {
+    label: 'Toggle echo…',
+    execute: args => {
+      let current = getCurrent(args);
+      if (!current) {
+        return;
+      }
+      return current.console.toggleForeignHandler();
+    },
+    isEnabled
+  });
   // Add command palette items
   [
     CommandIDs.create,
@@ -410,6 +424,7 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
     CommandIDs.interrupt,
     CommandIDs.changeKernel,
     CommandIDs.closeAndShutdown,
+    CommandIDs.toggleEcho,
   ].forEach(command => {
     palette.addItem({ command, category, args: { 'isPalette': true } });
   });
@@ -487,6 +502,7 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
 
   app.contextMenu.addItem({command: CommandIDs.clear, selector: '.jp-CodeConsole-content'});
   app.contextMenu.addItem({command: CommandIDs.restart, selector: '.jp-CodeConsole'});
+  app.contextMenu.addItem({command: CommandIDs.toggleEcho, selector: '.jp-CodeConsole'});
 
   return tracker;
 }

--- a/packages/console/src/foreign.ts
+++ b/packages/console/src/foreign.ts
@@ -160,7 +160,7 @@ class ForeignHandler implements IDisposable {
   }
 
   private _cells = new Map<string, CodeCell>();
-  private _enabled = true;
+  private _enabled = false;
   private _parent: ForeignHandler.IReceiver;
   private _factory: () => CodeCell;
   private _isDisposed = false;

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -275,6 +275,13 @@ class CodeConsole extends Widget {
   }
 
   /**
+   * Toggle ForeignHandler
+   */
+  toggleForeignHandler() {
+    this._foreignHandler.enabled = ! this._foreignHandler.enabled;
+  }
+
+  /**
    * Execute the current prompt.
    *
    * @param force - Whether to force execution without checking code


### PR DESCRIPTION
This patch disables `ForeignHandler` in console window by default so expressions evaluated in notebooks will not be echoed in associated console window. A command `console:toggle-echo` is added to the context menu to allow echo.

See details in #4424

