### PR TITLE
fix string interpolation type

### DIFF
--- a/packages/services/src/builder/index.ts
+++ b/packages/services/src/builder/index.ts
@@ -90,7 +90,7 @@ class BuildManager {
         throw new ServerConnection.ResponseError(response, 'Build aborted');
       }
       if (response.status !== 200) {
-        let message = 'Build failed with ${response.status}`, please run `jupyter lab build` on the server for full output';
+        let message = `Build failed with ${response.status}, please run 'jupyter lab build' on the server for full output`;
         throw new ServerConnection.ResponseError(response, message);
       }
     });

--- a/packages/services/src/builder/index.ts
+++ b/packages/services/src/builder/index.ts
@@ -90,7 +90,7 @@ class BuildManager {
         throw new ServerConnection.ResponseError(response, 'Build aborted');
       }
       if (response.status !== 200) {
-        let message = 'Build failed with ${response.status)`, please run `jupyter lab build` on the server for full output';
+        let message = 'Build failed with ${response.status}`, please run `jupyter lab build` on the server for full output';
         throw new ServerConnection.ResponseError(response, message);
       }
     });


### PR DESCRIPTION
Fixes `${response.status)`

![image](https://user-images.githubusercontent.com/6191849/41781320-d851946a-763f-11e8-8af3-3ff0d5a5f406.png)


Notice that the full message is cut off from the popup. But thats another issue 😄 
