### PR TITLE
Add `fontFamily` and `fontSize` to CodeEditor configuration.

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -562,6 +562,16 @@ namespace CodeEditor {
   export
   interface IConfig {
     /**
+     * The family of the font used in text editors.
+     */
+    fontFamily: string;
+
+    /**
+     * The size in pixel of the font used in text editors.
+     */
+    fontSize: number;
+
+    /**
      * Whether line numbers should be displayed.
      */
     lineNumbers: boolean;
@@ -602,6 +612,8 @@ namespace CodeEditor {
    */
   export
   let defaultConfig: IConfig = {
+    fontFamily: '\'Source Code Pro\', monospace',
+    fontSize: 13,
     lineNumbers: false,
     lineWrap: true,
     readOnly: false,

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -562,14 +562,19 @@ namespace CodeEditor {
   export
   interface IConfig {
     /**
-     * The family of the font used in text editors.
+     * User preferred font family for text editors.
      */
-    fontFamily: string;
+    fontFamily: string | null;
 
     /**
-     * The size in pixel of the font used in text editors.
+     * User preferred size in pixel of the font used in text editors.
      */
-    fontSize: number;
+    fontSize: number | null;
+
+    /**
+     * User preferred text line height, as a multiplier of font size.
+     */
+    lineHeight: number | null;
 
     /**
      * Whether line numbers should be displayed.
@@ -612,8 +617,9 @@ namespace CodeEditor {
    */
   export
   let defaultConfig: IConfig = {
-    fontFamily: '\'Source Code Pro\', monospace',
-    fontSize: 13,
+    fontFamily: null,
+    fontSize: null,
+    lineHeight: null,
     lineNumbers: false,
     lineWrap: true,
     readOnly: false,

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1096,6 +1096,7 @@ namespace Private {
       fontFamily,
       fontSize,
       insertSpaces,
+      lineHeight,
       lineWrap,
       tabSize,
       readOnly,
@@ -1110,9 +1111,18 @@ namespace Private {
       ...otherOptions
     };
     return CodeMirror(el => {
-      el.style.fontFamily = fontFamily;
-      el.style.fontSize = fontSize + 'px';
-      el.classList.toggle(READ_ONLY_CLASS, readOnly);
+      if (fontFamily) {
+        el.style.fontFamily = fontFamily;
+      }
+      if (fontSize) {
+        el.style.fontSize = fontSize + 'px';
+      }
+      if (lineHeight) {
+        el.style.lineHeight = lineHeight.toString();
+      }
+      if (readOnly) {
+        el.classList.add(READ_ONLY_CLASS);
+      }
       host.appendChild(el);
     }, bareConfig);
   }
@@ -1205,7 +1215,10 @@ namespace Private {
       el.style.fontFamily = value;
       break;
     case 'fontSize':
-      el.style.fontSize = value + 'px';
+      el.style.fontSize = value ? value + 'px' : null;
+      break;
+    case 'lineHeight':
+      el.style.lineHeight = value ? value.toString() : null;
       break;
     default:
       editor.setOption(option, value);

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -113,8 +113,12 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
     };
 
     let model = this._model = options.model;
-    let editor = this._editor = CodeMirror(host, {});
-    Private.handleConfig(editor, options.config || {});
+    let config = options.config || {};
+    let fullConfig = this._config = {
+      ...CodeMirrorEditor.defaultConfig,
+      ...config
+    };
+    let editor = this._editor = Private.createEditor(host, fullConfig);
 
     let doc = editor.getDoc();
 
@@ -261,14 +265,18 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
    * Get a config option for the editor.
    */
   getOption<K extends keyof CodeMirrorEditor.IConfig>(option: K): CodeMirrorEditor.IConfig[K] {
-    return Private.getOption(this.editor, option);
+    return this._config[option];
   }
 
   /**
    * Set a config option for the editor.
    */
   setOption<K extends keyof CodeMirrorEditor.IConfig>(option: K, value: CodeMirrorEditor.IConfig[K]): void {
-    Private.setOption(this.editor, option, value);
+    // Don't bother setting the option if it is already the same.
+    if (this._config[option] !== value) {
+      this._config[option] = value;
+      Private.setOption(this.editor, option, value);
+    }
   }
 
   /**
@@ -898,6 +906,7 @@ class CodeMirrorEditor implements CodeEditor.IEditor {
   private _editor: CodeMirror.Editor;
   protected selectionMarkers: { [key: string]: CodeMirror.TextMarker[] | undefined } = {};
   private _caretHover: HTMLElement | null;
+  private readonly _config: CodeMirrorEditor.IConfig;
   private _hoverTimeout: number;
   private _hoverId: string;
   private _keydownHandlers = new Array<CodeEditor.KeydownHandler>();
@@ -981,7 +990,7 @@ namespace CodeMirrorEditor {
      * (it will default to be to the right of all other gutters).
      * These class names are the keys passed to setGutterMarker.
      */
-    gutters?: ReadonlyArray<string>;
+    gutters?: string[];
 
     /**
      * Determines whether the gutter scrolls along with the content
@@ -1051,7 +1060,7 @@ namespace CodeMirrorEditor {
     electricChars: true,
     keyMap: 'default',
     extraKeys: null,
-    gutters: Object.freeze([]),
+    gutters: [],
     fixedGutter: true,
     showCursorWhenSelecting: false,
     coverGutterNextToScrollbar: false,
@@ -1080,19 +1089,32 @@ namespace CodeMirrorEditor {
  * The namespace for module private data.
  */
 namespace Private {
-  /**
-   * Handle the codemirror configuration options.
-   */
   export
-  function handleConfig(editor: CodeMirror.Editor, config: Partial<CodeMirrorEditor.IConfig>): void {
-    let fullConfig: CodeMirrorEditor.IConfig = {
-      ...CodeMirrorEditor.defaultConfig,
-      ...config
+  function createEditor(host: HTMLElement, config: CodeMirrorEditor.IConfig): CodeMirror.Editor {
+    let {
+      autoClosingBrackets,
+      fontFamily,
+      fontSize,
+      insertSpaces,
+      lineWrap,
+      tabSize,
+      readOnly,
+      ...otherOptions
+    } = config;
+    let bareConfig =  {
+      autoCloseBrackets: autoClosingBrackets,
+      indentUnit: tabSize,
+      indentWithTabs: !insertSpaces,
+      lineWrapping: lineWrap,
+      readOnly,
+      ...otherOptions
     };
-    let key: keyof CodeMirrorEditor.IConfig;
-    for (key in fullConfig) {
-      Private.setOption(editor, key, fullConfig[key]);
-    }
+    return CodeMirror(el => {
+      el.style.fontFamily = fontFamily;
+      el.style.fontSize = fontSize + 'px';
+      el.classList.toggle(READ_ONLY_CLASS, readOnly);
+      host.appendChild(el);
+    }, bareConfig);
   }
 
   /**
@@ -1157,34 +1179,11 @@ namespace Private {
   }
 
   /**
-   * Get a config option for the editor.
-   */
-  export
-  function getOption<K extends keyof CodeMirrorEditor.IConfig>(editor: CodeMirror.Editor, option: K): CodeMirrorEditor.IConfig[K] {
-    switch (option) {
-    case 'lineWrap':
-      return editor.getOption('lineWrapping');
-    case 'insertSpaces':
-      return !editor.getOption('indentWithTabs');
-    case 'tabSize':
-      return editor.getOption('indentUnit');
-    case 'autoClosingBrackets':
-      return editor.getOption('autoCloseBrackets');
-    default:
-      return editor.getOption(option);
-    }
-  }
-
-  /**
    * Set a config option for the editor.
    */
   export
   function setOption<K extends keyof CodeMirrorEditor.IConfig>(editor: CodeMirror.Editor, option: K, value: CodeMirrorEditor.IConfig[K]): void {
-    // Don't bother setting the option if it is already the same.
-    const oldValue = getOption(editor, option);
-    if (oldValue === value) {
-      return;
-    }
+    let el = editor.getWrapperElement();
     switch (option) {
     case 'lineWrap':
       editor.setOption('lineWrapping', value);
@@ -1199,9 +1198,14 @@ namespace Private {
       editor.setOption('autoCloseBrackets', value);
       break;
     case 'readOnly':
-      let el = editor.getWrapperElement();
       el.classList.toggle(READ_ONLY_CLASS, value);
       editor.setOption(option, value);
+      break;
+    case 'fontFamily':
+      el.style.fontFamily = value;
+      break;
+    case 'fontSize':
+      el.style.fontSize = value + 'px';
       break;
     default:
       editor.setOption(option, value);

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -23,8 +23,6 @@
 
 .CodeMirror {
   line-height: var(--jp-code-line-height);
-  font-size: var(--jp-code-font-size);
-  font-family: var(--jp-code-font-family);
   height: auto;
   /* Changed to auto to autogrow */
 }

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -23,6 +23,8 @@
 
 .CodeMirror {
   line-height: var(--jp-code-line-height);
+  font-size: var(--jp-code-font-size);
+  font-family: var(--jp-code-font-family);
   height: auto;
   /* Changed to auto to autogrow */
 }

--- a/packages/fileeditor-extension/schema/plugin.json
+++ b/packages/fileeditor-extension/schema/plugin.json
@@ -46,7 +46,7 @@
   "properties": {
     "editorConfig": {
       "title": "Editor Configuration",
-      "description": "The configuration for all text editors.",
+      "description": "The configuration for all text editors.\nIf `fontFamily`, `fontSize` or `lineHeight` are `null`, values from\ncurrent theme are used.",
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": true,

--- a/packages/fileeditor-extension/schema/plugin.json
+++ b/packages/fileeditor-extension/schema/plugin.json
@@ -9,6 +9,12 @@
         "autoClosingBrackets": {
           "type": "boolean"
         },
+        "fontFamily": {
+          "type": "string"
+        },
+        "fontSize": {
+          "type": "number"
+        },
         "lineNumbers": {
           "type": "boolean"
         },
@@ -39,6 +45,8 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": true,
+        "fontFamily": "'Source Code Pro', monospace",
+        "fontSize": 13,
         "lineNumbers": true,
         "lineWrap": true,
         "matchBrackets": true,

--- a/packages/fileeditor-extension/schema/plugin.json
+++ b/packages/fileeditor-extension/schema/plugin.json
@@ -10,10 +10,15 @@
           "type": "boolean"
         },
         "fontFamily": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "fontSize": {
-          "type": "number"
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        },
+        "lineHeight": {
+          "type": ["number", "null"]
         },
         "lineNumbers": {
           "type": "boolean"
@@ -45,8 +50,9 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": true,
-        "fontFamily": "'Source Code Pro', monospace",
-        "fontSize": 13,
+        "fontFamily": null,
+        "fontSize": null,
+        "lineHeight": null,
         "lineNumbers": true,
         "lineWrap": true,
         "matchBrackets": true,

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -9,6 +9,17 @@
         "autoClosingBrackets": {
           "type": "boolean"
         },
+        "fontFamily": {
+          "type": ["string", "null"]
+        },
+        "fontSize": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        },
+        "lineHeight": {
+          "type": ["number", "null"]
+        },
         "lineNumbers": {
           "type": "boolean"
         },
@@ -39,6 +50,9 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": true,
+        "fontFamily": null,
+        "fontSize": null,
+        "lineHeight": null,
         "lineNumbers": false,
         "lineWrap": false,
         "matchBrackets": true,
@@ -53,6 +67,9 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": false,
+        "fontFamily": null,
+        "fontSize": null,
+        "lineHeight": null,
         "lineNumbers": false,
         "lineWrap": true,
         "matchBrackets": false,
@@ -67,6 +84,9 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": false,
+        "fontFamily": null,
+        "fontSize": null,
+        "lineHeight": null,
         "lineNumbers": false,
         "lineWrap": true,
         "matchBrackets": false,


### PR DESCRIPTION
This PR intends to fix issue #4139.
I'm new to jupyterlab code, so the way I implemented this feature can be completely wrong.
If that is the case, feel free to move it to trash. :blush: 
Otherwise, I'll be happy to add any change you request.

Cheers