### PR TITLE
Mimerender tracker

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -137,7 +137,6 @@
       "@jupyterlab/inspector-extension": "",
       "@jupyterlab/launcher-extension": "",
       "@jupyterlab/mainmenu-extension": "",
-      "@jupyterlab/markdownviewer-extension": "",
       "@jupyterlab/mathjax2-extension": "",
       "@jupyterlab/notebook-extension": "",
       "@jupyterlab/rendermime-extension": "",
@@ -153,6 +152,7 @@
     "mimeExtensions": {
       "@jupyterlab/javascript-extension": "",
       "@jupyterlab/json-extension": "",
+      "@jupyterlab/markdownviewer-extension": "",
       "@jupyterlab/pdf-extension": "",
       "@jupyterlab/vdom-extension": "",
       "@jupyterlab/vega3-extension": ""

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -9,11 +9,11 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  CommandLinker
+  CommandLinker, IInstanceTracker, InstanceTracker
 } from '@jupyterlab/apputils';
 
 import {
-  Base64ModelFactory, DocumentRegistry
+  Base64ModelFactory, DocumentRegistry, MimeDocument
 } from '@jupyterlab/docregistry';
 
 import {
@@ -77,8 +77,11 @@ class JupyterLab extends Application<ApplicationShell> {
     let registry = this.docRegistry = new DocumentRegistry();
     registry.addModelFactory(new Base64ModelFactory());
 
+    const namespace = 'application-mimedocuments';
+    const tracker = this.mimeDocumentTracker = new InstanceTracker<MimeDocument>({ namespace });
+
     if (options.mimeExtensions) {
-      let plugins = createRendermimePlugins(options.mimeExtensions);
+      let plugins = createRendermimePlugins(tracker, options.mimeExtensions);
       plugins.forEach(plugin => { this.registerPlugin(plugin); });
     }
   }
@@ -102,6 +105,11 @@ class JupyterLab extends Application<ApplicationShell> {
    * A list of all errors encountered when registering plugins.
    */
   readonly registerPluginErrors: Array<Error> = [];
+
+  /**
+   * An instance tracker for mime documents.
+   */
+  readonly mimeDocumentTracker: IInstanceTracker<MimeDocument>;
 
   /**
    * Whether the application is dirty.

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -9,11 +9,11 @@ import {
 } from '@jupyterlab/coreutils';
 
 import {
-  CommandLinker, IInstanceTracker, InstanceTracker
+  CommandLinker
 } from '@jupyterlab/apputils';
 
 import {
-  Base64ModelFactory, DocumentRegistry, MimeDocument
+  Base64ModelFactory, DocumentRegistry
 } from '@jupyterlab/docregistry';
 
 import {
@@ -41,9 +41,10 @@ import {
 } from './shell';
 import { ISignal, Signal } from '@phosphor/signaling';
 
-export { ApplicationShell } from './shell';
 export { ILayoutRestorer, LayoutRestorer } from './layoutrestorer';
+export { IMimeDocumentTracker } from './mimerenderers';
 export { IRouter, Router } from './router';
+export { ApplicationShell } from './shell';
 
 
 /**
@@ -77,11 +78,8 @@ class JupyterLab extends Application<ApplicationShell> {
     let registry = this.docRegistry = new DocumentRegistry();
     registry.addModelFactory(new Base64ModelFactory());
 
-    const namespace = 'application-mimedocuments';
-    const tracker = this.mimeDocumentTracker = new InstanceTracker<MimeDocument>({ namespace });
-
     if (options.mimeExtensions) {
-      let plugins = createRendermimePlugins(tracker, options.mimeExtensions);
+      let plugins = createRendermimePlugins(options.mimeExtensions);
       plugins.forEach(plugin => { this.registerPlugin(plugin); });
     }
   }
@@ -105,11 +103,6 @@ class JupyterLab extends Application<ApplicationShell> {
    * A list of all errors encountered when registering plugins.
    */
   readonly registerPluginErrors: Array<Error> = [];
-
-  /**
-   * An instance tracker for mime documents.
-   */
-  readonly mimeDocumentTracker: IInstanceTracker<MimeDocument>;
 
   /**
    * Whether the application is dirty.

--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -30,7 +30,7 @@ import {
  * Create rendermime plugins for rendermime extension modules.
  */
 export
-function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): JupyterLabPlugin<void>[] {
+function createRendermimePlugins(mimeDocumentTracker: InstanceTracker<MimeDocument>, extensions: IRenderMime.IExtensionModule[]): JupyterLabPlugin<void>[] {
   const plugins: JupyterLabPlugin<void>[] = [];
 
   extensions.forEach(mod => {
@@ -44,7 +44,9 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
       data = [data] as ReadonlyArray<IRenderMime.IExtension>;
     }
     (data as ReadonlyArray<IRenderMime.IExtension>)
-      .forEach(item => { plugins.push(createRendermimePlugin(item)); });
+      .forEach(item => {
+        plugins.push(createRendermimePlugin(mimeDocumentTracker, item));
+      });
   });
 
   return plugins;
@@ -55,7 +57,7 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
  * Create rendermime plugins for rendermime extension modules.
  */
 export
-function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<void> {
+function createRendermimePlugin(mimeDocumentTracker: InstanceTracker<MimeDocument>, item: IRenderMime.IExtension): JupyterLabPlugin<void> {
   return {
     id: item.id,
     requires: [ILayoutRestorer, IRenderMimeRegistry],
@@ -117,6 +119,9 @@ function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<
           // Notify the instance tracker if restore data needs to update.
           widget.context.pathChanged.connect(() => { tracker.save(widget); });
           tracker.add(widget);
+          // Also add the widget to the application mime document tracker
+          // so that it can be accessible to extensions.
+          mimeDocumentTracker.add(widget);
         });
       });
     }

