### PR TITLE
FAQ moved to docs (#3835)

### DIFF
--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -1,0 +1,28 @@
+Frequently Asked Questions (FAQ)
+================================
+
+Below are some frequently asked questions regarding the beta release
+series. Click on a question to be directed to relevant information in
+our documentation or our GitHub repo.
+
+General
+-------
+
+-  `What is
+   JupyterLab? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html>`__
+-  `How stable is
+   JupyterLab? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html>`__
+-  `What will happen to the classic Jupyter
+   Notebook? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html#beta>`__
+-  `Where is the documentation for
+   JupyterLab? <https://jupyterlab.readthedocs.io/en/stable/>`__
+
+Development
+-----------
+
+-  `How can you report a bug or provide
+   feedback? <https://github.com/jupyterlab/jupyterlab/issues>`__
+-  `How can you
+   contribute? <https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`__
+-  `How can you extend or customize
+   JupyterLab? <https://jupyterlab.readthedocs.io/en/stable/user/extensions.html>`__

--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -11,9 +11,10 @@ General
 -  `What is
    JupyterLab? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html>`__
 -  `How stable is
-   JupyterLab? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html>`__
+   JupyterLab? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html#stability>`__
 -  `What will happen to the classic Jupyter
-   Notebook? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html#beta>`__
+   Notebook? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html#classic>`__
+-  `How long will JupyterLab be in beta? <https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html#beta>`__
 -  `Where is the documentation for
    JupyterLab? <https://jupyterlab.readthedocs.io/en/stable/>`__
 

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -4,7 +4,6 @@ Overview
 --------
 
 JupyterLab is the next-generation web-based user interface for Project Jupyter.
-The beta release series of JupyterLab is stable for daily use.
 
 .. image:: ../user/images/interface_jupyterlab.png
    :align: center
@@ -48,6 +47,22 @@ JupyterLab is served from the same `server
 `notebook document format <http://nbformat.readthedocs.io/en/latest/>`__ as the
 classic Jupyter Notebook.
 
+.. _stability:
+
+Stability of JupyterLab
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The current beta release of JupyterLab is stable for daily use.  
+Likewise, all future releases in the beta series will be stable for daily use.
+
+.. _classic:
+
+Classic Jupyter Notebook
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+JupyterLab 1.0 will eventually replace the classic Jupyter Notebook.
+Throughout this transition, the same notebook document format will be supported by both the classic Notebook and JupyterLab.
+
 .. _beta:
 
 Beta Series and Beyond
@@ -60,7 +75,3 @@ We plan to release JupyterLab 1.0 later in 2018.
 The beta releases leading up to 1.0 will focus on
 stabilizing the extension development API, UI/UX improvements,
 and additional core features.
-All releases in the beta series will be stable enough for daily usage.
-
-JupyterLab 1.0 will eventually replace the classic Jupyter Notebook.
-Throughout this transition, the same notebook document format will be supported by both the classic Notebook and JupyterLab.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@ JupyterLab is the next-generation web-based user interface for Project Jupyter. 
    getting_started/overview
    getting_started/installation
    getting_started/starting
+   getting_started/faq
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This PR closes #3835.

`./packages/faq-extension/faq.md` was converted to `faq.rst` and placed in `./docs/source/getting_started`

The FAQ and the pages it references were proofed.  

Some of `overview.rst` (which contains the meat of the answers to the FAQ) was edited to improve flow.

A separate issue was created to address accessing the FAQ directly from JupyterLab.

@ian-r-rose @ellisonbg @ivanov 