### PR TITLE
Upgrade marked

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -90,7 +90,7 @@
     "codemirror": "~5.39.0",
     "comment-json": "^1.1.3",
     "es6-promise": "~4.1.1",
-    "marked": "~0.3.9",
+    "marked": "~0.4.0",
     "moment": "~2.21.0",
     "path-posix": "~1.0.0",
     "react": "~16.4.0",

--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -68,8 +68,8 @@ class Sanitizer implements ISanitizer {
       'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),
       // Allow the "src" attribute for <img> tags.
       'img': ['src', 'height', 'width', 'alt'],
-      // Allow the "type" attribute for <input> tags.
-      'input': ['type', 'disabled'],
+      // Allow "type", "disabled", and "checked" attributes for <input> tags.
+      'input': ['type', 'disabled', 'checked'],
       // Allow "class" attribute for <code> tags.
       'code': ['class'],
       // Allow "class" attribute for <span> tags.

--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -90,7 +90,7 @@ class Sanitizer implements ISanitizer {
       // Set the "rel" attribute for <a> tags to "nofollow".
       'a': sanitize.simpleTransform('a', { 'rel': 'nofollow' }),
       // Set the "disabled" attribute for <input> tags.
-      'input': sanitize.simpleTransform('input', { 'disabled': true })
+      'input': sanitize.simpleTransform('input', { 'disabled': 'true' })
     },
     allowedSchemesByTag: {
       // Allow 'attachment:' img src (used for markdown cell attachments).

--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -62,12 +62,14 @@ class Sanitizer implements ISanitizer {
   private _options: sanitize.IOptions = {
     allowedTags: sanitize.defaults.allowedTags
       .concat('h1', 'h2', 'img', 'span', 'audio', 'video', 'del',
-              'kbd', 'sup', 'sub', 'colspan', 'rowspan'),
+              'kbd', 'sup', 'sub', 'colspan', 'rowspan', 'input'),
     allowedAttributes: {
       // Allow the "rel" attribute for <a> tags.
       'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),
       // Allow the "src" attribute for <img> tags.
       'img': ['src', 'height', 'width', 'alt'],
+      // Allow the "type" attribute for <input> tags.
+      'input': ['type', 'disabled'],
       // Allow "class" attribute for <code> tags.
       'code': ['class'],
       // Allow "class" attribute for <span> tags.
@@ -86,7 +88,9 @@ class Sanitizer implements ISanitizer {
     },
     transformTags: {
       // Set the "rel" attribute for <a> tags to "nofollow".
-      'a': sanitize.simpleTransform('a', { 'rel': 'nofollow' })
+      'a': sanitize.simpleTransform('a', { 'rel': 'nofollow' }),
+      // Set the "disabled" attribute for <input> tags.
+      'input': sanitize.simpleTransform('input', { 'disabled': true })
     },
     allowedSchemesByTag: {
       // Allow 'attachment:' img src (used for markdown cell attachments).

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -42,10 +42,10 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
     "ansi_up": "^3.0.0",
-    "marked": "~0.3.9"
+    "marked": "~0.4.0"
   },
   "devDependencies": {
-    "@types/marked": "~0.0.28",
+    "@types/marked": "~0.3.0",
     "rimraf": "~2.6.2",
     "typescript": "~2.9.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,13 +179,9 @@
   version "4.14.104"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz#53ee2357fa2e6e68379341d92eb2ecea4b11bb80"
 
-"@types/marked@0.3.0":
+"@types/marked@0.3.0", "@types/marked@~0.3.0":
   version "0.3.0"
   resolved "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz#583c223dd33385a1dda01aaf77b0cd0411c4b524"
-
-"@types/marked@~0.0.28":
-  version "0.0.28"
-  resolved "https://registry.npmjs.org/@types/marked/-/marked-0.0.28.tgz#44ba754e9fa51432583e8eb30a7c4dd249b52faa"
 
 "@types/minimatch@*", "@types/minimatch@3.0.3":
   version "3.0.3"
@@ -5356,9 +5352,9 @@ marked@^0.3.17:
   version "0.3.19"
   resolved "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
 
-marked@~0.3.9:
-  version "0.3.17"
-  resolved "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz#607f06668b3c6b1246b28f13da76116ac1aa2d2b"
+marked@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"


### PR DESCRIPTION
marked 0.4 adds support for checkboxes.

This is working correctly for code cells that output markdown but not for markdown cells and markdown documents:

![image](https://user-images.githubusercontent.com/512354/41430611-4fd2ccd8-6fc5-11e8-92b1-3a26f6bb6720.png)

They're both calling `renderMarkdown` and their stacktraces look identical, so I'm not sure where the discrepancy is...

Related to https://github.com/jupyter/notebook/pull/3686

Closes https://github.com/jupyterlab/jupyterlab/issues/4211