### PR TITLE
Always focus a new console prompt cell.

### DIFF
--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -440,6 +440,7 @@ export class CodeConsole extends Widget {
     // Suppress the default "Enter" key handling.
     let editor = promptCell.editor;
     editor.addKeydownHandler(this._onEditorKeydown);
+    editor.focus();
 
     this._history.editor = editor;
     this._promptCellCreated.emit(promptCell);


### PR DESCRIPTION
Fixes #4837.

The difference in behavior is down to whether the console execution is forced or unforced. In one case, an `activate()` request seems to be focusing the new cell, but in the other case there is no `activate()` request. 

I am not sure where that activate request is coming from, but I think it's fair to explicitly focus the new prompt.