### PR TITLE
Expose markdown viewer tracker in docregistry

### DIFF
--- a/packages/docregistry/src/index.ts
+++ b/packages/docregistry/src/index.ts
@@ -1,9 +1,44 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import {
+  IInstanceTracker
+} from '@jupyterlab/apputils';
+
+import {
+  Token
+} from '@phosphor/coreutils';
+
+import {
+  MimeDocument
+} from './mimedocument';
+
+import '../style/index.css';
+
 export * from './context';
 export * from './default';
 export * from './mimedocument';
 export * from './registry';
 
-import '../style/index.css';
+
+/**
+ * A class that tracks markdown viewer widgets.
+ */
+export
+interface IMarkdownViewerTracker extends IInstanceTracker<MimeDocument> {}
+
+
+/* tslint:disable */
+/**
+ * A token for a markdown viewer widget tracker.
+ *
+ * #### Notes
+ * These tokens are usually defined in the package which
+ * implements a given widget, but the rendered
+ * markdown widget is implemented as a MimeDocument.
+ * That being said, we still want extensions to be able
+ * to provide this token, so it is exported here.
+ */
+export
+const IMarkdownViewerTracker = new Token<IMarkdownViewerTracker>('@jupyterlab/imageviewer:IImageTracker');
+/* tslint:enable */

--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  MimeDocumentFactory, MimeDocument
+  IMarkdownViewerTracker, MimeDocumentFactory, MimeDocument
 } from '@jupyterlab/docregistry';
 
 import {
@@ -37,10 +37,11 @@ namespace CommandIDs {
 /**
  * The markdown handler extension.
  */
-const plugin: JupyterLabPlugin<void> = {
+const plugin: JupyterLabPlugin<IMarkdownViewerTracker> = {
   activate,
   id: '@jupyterlab/markdownviewer-extension:plugin',
   requires: [ILayoutRestorer, IRenderMimeRegistry],
+  provides: IMarkdownViewerTracker,
   autoStart: true
 };
 
@@ -87,6 +88,8 @@ function activate(app: JupyterLab, restorer: ILayoutRestorer, rendermime: IRende
         });
       }
     });
+
+    return tracker;
   }
 
 


### PR DESCRIPTION
We currently don't provide an instance tracker for rendered markdown documents, which makes it difficult for extension authors to interact with those widgets (I ran into this the other day). I think it is probably important to provide some sort of API for this.

The solution I have here is kind of awkward, since it defines a token in `@jupyterlab/docregistry` (we don't have a `markdownviewer` package that would be a more natural place to put it).
Another option is to expose a tracker for general `MimeDocuments`, along with a way to filter them for specificy mime types. I think this might be cleaner, but am wondering what people think.