### PR TITLE
If tab indentation is on, dont expand tabs elsewhere either

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1174,7 +1174,11 @@ namespace Private {
     if (/^\s*$/.test(before)) {
       CodeMirror.commands['indentMore'](cm);
     } else {
-      CodeMirror.commands['insertSoftTab'](cm);
+      if (cm.getOption('indentWithTabs')) {
+        CodeMirror.commands['insertTab'](cm);
+      } else {
+        CodeMirror.commands['insertSoftTab'](cm);
+      }
     }
   }
 


### PR DESCRIPTION
I was having trouble editing a csv file because the editor kept inserting spaces instead of tabs between columns. This fixes that.