### PR TITLE
Codespell run on the code base

### DIFF
--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -148,7 +148,7 @@ export interface IEnsurePackageOptions {
   depCache?: { [key: string]: string };
 
   /**
-   * A list of depedencies that can be unused.
+   * A list of dependencies that can be unused.
    */
   unused?: string[];
 

--- a/design/about.md
+++ b/design/about.md
@@ -58,7 +58,7 @@ Users should be able to:
 
 * Have an **overview** of tutorial contents on "Page 1" before scrolling
 
-* Read/Take action at the end (similiar to launcher)
+* Read/Take action at the end (similar to launcher)
 
   * _UI: Clicking Action_
 

--- a/docs/source/developer/css.rst
+++ b/docs/source/developer/css.rst
@@ -185,7 +185,7 @@ The reason is that these selectors are dependent on the implementation
 of the toolbar having the ``jp-Toolbar`` CSS class. When ``MyWidget``
 adds the ``jp-MyWidget-toolbar`` class, it can style the child
 independent of its implementation. The other reason to add the
-``jp-MyWidget-toolbar`` class is if the DOM stucture is highly
+``jp-MyWidget-toolbar`` class is if the DOM structure is highly
 recursive, the usual descendant selectors may not be specific to target
 only the desired children.
 

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -176,7 +176,7 @@ subsequently reversed by running
 
     jlpm run remove:package <extension-dir-name>
 
-This will remove the package metadata from the source tree, but wil
+This will remove the package metadata from the source tree, but will
 **not** remove any files added by the ``addsibling`` script, which
 should be removed manually.
 

--- a/examples/filebrowser/sample.md
+++ b/examples/filebrowser/sample.md
@@ -21,7 +21,7 @@
 ##### h6
 
 This is just a sample paragraph
-You can look at different level of nested unorderd list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc
+You can look at different level of nested unordered list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc
 
 * level 1
   * level 2

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1726,7 +1726,7 @@ def _semver_prerelease_key(prerelease):
 
 
 def _semver_key(version, prerelease_first=False):
-    """A sort key-function for sorting semver verion string.
+    """A sort key-function for sorting semver version string.
 
     The default sorting order is ascending (0.x -> 1.x -> 2.x).
 

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -92,7 +92,7 @@ def load_jupyter_server_extension(nbapp):
     page_config['buildCheck'] = not core_mode and not dev_mode
     page_config['token'] = nbapp.token
     page_config['devMode'] = dev_mode
-    # Export the version info tuple to a JSON array. This get's printed
+    # Export the version info tuple to a JSON array. This gets printed
     # inside double quote marks, so we render it to a JSON string of the
     # JSON data (so that we can call JSON.parse on the frontend on it).
     # We also have to wrap it in `Markup` so that it isn't escaped

--- a/jupyterlab/semver.py
+++ b/jupyterlab/semver.py
@@ -269,7 +269,7 @@ src[HYPHENRANGELOOSE] = ('^\\s*(' + src[XRANGEPLAINLOOSE] + ')' +
 STAR = R()
 src[STAR] = '(<|>)?=?\\s*\\*'
 
-# version name recovery for convinient
+# version name recovery for convenient
 RECOVERYVERSIONNAME = R()
 src[RECOVERYVERSIONNAME] = ('v?({n})(?:\\.({n}))?{pre}?'.format(n=src[NUMERICIDENTIFIER], pre=src[PRERELEASELOOSE]))
 
@@ -483,7 +483,7 @@ class SemVer(object):
                 self.patch += 1
             self.prerelease = []
         elif release == "pre":
-            #  This probably shouldn't be used publically.
+            #  This probably shouldn't be used publicly.
             #  1.0.0 "pre" would become 1.0.0-0 which is the wrong direction.
             logger.debug("inc prerelease %s", self.prerelease)
             if len(self.prerelease) == 0:

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -126,7 +126,7 @@ class SettingsConnector extends DataConnector<
 }
 
 /**
- * The default commmand palette extension.
+ * The default command palette extension.
  */
 const palette: JupyterLabPlugin<ICommandPalette> = {
   activate: activatePalette,
@@ -136,7 +136,7 @@ const palette: JupyterLabPlugin<ICommandPalette> = {
 };
 
 /**
- * The default commmand palette's restoration extension.
+ * The default command palette's restoration extension.
  *
  * #### Notes
  * The command palette's restoration logic is handled separately from the

--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -71,12 +71,12 @@ export interface IClientSession extends IDisposable {
   readonly kernel: Kernel.IKernelConnection | null;
 
   /**
-   * The current path associated with the client sesssion.
+   * The current path associated with the client session.
    */
   readonly path: string;
 
   /**
-   * The current name associated with the client sesssion.
+   * The current name associated with the client session.
    */
   readonly name: string;
 

--- a/packages/apputils/src/vdom.ts
+++ b/packages/apputils/src/vdom.ts
@@ -20,7 +20,7 @@ export abstract class VDomRenderer<
   T extends VDomRenderer.IModel | null
 > extends Widget {
   /**
-   * A signal emited when the model changes.
+   * A signal emitted when the model changes.
    */
   get modelChanged(): ISignal<this, void> {
     return this._modelChanged;
@@ -133,7 +133,7 @@ export namespace VDomRenderer {
    */
   export interface IModel extends IDisposable {
     /**
-     * A signal emited when any model state changes.
+     * A signal emitted when any model state changes.
      */
     readonly stateChanged: ISignal<this, void>;
   }

--- a/packages/apputils/style/iframe.css
+++ b/packages/apputils/style/iframe.css
@@ -15,7 +15,7 @@
 /*
 When drag events occur, `p-mod-override-cursor` is added to the body.
 Because iframes steal all cursor events, the following two rules are necessary
-to suppress pointer events while resize drags are occuring. There may be a
+to suppress pointer events while resize drags are occurring. There may be a
 better solution to this problem.
 */
 body.p-mod-override-cursor .jp-IFrame {

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -141,8 +141,8 @@ export namespace CodeEditor {
    *
    * #### Write access
    * - if a user code is a selection owner then:
-   *   - it can change selections beloging to it
-   *   - but it must not change selections beloging to other selection owners
+   *   - it can change selections belonging to it
+   *   - but it must not change selections belonging to other selection owners
    * - otherwise it must not change any selection
    */
 
@@ -255,7 +255,7 @@ export namespace CodeEditor {
     }
 
     /**
-     * Dipose of the resources used by the model.
+     * Dispose of the resources used by the model.
      */
     dispose(): void {
       if (this._isDisposed) {

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -286,7 +286,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   }
 
   /**
-   * Find a position fot the given offset.
+   * Find a position for the given offset.
    */
   getPositionAt(offset: number): CodeEditor.IPosition {
     const { ch, line } = this.doc.posFromIndex(offset);

--- a/packages/codemirror/typings/codemirror/codemirror.d.ts
+++ b/packages/codemirror/typings/codemirror/codemirror.d.ts
@@ -78,7 +78,7 @@ declare namespace CodeMirror {
     updateFunc: Function
   ): void;
 
-  /** If your extention just needs to run some code whenever a CodeMirror instance is initialized, use CodeMirror.defineInitHook.
+  /** If your extension just needs to run some code whenever a CodeMirror instance is initialized, use CodeMirror.defineInitHook.
     Give it a function as its only argument, and from then on, that function will be called (with the instance as argument)
     whenever a new CodeMirror instance is initialized. */
   function defineInitHook(func: Function): void;
@@ -365,7 +365,7 @@ declare namespace CodeMirror {
       }
     ): CodeMirror.LineWidget;
 
-    /** Programatically set the size of the editor (overriding the applicable CSS rules).
+    /** Programmatically set the size of the editor (overriding the applicable CSS rules).
         width and height height can be either numbers(interpreted as pixels) or CSS units ("100%", for example).
         You can pass null for either of them to indicate that that dimension should not be changed. */
     setSize(width: any, height: any): void;
@@ -717,7 +717,7 @@ declare namespace CodeMirror {
 
   interface Doc {
     /** Get the current editor content. You can pass it an optional argument to specify the string to be used to separate lines (defaults to "\n"). */
-    getValue(seperator?: string): string;
+    getValue(separator?: string): string;
 
     /** Set the editor content. */
     setValue(content: string): void;
@@ -727,7 +727,7 @@ declare namespace CodeMirror {
     getRange(
       from: Position,
       to: CodeMirror.Position,
-      seperator?: string
+      separator?: string
     ): string;
 
     /** Replace the part of the document between from and to with the given string.
@@ -962,7 +962,7 @@ declare namespace CodeMirror {
     text: string[];
     /**  Text that used to be between from and to, which is overwritten by this change. */
     removed: string[];
-    /**  String representing the origin of the change event and wether it can be merged with history */
+    /**  String representing the origin of the change event and whether it can be merged with history */
     origin: string;
   }
 
@@ -1471,7 +1471,7 @@ declare namespace CodeMirror {
 
   /**
    * An annotation contains a description of a lint error, detailing the location of the error within the code, the severity of the error,
-   * and an explaination as to why the error was thrown.
+   * and an explanation as to why the error was thrown.
    */
   interface Annotation {
     from: Position;

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -310,7 +310,7 @@ export class CompletionHandler implements IDisposable {
   }
 
   /**
-   * Handle a visiblity change signal from a completer widget.
+   * Handle a visibility change signal from a completer widget.
    */
   protected onVisibilityChanged(completer: Completer): void {
     // Completer is not active.

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -777,7 +777,7 @@ export namespace CodeConsole {
      * @param options - The options used to create the cell.
      *
      * @returns A new code cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      */
     createCodeCell(options: CodeCellModel.IOptions): ICodeCellModel;
 
@@ -787,7 +787,7 @@ export namespace CodeConsole {
      * @param options - The options used to create the cell.
      *
      * @returns A new raw cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      */
     createRawCell(options: CellModel.IOptions): IRawCellModel;
   }
@@ -815,7 +815,7 @@ export namespace CodeConsole {
      * @param source - The data to use for the original source data.
      *
      * @returns A new code cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      *   If the contentFactory is not provided, the instance
      *   `codeCellContentFactory` will be used.
      */
@@ -832,7 +832,7 @@ export namespace CodeConsole {
      * @param source - The data to use for the original source data.
      *
      * @returns A new raw cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      */
     createRawCell(options: CellModel.IOptions): IRawCellModel {
       return new RawCellModel(options);

--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -51,7 +51,7 @@ export namespace PathExt {
    * @returns the extension of the file.
    *
    * #### Notes
-   * The extension is the string from the last occurence of the `.`
+   * The extension is the string from the last occurrence of the `.`
    * character to end of string in the last portion of the path, inclusive.
    * If there is no `.` in the last portion of the path, or if the first
    * character of the basename of path [[basename]] is `.`, then an

--- a/packages/coreutils/typings/path-posix/path-posix.d.ts
+++ b/packages/coreutils/typings/path-posix/path-posix.d.ts
@@ -55,7 +55,7 @@ declare module 'path-posix' {
   /**
    * The right-most parameter is considered {to}.  Other parameters are considered an array of {from}.
    *
-   * Starting from leftmost {from} paramter, resolves {to} to an absolute path.
+   * Starting from leftmost {from} parameter, resolves {to} to an absolute path.
    *
    * If {to} isn't already absolute, {from} arguments are prepended in right to left order, until an absolute path is found. If after using all {from} paths still no absolute path is found, the current working directory is used as well. The resulting path is normalized, and trailing slashes are removed unless the path gets resolved to the root directory.
    *

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -34,7 +34,7 @@ import { Contents } from '@jupyterlab/services';
 const DOCUMENT_CLASS = 'jp-Document';
 
 /**
- * A class that maintains the lifecyle of file-backed widgets.
+ * A class that maintains the lifecycle of file-backed widgets.
  */
 export class DocumentWidgetManager implements IDisposable {
   /**

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -35,7 +35,7 @@ import { DocumentRegistry } from './registry';
 /**
  * An implementation of a document context.
  *
- * This class is typically instantiated by the document manger.
+ * This class is typically instantiated by the document manager.
  */
 export class Context<T extends DocumentRegistry.IModel>
   implements DocumentRegistry.IContext<T> {
@@ -659,7 +659,7 @@ export class Context<T extends DocumentRegistry.IModel>
   ): Promise<Contents.IModel> {
     let tDisk = new Date(model.last_modified);
     console.warn(
-      `Last saving peformed ${tClient} ` +
+      `Last saving performed ${tClient} ` +
         `while the current file seems to have been saved ` +
         `${tDisk}`
     );

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -320,7 +320,7 @@ export class ListModel extends VDomModel {
    *
    * This will query the NPM repository, and the notebook server.
    *
-   * Emits the `stateChanged` signal on succesfull completion.
+   * Emits the `stateChanged` signal on successful completion.
    */
   protected async update(refreshInstalled = false) {
     let search = this.searcher.searchExtensions(

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -54,7 +54,7 @@ const MATERIAL_CLASS = 'jp-MaterialIcon';
 /**
  * A widget which hosts a file browser.
  *
- * The widget uses the Jupyter Contents API to retreive contents,
+ * The widget uses the Jupyter Contents API to retrieve contents,
  * and presents itself as a flat list of files and directories with
  * breadcrumbs.
  */

--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -41,7 +41,7 @@ const LAUNCHER_CLASS = 'jp-Launcher';
 const KNOWN_CATEGORIES = ['Notebook', 'Console', 'Other'];
 
 /**
- * These laucher item categories are known to have kernels, so the kernel icons
+ * These launcher item categories are known to have kernels, so the kernel icons
  * are used.
  */
 const KERNEL_CATEGORIES = ['Notebook', 'Console'];

--- a/packages/mainmenu/src/file.ts
+++ b/packages/mainmenu/src/file.ts
@@ -103,7 +103,7 @@ export namespace IFileMenu {
   }
 
   /**
-   * Interface for an activity that has some persistance action
+   * Interface for an activity that has some persistence action
    * before saving.
    */
   export interface IPersistAndSave<T extends Widget> extends IMenuExtender<T> {
@@ -118,7 +118,7 @@ export namespace IFileMenu {
     action: string;
 
     /**
-     * A function to perform the persistance.
+     * A function to perform the persistence.
      */
     persistAndSave: (widget: T) => Promise<void>;
   }

--- a/packages/mainmenu/src/labmenu.ts
+++ b/packages/mainmenu/src/labmenu.ts
@@ -42,7 +42,7 @@ export interface IMenuExtender<T extends Widget> {
    * An additional function that determines whether the extender
    * is enabled. By default it is considered enabled if the application
    * active widget is contained in the `tracker`. If this is also
-   * provided, the critereon is equivalent to
+   * provided, the criterion is equivalent to
    * `tracker.has(widget) && extender.isEnabled(widget)`
    */
   isEnabled?: (widget: T) => boolean;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1372,13 +1372,13 @@ namespace Private {
   ): ICellModel {
     switch (cell.type) {
       case 'code':
-        // TODO why isnt modeldb or id passed here?
+        // TODO why isn't modeldb or id passed here?
         return model.contentFactory.createCodeCell({ cell: cell.toJSON() });
       case 'markdown':
-        // TODO why isnt modeldb or id passed here?
+        // TODO why isn't modeldb or id passed here?
         return model.contentFactory.createMarkdownCell({ cell: cell.toJSON() });
       default:
-        // TODO why isnt modeldb or id passed here?
+        // TODO why isn't modeldb or id passed here?
         return model.contentFactory.createRawCell({ cell: cell.toJSON() });
     }
   }

--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -264,7 +264,7 @@ export namespace CellTools {
      * Handle a change to the active cell.
      *
      * #### Notes
-     * The default implemenatation is a no-op.
+     * The default implementation is a no-op.
      */
     protected onActiveCellChanged(msg: Message): void {
       /* no-op */

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -356,7 +356,7 @@ export namespace NotebookModel {
      * @param options - The options used to create the cell.
      *
      * @returns A new code cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      */
     createCodeCell(options: CodeCellModel.IOptions): ICodeCellModel;
 
@@ -366,7 +366,7 @@ export namespace NotebookModel {
      * @param options - The options used to create the cell.
      *
      * @returns A new markdown cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      */
     createMarkdownCell(options: CellModel.IOptions): IMarkdownCellModel;
 
@@ -376,7 +376,7 @@ export namespace NotebookModel {
      * @param options - The options used to create the cell.
      *
      * @returns A new raw cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      */
     createRawCell(options: CellModel.IOptions): IRawCellModel;
 
@@ -415,7 +415,7 @@ export namespace NotebookModel {
      * @param source - The data to use for the original source data.
      *
      * @returns A new code cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      *   If the contentFactory is not provided, the instance
      *   `codeCellContentFactory` will be used.
      */
@@ -438,7 +438,7 @@ export namespace NotebookModel {
      * @param source - The data to use for the original source data.
      *
      * @returns A new markdown cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      */
     createMarkdownCell(options: CellModel.IOptions): IMarkdownCellModel {
       if (this.modelDB) {
@@ -456,7 +456,7 @@ export namespace NotebookModel {
      * @param source - The data to use for the original source data.
      *
      * @returns A new raw cell. If a source cell is provided, the
-     *   new cell will be intialized with the data from the source.
+     *   new cell will be initialized with the data from the source.
      */
     createRawCell(options: CellModel.IOptions): IRawCellModel {
       if (this.modelDB) {

--- a/packages/notebook/src/modelfactory.ts
+++ b/packages/notebook/src/modelfactory.ts
@@ -103,7 +103,7 @@ export namespace NotebookModelFactory {
 
     /**
      * The content factory used by the NotebookModelFactory.  If
-     * given, it will supercede the `codeCellContentFactory`.
+     * given, it will supersede the `codeCellContentFactory`.
      */
     contentFactory?: NotebookModel.IContentFactory;
   }

--- a/packages/observables/src/observablelist.ts
+++ b/packages/observables/src/observablelist.ts
@@ -695,7 +695,7 @@ export namespace ObservableList {
    */
   export interface IOptions<T> {
     /**
-     * An optional intial set of values.
+     * An optional initial set of values.
      */
     values?: IterableOrArrayLike<T>;
 

--- a/packages/observables/src/observablemap.ts
+++ b/packages/observables/src/observablemap.ts
@@ -325,7 +325,7 @@ export namespace ObservableMap {
    */
   export interface IOptions<T> {
     /**
-     * An optional intial set of values.
+     * An optional initial set of values.
      */
     values?: { [key: string]: T };
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -121,7 +121,7 @@ export class OutputArea extends Widget {
   readonly contentFactory: OutputArea.IContentFactory;
 
   /**
-   * Te rendermime instance used by the widget.
+   * The rendermime instance used by the widget.
    */
   readonly rendermime: RenderMimeRegistry;
 
@@ -454,7 +454,7 @@ export class OutputArea extends Widget {
    */
   private _onExecuteReply = (msg: KernelMessage.IExecuteReplyMsg) => {
     // API responses that contain a pager are special cased and their type
-    // is overriden from 'execute_reply' to 'display_data' in order to
+    // is overridden from 'execute_reply' to 'display_data' in order to
     // render output.
     let model = this.model;
     let content = msg.content as KernelMessage.IExecuteOkReply;

--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -71,7 +71,7 @@
 /*
 When drag events occur, `p-mod-override-cursor` is added to the body.
 Because iframes steal all cursor events, the following two rules are necessary
-to suppress pointer events while resize drags are occuring. There may be a
+to suppress pointer events while resize drags are occurring. There may be a
 better solution to this problem.
 */
 body.p-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated {

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -294,7 +294,7 @@ export namespace RenderMimeRegistry {
    */
   export interface IOptions {
     /**
-     * Intial factories to add to the rendermime instance.
+     * Initial factories to add to the rendermime instance.
      */
     initialFactories?: ReadonlyArray<IRenderMime.IRendererFactory>;
 

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -325,7 +325,7 @@ export function renderMarkdown(
 
       let originalContent = content;
 
-      // Santize the content it is not trusted.
+      // Sanitize the content it is not trusted.
       if (!trusted) {
         originalContent = `${content}`;
         content = sanitizer.sanitize(content);

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -218,7 +218,7 @@ export class RenderedImage extends RenderedCommon {
 }
 
 /**
- * A mime renderer for displaying Markdown with embeded latex.
+ * A mime renderer for displaying Markdown with embedded latex.
  */
 export class RenderedMarkdown extends RenderedHTMLCommon {
   /**

--- a/packages/services/src/config/index.ts
+++ b/packages/services/src/config/index.ts
@@ -26,7 +26,7 @@ export interface IConfigSection {
    *
    * #### Notes
    * Updates the local data immediately, sends the change to the server,
-   * and updates the local data with the response, and fullfils the promise
+   * and updates the local data with the response, and fulfils the promise
    * with that data.
    */
   update(newdata: JSONObject): Promise<JSONObject>;

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -304,7 +304,7 @@ export namespace Contents {
      *
      * @param path - The desired file path.
      *
-     * @param options - Optional overrrides to the model.
+     * @param options - Optional overrides to the model.
      *
      * @returns A promise which resolves with the file content model when the
      *   file is saved.
@@ -448,7 +448,7 @@ export namespace Contents {
      *
      * @param localPath - The desired file path.
      *
-     * @param options - Optional overrrides to the model.
+     * @param options - Optional overrides to the model.
      *
      * @returns A promise which resolves with the file content model when the
      *   file is saved.
@@ -1346,7 +1346,7 @@ export class Drive implements Contents.IDrive {
  */
 export namespace ContentsManager {
   /**
-   * The options used to intialize a contents manager.
+   * The options used to initialize a contents manager.
    */
   export interface IOptions {
     /**
@@ -1366,7 +1366,7 @@ export namespace ContentsManager {
  */
 export namespace Drive {
   /**
-   * The options used to intialize a `Drive`.
+   * The options used to initialize a `Drive`.
    */
   export interface IOptions {
     /**

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -641,7 +641,7 @@ export class DefaultKernel implements Kernel.IKernel {
    *
    * #### Notes
    * Only one comm target can be registered to a target name at a time, an
-   * existing callback for the same target name will be overidden.  A registered
+   * existing callback for the same target name will be overridden.  A registered
    * comm target handler will take precedence over a comm which specifies a
    * `target_module`.
    *
@@ -1072,7 +1072,7 @@ export class DefaultKernel implements Kernel.IKernel {
         console.error(error);
       });
 
-    // Emit the message recieve signal
+    // Emit the message receive signal
     this._anyMessage.emit({ msg, direction: 'recv' });
   };
 

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -333,7 +333,7 @@ export namespace Kernel {
      *
      * #### Notes
      * Only one comm target can be registered to a target name at a time, an
-     * existing callback for the same target name will be overidden.  A registered
+     * existing callback for the same target name will be overridden.  A registered
      * comm target handler will take precedence over a comm which specifies a
      * `target_module`.
      *

--- a/packages/services/src/kernel/validate.ts
+++ b/packages/services/src/kernel/validate.ts
@@ -11,7 +11,7 @@ import { KernelMessage } from './messages';
 const HEADER_FIELDS = ['username', 'version', 'session', 'msg_id', 'msg_type'];
 
 /**
- * Requred fields and types for contents of various types of `kernel.IMessage`
+ * Required fields and types for contents of various types of `kernel.IMessage`
  * messages on the iopub channel.
  */
 const IOPUB_CONTENT_FIELDS: { [key: string]: any } = {

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -67,12 +67,12 @@ export namespace Session {
     readonly id: string;
 
     /**
-     * The current path associated with the sesssion.
+     * The current path associated with the session.
      */
     readonly path: string;
 
     /**
-     * The current name associated with the sesssion.
+     * The current name associated with the session.
      */
     readonly name: string;
 

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -58,7 +58,7 @@ export class TerminalManager implements TerminalSession.IManager {
   readonly serverSettings: ServerConnection.ISettings;
 
   /**
-   * Test whether the manger is ready.
+   * Test whether the manager is ready.
    */
   get isReady(): boolean {
     return this._isReady;

--- a/packages/services/src/terminal/terminal.ts
+++ b/packages/services/src/terminal/terminal.ts
@@ -158,7 +158,7 @@ export namespace TerminalSession {
   }
 
   /**
-   * The options for intializing a terminal session object.
+   * The options for initializing a terminal session object.
    */
   export interface IOptions {
     /**

--- a/packages/services/test/src/kernel/kernel.spec.ts
+++ b/packages/services/test/src/kernel/kernel.spec.ts
@@ -164,7 +164,7 @@ describe('kernel', () => {
   });
 
   describe('Kernel.connectTo()', () => {
-    it('should connect to an exisiting kernel', () => {
+    it('should connect to an existing kernel', () => {
       let id = defaultKernel.id;
       const kernel = Kernel.connectTo(defaultKernel.model);
       expect(kernel.id).to.be(id);

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -229,7 +229,7 @@ namespace Private {
     registry: ISettingRegistry,
     plugin: ISettingRegistry.IPlugin
   ): string {
-    // First, give priorty to checking if the hint exists in the user data.
+    // First, give priority to checking if the hint exists in the user data.
     let hint = plugin.data.user[key];
 
     // Second, check to see if the hint exists in composite data, which folds

--- a/setupbase.py
+++ b/setupbase.py
@@ -354,7 +354,7 @@ def install_npm(path=None, build_dir=None, source_dir=None, build_cmd='build', f
 
             if not which(npm_cmd[0]):
                 log.error("`{0}` unavailable.  If you're running this command "
-                          "using sudo, make sure `{0}` is availble to sudo"
+                          "using sudo, make sure `{0}` is available to sudo"
                           .format(npm_cmd[0]))
                 return
 
@@ -459,7 +459,7 @@ def _wrap_command(cmds, cls, strict=True):
     cmds: list(str)
         The names of the other commands to run prior to the command.
     strict: boolean, optional
-        Wether to raise errors when a pre-command fails.
+        Whether to raise errors when a pre-command fails.
     """
     class WrappedCommand(cls):
 
@@ -507,7 +507,7 @@ def _get_data_files(data_specs, existing):
     data_specs: list of tuples
         See [createcmdclass] for description.
     existing: list of tuples
-        The existing distrubution data_files metadata.
+        The existing distribution data_files metadata.
 
     Returns
     -------

--- a/tests/test-console/src/history.spec.ts
+++ b/tests/test-console/src/history.spec.ts
@@ -123,7 +123,7 @@ describe('console/history', () => {
     });
 
     describe('#forward()', () => {
-      it('should return an emptry string if no history exists', () => {
+      it('should return an empty string if no history exists', () => {
         let history = new ConsoleHistory({ session });
         return history.forward('').then(result => {
           expect(result).to.be('');

--- a/tests/test-coreutils/src/path.spec.ts
+++ b/tests/test-coreutils/src/path.spec.ts
@@ -48,7 +48,7 @@ describe('@jupyterlab/coreutils', () => {
         expect(PathExt.extname(TESTPATH)).to.equal('.js');
       });
 
-      it('should only take the last occurance of a dot', () => {
+      it('should only take the last occurrence of a dot', () => {
         expect(PathExt.extname('foo.tar.gz')).to.equal('.gz');
       });
     });

--- a/tests/test-docregistry/src/default.spec.ts
+++ b/tests/test-docregistry/src/default.spec.ts
@@ -375,7 +375,7 @@ describe('docregistry/default', () => {
     });
 
     describe('defaultKernelLanguage', () => {
-      it('should get the default kernel langauge of the document', () => {
+      it('should get the default kernel language of the document', () => {
         let model = new DocumentModel();
         expect(model.defaultKernelLanguage).to.be('');
       });


### PR DESCRIPTION
I recently discovered the [codespell](https://github.com/codespell-project/codespell) tool for automatically fixing typos and wanted to try it out for the `jupyterlab` repo.

In the end it's mostly comments and strings that are affected, which is good!

For reference, here is an example of what the command looks like:

`codespell -c packages -i 3 -w --skip="node_modules,*.map,*.min.js,*.log,./jupyterlab/static,./jupyterlab/staging,dev_mode,.git,*.png,*.ttf,*.woff*,*.eot,*.pyc"`

Maybe a tool to add to the pre-commit hook (like prettier) in the future?