### PR TITLE
Make the comm and messagehook kernel registration functions return disposables

### DIFF
--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -331,6 +331,8 @@ export namespace Kernel {
      *
      * @param callback - The callback invoked for a comm open message.
      *
+     * @returns A disposable used to unregister the comm target.
+     *
      * #### Notes
      * Only one comm target can be registered to a target name at a time, an
      * existing callback for the same target name will be overidden.  A registered
@@ -346,25 +348,7 @@ export namespace Kernel {
         comm: Kernel.IComm,
         msg: KernelMessage.ICommOpenMsg
       ) => void | PromiseLike<void>
-    ): void;
-
-    /**
-     * Remove a comm target handler.
-     *
-     * @param targetName - The name of the comm target to remove.
-     *
-     * @param callback - The callback to remove.
-     *
-     * #### Notes
-     * The comm target is only removed if it matches the callback argument.
-     */
-    removeCommTarget(
-      targetName: string,
-      callback: (
-        comm: Kernel.IComm,
-        msg: KernelMessage.ICommOpenMsg
-      ) => void | PromiseLike<void>
-    ): void;
+    ): IDisposable;
 
     /**
      * Register an IOPub message hook.
@@ -373,6 +357,8 @@ export namespace Kernel {
      * intercept.
      *
      * @param hook - The callback invoked for the message.
+     *
+     * @returns A disposable used to unregister the message hook.
      *
      * #### Notes
      * The IOPub hook system allows you to preempt the handlers for IOPub
@@ -389,20 +375,7 @@ export namespace Kernel {
     registerMessageHook(
       msgId: string,
       hook: (msg: KernelMessage.IIOPubMessage) => boolean | PromiseLike<boolean>
-    ): void;
-
-    /**
-     * Remove an IOPub message hook.
-     *
-     * @param msg_id - The parent_header message id the hook intercepted.
-     *
-     * @param hook - The callback invoked for the message.
-     *
-     */
-    removeMessageHook(
-      msgId: string,
-      hook: (msg: KernelMessage.IIOPubMessage) => boolean | PromiseLike<boolean>
-    ): void;
+    ): IDisposable;
   }
 
   /**

--- a/packages/services/test/src/kernel/ikernel.spec.ts
+++ b/packages/services/test/src/kernel/ikernel.spec.ts
@@ -1145,11 +1145,11 @@ describe('Kernel.IKernel', () => {
           calls.push('delete');
           return true;
         };
-        kernel.registerMessageHook(parentHeader.msg_id, toDelete);
+        let registration = kernel.registerMessageHook(parentHeader.msg_id, toDelete);
         kernel.registerMessageHook(parentHeader.msg_id, msg => {
           if (calls.length > 0) {
             // delete the hook the second time around
-            kernel.removeMessageHook(parentHeader.msg_id, toDelete);
+            registration.dispose();
           }
           calls.push('first');
           return true;


### PR DESCRIPTION
This effectively reverts dd50e935d49319b30bacd2a2c14cca935da4d8c1.

The original idea was that register/remove paradigm was more versatile, more closely matched futures, and wasn't any more work since if you already had a reference to the kernel, keeping the hook you registered is the same pain as keeping the disposer.

However, a common pattern with sessions is to *not* keep a reference to the specific kernel, but instead rely on the `session.kernel` as the current kernel, whatever it is. Since the session kernel can change at any time, and all the warning we get is the signal that contains the new kernel, it's harder to keep the old kernel *and* the hook to unregister. It's easier to keep the disposer to unregister callbacks when the session changes kernels.

Another way to do this is to have the session kernelChanged event include both the old kernel and the new kernel.

One quirky thing about reinstating the disposable paradigm is that the future returned from a kernel execution still has [message hook register and remove functions](https://github.com/jupyterlab/jupyterlab/blob/62c529ff01355a7ecb8c0e6d53906066416efd68/packages/services/src/kernel/future.ts#L109-L152). I think this is fine (other than it being a bit different api), since it will be more common to keep a future around than to keep a kernel around.