### PR TITLE
CSS change to give inline code in Markdown a different background color

### DIFF
--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -311,7 +311,12 @@
   font-family: var(--jp-code-font-family);
   font-size: inherit;
   line-height: var(--jp-code-line-height);
-  padding: 0px;
+  padding: 0;
+}
+
+.jp-RenderedHTMLCommon p > code {
+  background-color: var(--jp-layout-color2);
+  padding: 1px 5px;
 }
 
 /* Tables */


### PR DESCRIPTION
A new CSS selector had to be added to prevent code blocks from also getting a different background color.
(Fix for #4549)