### PR TITLE
Modernize Some Tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,6 @@
     "prettier/prettier": ["error", { "singleQuote": true }],
     "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
-    "quotes": ["error", "single"],
     "no-console": ["error", { "allow": ["warn", "error"] }]
   }
 }

--- a/tests/convert-to-chai.js
+++ b/tests/convert-to-chai.js
@@ -28,8 +28,13 @@ glob.sync(path.join(target, 'src', '*.ts*')).forEach(function(filePath) {
   src = src
     .split("import expect = require('expect.js')")
     .join("import { expect } from 'chai'");
+  src = src.split('to.be(undefined)').join('to.be.undefined');
+  src = src.split('to.be(void 0)').join('to.be.undefined');
+  src = src.split('to.be(null').join('to.be.null');
   src = src.split('to.be(').join('to.equal(');
   src = src.split('to.not.be(').join('to.not.equal(');
+  src = src.split('to.be.ok()').join('to.be.ok');
+  src = src.split('to.be.empty(').join('to.be.empty');
   src = src.split('to.eql(').join('to.deep.equal(');
   src = src.split('to.be.a(').join('to.be.an.instanceof(');
   src = src.split('to.be.an(').join('to.be.an.instanceof(');

--- a/tests/convert-to-chai.js
+++ b/tests/convert-to-chai.js
@@ -29,6 +29,7 @@ glob.sync(path.join(target, 'src', '*.ts*')).forEach(function(filePath) {
     .split("import expect = require('expect.js')")
     .join("import { expect } from 'chai'");
   src = src.split('to.be(').join('to.equal(');
+  src = src.split('to.not.be(').join('to.not.equal(');
   src = src.split('to.eql(').join('to.deep.equal(');
   src = src.split('to.be.a(').join('to.be.an.instanceof(');
   src = src.split('to.be.an(').join('to.be.an.instanceof(');

--- a/tests/convert-to-chai.js
+++ b/tests/convert-to-chai.js
@@ -31,5 +31,7 @@ glob.sync(path.join(target, 'src', '*.ts*')).forEach(function(filePath) {
   src = src.split('to.be(').join('to.equal(');
   src = src.split('to.eql(').join('to.deep.equal(');
   src = src.split('to.be.a(').join('to.be.an.instanceof(');
+  src = src.split('to.be.an(').join('to.be.an.instanceof(');
+  src = src.split(').to.be.empty()').join('.length).to.be(0)');
   fs.writeFileSync(filePath, src, 'utf8');
 });

--- a/tests/convert-to-chai.js
+++ b/tests/convert-to-chai.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const glob = require('glob');
+const fs = require('fs-extra');
+const utils = require('@jupyterlab/buildutils/lib/utils');
+
+// yarn add chai && yarn add --dev @types/chai
+// Remove expect.js from package.json
+const source = path.resolve('./test-apputils');
+const pkgSrc = utils.readJSONFile(path.join(source, 'package.json'));
+const chaiVer = pkgSrc.dependencies['chai'];
+const chaiTypeVer = pkgSrc.devDependencies['@types/chai'];
+
+const target = path.resolve(process.argv[2]);
+if (!target) {
+  console.error('Specify a target dir');
+  process.exit(1);
+}
+
+const targetPkg = utils.readJSONFile(path.join(target, 'package.json'));
+delete targetPkg.dependencies['expect.js'];
+targetPkg.dependencies['chai'] = chaiVer;
+targetPkg.devDependencies['@types/chai'] = chaiTypeVer;
+
+utils.writePackageData(path.join(target, 'package.json'), targetPkg);
+
+glob.sync(path.join(target, 'src', '*.ts*')).forEach(function(filePath) {
+  let src = fs.readFileSync(filePath, 'utf8');
+  src = src
+    .split("import expect = require('expect.js')")
+    .join("import { expect } from 'chai'");
+  src = src.split('to.be(').join('to.equal(');
+  src = src.split('to.eql(').join('to.deep.equal(');
+  src = src.split('to.be.a(').join('to.be.an.instanceof(');
+  fs.writeFileSync(filePath, src, 'utf8');
+});

--- a/tests/convert-to-chai.js
+++ b/tests/convert-to-chai.js
@@ -30,7 +30,9 @@ glob.sync(path.join(target, 'src', '*.ts*')).forEach(function(filePath) {
     .join("import { expect } from 'chai'");
   src = src.split('to.be(undefined)').join('to.be.undefined');
   src = src.split('to.be(void 0)').join('to.be.undefined');
-  src = src.split('to.be(null').join('to.be.null');
+  src = src.split('to.be(null)').join('to.be.null');
+  src = src.split('to.not.be.ok()').join('to.not.be.ok');
+  src = src.split('to.not.be.empty()').join('to.not.be.empty');
   src = src.split('to.be(').join('to.equal(');
   src = src.split('to.not.be(').join('to.not.equal(');
   src = src.split('to.be.ok()').join('to.be.ok');

--- a/tests/convert-to-chai.js
+++ b/tests/convert-to-chai.js
@@ -32,6 +32,6 @@ glob.sync(path.join(target, 'src', '*.ts*')).forEach(function(filePath) {
   src = src.split('to.eql(').join('to.deep.equal(');
   src = src.split('to.be.a(').join('to.be.an.instanceof(');
   src = src.split('to.be.an(').join('to.be.an.instanceof(');
-  src = src.split(').to.be.empty()').join('.length).to.be(0)');
+  src = src.split(').to.be.empty()').join('.length).to.equal(0)');
   fs.writeFileSync(filePath, src, 'utf8');
 });

--- a/tests/test-application/package.json
+++ b/tests/test-application/package.json
@@ -23,10 +23,11 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1",
+    "chai": "~4.1.2",
     "simulate-event": "~1.4.0"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-application/src/layoutrestorer.spec.ts
+++ b/tests/test-application/src/layoutrestorer.spec.ts
@@ -89,7 +89,7 @@ describe('apputils', () => {
           state: new StateDB({ namespace: NAMESPACE })
         });
         const layout = await restorer.fetch();
-        expect(layout).to.be.not.be(null);
+        expect(layout).to.not.equal(null);
       });
 
       it('should fetch saved data', async () => {
@@ -155,10 +155,9 @@ describe('apputils', () => {
 
     describe('#save()', () => {
       it('should not run before `first` promise', async () => {
-        let called = false;
         const restorer = new LayoutRestorer({
           first: new Promise(() => {
-            called = true;
+            // no op
           }),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -168,8 +167,11 @@ describe('apputils', () => {
           leftArea: { currentWidget: null, collapsed: true, widgets: null },
           rightArea: { collapsed: true, currentWidget: null, widgets: null }
         };
-        await restorer.save(dehydrated);
-        expect(called).to.equal(true);
+        try {
+          await restorer.save(dehydrated);
+        } catch (e) {
+          expect(e).to.equal('save() was called prematurely.');
+        }
       });
 
       it('should save data', async () => {

--- a/tests/test-application/src/layoutrestorer.spec.ts
+++ b/tests/test-application/src/layoutrestorer.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ApplicationShell, LayoutRestorer } from '@jupyterlab/application';
 
@@ -26,7 +26,7 @@ describe('apputils', () => {
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
         });
-        expect(restorer).to.be.a(LayoutRestorer);
+        expect(restorer).to.be.an.instanceof(LayoutRestorer);
       });
     });
 
@@ -37,7 +37,7 @@ describe('apputils', () => {
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
         });
-        expect(restorer.restored).to.be.a(Promise);
+        expect(restorer.restored).to.be.an.instanceof(Promise);
       });
 
       it('should resolve when restorer is done', done => {
@@ -77,8 +77,8 @@ describe('apputils', () => {
           .then(() => restorer.save(dehydrated))
           .then(() => restorer.fetch())
           .then(layout => {
-            expect(layout.mainArea.currentWidget).to.be(currentWidget);
-            expect(layout.mainArea.mode).to.be(mode);
+            expect(layout.mainArea.currentWidget).to.equal(currentWidget);
+            expect(layout.mainArea.mode).to.equal(mode);
             done();
           })
           .catch(done);
@@ -95,7 +95,7 @@ describe('apputils', () => {
         restorer
           .fetch()
           .then(layout => {
-            expect(layout).to.be.ok();
+            expect(layout).to.be.not.be(null);
             done();
           })
           .catch(done);
@@ -126,7 +126,7 @@ describe('apputils', () => {
           .then(() => restorer.save(dehydrated))
           .then(() => restorer.fetch())
           .then(layout => {
-            expect(layout).to.eql(dehydrated);
+            expect(layout).to.deep.equal(dehydrated);
             done();
           })
           .catch(done);
@@ -165,7 +165,7 @@ describe('apputils', () => {
           .catch(done);
         restorer.restored
           .then(() => {
-            expect(called).to.be(true);
+            expect(called).to.equal(true);
           })
           .then(() => state.remove(key))
           .then(() => {
@@ -224,7 +224,7 @@ describe('apputils', () => {
           .then(() => restorer.save(dehydrated))
           .then(() => restorer.fetch())
           .then(layout => {
-            expect(layout).to.eql(dehydrated);
+            expect(layout).to.deep.equal(dehydrated);
             done();
           })
           .catch(done);

--- a/tests/test-application/src/layoutrestorer.spec.ts
+++ b/tests/test-application/src/layoutrestorer.spec.ts
@@ -21,7 +21,7 @@ describe('apputils', () => {
   describe('LayoutRestorer', () => {
     describe('#constructor()', () => {
       it('should construct a new layout restorer', () => {
-        let restorer = new LayoutRestorer({
+        const restorer = new LayoutRestorer({
           first: Promise.resolve<void>(void 0),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -32,7 +32,7 @@ describe('apputils', () => {
 
     describe('#restored', () => {
       it('should be a promise available right away', () => {
-        let restorer = new LayoutRestorer({
+        const restorer = new LayoutRestorer({
           first: Promise.resolve<void>(void 0),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -41,8 +41,8 @@ describe('apputils', () => {
       });
 
       it('should resolve when restorer is done', done => {
-        let ready = new PromiseDelegate<void>();
-        let restorer = new LayoutRestorer({
+        const ready = new PromiseDelegate<void>();
+        const restorer = new LayoutRestorer({
           first: ready.promise,
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
@@ -57,60 +57,51 @@ describe('apputils', () => {
     });
 
     describe('#add()', () => {
-      it('should add a widget to be tracked by the restorer', done => {
-        let ready = new PromiseDelegate<void>();
-        let restorer = new LayoutRestorer({
+      it('should add a widget to be tracked by the restorer', async () => {
+        const ready = new PromiseDelegate<void>();
+        const restorer = new LayoutRestorer({
           first: ready.promise,
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
         });
-        let currentWidget = new Widget();
-        let mode: DockPanel.Mode = 'single-document';
-        let dehydrated: ApplicationShell.ILayout = {
+        const currentWidget = new Widget();
+        const mode: DockPanel.Mode = 'single-document';
+        const dehydrated: ApplicationShell.ILayout = {
           mainArea: { currentWidget, dock: null, mode },
           leftArea: { collapsed: true, currentWidget: null, widgets: null },
           rightArea: { collapsed: true, currentWidget: null, widgets: null }
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);
-        restorer.restored
-          .then(() => restorer.save(dehydrated))
-          .then(() => restorer.fetch())
-          .then(layout => {
-            expect(layout.mainArea.currentWidget).to.equal(currentWidget);
-            expect(layout.mainArea.mode).to.equal(mode);
-            done();
-          })
-          .catch(done);
+        await restorer.restored;
+        await restorer.save(dehydrated);
+        const layout = await restorer.fetch();
+        expect(layout.mainArea.currentWidget).to.equal(currentWidget);
+        expect(layout.mainArea.mode).to.equal(mode);
       });
     });
 
     describe('#fetch()', () => {
-      it('should always return a value', done => {
-        let restorer = new LayoutRestorer({
+      it('should always return a value', async () => {
+        const restorer = new LayoutRestorer({
           first: Promise.resolve(void 0),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
         });
-        restorer
-          .fetch()
-          .then(layout => {
-            expect(layout).to.be.not.be(null);
-            done();
-          })
-          .catch(done);
+        const layout = await restorer.fetch();
+        expect(layout).to.be.not.be(null);
       });
 
-      it('should fetch saved data', done => {
-        let ready = new PromiseDelegate<void>();
-        let restorer = new LayoutRestorer({
+      it('should fetch saved data', async () => {
+        const ready = new PromiseDelegate<void>();
+        const restorer = new LayoutRestorer({
           first: ready.promise,
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
         });
-        let currentWidget = new Widget();
+        const currentWidget = new Widget();
         // The `fresh` attribute is only here to check against the return value.
-        let dehydrated: ApplicationShell.ILayout = {
+        const dehydrated: ApplicationShell.ILayout = {
           fresh: false,
           mainArea: { currentWidget: null, dock: null, mode: null },
           leftArea: {
@@ -122,93 +113,75 @@ describe('apputils', () => {
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);
-        restorer.restored
-          .then(() => restorer.save(dehydrated))
-          .then(() => restorer.fetch())
-          .then(layout => {
-            expect(layout).to.deep.equal(dehydrated);
-            done();
-          })
-          .catch(done);
+        await restorer.restored;
+        await restorer.save(dehydrated);
+        const layout = await restorer.fetch();
+        expect(layout).to.deep.equal(dehydrated);
       });
     });
 
     describe('#restore()', () => {
-      it('should restore the widgets in a tracker', done => {
-        let tracker = new InstanceTracker<Widget>({ namespace: 'foo-widget' });
-        let registry = new CommandRegistry();
-        let state = new StateDB({ namespace: NAMESPACE });
-        let ready = new PromiseDelegate<void>();
-        let restorer = new LayoutRestorer({
+      it('should restore the widgets in a tracker', async () => {
+        const tracker = new InstanceTracker<Widget>({
+          namespace: 'foo-widget'
+        });
+        const registry = new CommandRegistry();
+        const state = new StateDB({ namespace: NAMESPACE });
+        const ready = new PromiseDelegate<void>();
+        const restorer = new LayoutRestorer({
           first: ready.promise,
           registry,
           state
         });
         let called = false;
-        let key = `${tracker.namespace}:${tracker.namespace}`;
+        const key = `${tracker.namespace}:${tracker.namespace}`;
 
         registry.addCommand(tracker.namespace, {
           execute: () => {
             called = true;
           }
         });
-        state
-          .save(key, { data: null })
-          .then(() => {
-            ready.resolve(undefined);
-            return restorer.restore(tracker, {
-              args: () => null,
-              name: () => tracker.namespace,
-              command: tracker.namespace
-            });
-          })
-          .catch(done);
-        restorer.restored
-          .then(() => {
-            expect(called).to.equal(true);
-          })
-          .then(() => state.remove(key))
-          .then(() => {
-            done();
-          })
-          .catch(done);
+        await state.save(key, { data: null });
+        ready.resolve(undefined);
+        await restorer.restore(tracker, {
+          args: () => null,
+          name: () => tracker.namespace,
+          command: tracker.namespace
+        });
+        await restorer.restored;
+        expect(called).to.equal(true);
       });
     });
 
     describe('#save()', () => {
-      it('should not run before `first` promise', done => {
-        let restorer = new LayoutRestorer({
+      it('should not run before `first` promise', async () => {
+        let called = false;
+        const restorer = new LayoutRestorer({
           first: new Promise(() => {
-            /* no op */
+            called = true;
           }),
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
         });
-        let dehydrated: ApplicationShell.ILayout = {
+        const dehydrated: ApplicationShell.ILayout = {
           mainArea: { currentWidget: null, dock: null, mode: null },
           leftArea: { currentWidget: null, collapsed: true, widgets: null },
           rightArea: { collapsed: true, currentWidget: null, widgets: null }
         };
-        restorer
-          .save(dehydrated)
-          .then(() => {
-            done('save() ran before `first` promise resolved.');
-          })
-          .catch(() => {
-            done();
-          });
+        await restorer.save(dehydrated);
+        expect(called).to.equal(true);
       });
 
-      it('should save data', done => {
-        let ready = new PromiseDelegate<void>();
-        let restorer = new LayoutRestorer({
+      it('should save data', async () => {
+        const ready = new PromiseDelegate<void>();
+        const restorer = new LayoutRestorer({
           first: ready.promise,
           registry: new CommandRegistry(),
           state: new StateDB({ namespace: NAMESPACE })
         });
-        let currentWidget = new Widget();
+        const currentWidget = new Widget();
         // The `fresh` attribute is only here to check against the return value.
-        let dehydrated: ApplicationShell.ILayout = {
+        const dehydrated: ApplicationShell.ILayout = {
           fresh: false,
           mainArea: { currentWidget: null, dock: null, mode: null },
           leftArea: {
@@ -220,14 +193,10 @@ describe('apputils', () => {
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);
-        restorer.restored
-          .then(() => restorer.save(dehydrated))
-          .then(() => restorer.fetch())
-          .then(layout => {
-            expect(layout).to.deep.equal(dehydrated);
-            done();
-          })
-          .catch(done);
+        await restorer.restored;
+        await restorer.save(dehydrated);
+        const layout = await restorer.fetch();
+        expect(layout).to.deep.equal(dehydrated);
       });
     });
   });

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Router } from '@jupyterlab/application';
 
@@ -23,19 +23,19 @@ describe('apputils', () => {
 
     describe('#constructor()', () => {
       it('should construct a new router', () => {
-        expect(router).to.be.a(Router);
+        expect(router).to.be.an.instanceof(Router);
       });
     });
 
     describe('#base', () => {
       it('should be the base URL of the application', () => {
-        expect(router.base).to.be(base);
+        expect(router.base).to.equal(base);
       });
     });
 
     describe('#commands', () => {
       it('should be the command registry used by the router', () => {
-        expect(router.commands).to.be(commands);
+        expect(router.commands).to.equal(commands);
       });
     });
 
@@ -48,7 +48,7 @@ describe('apputils', () => {
         const search = '';
         const hash = '';
 
-        expect(router.current).to.eql({ hash, path, request, search });
+        expect(router.current).to.deep.equal({ hash, path, request, search });
       });
     });
 
@@ -64,7 +64,7 @@ describe('apputils', () => {
         router.register({ command: 'a', pattern: /.*/, rank: 10 });
 
         router.routed.connect(() => {
-          expect(routed).to.be(true);
+          expect(routed).to.equal(true);
           done();
         });
         router.route();
@@ -73,7 +73,7 @@ describe('apputils', () => {
 
     describe('#stop', () => {
       it('should be a unique token', () => {
-        expect(router.stop).to.be.a(Token);
+        expect(router.stop).to.be.an.instanceof(Token);
       });
 
       it('should stop routing if returned by a routed command', done => {
@@ -103,7 +103,7 @@ describe('apputils', () => {
         router.register({ command: 'd', pattern: /.*/, rank: 40 });
 
         router.routed.connect(() => {
-          expect(recorded).to.eql(wanted);
+          expect(recorded).to.deep.equal(wanted);
           done();
         });
         router.route();
@@ -130,7 +130,7 @@ describe('apputils', () => {
         router.register({ command: 'a', pattern: /.*/ });
 
         router.routed.connect(() => {
-          expect(recorded).to.eql(wanted);
+          expect(recorded).to.deep.equal(wanted);
           done();
         });
         router.route();
@@ -154,7 +154,7 @@ describe('apputils', () => {
         window.location.hash = 'a';
 
         router.routed.connect(() => {
-          expect(recorded).to.eql(wanted);
+          expect(recorded).to.deep.equal(wanted);
           window.location.hash = '';
           done();
         });

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -148,7 +148,7 @@ describe('apputils', () => {
           }
         });
         router.register({ command: 'a', pattern: /#a/, rank: 10 });
-        expect(recorded.length).to.be(0);
+        expect(recorded.length).to.equal(0);
 
         // Change the hash because changing location is a security error.
         window.location.hash = 'a';

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -78,7 +78,7 @@ describe('apputils', () => {
 
       it('should stop routing if returned by a routed command', done => {
         const wanted = ['a', 'b'];
-        let recorded: string[] = [];
+        const recorded: string[] = [];
 
         commands.addCommand('a', {
           execute: () => {
@@ -120,7 +120,7 @@ describe('apputils', () => {
     describe('#register()', () => {
       it('should register a command with a route pattern', done => {
         const wanted = ['a'];
-        let recorded: string[] = [];
+        const recorded: string[] = [];
 
         commands.addCommand('a', {
           execute: () => {
@@ -140,7 +140,7 @@ describe('apputils', () => {
     describe('#route()', () => {
       it('should route the location to a command', done => {
         const wanted = ['a'];
-        let recorded: string[] = [];
+        const recorded: string[] = [];
 
         commands.addCommand('a', {
           execute: () => {

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -148,7 +148,7 @@ describe('apputils', () => {
           }
         });
         router.register({ command: 'a', pattern: /#a/, rank: 10 });
-        expect(recorded).to.be.empty();
+        expect(recorded.length).to.be(0);
 
         // Change the hash because changing location is a security error.
         window.location.hash = 'a';

--- a/tests/test-application/src/shell.spec.ts
+++ b/tests/test-application/src/shell.spec.ts
@@ -33,7 +33,7 @@ describe('ApplicationShell', () => {
 
   describe('#constructor()', () => {
     it('should create an ApplicationShell instance', () => {
-      expect(shell).to.be.an(ApplicationShell);
+      expect(shell).to.be.an.instanceof(ApplicationShell);
     });
   });
 

--- a/tests/test-application/src/shell.spec.ts
+++ b/tests/test-application/src/shell.spec.ts
@@ -39,7 +39,7 @@ describe('ApplicationShell', () => {
 
   describe('#leftCollapsed', () => {
     it('should return whether the left area is collapsed', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
       expect(shell.leftCollapsed).to.equal(true);
@@ -50,7 +50,7 @@ describe('ApplicationShell', () => {
 
   describe('#rightCollapsed', () => {
     it('should return whether the right area is collapsed', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
       expect(shell.rightCollapsed).to.equal(true);
@@ -62,7 +62,7 @@ describe('ApplicationShell', () => {
   describe('#currentWidget', () => {
     it('should be the current widget in the shell main area', () => {
       expect(shell.currentWidget).to.equal(null);
-      let widget = new Widget();
+      const widget = new Widget();
       widget.node.tabIndex = -1;
       widget.id = 'foo';
       shell.addToMainArea(widget);
@@ -77,7 +77,7 @@ describe('ApplicationShell', () => {
   describe('#isEmpty()', () => {
     it('should test whether the main area is empty', () => {
       expect(shell.isEmpty('top')).to.equal(true);
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToMainArea(widget);
       expect(shell.isEmpty('main')).to.equal(false);
@@ -85,7 +85,7 @@ describe('ApplicationShell', () => {
 
     it('should test whether the top area is empty', () => {
       expect(shell.isEmpty('top')).to.equal(true);
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget);
       expect(shell.isEmpty('top')).to.equal(false);
@@ -93,7 +93,7 @@ describe('ApplicationShell', () => {
 
     it('should test whether the left area is empty', () => {
       expect(shell.isEmpty('left')).to.equal(true);
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
       expect(shell.isEmpty('left')).to.equal(false);
@@ -101,7 +101,7 @@ describe('ApplicationShell', () => {
 
     it('should test whether the right area is empty', () => {
       expect(shell.isEmpty('right')).to.equal(true);
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
       expect(shell.isEmpty('right')).to.equal(false);
@@ -110,7 +110,7 @@ describe('ApplicationShell', () => {
 
   describe('#restored', () => {
     it('should resolve when the app is restored for the first time', () => {
-      let state = shell.saveLayout();
+      const state = shell.saveLayout();
       shell.restoreLayout(state);
       return shell.restored;
     });
@@ -118,20 +118,20 @@ describe('ApplicationShell', () => {
 
   describe('#addToTopArea()', () => {
     it('should add a widget to the top area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget);
       expect(shell.isEmpty('top')).to.equal(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       shell.addToTopArea(widget);
       expect(shell.isEmpty('top')).to.equal(true);
     });
 
     it('should accept options', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget, { rank: 10 });
       expect(shell.isEmpty('top')).to.equal(false);
@@ -140,20 +140,20 @@ describe('ApplicationShell', () => {
 
   describe('#addToLeftArea()', () => {
     it('should add a widget to the left area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
       expect(shell.isEmpty('left')).to.equal(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       shell.addToLeftArea(widget);
       expect(shell.isEmpty('left')).to.equal(true);
     });
 
     it('should accept options', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget, { rank: 10 });
       expect(shell.isEmpty('left')).to.equal(false);
@@ -162,20 +162,20 @@ describe('ApplicationShell', () => {
 
   describe('#addToRightArea()', () => {
     it('should add a widget to the right area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
       expect(shell.isEmpty('right')).to.equal(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       shell.addToRightArea(widget);
       expect(shell.isEmpty('right')).to.equal(true);
     });
 
     it('should accept options', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget, { rank: 10 });
       expect(shell.isEmpty('right')).to.equal(false);
@@ -184,14 +184,14 @@ describe('ApplicationShell', () => {
 
   describe('#addToMainArea()', () => {
     it('should add a widget to the main area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToMainArea(widget);
       expect(shell.isEmpty('main')).to.equal(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       shell.addToMainArea(widget);
       expect(shell.isEmpty('main')).to.equal(true);
     });
@@ -199,7 +199,7 @@ describe('ApplicationShell', () => {
 
   describe('#activateById()', () => {
     it('should activate a widget in the left area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
       expect(widget.isVisible).to.equal(false);
@@ -208,7 +208,7 @@ describe('ApplicationShell', () => {
     });
 
     it('should be a no-op if the widget is not in the left area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       expect(widget.isVisible).to.equal(false);
       shell.activateById('foo');
@@ -216,7 +216,7 @@ describe('ApplicationShell', () => {
     });
 
     it('should activate a widget in the right area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
       expect(widget.isVisible).to.equal(false);
@@ -225,7 +225,7 @@ describe('ApplicationShell', () => {
     });
 
     it('should be a no-op if the widget is not in the right area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       expect(widget.isVisible).to.equal(false);
       shell.activateById('foo');
@@ -233,7 +233,7 @@ describe('ApplicationShell', () => {
     });
 
     it('should activate a widget in the main area', done => {
-      let widget = new ContentWidget();
+      const widget = new ContentWidget();
       widget.id = 'foo';
       shell.addToMainArea(widget);
       shell.activateById('foo');
@@ -244,7 +244,7 @@ describe('ApplicationShell', () => {
     });
 
     it('should be a no-op if the widget is not in the main area', done => {
-      let widget = new ContentWidget();
+      const widget = new ContentWidget();
       widget.id = 'foo';
       shell.activateById('foo');
       requestAnimationFrame(() => {
@@ -256,7 +256,7 @@ describe('ApplicationShell', () => {
 
   describe('#collapseLeft()', () => {
     it('should collapse all widgets in the left area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
       shell.activateById('foo');
@@ -268,7 +268,7 @@ describe('ApplicationShell', () => {
 
   describe('#collapseRight()', () => {
     it('should collapse all widgets in the right area', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
       shell.activateById('foo');
@@ -280,9 +280,9 @@ describe('ApplicationShell', () => {
 
   describe('#expandLeft()', () => {
     it('should expand the most recently used widget', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
-      let widget2 = new Widget();
+      const widget2 = new Widget();
       widget2.id = 'bar';
       shell.addToLeftArea(widget, { rank: 10 });
       shell.addToLeftArea(widget2, { rank: 1 });
@@ -294,9 +294,9 @@ describe('ApplicationShell', () => {
     });
 
     it('should expand the first widget if none have been activated', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
-      let widget2 = new Widget();
+      const widget2 = new Widget();
       widget2.id = 'bar';
       shell.addToLeftArea(widget, { rank: 10 });
       shell.addToLeftArea(widget2, { rank: 1 });
@@ -308,9 +308,9 @@ describe('ApplicationShell', () => {
 
   describe('#expandRight()', () => {
     it('should expand the most recently used widget', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
-      let widget2 = new Widget();
+      const widget2 = new Widget();
       widget2.id = 'bar';
       shell.addToRightArea(widget, { rank: 10 });
       shell.addToRightArea(widget2, { rank: 1 });
@@ -322,9 +322,9 @@ describe('ApplicationShell', () => {
     });
 
     it('should expand the first widget if none have been activated', () => {
-      let widget = new Widget();
+      const widget = new Widget();
       widget.id = 'foo';
-      let widget2 = new Widget();
+      const widget2 = new Widget();
       widget2.id = 'bar';
       shell.addToRightArea(widget, { rank: 10 });
       shell.addToRightArea(widget2, { rank: 1 });
@@ -336,10 +336,10 @@ describe('ApplicationShell', () => {
 
   describe('#closeAll()', () => {
     it('should close all of the widgets in the main area', () => {
-      let foo = new Widget();
+      const foo = new Widget();
       foo.id = 'foo';
       shell.addToMainArea(foo);
-      let bar = new Widget();
+      const bar = new Widget();
       bar.id = 'bar';
       shell.addToMainArea(bar);
       shell.closeAll();
@@ -350,10 +350,10 @@ describe('ApplicationShell', () => {
 
   describe('#saveLayout', () => {
     it('should save the layout of the shell', () => {
-      let foo = new Widget();
+      const foo = new Widget();
       foo.id = 'foo';
       shell.addToMainArea(foo);
-      let state = shell.saveLayout();
+      const state = shell.saveLayout();
       shell.activateById('foo');
       expect(state.mainArea.mode).to.equal('multiple-document');
       expect(state.mainArea.currentWidget).to.equal(null);
@@ -362,7 +362,7 @@ describe('ApplicationShell', () => {
 
   describe('#restoreLayout', () => {
     it('should restore the layout of the shell', () => {
-      let state = shell.saveLayout();
+      const state = shell.saveLayout();
       shell.mode = 'single-document';
       shell.restoreLayout(state);
       expect(state.mainArea.mode).to.equal('multiple-document');

--- a/tests/test-application/src/shell.spec.ts
+++ b/tests/test-application/src/shell.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Message } from '@phosphor/messaging';
 
@@ -42,9 +42,9 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
-      expect(shell.leftCollapsed).to.be(true);
+      expect(shell.leftCollapsed).to.equal(true);
       shell.activateById('foo');
-      expect(shell.leftCollapsed).to.be(false);
+      expect(shell.leftCollapsed).to.equal(false);
     });
   });
 
@@ -53,58 +53,58 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
-      expect(shell.rightCollapsed).to.be(true);
+      expect(shell.rightCollapsed).to.equal(true);
       shell.activateById('foo');
-      expect(shell.rightCollapsed).to.be(false);
+      expect(shell.rightCollapsed).to.equal(false);
     });
   });
 
   describe('#currentWidget', () => {
     it('should be the current widget in the shell main area', () => {
-      expect(shell.currentWidget).to.be(null);
+      expect(shell.currentWidget).to.equal(null);
       let widget = new Widget();
       widget.node.tabIndex = -1;
       widget.id = 'foo';
       shell.addToMainArea(widget);
-      expect(shell.currentWidget).to.be(null);
+      expect(shell.currentWidget).to.equal(null);
       simulate(widget.node, 'focus');
-      expect(shell.currentWidget).to.be(widget);
+      expect(shell.currentWidget).to.equal(widget);
       widget.parent = null;
-      expect(shell.currentWidget).to.be(null);
+      expect(shell.currentWidget).to.equal(null);
     });
   });
 
   describe('#isEmpty()', () => {
     it('should test whether the main area is empty', () => {
-      expect(shell.isEmpty('top')).to.be(true);
+      expect(shell.isEmpty('top')).to.equal(true);
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToMainArea(widget);
-      expect(shell.isEmpty('main')).to.be(false);
+      expect(shell.isEmpty('main')).to.equal(false);
     });
 
     it('should test whether the top area is empty', () => {
-      expect(shell.isEmpty('top')).to.be(true);
+      expect(shell.isEmpty('top')).to.equal(true);
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget);
-      expect(shell.isEmpty('top')).to.be(false);
+      expect(shell.isEmpty('top')).to.equal(false);
     });
 
     it('should test whether the left area is empty', () => {
-      expect(shell.isEmpty('left')).to.be(true);
+      expect(shell.isEmpty('left')).to.equal(true);
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
-      expect(shell.isEmpty('left')).to.be(false);
+      expect(shell.isEmpty('left')).to.equal(false);
     });
 
     it('should test whether the right area is empty', () => {
-      expect(shell.isEmpty('right')).to.be(true);
+      expect(shell.isEmpty('right')).to.equal(true);
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
-      expect(shell.isEmpty('right')).to.be(false);
+      expect(shell.isEmpty('right')).to.equal(false);
     });
   });
 
@@ -121,20 +121,20 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget);
-      expect(shell.isEmpty('top')).to.be(false);
+      expect(shell.isEmpty('top')).to.equal(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
       let widget = new Widget();
       shell.addToTopArea(widget);
-      expect(shell.isEmpty('top')).to.be(true);
+      expect(shell.isEmpty('top')).to.equal(true);
     });
 
     it('should accept options', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToTopArea(widget, { rank: 10 });
-      expect(shell.isEmpty('top')).to.be(false);
+      expect(shell.isEmpty('top')).to.equal(false);
     });
   });
 
@@ -143,20 +143,20 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
-      expect(shell.isEmpty('left')).to.be(false);
+      expect(shell.isEmpty('left')).to.equal(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
       let widget = new Widget();
       shell.addToLeftArea(widget);
-      expect(shell.isEmpty('left')).to.be(true);
+      expect(shell.isEmpty('left')).to.equal(true);
     });
 
     it('should accept options', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget, { rank: 10 });
-      expect(shell.isEmpty('left')).to.be(false);
+      expect(shell.isEmpty('left')).to.equal(false);
     });
   });
 
@@ -165,20 +165,20 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
-      expect(shell.isEmpty('right')).to.be(false);
+      expect(shell.isEmpty('right')).to.equal(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
       let widget = new Widget();
       shell.addToRightArea(widget);
-      expect(shell.isEmpty('right')).to.be(true);
+      expect(shell.isEmpty('right')).to.equal(true);
     });
 
     it('should accept options', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget, { rank: 10 });
-      expect(shell.isEmpty('right')).to.be(false);
+      expect(shell.isEmpty('right')).to.equal(false);
     });
   });
 
@@ -187,13 +187,13 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToMainArea(widget);
-      expect(shell.isEmpty('main')).to.be(false);
+      expect(shell.isEmpty('main')).to.equal(false);
     });
 
     it('should be a no-op if the widget has no id', () => {
       let widget = new Widget();
       shell.addToMainArea(widget);
-      expect(shell.isEmpty('main')).to.be(true);
+      expect(shell.isEmpty('main')).to.equal(true);
     });
   });
 
@@ -202,34 +202,34 @@ describe('ApplicationShell', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToLeftArea(widget);
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
       shell.activateById('foo');
-      expect(widget.isVisible).to.be(true);
+      expect(widget.isVisible).to.equal(true);
     });
 
     it('should be a no-op if the widget is not in the left area', () => {
       let widget = new Widget();
       widget.id = 'foo';
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
       shell.activateById('foo');
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
     });
 
     it('should activate a widget in the right area', () => {
       let widget = new Widget();
       widget.id = 'foo';
       shell.addToRightArea(widget);
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
       shell.activateById('foo');
-      expect(widget.isVisible).to.be(true);
+      expect(widget.isVisible).to.equal(true);
     });
 
     it('should be a no-op if the widget is not in the right area', () => {
       let widget = new Widget();
       widget.id = 'foo';
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
       shell.activateById('foo');
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
     });
 
     it('should activate a widget in the main area', done => {
@@ -238,7 +238,7 @@ describe('ApplicationShell', () => {
       shell.addToMainArea(widget);
       shell.activateById('foo');
       requestAnimationFrame(() => {
-        expect(widget.activated).to.be(true);
+        expect(widget.activated).to.equal(true);
         done();
       });
     });
@@ -248,7 +248,7 @@ describe('ApplicationShell', () => {
       widget.id = 'foo';
       shell.activateById('foo');
       requestAnimationFrame(() => {
-        expect(widget.activated).to.be(false);
+        expect(widget.activated).to.equal(false);
         done();
       });
     });
@@ -260,9 +260,9 @@ describe('ApplicationShell', () => {
       widget.id = 'foo';
       shell.addToLeftArea(widget);
       shell.activateById('foo');
-      expect(widget.isVisible).to.be(true);
+      expect(widget.isVisible).to.equal(true);
       shell.collapseLeft();
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
     });
   });
 
@@ -272,9 +272,9 @@ describe('ApplicationShell', () => {
       widget.id = 'foo';
       shell.addToRightArea(widget);
       shell.activateById('foo');
-      expect(widget.isVisible).to.be(true);
+      expect(widget.isVisible).to.equal(true);
       shell.collapseRight();
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
     });
   });
 
@@ -288,9 +288,9 @@ describe('ApplicationShell', () => {
       shell.addToLeftArea(widget2, { rank: 1 });
       shell.activateById('foo');
       shell.collapseLeft();
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
       shell.expandLeft();
-      expect(widget.isVisible).to.be(true);
+      expect(widget.isVisible).to.equal(true);
     });
 
     it('should expand the first widget if none have been activated', () => {
@@ -300,9 +300,9 @@ describe('ApplicationShell', () => {
       widget2.id = 'bar';
       shell.addToLeftArea(widget, { rank: 10 });
       shell.addToLeftArea(widget2, { rank: 1 });
-      expect(widget2.isVisible).to.be(false);
+      expect(widget2.isVisible).to.equal(false);
       shell.expandLeft();
-      expect(widget2.isVisible).to.be(true);
+      expect(widget2.isVisible).to.equal(true);
     });
   });
 
@@ -316,9 +316,9 @@ describe('ApplicationShell', () => {
       shell.addToRightArea(widget2, { rank: 1 });
       shell.activateById('foo');
       shell.collapseRight();
-      expect(widget.isVisible).to.be(false);
+      expect(widget.isVisible).to.equal(false);
       shell.expandRight();
-      expect(widget.isVisible).to.be(true);
+      expect(widget.isVisible).to.equal(true);
     });
 
     it('should expand the first widget if none have been activated', () => {
@@ -328,9 +328,9 @@ describe('ApplicationShell', () => {
       widget2.id = 'bar';
       shell.addToRightArea(widget, { rank: 10 });
       shell.addToRightArea(widget2, { rank: 1 });
-      expect(widget2.isVisible).to.be(false);
+      expect(widget2.isVisible).to.equal(false);
       shell.expandRight();
-      expect(widget2.isVisible).to.be(true);
+      expect(widget2.isVisible).to.equal(true);
     });
   });
 
@@ -343,8 +343,8 @@ describe('ApplicationShell', () => {
       bar.id = 'bar';
       shell.addToMainArea(bar);
       shell.closeAll();
-      expect(foo.parent).to.be(null);
-      expect(bar.parent).to.be(null);
+      expect(foo.parent).to.equal(null);
+      expect(bar.parent).to.equal(null);
     });
   });
 
@@ -355,8 +355,8 @@ describe('ApplicationShell', () => {
       shell.addToMainArea(foo);
       let state = shell.saveLayout();
       shell.activateById('foo');
-      expect(state.mainArea.mode).to.be('multiple-document');
-      expect(state.mainArea.currentWidget).to.be(null);
+      expect(state.mainArea.mode).to.equal('multiple-document');
+      expect(state.mainArea.currentWidget).to.equal(null);
     });
   });
 
@@ -365,7 +365,7 @@ describe('ApplicationShell', () => {
       let state = shell.saveLayout();
       shell.mode = 'single-document';
       shell.restoreLayout(state);
-      expect(state.mainArea.mode).to.be('multiple-document');
+      expect(state.mainArea.mode).to.equal('multiple-document');
     });
   });
 });

--- a/tests/test-apputils/package.json
+++ b/tests/test-apputils/package.json
@@ -25,7 +25,6 @@
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.6.0",
     "chai": "~4.1.2",
-    "expect.js": "~0.3.1",
     "react": "~16.4.0",
     "simulate-event": "~1.4.0"
   },

--- a/tests/test-apputils/src/clientsession.spec.ts
+++ b/tests/test-apputils/src/clientsession.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { SessionManager } from '@jupyterlab/services';
 
@@ -32,7 +32,7 @@ describe('@jupyterlab/apputils', () => {
 
     describe('#constructor()', () => {
       it('should create a client session', () => {
-        expect(session).to.be.a(ClientSession);
+        expect(session).to.be.an.instanceof(ClientSession);
       });
     });
 
@@ -40,8 +40,8 @@ describe('@jupyterlab/apputils', () => {
       it('should be emitted when the session is terminated', async () => {
         await session.initialize();
         session.terminated.connect((sender, args) => {
-          expect(sender).to.be(session);
-          expect(args).to.be(undefined);
+          expect(sender).to.equal(session);
+          expect(args).to.be.undefined;
         });
         await session.shutdown();
       });
@@ -50,9 +50,9 @@ describe('@jupyterlab/apputils', () => {
     describe('#kernelChanged', () => {
       it('should be emitted when the kernel changes', async () => {
         session.kernelChanged.connect((sender, { oldValue, newValue }) => {
-          expect(sender).to.be(session);
-          expect(oldValue).to.be(null);
-          expect(newValue).to.be(session.kernel);
+          expect(sender).to.equal(session);
+          expect(oldValue).to.be.null;
+          expect(newValue).to.equal(session.kernel);
         });
         await session.initialize();
       });
@@ -61,8 +61,8 @@ describe('@jupyterlab/apputils', () => {
     describe('#statusChanged', () => {
       it('should be emitted when the status changes', async () => {
         session.statusChanged.connect((sender, args) => {
-          expect(sender).to.be(session);
-          expect(typeof args).to.be('string');
+          expect(sender).to.equal(session);
+          expect(typeof args).to.equal('string');
         });
         await session.initialize();
       });
@@ -71,7 +71,7 @@ describe('@jupyterlab/apputils', () => {
     describe('#iopubMessage', () => {
       it('should be emitted for iopub kernel messages', async () => {
         session.iopubMessage.connect((sender, args) => {
-          expect(sender).to.be(session);
+          expect(sender).to.equal(session);
         });
         await session.initialize();
       });
@@ -81,8 +81,8 @@ describe('@jupyterlab/apputils', () => {
       it('should be emitted when a session path changes', async () => {
         session.kernelPreference = { canStart: false };
         session.propertyChanged.connect((sender, args) => {
-          expect(sender).to.be(session);
-          expect(args).to.be('path');
+          expect(sender).to.equal(session);
+          expect(args).to.equal('path');
         });
         await session.setPath('foo');
       });
@@ -90,8 +90,8 @@ describe('@jupyterlab/apputils', () => {
       it('should be emitted when a session name changes', async () => {
         session.kernelPreference = { canStart: false };
         session.propertyChanged.connect((sender, args) => {
-          expect(sender).to.be(session);
-          expect(args).to.be('name');
+          expect(sender).to.equal(session);
+          expect(args).to.equal('name');
         });
         await session.setName('foo');
       });
@@ -99,8 +99,8 @@ describe('@jupyterlab/apputils', () => {
       it('should be emitted when a session type changes', async () => {
         session.kernelPreference = { canStart: false };
         session.propertyChanged.connect((sender, args) => {
-          expect(sender).to.be(session);
-          expect(args).to.be('type');
+          expect(sender).to.equal(session);
+          expect(args).to.equal('type');
         });
         await session.setType('foo');
       });
@@ -108,36 +108,36 @@ describe('@jupyterlab/apputils', () => {
 
     describe('#kernel', () => {
       it('should be the current kernel of the the session', async () => {
-        expect(session.kernel).to.be(null);
+        expect(session.kernel).to.be.null;
         await session.initialize();
-        expect(session.kernel).to.be.ok();
+        expect(session.kernel).to.be.ok;
       });
     });
 
     describe('#path', () => {
       it('should current path of the the session', async () => {
         session.kernelPreference = { canStart: false };
-        expect(typeof session.path).to.be('string');
+        expect(typeof session.path).to.equal('string');
         await session.setPath('foo');
-        expect(session.path).to.be('foo');
+        expect(session.path).to.equal('foo');
       });
     });
 
     describe('#name', () => {
       it('should the current name of the the session', async () => {
         session.kernelPreference = { canStart: false };
-        expect(typeof session.name).to.be('string');
+        expect(typeof session.name).to.equal('string');
         await session.setName('foo');
-        expect(session.name).to.be('foo');
+        expect(session.name).to.equal('foo');
       });
     });
 
     describe('#type', () => {
       it('should the current type of the the session', async () => {
         session.kernelPreference = { canStart: false };
-        expect(typeof session.type).to.be('string');
+        expect(typeof session.type).to.equal('string');
         await session.setType('foo');
-        expect(session.type).to.be('foo');
+        expect(session.type).to.equal('foo');
       });
     });
 
@@ -151,41 +151,41 @@ describe('@jupyterlab/apputils', () => {
           canStart: true
         };
         session.kernelPreference = preference;
-        expect(session.kernelPreference).to.be(preference);
+        expect(session.kernelPreference).to.equal(preference);
       });
     });
 
     describe('#manager', () => {
       it('should be the session manager used by the session', () => {
-        expect(session.manager).to.be(manager);
+        expect(session.manager).to.equal(manager);
       });
     });
 
     describe('#status', () => {
       it('should be the current status of the session', () => {
-        expect(typeof session.status).to.be('string');
+        expect(typeof session.status).to.equal('string');
       });
     });
 
     describe('#isReady', () => {
       it('should be false until ready', async () => {
-        expect(session.isReady).to.be(false);
+        expect(session.isReady).to.equal(false);
         await session.initialize();
-        expect(session.isReady).to.be(true);
+        expect(session.isReady).to.equal(true);
       });
     });
 
     describe('#initialize()', () => {
       it('should start the default kernel', async () => {
         await session.initialize();
-        expect(session.kernel.name).to.be(manager.specs.default);
+        expect(session.kernel.name).to.equal(manager.specs.default);
       });
 
       it('should connect to an existing session on the path', async () => {
         const other = await manager.startNew({ path: session.path });
 
         await session.initialize();
-        expect(other.kernel.id).to.be(session.kernel.id);
+        expect(other.kernel.id).to.equal(session.kernel.id);
         other.dispose();
       });
 
@@ -198,7 +198,7 @@ describe('@jupyterlab/apputils', () => {
 
         session = new ClientSession({ manager, kernelPreference });
         await session.initialize();
-        expect(session.kernel.id).to.be(other.kernel.id);
+        expect(session.kernel.id).to.equal(other.kernel.id);
         other.dispose();
       });
 
@@ -210,44 +210,44 @@ describe('@jupyterlab/apputils', () => {
 
         await session.initialize();
         await accept;
-        expect(session.kernel.name).to.be(manager.specs.default);
+        expect(session.kernel.name).to.equal(manager.specs.default);
       });
 
       it('should be a no-op if if the shouldStart kernelPreference is false', async () => {
         session.kernelPreference = { shouldStart: false };
         await session.initialize();
-        expect(session.kernel).to.not.be.ok();
+        expect(session.kernel).to.not.be.ok;
       });
 
       it('should be a no-op if if the canStart kernelPreference is false', async () => {
         session.kernelPreference = { canStart: false };
         await session.initialize();
-        expect(session.kernel).to.not.be.ok();
+        expect(session.kernel).to.not.be.ok;
       });
     });
 
     describe('#kernelDisplayName', () => {
       it('should be the display name of the current kernel', async () => {
-        expect(session.kernelDisplayName).to.be('No Kernel!');
+        expect(session.kernelDisplayName).to.equal('No Kernel!');
         await session.initialize();
-        expect(session.kernelDisplayName).to.not.be('No Kernel!');
+        expect(session.kernelDisplayName).to.not.equal('No Kernel!');
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether a client session has been disposed', () => {
-        expect(session.isDisposed).to.be(false);
+        expect(session.isDisposed).to.equal(false);
         session.dispose();
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose the resources held by the client session', () => {
         session.dispose();
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
         session.dispose();
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
       });
     });
 
@@ -259,8 +259,8 @@ describe('@jupyterlab/apputils', () => {
         const id = session.kernel.id;
         const kernel = await session.changeKernel({ name });
 
-        expect(kernel.id).to.not.be(id);
-        expect(kernel.name).to.be(name);
+        expect(kernel.id).to.not.equal(id);
+        expect(kernel.name).to.equal(name);
       });
     });
 
@@ -274,8 +274,8 @@ describe('@jupyterlab/apputils', () => {
         await session.selectKernel();
         await accept;
 
-        expect(session.kernel.id).to.not.be(id);
-        expect(session.kernel.name).to.be(name);
+        expect(session.kernel.id).to.not.equal(id);
+        expect(session.kernel.name).to.equal(name);
       });
 
       it('should keep the existing kernel if dismissed', async () => {
@@ -287,17 +287,17 @@ describe('@jupyterlab/apputils', () => {
         await session.selectKernel();
         await dismiss;
 
-        expect(session.kernel.id).to.be(id);
-        expect(session.kernel.name).to.be(name);
+        expect(session.kernel.id).to.equal(id);
+        expect(session.kernel.name).to.equal(name);
       });
     });
 
     describe('#shutdown', () => {
       it('should kill the kernel and shut down the session', async () => {
         await session.initialize();
-        expect(session.kernel).to.not.be(null);
+        expect(session.kernel).to.not.equal(null);
         await session.shutdown();
-        expect(session.kernel).to.be(null);
+        expect(session.kernel).to.be.null;
       });
     });
 
@@ -315,8 +315,8 @@ describe('@jupyterlab/apputils', () => {
         const restart = session.restart();
 
         await acceptDialog();
-        expect(await restart).to.be(true);
-        expect(called).to.be(true);
+        expect(await restart).to.equal(true);
+        expect(called).to.equal(true);
       });
 
       it('should not restart if the user rejects the dialog', async () => {
@@ -332,15 +332,15 @@ describe('@jupyterlab/apputils', () => {
         const restart = session.restart();
 
         await dismissDialog();
-        expect(await restart).to.be(false);
-        expect(called).to.be(false);
+        expect(await restart).to.equal(false);
+        expect(called).to.equal(false);
       });
 
       it('should start the same kernel as the previously started kernel', async () => {
         await session.initialize();
         await session.shutdown();
         await session.restart();
-        expect(session.kernel).to.be.ok();
+        expect(session.kernel).to.be.ok;
       });
     });
 
@@ -348,7 +348,7 @@ describe('@jupyterlab/apputils', () => {
       it('should change the session path', async () => {
         session.kernelPreference = { canStart: false };
         await session.setPath('foo');
-        expect(session.path).to.be('foo');
+        expect(session.path).to.equal('foo');
       });
     });
 
@@ -356,7 +356,7 @@ describe('@jupyterlab/apputils', () => {
       it('should change the session name', async () => {
         session.kernelPreference = { canStart: false };
         await session.setName('foo');
-        expect(session.name).to.be('foo');
+        expect(session.name).to.equal('foo');
       });
     });
 
@@ -364,7 +364,7 @@ describe('@jupyterlab/apputils', () => {
       it('should set the session type', async () => {
         session.kernelPreference = { canStart: false };
         await session.setType('foo');
-        expect(session.type).to.be('foo');
+        expect(session.type).to.equal('foo');
       });
     });
 
@@ -383,7 +383,7 @@ describe('@jupyterlab/apputils', () => {
 
         await acceptDialog();
         await restart;
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should not restart if the user rejects the dialog', async () => {
@@ -400,7 +400,7 @@ describe('@jupyterlab/apputils', () => {
 
         await dismissDialog();
         await restart;
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
     });
 
@@ -415,7 +415,7 @@ describe('@jupyterlab/apputils', () => {
             specs: manager.specs,
             preference: {}
           })
-        ).to.be(null);
+        ).to.be.null;
       });
 
       it('should return a matching name', () => {
@@ -426,7 +426,7 @@ describe('@jupyterlab/apputils', () => {
             specs: manager.specs,
             preference: { name: spec.name }
           })
-        ).to.be(spec.name);
+        ).to.equal(spec.name);
       });
 
       it('should return null if no match is found', () => {
@@ -435,7 +435,7 @@ describe('@jupyterlab/apputils', () => {
             specs: manager.specs,
             preference: { name: 'foo' }
           })
-        ).to.be(null);
+        ).to.be.null;
       });
 
       it('should return a matching language', () => {
@@ -451,7 +451,7 @@ describe('@jupyterlab/apputils', () => {
             },
             preference: { language: spec.language }
           })
-        ).to.be(spec.name);
+        ).to.equal(spec.name);
       });
 
       it('should return null if a language matches twice', () => {
@@ -468,7 +468,7 @@ describe('@jupyterlab/apputils', () => {
             },
             preference: { language: spec.language }
           })
-        ).to.be(null);
+        ).to.be.null;
       });
     });
 
@@ -484,8 +484,8 @@ describe('@jupyterlab/apputils', () => {
           specs: manager.specs,
           preference: {}
         });
-        expect(div.firstChild).to.be.ok();
-        expect(div.value).to.not.be('null');
+        expect(div.firstChild).to.be.ok;
+        expect(div.value).to.not.equal('null');
       });
 
       it('should select the null option', () => {
@@ -495,8 +495,8 @@ describe('@jupyterlab/apputils', () => {
           specs: manager.specs,
           preference: { shouldStart: false }
         });
-        expect(div.firstChild).to.be.ok();
-        expect(div.value).to.be('null');
+        expect(div.firstChild).to.be.ok;
+        expect(div.value).to.equal('null');
       });
 
       it('should disable the node', () => {
@@ -506,9 +506,9 @@ describe('@jupyterlab/apputils', () => {
           specs: manager.specs,
           preference: { canStart: false }
         });
-        expect(div.firstChild).to.be.ok();
-        expect(div.value).to.be('null');
-        expect(div.disabled).to.be(true);
+        expect(div.firstChild).to.be.ok;
+        expect(div.value).to.equal('null');
+        expect(div.disabled).to.equal(true);
       });
     });
   });

--- a/tests/test-apputils/src/commandlinker.spec.ts
+++ b/tests/test-apputils/src/commandlinker.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -15,29 +15,29 @@ describe('@jupyterlab/apputils', () => {
   describe('CommandLinker', () => {
     describe('#constructor()', () => {
       it('should create a command linker', () => {
-        let linker = new CommandLinker({ commands: new CommandRegistry() });
-        expect(linker).to.be.a(CommandLinker);
+        const linker = new CommandLinker({ commands: new CommandRegistry() });
+        expect(linker).to.be.an.instanceof(CommandLinker);
         linker.dispose();
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether a command linker has been disposed', () => {
-        let linker = new CommandLinker({ commands: new CommandRegistry() });
-        expect(linker.isDisposed).to.be(false);
+        const linker = new CommandLinker({ commands: new CommandRegistry() });
+        expect(linker.isDisposed).to.equal(false);
         linker.dispose();
-        expect(linker.isDisposed).to.be(true);
+        expect(linker.isDisposed).to.equal(true);
       });
     });
 
     describe('#connectNode()', () => {
       it('should connect a node to a command', () => {
         let called = false;
-        let command = 'commandlinker:connect-node';
-        let commands = new CommandRegistry();
-        let linker = new CommandLinker({ commands });
-        let node = document.createElement('div');
-        let disposable = commands.addCommand(command, {
+        const command = 'commandlinker:connect-node';
+        const commands = new CommandRegistry();
+        const linker = new CommandLinker({ commands });
+        const node = document.createElement('div');
+        const disposable = commands.addCommand(command, {
           execute: () => {
             called = true;
           }
@@ -46,9 +46,9 @@ describe('@jupyterlab/apputils', () => {
         document.body.appendChild(node);
         linker.connectNode(node, command, null);
 
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
         simulate(node, 'click');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
 
         document.body.removeChild(node);
         linker.dispose();
@@ -59,11 +59,11 @@ describe('@jupyterlab/apputils', () => {
     describe('#disconnectNode()', () => {
       it('should disconnect a node from a command', () => {
         let called = false;
-        let command = 'commandlinker:disconnect-node';
-        let commands = new CommandRegistry();
-        let linker = new CommandLinker({ commands });
-        let node = document.createElement('div');
-        let disposable = commands.addCommand(command, {
+        const command = 'commandlinker:disconnect-node';
+        const commands = new CommandRegistry();
+        const linker = new CommandLinker({ commands });
+        const node = document.createElement('div');
+        const disposable = commands.addCommand(command, {
           execute: () => {
             called = true;
           }
@@ -73,18 +73,18 @@ describe('@jupyterlab/apputils', () => {
         linker.connectNode(node, command, null);
 
         // Make sure connection is working.
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
         simulate(node, 'click');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
 
         // Reset flag.
         called = false;
 
         // Make sure disconnection is working.
         linker.disconnectNode(node);
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
         simulate(node, 'click');
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
 
         document.body.removeChild(node);
         linker.dispose();
@@ -94,22 +94,22 @@ describe('@jupyterlab/apputils', () => {
 
     describe('#dispose()', () => {
       it('should dispose the resources held by the linker', () => {
-        let linker = new CommandLinker({ commands: new CommandRegistry() });
-        expect(linker.isDisposed).to.be(false);
+        const linker = new CommandLinker({ commands: new CommandRegistry() });
+        expect(linker.isDisposed).to.equal(false);
         linker.dispose();
-        expect(linker.isDisposed).to.be(true);
+        expect(linker.isDisposed).to.equal(true);
       });
     });
 
     describe('#populateVNodeDataset()', () => {
       it('should connect a node to a command', () => {
         let called = false;
-        let command = 'commandlinker:connect-node';
-        let commands = new CommandRegistry();
-        let linker = new CommandLinker({ commands });
+        const command = 'commandlinker:connect-node';
+        const commands = new CommandRegistry();
+        const linker = new CommandLinker({ commands });
         let node: HTMLElement;
         let vnode: VirtualNode;
-        let disposable = commands.addCommand(command, {
+        const disposable = commands.addCommand(command, {
           execute: () => {
             called = true;
           }
@@ -119,9 +119,9 @@ describe('@jupyterlab/apputils', () => {
         node = VirtualDOM.realize(vnode);
         document.body.appendChild(node);
 
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
         simulate(node, 'click');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
 
         document.body.removeChild(node);
         linker.dispose();

--- a/tests/test-apputils/src/instancetracker.spec.ts
+++ b/tests/test-apputils/src/instancetracker.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { InstanceTracker } from '@jupyterlab/apputils';
 
@@ -23,7 +23,7 @@ class TestTracker<T extends Widget> extends InstanceTracker<T> {
 }
 
 function createWidget(): Widget {
-  let widget = new Widget();
+  const widget = new Widget();
   widget.node.style.minHeight = '20px';
   widget.node.style.minWidth = '20px';
   widget.node.tabIndex = -1;
@@ -34,15 +34,15 @@ describe('@jupyterlab/apputils', () => {
   describe('InstanceTracker', () => {
     describe('#constructor()', () => {
       it('should create an InstanceTracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        expect(tracker).to.be.an(InstanceTracker);
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        expect(tracker).to.be.an.instanceof(InstanceTracker);
       });
     });
 
     describe('#currentChanged', () => {
       it('should emit when the current widget has been updated', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widget = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
         widget.node.tabIndex = -1;
         let called = false;
         tracker.currentChanged.connect(() => {
@@ -52,33 +52,33 @@ describe('@jupyterlab/apputils', () => {
         widget.node.focus();
         simulate(widget.node, 'focus');
         tracker.add(widget);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
         Widget.detach(widget);
       });
     });
 
     describe('#widgetAdded', () => {
       it('should emit when a widget has been added', done => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widget = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
         tracker.widgetAdded.connect((sender, added) => {
-          expect(added).to.be(widget);
+          expect(added).to.equal(widget);
           done();
         });
         tracker.add(widget);
       });
 
       it('should not emit when a widget has been injected', done => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let one = new Widget();
-        let two = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const one = new Widget();
+        const two = new Widget();
         two.node.tabIndex = -1;
         let total = 0;
         tracker.widgetAdded.connect(() => {
           total++;
         });
         tracker.currentChanged.connect(() => {
-          expect(total).to.be(1);
+          expect(total).to.equal(1);
           done();
         });
         tracker.add(one);
@@ -92,53 +92,53 @@ describe('@jupyterlab/apputils', () => {
 
     describe('#currentWidget', () => {
       it('should default to null', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        expect(tracker.currentWidget).to.be(null);
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        expect(tracker.currentWidget).to.be.null;
       });
 
       it('should be updated when a widget is added', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widget = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
         widget.node.tabIndex = -1;
         tracker.add(widget);
-        expect(tracker.currentWidget).to.be(widget);
+        expect(tracker.currentWidget).to.equal(widget);
         widget.dispose();
       });
 
       it('should be updated if when the first widget is focused', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let panel = new Panel();
-        let widget0 = createWidget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const panel = new Panel();
+        const widget0 = createWidget();
         tracker.add(widget0);
-        let widget1 = createWidget();
+        const widget1 = createWidget();
         tracker.add(widget1);
         panel.addWidget(widget0);
         panel.addWidget(widget1);
         Widget.attach(panel, document.body);
-        expect(tracker.currentWidget).to.be(widget1);
+        expect(tracker.currentWidget).to.equal(widget1);
         widget0.node.focus();
         simulate(widget0.node, 'focus');
-        expect(tracker.currentWidget).to.be(widget0);
+        expect(tracker.currentWidget).to.equal(widget0);
         panel.dispose();
         widget0.dispose();
         widget1.dispose();
       });
 
       it('should revert to the previously added widget on widget disposal', () => {
-        let tracker = new TestTracker<Widget>({ namespace });
-        let widget0 = new Widget();
+        const tracker = new TestTracker<Widget>({ namespace });
+        const widget0 = new Widget();
         tracker.add(widget0);
-        let widget1 = new Widget();
+        const widget1 = new Widget();
         tracker.add(widget1);
-        expect(tracker.currentWidget).to.be(widget1);
+        expect(tracker.currentWidget).to.equal(widget1);
         widget1.dispose();
-        expect(tracker.currentWidget).to.be(widget0);
+        expect(tracker.currentWidget).to.equal(widget0);
       });
 
       it('should preserve the tracked widget on widget disposal', () => {
-        let panel = new Panel();
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widgets = [createWidget(), createWidget(), createWidget()];
+        const panel = new Panel();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widgets = [createWidget(), createWidget(), createWidget()];
         each(widgets, widget => {
           tracker.add(widget);
           panel.addWidget(widget);
@@ -147,15 +147,15 @@ describe('@jupyterlab/apputils', () => {
 
         widgets[0].node.focus();
         simulate(widgets[0].node, 'focus');
-        expect(tracker.currentWidget).to.be(widgets[0]);
+        expect(tracker.currentWidget).to.equal(widgets[0]);
 
         let called = false;
         tracker.currentChanged.connect(() => {
           called = true;
         });
         widgets[2].dispose();
-        expect(tracker.currentWidget).to.be(widgets[0]);
-        expect(called).to.be(false);
+        expect(tracker.currentWidget).to.equal(widgets[0]);
+        expect(called).to.equal(false);
         panel.dispose();
         each(widgets, widget => {
           widget.dispose();
@@ -163,9 +163,9 @@ describe('@jupyterlab/apputils', () => {
       });
 
       it('should select the previously added widget on widget disposal', () => {
-        let panel = new Panel();
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widgets = [createWidget(), createWidget(), createWidget()];
+        const panel = new Panel();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widgets = [createWidget(), createWidget(), createWidget()];
         each(widgets, widget => {
           tracker.add(widget);
           panel.addWidget(widget);
@@ -177,8 +177,8 @@ describe('@jupyterlab/apputils', () => {
           called = true;
         });
         widgets[2].dispose();
-        expect(tracker.currentWidget).to.be(widgets[1]);
-        expect(called).to.be(true);
+        expect(tracker.currentWidget).to.equal(widgets[1]);
+        expect(called).to.equal(true);
         panel.dispose();
         each(widgets, widget => {
           widget.dispose();
@@ -188,119 +188,119 @@ describe('@jupyterlab/apputils', () => {
 
     describe('#isDisposed', () => {
       it('should test whether the tracker is disposed', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        expect(tracker.isDisposed).to.be(false);
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        expect(tracker.isDisposed).to.equal(false);
         tracker.dispose();
-        expect(tracker.isDisposed).to.be(true);
+        expect(tracker.isDisposed).to.equal(true);
       });
     });
 
     describe('#add()', () => {
       it('should add a widget to the tracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widget = new Widget();
-        expect(tracker.has(widget)).to.be(false);
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
+        expect(tracker.has(widget)).to.equal(false);
         tracker.add(widget);
-        expect(tracker.has(widget)).to.be(true);
+        expect(tracker.has(widget)).to.equal(true);
       });
 
       it('should remove an added widget if it is disposed', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widget = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
         tracker.add(widget);
-        expect(tracker.has(widget)).to.be(true);
+        expect(tracker.has(widget)).to.equal(true);
         widget.dispose();
-        expect(tracker.has(widget)).to.be(false);
+        expect(tracker.has(widget)).to.equal(false);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources used by the tracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        expect(tracker.isDisposed).to.be(false);
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        expect(tracker.isDisposed).to.equal(false);
         tracker.dispose();
-        expect(tracker.isDisposed).to.be(true);
+        expect(tracker.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        expect(tracker.isDisposed).to.be(false);
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        expect(tracker.isDisposed).to.equal(false);
         tracker.dispose();
         tracker.dispose();
-        expect(tracker.isDisposed).to.be(true);
+        expect(tracker.isDisposed).to.equal(true);
       });
     });
 
     describe('#find()', () => {
       it('should find a tracked item that matches a filter function', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widgetA = new Widget();
-        let widgetB = new Widget();
-        let widgetC = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widgetA = new Widget();
+        const widgetB = new Widget();
+        const widgetC = new Widget();
         widgetA.id = 'A';
         widgetB.id = 'B';
         widgetC.id = 'C';
         tracker.add(widgetA);
         tracker.add(widgetB);
         tracker.add(widgetC);
-        expect(tracker.find(widget => widget.id === 'B')).to.be(widgetB);
+        expect(tracker.find(widget => widget.id === 'B')).to.equal(widgetB);
       });
 
       it('should return a void if no item is found', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widgetA = new Widget();
-        let widgetB = new Widget();
-        let widgetC = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widgetA = new Widget();
+        const widgetB = new Widget();
+        const widgetC = new Widget();
         widgetA.id = 'A';
         widgetB.id = 'B';
         widgetC.id = 'C';
         tracker.add(widgetA);
         tracker.add(widgetB);
         tracker.add(widgetC);
-        expect(tracker.find(widget => widget.id === 'D')).to.not.be.ok();
+        expect(tracker.find(widget => widget.id === 'D')).to.not.be.ok;
       });
     });
 
     describe('#filter()', () => {
       it('should filter according to a predicate function', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widgetA = new Widget();
-        let widgetB = new Widget();
-        let widgetC = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widgetA = new Widget();
+        const widgetB = new Widget();
+        const widgetC = new Widget();
         widgetA.id = 'include-A';
         widgetB.id = 'include-B';
         widgetC.id = 'exclude-C';
         tracker.add(widgetA);
         tracker.add(widgetB);
         tracker.add(widgetC);
-        let list = tracker.filter(
+        const list = tracker.filter(
           widget => widget.id.indexOf('include') !== -1
         );
-        expect(list.length).to.be(2);
-        expect(list[0]).to.be(widgetA);
-        expect(list[1]).to.be(widgetB);
+        expect(list.length).to.equal(2);
+        expect(list[0]).to.equal(widgetA);
+        expect(list[1]).to.equal(widgetB);
       });
 
       it('should return an empty array if no item is found', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widgetA = new Widget();
-        let widgetB = new Widget();
-        let widgetC = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widgetA = new Widget();
+        const widgetB = new Widget();
+        const widgetC = new Widget();
         widgetA.id = 'A';
         widgetB.id = 'B';
         widgetC.id = 'C';
         tracker.add(widgetA);
         tracker.add(widgetB);
         tracker.add(widgetC);
-        expect(tracker.filter(widget => widget.id === 'D').length).to.be(0);
+        expect(tracker.filter(widget => widget.id === 'D').length).to.equal(0);
       });
     });
     describe('#forEach()', () => {
       it('should iterate through all the tracked items', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widgetA = new Widget();
-        let widgetB = new Widget();
-        let widgetC = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widgetA = new Widget();
+        const widgetB = new Widget();
+        const widgetC = new Widget();
         let visited = '';
         widgetA.id = 'A';
         widgetB.id = 'B';
@@ -311,43 +311,43 @@ describe('@jupyterlab/apputils', () => {
         tracker.forEach(widget => {
           visited += widget.id;
         });
-        expect(visited).to.be('ABC');
+        expect(visited).to.equal('ABC');
       });
     });
 
     describe('#has()', () => {
       it('should return `true` if an item exists in the tracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widget = new Widget();
-        expect(tracker.has(widget)).to.be(false);
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
+        expect(tracker.has(widget)).to.equal(false);
         tracker.add(widget);
-        expect(tracker.has(widget)).to.be(true);
+        expect(tracker.has(widget)).to.equal(true);
       });
     });
 
     describe('#inject()', () => {
       it('should inject a widget into the tracker', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widget = new Widget();
-        expect(tracker.has(widget)).to.be(false);
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
+        expect(tracker.has(widget)).to.equal(false);
         tracker.inject(widget);
-        expect(tracker.has(widget)).to.be(true);
+        expect(tracker.has(widget)).to.equal(true);
       });
 
       it('should remove an injected widget if it is disposed', () => {
-        let tracker = new InstanceTracker<Widget>({ namespace });
-        let widget = new Widget();
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
         tracker.inject(widget);
-        expect(tracker.has(widget)).to.be(true);
+        expect(tracker.has(widget)).to.equal(true);
         widget.dispose();
-        expect(tracker.has(widget)).to.be(false);
+        expect(tracker.has(widget)).to.equal(false);
       });
     });
 
     describe('#onCurrentChanged()', () => {
       it('should be called when the current widget is changed', () => {
-        let tracker = new TestTracker<Widget>({ namespace });
-        let widget = new Widget();
+        const tracker = new TestTracker<Widget>({ namespace });
+        const widget = new Widget();
         tracker.add(widget);
         expect(tracker.methods).to.contain('onCurrentChanged');
       });

--- a/tests/test-apputils/src/sanitizer.spec.ts
+++ b/tests/test-apputils/src/sanitizer.spec.ts
@@ -1,101 +1,103 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { defaultSanitizer } from '@jupyterlab/apputils';
 
 describe('defaultSanitizer', () => {
   describe('#sanitize()', () => {
     it('should allow h1 tags', () => {
-      let h1 = '<h1>foo</h1>';
-      expect(defaultSanitizer.sanitize(h1)).to.be(h1);
+      const h1 = '<h1>foo</h1>';
+      expect(defaultSanitizer.sanitize(h1)).to.equal(h1);
     });
 
     it('should allow h2 tags', () => {
-      let h2 = '<h2>foo</h2>';
-      expect(defaultSanitizer.sanitize(h2)).to.be(h2);
+      const h2 = '<h2>foo</h2>';
+      expect(defaultSanitizer.sanitize(h2)).to.equal(h2);
     });
 
     it('should not allow svg tags', () => {
-      let svg = '<svg>foo</svg>';
-      expect(defaultSanitizer.sanitize(svg)).to.be('foo');
+      const svg = '<svg>foo</svg>';
+      expect(defaultSanitizer.sanitize(svg)).to.equal('foo');
     });
 
     it('should allow img tags and some attributes', () => {
-      let img =
+      const img =
         '<img src="smiley.gif" alt="Smiley face" height="42" width="42" />';
-      expect(defaultSanitizer.sanitize(img)).to.be(img);
+      expect(defaultSanitizer.sanitize(img)).to.equal(img);
     });
 
     it('should allow span tags and class attribute', () => {
-      let span = '<span class="foo">bar</span>';
-      expect(defaultSanitizer.sanitize(span)).to.be(span);
+      const span = '<span class="foo">bar</span>';
+      expect(defaultSanitizer.sanitize(span)).to.equal(span);
     });
 
     it('should set the rel attribute for <a> tags to "nofollow', () => {
-      let a = '<a rel="foo" href="bar">Baz</a>';
-      let expected = a.replace('foo', 'nofollow');
-      expect(defaultSanitizer.sanitize(a)).to.be(expected);
+      const a = '<a rel="foo" href="bar">Baz</a>';
+      const expected = a.replace('foo', 'nofollow');
+      expect(defaultSanitizer.sanitize(a)).to.equal(expected);
     });
 
     it('should allow the class attribute for code tags', () => {
-      let code = '<code class="foo">bar</code>';
-      expect(defaultSanitizer.sanitize(code)).to.be(code);
+      const code = '<code class="foo">bar</code>';
+      expect(defaultSanitizer.sanitize(code)).to.equal(code);
     });
 
     it('should allow the class attribute for div tags', () => {
-      let div = '<div class="foo">bar</div>';
-      expect(defaultSanitizer.sanitize(div)).to.be(div);
+      const div = '<div class="foo">bar</div>';
+      expect(defaultSanitizer.sanitize(div)).to.equal(div);
     });
 
     it('should allow the class attribute for p tags', () => {
-      let p = '<p class="foo">bar</p>';
-      expect(defaultSanitizer.sanitize(p)).to.be(p);
+      const p = '<p class="foo">bar</p>';
+      expect(defaultSanitizer.sanitize(p)).to.equal(p);
     });
 
     it('should allow the class attribute for pre tags', () => {
-      let pre = '<pre class="foo">bar</pre>';
-      expect(defaultSanitizer.sanitize(pre)).to.be(pre);
+      const pre = '<pre class="foo">bar</pre>';
+      expect(defaultSanitizer.sanitize(pre)).to.equal(pre);
     });
 
     it('should strip script tags', () => {
-      let script = '<script>alert("foo")</script>';
-      expect(defaultSanitizer.sanitize(script)).to.be('');
+      const script = '<script>alert("foo")</script>';
+      expect(defaultSanitizer.sanitize(script)).to.equal('');
     });
 
     it('should strip link tags', () => {
-      let link = '<link rel="stylesheet" type="text/css" href="theme.css">';
-      expect(defaultSanitizer.sanitize(link)).to.be('');
+      const link = '<link rel="stylesheet" type="text/css" href="theme.css">';
+      expect(defaultSanitizer.sanitize(link)).to.equal('');
     });
 
     it('should pass through simple well-formed whitelisted markup', () => {
-      let div = '<div><p>Hello <b>there</b></p></div>';
-      expect(defaultSanitizer.sanitize(div)).to.be(div);
+      const div = '<div><p>Hello <b>there</b></p></div>';
+      expect(defaultSanitizer.sanitize(div)).to.equal(div);
     });
 
     it('should allow video tags with some attributes', () => {
-      let video =
+      const video =
         '<video src="my/video.mp4" height="42" width="42"' +
         ' autoplay controls loop muted></video>';
-      expect(defaultSanitizer.sanitize(video)).to.be(video);
+      expect(defaultSanitizer.sanitize(video)).to.equal(video);
     });
 
     it('should allow audio tags with some attributes', () => {
-      let audio =
+      const audio =
         '<audio src="my/audio.ogg autoplay loop ' + 'controls muted"></audio>';
-      expect(defaultSanitizer.sanitize(audio)).to.be(audio);
+      expect(defaultSanitizer.sanitize(audio)).to.equal(audio);
     });
 
     it('should allow input tags but disable them', () => {
-      let html = defaultSanitizer.sanitize('<input type="checkbox" checked />');
-      let div = document.createElement('div');
+      const html = defaultSanitizer.sanitize(
+        '<input type="checkbox" checked />'
+      );
+      const div = document.createElement('div');
       let input: HTMLInputElement;
 
       div.innerHTML = html;
       input = div.querySelector('input');
 
-      expect(input.disabled).to.be(true);
+      expect(input.disabled).to.equal(true);
     });
   });
 });

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ClientSession, Toolbar, ToolbarButton } from '@jupyterlab/apputils';
 
@@ -61,13 +61,13 @@ describe('@jupyterlab/apputils', () => {
   describe('Toolbar', () => {
     describe('#constructor()', () => {
       it('should construct a new toolbar widget', () => {
-        let widget = new Toolbar();
-        expect(widget).to.be.a(Toolbar);
+        const widget = new Toolbar();
+        expect(widget).to.be.an.instanceof(Toolbar);
       });
 
       it('should add the `jp-Toolbar` class', () => {
-        let widget = new Toolbar();
-        expect(widget.hasClass('jp-Toolbar')).to.be(true);
+        const widget = new Toolbar();
+        expect(widget.hasClass('jp-Toolbar')).to.equal(true);
       });
     });
 
@@ -76,26 +76,26 @@ describe('@jupyterlab/apputils', () => {
         widget.addItem('foo', new Widget());
         widget.addItem('bar', new Widget());
         widget.addItem('baz', new Widget());
-        expect(toArray(widget.names())).to.eql(['foo', 'bar', 'baz']);
+        expect(toArray(widget.names())).to.deep.equal(['foo', 'bar', 'baz']);
       });
     });
 
     describe('#addItem()', () => {
       it('should add an item to the toolbar', () => {
-        let item = new Widget();
-        expect(widget.addItem('test', item)).to.be(true);
+        const item = new Widget();
+        expect(widget.addItem('test', item)).to.equal(true);
         expect(toArray(widget.names())).to.contain('test');
       });
 
       it('should add the `jp-Toolbar-item` class to the widget', () => {
-        let item = new Widget();
+        const item = new Widget();
         widget.addItem('test', item);
-        expect(item.hasClass('jp-Toolbar-item')).to.be(true);
+        expect(item.hasClass('jp-Toolbar-item')).to.equal(true);
       });
 
       it('should return false if the name is already used', () => {
         widget.addItem('test', new Widget());
-        expect(widget.addItem('test', new Widget())).to.be(false);
+        expect(widget.addItem('test', new Widget())).to.equal(false);
       });
     });
 
@@ -104,21 +104,21 @@ describe('@jupyterlab/apputils', () => {
         widget.addItem('a', new Widget());
         widget.addItem('b', new Widget());
         widget.insertItem(1, 'c', new Widget());
-        expect(toArray(widget.names())).to.eql(['a', 'c', 'b']);
+        expect(toArray(widget.names())).to.deep.equal(['a', 'c', 'b']);
       });
 
       it('should clamp the bounds', () => {
         widget.addItem('a', new Widget());
         widget.addItem('b', new Widget());
         widget.insertItem(10, 'c', new Widget());
-        expect(toArray(widget.names())).to.eql(['a', 'b', 'c']);
+        expect(toArray(widget.names())).to.deep.equal(['a', 'b', 'c']);
       });
     });
 
     describe('.createFromCommand', () => {
-      let commands = new CommandRegistry();
-      let testLogCommandId = 'test:toolbar-log';
-      let logArgs: ReadonlyJSONObject[] = [];
+      const commands = new CommandRegistry();
+      const testLogCommandId = 'test:toolbar-log';
+      const logArgs: ReadonlyJSONObject[] = [];
       let enabled = false;
       let toggled = true;
       let visible = false;
@@ -138,33 +138,33 @@ describe('@jupyterlab/apputils', () => {
       });
 
       it('should create a button', () => {
-        let button = Toolbar.createFromCommand(commands, testLogCommandId);
-        expect(button).to.be.a(ToolbarButton);
+        const button = Toolbar.createFromCommand(commands, testLogCommandId);
+        expect(button).to.be.an.instanceof(ToolbarButton);
         button.dispose();
       });
 
       it('should dispose the button if the action is removed', () => {
-        let id = 'to-be-removed';
-        let cmd = commands.addCommand(id, {
+        const id = 'to-be-removed';
+        const cmd = commands.addCommand(id, {
           execute: () => {
             return;
           }
         });
-        let button = Toolbar.createFromCommand(commands, id);
+        const button = Toolbar.createFromCommand(commands, id);
         cmd.dispose();
-        expect(button.isDisposed).to.be(true);
+        expect(button.isDisposed).to.equal(true);
       });
 
       it('should add main class', () => {
-        let button = Toolbar.createFromCommand(commands, testLogCommandId);
-        expect(button.hasClass('test-log-class')).to.be(true);
+        const button = Toolbar.createFromCommand(commands, testLogCommandId);
+        expect(button.hasClass('test-log-class')).to.equal(true);
         button.dispose();
       });
 
       it('should add an icon with icon class and label', () => {
-        let button = Toolbar.createFromCommand(commands, testLogCommandId);
-        let iconNode = button.node as HTMLElement;
-        expect(iconNode.classList.contains('test-icon-class')).to.be(true);
+        const button = Toolbar.createFromCommand(commands, testLogCommandId);
+        const iconNode = button.node as HTMLElement;
+        expect(iconNode.classList.contains('test-icon-class')).to.equal(true);
         expect(iconNode.title).to.equal('Test log icon label');
         button.dispose();
       });
@@ -173,10 +173,10 @@ describe('@jupyterlab/apputils', () => {
         enabled = false;
         toggled = true;
         visible = false;
-        let button = Toolbar.createFromCommand(commands, testLogCommandId);
-        expect((button.node as HTMLButtonElement).disabled).to.be(true);
-        expect(button.hasClass('p-mod-toggled')).to.be(true);
-        expect(button.hasClass('p-mod-hidden')).to.be(true);
+        const button = Toolbar.createFromCommand(commands, testLogCommandId);
+        expect((button.node as HTMLButtonElement).disabled).to.equal(true);
+        expect(button.hasClass('p-mod-toggled')).to.equal(true);
+        expect(button.hasClass('p-mod-hidden')).to.equal(true);
         button.dispose();
       });
 
@@ -184,55 +184,55 @@ describe('@jupyterlab/apputils', () => {
         enabled = false;
         toggled = true;
         visible = false;
-        let button = Toolbar.createFromCommand(commands, testLogCommandId);
-        expect((button.node as HTMLButtonElement).disabled).to.be(true);
-        expect(button.hasClass('p-mod-toggled')).to.be(true);
-        expect(button.hasClass('p-mod-hidden')).to.be(true);
+        const button = Toolbar.createFromCommand(commands, testLogCommandId);
+        expect((button.node as HTMLButtonElement).disabled).to.equal(true);
+        expect(button.hasClass('p-mod-toggled')).to.equal(true);
+        expect(button.hasClass('p-mod-hidden')).to.equal(true);
         enabled = true;
         visible = true;
         commands.notifyCommandChanged(testLogCommandId);
-        expect((button.node as HTMLButtonElement).disabled).to.be(false);
-        expect(button.hasClass('p-mod-toggled')).to.be(true);
-        expect(button.hasClass('p-mod-hidden')).to.be(false);
+        expect((button.node as HTMLButtonElement).disabled).to.equal(false);
+        expect(button.hasClass('p-mod-toggled')).to.equal(true);
+        expect(button.hasClass('p-mod-hidden')).to.equal(false);
         enabled = false;
         visible = false;
         button.dispose();
       });
 
       it('should add use the command label if no icon class/label', () => {
-        let id = 'to-be-removed';
-        let cmd = commands.addCommand(id, {
+        const id = 'to-be-removed';
+        const cmd = commands.addCommand(id, {
           execute: () => {
             return;
           },
           label: 'Label-only button'
         });
-        let button = Toolbar.createFromCommand(commands, id);
-        expect(button.node.childElementCount).to.be(0);
+        const button = Toolbar.createFromCommand(commands, id);
+        expect(button.node.childElementCount).to.equal(0);
         expect(button.node.innerText).to.equal('Label-only button');
         cmd.dispose();
       });
 
       it('should update the node content on command change event', () => {
-        let id = 'to-be-removed';
+        const id = 'to-be-removed';
         let iconClassValue: string | null = null;
-        let cmd = commands.addCommand(id, {
+        const cmd = commands.addCommand(id, {
           execute: () => {
             /* no op */
           },
           label: 'Label-only button',
           iconClass: () => iconClassValue
         });
-        let button = Toolbar.createFromCommand(commands, id);
-        expect(button.node.childElementCount).to.be(0);
+        const button = Toolbar.createFromCommand(commands, id);
+        expect(button.node.childElementCount).to.equal(0);
         expect(button.node.innerText).to.equal('Label-only button');
 
         iconClassValue = 'updated-icon-class';
         commands.notifyCommandChanged(id);
 
         expect(button.node.innerText).to.equal('');
-        let iconNode = button.node as HTMLElement;
-        expect(iconNode.classList.contains(iconClassValue)).to.be(true);
+        const iconNode = button.node as HTMLElement;
+        expect(iconNode.classList.contains(iconClassValue)).to.equal(true);
 
         cmd.dispose();
       });
@@ -240,29 +240,29 @@ describe('@jupyterlab/apputils', () => {
 
     describe('.createInterruptButton()', () => {
       it("should have the `'jp-StopIcon'` class", () => {
-        let button = Toolbar.createInterruptButton(session);
-        expect(button.hasClass('jp-StopIcon')).to.be(true);
+        const button = Toolbar.createInterruptButton(session);
+        expect(button.hasClass('jp-StopIcon')).to.equal(true);
       });
     });
 
     describe('.createRestartButton()', () => {
       it("should have the `'jp-RefreshIcon'` class", () => {
-        let button = Toolbar.createRestartButton(session);
-        expect(button.hasClass('jp-RefreshIcon')).to.be(true);
+        const button = Toolbar.createRestartButton(session);
+        expect(button.hasClass('jp-RefreshIcon')).to.equal(true);
       });
     });
 
     describe('.createKernelNameItem()', () => {
       it("should display the `'display_name'` of the kernel", () => {
-        let item = Toolbar.createKernelNameItem(session);
+        const item = Toolbar.createKernelNameItem(session);
         return session.initialize().then(() => {
-          expect(item.node.textContent).to.be(session.kernelDisplayName);
+          expect(item.node.textContent).to.equal(session.kernelDisplayName);
         });
       });
 
       it("should display `'No Kernel!'` if there is no kernel", () => {
-        let item = Toolbar.createKernelNameItem(session);
-        expect(item.node.textContent).to.be('No Kernel!');
+        const item = Toolbar.createKernelNameItem(session);
+        expect(item.node.textContent).to.equal('No Kernel!');
       });
     });
 
@@ -274,26 +274,26 @@ describe('@jupyterlab/apputils', () => {
       });
 
       it('should display a busy status if the kernel status is not idle', () => {
-        let item = Toolbar.createKernelStatusItem(session);
+        const item = Toolbar.createKernelStatusItem(session);
         let called = false;
-        let future = session.kernel.requestExecute({ code: 'a = 1' });
+        const future = session.kernel.requestExecute({ code: 'a = 1' });
         future.onIOPub = msg => {
           if (session.status === 'busy') {
-            expect(item.hasClass('jp-FilledCircleIcon')).to.be(true);
+            expect(item.hasClass('jp-FilledCircleIcon')).to.equal(true);
             called = true;
           }
         };
         return future.done.then(() => {
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
         });
       });
 
       it('should show the current status in the node title', () => {
-        let item = Toolbar.createKernelStatusItem(session);
-        let status = session.status;
+        const item = Toolbar.createKernelStatusItem(session);
+        const status = session.status;
         expect(item.node.title.toLowerCase()).to.contain(status);
         let called = false;
-        let future = session.kernel.requestExecute({ code: 'a = 1' });
+        const future = session.kernel.requestExecute({ code: 'a = 1' });
         future.onIOPub = msg => {
           if (session.status === 'busy') {
             expect(item.node.title.toLowerCase()).to.contain('busy');
@@ -301,7 +301,7 @@ describe('@jupyterlab/apputils', () => {
           }
         };
         return future.done.then(() => {
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
         });
       });
 
@@ -312,9 +312,9 @@ describe('@jupyterlab/apputils', () => {
             return createClientSession();
           })
           .then(session => {
-            let item = Toolbar.createKernelStatusItem(session);
-            expect(item.node.title).to.be('Kernel Starting');
-            expect(item.hasClass('jp-FilledCircleIcon')).to.be(true);
+            const item = Toolbar.createKernelStatusItem(session);
+            expect(item.node.title).to.equal('Kernel Starting');
+            expect(item.hasClass('jp-FilledCircleIcon')).to.equal(true);
           });
       });
     });
@@ -323,35 +323,35 @@ describe('@jupyterlab/apputils', () => {
   describe('ToolbarButton', () => {
     describe('#constructor()', () => {
       it('should accept no arguments', () => {
-        let button = new ToolbarButton();
-        expect(button).to.be.a(ToolbarButton);
+        const button = new ToolbarButton();
+        expect(button).to.be.an.instanceof(ToolbarButton);
       });
 
       it('should accept options', () => {
-        let button = new ToolbarButton({
+        const button = new ToolbarButton({
           className: 'foo',
           onClick: () => {
             return void 0;
           },
           tooltip: 'bar'
         });
-        expect(button.hasClass('foo')).to.be(true);
-        expect(button.node.title).to.be('bar');
+        expect(button.hasClass('foo')).to.equal(true);
+        expect(button.node.title).to.equal('bar');
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources used by the widget', () => {
-        let button = new ToolbarButton();
+        const button = new ToolbarButton();
         button.dispose();
-        expect(button.isDisposed).to.be(true);
+        expect(button.isDisposed).to.equal(true);
       });
 
       it('should be safe to call more than once', () => {
-        let button = new ToolbarButton();
+        const button = new ToolbarButton();
         button.dispose();
         button.dispose();
-        expect(button.isDisposed).to.be(true);
+        expect(button.isDisposed).to.equal(true);
       });
     });
 
@@ -359,7 +359,7 @@ describe('@jupyterlab/apputils', () => {
       context('click', () => {
         it('should activate the callback', done => {
           let called = false;
-          let button = new ToolbarButton({
+          const button = new ToolbarButton({
             onClick: () => {
               called = true;
             }
@@ -367,7 +367,7 @@ describe('@jupyterlab/apputils', () => {
           Widget.attach(button, document.body);
           requestAnimationFrame(() => {
             simulate(button.node, 'click');
-            expect(called).to.be(true);
+            expect(called).to.equal(true);
             button.dispose();
             done();
           });
@@ -377,7 +377,7 @@ describe('@jupyterlab/apputils', () => {
 
     describe('#onAfterAttach()', () => {
       it('should add event listeners to the node', () => {
-        let button = new LogToolbarButton();
+        const button = new LogToolbarButton();
         Widget.attach(button, document.body);
         expect(button.methods).to.contain('onAfterAttach');
         simulate(button.node, 'click');
@@ -388,7 +388,7 @@ describe('@jupyterlab/apputils', () => {
 
     describe('#onBeforeDetach()', () => {
       it('should remove event listeners from the node', done => {
-        let button = new LogToolbarButton();
+        const button = new LogToolbarButton();
         Widget.attach(button, document.body);
         requestAnimationFrame(() => {
           Widget.detach(button);

--- a/tests/test-codemirror/package.json
+++ b/tests/test-codemirror/package.json
@@ -18,10 +18,11 @@
   "dependencies": {
     "@jupyterlab/codeeditor": "^0.17.2",
     "@jupyterlab/codemirror": "^0.17.3",
-    "expect.js": "~0.3.1",
+    "chai": "~4.1.2",
     "simulate-event": "~1.4.0"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-codemirror/src/editor.spec.ts
+++ b/tests/test-codemirror/src/editor.spec.ts
@@ -4,7 +4,7 @@
 // tslint:disable-next-line
 /// <reference path="../../../packages/codemirror/typings/codemirror/codemirror.d.ts"/>
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { generate, simulate } from 'simulate-event';
 
@@ -48,117 +48,119 @@ describe('CodeMirrorEditor', () => {
 
   describe('#constructor()', () => {
     it('should create a CodeMirrorEditor', () => {
-      expect(editor).to.be.a(CodeMirrorEditor);
+      expect(editor).to.be.an.instanceof(CodeMirrorEditor);
     });
   });
 
   describe('#edgeRequested', () => {
     it('should emit a signal when the top edge is requested', () => {
       let edge: CodeEditor.EdgeLocation = null;
-      let event = generate('keydown', { keyCode: UP_ARROW });
-      let listener = (sender: any, args: CodeEditor.EdgeLocation) => {
+      const event = generate('keydown', { keyCode: UP_ARROW });
+      const listener = (sender: any, args: CodeEditor.EdgeLocation) => {
         edge = args;
       };
       editor.edgeRequested.connect(listener);
-      expect(edge).to.be(null);
+      expect(edge).to.be.null;
       editor.editor.triggerOnKeyDown(event);
-      expect(edge).to.be('top');
+      expect(edge).to.equal('top');
     });
 
     it('should emit a signal when the bottom edge is requested', () => {
       let edge: CodeEditor.EdgeLocation = null;
-      let event = generate('keydown', { keyCode: DOWN_ARROW });
-      let listener = (sender: any, args: CodeEditor.EdgeLocation) => {
+      const event = generate('keydown', { keyCode: DOWN_ARROW });
+      const listener = (sender: any, args: CodeEditor.EdgeLocation) => {
         edge = args;
       };
       editor.edgeRequested.connect(listener);
-      expect(edge).to.be(null);
+      expect(edge).to.be.null;
       editor.editor.triggerOnKeyDown(event);
-      expect(edge).to.be('bottom');
+      expect(edge).to.equal('bottom');
     });
   });
 
   describe('#uuid', () => {
     it('should be the unique id of the editor', () => {
-      expect(editor.uuid).to.be.ok();
-      let uuid = 'foo';
+      expect(editor.uuid).to.be.ok;
+      const uuid = 'foo';
       editor = new LogFileEditor({ model, host, uuid });
-      expect(editor.uuid).to.be('foo');
+      expect(editor.uuid).to.equal('foo');
     });
   });
 
   describe('#selectionStyle', () => {
     it('should be the selection style of the editor', () => {
-      expect(editor.selectionStyle).to.eql(CodeEditor.defaultSelectionStyle);
+      expect(editor.selectionStyle).to.deep.equal(
+        CodeEditor.defaultSelectionStyle
+      );
     });
 
     it('should be settable', () => {
-      let style = {
+      const style = {
         className: 'foo',
         displayName: 'bar',
         color: 'black'
       };
       editor.selectionStyle = style;
-      expect(editor.selectionStyle).to.eql(style);
+      expect(editor.selectionStyle).to.deep.equal(style);
     });
   });
 
   describe('#editor', () => {
     it('should be the codemirror editor wrapped by the editor', () => {
-      let cm = editor.editor;
-      expect(cm.getDoc()).to.be(editor.doc);
+      const cm = editor.editor;
+      expect(cm.getDoc()).to.equal(editor.doc);
     });
   });
 
   describe('#doc', () => {
     it('should be the codemirror doc wrapped by the editor', () => {
-      let doc = editor.doc;
-      expect(doc.getEditor()).to.be(editor.editor);
+      const doc = editor.doc;
+      expect(doc.getEditor()).to.equal(editor.editor);
     });
   });
 
   describe('#lineCount', () => {
     it('should get the number of lines in the editor', () => {
-      expect(editor.lineCount).to.be(1);
+      expect(editor.lineCount).to.equal(1);
       editor.model.value.text = 'foo\nbar\nbaz';
-      expect(editor.lineCount).to.be(3);
+      expect(editor.lineCount).to.equal(3);
     });
   });
 
   describe('#getOption()', () => {
     it('should get whether line numbers should be shown', () => {
-      expect(editor.getOption('lineNumbers')).to.be(false);
+      expect(editor.getOption('lineNumbers')).to.equal(false);
     });
 
     it('should get whether horizontally scrolling should be used', () => {
-      expect(editor.getOption('lineWrap')).to.be('on');
+      expect(editor.getOption('lineWrap')).to.equal('on');
     });
 
     it('should get whether the editor is readonly', () => {
-      expect(editor.getOption('readOnly')).to.be(false);
+      expect(editor.getOption('readOnly')).to.equal(false);
     });
   });
 
   describe('#setOption()', () => {
     it('should set whether line numbers should be shown', () => {
       editor.setOption('lineNumbers', true);
-      expect(editor.getOption('lineNumbers')).to.be(true);
+      expect(editor.getOption('lineNumbers')).to.equal(true);
     });
 
     it('should set whether horizontally scrolling should be used', () => {
       editor.setOption('lineWrap', 'off');
-      expect(editor.getOption('lineWrap')).to.be('off');
+      expect(editor.getOption('lineWrap')).to.equal('off');
     });
 
     it('should set whether the editor is readonly', () => {
       editor.setOption('readOnly', true);
-      expect(editor.getOption('readOnly')).to.be(true);
+      expect(editor.getOption('readOnly')).to.equal(true);
     });
   });
 
   describe('#model', () => {
     it('should get the model used by the editor', () => {
-      expect(editor.model).to.be(model);
+      expect(editor.model).to.equal(model);
     });
   });
 
@@ -176,28 +178,28 @@ describe('CodeMirrorEditor', () => {
 
   describe('#isDisposed', () => {
     it('should test whether the editor is disposed', () => {
-      expect(editor.isDisposed).to.be(false);
+      expect(editor.isDisposed).to.equal(false);
       editor.dispose();
-      expect(editor.isDisposed).to.be(true);
+      expect(editor.isDisposed).to.equal(true);
     });
   });
 
   describe('#dispose()', () => {
     it('should dispose of the resources used by the editor', () => {
-      expect(editor.isDisposed).to.be(false);
+      expect(editor.isDisposed).to.equal(false);
       editor.dispose();
-      expect(editor.isDisposed).to.be(true);
+      expect(editor.isDisposed).to.equal(true);
       editor.dispose();
-      expect(editor.isDisposed).to.be(true);
+      expect(editor.isDisposed).to.equal(true);
     });
   });
 
   describe('#getLine()', () => {
     it('should get a line of text', () => {
       model.value.text = 'foo\nbar';
-      expect(editor.getLine(0)).to.be('foo');
-      expect(editor.getLine(1)).to.be('bar');
-      expect(editor.getLine(2)).to.be(void 0);
+      expect(editor.getLine(0)).to.equal('foo');
+      expect(editor.getLine(1)).to.equal('bar');
+      expect(editor.getLine(2)).to.be.undefined;
     });
   });
 
@@ -208,12 +210,12 @@ describe('CodeMirrorEditor', () => {
         column: 2,
         line: 1
       };
-      expect(editor.getOffsetAt(pos)).to.be(6);
+      expect(editor.getOffsetAt(pos)).to.equal(6);
       pos = {
         column: 2,
         line: 5
       };
-      expect(editor.getOffsetAt(pos)).to.be(7);
+      expect(editor.getOffsetAt(pos)).to.equal(7);
     });
   });
 
@@ -221,11 +223,11 @@ describe('CodeMirrorEditor', () => {
     it('should get the position for a given offset', () => {
       model.value.text = 'foo\nbar';
       let pos = editor.getPositionAt(6);
-      expect(pos.column).to.be(2);
-      expect(pos.line).to.be(1);
+      expect(pos.column).to.equal(2);
+      expect(pos.line).to.equal(1);
       pos = editor.getPositionAt(101);
-      expect(pos.column).to.be(3);
-      expect(pos.line).to.be(1);
+      expect(pos.column).to.equal(3);
+      expect(pos.line).to.equal(1);
     });
   });
 
@@ -233,7 +235,7 @@ describe('CodeMirrorEditor', () => {
     it('should undo one edit', () => {
       model.value.text = 'foo';
       editor.undo();
-      expect(model.value.text).to.be('');
+      expect(model.value.text).to.equal('');
     });
   });
 
@@ -242,7 +244,7 @@ describe('CodeMirrorEditor', () => {
       model.value.text = 'foo';
       editor.undo();
       editor.redo();
-      expect(model.value.text).to.be('foo');
+      expect(model.value.text).to.equal('foo');
     });
   });
 
@@ -251,32 +253,32 @@ describe('CodeMirrorEditor', () => {
       model.value.text = 'foo';
       editor.clearHistory();
       editor.undo();
-      expect(model.value.text).to.be('foo');
+      expect(model.value.text).to.equal('foo');
     });
   });
 
   describe('#focus()', () => {
     it('should give focus to the editor', () => {
-      expect(host.contains(document.activeElement)).to.be(false);
+      expect(host.contains(document.activeElement)).to.equal(false);
       editor.focus();
-      expect(host.contains(document.activeElement)).to.be(true);
+      expect(host.contains(document.activeElement)).to.equal(true);
     });
   });
 
   describe('#hasFocus()', () => {
     it('should test whether the editor has focus', () => {
-      expect(editor.hasFocus()).to.be(false);
+      expect(editor.hasFocus()).to.equal(false);
       editor.focus();
-      expect(editor.hasFocus()).to.be(true);
+      expect(editor.hasFocus()).to.equal(true);
     });
   });
 
   describe('#blur()', () => {
     it('should blur the editor', () => {
       editor.focus();
-      expect(host.contains(document.activeElement)).to.be(true);
+      expect(host.contains(document.activeElement)).to.equal(true);
       editor.blur();
-      expect(host.contains(document.activeElement)).to.be(false);
+      expect(host.contains(document.activeElement)).to.equal(false);
     });
   });
 
@@ -284,16 +286,16 @@ describe('CodeMirrorEditor', () => {
     context('focus', () => {
       it('should add the focus class to the host', () => {
         simulate(editor.editor.getInputField(), 'focus');
-        expect(host.classList.contains('jp-mod-focused')).to.be(true);
+        expect(host.classList.contains('jp-mod-focused')).to.equal(true);
       });
     });
 
     context('blur', () => {
       it('should remove the focus class from the host', () => {
         simulate(editor.editor.getInputField(), 'focus');
-        expect(host.classList.contains('jp-mod-focused')).to.be(true);
+        expect(host.classList.contains('jp-mod-focused')).to.equal(true);
         simulate(editor.editor.getInputField(), 'blur');
-        expect(host.classList.contains('jp-mod-focused')).to.be(false);
+        expect(host.classList.contains('jp-mod-focused')).to.equal(false);
       });
     });
   });
@@ -301,27 +303,27 @@ describe('CodeMirrorEditor', () => {
   describe('#refresh()', () => {
     it('should repaint the editor', () => {
       editor.refresh();
-      expect(editor).to.be.ok();
+      expect(editor).to.be.ok;
     });
   });
 
   describe('#addKeydownHandler()', () => {
     it('should add a keydown handler to the editor', () => {
       let called = 0;
-      let handler = () => {
+      const handler = () => {
         called++;
         return true;
       };
-      let disposable = editor.addKeydownHandler(handler);
+      const disposable = editor.addKeydownHandler(handler);
       let evt = generate('keydown', { keyCode: ENTER });
       editor.editor.triggerOnKeyDown(evt);
-      expect(called).to.be(1);
+      expect(called).to.equal(1);
       disposable.dispose();
-      expect(disposable.isDisposed).to.be(true);
+      expect(disposable.isDisposed).to.equal(true);
 
       evt = generate('keydown', { keyCode: ENTER });
       editor.editor.triggerOnKeyDown(evt);
-      expect(called).to.be(1);
+      expect(called).to.equal(1);
     });
   });
 
@@ -329,7 +331,7 @@ describe('CodeMirrorEditor', () => {
     it('should set the size of the editor in pixels', () => {
       editor.setSize({ width: 100, height: 100 });
       editor.setSize(null);
-      expect(editor).to.be.ok();
+      expect(editor).to.be.ok;
     });
   });
 
@@ -337,25 +339,25 @@ describe('CodeMirrorEditor', () => {
     it('should reveal the given position in the editor', () => {
       model.value.text = TEXT;
       editor.revealPosition({ line: 50, column: 0 });
-      expect(editor).to.be.ok();
+      expect(editor).to.be.ok;
     });
   });
 
   describe('#revealSelection()', () => {
     it('should reveal the given selection in the editor', () => {
       model.value.text = TEXT;
-      let start = { line: 50, column: 0 };
-      let end = { line: 52, column: 0 };
+      const start = { line: 50, column: 0 };
+      const end = { line: 52, column: 0 };
       editor.setSelection({ start, end });
       editor.revealSelection(editor.getSelection());
-      expect(editor).to.be.ok();
+      expect(editor).to.be.ok;
     });
   });
 
   describe('#getCoordinateForPosition()', () => {
     it('should get the window coordinates given a cursor position', () => {
       model.value.text = TEXT;
-      let coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
+      const coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
       expect(coord.left).to.be.above(0);
     });
   });
@@ -363,10 +365,10 @@ describe('CodeMirrorEditor', () => {
   describe('#getPositionForCoordinate()', () => {
     it('should get the window coordinates given a cursor position', () => {
       model.value.text = TEXT;
-      let coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
-      let newPos = editor.getPositionForCoordinate(coord);
-      expect(newPos.line).to.be.ok();
-      expect(newPos.column).to.ok();
+      const coord = editor.getCoordinateForPosition({ line: 10, column: 1 });
+      const newPos = editor.getPositionForCoordinate(coord);
+      expect(newPos.line).to.be.ok;
+      expect(newPos.column).to.be.ok;
     });
   });
 
@@ -374,13 +376,13 @@ describe('CodeMirrorEditor', () => {
     it('should get the primary position of the cursor', () => {
       model.value.text = TEXT;
       let pos = editor.getCursorPosition();
-      expect(pos.line).to.be(0);
-      expect(pos.column).to.be(0);
+      expect(pos.line).to.equal(0);
+      expect(pos.column).to.equal(0);
 
       editor.setCursorPosition({ line: 12, column: 3 });
       pos = editor.getCursorPosition();
-      expect(pos.line).to.be(12);
-      expect(pos.column).to.be(3);
+      expect(pos.line).to.equal(12);
+      expect(pos.column).to.equal(3);
     });
   });
 
@@ -388,93 +390,93 @@ describe('CodeMirrorEditor', () => {
     it('should set the primary position of the cursor', () => {
       model.value.text = TEXT;
       editor.setCursorPosition({ line: 12, column: 3 });
-      let pos = editor.getCursorPosition();
-      expect(pos.line).to.be(12);
-      expect(pos.column).to.be(3);
+      const pos = editor.getCursorPosition();
+      expect(pos.line).to.equal(12);
+      expect(pos.column).to.equal(3);
     });
   });
 
   describe('#getSelection()', () => {
     it('should get the primary selection of the editor', () => {
-      let selection = editor.getSelection();
-      expect(selection.start.line).to.be(0);
-      expect(selection.end.line).to.be(0);
+      const selection = editor.getSelection();
+      expect(selection.start.line).to.equal(0);
+      expect(selection.end.line).to.equal(0);
     });
   });
 
   describe('#setSelection()', () => {
     it('should set the primary selection of the editor', () => {
       model.value.text = TEXT;
-      let start = { line: 50, column: 0 };
-      let end = { line: 52, column: 0 };
+      const start = { line: 50, column: 0 };
+      const end = { line: 52, column: 0 };
       editor.setSelection({ start, end });
-      expect(editor.getSelection().start).to.eql(start);
-      expect(editor.getSelection().end).to.eql(end);
+      expect(editor.getSelection().start).to.deep.equal(start);
+      expect(editor.getSelection().end).to.deep.equal(end);
     });
 
     it('should remove any secondary cursors', () => {
       model.value.text = TEXT;
-      let range0 = {
+      const range0 = {
         start: { line: 50, column: 0 },
         end: { line: 52, column: 0 }
       };
-      let range1 = {
+      const range1 = {
         start: { line: 53, column: 0 },
         end: { line: 54, column: 0 }
       };
       editor.setSelections([range0, range1]);
       editor.setSelection(range1);
-      expect(editor.getSelections().length).to.be(1);
+      expect(editor.getSelections().length).to.equal(1);
     });
   });
 
   describe('#getSelections()', () => {
     it('should get the selections for all the cursors', () => {
       model.value.text = TEXT;
-      let range0 = {
+      const range0 = {
         start: { line: 50, column: 0 },
         end: { line: 52, column: 0 }
       };
-      let range1 = {
+      const range1 = {
         start: { line: 53, column: 0 },
         end: { line: 54, column: 0 }
       };
       editor.setSelections([range0, range1]);
-      let selections = editor.getSelections();
-      expect(selections[0].start.line).to.be(50);
-      expect(selections[1].end.line).to.be(54);
+      const selections = editor.getSelections();
+      expect(selections[0].start.line).to.equal(50);
+      expect(selections[1].end.line).to.equal(54);
     });
   });
 
   describe('#setSelections()', () => {
     it('should set the selections for all the cursors', () => {
       model.value.text = TEXT;
-      let range0 = {
+      const range0 = {
         start: { line: 50, column: 0 },
         end: { line: 52, column: 0 }
       };
-      let range1 = {
+      const range1 = {
         start: { line: 53, column: 0 },
         end: { line: 54, column: 0 }
       };
       editor.setSelections([range0, range1]);
-      let selections = editor.getSelections();
-      expect(selections[0].start.line).to.be(50);
-      expect(selections[1].end.line).to.be(54);
+      const selections = editor.getSelections();
+      expect(selections[0].start.line).to.equal(50);
+      expect(selections[1].end.line).to.equal(54);
     });
 
     it('should set a default selection for an empty array', () => {
       model.value.text = TEXT;
       editor.setSelections([]);
-      let selection = editor.getSelection();
-      expect(selection.start.line).to.be(0);
-      expect(selection.end.line).to.be(0);
+      const selection = editor.getSelection();
+      expect(selection.start.line).to.equal(0);
+      expect(selection.end.line).to.equal(0);
     });
   });
 
   describe('#onKeydown()', () => {
     it('should run when there is a keydown event on the editor', () => {
-      let event = generate('keydown', { keyCode: UP_ARROW });
+      const event = generate('keydown', { keyCode: UP_ARROW });
       expect(editor.methods).to.not.contain('onKeydown');
       editor.editor.triggerOnKeyDown(event);
       expect(editor.methods).to.contain('onKeydown');

--- a/tests/test-codemirror/src/factory.spec.ts
+++ b/tests/test-codemirror/src/factory.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
@@ -39,17 +39,17 @@ describe('CodeMirrorEditorFactory', () => {
 
   describe('#constructor()', () => {
     it('should create a CodeMirrorEditorFactory', () => {
-      let factory = new CodeMirrorEditorFactory();
-      expect(factory).to.be.a(CodeMirrorEditorFactory);
+      const factory = new CodeMirrorEditorFactory();
+      expect(factory).to.be.an.instanceof(CodeMirrorEditorFactory);
     });
 
     it('should create a CodeMirrorEditorFactory', () => {
-      let factory = new ExposeCodeMirrorEditorFactory(options);
-      expect(factory).to.be.a(CodeMirrorEditorFactory);
-      expect(factory.inlineCodeMirrorConfig.extraKeys).to.eql(
+      const factory = new ExposeCodeMirrorEditorFactory(options);
+      expect(factory).to.be.an.instanceof(CodeMirrorEditorFactory);
+      expect(factory.inlineCodeMirrorConfig.extraKeys).to.deep.equal(
         options.extraKeys
       );
-      expect(factory.documentCodeMirrorConfig.extraKeys).to.eql(
+      expect(factory.documentCodeMirrorConfig.extraKeys).to.deep.equal(
         options.extraKeys
       );
     });
@@ -57,18 +57,21 @@ describe('CodeMirrorEditorFactory', () => {
 
   describe('#newInlineEditor', () => {
     it('should create a new editor', () => {
-      let factory = new CodeMirrorEditorFactory();
-      let editor = factory.newInlineEditor({ host, model });
-      expect(editor).to.be.a(CodeMirrorEditor);
+      const factory = new CodeMirrorEditorFactory();
+      const editor = factory.newInlineEditor({ host, model });
+      expect(editor).to.be.an.instanceof(CodeMirrorEditor);
       editor.dispose();
     });
 
     it('should create a new editor with given options', () => {
-      let factory = new CodeMirrorEditorFactory(options);
-      let editor = factory.newInlineEditor({ host, model }) as CodeMirrorEditor;
-      expect(editor).to.be.a(CodeMirrorEditor);
+      const factory = new CodeMirrorEditorFactory(options);
+      const editor = factory.newInlineEditor({
+        host,
+        model
+      }) as CodeMirrorEditor;
+      expect(editor).to.be.an.instanceof(CodeMirrorEditor);
       for (let key in Object.keys(options)) {
-        let option = key as keyof CodeMirrorEditor.IConfig;
+        const option = key as keyof CodeMirrorEditor.IConfig;
         expect(editor.getOption(option)).to.equal(options[option]);
       }
       editor.dispose();
@@ -77,21 +80,21 @@ describe('CodeMirrorEditorFactory', () => {
 
   describe('#newDocumentEditor', () => {
     it('should create a new editor', () => {
-      let factory = new CodeMirrorEditorFactory();
-      let editor = factory.newDocumentEditor({ host, model });
-      expect(editor).to.be.a(CodeMirrorEditor);
+      const factory = new CodeMirrorEditorFactory();
+      const editor = factory.newDocumentEditor({ host, model });
+      expect(editor).to.be.an.instanceof(CodeMirrorEditor);
       editor.dispose();
     });
 
     it('should create a new editor with given options', () => {
-      let factory = new CodeMirrorEditorFactory(options);
-      let editor = factory.newDocumentEditor({
+      const factory = new CodeMirrorEditorFactory(options);
+      const editor = factory.newDocumentEditor({
         host,
         model
       }) as CodeMirrorEditor;
-      expect(editor).to.be.a(CodeMirrorEditor);
+      expect(editor).to.be.an.instanceof(CodeMirrorEditor);
       for (let key in Object.keys(options)) {
-        let option = key as keyof CodeMirrorEditor.IConfig;
+        const option = key as keyof CodeMirrorEditor.IConfig;
         expect(editor.getOption(option)).to.equal(options[option]);
       }
       editor.dispose();

--- a/tests/test-coreutils/package.json
+++ b/tests/test-coreutils/package.json
@@ -19,7 +19,8 @@
     "@jupyterlab/coreutils": "^2.0.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/signaling": "^1.2.2",
-    "chai": "~4.1.2"
+    "chai": "~4.1.2",
+    "expect.js": "~0.3.1"
   },
   "devDependencies": {
     "karma": "~2.0.4",

--- a/tests/test-coreutils/package.json
+++ b/tests/test-coreutils/package.json
@@ -19,10 +19,10 @@
     "@jupyterlab/coreutils": "^2.0.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/signaling": "^1.2.2",
-    "chai": "~4.1.2",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-coreutils/package.json
+++ b/tests/test-coreutils/package.json
@@ -19,8 +19,7 @@
     "@jupyterlab/coreutils": "^2.0.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/signaling": "^1.2.2",
-    "chai": "~4.1.2",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
     "karma": "~2.0.4",

--- a/tests/test-coreutils/src/activitymonitor.spec.ts
+++ b/tests/test-coreutils/src/activitymonitor.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Signal } from '@phosphor/signaling';
 
@@ -26,7 +26,7 @@ describe('@jupyterlab/coreutils', () => {
     describe('#constructor()', () => {
       it('should accept a signal', () => {
         let monitor = new ActivityMonitor<TestObject, number>({ signal });
-        expect(monitor).to.be.an(ActivityMonitor);
+        expect(monitor).to.be.an.instanceof(ActivityMonitor);
       });
 
       it('should accept a timeout', () => {
@@ -34,7 +34,7 @@ describe('@jupyterlab/coreutils', () => {
           signal: testObj.two,
           timeout: 100
         });
-        expect(monitor).to.be.an(ActivityMonitor);
+        expect(monitor).to.be.an.instanceof(ActivityMonitor);
       });
     });
 
@@ -43,15 +43,15 @@ describe('@jupyterlab/coreutils', () => {
         let called = false;
         let monitor = new ActivityMonitor({ signal, timeout: 100 });
         monitor.activityStopped.connect((sender, args) => {
-          expect(sender).to.be(monitor);
-          expect(args.sender).to.be(testObj);
-          expect(args.args).to.be(10);
+          expect(sender).to.equal(monitor);
+          expect(args.sender).to.equal(testObj);
+          expect(args.args).to.equal(10);
           called = true;
         });
         signal.emit(10);
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
         setTimeout(() => {
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
           done();
         }, 100);
       });
@@ -60,22 +60,22 @@ describe('@jupyterlab/coreutils', () => {
     describe('#timeout', () => {
       it('should default to `1000`', () => {
         let monitor = new ActivityMonitor<TestObject, number>({ signal });
-        expect(monitor.timeout).to.be(1000);
+        expect(monitor.timeout).to.equal(1000);
       });
 
       it('should be set-able', () => {
         let monitor = new ActivityMonitor<TestObject, number>({ signal });
         monitor.timeout = 200;
-        expect(monitor.timeout).to.be(200);
+        expect(monitor.timeout).to.equal(200);
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether the monitor is disposed', () => {
         let monitor = new ActivityMonitor<TestObject, number>({ signal });
-        expect(monitor.isDisposed).to.be(false);
+        expect(monitor.isDisposed).to.equal(false);
         monitor.dispose();
-        expect(monitor.isDisposed).to.be(true);
+        expect(monitor.isDisposed).to.equal(true);
       });
     });
 
@@ -83,14 +83,14 @@ describe('@jupyterlab/coreutils', () => {
       it('should dispose of the resources used by the monitor', () => {
         let monitor = new ActivityMonitor<TestObject, number>({ signal });
         monitor.dispose();
-        expect(monitor.isDisposed).to.be(true);
+        expect(monitor.isDisposed).to.equal(true);
       });
 
       it('should be a no-op if called more than once', () => {
         let monitor = new ActivityMonitor<TestObject, number>({ signal });
         monitor.dispose();
         monitor.dispose();
-        expect(monitor.isDisposed).to.be(true);
+        expect(monitor.isDisposed).to.equal(true);
       });
     });
   });

--- a/tests/test-coreutils/src/activitymonitor.spec.ts
+++ b/tests/test-coreutils/src/activitymonitor.spec.ts
@@ -25,12 +25,12 @@ describe('@jupyterlab/coreutils', () => {
 
     describe('#constructor()', () => {
       it('should accept a signal', () => {
-        let monitor = new ActivityMonitor<TestObject, number>({ signal });
+        const monitor = new ActivityMonitor<TestObject, number>({ signal });
         expect(monitor).to.be.an.instanceof(ActivityMonitor);
       });
 
       it('should accept a timeout', () => {
-        let monitor = new ActivityMonitor<TestObject, string[]>({
+        const monitor = new ActivityMonitor<TestObject, string[]>({
           signal: testObj.two,
           timeout: 100
         });
@@ -41,7 +41,7 @@ describe('@jupyterlab/coreutils', () => {
     describe('#activityStopped', () => {
       it('should be emitted after the signal has fired and a timeout', done => {
         let called = false;
-        let monitor = new ActivityMonitor({ signal, timeout: 100 });
+        const monitor = new ActivityMonitor({ signal, timeout: 100 });
         monitor.activityStopped.connect((sender, args) => {
           expect(sender).to.equal(monitor);
           expect(args.sender).to.equal(testObj);
@@ -59,12 +59,12 @@ describe('@jupyterlab/coreutils', () => {
 
     describe('#timeout', () => {
       it('should default to `1000`', () => {
-        let monitor = new ActivityMonitor<TestObject, number>({ signal });
+        const monitor = new ActivityMonitor<TestObject, number>({ signal });
         expect(monitor.timeout).to.equal(1000);
       });
 
       it('should be set-able', () => {
-        let monitor = new ActivityMonitor<TestObject, number>({ signal });
+        const monitor = new ActivityMonitor<TestObject, number>({ signal });
         monitor.timeout = 200;
         expect(monitor.timeout).to.equal(200);
       });
@@ -72,7 +72,7 @@ describe('@jupyterlab/coreutils', () => {
 
     describe('#isDisposed', () => {
       it('should test whether the monitor is disposed', () => {
-        let monitor = new ActivityMonitor<TestObject, number>({ signal });
+        const monitor = new ActivityMonitor<TestObject, number>({ signal });
         expect(monitor.isDisposed).to.equal(false);
         monitor.dispose();
         expect(monitor.isDisposed).to.equal(true);
@@ -81,13 +81,13 @@ describe('@jupyterlab/coreutils', () => {
 
     describe('#dispose()', () => {
       it('should dispose of the resources used by the monitor', () => {
-        let monitor = new ActivityMonitor<TestObject, number>({ signal });
+        const monitor = new ActivityMonitor<TestObject, number>({ signal });
         monitor.dispose();
         expect(monitor.isDisposed).to.equal(true);
       });
 
       it('should be a no-op if called more than once', () => {
-        let monitor = new ActivityMonitor<TestObject, number>({ signal });
+        const monitor = new ActivityMonitor<TestObject, number>({ signal });
         monitor.dispose();
         monitor.dispose();
         expect(monitor.isDisposed).to.equal(true);

--- a/tests/test-coreutils/src/markdowncodeblocks.spec.ts
+++ b/tests/test-coreutils/src/markdowncodeblocks.spec.ts
@@ -12,26 +12,26 @@ describe('@jupyterlab/coreutils', () => {
   describe('MarkdownCodeBlocks', () => {
     describe('.isMarkdown()', () => {
       it('should return true for a valid markdown extension', () => {
-        let isMarkdown = MarkdownCodeBlocks.isMarkdown('.md');
+        const isMarkdown = MarkdownCodeBlocks.isMarkdown('.md');
         expect(isMarkdown).to.equal(true);
       });
     });
 
     describe('.findMarkdownCodeBlocks()', () => {
       it('should find a simple block', () => {
-        let codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK1);
+        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK1);
         expect(codeblocks.length).to.equal(1);
         expect(codeblocks[0].code).to.equal('a = 10\nb = 20\n');
       });
 
       it('should find a single line block', () => {
-        let codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK2);
+        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK2);
         expect(codeblocks.length).to.equal(1);
         expect(codeblocks[0].code).to.equal('a = 10');
       });
 
       it('should find a block with a language', () => {
-        let codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK1);
+        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK1);
         expect(codeblocks.length).to.equal(1);
         expect(codeblocks[0].code).to.equal('a = 10\nb = 20\n');
       });

--- a/tests/test-coreutils/src/path.spec.ts
+++ b/tests/test-coreutils/src/path.spec.ts
@@ -11,12 +11,12 @@ describe('@jupyterlab/coreutils', () => {
   describe('PathExt', () => {
     describe('.join()', () => {
       it('should join the arguments and normalize the path', () => {
-        let path = PathExt.join('foo', '../../../bar');
+        const path = PathExt.join('foo', '../../../bar');
         expect(path).to.equal('../../bar');
       });
 
       it('should not return "." for an empty path', () => {
-        let path = PathExt.join('', '');
+        const path = PathExt.join('', '');
         expect(path).to.equal('');
       });
     });
@@ -33,12 +33,12 @@ describe('@jupyterlab/coreutils', () => {
       });
 
       it('should not return "." for an empty path', () => {
-        let path = PathExt.dirname('');
+        const path = PathExt.dirname('');
         expect(path).to.equal('');
       });
 
       it('should not return "." for a path in the root directory', () => {
-        let path = PathExt.dirname('foo.txt');
+        const path = PathExt.dirname('foo.txt');
         expect(path).to.equal('');
       });
     });
@@ -55,26 +55,26 @@ describe('@jupyterlab/coreutils', () => {
 
     describe('.normalize()', () => {
       it('should normalize a string path', () => {
-        let path = PathExt.normalize('./fixtures///b/../b/c.js');
+        const path = PathExt.normalize('./fixtures///b/../b/c.js');
         expect(path).to.equal('fixtures/b/c.js');
       });
 
       it('should not return "." for an empty path', () => {
-        let path = PathExt.normalize('');
+        const path = PathExt.normalize('');
         expect(path).to.equal('');
       });
     });
 
     describe('.resolve()', () => {
       it('should resolve a sequence of paths to an absolute path on the server', () => {
-        let path = PathExt.resolve('var/lib', '../', 'file/');
+        const path = PathExt.resolve('var/lib', '../', 'file/');
         expect(path).to.equal('var/file');
       });
     });
 
     describe('.relative()', () => {
       it('should solve the relative path', () => {
-        let path = PathExt.relative('var/lib', 'var/apache');
+        const path = PathExt.relative('var/lib', 'var/apache');
         expect(path).to.equal('../apache');
       });
     });

--- a/tests/test-coreutils/src/settingregistry.spec.ts
+++ b/tests/test-coreutils/src/settingregistry.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import {
   DefaultSchemaValidator,
@@ -45,7 +45,7 @@ describe('@jupyterlab/coreutils', () => {
       it('should create a new schema validator', () => {
         const validator = new DefaultSchemaValidator();
 
-        expect(validator).to.be.a(DefaultSchemaValidator);
+        expect(validator).to.be.an.instanceof(DefaultSchemaValidator);
       });
     });
 
@@ -66,7 +66,7 @@ describe('@jupyterlab/coreutils', () => {
         const plugin = { id, data: { composite, user }, raw, schema };
         const errors = validator.validateData(plugin);
 
-        expect(errors).to.be(null);
+        expect(errors).to.equal(null);
       });
 
       it('should return errors if the data fails to validate', () => {
@@ -85,7 +85,7 @@ describe('@jupyterlab/coreutils', () => {
         const plugin = { id, data: { composite, user }, raw, schema };
         const errors = validator.validateData(plugin);
 
-        expect(errors).to.not.be(null);
+        expect(errors).to.not.equal(null);
       });
 
       it('should populate the composite data', () => {
@@ -104,9 +104,11 @@ describe('@jupyterlab/coreutils', () => {
         const plugin = { id, data: { composite, user }, raw, schema };
         const errors = validator.validateData(plugin);
 
-        expect(errors).to.be(null);
-        expect(plugin.data.user.bar).to.be(undefined);
-        expect(plugin.data.composite.bar).to.be(schema.properties.bar.default);
+        expect(errors).to.equal(null);
+        expect(plugin.data.user.bar).to.equal(undefined);
+        expect(plugin.data.composite.bar).to.equal(
+          schema.properties.bar.default
+        );
       });
     });
   });
@@ -126,7 +128,7 @@ describe('@jupyterlab/coreutils', () => {
 
     describe('#constructor()', () => {
       it('should create a new setting registry', () => {
-        expect(registry).to.be.a(SettingRegistry);
+        expect(registry).to.be.an.instanceof(SettingRegistry);
       });
     });
 
@@ -138,7 +140,7 @@ describe('@jupyterlab/coreutils', () => {
 
         connector.schemas[id] = { type: 'object' };
         registry.pluginChanged.connect((sender: any, plugin: string) => {
-          expect(id).to.be(plugin);
+          expect(id).to.equal(plugin);
           done();
         });
         registry
@@ -153,7 +155,7 @@ describe('@jupyterlab/coreutils', () => {
         const one = 'foo';
         const two = 'bar';
 
-        expect(registry.plugins).to.be.empty();
+        expect(registry.plugins.length).to.equal(0);
         connector.schemas[one] = { type: 'object' };
         connector.schemas[two] = { type: 'object' };
         registry
@@ -182,7 +184,7 @@ describe('@jupyterlab/coreutils', () => {
           .then(() => registry.load(id))
           .then(() => registry.get(id, key))
           .then(saved => {
-            expect(saved.user).to.be(value);
+            expect(saved.user).to.equal(value);
           })
           .then(done)
           .catch(done);
@@ -198,7 +200,7 @@ describe('@jupyterlab/coreutils', () => {
           .save(id, JSON.stringify({ [key]: value }))
           .then(() => registry.get(id, key))
           .then(saved => {
-            expect(saved.composite).to.be(value);
+            expect(saved.composite).to.equal(value);
           })
           .then(done)
           .catch(done);
@@ -218,8 +220,8 @@ describe('@jupyterlab/coreutils', () => {
         registry
           .get(id, key)
           .then(saved => {
-            expect(saved.composite).to.be(schema.properties[key].default);
-            expect(saved.composite).to.not.be(saved.user);
+            expect(saved.composite).to.equal(schema.properties[key].default);
+            expect(saved.composite).to.not.equal(saved.user);
           })
           .then(done)
           .catch(done);
@@ -240,10 +242,12 @@ describe('@jupyterlab/coreutils', () => {
           .save(id, JSON.stringify({ [key]: value }))
           .then(() => registry.get(id, key))
           .then(saved => {
-            expect(saved.composite).to.be(value);
-            expect(saved.user).to.be(value);
-            expect(saved.composite).to.not.be(schema.properties[key].default);
-            expect(saved.user).to.not.be(schema.properties[key].default);
+            expect(saved.composite).to.equal(value);
+            expect(saved.user).to.equal(value);
+            expect(saved.composite).to.not.equal(
+              schema.properties[key].default
+            );
+            expect(saved.user).to.not.equal(schema.properties[key].default);
           })
           .then(done)
           .catch(done);
@@ -269,8 +273,8 @@ describe('@jupyterlab/coreutils', () => {
         registry
           .get(id, key)
           .then(saved => {
-            expect(saved.composite).to.be(void 0);
-            expect(saved.user).to.be(void 0);
+            expect(saved.composite).to.equal(void 0);
+            expect(saved.user).to.equal(void 0);
           })
           .then(done)
           .catch(done);
@@ -281,12 +285,12 @@ describe('@jupyterlab/coreutils', () => {
       it(`should resolve a registered plugin's settings`, done => {
         const id = 'foo';
 
-        expect(registry.plugins).to.be.empty();
+        expect(registry.plugins.length).to.equal(0);
         connector.schemas[id] = { type: 'object' };
         registry
           .load(id)
           .then(settings => {
-            expect(settings.plugin).to.be(id);
+            expect(settings.plugin).to.equal(id);
           })
           .then(done)
           .catch(done);
@@ -308,12 +312,12 @@ describe('@jupyterlab/coreutils', () => {
       it(`should load a registered plugin's settings`, done => {
         const id = 'foo';
 
-        expect(registry.plugins).to.be.empty();
+        expect(registry.plugins.length).to.equal(0);
         connector.schemas[id] = { type: 'object' };
         registry
           .reload(id)
           .then(settings => {
-            expect(settings.plugin).to.be(id);
+            expect(settings.plugin).to.equal(id);
           })
           .then(done)
           .catch(done);
@@ -324,19 +328,19 @@ describe('@jupyterlab/coreutils', () => {
         const first = 'Foo';
         const second = 'Bar';
 
-        expect(registry.plugins).to.be.empty();
+        expect(registry.plugins.length).to.equal(0);
         connector.schemas[id] = { type: 'object', title: first };
         registry
           .reload(id)
           .then(settings => {
-            expect(settings.schema.title).to.be(first);
+            expect(settings.schema.title).to.equal(first);
           })
           .then(() => {
             connector.schemas[id].title = second;
           })
           .then(() => registry.reload(id))
           .then(settings => {
-            expect(settings.schema.title).to.be(second);
+            expect(settings.schema.title).to.equal(second);
           })
           .then(done)
           .catch(done);
@@ -382,7 +386,7 @@ describe('@jupyterlab/coreutils', () => {
         const plugin = { id, data, raw, schema };
 
         settings = new Settings({ plugin, registry });
-        expect(settings).to.be.a(Settings);
+        expect(settings).to.be.an.instanceof(Settings);
       });
     });
 
@@ -467,9 +471,9 @@ describe('@jupyterlab/coreutils', () => {
         const plugin = { id, data, raw, schema };
 
         settings = new Settings({ plugin, registry });
-        expect(settings.isDisposed).to.be(false);
+        expect(settings.isDisposed).to.equal(false);
         settings.dispose();
-        expect(settings.isDisposed).to.be(true);
+        expect(settings.isDisposed).to.equal(true);
       });
     });
 
@@ -482,7 +486,7 @@ describe('@jupyterlab/coreutils', () => {
         const plugin = { id, data, raw, schema };
 
         settings = new Settings({ plugin, registry });
-        expect(settings.schema).to.eql(schema);
+        expect(settings.schema).to.deep.equal(schema);
       });
     });
 
@@ -535,7 +539,7 @@ describe('@jupyterlab/coreutils', () => {
         const plugin = { id, data, raw, schema };
 
         settings = new Settings({ plugin, registry });
-        expect(settings.registry).to.be(registry);
+        expect(settings.registry).to.equal(registry);
       });
     });
 
@@ -548,9 +552,9 @@ describe('@jupyterlab/coreutils', () => {
         const plugin = { id, data, raw, schema };
 
         settings = new Settings({ plugin, registry });
-        expect(settings.isDisposed).to.be(false);
+        expect(settings.isDisposed).to.equal(false);
         settings.dispose();
-        expect(settings.isDisposed).to.be(true);
+        expect(settings.isDisposed).to.equal(true);
       });
     });
 
@@ -604,11 +608,11 @@ describe('@jupyterlab/coreutils', () => {
         registry
           .load(id)
           .then(settings => {
-            expect(settings.default('nonexistent-key')).to.be(undefined);
-            expect(settings.default('foo')).to.be(defaults.foo);
-            expect(settings.default('bar')).to.be(defaults.bar);
-            expect(settings.default('baz')).to.eql(defaults.baz);
-            expect(settings.default('nonexistent-default')).to.be(undefined);
+            expect(settings.default('nonexistent-key')).to.equal(undefined);
+            expect(settings.default('foo')).to.equal(defaults.foo);
+            expect(settings.default('bar')).to.equal(defaults.bar);
+            expect(settings.default('baz')).to.deep.equal(defaults.baz);
+            expect(settings.default('nonexistent-default')).to.equal(undefined);
           })
           .then(done)
           .catch(done);
@@ -628,7 +632,7 @@ describe('@jupyterlab/coreutils', () => {
           .then(s => {
             const saved = (settings = s as Settings).get(key);
 
-            expect(saved.user).to.be(value);
+            expect(saved.user).to.equal(value);
           })
           .then(done)
           .catch(done);
@@ -650,8 +654,8 @@ describe('@jupyterlab/coreutils', () => {
           .then(s => {
             const saved = (settings = s as Settings).get(key);
 
-            expect(saved.composite).to.be(schema.properties[key].default);
-            expect(saved.composite).to.not.be(saved.user);
+            expect(saved.composite).to.equal(schema.properties[key].default);
+            expect(saved.composite).to.not.equal(saved.user);
           })
           .then(done)
           .catch(done);
@@ -674,10 +678,12 @@ describe('@jupyterlab/coreutils', () => {
           .then(s => {
             const saved = (settings = s as Settings).get(key);
 
-            expect(saved.composite).to.be(value);
-            expect(saved.user).to.be(value);
-            expect(saved.composite).to.not.be(schema.properties[key].default);
-            expect(saved.user).to.not.be(schema.properties[key].default);
+            expect(saved.composite).to.equal(value);
+            expect(saved.user).to.equal(value);
+            expect(saved.composite).to.not.equal(
+              schema.properties[key].default
+            );
+            expect(saved.user).to.not.equal(schema.properties[key].default);
           })
           .then(done)
           .catch(done);
@@ -694,8 +700,8 @@ describe('@jupyterlab/coreutils', () => {
           .then(s => {
             const saved = (settings = s as Settings).get(key);
 
-            expect(saved.composite).to.be(void 0);
-            expect(saved.user).to.be(void 0);
+            expect(saved.composite).to.equal(void 0);
+            expect(saved.user).to.equal(void 0);
           })
           .then(done)
           .catch(done);
@@ -715,14 +721,14 @@ describe('@jupyterlab/coreutils', () => {
           .then(s => {
             const saved = (settings = s as Settings).get(key);
 
-            expect(saved.user).to.be(value);
+            expect(saved.user).to.equal(value);
             return settings.remove(key);
           })
           .then(() => {
             const saved = settings.get(key);
 
-            expect(saved.composite).to.be(void 0);
-            expect(saved.user).to.be(void 0);
+            expect(saved.composite).to.equal(void 0);
+            expect(saved.user).to.equal(void 0);
           })
           .then(done)
           .catch(done);
@@ -746,13 +752,13 @@ describe('@jupyterlab/coreutils', () => {
           .then(() => {
             let saved = settings.get('one');
 
-            expect(saved.composite).to.be(one);
-            expect(saved.user).to.be(one);
+            expect(saved.composite).to.equal(one);
+            expect(saved.user).to.equal(one);
 
             saved = settings.get('two');
 
-            expect(saved.composite).to.be(two);
-            expect(saved.user).to.be(two);
+            expect(saved.composite).to.equal(two);
+            expect(saved.user).to.equal(two);
           })
           .then(done)
           .catch(done);
@@ -773,8 +779,8 @@ describe('@jupyterlab/coreutils', () => {
           .then(() => {
             let saved = settings.get('one');
 
-            expect(saved.composite).to.be(one);
-            expect(saved.user).to.be(one);
+            expect(saved.composite).to.equal(one);
+            expect(saved.user).to.equal(one);
           })
           .then(done)
           .catch(done);

--- a/tests/test-coreutils/src/statedb.spec.ts
+++ b/tests/test-coreutils/src/statedb.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { StateDB } from '@jupyterlab/coreutils';
 
@@ -15,7 +15,7 @@ describe('StateDB', () => {
   describe('#constructor()', () => {
     it('should create a state database', () => {
       let db = new StateDB({ namespace: 'test' });
-      expect(db).to.be.a(StateDB);
+      expect(db).to.be.an.instanceof(StateDB);
     });
 
     it('should allow an overwrite data transformation', done => {
@@ -35,14 +35,14 @@ describe('StateDB', () => {
         .save(key, incorrect)
         .then(() => prepopulate.fetch(key))
         .then(value => {
-          expect(value).to.be(incorrect);
+          expect(value).to.equal(incorrect);
         })
         .then(() => {
           transform.resolve(transformation);
         })
         .then(() => db.fetch(key))
         .then(value => {
-          expect(value).to.be(correct);
+          expect(value).to.equal(correct);
         })
         .then(() => db.clear())
         .then(done)
@@ -61,11 +61,11 @@ describe('StateDB', () => {
         .save('foo', 'bar')
         .then(() => db.fetch('foo'))
         .then(saved => {
-          expect(saved).to.be('bar');
+          expect(saved).to.equal('bar');
         })
         .then(() => db.fetch(key))
         .then(saved => {
-          expect(saved).to.be(value);
+          expect(saved).to.equal(value);
         })
         .then(() => db.clear())
         .then(done)
@@ -96,7 +96,7 @@ describe('StateDB', () => {
         .then(() => db.save('bar', 1))
         .then(() => db.remove('bar'))
         .then(() => {
-          expect(recorded).to.eql(changes);
+          expect(recorded).to.deep.equal(changes);
         })
         .then(() => db.clear())
         .then(done)
@@ -124,7 +124,7 @@ describe('StateDB', () => {
     it('should be the read-only internal namespace', () => {
       let namespace = 'test-namespace';
       let db = new StateDB({ namespace });
-      expect(db.namespace).to.be(namespace);
+      expect(db.namespace).to.equal(namespace);
     });
   });
 
@@ -136,7 +136,7 @@ describe('StateDB', () => {
       let key = 'foo:bar';
       let value = { qux: 'quux' };
 
-      expect(localStorage.length).to.be(0);
+      expect(localStorage.length).to.equal(0);
       db
         .save(key, value)
         .then(() => {
@@ -144,7 +144,7 @@ describe('StateDB', () => {
         })
         .then(() => db.clear())
         .then(() => {
-          expect(localStorage).to.be.empty();
+          expect(localStorage.length).to.equal(0);
         })
         .then(done)
         .catch(done);
@@ -156,7 +156,7 @@ describe('StateDB', () => {
       let db1 = new StateDB({ namespace: 'test-namespace-1' });
       let db2 = new StateDB({ namespace: 'test-namespace-2' });
 
-      expect(localStorage.length).to.be(0);
+      expect(localStorage.length).to.equal(0);
       db1
         .save('foo', { bar: null })
         .then(() => {
@@ -172,7 +172,7 @@ describe('StateDB', () => {
         })
         .then(() => db2.clear())
         .then(() => {
-          expect(localStorage).to.be.empty();
+          expect(localStorage.length).to.equal(0);
         })
         .then(done)
         .catch(done);
@@ -187,7 +187,7 @@ describe('StateDB', () => {
       let key = 'foo:bar';
       let value = { baz: 'qux' };
 
-      expect(localStorage.length).to.be(0);
+      expect(localStorage.length).to.equal(0);
       db
         .save(key, value)
         .then(() => {
@@ -195,7 +195,7 @@ describe('StateDB', () => {
         })
         .then(() => db.fetch(key))
         .then(fetched => {
-          expect(fetched).to.eql(value);
+          expect(fetched).to.deep.equal(value);
         })
         .then(() => db.clear())
         .then(done)
@@ -208,11 +208,11 @@ describe('StateDB', () => {
       let db = new StateDB({ namespace: 'test-namespace' });
       let key = 'foo:bar';
 
-      expect(localStorage.length).to.be(0);
+      expect(localStorage.length).to.equal(0);
       db
         .fetch(key)
         .then(fetched => {
-          expect(fetched).to.be(undefined);
+          expect(fetched).to.equal(undefined);
         })
         .then(done)
         .catch(done);
@@ -233,7 +233,7 @@ describe('StateDB', () => {
         'abc:jkl'
       ];
 
-      expect(localStorage.length).to.be(0);
+      expect(localStorage.length).to.equal(0);
       let promises = keys.map(key => db.save(key, { value: key }));
       Promise.all(promises)
         .then(() => {
@@ -241,23 +241,23 @@ describe('StateDB', () => {
         })
         .then(() => db.fetchNamespace('foo'))
         .then(fetched => {
-          expect(fetched.length).to.be(3);
+          expect(fetched.length).to.equal(3);
 
           let sorted = fetched.sort((a, b) => a.id.localeCompare(b.id));
 
-          expect(sorted[0].id).to.be(keys[0]);
-          expect(sorted[1].id).to.be(keys[1]);
-          expect(sorted[2].id).to.be(keys[2]);
+          expect(sorted[0].id).to.equal(keys[0]);
+          expect(sorted[1].id).to.equal(keys[1]);
+          expect(sorted[2].id).to.equal(keys[2]);
         })
         .then(() => db.fetchNamespace('abc'))
         .then(fetched => {
-          expect(fetched.length).to.be(3);
+          expect(fetched.length).to.equal(3);
 
           let sorted = fetched.sort((a, b) => a.id.localeCompare(b.id));
 
-          expect(sorted[0].id).to.be(keys[3]);
-          expect(sorted[1].id).to.be(keys[4]);
-          expect(sorted[2].id).to.be(keys[5]);
+          expect(sorted[0].id).to.equal(keys[3]);
+          expect(sorted[1].id).to.equal(keys[4]);
+          expect(sorted[2].id).to.equal(keys[5]);
         })
         .then(() => db.clear())
         .then(done)
@@ -273,7 +273,7 @@ describe('StateDB', () => {
       let key = 'foo:bar';
       let value = { baz: 'qux' };
 
-      expect(localStorage.length).to.be(0);
+      expect(localStorage.length).to.equal(0);
       db
         .save(key, value)
         .then(() => {
@@ -281,7 +281,7 @@ describe('StateDB', () => {
         })
         .then(() => db.remove(key))
         .then(() => {
-          expect(localStorage).to.be.empty();
+          expect(localStorage.length).to.equal(0);
         })
         .then(done)
         .catch(done);
@@ -296,16 +296,16 @@ describe('StateDB', () => {
       let key = 'foo:bar';
       let value = { baz: 'qux' };
 
-      expect(localStorage.length).to.be(0);
+      expect(localStorage.length).to.equal(0);
       db
         .save(key, value)
         .then(() => db.fetch(key))
         .then(fetched => {
-          expect(fetched).to.eql(value);
+          expect(fetched).to.deep.equal(value);
         })
         .then(() => db.remove(key))
         .then(() => {
-          expect(localStorage).to.be.empty();
+          expect(localStorage.length).to.equal(0);
         })
         .then(done)
         .catch(done);
@@ -326,11 +326,11 @@ describe('StateDB', () => {
         }
       };
 
-      expect(localStorage.length).to.be(0);
+      expect(localStorage.length).to.equal(0);
       Promise.all(Object.keys(contents).map(key => db.save(key, contents[key])))
         .then(() => db.toJSON())
         .then(serialized => {
-          expect(serialized).to.eql(contents);
+          expect(serialized).to.deep.equal(contents);
         })
         .then(() => db.clear())
         .then(done)

--- a/tests/test-coreutils/src/time.spec.ts
+++ b/tests/test-coreutils/src/time.spec.ts
@@ -9,9 +9,9 @@ describe('@jupyterlab/coreutils', () => {
   describe('Time', () => {
     describe('.formatHuman()', () => {
       it('should convert a time to a human readable string', () => {
-        let date = new Date();
+        const date = new Date();
         date.setSeconds(date.getSeconds() - 10);
-        let value = Time.formatHuman(date);
+        const value = Time.formatHuman(date);
         expect(value).to.equal('seconds ago');
         date.setMinutes(date.getMinutes() - 3);
         expect(Time.formatHuman(date.toISOString())).to.equal('3 minutes ago');
@@ -21,8 +21,8 @@ describe('@jupyterlab/coreutils', () => {
     describe('.format()', () => {
       it('should convert a timestring to a date format', () => {
         expect(Time.format(new Date()).length).to.equal(16);
-        let date = new Date();
-        let value = Time.format(date.toISOString(), 'MM-DD');
+        const date = new Date();
+        const value = Time.format(date.toISOString(), 'MM-DD');
         expect(value.length).to.equal(5);
       });
     });

--- a/tests/test-coreutils/src/url.spec.ts
+++ b/tests/test-coreutils/src/url.spec.ts
@@ -9,7 +9,7 @@ describe('@jupyterlab/coreutils', () => {
   describe('URLExt', () => {
     describe('.parse()', () => {
       it('should parse a url into a URLExt object', () => {
-        let obj = URLExt.parse('http://www.example.com');
+        const obj = URLExt.parse('http://www.example.com');
         expect(obj.href).to.equal('http://www.example.com/');
         expect(obj.protocol).to.equal('http:');
         expect(obj.host).to.equal('www.example.com');
@@ -18,8 +18,8 @@ describe('@jupyterlab/coreutils', () => {
       });
 
       it('should handle query and hash', () => {
-        let url = "http://example.com/path?that's#all, folks";
-        let obj = URLExt.parse(url);
+        const url = "http://example.com/path?that's#all, folks";
+        const obj = URLExt.parse(url);
         try {
           expect(obj.href).to.equal(
             'http://example.com/path?that%27s#all,%20folks'
@@ -58,7 +58,7 @@ describe('@jupyterlab/coreutils', () => {
 
     describe('objectToQueryString()', () => {
       it('should return a serialized object string suitable for a query', () => {
-        let obj = {
+        const obj = {
           name: 'foo',
           id: 'baz'
         };

--- a/tslint.json
+++ b/tslint.json
@@ -46,7 +46,6 @@
     "no-string-literal": false,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
-    "no-unused-expression": true,
     "no-use-before-declare": false,
     "no-var-keyword": true,
     "no-var-requires": true,


### PR DESCRIPTION
Partially addresses #4727.  Adds a script to convert test files that we can remove when they're all done.  Updates  apputils, coreutils, codemirror, codeeditor, and application.