### PR TITLE
URI encoded src attribute embedded SVG data

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -458,7 +458,7 @@ export function renderSVG(options: renderSVG.IRenderOptions): Promise<void> {
 
   // Render in img so that user can save it easily
   const img = new Image();
-  img.src = `data:image/svg+xml,${source}`;
+  img.src = `data:image/svg+xml,${encodeURIComponent(source)}`;
   host.appendChild(img);
 
   if (unconfined === true) {

--- a/tests/test-rendermime/src/factories.spec.ts
+++ b/tests/test-rendermime/src/factories.spec.ts
@@ -137,7 +137,7 @@ describe('rendermime/factories', () => {
     });
 
     describe('#createRenderer()', () => {
-      it('should create an img element with the svg inline', () => {
+      it('should create an img element with the uri encoded svg inline', () => {
         const source = '<svg></svg>';
         let f = svgRendererFactory;
         let mimeType = 'image/svg+xml';
@@ -146,7 +146,7 @@ describe('rendermime/factories', () => {
         return w.renderModel(model).then(() => {
           let imgEl = w.node.getElementsByTagName('img')[0];
           expect(imgEl).to.be.ok();
-          expect(imgEl.src).to.contain(source);
+          expect(imgEl.src).to.contain(encodeURIComponent(source));
         });
       });
     });


### PR DESCRIPTION
Simple fix for issue #4779.

A quick test showed that Firefox now also renders the SVG,  as Chrome and Edge already did.

**Firefox**

![firefox_svg](https://user-images.githubusercontent.com/974908/43305873-9381b9aa-9179-11e8-82c3-f0ff9a4aeb96.png)

**Edge**

![edge_svg](https://user-images.githubusercontent.com/974908/43305918-bcd4a858-9179-11e8-81c7-29cfe5ed5459.png)

**Chrome**

![chrome_svg](https://user-images.githubusercontent.com/974908/43305928-c2be1b14-9179-11e8-93b3-da8eac9b0895.png)
