### PR TITLE
Add Reload from Disk command and menu item.

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -320,7 +320,7 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
   });
 
   commands.addCommand(CommandIDs.restoreCheckpoint, {
-    label: () => `Revert ${fileType()} to Saved`,
+    label: () => `Revert ${fileType()} to Checkpoint`,
     caption: 'Revert contents to previous checkpoint',
     isEnabled,
     execute: () => {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -479,7 +479,7 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
   [
     CommandIDs.openDirect,
     CommandIDs.save,
-	CommandIDs.reload,
+    CommandIDs.reload,
     CommandIDs.restoreCheckpoint,
     CommandIDs.saveAs,
     CommandIDs.clone,

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -63,6 +63,9 @@ namespace CommandIDs {
   const openDirect = 'docmanager:open-direct';
 
   export
+  const reload = 'docmanager:reload';
+
+  export
   const rename = 'docmanager:rename';
 
   export
@@ -304,6 +307,18 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
     },
   });
 
+  commands.addCommand(CommandIDs.reload, {
+    label: () => `Reload ${fileType()} from Disk`,
+    caption: 'Reload contents from disk',
+    isEnabled,
+    execute: () => {
+      if (isEnabled()) {
+        let context = docManager.contextForWidget(app.shell.currentWidget);
+        return context.revert();
+      }
+    }
+  });
+
   commands.addCommand(CommandIDs.restoreCheckpoint, {
     label: () => `Revert ${fileType()} to Saved`,
     caption: 'Revert contents to previous checkpoint',
@@ -464,6 +479,7 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
   [
     CommandIDs.openDirect,
     CommandIDs.save,
+	CommandIDs.reload,
     CommandIDs.restoreCheckpoint,
     CommandIDs.saveAs,
     CommandIDs.clone,

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -278,6 +278,7 @@ function createFileMenu(app: JupyterLab, menu: FileMenu): void {
 
   // Add the re group.
   const reGroup = [
+    'docmanager:reload',
     'docmanager:restore-checkpoint',
     'docmanager:rename'
   ].map(command => { return { command }; });


### PR DESCRIPTION
Issue #4154 looked straightforward so I added the reload ability as specified.  However, there is an existing Revert command (named restoreCheckpoint in the code) which calls restoreCheckpoint() and revert().  Is there any concern the two options could be confusing?