### PR TITLE
Add a flag in the dsv model for starting parsing

### DIFF
--- a/packages/csvviewer/src/model.ts
+++ b/packages/csvviewer/src/model.ts
@@ -262,11 +262,13 @@ class DSVModel extends DataModel implements IDisposable {
 
     // Return if we didn't actually get any new rows beyond the one we've
     // already parsed.
-    if (nrows <= 1) {
+    if (this._startedParsing && nrows <= 1) {
       this._doneParsing = true;
       this._ready.resolve(undefined);
       return;
     }
+
+    this._startedParsing = true;
 
     // Update the row count.
     let oldRowCount = this._rowCount;
@@ -536,6 +538,7 @@ class DSVModel extends DataModel implements IDisposable {
     // First row offset is *always* 0, so we always have the first row offset.
     this._rowOffsets = new Uint32Array(1);
     this._rowCount = 1;
+    this._startedParsing = false;
 
     this._columnOffsets = new Uint32Array(0);
 
@@ -602,6 +605,7 @@ class DSVModel extends DataModel implements IDisposable {
 
   // Bookkeeping variables.
   private _delayedParse: number = null;
+  private _startedParsing: boolean = false;
   private _doneParsing: boolean = false;
   private _isDisposed: boolean = false;
   private _ready = new PromiseDelegate<void>();

--- a/tests/test-csvviewer/src/model.spec.ts
+++ b/tests/test-csvviewer/src/model.spec.ts
@@ -116,6 +116,25 @@ describe('csvviewer/model', () => {
       expect([0, 1, 2].map(i => d.data('body', 1, i))).to.eql(['d', 'e', 'f']);
     });
 
+    it('handles having only a header', () => {
+      let d = new DSVModel({data: 'a,b,c\n', delimiter: ',', header: true});
+      expect(d.rowCount('column-header')).to.be(1);
+      expect(d.rowCount('body')).to.be(0);
+      expect(d.columnCount('row-header')).to.be(1);
+      expect(d.columnCount('body')).to.be(3);
+      expect([0, 1, 2].map(i => d.data('column-header', 0, i))).to.eql(['a', 'b', 'c']);
+    });
+
+    it('handles single non-header line', () => {
+      let d = new DSVModel({data: 'a,b,c\n', delimiter: ',', header: false});
+      expect(d.rowCount('column-header')).to.be(1);
+      expect(d.rowCount('body')).to.be(1);
+      expect(d.columnCount('row-header')).to.be(1);
+      expect(d.columnCount('body')).to.be(3);
+      expect([0, 1, 2].map(i => d.data('column-header', 0, i))).to.eql(['1', '2', '3']);
+      expect([0, 1, 2].map(i => d.data('body', 0, i))).to.eql(['a', 'b', 'c']);
+    });
+
     it('handles CRLF row delimiter', () => {
       let d = new DSVModel({data: 'a,b,c\r\nd,e,f\r\n', delimiter: ',', rowDelimiter: '\r\n'});
       expect(d.rowCount('column-header')).to.be(1);

--- a/tests/test-csvviewer/src/parse-noquotes.spec.ts
+++ b/tests/test-csvviewer/src/parse-noquotes.spec.ts
@@ -45,6 +45,21 @@ describe('csvviewer/parsenoquotes', () => {
       expect(results.offsets).to.eql([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]);
     });
 
+    it('handles single-line data', () => {
+      let data = `a,b,c,d\n`;
+      let options = {data, rowDelimiter: '\n'};
+      let results;
+
+      results = parser({...options, columnOffsets: false});
+      expect(results.nrows).to.eql(1);
+      expect(results.offsets).to.eql([0]);
+
+      results = parser({...options, columnOffsets: true});
+      expect(results.nrows).to.eql(1);
+      expect(results.ncols).to.eql(4);
+      expect(results.offsets).to.eql([0, 2, 4, 6]);
+    });
+
     it('handles changing the field delimiter', () => {
       let data = `a\tb\tc\td\n0\t1\t2\t3\n4\t5\t6\t7\n`;
       let options = {data, delimiter: '\t', rowDelimiter: '\n'};

--- a/tests/test-csvviewer/src/parse.spec.ts
+++ b/tests/test-csvviewer/src/parse.spec.ts
@@ -44,6 +44,21 @@ describe('csvviewer/parse', () => {
       expect(results.offsets).to.eql([0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]);
     });
 
+    it('handles single-line data', () => {
+      let data = `a,b,c,d\n`;
+      let options = {data, rowDelimiter: '\n'};
+      let results;
+
+      results = parser({...options, columnOffsets: false});
+      expect(results.nrows).to.eql(1);
+      expect(results.offsets).to.eql([0]);
+
+      results = parser({...options, columnOffsets: true});
+      expect(results.nrows).to.eql(1);
+      expect(results.ncols).to.eql(4);
+      expect(results.offsets).to.eql([0, 2, 4, 6]);
+    });
+
     it('handles changing the field delimiter', () => {
       let data = `a\tb\tc\td\n0\t1\t2\t3\n4\t5\t6\t7\n`;
       let options = {data, delimiter: '\t', rowDelimiter: '\n'};


### PR DESCRIPTION
Fixes #4795 - handling single-line csv files.