### PR TITLE
Allow additional tags in sanitizer

### DIFF
--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -61,7 +61,8 @@ class Sanitizer implements ISanitizer {
 
   private _options: sanitize.IOptions = {
     allowedTags: sanitize.defaults.allowedTags
-      .concat('h1', 'h2', 'img', 'span', 'audio', 'video', 'del'),
+      .concat('h1', 'h2', 'img', 'span', 'audio', 'video', 'del',
+              'kbd', 'sup', 'sub', 'colspan', 'rowspan'),
     allowedAttributes: {
       // Allow the "rel" attribute for <a> tags.
       'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),


### PR DESCRIPTION
Whitelists the `kbd`, `sup`, `sub`, `colspan`, and `rowspan` tags