### PR TITLE
Fix linkrot in the Extension Developer Guide

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -59,7 +59,7 @@ The default plugins in the JupyterLab application include:
    - Sets the default set of shortcuts for the application.
 -  `Images <https://github.com/jupyterlab/jupyterlab/blob/master/packages/imageviewer-extension/src/index.ts>`__
    - Adds a widget factory for displaying image files.
--  `Help <https://github.com/jupyterlab/jupyterlab/blob/master/packages/help-extension/src/index.ts>`__
+-  `Help <https://github.com/jupyterlab/jupyterlab/blob/master/packages/help-extension/src/index.tsx>`__
    - Adds a side bar widget for displaying external documentation.
 -  `File
    Browser <https://github.com/jupyterlab/jupyterlab/blob/master/packages/filebrowser-extension/src/index.ts>`__


### PR DESCRIPTION
The default Help plugin extension's link is https://github.com/jupyterlab/jupyterlab/blob/master/packages/help-extension/src/index.tsx now (was https://github.com/jupyterlab/jupyterlab/blob/master/packages/help-extension/src/index.ts). Updating the Extension Developer Guide to reflect the change.