### PR TITLE
Fix example theme imports

### DIFF
--- a/examples/cell/src/index.ts
+++ b/examples/cell/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import 'es6-promise/auto';  // polyfill Promise on IE
-import '@jupyterlab/theme-light-extension/style/embed.css';
+import '@jupyterlab/theme-light-extension/static/embed.css';
 import '../index.css';
 
 import {

--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import 'es6-promise/auto';  // polyfill Promise on IE
-import '@jupyterlab/theme-light-extension/style/embed.css';
+import '@jupyterlab/theme-light-extension/static/embed.css';
 import '../index.css';
 
 import {

--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import 'es6-promise/auto';  // polyfill Promise on IE
-import '@jupyterlab/theme-light-extension/style/embed.css';
+import '@jupyterlab/theme-light-extension/static/embed.css';
 import '../index.css';
 
 import {

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import 'es6-promise/auto';  // polyfill Promise on IE
-import '@jupyterlab/theme-light-extension/style/embed.css';
+import '@jupyterlab/theme-light-extension/static/embed.css';
 import '../index.css';
 
 import {

--- a/examples/terminal/src/index.ts
+++ b/examples/terminal/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import 'es6-promise/auto';  // polyfill Promise on IE
-import '@jupyterlab/theme-light-extension/style/embed.css';
+import '@jupyterlab/theme-light-extension/static/embed.css';
 import '../index.css';
 
 

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -12,8 +12,11 @@
     "lib/*.d.ts",
     "lib/*.js.map",
     "lib/*.js",
-    "static/index.css",
-    "static/*.ttf"
+    "static/*.css",
+    "static/*.ttf",
+    "static/*.eot",
+    "static/*.woff",
+    "static/*.woff2"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/theme-dark-extension/webpack.config.js
+++ b/packages/theme-dark-extension/webpack.config.js
@@ -1,34 +1,34 @@
-const ExtractTextPlugin = require("extract-text-webpack-plugin");
-const path = require("path");
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const path = require('path');
 
 module.exports = {
   entry: {
-    index: "./style/index.css",
-    embed: "./style/embed.css"
+    index: './style/index.css',
+    embed: './style/embed.css'
   },
   output: {
-    path: path.resolve(__dirname, "static"),
+    path: path.resolve(__dirname, 'static'),
     // we won't use these JS files, only the extracted CSS
-    filename: "[name].js"
+    filename: '[name].js'
   },
   module: {
     rules: [
       {
         test: /\.css$/,
         use: ExtractTextPlugin.extract({
-          fallback: "style-loader",
-          use: "css-loader"
+          fallback: 'style-loader',
+          use: 'css-loader'
         })
       },
       {
         test: /\.svg/,
         use: [
           {
-            loader: "svg-url-loader",
+            loader: 'svg-url-loader',
             options: {}
           },
           {
-            loader: "svgo-loader",
+            loader: 'svgo-loader',
             options: {
               plugins: []
             }
@@ -39,7 +39,7 @@ module.exports = {
         test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: [
           {
-            loader: "url-loader",
+            loader: 'url-loader',
             options: {
               limit: 10000
             }
@@ -48,5 +48,5 @@ module.exports = {
       }
     ]
   },
-  plugins: [new ExtractTextPlugin("[name].css")]
+  plugins: [new ExtractTextPlugin('[name].css')]
 };

--- a/packages/theme-dark-extension/webpack.config.js
+++ b/packages/theme-dark-extension/webpack.config.js
@@ -1,44 +1,45 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const path = require('path');
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const path = require("path");
 
 module.exports = {
-  entry: './style/index.css',
+  entry: {
+    index: "./style/index.css",
+    embed: "./style/embed.css"
+  },
   output: {
-    path: path.resolve(__dirname, 'static'),
-    // we won't use this JS file, only the extracted CSS
-    filename: 'ignore.js'
+    path: path.resolve(__dirname, "static"),
+    // we won't use these JS files, only the extracted CSS
+    filename: "[name].js"
   },
   module: {
     rules: [
       {
         test: /\.css$/,
         use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
-          use: 'css-loader'
+          fallback: "style-loader",
+          use: "css-loader"
         })
       },
       {
         test: /\.svg/,
         use: [
           {
-            loader: 'svg-url-loader',
-            options: {
-            }
+            loader: "svg-url-loader",
+            options: {}
           },
           {
-            loader: 'svgo-loader',
+            loader: "svgo-loader",
             options: {
-              plugins: [
-              ]
+              plugins: []
             }
           }
         ]
       },
       {
-        test: /\.(png|jpg|gif|ttf)$/,
+        test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: [
           {
-            loader: 'url-loader',
+            loader: "url-loader",
             options: {
               limit: 10000
             }
@@ -47,7 +48,5 @@ module.exports = {
       }
     ]
   },
-  plugins: [
-    new ExtractTextPlugin('index.css'),
-  ]
+  plugins: [new ExtractTextPlugin("[name].css")]
 };

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -12,8 +12,11 @@
     "lib/*.d.ts",
     "lib/*.js.map",
     "lib/*.js",
-    "static/index.css",
-    "static/*.ttf"
+    "static/*.css",
+    "static/*.ttf",
+    "static/*.eot",
+    "static/*.woff",
+    "static/*.woff2"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/theme-light-extension/webpack.config.js
+++ b/packages/theme-light-extension/webpack.config.js
@@ -1,34 +1,34 @@
-const ExtractTextPlugin = require("extract-text-webpack-plugin");
-const path = require("path");
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const path = require('path');
 
 module.exports = {
   entry: {
-    index: "./style/index.css",
-    embed: "./style/embed.css"
+    index: './style/index.css',
+    embed: './style/embed.css'
   },
   output: {
-    path: path.resolve(__dirname, "static"),
+    path: path.resolve(__dirname, 'static'),
     // we won't use these JS files, only the extracted CSS
-    filename: "[name].js"
+    filename: '[name].js'
   },
   module: {
     rules: [
       {
         test: /\.css$/,
         use: ExtractTextPlugin.extract({
-          fallback: "style-loader",
-          use: "css-loader"
+          fallback: 'style-loader',
+          use: 'css-loader'
         })
       },
       {
         test: /\.svg/,
         use: [
           {
-            loader: "svg-url-loader",
+            loader: 'svg-url-loader',
             options: {}
           },
           {
-            loader: "svgo-loader",
+            loader: 'svgo-loader',
             options: {
               plugins: []
             }
@@ -39,7 +39,7 @@ module.exports = {
         test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: [
           {
-            loader: "url-loader",
+            loader: 'url-loader',
             options: {
               limit: 10000
             }
@@ -48,5 +48,5 @@ module.exports = {
       }
     ]
   },
-  plugins: [new ExtractTextPlugin("[name].css")]
+  plugins: [new ExtractTextPlugin('[name].css')]
 };

--- a/packages/theme-light-extension/webpack.config.js
+++ b/packages/theme-light-extension/webpack.config.js
@@ -1,44 +1,45 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const path = require('path');
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
+const path = require("path");
 
 module.exports = {
-  entry: './style/index.css',
+  entry: {
+    index: "./style/index.css",
+    embed: "./style/embed.css"
+  },
   output: {
-    path: path.resolve(__dirname, 'static'),
-    // we won't use this JS file, only the extracted CSS
-    filename: 'ignore.js'
+    path: path.resolve(__dirname, "static"),
+    // we won't use these JS files, only the extracted CSS
+    filename: "[name].js"
   },
   module: {
     rules: [
       {
         test: /\.css$/,
         use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
-          use: 'css-loader'
+          fallback: "style-loader",
+          use: "css-loader"
         })
       },
       {
         test: /\.svg/,
         use: [
           {
-            loader: 'svg-url-loader',
-            options: {
-            }
+            loader: "svg-url-loader",
+            options: {}
           },
           {
-            loader: 'svgo-loader',
+            loader: "svgo-loader",
             options: {
-              plugins: [
-              ]
+              plugins: []
             }
           }
         ]
       },
       {
-        test: /\.(png|jpg|gif|ttf)$/,
+        test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: [
           {
-            loader: 'url-loader',
+            loader: "url-loader",
             options: {
               limit: 10000
             }
@@ -47,7 +48,5 @@ module.exports = {
       }
     ]
   },
-  plugins: [
-    new ExtractTextPlugin('index.css'),
-  ]
+  plugins: [new ExtractTextPlugin("[name].css")]
 };


### PR DESCRIPTION
They now use compiled versions of the themes that are included
when the npm packages are published

Fixes #4535 and #2813