### PR TITLE
Fix extra launcher flimflam

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -269,12 +269,18 @@ class ApplicationShell extends Widget {
 
     // Add any widgets created during single document mode, which have
     // subsequently been removed from the dock panel after the multiple document
-    // layout has been restored.
+    // layout has been restored. If the widget has add options cached for
+    // it (i.e., if it has been placed with respect to another widget),
+    // then take that into account.
     widgets.forEach(widget => {
       if (!widget.parent) {
-        this.addToMainArea(widget, { activate: false });
+        this.addToMainArea(widget, {
+          ...this._addOptionsCache.get(widget),
+          activate: false
+        });
       }
     });
+    this._addOptionsCache.clear();
 
     // In case the active widget in the dock panel is *not* the active widget
     // of the application, defer to the application.
@@ -426,6 +432,14 @@ class ApplicationShell extends Widget {
     let mode = options.mode || 'tab-after';
 
     dock.addWidget(widget, { mode, ref });
+
+    // The dock panel doesn't account for placement information while
+    // in single document mode, so upon rehydrating any widgets that were
+    // added will not be in the correct place. Cache the placement information
+    // here so that we can later rehydrate correctly.
+    if (dock.mode === 'single-document') {
+      this._addOptionsCache.set(widget, options);
+    }
 
     if (options.activate !== false) {
       dock.activateWidget(widget);

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -227,6 +227,8 @@ class ApplicationShell extends Widget {
       return;
     }
 
+    const applicationCurrentWidget = this.currentWidget;
+
     // Changing the mode of the dock panel can result in mulitple layout
     // modified signals being emitted as the widgets are rearranged.
     // During that time, it may not be reliable to query the dock panel
@@ -284,8 +286,8 @@ class ApplicationShell extends Widget {
 
     // In case the active widget in the dock panel is *not* the active widget
     // of the application, defer to the application.
-    if (this.currentWidget) {
-      dock.activateWidget(this.currentWidget);
+    if (applicationCurrentWidget) {
+      dock.activateWidget(applicationCurrentWidget);
     }
 
     // Set the mode data attribute on the document body.

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -227,6 +227,13 @@ class ApplicationShell extends Widget {
       return;
     }
 
+    // Changing the mode of the dock panel can result in mulitple layout
+    // modified signals being emitted as the widgets are rearranged.
+    // During that time, it may not be reliable to query the dock panel
+    // state. Here we prevent the layout modified signal from being emitted
+    // until the mode is finished switching.
+    this._modifiedGuard = true;
+
     if (mode === 'single-document') {
       this._cachedLayout = dock.saveLayout();
       dock.mode = mode;
@@ -239,6 +246,9 @@ class ApplicationShell extends Widget {
 
       // Set the mode data attribute on the document body.
       document.body.setAttribute(MODE_ATTRIBUTE, mode);
+
+      this._modifiedGuard = false;
+      this._onLayoutModified();
       return;
     }
 
@@ -274,6 +284,9 @@ class ApplicationShell extends Widget {
 
     // Set the mode data attribute on the document body.
     document.body.setAttribute(MODE_ATTRIBUTE, mode);
+
+    this._modifiedGuard = false;
+    this._onLayoutModified();
   }
 
   /**
@@ -704,7 +717,9 @@ class ApplicationShell extends Widget {
    * Handle a change to the layout.
    */
   private _onLayoutModified(): void {
-    this._layoutModified.emit(void 0);
+    if (!this._modifiedGuard) {
+      this._layoutModified.emit(void 0);
+    }
   }
 
   /**
@@ -740,6 +755,8 @@ class ApplicationShell extends Widget {
   private _tracker = new FocusTracker<Widget>();
   private _topPanel: Panel;
   private _bottomPanel: Panel;
+  private _modifiedGuard = false;
+  private _addOptionsCache = new Map<Widget, ApplicationShell.IMainAreaOptions>();
 }
 
 


### PR DESCRIPTION
Fixes #4228.

This wound up being pretty subtle. We have some logic with the launcher where, when the dock layout is modified, we check whether the dock is empty. If the dock is empty, we add a new launcher. The problem is: some dock modified signals are emitted during the rehydration of the layout from single document mode. In particular, one of them is emitted in a transient state when the dock is empty. This triggers a new launcher being added to the main area *in the middle of rehydration*. This seems to make the DOM structure (to use technical terms) all messed up. I found a bunch of different ways to trigger this behavior upon leaving single document mode, one of which is demonstrated in #4228.

This PR does the following:
1. Adds a guard to the application `layoutModified` signal so that it is only emitted once upon changing the dock mode.
2. Caches the widget add options while in single document mode so that they may be added in the location that the user requested once you go back to multi-document mode.
3. Fixes a bug in the logic for which widget gets focus upon leaving single document mode.

It is a bit messy, so if you have other ideas about how to fix this, I am all ears.