### PR TITLE
Work on also checking for IDrives in rendermime.

### DIFF
--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -330,6 +330,17 @@ namespace IRenderMime {
      * Get the download url of a given absolute server path.
      */
     getDownloadUrl(path: string): Promise<string>;
+
+    /**
+     * Whether the URL should be handled by the resolver
+     * or not.
+     *
+     * #### Notes
+     * This is similar to the `isLocal` check in `URLExt`,
+     * but can also perform additional checks on whether the
+     * resolver should handle a given URL.
+     */
+    isLocal?: (url: string) => boolean;
   }
 
   /**

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -374,7 +374,7 @@ namespace RenderMimeRegistry {
      * Resolve a relative url to a correct server path.
      */
     resolveUrl(url: string): Promise<string> {
-      if (URLExt.isLocal(url)) {
+      if (this.isLocal(url)) {
         let cwd = PathExt.dirname(this._session.path);
         url = PathExt.resolve(cwd, url);
       }
@@ -385,10 +385,24 @@ namespace RenderMimeRegistry {
      * Get the download url of a given absolute server path.
      */
     getDownloadUrl(path: string): Promise<string> {
-      if (URLExt.isLocal(path)) {
+      if (this.isLocal(path)) {
         return this._contents.getDownloadUrl(path);
       }
       return Promise.resolve(path);
+    }
+
+    /**
+     * Whether the URL should be handled by the resolver
+     * or not.
+     *
+     * #### Notes
+     * This is similar to the `isLocal` check in `URLExt`,
+     * but it also checks whether the path points to any
+     * of the `IDrive`s that may be registered with the contents
+     * manager.
+     */
+    isLocal(url: string): boolean {
+      return URLExt.isLocal(url) || !!this._contents.driveName(url);
     }
 
     private _session: Session.ISession | IClientSession;

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -680,7 +680,7 @@ namespace Private {
       let headers = node.getElementsByTagName(headerType);
       for (let i=0; i < headers.length; i++) {
         let header = headers[i];
-        header.id = header.innerHTML.replace(/ /g, '-');
+        header.id = encodeURIComponent(header.innerHTML.replace(/ /g, '-'));
         let anchor = document.createElement('a');
         anchor.target = '_self';
         anchor.textContent = '¶';

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -78,7 +78,7 @@ function renderHTML(options: renderHTML.IOptions): Promise<void> {
   // }
 
   // Handle default behavior of nodes.
-  Private.handleDefaults(host);
+  Private.handleDefaults(host, resolver);
 
   // Patch the urls if a resolver is available.
   let promise: Promise<void>;
@@ -343,7 +343,7 @@ function renderMarkdown(options: renderMarkdown.IRenderOptions): Promise<void> {
     // }
 
     // Handle default behavior of nodes.
-    Private.handleDefaults(host);
+    Private.handleDefaults(host, resolver);
 
     // Apply ids to the header nodes.
     Private.headerAnchors(host);
@@ -608,12 +608,15 @@ namespace Private {
    * Handle the default behavior of nodes.
    */
   export
-  function handleDefaults(node: HTMLElement): void {
+  function handleDefaults(node: HTMLElement, resolver?: IRenderMime.IResolver): void {
     // Handle anchor elements.
     let anchors = node.getElementsByTagName('a');
     for (let i = 0; i < anchors.length; i++) {
       let path = anchors[i].href;
-      if (URLExt.isLocal(path)) {
+      const isLocal = (resolver && resolver.isLocal) ?
+                      resolver.isLocal(path) :
+                      URLExt.isLocal(path);
+      if (isLocal) {
         anchors[i].target = '_self';
       } else {
         anchors[i].target = '_blank';
@@ -693,7 +696,10 @@ namespace Private {
    */
   function handleAttr(node: HTMLElement, name: 'src' | 'href', resolver: IRenderMime.IResolver): Promise<void> {
     let source = node.getAttribute(name);
-    if (!source || URLExt.parse(source).protocol === 'data:') {
+    const isLocal = resolver.isLocal ?
+                    resolver.isLocal(source) :
+                    URLExt.isLocal(source);
+    if (!source || !isLocal) {
       return Promise.resolve(undefined);
     }
     node.setAttribute(name, '');
@@ -718,8 +724,11 @@ namespace Private {
     // Get the link path without the location prepended.
     // (e.g. "./foo.md#Header 1" vs "http://localhost:8888/foo.md#Header 1")
     let href = anchor.getAttribute('href');
+    const isLocal = resolver.isLocal ?
+                    resolver.isLocal(href) :
+                    URLExt.isLocal(href);
     // Bail if it is not a file-like url.
-    if (!href || href.indexOf('://') !== -1 && href.indexOf('//') === 0) {
+    if (!href || !isLocal) {
       return Promise.resolve(undefined);
     }
     // Remove the hash until we can handle it.
@@ -736,7 +745,7 @@ namespace Private {
     // Get the appropriate file path.
     return resolver.resolveUrl(href).then(path => {
       // Handle the click override.
-      if (linkHandler && URLExt.isLocal(path)) {
+      if (linkHandler) {
         linkHandler.handleLink(anchor, path);
       }
       // Get the appropriate file download path.

--- a/tests/test-rendermime/src/registry.spec.ts
+++ b/tests/test-rendermime/src/registry.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  Contents, ServiceManager, Session
+  Contents, Drive, ServiceManager, Session
 } from '@jupyterlab/services';
 
 import {
@@ -274,7 +274,9 @@ describe('rendermime/registry', () => {
 
       before(() => {
         const manager = new ServiceManager();
+        const drive = new Drive({ name: 'extra' });
         contents = manager.contents;
+        contents.addDrive(drive);
         return manager.ready.then(() => {
           return manager.sessions.startNew({ path: uuid() });
         }).then(s => {
@@ -329,6 +331,22 @@ describe('rendermime/registry', () => {
           return resolver.getDownloadUrl('http://foo').then(path => {
             expect(path).to.be('http://foo');
           });
+        });
+
+      });
+
+      context('#isLocal', () => {
+
+        it('should return true for a registered IDrive`', () => {
+          expect(resolver.isLocal('extra:path/to/file')).to.be(true);
+        });
+
+        it('should return false for an unrecognized Drive`', () => {
+          expect(resolver.isLocal('unregistered:path/to/file')).to.be(false);
+        });
+
+        it('should return true for a normal filesystem-like path`', () => {
+          expect(resolver.isLocal('path/to/file')).to.be(true);
         });
 
       });


### PR DESCRIPTION
Fix for jupyterlab/jupyterlab-github#57.

Our `isLocal` check was not working properly for recognizing alternative storage backends to the contents manager. This was making relative links incorrect (for an example, see [here](https://github.com/jakevdp/PythonDataScienceHandbook/blob/master/notebooks/01.00-IPython-Beyond-Normal-Python.ipynb)).

This adds an optional `isLocal` function to the `IRenderMime.IResolver` that checks whether a path *should* be handled by the application, or whether it should be left alone. It performs similarly to `URLExt.isLocal`, but also checks if the path matches any of the alternative `IDrive` objects. I think we can get away with making this a minor release to `rendermime-interfaces`.