### PR TITLE
 Tighten trust/safety for renderers

### DIFF
--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -187,9 +187,9 @@ class KarmaTestApp(ProcessTestApp):
             )
 
         env = os.environ.copy()
-        env['KARMA_INJECT_FILE'] = karma_inject_file.encode('utf-8')
+        env['KARMA_INJECT_FILE'] = karma_inject_file
         env.setdefault('KARMA_FILE_PATTERN', pattern)
-        env.setdefault('KARMA_COVER_FOLDER', folder.encode('utf-8'))
+        env.setdefault('KARMA_COVER_FOLDER', folder)
         cwd = self.karma_base_dir
         cmd = ['karma', 'start'] + sys.argv[1:]
         return cmd, dict(env=env, cwd=cwd)

--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -30,6 +30,13 @@ from jupyterlab.process_app import ProcessApp
 HERE = osp.realpath(osp.dirname(__file__))
 
 
+try:
+    basestring
+    PY2 = True
+except NameError:
+    PY2 = False
+
+
 def _create_notebook_dir():
     """Create a temporary directory with some file structure."""
     root_dir = tempfile.mkdtemp(prefix='mock_contents')
@@ -186,6 +193,9 @@ class KarmaTestApp(ProcessTestApp):
                 '"@jupyterlab/test-<package_dir_name>"' % name
             )
 
+        if PY2:
+            karma_inject_file = karma_inject_file.encode('utf-8')
+            folder = folder.encode('utf-8')
         env = os.environ.copy()
         env['KARMA_INJECT_FILE'] = karma_inject_file
         env.setdefault('KARMA_FILE_PATTERN', pattern)

--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -28,13 +28,7 @@ from jupyterlab.process_app import ProcessApp
 
 
 HERE = osp.realpath(osp.dirname(__file__))
-
-
-try:
-    basestring
-    PY2 = True
-except NameError:
-    PY2 = False
+PY2 = sys.version_info[0] < 3
 
 
 def _create_notebook_dir():

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -157,7 +157,7 @@ class InspectionHandler implements IDisposable, IInspector.IInspectable {
       }
 
       const { data } = reply;
