### PR TITLE
Expose the document context on MimeContent.

### DIFF
--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -86,6 +86,13 @@ class MimeContent extends Widget {
   readonly mimeType: string;
 
   /**
+   * The context associated with the rendered content.
+   */
+  get context(): DocumentRegistry.IContext<DocumentRegistry.IModel> {
+    return this._context;
+  }
+
+  /**
    * A promise that resolves when the widget is ready.
    */
   get ready(): Promise<void> {

--- a/tests/test-docregistry/src/mimedocument.spec.ts
+++ b/tests/test-docregistry/src/mimedocument.spec.ts
@@ -107,6 +107,23 @@ describe('docregistry/mimedocument', () => {
 
     });
 
+    describe('#context', () => {
+
+      it('should return the context associated with the widget', () => {
+        const renderer = RENDERMIME.createRenderer('text/markdown');
+        let widget = new LogRenderer({
+          context: dContext,
+          renderer,
+          mimeType: 'text/markdown',
+          renderTimeout: 1000,
+          dataType: 'string'
+        });
+        dContext.initialize(true);
+        expect(widget.context).to.be(dContext);
+      });
+
+    });
+
     describe('#ready', () => {
 
       it('should resolve when the widget is ready', () => {


### PR DESCRIPTION
I was taking the Beta 3 RC out for a spin and realized that the spiffy new `InstanceTracker` for mime documents is not very useful unless we expose their context.