### PR TITLE
Fixes broken open command in context menu.

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -335,7 +335,7 @@ function addCommands(
         toArray(
           map(widget.selectedItems(), item => {
             if (item.type === 'directory') {
-              return widget.model.cd(item.path);
+              return widget.model.cd(item.name);
             }
 
             return commands.execute('docmanager:open', { path: item.path });


### PR DESCRIPTION
Fixes #4913 (and duplicate #4975). In the file browser, the open command in right-click context menu was broken for nested directories.