### PR TITLE
Mismatch in apputils and application version

### DIFF
--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -265,7 +265,7 @@ repository root folder install the dependency and save it to your
 
 .. code:: bash
 
-    npm install --save @jupyterlab/apputils
+    npm install --save @jupyterlab/apputils@0.16.0
 
 Locate the ``extension`` object of type ``JupyterLabPlugin``. Change the
 definition so that it reads like so:


### PR DESCRIPTION
Following the tutorial I ran into a `No provider for: @jupyterlab/apputils..` error. Installing apputils pulled version  `0.17.0-1` and changing to 0.16.0 (aligning with the `"@jupyterlab/application": "^0.16.0",` from the package.json in boilerplate) fixed the issue.

Alternatively the version of `@jupyterlab/application` in the generate boilerplate should match the latest.