### PR TITLE
Add nodejs to docs requirement

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,6 +2,7 @@ name: jupyterlab_documentation
 channels:
   - conda-forge
 dependencies:
+- nodejs
 - python=3.5
 - sphinx>=1.6
 - sphinx_rtd_theme


### PR DESCRIPTION
Follow up to #4927, fixing https://readthedocs.org/projects/jupyterlab/builds/7510206/.  

cc @willingc 