### PR TITLE
Fix selection update on editor focusin event

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -823,6 +823,11 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       this.refresh();
     }
     this.host.classList.add('jp-mod-focused');
+
+    // Update the selections on editor gaining focus because
+    // the onCursorActivity function filters usual cursor events
+    // based on the editor's focus.
+    this._onCursorActivity();
   }
 
   /**


### PR DESCRIPTION
Currently, when a cell's code editor is focused from command mode the selection will change but the `selections.changed` `Signal` will not fire. This is because the `cursorActivity` event fires before the editor gains focus, the desired event is lost.

https://github.com/jupyterlab/jupyterlab/blob/f1540643c25c01c019a78eb992af7a42696fbe37/packages/codemirror/src/editor.ts#L133

and

https://github.com/jupyterlab/jupyterlab/blob/f1540643c25c01c019a78eb992af7a42696fbe37/packages/codemirror/src/editor.ts#L645-L652

This change just updates the selection every single time the focus is gained.

@ian-r-rose 