### PR TITLE
Add status to comm info reply msg

### DIFF
--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -713,6 +713,8 @@ namespace KernelMessage {
        * Mapping of comm ids to target names.
        */
       comms: { [commId: string]: { 'target_name': string } };
+
+      status: 'ok' | 'error';
     };
   }
 


### PR DESCRIPTION
I tested this, and indeed there is a `status` on the content.

fixes https://github.com/jupyterlab/jupyterlab/issues/4639