### PR TITLE
set kernel.isReady to true after KernelInfoReply

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1029,11 +1029,12 @@ export class DefaultKernel implements Kernel.IKernel {
     this.requestKernelInfo()
       .then(() => {
         this._connectionPromise.resolve(void 0);
+        this._isReady = true;
       })
       .catch(err => {
         this._connectionPromise.reject(err);
+        this._isReady = false;
       });
-    this._isReady = false;
   };
 
   /**


### PR DESCRIPTION
This little change unblocks Kernels after the KernelInfo message is received. Otherwise the kernel waits for a 'idle' IOPub message on startup which is not specified by the jupyter messaging protocoll (correct me if that is wrong!). The Haskell kernel for example doesn't send an IOPub message on startup right now ...

A problem remains: the little white Kernel status indicator in the notebook remains black and keeps showing 'connected' instead of idle as kernel status. So not sure if this fix is good enough ...