### PR TITLE
Close tabs to the right/others. #4124

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1,14 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import {
-  ArrayExt,
-  each,
-  find,
-  IIterator,
-  iter,
-  toArray
-} from '@phosphor/algorithm';
+import { ArrayExt, find, IIterator, iter, toArray } from '@phosphor/algorithm';
 
 import { PromiseDelegate } from '@phosphor/coreutils';
 
@@ -561,9 +554,7 @@ export class ApplicationShell extends Widget {
     // Make a copy of all the widget in the dock panel (using `toArray()`)
     // before removing them because removing them while iterating through them
     // modifies the underlying data of the iterator.
-    each(toArray(this._dockPanel.widgets()), widget => {
-      widget.close();
-    });
+    toArray(this._dockPanel.widgets()).forEach(widget => widget.close());
   }
 
   /**

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -37,7 +37,9 @@
     "@jupyterlab/docregistry": "^0.17.0-1",
     "@jupyterlab/mainmenu": "^0.6.0-1",
     "@jupyterlab/services": "^3.0.0-1",
-    "@phosphor/disposable": "^1.1.2"
+    "@phosphor/algorithm": "^1.1.2",
+    "@phosphor/disposable": "^1.1.2",
+    "@phosphor/widgets": "^1.6.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",


### PR DESCRIPTION
This PR adds the enhancement from issue #4124.

I added a new function in app shell closeWidgets() and modified closeAll() to use it.  This function is used by the new commands in docmanager-extension to close the widgets.  I added a new helped function to determine the widgets to the right of the chose widget.

I tested the functionality and it works except in the main area.  Right clicking on a tab/widget that is not the active widget does not work correctly, but this is a known issue.  It is discussed and already addressed in #4529.  telamonian's solution worked correctly when I tested it.  When that functionality is merged, my changes just need to be updated from using app.shell.widget to his new contextMenuWidget() function.
 
The context menu does work correctly when right clicking on a tab from the left sidebars Tabs pane.