### PR TITLE
Render commandpalette checks

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -286,7 +286,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
         app.shell.expandLeft();
       } else {
         app.shell.collapseLeft();
-        app.shell.activateById(app.shell.currentWidget.id);
+        if (app.shell.currentWidget) {
+          app.shell.activateById(app.shell.currentWidget.id);
+        }
       }
     },
     isToggled: () => !app.shell.leftCollapsed,
@@ -302,7 +304,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
         app.shell.expandRight();
       } else {
         app.shell.collapseRight();
-        app.shell.activateById(app.shell.currentWidget.id);
+        if (app.shell.currentWidget) {
+          app.shell.activateById(app.shell.currentWidget.id);
+        }
       }
     },
     isToggled: () => !app.shell.rightCollapsed,

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -280,8 +280,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
 
   command = CommandIDs.toggleLeftArea;
   app.commands.addCommand(command, {
-    label: args => args['isPalette'] ?
-    'Toggle Left Area' : 'Show Left Area',
+    label: args => 'Show Left Area',
     execute: () => {
       if (app.shell.leftCollapsed) {
         app.shell.expandLeft();
@@ -293,12 +292,11 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     isToggled: () => !app.shell.leftCollapsed,
     isVisible: () => !app.shell.isEmpty('left')
   });
-  palette.addItem({ command, category, args: { 'isPalette': true } });
+  palette.addItem({ command, category });
 
   command = CommandIDs.toggleRightArea;
   app.commands.addCommand(command, {
-    label: args => args['isPalette'] ?
-    'Toggle Right Area' : 'Show Right Area',
+    label: args => 'Show Right Area',
     execute: () => {
       if (app.shell.rightCollapsed) {
         app.shell.expandRight();
@@ -310,19 +308,18 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     isToggled: () => !app.shell.rightCollapsed,
     isVisible: () => !app.shell.isEmpty('right')
   });
-  palette.addItem({ command, category, args: { 'isPalette': true } });
+  palette.addItem({ command, category });
 
   command = CommandIDs.togglePresentationMode;
   app.commands.addCommand(command, {
-    label: args => args['isPalette'] ?
-      'Toggle Presentation Mode' : 'Presentation Mode',
+    label: args => 'Presentation Mode',
     execute: () => {
       app.shell.presentationMode = !app.shell.presentationMode;
     },
     isToggled: () => app.shell.presentationMode,
     isVisible: () => true
   });
-  palette.addItem({ command, category,  args: { 'isPalette': true } });
+  palette.addItem({ command, category });
 
   command = CommandIDs.setMode;
   app.commands.addCommand(command, {
@@ -342,8 +339,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
 
   command = CommandIDs.toggleMode;
   app.commands.addCommand(command, {
-    label: args => args['isPalette'] ?
-      'Toggle Single-Document Mode' : 'Single-Document Mode',
+    label: 'Single-Document Mode',
     isToggled: () => app.shell.mode === 'single-document',
     execute: () => {
       const args = app.shell.mode === 'multiple-document' ?
@@ -351,7 +347,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
       return app.commands.execute(CommandIDs.setMode, args);
     }
   });
-  palette.addItem({ command, category, args: { 'isPalette': true } });
+  palette.addItem({ command, category });
 }
 
 

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -39,6 +39,7 @@
     "@jupyterlab/services": "^2.0.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
+    "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.5.0",
     "es6-promise": "~4.1.1"
   },

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -183,7 +183,14 @@ const themes: JupyterLabPlugin<IThemeManager> = {
         if (args['theme'] === manager.theme) {
           return;
         }
-        manager.setTheme(args['theme'] as string);
+        manager.setTheme(args['theme'] as string).then(() => {
+          // The theme manager only loads new CSS onto the page,
+          // and anything that has rendered this command's `isToggled`
+          // state will not have updated when that happens (such as
+          // the application command palette). Force a refresh of those
+          // rendered commands.
+          commands.notifyCommandChanged(CommandIDs.changeTheme);
+        });
       }
     });
 

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -8,6 +8,10 @@ import {
 } from '@phosphor/disposable';
 
 import {
+  VirtualElement, h
+} from '@phosphor/virtualdom';
+
+import {
   CommandPalette
 } from '@phosphor/widgets';
 
@@ -74,6 +78,43 @@ class Palette implements ICommandPalette {
   private _palette: CommandPalette;
 }
 
+/**
+ * A custom renderer for the command palette that adds
+ * `isToggled` checkmarks to the items.
+ */
+class Renderer extends CommandPalette.Renderer {
+    /**
+     * Render the icon element for a menu item.
+     *
+     * @param data - The data to use for rendering the icon.
+     *
+     * @returns A virtual element representing the item icon.
+     */
+    renderItemIcon(data: CommandPalette.IItemRenderData): VirtualElement {
+      let className = 'jp-CommandPalette-itemIcon';
+      return h.div({ className });
+    }
+
+    /**
+     * Render the virtual element for a command palette item.
+     *
+     * @param data - The data to use for rendering the item.
+     *
+     * @returns A virtual element representing the item.
+     */
+    renderItem(data: CommandPalette.IItemRenderData): VirtualElement {
+      let className = this.createItemClass(data);
+      let dataset = this.createItemDataset(data);
+      return (
+        h.li({ className, dataset },
+          this.renderItemIcon(data),
+          this.renderItemLabel(data),
+          this.renderItemShortcut(data),
+          this.renderItemCaption(data)
+        )
+      );
+    }
+}
 
 /**
  * Activate the command palette.
@@ -81,7 +122,8 @@ class Palette implements ICommandPalette {
 export
 function activatePalette(app: JupyterLab, restorer: ILayoutRestorer): ICommandPalette {
   const { commands, shell } = app;
-  const palette = new CommandPalette({ commands });
+  const renderer = new Renderer();
+  const palette = new CommandPalette({ commands, renderer });
 
   // Let the application restorer track the command palette for restoration of
   // application state (e.g. setting the command palette as the current side bar

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -136,7 +136,7 @@
 
 
 .p-CommandPalette-item {
-  padding: 4px 12px 4px 0px;
+  padding: 4px 12px 4px 4px;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   font-weight: 400;
@@ -177,7 +177,7 @@
 }
 
 .p-CommandPalette-item .jp-CommandPalette-itemIcon {
-  padding: 0px 2px 0px 4px;
+  padding: 0px 0px 0px 4px;
   position: relative;
   width: 16px;
   top: 2px;

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -106,7 +106,7 @@
 
 
 .p-CommandPalette-header {
-  padding: 12px 0 4px 12px;
+  padding: 12px 0 4px 22px;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size0);
   font-weight: 600;
@@ -136,7 +136,7 @@
 
 
 .p-CommandPalette-item {
-  padding: 4px 12px;
+  padding: 4px 0px;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   font-weight: 400;
@@ -169,7 +169,20 @@
   color: rgba(0, 0, 0, 0.4);
 }
 
+.p-CommandPalette-item.p-mod-toggled .p-CommandPalette-itemLabel:before {
+  background-image: var(--jp-icon-checkmark);
+  background-size: 16px;
+  background-repeat: no-repeat;
+}
 
+.p-CommandPalette-item .p-CommandPalette-itemLabel:before {
+  content: "";
+  padding: 0px 2px 0px 4px;
+  position: relative;
+  display: inline-block;
+  width: 16px;
+  height: 1em;
+}
 .p-CommandPalette-itemCaption {
   display: none;
 }

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -136,10 +136,11 @@
 
 
 .p-CommandPalette-item {
-  padding: 4px 0px;
+  padding: 4px 12px 4px 0px;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   font-weight: 400;
+  display: flex;
 }
 
 
@@ -169,20 +170,32 @@
   color: rgba(0, 0, 0, 0.4);
 }
 
-.p-CommandPalette-item.p-mod-toggled .p-CommandPalette-itemLabel:before {
+.p-CommandPalette-item.p-mod-toggled .jp-CommandPalette-itemIcon {
   background-image: var(--jp-icon-checkmark);
   background-size: 16px;
   background-repeat: no-repeat;
 }
 
-.p-CommandPalette-item .p-CommandPalette-itemLabel:before {
-  content: "";
+.p-CommandPalette-item .jp-CommandPalette-itemIcon {
   padding: 0px 2px 0px 4px;
   position: relative;
-  display: inline-block;
   width: 16px;
-  height: 1em;
+  top: 2px;
+  flex: 0 0 auto;
 }
+
+.p-CommandPalette-item.p-mod-disabled .jp-CommandPalette-itemIcon {
+  opacity: 0.4;
+}
+
+.p-CommandPalette-item .p-CommandPalette-itemLabel {
+  flex: 1 1 auto;
+}
+
+.p-CommandPalette-item .p-CommandPalette-itemShortcut {
+  flex: 0 0 auto;
+}
+
 .p-CommandPalette-itemCaption {
   display: none;
 }

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -403,8 +403,7 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
   });
 
   commands.addCommand(CommandIDs.toggleShowAllActivity, {
-    label: args => args['isPalette'] ? 'Toggle Show All Kernel Activity' : 'Show All Kernel Activity',
-
+    label: args => 'Show All Kernel Activity',
     execute: args => {
       let current = getCurrent(args);
       if (!current) {
@@ -412,7 +411,9 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
       }
       current.console.showAllActivity = !current.console.showAllActivity;
     },
-    isToggled: () => tracker.currentWidget ? tracker.currentWidget.console.showAllActivity : false,
+    isToggled: () => tracker.currentWidget ?
+                     tracker.currentWidget.console.showAllActivity :
+                     false,
     isEnabled
   });
   // Add command palette items
@@ -428,7 +429,7 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
     CommandIDs.closeAndShutdown,
     CommandIDs.toggleShowAllActivity,
   ].forEach(command => {
-    palette.addItem({ command, category, args: { 'isPalette': true } });
+    palette.addItem({ command, category });
   });
 
   // Add a console creator to the File menu

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -416,8 +416,7 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
   });
 
   commands.addCommand(CommandIDs.toggleAutosave, {
-    label: args =>
-      args['isPalette'] ? 'Toggle Document Autosave' : 'Autosave Documents',
+    label: 'Autosave Documents',
     isToggled: () => docManager.autosave,
     execute: () => {
       const value = !docManager.autosave;
@@ -447,13 +446,9 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     CommandIDs.saveAs,
     CommandIDs.clone,
     CommandIDs.close,
-    CommandIDs.closeAllFiles
+    CommandIDs.closeAllFiles,
+    CommandIDs.toggleAutosave
   ].forEach(command => { palette.addItem({ command, category }); });
-  palette.addItem({
-    command: CommandIDs.toggleAutosave,
-    category,
-    args: { isPalette: true }
-  });
 }
 
 


### PR DESCRIPTION
This adds a new renderer to the Command Palette to render the `isToggled` state for commands. One consequence of this is that we can remove several instances of having a different labels for the command palette vs the menus. Another consequence of this is that several places where keyboard shorctuts were incorrectly labeled (due to the `isPalette` workaround) are now fixed. Before:
![image](https://user-images.githubusercontent.com/5728311/39504857-7884f912-4d83-11e8-90d9-d6673e54af3d.png)

After:
![image](https://user-images.githubusercontent.com/5728311/39504839-5820f9d2-4d83-11e8-9bb6-f7ae01ed8385.png)

Addresses #3630.
