### PR TITLE
[WIP] Websocket Datastore

### DIFF
--- a/packages/services/src/collab/index.ts
+++ b/packages/services/src/collab/index.ts
@@ -1,2 +1,3 @@
 
 export * from './localadapter';
+export * from './wsadapter';

--- a/packages/services/src/collab/index.ts
+++ b/packages/services/src/collab/index.ts
@@ -1,0 +1,2 @@
+
+export * from './localadapter';

--- a/packages/services/src/collab/localadapter.ts
+++ b/packages/services/src/collab/localadapter.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  ReadonlyJSONObject, UUID
+} from '@phosphor/coreutils';
+
+import {
+  IDisposable, DisposableDelegate
+} from '@phosphor/disposable';
+
+import {
+  IMessageHandler
+} from '@phosphor/messaging';
+
+import {
+  IServerAdapter, Patch, PatchHistoryMessage, RemotePatchMessage
+} from '@phosphor/datastore';
+
+
+
+/**
+ * An local-only data store server adapter.
+ */
+export
+class LocalServerAdapter implements IServerAdapter, IDisposable {
+  static _storeIdGen = 0;
+  /**
+   *
+   */
+  constructor(checkpoint: ReadonlyJSONObject) {
+    this._handlers = new Map<number, IMessageHandler>();
+    this._checkpoint = checkpoint;
+    this._history = new Map<string, Patch>();
+  }
+
+
+  /**
+   * Dispose of the resources held by the adapter.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this._handlers.clear();
+  }
+
+  /**
+   * Test whether the kernel has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Create a new, unique store id.
+   *
+   * @returns {Promise<number>} A promise to the new store id.
+   */
+  createStoreId(): Promise<number> {
+    return Promise.resolve(LocalServerAdapter._storeIdGen++);
+  }
+
+  /**
+   * Create a new, unique patch id.
+   *
+   * @returns {string} The patch id.
+   */
+  createPatchId(storeId: number): string {
+    return `${storeId}:${UUID.uuid4()}`;
+  }
+
+  /**
+   * Register a handler for messages from the server adaptor.
+   *
+   * @param {number} storeId The store id of the patch handler.
+   * @param {IMessageHandler} handler The patch handler to register.
+   * @returns {IDisposable} Disposable to use to unregister the handler.
+   */
+  registerPatchHandler(storeId: number, handler: IMessageHandler): IDisposable {
+    this._handlers.set(storeId, handler);
+    const history = {
+      checkpoint: this._checkpoint,
+      patches: this._history,
+    };
+    const message = new PatchHistoryMessage(history);
+    handler.processMessage(message);
+    return new DisposableDelegate(() => {
+      this._handlers.delete(storeId);
+    });
+  }
+
+  /**
+   * Broadcast a patch to all data stores.
+   *
+   * @param {Patch} patch The patch to broadcast.
+   */
+  broadcastPatch(patch: Patch): void {
+    this._history.set(patch.patchId, patch);
+    const message = new RemotePatchMessage(patch);
+    this._handlers.forEach((handler, storeId) => {
+      if (storeId !== patch.storeId) {
+        handler.processMessage(message);
+      }
+    });
+  }
+
+  /**
+   * Fetch specific patches from history by their id.
+   *
+   * @param {string[]} patchIds The patch ids to fetch.
+   * @returns {Promise<Patch[]>} A promise to the patches that are fetched.
+   */
+  fetchPatches(patchIds: string[]): Promise<Patch[]> {
+    const patches = patchIds.map((id) => {
+      if (!this._history.has(id)) {
+        throw new Error(`Cannot fetch patch with id '${id}', no such patch exists`);
+      }
+      return this._history.get(id)!;
+    });
+    return Promise.resolve(patches);
+  }
+
+  private _isDisposed = false;
+  private _handlers: Map<number, IMessageHandler>;
+
+  private _checkpoint: ReadonlyJSONObject;
+  private _history: Map<string, Patch>;
+}

