### PR TITLE
Add default types for the test packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__
 .idea/
 
 tests/**/coverage
+tests/**/.cache-loader
 docs/_build
 docs/api
 packages/services/examples/node/config.json

--- a/tests/package.json
+++ b/tests/package.json
@@ -42,10 +42,11 @@
     "simulate-event": "~1.4.0"
   },
   "devDependencies": {
-    "awesome-typescript-loader": "~3.4.1",
+    "cache-loader": "^1.2.2",
     "css-loader": "~0.28.7",
     "es6-promise": "~4.1.1",
     "file-loader": "~0.10.1",
+    "fork-ts-checker-webpack-plugin": "^0.4.2",
     "fs-extra": "~4.0.2",
     "istanbul-instrumenter-loader": "~3.0.0",
     "json-loader": "~0.5.7",
@@ -63,6 +64,8 @@
     "raw-loader": "~0.5.1",
     "rimraf": "~2.6.2",
     "style-loader": "~0.13.2",
+    "thread-loader": "^1.1.5",
+    "ts-loader": "^3.5.0",
     "typescript": "~2.9.1",
     "url-loader": "~0.5.9",
     "webpack": "~2.7.0"

--- a/tests/test-application/tsconfig.json
+++ b/tests/test-application/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
   },

--- a/tests/test-apputils/tsconfig.json
+++ b/tests/test-apputils/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "jsx": "react",
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-apputils/tsconfig.json
+++ b/tests/test-apputils/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "jsx": "react",
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-cells/tsconfig.json
+++ b/tests/test-cells/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
   },

