### PR TITLE
Fixing broken links in documentation

### DIFF
--- a/docs/source/developer/adding_content.rst
+++ b/docs/source/developer/adding_content.rst
@@ -17,7 +17,7 @@ As an example: Add a leaflet viewer plugin for geoJSON files.
    file that exports functions is
    `path-posix <https://github.com/jupyterlab/jupyterlab/blob/master/packages/coreutils/typings/path-posix/path-posix.d.ts>`__.
    An example with a class is
-   `xterm <https://github.com/jupyterlab/jupyterlab/blob/master/packages/terminal/typings/xterm/xterm.d.ts>`__.
+   `xterm <https://github.com/jupyterlab/jupyterlab/blob/master/packages/terminal/src/xterm.d.ts>`__.
 
 -  Add a reference to the new library in ``src/typings.d.ts``.
 

--- a/docs/source/developer/documents.rst
+++ b/docs/source/developer/documents.rst
@@ -22,7 +22,7 @@ A 'document' in JupyterLab is represented by a model instance implementing the `
 
 A single file path can have multiple different models (and hence different contexts) representing the file. For example, a notebook can be opened with a notebook model and with a text model. Different models for the same file path do not directly communicate with each other.
 
-`Document widgets <http://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_registry_.documentregistry.ireadywidget.html>`__ represent a view of a document model. There can be multiple document widgets associated with a single document model, and they naturally stay in sync with each other since they are views on the same underlying data model.
+`Document widgets <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html>`__ represent a view of a document model. There can be multiple document widgets associated with a single document model, and they naturally stay in sync with each other since they are views on the same underlying data model.
 
 
 The `Document

--- a/docs/source/developer/notebook.rst
+++ b/docs/source/developer/notebook.rst
@@ -96,7 +96,7 @@ Higher level actions using NotebookActions
 ''''''''''''''''''''''''''''''''''''''''''
 
 Higher-level actions are contained in the
-`NotebookActions <http://jupyterlab.github.io/jupyterlab/modules/_notebook_src_actions_.notebookactions.html>`__
+`NotebookActions <http://jupyterlab.github.io/jupyterlab/classes/_notebook_src_actions_.notebookactions.html>`__
 namespace, which has functions, when given a notebook widget, to run a
 cell and select the next cell, merge or split cells at the cursor,
 delete selected cells, etc.

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -214,7 +214,7 @@ You should see a message that says
 ``JupyterLab extension jupyterlab_xkcd is activated!`` in the console.
 If you do, congrats, you're ready to start modifying the the extension!
 If not, go back, make sure you didn't miss a step, and `reach
-out <README.html#getting-help>`__ if you're stuck.
+out <https://github.com/jupyterlab/jupyterlab/blob/master/README.md#getting-help>`__ if you're stuck.
 
 Note: Leave the terminal running the ``jupyter lab --watch`` command
 open.


### PR DESCRIPTION
Fixes #4987 
I tried to resolve most of the link errors that I found in the documentation. I did not know exactly which link to use for the Document widgets, so please check that the attached link is correct. Also, should there be any further work done on resolving the blank pages? 