### PR TITLE
Update copyright notice.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,19 @@
-BSD 3-Clause License
-
-Copyright (c) 2015-2017, Project Jupyter Contributors
+Copyright (c) 2015 Project Jupyter Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -303,7 +303,9 @@ function activate(
         </span>
       );
       let copyright = (
-        <span className="jp-About-copyright">© 2018 Project Jupyter</span>
+        <span className="jp-About-copyright">
+          © 2015 Project Jupyter Contributors
+        </span>
       );
       let body = (
         <div className="jp-About-body">


### PR DESCRIPTION
Based on discussions at https://github.com/jupyter/governance/issues/37,  as well as information at the links from that discussion, I made the following updates:

1. Changed the copyright notice years to just the first year.
2. Formatted the BSD license as on the OSI license page at https://opensource.org/licenses/BSD-3-Clause (change the bullets to numbers, insert spaces to line things up)
3. Update the Help|About dialog to reflect these updates (both the license year, and correct the license holder to our official “Project Jupyter Contributors”)