### PR TITLE
Upgrade CodeMirror to release 5.39.0, start sTeX directly in math mode

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -87,7 +87,7 @@
     "@phosphor/widgets": "^1.6.0",
     "ajv": "~5.1.6",
     "ansi_up": "^3.0.0",
-    "codemirror": "~5.37.0",
+    "codemirror": "~5.39.0",
     "comment-json": "^1.1.3",
     "es6-promise": "~4.1.1",
     "marked": "~0.3.9",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -38,7 +38,7 @@
     "@jupyterlab/fileeditor": "^0.16.2",
     "@jupyterlab/mainmenu": "^0.5.2",
     "@phosphor/widgets": "^1.6.0",
-    "codemirror": "~5.37.0"
+    "codemirror": "~5.39.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -38,7 +38,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "codemirror": "~5.37.0"
+    "codemirror": "~5.39.0"
   },
   "devDependencies": {
     "@types/codemirror": "~0.0.46",

--- a/packages/codemirror/src/codemirror-ipythongfm.ts
+++ b/packages/codemirror/src/codemirror-ipythongfm.ts
@@ -19,7 +19,7 @@ import 'codemirror/addon/mode/multiplex';
  */
 CodeMirror.defineMode('ipythongfm', (config: CodeMirror.EditorConfiguration, modeOptions?: any) => {
   let gfmMode = CodeMirror.getMode(config, 'gfm');
-  let texMode = CodeMirror.getMode(config, 'stex');
+  let texMode = CodeMirror.getMode(config, { name: 'stex', inMathMode: true });
 
   return CodeMirror.multiplexingMode(
     gfmMode,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,9 +1653,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror@~5.37.0:
-  version "5.37.0"
-  resolved "https://registry.npmjs.org/codemirror/-/codemirror-5.37.0.tgz#c349b584e158f590277f26d37c2469a6bc538036"
+codemirror@~5.39.0:
+  version "5.39.0"
+  resolved "https://registry.npmjs.org/codemirror/-/codemirror-5.39.0.tgz#4654f7d2f7e525e04a62e72d9482348ccb37dce5"
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The CodeMirror mode used by jupyterlab to highlight markdown document is based on multiplex CodeMirror addon.
It starts parsing text in markdown mode; when a math delimiter ('$', '$$', etc) is encountered, the parser consumes it and then switches to sTeX mode.
The problem is sTeX starts assuming to be in text mode, therefore math formulas are highlighted as if they were normal text (see codemirror/CodeMirror#5430).
The latest CodeMirror release (5.39.0) has a new feature, an option to starts sTeX directly in math mode.

This PR updates CodeMirror to the latest release and uses the new sTeX option to fix the described issue.

Cheers