### PR TITLE
Force pip install on rtd

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,3 +2,4 @@ conda:
     file: docs/environment.yml
 python:
     version: 3
+    pip_install: true


### PR DESCRIPTION
Attempting to fix https://readthedocs.org/projects/jupyterlab/builds/7504676/ using http://docs.readthedocs.io/en/latest/yaml-config.html#python-pip-install

cc @willingc 