### PR TITLE
Test cleanup cont

### DIFF
--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -17,7 +17,7 @@ if [[ $GROUP == js ]]; then
 
     jlpm build:packages
     jlpm build:test
-    jlpm test
+    jlpm test --loglevel success > /dev/null
     jlpm run clean
 fi
 

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -17,7 +17,7 @@ if [[ $GROUP == js ]]; then
 
     jlpm build:packages
     jlpm build:test
-    jlpm test --loglevel success > /dev/null
+    jlpm test
     jlpm run clean
 fi
 

--- a/tests/test-application/src/router.spec.ts
+++ b/tests/test-application/src/router.spec.ts
@@ -9,7 +9,7 @@ import { CommandRegistry } from '@phosphor/commands';
 
 import { Token } from '@phosphor/coreutils';
 
-import { testEmission } from '@jupyterlab/testutils';
+import { signalToPromise } from '@jupyterlab/testutils';
 
 const base = '/';
 
@@ -106,13 +106,10 @@ describe('apputils', () => {
         router.register({ command: 'c', pattern: /.*/, rank: 30 });
         router.register({ command: 'd', pattern: /.*/, rank: 40 });
 
-        let promise = testEmission(router.routed, {
-          test: () => {
-            expect(recorded).to.deep.equal(wanted);
-          }
-        });
+        let promise = signalToPromise(router.routed);
         await router.route();
         await promise;
+        expect(recorded).to.deep.equal(wanted);
       });
     });
 

--- a/tests/test-apputils/src/instancetracker.spec.ts
+++ b/tests/test-apputils/src/instancetracker.spec.ts
@@ -62,7 +62,7 @@ describe('@jupyterlab/apputils', () => {
         const widget = new Widget();
         let promise = signalToPromise(tracker.widgetAdded);
         tracker.add(widget);
-        const { sender, args } = await promise;
+        const [sender, args] = await promise;
         expect(args).to.equal(widget);
       });
 

--- a/tests/test-apputils/src/instancetracker.spec.ts
+++ b/tests/test-apputils/src/instancetracker.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 
 import { InstanceTracker } from '@jupyterlab/apputils';
 
-import { testEmission } from '@jupyterlab/testutils';
+import { signalToPromise, testEmission } from '@jupyterlab/testutils';
 
 import { each } from '@phosphor/algorithm';
 
