### PR TITLE
Improve anchor tags

### DIFF
--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -138,7 +138,8 @@ export function createRendermimePlugin(
           name: option.name,
           primaryFileType: registry.getFileType(option.primaryFileType),
           fileTypes: option.fileTypes,
-          defaultFor: option.defaultFor
+          defaultFor: option.defaultFor,
+          defaultRendered: option.defaultRendered
         });
         registry.addWidgetFactory(factory);
 

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -282,6 +282,7 @@ export abstract class ABCWidgetFactory<
     this._name = options.name;
     this._readOnly = options.readOnly === undefined ? false : options.readOnly;
     this._defaultFor = options.defaultFor ? options.defaultFor.slice() : [];
+    this._defaultRendered = (options.defaultRendered || []).slice();
     this._fileTypes = options.fileTypes.slice();
     this._modelName = options.modelName || 'text';
     this._preferKernel = !!options.preferKernel;
@@ -345,6 +346,14 @@ export abstract class ABCWidgetFactory<
   }
 
   /**
+   * The file types for which the factory should be the default for
+   * rendering a document model, if different from editing.
+   */
+  get defaultRendered(): string[] {
+    return this._defaultRendered.slice();
+  }
+
+  /**
    * Whether the widgets prefer having a kernel started.
    */
   get preferKernel(): boolean {
@@ -383,6 +392,7 @@ export abstract class ABCWidgetFactory<
   private _modelName: string;
   private _fileTypes: string[];
   private _defaultFor: string[];
+  private _defaultRendered: string[];
   private _widgetCreated = new Signal<DocumentRegistry.IWidgetFactory<T, U>, T>(
     this
   );

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -297,6 +297,7 @@ export class DocumentRegistry implements IDisposable {
    * The first item is considered the default. The returned array
    * has widget factories in the following order:
    * - path-specific default factory
+   * - path-specific default rendered factory
    * - global default factory
    * - all other path-specific factories
    * - all other global factories
@@ -311,6 +312,13 @@ export class DocumentRegistry implements IDisposable {
     fts.forEach(ft => {
       if (ft.name in this._defaultWidgetFactories) {
         factories.add(this._defaultWidgetFactories[ft.name]);
+      }
+    });
+
+    // Add the file type default rendered factories.
+    fts.forEach(ft => {
+      if (ft.name in this._defaultRenderedWidgetFactories) {
+        factories.add(this._defaultRenderedWidgetFactories[ft.name]);
       }
     });
 

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -117,7 +117,11 @@ function activate(
   const namespace = 'editor';
   const factory = new FileEditorFactory({
     editorServices,
-    factoryOptions: { name: FACTORY, fileTypes: ['*'], defaultFor: ['*'] }
+    factoryOptions: {
+      name: FACTORY,
+      fileTypes: ['markdown', '*'], // Explicitly add the markdown fileType so
+      defaultFor: ['markdown', '*'] // it outranks the defaultRendered viewer.
+    }
   });
   const { commands, restored } = app;
   const tracker = new InstanceTracker<IDocumentWidget<FileEditor>>({

--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -20,7 +20,8 @@ const extension: IRenderMime.IExtension = {
   documentWidgetFactoryOptions: {
     name: FACTORY,
     primaryFileType: 'markdown',
-    fileTypes: ['markdown']
+    fileTypes: ['markdown'],
+    defaultRendered: ['markdown']
   }
 };
 

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.17.0-1",
+    "@jupyterlab/docmanager": "^0.17.0-1",
     "@jupyterlab/rendermime": "^0.17.0-1"
   },
   "devDependencies": {

--- a/packages/rendermime-extension/src/index.ts
+++ b/packages/rendermime-extension/src/index.ts
@@ -5,6 +5,8 @@
 
 import { JupyterLab, JupyterLabPlugin } from '@jupyterlab/application';
 
+import { IDocumentManager } from '@jupyterlab/docmanager';
+
 import {
   ILatexTypesetter,
   IRenderMimeRegistry,
@@ -12,11 +14,16 @@ import {
   standardRendererFactories
 } from '@jupyterlab/rendermime';
 
+namespace CommandIDs {
+  export const handleLink = 'rendermime:handle-local-link';
+}
+
 /**
  * A plugin providing a rendermime registry.
  */
 const plugin: JupyterLabPlugin<RenderMimeRegistry> = {
   id: '@jupyterlab/rendermime-extension:plugin',
+  requires: [IDocumentManager],
   optional: [ILatexTypesetter],
   provides: IRenderMimeRegistry,
   activate: activate,
@@ -31,12 +38,58 @@ export default plugin;
 /**
  * Activate the rendermine plugin.
  */
-function activate(app: JupyterLab, latexTypesetter: ILatexTypesetter) {
+function activate(
+  app: JupyterLab,
+  docManager: IDocumentManager,
+  latexTypesetter: ILatexTypesetter | null
+) {
+  app.commands.addCommand(CommandIDs.handleLink, {
+    label: 'Handle Local Link',
+    execute: args => {
+      const path = args['path'] as string | undefined | null;
+      const id = args['id'] as string | undefined | null;
+      if (!path) {
+        return;
+      }
+      // First check if the path exists on the server.
+      return docManager.services.contents
+        .get(path, { content: false })
+        .then(() => {
+          // Open the link with the default rendered widget factory,
+          // if applicable.
+          const factory = docManager.registry.defaultRenderedWidgetFactory(
+            path
+          );
+          const widget = docManager.openOrReveal(path, factory.name);
+          if (!widget) {
+            return;
+          }
+          return widget.revealed.then(() => {
+            // Once the widget is ready, attempt to scroll the hash into view
+            // if one has been provided.
+            if (!id) {
+              return;
+            }
+            // Look for the an element with the hash id in the document.
+            // This id is set automatically for headers tags when
+            // we render markdown.
+            const element = widget.node.querySelector(id);
+            if (element) {
+              element.scrollIntoView();
+            }
+            return;
+          });
+        });
+    }
+  });
   return new RenderMimeRegistry({
     initialFactories: standardRendererFactories,
     linkHandler: {
-      handleLink: (node, path) => {
-        app.commandLinker.connectNode(node, 'docmanager:open', { path: path });
+      handleLink: (node: HTMLElement, path: string, id?: string) => {
+        app.commandLinker.connectNode(node, CommandIDs.handleLink, {
+          path,
+          id
+        });
       }
     },
     latexTypesetter

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -303,8 +303,14 @@ export namespace IRenderMime {
   export interface ILinkHandler {
     /**
      * Add the link handler to the node.
+     *
+     * @param node: the node for which to handle the link.
+     *
+     * @param path: the path to open when the link is clicked.
+     *
+     * @param id: an optional element id to scroll to when the path is opened.
      */
-    handleLink(node: HTMLElement, url: string): void;
+    handleLink(node: HTMLElement, path: string, id?: string): void;
   }
 
   /**

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -91,6 +91,13 @@ export namespace IRenderMime {
      * The file types for which the factory should be the default.
      */
     readonly defaultFor?: ReadonlyArray<string>;
+
+    /**
+     * The file types for which the factory should be the default for rendering,
+     * if that is different than the default factory (which may be for editing)
+     * If undefined, then it will fall back on the default file type.
+     */
+    readonly defaultRendered?: ReadonlyArray<string>;
   }
 
   /**

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -767,7 +767,7 @@ namespace Private {
       .then(path => {
         // Handle the click override.
         if (linkHandler) {
-          linkHandler.handleLink(anchor, path);
+          linkHandler.handleLink(anchor, path, hash);
         }
         // Get the appropriate file download path.
         return resolver.getDownloadUrl(path);

--- a/tests/test-docregistry/src/default.spec.ts
+++ b/tests/test-docregistry/src/default.spec.ts
@@ -81,6 +81,25 @@ describe('docregistry/default', () => {
       });
     });
 
+    describe('#defaultRendered', () => {
+      it('should default to an empty array', () => {
+        let factory = new WidgetFactory({
+          name: 'test',
+          fileTypes: ['text']
+        });
+        expect(factory.defaultRendered).to.eql([]);
+      });
+
+      it('should be the value passed in', () => {
+        let factory = new WidgetFactory({
+          name: 'test',
+          fileTypes: ['text'],
+          defaultRendered: ['text']
+        });
+        expect(factory.defaultRendered).to.eql(['text']);
+      });
+    });
+
     describe('#readOnly', () => {
       it('should default to false', () => {
         let factory = new WidgetFactory({

--- a/tests/test-docregistry/src/registry.spec.ts
+++ b/tests/test-docregistry/src/registry.spec.ts
@@ -275,6 +275,26 @@ describe('docregistry/registry', () => {
         expect(toArray(factories)).to.eql([factory, gFactory]);
       });
 
+      it('should list a default rendered factory after the default factory', () => {
+        let factory = createFactory();
+        registry.addWidgetFactory(factory);
+        let gFactory = new WidgetFactory({
+          name: 'global',
+          fileTypes: ['*'],
+          defaultFor: ['*']
+        });
+        registry.addWidgetFactory(gFactory);
+        let mdFactory = new WidgetFactory({
+          name: 'markdown',
+          fileTypes: ['markdown'],
+          defaultRendered: ['markdown']
+        });
+        registry.addWidgetFactory(mdFactory);
+
+        let factories = registry.preferredWidgetFactories('a.md');
+        expect(factories).to.eql([mdFactory, gFactory]);
+      });
+
       it('should handle multi-part extensions', () => {
         let factory = createFactory();
         registry.addWidgetFactory(factory);

--- a/tests/test-docregistry/src/registry.spec.ts
+++ b/tests/test-docregistry/src/registry.spec.ts
@@ -40,8 +40,9 @@ function createFactory(modelName?: string) {
   return new WidgetFactory({
     name: UUID.uuid4(),
     modelName: modelName || 'text',
-    fileTypes: ['text', 'foobar'],
-    defaultFor: ['text', 'foobar']
+    fileTypes: ['text', 'foobar', 'baz'],
+    defaultFor: ['text', 'foobar'],
+    defaultRendered: ['baz']
   });
 }
 
@@ -54,6 +55,10 @@ describe('docregistry/registry', () => {
       registry.addFileType({
         name: 'foobar',
         extensions: ['.foo.bar']
+      });
+      registry.addFileType({
+        name: 'baz',
+        extensions: ['.baz']
       });
     });
 
@@ -321,6 +326,31 @@ describe('docregistry/registry', () => {
         expect(registry.defaultWidgetFactory('a.foo.bar')).to.be(factory);
         expect(registry.defaultWidgetFactory('a.md')).to.be(mdFactory);
         expect(registry.defaultWidgetFactory()).to.be(gFactory);
+      });
+    });
+
+    describe('#defaultRenderedWidgetFactory()', () => {
+      it('should get the default rendered widget factory for a given extension', () => {
+        let factory = createFactory();
+        registry.addWidgetFactory(factory);
+        let mdFactory = new WidgetFactory({
+          name: 'markdown',
+          fileTypes: ['markdown'],
+          defaultRendered: ['markdown']
+        });
+        registry.addWidgetFactory(mdFactory);
+        expect(registry.defaultRenderedWidgetFactory('a.baz')).to.be(factory);
+        expect(registry.defaultRenderedWidgetFactory('a.md')).to.be(mdFactory);
+      });
+
+      it('should get the default widget factory if no default rendered factory is registered', () => {
+        let gFactory = new WidgetFactory({
+          name: 'global',
+          fileTypes: ['*'],
+          defaultFor: ['*']
+        });
+        registry.addWidgetFactory(gFactory);
+        expect(registry.defaultRenderedWidgetFactory('a.md')).to.be(gFactory);
       });
     });
 


### PR DESCRIPTION
Supersedes #1945.

This fixes a longstanding issue with relative links between documents that involve a header anchor tag. Does the following:
1. Our rendered markdown automatically generates header ids for markdown headers.
2. The link handler for the `rendermime-extension` now opens the relative document, and *then* calls a `node.querySelector` to search for an element with the corresponding id. If it finds that element, we scroll it into view.
3. Introduces a concept of `defaultRendered` for document widget factories, distinct from the default file type for that factory. This way we can have a file type (such as markdown), that opens with the text editor by default, but can also be opened with a `defaultRendered` factory. By default the `linkHandler` opens files with the `defaultRendered`.