### PR TITLE
typo in docs 

### DIFF
--- a/docs/source/user/notebook.rst
+++ b/docs/source/user/notebook.rst
@@ -139,7 +139,7 @@ You can connect a :ref:`code console <code-console>` to a notebook kernel to hav
 computations done in the kernel, in the order in which they were done.
 The attached code console also provides a place to interactively inspect
 kernel state without changing the notebook. Right-click on a notebook
-and select “Create Console for Notebook”:
+and select “New Console for Notebook”:
 
 .. raw:: html
 


### PR DESCRIPTION
I installed jupyterlab under Ubuntu 16.04, python 3.5, and venv.
In this settings, right-click on a notebook, the popup menu item is "New Console for Notebook" instead of "Create Console for Notebook".
![2018-05-05 21-52-04-screenshot](https://user-images.githubusercontent.com/7425499/39664107-e5b9bd8a-50b0-11e8-8cbb-71a9205dc5b3.png)
