### PR TITLE
Add command to change fileeditor font size.

### DIFF
--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -210,12 +210,13 @@ function activate(
   // Add a command to change font size.
   commands.addCommand(CommandIDs.changeFontSize, {
     execute: args => {
-      const delta = args ['delta'] as number;
+      const delta = args['delta'] as number;
       const style = window.getComputedStyle(document.documentElement);
       const cssSize = parseInt(style.getPropertyValue('--jp-code-font-size'));
       const currentSize = config.fontSize || cssSize;
       config.fontSize = currentSize + delta;
-      return settingRegistry.set(id, 'editorConfig', config)
+      return settingRegistry
+        .set(id, 'editorConfig', config)
         .catch((reason: Error) => {
           console.error(`Failed to set ${id}: ${reason.message}`);
         });
@@ -494,7 +495,7 @@ function activate(
         },
         { type: 'submenu', submenu: tabMenu },
         { command: CommandIDs.autoClosingBrackets }
-      ], 
+      ],
       30
     );
 

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -210,7 +210,13 @@ function activate(
   // Add a command to change font size.
   commands.addCommand(CommandIDs.changeFontSize, {
     execute: args => {
-      const delta = args['delta'] as number;
+      const delta = Number(args['delta']);
+      if (Number.isNaN(delta)) {
+        console.error(
+          `${CommandIDs.changeFontSize}: delta arg must be a number`
+        );
+        return;
+      }
       const style = window.getComputedStyle(document.documentElement);
       const cssSize = parseInt(
         style.getPropertyValue('--jp-code-font-size'),

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -212,7 +212,10 @@ function activate(
     execute: args => {
       const delta = args['delta'] as number;
       const style = window.getComputedStyle(document.documentElement);
-      const cssSize = parseInt(style.getPropertyValue('--jp-code-font-size'));
+      const cssSize = parseInt(
+        style.getPropertyValue('--jp-code-font-size'),
+        10
+      );
       const currentSize = config.fontSize || cssSize;
       config.fontSize = currentSize + delta;
       return settingRegistry

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -59,6 +59,8 @@ const FACTORY = 'Editor';
 namespace CommandIDs {
   export const createNew = 'fileeditor:create-new';
 
+  export const changeFontSize = 'fileeditor:change-font-size';
+
   export const lineNumbers = 'fileeditor:toggle-line-numbers';
 
   export const lineWrap = 'fileeditor:toggle-line-wrap';
@@ -203,6 +205,23 @@ function activate(
   // Handle the settings of new widgets.
   tracker.widgetAdded.connect((sender, widget) => {
     updateWidget(widget.content);
+  });
+
+  // Add a command to change font size.
+  commands.addCommand(CommandIDs.changeFontSize, {
+    execute: args => {
+      const delta = args ['delta'] as number;
+      const style = window.getComputedStyle(document.documentElement);
+      const cssSize = parseInt(style.getPropertyValue('--jp-code-font-size'));
+      const currentSize = config.fontSize || cssSize;
+      config.fontSize = currentSize + delta;
+      return settingRegistry.set(id, 'editorConfig', config)
+        .catch((reason: Error) => {
+          console.error(`Failed to set ${id}: ${reason.message}`);
+        });
+    },
+    isEnabled,
+    label: args => args['name'] as string
   });
 
   commands.addCommand(CommandIDs.lineNumbers, {
@@ -432,6 +451,14 @@ function activate(
       };
       palette.addItem({ command, args, category: 'Text Editor' });
     }
+
+    args = { name: 'Increase Font Size', delta: 1 };
+    command = CommandIDs.changeFontSize;
+    palette.addItem({ command, args, category: 'Text Editor' });
+
+    args = { name: 'Decrease Font Size', delta: -1 };
+    command = CommandIDs.changeFontSize;
+    palette.addItem({ command, args, category: 'Text Editor' });
   }
 
   if (menu) {
@@ -454,11 +481,20 @@ function activate(
       };
       tabMenu.addItem({ command, args });
     }
+
     menu.settingsMenu.addGroup(
       [
+        {
+          command: CommandIDs.changeFontSize,
+          args: { name: 'Increase Text Editor Font Size', delta: +1 }
+        },
+        {
+          command: CommandIDs.changeFontSize,
+          args: { name: 'Decrease Text Editor Font Size', delta: -1 }
+        },
         { type: 'submenu', submenu: tabMenu },
         { command: CommandIDs.autoClosingBrackets }
-      ],
+      ], 
       30
     );
 


### PR DESCRIPTION
This PR is related to #4673.

A command to change font size is added to the fileeditor extension.
That command is then used to add two new items to the *Settings* menu and to the *Text Editor* palette section: to increase and decrease, respectively, by one pixel the editor font size.

Cheers
