### PR TITLE
Increase size of home icon

### DIFF
--- a/packages/application/style/icons.css
+++ b/packages/application/style/icons.css
@@ -87,9 +87,9 @@
 
 .jp-HomeIcon {
   background-image: var(--jp-icon-home);
-  min-width: 14px;
-  min-height: 14px;
-  background-size: 14px;
+  min-width: 16px;
+  min-height: 16px;
+  background-size: 16px;
   vertical-align: sub;
 }
 


### PR DESCRIPTION
I've increased the size of the icon for the home button in the address field from 14px. It now matches the 16px size of the other buttons.

@ellisonbg made the suggestion on what I should change, and I've checked that makes the correct change. Left image shows before, right image shows after the change.

![image](https://user-images.githubusercontent.com/2721423/43038139-7552c8ca-8d14-11e8-9d98-4f78308bd39e.png) ![image](https://user-images.githubusercontent.com/2721423/43038098-ff61b89c-8d13-11e8-9e02-f77adbbbc3b4.png)