--- a/packages/services/src/collab/wsadapter.ts
+++ b/packages/services/src/collab/wsadapter.ts
@@ -1,0 +1,530 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  ReadonlyJSONObject, UUID, PromiseDelegate
+} from '@phosphor/coreutils';
+
+import {
+  IDisposable, DisposableDelegate
+} from '@phosphor/disposable';
+
+import {
+  IMessageHandler
+} from '@phosphor/messaging';
+
+import {
+  ISignal, Signal
+} from '@phosphor/signaling';
+
+import {
+  IServerAdapter, Patch, PatchHistory, PatchHistoryMessage, RemotePatchMessage
+} from '@phosphor/datastore';
+
+import {
+  ServerConnection
+} from '../serverconnection';
+
+import {
+  WsConnection
+} from '../wsconnection';
+
+
+/**
+ * The url for the adapter service.
+ */
+const DATASTORE_URL = 'api/datastore';
+
+
+/**
+ * Implementation of the WebSocket adapter object
+ */
+export
+class WsAdapter implements IServerAdapter, IDisposable {
+  /**
+   * Construct an WebSocket adapter object.
+   */
+  constructor(options: WsAdapter.IOptions) {
+    const socket = this.socket = new WsConnection(
+      {...options, apiUrl: DATASTORE_URL});
+    socket.message.connect(this.onMessage);
+    if (socket.isReady) {
+      socket.statusChanged.connect(this.onSocketStatusChanged);
+    } else {
+      // Don't handle initial connect status:
+      socket.ready.then(() => {
+        socket.statusChanged.connect(this.onSocketStatusChanged);
+      }, () => {
+        socket.statusChanged.connect(this.onSocketStatusChanged);
+      });
+    }
+  }
+
+  /**
+   * A signal emitted when the adapter status changes.
+   */
+  get statusChanged(): ISignal<this, WsConnection.Status> {
+    return this._statusChanged;
+  }
+
+  /**
+   * The current status of the connection.
+   */
+  get status(): WsConnection.Status {
+    return this.socket.status;
+  }
+
+  /**
+   * Test whether the adapter has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Test whether the adapter is ready.
+   */
+  get isReady(): boolean {
+    return this.socket.isReady;
+  }
+
+  /**
+   * A promise that is fulfilled when the adapter is ready.
+   */
+  get ready(): Promise<void> {
+    return this.socket.ready;
+  }
+
+  /**
+   * Dispose of the resources held by the adapter.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this.socket.dispose();
+    this.socket = null;
+    Signal.clearData(this);
+  }
+
+  /**
+   * Reconnect a disconnected adapter.
+   *
+   * #### Notes
+   * Used when the websocket connection is lost.
+   */
+  reconnect(): Promise<void> {
+    return this.socket.reconnect();
+  }
+
+  /**
+   * Create a new, unique store id.
+   *
+   * @returns {Promise<number>} A promise to the new store id.
+   */
+  createStoreId(): Promise<number> {
+    const msg = WsAdapterMessages.createStoreIdRequestMessage(this.socket.clientId);
+    return this.handleRequestMessage(msg).then((reply: WsAdapterMessages.IStoreIdMessageReply) => {
+      return reply.content.storeId;
+    });
+  }
+
+  /**
+   * Create a new, unique patch id.
+   *
+   * @returns {string} The patch id.
+   */
+  createPatchId(): string {
+    return UUID.uuid4();
+  }
+
+  /**
+   * Register a handler for messages from the server adaptor.
+   *
+   * @param {number} storeId The store id of the patch handler.
+   * @param {IMessageHandler} handler The patch handler to register.
+   * @returns {IDisposable} Disposable to use to unregister the handler.
+   */
+  registerPatchHandler(storeId: number, handler: IMessageHandler): IDisposable {
+    this._handlers.set(storeId, handler);
+    const fetchMsg = WsAdapterMessages.createPatchHistoryRequestMessage(this.socket.clientId);
+    // TODO: Record any patches that arrive while waiting for reply
+    this.handleRequestMessage(fetchMsg).then((historyMsg: WsAdapterMessages.IPatchHistoryReply) => {
+      // TODO: Add any recorded patches that arrived
+      const message = new PatchHistoryMessage(historyMsg.content.patchHistory);
+      // Only report to a signle handler if passed:
+      handler.processMessage(message);
+    });
+    return new DisposableDelegate(() => {
+      this._handlers.delete(storeId);
+    });
+  }
+
+  /**
+   * Broadcast a patch to all data stores.
+   *
+   * @param {Patch} patch The patch to broadcast.
+   */
+  broadcastPatch(patch: Patch): void {
+    const msg = WsAdapterMessages.createPatchBroadcastMessage(this.socket.clientId, patch);
+    this.sendMessage(msg);
+    this.broadcastLocal(patch);
+  }
+
+  /**
+   * Fetch specific patches from history by their id.
+   *
+   * @param {string[]} patchIds The patch ids to fetch.
+   * @returns {Promise<Patch[]>} A promise to the patches that are fetched.
+   */
+  fetchPatches(patchIds: string[]): Promise<Patch[]> {
+    const msg = WsAdapterMessages.createPatchFetchRequestMessage(this.socket.clientId, patchIds);
+    return this.handleRequestMessage(msg).then((reply: WsAdapterMessages.IPatchFetchReplyMessage) => {
+      return reply.content.patches;
+    });
+  }
+
+  /**
+   * Handle messages from the socket.
+   */
+  protected onMessage(sender: WsConnection, msg: WsAdapterMessages.IMessage): void {
+    try {
+      // TODO: Write a validator
+      // validate.validateMessage(msg);
+    } catch (error) {
+      console.error(`Invalid message: ${error.message}`);
+      return;
+    }
+
+    let handled = false;
+    if (msg.parentId) {
+      let delegate = this._delegates && this._delegates.get(msg.parentId);
+      if (delegate) {
+        delegate.resolve(msg as WsAdapterMessages.IReplyMessage);
+        handled = true;
+      }
+    }
+    if (msg.msgType === 'patch-broadcast') {
+      this._lastPatchIdReceived = msg.content.patch.patchId;
+      this.broadcastLocal(msg.content.patch);
+      handled = true;
+    }
+    if (!handled) {
+      console.log('Unhandled server adapter message.', msg);
+    }
+  }
+
+
+  /**
+   * Send a message to the server and resolve the reply message.
+   */
+  protected handleRequestMessage(msg: WsAdapterMessages.IStoreIdMessageRequest): Promise<WsAdapterMessages.IStoreIdMessageReply>;
+  protected handleRequestMessage(msg: WsAdapterMessages.IPatchFetchRequestMessage): Promise<WsAdapterMessages.IPatchFetchReplyMessage>;
+  protected handleRequestMessage(msg: WsAdapterMessages.IPatchHistoryRequestMessage): Promise<WsAdapterMessages.IPatchHistoryReply>;
+  protected handleRequestMessage(msg: WsAdapterMessages.IMessage): Promise<WsAdapterMessages.IReplyMessage> {
+    const delegate = new PromiseDelegate<WsAdapterMessages.IReplyMessage>();
+    this._delegates.set(msg.msgId, delegate);
+
+    this.sendMessage(msg);
+
+    return delegate.promise.then((reply) => {
+      this._delegates.delete(msg.msgId);
+      return reply;
+    });
+  }
+
+  /**
+   * Send a message over the socket.
+   *
+   * @param {WsAdapterMessages.IMessage} msg The message to send.
+   */
+  protected sendMessage(msg: WsAdapterMessages.IMessage): void {
+    this.socket.sendWSMessage(msg);
+  }
+
+  /**
+   * Broadcast a patch to all the local handlers.
+   *
+   * @param {Patch} patch The patch to broadcast.
+   */
+  protected broadcastLocal(patch: Patch): void {
+    const message = new RemotePatchMessage(patch);
+    this._handlers.forEach((handler, storeId) => {
+      if (storeId === patch.storeId) {
+        return;
+      }
+      handler.processMessage(message);
+    });
+  }
+
+  /**
+   * Trigger a replay of missing patches.
+   *
+   * Sends a message to the server that it should replay
+   * all messages since the last received patch that did
+   * not originate from this client. The messages will be
+   * replayed by normal 'patch-broadcast' messages.
+   */
+  protected replayMissingPatches() {
+    this.sendMessage(WsAdapterMessages.createReplayPatchedRequestMessage(
+      this.socket.clientId, this._lastPatchIdReceived));
+  }
+
+  /**
+   * Handler for statusChanged signal on socket.
+   *
+   * @param sender The originating WsConnection.
+   * @param status The new status of the socket.
+   */
+  protected onSocketStatusChanged(sender: WsConnection, status: WsConnection.Status): void {
+    switch (status) {
+    case 'connected':
+      // When reconnected after dead socket, refetch history:
+      this.replayMissingPatches();
+      break;
+    default:
+      break;
+    }
+    this._statusChanged.emit(status);
+  }
+
+  protected socket: WsConnection;
+
+  private _isDisposed = false;
+  private _delegates: Map<string, PromiseDelegate<WsAdapterMessages.IReplyMessage>>;
+  private _handlers: Map<number, IMessageHandler>;
+  private _statusChanged = new Signal<this, WsConnection.Status>(this);
+  private _lastPatchIdReceived: string;
+}
+
+
+/**
+ * The namespace for `WsAdapater` statics.
+ */
+export
+namespace WsAdapter {
+  /**
+   * The options object used to initialize a websocket adapter.
+   */
+  export
+  interface IOptions {
+    /**
+     * The server settings for the websocket connection.
+     */
+    serverSettings?: ServerConnection.ISettings;
+
+    /**
+     * The session ID to use for the websocket.
+     */
+    clientId?: string;
+  }
+}
+
+
+/**
+ * Message format for WsAdapter wire format.
+ */
+export
+namespace WsAdapterMessages {
+
+  /**
+   * Base message type.
+   */
+  export
+  type IBaseMessage = {
+    msgId: string;
+    msgType: (
+      'storeid-request' | 'storeid-reply' | 'patch-broadcast' |
+      'patch-history-request' | 'patch-history-reply' |
+      'fetch-patch-request' | 'fetch-patch-reply' |
+      'replay-patches-request'
+    );
+    clientId: string;
+    parentId: undefined;
+
+    readonly content: ReadonlyJSONObject;
+  };
+
+  /**
+   * Base type for reply messages.
+   */
+  export
+  type IReplyMessage = IBaseMessage & {
+    parentId: string;
+  };
+
+  /**
+   * A `'storeid-request'` message.
+   */
+  export
+  type IStoreIdMessageRequest = IBaseMessage & {
+    msgType: 'storeid-request';
+    content: {};
+  };
+
+  /**
+   * A `'storeid-request'` message.
+   */
+  export
+  type IStoreIdMessageReply = IReplyMessage & {
+    msgType: 'storeid-reply';
+    content: {
+      readonly storeId: number
+    };
+  };
+
+  /**
+   * A `'patch-broadcast'` message.
+   */
+  export
+  type IPatchBroadcastMessage = IBaseMessage & {
+    msgType: 'patch-broadcast';
+    content: {
+      readonly serial: Patch;
+      readonly patch: Patch;
+    };
+  };
+
+  /**
+   * A `'patch-history-request'` message.
+   */
+  export
+  type IPatchHistoryRequestMessage = IBaseMessage & {
+    msgType: 'patch-history-request';
+    content: {};
+  };
+
+  /**
+   * A `'patch-history-reply'` message.
+   */
+  export
+  type IPatchHistoryReply = IReplyMessage & {
+    msgType: 'patch-history-reply';
+    content: {
+      lastSerial: number;
+      patchHistory: PatchHistory
+    };
+  };
+
+  /**
+   * A `'fetch-patch-request'` message.
+   */
+  export
+  type IPatchFetchRequestMessage = IBaseMessage & {
+    msgType: 'fetch-patch-request';
+    content: {
+      readonly patchIds: ReadonlyArray<string>;
+    };
+  };
+
+  /**
+   * A `'fetch-patch-reply'` message.
+   */
+  export
+  type IPatchFetchReplyMessage = IReplyMessage & {
+    msgType: 'fetch-patch-reply';
+    content: {
+      readonly patches: Patch[];
+    };
+  };
+
+  /**
+   * A `'replay-patches-request'` message.
+   */
+  export
+  type IReplayPatchesMessage = IBaseMessage & {
+    msgType: 'replay-patches-request';
+    content: {
+      readonly lastPatchId: string;
+    };
+  };
+
+  /**
+   * A union type for all message types.
+   */
+  export
+  type IMessage = (
+    IStoreIdMessageRequest | IStoreIdMessageReply | IPatchBroadcastMessage |
+    IPatchHistoryRequestMessage | IPatchHistoryReply |
+    IPatchFetchRequestMessage | IPatchHistoryReply | IReplayPatchesMessage
+  );
+
+
+  /**
+   * Create a WSServerAdapter message.
+   *
+   * @param {string} msgType The message type.
+   * @param {ReadonlyJSONObject} content The content of the message.
+   * @param {string} parentId An optional id of the parent of this message.
+   * @returns {IPatchBroadcastMessage} The created message.
+   */
+  export
+  function createMessage(msgType: IMessage['msgType'],
+                         content: ReadonlyJSONObject,
+                         clientId: string,
+                         parentId?: string): IMessage {
+    const msgId = UUID.uuid4();
+    return {
+      msgId,
+      msgType,
+      parentId,
+      content,
+      clientId,
+    } as IMessage;
+  }
+
+  /**
+   * Create a `'storeid-request'` message.
+   *
+   * @returns {IStoreIdMessageRequest} The created message.
+   */
+  export
+  function createStoreIdRequestMessage(clientId: string): IStoreIdMessageRequest {
+    return createMessage('storeid-request', {}, clientId) as IStoreIdMessageRequest;
+  }
+
+  /**
+   * Create a `'patch-broadcast'` message.
+   *
+   * @param {Patch} patch The patch of the message.
+   * @returns {IPatchBroadcastMessage} The created message.
+   */
+  export
+  function createPatchBroadcastMessage(clientId: string, patch: Patch): IPatchBroadcastMessage {
+    return createMessage('patch-broadcast', { patch }, clientId) as IPatchBroadcastMessage;
+  }
+
+  /**
+   * Create a `'patch-history-request'` message.
+   *
+   * @returns {IPatchHistoryRequestMessage} The created message.
+   */
+  export
+  function createPatchHistoryRequestMessage(clientId: string): IPatchHistoryRequestMessage {
+    return createMessage('patch-history-request', {}, clientId) as IPatchHistoryRequestMessage;
+  }
+
+  /**
+   * Create a `'fetch-patch-request'` message.
+   *
+   * @param {ReadonlyArray<string>} patchIds The patch ids of the message.
+   * @returns {IPatchFetchRequestMessage} The created message.
+   */
+  export
+  function createPatchFetchRequestMessage(clientId: string, patchIds: ReadonlyArray<string>): IPatchFetchRequestMessage {
+    return createMessage('fetch-patch-request', { patchIds }, clientId) as IPatchFetchRequestMessage;
+  }
+
+  /**
+   * Create a `'replay-patch-request'` message.
+   *
+   * @param {ReadonlyArray<string>} patchIds The patch ids of the message.
+   * @returns {IPatchFetchRequestMessage} The created message.
+   */
+  export
+  function createReplayPatchedRequestMessage(clientId: string, lastPatchId: string): IPatchFetchRequestMessage {
+    return createMessage('replay-patches-request', { lastPatchId }, clientId) as IPatchFetchRequestMessage;
+  }
+
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -11,5 +11,6 @@ export * from './session';
 export * from './setting';
 export * from './terminal';
 export * from './workspace';
+export * from './wsconnection';
 
 export { Builder } from './builder';

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+export * from './collab';
 export * from './config';
 export * from './contents';
 export * from './kernel';

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -51,7 +51,7 @@ export class DefaultKernel implements Kernel.IKernel {
    * Construct a kernel object.
    */
   constructor(options: Kernel.IOptions, id: string) {
-    this._name = options.name;
+    this._name = options.name || this._name;
     this._id = id;
     this.serverSettings =
       options.serverSettings || ServerConnection.makeSettings();

--- a/packages/services/src/wsconnection.ts
+++ b/packages/services/src/wsconnection.ts
@@ -1,0 +1,393 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  URLExt, uuid
+} from '@jupyterlab/coreutils';
+
+import {
+  PromiseDelegate, ReadonlyJSONObject
+} from '@phosphor/coreutils';
+
+import {
+  IDisposable
+} from '@phosphor/disposable';
+
+import {
+  ISignal, Signal
+} from '@phosphor/signaling';
+
+import {
+  ServerConnection
+} from './serverconnection';
+
+
+/**
+ * A WebSocket connection object
+ */
+export
+class WsConnection implements IDisposable {
+  /**
+   * Construct a WebSocket connection object.
+   */
+  constructor(options: WsConnection.IOptions) {
+    this.serverSettings = options.serverSettings || ServerConnection.makeSettings();
+    this._clientId = options.clientId || uuid();
+    this._apiUrl = options.apiUrl || this._apiUrl;
+    this._createSocket();
+  }
+
+  /**
+   * A signal emitted when the kernel is shut down.
+   */
+  get terminated(): ISignal<this, void> {
+    return this._terminated;
+  }
+
+  /**
+   * The server settings for the kernel.
+   */
+  readonly serverSettings: ServerConnection.ISettings;
+
+  /**
+   * A signal emitted when the connection status changes.
+   */
+  get statusChanged(): ISignal<this, WsConnection.Status> {
+    return this._statusChanged;
+  }
+
+  /**
+   * The current status of the kernel.
+   */
+  get status(): WsConnection.Status {
+    return this._status;
+  }
+
+  /**
+   * The client unique id.
+   */
+  get clientId(): string {
+    return this._clientId;
+  }
+
+  /**
+   * Test whether the kernel has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Test whether the kernel is ready.
+   */
+  get isReady(): boolean {
+    return this._isReady;
+  }
+
+  /**
+   * A promise that is fulfilled when the kernel is ready.
+   */
+  get ready(): Promise<void> {
+    return this._connectionPromise.promise;
+  }
+
+  /**
+   * A signal emitted when a message is received.
+   */
+  get message(): ISignal<this, ReadonlyJSONObject> {
+    return this._message;
+  }
+
+  /**
+   * Dispose of the resources held by the kernel.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    this._terminated.emit(void 0);
+    this._status = 'dead';
+    this._clearState();
+    this._clearSocket();
+    Signal.clearData(this);
+  }
+
+  /**
+   * Serialize a message.
+   *
+   * @param {ReadonlyJSONObject} msg The message to serialize.
+   * @returns {string} The serialized message.
+   */
+  protected serialize(msg: ReadonlyJSONObject): string {
+    return JSON.stringify(msg);
+  }
+
+  /**
+   * Deserialize a message.
+   *
+   * @param {string} data The serialized message.
+   * @returns {ReadonlyJSONObject} The deserialzied message.
+   */
+  protected deserialize(data: string | ArrayBuffer): ReadonlyJSONObject {
+    if (typeof data === 'string') {
+      return JSON.parse(data);
+    } else {
+      throw new Error('Cannot deserialize binary websocket.');
+    }
+  }
+
+  /**
+   * Send a shell message over the websocket.
+   *
+   * If the socket status is `dead`, this will throw an error.
+   */
+  sendWSMessage(msg: ReadonlyJSONObject): void {
+    if (this.status === 'dead') {
+      throw new Error('Connection is dead');
+    }
+    if (!this._isReady || !this._ws) {
+      this._pendingMessages.push(msg);
+    } else {
+      this._ws.send(this.serialize(msg));
+    }
+  }
+
+  /**
+   * Reconnect to a disconnected kernel.
+   *
+   * #### Notes
+   * Used when the websocket connection to the kernel is lost.
+   */
+  reconnect(): Promise<void> {
+    this._clearSocket();
+    this._updateStatus('reconnecting');
+    this._createSocket();
+    return this._connectionPromise.promise;
+  }
+
+  /**
+   * Shutdown a kernel.
+   *
+   * #### Notes
+   * Uses the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernels).
+   *
+   * The promise is fulfilled on a valid response and rejected otherwise.
+   *
+   * On a valid response, closes the websocket and disposes of the kernel
+   * object, and fulfills the promise.
+   *
+   * The promise will be rejected if the socket status is `dead`.
+   */
+  close(): void {
+    if (this.status === 'dead') {
+      throw new Error('Connection is dead');
+    }
+    this._clearState();
+    this._clearSocket();
+  }
+
+
+  /**
+   * Clear the socket state.
+   */
+  private _clearSocket(): void {
+    this._wsStopped = true;
+    this._isReady = false;
+    if (this._ws !== null) {
+      // Clear the websocket event handlers and the socket itself.
+      this._ws.onopen = this._noOp;
+      this._ws.onclose = this._noOp;
+      this._ws.onerror = this._noOp;
+      this._ws.onmessage = this._noOp;
+      this._ws.close();
+      this._ws = null;
+    }
+  }
+
+  /**
+   * Handle status iopub messages from the kernel.
+   */
+  private _updateStatus(status: WsConnection.Status): void {
+    switch (status) {
+    case 'connected':
+      this._isReady = true;
+      break;
+    case 'reconnecting':
+    case 'dead':
+      this._isReady = false;
+      break;
+    default:
+      console.error('invalid kernel status:', status);
+      return;
+    }
+    if (status !== this._status) {
+      this._status = status;
+      this._statusChanged.emit(status);
+      if (status === 'dead') {
+        this.dispose();
+      }
+    }
+    if (this._isReady) {
+      this._sendPending();
+    }
+  }
+
+  /**
+   * Send pending messages to the kernel.
+   */
+  private _sendPending(): void {
+    // We shift the message off the queue
+    // after the message is sent so that if there is an exception,
+    // the message is still pending.
+    while (this._ws && this._pendingMessages.length > 0) {
+      let msg = this.serialize(this._pendingMessages[0]);
+      this._ws.send(msg);
+      this._pendingMessages.shift();
+    }
+  }
+
+  /**
+   * Clear the internal state.
+   */
+  private _clearState(): void {
+    this._isReady = false;
+    this._pendingMessages = [];
+    this._delegates.forEach((delegate) => {
+      delegate.reject('Disposing of adaptor');
+    });
+    this._delegates = new Map<string, PromiseDelegate<ReadonlyJSONObject>>();
+  }
+
+  /**
+   * Create the kernel websocket connection and add socket status handlers.
+   */
+  private _createSocket = () => {
+    let settings = this.serverSettings;
+    let partialUrl = URLExt.join(settings.wsUrl, this._apiUrl);
+
+    // Strip any authentication from the display string.
+    let display = partialUrl.replace(/^((?:\w+:)?\/\/)(?:[^@\/]+@)/, '$1');
+    console.log('Starting WebSocket:', display);
+
+    let url = URLExt.join(
+      partialUrl,
+      '?session_id=' + encodeURIComponent(this._clientId)
+  );
+
+    // If token authentication is in use.
+    let token = settings.token;
+    if (token !== '') {
+      url = url + `&token=${encodeURIComponent(token)}`;
+    }
+
+    this._connectionPromise = new PromiseDelegate<void>();
+    this._wsStopped = false;
+    this._ws = new settings.WebSocket(url);
+
+    // Ensure incoming binary messages are not Blobs
+    this._ws.binaryType = 'arraybuffer';
+
+    this._ws.onmessage = this._onWSMessage;
+    this._ws.onopen = this._onWSOpen;
+    this._ws.onclose = this._onWSClose;
+    this._ws.onerror = this._onWSClose;
+  }
+
+  /**
+   * Handle a websocket open event.
+   */
+  private _onWSOpen = (evt: Event) => {
+    this._reconnectAttempt = 0;
+    // Allow the message to get through.
+    this._isReady = true;
+    // Update our status to connected.
+    this._updateStatus('connected');
+    // Signaling that the socket is ready.
+    this._connectionPromise.resolve(void 0);
+  }
+
+  /**
+   * Handle a websocket message, validating and routing appropriately.
+   */
+  private _onWSMessage = (evt: MessageEvent) => {
+    if (this._wsStopped) {
+      // If the socket is being closed, ignore any messages
+      return;
+    }
+    this._message.emit(this.deserialize(evt.data));
+  }
+
+  /**
+   * Handle a websocket close event.
+   */
+  private _onWSClose = (evt: Event) => {
+    if (this._wsStopped || !this._ws) {
+      return;
+    }
+    // Clear the websocket event handlers and the socket itself.
+    this._ws.onclose = this._noOp;
+    this._ws.onerror = this._noOp;
+    this._ws = null;
+
+    if (this._reconnectAttempt < this._reconnectLimit) {
+      this._updateStatus('reconnecting');
+      let timeout = Math.pow(2, this._reconnectAttempt);
+      console.error('Connection lost, reconnecting in ' + timeout + ' seconds.');
+      setTimeout(this._createSocket, 1e3 * timeout);
+      this._reconnectAttempt += 1;
+    } else {
+      this._updateStatus('dead');
+      this._connectionPromise.reject(new Error('Could not establish connection'));
+    }
+  }
+
+  private _status: WsConnection.Status = 'unknown';
+  private _apiUrl = '';
+  private _clientId = '';
+  private _isDisposed = false;
+  private _wsStopped = false;
+  private _ws: WebSocket | null = null;
+  private _reconnectLimit = 7;
+  private _reconnectAttempt = 0;
+  private _isReady = false;
+  private _delegates: Map<string, PromiseDelegate<ReadonlyJSONObject>>;
+  private _pendingMessages: ReadonlyJSONObject[] = [];
+  private _connectionPromise: PromiseDelegate<void>;
+  private _statusChanged = new Signal<this, WsConnection.Status>(this);
+  private _message = new Signal<this, ReadonlyJSONObject>(this);
+  private _terminated = new Signal<this, void>(this);
+  private _noOp = () => { /* no-op */};
+}
+
+
+/**
+ * The namespace for `WsConnection` statics.
+ */
+export
+namespace WsConnection {
+
+  /**
+   * The options object used to initialize a websocket connection.
+   */
+  export
+  interface IOptions {
+    /**
+     * The server settings for the websocket.
+     */
+    serverSettings?: ServerConnection.ISettings;
+
+    /**
+     * The session ID to use for the websocket.
+     */
+    clientId?: string;
+
+    /**
+     * The URL relative to settings.wsUrl to connect to.
+     */
+    apiUrl?: string;
+  }
+
+  export
+  type Status = 'dead' | 'unknown' | 'connected' | 'reconnecting';
+}


### PR DESCRIPTION
Adds two datastore adapters (WIP on phosphor repo):
- `LocalServerAdapter`, a local "loopback" adapter. Can be useful e.g. for testing.
- `WsAdapter`, a websocket based adapter. The WS code for this is compartmentalized in the separate `WsConnection` module.

The wire format for the `WsAdapter` messages is typed up in the `WsAdapterMessages` namespace.