### PR TITLE
Remove icons in command palette for "Create New"

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -267,7 +267,7 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
       }
       return 'Console';
     },
-    iconClass: 'jp-CodeConsoleIcon',
+    iconClass: args => args['isPalette'] ? '' : 'jp-CodeConsoleIcon',
     execute: args => {
       let basePath = args['basePath'] as string || args['cwd'] as string ||
         browserFactory.defaultBrowser.model.path;
@@ -523,7 +523,7 @@ function activateConsole(app: JupyterLab, mainMenu: IMainMenu, palette: ICommand
     CommandIDs.closeAndShutdown,
     CommandIDs.toggleShowAllActivity,
   ].forEach(command => {
-    palette.addItem({ command, category });
+    palette.addItem({ command, category, args: { isPalette: true } });
   });
 
   // Add a console creator to the File menu

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -525,7 +525,7 @@ function activateNotebookHandler(app: JupyterLab, mainMenu: IMainMenu, palette: 
       return 'Notebook';
     },
     caption: 'Create a new notebook',
-    iconClass: 'jp-NotebookIcon',
+    iconClass: args => args['isLauncher'] ? '' : 'jp-NotebookIcon',
     execute: args => {
       const cwd = args['cwd'] || browserFactory ?
         browserFactory.defaultBrowser.model.path : '';
@@ -1544,8 +1544,12 @@ function populatePalette(palette: ICommandPalette): void {
   ].forEach(command => { palette.addItem({ command, category }); });
 
   EXPORT_TO_FORMATS.forEach(exportToFormat => {
-    let args = { 'format': exportToFormat['format'], 'label': exportToFormat['label'], 'isPalette': true };
-    palette.addItem({ command: CommandIDs.exportToFormat, category: category, args: args });
+    let args = {
+      'format': exportToFormat['format'],
+      'label': exportToFormat['label'],
+      'isPalette': true
+    };
+    palette.addItem({ command: CommandIDs.exportToFormat, category, args });
   });
 
   category = 'Notebook Cell Operations';

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -155,7 +155,7 @@ function addCommands(app: JupyterLab, services: ServiceManager, tracker: Instanc
   commands.addCommand(CommandIDs.createNew, {
     label: args => args['isPalette'] ? 'New Terminal' : 'Terminal',
     caption: 'Start a new terminal session',
-    iconClass: TERMINAL_ICON_CLASS,
+    iconClass: args => args['isPalette'] ? '' : TERMINAL_ICON_CLASS,
     execute: args => {
       const name = args['name'] as string;
       const initialCommand = args['initialCommand'] as string;


### PR DESCRIPTION
I kept the ones for the "Create New" submenu because I thought they looked kind of nice.