### PR TITLE
Specify the latest Node version <10 in instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Building JupyterLab from its GitHub source code requires Node.js version
 If you use `conda`, you can get it with:
 
 ```bash
-conda install -c conda-forge nodejs=9.11.1
+conda install -c conda-forge 'nodejs<10'
 ```
 
 If you use [Homebrew](http://brew.sh/) on Mac OS X:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Building JupyterLab from its GitHub source code requires Node.js version
 If you use `conda`, you can get it with:
 
 ```bash
-conda install -c conda-forge nodejs
+conda install -c conda-forge nodejs=9.11.1
 ```
 
 If you use [Homebrew](http://brew.sh/) on Mac OS X:


### PR DESCRIPTION
Instructions further down the page state "There are versions of Node that are too modern. You should use a version of Node < 10". The install command however installs the latest version, which is 10.4.1. This edit installs the most recent appropriate version, but there might be a better fix than hard-coding the version like this?