### PR TITLE
We should also trigger a model content change signal on cell move.

### DIFF
--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -281,7 +281,7 @@ class NotebookModel extends DocumentModel implements INotebookModel {
       });
       break;
     default:
-      return;
+      break;
     }
     let factory = this.contentFactory;
     // Add code cell if there are no cells remaining.

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  each
-} from '@phosphor/algorithm';
-
-import {
   DocumentModel, DocumentRegistry
 } from '@jupyterlab/docregistry';
 
@@ -265,19 +261,15 @@ class NotebookModel extends DocumentModel implements INotebookModel {
   private _onCellsChanged(list: IObservableList<ICellModel>, change: IObservableList.IChangedArgs<ICellModel>): void {
     switch (change.type) {
     case 'add':
-      each(change.newValues, cell => {
+      change.newValues.forEach(cell => {
         cell.contentChanged.connect(this.triggerContentChange, this);
       });
       break;
     case 'remove':
-      each(change.oldValues, cell => { /* no op */
-      });
       break;
     case 'set':
-      each(change.newValues, cell => {
+      change.newValues.forEach(cell => {
         cell.contentChanged.connect(this.triggerContentChange, this);
-      });
-      each(change.oldValues, cell => { /* no op */
       });
       break;
     default:

--- a/tests/test-notebook/src/model.spec.ts
+++ b/tests/test-notebook/src/model.spec.ts
@@ -122,12 +122,34 @@ describe('@jupyterlab/notebook', () => {
 
       context('cells `changed` signal', () => {
 
-        it('should emit a `contentChanged` signal', () => {
+        it('should emit a `contentChanged` signal upon cell addition', () => {
           let model = new NotebookModel();
           let cell = model.contentFactory.createCodeCell({});
           let called = false;
           model.contentChanged.connect(() => { called = true; });
           model.cells.push(cell);
+          expect(called).to.be(true);
+        });
+
+        it('should emit a `contentChanged` signal upon cell removal', () => {
+          let model = new NotebookModel();
+          let cell = model.contentFactory.createCodeCell({});
+          model.cells.push(cell);
+          let called = false;
+          model.contentChanged.connect(() => { called = true; });
+          model.cells.remove(0);
+          expect(called).to.be(true);
+        });
+
+        it('should emit a `contentChanged` signal upon cell move', () => {
+          let model = new NotebookModel();
+          let cell0 = model.contentFactory.createCodeCell({});
+          let cell1 = model.contentFactory.createCodeCell({});
+          model.cells.push(cell0);
+          model.cells.push(cell1);
+          let called = false;
+          model.contentChanged.connect(() => { called = true; });
+          model.cells.move(0, 1);
           expect(called).to.be(true);
         });
 


### PR DESCRIPTION
Fixes ian-r-rose/jupyterlab-toc#21.

We were missing a place where the `model.contentChanged` signal should be emitted but was not, since the control flow was returning too early. I don't think we were using this particular signal anywhere in the core codebase (and so we didn't catch it earlier), but I ran into it in an extension.