### PR TITLE
Extension disclaimers

### DIFF
--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.17.0-1",
+    "@jupyterlab/apputils": "^0.17.0-1",
     "@jupyterlab/coreutils": "^2.0.0-1",
     "@jupyterlab/extensionmanager": "^0.17.0-1"
   },

--- a/packages/extensionmanager-extension/schema/plugin.json
+++ b/packages/extensionmanager-extension/schema/plugin.json
@@ -6,7 +6,8 @@
   "properties": {
     "enabled": {
       "title": "Enabled Status",
-      "description": "Requires Node.js/npm so the manager disabled by default.",
+      "description":
+        "Enables the extension manager (requires Node.js/npm, so disabled by default). WARNING: installing untrusted extensions can introduce security issues.",
       "default": false,
       "type": "boolean"
     }

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -134,7 +134,10 @@ namespace Private {
         'However, we cannot vouch for every extension, ' +
         'and some may introduce security risks. ' +
         'Do you want to continue?',
-      buttons: [Dialog.cancelButton(), Dialog.warnButton()]
+      buttons: [
+        Dialog.cancelButton({ label: 'DISABLE' }),
+        Dialog.warnButton({ label: 'ENABLE' })
+      ]
     }).then(result => {
       if (result.button.accept) {
         return true;

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -134,7 +134,7 @@ namespace Private {
         'However, we cannot vouch for every extension, ' +
         'and some may introduce security risks. ' +
         'Do you want to continue?',
-      buttons: [Dialog.cancelButton(), Dialog.okButton()]
+      buttons: [Dialog.cancelButton(), Dialog.warnButton()]
     }).then(result => {
       if (result.button.accept) {
         return true;

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -17,7 +17,7 @@ import {
 
 import { reportInstallError } from './dialog';
 
-import { Searcher, ISearchResult } from './query';
+import { Searcher, ISearchResult, isJupyterOrg } from './query';
 
 /**
  * Information about an extension.
@@ -344,7 +344,7 @@ export class ListModel extends VDomModel {
     for (let key of Object.keys(installedMap)) {
       installed.push(installedMap[key]);
     }
-    this._installed = installed;
+    this._installed = installed.sort(Private.comparator);
 
     let searchResult: IEntry[] = [];
     for (let key of Object.keys(searchMap)) {
@@ -354,7 +354,7 @@ export class ListModel extends VDomModel {
         searchResult.push(installedMap[key]);
       }
     }
-    this._searchResult = searchResult;
+    this._searchResult = searchResult.sort(Private.comparator);
     try {
       this._totalEntries = (await search).total;
     } catch (error) {
@@ -678,4 +678,29 @@ function handleError(response: Response): Response {
     throw new Error(`${response.status} (${response.statusText})`);
   }
   return response;
+}
+
+/**
+ * A namespace for private functionality.
+ */
+namespace Private {
+  /**
+   * A comparator function that sorts whitelisted orgs to the top.
+   */
+  export function comparator(a: IEntry, b: IEntry): number {
+    if (a.name === b.name) {
+      return 0;
+    }
+
+    let testA = isJupyterOrg(a.name);
+    let testB = isJupyterOrg(b.name);
+
+    if (testA === testB) {
+      return a.name.localeCompare(b.name);
+    } else if (testA && !testB) {
+      return -1;
+    } else {
+      return 1;
+    }
+  }
 }

--- a/packages/extensionmanager/src/query.ts
+++ b/packages/extensionmanager/src/query.ts
@@ -282,3 +282,21 @@ export class Searcher {
    */
   cdnUri: string;
 }
+
+/**
+ * Check whether the NPM org is a Jupyter one.
+ */
+export function isJupyterOrg(name: string): boolean {
+  /**
+   * A list of whitelisted NPM orgs.
+   */
+  const whitelist = ['jupyterlab', 'jupyter-widgets'];
+  const parts = name.split('/');
+  const first = parts[0];
+  return (
+    parts.length > 1 && // Has a first part
+    first && // with a finite length
+    first[0] === '@' && // corresponding to an org name
+    whitelist.indexOf(first.slice(1)) !== -1 // in the org whitelist.
+  );
+}

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -13,6 +13,8 @@ import ReactPaginate from 'react-paginate';
 
 import { ListModel, IEntry, Action } from './model';
 
+import { isJupyterOrg } from './query';
+
 // TODO: Replace pagination with lazy loading of lower search results
 
 /**
@@ -150,7 +152,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
     flagClasses.push(`jp-extensionmanager-entry-${entry.status}`);
   }
   let title = entry.name;
-  if (Private.isJupyterOrg(entry.name)) {
+  if (isJupyterOrg(entry.name)) {
     flagClasses.push(`jp-extensionmanager-entry-mod-whitelisted`);
     title = `${entry.name} (Developed by Project Jupyter)`;
   }
@@ -519,29 +521,5 @@ export class ExtensionView extends VDomRenderer<ListModel> {
   private _toggleFocused(): void {
     let focused = document.activeElement === this.inputNode;
     this.toggleClass('p-mod-focused', focused);
-  }
-}
-
-/**
- * A namespace for private functions.
- */
-namespace Private {
-  /**
-   * A list of whitelisted NPM orgs.
-   */
-  const whitelist = ['jupyterlab', 'jupyter-widgets'];
-
-  /**
-   * Check whether the org is a Jupyter one.
-   */
-  export function isJupyterOrg(name: string): boolean {
-    const parts = name.split('/');
-    const first = parts[0];
-    return (
-      parts.length > 1 && // Has a first part
-      first && // with a finite length
-      first[0] === '@' && // corresponding to an org name
-      whitelist.indexOf(first.slice(1)) !== -1 // in the org whitelist.
-    );
   }
 }

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -372,7 +372,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
         </div>
       );
     } else if (!model.query && model.installed.length) {
-      content.push(
+      elements.push(
         <header key="installed-header">
           Installed<button
             className="jp-extensionmanager-refresh"
@@ -382,7 +382,9 @@ export class ExtensionView extends VDomRenderer<ListModel> {
           >
             &#8635;
           </button>
-        </header>,
+        </header>
+      );
+      content.push(
         <ListView
           key="installed"
           entries={model.installed}
@@ -394,8 +396,8 @@ export class ExtensionView extends VDomRenderer<ListModel> {
         />
       );
     } else if (model.searchError === null) {
+      elements.push(<header key="installable-header">Search results</header>);
       content.push(
-        <header key="installable-header">Search results</header>,
         <ListView
           key="installable"
           entries={model.searchResult}

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -149,9 +149,20 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
   if (entry.status && ['ok', 'warning', 'error'].indexOf(entry.status) !== -1) {
     flagClasses.push(`jp-extensionmanager-entry-${entry.status}`);
   }
+  let title = entry.name;
+  if (Private.isJupyterOrg(entry.name)) {
+    flagClasses.push(`jp-extensionmanager-entry-mod-whitelisted`);
+    title = `${entry.name} (Developed by Project Jupyter)`;
+  }
   return (
-    <li className={`jp-extensionmanager-entry ${flagClasses.join(' ')}`}>
-      <div className="jp-extensionmanager-entry-name">{entry.name}</div>
+    <li
+      className={`jp-extensionmanager-entry ${flagClasses.join(' ')}`}
+      title={title}
+    >
+      <div className="jp-extensionmanager-entry-title">
+        <div className="jp-extensionmanager-entry-name">{entry.name}</div>
+        <div className="jp-extensionmanager-entry-jupyter-org" />
+      </div>
       <div className="jp-extensionmanager-entry-content">
         <div className="jp-extensionmanager-entry-description">
           {entry.description}
@@ -508,5 +519,29 @@ export class ExtensionView extends VDomRenderer<ListModel> {
   private _toggleFocused(): void {
     let focused = document.activeElement === this.inputNode;
     this.toggleClass('p-mod-focused', focused);
+  }
+}
+
+/**
+ * A namespace for private functions.
+ */
+namespace Private {
+  /**
+   * A list of whitelisted NPM orgs.
+   */
+  const whitelist = ['jupyterlab', 'jupyter-widgets'];
+
+  /**
+   * Check whether the org is a Jupyter one.
+   */
+  export function isJupyterOrg(name: string): boolean {
+    const parts = name.split('/');
+    const first = parts[0];
+    return (
+      parts.length > 1 && // Has a first part
+      first && // with a finite length
+      first[0] === '@' && // corresponding to an org name
+      whitelist.indexOf(first.slice(1)) !== -1 // in the org whitelist.
+    );
   }
 }

--- a/packages/extensionmanager/style/index.css
+++ b/packages/extensionmanager/style/index.css
@@ -178,6 +178,24 @@
   border-bottom: solid var(--jp-border-width) var(--jp-border-color2);
 }
 
+.jp-extensionmanager-entry-title {
+  display: flex;
+  flex-direction: row;
+}
+
+.jp-extensionmanager-entry-jupyter-org {
+  background-image: var(--jp-image-jupyter);
+  background-size: 1em;
+  background-repeat: no-repeat;
+  width: 1em;
+  display: none;
+}
+
+.jp-extensionmanager-entry.jp-extensionmanager-entry-mod-whitelisted
+  .jp-extensionmanager-entry-jupyter-org {
+  display: inline;
+}
+
 /* Precedence order update/error/warning matters! */
 .jp-extensionmanager-entry.jp-extensionmanager-entry-update {
   border-left: solid 8px var(--jp-brand-color2);
@@ -197,6 +215,7 @@
 .jp-extensionmanager-entry-name {
   font-size: var(--jp-ui-font-size1);
   font-weight: 600;
+  padding: 0 8px 0 0;
   margin-bottom: 3px;
 }
 .jp-extensionmanager-entry-description {

--- a/packages/extensionmanager/style/index.css
+++ b/packages/extensionmanager/style/index.css
@@ -216,8 +216,6 @@
 }
 
 .jp-extensionmanager-entry.jp-extensionmanager-entry-warning {
-  border-left: solid 8px var(--jp-warn-color2);
-  padding-left: 4px;
 }
 
 .jp-extensionmanager-entry-name {

--- a/packages/extensionmanager/style/index.css
+++ b/packages/extensionmanager/style/index.css
@@ -8,6 +8,7 @@
   background: var(--jp-layout-color1);
   display: flex;
   flex-direction: column;
+  font-size: var(--jp-ui-font-size1);
 }
 
 .jp-extensionmanager-content {
@@ -28,7 +29,14 @@
 }
 
 .jp-extensionmanager-view header {
-  padding: 0 5px;
+  flex: 0 0 auto;
+  margin: 4px 0px;
+  padding: 12px 0 4px 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
+  letter-spacing: 1px;
+  font-size: var(--jp-ui-font-size0);
 }
 
 .jp-extensionmanager-listview {
@@ -51,7 +59,7 @@
 
 .jp-extensionmanager-search-bar {
   padding: 8px;
-  background-color: var(--jp-border-color3);
+  background-color: var(--jp-layout-color2);
   border-bottom: 1px solid var(--jp-border-color1);
   box-shadow: var(--jp-toolbar-box-shadow);
   z-index: 2;
@@ -73,7 +81,7 @@
   overflow: overlay;
   padding: 0px 8px;
   border: 1px solid var(--jp-border-color0);
-  background-color: var(--jp-input-background-color-active);
+  background-color: var(--jp-input-active-background);
   height: 30px;
 }
 

--- a/packages/extensionmanager/style/index.css
+++ b/packages/extensionmanager/style/index.css
@@ -197,6 +197,8 @@
   background-repeat: no-repeat;
   width: 1em;
   display: none;
+  position: relative;
+  top: 3px;
 }
 
 .jp-extensionmanager-entry.jp-extensionmanager-entry-mod-whitelisted


### PR DESCRIPTION
Fixes #4820.
1. Adds a badge to packages published under the `@jupyterlab` or `@jupyter-widgets` orgs.
1. Sorts packages from those orgs to the top of the list.
1. Gives a warning when you enable the extension manager that there are potential security risks.
1. Makes the styling of the extension manager a bit more consistent with the rest of the app.

Before:
![image](https://user-images.githubusercontent.com/5728311/42914746-d9cf829a-8ab0-11e8-8e18-ccabe41cca5e.png)

After:
![image](https://user-images.githubusercontent.com/5728311/42914689-8d014d36-8ab0-11e8-97e8-85a44b7cd115.png)

Dialog:
![image](https://user-images.githubusercontent.com/5728311/42914761-fa73dcee-8ab0-11e8-8205-7e313b417f98.png)

A few questions:
1. Am I missing any obvious npm orgs?
1. Is this too heavy-handed in promoting `@jupyterlab` org extensions?
2. How do we like the warning dialog language?