### PR TITLE
Added shortcut for run all cells

### DIFF
--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -600,6 +600,15 @@
       },
       "type": "object"
     },
+    "runmenu:run-all": {
+      "default": { },
+      "properties": {
+        "command": { "default": "runmenu:run-all" },
+        "keys": { "default": ["Ctrl Shift Enter"] },
+        "selector": { "default": "[data-jp-code-runner]" }
+      },
+      "type": "object"
+    },
     "settingeditor:debug": {
       "default": { },
       "properties": {

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -604,7 +604,7 @@
       "default": { },
       "properties": {
         "command": { "default": "runmenu:run-all" },
-        "keys": { "default": ["Ctrl Shift Enter"] },
+        "keys": { "default": ["Accel Shift Enter"] },
         "selector": { "default": "[data-jp-code-runner]" }
       },
       "type": "object"


### PR DESCRIPTION
I propose adding this new shortcut: `CTRL+SHIFT+ENTER`. It will run all cells in the active notebook.

This is something I find myself doing often in my daily use of the notebook. It will be immediately useful to me and I suspect to many others. 