### PR TITLE
Don't emit changed and stateChanged signal on OutputAreaModel._onListChanged

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -346,7 +346,7 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
       values: outputs,
       modelDB: this.modelDB
     });
-    this._outputs.stateChanged.connect(this.onGenericChange, this);
+    this._outputs.changed.connect(this.onGenericChange, this);
   }
 
   /**

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -442,7 +442,6 @@ class OutputAreaModel implements IOutputAreaModel {
       this._changeGuard = false;
     }
     this._changed.emit(args);
-    this._stateChanged.emit(void 0);
   }
 
   /**


### PR DESCRIPTION
This fixes an issue where outputs are unnecessarily being rendered twice because both `OutputAreaModel.changed` and `OutputAreaModel._stateChanged` are being called on `OutputAreaModel._onListChanged`.

Closes https://github.com/jupyterlab/jupyterlab/issues/4627