### PR TITLE
Add pypi badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 # [JupyterLab](http://jupyterlab.github.io/jupyterlab/)
 
+[![PyPI version](https://badge.fury.io/py/jupyterlab.svg)](https://badge.fury.io/py/jupyterlab)
 [![Build Status](https://travis-ci.org/jupyterlab/jupyterlab.svg?branch=master)](https://travis-ci.org/jupyterlab/jupyterlab)
 [![Documentation Status](https://readthedocs.org/projects/jupyterlab/badge/?version=stable)](http://jupyterlab.readthedocs.io/en/stable/)
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)


### PR DESCRIPTION
The badge shows the most recent pip release and is helpful for users to learn the progress of the project.

See the badge in action: https://github.com/vatlab/jupyterlab/tree/pip-badge
