### PR TITLE
Include chrome-test.js in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ data_files_spec = [
 package_data_spec = dict()
 package_data_spec[NAME] = [
     'staging/*', 'staging/templates/*', 'static/**', 'tests/mock_packages/**',
-    'themes/**', 'schemas/**', 'node-version-check.js'
+    'themes/**', 'schemas/**', 'node-version-check.js', 'chrome-test.js'
 ]
 
 staging = pjoin(HERE, NAME, 'staging')


### PR DESCRIPTION
Hopefully fixes https://github.com/jupyterlab/jupyterlab/issues/4873.

I see that `node-version-check.js` *is* included in the package, but `chrome-test.js` is not and they are in the same folder. Only difference is that `node-version-check.js` is part of this `package_data_spec` list but `chrome-test.js` is not. So hopefully adding it there will add it to the package.