### PR TITLE
Add execution timings to cell metadata

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1296,7 +1296,7 @@ function addCommands(
       }
     },
     isEnabled
-  })
+  });
   commands.addCommand(CommandIDs.commandMode, {
     label: 'Enter Command Mode',
     execute: args => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -157,6 +157,8 @@ namespace CommandIDs {
 
   export const toggleAllLines = 'notebook:toggle-all-cell-line-numbers';
 
+  export const toggleRecordTiming = 'notebook:toggle-record-timing';
+
   export const undoCellAction = 'notebook:undo-cell-action';
 
   export const redoCellAction = 'notebook:redo-cell-action';
@@ -1284,6 +1286,17 @@ function addCommands(
     },
     isEnabled
   });
+  commands.addCommand(CommandIDs.toggleRecordTiming, {
+    label: 'Toggle Recording Cell Timing',
+    execute: args => {
+      const current = getCurrent(args);
+
+      if (current) {
+        return NotebookActions.toggleRecordTiming(current.content);
+      }
+    },
+    isEnabled
+  })
   commands.addCommand(CommandIDs.commandMode, {
     label: 'Enter Command Mode',
     execute: args => {
@@ -1616,6 +1629,7 @@ function populatePalette(
     CommandIDs.deselectAll,
     CommandIDs.clearAllOutputs,
     CommandIDs.toggleAllLines,
+    CommandIDs.toggleRecordTiming,
     CommandIDs.editMode,
     CommandIDs.commandMode,
     CommandIDs.changeKernel,

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -914,6 +914,19 @@ export namespace NotebookActions {
   }
 
   /**
+   * Toggle whether to record cell timing execution.
+   *
+   * @param notebook - The target notebook widget.
+   */
+  export function toggleRecordTiming(notebook: Notebook): void {
+    if (!notebook.model) {
+      return;
+    }
+    const currentValue = notebook.model.metadata.get('record_timing') || false;
+    notebook.model.metadata.set('record_timing', !currentValue);
+  }
+
+  /**
    * Clear the code outputs of the selected cells.
    *
    * @param notebook - The target notebook widget.
@@ -1454,7 +1467,8 @@ namespace Private {
       case 'code':
         if (session) {
           return CodeCell.execute(cell as CodeCell, session, {
-            deletedCells: notebook.model.deletedCells
+            deletedCells: notebook.model.deletedCells,
+            recordTiming: notebook.model.metadata.get('record_timing') || false
           })
             .then(reply => {
               notebook.model.deletedCells.splice(

--- a/tests/test-cells/src/widget.spec.ts
+++ b/tests/test-cells/src/widget.spec.ts
@@ -460,6 +460,14 @@ describe('cells/widget', () => {
         await CodeCell.execute(widget, session);
         const executionCount = widget.model.executionCount;
         expect(executionCount).to.not.equal(originalCount);
+        expect(widget.model.metadata.get('timing.iopub.execute_input')).to
+          .exist;
+        expect(widget.model.metadata.get('timing.shell.execute_reply.started'))
+          .to.exist;
+        expect(widget.model.metadata.get('timing.shell.execute_reply')).to
+          .exist;
+        expect(widget.model.metadata.get('timing.iopub.status.busy')).to.exist;
+        expect(widget.model.metadata.get('timing.iopub.status.idle')).to.exist;
       });
     });
   });

--- a/tests/test-cells/src/widget.spec.ts
+++ b/tests/test-cells/src/widget.spec.ts
@@ -460,14 +460,29 @@ describe('cells/widget', () => {
         await CodeCell.execute(widget, session);
         const executionCount = widget.model.executionCount;
         expect(executionCount).to.not.equal(originalCount);
-        expect(widget.model.metadata.get('timing.iopub.execute_input')).to
-          .exist;
-        expect(widget.model.metadata.get('timing.shell.execute_reply.started'))
-          .to.exist;
-        expect(widget.model.metadata.get('timing.shell.execute_reply')).to
-          .exist;
-        expect(widget.model.metadata.get('timing.iopub.status.busy')).to.exist;
-        expect(widget.model.metadata.get('timing.iopub.status.idle')).to.exist;
+      });
+
+      const TIMING_KEYS = [
+        'timing.iopub.execute_input',
+        'timing.shell.execute_reply.started',
+        'timing.shell.execute_reply',
+        'timing.iopub.status.busy',
+        'timing.iopub.status.idle'
+      ];
+
+      it('should not save timing info by default', async () => {
+        const widget = new CodeCell({ model, rendermime, contentFactory });
+        await CodeCell.execute(widget, session);
+        for (const key of TIMING_KEYS) {
+          expect(widget.model.metadata.get(key)).to.not.exist;
+        }
+      });
+      it('should save timing info if requested', async () => {
+        const widget = new CodeCell({ model, rendermime, contentFactory });
+        await CodeCell.execute(widget, session, { recordTiming: true });
+        for (const key of TIMING_KEYS) {
+          expect(widget.model.metadata.get(key)).to.exist;
+        }
       });
     });
   });


### PR DESCRIPTION
Partially addresses #3320 by allowing users to record cell execution timing information.

* Adds `Toggle Recording Cell Timing` command that sets the `recording_timing` notebook metadata key to true/false.
* If the `record_timing` metadata key is true timing information is saved to the cell metadata when a cell is executed. 

We record multiple timing events that could be interpreted as "starting" and "ending" execution.

* Starting:
  * `timing.iopub.status.busy`: `header.date` of `iopub` `status` busy message
  * `timing.iopub.execute_input`: `header.date` of `iopub` `execute_input` message
  * `timing.shell.execute_reply.started`: `metadata.started` of `shell` `execute_reply` message
* Ending
  * `timing.shell.execute_reply`: `header.date` of `shell` `execute_repl` 
  * `timing.iopub.status.idle`: `header.date` of `iopub` `status` busy message 

<img width="933" alt="screen shot 2018-10-04 at 3 57 07 pm" src="https://user-images.githubusercontent.com/1186124/46499484-362f1800-c7ee-11e8-8a5c-edb1e404231b.png">

Now third party extensions can use this information to display elapsed time of cell execution. Subsequent work includes:

* Adding semantics of "duration" and "start time" to cell abstraction so that different UXs can display these times (i.e. do we have users choose which key to use as start time and which as end time? With defaults? Or does it make sense to have different durations that correspond to different parts of the execution?)
* Display elapsed time in status bar (depends on merging in status bar first https://github.com/jupyterlab/jupyterlab/issues/5352)
* Figure out UX design for how to enable showing timing on all cells simultaneously.  
