### PR TITLE
Allow native context menu to be shown for notebook cell in Chrome.

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1382,6 +1382,12 @@ class Notebook extends StaticNotebook {
    * Handle `contextmenu` event.
    */
   private _evtContextMenuCapture(event: PointerEvent): void {
+    // Allow the event to propagate un-modified if the user
+    // is holding the shift-key (and probably requesting
+    // the native context menu).
+    if (event.shiftKey) {
+      return;
+    }
     // `event.target` sometimes gives an orphaned node in Firefox 57, which
     // can have `null` anywhere in its parent tree. If we fail to find a
     // cell using `event.target`, try again using a target reconstructed from
@@ -1394,7 +1400,7 @@ class Notebook extends StaticNotebook {
     }
     let widget = this.widgets[index];
 
-    if (!event.shiftKey && widget && widget.editorWidget.node.contains(target)) {
+    if (widget && widget.editorWidget.node.contains(target)) {
       // Prevent CodeMirror from focusing the editor.
       // TODO: find an editor-agnostic solution.
       event.preventDefault();

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1394,7 +1394,7 @@ class Notebook extends StaticNotebook {
     }
     let widget = this.widgets[index];
 
-    if (widget && widget.editorWidget.node.contains(target)) {
+    if (!event.shiftKey && widget && widget.editorWidget.node.contains(target)) {
       // Prevent CodeMirror from focusing the editor.
       // TODO: find an editor-agnostic solution.
       event.preventDefault();


### PR DESCRIPTION
Fixes #4718.

This is a consequence of the saga of #3554. To refresh people's memory: CodeMirror has some special context menu logic that differs depending on whether Firefox or Chrome is being used. That logic was causing some *extremely* subtle focusing problems for notebook cells that ate up several developer-days.

We ultimately fixed it with a somewhat-hackish solution of calling `preventDefault` on context menu events for notebook cells. This lets CodeMirror know that is should not handle the event itself. However, we inadvertently prevented native context menus for notebook cells (and only in Chrome).

This fix continues in the somewhat-hackish code path by allowing the context menu to continue un-cancelled if the shift key is pressed.