--- a/tests/test-codeeditor/tsconfig.json
+++ b/tests/test-codeeditor/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-codeeditor/tsconfig.json
+++ b/tests/test-codeeditor/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-codemirror/tsconfig.json
+++ b/tests/test-codemirror/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-codemirror/tsconfig.json
+++ b/tests/test-codemirror/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-completer/tsconfig.json
+++ b/tests/test-completer/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-completer/tsconfig.json
+++ b/tests/test-completer/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-console/tsconfig.json
+++ b/tests/test-console/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-console/tsconfig.json
+++ b/tests/test-console/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-coreutils/tsconfig.json
+++ b/tests/test-coreutils/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-coreutils/tsconfig.json
+++ b/tests/test-coreutils/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-csvviewer/tsconfig.json
+++ b/tests/test-csvviewer/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-csvviewer/tsconfig.json
+++ b/tests/test-csvviewer/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-docmanager/tsconfig.json
+++ b/tests/test-docmanager/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-docmanager/tsconfig.json
+++ b/tests/test-docmanager/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-docregistry/tsconfig.json
+++ b/tests/test-docregistry/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-docregistry/tsconfig.json
+++ b/tests/test-docregistry/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-filebrowser/tsconfig.json
+++ b/tests/test-filebrowser/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-filebrowser/tsconfig.json
+++ b/tests/test-filebrowser/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-fileeditor/src/widget.spec.ts
+++ b/tests/test-fileeditor/src/widget.spec.ts
@@ -68,7 +68,7 @@ describe('fileeditorcodewrapper', () => {
   let factoryService = new CodeMirrorEditorFactory();
   let modelFactory = new TextModelFactory();
   let mimeTypeService = new CodeMirrorMimeTypeService();
-  let context: DocumentRegistry.CodeContext;
+  let context: Context<DocumentRegistry.ICodeModel>;
   let manager: ServiceManager.IManager;
 
   before((done) => {

--- a/tests/test-fileeditor/tsconfig.json
+++ b/tests/test-fileeditor/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-fileeditor/tsconfig.json
+++ b/tests/test-fileeditor/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-imageviewer/src/widget.spec.ts
+++ b/tests/test-imageviewer/src/widget.spec.ts
@@ -72,7 +72,7 @@ const OTHER = ('iVBORw0KGgoAAAANSUhEUgAAAAUA' +
 describe('ImageViewer', () => {
 
   let factory = new Base64ModelFactory();
-  let context: DocumentRegistry.Context;
+  let context: Context<DocumentRegistry.IModel>;
   let manager: ServiceManager.IManager;
   let widget: LogImage;
 

--- a/tests/test-imageviewer/tsconfig.json
+++ b/tests/test-imageviewer/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-imageviewer/tsconfig.json
+++ b/tests/test-imageviewer/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-inspector/tsconfig.json
+++ b/tests/test-inspector/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-inspector/tsconfig.json
+++ b/tests/test-inspector/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-mainmenu/src/util.ts
+++ b/tests/test-mainmenu/src/util.ts
@@ -30,11 +30,15 @@ function findExtender<E extends IMenuExtender<Widget>>(widget: Widget, s: Set<E>
  */
 export
 function delegateExecute<E extends IMenuExtender<Widget>>(widget: Widget, s: Set<E>, executor: keyof E): Promise<any> {
-  const extender = findExtender(widget, s);
-  if (!extender) {
-    return Promise.resolve(void 0);
-  }
-  return extender[executor](widget);
+    const extender = findExtender(widget, s);
+    if (!extender) {
+      return Promise.resolve(void 0);
+    }
+    // Coerce the result to be a function. When Typedoc is updated to use
+    // Typescript 2.8, we can possibly use conditional types to get Typescript
+    // to recognize this is a function.
+    let f = extender[executor] as any as (w: Widget) => Promise<any>;
+    return f(widget);
 }
 
 /**
@@ -44,5 +48,12 @@ function delegateExecute<E extends IMenuExtender<Widget>>(widget: Widget, s: Set
 export
 function delegateToggled<E extends IMenuExtender<Widget>>(widget: Widget, s: Set<E>, toggled: keyof E): boolean {
   const extender = findExtender(widget, s);
-  return !!extender && !!extender[toggled] && !!extender[toggled](widget);
+  if (extender && extender[toggled]) {
+    // Coerce the result to be a function. When Typedoc is updated to use
+    // Typescript 2.8, we can possibly use conditional types to get Typescript
+    // to recognize this is a function.
+    let f = extender[toggled] as any as (w: Widget) => boolean;
+    return f(widget);
+  }
+  return false;
 }

--- a/tests/test-mainmenu/tsconfig.json
+++ b/tests/test-mainmenu/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-mainmenu/tsconfig.json
+++ b/tests/test-mainmenu/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-notebook/src/panel.spec.ts
+++ b/tests/test-notebook/src/panel.spec.ts
@@ -20,7 +20,7 @@ import {
 } from '../../utils';
 
 import {
-  DEFAULT_CONTENT, createNotebookPanelFactory, rendermime,
+  createNotebookPanelFactory, rendermime,
   mimeTypeService, editorFactory, createNotebookPanel, createNotebook
 } from '../../notebook-utils';
 

--- a/tests/test-notebook/tsconfig.json
+++ b/tests/test-notebook/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
   },

--- a/tests/test-observables/tsconfig.json
+++ b/tests/test-observables/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-observables/tsconfig.json
+++ b/tests/test-observables/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-outputarea/tsconfig.json
+++ b/tests/test-outputarea/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-outputarea/tsconfig.json
+++ b/tests/test-outputarea/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-rendermime/src/registry.spec.ts
+++ b/tests/test-rendermime/src/registry.spec.ts
@@ -266,7 +266,7 @@ describe('rendermime/registry', () => {
       it('should remove a factory by mimeType', () => {
         r.removeMimeType('text/html');
         let model = createModel({ 'text/html': '<h1>foo</h1>' });
-        expect(r.preferredMimeType(model.data, true)).to.be(void 0);
+        expect(r.preferredMimeType(model.data, 'any')).to.be(void 0);
       });
 
       it('should be a no-op if the mimeType is not registered', () => {

--- a/tests/test-rendermime/tsconfig.json
+++ b/tests/test-rendermime/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-rendermime/tsconfig.json
+++ b/tests/test-rendermime/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/test-terminal/tsconfig.json
+++ b/tests/test-terminal/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "extends": "../../tsconfigbase",
+  "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
+
   },
   "include": ["src/*"]
 }

--- a/tests/test-terminal/tsconfig.json
+++ b/tests/test-terminal/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfigtestbase",
   "compilerOptions": {
     "outDir": "./build"
-
   },
   "include": ["src/*"]
 }

--- a/tests/tsconfigtestbase.json
+++ b/tests/tsconfigtestbase.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfigbase",
+  "compilerOptions": {
+    "types": ["mocha", "node"]
+  }
+}

--- a/tests/webpack.config.js
+++ b/tests/webpack.config.js
@@ -26,19 +26,9 @@ module.exports = {
   module: {
     rules: [
       { test: /\.tsx?$/, use: [
-        {loader: 'cache-loader'},
-        {
-          loader: 'thread-loader',
-          options: {
-              workers: threadCpus,
-          },
-      },
-      {
-          loader: 'ts-loader',
-          options: {
-              happyPackMode: true
-          }
-      }
+        { loader: 'cache-loader' },
+        { loader: 'thread-loader', options: {workers: threadCpus} },
+        { loader: 'ts-loader', options: {happyPackMode: true} },
       ]},
       { test: /\.js$/,
         use: ['source-map-loader'],

--- a/tests/webpack.config.js
+++ b/tests/webpack.config.js
@@ -1,9 +1,9 @@
 var path = require('path');
-// `CheckerPlugin` is optional. Use it if you want async error reporting.
-// We need this plugin to detect a `--watch` mode. It may be removed later
-// after https://github.com/webpack/webpack/issues/3460 will be resolved.
-var CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin;
+var ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
+var cpus = require('os').cpus().length;
+var forkCheckerCpus = cpus > 2 ? 2 : 1;
+var threadCpus = cpus - forkCheckerCpus;
 
 // Use sourcemaps if in watch or debug mode;
 var devtool = 'eval';
@@ -13,30 +13,33 @@ if (process.argv.indexOf('--watch') !== -1) {
 
 module.exports = {
   resolve: {
-    extensions: ['.ts', '.js']
+    extensions: ['.ts', '.tsx', '.js']
   },
   bail: true,
   devtool: devtool,
   plugins: [
-    new CheckerPlugin(),
+    new ForkTsCheckerWebpackPlugin({
+      workers: forkCheckerCpus,
+      checkSyntacticErrors: true
+    })
   ],
   module: {
     rules: [
-      {
-        test: /\.ts$/,
-        use: [
-          {
-            loader: 'awesome-typescript-loader',
-            query: {
-              sourceMap: false,
-              inlineSourceMap: true,
-              compilerOptions: {
-                removeComments: true
-              }
-            }
-          }
-        ]
+      { test: /\.tsx?$/, use: [
+        {loader: 'cache-loader'},
+        {
+          loader: 'thread-loader',
+          options: {
+              workers: threadCpus,
+          },
       },
+      {
+          loader: 'ts-loader',
+          options: {
+              happyPackMode: true
+          }
+      }
+      ]},
       { test: /\.js$/,
         use: ['source-map-loader'],
         enforce: 'pre',

--- a/yarn.lock
+++ b/yarn.lock
@@ -701,6 +701,12 @@ async@^2.0.0, async@^2.1.2, async@^2.1.4, async@^2.5.0:
   dependencies:
     lodash "^4.14.0"
 
+async@^2.3.0:
+  version "2.6.1"
+  resolved "https://registry.npmjs.org/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+  dependencies:
+    lodash "^4.17.10"
+
 async@~2.1.2:
   version "2.1.5"
   resolved "https://registry.npmjs.org/async/-/async-2.1.5.tgz#e587c68580994ac67fc56ff86d3ac56bdbe810bc"
@@ -725,19 +731,6 @@ autoprefixer@^6.3.1:
     num2fraction "^1.2.2"
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
-
-awesome-typescript-loader@~3.4.1:
-  version "3.4.1"
-  resolved "https://registry.npmjs.org/awesome-typescript-loader/-/awesome-typescript-loader-3.4.1.tgz#22fa49800f0619ec18ab15383aef93b95378dea9"
-  dependencies:
-    colors "^1.1.2"
-    enhanced-resolve "3.3.0"
-    loader-utils "^1.1.0"
-    lodash "^4.17.4"
-    micromatch "^3.0.3"
-    mkdirp "^0.5.1"
-    object-assign "^4.1.1"
-    source-map-support "^0.4.15"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -1216,6 +1209,15 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cache-loader@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/cache-loader/-/cache-loader-1.2.2.tgz#6d5c38ded959a09cc5d58190ab5af6f73bd353f5"
+  dependencies:
+    loader-utils "^1.1.0"
+    mkdirp "^0.5.1"
+    neo-async "^2.5.0"
+    schema-utils "^0.4.2"
+
 cached-path-relative@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz#d09c4b52800aa4c078e2dd81a869aac90d2e54e7"
@@ -1355,7 +1357,7 @@ child_process@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz#b1f7e7fc73d25e7fd1d455adc94e143830182b5a"
 
-chokidar@^1.4.1:
+chokidar@^1.4.1, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1544,7 +1546,7 @@ colormin@^1.0.5:
     css-color-names "0.0.4"
     has "^1.0.1"
 
-colors@^1.1.0, colors@^1.1.2, colors@~1.1.2:
+colors@^1.1.0, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -2704,16 +2706,7 @@ engine.io@~3.1.0:
   optionalDependencies:
     uws "~9.14.0"
 
-enhanced-resolve@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz#950964ecc7f0332a42321b673b38dc8ff15535b3"
-  dependencies:
-    graceful-fs "^4.1.2"
-    memory-fs "^0.4.0"
-    object-assign "^4.0.1"
-    tapable "^0.2.5"
-
-enhanced-resolve@^3.3.0:
+enhanced-resolve@^3.0.0, enhanced-resolve@^3.3.0:
   version "3.4.1"
   resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
   dependencies:
@@ -3256,6 +3249,22 @@ foreach@^2.0.5:
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+fork-ts-checker-webpack-plugin@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-0.4.2.tgz#8b57b736a6623110ee8899f575aef044d64a38ba"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^1.1.3"
+    chokidar "^1.7.0"
+    lodash.endswith "^4.2.1"
+    lodash.isfunction "^3.0.8"
+    lodash.isstring "^4.0.1"
+    lodash.startswith "^4.2.1"
+    minimatch "^3.0.4"
+    resolve "^1.5.0"
+    tapable "^1.0.0"
+    vue-parser "^1.1.5"
 
 form-data@~2.0.0:
   version "2.0.0"
@@ -4936,6 +4945,10 @@ lodash.curry@^4.0.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
 
+lodash.endswith@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz#fed59ac1738ed3e236edd7064ec456448b37bc09"
+
 lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
@@ -4952,6 +4965,14 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isfunction@^3.0.8:
+  version "3.0.9"
+  resolved "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -4967,6 +4988,10 @@ lodash.memoize@^4.1.2:
 lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
+
+lodash.startswith@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz#c598c4adce188a27e53145731cdc6c0e7177600c"
 
 lodash.template@^4.0.2:
   version "4.4.0"
@@ -4992,6 +5017,10 @@ lodash@^3.8.0, lodash@^3.9.3:
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.5"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log4js@^0.6.31:
   version "0.6.38"
@@ -5211,7 +5240,7 @@ micromatch@^2.1.5:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.0.3, micromatch@^3.1.4:
+micromatch@^3.1.4:
   version "3.1.9"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz#15dc93175ae39e52e93087847096effc73efcf89"
   dependencies:
@@ -5905,6 +5934,12 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse5@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parsejson@0.0.3:
   version "0.0.3"
@@ -6981,6 +7016,12 @@ resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.5.0:
+  version "1.7.1"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -7072,7 +7113,7 @@ schema-utils@^0.4.2, schema-utils@^0.4.5:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -7395,12 +7436,6 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
-
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  dependencies:
-    source-map "^0.5.6"
 
 source-map-url@^0.4.0:
   version "0.4.0"
@@ -7764,9 +7799,13 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tapable@^0.2.5, tapable@^0.2.7, tapable@~0.2.5:
+tapable@^0.2.7, tapable@~0.2.5:
   version "0.2.8"
   resolved "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
+
+tapable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
 
 tar-pack@^3.4.0:
   version "3.4.1"
@@ -7822,6 +7861,14 @@ text-extensions@^1.0.0:
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+thread-loader@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/thread-loader/-/thread-loader-1.1.5.tgz#7f9d6701f773734fff1832586779021ab8571917"
+  dependencies:
+    async "^2.3.0"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
 
 through2@^2.0.0, through2@^2.0.2:
   version "2.0.3"
@@ -7939,6 +7986,16 @@ trim-off-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+ts-loader@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/ts-loader/-/ts-loader-3.5.0.tgz#151d004dcddb4cf8e381a3bf9d6b74c2d957a9c0"
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^3.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^3.1.4"
+    semver "^5.0.1"
 
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.2:
   version "1.9.2"
@@ -8553,6 +8610,12 @@ vm-browserify@0.0.4, vm-browserify@~0.0.1:
 void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
+
+vue-parser@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.npmjs.org/vue-parser/-/vue-parser-1.1.6.tgz#3063c8431795664ebe429c23b5506899706e6355"
+  dependencies:
+    parse5 "^3.0.3"
 
 watch@~1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Looking more carefully at the test runs at https://travis-ci.org/jupyterlab/jupyterlab/jobs/389434330#L1745-L1746, I noticed that the tsconfig for the tests was missing some types to help compilation.

This fixes the errors in the test suite, and moves us to using ts-loader instead of awesome-ts-loader. ts-loader seems to play more nicely with other tools in the webpack ecosystem (like the caching, etc.), and doesn't seem to be any slower in running the CI tests anymore.