### PR TITLE
Add new notebook command to command palette

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1522,6 +1522,7 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Noteboo
 function populatePalette(palette: ICommandPalette): void {
   let category = 'Notebook Operations';
   [
+    CommandIDs.createNew,
     CommandIDs.interrupt,
     CommandIDs.restart,
     CommandIDs.restartClear,


### PR DESCRIPTION
There is a `Console` command that starts a new console, so it seems
to make sense to have a corresponding `Notebook` command that starts
a new notebook.

Issues was raised by @MMesch on gittter

https://gitter.im/jupyterlab/jupyterlab?at=5b363d4abe98b1422413c3a3