@@ -46,7 +46,7 @@ describe('@jupyterlab/apputils', () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widget = new Widget();
         widget.node.tabIndex = -1;
-        let promise = testEmission(tracker.currentChanged, {});
+        let promise = signalToPromise(tracker.currentChanged);
         Widget.attach(widget, document.body);
         widget.node.focus();
         simulate(widget.node, 'focus');
@@ -60,13 +60,10 @@ describe('@jupyterlab/apputils', () => {
       it('should emit when a widget has been added', async () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widget = new Widget();
-        let promise = testEmission(tracker.widgetAdded, {
-          test: (sender, added) => {
-            expect(added).to.equal(widget);
-          }
-        });
+        let promise = signalToPromise(tracker.widgetAdded);
         tracker.add(widget);
-        await promise;
+        const { sender, args } = await promise;
+        expect(args).to.equal(widget);
       });
 
       it('should not emit when a widget has been injected', async () => {

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -249,8 +249,8 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('.createKernelNameItem()', async () => {
-      it("should display the `'display_name'` of the kernel", () => {
+    describe('.createKernelNameItem()', () => {
+      it("should display the `'display_name'` of the kernel", async () => {
         const item = Toolbar.createKernelNameItem(session);
         await session.initialize();
         expect(item.node.textContent).to.equal(session.kernelDisplayName);
@@ -300,7 +300,7 @@ describe('@jupyterlab/apputils', () => {
 
       it('should handle a starting session', async () => {
         await session.shutdown();
-        const session = await createClientSession();
+        session = await createClientSession();
         const item = Toolbar.createKernelStatusItem(session);
         expect(item.node.title).to.equal('Kernel Starting');
         expect(item.hasClass('jp-FilledCircleIcon')).to.equal(true);

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -44,18 +44,15 @@ describe('@jupyterlab/apputils', () => {
   let widget: Toolbar<Widget>;
   let session: ClientSession;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     widget = new Toolbar();
-    return createClientSession().then(s => {
-      session = s;
-    });
+    session = await createClientSession();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     widget.dispose();
-    return session.shutdown().then(() => {
-      session.dispose();
-    });
+    await session.shutdown();
+    session.dispose();
   });
 
   describe('Toolbar', () => {
@@ -252,12 +249,11 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('.createKernelNameItem()', () => {
+    describe('.createKernelNameItem()', async () => {
       it("should display the `'display_name'` of the kernel", () => {
         const item = Toolbar.createKernelNameItem(session);
-        return session.initialize().then(() => {
-          expect(item.node.textContent).to.equal(session.kernelDisplayName);
-        });
+        await session.initialize();
+        expect(item.node.textContent).to.equal(session.kernelDisplayName);
       });
 
       it("should display `'No Kernel!'` if there is no kernel", () => {
@@ -267,13 +263,12 @@ describe('@jupyterlab/apputils', () => {
     });
 
     describe('.createKernelStatusItem()', () => {
-      beforeEach(() => {
-        return session.initialize().then(() => {
-          return session.kernel.ready;
-        });
+      beforeEach(async () => {
+        await session.initialize();
+        await session.kernel.ready;
       });
 
-      it('should display a busy status if the kernel status is not idle', () => {
+      it('should display a busy status if the kernel status is not idle', async () => {
         const item = Toolbar.createKernelStatusItem(session);
         let called = false;
         const future = session.kernel.requestExecute({ code: 'a = 1' });
@@ -283,12 +278,11 @@ describe('@jupyterlab/apputils', () => {
             called = true;
           }
         };
-        return future.done.then(() => {
-          expect(called).to.equal(true);
-        });
+        await future.done;
+        expect(called).to.equal(true);
       });
 
-      it('should show the current status in the node title', () => {
+      it('should show the current status in the node title', async () => {
         const item = Toolbar.createKernelStatusItem(session);
         const status = session.status;
         expect(item.node.title.toLowerCase()).to.contain(status);
@@ -300,22 +294,16 @@ describe('@jupyterlab/apputils', () => {
             called = true;
           }
         };
-        return future.done.then(() => {
-          expect(called).to.equal(true);
-        });
+        await future.done;
+        expect(called).to.equal(true);
       });
 
-      it('should handle a starting session', () => {
-        return session
-          .shutdown()
-          .then(() => {
-            return createClientSession();
-          })
-          .then(session => {
-            const item = Toolbar.createKernelStatusItem(session);
-            expect(item.node.title).to.equal('Kernel Starting');
-            expect(item.hasClass('jp-FilledCircleIcon')).to.equal(true);
-          });
+      it('should handle a starting session', async () => {
+        await session.shutdown();
+        const session = await createClientSession();
+        const item = Toolbar.createKernelStatusItem(session);
+        expect(item.node.title).to.equal('Kernel Starting');
+        expect(item.hasClass('jp-FilledCircleIcon')).to.equal(true);
       });
     });
   });

--- a/tests/test-cells/src/widget.spec.ts
+++ b/tests/test-cells/src/widget.spec.ts
@@ -423,15 +423,10 @@ describe('cells/widget', () => {
     describe('.execute()', () => {
       let session: IClientSession;
 
-      beforeEach(() => {
-        return createClientSession()
-          .then(s => {
-            session = s;
-            return s.initialize();
-          })
-          .then(() => {
-            return session.kernel.ready;
-          });
+      beforeEach(async () => {
+        session = await createClientSession();
+        await s.initialize();
+        await session.kernel.ready;
       });
 
       afterEach(() => {
@@ -443,15 +438,14 @@ describe('cells/widget', () => {
         return CodeCell.execute(widget, session);
       });
 
-      it('should fulfill a promise if there is code to execute', () => {
+      it('should fulfill a promise if there is code to execute', async () => {
         const widget = new CodeCell({ model, rendermime, contentFactory });
         let originalCount: number;
         widget.model.value.text = 'foo';
         originalCount = widget.model.executionCount;
-        return CodeCell.execute(widget, session).then(() => {
-          const executionCount = widget.model.executionCount;
-          expect(executionCount).to.not.equal(originalCount);
-        });
+        await CodeCell.execute(widget, session);
+        const executionCount = widget.model.executionCount;
+        expect(executionCount).to.not.equal(originalCount);
       });
     });
   });

--- a/tests/test-cells/src/widget.spec.ts
+++ b/tests/test-cells/src/widget.spec.ts
@@ -425,7 +425,7 @@ describe('cells/widget', () => {
 
       beforeEach(async () => {
         session = await createClientSession();
-        await s.initialize();
+        await session.initialize();
         await session.kernel.ready;
       });
 

--- a/tests/test-completer/src/handler.spec.ts
+++ b/tests/test-completer/src/handler.spec.ts
@@ -58,13 +58,10 @@ describe('@jupyterlab/completer', () => {
   let connector: KernelConnector;
   let session: IClientSession;
 
-  before(() => {
-    return createClientSession().then(s => {
-      return s.initialize().then(() => {
-        session = s;
-        connector = new KernelConnector({ session });
-      });
-    });
+  before(async () => {
+    session = await createClientSession();
+    await session.initialize();
+    connector = new KernelConnector({ session });
   });
 
   after(() => session.shutdown());

--- a/tests/test-console/src/history.spec.ts
+++ b/tests/test-console/src/history.spec.ts
@@ -13,7 +13,7 @@ import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
 import { ConsoleHistory } from '@jupyterlab/console';
 
-import { createClientSession, testEmission } from '@jupyterlab/testutils';
+import { createClientSession, signalToPromise } from '@jupyterlab/testutils';
 
 const mockHistory: KernelMessage.IHistoryReplyMsg = {
   header: null,
@@ -167,14 +167,11 @@ describe('console/history', () => {
         const editor = new CodeMirrorEditor({ model, host });
         history.editor = editor;
         history.push('foo');
-        const promise = testEmission(editor.model.value.changed, {
-          test: () => {
-            return editor.model.value.text === 'foo';
-          }
-        });
+        const promise = signalToPromise(editor.model.value.changed);
         editor.edgeRequested.emit('top');
         expect(history.methods).to.contain('onEdgeRequest');
         await promise;
+        expect(editor.model.value.text).to.equal('foo');
       });
     });
   });

--- a/tests/test-console/src/history.spec.ts
+++ b/tests/test-console/src/history.spec.ts
@@ -13,7 +13,7 @@ import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
 import { ConsoleHistory } from '@jupyterlab/console';
 
-import { createClientSession } from '@jupyterlab/testutils';
+import { createClientSession, testEmission } from '@jupyterlab/testutils';
 
 const mockHistory: KernelMessage.IHistoryReplyMsg = {
   header: null,
@@ -51,10 +51,8 @@ class TestHistory extends ConsoleHistory {
 describe('console/history', () => {
   let session: IClientSession;
 
-  beforeEach(() => {
-    return createClientSession().then(s => {
-      session = s;
-    });
+  beforeEach(async () => {
+    session = await createClientSession();
   });
 
   after(() => {
@@ -64,14 +62,14 @@ describe('console/history', () => {
   describe('ConsoleHistory', () => {
     describe('#constructor()', () => {
       it('should create a console history object', () => {
-        let history = new ConsoleHistory({ session });
+        const history = new ConsoleHistory({ session });
         expect(history).to.be.an.instanceof(ConsoleHistory);
       });
     });
 
     describe('#isDisposed', () => {
       it('should get whether the object is disposed', () => {
-        let history = new ConsoleHistory({ session });
+        const history = new ConsoleHistory({ session });
         expect(history.isDisposed).to.equal(false);
         history.dispose();
         expect(history.isDisposed).to.equal(true);
@@ -80,21 +78,21 @@ describe('console/history', () => {
 
     describe('#session', () => {
       it('should be the client session object', () => {
-        let history = new ConsoleHistory({ session });
+        const history = new ConsoleHistory({ session });
         expect(history.session).to.equal(session);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose the history object', () => {
-        let history = new ConsoleHistory({ session });
+        const history = new ConsoleHistory({ session });
         expect(history.isDisposed).to.equal(false);
         history.dispose();
         expect(history.isDisposed).to.equal(true);
       });
 
       it('should be safe to dispose multiple times', () => {
-        let history = new ConsoleHistory({ session });
+        const history = new ConsoleHistory({ session });
         expect(history.isDisposed).to.equal(false);
         history.dispose();
         history.dispose();
@@ -103,66 +101,57 @@ describe('console/history', () => {
     });
 
     describe('#back()', () => {
-      it('should return an empty string if no history exists', () => {
-        let history = new ConsoleHistory({ session });
-        return history.back('').then(result => {
-          expect(result).to.equal('');
-        });
+      it('should return an empty string if no history exists', async () => {
+        const history = new ConsoleHistory({ session });
+        const result = await history.back('');
+        expect(result).to.equal('');
       });
 
-      it('should return previous items if they exist', done => {
-        let history = new TestHistory({ session });
+      it('should return previous items if they exist', async () => {
+        const history = new TestHistory({ session });
         history.onHistory(mockHistory);
-        history.back('').then(result => {
-          let index = mockHistory.content.history.length - 1;
-          let last = (mockHistory.content.history[index] as any)[2];
-          expect(result).to.equal(last);
-          done();
-        });
+        const result = await history.back('');
+        const index = mockHistory.content.history.length - 1;
+        const last = (mockHistory.content.history[index] as any)[2];
+        expect(result).to.equal(last);
       });
     });
 
     describe('#forward()', () => {
-      it('should return an empty string if no history exists', () => {
-        let history = new ConsoleHistory({ session });
-        return history.forward('').then(result => {
-          expect(result).to.equal('');
-        });
+      it('should return an empty string if no history exists', async () => {
+        const history = new ConsoleHistory({ session });
+        const result = await history.forward('');
+        expect(result).to.equal('');
       });
 
-      it('should return next items if they exist', done => {
-        let history = new TestHistory({ session });
+      it('should return next items if they exist', async () => {
+        const history = new TestHistory({ session });
         history.onHistory(mockHistory);
-        Promise.all([history.back(''), history.back('')]).then(() => {
-          history.forward('').then(result => {
-            let index = mockHistory.content.history.length - 1;
-            let last = (mockHistory.content.history[index] as any)[2];
-            expect(result).to.equal(last);
-            done();
-          });
-        });
+        await Promise.all([history.back(''), history.back('')]);
+        const result = await history.forward('');
+        const index = mockHistory.content.history.length - 1;
+        const last = (mockHistory.content.history[index] as any)[2];
+        expect(result).to.equal(last);
       });
     });
 
     describe('#push()', () => {
-      it('should allow addition of history items', done => {
-        let history = new ConsoleHistory({ session });
-        let item = 'foo';
+      it('should allow addition of history items', async () => {
+        const history = new ConsoleHistory({ session });
+        const item = 'foo';
         history.push(item);
-        history.back('').then(result => {
-          expect(result).to.equal(item);
-          done();
-        });
+        const result = await history.back('');
+        expect(result).to.equal(item);
       });
     });
 
     describe('#onTextChange()', () => {
       it('should be called upon an editor text change', () => {
-        let history = new TestHistory({ session });
+        const history = new TestHistory({ session });
         expect(history.methods).to.not.contain('onTextChange');
-        let model = new CodeEditor.Model();
-        let host = document.createElement('div');
-        let editor = new CodeMirrorEditor({ model, host });
+        const model = new CodeEditor.Model();
+        const host = document.createElement('div');
+        const editor = new CodeMirrorEditor({ model, host });
         history.editor = editor;
         model.value.text = 'foo';
         expect(history.methods).to.contain('onTextChange');
@@ -170,20 +159,22 @@ describe('console/history', () => {
     });
 
     describe('#onEdgeRequest()', () => {
-      it('should be called upon an editor edge request', done => {
-        let history = new TestHistory({ session });
+      it('should be called upon an editor edge request', async () => {
+        const history = new TestHistory({ session });
         expect(history.methods).to.not.contain('onEdgeRequest');
-        let host = document.createElement('div');
-        let model = new CodeEditor.Model();
-        let editor = new CodeMirrorEditor({ model, host });
+        const host = document.createElement('div');
+        const model = new CodeEditor.Model();
+        const editor = new CodeMirrorEditor({ model, host });
         history.editor = editor;
         history.push('foo');
-        editor.model.value.changed.connect(() => {
-          expect(editor.model.value.text).to.equal('foo');
-          done();
+        const promise = testEmission(editor.model.value.changed, {
+          test: () => {
+            return editor.model.value.text === 'foo';
+          }
         });
         editor.edgeRequested.emit('top');
         expect(history.methods).to.contain('onEdgeRequest');
+        await promise;
       });
     });
   });

--- a/tests/test-console/src/panel.spec.ts
+++ b/tests/test-console/src/panel.spec.ts
@@ -38,7 +38,7 @@ const contentFactory = createConsolePanelFactory();
 
 describe('console/panel', () => {
   let panel: TestPanel;
-  let manager = new ServiceManager();
+  const manager = new ServiceManager();
 
   before(() => {
     return manager.ready;
@@ -119,14 +119,14 @@ describe('console/panel', () => {
     describe('.ContentFactory', () => {
       describe('#constructor', () => {
         it('should create a new code console factory', () => {
-          let factory = new ConsolePanel.ContentFactory({ editorFactory });
+          const factory = new ConsolePanel.ContentFactory({ editorFactory });
           expect(factory).to.be.an.instanceof(ConsolePanel.ContentFactory);
         });
       });
 
       describe('#createConsole()', () => {
         it('should create a console widget', () => {
-          let options = {
+          const options = {
             contentFactory: contentFactory,
             rendermime,
             mimeTypeService,

--- a/tests/test-coreutils/src/settingregistry.spec.ts
+++ b/tests/test-coreutils/src/settingregistry.spec.ts
@@ -12,7 +12,7 @@ import {
   StateDB
 } from '@jupyterlab/coreutils';
 
-import { testEmission } from '@jupyterlab/testutils';
+import { signalToPromise } from '@jupyterlab/testutils';
 
 import { JSONObject } from '@phosphor/coreutils';
 
@@ -344,7 +344,7 @@ describe('@jupyterlab/coreutils', () => {
 
         connector.schemas[id] = schema;
         settings = (await registry.load(id)) as Settings;
-        let promise = testEmission(settings.changed, {});
+        let promise = signalToPromise(settings.changed);
         await settings.set('foo', 'bar');
         await promise;
       });

--- a/tests/test-docmanager/src/savehandler.spec.ts
+++ b/tests/test-docmanager/src/savehandler.spec.ts
@@ -17,6 +17,7 @@ import { PromiseDelegate, UUID } from '@phosphor/coreutils';
 
 import {
   acceptDialog,
+  signalToPromise,
   testEmission,
   waitForDialog
 } from '@jupyterlab/testutils';
@@ -103,7 +104,7 @@ describe('docregistry/savehandler', () => {
       });
 
       it('should trigger a save', () => {
-        let promise = testEmission(context.fileChanged, {});
+        let promise = signalToPromise(context.fileChanged);
         context.model.fromString('bar');
         expect(handler.isActive).to.equal(false);
         handler.saveInterval = 1;

--- a/tests/test-docregistry/package.json
+++ b/tests/test-docregistry/package.json
@@ -25,9 +25,10 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -27,7 +27,7 @@ import {
 
 describe('docregistry/context', () => {
   let manager: ServiceManager.IManager;
-  let factory = new TextModelFactory();
+  const factory = new TextModelFactory();
 
   before(() => {
     manager = new ServiceManager();
@@ -45,10 +45,9 @@ describe('docregistry/context', () => {
       });
     });
 
-    afterEach(() => {
-      return context.session.shutdown().then(() => {
-        context.dispose();
-      });
+    afterEach(async () => {
+      await context.session.shutdown();
+      context.dispose();
     });
 
     describe('#constructor()', () => {
@@ -58,47 +57,49 @@ describe('docregistry/context', () => {
           factory,
           path: UUID.uuid4() + '.txt'
         });
-        expect(context).to.be.a(Context);
+        expect(context).to.be.an.instanceof(Context);
       });
     });
 
     describe('#pathChanged', () => {
-      it('should be emitted when the path changes', done => {
-        let newPath = UUID.uuid4() + '.txt';
+      it('should be emitted when the path changes', async () => {
+        const newPath = UUID.uuid4() + '.txt';
+        let called = false;
         context.pathChanged.connect((sender, args) => {
-          expect(sender).to.be(context);
-          expect(args).to.be(newPath);
-          done();
+          expect(sender).to.equal(context);
+          expect(args).to.equal(newPath);
+          called = true;
         });
-        context
-          .initialize(true)
-          .then(() => manager.contents.rename(context.path, newPath))
-          .catch(done);
+        await context.initialize(true);
+        await manager.contents.rename(context.path, newPath);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#fileChanged', () => {
-      it('should be emitted when the file is saved', done => {
-        let path = context.path;
+      it('should be emitted when the file is saved', async () => {
+        const path = context.path;
+        let called = false;
         context.fileChanged.connect((sender, args) => {
-          expect(sender).to.be(context);
-          expect(args.path).to.be(path);
-          done();
+          expect(sender).to.equal(context);
+          expect(args.path).to.equal(path);
+          called = true;
         });
-        context.initialize(true).catch(done);
+        await context.initialize(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#isReady', () => {
-      it('should indicate whether the context is ready', done => {
-        expect(context.isReady).to.be(false);
-        context.ready
-          .then(() => {
-            expect(context.isReady).to.be(true);
-            done();
-          })
-          .catch(done);
-        context.initialize(true).catch(done);
+      it('should indicate whether the context is ready', async () => {
+        expect(context.isReady).to.equal(false);
+        const func = async () => {
+          await context.ready;
+          expect(context.isReady).to.equal(true);
+        };
+        const promise = func();
+        await context.initialize(true);
+        await promise;
       });
     });
 
@@ -121,10 +122,10 @@ describe('docregistry/context', () => {
       it('should initialize the model when the file is saved for the first time', async () => {
         const context = await createNotebookContext();
         context.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(context.model.cells.canUndo).to.be(true);
+        expect(context.model.cells.canUndo).to.equal(true);
         await context.initialize(true);
         await context.ready;
-        expect(context.model.cells.canUndo).to.be(false);
+        expect(context.model.cells.canUndo).to.equal(false);
         await dismissDialog();
       });
 
@@ -136,45 +137,47 @@ describe('docregistry/context', () => {
           content: NBTestUtils.DEFAULT_CONTENT
         });
         context.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(context.model.cells.canUndo).to.be(true);
+        expect(context.model.cells.canUndo).to.equal(true);
         await context.initialize(false);
         await context.ready;
-        expect(context.model.cells.canUndo).to.be(false);
+        expect(context.model.cells.canUndo).to.equal(false);
       });
     });
 
     describe('#disposed', () => {
-      it('should be emitted when the context is disposed', done => {
+      it('should be emitted when the context is disposed', () => {
+        let called = false;
         context.disposed.connect((sender, args) => {
-          expect(sender).to.be(context);
-          expect(args).to.be(undefined);
-          done();
+          expect(sender).to.equal(context);
+          expect(args).to.be.undefined;
+          called = true;
         });
         context.dispose();
+        expect(called).to.equal(true);
       });
     });
 
     describe('#model', () => {
       it('should be the model associated with the document', () => {
-        expect(context.model.toString()).to.be('');
+        expect(context.model.toString()).to.equal('');
       });
     });
 
     describe('#session', () => {
       it('should be a client session object', () => {
-        expect(context.session.path).to.be(context.path);
+        expect(context.session.path).to.equal(context.path);
       });
     });
 
     describe('#path', () => {
       it('should be the current path for the context', () => {
-        expect(typeof context.path).to.be('string');
+        expect(typeof context.path).to.equal('string');
       });
     });
 
     describe('#contentsModel', () => {
       it('should be `null` before population', () => {
-        expect(context.contentsModel).to.be(null);
+        expect(context.contentsModel).to.be.null;
       });
 
       it('should be set after population', async () => {
@@ -182,30 +185,30 @@ describe('docregistry/context', () => {
 
         context.initialize(true);
         await context.ready;
-        expect(context.contentsModel.path).to.be(path);
+        expect(context.contentsModel.path).to.equal(path);
       });
     });
 
     describe('#factoryName', () => {
       it('should be the name of the factory used by the context', () => {
-        expect(context.factoryName).to.be(factory.name);
+        expect(context.factoryName).to.equal(factory.name);
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether the context is disposed', () => {
-        expect(context.isDisposed).to.be(false);
+        expect(context.isDisposed).to.equal(false);
         context.dispose();
-        expect(context.isDisposed).to.be(true);
+        expect(context.isDisposed).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources used by the context', () => {
         context.dispose();
-        expect(context.isDisposed).to.be(true);
+        expect(context.isDisposed).to.equal(true);
         context.dispose();
-        expect(context.isDisposed).to.be(true);
+        expect(context.isDisposed).to.equal(true);
       });
     });
 
@@ -222,211 +225,161 @@ describe('docregistry/context', () => {
         };
         const model = await manager.contents.get(context.path, opts);
 
-        expect(model.content).to.be('foo');
+        expect(model.content).to.equal('foo');
         await dismissDialog();
       });
     });
 
     describe('#saveAs()', () => {
-      it('should save the document to a different path chosen by the user', () => {
+      it('should save the document to a different path chosen by the user', async () => {
         const initialize = context.initialize(true);
         const newPath = UUID.uuid4() + '.txt';
 
-        initialize.then(() => waitForDialog()).then(() => {
+        const func = async () => {
+          await initialize;
+          await waitForDialog();
           const dialog = document.body.getElementsByClassName('jp-Dialog')[0];
           const input = dialog.getElementsByTagName('input')[0];
 
           input.value = newPath;
-          acceptDialog();
-        });
-
-        return initialize.then(() => context.saveAs()).then(() => {
-          expect(context.path).to.be(newPath);
-        });
+          await acceptDialog();
+        };
+        const promise = func();
+        await initialize;
+        await context.saveAs();
+        expect(context.path).to.equal(newPath);
+        await promise;
       });
 
-      it('should bring up a conflict dialog', () => {
+      it('should bring up a conflict dialog', async () => {
         const newPath = UUID.uuid4() + '.txt';
-        waitForDialog()
-          .then(() => {
-            let dialog = document.body.getElementsByClassName('jp-Dialog')[0];
-            let input = dialog.getElementsByTagName('input')[0];
-            input.value = newPath;
-            return acceptDialog();
-          })
-          .then(() => {
-            return acceptDialog();
-          });
-        return manager.contents
-          .save(newPath, {
-            type: factory.contentType,
-            format: factory.fileFormat,
-            content: 'foo'
-          })
-          .then(() => {
-            return context.initialize(true);
-          })
-          .then(() => {
-            return context.saveAs();
-          })
-          .then(() => {
-            expect(context.path).to.be(newPath);
-          });
+
+        const func = async () => {
+          await waitForDialog();
+          const dialog = document.body.getElementsByClassName('jp-Dialog')[0];
+          const input = dialog.getElementsByTagName('input')[0];
+          input.value = newPath;
+          await acceptDialog();
+          await acceptDialog();
+        };
+        const promise = func();
+        await manager.contents.save(newPath, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo'
+        });
+        await context.initialize(true);
+        await context.saveAs();
+        expect(context.path).to.equal(newPath);
+        await promise;
       });
 
-      it('should keep the file if overwrite is aborted', () => {
-        let oldPath = context.path;
-        let newPath = UUID.uuid4() + '.txt';
-        waitForDialog()
-          .then(() => {
-            let dialog = document.body.getElementsByClassName('jp-Dialog')[0];
-            let input = dialog.getElementsByTagName('input')[0];
-            input.value = newPath;
-            return acceptDialog();
-          })
-          .then(() => {
-            return dismissDialog();
-          });
-        return manager.contents
-          .save(newPath, {
-            type: factory.contentType,
-            format: factory.fileFormat,
-            content: 'foo'
-          })
-          .then(() => {
-            return context.initialize(true);
-          })
-          .then(() => {
-            return context.saveAs();
-          })
-          .then(() => {
-            expect(context.path).to.be(oldPath);
-          });
+      it('should keep the file if overwrite is aborted', async () => {
+        const oldPath = context.path;
+        const newPath = UUID.uuid4() + '.txt';
+        const func = async () => {
+          await waitForDialog();
+          const dialog = document.body.getElementsByClassName('jp-Dialog')[0];
+          const input = dialog.getElementsByTagName('input')[0];
+          input.value = newPath;
+          await acceptDialog();
+          await dismissDialog();
+        };
+        const promise = func();
+        await manager.contents.save(newPath, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo'
+        });
+        await context.initialize(true);
+        await context.saveAs();
+        expect(context.path).to.equal(oldPath);
+        await promise;
+        await dismissDialog();
       });
 
-      it('should just save if the file name does not change', () => {
-        acceptDialog();
-        let path = context.path;
-        return context
-          .initialize(true)
-          .then(() => {
-            return context.saveAs();
-          })
-          .then(() => {
-            expect(context.path).to.be(path);
-          });
+      it('should just save if the file name does not change', async () => {
+        const path = context.path;
+        await context.initialize(true);
+        const promise = context.saveAs();
+        await acceptDialog();
+        await promise;
+        expect(context.path).to.equal(path);
       });
     });
 
     describe('#revert()', () => {
-      it('should revert the contents of the file to the disk', () => {
-        return context
-          .initialize(true)
-          .then(() => {
-            context.model.fromString('foo');
-            return context.save();
-          })
-          .then(() => {
-            context.model.fromString('bar');
-            return context.revert();
-          })
-          .then(() => {
-            expect(context.model.toString()).to.be('foo');
-          });
+      it('should revert the contents of the file to the disk', async () => {
+        await context.initialize(true);
+        context.model.fromString('foo');
+        await context.save();
+        context.model.fromString('bar');
+        await context.revert();
+        expect(context.model.toString()).to.equal('foo');
       });
     });
 
     describe('#createCheckpoint()', () => {
-      it('should create a checkpoint for the file', () => {
-        return context
-          .initialize(true)
-          .then(() => {
-            return context.createCheckpoint();
-          })
-          .then(model => {
-            expect(model.id).to.be.ok();
-            expect(model.last_modified).to.be.ok();
-          });
+      it('should create a checkpoint for the file', async () => {
+        await context.initialize(true);
+        const model = await context.createCheckpoint();
+        expect(model.id).to.be.ok;
+        expect(model.last_modified).to.be.ok;
       });
     });
 
     describe('#deleteCheckpoint()', () => {
-      it('should delete the given checkpoint', () => {
-        return context
-          .initialize(true)
-          .then(() => {
-            return context.createCheckpoint();
-          })
-          .then(model => {
-            return context.deleteCheckpoint(model.id);
-          })
-          .then(() => {
-            return context.listCheckpoints();
-          })
-          .then(models => {
-            expect(models.length).to.be(0);
-          });
+      it('should delete the given checkpoint', async () => {
+        await context.initialize(true);
+        const model = await context.createCheckpoint();
+        context.deleteCheckpoint(model.id);
+        const models = await context.listCheckpoints();
+        expect(models.length).to.equal(0);
       });
     });
 
     describe('#restoreCheckpoint()', () => {
-      it('should restore the value to the last checkpoint value', () => {
+      it('should restore the value to the last checkpoint value', async () => {
         context.model.fromString('bar');
-        let id = '';
-        return context
-          .initialize(true)
-          .then(() => {
-            return context.createCheckpoint();
-          })
-          .then(model => {
-            context.model.fromString('foo');
-            id = model.id;
-            return context.save();
-          })
-          .then(() => {
-            return context.restoreCheckpoint(id);
-          })
-          .then(() => {
-            return context.revert();
-          })
-          .then(() => {
-            expect(context.model.toString()).to.be('bar');
-          });
+        await context.initialize(true);
+        const model = await context.createCheckpoint();
+        context.model.fromString('foo');
+        const id = model.id;
+        await context.save();
+        await context.restoreCheckpoint(id);
+        await context.revert();
+        expect(context.model.toString()).to.equal('bar');
       });
     });
 
     describe('#listCheckpoints()', () => {
-      it('should list the checkpoints for the file', () => {
-        let id = '';
-        return context.initialize(true).then(() => {
-          context
-            .createCheckpoint()
-            .then(model => {
-              id = model.id;
-              return context.listCheckpoints();
-            })
-            .then(models => {
-              for (let model of models) {
-                if (model.id === id) {
-                  return;
-                }
-              }
-              throw new Error('Model not found');
-            });
-        });
+      it('should list the checkpoints for the file', async () => {
+        await context.initialize(true);
+        const model = await context.createCheckpoint();
+        const id = model.id;
+        const models = await context.listCheckpoints();
+        let found = false;
+        for (const model of models) {
+          if (model.id === id) {
+            found = true;
+          }
+        }
+        expect(found).to.equal(true);
       });
     });
 
     describe('#urlResolver', () => {
       it('should be a url resolver', () => {
-        expect(context.urlResolver).to.be.a(RenderMimeRegistry.UrlResolver);
+        expect(context.urlResolver).to.be.an.instanceof(
+          RenderMimeRegistry.UrlResolver
+        );
       });
     });
 
     describe('#addSibling()', () => {
       it('should add a sibling widget', () => {
         let called = false;
-        let opener = (widget: Widget) => {
+        const opener = (widget: Widget) => {
           called = true;
         };
         context = new Context({
@@ -436,7 +389,7 @@ describe('docregistry/context', () => {
           opener
         });
         context.addSibling(new Widget());
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
   });

--- a/tests/test-docregistry/src/default.spec.ts
+++ b/tests/test-docregistry/src/default.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -44,168 +44,168 @@ describe('docregistry/default', () => {
   describe('ABCWidgetFactory', () => {
     describe('#fileTypes', () => {
       it('should be the value passed in', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text']
         });
-        expect(factory.fileTypes).to.eql(['text']);
+        expect(factory.fileTypes).to.deep.equal(['text']);
       });
     });
 
     describe('#name', () => {
       it('should be the value passed in', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text']
         });
-        expect(factory.name).to.be('test');
+        expect(factory.name).to.equal('test');
       });
     });
 
     describe('#defaultFor', () => {
       it('should default to an empty array', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text']
         });
-        expect(factory.defaultFor).to.eql([]);
+        expect(factory.defaultFor).to.deep.equal([]);
       });
 
       it('should be the value passed in', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text'],
           defaultFor: ['text']
         });
-        expect(factory.defaultFor).to.eql(['text']);
+        expect(factory.defaultFor).to.deep.equal(['text']);
       });
     });
 
     describe('#defaultRendered', () => {
       it('should default to an empty array', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text']
         });
-        expect(factory.defaultRendered).to.eql([]);
+        expect(factory.defaultRendered).to.deep.equal([]);
       });
 
       it('should be the value passed in', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text'],
           defaultRendered: ['text']
         });
-        expect(factory.defaultRendered).to.eql(['text']);
+        expect(factory.defaultRendered).to.deep.equal(['text']);
       });
     });
 
     describe('#readOnly', () => {
       it('should default to false', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text']
         });
-        expect(factory.readOnly).to.be(false);
+        expect(factory.readOnly).to.equal(false);
       });
 
       it('should be the value passed in', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text'],
           readOnly: true
         });
-        expect(factory.readOnly).to.be(true);
+        expect(factory.readOnly).to.equal(true);
       });
     });
 
     describe('#modelName', () => {
       it('should default to `text`', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text']
         });
-        expect(factory.modelName).to.be('text');
+        expect(factory.modelName).to.equal('text');
       });
 
       it('should be the value passed in', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text'],
           modelName: 'notebook'
         });
-        expect(factory.modelName).to.be('notebook');
+        expect(factory.modelName).to.equal('notebook');
       });
     });
 
     describe('#preferKernel', () => {
       it('should default to false', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text']
         });
-        expect(factory.preferKernel).to.be(false);
+        expect(factory.preferKernel).to.equal(false);
       });
 
       it('should be the value passed in', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text'],
           preferKernel: true
         });
-        expect(factory.preferKernel).to.be(true);
+        expect(factory.preferKernel).to.equal(true);
       });
     });
 
     describe('#canStartKernel', () => {
       it('should default to false', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text']
         });
-        expect(factory.canStartKernel).to.be(false);
+        expect(factory.canStartKernel).to.equal(false);
       });
 
       it('should be the value passed in', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text'],
           canStartKernel: true
         });
-        expect(factory.canStartKernel).to.be(true);
+        expect(factory.canStartKernel).to.equal(true);
       });
     });
 
     describe('#isDisposed', () => {
       it('should get whether the factory has been disposed', () => {
-        let factory = createFactory();
-        expect(factory.isDisposed).to.be(false);
+        const factory = createFactory();
+        expect(factory.isDisposed).to.equal(false);
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the factory', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         factory.dispose();
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
     });
 
     describe('#createNew()', () => {
       it('should create a new widget given a document model and a context', () => {
-        let factory = createFactory();
-        let context = createFileContext();
-        let widget = factory.createNew(context);
-        expect(widget).to.be.a(Widget);
+        const factory = createFactory();
+        const context = createFileContext();
+        const widget = factory.createNew(context);
+        expect(widget).to.be.an.instanceof(Widget);
       });
     });
   });
@@ -213,22 +213,22 @@ describe('docregistry/default', () => {
   describe('Base64ModelFactory', () => {
     describe('#name', () => {
       it('should get the name of the model type', () => {
-        let factory = new Base64ModelFactory();
-        expect(factory.name).to.be('base64');
+        const factory = new Base64ModelFactory();
+        expect(factory.name).to.equal('base64');
       });
     });
 
     describe('#contentType', () => {
       it('should get the file type', () => {
-        let factory = new Base64ModelFactory();
-        expect(factory.contentType).to.be('file');
+        const factory = new Base64ModelFactory();
+        expect(factory.contentType).to.equal('file');
       });
     });
 
     describe('#fileFormat', () => {
       it('should get the file format', () => {
-        let factory = new Base64ModelFactory();
-        expect(factory.fileFormat).to.be('base64');
+        const factory = new Base64ModelFactory();
+        expect(factory.fileFormat).to.equal('base64');
       });
     });
   });
@@ -236,201 +236,201 @@ describe('docregistry/default', () => {
   describe('DocumentModel', () => {
     describe('#constructor()', () => {
       it('should create a new document model', () => {
-        let model = new DocumentModel();
-        expect(model).to.be.a(DocumentModel);
+        const model = new DocumentModel();
+        expect(model).to.be.an.instanceof(DocumentModel);
       });
 
       it('should accept an optional language preference', () => {
-        let model = new DocumentModel('foo');
-        expect(model.defaultKernelLanguage).to.be('foo');
+        const model = new DocumentModel('foo');
+        expect(model.defaultKernelLanguage).to.equal('foo');
       });
     });
 
     describe('#isDisposed', () => {
       it('should get whether the model has been disposed', () => {
-        let model = new DocumentModel();
-        expect(model.isDisposed).to.be(false);
+        const model = new DocumentModel();
+        expect(model.isDisposed).to.equal(false);
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
     });
 
     describe('#contentChanged', () => {
       it('should be emitted when the content of the model changes', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         let called = false;
         model.contentChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args).to.be(void 0);
+          expect(sender).to.equal(model);
+          expect(args).to.be.undefined;
           called = true;
         });
         model.fromString('foo');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should not be emitted if the content does not change', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         let called = false;
         model.contentChanged.connect(() => {
           called = true;
         });
         model.fromString('');
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
     });
 
     describe('#stateChanged', () => {
       it('should be emitted when the state of the model changes', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         let called = false;
         model.stateChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.name).to.be('readOnly');
-          expect(args.oldValue).to.be(false);
-          expect(args.newValue).to.be(true);
+          expect(sender).to.equal(model);
+          expect(args.name).to.equal('readOnly');
+          expect(args.oldValue).to.equal(false);
+          expect(args.newValue).to.equal(true);
           called = true;
         });
         model.readOnly = true;
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should not be emitted if the state does not change', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         let called = false;
         model.stateChanged.connect(() => {
           called = true;
         });
         model.dirty = false;
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
     });
 
     describe('#dirty', () => {
       it('should get the dirty state of the document', () => {
-        let model = new DocumentModel();
-        expect(model.dirty).to.be(false);
+        const model = new DocumentModel();
+        expect(model.dirty).to.equal(false);
       });
 
       it('should emit `stateChanged` when changed', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         let called = false;
         model.stateChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.name).to.be('dirty');
-          expect(args.oldValue).to.be(false);
-          expect(args.newValue).to.be(true);
+          expect(sender).to.equal(model);
+          expect(args.name).to.equal('dirty');
+          expect(args.oldValue).to.equal(false);
+          expect(args.newValue).to.equal(true);
           called = true;
         });
         model.dirty = true;
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should not emit `stateChanged` when not changed', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         let called = false;
         model.stateChanged.connect(() => {
           called = true;
         });
         model.dirty = false;
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
     });
 
     describe('#readOnly', () => {
       it('should get the read only state of the document', () => {
-        let model = new DocumentModel();
-        expect(model.readOnly).to.be(false);
+        const model = new DocumentModel();
+        expect(model.readOnly).to.equal(false);
       });
 
       it('should emit `stateChanged` when changed', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         let called = false;
         model.stateChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.name).to.be('readOnly');
-          expect(args.oldValue).to.be(false);
-          expect(args.newValue).to.be(true);
+          expect(sender).to.equal(model);
+          expect(args.name).to.equal('readOnly');
+          expect(args.oldValue).to.equal(false);
+          expect(args.newValue).to.equal(true);
           called = true;
         });
         model.readOnly = true;
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should not emit `stateChanged` when not changed', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         let called = false;
         model.stateChanged.connect(() => {
           called = true;
         });
         model.readOnly = false;
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
     });
 
     describe('#defaultKernelName', () => {
       it('should get the default kernel name of the document', () => {
-        let model = new DocumentModel();
-        expect(model.defaultKernelName).to.be('');
+        const model = new DocumentModel();
+        expect(model.defaultKernelName).to.equal('');
       });
     });
 
     describe('defaultKernelLanguage', () => {
       it('should get the default kernel language of the document', () => {
-        let model = new DocumentModel();
-        expect(model.defaultKernelLanguage).to.be('');
+        const model = new DocumentModel();
+        expect(model.defaultKernelLanguage).to.equal('');
       });
 
       it('should be set by the constructor arg', () => {
-        let model = new DocumentModel('foo');
-        expect(model.defaultKernelLanguage).to.be('foo');
+        const model = new DocumentModel('foo');
+        expect(model.defaultKernelLanguage).to.equal('foo');
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the document manager', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
 
       it('should be safe to call more than once', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         model.dispose();
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
     });
 
     describe('#toString()', () => {
       it('should serialize the model to a string', () => {
-        let model = new DocumentModel();
-        expect(model.toString()).to.be('');
+        const model = new DocumentModel();
+        expect(model.toString()).to.equal('');
       });
     });
 
     describe('#fromString()', () => {
       it('should deserialize the model from a string', () => {
-        let model = new DocumentModel();
+        const model = new DocumentModel();
         model.fromString('foo');
-        expect(model.toString()).to.be('foo');
+        expect(model.toString()).to.equal('foo');
       });
     });
 
     describe('#toJSON()', () => {
       it('should serialize the model to JSON', () => {
-        let model = new DocumentModel();
-        let data = { foo: 1 };
+        const model = new DocumentModel();
+        const data = { foo: 1 };
         model.fromJSON(data);
-        expect(model.toJSON()).to.eql(data);
+        expect(model.toJSON()).to.deep.equal(data);
       });
     });
 
     describe('#fromJSON()', () => {
       it('should deserialize the model from JSON', () => {
-        let model = new DocumentModel();
-        let data = null;
+        const model = new DocumentModel();
+        const data: null = null;
         model.fromJSON(data);
-        expect(model.toString()).to.be('null');
+        expect(model.toString()).to.equal('null');
       });
     });
   });
@@ -438,68 +438,68 @@ describe('docregistry/default', () => {
   describe('TextModelFactory', () => {
     describe('#name', () => {
       it('should get the name of the model type', () => {
-        let factory = new TextModelFactory();
-        expect(factory.name).to.be('text');
+        const factory = new TextModelFactory();
+        expect(factory.name).to.equal('text');
       });
     });
 
     describe('#contentType', () => {
       it('should get the file type', () => {
-        let factory = new TextModelFactory();
-        expect(factory.contentType).to.be('file');
+        const factory = new TextModelFactory();
+        expect(factory.contentType).to.equal('file');
       });
     });
 
     describe('#fileFormat', () => {
       it('should get the file format', () => {
-        let factory = new TextModelFactory();
-        expect(factory.fileFormat).to.be('text');
+        const factory = new TextModelFactory();
+        expect(factory.fileFormat).to.equal('text');
       });
     });
 
     describe('#isDisposed', () => {
       it('should get whether the factory is disposed', () => {
-        let factory = new TextModelFactory();
-        expect(factory.isDisposed).to.be(false);
+        const factory = new TextModelFactory();
+        expect(factory.isDisposed).to.equal(false);
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the factory', () => {
-        let factory = new TextModelFactory();
+        const factory = new TextModelFactory();
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let factory = new TextModelFactory();
+        const factory = new TextModelFactory();
         factory.dispose();
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
     });
 
     describe('#createNew()', () => {
       it('should create a new model', () => {
-        let factory = new TextModelFactory();
-        let model = factory.createNew();
-        expect(model).to.be.a(DocumentModel);
+        const factory = new TextModelFactory();
+        const model = factory.createNew();
+        expect(model).to.be.an.instanceof(DocumentModel);
       });
 
       it('should accept a language preference', () => {
-        let factory = new TextModelFactory();
-        let model = factory.createNew('foo');
-        expect(model.defaultKernelLanguage).to.be('foo');
+        const factory = new TextModelFactory();
+        const model = factory.createNew('foo');
+        expect(model.defaultKernelLanguage).to.equal('foo');
       });
     });
 
     describe('#preferredLanguage()', () => {
       it('should get the preferred kernel language given an extension', () => {
-        let factory = new TextModelFactory();
-        expect(factory.preferredLanguage('.py')).to.be('python');
-        expect(factory.preferredLanguage('.jl')).to.be('julia');
+        const factory = new TextModelFactory();
+        expect(factory.preferredLanguage('.py')).to.equal('python');
+        expect(factory.preferredLanguage('.jl')).to.equal('julia');
       });
     });
   });
@@ -511,7 +511,7 @@ describe('docregistry/default', () => {
     let content: Widget;
     let widget: DocumentWidget;
 
-    let setup = () => {
+    const setup = () => {
       context = createFileContext(undefined, manager);
       content = new Widget();
       widget = new DocumentWidget({ context, content });
@@ -526,14 +526,14 @@ describe('docregistry/default', () => {
       beforeEach(setup);
 
       it('should set the title for the path', () => {
-        expect(widget.title.label).to.be(context.localPath);
+        expect(widget.title.label).to.equal(context.localPath);
       });
 
       it('should update the title when the path changes', async () => {
-        let path = UUID.uuid4() + '.jl';
+        const path = UUID.uuid4() + '.jl';
         await context.initialize(true);
         await manager.contents.rename(context.path, path);
-        expect(widget.title.label).to.be(path);
+        expect(widget.title.label).to.equal(path);
       });
 
       it('should add the dirty class when the model is dirty', async () => {
@@ -544,7 +544,7 @@ describe('docregistry/default', () => {
       });
 
       it('should store the context', () => {
-        expect(widget.context).to.be(context);
+        expect(widget.context).to.equal(context);
       });
     });
 
@@ -552,22 +552,21 @@ describe('docregistry/default', () => {
       beforeEach(setup);
 
       it('should resolve after the reveal and context ready promises', async () => {
-        let x = Object.create(null);
-        let reveal = sleep(300, x);
-        let contextReady = Promise.all([context.ready, x]);
-        let widget = new DocumentWidget({ context, content, reveal });
-        expect(widget.isRevealed).to.be(false);
+        const x = Object.create(null);
+        const reveal = sleep(300, x);
+        const contextReady = Promise.all([context.ready, x]);
+        const widget = new DocumentWidget({ context, content, reveal });
+        expect(widget.isRevealed).to.equal(false);
 
         // Our promise should resolve before the widget reveal promise.
-        expect(await Promise.race([widget.revealed, reveal])).to.be(x);
+        expect(await Promise.race([widget.revealed, reveal])).to.equal(x);
         // The context ready promise should also resolve first.
         context.initialize(true);
-        expect(await Promise.race([widget.revealed, contextReady])).to.eql([
-          undefined,
-          x
-        ]);
+        expect(
+          await Promise.race([widget.revealed, contextReady])
+        ).to.deep.equal([undefined, x]);
         // The widget.revealed promise should finally resolve.
-        expect(await widget.revealed).to.be(undefined);
+        expect(await widget.revealed).to.be.undefined;
       });
     });
   });

--- a/tests/test-docregistry/src/mimedocument.spec.ts
+++ b/tests/test-docregistry/src/mimedocument.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Message } from '@phosphor/messaging';
 
@@ -36,10 +36,9 @@ class LogRenderer extends MimeContent {
 }
 
 class FooText extends RenderedText {
-  render(model: IRenderMime.IMimeModel): Promise<void> {
-    return super.render(model).then(() => {
-      model.setData({ data: { 'text/foo': 'bar' } });
-    });
+  async render(model: IRenderMime.IMimeModel): Promise<void> {
+    await super.render(model);
+    model.setData({ data: { 'text/foo': 'bar' } });
   }
 }
 
@@ -63,13 +62,15 @@ describe('docregistry/mimedocument', () => {
   describe('MimeDocumentFactory', () => {
     describe('#createNew()', () => {
       it('should require a context parameter', () => {
-        let widgetFactory = new MimeDocumentFactory({
+        const widgetFactory = new MimeDocumentFactory({
           name: 'markdown',
           fileTypes: ['markdown'],
           rendermime: RENDERMIME,
           primaryFileType: DocumentRegistry.defaultTextFileType
         });
-        expect(widgetFactory.createNew(dContext)).to.be.a(MimeDocument);
+        expect(widgetFactory.createNew(dContext)).to.be.an.instanceof(
+          MimeDocument
+        );
       });
     });
   });
@@ -78,21 +79,21 @@ describe('docregistry/mimedocument', () => {
     describe('#constructor()', () => {
       it('should require options', () => {
         const renderer = RENDERMIME.createRenderer('text/markdown');
-        let widget = new MimeContent({
+        const widget = new MimeContent({
           context: dContext,
           renderer,
           mimeType: 'text/markdown',
           renderTimeout: 1000,
           dataType: 'string'
         });
-        expect(widget).to.be.a(MimeContent);
+        expect(widget).to.be.an.instanceof(MimeContent);
       });
     });
 
     describe('#ready', () => {
-      it('should resolve when the widget is ready', () => {
+      it('should resolve when the widget is ready', async () => {
         const renderer = RENDERMIME.createRenderer('text/markdown');
-        let widget = new LogRenderer({
+        const widget = new LogRenderer({
           context: dContext,
           renderer,
           mimeType: 'text/markdown',
@@ -100,34 +101,31 @@ describe('docregistry/mimedocument', () => {
           dataType: 'string'
         });
         dContext.initialize(true);
-        return widget.ready.then(() => {
-          let layout = widget.layout as BoxLayout;
-          expect(layout.widgets.length).to.be(1);
-        });
+        await widget.ready;
+        const layout = widget.layout as BoxLayout;
+        expect(layout.widgets.length).to.equal(1);
       });
     });
 
     context('contents changed', () => {
-      it('should change the document contents', done => {
+      it('should change the document contents', async () => {
         RENDERMIME.addFactory(fooFactory);
-        dContext
-          .initialize(true)
-          .then(() => {
-            dContext.model.contentChanged.connect(() => {
-              expect(dContext.model.toString()).to.be('bar');
-              done();
-            });
-            const renderer = RENDERMIME.createRenderer('text/foo');
-            let widget = new LogRenderer({
-              context: dContext,
-              renderer,
-              mimeType: 'text/foo',
-              renderTimeout: 1000,
-              dataType: 'string'
-            });
-            return widget.ready;
-          })
-          .catch(done);
+        await dContext.initialize(true);
+        let called = false;
+        dContext.model.contentChanged.connect(() => {
+          expect(dContext.model.toString()).to.equal('bar');
+          called = true;
+        });
+        const renderer = RENDERMIME.createRenderer('text/foo');
+        const widget = new LogRenderer({
+          context: dContext,
+          renderer,
+          mimeType: 'text/foo',
+          renderTimeout: 1000,
+          dataType: 'string'
+        });
+        await widget.ready;
+        expect(called).to.equal(true);
       });
     });
   });

--- a/tests/test-docregistry/src/registry.spec.ts
+++ b/tests/test-docregistry/src/registry.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -48,7 +48,7 @@ function createFactory(modelName?: string) {
 
 describe('docregistry/registry', () => {
   describe('DocumentRegistry', () => {
-    let registry: DocumentRegistry;
+    const registry: DocumentRegistry;
 
     beforeEach(() => {
       registry = new DocumentRegistry();
@@ -68,9 +68,9 @@ describe('docregistry/registry', () => {
 
     describe('#isDisposed', () => {
       it('should get whether the registry has been disposed', () => {
-        expect(registry.isDisposed).to.be(false);
+        expect(registry.isDisposed).to.equal(false);
         registry.dispose();
-        expect(registry.isDisposed).to.be(true);
+        expect(registry.isDisposed).to.equal(true);
       });
     });
 
@@ -78,34 +78,34 @@ describe('docregistry/registry', () => {
       it('should dispose of the resources held by the registry', () => {
         registry.addFileType({ name: 'notebook', extensions: ['.ipynb'] });
         registry.dispose();
-        expect(registry.isDisposed).to.be(true);
+        expect(registry.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
         registry.dispose();
         registry.dispose();
-        expect(registry.isDisposed).to.be(true);
+        expect(registry.isDisposed).to.equal(true);
       });
     });
 
     describe('#addWidgetFactory()', () => {
       it('should add the widget factory to the registry', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        expect(registry.getWidgetFactory(factory.name)).to.be(factory);
-        expect(registry.getWidgetFactory(factory.name.toUpperCase())).to.be(
+        expect(registry.getWidgetFactory(factory.name)).to.equal(factory);
+        expect(registry.getWidgetFactory(factory.name.toUpperCase())).to.equal(
           factory
         );
       });
 
       it('should become the global default if `*` is given as a defaultFor', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'global',
           fileTypes: ['*'],
           defaultFor: ['*']
         });
         registry.addWidgetFactory(factory);
-        expect(registry.defaultWidgetFactory('*').name).to.be('global');
+        expect(registry.defaultWidgetFactory('*').name).to.equal('global');
       });
 
       it('should override an existing global default', () => {
@@ -116,103 +116,103 @@ describe('docregistry/registry', () => {
             defaultFor: ['*']
           })
         );
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'bar',
           fileTypes: ['*'],
           defaultFor: ['*']
         });
         registry.addWidgetFactory(factory);
-        expect(registry.defaultWidgetFactory('*').name).to.be('bar');
+        expect(registry.defaultWidgetFactory('*').name).to.equal('bar');
       });
 
       it('should override an existing extension default', () => {
         registry.addWidgetFactory(createFactory());
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        expect(registry.defaultWidgetFactory('a.foo.bar')).to.be(factory);
+        expect(registry.defaultWidgetFactory('a.foo.bar')).to.equal(factory);
       });
 
       it('should be removed from the registry when disposed', () => {
-        let factory = createFactory();
-        let disposable = registry.addWidgetFactory(factory);
+        const factory = createFactory();
+        const disposable = registry.addWidgetFactory(factory);
         disposable.dispose();
-        expect(registry.getWidgetFactory('test')).to.be(void 0);
+        expect(registry.getWidgetFactory('test')).to.be.undefined;
       });
     });
 
     describe('#addModelFactory()', () => {
       it('should add the model factory to the registry', () => {
-        let factory = new Base64ModelFactory();
+        const factory = new Base64ModelFactory();
         registry.addModelFactory(factory);
       });
 
       it('should be a no-op a factory with the given `name` is already registered', () => {
-        let factory = new Base64ModelFactory();
+        const factory = new Base64ModelFactory();
         registry.addModelFactory(factory);
-        let disposable = registry.addModelFactory(new Base64ModelFactory());
+        const disposable = registry.addModelFactory(new Base64ModelFactory());
         disposable.dispose();
       });
 
       it('should be a no-op if the same factory is already registered', () => {
-        let factory = new Base64ModelFactory();
+        const factory = new Base64ModelFactory();
         registry.addModelFactory(factory);
-        let disposable = registry.addModelFactory(factory);
+        const disposable = registry.addModelFactory(factory);
         disposable.dispose();
       });
 
       it('should be removed from the registry when disposed', () => {
-        let factory = new Base64ModelFactory();
-        let disposable = registry.addModelFactory(factory);
+        const factory = new Base64ModelFactory();
+        const disposable = registry.addModelFactory(factory);
         disposable.dispose();
       });
     });
 
     describe('#addWidgetExtension()', () => {
       it('should add a widget extension to the registry', () => {
-        let extension = new WidgetExtension();
+        const extension = new WidgetExtension();
         registry.addWidgetExtension('foo', extension);
-        expect(registry.widgetExtensions('foo').next()).to.be(extension);
+        expect(registry.widgetExtensions('foo').next()).to.equal(extension);
       });
 
       it('should be a no-op if the extension is already registered for a given widget factory', () => {
-        let extension = new WidgetExtension();
+        const extension = new WidgetExtension();
         registry.addWidgetExtension('foo', extension);
-        let disposable = registry.addWidgetExtension('foo', extension);
+        const disposable = registry.addWidgetExtension('foo', extension);
         disposable.dispose();
-        expect(registry.widgetExtensions('foo').next()).to.be(extension);
+        expect(registry.widgetExtensions('foo').next()).to.equal(extension);
       });
 
       it('should be removed from the registry when disposed', () => {
-        let extension = new WidgetExtension();
-        let disposable = registry.addWidgetExtension('foo', extension);
+        const extension = new WidgetExtension();
+        const disposable = registry.addWidgetExtension('foo', extension);
         disposable.dispose();
-        expect(toArray(registry.widgetExtensions('foo')).length).to.be(0);
+        expect(toArray(registry.widgetExtensions('foo')).length).to.equal(0);
       });
     });
 
     describe('#addFileType()', () => {
       it('should add a file type to the document registry', () => {
         registry = new DocumentRegistry({ initialFileTypes: [] });
-        let fileType = { name: 'notebook', extensions: ['.ipynb'] };
+        const fileType = { name: 'notebook', extensions: ['.ipynb'] };
         registry.addFileType(fileType);
-        expect(registry.fileTypes().next().name).to.be(fileType.name);
+        expect(registry.fileTypes().next().name).to.equal(fileType.name);
       });
 
       it('should be removed from the registry when disposed', () => {
         registry = new DocumentRegistry({ initialFileTypes: [] });
-        let fileType = { name: 'notebook', extensions: ['.ipynb'] };
-        let disposable = registry.addFileType(fileType);
+        const fileType = { name: 'notebook', extensions: ['.ipynb'] };
+        const disposable = registry.addFileType(fileType);
         disposable.dispose();
-        expect(toArray(registry.fileTypes()).length).to.be(0);
+        expect(toArray(registry.fileTypes()).length).to.equal(0);
       });
 
       it('should be a no-op if a file type of the same name is registered', () => {
         registry = new DocumentRegistry({ initialFileTypes: [] });
-        let fileType = { name: 'notebook', extensions: ['.ipynb'] };
+        const fileType = { name: 'notebook', extensions: ['.ipynb'] };
         registry.addFileType(fileType);
-        let disposable = registry.addFileType(fileType);
+        const disposable = registry.addFileType(fileType);
         disposable.dispose();
-        expect(registry.fileTypes().next().name).to.be(fileType.name);
+        expect(registry.fileTypes().next().name).to.equal(fileType.name);
       });
     });
 
@@ -225,160 +225,170 @@ describe('docregistry/registry', () => {
       });
 
       it('should give the valid registered widget factories', () => {
-        expect(toArray(registry.preferredWidgetFactories('foo.txt'))).to.eql(
-          []
-        );
-        let factory = createFactory();
+        expect(
+          toArray(registry.preferredWidgetFactories('foo.txt'))
+        ).to.deep.equal([]);
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        let gFactory = new WidgetFactory({
+        const gFactory = new WidgetFactory({
           name: 'global',
           fileTypes: ['*'],
           defaultFor: ['*']
         });
         registry.addWidgetFactory(gFactory);
-        let factories = registry.preferredWidgetFactories('a.foo.bar');
-        expect(toArray(factories)).to.eql([factory, gFactory]);
+        const factories = registry.preferredWidgetFactories('a.foo.bar');
+        expect(toArray(factories)).to.deep.equal([factory, gFactory]);
       });
 
       it('should not list a factory whose model is not registered', () => {
         registry.addWidgetFactory(createFactory('foobar'));
-        expect(registry.preferredWidgetFactories('a.foo.bar').length).to.eql(0);
+        expect(
+          registry.preferredWidgetFactories('a.foo.bar').length
+        ).to.deep.equal(0);
       });
 
       it('should select the factory for a given extension', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        let mdFactory = new WidgetFactory({
+        const mdFactory = new WidgetFactory({
           name: 'markdown',
           fileTypes: ['markdown']
         });
         registry.addWidgetFactory(mdFactory);
-        expect(registry.preferredWidgetFactories('a.txt')[0]).to.be(factory);
-        expect(registry.preferredWidgetFactories('a.md')[0]).to.be(mdFactory);
+        expect(registry.preferredWidgetFactories('a.txt')[0]).to.equal(factory);
+        expect(registry.preferredWidgetFactories('a.md')[0]).to.equal(
+          mdFactory
+        );
       });
 
       it('should respect the priority order', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        let gFactory = new WidgetFactory({
+        const gFactory = new WidgetFactory({
           name: 'global',
           fileTypes: ['*'],
           defaultFor: ['*']
         });
         registry.addWidgetFactory(gFactory);
-        let mdFactory = new WidgetFactory({
+        const mdFactory = new WidgetFactory({
           name: 'markdown',
           fileTypes: ['markdown']
         });
         registry.addWidgetFactory(mdFactory);
-        let factories = registry.preferredWidgetFactories('a.txt');
-        expect(toArray(factories)).to.eql([factory, gFactory]);
+        const factories = registry.preferredWidgetFactories('a.txt');
+        expect(toArray(factories)).to.deep.equal([factory, gFactory]);
       });
 
       it('should list a default rendered factory after the default factory', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        let gFactory = new WidgetFactory({
+        const gFactory = new WidgetFactory({
           name: 'global',
           fileTypes: ['*'],
           defaultFor: ['*']
         });
         registry.addWidgetFactory(gFactory);
-        let mdFactory = new WidgetFactory({
+        const mdFactory = new WidgetFactory({
           name: 'markdown',
           fileTypes: ['markdown'],
           defaultRendered: ['markdown']
         });
         registry.addWidgetFactory(mdFactory);
 
-        let factories = registry.preferredWidgetFactories('a.md');
-        expect(factories).to.eql([mdFactory, gFactory]);
+        const factories = registry.preferredWidgetFactories('a.md');
+        expect(factories).to.deep.equal([mdFactory, gFactory]);
       });
 
       it('should handle multi-part extensions', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        let tFactory = new WidgetFactory({
+        const tFactory = new WidgetFactory({
           name: 'table',
           fileTypes: ['tablejson']
         });
         registry.addWidgetFactory(tFactory);
-        let jFactory = new WidgetFactory({
+        const jFactory = new WidgetFactory({
           name: 'json',
           fileTypes: ['json']
         });
         registry.addWidgetFactory(jFactory);
-        let factories = registry.preferredWidgetFactories('foo.table.json');
-        expect(toArray(factories)).to.eql([tFactory, jFactory]);
+        const factories = registry.preferredWidgetFactories('foo.table.json');
+        expect(toArray(factories)).to.deep.equal([tFactory, jFactory]);
         factories = registry.preferredWidgetFactories('foo.json');
-        expect(toArray(factories)).to.eql([jFactory]);
+        expect(toArray(factories)).to.deep.equal([jFactory]);
       });
 
       it('should handle just a multi-part extension', () => {
-        let factory = new WidgetFactory({
+        const factory = new WidgetFactory({
           name: 'table',
           fileTypes: ['tablejson']
         });
         registry.addWidgetFactory(factory);
-        let factories = registry.preferredWidgetFactories('foo.table.json');
-        expect(toArray(factories)).to.eql([factory]);
+        const factories = registry.preferredWidgetFactories('foo.table.json');
+        expect(toArray(factories)).to.deep.equal([factory]);
         factories = registry.preferredWidgetFactories('foo.json');
-        expect(toArray(factories)).to.eql([]);
+        expect(toArray(factories)).to.deep.equal([]);
       });
     });
 
     describe('#defaultWidgetFactory()', () => {
       it('should get the default widget factory for a given extension', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        let gFactory = new WidgetFactory({
+        const gFactory = new WidgetFactory({
           name: 'global',
           fileTypes: ['*'],
           defaultFor: ['*']
         });
         registry.addWidgetFactory(gFactory);
-        let mdFactory = new WidgetFactory({
+        const mdFactory = new WidgetFactory({
           name: 'markdown',
           fileTypes: ['markdown'],
           defaultFor: ['markdown']
         });
         registry.addWidgetFactory(mdFactory);
-        expect(registry.defaultWidgetFactory('a.foo.bar')).to.be(factory);
-        expect(registry.defaultWidgetFactory('a.md')).to.be(mdFactory);
-        expect(registry.defaultWidgetFactory()).to.be(gFactory);
+        expect(registry.defaultWidgetFactory('a.foo.bar')).to.equal(factory);
+        expect(registry.defaultWidgetFactory('a.md')).to.equal(mdFactory);
+        expect(registry.defaultWidgetFactory()).to.equal(gFactory);
       });
     });
 
     describe('#defaultRenderedWidgetFactory()', () => {
       it('should get the default rendered widget factory for a given extension', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        let mdFactory = new WidgetFactory({
+        const mdFactory = new WidgetFactory({
           name: 'markdown',
           fileTypes: ['markdown'],
           defaultRendered: ['markdown']
         });
         registry.addWidgetFactory(mdFactory);
-        expect(registry.defaultRenderedWidgetFactory('a.baz')).to.be(factory);
-        expect(registry.defaultRenderedWidgetFactory('a.md')).to.be(mdFactory);
+        expect(registry.defaultRenderedWidgetFactory('a.baz')).to.equal(
+          factory
+        );
+        expect(registry.defaultRenderedWidgetFactory('a.md')).to.equal(
+          mdFactory
+        );
       });
 
       it('should get the default widget factory if no default rendered factory is registered', () => {
-        let gFactory = new WidgetFactory({
+        const gFactory = new WidgetFactory({
           name: 'global',
           fileTypes: ['*'],
           defaultFor: ['*']
         });
         registry.addWidgetFactory(gFactory);
-        expect(registry.defaultRenderedWidgetFactory('a.md')).to.be(gFactory);
+        expect(registry.defaultRenderedWidgetFactory('a.md')).to.equal(
+          gFactory
+        );
       });
     });
 
     describe('#fileTypes()', () => {
       it('should get the registered file types', () => {
         registry = new DocumentRegistry({ initialFileTypes: [] });
-        expect(toArray(registry.fileTypes()).length).to.be(0);
-        let fileTypes = [
+        expect(toArray(registry.fileTypes()).length).to.equal(0);
+        const fileTypes = [
           { name: 'notebook', extensions: ['.ipynb'] },
           { name: 'python', extensions: ['.py'] },
           { name: 'table', extensions: ['.table.json'] }
@@ -386,18 +396,18 @@ describe('docregistry/registry', () => {
         registry.addFileType(fileTypes[0]);
         registry.addFileType(fileTypes[1]);
         registry.addFileType(fileTypes[2]);
-        let values = registry.fileTypes();
-        expect(values.next().name).to.be(fileTypes[0].name);
-        expect(values.next().name).to.be(fileTypes[1].name);
-        expect(values.next().name).to.be(fileTypes[2].name);
+        const values = registry.fileTypes();
+        expect(values.next().name).to.equal(fileTypes[0].name);
+        expect(values.next().name).to.equal(fileTypes[1].name);
+        expect(values.next().name).to.equal(fileTypes[2].name);
       });
     });
 
     describe('#getFileType()', () => {
       it('should get a file type by name', () => {
-        expect(registry.getFileType('notebook')).to.be.ok();
-        expect(registry.getFileType('python')).to.be.ok();
-        expect(registry.getFileType('fizzbuzz')).to.be(void 0);
+        expect(registry.getFileType('notebook')).to.be.ok;
+        expect(registry.getFileType('python')).to.be.ok;
+        expect(registry.getFileType('fizzbuzz')).to.be.undefined;
       });
     });
 
@@ -419,60 +429,60 @@ describe('docregistry/registry', () => {
             defaultFor: ['*']
           })
         );
-        let pref = registry.getKernelPreference('.c', 'global');
-        expect(pref.language).to.be('clike');
-        expect(pref.shouldStart).to.be(false);
-        expect(pref.canStart).to.be(false);
+        const pref = registry.getKernelPreference('.c', 'global');
+        expect(pref.language).to.equal('clike');
+        expect(pref.shouldStart).to.equal(false);
+        expect(pref.canStart).to.equal(false);
 
         pref = registry.getKernelPreference('.py', 'python');
-        expect(pref.language).to.be('python');
-        expect(pref.shouldStart).to.be(true);
-        expect(pref.canStart).to.be(true);
+        expect(pref.language).to.equal('python');
+        expect(pref.shouldStart).to.equal(true);
+        expect(pref.canStart).to.equal(true);
 
         pref = registry.getKernelPreference('.py', 'baz');
-        expect(pref).to.be(void 0);
+        expect(pref).to.be.undefined;
       });
     });
 
     describe('#getModelFactory()', () => {
       it('should get a registered model factory by name', () => {
-        let mFactory = new Base64ModelFactory();
+        const mFactory = new Base64ModelFactory();
         registry.addModelFactory(mFactory);
-        expect(registry.getModelFactory('base64')).to.be(mFactory);
+        expect(registry.getModelFactory('base64')).to.equal(mFactory);
       });
     });
 
     describe('#getWidgetFactory()', () => {
       it('should get a widget factory by name', () => {
         registry.addModelFactory(new Base64ModelFactory());
-        let factory = createFactory();
+        const factory = createFactory();
         registry.addWidgetFactory(factory);
-        let mdFactory = new WidgetFactory({
+        const mdFactory = new WidgetFactory({
           name: 'markdown',
           fileTypes: ['markdown']
         });
         registry.addWidgetFactory(mdFactory);
-        expect(registry.getWidgetFactory(factory.name)).to.be(factory);
-        expect(registry.getWidgetFactory('markdown')).to.be(mdFactory);
-        expect(registry.getWidgetFactory('baz')).to.be(void 0);
+        expect(registry.getWidgetFactory(factory.name)).to.equal(factory);
+        expect(registry.getWidgetFactory('markdown')).to.equal(mdFactory);
+        expect(registry.getWidgetFactory('baz')).to.be.undefined;
       });
     });
 
     describe('#widgetExtensions()', () => {
       it('should get the registered extensions for a given widget', () => {
-        let foo = new WidgetExtension();
-        let bar = new WidgetExtension();
+        const foo = new WidgetExtension();
+        const bar = new WidgetExtension();
         registry.addWidgetExtension('fizz', foo);
         registry.addWidgetExtension('fizz', bar);
         registry.addWidgetExtension('buzz', foo);
-        let fizz = toArray(registry.widgetExtensions('fizz'));
-        expect(fizz[0]).to.be(foo);
-        expect(fizz[1]).to.be(bar);
-        expect(fizz.length).to.be(2);
-        let buzz = toArray(registry.widgetExtensions('buzz'));
-        expect(buzz[0]).to.be(foo);
-        expect(toArray(buzz).length).to.be(1);
-        expect(registry.widgetExtensions('baz').next()).to.be(void 0);
+        const fizz = toArray(registry.widgetExtensions('fizz'));
+        expect(fizz[0]).to.equal(foo);
+        expect(fizz[1]).to.equal(bar);
+        expect(fizz.length).to.equal(2);
+        const buzz = toArray(registry.widgetExtensions('buzz'));
+        expect(buzz[0]).to.equal(foo);
+        expect(toArray(buzz).length).to.equal(1);
+        expect(registry.widgetExtensions('baz').next()).to.be.undefined;
       });
     });
 
@@ -484,31 +494,31 @@ describe('docregistry/registry', () => {
       });
 
       it('should handle a directory', () => {
-        let ft = registry.getFileTypeForModel({
+        const ft = registry.getFileTypeForModel({
           type: 'directory'
         });
-        expect(ft.name).to.be('directory');
+        expect(ft.name).to.equal('directory');
       });
 
       it('should handle a notebook', () => {
-        let ft = registry.getFileTypeForModel({
+        const ft = registry.getFileTypeForModel({
           type: 'notebook'
         });
-        expect(ft.name).to.be('notebook');
+        expect(ft.name).to.equal('notebook');
       });
 
       it('should handle a python file', () => {
-        let ft = registry.getFileTypeForModel({
+        const ft = registry.getFileTypeForModel({
           name: 'foo.py'
         });
-        expect(ft.name).to.be('python');
+        expect(ft.name).to.equal('python');
       });
 
       it('should handle an unknown file', () => {
-        let ft = registry.getFileTypeForModel({
+        const ft = registry.getFileTypeForModel({
           name: 'foo.bar'
         });
-        expect(ft.name).to.be('text');
+        expect(ft.name).to.equal('text');
       });
 
       it('should get the most specific extension', () => {
@@ -518,17 +528,17 @@ describe('docregistry/registry', () => {
         ].forEach(ft => {
           registry.addFileType(ft);
         });
-        let ft = registry.getFileTypeForModel({
+        const ft = registry.getFileTypeForModel({
           name: 'foo.vg.json'
         });
-        expect(ft.name).to.be('vega');
+        expect(ft.name).to.equal('vega');
       });
 
       it('should be case insensitive', () => {
-        let ft = registry.getFileTypeForModel({
+        const ft = registry.getFileTypeForModel({
           name: 'foo.PY'
         });
-        expect(ft.name).to.be('python');
+        expect(ft.name).to.equal('python');
       });
     });
 
@@ -540,18 +550,18 @@ describe('docregistry/registry', () => {
       });
 
       it('should handle a notebook', () => {
-        let ft = registry.getFileTypesForPath('foo/bar/baz.ipynb');
-        expect(ft[0].name).to.be('notebook');
+        const ft = registry.getFileTypesForPath('foo/bar/baz.ipynb');
+        expect(ft[0].name).to.equal('notebook');
       });
 
       it('should handle a python file', () => {
-        let ft = registry.getFileTypesForPath('foo/bar/baz.py');
-        expect(ft[0].name).to.be('python');
+        const ft = registry.getFileTypesForPath('foo/bar/baz.py');
+        expect(ft[0].name).to.equal('python');
       });
 
       it('should return an empty list for an unknown file', () => {
-        let ft = registry.getFileTypesForPath('foo/bar/baz.weird');
-        expect(ft.length).to.be(0);
+        const ft = registry.getFileTypesForPath('foo/bar/baz.weird');
+        expect(ft.length).to.equal(0);
       });
 
       it('should get the most specific extension first', () => {
@@ -561,14 +571,14 @@ describe('docregistry/registry', () => {
         ].forEach(ft => {
           registry.addFileType(ft);
         });
-        let ft = registry.getFileTypesForPath('foo/bar/baz.vg.json');
-        expect(ft[0].name).to.be('vega');
-        expect(ft[1].name).to.be('json');
+        const ft = registry.getFileTypesForPath('foo/bar/baz.vg.json');
+        expect(ft[0].name).to.equal('vega');
+        expect(ft[1].name).to.equal('json');
       });
 
       it('should be case insensitive', () => {
-        let ft = registry.getFileTypesForPath('foo/bar/baz.PY');
-        expect(ft[0].name).to.be('python');
+        const ft = registry.getFileTypesForPath('foo/bar/baz.PY');
+        expect(ft[0].name).to.equal('python');
       });
     });
   });

--- a/tests/test-docregistry/src/registry.spec.ts
+++ b/tests/test-docregistry/src/registry.spec.ts
@@ -48,7 +48,7 @@ function createFactory(modelName?: string) {
 
 describe('docregistry/registry', () => {
   describe('DocumentRegistry', () => {
-    const registry: DocumentRegistry;
+    let registry: DocumentRegistry;
 
     beforeEach(() => {
       registry = new DocumentRegistry();
@@ -312,7 +312,7 @@ describe('docregistry/registry', () => {
           fileTypes: ['json']
         });
         registry.addWidgetFactory(jFactory);
-        const factories = registry.preferredWidgetFactories('foo.table.json');
+        let factories = registry.preferredWidgetFactories('foo.table.json');
         expect(toArray(factories)).to.deep.equal([tFactory, jFactory]);
         factories = registry.preferredWidgetFactories('foo.json');
         expect(toArray(factories)).to.deep.equal([jFactory]);
@@ -324,7 +324,7 @@ describe('docregistry/registry', () => {
           fileTypes: ['tablejson']
         });
         registry.addWidgetFactory(factory);
-        const factories = registry.preferredWidgetFactories('foo.table.json');
+        let factories = registry.preferredWidgetFactories('foo.table.json');
         expect(toArray(factories)).to.deep.equal([factory]);
         factories = registry.preferredWidgetFactories('foo.json');
         expect(toArray(factories)).to.deep.equal([]);
@@ -429,7 +429,7 @@ describe('docregistry/registry', () => {
             defaultFor: ['*']
           })
         );
-        const pref = registry.getKernelPreference('.c', 'global');
+        let pref = registry.getKernelPreference('.c', 'global');
         expect(pref.language).to.equal('clike');
         expect(pref.shouldStart).to.equal(false);
         expect(pref.canStart).to.equal(false);

--- a/tests/test-filebrowser/package.json
+++ b/tests/test-filebrowser/package.json
@@ -27,10 +27,11 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1",
+    "chai": "~4.1.2",
     "simulate-event": "~1.4.0"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-filebrowser/package.json
+++ b/tests/test-filebrowser/package.json
@@ -25,7 +25,6 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
     "chai": "~4.1.2",
     "simulate-event": "~1.4.0"

--- a/tests/test-filebrowser/src/model.spec.ts
+++ b/tests/test-filebrowser/src/model.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { StateDB, PageConfig } from '@jupyterlab/coreutils';
 
@@ -11,7 +11,7 @@ import { DocumentManager, IDocumentManager } from '@jupyterlab/docmanager';
 
 import { DocumentRegistry, TextModelFactory } from '@jupyterlab/docregistry';
 
-import { ServiceManager, Session } from '@jupyterlab/services';
+import { ServiceManager } from '@jupyterlab/services';
 
 import {
   FileBrowserModel,
@@ -19,9 +19,12 @@ import {
   CHUNK_SIZE
 } from '@jupyterlab/filebrowser';
 
-import { acceptDialog, dismissDialog } from '@jupyterlab/testutils';
-import { ISignal } from '@phosphor/signaling';
-import { IIterator } from '@phosphor/algorithm';
+import {
+  acceptDialog,
+  dismissDialog,
+  signalToPromises
+} from '@jupyterlab/testutils';
+import { toArray } from '@phosphor/algorithm';
 
 describe('filebrowser/model', () => {
   let manager: IDocumentManager;
@@ -32,7 +35,7 @@ describe('filebrowser/model', () => {
   let state: StateDB;
 
   before(() => {
-    let opener: DocumentManager.IWidgetOpener = {
+    const opener: DocumentManager.IWidgetOpener = {
       open: widget => {
         /* no op */
       }
@@ -50,13 +53,12 @@ describe('filebrowser/model', () => {
     state = new StateDB({ namespace: 'filebrowser/model' });
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     state.clear();
     model = new FileBrowserModel({ manager, state });
-    return manager.newUntitled({ type: 'file' }).then(contents => {
-      name = contents.name;
-      return model.cd();
-    });
+    const contents = await manager.newUntitled({ type: 'file' });
+    name = contents.name;
+    return model.cd();
   });
 
   afterEach(() => {
@@ -67,229 +69,186 @@ describe('filebrowser/model', () => {
     describe('#constructor()', () => {
       it('should construct a new file browser model', () => {
         model = new FileBrowserModel({ manager });
-        expect(model).to.be.a(FileBrowserModel);
+        expect(model).to.be.an.instanceof(FileBrowserModel);
       });
     });
 
     describe('#pathChanged', () => {
-      it('should be emitted when the path changes', done => {
+      it('should be emitted when the path changes', async () => {
+        let called = false;
         model.pathChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.name).to.be('path');
-          expect(args.oldValue).to.be('');
-          expect(args.newValue).to.be('src');
-          done();
+          expect(sender).to.equal(model);
+          expect(args.name).to.equal('path');
+          expect(args.oldValue).to.equal('');
+          expect(args.newValue).to.equal('src');
+          called = true;
         });
-        model.cd('src').catch(done);
+        await model.cd('src');
+        expect(called).to.equal(true);
       });
     });
 
     describe('#refreshed', () => {
-      it('should be emitted after a refresh', done => {
+      it('should be emitted after a refresh', async () => {
+        let called = false;
         model.refreshed.connect((sender, arg) => {
-          expect(sender).to.be(model);
-          expect(arg).to.be(void 0);
-          done();
+          expect(sender).to.equal(model);
+          expect(arg).to.be.undefined;
+          called = true;
         });
-        model.cd().catch(done);
+        await model.cd();
+        expect(called).to.equal(true);
       });
 
-      it('should be emitted when the path changes', done => {
+      it('should be emitted when the path changes', async () => {
+        let called = false;
         model.refreshed.connect((sender, arg) => {
-          expect(sender).to.be(model);
-          expect(arg).to.be(void 0);
-          done();
+          expect(sender).to.equal(model);
+          expect(arg).to.be.undefined;
+          called = true;
         });
-        model.cd('src').catch(done);
+        await model.cd('src');
+        expect(called).to.equal(true);
       });
     });
 
     describe('#fileChanged', () => {
-      it('should be emitted when a file is created', done => {
+      it('should be emitted when a file is created', async () => {
+        let called = false;
         model.fileChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.type).to.be('new');
-          expect(args.oldValue).to.be(null);
-          expect(args.newValue.type).to.be('file');
-          done();
+          expect(sender).to.equal(model);
+          expect(args.type).to.equal('new');
+          expect(args.oldValue).to.be.null;
+          expect(args.newValue.type).to.equal('file');
+          called = true;
         });
-        manager.newUntitled({ type: 'file' }).catch(done);
+        await manager.newUntitled({ type: 'file' });
+        expect(called).to.equal(true);
       });
 
-      it('should be emitted when a file is renamed', done => {
+      it('should be emitted when a file is renamed', async () => {
+        let called = false;
         model.fileChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.type).to.be('rename');
-          expect(args.oldValue.path).to.be(name);
-          expect(args.newValue.path).to.be(name + '.bak');
-          done();
+          expect(sender).to.equal(model);
+          expect(args.type).to.equal('rename');
+          expect(args.oldValue.path).to.equal(name);
+          expect(args.newValue.path).to.equal(name + '.bak');
+          called = true;
         });
-        manager.rename(name, name + '.bak').catch(done);
+        await manager.rename(name, name + '.bak');
+        expect(called).to.equal(true);
       });
 
-      it('should be emitted when a file is deleted', done => {
+      it('should be emitted when a file is deleted', async () => {
+        let called = false;
         model.fileChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.type).to.be('delete');
-          expect(args.oldValue.path).to.be(name);
-          expect(args.newValue).to.be(null);
-          done();
+          expect(sender).to.equal(model);
+          expect(args.type).to.equal('delete');
+          expect(args.oldValue.path).to.equal(name);
+          expect(args.newValue).to.be.null;
+          called = true;
         });
-        manager.deleteFile(name).catch(done);
+        await manager.deleteFile(name);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#path', () => {
-      it('should be the current path of the model', done => {
-        expect(model.path).to.be('');
-        model
-          .cd('src/')
-          .then(() => {
-            expect(model.path).to.be('src');
-            done();
-          })
-          .catch(done);
+      it('should be the current path of the model', async () => {
+        expect(model.path).to.equal('');
+        await model.cd('src/');
+        expect(model.path).to.equal('src');
       });
     });
 
     describe('#items()', () => {
       it('should get an iterator of items in the current path', () => {
-        let items = model.items();
-        expect(items.next()).to.be.ok();
+        const items = model.items();
+        expect(items.next()).to.be.ok;
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether the model is disposed', () => {
-        expect(model.isDisposed).to.be(false);
+        expect(model.isDisposed).to.equal(false);
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
     });
 
     describe('#sessions()', () => {
-      it('should be the session models for the active notebooks', done => {
-        let session: Session.ISession;
-        manager
-          .newUntitled({ type: 'notebook' })
-          .then(contents => {
-            return serviceManager.sessions.startNew({ path: contents.path });
-          })
-          .then(s => {
-            session = s;
-            return model.cd();
-          })
-          .then(() => {
-            expect(model.sessions().next()).to.be.ok();
-            return session.shutdown();
-          })
-          .then(() => {
-            done();
-          })
-          .catch(done);
+      it('should be the session models for the active notebooks', async () => {
+        const contents = await manager.newUntitled({ type: 'notebook' });
+        const session = await serviceManager.sessions.startNew({
+          path: contents.path
+        });
+        await model.cd();
+        expect(model.sessions().next()).to.be.ok;
+        await session.shutdown();
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the model', () => {
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
 
       it('should be safe to call more than once', () => {
         model.dispose();
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
     });
 
     describe('#refresh()', () => {
-      it('should refresh the contents', done => {
-        model.refresh().then(done, done);
+      it('should refresh the contents', () => {
+        return model.refresh();
       });
     });
 
     describe('#cd()', () => {
-      it('should change directory', done => {
-        model
-          .cd('src')
-          .then(() => {
-            expect(model.path).to.be('src');
-            done();
-          })
-          .catch(done);
+      it('should change directory', async () => {
+        await model.cd('src');
+        expect(model.path).to.equal('src');
       });
 
-      it('should accept a relative path', done => {
-        model
-          .cd('./src')
-          .then(() => {
-            expect(model.path).to.be('src');
-            done();
-          })
-          .catch(done);
+      it('should accept a relative path', async () => {
+        await model.cd('./src');
+        expect(model.path).to.equal('src');
       });
 
-      it('should accept a parent directory', done => {
-        model
-          .cd('src')
-          .then(() => {
-            return model.cd('..');
-          })
-          .then(() => {
-            expect(model.path).to.be('');
-            done();
-          })
-          .catch(done);
+      it('should accept a parent directory', async () => {
+        await model.cd('src');
+        await model.cd('..');
+        expect(model.path).to.equal('');
       });
     });
 
     describe('#restore()', () => {
-      it('should restore based on ID', done => {
+      it('should restore based on ID', async () => {
         const id = 'foo';
         const model2 = new FileBrowserModel({ manager, state });
-        model
-          .restore(id)
-          .then(() => model.cd('src'))
-          .then(() => {
-            expect(model.path).to.be('src');
-          })
-          .then(() => {
-            expect(model2.path).to.be('');
-          })
-          .then(() => model2.restore(id))
-          .then(() => {
-            expect(model2.path).to.be('src');
-          })
-          .then(() => {
-            model2.dispose();
-            done();
-          })
-          .catch(done);
+        await model.restore(id);
+        await model.cd('src');
+        expect(model.path).to.equal('src');
+        expect(model2.path).to.equal('');
+        await model2.restore(id);
+        expect(model2.path).to.equal('src');
+        model2.dispose();
       });
 
-      it('should be safe to call multiple times', done => {
+      it('should be safe to call multiple times', async () => {
         const id = 'bar';
         const model2 = new FileBrowserModel({ manager, state });
-        model
-          .restore(id)
-          .then(() => model.cd('src'))
-          .then(() => {
-            expect(model.path).to.be('src');
-          })
-          .then(() => {
-            expect(model2.path).to.be('');
-          })
-          .then(() => model2.restore(id))
-          .then(() => model2.restore(id))
-          .then(() => {
-            expect(model2.path).to.be('src');
-          })
-          .then(() => {
-            model2.dispose();
-            done();
-          })
-          .catch(done);
+        await model.restore(id);
+        await model.cd('src');
+        expect(model.path).to.equal('src');
+        expect(model2.path).to.equal('');
+        await model2.restore(id);
+        await model2.restore(id);
+        expect(model2.path).to.equal('src');
+        model2.dispose();
       });
     });
 
@@ -300,67 +259,59 @@ describe('filebrowser/model', () => {
     });
 
     describe('#upload()', () => {
-      it('should upload a file object', done => {
-        let fname = UUID.uuid4() + '.html';
-        let file = new File(['<p>Hello world!</p>'], fname, {
+      it('should upload a file object', async () => {
+        const fname = UUID.uuid4() + '.html';
+        const file = new File(['<p>Hello world!</p>'], fname, {
           type: 'text/html'
         });
-        model
-          .upload(file)
-          .then(contents => {
-            expect(contents.name).to.be(fname);
-            done();
-          })
-          .catch(done);
+        const contents = await model.upload(file);
+        expect(contents.name).to.equal(fname);
       });
 
-      it('should overwrite', () => {
-        let fname = UUID.uuid4() + '.html';
-        let file = new File(['<p>Hello world!</p>'], fname, {
+      it('should overwrite', async () => {
+        const fname = UUID.uuid4() + '.html';
+        const file = new File(['<p>Hello world!</p>'], fname, {
           type: 'text/html'
         });
-        return model
-          .upload(file)
-          .then(contents => {
-            expect(contents.name).to.be(fname);
-            acceptDialog();
-            return model.upload(file);
-          })
-          .then(contents => {
-            expect(contents.name).to.be(fname);
-          });
+        const contents = await model.upload(file);
+        expect(contents.name).to.equal(fname);
+        const promise = model.upload(file);
+        await acceptDialog();
+        await promise;
+        expect(contents.name).to.equal(fname);
       });
 
-      it('should not overwrite', () => {
-        let fname = UUID.uuid4() + '.html';
-        let file = new File(['<p>Hello world!</p>'], fname, {
+      it('should not overwrite', async () => {
+        const fname = UUID.uuid4() + '.html';
+        const file = new File(['<p>Hello world!</p>'], fname, {
           type: 'text/html'
         });
-        return model
-          .upload(file)
-          .then(contents => {
-            expect(contents.name).to.be(fname);
-            dismissDialog();
-            return model.upload(file);
-          })
-          .catch(err => {
-            expect(err).to.be('File not uploaded');
-          });
+        const contents = await model.upload(file);
+        expect(contents.name).to.equal(fname);
+        const promise = model.upload(file);
+        await dismissDialog();
+        try {
+          await promise;
+        } catch (e) {
+          expect(e).to.equal('File not uploaded');
+        }
       });
 
-      it('should emit the fileChanged signal', done => {
-        let fname = UUID.uuid4() + '.html';
+      it('should emit the fileChanged signal', async () => {
+        const fname = UUID.uuid4() + '.html';
+        let called = false;
         model.fileChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.type).to.be('save');
-          expect(args.oldValue).to.be(null);
-          expect(args.newValue.path).to.be(fname);
-          done();
+          expect(sender).to.equal(model);
+          expect(args.type).to.equal('save');
+          expect(args.oldValue).to.be.null;
+          expect(args.newValue.path).to.equal(fname);
+          called = true;
         });
-        let file = new File(['<p>Hello world!</p>'], fname, {
+        const file = new File(['<p>Hello world!</p>'], fname, {
           type: 'text/html'
         });
-        model.upload(file).catch(done);
+        await model.upload(file);
+        expect(called).to.equal(true);
       });
 
       describe('older notebook version', () => {
@@ -373,17 +324,15 @@ describe('filebrowser/model', () => {
           );
         });
 
-        it('should not upload large file', () => {
+        it('should not upload large file', async () => {
           const fname = UUID.uuid4() + '.html';
           const file = new File([new ArrayBuffer(LARGE_FILE_SIZE + 1)], fname);
-          return model
-            .upload(file)
-            .then(() => {
-              expect().fail('Upload should have failed');
-            })
-            .catch(err => {
-              expect(err).to.be(`Cannot upload file (>15 MB). ${fname}`);
-            });
+          try {
+            await model.upload(file);
+            throw new Error('Upload should have failed');
+          } catch (err) {
+            expect(err).to.equal(`Cannot upload file (>15 MB). ${fname}`);
+          }
         });
 
         after(() => {
@@ -401,17 +350,15 @@ describe('filebrowser/model', () => {
           );
         });
 
-        it('should not upload large notebook file', () => {
+        it('should not upload large notebook file', async () => {
           const fname = UUID.uuid4() + '.ipynb';
           const file = new File([new ArrayBuffer(LARGE_FILE_SIZE + 1)], fname);
-          return model
-            .upload(file)
-            .then(() => {
-              expect().fail('Upload should have failed');
-            })
-            .catch(err => {
-              expect(err).to.be(`Cannot upload file (>15 MB). ${fname}`);
-            });
+          try {
+            await model.upload(file);
+            throw Error('Upload should have failed');
+          } catch (err) {
+            expect(err).to.equal(`Cannot upload file (>15 MB). ${fname}`);
+          }
         });
 
         for (const size of [
@@ -428,21 +375,21 @@ describe('filebrowser/model', () => {
             const contentsModel = await model.manager.services.contents.get(
               fname
             );
-            expect(contentsModel.content).to.be(content);
+            expect(contentsModel.content).to.equal(content);
           });
         }
         it(`should produce progress as a large file uploads`, async () => {
           const fname = UUID.uuid4() + '.txt';
           const file = new File([new ArrayBuffer(2 * CHUNK_SIZE)], fname);
 
-          const {
-            cleanup,
-            values: [start, first, second, finished]
-          } = signalToPromises(model.uploadChanged, 4);
+          const [start, first, second, finished] = signalToPromises(
+            model.uploadChanged,
+            4
+          );
 
           model.upload(file);
-          expect(iteratorToList(model.uploads())).to.eql([]);
-          expect(await start).to.eql([
+          expect(toArray(model.uploads())).to.deep.equal([]);
+          expect(await start).to.deep.equal([
             model,
             {
               name: 'start',
@@ -450,10 +397,10 @@ describe('filebrowser/model', () => {
               newValue: { path: fname, progress: 0 }
             }
           ]);
-          expect(iteratorToList(model.uploads())).to.eql([
+          expect(toArray(model.uploads())).to.deep.equal([
             { path: fname, progress: 0 }
           ]);
-          expect(await first).to.eql([
+          expect(await first).to.deep.equal([
             model,
             {
               name: 'update',
@@ -461,10 +408,10 @@ describe('filebrowser/model', () => {
               newValue: { path: fname, progress: 0 }
             }
           ]);
-          expect(iteratorToList(model.uploads())).to.eql([
+          expect(toArray(model.uploads())).to.deep.equal([
             { path: fname, progress: 0 }
           ]);
-          expect(await second).to.eql([
+          expect(await second).to.deep.equal([
             model,
             {
               name: 'update',
@@ -472,10 +419,10 @@ describe('filebrowser/model', () => {
               newValue: { path: fname, progress: 1 / 2 }
             }
           ]);
-          expect(iteratorToList(model.uploads())).to.eql([
+          expect(toArray(model.uploads())).to.deep.equal([
             { path: fname, progress: 1 / 2 }
           ]);
-          expect(await finished).to.eql([
+          expect(await finished).to.deep.equal([
             model,
             {
               name: 'finish',
@@ -483,8 +430,7 @@ describe('filebrowser/model', () => {
               newValue: null
             }
           ]);
-          expect(iteratorToList(model.uploads())).to.eql([]);
-          cleanup();
+          expect(toArray(model.uploads())).to.deep.equal([]);
         });
 
         after(() => {
@@ -494,42 +440,3 @@ describe('filebrowser/model', () => {
     });
   });
 });
-
-/**
- * Creates a number of promises from a signal, which each resolve to the successive values in the signal.
- */
-function signalToPromises<T, U>(
-  signal: ISignal<T, U>,
-  numberValues: number
-): { values: Promise<[T, U]>[]; cleanup: () => void } {
-  const values: Promise<[T, U]>[] = new Array(numberValues);
-  const resolvers: Array<((value: [T, U]) => void)> = new Array(numberValues);
-
-  for (let i = 0; i < numberValues; i++) {
-    values[i] = new Promise<[T, U]>(resolve => {
-      resolvers[i] = resolve;
-    });
-  }
-
-  let current = 0;
-  function slot(sender: T, args: U) {
-    resolvers[current++]([sender, args]);
-  }
-  signal.connect(slot);
-
-  function cleanup() {
-    signal.disconnect(slot);
-  }
-  return { values, cleanup };
-}
-
-/**
- * Convert an IIterator into a list.
- */
-function iteratorToList<T>(i: IIterator<T>): T[] {
-  const a: T[] = [];
-  for (let v = i.next(); v !== undefined; v = i.next()) {
-    a.push(v);
-  }
-  return a;
-}

--- a/tests/test-fileeditor/package.json
+++ b/tests/test-fileeditor/package.json
@@ -23,10 +23,11 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1",
+    "chai": "~4.1.2",
     "simulate-event": "~1.4.0"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-fileeditor/package.json
+++ b/tests/test-fileeditor/package.json
@@ -20,6 +20,7 @@
     "@jupyterlab/docregistry": "^0.17.2",
     "@jupyterlab/fileeditor": "^0.17.2",
     "@jupyterlab/services": "^3.0.3",
+    "@jupyterlab/testutils": "^0.1.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",

--- a/tests/test-imageviewer/package.json
+++ b/tests/test-imageviewer/package.json
@@ -23,9 +23,10 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-imageviewer/src/widget.spec.ts
+++ b/tests/test-imageviewer/src/widget.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -56,16 +56,15 @@ const OTHER =
   '9TXL0Y4OHwAAAABJRU5ErkJggg==';
 
 describe('ImageViewer', () => {
-  let factory = new Base64ModelFactory();
+  const factory = new Base64ModelFactory();
   let context: Context<DocumentRegistry.IModel>;
   let manager: ServiceManager.IManager;
   let widget: LogImage;
 
-  before(() => {
+  before(async () => {
     manager = new ServiceManager();
-    return manager.ready.then(() => {
-      return manager.contents.save(IMAGE.path, IMAGE);
-    });
+    await manager.ready;
+    return manager.contents.save(IMAGE.path, IMAGE);
   });
 
   beforeEach(() => {
@@ -80,73 +79,67 @@ describe('ImageViewer', () => {
 
   describe('#constructor()', () => {
     it('should create an ImageViewer', () => {
-      expect(widget).to.be.an(ImageViewer);
+      expect(widget).to.be.an.instanceof(ImageViewer);
     });
 
-    it('should keep the title in sync with the file name', done => {
-      let newPath = ((IMAGE as any).path = UUID.uuid4() + '.png');
-      expect(widget.title.label).to.be(context.path);
+    it('should keep the title in sync with the file name', async () => {
+      const newPath = ((IMAGE as any).path = UUID.uuid4() + '.png');
+      expect(widget.title.label).to.equal(context.path);
+      let called = false;
       context.pathChanged.connect(() => {
-        expect(widget.title.label).to.be(newPath);
-        done();
+        expect(widget.title.label).to.equal(newPath);
+        called = true;
       });
-      manager.contents.rename(context.path, newPath).catch(done);
+      await manager.contents.rename(context.path, newPath);
+      expect(called).to.equal(true);
     });
 
-    it('should set the content after the context is ready', done => {
-      context.ready
-        .then(() => {
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          let img = widget.node.querySelector('img') as HTMLImageElement;
-          expect(img.src).to.contain(IMAGE.content);
-          done();
-        })
-        .catch(done);
+    it('should set the content after the context is ready', async () => {
+      await context.ready;
+      MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+      const img = widget.node.querySelector('img') as HTMLImageElement;
+      expect(img.src).to.contain(IMAGE.content);
     });
 
-    it('should handle a change to the content', done => {
-      context.ready
-        .then(() => {
-          context.model.fromString(OTHER);
-          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-          let img = widget.node.querySelector('img') as HTMLImageElement;
-          expect(img.src).to.contain(OTHER);
-          done();
-        })
-        .catch(done);
+    it('should handle a change to the content', async () => {
+      await context.ready;
+      context.model.fromString(OTHER);
+      MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+      const img = widget.node.querySelector('img') as HTMLImageElement;
+      expect(img.src).to.contain(OTHER);
     });
   });
 
   describe('#context', () => {
     it('should be the context associated with the widget', () => {
-      expect(widget.context).to.be(context);
+      expect(widget.context).to.equal(context);
     });
   });
 
   describe('#scale', () => {
     it('should default to 1', () => {
-      expect(widget.scale).to.be(1);
+      expect(widget.scale).to.equal(1);
     });
 
     it('should be settable', () => {
       widget.scale = 0.5;
-      expect(widget.scale).to.be(0.5);
+      expect(widget.scale).to.equal(0.5);
     });
   });
 
   describe('#dispose()', () => {
     it('should dispose of the resources used by the widget', () => {
-      expect(widget.isDisposed).to.be(false);
+      expect(widget.isDisposed).to.equal(false);
       widget.dispose();
-      expect(widget.isDisposed).to.be(true);
+      expect(widget.isDisposed).to.equal(true);
       widget.dispose();
-      expect(widget.isDisposed).to.be(true);
+      expect(widget.isDisposed).to.equal(true);
     });
   });
 
   describe('#onUpdateRequest()', () => {
     it('should render the image', () => {
-      let img: HTMLImageElement = widget.node.querySelector('img');
+      const img: HTMLImageElement = widget.node.querySelector('img');
       return widget.ready.then(() => {
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
         expect(widget.methods).to.contain('onUpdateRequest');
@@ -160,7 +153,7 @@ describe('ImageViewer', () => {
       Widget.attach(widget, document.body);
       MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
       expect(widget.methods).to.contain('onActivateRequest');
-      expect(widget.node.contains(document.activeElement)).to.be(true);
+      expect(widget.node.contains(document.activeElement)).to.equal(true);
     });
   });
 });
@@ -168,16 +161,16 @@ describe('ImageViewer', () => {
 describe('ImageViewerFactory', () => {
   describe('#createNewWidget', () => {
     it('should create an image document widget', () => {
-      let factory = new ImageViewerFactory({
+      const factory = new ImageViewerFactory({
         name: 'Image',
         modelName: 'base64',
         fileTypes: ['png'],
         defaultFor: ['png']
       });
-      let context = createFileContext(IMAGE.path);
-      let d = factory.createNew(context);
-      expect(d).to.be.an(DocumentWidget);
-      expect(d.content).to.be.an(ImageViewer);
+      const context = createFileContext(IMAGE.path);
+      const d = factory.createNew(context);
+      expect(d).to.be.an.instanceof(DocumentWidget);
+      expect(d.content).to.be.an.instanceof(ImageViewer);
     });
   });
 });

--- a/tests/test-inspector/package.json
+++ b/tests/test-inspector/package.json
@@ -19,9 +19,10 @@
     "@jupyterlab/inspector": "^0.17.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-inspector/src/inspector.spec.ts
+++ b/tests/test-inspector/src/inspector.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Signal } from '@phosphor/signaling';
 
@@ -35,92 +35,92 @@ describe('inspector/index', () => {
   describe('Inspector', () => {
     describe('#constructor()', () => {
       it('should construct a new inspector widget', () => {
-        let widget = new InspectorPanel();
-        expect(widget).to.be.an(InspectorPanel);
+        const widget = new InspectorPanel();
+        expect(widget).to.be.an.instanceof(InspectorPanel);
       });
 
       it('should add the `jp-Inspector` class', () => {
-        let widget = new InspectorPanel();
-        expect(widget.hasClass('jp-Inspector')).to.be(true);
+        const widget = new InspectorPanel();
+        expect(widget.hasClass('jp-Inspector')).to.equal(true);
       });
 
       it('should hide its tab bar if there are less than two items', () => {
-        let widget = new InspectorPanel();
+        const widget = new InspectorPanel();
         widget.add({ name: 'Foo', rank: 20, type: 'foo' });
-        expect(widget).to.be.an(InspectorPanel);
-        expect(widget.tabBar.isHidden).to.be(true);
+        expect(widget).to.be.an.instanceof(InspectorPanel);
+        expect(widget.tabBar.isHidden).to.equal(true);
       });
 
       it('should show its tab bar if there is more than one item', () => {
-        let widget = new InspectorPanel();
+        const widget = new InspectorPanel();
         widget.add({ name: 'Foo', rank: 20, type: 'foo' });
         widget.add({ name: 'Boo', rank: 30, type: 'bar' });
-        expect(widget).to.be.an(InspectorPanel);
-        expect(widget.tabBar.isHidden).to.be(false);
+        expect(widget).to.be.an.instanceof(InspectorPanel);
+        expect(widget.tabBar.isHidden).to.equal(false);
       });
     });
 
     describe('#source', () => {
       it('should default to `null`', () => {
-        let widget = new InspectorPanel();
-        expect(widget.source).to.be(null);
+        const widget = new InspectorPanel();
+        expect(widget.source).to.be.null;
       });
 
       it('should be settable multiple times', () => {
-        let widget = new InspectorPanel();
-        let source = new TestInspectable();
-        expect(widget.source).to.be(null);
+        const widget = new InspectorPanel();
+        const source = new TestInspectable();
+        expect(widget.source).to.be.null;
         widget.source = source;
-        expect(widget.source).to.be(source);
+        expect(widget.source).to.equal(source);
         widget.source = null;
-        expect(widget.source).to.be(null);
+        expect(widget.source).to.be.null;
         widget.source = new TestInspectable();
-        expect(widget.source).to.be.a(TestInspectable);
+        expect(widget.source).to.be.an.instanceof(TestInspectable);
       });
     });
 
     describe('#add()', () => {
       it('should add inspector child items', () => {
-        let panel = new InspectorPanel();
-        let original = panel.widgets.length;
+        const panel = new InspectorPanel();
+        const original = panel.widgets.length;
 
         panel.add({ name: 'Foo', rank: 20, type: 'foo' });
         panel.add({ name: 'Boo', rank: 30, type: 'bar' });
 
-        expect(panel.widgets.length).to.be(original + 2);
+        expect(panel.widgets.length).to.equal(original + 2);
       });
 
       it('should return disposables to remove child items', () => {
-        let panel = new InspectorPanel();
-        let original = panel.widgets.length;
-        let disposable = panel.add({ name: 'Boo', rank: 30, type: 'bar' });
+        const panel = new InspectorPanel();
+        const original = panel.widgets.length;
+        const disposable = panel.add({ name: 'Boo', rank: 30, type: 'bar' });
 
-        expect(panel.widgets.length).to.be(original + 1);
+        expect(panel.widgets.length).to.equal(original + 1);
         disposable.dispose();
-        expect(panel.widgets.length).to.be(original);
+        expect(panel.widgets.length).to.equal(original);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources used by the inspector', () => {
-        let widget = new InspectorPanel();
-        expect(widget.isDisposed).to.be(false);
+        const widget = new InspectorPanel();
+        expect(widget.isDisposed).to.equal(false);
         widget.dispose();
-        expect(widget.isDisposed).to.be(true);
+        expect(widget.isDisposed).to.equal(true);
       });
 
       it('should be a no-op if called more than once', () => {
-        let widget = new InspectorPanel();
-        expect(widget.isDisposed).to.be(false);
+        const widget = new InspectorPanel();
+        expect(widget.isDisposed).to.equal(false);
         widget.dispose();
         widget.dispose();
-        expect(widget.isDisposed).to.be(true);
+        expect(widget.isDisposed).to.equal(true);
       });
     });
 
     describe('#onInspectorUpdate()', () => {
       it('should fire when a source updates', () => {
-        let widget = new TestInspectorPanel();
+        const widget = new TestInspectorPanel();
         widget.source = new TestInspectable();
         expect(widget.methods).to.not.contain('onInspectorUpdate');
         (widget.source.inspected as any).emit({

--- a/tests/test-mainmenu/package.json
+++ b/tests/test-mainmenu/package.json
@@ -21,9 +21,10 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/commands": "^1.5.0",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-mainmenu/src/edit.spec.ts
+++ b/tests/test-mainmenu/src/edit.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -22,7 +22,7 @@ describe('@jupyterlab/mainmenu', () => {
     let commands: CommandRegistry;
     let menu: EditMenu;
     let tracker: InstanceTracker<Wodget>;
-    let wodget = new Wodget();
+    const wodget = new Wodget();
 
     before(() => {
       commands = new CommandRegistry();
@@ -42,8 +42,8 @@ describe('@jupyterlab/mainmenu', () => {
 
     describe('#constructor()', () => {
       it('should construct a new edit menu', () => {
-        expect(menu).to.be.an(EditMenu);
-        expect(menu.menu.title.label).to.be('Edit');
+        expect(menu).to.be.an.instanceof(EditMenu);
+        expect(menu.menu.title.label).to.equal('Edit');
       });
     });
 
@@ -62,9 +62,9 @@ describe('@jupyterlab/mainmenu', () => {
         };
         menu.undoers.add(undoer);
         delegateExecute(wodget, menu.undoers, 'undo');
-        expect(wodget.state).to.be('undo');
+        expect(wodget.state).to.equal('undo');
         delegateExecute(wodget, menu.undoers, 'redo');
-        expect(wodget.state).to.be('redo');
+        expect(wodget.state).to.equal('redo');
       });
     });
 
@@ -84,9 +84,9 @@ describe('@jupyterlab/mainmenu', () => {
         };
         menu.clearers.add(clearer);
         delegateExecute(wodget, menu.clearers, 'clearCurrent');
-        expect(wodget.state).to.be('clearCurrent');
+        expect(wodget.state).to.equal('clearCurrent');
         delegateExecute(wodget, menu.clearers, 'clearAll');
-        expect(wodget.state).to.be('clearAll');
+        expect(wodget.state).to.equal('clearAll');
       });
     });
 
@@ -105,9 +105,9 @@ describe('@jupyterlab/mainmenu', () => {
         };
         menu.findReplacers.add(finder);
         delegateExecute(wodget, menu.findReplacers, 'find');
-        expect(wodget.state).to.be('find');
+        expect(wodget.state).to.equal('find');
         delegateExecute(wodget, menu.findReplacers, 'findAndReplace');
-        expect(wodget.state).to.be('findAndReplace');
+        expect(wodget.state).to.equal('findAndReplace');
       });
     });
   });

--- a/tests/test-mainmenu/src/file.spec.ts
+++ b/tests/test-mainmenu/src/file.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -22,7 +22,7 @@ describe('@jupyterlab/mainmenu', () => {
     let commands: CommandRegistry;
     let menu: FileMenu;
     let tracker: InstanceTracker<Wodget>;
-    let wodget = new Wodget();
+    const wodget = new Wodget();
 
     before(() => {
       commands = new CommandRegistry();
@@ -42,14 +42,14 @@ describe('@jupyterlab/mainmenu', () => {
 
     describe('#constructor()', () => {
       it('should construct a new file menu', () => {
-        expect(menu).to.be.an(FileMenu);
-        expect(menu.menu.title.label).to.be('File');
+        expect(menu).to.be.an.instanceof(FileMenu);
+        expect(menu.menu.title.label).to.equal('File');
       });
     });
 
     describe('#newMenu', () => {
       it('should be a submenu for `New...` commands', () => {
-        expect(menu.newMenu.menu.title.label).to.be('New');
+        expect(menu.newMenu.menu.title.label).to.equal('New');
       });
     });
 
@@ -66,7 +66,7 @@ describe('@jupyterlab/mainmenu', () => {
         };
         menu.closeAndCleaners.add(cleaner);
         delegateExecute(wodget, menu.closeAndCleaners, 'closeAndCleanup');
-        expect(wodget.state).to.be('clean');
+        expect(wodget.state).to.equal('clean');
       });
     });
 
@@ -83,7 +83,7 @@ describe('@jupyterlab/mainmenu', () => {
         };
         menu.persistAndSavers.add(persistAndSaver);
         delegateExecute(wodget, menu.persistAndSavers, 'persistAndSave');
-        expect(wodget.state).to.be('saved');
+        expect(wodget.state).to.equal('saved');
       });
     });
 
@@ -99,7 +99,7 @@ describe('@jupyterlab/mainmenu', () => {
         };
         menu.consoleCreators.add(creator);
         delegateExecute(wodget, menu.consoleCreators, 'createConsole');
-        expect(wodget.state).to.be('create');
+        expect(wodget.state).to.equal('create');
       });
     });
   });

--- a/tests/test-mainmenu/src/help.spec.ts
+++ b/tests/test-mainmenu/src/help.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -26,8 +26,8 @@ describe('@jupyterlab/mainmenu', () => {
 
     describe('#constructor()', () => {
       it('should construct a new help menu', () => {
-        expect(menu).to.be.an(HelpMenu);
-        expect(menu.menu.title.label).to.be('Help');
+        expect(menu).to.be.an.instanceof(HelpMenu);
+        expect(menu.menu.title.label).to.equal('Help');
       });
     });
   });

--- a/tests/test-mainmenu/src/kernel.spec.ts
+++ b/tests/test-mainmenu/src/kernel.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -22,7 +22,7 @@ describe('@jupyterlab/mainmenu', () => {
     let commands: CommandRegistry;
     let menu: KernelMenu;
     let tracker: InstanceTracker<Wodget>;
-    let wodget = new Wodget();
+    const wodget = new Wodget();
 
     before(() => {
       commands = new CommandRegistry();
@@ -42,8 +42,8 @@ describe('@jupyterlab/mainmenu', () => {
 
     describe('#constructor()', () => {
       it('should construct a new kernel menu', () => {
-        expect(menu).to.be.an(KernelMenu);
-        expect(menu.menu.title.label).to.be('Kernel');
+        expect(menu).to.be.an.instanceof(KernelMenu);
+        expect(menu.menu.title.label).to.equal('Kernel');
       });
     });
 
@@ -75,15 +75,15 @@ describe('@jupyterlab/mainmenu', () => {
         };
         menu.kernelUsers.add(user);
         delegateExecute(wodget, menu.kernelUsers, 'interruptKernel');
-        expect(wodget.state).to.be('interrupt');
+        expect(wodget.state).to.equal('interrupt');
         delegateExecute(wodget, menu.kernelUsers, 'restartKernel');
-        expect(wodget.state).to.be('restart');
+        expect(wodget.state).to.equal('restart');
         delegateExecute(wodget, menu.kernelUsers, 'restartKernelAndClear');
-        expect(wodget.state).to.be('restartAndClear');
+        expect(wodget.state).to.equal('restartAndClear');
         delegateExecute(wodget, menu.kernelUsers, 'changeKernel');
-        expect(wodget.state).to.be('change');
+        expect(wodget.state).to.equal('change');
         delegateExecute(wodget, menu.kernelUsers, 'shutdownKernel');
-        expect(wodget.state).to.be('shutdown');
+        expect(wodget.state).to.equal('shutdown');
       });
     });
   });

--- a/tests/test-mainmenu/src/labmenu.spec.ts
+++ b/tests/test-mainmenu/src/labmenu.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ArrayExt } from '@phosphor/algorithm';
 
@@ -44,7 +44,7 @@ describe('@jupyterlab/mainmenu', () => {
 
     describe('#constructor()', () => {
       it('should construct a new main menu', () => {
-        expect(menu).to.be.a(JupyterLabMenu);
+        expect(menu).to.be.an.instanceof(JupyterLabMenu);
       });
 
       it('should accept useSeparators as an option', () => {
@@ -53,8 +53,8 @@ describe('@jupyterlab/mainmenu', () => {
         menu1.addGroup([{ command: 'run1' }, { command: 'run2' }]);
         menu2.addGroup([{ command: 'run1' }, { command: 'run2' }]);
 
-        expect(menu1.menu.items.length).to.be(2);
-        expect(menu2.menu.items.length).to.be(4);
+        expect(menu1.menu.items.length).to.equal(2);
+        expect(menu2.menu.items.length).to.equal(4);
       });
     });
 
@@ -62,43 +62,43 @@ describe('@jupyterlab/mainmenu', () => {
       it('should add a new group to the menu', () => {
         menu.addGroup([{ command: 'run1' }, { command: 'run2' }]);
 
-        let idx1 = ArrayExt.findFirstIndex(
+        const idx1 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run1'
         );
-        let idx2 = ArrayExt.findFirstIndex(
+        const idx2 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run2'
         );
 
-        expect(idx1 === -1).to.be(false);
-        expect(idx2 === -1).to.be(false);
-        expect(idx1 > idx2).to.be(false);
+        expect(idx1 === -1).to.equal(false);
+        expect(idx2 === -1).to.equal(false);
+        expect(idx1 > idx2).to.equal(false);
       });
 
       it('should take a rank as an option', () => {
         menu.addGroup([{ command: 'run1' }, { command: 'run2' }], 2);
         menu.addGroup([{ command: 'run3' }, { command: 'run4' }], 1);
 
-        let idx1 = ArrayExt.findFirstIndex(
+        const idx1 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run1'
         );
-        let idx2 = ArrayExt.findFirstIndex(
+        const idx2 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run2'
         );
-        let idx3 = ArrayExt.findFirstIndex(
+        const idx3 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run3'
         );
-        let idx4 = ArrayExt.findFirstIndex(
+        const idx4 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run4'
         );
-        expect(idx3 < idx4).to.be(true);
-        expect(idx4 < idx1).to.be(true);
-        expect(idx1 < idx2).to.be(true);
+        expect(idx3 < idx4).to.equal(true);
+        expect(idx4 < idx1).to.equal(true);
+        expect(idx1 < idx2).to.equal(true);
       });
 
       it('should return a disposable that can be used to remove the group', () => {
@@ -108,27 +108,27 @@ describe('@jupyterlab/mainmenu', () => {
         menu.addGroup(group2);
         disposable.dispose();
 
-        let idx1 = ArrayExt.findFirstIndex(
+        const idx1 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run1'
         );
-        let idx2 = ArrayExt.findFirstIndex(
+        const idx2 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run2'
         );
-        let idx3 = ArrayExt.findFirstIndex(
+        const idx3 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run3'
         );
-        let idx4 = ArrayExt.findFirstIndex(
+        const idx4 = ArrayExt.findFirstIndex(
           menu.menu.items,
           m => m.command === 'run4'
         );
 
-        expect(idx1).to.be(-1);
-        expect(idx2).to.be(-1);
-        expect(idx3 === -1).to.be(false);
-        expect(idx4 === -1).to.be(false);
+        expect(idx1).to.equal(-1);
+        expect(idx2).to.equal(-1);
+        expect(idx3 === -1).to.equal(false);
+        expect(idx4 === -1).to.equal(false);
       });
     });
   });

--- a/tests/test-mainmenu/src/mainmenu.spec.ts
+++ b/tests/test-mainmenu/src/mainmenu.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { find, ArrayExt } from '@phosphor/algorithm';
 
@@ -41,7 +41,7 @@ describe('@jupyterlab/mainmenu', () => {
     describe('#constructor()', () => {
       it('should construct a new main menu', () => {
         const menu = new MainMenu(new CommandRegistry());
-        expect(menu).to.be.a(MainMenu);
+        expect(menu).to.be.an.instanceof(MainMenu);
       });
     });
 
@@ -49,7 +49,9 @@ describe('@jupyterlab/mainmenu', () => {
       it('should add a new menu', () => {
         const menu = new Menu({ commands });
         mainMenu.addMenu(menu);
-        expect(find(mainMenu.menus, m => menu === m) !== undefined).to.be(true);
+        expect(find(mainMenu.menus, m => menu === m) !== undefined).to.equal(
+          true
+        );
       });
 
       it('should take a rank as an option', () => {
@@ -57,104 +59,104 @@ describe('@jupyterlab/mainmenu', () => {
         const menu2 = new Menu({ commands });
         mainMenu.addMenu(menu1, { rank: 300 });
         mainMenu.addMenu(menu2, { rank: 200 });
-        expect(ArrayExt.firstIndexOf(mainMenu.menus, menu1)).to.be(6);
-        expect(ArrayExt.firstIndexOf(mainMenu.menus, menu2)).to.be(5);
+        expect(ArrayExt.firstIndexOf(mainMenu.menus, menu1)).to.equal(6);
+        expect(ArrayExt.firstIndexOf(mainMenu.menus, menu2)).to.equal(5);
       });
     });
 
     describe('#fileMenu', () => {
       it('should be a FileMenu', () => {
-        expect(mainMenu.fileMenu).to.be.a(FileMenu);
+        expect(mainMenu.fileMenu).to.be.an.instanceof(FileMenu);
       });
 
       it('should be the first menu', () => {
         expect(
           ArrayExt.firstIndexOf(mainMenu.menus, mainMenu.fileMenu.menu)
-        ).to.be(0);
+        ).to.equal(0);
       });
     });
 
     describe('#editMenu', () => {
       it('should be a EditMenu', () => {
-        expect(mainMenu.editMenu).to.be.a(EditMenu);
+        expect(mainMenu.editMenu).to.be.an.instanceof(EditMenu);
       });
 
       it('should be the second menu', () => {
         expect(
           ArrayExt.firstIndexOf(mainMenu.menus, mainMenu.editMenu.menu)
-        ).to.be(1);
+        ).to.equal(1);
       });
     });
 
     describe('#viewMenu', () => {
       it('should be a ViewMenu', () => {
-        expect(mainMenu.viewMenu).to.be.a(ViewMenu);
+        expect(mainMenu.viewMenu).to.be.an.instanceof(ViewMenu);
       });
 
       it('should be the third menu', () => {
         expect(
           ArrayExt.firstIndexOf(mainMenu.menus, mainMenu.viewMenu.menu)
-        ).to.be(2);
+        ).to.equal(2);
       });
     });
 
     describe('#runMenu', () => {
       it('should be a RunMenu', () => {
-        expect(mainMenu.runMenu).to.be.a(RunMenu);
+        expect(mainMenu.runMenu).to.be.an.instanceof(RunMenu);
       });
 
       it('should be the fourth menu', () => {
         expect(
           ArrayExt.firstIndexOf(mainMenu.menus, mainMenu.runMenu.menu)
-        ).to.be(3);
+        ).to.equal(3);
       });
     });
 
     describe('#kernelMenu', () => {
       it('should be a KernelMenu', () => {
-        expect(mainMenu.kernelMenu).to.be.a(KernelMenu);
+        expect(mainMenu.kernelMenu).to.be.an.instanceof(KernelMenu);
       });
 
       it('should be the fifth menu', () => {
         expect(
           ArrayExt.firstIndexOf(mainMenu.menus, mainMenu.kernelMenu.menu)
-        ).to.be(4);
+        ).to.equal(4);
       });
     });
 
     describe('#tabsMenu', () => {
       it('should be a TabsMenu', () => {
-        expect(mainMenu.tabsMenu).to.be.a(TabsMenu);
+        expect(mainMenu.tabsMenu).to.be.an.instanceof(TabsMenu);
       });
 
       it('should be the sixth menu', () => {
         expect(
           ArrayExt.firstIndexOf(mainMenu.menus, mainMenu.tabsMenu.menu)
-        ).to.be(5);
+        ).to.equal(5);
       });
     });
 
     describe('#settingsMenu', () => {
       it('should be a SettingsMenu', () => {
-        expect(mainMenu.settingsMenu).to.be.a(SettingsMenu);
+        expect(mainMenu.settingsMenu).to.be.an.instanceof(SettingsMenu);
       });
 
       it('should be the seventh menu', () => {
         expect(
           ArrayExt.firstIndexOf(mainMenu.menus, mainMenu.settingsMenu.menu)
-        ).to.be(6);
+        ).to.equal(6);
       });
     });
 
     describe('#helpMenu', () => {
       it('should be a HelpMenu', () => {
-        expect(mainMenu.helpMenu).to.be.a(HelpMenu);
+        expect(mainMenu.helpMenu).to.be.an.instanceof(HelpMenu);
       });
 
       it('should be the eighth menu', () => {
         expect(
           ArrayExt.firstIndexOf(mainMenu.menus, mainMenu.helpMenu.menu)
-        ).to.be(7);
+        ).to.equal(7);
       });
     });
   });

--- a/tests/test-mainmenu/src/run.spec.ts
+++ b/tests/test-mainmenu/src/run.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -22,7 +22,7 @@ describe('@jupyterlab/mainmenu', () => {
     let commands: CommandRegistry;
     let menu: RunMenu;
     let tracker: InstanceTracker<Wodget>;
-    let wodget = new Wodget();
+    const wodget = new Wodget();
 
     before(() => {
       commands = new CommandRegistry();
@@ -42,8 +42,8 @@ describe('@jupyterlab/mainmenu', () => {
 
     describe('#constructor()', () => {
       it('should construct a new run menu', () => {
-        expect(menu).to.be.an(RunMenu);
-        expect(menu.menu.title.label).to.be('Run');
+        expect(menu).to.be.an.instanceof(RunMenu);
+        expect(menu.menu.title.label).to.equal('Run');
       });
     });
 
@@ -67,11 +67,11 @@ describe('@jupyterlab/mainmenu', () => {
         };
         menu.codeRunners.add(runner);
         delegateExecute(wodget, menu.codeRunners, 'run');
-        expect(wodget.state).to.be('run');
+        expect(wodget.state).to.equal('run');
         delegateExecute(wodget, menu.codeRunners, 'runAll');
-        expect(wodget.state).to.be('runAll');
+        expect(wodget.state).to.equal('runAll');
         delegateExecute(wodget, menu.codeRunners, 'restartAndRunAll');
-        expect(wodget.state).to.be('restartAndRunAll');
+        expect(wodget.state).to.equal('restartAndRunAll');
       });
     });
   });

--- a/tests/test-mainmenu/src/view.spec.ts
+++ b/tests/test-mainmenu/src/view.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -45,8 +45,8 @@ describe('@jupyterlab/mainmenu', () => {
 
     describe('#constructor()', () => {
       it('should construct a new view menu', () => {
-        expect(menu).to.be.an(ViewMenu);
-        expect(menu.menu.title.label).to.be('View');
+        expect(menu).to.be.an.instanceof(ViewMenu);
+        expect(menu.menu.title.label).to.equal('View');
       });
     });
 
@@ -74,13 +74,13 @@ describe('@jupyterlab/mainmenu', () => {
 
         expect(
           delegateToggled(wodget, menu.editorViewers, 'matchBracketsToggled')
-        ).to.be(false);
+        ).to.equal(false);
         expect(
           delegateToggled(wodget, menu.editorViewers, 'wordWrapToggled')
-        ).to.be(false);
+        ).to.equal(false);
         expect(
           delegateToggled(wodget, menu.editorViewers, 'lineNumbersToggled')
-        ).to.be(false);
+        ).to.equal(false);
 
         delegateExecute(wodget, menu.editorViewers, 'toggleLineNumbers');
         delegateExecute(wodget, menu.editorViewers, 'toggleMatchBrackets');
@@ -88,13 +88,13 @@ describe('@jupyterlab/mainmenu', () => {
 
         expect(
           delegateToggled(wodget, menu.editorViewers, 'matchBracketsToggled')
-        ).to.be(true);
+        ).to.equal(true);
         expect(
           delegateToggled(wodget, menu.editorViewers, 'wordWrapToggled')
-        ).to.be(true);
+        ).to.equal(true);
         expect(
           delegateToggled(wodget, menu.editorViewers, 'lineNumbersToggled')
-        ).to.be(true);
+        ).to.equal(true);
       });
     });
   });

--- a/tests/test-observables/package.json
+++ b/tests/test-observables/package.json
@@ -19,9 +19,10 @@
     "@jupyterlab/observables": "^2.0.2",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-observables/src/modeldb.spec.ts
+++ b/tests/test-observables/src/modeldb.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { JSONExt } from '@phosphor/coreutils';
 
@@ -17,76 +17,76 @@ describe('@jupyterlab/observables', () => {
   describe('ObservableValue', () => {
     describe('#constructor', () => {
       it('should accept no arguments', () => {
-        let value = new ObservableValue();
-        expect(value instanceof ObservableValue).to.be(true);
-        expect(value.get()).to.be(null);
+        const value = new ObservableValue();
+        expect(value instanceof ObservableValue).to.equal(true);
+        expect(value.get()).to.be.null;
       });
 
       it('should accept an initial JSON value', () => {
-        let value = new ObservableValue('value');
-        expect(value instanceof ObservableValue).to.be(true);
-        let value2 = new ObservableValue({ one: 'one', two: 2 });
-        expect(value2 instanceof ObservableValue).to.be(true);
+        const value = new ObservableValue('value');
+        expect(value instanceof ObservableValue).to.equal(true);
+        const value2 = new ObservableValue({ one: 'one', two: 2 });
+        expect(value2 instanceof ObservableValue).to.equal(true);
       });
     });
 
     describe('#type', () => {
       it('should return `Value`', () => {
-        let value = new ObservableValue();
-        expect(value.type).to.be('Value');
+        const value = new ObservableValue();
+        expect(value.type).to.equal('Value');
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether the value is disposed', () => {
-        let value = new ObservableValue();
-        expect(value.isDisposed).to.be(false);
+        const value = new ObservableValue();
+        expect(value.isDisposed).to.equal(false);
         value.dispose();
-        expect(value.isDisposed).to.be(true);
+        expect(value.isDisposed).to.equal(true);
       });
     });
 
     describe('#changed', () => {
       it('should be emitted when the map changes state', () => {
         let called = false;
-        let value = new ObservableValue();
+        const value = new ObservableValue();
         value.changed.connect(() => {
           called = true;
         });
         value.set('set');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should have value changed args', () => {
         let called = false;
-        let value = new ObservableValue();
+        const value = new ObservableValue();
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.newValue).to.be('set');
-          expect(args.oldValue).to.be(null);
+          expect(sender).to.equal(value);
+          expect(args.newValue).to.equal('set');
+          expect(args.oldValue).to.be.null;
           called = true;
         });
         value.set('set');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#get', () => {
       it('should get the value of the object', () => {
-        let value = new ObservableValue('value');
-        expect(value.get()).to.be('value');
-        let value2 = new ObservableValue({ one: 'one', two: 2 });
-        expect(JSONExt.deepEqual(value2.get(), { one: 'one', two: 2 })).to.be(
-          true
-        );
+        const value = new ObservableValue('value');
+        expect(value.get()).to.equal('value');
+        const value2 = new ObservableValue({ one: 'one', two: 2 });
+        expect(
+          JSONExt.deepEqual(value2.get(), { one: 'one', two: 2 })
+        ).to.equal(true);
       });
     });
 
     describe('#set', () => {
       it('should set the value of the object', () => {
-        let value = new ObservableValue();
+        const value = new ObservableValue();
         value.set('value');
-        expect(value.get()).to.be('value');
+        expect(value.get()).to.equal('value');
       });
     });
   });
@@ -94,242 +94,242 @@ describe('@jupyterlab/observables', () => {
   describe('ModelDB', () => {
     describe('#constructor()', () => {
       it('should accept no arguments', () => {
-        let db = new ModelDB();
-        expect(db instanceof ModelDB).to.be(true);
+        const db = new ModelDB();
+        expect(db instanceof ModelDB).to.equal(true);
       });
 
       it('should accept a basePath', () => {
-        let db = new ModelDB({ basePath: 'base' });
-        expect(db instanceof ModelDB).to.be(true);
+        const db = new ModelDB({ basePath: 'base' });
+        expect(db instanceof ModelDB).to.equal(true);
       });
 
       it('should accept a baseDB', () => {
-        let base = new ModelDB();
-        let db = new ModelDB({ baseDB: base });
-        expect(db instanceof ModelDB).to.be(true);
+        const base = new ModelDB();
+        const db = new ModelDB({ baseDB: base });
+        expect(db instanceof ModelDB).to.equal(true);
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether it is disposed', () => {
-        let db = new ModelDB();
-        expect(db.isDisposed).to.be(false);
+        const db = new ModelDB();
+        expect(db.isDisposed).to.equal(false);
         db.dispose();
-        expect(db.isDisposed).to.be(true);
+        expect(db.isDisposed).to.equal(true);
       });
     });
 
     describe('#basePath', () => {
       it('should return an empty string for a model without a baseDB', () => {
-        let db = new ModelDB();
-        expect(db.basePath).to.be('');
+        const db = new ModelDB();
+        expect(db.basePath).to.equal('');
       });
 
       it('should return the base path', () => {
-        let db = new ModelDB({ basePath: 'base' });
-        expect(db.basePath).to.be('base');
+        const db = new ModelDB({ basePath: 'base' });
+        expect(db.basePath).to.equal('base');
       });
     });
 
     describe('#isPrepopulated', () => {
       it('should return false for an in-memory database', () => {
-        let db = new ModelDB();
-        expect(db.isPrepopulated).to.be(false);
+        const db = new ModelDB();
+        expect(db.isPrepopulated).to.equal(false);
       });
     });
 
     describe('#isCollaborative', () => {
       it('should return false for an in-memory database', () => {
-        let db = new ModelDB();
-        expect(db.isCollaborative).to.be(false);
+        const db = new ModelDB();
+        expect(db.isCollaborative).to.equal(false);
       });
     });
 
     describe('#connected', () => {
-      it('should resolve immediately for an in-memory database', done => {
-        let db = new ModelDB();
-        db.connected.then(done);
+      it('should resolve immediately for an in-memory database', () => {
+        const db = new ModelDB();
+        return db.connected;
       });
     });
 
     describe('#get', () => {
       it('should get a value that exists at a path', () => {
-        let db = new ModelDB();
-        let value = db.createValue('value');
-        let value2 = db.get('value');
-        expect(value2).to.be(value);
+        const db = new ModelDB();
+        const value = db.createValue('value');
+        const value2 = db.get('value');
+        expect(value2).to.equal(value);
       });
 
       it('should return undefined for a value that does not exist', () => {
-        let db = new ModelDB();
-        expect(db.get('value')).to.be(undefined);
+        const db = new ModelDB();
+        expect(db.get('value')).to.be.undefined;
       });
     });
 
     describe('#has', () => {
       it('should return true if a value exists at a path', () => {
-        let db = new ModelDB();
+        const db = new ModelDB();
         db.createValue('value');
-        expect(db.has('value')).to.be(true);
+        expect(db.has('value')).to.equal(true);
       });
 
       it('should return false for a value that does not exist', () => {
-        let db = new ModelDB();
-        expect(db.has('value')).to.be(false);
+        const db = new ModelDB();
+        expect(db.has('value')).to.equal(false);
       });
     });
 
     describe('#createString', () => {
       it('should create an ObservableString`', () => {
-        let db = new ModelDB();
-        let str = db.createString('str');
-        expect(str instanceof ObservableString).to.be(true);
+        const db = new ModelDB();
+        const str = db.createString('str');
+        expect(str instanceof ObservableString).to.equal(true);
       });
 
       it('should be able to retrieve that string using `get`', () => {
-        let db = new ModelDB();
-        let str = db.createString('str');
-        expect(db.get('str')).to.be(str);
+        const db = new ModelDB();
+        const str = db.createString('str');
+        expect(db.get('str')).to.equal(str);
       });
     });
 
     describe('#createList', () => {
       it('should create an ObservableUndoableList`', () => {
-        let db = new ModelDB();
-        let str = db.createList('vec');
-        expect(str instanceof ObservableUndoableList).to.be(true);
+        const db = new ModelDB();
+        const str = db.createList('vec');
+        expect(str instanceof ObservableUndoableList).to.equal(true);
       });
 
       it('should be able to retrieve that vector using `get`', () => {
-        let db = new ModelDB();
-        let vec = db.createList('vec');
-        expect(db.get('vec')).to.be(vec);
+        const db = new ModelDB();
+        const vec = db.createList('vec');
+        expect(db.get('vec')).to.equal(vec);
       });
     });
 
     describe('#createMap', () => {
       it('should create an ObservableMap`', () => {
-        let db = new ModelDB();
-        let map = db.createMap('map');
-        expect(map instanceof ObservableJSON).to.be(true);
+        const db = new ModelDB();
+        const map = db.createMap('map');
+        expect(map instanceof ObservableJSON).to.equal(true);
       });
 
       it('should be able to retrieve that map using `get`', () => {
-        let db = new ModelDB();
-        let map = db.createMap('map');
-        expect(db.get('map')).to.be(map);
+        const db = new ModelDB();
+        const map = db.createMap('map');
+        expect(db.get('map')).to.equal(map);
       });
     });
 
     describe('#createValue', () => {
       it('should create an ObservableValue`', () => {
-        let db = new ModelDB();
-        let value = db.createValue('value');
-        expect(value instanceof ObservableValue).to.be(true);
+        const db = new ModelDB();
+        const value = db.createValue('value');
+        expect(value instanceof ObservableValue).to.equal(true);
       });
 
       it('should be able to retrieve that value using `get`', () => {
-        let db = new ModelDB();
-        let value = db.createString('value');
-        expect(db.get('value')).to.be(value);
+        const db = new ModelDB();
+        const value = db.createString('value');
+        expect(db.get('value')).to.equal(value);
       });
     });
 
     describe('#setValue', () => {
       it('should set a value at a path', () => {
-        let db = new ModelDB();
-        let value = db.createValue('value');
+        const db = new ModelDB();
+        const value = db.createValue('value');
         db.setValue('value', 'set');
-        expect(value.get()).to.be('set');
+        expect(value.get()).to.equal('set');
       });
     });
 
     describe('#getValue', () => {
       it('should get a value at a path', () => {
-        let db = new ModelDB();
-        let value = db.createValue('value');
+        const db = new ModelDB();
+        const value = db.createValue('value');
         value.set('set');
-        expect(db.getValue('value')).to.be('set');
+        expect(db.getValue('value')).to.equal('set');
       });
     });
 
     describe('#view', () => {
       it('should should return a ModelDB', () => {
-        let db = new ModelDB();
-        let view = db.view('');
-        expect(view instanceof ModelDB).to.be(true);
-        expect(view === db).to.be(false);
+        const db = new ModelDB();
+        const view = db.view('');
+        expect(view instanceof ModelDB).to.equal(true);
+        expect(view === db).to.equal(false);
       });
 
       it('should set the baseDB path on the view', () => {
-        let db = new ModelDB();
-        let view = db.view('base');
-        expect(view.basePath).to.be('base');
+        const db = new ModelDB();
+        const view = db.view('base');
+        expect(view.basePath).to.equal('base');
       });
 
       it('should return a view onto the base ModelDB', () => {
-        let db = new ModelDB();
-        let view = db.view('base');
+        const db = new ModelDB();
+        const view = db.view('base');
 
         db.createString('base.str1');
-        expect(db.get('base.str1')).to.be(view.get('str1'));
+        expect(db.get('base.str1')).to.equal(view.get('str1'));
 
         view.createString('str2');
-        expect(db.get('base.str2')).to.be(view.get('str2'));
+        expect(db.get('base.str2')).to.equal(view.get('str2'));
       });
 
       it('should be stackable', () => {
-        let db = new ModelDB();
-        let view = db.view('one');
-        let viewView = view.view('two');
+        const db = new ModelDB();
+        const view = db.view('one');
+        const viewView = view.view('two');
 
-        expect(view.basePath).to.be('one');
-        expect(viewView.basePath).to.be('two');
+        expect(view.basePath).to.equal('one');
+        expect(viewView.basePath).to.equal('two');
 
         viewView.createString('str');
-        expect(viewView.get('str')).to.be(view.get('two.str'));
-        expect(viewView.get('str')).to.be(db.get('one.two.str'));
+        expect(viewView.get('str')).to.equal(view.get('two.str'));
+        expect(viewView.get('str')).to.equal(db.get('one.two.str'));
       });
     });
 
     describe('#dispose', () => {
       it('should dispose of the resources used by the model', () => {
-        let db = new ModelDB();
-        let str = db.createString('str');
-        let view = db.view('base');
-        let str2 = view.createString('str');
-        expect(db.isDisposed).to.be(false);
-        expect(str.isDisposed).to.be(false);
-        expect(view.isDisposed).to.be(false);
-        expect(str2.isDisposed).to.be(false);
+        const db = new ModelDB();
+        const str = db.createString('str');
+        const view = db.view('base');
+        const str2 = view.createString('str');
+        expect(db.isDisposed).to.equal(false);
+        expect(str.isDisposed).to.equal(false);
+        expect(view.isDisposed).to.equal(false);
+        expect(str2.isDisposed).to.equal(false);
         db.dispose();
-        expect(db.isDisposed).to.be(true);
-        expect(str.isDisposed).to.be(true);
-        expect(view.isDisposed).to.be(true);
-        expect(str2.isDisposed).to.be(true);
+        expect(db.isDisposed).to.equal(true);
+        expect(str.isDisposed).to.equal(true);
+        expect(view.isDisposed).to.equal(true);
+        expect(str2.isDisposed).to.equal(true);
       });
 
       it('should not dispose of resources in base databases', () => {
-        let db = new ModelDB();
-        let view = db.view('base');
-        let str = db.createString('str');
-        let str2 = view.createString('str');
-        expect(db.isDisposed).to.be(false);
-        expect(str.isDisposed).to.be(false);
-        expect(view.isDisposed).to.be(false);
-        expect(str2.isDisposed).to.be(false);
+        const db = new ModelDB();
+        const view = db.view('base');
+        const str = db.createString('str');
+        const str2 = view.createString('str');
+        expect(db.isDisposed).to.equal(false);
+        expect(str.isDisposed).to.equal(false);
+        expect(view.isDisposed).to.equal(false);
+        expect(str2.isDisposed).to.equal(false);
         view.dispose();
-        expect(view.isDisposed).to.be(true);
-        expect(str2.isDisposed).to.be(true);
-        expect(db.isDisposed).to.be(false);
-        expect(str.isDisposed).to.be(false);
+        expect(view.isDisposed).to.equal(true);
+        expect(str2.isDisposed).to.equal(true);
+        expect(db.isDisposed).to.equal(false);
+        expect(str.isDisposed).to.equal(false);
       });
 
       it('should be safe to call more than once', () => {
-        let db = new ModelDB();
-        expect(db.isDisposed).to.be(false);
+        const db = new ModelDB();
+        expect(db.isDisposed).to.equal(false);
         db.dispose();
-        expect(db.isDisposed).to.be(true);
+        expect(db.isDisposed).to.equal(true);
       });
     });
   });

--- a/tests/test-observables/src/observablejson.spec.ts
+++ b/tests/test-observables/src/observablejson.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { IObservableJSON, ObservableJSON } from '@jupyterlab/observables';
 
@@ -9,31 +9,31 @@ describe('@jupyterlab/observables', () => {
   describe('ObservableJSON', () => {
     describe('#constructor()', () => {
       it('should create an observable JSON object', () => {
-        let item = new ObservableJSON();
-        expect(item).to.be.an(ObservableJSON);
+        const item = new ObservableJSON();
+        expect(item).to.be.an.instanceof(ObservableJSON);
       });
 
       it('should accept initial values', () => {
-        let item = new ObservableJSON({
+        const item = new ObservableJSON({
           values: { foo: 1, bar: 'baz' }
         });
-        expect(item).to.be.an(ObservableJSON);
+        expect(item).to.be.an.instanceof(ObservableJSON);
       });
     });
 
     describe('#toJSON()', () => {
       it('should serialize the model to JSON', () => {
-        let item = new ObservableJSON();
+        const item = new ObservableJSON();
         item.set('foo', 1);
-        expect(item.toJSON()['foo']).to.be(1);
+        expect(item.toJSON()['foo']).to.equal(1);
       });
 
       it('should return a copy of the data', () => {
-        let item = new ObservableJSON();
+        const item = new ObservableJSON();
         item.set('foo', { bar: 1 });
-        let value = item.toJSON();
+        const value = item.toJSON();
         value['bar'] = 2;
-        expect((item.get('foo') as any)['bar']).to.be(1);
+        expect((item.get('foo') as any)['bar']).to.equal(1);
       });
     });
   });
@@ -41,26 +41,26 @@ describe('@jupyterlab/observables', () => {
   describe('ObservableJSON.ChangeMessage', () => {
     describe('#constructor()', () => {
       it('should create a new message', () => {
-        let message = new ObservableJSON.ChangeMessage({
+        const message = new ObservableJSON.ChangeMessage({
           key: 'foo',
           type: 'add',
           oldValue: 1,
           newValue: 2
         });
-        expect(message).to.be.a(ObservableJSON.ChangeMessage);
+        expect(message).to.be.an.instanceof(ObservableJSON.ChangeMessage);
       });
     });
 
     describe('#args', () => {
       it('should be the args of the message', () => {
-        let args: IObservableJSON.IChangedArgs = {
+        const args: IObservableJSON.IChangedArgs = {
           key: 'foo',
           type: 'add',
           oldValue: 'ho',
           newValue: 'hi'
         };
-        let message = new ObservableJSON.ChangeMessage(args);
-        expect(message.args).to.be(args);
+        const message = new ObservableJSON.ChangeMessage(args);
+        expect(message.args).to.equal(args);
       });
     });
   });

--- a/tests/test-observables/src/observablelist.spec.ts
+++ b/tests/test-observables/src/observablelist.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { toArray } from '@phosphor/algorithm';
 
@@ -11,360 +11,360 @@ describe('@jupyterlab/observables', () => {
   describe('ObservableList', () => {
     describe('#constructor()', () => {
       it('should accept no arguments', () => {
-        let value = new ObservableList<number>();
-        expect(value instanceof ObservableList).to.be(true);
+        const value = new ObservableList<number>();
+        expect(value instanceof ObservableList).to.equal(true);
       });
 
       it('should accept an array argument', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
-        expect(value instanceof ObservableList).to.be(true);
-        expect(toArray(value)).to.eql([1, 2, 3]);
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
+        expect(value instanceof ObservableList).to.equal(true);
+        expect(toArray(value)).to.deep.equal([1, 2, 3]);
       });
     });
 
     describe('#type', () => {
       it('should return `List`', () => {
-        let value = new ObservableList<number>();
-        expect(value.type).to.be('List');
+        const value = new ObservableList<number>();
+        expect(value.type).to.equal('List');
       });
     });
 
     describe('#changed', () => {
       it('should be emitted when the list changes state', () => {
         let called = false;
-        let value = new ObservableList<number>();
+        const value = new ObservableList<number>();
         value.changed.connect(() => {
           called = true;
         });
         value.insert(0, 1);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should have value changed args', () => {
         let called = false;
-        let value = new ObservableList<number>();
+        const value = new ObservableList<number>();
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('add');
-          expect(args.newIndex).to.be(0);
-          expect(args.oldIndex).to.be(-1);
-          expect(args.newValues[0]).to.be(1);
-          expect(args.oldValues.length).to.be(0);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('add');
+          expect(args.newIndex).to.equal(0);
+          expect(args.oldIndex).to.equal(-1);
+          expect(args.newValues[0]).to.equal(1);
+          expect(args.oldValues.length).to.equal(0);
           called = true;
         });
         value.push(1);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether the list is disposed', () => {
-        let value = new ObservableList<number>();
-        expect(value.isDisposed).to.be(false);
+        const value = new ObservableList<number>();
+        expect(value.isDisposed).to.equal(false);
         value.dispose();
-        expect(value.isDisposed).to.be(true);
+        expect(value.isDisposed).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the list', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.dispose();
-        expect(value.isDisposed).to.be(true);
+        expect(value.isDisposed).to.equal(true);
       });
     });
 
     describe('#get()', () => {
       it('should get the value at the specified index', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
-        expect(value.get(1)).to.be(2);
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
+        expect(value.get(1)).to.equal(2);
       });
     });
 
     describe('#set()', () => {
       it('should set the item at a specific index', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.set(1, 4);
-        expect(toArray(value)).to.eql([1, 4, 3]);
+        expect(toArray(value)).to.deep.equal([1, 4, 3]);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('set');
-          expect(args.newIndex).to.be(1);
-          expect(args.oldIndex).to.be(1);
-          expect(args.oldValues[0]).to.be(2);
-          expect(args.newValues[0]).to.be(4);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('set');
+          expect(args.newIndex).to.equal(1);
+          expect(args.oldIndex).to.equal(1);
+          expect(args.oldValues[0]).to.equal(2);
+          expect(args.newValues[0]).to.equal(4);
           called = true;
         });
         value.set(1, 4);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#push()', () => {
       it('should add an item to the end of the list', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.push(4);
-        expect(toArray(value)).to.eql([1, 2, 3, 4]);
+        expect(toArray(value)).to.deep.equal([1, 2, 3, 4]);
       });
 
       it('should return the new length of the list', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
-        expect(value.push(4)).to.be(4);
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
+        expect(value.push(4)).to.equal(4);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('add');
-          expect(args.newIndex).to.be(3);
-          expect(args.oldIndex).to.be(-1);
-          expect(args.oldValues.length).to.be(0);
-          expect(args.newValues[0]).to.be(4);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('add');
+          expect(args.newIndex).to.equal(3);
+          expect(args.oldIndex).to.equal(-1);
+          expect(args.oldValues.length).to.equal(0);
+          expect(args.newValues[0]).to.equal(4);
           called = true;
         });
         value.push(4);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#insert()', () => {
       it('should insert an item into the list at a specific index', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.insert(1, 4);
-        expect(toArray(value)).to.eql([1, 4, 2, 3]);
+        expect(toArray(value)).to.deep.equal([1, 4, 2, 3]);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('add');
-          expect(args.newIndex).to.be(1);
-          expect(args.oldIndex).to.be(-1);
-          expect(args.oldValues.length).to.be(0);
-          expect(args.newValues[0]).to.be(4);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('add');
+          expect(args.newIndex).to.equal(1);
+          expect(args.oldIndex).to.equal(-1);
+          expect(args.oldValues.length).to.equal(0);
+          expect(args.newValues[0]).to.equal(4);
           called = true;
         });
         value.insert(1, 4);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#move()', () => {
       it('should move an item from one index to another', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.move(1, 2);
-        expect(toArray(value)).to.eql([1, 3, 2]);
+        expect(toArray(value)).to.deep.equal([1, 3, 2]);
         value.move(2, 0);
-        expect(toArray(value)).to.eql([2, 1, 3]);
+        expect(toArray(value)).to.deep.equal([2, 1, 3]);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let values = [1, 2, 3, 4, 5, 6];
-        let value = new ObservableList<number>({ values });
+        const values = [1, 2, 3, 4, 5, 6];
+        const value = new ObservableList<number>({ values });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('move');
-          expect(args.newIndex).to.be(1);
-          expect(args.oldIndex).to.be(0);
-          expect(args.oldValues[0]).to.be(1);
-          expect(args.newValues[0]).to.be(1);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('move');
+          expect(args.newIndex).to.equal(1);
+          expect(args.oldIndex).to.equal(0);
+          expect(args.oldValues[0]).to.equal(1);
+          expect(args.newValues[0]).to.equal(1);
           called = true;
         });
         value.move(0, 1);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#removeValue()', () => {
       it('should remove the first occurrence of a specific item from the list', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.removeValue(1);
-        expect(toArray(value)).to.eql([2, 3]);
+        expect(toArray(value)).to.deep.equal([2, 3]);
       });
 
       it('should return the index occupied by the item', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
-        expect(value.removeValue(1)).to.be(0);
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
+        expect(value.removeValue(1)).to.equal(0);
       });
 
       it('should return `-1` if the item is not in the list', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
-        expect(value.removeValue(10)).to.be(-1);
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
+        expect(value.removeValue(10)).to.equal(-1);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let values = [1, 2, 3, 4, 5, 6];
-        let value = new ObservableList<number>({ values });
+        const values = [1, 2, 3, 4, 5, 6];
+        const value = new ObservableList<number>({ values });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('remove');
-          expect(args.newIndex).to.be(-1);
-          expect(args.oldIndex).to.be(1);
-          expect(args.oldValues[0]).to.be(2);
-          expect(args.newValues.length).to.be(0);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('remove');
+          expect(args.newIndex).to.equal(-1);
+          expect(args.oldIndex).to.equal(1);
+          expect(args.oldValues[0]).to.equal(2);
+          expect(args.newValues.length).to.equal(0);
           called = true;
         });
         value.removeValue(2);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#remove()', () => {
       it('should remove the item at a specific index', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.remove(1);
-        expect(toArray(value)).to.eql([1, 3]);
+        expect(toArray(value)).to.deep.equal([1, 3]);
       });
 
       it('should return the item at the specified index', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
-        expect(value.remove(1)).to.be(2);
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
+        expect(value.remove(1)).to.equal(2);
       });
 
       it('should return `undefined` if the index is out of range', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
-        expect(value.remove(10)).to.be(void 0);
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
+        expect(value.remove(10)).to.be.undefined;
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let values = [1, 2, 3, 4, 5, 6];
-        let value = new ObservableList<number>({ values });
+        const values = [1, 2, 3, 4, 5, 6];
+        const value = new ObservableList<number>({ values });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('remove');
-          expect(args.newIndex).to.be(-1);
-          expect(args.oldIndex).to.be(1);
-          expect(args.oldValues[0]).to.be(2);
-          expect(args.newValues.length).to.be(0);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('remove');
+          expect(args.newIndex).to.equal(-1);
+          expect(args.oldIndex).to.equal(1);
+          expect(args.oldValues[0]).to.equal(2);
+          expect(args.newValues.length).to.equal(0);
           called = true;
         });
         value.remove(1);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#clear()', () => {
       it('should remove all items from the list', () => {
-        let values = [1, 2, 3, 4, 5, 6];
-        let value = new ObservableList<number>({ values });
+        const values = [1, 2, 3, 4, 5, 6];
+        const value = new ObservableList<number>({ values });
         value.clear();
-        expect(value.length).to.be(0);
+        expect(value.length).to.equal(0);
         value.clear();
-        expect(value.length).to.be(0);
+        expect(value.length).to.equal(0);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let values = [1, 2, 3, 4, 5, 6];
-        let value = new ObservableList<number>({ values });
+        const values = [1, 2, 3, 4, 5, 6];
+        const value = new ObservableList<number>({ values });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('remove');
-          expect(args.newIndex).to.be(0);
-          expect(args.oldIndex).to.be(0);
-          expect(toArray(args.oldValues)).to.eql(values);
-          expect(args.newValues.length).to.be(0);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('remove');
+          expect(args.newIndex).to.equal(0);
+          expect(args.oldIndex).to.equal(0);
+          expect(toArray(args.oldValues)).to.deep.equal(values);
+          expect(args.newValues.length).to.equal(0);
           called = true;
         });
         value.clear();
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#pushAll()', () => {
       it('should push an array of items to the end of the list', () => {
-        let value = new ObservableList<number>({ values: [1] });
+        const value = new ObservableList<number>({ values: [1] });
         value.pushAll([2, 3, 4]);
-        expect(toArray(value)).to.eql([1, 2, 3, 4]);
+        expect(toArray(value)).to.deep.equal([1, 2, 3, 4]);
       });
 
       it('should return the new length of the list', () => {
-        let value = new ObservableList<number>({ values: [1] });
-        expect(value.pushAll([2, 3, 4])).to.be(4);
+        const value = new ObservableList<number>({ values: [1] });
+        expect(value.pushAll([2, 3, 4])).to.equal(4);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('add');
-          expect(args.newIndex).to.be(3);
-          expect(args.oldIndex).to.be(-1);
-          expect(toArray(args.newValues)).to.eql([4, 5, 6]);
-          expect(args.oldValues.length).to.be(0);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('add');
+          expect(args.newIndex).to.equal(3);
+          expect(args.oldIndex).to.equal(-1);
+          expect(toArray(args.newValues)).to.deep.equal([4, 5, 6]);
+          expect(args.oldValues.length).to.equal(0);
           called = true;
         });
         value.pushAll([4, 5, 6]);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#insertAll()', () => {
       it('should push an array of items into a list', () => {
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.insertAll(1, [2, 3, 4]);
-        expect(toArray(value)).to.eql([1, 2, 3, 4, 2, 3]);
+        expect(toArray(value)).to.deep.equal([1, 2, 3, 4, 2, 3]);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableList<number>({ values: [1, 2, 3] });
+        const value = new ObservableList<number>({ values: [1, 2, 3] });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('add');
-          expect(args.newIndex).to.be(1);
-          expect(args.oldIndex).to.be(-1);
-          expect(toArray(args.newValues)).to.eql([4, 5, 6]);
-          expect(args.oldValues.length).to.be(0);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('add');
+          expect(args.newIndex).to.equal(1);
+          expect(args.oldIndex).to.equal(-1);
+          expect(toArray(args.newValues)).to.deep.equal([4, 5, 6]);
+          expect(args.oldValues.length).to.equal(0);
           called = true;
         });
         value.insertAll(1, [4, 5, 6]);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#removeRange()', () => {
       it('should remove a range of items from the list', () => {
-        let values = [1, 2, 3, 4, 5, 6];
-        let value = new ObservableList<number>({ values });
+        const values = [1, 2, 3, 4, 5, 6];
+        const value = new ObservableList<number>({ values });
         value.removeRange(1, 3);
-        expect(toArray(value)).to.eql([1, 4, 5, 6]);
+        expect(toArray(value)).to.deep.equal([1, 4, 5, 6]);
       });
 
       it('should return the new length of the list', () => {
-        let values = [1, 2, 3, 4, 5, 6];
-        let value = new ObservableList<number>({ values });
-        expect(value.removeRange(1, 3)).to.be(4);
+        const values = [1, 2, 3, 4, 5, 6];
+        const value = new ObservableList<number>({ values });
+        expect(value.removeRange(1, 3)).to.equal(4);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let values = [1, 2, 3, 4];
-        let value = new ObservableList<number>({ values });
+        const values = [1, 2, 3, 4];
+        const value = new ObservableList<number>({ values });
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('remove');
-          expect(args.newIndex).to.be(-1);
-          expect(args.oldIndex).to.be(1);
-          expect(toArray(args.oldValues)).to.eql([2, 3]);
-          expect(args.newValues.length).to.be(0);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('remove');
+          expect(args.newIndex).to.equal(-1);
+          expect(args.oldIndex).to.equal(1);
+          expect(toArray(args.oldValues)).to.deep.equal([2, 3]);
+          expect(args.newValues.length).to.equal(0);
           called = true;
         });
         value.removeRange(1, 3);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
   });

--- a/tests/test-observables/src/observablemap.spec.ts
+++ b/tests/test-observables/src/observablemap.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ObservableMap } from '@jupyterlab/observables';
 
@@ -9,212 +9,212 @@ describe('@jupyterlab/observables', () => {
   describe('ObservableMap', () => {
     describe('#constructor()', () => {
       it('should accept no arguments', () => {
-        let value = new ObservableMap<number>();
-        expect(value instanceof ObservableMap).to.be(true);
+        const value = new ObservableMap<number>();
+        expect(value instanceof ObservableMap).to.equal(true);
       });
     });
 
     describe('#type', () => {
       it('should return `Map`', () => {
-        let value = new ObservableMap<number>();
-        expect(value.type).to.be('Map');
+        const value = new ObservableMap<number>();
+        expect(value.type).to.equal('Map');
       });
     });
 
     describe('#size', () => {
       it('should return the number of entries in the map', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
         value.set('two', 2);
-        expect(value.size).to.be(2);
+        expect(value.size).to.equal(2);
       });
     });
 
     describe('#changed', () => {
       it('should be emitted when the map changes state', () => {
         let called = false;
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.changed.connect(() => {
           called = true;
         });
         value.set('entry', 1);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should have value changed args', () => {
         let called = false;
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('add');
-          expect(args.newValue).to.be(0);
-          expect(args.oldValue).to.be(undefined);
-          expect(args.key).to.be('entry');
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('add');
+          expect(args.newValue).to.equal(0);
+          expect(args.oldValue).to.be.undefined;
+          expect(args.key).to.equal('entry');
           called = true;
         });
         value.set('entry', 0);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether the map is disposed', () => {
-        let value = new ObservableMap<number>();
-        expect(value.isDisposed).to.be(false);
+        const value = new ObservableMap<number>();
+        expect(value.isDisposed).to.equal(false);
         value.dispose();
-        expect(value.isDisposed).to.be(true);
+        expect(value.isDisposed).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the map', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
         value.set('two', 2);
         value.dispose();
-        expect(value.isDisposed).to.be(true);
+        expect(value.isDisposed).to.equal(true);
       });
     });
 
     describe('#set()', () => {
       it('should set the item at a specific key', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
-        expect(value.get('one')).to.be(1);
+        expect(value.get('one')).to.equal(1);
       });
 
       it('should return the old value for that key', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
-        let x = value.set('one', 1.01);
-        expect(x).to.be(1);
+        const x = value.set('one', 1.01);
+        expect(x).to.equal(1);
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('add');
-          expect(args.newValue).to.be(1);
-          expect(args.oldValue).to.be(undefined);
-          expect(args.key).to.be('one');
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('add');
+          expect(args.newValue).to.equal(1);
+          expect(args.oldValue).to.be.undefined;
+          expect(args.key).to.equal('one');
           called = true;
         });
         value.set('one', 1);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#get()', () => {
       it('should get the value for a key', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
-        expect(value.get('one')).to.be(1);
+        expect(value.get('one')).to.equal(1);
       });
 
       it('should return undefined if the key does not exist', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
-        expect(value.get('two')).to.be(undefined);
+        expect(value.get('two')).to.be.undefined;
       });
     });
 
     describe('#has()', () => {
       it('should whether the key exists in a map', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
-        expect(value.has('one')).to.be(true);
-        expect(value.has('two')).to.be(false);
+        expect(value.has('one')).to.equal(true);
+        expect(value.has('two')).to.equal(false);
       });
     });
 
     describe('#keys()', () => {
       it('should return a list of the keys in the map', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
         value.set('two', 2);
         value.set('three', 3);
-        let keys = value.keys();
-        expect(keys).to.eql(['one', 'two', 'three']);
+        const keys = value.keys();
+        expect(keys).to.deep.equal(['one', 'two', 'three']);
       });
     });
 
     describe('#values()', () => {
       it('should return a list of the values in the map', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
         value.set('two', 2);
         value.set('three', 3);
-        let keys = value.values();
-        expect(keys).to.eql([1, 2, 3]);
+        const keys = value.values();
+        expect(keys).to.deep.equal([1, 2, 3]);
       });
     });
 
     describe('#delete()', () => {
       it('should remove an item from the map', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
         value.set('two', 2);
         value.set('three', 3);
-        expect(value.get('two')).to.be(2);
+        expect(value.get('two')).to.equal(2);
         value.delete('two');
-        expect(value.get('two')).to.be(undefined);
+        expect(value.get('two')).to.be.undefined;
       });
 
       it('should return the value of the key it removed', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
-        expect(value.delete('one')).to.be(1);
-        expect(value.delete('one')).to.be(undefined);
+        expect(value.delete('one')).to.equal(1);
+        expect(value.delete('one')).to.be.undefined;
       });
 
       it('should trigger a changed signal', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
         value.set('two', 2);
         value.set('three', 3);
         let called = false;
 
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('remove');
-          expect(args.key).to.be('two');
-          expect(args.oldValue).to.be(2);
-          expect(args.newValue).to.be(undefined);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('remove');
+          expect(args.key).to.equal('two');
+          expect(args.oldValue).to.equal(2);
+          expect(args.newValue).to.be.undefined;
           called = true;
         });
         value.delete('two');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#clear()', () => {
       it('should remove all items from the map', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
         value.set('two', 2);
         value.set('three', 3);
         value.clear();
-        expect(value.size).to.be(0);
+        expect(value.size).to.equal(0);
         value.clear();
-        expect(value.size).to.be(0);
+        expect(value.size).to.equal(0);
       });
 
       it('should trigger a changed signal', () => {
-        let value = new ObservableMap<number>();
+        const value = new ObservableMap<number>();
         value.set('one', 1);
         let called = false;
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('remove');
-          expect(args.key).to.be('one');
-          expect(args.oldValue).to.be(1);
-          expect(args.newValue).to.be(undefined);
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('remove');
+          expect(args.key).to.equal('one');
+          expect(args.oldValue).to.equal(1);
+          expect(args.newValue).to.be.undefined;
           called = true;
         });
         value.clear();
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
   });

--- a/tests/test-observables/src/observablestring.spec.ts
+++ b/tests/test-observables/src/observablestring.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ObservableString } from '@jupyterlab/observables';
 
@@ -9,154 +9,154 @@ describe('@jupyterlab/observables', () => {
   describe('ObservableString', () => {
     describe('#constructor()', () => {
       it('should accept no arguments', () => {
-        let value = new ObservableString();
-        expect(value instanceof ObservableString).to.be(true);
+        const value = new ObservableString();
+        expect(value instanceof ObservableString).to.equal(true);
       });
 
       it('should accept a string argument', () => {
-        let value = new ObservableString('hello');
-        expect(value instanceof ObservableString).to.be(true);
+        const value = new ObservableString('hello');
+        expect(value instanceof ObservableString).to.equal(true);
       });
 
       it('should initialize the string value', () => {
-        let value = new ObservableString('hello');
-        expect(value.text).to.eql('hello');
+        const value = new ObservableString('hello');
+        expect(value.text).to.deep.equal('hello');
       });
     });
 
     describe('#type', () => {
       it('should return `String`', () => {
-        let value = new ObservableString();
-        expect(value.type).to.be('String');
+        const value = new ObservableString();
+        expect(value.type).to.equal('String');
       });
     });
 
     describe('#changed', () => {
       it('should be emitted when the string changes', () => {
         let called = false;
-        let value = new ObservableString();
+        const value = new ObservableString();
         value.changed.connect(() => {
           called = true;
         });
         value.text = 'change';
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should have value changed args', () => {
         let called = false;
-        let value = new ObservableString();
+        const value = new ObservableString();
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('set');
-          expect(args.start).to.be(0);
-          expect(args.end).to.be(3);
-          expect(args.value).to.be('new');
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('set');
+          expect(args.start).to.equal(0);
+          expect(args.end).to.equal(3);
+          expect(args.value).to.equal('new');
           called = true;
         });
         value.text = 'new';
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#isDisposed', () => {
       it('should test whether the string is disposed', () => {
-        let value = new ObservableString();
-        expect(value.isDisposed).to.be(false);
+        const value = new ObservableString();
+        expect(value.isDisposed).to.equal(false);
         value.dispose();
-        expect(value.isDisposed).to.be(true);
+        expect(value.isDisposed).to.equal(true);
       });
     });
 
     describe('#setter()', () => {
       it('should set the item at a specific index', () => {
-        let value = new ObservableString('old');
+        const value = new ObservableString('old');
         value.text = 'new';
-        expect(value.text).to.eql('new');
+        expect(value.text).to.deep.equal('new');
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableString('old');
+        const value = new ObservableString('old');
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('set');
-          expect(args.start).to.be(0);
-          expect(args.end).to.be(3);
-          expect(args.value).to.be('new');
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('set');
+          expect(args.start).to.equal(0);
+          expect(args.end).to.equal(3);
+          expect(args.value).to.equal('new');
           called = true;
         });
         value.text = 'new';
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#insert()', () => {
       it('should insert an substring into the string at a specific index', () => {
-        let value = new ObservableString('one three');
+        const value = new ObservableString('one three');
         value.insert(4, 'two ');
-        expect(value.text).to.eql('one two three');
+        expect(value.text).to.deep.equal('one two three');
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableString('one three');
+        const value = new ObservableString('one three');
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('insert');
-          expect(args.start).to.be(4);
-          expect(args.end).to.be(8);
-          expect(args.value).to.be('two ');
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('insert');
+          expect(args.start).to.equal(4);
+          expect(args.end).to.equal(8);
+          expect(args.value).to.equal('two ');
           called = true;
         });
         value.insert(4, 'two ');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#remove()', () => {
       it('should remove a substring from the string', () => {
-        let value = new ObservableString('one two two three');
+        const value = new ObservableString('one two two three');
         value.remove(4, 8);
-        expect(value.text).to.eql('one two three');
+        expect(value.text).to.deep.equal('one two three');
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableString('one two two three');
+        const value = new ObservableString('one two two three');
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('remove');
-          expect(args.start).to.be(4);
-          expect(args.end).to.be(8);
-          expect(args.value).to.be('two ');
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('remove');
+          expect(args.start).to.equal(4);
+          expect(args.end).to.equal(8);
+          expect(args.value).to.equal('two ');
           called = true;
         });
         value.remove(4, 8);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#clear()', () => {
       it('should empty the string', () => {
-        let value = new ObservableString('full');
+        const value = new ObservableString('full');
         value.clear();
-        expect(value.text.length).to.be(0);
-        expect(value.text).to.be('');
+        expect(value.text.length).to.equal(0);
+        expect(value.text).to.equal('');
       });
 
       it('should trigger a changed signal', () => {
         let called = false;
-        let value = new ObservableString('full');
+        const value = new ObservableString('full');
         value.changed.connect((sender, args) => {
-          expect(sender).to.be(value);
-          expect(args.type).to.be('set');
-          expect(args.start).to.be(0);
-          expect(args.end).to.be(0);
-          expect(args.value).to.be('');
+          expect(sender).to.equal(value);
+          expect(args.type).to.equal('set');
+          expect(args.start).to.equal(0);
+          expect(args.end).to.equal(0);
+          expect(args.value).to.equal('');
           called = true;
         });
         value.clear();
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
   });

--- a/tests/test-observables/src/undoablelist.spec.ts
+++ b/tests/test-observables/src/undoablelist.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { JSONObject } from '@phosphor/coreutils';
 
@@ -39,108 +39,108 @@ describe('@jupyterlab/observables', () => {
   describe('ObservableUndoableList', () => {
     describe('#constructor', () => {
       it('should create a new ObservableUndoableList', () => {
-        let list = new ObservableUndoableList(serializer);
-        expect(list).to.be.an(ObservableUndoableList);
+        const list = new ObservableUndoableList(serializer);
+        expect(list).to.be.an.instanceof(ObservableUndoableList);
       });
     });
 
     describe('#canRedo', () => {
       it('should return false if there is no history', () => {
-        let list = new ObservableUndoableList(serializer);
-        expect(list.canRedo).to.be(false);
+        const list = new ObservableUndoableList(serializer);
+        expect(list.canRedo).to.equal(false);
       });
 
       it('should return true if there is an undo that can be redone', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.push(new Test(value));
         list.undo();
-        expect(list.canRedo).to.be(true);
+        expect(list.canRedo).to.equal(true);
       });
     });
 
     describe('#canUndo', () => {
       it('should return false if there is no history', () => {
-        let list = new ObservableUndoableList(serializer);
-        expect(list.canUndo).to.be(false);
+        const list = new ObservableUndoableList(serializer);
+        expect(list.canUndo).to.equal(false);
       });
 
       it('should return true if there is a change that can be undone', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.push(serializer.fromJSON(value));
-        expect(list.canUndo).to.be(true);
+        expect(list.canUndo).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources used by the list', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.dispose();
-        expect(list.isDisposed).to.be(true);
+        expect(list.isDisposed).to.equal(true);
         list.dispose();
-        expect(list.isDisposed).to.be(true);
+        expect(list.isDisposed).to.equal(true);
       });
     });
 
     describe('#beginCompoundOperation()', () => {
       it('should begin a compound operation', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.beginCompoundOperation();
         list.push(serializer.fromJSON(value));
         list.push(serializer.fromJSON(value));
         list.endCompoundOperation();
-        expect(list.canUndo).to.be(true);
+        expect(list.canUndo).to.equal(true);
         list.undo();
-        expect(list.canUndo).to.be(false);
+        expect(list.canUndo).to.equal(false);
       });
 
       it('should not be undoable if isUndoAble is set to false', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.beginCompoundOperation(false);
         list.push(serializer.fromJSON(value));
         list.push(serializer.fromJSON(value));
         list.endCompoundOperation();
-        expect(list.canUndo).to.be(false);
+        expect(list.canUndo).to.equal(false);
       });
     });
 
     describe('#endCompoundOperation()', () => {
       it('should end a compound operation', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.beginCompoundOperation();
         list.push(serializer.fromJSON(value));
         list.push(serializer.fromJSON(value));
         list.endCompoundOperation();
-        expect(list.canUndo).to.be(true);
+        expect(list.canUndo).to.equal(true);
         list.undo();
-        expect(list.canUndo).to.be(false);
+        expect(list.canUndo).to.equal(false);
       });
     });
 
     describe('#undo()', () => {
       it('should undo a push', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.push(serializer.fromJSON(value));
         list.undo();
-        expect(list.length).to.be(0);
+        expect(list.length).to.equal(0);
       });
 
       it('should undo a pushAll', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.pushAll([serializer.fromJSON(value), serializer.fromJSON(value)]);
         list.undo();
-        expect(list.length).to.be(0);
+        expect(list.length).to.equal(0);
       });
 
       it('should undo a remove', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.pushAll([serializer.fromJSON(value), serializer.fromJSON(value)]);
         list.remove(0);
         list.undo();
-        expect(list.length).to.be(2);
+        expect(list.length).to.equal(2);
       });
 
       it('should undo a removeRange', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.pushAll([
           serializer.fromJSON(value),
           serializer.fromJSON(value),
@@ -151,51 +151,53 @@ describe('@jupyterlab/observables', () => {
         ]);
         list.removeRange(1, 3);
         list.undo();
-        expect(list.length).to.be(6);
+        expect(list.length).to.equal(6);
       });
 
       it('should undo a move', () => {
-        let items = [
+        const items = [
           serializer.fromJSON(value),
           serializer.fromJSON(value),
           serializer.fromJSON(value)
         ];
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.pushAll(items);
         list.move(1, 2);
         list.undo();
-        expect((list.get(1) as any)['count']).to.be((items[1] as any)['count']);
+        expect((list.get(1) as any)['count']).to.equal(
+          (items[1] as any)['count']
+        );
       });
     });
 
     describe('#redo()', () => {
       it('should redo a push', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.push(serializer.fromJSON(value));
         list.undo();
         list.redo();
-        expect(list.length).to.be(1);
+        expect(list.length).to.equal(1);
       });
 
       it('should redo a pushAll', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.pushAll([serializer.fromJSON(value), serializer.fromJSON(value)]);
         list.undo();
         list.redo();
-        expect(list.length).to.be(2);
+        expect(list.length).to.equal(2);
       });
 
       it('should redo a remove', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.pushAll([serializer.fromJSON(value), serializer.fromJSON(value)]);
         list.remove(0);
         list.undo();
         list.redo();
-        expect(list.length).to.be(1);
+        expect(list.length).to.equal(1);
       });
 
       it('should redo a removeRange', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.pushAll([
           serializer.fromJSON(value),
           serializer.fromJSON(value),
@@ -207,30 +209,32 @@ describe('@jupyterlab/observables', () => {
         list.removeRange(1, 3);
         list.undo();
         list.redo();
-        expect(list.length).to.be(4);
+        expect(list.length).to.equal(4);
       });
 
       it('should undo a move', () => {
-        let items = [
+        const items = [
           serializer.fromJSON(value),
           serializer.fromJSON(value),
           serializer.fromJSON(value)
         ];
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.pushAll(items);
         list.move(1, 2);
         list.undo();
         list.redo();
-        expect((list.get(2) as any)['count']).to.be((items[1] as any)['count']);
+        expect((list.get(2) as any)['count']).to.equal(
+          (items[1] as any)['count']
+        );
       });
     });
 
     describe('#clearUndo()', () => {
       it('should clear the undo stack', () => {
-        let list = new ObservableUndoableList(serializer);
+        const list = new ObservableUndoableList(serializer);
         list.push(serializer.fromJSON(value));
         list.clearUndo();
-        expect(list.canUndo).to.be(false);
+        expect(list.canUndo).to.equal(false);
       });
     });
   });

--- a/tests/test-rendermime/package.json
+++ b/tests/test-rendermime/package.json
@@ -25,9 +25,10 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-rendermime/src/factories.spec.ts
+++ b/tests/test-rendermime/src/factories.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { JSONObject, JSONValue } from '@phosphor/coreutils';
 
@@ -25,7 +25,7 @@ function createModel(
   source: JSONValue,
   trusted = false
 ): IRenderMime.IMimeModel {
-  let data: JSONObject = {};
+  const data: JSONObject = {};
   data[mimeType] = source;
   return new MimeModel({ data, trusted });
 }
@@ -41,57 +41,54 @@ describe('rendermime/factories', () => {
   describe('textRendererFactory', () => {
     describe('#mimeTypes', () => {
       it('should have text related mimeTypes', () => {
-        let mimeTypes = [
+        const mimeTypes = [
           'text/plain',
           'application/vnd.jupyter.stdout',
           'application/vnd.jupyter.stderr'
         ];
-        expect(textRendererFactory.mimeTypes).to.eql(mimeTypes);
+        expect(textRendererFactory.mimeTypes).to.deep.equal(mimeTypes);
       });
     });
 
     describe('#safe', () => {
       it('should be safe', () => {
-        expect(textRendererFactory.safe).to.be(true);
+        expect(textRendererFactory.safe).to.equal(true);
       });
     });
 
     describe('#createRenderer()', () => {
-      it('should output the correct HTML', () => {
-        let f = textRendererFactory;
-        let mimeType = 'text/plain';
-        let model = createModel(mimeType, 'x = 2 ** a');
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          expect(w.node.innerHTML).to.be('<pre>x = 2 ** a</pre>');
-        });
+      it('should output the correct HTML', async () => {
+        const f = textRendererFactory;
+        const mimeType = 'text/plain';
+        const model = createModel(mimeType, 'x = 2 ** a');
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal('<pre>x = 2 ** a</pre>');
       });
 
-      it('should output the correct HTML with ansi colors', () => {
-        let f = textRendererFactory;
-        let source = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
-        let mimeType = 'application/vnd.jupyter.console-text';
-        let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          expect(w.node.innerHTML).to.be(
-            '<pre>There is no text but <span style="font-weight:bold" class="ansi-green-fg ansi-red-bg">text</span>.\nWoo.</pre>'
-          );
-        });
+      it('should output the correct HTML with ansi colors', async () => {
+        const f = textRendererFactory;
+        const source = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
+        const mimeType = 'application/vnd.jupyter.console-text';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal(
+          '<pre>There is no text but <span style="font-weight:bold" class="ansi-green-fg ansi-red-bg">text</span>.\nWoo.</pre>'
+        );
       });
 
-      it('should escape inline html', () => {
-        let f = textRendererFactory;
-        let source =
+      it('should escape inline html', async () => {
+        const f = textRendererFactory;
+        const source =
           'There is no text <script>window.x=1</script> but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
-        let mimeType = 'application/vnd.jupyter.console-text';
-        let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          expect(w.node.innerHTML).to.be(
-            '<pre>There is no text &lt;script&gt;window.x=1&lt;/script&gt; but <span style="font-weight:bold" class="ansi-green-fg ansi-red-bg">text</span>.\nWoo.</pre>'
-          );
-        });
+        const mimeType = 'application/vnd.jupyter.console-text';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal(
+          '<pre>There is no text &lt;script&gt;window.x=1&lt;/script&gt; but <span style="font-weight:bold" class="ansi-green-fg ansi-red-bg">text</span>.\nWoo.</pre>'
+        );
       });
     });
   });
@@ -99,26 +96,25 @@ describe('rendermime/factories', () => {
   describe('latexRendererFactory', () => {
     describe('#mimeTypes', () => {
       it('should have the text/latex mimeType', () => {
-        expect(latexRendererFactory.mimeTypes).to.eql(['text/latex']);
+        expect(latexRendererFactory.mimeTypes).to.deep.equal(['text/latex']);
       });
     });
 
     describe('#safe', () => {
       it('should be safe', () => {
-        expect(latexRendererFactory.safe).to.be(true);
+        expect(latexRendererFactory.safe).to.equal(true);
       });
     });
 
     describe('#createRenderer()', () => {
-      it('should set the textContent of the widget', () => {
-        let source = 'sumlimits_{i=0}^{infty} \frac{1}{n^2}';
-        let f = latexRendererFactory;
-        let mimeType = 'text/latex';
-        let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          expect(w.node.textContent).to.be(source);
-        });
+      it('should set the textContent of the widget', async () => {
+        const source = 'sumlimits_{i=0}^{infty} \frac{1}{n^2}';
+        const f = latexRendererFactory;
+        const mimeType = 'text/latex';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.textContent).to.equal(source);
       });
     });
   });
@@ -126,28 +122,27 @@ describe('rendermime/factories', () => {
   describe('svgRendererFactory', () => {
     describe('#mimeTypes', () => {
       it('should have the image/svg+xml mimeType', () => {
-        expect(svgRendererFactory.mimeTypes).to.eql(['image/svg+xml']);
+        expect(svgRendererFactory.mimeTypes).to.deep.equal(['image/svg+xml']);
       });
     });
 
     describe('#safe', () => {
       it('should not be safe', () => {
-        expect(svgRendererFactory.safe).to.be(false);
+        expect(svgRendererFactory.safe).to.equal(false);
       });
     });
 
     describe('#createRenderer()', () => {
-      it('should create an img element with the uri encoded svg inline', () => {
+      it('should create an img element with the uri encoded svg inline', async () => {
         const source = '<svg></svg>';
-        let f = svgRendererFactory;
-        let mimeType = 'image/svg+xml';
-        let model = createModel(mimeType, source, true);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          let imgEl = w.node.getElementsByTagName('img')[0];
-          expect(imgEl).to.be.ok();
-          expect(imgEl.src).to.contain(encodeURIComponent(source));
-        });
+        const f = svgRendererFactory;
+        const mimeType = 'image/svg+xml';
+        const model = createModel(mimeType, source, true);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        const imgEl = w.node.getElementsByTagName('img')[0];
+        expect(imgEl).to.be.ok;
+        expect(imgEl.src).to.contain(encodeURIComponent(source));
       });
     });
   });
@@ -155,56 +150,55 @@ describe('rendermime/factories', () => {
   describe('markdownRendererFactory', () => {
     describe('#mimeTypes', () => {
       it('should have the text/markdown mimeType', function() {
-        expect(markdownRendererFactory.mimeTypes).to.eql(['text/markdown']);
+        expect(markdownRendererFactory.mimeTypes).to.deep.equal([
+          'text/markdown'
+        ]);
       });
     });
 
     describe('#safe', () => {
       it('should be safe', () => {
-        expect(markdownRendererFactory.safe).to.be(true);
+        expect(markdownRendererFactory.safe).to.equal(true);
       });
     });
 
     describe('#createRenderer()', () => {
-      it('should set the inner html', () => {
-        let f = markdownRendererFactory;
-        let source = '<p>hello</p>';
-        let mimeType = 'text/markdown';
-        let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          expect(w.node.innerHTML).to.be(source);
-        });
+      it('should set the inner html', async () => {
+        const f = markdownRendererFactory;
+        const source = '<p>hello</p>';
+        const mimeType = 'text/markdown';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal(source);
       });
 
-      it('should add header anchors', () => {
-        let source = require('../../../examples/filebrowser/sample.md') as string;
-        let f = markdownRendererFactory;
-        let mimeType = 'text/markdown';
-        let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          Widget.attach(w, document.body);
-          let node = document.getElementById('Title-third-level');
-          expect(node.localName).to.be('h3');
-          let anchor = node.firstChild.nextSibling as HTMLAnchorElement;
-          expect(anchor.href).to.contain('#Title-third-level');
-          expect(anchor.target).to.be('_self');
-          expect(anchor.className).to.contain('jp-InternalAnchorLink');
-          expect(anchor.textContent).to.be('¶');
-          Widget.detach(w);
-        });
+      it('should add header anchors', async () => {
+        const source = require('../../../examples/filebrowser/sample.md') as string;
+        const f = markdownRendererFactory;
+        const mimeType = 'text/markdown';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        Widget.attach(w, document.body);
+        const node = document.getElementById('Title-third-level');
+        expect(node.localName).to.equal('h3');
+        const anchor = node.firstChild.nextSibling as HTMLAnchorElement;
+        expect(anchor.href).to.contain('#Title-third-level');
+        expect(anchor.target).to.equal('_self');
+        expect(anchor.className).to.contain('jp-InternalAnchorLink');
+        expect(anchor.textContent).to.equal('¶');
+        Widget.detach(w);
       });
 
-      it('should sanitize the html', () => {
-        let f = markdownRendererFactory;
-        let source = '<p>hello</p><script>alert("foo")</script>';
-        let mimeType = 'text/markdown';
-        let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          expect(w.node.innerHTML).to.not.contain('script');
-        });
+      it('should sanitize the html', async () => {
+        const f = markdownRendererFactory;
+        const source = '<p>hello</p><script>alert("foo")</script>';
+        const mimeType = 'text/markdown';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.not.contain('script');
       });
     });
   });
@@ -212,73 +206,70 @@ describe('rendermime/factories', () => {
   describe('htmlRendererFactory', () => {
     describe('#mimeTypes', () => {
       it('should have the text/html mimeType', () => {
-        expect(htmlRendererFactory.mimeTypes).to.eql(['text/html']);
+        expect(htmlRendererFactory.mimeTypes).to.deep.equal(['text/html']);
       });
     });
 
     describe('#safe', () => {
       it('should be safe', () => {
-        expect(htmlRendererFactory.safe).to.be(true);
+        expect(htmlRendererFactory.safe).to.equal(true);
       });
     });
 
     describe('#createRenderer()', () => {
-      it('should set the inner HTML', () => {
-        let f = htmlRendererFactory;
+      it('should set the inner HTML', async () => {
+        const f = htmlRendererFactory;
         const source = '<h1>This is great</h1>';
-        let mimeType = 'text/html';
-        let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          expect(w.node.innerHTML).to.be('<h1>This is great</h1>');
-        });
+        const mimeType = 'text/html';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal('<h1>This is great</h1>');
       });
 
       // TODO we are disabling script execution for now.
       // it('should execute a script tag when attached', () => {
       //   const source = '<script>window.y=3;</script>';
-      //   let f = htmlRendererFactory;
-      //   let mimeType = 'text/html';
-      //   let model = createModel(mimeType, source, true);
-      //   let w = f.createRenderer({ mimeType, ...defaultOptions });
+      //   const f = htmlRendererFactory;
+      //   const mimeType = 'text/html';
+      //   const model = createModel(mimeType, source, true);
+      //   const w = f.createRenderer({ mimeType, ...defaultOptions });
       //   return w.renderModel(model).then(() => {
-      //     expect((window as any).y).to.be(void 0);
+      //     expect((window as any).y).to.be.undefined;
       //     Widget.attach(w, document.body);
-      //     expect((window as any).y).to.be(3);
+      //     expect((window as any).y).to.equal(3);
       //     w.dispose();
       //   });
       // });
 
-      it('should sanitize when untrusted', () => {
+      it('should sanitize when untrusted', async () => {
         const source = '<pre><script>window.y=3;</script></pre>';
-        let f = htmlRendererFactory;
-        let mimeType = 'text/html';
-        let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, ...defaultOptions });
-        return w.renderModel(model).then(() => {
-          expect(w.node.innerHTML).to.be('<pre></pre>');
-        });
+        const f = htmlRendererFactory;
+        const mimeType = 'text/html';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal('<pre></pre>');
       });
     });
 
-    it('should sanitize html', () => {
-      let model = createModel(
+    it('should sanitize html', async () => {
+      const model = createModel(
         'text/html',
         '<h1>foo <script>window.x=1></scrip></h1>'
       );
-      let f = htmlRendererFactory;
-      let mimeType = 'text/html';
-      let w = f.createRenderer({ mimeType, ...defaultOptions });
-      return w.renderModel(model).then(() => {
-        expect(w.node.innerHTML).to.be('<h1>foo </h1>');
-      });
+      const f = htmlRendererFactory;
+      const mimeType = 'text/html';
+      const w = f.createRenderer({ mimeType, ...defaultOptions });
+      await w.renderModel(model);
+      expect(w.node.innerHTML).to.equal('<h1>foo </h1>');
     });
   });
 
   describe('imageRendererFactory', () => {
     describe('#mimeTypes', () => {
       it('should support multiple mimeTypes', () => {
-        expect(imageRendererFactory.mimeTypes).to.eql([
+        expect(imageRendererFactory.mimeTypes).to.deep.equal([
           'image/bmp',
           'image/png',
           'image/jpeg',
@@ -289,38 +280,33 @@ describe('rendermime/factories', () => {
 
     describe('#safe', () => {
       it('should be safe', () => {
-        expect(imageRendererFactory.safe).to.be(true);
+        expect(imageRendererFactory.safe).to.equal(true);
       });
     });
 
     describe('#createRenderer()', () => {
-      it('should create an <img> with the right mimeType', () => {
+      it('should create an <img> with the right mimeType', async () => {
         let source = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-        let f = imageRendererFactory;
+        const f = imageRendererFactory;
         let mimeType = 'image/png';
         let model = createModel(mimeType, source);
         let w = f.createRenderer({ mimeType, ...defaultOptions });
 
-        return w
-          .renderModel(model)
-          .then(() => {
-            let el = w.node.firstChild as HTMLImageElement;
-            expect(el.src).to.be('data:image/png;base64,' + source);
-            expect(el.localName).to.be('img');
-            expect(el.innerHTML).to.be('');
+        await w.renderModel(model);
+        let el = w.node.firstChild as HTMLImageElement;
+        expect(el.src).to.equal('data:image/png;base64,' + source);
+        expect(el.localName).to.equal('img');
+        expect(el.innerHTML).to.equal('');
 
-            source = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
-            mimeType = 'image/gif';
-            model = createModel(mimeType, source);
-            w = f.createRenderer({ mimeType, ...defaultOptions });
-            return w.renderModel(model);
-          })
-          .then(() => {
-            let el = w.node.firstChild as HTMLImageElement;
-            expect(el.src).to.be('data:image/gif;base64,' + source);
-            expect(el.localName).to.be('img');
-            expect(el.innerHTML).to.be('');
-          });
+        source = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
+        mimeType = 'image/gif';
+        model = createModel(mimeType, source);
+        w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        el = w.node.firstChild as HTMLImageElement;
+        expect(el.src).to.equal('data:image/gif;base64,' + source);
+        expect(el.localName).to.equal('img');
+        expect(el.innerHTML).to.equal('');
       });
     });
   });

--- a/tests/test-rendermime/src/latex.spec.ts
+++ b/tests/test-rendermime/src/latex.spec.ts
@@ -1,98 +1,98 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { removeMath, replaceMath } from '@jupyterlab/rendermime';
 
 describe('jupyter-ui', () => {
   describe('removeMath()', () => {
     it('should split the text into text and math', () => {
-      let input = 'hello, $ /alpha $, there';
-      let { text, math } = removeMath(input);
-      expect(text).to.be('hello, @@0@@, there');
-      expect(math).to.eql(['$ /alpha $']);
+      const input = 'hello, $ /alpha $, there';
+      const { text, math } = removeMath(input);
+      expect(text).to.equal('hello, @@0@@, there');
+      expect(math).to.deep.equal(['$ /alpha $']);
     });
 
     it('should handle code spans', () => {
-      let input = '`$foo` and `$bar` are variables';
-      let { text, math } = removeMath(input);
-      expect(text).to.be(input);
-      expect(math).to.eql([]);
+      const input = '`$foo` and `$bar` are variables';
+      const { text, math } = removeMath(input);
+      expect(text).to.equal(input);
+      expect(math).to.deep.equal([]);
     });
 
     it('should handle math markers', () => {
-      let input = ' @@0@@ hello, $ /alpha $, there';
-      let { text, math } = removeMath(input);
-      expect(text).to.be(' @@0@@ hello, @@1@@, there');
-      expect(math).to.eql(['@@0@@', '$ /alpha $']);
+      const input = ' @@0@@ hello, $ /alpha $, there';
+      const { text, math } = removeMath(input);
+      expect(text).to.equal(' @@0@@ hello, @@1@@, there');
+      expect(math).to.deep.equal(['@@0@@', '$ /alpha $']);
     });
 
     it('should handle unbalanced braces', () => {
-      let input = 'hello, $ /alpha { $, there';
-      let { text, math } = removeMath(input);
-      expect(text).to.be('hello, @@0@@, there');
-      expect(math).to.eql(['$ /alpha { $']);
+      const input = 'hello, $ /alpha { $, there';
+      const { text, math } = removeMath(input);
+      expect(text).to.equal('hello, @@0@@, there');
+      expect(math).to.deep.equal(['$ /alpha { $']);
     });
 
     it('should handle balanced braces', () => {
-      let input = 'hello, $ /alpha { } $, there';
-      let { text, math } = removeMath(input);
-      expect(text).to.be('hello, @@0@@, there');
-      expect(math).to.eql(['$ /alpha { } $']);
+      const input = 'hello, $ /alpha { } $, there';
+      const { text, math } = removeMath(input);
+      expect(text).to.equal('hello, @@0@@, there');
+      expect(math).to.deep.equal(['$ /alpha { } $']);
     });
 
     it('should handle math blocks', () => {
-      let input = 'hello, $$\nfoo\n$$, there';
-      let { text, math } = removeMath(input);
-      expect(text).to.be('hello, @@0@@, there');
-      expect(math).to.eql(['$$\nfoo\n$$']);
+      const input = 'hello, $$\nfoo\n$$, there';
+      const { text, math } = removeMath(input);
+      expect(text).to.equal('hello, @@0@@, there');
+      expect(math).to.deep.equal(['$$\nfoo\n$$']);
     });
 
     it('should handle begin statements', () => {
-      let input = 'hello, \\begin{align} \\end{align}, there';
-      let { text, math } = removeMath(input);
-      expect(text).to.be('hello, @@0@@, there');
-      expect(math).to.eql(['\\begin{align} \\end{align}']);
+      const input = 'hello, \\begin{align} \\end{align}, there';
+      const { text, math } = removeMath(input);
+      expect(text).to.equal('hello, @@0@@, there');
+      expect(math).to.deep.equal(['\\begin{align} \\end{align}']);
     });
 
     it('should handle `\\(` delimiters in GFM', () => {
-      let input = `
+      const input = `
       \`\`\`
         Some \\(text
         \'\'\'
         **bold**
         ## header
       `;
-      let { text, math } = removeMath(input);
-      expect(text).to.be(input);
-      expect(math).to.eql([]);
+      const { text, math } = removeMath(input);
+      expect(text).to.equal(input);
+      expect(math).to.deep.equal([]);
     });
 
     it('should handle `\\\\(` delimiters for math', () => {
-      let input = `hello, \\\\\(
+      const input = `hello, \\\\\(
           /alpha
       \\\\\), there`;
-      let { text, math } = removeMath(input);
-      expect(text).to.be('hello, @@0@@, there');
-      expect(math).to.eql(['\\\\(\n          /alpha\n      \\\\)']);
+      const { text, math } = removeMath(input);
+      expect(text).to.equal('hello, @@0@@, there');
+      expect(math).to.deep.equal(['\\\\(\n          /alpha\n      \\\\)']);
     });
 
     it('should handle `\\\\[` delimiters for math', () => {
-      let input = `hello, \\\\\[
+      const input = `hello, \\\\\[
           /alpha
       \\\\\], there`;
-      let { text, math } = removeMath(input);
-      expect(text).to.be('hello, @@0@@, there');
-      expect(math).to.eql(['\\\\[\n          /alpha\n      \\\\]']);
+      const { text, math } = removeMath(input);
+      expect(text).to.equal('hello, @@0@@, there');
+      expect(math).to.deep.equal(['\\\\[\n          /alpha\n      \\\\]']);
     });
   });
 
   describe('replaceMath()', () => {
     it('should recombine text split with removeMath', () => {
-      let input = 'hello, $ /alpha $, there';
-      let { text, math } = removeMath(input);
-      expect(replaceMath(text, math)).to.be(input);
+      const input = 'hello, $ /alpha $, there';
+      const { text, math } = removeMath(input);
+      expect(replaceMath(text, math)).to.equal(input);
     });
   });
 });

--- a/tests/test-rendermime/src/mimemodel.spec.ts
+++ b/tests/test-rendermime/src/mimemodel.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { MimeModel } from '@jupyterlab/rendermime';
 
@@ -9,34 +9,34 @@ describe('rendermime/mimemodel', () => {
   describe('MimeModel', () => {
     describe('#constructor()', () => {
       it('should create a new mime model', () => {
-        let model = new MimeModel();
-        expect(model).to.be.a(MimeModel);
+        const model = new MimeModel();
+        expect(model).to.be.an.instanceof(MimeModel);
       });
 
       it('should accept arguments', () => {
-        let model = new MimeModel({
+        const model = new MimeModel({
           data: { foo: 1 },
           metadata: { bar: 'baz' }
         });
-        expect(model).to.be.a(MimeModel);
+        expect(model).to.be.an.instanceof(MimeModel);
       });
     });
 
     describe('#data', () => {
       it('should be the data observable map', () => {
-        let model = new MimeModel({
+        const model = new MimeModel({
           data: { bar: 'baz' }
         });
-        expect(model.data['bar']).to.be('baz');
+        expect(model.data['bar']).to.equal('baz');
       });
     });
 
     describe('#metadata', () => {
       it('should be the metadata observable map', () => {
-        let model = new MimeModel({
+        const model = new MimeModel({
           metadata: { bar: 'baz' }
         });
-        expect(model.metadata['bar']).to.be('baz');
+        expect(model.metadata['bar']).to.equal('baz');
       });
     });
   });

--- a/tests/test-rendermime/src/outputmodel.spec.ts
+++ b/tests/test-rendermime/src/outputmodel.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { nbformat } from '@jupyterlab/coreutils';
 
@@ -29,62 +29,62 @@ describe('rendermime/outputmodel', () => {
   describe('OutputModel', () => {
     describe('#constructor()', () => {
       it('should create a new output model', () => {
-        let value = DEFAULT_EXECUTE;
+        const value = DEFAULT_EXECUTE;
         let model = new OutputModel({ value });
-        expect(model).to.be.an(OutputModel);
+        expect(model).to.be.an.instanceof(OutputModel);
         model = new OutputModel({ value, trusted: true });
-        expect(model).to.be.an(OutputModel);
+        expect(model).to.be.an.instanceof(OutputModel);
       });
     });
 
     describe('#type', () => {
       it('should be the output type', () => {
         let model = new OutputModel({ value: DEFAULT_EXECUTE });
-        expect(model.type).to.be(DEFAULT_EXECUTE.output_type);
+        expect(model.type).to.equal(DEFAULT_EXECUTE.output_type);
         model = new OutputModel({ value: DEFAULT_STREAM });
-        expect(model.type).to.be(DEFAULT_STREAM.output_type);
+        expect(model.type).to.equal(DEFAULT_STREAM.output_type);
       });
     });
 
     describe('#executionCount', () => {
       it('should be the execution count of an execution result', () => {
-        let model = new OutputModel({ value: DEFAULT_EXECUTE });
-        expect(model.executionCount).to.be(1);
+        const model = new OutputModel({ value: DEFAULT_EXECUTE });
+        expect(model.executionCount).to.equal(1);
       });
 
       it('should be null for non-execution results', () => {
-        let model = new OutputModel({ value: DEFAULT_STREAM });
-        expect(model.executionCount).to.be(null);
+        const model = new OutputModel({ value: DEFAULT_STREAM });
+        expect(model.executionCount).to.be.null;
       });
     });
 
     describe('#toJSON()', () => {
       it('should yield the raw value', () => {
-        let model = new OutputModel({ value: DEFAULT_EXECUTE });
-        expect(model.toJSON()).to.eql(DEFAULT_EXECUTE);
+        const model = new OutputModel({ value: DEFAULT_EXECUTE });
+        expect(model.toJSON()).to.deep.equal(DEFAULT_EXECUTE);
       });
     });
 
     describe('.getData()', () => {
       it('should handle all bundle types', () => {
         for (let i = 0; i < NBTestUtils.DEFAULT_OUTPUTS.length; i++) {
-          let output = NBTestUtils.DEFAULT_OUTPUTS[i];
-          let bundle = OutputModel.getData(output);
-          expect(Object.keys(bundle).length).to.not.be(0);
+          const output = NBTestUtils.DEFAULT_OUTPUTS[i];
+          const bundle = OutputModel.getData(output);
+          expect(Object.keys(bundle).length).to.not.equal(0);
         }
       });
     });
 
     describe('.getMetadata()', () => {
       it('should get the metadata from the bundle', () => {
-        let metadata = OutputModel.getMetadata(DEFAULT_EXECUTE);
-        expect(metadata['foo']).to.be(1);
-        expect(metadata['bar']).to.be('baz');
+        const metadata = OutputModel.getMetadata(DEFAULT_EXECUTE);
+        expect(metadata['foo']).to.equal(1);
+        expect(metadata['bar']).to.equal('baz');
       });
 
       it('should handle output with no metadata field', () => {
-        let metadata = OutputModel.getMetadata(DEFAULT_STREAM);
-        expect(Object.keys(metadata).length).to.be(0);
+        const metadata = OutputModel.getMetadata(DEFAULT_STREAM);
+        expect(Object.keys(metadata).length).to.equal(0);
       });
     });
   });

--- a/tests/test-rendermime/src/registry.spec.ts
+++ b/tests/test-rendermime/src/registry.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -47,167 +47,173 @@ describe('rendermime/registry', () => {
   describe('RenderMimeRegistry', () => {
     describe('#constructor()', () => {
       it('should create a new rendermime instance', () => {
-        expect(r instanceof RenderMimeRegistry).to.be(true);
+        expect(r instanceof RenderMimeRegistry).to.equal(true);
       });
     });
 
     describe('#resolver', () => {
       it('should be the resolver used by the rendermime', () => {
-        expect(r.resolver).to.be(null);
-        let clone = r.clone({ resolver: RESOLVER });
-        expect(clone.resolver).to.be(RESOLVER);
+        expect(r.resolver).to.be.null;
+        const clone = r.clone({ resolver: RESOLVER });
+        expect(clone.resolver).to.equal(RESOLVER);
       });
     });
 
     describe('#linkHandler', () => {
       it('should be the link handler used by the rendermime', () => {
-        expect(r.linkHandler).to.be(null);
-        let handler = {
+        expect(r.linkHandler).to.be.null;
+        const handler = {
           handleLink: () => {
             /* no-op */
           }
         };
-        let clone = r.clone({ linkHandler: handler });
-        expect(clone.linkHandler).to.be(handler);
+        const clone = r.clone({ linkHandler: handler });
+        expect(clone.linkHandler).to.equal(handler);
       });
     });
 
     describe('#latexTypesetter', () => {
       it('should be the null typesetter by default', () => {
-        expect(r.latexTypesetter).to.be(null);
+        expect(r.latexTypesetter).to.be.null;
       });
 
       it('should be clonable', () => {
-        let typesetter1 = new MathJaxTypesetter();
-        let clone1 = r.clone({ latexTypesetter: typesetter1 });
-        expect(clone1.latexTypesetter).to.be(typesetter1);
-        let typesetter2 = new MathJaxTypesetter();
-        let clone2 = r.clone({ latexTypesetter: typesetter2 });
-        expect(clone2.latexTypesetter).to.be(typesetter2);
+        const typesetter1 = new MathJaxTypesetter();
+        const clone1 = r.clone({ latexTypesetter: typesetter1 });
+        expect(clone1.latexTypesetter).to.equal(typesetter1);
+        const typesetter2 = new MathJaxTypesetter();
+        const clone2 = r.clone({ latexTypesetter: typesetter2 });
+        expect(clone2.latexTypesetter).to.equal(typesetter2);
       });
     });
 
     describe('#createRenderer()', () => {
       it('should create a mime renderer', () => {
-        let w = r.createRenderer('text/plain');
-        expect(w instanceof Widget).to.be(true);
+        const w = r.createRenderer('text/plain');
+        expect(w instanceof Widget).to.equal(true);
       });
 
       it('should raise an error for an unregistered mime type', () => {
         expect(() => {
           r.createRenderer('text/fizz');
-        }).to.throwError();
+        }).to.throw();
       });
 
       it('should render json data', () => {
-        let model = createModel({
+        const model = createModel({
           'application/json': { foo: 1 }
         });
-        let w = r.createRenderer('application/json');
+        const w = r.createRenderer('application/json');
         return w.renderModel(model).then(() => {
-          expect(w.node.textContent).to.be('{\n  "foo": 1\n}');
+          expect(w.node.textContent).to.equal('{\n  "foo": 1\n}');
         });
       });
 
-      it('should send a url resolver', done => {
-        let model = createModel({
+      it('should send a url resolver', async () => {
+        const model = createModel({
           'text/html': '<img src="./foo">foo</img>'
         });
-        let called = false;
+        let called0 = false;
+        let called1 = false;
         r = r.clone({
           resolver: {
             resolveUrl: (path: string) => {
-              called = true;
+              called0 = true;
               return Promise.resolve(path);
             },
             getDownloadUrl: (path: string) => {
-              expect(called).to.be(true);
-              done();
+              expect(called0).to.equal(true);
+              called1 = true;
               return Promise.resolve(path);
             }
           }
         });
-        let w = r.createRenderer('text/html');
-        w.renderModel(model);
+        const w = r.createRenderer('text/html');
+        await w.renderModel(model);
+        expect(called1).to.equal(true);
       });
 
-      it('should send a link handler', done => {
-        let model = createModel({
+      it('should send a link handler', async () => {
+        const model = createModel({
           'text/html': '<a href="./foo/bar.txt">foo</a>'
         });
+        let called = false;
         r = r.clone({
           resolver: RESOLVER,
           linkHandler: {
             handleLink: (node: HTMLElement, url: string) => {
-              expect(url).to.be('foo/bar.txt');
-              done();
+              expect(url).to.equal('foo/bar.txt');
+              called = true;
             }
           }
         });
-        let w = r.createRenderer('text/html');
-        w.renderModel(model);
+        const w = r.createRenderer('text/html');
+        await w.renderModel(model);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#preferredMimeType()', () => {
       it('should find the preferred mimeType in a bundle', () => {
-        let model = createModel({
+        const model = createModel({
           'text/plain': 'foo',
           'text/html': '<h1>foo</h1>'
         });
-        expect(r.preferredMimeType(model.data, 'any')).to.be('text/html');
+        expect(r.preferredMimeType(model.data, 'any')).to.equal('text/html');
       });
 
       it('should return `undefined` if there are no registered mimeTypes', () => {
-        let model = createModel({ 'text/fizz': 'buzz' });
-        expect(r.preferredMimeType(model.data, 'any')).to.be(void 0);
+        const model = createModel({ 'text/fizz': 'buzz' });
+        expect(r.preferredMimeType(model.data, 'any')).to.be.undefined;
       });
 
       it('should select the mimeType that is safe', () => {
-        let model = createModel({
+        const model = createModel({
           'text/plain': 'foo',
           'text/javascript': 'window.x = 1',
           'image/png':
             'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
         });
-        expect(r.preferredMimeType(model.data)).to.be('image/png');
+        expect(r.preferredMimeType(model.data)).to.equal('image/png');
       });
 
       it('should render the mimeType that is sanitizable', () => {
-        let model = createModel({
+        const model = createModel({
           'text/plain': 'foo',
           'text/html': '<h1>foo</h1>'
         });
-        expect(r.preferredMimeType(model.data)).to.be('text/html');
+        expect(r.preferredMimeType(model.data)).to.equal('text/html');
       });
 
       it('should return `undefined` if only unsafe options with default `ensure`', () => {
-        let model = createModel({
+        const model = createModel({
           'image/svg+xml': ''
         });
-        expect(r.preferredMimeType(model.data)).to.be(void 0);
+        expect(r.preferredMimeType(model.data)).to.be.undefined;
       });
 
       it('should return `undefined` if only unsafe options with `ensure`', () => {
-        let model = createModel({
+        const model = createModel({
           'image/svg+xml': ''
         });
-        expect(r.preferredMimeType(model.data, 'ensure')).to.be(void 0);
+        expect(r.preferredMimeType(model.data, 'ensure')).to.be.undefined;
       });
 
       it('should return safe option if called with `prefer`', () => {
-        let model = createModel({
+        const model = createModel({
           'image/svg+xml': '',
           'text/plain': ''
         });
-        expect(r.preferredMimeType(model.data, 'prefer')).to.be('text/plain');
+        expect(r.preferredMimeType(model.data, 'prefer')).to.equal(
+          'text/plain'
+        );
       });
 
       it('should return unsafe option if called with `prefer`, and no safe alternative', () => {
-        let model = createModel({
+        const model = createModel({
           'image/svg+xml': ''
         });
-        expect(r.preferredMimeType(model.data, 'prefer')).to.be(
+        expect(r.preferredMimeType(model.data, 'prefer')).to.equal(
           'image/svg+xml'
         );
       });
@@ -215,34 +221,34 @@ describe('rendermime/registry', () => {
 
     describe('#clone()', () => {
       it('should clone the rendermime instance with shallow copies of data', () => {
-        let c = r.clone();
-        expect(toArray(c.mimeTypes)).to.eql(r.mimeTypes);
+        const c = r.clone();
+        expect(toArray(c.mimeTypes)).to.deep.equal(r.mimeTypes);
         c.addFactory(fooFactory);
-        expect(r).to.not.be(c);
+        expect(r).to.not.equal(c);
       });
     });
 
     describe('#addFactory()', () => {
       it('should add a factory', () => {
         r.addFactory(fooFactory);
-        let index = r.mimeTypes.indexOf('text/foo');
-        expect(index).to.be(r.mimeTypes.length - 1);
+        const index = r.mimeTypes.indexOf('text/foo');
+        expect(index).to.equal(r.mimeTypes.length - 1);
       });
 
       it('should take an optional rank', () => {
-        let len = r.mimeTypes.length;
+        const len = r.mimeTypes.length;
         r.addFactory(fooFactory, 0);
-        let index = r.mimeTypes.indexOf('text/foo');
-        expect(index).to.be(0);
-        expect(r.mimeTypes.length).to.be(len + 1);
+        const index = r.mimeTypes.indexOf('text/foo');
+        expect(index).to.equal(0);
+        expect(r.mimeTypes.length).to.equal(len + 1);
       });
     });
 
     describe('#removeMimeType()', () => {
       it('should remove a factory by mimeType', () => {
         r.removeMimeType('text/html');
-        let model = createModel({ 'text/html': '<h1>foo</h1>' });
-        expect(r.preferredMimeType(model.data, 'any')).to.be(void 0);
+        const model = createModel({ 'text/html': '<h1>foo</h1>' });
+        expect(r.preferredMimeType(model.data, 'any')).to.be.undefined;
       });
 
       it('should be a no-op if the mimeType is not registered', () => {
@@ -252,18 +258,18 @@ describe('rendermime/registry', () => {
 
     describe('#getFactory()', () => {
       it('should get a factory by mimeType', () => {
-        let f = r.getFactory('text/plain');
+        const f = r.getFactory('text/plain');
         expect(f.mimeTypes).to.contain('text/plain');
       });
 
       it('should return undefined for missing mimeType', () => {
-        expect(r.getFactory('hello/world')).to.be(undefined);
+        expect(r.getFactory('hello/world')).to.be.undefined;
       });
     });
 
     describe('#mimeTypes', () => {
       it('should get the ordered list of mimeTypes', () => {
-        expect(r.mimeTypes.indexOf('text/html')).to.not.be(-1);
+        expect(r.mimeTypes.indexOf('text/html')).to.not.equal(-1);
       });
     });
 
@@ -272,22 +278,17 @@ describe('rendermime/registry', () => {
       let contents: Contents.IManager;
       let session: Session.ISession;
 
-      before(() => {
+      before(async () => {
         const manager = new ServiceManager();
         const drive = new Drive({ name: 'extra' });
         contents = manager.contents;
         contents.addDrive(drive);
-        return manager.ready
-          .then(() => {
-            return manager.sessions.startNew({ path: UUID.uuid4() });
-          })
-          .then(s => {
-            session = s;
-            resolver = new RenderMimeRegistry.UrlResolver({
-              session,
-              contents: manager.contents
-            });
-          });
+        await manager.ready;
+        session = await manager.sessions.startNew({ path: UUID.uuid4() });
+        resolver = new RenderMimeRegistry.UrlResolver({
+          session,
+          contents: manager.contents
+        });
       });
 
       after(() => {
@@ -296,51 +297,47 @@ describe('rendermime/registry', () => {
 
       context('#constructor', () => {
         it('should create a UrlResolver instance', () => {
-          expect(resolver).to.be.a(RenderMimeRegistry.UrlResolver);
+          expect(resolver).to.be.an.instanceof(RenderMimeRegistry.UrlResolver);
         });
       });
 
       context('#resolveUrl()', () => {
-        it('should resolve a relative url', () => {
-          return resolver.resolveUrl('./foo').then(path => {
-            expect(path).to.be('foo');
-          });
+        it('should resolve a relative url', async () => {
+          const path = await resolver.resolveUrl('./foo');
+          expect(path).to.equal('foo');
         });
 
-        it('should ignore urls that have a protocol', () => {
-          return resolver.resolveUrl('http://foo').then(path => {
-            expect(path).to.be('http://foo');
-          });
+        it('should ignore urls that have a protocol', async () => {
+          const path = await resolver.resolveUrl('http://foo');
+          expect(path).to.equal('http://foo');
         });
       });
 
       context('#getDownloadUrl()', () => {
-        it('should resolve an absolute server url to a download url', () => {
-          let contextPromise = resolver.getDownloadUrl('foo');
-          let contentsPromise = contents.getDownloadUrl('foo');
-          return Promise.all([contextPromise, contentsPromise]).then(values => {
-            expect(values[0]).to.be(values[1]);
-          });
+        it('should resolve an absolute server url to a download url', async () => {
+          const contextPromise = resolver.getDownloadUrl('foo');
+          const contentsPromise = contents.getDownloadUrl('foo');
+          const values = await Promise.all([contextPromise, contentsPromise]);
+          expect(values[0]).to.equal(values[1]);
         });
 
-        it('should ignore urls that have a protocol', () => {
-          return resolver.getDownloadUrl('http://foo').then(path => {
-            expect(path).to.be('http://foo');
-          });
+        it('should ignore urls that have a protocol', async () => {
+          const path = await resolver.getDownloadUrl('http://foo');
+          expect(path).to.equal('http://foo');
         });
       });
 
       context('#isLocal', () => {
         it('should return true for a registered IDrive`', () => {
-          expect(resolver.isLocal('extra:path/to/file')).to.be(true);
+          expect(resolver.isLocal('extra:path/to/file')).to.equal(true);
         });
 
         it('should return false for an unrecognized Drive`', () => {
-          expect(resolver.isLocal('unregistered:path/to/file')).to.be(false);
+          expect(resolver.isLocal('unregistered:path/to/file')).to.equal(false);
         });
 
         it('should return true for a normal filesystem-like path`', () => {
-          expect(resolver.isLocal('path/to/file')).to.be(true);
+          expect(resolver.isLocal('path/to/file')).to.equal(true);
         });
       });
     });

--- a/tests/test-terminal/package.json
+++ b/tests/test-terminal/package.json
@@ -20,9 +20,10 @@
     "@jupyterlab/terminal": "^0.17.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-terminal/package.json
+++ b/tests/test-terminal/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@jupyterlab/services": "^3.0.3",
     "@jupyterlab/terminal": "^0.17.2",
+    "@jupyterlab/testutils": "^0.1.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
     "chai": "~4.1.2"


### PR DESCRIPTION
Work on #4727 cont.

- Went back and caught uses of `done` and `then` in previous packages
- Add `signalToPromises` and `signalToPromise` utilities (thanks, @saulshanabrook!)
- Docregistry
- Filebrowser
- Fileeditor
- ImageViewer
- Inspector
- Rendermime
- Mainmenu
- Observables
- Terminal