### PR TITLE
Reconcile tree routing handler  with workspaces.

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -215,7 +215,7 @@ const tree: JupyterLabPlugin<void> = {
 
     commands.addCommand(CommandIDs.tree, {
       execute: (args: IRouter.ILocation) => {
-        const { request } = router.current;
+        const { request } = args;
         const path = decodeURIComponent((args.path.match(Patterns.tree)[2]));
         const url = request.replace(request.match(Patterns.tree)[1], '');
         const immediate = true;

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -70,7 +70,7 @@ const main: JupyterLabPlugin<void> = {
     // will short-circuit and ask the user to navigate away.
     const workspace = resolver.name ? `"${resolver.name}"` : '[default: /lab]';
 
-    console.log(`Starting ${main.id} in workspace ${workspace}`);
+    console.log(`Starting application in workspace: ${workspace}`);
 
     // If there were errors registering plugins, tell the user.
     if (app.registerPluginErrors.length !== 0) {
@@ -105,7 +105,7 @@ const main: JupyterLabPlugin<void> = {
           router.reload();
         }
       }).catch(err => {
-        showDialog({ title: 'Build Failed', body: (<pre>{err.message}</pre>) });
+        showErrorMessage('Build Failed', { message: <pre>{err.message}</pre> });
       });
     };
 
@@ -242,6 +242,9 @@ const notfound: JupyterLabPlugin<void> = {
   activate: (app: JupyterLab, router: IRouter) => {
     const bad = PageConfig.getOption('notFoundUrl');
     const base = router.base;
+    const message = `
+      The path: ${bad} was not found. JupyterLab redirected to: ${base}
+    `;
 
     if (!bad) {
       return;
@@ -251,11 +254,7 @@ const notfound: JupyterLabPlugin<void> = {
     // URL change to the browser history.
     router.navigate('', { silent: true });
 
-    showDialog({
-      title: 'Path Not Found',
-      body: `The path: ${bad} was not found. JupyterLab redirected to: ${base}`,
-      buttons: [Dialog.okButton()]
-    });
+    showErrorMessage('Path Not Found', { message });
   },
   requires: [IRouter],
   autoStart: true

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -13,7 +13,8 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  DataConnector, ISettingRegistry, IStateDB, SettingRegistry, StateDB, URLExt
+  DataConnector, ISettingRegistry, IStateDB, PageConfig, SettingRegistry,
+  StateDB, URLExt
 } from '@jupyterlab/coreutils';
 
 import {
@@ -273,7 +274,11 @@ const resolver: JupyterLabPlugin<IWindowResolver> = {
 
         return Private.redirect(router);
       })
-      .then(() => resolver);
+      .then(() => {
+        PageConfig.setOption('workspace', resolver.name);
+
+        return resolver;
+      });
   }
 };
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -96,7 +96,7 @@ namespace Patterns {
   const cloneState = /(\?clone\=|\&clone\=)([^&]+)($|&)/;
 
   export
-  const loadState = /^\/workspaces\/([^?]+)/;
+  const loadState = /^\/workspaces\/([^?\/]+)/;
 
   export
   const resetOnLoad = /(\?reset|\&reset)($|&)/;

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -51,14 +51,13 @@ function showDialog<T>(options: Partial<Dialog.IOptions<T>>={}): Promise<Dialog.
  */
 export
 function showErrorMessage(title: string, error: any): Promise<void> {
-  console.error(error);
-  let options = {
+  console.warn('Showing error:', error);
+
+  return showDialog({
     title: title,
     body: error.message || title,
-    buttons: [Dialog.okButton()],
-    okText: 'DISMISS'
-  };
-  return showDialog(options).then(() => { /* no-op */ });
+    buttons: [Dialog.okButton({ label: 'DISMISS' })]
+  }).then(() => { /* no-op */ });
 }
 
 /**

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -140,8 +140,9 @@ namespace PageConfig {
     const base = getBaseUrl();
     const page = getOption('pageUrl');
     const workspace = getOption('workspace');
+    const includeWorkspace = !!options.workspace;
 
-    if (workspace) {
+    if (includeWorkspace && workspace) {
       return URLExt.join(base, page, 'workspaces', workspace, 'tree');
     } else {
       return URLExt.join(base, page, 'tree');

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -139,11 +139,12 @@ namespace PageConfig {
   function getTreeUrl(options: ITreeOptions = { }): string {
     const base = getBaseUrl();
     const page = getOption('pageUrl');
+    const workspaces = getOption('workspacesUrl');
     const workspace = getOption('workspace');
     const includeWorkspace = !!options.workspace;
 
     if (includeWorkspace && workspace) {
-      return URLExt.join(base, page, 'workspaces', workspace, 'tree');
+      return URLExt.join(base, workspaces, workspace, 'tree');
     } else {
       return URLExt.join(base, page, 'tree');
     }

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -25,6 +25,17 @@ declare var require: any;
 export
 namespace PageConfig {
   /**
+   * The tree URL construction options.
+   */
+  export
+  interface ITreeOptions {
+    /**
+     * If `true`, the tree URL will include the current workspace, if any.
+     */
+    workspace?: boolean;
+  }
+
+  /**
    * Get global configuration data for the Jupyter application.
    *
    * @param name - The name of the configuration option.
@@ -121,10 +132,20 @@ namespace PageConfig {
 
   /**
    * Get the tree url for a JupyterLab application.
+   *
+   * @param options - The tree URL construction options.
    */
   export
-  function getTreeUrl(): string {
-    return URLExt.join(getBaseUrl(), getOption('pageUrl'), 'tree');
+  function getTreeUrl(options: ITreeOptions = { }): string {
+    const base = getBaseUrl();
+    const page = getOption('pageUrl');
+    const workspace = getOption('workspace');
+
+    if (workspace) {
+      return URLExt.join(base, page, 'workspaces', workspace, 'tree');
+    } else {
+      return URLExt.join(base, page, 'tree');
+    }
   }
 
   /**

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -400,7 +400,7 @@ function addCommands(app: JupyterLab, tracker: InstanceTracker<FileBrowser>, bro
   commands.addCommand(CommandIDs.share, {
     execute: () => {
       const path = encodeURIComponent(browser.selectedItems().next().path);
-      const tree = PageConfig.getTreeUrl();
+      const tree = PageConfig.getTreeUrl({ workspace: true });
 
       Clipboard.copyToSystem(URLExt.join(tree, path));
     },


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/4502

* Tree URLs in the default workspace work as before: `http://localhost:8888/lab/tree/path/to/notebook.ipynb`
* Tree URLs in a named workspace look like this: `http://localhost:8888/lab/workspaces/foo/tree/path/to/notebook.ipynb`
* The `reset` query string parameter outranks the `clone` parameter. If *both* `reset` and `clone` exist in the URL, then `reset` will first blow away the state database and then `clone` will copy the contents of a different workspace.
* Both `reset` and `clone` outrank the tree routing, meaning their effects will manifest first and *then* the tree URL will be loaded.
* `reset` and `clone` play nicely with named workspaces as well as the default workspace
* `reset` and `clone` place nicely with tree URLs: after the state database is cleared out, the tree URL is loaded.

The points above mean every URL below should work in a deterministic way that users can reason about:

* `http://localhost:8888/lab/tree/path/to/notebook.ipynb` load a tree URL into the default workspace
* `http://localhost:8888/lab/workspaces/foo/tree/path/to/notebook.ipynb` load a tree URL into the `foo` workspace, even if it doesn't already exist
* `http://localhost:8888/lab/workspaces/bar/tree/path/to/notebook.ipynb` load a tree URL into the `bar` workspace, even if it doesn't already exist
* `http://localhost:8888/lab/workspaces/bar/tree/path/to/notebook.ipynb?clone` clone the contents of the default workspace into the `bar` workspace and then load a tree URL
* `http://localhost:8888/lab/workspaces/bar/tree/path/to/notebook.ipynb?clone=foo` clone the contents of the `foo` workspace into the `bar` workspace and then load a tree URL
* `http://localhost:8888/lab/workspaces/bar/tree/path/to/notebook.ipynb?clone=foo&reset` reset the contents of the `bar` workspace (this is superfluous immediately before a `clone`, but not a problem), clone the contents of the `foo` workspace into the `bar` workspace and then load a tree URL
* `http://localhost:8888/lab/workspaces/bar/tree/path/to/notebook.ipynb?reset` reset the contents of the `bar` workspace and then load a tree URL
* `http://localhost:8888/lab/tree/path/to/notebook.ipynb?reset` reset the contents of the default workspace and then load a tree URL