### PR TITLE
Allow theme override of content base font to take effect

### DIFF
--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -91,9 +91,9 @@
 
 .jp-RenderedHTMLCommon {
   color: var(--jp-content-font-color1);
+  font-family: var(--jp-content-font-family);
   font-size: var(--jp-content-font-size1);
   line-height: var(--jp-content-line-height);
-  font-family: var(--jp-content-font-family);
   /* Give a bit more R padding on Markdown text to keep line lengths reasonable */
   padding-right: 20px;
 }


### PR DESCRIPTION
Adds actual use of the previously un-used `--jp-content-font-family` in rendermime HTML common, as that seemed about the only place that a user's words get rendered. I couldn't find anywhere else it was meaningful. Practically this does nothing, as it defaults to the same explicit list of system fallbacks.

`--jp-content-font-scale-factor` is also never used, but I don't know how that would be applied aside from `calc`ing for every theme variable... adding to every usage seems a bit crazy, and one can probably just use browser zoom.

Semi-unrelated to this, I'd also like to propose a `--jp-content-heading-font-family` and maybe `--jp-content-blockquote-font-family`, as those are two elements a theme could use to give a differentiated presentation style. Indeed, both of these could be `*-content-presentation-*` for precisely that purpose, but I feel like randomly swapping fonts is way more jarring than subtly incrementing sizes. Also they woud be humorously long.