### PR TITLE
Rationalize path handling and workspaces.

### DIFF
--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -6,10 +6,13 @@
 require('es6-promise/auto');  // polyfill Promise on IE
 
 import {
-  PageConfig
+  PageConfig, URLExt
 } from '@jupyterlab/coreutils';
 
-__webpack_public_path__ = PageConfig.getOption('publicUrl');
+__webpack_public_path__ = URLExt.join(
+  PageConfig.getOption('baseUrl'),
+  PageConfig.getOption('publicUrl')
+);
 
 // This needs to come after __webpack_public_path__ is set.
 require('font-awesome/css/font-awesome.min.css');

--- a/jupyterlab/extension_manager_handler.py
+++ b/jupyterlab/extension_manager_handler.py
@@ -11,7 +11,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 from notebook.base.handlers import APIHandler
 from tornado import gen, web
-from tornado.ioloop import IOLoop
 
 from .commands import (
     get_app_info, install_extension, uninstall_extension,

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -234,9 +234,9 @@ const tree: JupyterLabPlugin<void> = {
         const workspaceMatch = args.path.match(Patterns.workspace);
         const match = treeMatch || workspaceMatch;
         const path = decodeURIComponent(match[1]);
-        const workspaces = PageConfig.getOption('workspacesUrl');
+        const workspaces = app.info.urls.workspaces;
         const workspace = PageConfig.getOption('workspace');
-        const page = PageConfig.getOption('pageUrl');
+        const page = app.info.urls.page;
         const url =
           (workspaceMatch ? URLExt.join(workspaces, workspace) : page) +
           args.search +

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -18,7 +18,7 @@ import {
   showErrorMessage
 } from '@jupyterlab/apputils';
 
-import { IStateDB, PageConfig } from '@jupyterlab/coreutils';
+import { IStateDB, PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 import * as React from 'react';
 
@@ -193,8 +193,9 @@ const router: JupyterLabPlugin<IRouter> = {
   id: '@jupyterlab/application-extension:router',
   activate: (app: JupyterLab) => {
     const { commands } = app;
-    const base = PageConfig.getOption('pageUrl');
-    const router = new Router({ base, commands });
+    const base = PageConfig.getOption('baseUrl');
+    const page = PageConfig.getOption('pageUrl');
+    const router = new Router({ base: URLExt.join(base, page), commands });
 
     app.started.then(() => {
       // Route the very first request on load.

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -235,7 +235,7 @@ const tree: JupyterLabPlugin<void> = {
         const match = treeMatch || workspaceMatch;
         const path = decodeURIComponent(match[1]);
         const workspaces = app.info.urls.workspaces;
-        const workspace = PageConfig.getOption('workspace');
+        const workspace = app.info.workspace;
         const page = app.info.urls.page;
         const url =
           (workspaceMatch ? URLExt.join(workspaces, workspace) : page) +

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -75,7 +75,7 @@ const main: JupyterLabPlugin<void> = {
     // Requiring the window resolver guarantees that the application extension
     // only loads if there is a viable window name. Otherwise, the application
     // will short-circuit and ask the user to navigate away.
-    const workspace = resolver.name ? `"${resolver.name}"` : '[default: /lab]';
+    const workspace = resolver.name;
 
     console.log(`Starting application in workspace: ${workspace}`);
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -18,7 +18,7 @@ import {
   showErrorMessage
 } from '@jupyterlab/apputils';
 
-import { IStateDB, PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { IStateDB, PageConfig, PathExt, URLExt } from '@jupyterlab/coreutils';
 
 import * as React from 'react';
 
@@ -235,7 +235,7 @@ const tree: JupyterLabPlugin<void> = {
         const match = treeMatch || workspaceMatch;
         const path = decodeURIComponent(match[1]);
         const { page, workspaces } = app.info.urls;
-        const workspace = app.info.workspace;
+        const workspace = PathExt.basename(app.info.workspace);
         const url =
           (workspaceMatch ? URLExt.join(workspaces, workspace) : page) +
           args.search +

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -229,7 +229,7 @@ const tree: JupyterLabPlugin<void> = {
     const { commands } = app;
 
     commands.addCommand(CommandIDs.tree, {
-      execute: (args: IRouter.ILocation) => {
+      execute: async (args: IRouter.ILocation) => {
         const treeMatch = args.path.match(Patterns.tree);
         const workspaceMatch = args.path.match(Patterns.workspace);
         const match = treeMatch || workspaceMatch;
@@ -241,16 +241,17 @@ const tree: JupyterLabPlugin<void> = {
           args.search +
           args.hash;
         const immediate = true;
+        const silent = true;
 
         // Silently remove the tree portion of the URL leaving the rest intact.
-        router.navigate(url, { silent: true });
+        router.navigate(url, { silent });
 
-        return commands
-          .execute('filebrowser:navigate', { path })
-          .then(() => commands.execute('apputils:save-statedb', { immediate }))
-          .catch(reason => {
-            console.warn(`Tree routing failed:`, reason);
-          });
+        try {
+          await commands.execute('filebrowser:navigate', { path });
+          await commands.execute('apputils:save-statedb', { immediate });
+        } catch (error) {
+          console.warn('Tree routing failed.', error);
+        }
       }
     });
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -234,9 +234,8 @@ const tree: JupyterLabPlugin<void> = {
         const workspaceMatch = args.path.match(Patterns.workspace);
         const match = treeMatch || workspaceMatch;
         const path = decodeURIComponent(match[1]);
-        const workspaces = app.info.urls.workspaces;
+        const { page, workspaces } = app.info.urls;
         const workspace = app.info.workspace;
-        const page = app.info.urls.page;
         const url =
           (workspaceMatch ? URLExt.join(workspaces, workspace) : page) +
           args.search +

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -340,13 +340,16 @@ export namespace JupyterLab {
     },
     filesCached: PageConfig.getOption('cacheFiles').toLowerCase() === 'true',
     workspace: '',
-    defaultWorkspace: PageConfig.setOption(
-      'defaultWorkspace',
-      URLExt.join(
+    defaultWorkspace: (() => {
+      const defaultWorkspace = URLExt.join(
         PageConfig.getOption('baseUrl'),
         PageConfig.getOption('pageUrl')
-      )
-    )
+      );
+
+      PageConfig.setOption('defaultWorkspace', defaultWorkspace);
+
+      return defaultWorkspace;
+    })()
   };
 
   /**

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -340,9 +340,12 @@ export namespace JupyterLab {
     },
     filesCached: PageConfig.getOption('cacheFiles').toLowerCase() === 'true',
     workspace: '',
-    defaultWorkspace: URLExt.join(
-      PageConfig.getOption('baseUrl'),
-      PageConfig.getOption('pageUrl')
+    defaultWorkspace: PageConfig.setOption(
+      'defaultWorkspace',
+      URLExt.join(
+        PageConfig.getOption('baseUrl'),
+        PageConfig.getOption('pageUrl')
+      )
     )
   };
 

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -263,10 +263,13 @@ export namespace JupyterLab {
      * The urls used by the application.
      */
     readonly urls: {
+      readonly base: string;
       readonly page: string;
       readonly public: string;
       readonly settings: string;
       readonly themes: string;
+      readonly tree: string;
+      readonly workspaces: string;
     };
 
     /**
@@ -280,6 +283,7 @@ export namespace JupyterLab {
       readonly themes: string;
       readonly userSettings: string;
       readonly serverRoot: string;
+      readonly workspaces: string;
     };
 
     /**
@@ -300,10 +304,13 @@ export namespace JupyterLab {
     disabled: { patterns: [], matches: [] },
     mimeExtensions: [],
     urls: {
+      base: PageConfig.getOption('baseUrl'),
       page: PageConfig.getOption('pageUrl'),
       public: PageConfig.getOption('publicUrl'),
       settings: PageConfig.getOption('settingsUrl'),
-      themes: PageConfig.getOption('themesUrl')
+      themes: PageConfig.getOption('themesUrl'),
+      tree: PageConfig.getOption('treeUrl'),
+      workspaces: PageConfig.getOption('workspacesUrl')
     },
     directories: {
       appSettings: PageConfig.getOption('appSettingsDir'),
@@ -312,7 +319,8 @@ export namespace JupyterLab {
       templates: PageConfig.getOption('templatesDir'),
       themes: PageConfig.getOption('themesDir'),
       userSettings: PageConfig.getOption('userSettingsDir'),
-      serverRoot: PageConfig.getOption('serverRoot')
+      serverRoot: PageConfig.getOption('serverRoot'),
+      workspaces: PageConfig.getOption('workspacesDir')
     },
     filesCached: PageConfig.getOption('cacheFiles').toLowerCase() === 'true'
   };

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -45,13 +45,27 @@ export class JupyterLab extends Application<ApplicationShell> {
     this._busySignal = new Signal(this);
     this._dirtySignal = new Signal(this);
 
+    // Construct the default workspace name.
+    const defaultWorkspace = URLExt.join(
+      PageConfig.getOption('baseUrl'),
+      PageConfig.getOption('pageUrl')
+    );
+
+    // Set default workspace in page config.
+    PageConfig.setOption('defaultWorkspace', defaultWorkspace);
+
     // Populate application info.
-    this._info = { ...JupyterLab.defaultInfo, ...options };
+    this._info = {
+      ...JupyterLab.defaultInfo,
+      ...options,
+      ...{ defaultWorkspace }
+    };
+
     if (this._info.devMode) {
       this.shell.addClass('jp-mod-devMode');
     }
 
-    // Make workspace accessible from application info.
+    // Make workspace accessible via a getter because it is set at runtime.
     Object.defineProperty(this._info, 'workspace', {
       get: () => PageConfig.getOption('workspace') || ''
     });
@@ -340,16 +354,7 @@ export namespace JupyterLab {
     },
     filesCached: PageConfig.getOption('cacheFiles').toLowerCase() === 'true',
     workspace: '',
-    defaultWorkspace: (() => {
-      const defaultWorkspace = URLExt.join(
-        PageConfig.getOption('baseUrl'),
-        PageConfig.getOption('pageUrl')
-      );
-
-      PageConfig.setOption('defaultWorkspace', defaultWorkspace);
-
-      return defaultWorkspace;
-    })()
+    defaultWorkspace: ''
   };
 
   /**

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -4,7 +4,7 @@
 // Local CSS must be loaded prior to loading other libs.
 import '../style/index.css';
 
-import { PageConfig } from '@jupyterlab/coreutils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 import { CommandLinker } from '@jupyterlab/apputils';
 
@@ -299,11 +299,13 @@ export namespace JupyterLab {
 
     /**
      * The name of the current workspace.
-     *
-     * #### Notes
-     * The default /lab workspace name is empty.
      */
     readonly workspace: string;
+
+    /**
+     * The name of the default workspace.
+     */
+    readonly defaultWorkspace: string;
   }
 
   /**
@@ -337,7 +339,11 @@ export namespace JupyterLab {
       workspaces: PageConfig.getOption('workspacesDir')
     },
     filesCached: PageConfig.getOption('cacheFiles').toLowerCase() === 'true',
-    workspace: ''
+    workspace: '',
+    defaultWorkspace: URLExt.join(
+      PageConfig.getOption('baseUrl'),
+      PageConfig.getOption('pageUrl')
+    )
   };
 
   /**

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -212,9 +212,11 @@ export class Router implements IRouter {
    * @param options - The navigation options.
    */
   navigate(path: string, options: IRouter.INavOptions = {}): void {
-    const url = path ? URLExt.join(this.base, path) : this.base;
+    const { base } = this;
     const { history } = window;
     const { hard, silent } = options;
+    const url =
+      path && path.indexOf(base) === 0 ? path : URLExt.join(base, path);
 
     if (silent) {
       history.replaceState({}, '', url);

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -185,7 +185,7 @@ export class Router implements IRouter {
     const { base } = this;
     const parsed = URLExt.parse(window.location.href);
     const { search, hash } = parsed;
-    const path = parsed.pathname.replace(base, '');
+    const path = parsed.pathname.replace(base, '/');
     const request = path + search + hash;
 
     return { hash, path, request, search };

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -261,8 +261,14 @@ const resolver: JupyterLabPlugin<IWindowResolver> = {
   provides: IWindowResolver,
   requires: [IRouter],
   activate: (app: JupyterLab, router: IRouter) => {
-    const candidate = Private.getWorkspace(router) || '';
     const resolver = new WindowResolver();
+    const base = PageConfig.getOption('baseUrl');
+    const page = PageConfig.getOption('pageUrl');
+    const workspaces = PageConfig.getOption('workspacesUrl');
+    const workspace = Private.getWorkspace(router) || '';
+    const candidate = workspace
+      ? URLExt.join(base, workspaces, workspace)
+      : URLExt.join(base, page);
 
     return resolver
       .resolve(candidate)

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -557,7 +557,9 @@ const state: JupyterLabPlugin<IStateDB> = {
     window.addEventListener('beforeunload', () => {
       const silent = true;
 
-      state.clear(silent);
+      state.clear(silent).catch(() => {
+        /* no-op */
+      });
     });
 
     return state;

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -682,7 +682,7 @@ namespace Private {
   /**
    * Allows the user to clear state if splash screen takes too long.
    */
-  export function redirect(router: IRouter, warn = false): Promise<void> {
+  export async function redirect(router: IRouter, warn = false): Promise<void> {
     const form = createRedirectForm(warn);
     const dialog = new Dialog({
       title: 'Please use a different workspace.',
@@ -691,24 +691,23 @@ namespace Private {
       buttons: [Dialog.okButton({ label: 'Switch Workspace' })]
     });
 
-    return dialog.launch().then(result => {
-      dialog.dispose();
+    const result = await dialog.launch();
 
-      if (result.value) {
-        const workspaces = PageConfig.getOption('workspacesUrl');
-        const url = URLExt.join(workspaces, result.value);
-
-        // Navigate to a new workspace URL and abandon this session altogether.
-        router.navigate(url, { hard: true, silent: true });
-
-        // This promise will never resolve because the application navigates
-        // away to a new location. It only exists to satisfy the return type
-        // of the `redirect` function.
-        return new Promise<void>(() => undefined);
-      }
-
+    dialog.dispose();
+    if (!result.value) {
       return redirect(router, true);
-    });
+    }
+
+    // Navigate to a new workspace URL and abandon this session altogether.
+    const workspaces = PageConfig.getOption('workspacesUrl');
+    const url = URLExt.join(workspaces, result.value);
+
+    router.navigate(url, { hard: true, silent: true });
+
+    // This promise will never resolve because the application navigates
+    // away to a new location. It only exists to satisfy the return type
+    // of the `redirect` function.
+    return new Promise<void>(() => undefined);
   }
 
   /**

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -477,6 +477,7 @@ const state: JupyterLabPlugin<IStateDB> = {
         return commands.execute(CommandIDs.saveState, { immediate });
       }
     });
+
     router.register({
       command: CommandIDs.loadState,
       pattern: /.?/,
@@ -545,23 +546,19 @@ const state: JupyterLabPlugin<IStateDB> = {
         return cleared;
       }
     });
+
     router.register({
       command: CommandIDs.resetOnLoad,
       pattern: Patterns.resetOnLoad,
       rank: 10 // Set reset rank at a higher priority than the default 100.
     });
 
-    const fallthrough = () => {
-      // If the state database is still unresolved after the first URL has been
-      // routed, leave it intact.
-      if (!resolved) {
-        resolved = true;
-        transform.resolve({ type: 'cancel', contents: null });
-      }
-      router.routed.disconnect(fallthrough, state);
-    };
+    // Clean up state database when the window unloads.
+    window.addEventListener('beforeunload', () => {
+      const silent = true;
 
-    router.routed.connect(fallthrough, state);
+      state.clear(silent);
+    });
 
     return state;
   }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -83,7 +83,9 @@ namespace CommandIDs {
 namespace Patterns {
   export const cloneState = /[?&]clone([=&]|$)/;
 
-  export const loadState = /^\/workspaces\/([^?\/]+)/;
+  export const loadState = new RegExp(
+    `^${PageConfig.getOption('workspacesUrl')}([^?\/]+)`
+  );
 
   export const resetOnLoad = /(\?reset|\&reset)($|&)/;
 }
@@ -181,7 +183,7 @@ const themes: JupyterLabPlugin<IThemeManager> = {
   ): IThemeManager => {
     const host = app.shell;
     const commands = app.commands;
-    const url = app.info.urls.themes;
+    const url = URLExt.join(app.info.urls.base, app.info.urls.themes);
     const key = themes.id;
     const manager = new ThemeManager({ key, host, settings, splash, url });
 
@@ -465,6 +467,7 @@ const state: JupyterLabPlugin<IStateDB> = {
 
               // After the state has been cloned, navigate to the URL.
               cloned.then(() => {
+                console.log(`THIS URL: ${url}`);
                 router.navigate(url, { silent: true });
               });
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -427,10 +427,9 @@ const state: JupyterLabPlugin<IStateDB> = {
                 )
             : null;
         const source = clone || workspace;
-        const fetch = workspaces.fetch(source);
 
         try {
-          const saved = await fetch;
+          const saved = await workspaces.fetch(source);
 
           // If this command is called after a reset, the state database
           // will already be resolved.

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -695,7 +695,8 @@ namespace Private {
       dialog.dispose();
 
       if (result.value) {
-        const url = `workspaces/${result.value}`;
+        const workspaces = PageConfig.getOption('workspacesUrl');
+        const url = URLExt.join(workspaces, result.value);
 
         // Navigate to a new workspace URL and abandon this session altogether.
         router.navigate(url, { hard: true, silent: true });
@@ -703,9 +704,7 @@ namespace Private {
         // This promise will never resolve because the application navigates
         // away to a new location. It only exists to satisfy the return type
         // of the `redirect` function.
-        return new Promise<void>(() => {
-          /* no-op */
-        });
+        return new Promise<void>(() => undefined);
       }
 
       return redirect(router, true);

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -129,17 +129,14 @@ export namespace PageConfig {
    * @param options - The tree URL construction options.
    */
   export function getTreeUrl(options: ITreeOptions = {}): string {
-    const base = getOption('baseUrl');
-    const page = getOption('pageUrl');
+    const base = getBaseUrl();
+    const tree = getOption('treeUrl');
     const workspaces = getOption('workspacesUrl');
     const workspace = getOption('workspace');
-    const includeWorkspace = !!options.workspace;
-    const url =
-      includeWorkspace && workspace
-        ? URLExt.join(workspaces, workspace, 'tree')
-        : URLExt.join(base, page, 'tree');
 
-    return URLExt.parse(url).toString();
+    return !!options.workspace && workspace
+      ? URLExt.join(base, workspaces, workspace, 'tree')
+      : URLExt.join(base, tree);
   }
 
   /**

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -129,17 +129,17 @@ export namespace PageConfig {
    * @param options - The tree URL construction options.
    */
   export function getTreeUrl(options: ITreeOptions = {}): string {
-    const base = getBaseUrl();
+    const base = getOption('baseUrl');
     const page = getOption('pageUrl');
     const workspaces = getOption('workspacesUrl');
     const workspace = getOption('workspace');
     const includeWorkspace = !!options.workspace;
+    const url =
+      includeWorkspace && workspace
+        ? URLExt.join(workspaces, workspace, 'tree')
+        : URLExt.join(base, page, 'tree');
 
-    if (includeWorkspace && workspace) {
-      return URLExt.join(base, workspaces, workspace, 'tree');
-    } else {
-      return URLExt.join(base, page, 'tree');
-    }
+    return URLExt.parse(url).toString();
   }
 
   /**

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -5,6 +5,8 @@ import { JSONExt } from '@phosphor/coreutils';
 
 import minimist from 'minimist';
 
+import { PathExt } from './path';
+
 import { URLExt } from './url';
 
 /**
@@ -134,11 +136,9 @@ export namespace PageConfig {
     const defaultWorkspace = getOption('defaultWorkspace');
     const workspaces = getOption('workspacesUrl');
     const workspace = getOption('workspace');
-    const prefix = URLExt.join(PageConfig.getOption('baseUrl'), workspaces);
-    const token = workspace.substring(prefix.length);
 
     return !!options.workspace && workspace && workspace !== defaultWorkspace
-      ? URLExt.join(base, workspaces, token, 'tree')
+      ? URLExt.join(base, workspaces, PathExt.basename(workspace), 'tree')
       : URLExt.join(base, tree);
   }
 

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -131,11 +131,14 @@ export namespace PageConfig {
   export function getTreeUrl(options: ITreeOptions = {}): string {
     const base = getBaseUrl();
     const tree = getOption('treeUrl');
+    const defaultWorkspace = getOption('defaultWorkspace');
     const workspaces = getOption('workspacesUrl');
     const workspace = getOption('workspace');
+    const prefix = URLExt.join(PageConfig.getOption('baseUrl'), workspaces);
+    const token = workspace.substring(prefix.length);
 
-    return !!options.workspace && workspace
-      ? URLExt.join(base, workspaces, workspace, 'tree')
+    return !!options.workspace && workspace && workspace !== defaultWorkspace
+      ? URLExt.join(base, workspaces, token, 'tree')
       : URLExt.join(base, tree);
   }
 

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -33,24 +33,36 @@ export namespace URLExt {
    * @returns the joined url.
    */
   export function join(...parts: string[]): string {
-    // Adapted from url-join.
-    // Copyright (c) 2016 José F. Romaniello, MIT License.
-    // https://github.com/jfromaniello/url-join/blob/v1.1.0/lib/url-join.js
-    let str = [].slice.call(parts, 0).join('/');
+    parts = parts || [];
 
-    // make sure protocol is followed by two slashes
-    str = str.replace(/:\//g, '://');
+    // Isolate the top element.
+    const top = parts[0] || '';
 
-    // remove consecutive slashes
-    str = str.replace(/([^:\s])\/+/g, '$1/');
+    // Check whether protocol shorthand is being used.
+    const shorthand = top.indexOf('//') === 0;
 
-    // remove trailing slash before parameters or hash
-    str = str.replace(/\/(\?|&|#[^!])/g, '$1');
+    // Parse the top element into a header collection.
+    const header = top.match(/(\w+)(:)(\/\/)?/);
+    const protocol = header && header[1];
+    const colon = protocol && header[2];
+    const slashes = colon && header[3];
 
-    // replace ? in parameters with &
-    str = str.replace(/(\?.+)\?/g, '$1&');
+    // Construct the URL prefix.
+    const prefix = shorthand
+      ? '//'
+      : [protocol, colon, slashes].filter(str => str).join('');
 
-    return str;
+    // Construct the URL body omitting the prefix of the top value.
+    const body = [top.indexOf(prefix) === 0 ? top.replace(prefix, '') : top]
+      // Filter out top value if empty.
+      .filter(str => str)
+      // Remove leading slashes in all subsequent URL body elements.
+      .concat(parts.slice(1).map(str => str.replace(/^\//, '')))
+      .join('/')
+      // Replace multiple slashes with one.
+      .replace(/\/+/g, '/');
+
+    return prefix + body;
   }
 
   /**

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -438,7 +438,7 @@ function addCommands(
 
       Clipboard.copyToSystem(item.path);
     },
-    isVisible: () => toArray(browser.selectedItems()).length === 1,
+    isVisible: () => browser.selectedItems().next !== undefined,
     iconClass: 'jp-MaterialIcon jp-FileIcon',
     label: 'Copy Path'
   });

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -57,6 +57,7 @@
     "@types/chai": "~4.0.10",
     "@types/mocha": "~2.2.44",
     "@types/node-fetch": "~1.6.7",
+    "@types/text-encoding": "0.0.33",
     "@types/ws": "~0.0.39",
     "chai": "~4.1.2",
     "istanbul": "~0.3.22",

--- a/packages/services/test/src/workspace/manager.spec.ts
+++ b/packages/services/test/src/workspace/manager.spec.ts
@@ -50,8 +50,8 @@ describe('workspace', () => {
     });
 
     describe('#list()', async () => {
-      it('should fetch a list of workspaces', async () => {
-        const ids = ['foo', 'bar', 'baz'];
+      it('should fetch a workspace list supporting arbitrary IDs', async () => {
+        const ids = ['foo', 'bar', 'baz', 'f/o/o', 'b/a/r', 'b/a/z'];
 
         ids.forEach(async id => {
           await manager.save(id, { data: {}, metadata: { id } });

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup_args = dict(
 
 setup_args['install_requires'] = [
     'notebook>=4.3.1',
-    'jupyterlab_launcher>=0.11.2,<0.12.0',
+    'jupyterlab_launcher>=0.12.0,<0.13.0',
     'ipython_genutils',
     'futures;python_version<"3.0"',
     'subprocess32;python_version<"3.0"'

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -43,9 +43,9 @@ describe('apputils', () => {
 
     describe('#current', () => {
       it('should return the current window location as an object', () => {
-        // The karma test window location is a file called `context.html`
+        // The karma test window location is the path `/context.html`
         // without any query string parameters or hash.
-        const path = 'context.html';
+        const path = '/context.html';
         const request = path;
         const search = '';
         const hash = '';

--- a/tests/test-apputils/src/clientsession.spec.ts
+++ b/tests/test-apputils/src/clientsession.spec.ts
@@ -372,12 +372,12 @@ describe('@jupyterlab/apputils', () => {
       it('should restart if the user accepts the dialog', async () => {
         let called = false;
 
-        await session.initialize();
         session.statusChanged.connect((sender, args) => {
           if (args === 'restarting') {
             called = true;
           }
         });
+        await session.initialize();
 
         const restart = ClientSession.restartKernel(session.kernel);
 

--- a/tests/test-apputils/src/instancetracker.spec.ts
+++ b/tests/test-apputils/src/instancetracker.spec.ts
@@ -62,7 +62,7 @@ describe('@jupyterlab/apputils', () => {
         const widget = new Widget();
         let promise = signalToPromise(tracker.widgetAdded);
         tracker.add(widget);
-        const [sender, args] = await promise;
+        const args = (await promise)[1];
         expect(args).to.equal(widget);
       });
 

--- a/tests/test-cells/src/widget.spec.ts
+++ b/tests/test-cells/src/widget.spec.ts
@@ -7,7 +7,7 @@ import { Message, MessageLoop } from '@phosphor/messaging';
 
 import { Widget } from '@phosphor/widgets';
 
-import { IClientSession } from '@jupyterlab/apputils';
+import { ClientSession, IClientSession } from '@jupyterlab/apputils';
 
 import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
@@ -425,7 +425,7 @@ describe('cells/widget', () => {
 
       beforeEach(async () => {
         session = await createClientSession();
-        await session.initialize();
+        await (session as ClientSession).initialize();
         await session.kernel.ready;
       });
 
@@ -433,9 +433,14 @@ describe('cells/widget', () => {
         return session.shutdown();
       });
 
-      it('should fulfill a promise if there is no code to execute', () => {
+      it('should fulfill a promise if there is no code to execute', async () => {
         const widget = new CodeCell({ model, rendermime, contentFactory });
-        return CodeCell.execute(widget, session);
+        try {
+          await CodeCell.execute(widget, session);
+        } catch (error) {
+          console.log('IT BREAKS HERE');
+          throw error;
+        }
       });
 
       it('should fulfill a promise if there is code to execute', async () => {


### PR DESCRIPTION
- [x] Hard dependency on: https://github.com/jupyterlab/jupyterlab_launcher/pull/51
- Fixes https://github.com/jupyterlab/jupyterlab/issues/5002 (workspace creation in JupyterHub)
- Fixes https://github.com/jupyterlab/jupyterlab/issues/5032 (shareable links in JupyterHub)
- Makes "Reset Application State" command (`apputils:reset`) more robust.
- Improves `URLExt.join()` command.
- Rationalizes path handling for paths contained in `PageConfig`. All specific URLs (`pageUrl`, `workspacesUrl`, `treeUrl`) are **siblings** and they all require being prefixed with `baseUrl` in order to be qualified.
- Application info (`app.info`) now includes `workspace` and `defaultWorkspace`.
- The default JupyterLab workspace `/lab` (or its JupyterHub analogues) is now saved just like all named workspaces.
- Refactors state database management and lifecycle. Since all workspaces are saved, the code is simpler.
- Fixes a workspace name collision that occurs on JupyterHub (cc: @SylvainCorlay)
- Updates tests, fixes a couple intermittent broken ones.
- State database attempts to garbage collect local storage upon unload.