### PR TITLE
Fix HTML `disabled` attribute value.

### DIFF
--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -90,7 +90,7 @@ class Sanitizer implements ISanitizer {
       // Set the "rel" attribute for <a> tags to "nofollow".
       'a': sanitize.simpleTransform('a', { 'rel': 'nofollow' }),
       // Set the "disabled" attribute for <input> tags.
-      'input': sanitize.simpleTransform('input', { 'disabled': 'true' })
+      'input': sanitize.simpleTransform('input', { 'disabled': 'disabled' })
     },
     allowedSchemesByTag: {
       // Allow 'attachment:' img src (used for markdown cell attachments).

--- a/tests/test-apputils/src/sanitizer.spec.ts
+++ b/tests/test-apputils/src/sanitizer.spec.ts
@@ -90,6 +90,17 @@ describe('defaultSanitizer', () => {
       expect(defaultSanitizer.sanitize(audio)).to.be(audio);
     });
 
+    it('should allow input tags but disable them', () => {
+      let html = defaultSanitizer.sanitize('<input type="checkbox" checked />');
+      let div = document.createElement('div');
+      let input: HTMLInputElement;
+
+      div.innerHTML = html;
+      input = div.querySelector('input');
+
+      expect(input.disabled).to.be(true);
+    });
+
   });
 
 });


### PR DESCRIPTION
According to the spec, the `disabled` attribute can't be set to the strings `"true"` or `"false"`

> If the attribute is present, its value must either be the empty string or a value that is an ASCII case-insensitive match for the attribute’s canonical name, with no leading or trailing white space.
...
> The values "true" and "false" are not allowed on boolean attributes. To represent a false value, the attribute has to be omitted altogether.

https://www.w3.org/TR/html5/infrastructure.html#sec-boolean-attributes

cc: @ian-r-rose @gnestor 