### PR TITLE
url encoding fix for terminal websockets

### DIFF
--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -198,7 +198,7 @@ class DefaultTerminalSession implements TerminalSession.ISession {
       let wsUrl = URLExt.join(settings.wsUrl, `terminals/websocket/${name}`);
 
       if (token) {
-        wsUrl = wsUrl + `?token=${token}`;
+        wsUrl = wsUrl + `?token=${encodeURIComponent(token)}`;
       }
 
       socket = this._ws = new settings.WebSocket(wsUrl);


### PR DESCRIPTION
Encode token parameter when setting up websocket URLs for terminals.
References issue #4504.