### PR TITLE
Universal filebrowser support for "Show in file browser"

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -233,7 +233,7 @@ const tree: JupyterLabPlugin<void> = {
         router.navigate(url, { silent: true });
 
         return commands
-          .execute('filebrowser:navigate-main', { path })
+          .execute('filebrowser:navigate', { path })
           .then(() => commands.execute('apputils:save-statedb', { immediate }))
           .catch(reason => {
             console.warn(`Tree routing failed:`, reason);

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -543,8 +543,8 @@ function addCommands(
       }
 
       // 'activate' is needed if this command is selected in the "open tabs" sidebar
-      commands.execute('filebrowser:activate', {path: context.path});
-      commands.execute('filebrowser:navigate', {path: context.path});
+      commands.execute('filebrowser:activate', { path: context.path });
+      commands.execute('filebrowser:navigate', { path: context.path });
     }
   });
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -542,9 +542,9 @@ function addCommands(
         return;
       }
 
-      // 'activate-main' is needed if this command is selected in the "open tabs" sidebar
-      commands.execute('filebrowser:activate-main');
-      commands.execute('filebrowser:navigate-main', { path: context.path });
+      // 'activate' is needed if this command is selected in the "open tabs" sidebar
+      commands.execute('filebrowser:activate', {path: context.path});
+      commands.execute('filebrowser:navigate', {path: context.path});
     }
   });
 

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -117,6 +117,13 @@ export class FileBrowserModel implements IDisposable {
   }
 
   /**
+   * The drive name that gets prepended to the path.
+   */
+  get driveName(): string {
+    return this._driveName;
+  }
+
+  /**
    * A promise that resolves when the model is first restored.
    */
   get restored(): Promise<void> {


### PR DESCRIPTION
As requested in #4528, the "Show in file browser" tab context menu item now supports filebrowsers other than the main one. I've thoroughly tested this PR with the Github filebrowser supplied by the `@jupyterlab/github` extension, and it seems to be working perfectly.

However, I ran into some bugs when I tried to do a dev mode install of the Google Drive browser from the `@jupyterlab/google-drive` extension  (see #4528 for details). If someone who already has a dev mode install of the Google Drive filebrowser could please test this PR out, that would be a big help.