### PR TITLE
fix for focus/information issues in the right-click context menu

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -86,6 +86,59 @@ export class JupyterLab extends Application<ApplicationShell> {
   readonly registerPluginErrors: Array<Error> = [];
 
   /**
+   * A method invoked on a document `'contextmenu'` event.
+   *
+   * #### Notes
+   * The default implementation of this method opens the application
+   * `contextMenu` at the current mouse position.
+   *
+   * If the application context menu has no matching content *or* if
+   * the shift key is pressed, the default browser context menu will
+   * be opened instead.
+   *
+   * A subclass may reimplement this method as needed.
+   */
+  protected evtContextMenu(event: MouseEvent): void {
+    if (event.shiftKey) {
+      return;
+    }
+
+    this._contextEvent = event;
+    if (this.contextMenu.open(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  get contextMenuEvent(): Event {
+    return this._contextEvent;
+  }
+
+  get contextMenuTargetPath(): string {
+    if (!this.contextMenuEvent) {
+      return;
+    }
+
+    let target = this.contextMenuEvent.target as HTMLSelectElement;
+    let pathRe = /[Pp]ath:\s?(.*)\n?/;
+
+    let pathMatch = target.title.match(pathRe);
+
+    if (pathMatch == null) {
+      // if path could not be found in .title, search for it in .parentElement
+      pathMatch = target.parentElement.title.match(pathRe);
+    }
+
+    if (pathMatch == null) {
+      // (for now) no other place to search, just return
+      return;
+    }
+
+    // return the found path
+    return pathMatch[1];
+  }
+
+  /**
    * Whether the application is dirty.
    */
   get isDirty(): boolean {
@@ -204,6 +257,7 @@ export class JupyterLab extends Application<ApplicationShell> {
     });
   }
 
+  private _contextEvent: Event;
   private _info: JupyterLab.IInfo;
   private _dirtyCount = 0;
   private _busyCount = 0;

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -103,39 +103,35 @@ export class JupyterLab extends Application<ApplicationShell> {
       return;
     }
 
-    this._contextEvent = event;
+    this._contextMenuEvent = event;
     if (this.contextMenu.open(event)) {
       event.preventDefault();
       event.stopPropagation();
     }
   }
 
-  get contextMenuEvent(): Event {
-    return this._contextEvent;
-  }
-
-  get contextMenuTargetPath(): string {
-    if (!this.contextMenuEvent) {
-      return;
+  /**
+   * Gets the hierarchy of html nodes that was under the cursor
+   * when the most recent contextmenu event was issued
+   */
+  get contextMenuNodes(): HTMLElement[] {
+    if (!this._contextMenuEvent) {
+      return [];
     }
 
-    let target = this.contextMenuEvent.target as HTMLSelectElement;
-    let pathRe = /[Pp]ath:\s?(.*)\n?/;
+    // this one-liner doesn't work, but should at some point
+    // in the future (https://developer.mozilla.org/en-US/docs/Web/API/Event)
+    // return this._contextMenuEvent.composedPath() as HTMLElement[];
 
-    let pathMatch = target.title.match(pathRe);
-
-    if (pathMatch == null) {
-      // if path could not be found in .title, search for it in .parentElement
-      pathMatch = target.parentElement.title.match(pathRe);
+    let nodes: HTMLElement[] = [this._contextMenuEvent.target as HTMLElement];
+    while (
+      'parentNode' in nodes[nodes.length - 1] &&
+      nodes[nodes.length - 1].parentNode &&
+      nodes[nodes.length - 1] !== nodes[nodes.length - 1].parentNode
+    ) {
+      nodes.push(nodes[nodes.length - 1].parentNode as HTMLElement);
     }
-
-    if (pathMatch == null) {
-      // (for now) no other place to search, just return
-      return;
-    }
-
-    // return the found path
-    return pathMatch[1];
+    return nodes;
   }
 
   /**
@@ -181,6 +177,46 @@ export class JupyterLab extends Application<ApplicationShell> {
    */
   get restored(): Promise<ApplicationShell.ILayout> {
     return this.shell.restored;
+  }
+
+  /**
+   * Gets all of the valid, non-empty values of a given property
+   * across all of the nodes in the hierarchy returned by contextMenuNodes
+   */
+  contextMenuValues(prop: string): any[] {
+    let vals: any[] = [];
+    for (let node of this.contextMenuNodes as any[]) {
+      if (prop in node && node[prop]) {
+        vals.push(node[prop]);
+      }
+    }
+    return vals;
+  }
+
+  /**
+   * Gets the first valid, non-empty value of a property
+   * in the node hierarchy returned by contextMenuNodes.
+   * Optionally, gets the first value that matches a passed-in RegExp
+   */
+  contextMenuFirst(prop: string, regexp: RegExp | null = null): any | null {
+    if (regexp) {
+      for (let node of this.contextMenuNodes as any[]) {
+        if (prop in node && node[prop]) {
+          let match = node[prop].match(regexp);
+          if (match) {
+            return match;
+          }
+        }
+      }
+    } else {
+      for (let node of this.contextMenuNodes as any[]) {
+        if (prop in node && node[prop]) {
+          return node[prop];
+        }
+      }
+    }
+
+    return;
   }
 
   /**
@@ -257,7 +293,7 @@ export class JupyterLab extends Application<ApplicationShell> {
     });
   }
 
-  private _contextEvent: Event;
+  private _contextMenuEvent: MouseEvent;
   private _info: JupyterLab.IInfo;
   private _dirtyCount = 0;
   private _busyCount = 0;

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -179,13 +179,15 @@ function addCommands(
 
   // fetches the doc widget associated with the most recent contextmenu event
   const contextMenuWidget = (): Widget => {
-    let path = app.contextMenuTargetPath;
-    if (!path) {
+    let pathRe = /[Pp]ath:\s?(.*)\n?/;
+    let pathMatch = app.contextMenuFirst('title', pathRe);
+
+    if (!pathMatch) {
       // fall back to active doc widget if path cannot be obtained from event
       return app.shell.currentWidget;
     }
 
-    return docManager.findWidget(path);
+    return docManager.findWidget(pathMatch[1]);
   };
 
   // operates on active widget by default
@@ -282,7 +284,7 @@ function addCommands(
       return !!iterator.next() && !!iterator.next();
     },
     execute: () => {
-      const widget = shell.currentWidget;
+      const widget = contextMenuWidget();
       if (!widget) {
         return;
       }
@@ -297,9 +299,9 @@ function addCommands(
   commands.addCommand(CommandIDs.closeRightTabs, {
     label: () => `Close Tabs to Right`,
     isEnabled: () =>
-      shell.currentWidget && widgetsRightOf(shell.currentWidget).length > 0,
+      contextMenuWidget() && widgetsRightOf(contextMenuWidget()).length > 0,
     execute: () => {
-      const widget = shell.currentWidget;
+      const widget = contextMenuWidget();
       if (!widget) {
         return;
       }


### PR DESCRIPTION
A potential fix for the context menu focus issues mentioned in #4500 and the more general context menu information issues mentioned in #4529. ~~This is meant as a jumping-off point for discussion in #4529, and not necessarily as a complete PR.~~ 

### Update: the PR has now gone through a few revisions, and I'm reasonably confident in the robustness of the latest version. See recent comments below for details.

The fix works by having the main app (ie the `JupyterLab` object) capture the most recent `contextmenu` event in a `._contextEvent` property. The context menu constructor code can then inspect this property in order to get any information it needs about the menu-initiating event that isn't exposed by the current framework.

In addition to the basic code for handling `._contextEvent`, the current version of my fix also includes a reimplementation of the commands from the document tab context menu that makes full use of the newly available information. This makes it so that the context menu commands operate on the tab you actually right-click on, instead of just always operating on the current active document (which is the behavior in the current `master` branch code).

@blink1073 edit: Fixes https://github.com/jupyterlab/jupyterlab/issues/4945, Fixes #4529.