### PR TITLE
Explain why the application directory exists

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -129,7 +129,7 @@ Advanced Usage
 Any information that JupyterLab persists is stored in its application directory,
 including settings and built assets.
 This is separate from where the Python package is installed (like in ``site_packages``)
-so that this folder is immutable.
+so that the install directory is immutable.
 
 The application directory can be overridden using ``--app-dir`` in
 any of the JupyterLab commands, or by setting the ``JUPYTERLAB_DIR``

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -126,9 +126,9 @@ You can re-enable an extension using the command:
 Advanced Usage
 ~~~~~~~~~~~~~~
 
-Any information that JupyterLab persists is stored in it's application directory,
+Any information that JupyterLab persists is stored in its application directory,
 including settings and built assets.
-This is seperate from where the Python package is installed (like in ``site_packages``),
+This is separate from where the Python package is installed (like in ``site_packages``)
 so that this folder is immutable.
 
 The application directory can be overridden using ``--app-dir`` in

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -126,8 +126,12 @@ You can re-enable an extension using the command:
 Advanced Usage
 ~~~~~~~~~~~~~~
 
-The JupyterLab application directory (where the application assets are
-built and the settings reside) can be overridden using ``--app-dir`` in
+Any information that JupyterLab persists is stored in it's application directory,
+including settings and built assets.
+This is seperate from where the Python package is installed (like in ``site_packages``),
+so that this folder is immutable.
+
+The application directory can be overridden using ``--app-dir`` in
 any of the JupyterLab commands, or by setting the ``JUPYTERLAB_DIR``
 environment variable. If not specified, it will default to
 ``<sys-prefix>/share/jupyter/lab``, where ``<sys-prefix>`` is the


### PR DESCRIPTION
I asked last week why the application directory exists, instead of JupyterLab just storing everything where it was installed. The reasoning is to keep this install directory immutable. I updated the docs to include this reasoning. If anyone has anything else to flesh this out, feel free to comment on this PR (even in a rough form) and I am happy to update the text with it. 