### PR TITLE
Prevent cascading test failures due to failing to await a save.

### DIFF
--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -132,7 +132,7 @@ describe('docregistry/context', () => {
 
       it('should initialize the model when the file is reverted for the first time', async () => {
         const context = await createNotebookContext();
-        manager.contents.save(context.path, {
+        await manager.contents.save(context.path, {
           type: 'notebook',
           format: 'json',
           content: DEFAULT_CONTENT


### PR DESCRIPTION
Fixes-- https://github.com/jupyterlab/jupyterlab/issues/4810#issuecomment-401436346
Fixes-- https://github.com/jupyterlab/jupyterlab/issues/4810#issuecomment-404257599

This was resulting in a race condition. It affected not just this test, but multiple others down the line as it results in an undismissed dialog that interferes with some logic.