### PR TITLE
Run a prettier check in CI and run integrity in first group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
 matrix:
   include:
   - env: GROUP=js
-  - env: GROUP=js_cov
   - env: GROUP=python
     python: 2.7
   - env: GROUP=python
@@ -20,6 +19,7 @@ matrix:
   - env: GROUP=python
   - env: GROUP=integrity
   - env: GROUP=js_services
+  - env: GROUP=js_cov
   - env: GROUP=cli
     python: 2.7
   - env: GROUP=cli

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:ie": "lerna run test:ie --scope \"@jupyterlab/test-*\" --concurrency 1 --stream",
     "test:services": "cd packages/services && jlpm test && cd examples/node && python main.py",
     "prettier": "prettier --write '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
+    "prettier:check": "prettier --list-different '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
     "update:dependency": "node buildutils/lib/update-dependency.js",
     "watch": "run-p watch:dev watch:themes",
     "watch:dev": "python scripts/watch_dev.py",

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -65,17 +65,14 @@ if [[ $GROUP == integrity ]]; then
     # Run the integrity script first
     jlpm run integrity
 
-    # Lint our JavaScript files.
-    ./node_modules/.bin/eslint .
-
     # Build the packages individually.
     jlpm run build:src
 
     # Make sure the examples build
     jlpm run build:examples
 
-    # Run a tslint check
-    ./node_modules/.bin/tslint -c tslint.json -e '**/*.d.ts' -e 'node_modules/**/*.ts' -e 'jupyterlab/**/*.ts' '**/*.ts'
+    # Run a prettier check
+    jlpm run prettier:check
 
     # Make sure we have CSS that can be converted with postcss
     jlpm global add postcss-cli


### PR DESCRIPTION
The original tslint check is slightly different, but this way we are verifying the changes that would have been automatically applied.  Also, moves the integrity check to the first group of runs on Travis so we see it fail earlier.  The coverage check should only be failing differently from the JS check due to random failures.