### PR TITLE
Use tslib. Fixes #4624

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -38,6 +38,7 @@
     "inquirer": "~3.3.0",
     "path": "~0.12.7",
     "sort-package-json": "~1.7.1",
+    "tslib": "^1.9.1",
     "typescript": "~2.8.3"
   },
   "devDependencies": {

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -98,6 +98,10 @@ function ensurePackage(options: IEnsurePackageOptions): string[] {
 
   // Look for unused packages
   Object.keys(deps).forEach(name => {
+    // ignore tslib: https://github.com/Microsoft/tslib
+    if (name === 'tslib') {
+      return;
+    }
     if (unused.indexOf(name) !== -1) {
       return;
     }

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -27,6 +27,9 @@
     "prepublishOnly": "npm run build",
     "watch": "tsc -w"
   },
+  "dependencies": {
+    "tslib": "^1.9.1"
+  },
   "devDependencies": {
     "rimraf": "~2.6.2",
     "typescript": "~2.8.3"

--- a/buildutils/template/tsconfig.json
+++ b/buildutils/template/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/buildutils/tsconfig.json
+++ b/buildutils/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -32,7 +32,8 @@
     "@jupyterlab/application": "^0.16.2",
     "@jupyterlab/apputils": "^0.16.3",
     "@jupyterlab/coreutils": "^1.1.2",
-    "react": "~16.2.0"
+    "react": "~16.2.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/application-extension/tsconfig.json
+++ b/packages/application-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -45,7 +45,8 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/application/tsconfig.json
+++ b/packages/application/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -40,7 +40,8 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/widgets": "^1.6.0",
-    "es6-promise": "~4.1.1"
+    "es6-promise": "~4.1.1",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/apputils-extension/tsconfig.json
+++ b/packages/apputils-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -45,7 +45,8 @@
     "@types/react": "~16.0.19",
     "react": "~16.2.0",
     "react-dom": "~16.2.0",
-    "sanitize-html": "~1.14.3"
+    "sanitize-html": "~1.14.3",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/react-dom": "~16.0.2",

--- a/packages/apputils/tsconfig.json
+++ b/packages/apputils/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -42,7 +42,8 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "react": "~16.2.0"
+    "react": "~16.2.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/react": "~16.0.19",

--- a/packages/cells/tsconfig.json
+++ b/packages/cells/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -38,7 +38,8 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
     "react": "~16.2.0",
-    "react-dom": "~16.2.0"
+    "react-dom": "~16.2.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/codeeditor/tsconfig.json
+++ b/packages/codeeditor/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -37,7 +37,8 @@
     "@jupyterlab/fileeditor": "^0.16.2",
     "@jupyterlab/mainmenu": "^0.5.2",
     "@phosphor/widgets": "^1.6.0",
-    "codemirror": "~5.37.0"
+    "codemirror": "~5.37.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/codemirror-extension/tsconfig.json
+++ b/packages/codemirror-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -38,7 +38,8 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "codemirror": "~5.37.0"
+    "codemirror": "~5.37.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/codemirror": "~0.0.46",

--- a/packages/codemirror/tsconfig.json
+++ b/packages/codemirror/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -33,7 +33,8 @@
     "@jupyterlab/completer": "^0.16.2",
     "@jupyterlab/console": "^0.16.2",
     "@jupyterlab/notebook": "^0.16.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/completer-extension/tsconfig.json
+++ b/packages/completer-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -40,7 +40,8 @@
     "@phosphor/domutils": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/completer/tsconfig.json
+++ b/packages/completer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -40,7 +40,8 @@
     "@jupyterlab/rendermime": "^0.16.2",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/console-extension/tsconfig.json
+++ b/packages/console-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -42,7 +42,8 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/console/tsconfig.json
+++ b/packages/console/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -38,6 +38,7 @@
     "minimist": "~1.2.0",
     "moment": "~2.21.0",
     "path-posix": "~1.0.0",
+    "tslib": "^1.9.1",
     "url-parse": "~1.1.9"
   },
   "devDependencies": {

--- a/packages/coreutils/tsconfig.json
+++ b/packages/coreutils/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@jupyterlab/application": "^0.16.2",
     "@jupyterlab/apputils": "^0.16.3",
-    "@jupyterlab/csvviewer": "^0.16.2"
+    "@jupyterlab/csvviewer": "^0.16.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/csvviewer-extension/tsconfig.json
+++ b/packages/csvviewer-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -39,7 +39,8 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/csvviewer/tsconfig.json
+++ b/packages/csvviewer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -37,7 +37,8 @@
     "@jupyterlab/docregistry": "^0.16.2",
     "@jupyterlab/mainmenu": "^0.5.2",
     "@jupyterlab/services": "^2.0.2",
-    "@phosphor/disposable": "^1.1.2"
+    "@phosphor/disposable": "^1.1.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/docmanager-extension/tsconfig.json
+++ b/packages/docmanager-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -39,7 +39,8 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/docmanager/tsconfig.json
+++ b/packages/docmanager/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -43,7 +43,8 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/docregistry/tsconfig.json
+++ b/packages/docregistry/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/faq-extension/package.json
+++ b/packages/faq-extension/package.json
@@ -34,7 +34,8 @@
     "@jupyterlab/application": "^0.16.2",
     "@jupyterlab/apputils": "^0.16.3",
     "@jupyterlab/rendermime": "^0.16.2",
-    "@phosphor/coreutils": "^1.3.0"
+    "@phosphor/coreutils": "^1.3.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/node": "~8.0.47",

--- a/packages/faq-extension/tsconfig.json
+++ b/packages/faq-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -39,7 +39,8 @@
     "@jupyterlab/services": "^2.0.2",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/commands": "^1.5.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/filebrowser-extension/tsconfig.json
+++ b/packages/filebrowser-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -43,7 +43,8 @@
     "@phosphor/dragdrop": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/filebrowser/tsconfig.json
+++ b/packages/filebrowser/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -40,7 +40,8 @@
     "@jupyterlab/launcher": "^0.16.2",
     "@jupyterlab/mainmenu": "^0.5.2",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/fileeditor-extension/tsconfig.json
+++ b/packages/fileeditor-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -36,7 +36,8 @@
     "@jupyterlab/docregistry": "^0.16.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/fileeditor/tsconfig.json
+++ b/packages/fileeditor/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -36,7 +36,8 @@
     "@jupyterlab/mainmenu": "^0.5.2",
     "@jupyterlab/services": "^2.0.2",
     "@phosphor/widgets": "^1.6.0",
-    "react": "~16.2.0"
+    "react": "~16.2.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/help-extension/tsconfig.json
+++ b/packages/help-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@jupyterlab/application": "^0.16.2",
     "@jupyterlab/apputils": "^0.16.3",
-    "@jupyterlab/imageviewer": "^0.16.2"
+    "@jupyterlab/imageviewer": "^0.16.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/imageviewer-extension/tsconfig.json
+++ b/packages/imageviewer-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -35,7 +35,8 @@
     "@jupyterlab/docregistry": "^0.16.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/imageviewer/tsconfig.json
+++ b/packages/imageviewer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -34,7 +34,8 @@
     "@jupyterlab/console": "^0.16.2",
     "@jupyterlab/inspector": "^0.16.2",
     "@jupyterlab/notebook": "^0.16.2",
-    "@phosphor/disposable": "^1.1.2"
+    "@phosphor/disposable": "^1.1.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/inspector-extension/tsconfig.json
+++ b/packages/inspector-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -38,7 +38,8 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/inspector/tsconfig.json
+++ b/packages/inspector/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -35,7 +35,8 @@
     "react": "~16.2.0",
     "react-dom": "~16.2.0",
     "react-highlighter": "^0.4.0",
-    "react-json-tree": "^0.10.9"
+    "react-json-tree": "^0.10.9",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/react": "~16.0.19",

--- a/packages/json-extension/tsconfig.json
+++ b/packages/json-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -35,7 +35,8 @@
     "@jupyterlab/launcher": "^0.16.2",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/launcher-extension/tsconfig.json
+++ b/packages/launcher-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -36,7 +36,8 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/properties": "^1.1.2",
     "@phosphor/widgets": "^1.6.0",
-    "react": "~16.2.0"
+    "react": "~16.2.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/react": "~16.0.19",

--- a/packages/launcher/tsconfig.json
+++ b/packages/launcher/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -32,7 +32,8 @@
     "@jupyterlab/apputils": "^0.16.3",
     "@jupyterlab/mainmenu": "^0.5.2",
     "@phosphor/algorithm": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/mainmenu-extension/tsconfig.json
+++ b/packages/mainmenu-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -34,7 +34,8 @@
     "@phosphor/commands": "^1.5.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/mainmenu/tsconfig.json
+++ b/packages/mainmenu/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -33,7 +33,8 @@
     "@jupyterlab/application": "^0.16.2",
     "@jupyterlab/apputils": "^0.16.3",
     "@jupyterlab/docregistry": "^0.16.2",
-    "@jupyterlab/rendermime": "^0.16.2"
+    "@jupyterlab/rendermime": "^0.16.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/markdownviewer-extension/tsconfig.json
+++ b/packages/markdownviewer-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/mathjax2-extension/package.json
+++ b/packages/mathjax2-extension/package.json
@@ -32,7 +32,8 @@
     "@jupyterlab/coreutils": "^1.1.2",
     "@jupyterlab/rendermime": "^0.16.2",
     "@jupyterlab/rendermime-interfaces": "^1.0.9",
-    "@phosphor/coreutils": "^1.3.0"
+    "@phosphor/coreutils": "^1.3.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/mathjax2-extension/tsconfig.json
+++ b/packages/mathjax2-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/metapackage/tsconfig.json
+++ b/packages/metapackage/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -43,7 +43,8 @@
     "@jupyterlab/services": "^2.0.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/notebook-extension/tsconfig.json
+++ b/packages/notebook-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -47,7 +47,8 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.6.0",
-    "react": "~16.2.0"
+    "react": "~16.2.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/notebook/tsconfig.json
+++ b/packages/notebook/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -32,7 +32,8 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/signaling": "^1.2.2"
+    "@phosphor/signaling": "^1.2.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/observables/tsconfig.json
+++ b/packages/observables/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -41,7 +41,8 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/outputarea/tsconfig.json
+++ b/packages/outputarea/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^1.0.9",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/pdf-extension/tsconfig.json
+++ b/packages/pdf-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.16.2",
-    "@jupyterlab/rendermime": "^0.16.2"
+    "@jupyterlab/rendermime": "^0.16.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/rendermime-extension/tsconfig.json
+++ b/packages/rendermime-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/rendermime-interfaces/tsconfig.json
+++ b/packages/rendermime-interfaces/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -41,7 +41,8 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
     "ansi_up": "^3.0.0",
-    "marked": "~0.3.9"
+    "marked": "~0.3.9",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/marked": "~0.0.28",

--- a/packages/rendermime/tsconfig.json
+++ b/packages/rendermime/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.16.2",
-    "@jupyterlab/running": "^0.16.2"
+    "@jupyterlab/running": "^0.16.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/running-extension/tsconfig.json
+++ b/packages/running-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -36,7 +36,8 @@
     "@phosphor/domutils": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/running/tsconfig.json
+++ b/packages/running/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^2.0.2",
-    "es6-promise": "~4.1.1"
+    "es6-promise": "~4.1.1",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/services/examples/node/package.json
+++ b/packages/services/examples/node/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@jupyterlab/services": "^2.0.2",
     "node-fetch": "~1.7.3",
+    "tslib": "^1.9.1",
     "ws": "~1.1.4"
   },
   "devDependencies": {

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -11,7 +11,8 @@
     "@jupyterlab/outputarea": "^0.16.2",
     "@jupyterlab/rendermime": "^0.16.2",
     "@jupyterlab/services": "^2.0.2",
-    "es6-promise": "~4.1.1"
+    "es6-promise": "~4.1.1",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "css-loader": "~0.28.7",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -51,6 +51,7 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
     "node-fetch": "~1.7.3",
+    "tslib": "^1.9.1",
     "ws": "~1.1.4"
   },
   "devDependencies": {

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -35,7 +35,8 @@
     "@jupyterlab/codeeditor": "^0.16.1",
     "@jupyterlab/coreutils": "^1.1.2",
     "@jupyterlab/rendermime": "^0.16.2",
-    "@jupyterlab/settingeditor": "^0.5.2"
+    "@jupyterlab/settingeditor": "^0.5.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/settingeditor-extension/tsconfig.json
+++ b/packages/settingeditor-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -40,7 +40,8 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
     "react": "~16.2.0",
-    "react-dom": "~16.2.0"
+    "react-dom": "~16.2.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/react": "~16.0.19",

--- a/packages/settingeditor/tsconfig.json
+++ b/packages/settingeditor/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -34,7 +34,8 @@
     "@jupyterlab/coreutils": "^1.1.2",
     "@phosphor/commands": "^1.5.0",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/disposable": "^1.1.2"
+    "@phosphor/disposable": "^1.1.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/shortcuts-extension/tsconfig.json
+++ b/packages/shortcuts-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/tabmanager-extension/package.json
+++ b/packages/tabmanager-extension/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "@jupyterlab/application": "^0.16.2",
     "@phosphor/algorithm": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/tabmanager-extension/tsconfig.json
+++ b/packages/tabmanager-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -34,7 +34,8 @@
     "@jupyterlab/launcher": "^0.16.2",
     "@jupyterlab/mainmenu": "^0.5.2",
     "@jupyterlab/services": "^2.0.2",
-    "@jupyterlab/terminal": "^0.16.2"
+    "@jupyterlab/terminal": "^0.16.2",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/terminal-extension/tsconfig.json
+++ b/packages/terminal-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -35,6 +35,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1",
     "xterm": "~3.3.0"
   },
   "devDependencies": {

--- a/packages/terminal/tsconfig.json
+++ b/packages/terminal/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@jupyterlab/application": "^0.16.2",
     "@jupyterlab/apputils": "^0.16.3",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "css-loader": "~0.28.7",

--- a/packages/theme-dark-extension/tsconfig.json
+++ b/packages/theme-dark-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "@jupyterlab/application": "^0.16.2",
     "@jupyterlab/apputils": "^0.16.3",
-    "font-awesome": "~4.7.0"
+    "font-awesome": "~4.7.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "css-loader": "~0.28.7",

--- a/packages/theme-light-extension/tsconfig.json
+++ b/packages/theme-light-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -37,7 +37,8 @@
     "@jupyterlab/services": "^2.0.2",
     "@jupyterlab/tooltip": "^0.16.2",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/tooltip-extension/tsconfig.json
+++ b/packages/tooltip-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -36,7 +36,8 @@
     "@jupyterlab/services": "^2.0.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/tooltip/tsconfig.json
+++ b/packages/tooltip/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/vdom-extension/package.json
+++ b/packages/vdom-extension/package.json
@@ -33,7 +33,8 @@
     "@nteract/transform-vdom": "^1.1.1",
     "@phosphor/widgets": "^1.6.0",
     "react": "~16.2.0",
-    "react-dom": "~16.2.0"
+    "react-dom": "~16.2.0",
+    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/react": "~16.0.19",

--- a/packages/vdom-extension/tsconfig.json
+++ b/packages/vdom-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/packages/vega3-extension/package.json
+++ b/packages/vega3-extension/package.json
@@ -32,6 +32,7 @@
     "@jupyterlab/rendermime-interfaces": "^1.0.9",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/widgets": "^1.6.0",
+    "tslib": "^1.9.1",
     "vega-embed": "^3.4.0"
   },
   "devDependencies": {

--- a/packages/vega3-extension/tsconfig.json
+++ b/packages/vega3-extension/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "importHelpers": true,
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7939,6 +7939,10 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
+tslib@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz#a5d1f0532a49221c87755cfcc89ca37197242ba7"
+
 tslint@~5.10.0:
   version "5.10.0"
   resolved "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"


### PR DESCRIPTION
The benefit is smaller than expected because many libraries that are being used don't use tslib and so adding tslib at the extension package doesn't change anything. 