### PR TITLE
Add a NotebookActions.executed signal.

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -35,7 +35,7 @@ import {
 
 import {
   CellTools, ICellTools, INotebookTracker, NotebookActions,
-  NotebookModelFactory,  NotebookPanel, NotebookTracker, NotebookWidgetFactory,
+  NotebookModelFactory, NotebookPanel, NotebookTracker, NotebookWidgetFactory,
   StaticNotebook
 } from '@jupyterlab/notebook';
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -75,7 +75,7 @@ class NotebookActions {
   /**
    * A signal that emits whenever a cell is run.
    */
-  static get executed(): ISignal<null, { parent: Notebook, child: Cell }> {
+  static get executed(): ISignal<any, { parent: Notebook, child: Cell }> {
     return Private.executed;
   }
 
@@ -1251,7 +1251,7 @@ namespace Private {
    * A signal that emits whenever a cell is run.
    */
   export
-  const executed = new Signal<null, { parent: Notebook, child: Cell }>(null);
+  const executed = new Signal<any, { parent: Notebook, child: Cell }>({ });
 
   /**
    * The interface for a widget state.

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1376,15 +1376,18 @@ namespace Private {
           if (child.isDisposed) {
             return false;
           }
-          if (reply && reply.content.status === 'ok') {
-            let content = reply.content as KernelMessage.IExecuteOkReply;
+
+          if (!reply) {
+            return true;
+          }
+
+          if (reply.content.status === 'ok') {
+            const content = reply.content as KernelMessage.IExecuteOkReply;
+
             if (content.payload && content.payload.length) {
               handlePayload(content, parent, child);
             }
-          }
 
-          if (reply ? reply.content.status === 'ok' : true) {
-            executed.emit({ parent, child });
             return true;
           }
 
@@ -1393,7 +1396,14 @@ namespace Private {
           if (reason.message !== 'Canceled') {
             throw reason;
           }
+
           return false;
+        }).then(ran => {
+          if (ran) {
+            executed.emit({ parent, child });
+          }
+
+          return ran;
         });
       }
       (child.model as ICodeCellModel).executionCount = null;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1368,6 +1368,7 @@ namespace Private {
     case 'markdown':
       (child as MarkdownCell).rendered = true;
       child.inputHidden = false;
+      executed.emit({ parent, child });
       break;
     case 'code':
       if (session) {
@@ -1382,13 +1383,12 @@ namespace Private {
             }
           }
 
-          const run = reply ? reply.content.status === 'ok' : true;
-
           if (reply ? reply.content.status === 'ok' : true) {
             executed.emit({ parent, child });
+            return true;
           }
 
-          return run;
+          return false;
         }).catch(reason => {
           if (reason.message !== 'Canceled') {
             throw reason;
@@ -1401,8 +1401,6 @@ namespace Private {
     default:
       break;
     }
-
-    executed.emit({ parent, child });
 
     return Promise.resolve(true);
   }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -173,7 +173,7 @@ namespace NotebookActions {
     let index = widget.activeCellIndex;
 
     // Get the cells to merge.
-    each(widget.widgets, (child, i) => {
+    widget.widgets.forEach((child, i) => {
       if (widget.isSelectedOrActive(child)) {
         toMerge.push(child.model.value.text);
         if (i !== index) {
@@ -206,9 +206,7 @@ namespace NotebookActions {
     // Make the changes while preserving history.
     cells.beginCompoundOperation();
     cells.set(index, newModel);
-    each(toDelete, cell => {
-      cells.removeValue(cell);
-    });
+    toDelete.forEach(cell => { cells.removeValue(cell); });
     cells.endCompoundOperation();
 
     // If the original cell is a markdown cell, make sure
@@ -486,9 +484,7 @@ namespace NotebookActions {
       return Promise.resolve(false);
     }
     let state = Private.getState(widget);
-    each(widget.widgets, child => {
-      widget.select(child);
-    });
+    widget.widgets.forEach(child => { widget.select(child); });
     let promise = Private.runSelected(widget, session);
     Private.handleRunState(widget, state, true);
     return promise;
@@ -658,9 +654,7 @@ namespace NotebookActions {
     if (!widget.model || !widget.activeCell) {
       return;
     }
-    each(widget.widgets, child => {
-      widget.select(child);
-    });
+    widget.widgets.forEach(child => { widget.select(child); });
   }
 
   /**
@@ -730,7 +724,7 @@ namespace NotebookActions {
     let newCells: ICellModel[] = [];
     widget.mode = 'command';
 
-    each(values, cell => {
+    values.forEach(cell => {
       switch (cell.cell_type) {
       case 'code':
         newCells.push(model.contentFactory.createCodeCell({ cell }));
@@ -760,7 +754,7 @@ namespace NotebookActions {
       case 'replace':
         // Find the cells to delete.
         const toDelete: number[] = [];
-        each(widget.widgets, (child, i) => {
+        widget.widgets.forEach((child, i) => {
           let deletable = child.model.metadata.get('deletable');
           if (widget.isSelectedOrActive(child) && deletable !== false) {
             toDelete.push(i);
@@ -769,9 +763,7 @@ namespace NotebookActions {
         // If cells are not deletable, we may not have anything to delete.
         if (toDelete.length > 0) {
           // Delete the cells as one undo event.
-          each(toDelete.reverse(), i => {
-            cells.remove(i);
-          });
+          toDelete.reverse().forEach(i => { cells.remove(i); });
         }
         index = toDelete[0];
         break;
@@ -779,9 +771,7 @@ namespace NotebookActions {
         break;
     }
 
-    each(newCells, cell => {
-      cells.insert(++index, cell);
-    });
+    newCells.forEach(cell => { cells.insert(++index, cell); });
     cells.endCompoundOperation();
 
     widget.activeCellIndex += newCells.length;
@@ -870,16 +860,13 @@ namespace NotebookActions {
       return;
     }
     let state = Private.getState(widget);
-    let cells = widget.model.cells;
-    let i = 0;
-    each(cells, (cell: ICodeCellModel) => {
-      let child = widget.widgets[i];
+    each(widget.model.cells, (cell: ICodeCellModel, index) => {
+      let child = widget.widgets[index];
       if (widget.isSelectedOrActive(child) && cell.type === 'code') {
         cell.outputs.clear();
         (child as CodeCell).outputHidden = false;
         cell.executionCount = null;
       }
-      i++;
     });
     Private.handleState(widget, state);
   }
@@ -898,15 +885,13 @@ namespace NotebookActions {
       return;
     }
     let state = Private.getState(widget);
-    let i = 0;
-    each(widget.model.cells, (cell: ICodeCellModel) => {
-      let child = widget.widgets[i];
+    each(widget.model.cells, (cell: ICodeCellModel, index) => {
+      let child = widget.widgets[index];
       if (cell.type === 'code') {
         cell.outputs.clear();
         cell.executionCount = null;
         (child as CodeCell).outputHidden = false;
       }
-      i++;
     });
     Private.handleState(widget, state);
   }
@@ -923,7 +908,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         cell.inputHidden = true;
       }
@@ -943,7 +928,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         cell.inputHidden = false;
       }
@@ -963,7 +948,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (cell.model.type === 'code') {
         cell.inputHidden = true;
       }
@@ -983,7 +968,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (cell.model.type === 'code') {
         cell.inputHidden = false;
       }
@@ -1003,7 +988,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).outputHidden = true;
       }
@@ -1023,7 +1008,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).outputHidden = false;
       }
@@ -1043,7 +1028,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (cell.model.type === 'code') {
         (cell as CodeCell).outputHidden = true;
       }
@@ -1063,7 +1048,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (cell.model.type === 'code') {
         (cell as CodeCell).outputHidden = false;
       }
@@ -1083,7 +1068,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).outputsScrolled = true;
       }
@@ -1103,7 +1088,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).outputsScrolled = false;
       }
@@ -1123,7 +1108,7 @@ namespace NotebookActions {
     }
     let state = Private.getState(widget);
     let cells = widget.widgets;
-    each(cells, (cell: Cell) => {
+    cells.forEach(cell => {
       const {model, inputHidden} = cell;
       const metadata = model.metadata;
       const jupyter = metadata.get('jupyter') as any || {};
@@ -1186,12 +1171,10 @@ namespace NotebookActions {
     let state = Private.getState(widget);
     level = Math.min(Math.max(level, 1), 6);
     let cells = widget.model.cells;
-    let i = 0;
-    each(widget.widgets, (child: MarkdownCell) => {
+    widget.widgets.forEach((child, index) => {
       if (widget.isSelectedOrActive(child)) {
-        Private.setMarkdownHeader(cells.get(i), level);
+        Private.setMarkdownHeader(cells.get(index), level);
       }
-      i++;
     });
     Private.changeCellType(widget, 'markdown');
     Private.handleState(widget, state);
@@ -1210,22 +1193,16 @@ namespace NotebookActions {
   export
   function trust(widget: Notebook): Promise<void> {
     if (!widget.model) {
-      return Promise.resolve(void 0);
+      return Promise.resolve();
     }
     // Do nothing if already trusted.
-    let cells = widget.model.cells;
-    let trusted = true;
-    for (let i = 0; i < cells.length; i++) {
-      let cell = cells.get(i);
-      if (!cell.trusted) {
-        trusted = false;
-      }
-    }
+    let cells = toArray(widget.model.cells);
+    let trusted = cells.every(cell => cell.trusted);
     if (trusted) {
       return showDialog({
         body: 'Notebook is already trusted',
         buttons: [Dialog.okButton()]
-      }).then(() => void 0);
+      }).then(() => undefined);
     }
     return showDialog({
       body: TRUST_MESSAGE,
@@ -1233,10 +1210,7 @@ namespace NotebookActions {
       buttons: [Dialog.cancelButton(), Dialog.warnButton()]
     }).then(result => {
       if (result.button.accept) {
-        for (let i = 0; i < cells.length; i++) {
-          let cell = cells.get(i);
-          cell.trusted = true;
-        }
+        cells.forEach(cell => { cell.trusted = true; });
       }
     });
   }
@@ -1469,7 +1443,7 @@ namespace Private {
     let clipboard = Clipboard.getInstance();
     clipboard.clear();
     let data: nbformat.IBaseCell[] = [];
-    each(widget.widgets, child => {
+    widget.widgets.forEach(child => {
       if (widget.isSelectedOrActive(child)) {
         data.push(child.model.toJSON());
       }
@@ -1502,7 +1476,7 @@ namespace Private {
     let cells = model.cells;
 
     cells.beginCompoundOperation();
-    each(widget.widgets, (child, i) => {
+    widget.widgets.forEach((child, i) => {
       if (!widget.isSelectedOrActive(child)) {
         return;
       }
@@ -1556,7 +1530,7 @@ namespace Private {
     widget.mode = 'command';
 
     // Find the cells to delete.
-    each(widget.widgets, (child, i) => {
+    widget.widgets.forEach((child, i) => {
       let deletable = child.model.metadata.get('deletable');
       if (widget.isSelectedOrActive(child) && deletable !== false) {
         toDelete.push(i);

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -112,23 +112,27 @@ namespace NotebookActions {
    * This action can be undone.
    */
   export
-  function splitCell(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function splitCell(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    widget.deselectAll();
-    let nbModel = widget.model;
-    let index = widget.activeCellIndex;
-    let child = widget.widgets[index];
-    let editor = child.editor;
-    let position = editor.getCursorPosition();
-    let offset = editor.getOffsetAt(position);
-    let orig = child.model.value.text;
+
+    const state = Private.getState(notebook);
+
+    notebook.deselectAll();
+
+    const nbModel = notebook.model;
+    const index = notebook.activeCellIndex;
+    const child = notebook.widgets[index];
+    const editor = child.editor;
+    const position = editor.getCursorPosition();
+    const offset = editor.getOffsetAt(position);
+    const orig = child.model.value.text;
 
     // Create new models to preserve history.
-    let clone0 = Private.cloneCell(nbModel, child.model);
-    let clone1 = Private.cloneCell(nbModel, child.model);
+    const clone0 = Private.cloneCell(nbModel, child.model);
+    const clone1 = Private.cloneCell(nbModel, child.model);
+
     if (clone0.type === 'code') {
       (clone0 as ICodeCellModel).outputs.clear();
     }
@@ -136,20 +140,21 @@ namespace NotebookActions {
     clone1.value.text = orig.slice(offset).replace(/^\n+/, '').replace(/\n+$/, '');
 
     // Make the changes while preserving history.
-    let cells = nbModel.cells;
+    const cells = nbModel.cells;
+
     cells.beginCompoundOperation();
     cells.set(index, clone0);
     cells.insert(index + 1, clone1);
     cells.endCompoundOperation();
 
-    widget.activeCellIndex++;
-    Private.handleState(widget, state);
+    notebook.activeCellIndex++;
+    Private.handleState(notebook, state);
   }
 
   /**
    * Merge the selected cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The widget mode will be preserved.
@@ -160,23 +165,24 @@ namespace NotebookActions {
    * If the active cell is a markdown cell, it will be unrendered.
    */
   export
-  function mergeCells(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function mergeCells(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let toMerge: string[] = [];
-    let toDelete: ICellModel[] = [];
-    let model = widget.model;
-    let cells = model.cells;
-    let primary = widget.activeCell;
-    let index = widget.activeCellIndex;
+
+    const state = Private.getState(notebook);
+    const toMerge: string[] = [];
+    const toDelete: ICellModel[] = [];
+    const model = notebook.model;
+    const cells = model.cells;
+    const primary = notebook.activeCell;
+    const active = notebook.activeCellIndex;
 
     // Get the cells to merge.
-    widget.widgets.forEach((child, i) => {
-      if (widget.isSelectedOrActive(child)) {
+    notebook.widgets.forEach((child, index) => {
+      if (notebook.isSelectedOrActive(child)) {
         toMerge.push(child.model.value.text);
-        if (i !== index) {
+        if (index !== active) {
           toDelete.push(child.model);
         }
       }
@@ -185,19 +191,22 @@ namespace NotebookActions {
     // Check for only a single cell selected.
     if (toMerge.length === 1) {
       // Bail if it is the last cell.
-      if (index === cells.length - 1) {
+      if (active === cells.length - 1) {
         return;
       }
+
       // Otherwise merge with the next cell.
-      let cellModel = cells.get(index + 1);
+      const cellModel = cells.get(active + 1);
+
       toMerge.push(cellModel.value.text);
       toDelete.push(cellModel);
     }
 
-    widget.deselectAll();
+    notebook.deselectAll();
 
     // Create a new cell for the source to preserve history.
-    let newModel = Private.cloneCell(model, primary.model);
+    const newModel = Private.cloneCell(model, primary.model);
+
     newModel.value.text = toMerge.join('\n\n');
     if (newModel.type === 'code') {
       (newModel as ICodeCellModel).outputs.clear();
@@ -205,24 +214,23 @@ namespace NotebookActions {
 
     // Make the changes while preserving history.
     cells.beginCompoundOperation();
-    cells.set(index, newModel);
+    cells.set(active, newModel);
     toDelete.forEach(cell => { cells.removeValue(cell); });
     cells.endCompoundOperation();
 
     // If the original cell is a markdown cell, make sure
     // the new cell is unrendered.
     if (primary instanceof MarkdownCell) {
-      let cell = widget.activeCell as MarkdownCell;
-      cell.rendered = false;
+      (notebook.activeCell as MarkdownCell).rendered = false;
     }
 
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Delete the selected cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The cell after the last selected cell will be activated.
@@ -230,19 +238,21 @@ namespace NotebookActions {
    * This action can be undone.
    */
   export
-  function deleteCells(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function deleteCells(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    Private.deleteCells(widget);
-    Private.handleState(widget, state);
+
+    const state = Private.getState(notebook);
+
+    Private.deleteCells(notebook);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Insert a new code cell above the active cell.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The widget mode will be preserved.
@@ -251,25 +261,28 @@ namespace NotebookActions {
    * The new cell will the active cell.
    */
   export
-  function insertAbove(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function insertAbove(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let model = widget.model;
-    let cell = model.contentFactory.createCodeCell({ });
-    let index = widget.activeCellIndex;
-    model.cells.insert(index, cell);
+
+    const state = Private.getState(notebook);
+    const model = notebook.model;
+    const cell = model.contentFactory.createCodeCell({ });
+    const active = notebook.activeCellIndex;
+
+    model.cells.insert(active, cell);
+
     // Make the newly inserted cell active.
-    widget.activeCellIndex = index;
-    widget.deselectAll();
-    Private.handleState(widget, state, true);
+    notebook.activeCellIndex = active;
+    notebook.deselectAll();
+    Private.handleState(notebook, state, true);
   }
 
   /**
    * Insert a new code cell below the active cell.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The widget mode will be preserved.
@@ -278,48 +291,53 @@ namespace NotebookActions {
    * The new cell will be the active cell.
    */
   export
-  function insertBelow(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function insertBelow(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let model = widget.model;
-    let cell = model.contentFactory.createCodeCell({});
-    model.cells.insert(widget.activeCellIndex + 1, cell);
+
+    const state = Private.getState(notebook);
+    const model = notebook.model;
+    const cell = model.contentFactory.createCodeCell({});
+
+    model.cells.insert(notebook.activeCellIndex + 1, cell);
+
     // Make the newly inserted cell active.
-    widget.activeCellIndex++;
-    widget.deselectAll();
-    Private.handleState(widget, state, true);
+    notebook.activeCellIndex++;
+    notebook.deselectAll();
+    Private.handleState(notebook, state, true);
   }
 
   /**
    * Move the selected cell(s) down.
    *
-   * @param widget = The target notebook widget.
+   * @param notebook = The target notebook widget.
    */
   export
-  function moveDown(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function moveDown(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.model.cells;
-    let widgets = widget.widgets;
+
+    const state = Private.getState(notebook);
+    const cells = notebook.model.cells;
+    const widgets = notebook.widgets;
+
     cells.beginCompoundOperation();
     for (let i = cells.length - 2; i > -1; i--) {
-      if (widget.isSelectedOrActive(widgets[i])) {
-        if (!widget.isSelectedOrActive(widgets[i + 1])) {
+      if (notebook.isSelectedOrActive(widgets[i])) {
+        if (!notebook.isSelectedOrActive(widgets[i + 1])) {
           cells.move(i, i + 1);
-          if (widget.activeCellIndex === i) {
-            widget.activeCellIndex++;
+          if (notebook.activeCellIndex === i) {
+            notebook.activeCellIndex++;
           }
-          widget.select(widgets[i + 1]);
-          widget.deselect(widgets[i]);
+          notebook.select(widgets[i + 1]);
+          notebook.deselect(widgets[i]);
         }
       }
     }
     cells.endCompoundOperation();
-    Private.handleState(widget, state, true);
+    Private.handleState(notebook, state, true);
   }
 
   /**
@@ -328,34 +346,36 @@ namespace NotebookActions {
    * @param widget - The target notebook widget.
    */
   export
-  function moveUp(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function moveUp(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.model.cells;
-    let widgets = widget.widgets;
+
+    const state = Private.getState(notebook);
+    const cells = notebook.model.cells;
+    const widgets = notebook.widgets;
+
     cells.beginCompoundOperation();
     for (let i = 1; i < cells.length; i++) {
-      if (widget.isSelectedOrActive(widgets[i])) {
-        if (!widget.isSelectedOrActive(widgets[i - 1])) {
+      if (notebook.isSelectedOrActive(widgets[i])) {
+        if (!notebook.isSelectedOrActive(widgets[i - 1])) {
           cells.move(i, i - 1);
-          if (widget.activeCellIndex === i) {
-            widget.activeCellIndex--;
+          if (notebook.activeCellIndex === i) {
+            notebook.activeCellIndex--;
           }
-          widget.select(widgets[i - 1]);
-          widget.deselect(widgets[i]);
+          notebook.select(widgets[i - 1]);
+          notebook.deselect(widgets[i]);
         }
       }
     }
     cells.endCompoundOperation();
-    Private.handleState(widget, state, true);
+    Private.handleState(notebook, state, true);
   }
 
   /**
    * Change the selected cell type(s).
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param value - The target cell type.
    *
@@ -366,19 +386,21 @@ namespace NotebookActions {
    * Any cells converted to markdown will be unrendered.
    */
   export
-  function changeCellType(widget: Notebook, value: nbformat.CellType): void {
-    if (!widget.model || !widget.activeCell) {
+  function changeCellType(notebook: Notebook, value: nbformat.CellType): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    Private.changeCellType(widget, value);
-    Private.handleState(widget, state);
+
+    const state = Private.getState(notebook);
+
+    Private.changeCellType(notebook, value);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Run the selected cell(s).
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param session - The optional client session object.
    *
@@ -389,20 +411,22 @@ namespace NotebookActions {
    * All markdown cells will be rendered.
    */
   export
-  function run(widget: Notebook, session?: IClientSession): Promise<boolean> {
-    if (!widget.model || !widget.activeCell) {
+  function run(notebook: Notebook, session?: IClientSession): Promise<boolean> {
+    if (!notebook.model || !notebook.activeCell) {
       return Promise.resolve(false);
     }
-    let state = Private.getState(widget);
-    let promise = Private.runSelected(widget, session);
-    Private.handleRunState(widget, state, false);
+
+    const state = Private.getState(notebook);
+    const promise = Private.runSelected(notebook, session);
+
+    Private.handleRunState(notebook, state, false);
     return promise;
   }
 
   /**
    * Run the selected cell(s) and advance to the next cell.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param session - The optional client session object.
    *
@@ -415,29 +439,32 @@ namespace NotebookActions {
    * will be created in `'edit'` mode.  The new cell creation can be undone.
    */
   export
-  function runAndAdvance(widget: Notebook, session?: IClientSession): Promise<boolean> {
-    if (!widget.model || !widget.activeCell) {
+  function runAndAdvance(notebook: Notebook, session?: IClientSession): Promise<boolean> {
+    if (!notebook.model || !notebook.activeCell) {
       return Promise.resolve(false);
     }
-    let state = Private.getState(widget);
-    let promise = Private.runSelected(widget, session);
-    let model = widget.model;
-    if (widget.activeCellIndex === widget.widgets.length - 1) {
-      let cell = model.contentFactory.createCodeCell({});
+
+    const state = Private.getState(notebook);
+    const promise = Private.runSelected(notebook, session);
+    const model = notebook.model;
+
+    if (notebook.activeCellIndex === notebook.widgets.length - 1) {
+      const cell = model.contentFactory.createCodeCell({});
+
       model.cells.push(cell);
-      widget.activeCellIndex++;
-      widget.mode = 'edit';
+      notebook.activeCellIndex++;
+      notebook.mode = 'edit';
     } else {
-      widget.activeCellIndex++;
+      notebook.activeCellIndex++;
     }
-    Private.handleRunState(widget, state, true);
+    Private.handleRunState(notebook, state, true);
     return promise;
   }
 
   /**
    * Run the selected cell(s) and insert a new code cell.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param session - The optional client session object.
    *
@@ -450,25 +477,27 @@ namespace NotebookActions {
    * The new cell will be scrolled into view.
    */
   export
-  function runAndInsert(widget: Notebook, session?: IClientSession): Promise<boolean> {
-    if (!widget.model || !widget.activeCell) {
+  function runAndInsert(notebook: Notebook, session?: IClientSession): Promise<boolean> {
+    if (!notebook.model || !notebook.activeCell) {
       return Promise.resolve(false);
     }
-    let state = Private.getState(widget);
-    let promise = Private.runSelected(widget, session);
-    let model = widget.model;
-    let cell = model.contentFactory.createCodeCell({});
-    model.cells.insert(widget.activeCellIndex + 1, cell);
-    widget.activeCellIndex++;
-    widget.mode = 'edit';
-    Private.handleRunState(widget, state, true);
+
+    const state = Private.getState(notebook);
+    const promise = Private.runSelected(notebook, session);
+    const model = notebook.model;
+    const cell = model.contentFactory.createCodeCell({ });
+
+    model.cells.insert(notebook.activeCellIndex + 1, cell);
+    notebook.activeCellIndex++;
+    notebook.mode = 'edit';
+    Private.handleRunState(notebook, state, true);
     return promise;
   }
 
   /**
    * Run all of the cells in the notebook.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param session - The optional client session object.
    *
@@ -479,21 +508,25 @@ namespace NotebookActions {
    * The last cell in the notebook will be activated and scrolled into view.
    */
   export
-  function runAll(widget: Notebook, session?: IClientSession): Promise<boolean> {
-    if (!widget.model || !widget.activeCell) {
+  function runAll(notebook: Notebook, session?: IClientSession): Promise<boolean> {
+    if (!notebook.model || !notebook.activeCell) {
       return Promise.resolve(false);
     }
-    let state = Private.getState(widget);
-    widget.widgets.forEach(child => { widget.select(child); });
-    let promise = Private.runSelected(widget, session);
-    Private.handleRunState(widget, state, true);
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(child => { notebook.select(child); });
+
+    const promise = Private.runSelected(notebook, session);
+
+    Private.handleRunState(notebook, state, true);
     return promise;
   }
 
   /**
    * Run all of the cells before the currently active cell (exclusive).
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param session - The optional client session object.
    *
@@ -504,26 +537,32 @@ namespace NotebookActions {
    * The currently active cell will remain selected.
    */
   export
-  function runAllAbove(widget: Notebook, session?: IClientSession): Promise<boolean> {
-    if (!widget.model || !widget.activeCell || widget.activeCellIndex === 0) {
+  function runAllAbove(notebook: Notebook, session?: IClientSession): Promise<boolean> {
+    const { activeCell, activeCellIndex, model } = notebook;
+
+    if (!model || !activeCell || activeCellIndex < 1) {
       return Promise.resolve(false);
     }
-    let state = Private.getState(widget);
-    widget.activeCellIndex--;
-    widget.deselectAll();
-    for (let i = 0; i < widget.activeCellIndex; ++i) {
-      widget.select(widget.widgets[i]);
+
+    const state = Private.getState(notebook);
+
+    notebook.activeCellIndex--;
+    notebook.deselectAll();
+    for (let i = 0; i < notebook.activeCellIndex; ++i) {
+      notebook.select(notebook.widgets[i]);
     }
-    let promise = Private.runSelected(widget, session);
-    widget.activeCellIndex++;
-    Private.handleRunState(widget, state, true);
+
+    const promise = Private.runSelected(notebook, session);
+
+    notebook.activeCellIndex++;
+    Private.handleRunState(notebook, state, true);
     return promise;
   }
 
   /**
    * Run all of the cells after the currently active cell (inclusive).
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param session - The optional client session object.
    *
@@ -534,24 +573,28 @@ namespace NotebookActions {
    * The last cell in the notebook will be activated and scrolled into view.
    */
   export
-  function runAllBelow(widget: Notebook, session?: IClientSession): Promise<boolean> {
-    if (!widget.model || !widget.activeCell) {
+  function runAllBelow(notebook: Notebook, session?: IClientSession): Promise<boolean> {
+    if (!notebook.model || !notebook.activeCell) {
       return Promise.resolve(false);
     }
-    let state = Private.getState(widget);
-    widget.deselectAll();
-    for (let i = widget.activeCellIndex; i < widget.widgets.length; ++i) {
-      widget.select(widget.widgets[i]);
+
+    const state = Private.getState(notebook);
+
+    notebook.deselectAll();
+    for (let i = notebook.activeCellIndex; i < notebook.widgets.length; ++i) {
+      notebook.select(notebook.widgets[i]);
     }
-    let promise = Private.runSelected(widget, session);
-    Private.handleRunState(widget, state, true);
+
+    const promise = Private.runSelected(notebook, session);
+
+    Private.handleRunState(notebook, state, true);
     return promise;
   }
 
   /**
    * Select the above the active cell.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The widget mode will be preserved.
@@ -559,23 +602,25 @@ namespace NotebookActions {
    * The existing selection will be cleared.
    */
   export
-  function selectAbove(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function selectAbove(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    if (widget.activeCellIndex === 0) {
+    if (notebook.activeCellIndex === 0) {
       return;
     }
-    let state = Private.getState(widget);
-    widget.activeCellIndex -= 1;
-    widget.deselectAll();
-    Private.handleState(widget, state, true);
+
+    const state = Private.getState(notebook);
+
+    notebook.activeCellIndex -= 1;
+    notebook.deselectAll();
+    Private.handleState(notebook, state, true);
   }
 
   /**
    * Select the cell below the active cell.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The widget mode will be preserved.
@@ -583,121 +628,127 @@ namespace NotebookActions {
    * The existing selection will be cleared.
    */
   export
-  function selectBelow(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function selectBelow(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    if (widget.activeCellIndex === widget.widgets.length - 1) {
+    if (notebook.activeCellIndex === notebook.widgets.length - 1) {
       return;
     }
-    let state = Private.getState(widget);
-    widget.activeCellIndex += 1;
-    widget.deselectAll();
-    Private.handleState(widget, state, true);
+
+    const state = Private.getState(notebook);
+
+    notebook.activeCellIndex += 1;
+    notebook.deselectAll();
+    Private.handleState(notebook, state, true);
   }
 
   /**
    * Extend the selection to the cell above.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * This is a no-op if the first cell is the active cell.
    * The new cell will be activated.
    */
   export
-  function extendSelectionAbove(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function extendSelectionAbove(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
     // Do not wrap around.
-    if (widget.activeCellIndex === 0) {
+    if (notebook.activeCellIndex === 0) {
       return;
     }
-    let state = Private.getState(widget);
-    widget.mode = 'command';
-    widget.extendContiguousSelectionTo(widget.activeCellIndex - 1);
-    Private.handleState(widget, state, true);
+
+    const state = Private.getState(notebook);
+
+    notebook.mode = 'command';
+    notebook.extendContiguousSelectionTo(notebook.activeCellIndex - 1);
+    Private.handleState(notebook, state, true);
   }
 
   /**
    * Extend the selection to the cell below.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * This is a no-op if the last cell is the active cell.
    * The new cell will be activated.
    */
   export
-  function extendSelectionBelow(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function extendSelectionBelow(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
     // Do not wrap around.
-    if (widget.activeCellIndex === widget.widgets.length - 1) {
+    if (notebook.activeCellIndex === notebook.widgets.length - 1) {
       return;
     }
-    let state = Private.getState(widget);
-    widget.mode = 'command';
-    widget.extendContiguousSelectionTo(widget.activeCellIndex + 1);
-    Private.handleState(widget, state, true);
+
+    const state = Private.getState(notebook);
+
+    notebook.mode = 'command';
+    notebook.extendContiguousSelectionTo(notebook.activeCellIndex + 1);
+    Private.handleState(notebook, state, true);
   }
 
   /**
    * Select all of the cells of the notebook.
    *
-   * @param widget - the targe notebook widget.
+   * @param notebook - the targe notebook widget.
    */
   export
-  function selectAll(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function selectAll(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    widget.widgets.forEach(child => { widget.select(child); });
+    notebook.widgets.forEach(child => { notebook.select(child); });
   }
 
   /**
    * Deselect all of the cells of the notebook.
    *
-   * @param widget - the targe notebook widget.
+   * @param notebook - the targe notebook widget.
    */
   export
-  function deselectAll(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function deselectAll(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    widget.deselectAll();
+    notebook.deselectAll();
   }
 
   /**
    * Copy the selected cell data to a clipboard.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function copy(widget: Notebook): void {
-    Private.copyOrCut(widget, false);
+  function copy(notebook: Notebook): void {
+    Private.copyOrCut(notebook, false);
   }
 
   /**
    * Cut the selected cell data to a clipboard.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * This action can be undone.
    * A new code cell is added if all cells are cut.
    */
   export
-  function cut(widget: Notebook): void {
-    Private.copyOrCut(widget, true);
+  function cut(notebook: Notebook): void {
+    Private.copyOrCut(notebook, true);
   }
 
   /**
    * Paste cells from the application clipboard.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param mode - the mode of the paste operation: 'below' pastes cells
    *   below the active cell, 'above' pastes cells above the active cell,
@@ -710,56 +761,59 @@ namespace NotebookActions {
    * This action can be undone.
    */
   export
-  function paste(widget: Notebook, mode: 'below' | 'above' | 'replace' = 'below'): void {
-    if (!widget.model || !widget.activeCell) {
+  function paste(notebook: Notebook, mode: 'below' | 'above' | 'replace' = 'below'): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let clipboard = Clipboard.getInstance();
+
+    const clipboard = Clipboard.getInstance();
+
     if (!clipboard.hasData(JUPYTER_CELL_MIME)) {
       return;
     }
-    let state = Private.getState(widget);
-    let values = clipboard.getData(JUPYTER_CELL_MIME) as nbformat.IBaseCell[];
-    let model = widget.model;
-    let newCells: ICellModel[] = [];
-    widget.mode = 'command';
 
-    values.forEach(cell => {
+    const state = Private.getState(notebook);
+    const values = clipboard.getData(JUPYTER_CELL_MIME) as nbformat.IBaseCell[];
+    const model = notebook.model;
+
+    notebook.mode = 'command';
+
+    const newCells = values.map(cell => {
       switch (cell.cell_type) {
       case 'code':
-        newCells.push(model.contentFactory.createCodeCell({ cell }));
-        break;
+        return model.contentFactory.createCodeCell({ cell });
       case 'markdown':
-        newCells.push(model.contentFactory.createMarkdownCell({ cell }));
-        break;
+        return model.contentFactory.createMarkdownCell({ cell });
       default:
-        newCells.push(model.contentFactory.createRawCell({ cell }));
-        break;
+        return model.contentFactory.createRawCell({ cell });
       }
     });
 
-    let cells = widget.model.cells;
+    const cells = notebook.model.cells;
     let index: number;
+
     cells.beginCompoundOperation();
 
-    // Set the starting index of the paste
-    // operation depending upon the mode.
+    // Set the starting index of the paste operation depending upon the mode.
     switch (mode) {
       case 'below':
-        index = widget.activeCellIndex;
+        index = notebook.activeCellIndex;
         break;
       case 'above':
-        index = widget.activeCellIndex - 1;
+        index = notebook.activeCellIndex - 1;
         break;
       case 'replace':
         // Find the cells to delete.
         const toDelete: number[] = [];
-        widget.widgets.forEach((child, i) => {
-          let deletable = child.model.metadata.get('deletable');
-          if (widget.isSelectedOrActive(child) && deletable !== false) {
-            toDelete.push(i);
+
+        notebook.widgets.forEach((child, index) => {
+          const deletable = child.model.metadata.get('deletable') !== false;
+
+          if (notebook.isSelectedOrActive(child) && deletable) {
+            toDelete.push(index);
           }
         });
+
         // If cells are not deletable, we may not have anything to delete.
         if (toDelete.length > 0) {
           // Delete the cells as one undo event.
@@ -774,67 +828,72 @@ namespace NotebookActions {
     newCells.forEach(cell => { cells.insert(++index, cell); });
     cells.endCompoundOperation();
 
-    widget.activeCellIndex += newCells.length;
-    widget.deselectAll();
-    Private.handleState(widget, state);
+    notebook.activeCellIndex += newCells.length;
+    notebook.deselectAll();
+    Private.handleState(notebook, state);
   }
 
   /**
    * Undo a cell action.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * This is a no-op if if there are no cell actions to undo.
    */
   export
-  function undo(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function undo(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    widget.mode = 'command';
-    widget.model.cells.undo();
-    widget.deselectAll();
-    Private.handleState(widget, state);
+
+    const state = Private.getState(notebook);
+
+    notebook.mode = 'command';
+    notebook.model.cells.undo();
+    notebook.deselectAll();
+    Private.handleState(notebook, state);
   }
 
   /**
    * Redo a cell action.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * This is a no-op if there are no cell actions to redo.
    */
   export
-  function redo(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function redo(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    widget.mode = 'command';
-    widget.model.cells.redo();
-    widget.deselectAll();
-    Private.handleState(widget, state);
+
+    const state = Private.getState(notebook);
+
+    notebook.mode = 'command';
+    notebook.model.cells.redo();
+    notebook.deselectAll();
+    Private.handleState(notebook, state);
   }
 
   /**
    * Toggle the line number of all cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The original state is based on the state of the active cell.
    * The `mode` of the widget will be preserved.
    */
   export
-  function toggleAllLineNumbers(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function toggleAllLineNumbers(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    const config = widget.editorConfig;
+
+    const state = Private.getState(notebook);
+    const config = notebook.editorConfig;
     const lineNumbers = !(config.code.lineNumbers &&
       config.markdown.lineNumbers && config.raw.lineNumbers);
     const newConfig = {
@@ -842,118 +901,128 @@ namespace NotebookActions {
       markdown: { ...config.markdown, lineNumbers },
       raw: { ...config.raw, lineNumbers }
     };
-    widget.editorConfig = newConfig;
-    Private.handleState(widget, state);
+
+    notebook.editorConfig = newConfig;
+    Private.handleState(notebook, state);
   }
 
   /**
    * Clear the code outputs of the selected cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The widget `mode` will be preserved.
    */
   export
-  function clearOutputs(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function clearOutputs(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    each(widget.model.cells, (cell: ICodeCellModel, index) => {
-      let child = widget.widgets[index];
-      if (widget.isSelectedOrActive(child) && cell.type === 'code') {
+
+    const state = Private.getState(notebook);
+
+    each(notebook.model.cells, (cell: ICodeCellModel, index) => {
+      const child = notebook.widgets[index];
+
+      if (notebook.isSelectedOrActive(child) && cell.type === 'code') {
         cell.outputs.clear();
         (child as CodeCell).outputHidden = false;
         cell.executionCount = null;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Clear all the code outputs on the widget.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The widget `mode` will be preserved.
    */
   export
-  function clearAllOutputs(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function clearAllOutputs(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    each(widget.model.cells, (cell: ICodeCellModel, index) => {
-      let child = widget.widgets[index];
+
+    const state = Private.getState(notebook);
+
+    each(notebook.model.cells, (cell: ICodeCellModel, index) => {
+      const child = notebook.widgets[index];
+
       if (cell.type === 'code') {
         cell.outputs.clear();
         cell.executionCount = null;
         (child as CodeCell).outputHidden = false;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Hide the code on selected code cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function hideCode(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function hideCode(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
-      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
+      if (notebook.isSelectedOrActive(cell) && cell.model.type === 'code') {
         cell.inputHidden = true;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Show the code on selected code cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function showCode(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function showCode(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
-      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
+      if (notebook.isSelectedOrActive(cell) && cell.model.type === 'code') {
         cell.inputHidden = false;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Hide the code on all code cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function hideAllCode(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function hideAllCode(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
       if (cell.model.type === 'code') {
         cell.inputHidden = true;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
@@ -962,153 +1031,161 @@ namespace NotebookActions {
    * @param widget - The target notebook widget.
    */
   export
-  function showAllCode(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function showAllCode(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
       if (cell.model.type === 'code') {
         cell.inputHidden = false;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Hide the output on selected code cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function hideOutput(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function hideOutput(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
-      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
+      if (notebook.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).outputHidden = true;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Show the output on selected code cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function showOutput(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function showOutput(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
-      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
+      if (notebook.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).outputHidden = false;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Hide the output on all code cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function hideAllOutputs(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function hideAllOutputs(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
       if (cell.model.type === 'code') {
         (cell as CodeCell).outputHidden = true;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Show the output on all code cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function showAllOutputs(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function showAllOutputs(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
       if (cell.model.type === 'code') {
         (cell as CodeCell).outputHidden = false;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Enable output scrolling for all selected cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function enableOutputScrolling(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function enableOutputScrolling(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
-      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
+      if (notebook.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).outputsScrolled = true;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Disable output scrolling for all selected cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function disableOutputScrolling(widget: Notebook): void {
-    if (!widget.model || !widget.activeCell) {
+  function disableOutputScrolling(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
-      if (widget.isSelectedOrActive(cell) && cell.model.type === 'code') {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
+      if (notebook.isSelectedOrActive(cell) && cell.model.type === 'code') {
         (cell as CodeCell).outputsScrolled = false;
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
   /**
    * Persists the collapsed state of all code cell outputs to the model.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    */
   export
-  function persistViewState(widget: Notebook): void {
-    if (!widget.model) {
+  function persistViewState(notebook: Notebook): void {
+    if (!notebook.model) {
       return;
     }
-    let state = Private.getState(widget);
-    let cells = widget.widgets;
-    cells.forEach(cell => {
+
+    const state = Private.getState(notebook);
+
+    notebook.widgets.forEach(cell => {
       const {model, inputHidden} = cell;
       const metadata = model.metadata;
       const jupyter = metadata.get('jupyter') as any || {};
@@ -1145,14 +1222,14 @@ namespace NotebookActions {
         metadata.set('jupyter', jupyter);
       }
     });
-    Private.handleState(widget, state);
+    Private.handleState(notebook, state);
   }
 
 
   /**
    * Set the markdown header level.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param level - The header level.
    *
@@ -1164,26 +1241,28 @@ namespace NotebookActions {
    * The cells will be unrendered.
    */
   export
-  function setMarkdownHeader(widget: Notebook, level: number) {
-    if (!widget.model || !widget.activeCell) {
+  function setMarkdownHeader(notebook: Notebook, level: number) {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = Private.getState(widget);
+
+    const state = Private.getState(notebook);
+    const cells = notebook.model.cells;
+
     level = Math.min(Math.max(level, 1), 6);
-    let cells = widget.model.cells;
-    widget.widgets.forEach((child, index) => {
-      if (widget.isSelectedOrActive(child)) {
+    notebook.widgets.forEach((child, index) => {
+      if (notebook.isSelectedOrActive(child)) {
         Private.setMarkdownHeader(cells.get(index), level);
       }
     });
-    Private.changeCellType(widget, 'markdown');
-    Private.handleState(widget, state);
+    Private.changeCellType(notebook, 'markdown');
+    Private.handleState(notebook, state);
   }
 
   /**
    * Trust the notebook after prompting the user.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @returns a promise that resolves when the transaction is finished.
    *
@@ -1191,19 +1270,22 @@ namespace NotebookActions {
    * No dialog will be presented if the notebook is already trusted.
    */
   export
-  function trust(widget: Notebook): Promise<void> {
-    if (!widget.model) {
+  function trust(notebook: Notebook): Promise<void> {
+    if (!notebook.model) {
       return Promise.resolve();
     }
     // Do nothing if already trusted.
-    let cells = toArray(widget.model.cells);
-    let trusted = cells.every(cell => cell.trusted);
+
+    const cells = toArray(notebook.model.cells);
+    const trusted = cells.every(cell => cell.trusted);
+
     if (trusted) {
       return showDialog({
         body: 'Notebook is already trusted',
         buttons: [Dialog.okButton()]
       }).then(() => undefined);
     }
+
     return showDialog({
       body: TRUST_MESSAGE,
       title: 'Trust this notebook?',
@@ -1247,10 +1329,10 @@ namespace Private {
    * Get the state of a widget before running an action.
    */
   export
-  function getState(widget: Notebook): IState {
+  function getState(notebook: Notebook): IState {
     return {
-      wasFocused: widget.node.contains(document.activeElement),
-      activeCell: widget.activeCell
+      wasFocused: notebook.node.contains(document.activeElement),
+      activeCell: notebook.activeCell
     };
   }
 
@@ -1258,12 +1340,15 @@ namespace Private {
    * Handle the state of a widget after running an action.
    */
   export
-  function handleState(widget: Notebook, state: IState, scrollIfNeeded=false): void {
-    if (state.wasFocused || widget.mode === 'edit') {
-      widget.activate();
+  function handleState(notebook: Notebook, state: IState, scrollIfNeeded=false): void {
+    const { activeCell, node } = notebook;
+
+    if (state.wasFocused || notebook.mode === 'edit') {
+      notebook.activate();
     }
+
     if (scrollIfNeeded) {
-      ElementExt.scrollIntoViewIfNeeded(widget.node, widget.activeCell.node);
+      ElementExt.scrollIntoViewIfNeeded(node, activeCell.node);
     }
   }
 
@@ -1271,14 +1356,15 @@ namespace Private {
    * Handle the state of a widget after running a run action.
    */
   export
-  function handleRunState(widget: Notebook, state: IState, scroll = false): void {
-    if (state.wasFocused || widget.mode === 'edit') {
-      widget.activate();
+  function handleRunState(notebook: Notebook, state: IState, scroll = false): void {
+    if (state.wasFocused || notebook.mode === 'edit') {
+      notebook.activate();
     }
     if (scroll) {
       // Scroll to the top of the previous active cell output.
-      let er = state.activeCell.inputArea.node.getBoundingClientRect();
-      widget.scrollToPosition(er.bottom, 45);
+      const rect = state.activeCell.inputArea.node.getBoundingClientRect();
+
+      notebook.scrollToPosition(rect.bottom, 45);
     }
   }
 
@@ -1304,12 +1390,12 @@ namespace Private {
    * Run the selected cells.
    */
   export
-  function runSelected(widget: Notebook, session?: IClientSession): Promise<boolean> {
-    widget.mode = 'command';
+  function runSelected(notebook: Notebook, session?: IClientSession): Promise<boolean> {
+    notebook.mode = 'command';
 
-    let lastIndex = widget.activeCellIndex;
-    const selected = widget.widgets.filter((child, index) => {
-      const active = widget.isSelectedOrActive(child);
+    let lastIndex = notebook.activeCellIndex;
+    const selected = notebook.widgets.filter((child, index) => {
+      const active = notebook.isSelectedOrActive(child);
 
       if (active) {
         lastIndex = index;
@@ -1318,17 +1404,17 @@ namespace Private {
       return active;
     });
 
-    widget.activeCellIndex = lastIndex;
-    widget.deselectAll();
+    notebook.activeCellIndex = lastIndex;
+    notebook.deselectAll();
 
-    return Promise.all(selected.map(child => runCell(widget, child, session)))
+    return Promise.all(selected.map(child => runCell(notebook, child, session)))
       .then(results => {
-        if (widget.isDisposed) {
+        if (notebook.isDisposed) {
           return false;
         }
 
         // Post an update request.
-        widget.update();
+        notebook.update();
 
         return results.every(result => result);
       });
@@ -1398,7 +1484,7 @@ namespace Private {
    * See [Payloads (DEPRECATED)](https://jupyter-client.readthedocs.io/en/latest/messaging.html#payloads-deprecated).
    */
   function handlePayload(content: KernelMessage.IExecuteOkReply, parent: Notebook, child: Cell) {
-    let setNextInput = content.payload.filter(i => {
+    const setNextInput = content.payload.filter(i => {
       return (i as any).source === 'set_next_input';
     })[0];
 
@@ -1406,8 +1492,8 @@ namespace Private {
       return;
     }
 
-    let text = (setNextInput as any).text;
-    let replace = (setNextInput as any).replace;
+    const text = (setNextInput as any).text;
+    const replace = (setNextInput as any).replace;
 
     if (replace) {
       child.model.value.text = text;
@@ -1415,52 +1501,54 @@ namespace Private {
     }
 
     // Create a new code cell and add as the next cell.
-    let cell = parent.model.contentFactory.createCodeCell({});
+    const cell = parent.model.contentFactory.createCodeCell({ });
+    const cells = parent.model.cells;
+    const index = ArrayExt.firstIndexOf(toArray(cells), child.model);
+
     cell.value.text = text;
-    let cells = parent.model.cells;
-    let i = ArrayExt.firstIndexOf(toArray(cells), child.model);
-    if (i === -1) {
+    if (index === -1) {
       cells.push(cell);
     } else {
-      cells.insert(i + 1, cell);
+      cells.insert(index + 1, cell);
     }
   }
 
   /**
    * Copy or cut the selected cell data to the application clipboard.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param cut - Whether to copy or cut.
    */
   export
-  function copyOrCut(widget: Notebook, cut: boolean): void {
-    if (!widget.model || !widget.activeCell) {
+  function copyOrCut(notebook: Notebook, cut: boolean): void {
+    if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    let state = getState(widget);
-    widget.mode = 'command';
-    let clipboard = Clipboard.getInstance();
+
+    const state = getState(notebook);
+    const clipboard = Clipboard.getInstance();
+
+    notebook.mode = 'command';
     clipboard.clear();
-    let data: nbformat.IBaseCell[] = [];
-    widget.widgets.forEach(child => {
-      if (widget.isSelectedOrActive(child)) {
-        data.push(child.model.toJSON());
-      }
-    });
+
+    const data = notebook.widgets
+      .filter(cell => notebook.isSelectedOrActive(cell))
+      .map(cell => cell.model.toJSON())
+
     clipboard.setData(JUPYTER_CELL_MIME, data);
     if (cut) {
-      deleteCells(widget);
+      deleteCells(notebook);
     } else {
-      widget.deselectAll();
+      notebook.deselectAll();
     }
-    handleState(widget, state);
+    handleState(notebook, state);
   }
 
   /**
    * Change the selected cell type(s).
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * @param value - The target cell type.
    *
@@ -1471,18 +1559,19 @@ namespace Private {
    * Any cells converted to markdown will be unrendered.
    */
   export
-  function changeCellType(widget: Notebook, value: nbformat.CellType): void {
-    let model = widget.model;
-    let cells = model.cells;
+  function changeCellType(notebook: Notebook, value: nbformat.CellType): void {
+    const model = notebook.model;
+    const cells = model.cells;
 
     cells.beginCompoundOperation();
-    widget.widgets.forEach((child, i) => {
-      if (!widget.isSelectedOrActive(child)) {
+    notebook.widgets.forEach((child, index) => {
+      if (!notebook.isSelectedOrActive(child)) {
         return;
       }
       if (child.model.type !== value) {
-        let cell: nbformat.IBaseCell = child.model.toJSON();
+        const cell = child.model.toJSON();
         let newCell: ICellModel;
+
         switch (value) {
         case 'code':
           newCell = model.contentFactory.createCodeCell({ cell });
@@ -1499,22 +1588,22 @@ namespace Private {
             newCell.trusted = false;
           }
         }
-        cells.set(i, newCell);
+        cells.set(index, newCell);
       }
       if (value === 'markdown') {
         // Fetch the new widget and unrender it.
-        child = widget.widgets[i];
+        child = notebook.widgets[index];
         (child as MarkdownCell).rendered = false;
       }
     });
     cells.endCompoundOperation();
-    widget.deselectAll();
+    notebook.deselectAll();
   }
 
   /**
    * Delete the selected cells.
    *
-   * @param widget - The target notebook widget.
+   * @param notebook - The target notebook widget.
    *
    * #### Notes
    * The cell after the last selected cell will be activated.
@@ -1523,17 +1612,19 @@ namespace Private {
    * This action can be undone.
    */
   export
-  function deleteCells(widget: Notebook): void {
-    let model = widget.model;
-    let cells = model.cells;
-    let toDelete: number[] = [];
-    widget.mode = 'command';
+  function deleteCells(notebook: Notebook): void {
+    const model = notebook.model;
+    const cells = model.cells;
+    const toDelete: number[] = [];
+
+    notebook.mode = 'command';
 
     // Find the cells to delete.
-    widget.widgets.forEach((child, i) => {
-      let deletable = child.model.metadata.get('deletable');
-      if (widget.isSelectedOrActive(child) && deletable !== false) {
-        toDelete.push(i);
+    notebook.widgets.forEach((child, index) => {
+      const deletable = child.model.metadata.get('deletable') !== false;
+
+      if (notebook.isSelectedOrActive(child) && deletable) {
+        toDelete.push(index);
       }
     });
 
@@ -1542,9 +1633,7 @@ namespace Private {
       // Delete the cells as one undo event.
       cells.beginCompoundOperation();
       // Delete cells in reverse order to maintain the correct indices.
-      toDelete.reverse().forEach(i => {
-        cells.remove(i);
-      });
+      toDelete.reverse().forEach(index => { cells.remove(index); });
       // Add a new cell if the notebook is empty. This is done
       // within the compound operation to make the deletion of
       // a notebook's last cell undoable.
@@ -1559,12 +1648,12 @@ namespace Private {
       // so if the last cell is deleted the previous cell will be activated.
       // The *first* index is the index of the last cell in the initial
       // toDelete list due to the `reverse` operation above.
-      widget.activeCellIndex = toDelete[0] - toDelete.length + 1;
+      notebook.activeCellIndex = toDelete[0] - toDelete.length + 1;
     }
 
     // Deselect any remaining, undeletable cells. Do this even if we don't
     // delete anything so that users are aware *something* happened.
-    widget.deselectAll();
+    notebook.deselectAll();
   }
 
   /**
@@ -1572,11 +1661,12 @@ namespace Private {
    */
   export
   function setMarkdownHeader(cell: ICellModel, level: number) {
-    let source = cell.value.text;
-    let newHeader = Array(level + 1).join('#') + ' ';
     // Remove existing header or leading white space.
-    let regex = /^(#+\s*)|^(\s*)/;
-    let matches = regex.exec(source);
+    let source = cell.value.text;
+    const regex = /^(#+\s*)|^(\s*)/;
+    const newHeader = Array(level + 1).join('#') + ' ';
+    const matches = regex.exec(source);
+
     if (matches) {
       source = source.slice(matches[0].length);
     }

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -82,6 +82,26 @@ describe('@jupyterlab/notebook', () => {
       return Promise.all([session.shutdown(), ipySession.shutdown()]);
     });
 
+    describe('#executed', () => {
+
+      it('should emit when Markdown and code cells are run', () => {
+        let cell = widget.activeCell as CodeCell;
+        let next = widget.widgets[1] as MarkdownCell;
+        let emitted = 0;
+
+        widget.select(next);
+        cell.model.outputs.clear();
+        next.rendered = false;
+        NotebookActions.executed.connect(() => { emitted += 1; });
+
+        return NotebookActions.run(widget, session).then(result => {
+          expect(emitted).to.be(2);
+          expect(next.rendered).to.be(true);
+        });
+      });
+
+    });
+
     describe('#splitCell({})', () => {
 
       it('should split the active cell into two cells', () => {
@@ -470,7 +490,7 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#run()', () => {
 
-      it('should run the selected cells', function () {
+      it('should run the selected cells', () => {
         let next = widget.widgets[1] as MarkdownCell;
         widget.select(next);
         let cell = widget.activeCell as CodeCell;


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/4740

Adds an `executed` signal on the `NotebookActions` collection of functionality that emits whenever a Markdown or code cell is run. The `args` that the signal receiver gets is an object that has the `notebook: Notebook` and the `cell: Cell`.

If multiple cells are run, each individual cell will be emitted.

Here is an example extension that uses this signal:
```typescript
import {
  JupyterLabPlugin
} from '@jupyterlab/application';

import {
  NotebookActions
} from '@jupyterlab/notebook';

/**
 * A cell execution notifier extension.
 */
const plugin: JupyterLabPlugin<void> = {
  id: '@jupyterlab/pull-4744:plugin',
  autoStart: true,
  activate: () => {
    NotebookActions.executed.connect((sender, args) => {
      const { notebook, cell } = args;

      console.log('Executed cell:', cell);
      console.log('Parent notebook:', notebook);
    });
  }
};

export default plugin;
```

Additionally, this PR cleans up the `actions.tsx` file:

* Use native array `forEach()`, `filter()`, and `map()` where appropriate.
* Only use `let` when a variable is mutable, otherwise use `const`.
* Name the notebook parameter of functions `notebook` instead of `widget` for clarity.