### PR TITLE
A lighter-touch fix for console focus.

### DIFF
--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -298,6 +298,7 @@ export class CodeConsole extends Widget {
       if (should) {
         // Create a new prompt cell before kernel execution to allow typeahead.
         this.newPromptCell();
+        this.promptCell!.editor.focus();
         return this._execute(promptCell);
       } else {
         // add a newline if we shouldn't execute
@@ -440,7 +441,6 @@ export class CodeConsole extends Widget {
     // Suppress the default "Enter" key handling.
     let editor = promptCell.editor;
     editor.addKeydownHandler(this._onEditorKeydown);
-    editor.focus();
 
     this._history.editor = editor;
     this._promptCellCreated.emit(promptCell);


### PR DESCRIPTION
Fix for #4837, alternative to #4886.

@jasongrout, can you comment on whether this interferes with #4330?

TLDR: there was a race condition in the console focusing for a new prompt cell.

The problem comes down to the difference in processing of a forced console execution vs an unforced one. The forced one is processed synchronously, the unforced one is processed asynchronously. The difference in control flow is as such:

#### Forced
1. A console command is executed, [getCurrent](https://github.com/jupyterlab/jupyterlab/blob/master/packages/console-extension/src/index.ts#L304-L311) is called. *This function sends and activate request to the console, which is processed asynchronously*.
2. The code is sent to the kernel, and a new prompt cell is created.
3. The `activate` request is handled later, and the new prompt cell is focused.

#### Unforced
1. 1. A console command is executed, [getCurrent](https://github.com/jupyterlab/jupyterlab/blob/master/packages/console-extension/src/index.ts#L304-L311) is called. 
2. The console checks with the kernel whether it should run code.
3. The `activate` request is handled, it seems in practice before the above check is complete. This activates the old prompt.
4. Later, the console learns it should execute, sends code to the kernel, and a new prompt cell is created.
5. The new prompt cell never gets an activate request.

As an aside, I have been bit by this auto-focusing side-effect of `getCurrent` before. Perhaps we should rethink that behavior?