### PR TITLE
Make the metapackage public

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -135,7 +135,7 @@ function ensureJupyterlab(): string[] {
     } catch (e) {
       return;
     }
-    if (data.private === true) {
+    if (data.private === true || data.name === '@jupyterlab/metapackage') {
       return;
     }
 

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@jupyterlab/metapackage",
   "version": "0.17.0-1",
-  "private": true,
-  "description": "JupyterLab - All Packages",
+  "description": "JupyterLab - Meta Package.  All of the packages used by the core JupyterLab application",
   "homepage": "https://github.com/jupyterlab/jupyterlab",
   "bugs": {
     "url": "https://github.com/jupyterlab/jupyterlab/issues"


### PR DESCRIPTION
This makes it easier for a JupyterLab consumer to pull in all of the JupyterLab packages if so desired.  