### PR TITLE
Remove “Beta” from the app name.

### DIFF
--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -59,7 +59,7 @@ def load_jupyter_server_extension(nbapp):
     logger.info('JupyterLab extension loaded from %s' % HERE)
     logger.info('JupyterLab application directory is %s' % app_dir)
 
-    config.app_name = 'JupyterLab Beta'
+    config.app_name = 'JupyterLab'
     config.app_namespace = 'jupyterlab'
     config.page_url = '/lab'
     config.cache_files = True


### PR DESCRIPTION
This finishes fixing #4920. See also #4898.

This removes the "Beta" label in the Help | About JupyterLab menu item.