### PR TITLE
Make session.kernelChanged signal include both the old and new kernels.

### DIFF
--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Kernel, KernelMessage } from '@jupyterlab/services';
+import { Kernel, KernelMessage, Session } from '@jupyterlab/services';
 
 import { Token } from '@phosphor/coreutils';
 
@@ -131,17 +131,18 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
    */
   private _onKernelChanged(
     sender: any,
-    kernel: Kernel.IKernelConnection
+    args: Session.IKernelChangedArgs
   ): void {
-    if (!this.model || !kernel) {
+    if (!this.model || !args.newValue) {
       return;
     }
-    kernel.ready.then(() => {
+    let { newValue } = args;
+    newValue.ready.then(() => {
       if (this.model) {
-        this._updateLanguage(kernel.info.language_info);
+        this._updateLanguage(newValue.info.language_info);
       }
     });
-    this._updateSpec(kernel);
+    this._updateSpec(newValue);
   }
 
   /**

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -50,7 +50,7 @@ export class DefaultSession implements Session.ISession {
   /**
    * A signal emitted when the kernel changes.
    */
-  get kernelChanged(): ISignal<this, Kernel.IKernelConnection> {
+  get kernelChanged(): ISignal<this, Session.IKernelChangedArgs> {
     return this._kernelChanged;
   }
 
@@ -196,9 +196,10 @@ export class DefaultSession implements Session.ISession {
     this._type = model.type;
 
     if (this._kernel.isDisposed || model.kernel.id !== this._kernel.id) {
-      let kernel = Kernel.connectTo(model.kernel, this.serverSettings);
-      this.setupKernel(kernel);
-      this._kernelChanged.emit(kernel);
+      let newValue = Kernel.connectTo(model.kernel, this.serverSettings);
+      let oldValue = this._kernel;
+      this.setupKernel(newValue);
+      this._kernelChanged.emit({ oldValue, newValue });
       this._handleModelChange(oldModel);
       return;
     }
@@ -404,7 +405,7 @@ export class DefaultSession implements Session.ISession {
   private _kernel: Kernel.IKernel;
   private _isDisposed = false;
   private _updating = false;
-  private _kernelChanged = new Signal<this, Kernel.IKernelConnection>(this);
+  private _kernelChanged = new Signal<this, Session.IKernelChangedArgs>(this);
   private _statusChanged = new Signal<this, Kernel.Status>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -31,7 +31,7 @@ export namespace Session {
     /**
      * A signal emitted when the kernel changes.
      */
-    kernelChanged: ISignal<this, Kernel.IKernelConnection>;
+    kernelChanged: ISignal<this, IKernelChangedArgs>;
 
     /**
      * A signal emitted when the session status changes.
@@ -346,6 +346,20 @@ export namespace Session {
      * The unique identifier for the session client.
      */
     clientId?: string;
+  }
+
+  /**
+   * An arguments object for the kernel changed signal.
+   */
+  export interface IKernelChangedArgs {
+    /**
+     * The old kernel.
+     */
+    oldValue: Kernel.IKernelConnection | null;
+    /**
+     * The new kernel.
+     */
+    newValue: Kernel.IKernelConnection | null;
   }
 
   /**

--- a/packages/services/test/src/session/session.spec.ts
+++ b/packages/services/test/src/session/session.spec.ts
@@ -227,16 +227,20 @@ describe('session', () => {
 
     context('#kernelChanged', () => {
       it('should emit when the kernel changes', async () => {
-        let called = false;
+        let called: Session.IKernelChangedArgs | null = null;
         let object = {};
-        defaultSession.kernelChanged.connect((s, kernel) => {
-          called = true;
+        defaultSession.kernelChanged.connect((s, args) => {
+          called = args;
           Signal.disconnectReceiver(object);
         }, object);
         let previous = defaultSession.kernel;
         await defaultSession.changeKernel({ name: previous.name });
         await defaultSession.kernel.ready;
-        expect(called).to.be(true);
+        expect(previous).to.not.be(defaultSession.kernel);
+        expect(called).to.eql({
+          oldValue: previous,
+          newValue: defaultSession.kernel
+        });
         previous.dispose();
       });
     });

--- a/tests/test-apputils/src/clientsession.spec.ts
+++ b/tests/test-apputils/src/clientsession.spec.ts
@@ -59,7 +59,7 @@ describe('@jupyterlab/apputils', () => {
       it('should be emitted when the kernel changes', done => {
         session.kernelChanged.connect((sender, args) => {
           expect(sender).to.be(session);
-          expect(args).to.be.ok();
+          expect(args).to.eql({ oldValue: null, newValue: sender.kernel });
           done();
         });
         session.initialize().catch(done);


### PR DESCRIPTION
This makes it much easier to unregister anything (such as comm targets, message hooks, etc.) we had registered on the old kernel before registering such things on the new kernel.