### PR TITLE
Bottom Panel Styling

### DIFF
--- a/packages/application/style/index.css
+++ b/packages/application/style/index.css
@@ -41,7 +41,6 @@ body {
 }
 
 #jp-bottom-panel {
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color0);
   background: var(--jp-layout-color1);
   display: flex;
 }


### PR DESCRIPTION
As of now, the bottom panel has a `bottom-border`, which creates an unsightly gap between the bottom panel and end of window. This PR would eliminate that `bottom-border`. 
@ellisonbg @ian-r-rose 