--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -57,7 +57,7 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
   const plugins: JupyterLabPlugin<void | IMimeDocumentTracker>[] = [];
 
   const namespace = 'application-mimedocuments';
-  const mimeDocumentTracker = new InstanceTracker<MimeDocument>({ namespace });
+  const tracker = new InstanceTracker<MimeDocument>({ namespace });
 
   extensions.forEach(mod => {
     let data = mod.default;
@@ -71,7 +71,7 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
     }
     (data as ReadonlyArray<IRenderMime.IExtension>)
       .forEach(item => {
-        plugins.push(createRendermimePlugin(mimeDocumentTracker, item));
+        plugins.push(createRendermimePlugin(tracker, item));
       });
   });
 
@@ -83,7 +83,7 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
     provides: IMimeDocumentTracker,
     autoStart: true,
     activate: (app: JupyterLab, restorer: ILayoutRestorer) => {
-      restorer.restore(mimeDocumentTracker, {
+      restorer.restore(tracker, {
         command: 'docmanager:open',
         args: widget => ({
           path: widget.context.path,
@@ -92,7 +92,7 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
         name: widget =>
           `${widget.context.path}:${Private.factoryNameProperty.get(widget)}`
       });
-      return mimeDocumentTracker;
+      return tracker;
     }
   });
 
@@ -104,7 +104,7 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
  * Create rendermime plugins for rendermime extension modules.
  */
 export
-function createRendermimePlugin(mimeDocumentTracker: InstanceTracker<MimeDocument>, item: IRenderMime.IExtension): JupyterLabPlugin<void> {
+function createRendermimePlugin(tracker: InstanceTracker<MimeDocument>, item: IRenderMime.IExtension): JupyterLabPlugin<void> {
   return {
     id: item.id,
     requires: [ILayoutRestorer, IRenderMimeRegistry],
@@ -156,9 +156,9 @@ function createRendermimePlugin(mimeDocumentTracker: InstanceTracker<MimeDocumen
           Private.factoryNameProperty.set(widget, factory.name);
           // Notify the instance tracker if restore data needs to update.
           widget.context.pathChanged.connect(() => {
-            mimeDocumentTracker.save(widget);
+            tracker.save(widget);
           });
-          mimeDocumentTracker.add(widget);
+          tracker.add(widget);
         });
       });
     }

--- a/packages/apputils/src/instancetracker.ts
+++ b/packages/apputils/src/instancetracker.ts
@@ -71,11 +71,28 @@ interface IInstanceTracker<T extends Widget> extends IDisposable {
   readonly size: number;
 
   /**
+   * Find the first widget in the tracker that satisfies a filter function.
+   *
+   * @param - fn The filter function to call on each widget.
+   *
+   * #### Notes
+   * If no widget is found, the value returned is `undefined`.
+   */
+  find(fn: (widget: T) => boolean): T | undefined;
+
+  /**
    * Iterate through each widget in the tracker.
    *
    * @param fn - The function to call on each widget.
    */
   forEach(fn: (widget: T) => void): void;
+
+  /**
+   * Filter the widgets in the tracker based on a predicate.
+   *
+   * @param fn - The function by which to filter.
+   */
+  filter(fn: (widget: T) => boolean): T[];
 
   /**
    * Check if this tracker has the specified widget.
@@ -261,6 +278,15 @@ class InstanceTracker<T extends Widget> implements IInstanceTracker<T>, IDisposa
    */
   forEach(fn: (widget: T) => void): void {
     each(this._tracker.widgets, widget => { fn(widget); });
+  }
+
+  /**
+   * Filter the widgets in the tracker based on a predicate.
+   *
+   * @param fn - The function by which to filter.
+   */
+  filter(fn: (widget: T) => boolean): T[] {
+    return this._tracker.widgets.filter(fn);
   }
 
   /**

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -35,6 +35,11 @@ import {
 
 
 /**
+ * The name of the factory that creates markdown widgets.
+ */
+const MARKDOWN_FACTORY = 'Markdown Preview';
+
+/**
  * The command IDs used by the document manager plugin.
  */
 namespace CommandIDs {
@@ -85,6 +90,9 @@ namespace CommandIDs {
 
   export
   const showInFileBrowser = 'docmanager:show-in-file-browser';
+
+  export
+  const markdownPreview = 'markdownviewer:open';
 }
 
 const pluginId = '@jupyterlab/docmanager-extension:plugin';
@@ -449,6 +457,20 @@ function addCommands(app: JupyterLab, docManager: IDocumentManager, palette: ICo
       commands.execute('filebrowser:navigate-main', {path: context.path});
     }
   });
+
+  commands.addCommand(CommandIDs.markdownPreview, {
+    label: 'Markdown Preview',
+    execute: (args) => {
+      let path = args['path'];
+      if (typeof path !== 'string') {
+        return;
+      }
+      return commands.execute('docmanager:open', {
+        path, factory: MARKDOWN_FACTORY
+      });
+    }
+  });
+
 
   app.contextMenu.addItem({
     command: CommandIDs.rename,

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -45,7 +45,7 @@ class MimeContent extends Widget {
   constructor(options: MimeContent.IOptions) {
     super();
     this.addClass('jp-MimeDocument');
-    this._mimeType = options.mimeType;
+    this.mimeType = options.mimeType;
     this._dataType = options.dataType || 'string';
     this._context = options.context;
     this._renderer = options.renderer;
@@ -79,6 +79,11 @@ class MimeContent extends Widget {
       showErrorMessage(`Renderer Failure: ${this._context.path}`, reason);
     });
   }
+
+  /**
+   * The mimetype for this rendered content.
+   */
+  readonly mimeType: string;
 
   /**
    * A promise that resolves when the widget is ready.
@@ -131,9 +136,9 @@ class MimeContent extends Widget {
     let model = context.model;
     let data: JSONObject = {};
     if (this._dataType === 'string') {
-      data[this._mimeType] = model.toString();
+      data[this.mimeType] = model.toString();
     } else {
-      data[this._mimeType] = model.toJSON();
+      data[this.mimeType] = model.toJSON();
     }
     let mimeModel = new MimeModel({ data, callback: this._changeCallback });
 
@@ -158,10 +163,10 @@ class MimeContent extends Widget {
    * A bound change callback.
    */
   private _changeCallback = (options: IRenderMime.IMimeModel.ISetDataOptions) => {
-    if (!options.data || !options.data[this._mimeType]) {
+    if (!options.data || !options.data[this.mimeType]) {
       return;
     }
-    let data = options.data[this._mimeType];
+    let data = options.data[this.mimeType];
     if (typeof data === 'string') {
       this._context.model.fromString(data);
     } else {
@@ -172,7 +177,6 @@ class MimeContent extends Widget {
   private _context: DocumentRegistry.IContext<DocumentRegistry.IModel>;
   private _renderer: IRenderMime.IRenderer;
   private _monitor: ActivityMonitor<any, any> | null;
-  private _mimeType: string;
   private _ready = new PromiseDelegate<void>();
   private _dataType: 'string' | 'json';
   private _isRendering = false;

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -30,9 +30,6 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.16.2",
-    "@jupyterlab/apputils": "^0.16.3",
-    "@jupyterlab/docregistry": "^0.16.2",
     "@jupyterlab/rendermime": "^0.16.2"
   },
   "devDependencies": {
@@ -40,6 +37,6 @@
     "typescript": "~2.9.1"
   },
   "jupyterlab": {
-    "extension": true
+    "mimeExtension": true
   }
 }

--- a/tests/test-apputils/src/instancetracker.spec.ts
+++ b/tests/test-apputils/src/instancetracker.spec.ts
@@ -284,6 +284,40 @@ describe('@jupyterlab/apputils', () => {
 
     });
 
+    describe('#filter()', () => {
+
+      it('should filter according to a predicate function', () => {
+        let tracker = new InstanceTracker<Widget>({ namespace });
+        let widgetA = new Widget();
+        let widgetB = new Widget();
+        let widgetC = new Widget();
+        widgetA.id = 'include-A';
+        widgetB.id = 'include-B';
+        widgetC.id = 'exclude-C';
+        tracker.add(widgetA);
+        tracker.add(widgetB);
+        tracker.add(widgetC);
+        let list = tracker.filter(widget => widget.id.indexOf('include') !== -1);
+        expect(list.length).to.be(2);
+        expect(list[0]).to.be(widgetA);
+        expect(list[1]).to.be(widgetB);
+      });
+
+      it('should return an empty array if no item is found', () => {
+        let tracker = new InstanceTracker<Widget>({ namespace });
+        let widgetA = new Widget();
+        let widgetB = new Widget();
+        let widgetC = new Widget();
+        widgetA.id = 'A';
+        widgetB.id = 'B';
+        widgetC.id = 'C';
+        tracker.add(widgetA);
+        tracker.add(widgetB);
+        tracker.add(widgetC);
+        expect(tracker.filter(widget => widget.id === 'D').length).to.be(0);
+      });
+
+    });
     describe('#forEach()', () => {
 
       it('should iterate through all the tracked items', () => {


### PR DESCRIPTION
Supersedes #4554.

We currently have no way for extension authors to interact with any documents created by the rendermime extension interface. So if anybody wants to iterate over open PDFs, JSON files, Vega files, rendered Markdown files, etc, they are out of luck.

This adds a top-level `mimeDocumentTracker` to the application object, and allows extension authors to filter those by mimetype.