### PR TITLE
Send same-origin cookies with Vega loader requests

### DIFF
--- a/packages/vega3-extension/src/index.ts
+++ b/packages/vega3-extension/src/index.ts
@@ -80,11 +80,10 @@ class RenderedVega3 extends Widget implements IRenderMime.IRenderer {
     const mode: Mode = this._mimeType === VEGA_MIME_TYPE ? 'vega' : 'vega-lite';
     return this._resolver.resolveUrl('').then((path: string) => {
       return this._resolver.getDownloadUrl(path).then(baseURL => {
-        const loader = vega.loader({ baseURL,
-                                     http: {
-                                       credentials: 'same-origin',
-                                     },
-                                   });
+        const loader = vega.loader({
+          baseURL,
+          http: { credentials: 'same-origin' }
+        });
         const options: EmbedOptions = {
           actions: true,
           defaultStyle: true,

--- a/packages/vega3-extension/src/index.ts
+++ b/packages/vega3-extension/src/index.ts
@@ -80,7 +80,11 @@ class RenderedVega3 extends Widget implements IRenderMime.IRenderer {
     const mode: Mode = this._mimeType === VEGA_MIME_TYPE ? 'vega' : 'vega-lite';
     return this._resolver.resolveUrl('').then((path: string) => {
       return this._resolver.getDownloadUrl(path).then(baseURL => {
-        const loader = vega.loader({ baseURL });
+        const loader = vega.loader({ baseURL,
+                                     http: {
+                                       credentials: 'same-origin',
+                                     },
+                                   });
         const options: EmbedOptions = {
           actions: true,
           defaultStyle: true,


### PR DESCRIPTION
Currently, the Vega loader does not work with data in JSON format when the notebook has a password, because Vega does not send the cookies when loading the `.json` data. When this happens, the rendered plot is empty because Vega wasn't able to load the data.

Here's an example that does not currently work, but works with this patch:
```python
import json

class RenderJupyter:
    def __init__(self, mimetype, data):
        self.mimetype = mimetype
        self.data = data
    
    def _repr_mimebundle_(self, include, exclude):
        return { self.mimetype: self.data }

data = [
    {"a": "A","b": 28}, {"a": "B","b": 55}, {"a": "C","b": 43},
    {"a": "D","b": 91}, {"a": "E","b": 81}, {"a": "F","b": 53},
    {"a": "G","b": 19}, {"a": "H","b": 87}, {"a": "I","b": 52}
]
json.dump(data, open('vega-data.json', 'w'))

vega_json_data = {
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "A simple bar chart with embedded data.",
  "data": {
    "url": "vega-data.json"
  },
  "mark": "bar",
  "encoding": {
    "x": {"field": "a", "type": "ordinal"},
    "y": {"field": "b", "type": "quantitative"}
  }
}
mimetype = 'application/vnd.vegalite.v2+json'

RenderJupyter(mimetype, vega_json_data)
```