-      const mimeType = this._rendermime.preferredMimeType(data, true);
+      const mimeType = this._rendermime.preferredMimeType(data);
 
       if (mimeType) {
         const widget = this._rendermime.createRenderer(mimeType);

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -382,7 +382,7 @@ class OutputArea extends Widget {
   protected createRenderedMimetype(model: IOutputModel): Widget {
     let widget: Widget;
     let mimeType = this.rendermime.preferredMimeType(
-      model.data, !model.trusted
+      model.data, model.trusted ? 'any' : 'ensure'
     );
     if (mimeType) {
       let metadata = model.metadata;

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -404,6 +404,10 @@ class OutputArea extends Widget {
       widget = output;
     } else {
       widget = new Widget();
+      widget.node.innerHTML =
+        `No ${model.trusted ? '' : '(safe) '}renderer could be ` +
+        'found for output. It has the following MIME types: ' +
+        Object.keys(model.data).join(', ');
     }
     return widget;
   }

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -116,20 +116,18 @@ class RenderMimeRegistry {
    *
    * @param bundle - The bundle of mime data.
    *
-   * @param safe - How to consider safe/unsafe factories. If true or 'ensure',
-   *   it will only consider safe factories. If false, any factory will be
+   * @param safe - How to consider safe/unsafe factories. If 'ensure',
+   *   it will only consider safe factories. If 'any', any factory will be
    *   considered. If 'prefer', unsafe factories will be considered, but
    *   only after the safe options have been exhausted.
    *
    * @returns The preferred mime type from the available factories,
    *   or `undefined` if the mime type cannot be rendered.
    */
-  preferredMimeType(bundle: ReadonlyJSONObject, safe: boolean | 'prefer' | 'ensure'): string | undefined {
-    if (safe === 'ensure') {
-      safe = true;  // Equivalent
-    }
+  preferredMimeType(bundle: ReadonlyJSONObject, safe: 'ensure' | 'prefer' | 'any' = 'ensure'): string | undefined {
+
     // Try to find a safe factory first, if preferred.
-    if (safe === true || safe === 'prefer') {
+    if (safe === 'ensure' || safe === 'prefer') {
       for (let mt of this.mimeTypes) {
         if (mt in bundle && this._factories[mt].safe) {
           return mt;
@@ -137,7 +135,7 @@ class RenderMimeRegistry {
       }
     }
 
-    if (safe === 'prefer' || safe === false) {
+    if (safe !== 'ensure') {
       // Otherwise, search for the best factory among all factories.
       for (let mt of this.mimeTypes) {
         if (mt in bundle) {

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -116,14 +116,20 @@ class RenderMimeRegistry {
    *
    * @param bundle - The bundle of mime data.
    *
-   * @param preferSafe - Whether to prefer a safe factory.
+   * @param safe - How to consider safe/unsafe factories. If true or 'ensure',
+   *   it will only consider safe factories. If false, any factory will be
+   *   considered. If 'prefer', unsafe factories will be considered, but
+   *   only after the safe options have been exhausted.
    *
    * @returns The preferred mime type from the available factories,
    *   or `undefined` if the mime type cannot be rendered.
    */
-  preferredMimeType(bundle: ReadonlyJSONObject, preferSafe: boolean): string | undefined {
+  preferredMimeType(bundle: ReadonlyJSONObject, safe: boolean | 'prefer' | 'ensure'): string | undefined {
+    if (safe === 'ensure') {
+      safe = true;  // Equivalent
+    }
     // Try to find a safe factory first, if preferred.
-    if (preferSafe) {
+    if (safe === true || safe === 'prefer') {
       for (let mt of this.mimeTypes) {
         if (mt in bundle && this._factories[mt].safe) {
           return mt;
@@ -131,10 +137,12 @@ class RenderMimeRegistry {
       }
     }
 
-    // Otherwise, search for the best factory among all factories.
-    for (let mt of this.mimeTypes) {
-      if (mt in bundle) {
-        return mt;
+    if (safe === 'prefer' || safe === false) {
+      // Otherwise, search for the best factory among all factories.
+      for (let mt of this.mimeTypes) {
+        if (mt in bundle) {
+          return mt;
+        }
       }
     }
 

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -677,7 +677,7 @@ namespace Private {
   }
 
   /**
-   * Create a new session, or return an existing session if a session if
+   * Create a new session, or return an existing session if
    * the session path already exists
    */
   export

--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -79,7 +79,7 @@ class Tooltip extends Widget {
     this._editor = options.editor;
     this._rendermime = options.rendermime;
 
-    const mimeType = this._rendermime.preferredMimeType(options.bundle, false);
+    const mimeType = this._rendermime.preferredMimeType(options.bundle, 'any');
 
     if (!mimeType) {
       return;

--- a/tests/test-rendermime/src/registry.spec.ts
+++ b/tests/test-rendermime/src/registry.spec.ts
@@ -201,6 +201,35 @@ describe('rendermime/registry', () => {
         });
         expect(r.preferredMimeType(model.data, true)).to.be('text/html');
       });
+
+      it('should return `undefined` if only unsafe options with `ensure`', () => {
+        let model = createModel({
+          'image/svg+xml': '',
+        });
+        expect(r.preferredMimeType(model.data, true)).to.be(void 0);
+      });
+
+      it('should return `undefined` if only unsafe options with `ensure`', () => {
+        let model = createModel({
+          'image/svg+xml': '',
+        });
+        expect(r.preferredMimeType(model.data, 'ensure')).to.be(void 0);
+      });
+
+      it('should return safe option if called with `prefer`', () => {
+        let model = createModel({
+          'image/svg+xml': '',
+          'text/plain': '',
+        });
+        expect(r.preferredMimeType(model.data, 'prefer')).to.be('text/plain');
+      });
+
+      it('should return unsafe option if called with `prefer`, and no safe alternative', () => {
+        let model = createModel({
+          'image/svg+xml': '',
+        });
+        expect(r.preferredMimeType(model.data, 'prefer')).to.be('image/svg+xml');
+      });
     });
 
     describe('#clone()', () => {

--- a/tests/test-rendermime/src/registry.spec.ts
+++ b/tests/test-rendermime/src/registry.spec.ts
@@ -177,12 +177,12 @@ describe('rendermime/registry', () => {
           'text/plain': 'foo',
           'text/html': '<h1>foo</h1>'
         });
-        expect(r.preferredMimeType(model.data, false)).to.be('text/html');
+        expect(r.preferredMimeType(model.data, 'any')).to.be('text/html');
       });
 
       it('should return `undefined` if there are no registered mimeTypes', () => {
         let model = createModel({ 'text/fizz': 'buzz' });
-        expect(r.preferredMimeType(model.data, false)).to.be(void 0);
+        expect(r.preferredMimeType(model.data, 'any')).to.be(void 0);
       });
 
       it('should select the mimeType that is safe', () => {
@@ -191,7 +191,7 @@ describe('rendermime/registry', () => {
           'text/javascript': 'window.x = 1',
           'image/png': 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
         });
-        expect(r.preferredMimeType(model.data, true)).to.be('image/png');
+        expect(r.preferredMimeType(model.data)).to.be('image/png');
       });
 
       it('should render the mimeType that is sanitizable', () => {
@@ -199,14 +199,14 @@ describe('rendermime/registry', () => {
           'text/plain': 'foo',
           'text/html': '<h1>foo</h1>'
         });
-        expect(r.preferredMimeType(model.data, true)).to.be('text/html');
+        expect(r.preferredMimeType(model.data)).to.be('text/html');
       });
 
-      it('should return `undefined` if only unsafe options with `ensure`', () => {
+      it('should return `undefined` if only unsafe options with default `ensure`', () => {
         let model = createModel({
           'image/svg+xml': '',
         });
-        expect(r.preferredMimeType(model.data, true)).to.be(void 0);
+        expect(r.preferredMimeType(model.data)).to.be(void 0);
       });
 
       it('should return `undefined` if only unsafe options with `ensure`', () => {


### PR DESCRIPTION
A lot of external renderers rely on not being asked to render untrusted models if they mark themselves as unsafe, and therefore do not check the "trusted" flag of the model before rendering (like [ipywidgets](https://github.com/jupyter-widgets/ipywidgets/blob/766cad54a47c07520e9d695534c4664c3391e7ec/packages/jupyterlab-manager/src/renderer.ts#L32-L61)). Currently, JupyterLab *can* ask a factory to render an untrusted model *if no safe alternative is found*. We should probably avoid this altogether.

While I cannot find any examples in the wild who benefit from trying to render an untrusted model with an unsafe renderer, I've left the door open for this pattern by allowing `'prefer'` to be passed as the argument for the `preferredMimeType()` call.

An alternative to this PR is to really stress that the trusted flag needs to be checked in the documentation/examples/cookie-cutters for mime renderers.

Other points to this PR:
 - I fixed an issue that prevented me from running tests for just a single lab package.
 - I added a fallback message for the case where no renderer can be found. It seemed like a good idea to me, but if anyone opposes it, I will move it to a separate PR where it can be discussed in isolation.