### PR TITLE
Fix bug for shutdown button in runsession

### DIFF
--- a/packages/running/src/index.ts
+++ b/packages/running/src/index.ts
@@ -321,11 +321,9 @@ class RunningSessions extends Widget {
       return;
     }
 
-    // Create a dummy div if terminals are not available.
-    shutdownTerms = shutdownTerms || document.createElement('div');
-
     // Check for terminals shutdown.
-    if (ElementExt.hitTest(shutdownTerms, clientX, clientY)) {
+    // Terminals might be disabled, check node exist first.
+    if (shutdownTerms && ElementExt.hitTest(shutdownTerms, clientX, clientY)) {
       showDialog({
         title: 'Shutdown All Terminals?',
         body: 'Shut down all terminals?',

--- a/packages/running/src/index.ts
+++ b/packages/running/src/index.ts
@@ -321,6 +321,9 @@ class RunningSessions extends Widget {
       return;
     }
 
+    // Create a dummy div if terminals are not available.
+    shutdownTerms = shutdownTerms || document.createElement('div');
+
     // Check for terminals shutdown.
     if (ElementExt.hitTest(shutdownTerms, clientX, clientY)) {
       showDialog({


### PR DESCRIPTION
Fix bug:Kernel shutdown button in Runsessions doesn't work when
terminal is unavaliable.
[issue 4709](https://github.com/jupyterlab/jupyterlab/issues/4709)