### PR TITLE
Fix reset className

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -411,14 +411,11 @@ class OutputArea extends Widget {
       if (isolated === true) {
         output = new Private.IsolatedRenderer(output);
       }
-      const className = output.node.className;
       output.renderModel(model).catch(error => {
         // Manually append error message to output
         output.node.innerHTML = `<pre>Javascript Error: ${error.message}</pre>`;
         // Remove mime-type-specific CSS classes
-        output.node.className = className;
-        // Add stderr-specific attributes
-        output.addClass('jp-RenderedText');
+        output.node.className = 'p-Widget jp-RenderedText';
         output.node.setAttribute('data-mime-type', 'application/vnd.jupyter.stderr');
       });
       widget = output;


### PR DESCRIPTION
When testing https://github.com/jupyterlab/jupyterlab/pull/4625, I noticed that the error output was inheriting the vega-extension styles. This is a patch to https://github.com/jupyterlab/jupyterlab/pull/4465 that resets the node's className before adding error className and attributes.