### PR TITLE
Improve labext link usablility

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -838,6 +838,19 @@ class _AppHandler(object):
                 path = path.lower()
             return path
 
+        jlab['linkedPackages'] = dict()
+
+        # Handle local extensions.
+        for (key, source) in local.items():
+            jlab['linkedPackages'][key] = source
+
+        # Handle linked packages.
+        for (key, item) in linked.items():
+            path = pjoin(self.app_dir, 'staging', 'linked_packages')
+            path = pjoin(path, item['filename'])
+            data['dependencies'][key] = format_path(path)
+            jlab['linkedPackages'][key] = item['source']
+
         # Handle extensions
         compat_errors = self._get_extension_compat()
         for (key, value) in extensions.items():
@@ -861,19 +874,6 @@ class _AppHandler(object):
                 if ext is True:
                     ext = ''
                 jlab[item + 's'][key] = ext
-
-        jlab['linkedPackages'] = dict()
-
-        # Handle local extensions.
-        for (key, source) in local.items():
-            jlab['linkedPackages'][key] = source
-
-        # Handle linked packages.
-        for (key, item) in linked.items():
-            path = pjoin(self.app_dir, 'staging', 'linked_packages')
-            path = pjoin(path, item['filename'])
-            data['dependencies'][key] = format_path(path)
-            jlab['linkedPackages'][key] = item['source']
 
         # Handle uninstalled core extensions.
         for item in self.info['uninstalled_core']:


### PR DESCRIPTION
yarn deduplication sometimes depend on the order that dependencies are specified in. For this reason, if a library package is linked, and an extension that depends on it is installed with a local install, the
linked package needs to be specified first in order for correct deduplication to work. While this should ideally be done intelligently by dependency resolution, simply putting the linked packages before the local ones is a simple fix for most cases.

### Case:

Extension package `foo-ext` depends on a library package 'foo'. Developing them both from a mono-repo, you would link foo with `jupyter labextension link ./packages/foo`, and install the extension with `jupyter labextension install ./packages/foo-ext`. With the previous setup, this would result in a yarn lockfile along these lines:

```lock
...
"foo-ext@file:../extensions/foo-ext-1.0.0-hash.tgz":
  version "1.0.0"
  resolved "file:../extensions/foo-ext-1.0.0-hash.tgz#otherhash"
  dependencies:
    foo "^1.0.0"

foo@^1.0.0:
  version "1.0.0"
  resolved "https://registry.yarnpkg.com/<...>

"foo@file:linked_packages/foo-1.0.0-hash.tgz":
  version "1.0.0"
  resolved "file:linked_packages/foo-1.0.0-hash.tgz#otherhash"
```

After this PR, it becomes:

```lock
...
"foo-ext@file:../extensions/foo-ext-1.0.0-hash.tgz":
  version "1.0.0"
  resolved "file:../extensions/foo-ext-1.0.0-hash.tgz#otherhash"
  dependencies:
    foo "^1.0.0"

foo@^1.0.0, "foo@file:linked_packages/foo-1.0.0-hash.tgz":
  version "1.0.0"
  resolved "file:linked_packages/foo-1.0.0-hash.tgz#otherhash"
```

Xref yarn issue: https://github.com/yarnpkg/yarn/issues/3778