### PR TITLE
Trigger renderModel if an output's model changes

### DIFF
--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -429,7 +429,6 @@ class OutputAreaModel implements IOutputAreaModel {
     let factory = this.contentFactory;
     let item = factory.createOutputModel(options);
     item.changed.connect(this._onGenericChange, this);
-    item.changed.connect(this._onGenericChange, this);
     return item;
   }
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -330,7 +330,7 @@ class OutputArea extends Widget {
   private _setOutput(index: number, model: IOutputModel): void {
     let layout = this.layout as PanelLayout;
     let panel = layout.widgets[index] as Panel;
-    let renderer = panel.widgets[1] as IRenderMime.IRenderer;
+    let renderer = (panel.widgets ? panel.widgets[1] : panel) as IRenderMime.IRenderer;
     if (renderer.renderModel) {
       renderer.renderModel(model);
     } else {

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -135,6 +135,7 @@ class OutputArea extends Widget {
       this._insertOutput(i, output);
     }
     model.changed.connect(this.onModelChanged, this);
+    model.stateChanged.connect(this.onStateChanged, this);
   }
 
   /**
@@ -247,6 +248,16 @@ class OutputArea extends Widget {
       break;
     default:
       break;
+    }
+  }
+
+  /**
+   * Follow changes on the output model state.
+   */
+  protected onStateChanged(sender: IOutputAreaModel): void {
+    for (let i = 0; i < this.model.length; i++) {
+      this._setOutput(i, this.model.get(i));
+      this.outputLengthChanged.emit(this.model.length);
     }
   }
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -257,8 +257,8 @@ class OutputArea extends Widget {
   protected onStateChanged(sender: IOutputAreaModel): void {
     for (let i = 0; i < this.model.length; i++) {
       this._setOutput(i, this.model.get(i));
-      this.outputLengthChanged.emit(this.model.length);
     }
+    this.outputLengthChanged.emit(this.model.length);
   }
 
   /**


### PR DESCRIPTION
Context: 

[jupyterlab-chart-editor](https://github.com/plotly/jupyterlab-chart-editor) is an IRenderer extension that allows lab users to interactively create charts from data in the notebook and from csv/tsv documents. In a notebook context, if saves the state of the chart editor to the metadata of the output so that the chart is persisted. Given that an outputrea has limited real estate, the “Open new view for output” feature is really helpful. However, when changes were made in the new output view, they were not reflected in the original output. This PR simply observes an output’s model and calls `renderModel` when it changes. I’m hooking this up in `createRenderedMimetype` inside the `OutputArea` class. There may be a better place to do this so I’m open to suggestions…

Before:

![](https://files.gitter.im/jupyterlab/jupyterlab/A5Jl/thumb/imimemodel.gif)

After:

![ezgif-5-c9d63824b4](https://user-images.githubusercontent.com/512354/39588039-c8f840b6-4eaf-11e8-8191-89d9c58c0796.gif)
