### PR TITLE
Test cleanup finished

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -54,11 +54,11 @@
     "ws": "~1.1.4"
   },
   "devDependencies": {
-    "@types/expect.js": "~0.3.29",
+    "@types/chai": "~4.0.10",
     "@types/mocha": "~2.2.44",
     "@types/node-fetch": "~1.6.7",
     "@types/ws": "~0.0.39",
-    "expect.js": "~0.3.1",
+    "chai": "~4.1.2",
     "istanbul": "~0.3.22",
     "mocha": "~3.5.3",
     "npm-run-all": "~4.1.1",

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1146,9 +1146,7 @@ export class DefaultKernel implements Kernel.IKernel {
       return;
     }
     // Clear the websocket event handlers and the socket itself.
-    this._ws.onclose = this._noOp;
-    this._ws.onerror = this._noOp;
-    this._ws = null;
+    this._clearSocket();
 
     if (this._reconnectAttempt < this._reconnectLimit) {
       this._updateStatus('reconnecting');

--- a/packages/services/test/src/config/config.spec.ts
+++ b/packages/services/test/src/config/config.spec.ts
@@ -34,26 +34,23 @@ function randomName() {
 
 describe('config', () => {
   describe('ConfigSection.create()', () => {
-    it('should load a config', () => {
-      return ConfigSection.create({ name: randomName() }).then(config => {
-        expect(Object.keys(config.data).length).to.equal(0);
-      });
+    it('should load a config', async () => {
+      const config = await ConfigSection.create({ name: randomName() });
+      expect(Object.keys(config.data).length).to.equal(0);
     });
 
-    it('should load a config', () => {
-      return ConfigSection.create({ name: randomName() }).then(config => {
-        expect(Object.keys(config.data).length).to.equal(0);
-      });
+    it('should load a config', async () => {
+      const config = await ConfigSection.create({ name: randomName() });
+      expect(Object.keys(config.data).length).to.equal(0);
     });
 
-    it('should accept server settings', () => {
+    it('should accept server settings', async () => {
       const serverSettings = makeSettings();
-      return ConfigSection.create({
+      const config = await ConfigSection.create({
         name: randomName(),
         serverSettings
-      }).then(config => {
-        expect(Object.keys(config.data).length).to.equal(0);
       });
+      expect(Object.keys(config.data).length).to.equal(0);
     });
 
     it('should fail for an incorrect response', async () => {
@@ -62,182 +59,153 @@ describe('config', () => {
         name: randomName(),
         serverSettings
       });
-      expectFailure(configPromise, done, 'Invalid response: 201 Created');
+      await expectFailure(configPromise, 'Invalid response: 201 Created');
     });
   });
 
   describe('#update()', () => {
-    it('should update a config', () => {
-      const config: IConfigSection;
-      return ConfigSection.create({ name: randomName() })
-        .then(c => {
-          config = c;
-          return config.update({ foo: 'baz', spam: 'eggs' });
-        })
-        .then((data: any) => {
-          expect(data.foo).to.equal('baz');
-          expect(config.data['foo']).to.equal('baz');
-          expect(data['spam']).to.equal('eggs');
-          expect(config.data['spam']).to.equal('eggs');
-        });
+    it('should update a config', async () => {
+      const config = await ConfigSection.create({ name: randomName() });
+      const data: any = await config.update({ foo: 'baz', spam: 'eggs' });
+      expect(data.foo).to.equal('baz');
+      expect(config.data['foo']).to.equal('baz');
+      expect(data['spam']).to.equal('eggs');
+      expect(config.data['spam']).to.equal('eggs');
     });
 
-    it('should accept server settings', () => {
-      const config: IConfigSection;
+    it('should accept server settings', async () => {
       const serverSettings = makeSettings();
-      return ConfigSection.create({ name: randomName(), serverSettings })
-        .then(c => {
-          config = c;
-          return config.update({ foo: 'baz', spam: 'eggs' });
-        })
-        .then((data: any) => {
-          expect(data.foo).to.equal('baz');
-          expect(config.data['foo']).to.equal('baz');
-          expect(data['spam']).to.equal('eggs');
-          expect(config.data['spam']).to.equal('eggs');
-        });
+      const config = await ConfigSection.create({
+        name: randomName(),
+        serverSettings
+      });
+      const data: any = await config.update({ foo: 'baz', spam: 'eggs' });
+      expect(data.foo).to.equal('baz');
+      expect(config.data['foo']).to.equal('baz');
+      expect(data['spam']).to.equal('eggs');
+      expect(config.data['spam']).to.equal('eggs');
     });
 
     it('should fail for an incorrect response', async () => {
-      ConfigSection.create({ name: randomName() })
-        .then(config => {
-          handleRequest(config, 201, {});
-          const update = config.update({ foo: 'baz' });
-          expectFailure(update, done, 'Invalid response: 201 Created');
-        })
-        .catch(done);
+      const config = await ConfigSection.create({ name: randomName() });
+      handleRequest(config, 201, {});
+      const update = config.update({ foo: 'baz' });
+      await expectFailure(update, 'Invalid response: 201 Created');
     });
   });
 });
 
 describe('jupyter.services - ConfigWithDefaults', () => {
   describe('#constructor()', () => {
-    it('should complete properly', () => {
+    it('should complete properly', async () => {
       const defaults: JSONObject = { spam: 'eggs' };
       const className = 'testclass';
-      return ConfigSection.create({
+      const section = await ConfigSection.create({
         name: randomName()
-      }).then(section => {
-        const config = new ConfigWithDefaults({
-          section,
-          defaults,
-          className
-        });
-        expect(config).to.be.an.instanceof(ConfigWithDefaults);
       });
+      const config = new ConfigWithDefaults({
+        section,
+        defaults,
+        className
+      });
+      expect(config).to.be.an.instanceof(ConfigWithDefaults);
     });
   });
 
   describe('#get()', () => {
-    it('should get a new config value', () => {
+    it('should get a new config value', async () => {
       const defaults: JSONObject = { foo: 'bar' };
       const className = 'testclass';
-      return ConfigSection.create({
+      const section = await ConfigSection.create({
         name: randomName()
-      }).then(section => {
-        const config = new ConfigWithDefaults({
-          section,
-          defaults,
-          className
-        });
-        const data = config.get('foo');
-        expect(data).to.equal('bar');
       });
+      const config = new ConfigWithDefaults({
+        section,
+        defaults,
+        className
+      });
+      const data = config.get('foo');
+      expect(data).to.equal('bar');
     });
 
-    it('should get a default config value', () => {
+    it('should get a default config value', async () => {
       const defaults: JSONObject = { spam: 'eggs' };
       const className = 'testclass';
-      return ConfigSection.create({
+      const section = await ConfigSection.create({
         name: randomName()
-      }).then(section => {
-        const config = new ConfigWithDefaults({
-          section,
-          defaults,
-          className
-        });
-        const data = config.get('spam');
-        expect(data).to.equal('eggs');
       });
+      const config = new ConfigWithDefaults({
+        section,
+        defaults,
+        className
+      });
+      const data = config.get('spam');
+      expect(data).to.equal('eggs');
     });
 
-    it('should get a default config value with no class', () => {
+    it('should get a default config value with no class', async () => {
       const defaults: JSONObject = { spam: 'eggs' };
       const className = 'testclass';
-      return ConfigSection.create({
+      const section = await ConfigSection.create({
         name: randomName()
-      }).then(section => {
-        const config = new ConfigWithDefaults({
-          section,
-          defaults,
-          className
-        });
-        const data = config.get('spam');
-        expect(data).to.equal('eggs');
       });
+      const config = new ConfigWithDefaults({
+        section,
+        defaults,
+        className
+      });
+      const data = config.get('spam');
+      expect(data).to.equal('eggs');
     });
 
-    it('should get a falsey value', () => {
+    it('should get a falsey value', async () => {
       const defaults: JSONObject = { foo: true };
       const className = 'testclass';
       const serverSettings = getRequestHandler(200, { foo: false });
-      return ConfigSection.create({
+      const section = await ConfigSection.create({
         name: randomName(),
         serverSettings
-      }).then(section => {
-        const config = new ConfigWithDefaults({
-          section,
-          defaults,
-          className
-        });
-        const data = config.get('foo');
-        expect(data).to.not.be.ok;
       });
+      const config = new ConfigWithDefaults({
+        section,
+        defaults,
+        className
+      });
+      const data = config.get('foo');
+      expect(data).to.not.be.ok;
     });
   });
 
   describe('#set()', () => {
-    it('should set a value in a class immediately', () => {
+    it('should set a value in a class immediately', async () => {
       const className = 'testclass';
-      const section: IConfigSection;
-      return ConfigSection.create({ name: randomName() })
-        .then(s => {
-          section = s;
-          const config = new ConfigWithDefaults({ section, className });
-          return config.set('foo', 'bar');
-        })
-        .then(() => {
-          const data = section.data['testclass'] as JSONObject;
-          expect(data['foo']).to.equal('bar');
-        });
+      const section = await ConfigSection.create({ name: randomName() });
+      const config = new ConfigWithDefaults({ section, className });
+      let data: any = await config.set('foo', 'bar');
+      data = section.data['testclass'] as JSONObject;
+      expect(data['foo']).to.equal('bar');
     });
 
-    it('should set a top level value', () => {
-      const section: IConfigSection;
-      return ConfigSection.create({ name: randomName() })
-        .then(s => {
-          section = s;
-          const config = new ConfigWithDefaults({ section });
-          const set = config.set('foo', 'bar');
-          expect(section.data['foo']).to.equal('bar');
-          return set;
-        })
-        .then(data => {
-          expect(section.data['foo']).to.equal('bar');
-        });
+    it('should set a top level value', async () => {
+      const section = await ConfigSection.create({ name: randomName() });
+      const config = new ConfigWithDefaults({ section });
+      const set = config.set('foo', 'bar');
+      expect(section.data['foo']).to.equal('bar');
+      const data: any = await set;
+      expect(section.data['foo']).to.equal('bar');
     });
 
     it('should fail for an invalid response', async () => {
       const serverSettings = getRequestHandler(200, {});
-      ConfigSection.create({ name: randomName(), serverSettings })
-        .then(section => {
-          handleRequest(section, 201, { foo: 'bar' });
-          const config = new ConfigWithDefaults({ section });
-          const set = config.set('foo', 'bar');
-          expect(section.data['foo']).to.equal('bar');
-          expectFailure(set, done, 'Invalid response: 201 Created');
-        })
-        .catch(done);
+      const section = await ConfigSection.create({
+        name: randomName(),
+        serverSettings
+      });
+      handleRequest(section, 201, { foo: 'bar' });
+      const config = new ConfigWithDefaults({ section });
+      const set = config.set('foo', 'bar');
+      expect(section.data['foo']).to.equal('bar');
+      await expectFailure(set, 'Invalid response: 201 Created');
     });
   });
 });

--- a/packages/services/test/src/config/config.spec.ts
+++ b/packages/services/test/src/config/config.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -36,13 +36,13 @@ describe('config', () => {
   describe('ConfigSection.create()', () => {
     it('should load a config', () => {
       return ConfigSection.create({ name: randomName() }).then(config => {
-        expect(Object.keys(config.data).length).to.be(0);
+        expect(Object.keys(config.data).length).to.equal(0);
       });
     });
 
     it('should load a config', () => {
       return ConfigSection.create({ name: randomName() }).then(config => {
-        expect(Object.keys(config.data).length).to.be(0);
+        expect(Object.keys(config.data).length).to.equal(0);
       });
     });
 
@@ -52,7 +52,7 @@ describe('config', () => {
         name: randomName(),
         serverSettings
       }).then(config => {
-        expect(Object.keys(config.data).length).to.be(0);
+        expect(Object.keys(config.data).length).to.equal(0);
       });
     });
 
@@ -75,10 +75,10 @@ describe('config', () => {
           return config.update({ foo: 'baz', spam: 'eggs' });
         })
         .then((data: any) => {
-          expect(data.foo).to.be('baz');
-          expect(config.data['foo']).to.be('baz');
-          expect(data['spam']).to.be('eggs');
-          expect(config.data['spam']).to.be('eggs');
+          expect(data.foo).to.equal('baz');
+          expect(config.data['foo']).to.equal('baz');
+          expect(data['spam']).to.equal('eggs');
+          expect(config.data['spam']).to.equal('eggs');
         });
     });
 
@@ -91,10 +91,10 @@ describe('config', () => {
           return config.update({ foo: 'baz', spam: 'eggs' });
         })
         .then((data: any) => {
-          expect(data.foo).to.be('baz');
-          expect(config.data['foo']).to.be('baz');
-          expect(data['spam']).to.be('eggs');
-          expect(config.data['spam']).to.be('eggs');
+          expect(data.foo).to.equal('baz');
+          expect(config.data['foo']).to.equal('baz');
+          expect(data['spam']).to.equal('eggs');
+          expect(config.data['spam']).to.equal('eggs');
         });
     });
 
@@ -123,7 +123,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
           defaults,
           className
         });
-        expect(config).to.be.a(ConfigWithDefaults);
+        expect(config).to.be.an.instanceof(ConfigWithDefaults);
       });
     });
   });
@@ -141,7 +141,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
           className
         });
         let data = config.get('foo');
-        expect(data).to.be('bar');
+        expect(data).to.equal('bar');
       });
     });
 
@@ -157,7 +157,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
           className
         });
         let data = config.get('spam');
-        expect(data).to.be('eggs');
+        expect(data).to.equal('eggs');
       });
     });
 
@@ -173,7 +173,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
           className
         });
         let data = config.get('spam');
-        expect(data).to.be('eggs');
+        expect(data).to.equal('eggs');
       });
     });
 
@@ -191,7 +191,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
           className
         });
         let data = config.get('foo');
-        expect(data).to.not.be.ok();
+        expect(data).to.not.be.ok;
       });
     });
   });
@@ -208,7 +208,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
         })
         .then(() => {
           let data = section.data['testclass'] as JSONObject;
-          expect(data['foo']).to.be('bar');
+          expect(data['foo']).to.equal('bar');
         });
     });
 
@@ -219,11 +219,11 @@ describe('jupyter.services - ConfigWithDefaults', () => {
           section = s;
           let config = new ConfigWithDefaults({ section });
           let set = config.set('foo', 'bar');
-          expect(section.data['foo']).to.be('bar');
+          expect(section.data['foo']).to.equal('bar');
           return set;
         })
         .then(data => {
-          expect(section.data['foo']).to.be('bar');
+          expect(section.data['foo']).to.equal('bar');
         });
     });
 
@@ -234,7 +234,7 @@ describe('jupyter.services - ConfigWithDefaults', () => {
           handleRequest(section, 201, { foo: 'bar' });
           let config = new ConfigWithDefaults({ section });
           let set = config.set('foo', 'bar');
-          expect(section.data['foo']).to.be('bar');
+          expect(section.data['foo']).to.equal('bar');
           expectFailure(set, done, 'Invalid response: 201 Created');
         })
         .catch(done);

--- a/packages/services/test/src/config/config.spec.ts
+++ b/packages/services/test/src/config/config.spec.ts
@@ -47,7 +47,7 @@ describe('config', () => {
     });
 
     it('should accept server settings', () => {
-      let serverSettings = makeSettings();
+      const serverSettings = makeSettings();
       return ConfigSection.create({
         name: randomName(),
         serverSettings
@@ -56,9 +56,9 @@ describe('config', () => {
       });
     });
 
-    it('should fail for an incorrect response', done => {
-      let serverSettings = getRequestHandler(201, {});
-      let configPromise = ConfigSection.create({
+    it('should fail for an incorrect response', async () => {
+      const serverSettings = getRequestHandler(201, {});
+      const configPromise = ConfigSection.create({
         name: randomName(),
         serverSettings
       });
@@ -68,7 +68,7 @@ describe('config', () => {
 
   describe('#update()', () => {
     it('should update a config', () => {
-      let config: IConfigSection;
+      const config: IConfigSection;
       return ConfigSection.create({ name: randomName() })
         .then(c => {
           config = c;
@@ -83,8 +83,8 @@ describe('config', () => {
     });
 
     it('should accept server settings', () => {
-      let config: IConfigSection;
-      let serverSettings = makeSettings();
+      const config: IConfigSection;
+      const serverSettings = makeSettings();
       return ConfigSection.create({ name: randomName(), serverSettings })
         .then(c => {
           config = c;
@@ -98,11 +98,11 @@ describe('config', () => {
         });
     });
 
-    it('should fail for an incorrect response', done => {
+    it('should fail for an incorrect response', async () => {
       ConfigSection.create({ name: randomName() })
         .then(config => {
           handleRequest(config, 201, {});
-          let update = config.update({ foo: 'baz' });
+          const update = config.update({ foo: 'baz' });
           expectFailure(update, done, 'Invalid response: 201 Created');
         })
         .catch(done);
@@ -113,12 +113,12 @@ describe('config', () => {
 describe('jupyter.services - ConfigWithDefaults', () => {
   describe('#constructor()', () => {
     it('should complete properly', () => {
-      let defaults: JSONObject = { spam: 'eggs' };
-      let className = 'testclass';
+      const defaults: JSONObject = { spam: 'eggs' };
+      const className = 'testclass';
       return ConfigSection.create({
         name: randomName()
       }).then(section => {
-        let config = new ConfigWithDefaults({
+        const config = new ConfigWithDefaults({
           section,
           defaults,
           className
@@ -130,67 +130,67 @@ describe('jupyter.services - ConfigWithDefaults', () => {
 
   describe('#get()', () => {
     it('should get a new config value', () => {
-      let defaults: JSONObject = { foo: 'bar' };
-      let className = 'testclass';
+      const defaults: JSONObject = { foo: 'bar' };
+      const className = 'testclass';
       return ConfigSection.create({
         name: randomName()
       }).then(section => {
-        let config = new ConfigWithDefaults({
+        const config = new ConfigWithDefaults({
           section,
           defaults,
           className
         });
-        let data = config.get('foo');
+        const data = config.get('foo');
         expect(data).to.equal('bar');
       });
     });
 
     it('should get a default config value', () => {
-      let defaults: JSONObject = { spam: 'eggs' };
-      let className = 'testclass';
+      const defaults: JSONObject = { spam: 'eggs' };
+      const className = 'testclass';
       return ConfigSection.create({
         name: randomName()
       }).then(section => {
-        let config = new ConfigWithDefaults({
+        const config = new ConfigWithDefaults({
           section,
           defaults,
           className
         });
-        let data = config.get('spam');
+        const data = config.get('spam');
         expect(data).to.equal('eggs');
       });
     });
 
     it('should get a default config value with no class', () => {
-      let defaults: JSONObject = { spam: 'eggs' };
-      let className = 'testclass';
+      const defaults: JSONObject = { spam: 'eggs' };
+      const className = 'testclass';
       return ConfigSection.create({
         name: randomName()
       }).then(section => {
-        let config = new ConfigWithDefaults({
+        const config = new ConfigWithDefaults({
           section,
           defaults,
           className
         });
-        let data = config.get('spam');
+        const data = config.get('spam');
         expect(data).to.equal('eggs');
       });
     });
 
     it('should get a falsey value', () => {
-      let defaults: JSONObject = { foo: true };
-      let className = 'testclass';
-      let serverSettings = getRequestHandler(200, { foo: false });
+      const defaults: JSONObject = { foo: true };
+      const className = 'testclass';
+      const serverSettings = getRequestHandler(200, { foo: false });
       return ConfigSection.create({
         name: randomName(),
         serverSettings
       }).then(section => {
-        let config = new ConfigWithDefaults({
+        const config = new ConfigWithDefaults({
           section,
           defaults,
           className
         });
-        let data = config.get('foo');
+        const data = config.get('foo');
         expect(data).to.not.be.ok;
       });
     });
@@ -198,27 +198,27 @@ describe('jupyter.services - ConfigWithDefaults', () => {
 
   describe('#set()', () => {
     it('should set a value in a class immediately', () => {
-      let className = 'testclass';
-      let section: IConfigSection;
+      const className = 'testclass';
+      const section: IConfigSection;
       return ConfigSection.create({ name: randomName() })
         .then(s => {
           section = s;
-          let config = new ConfigWithDefaults({ section, className });
+          const config = new ConfigWithDefaults({ section, className });
           return config.set('foo', 'bar');
         })
         .then(() => {
-          let data = section.data['testclass'] as JSONObject;
+          const data = section.data['testclass'] as JSONObject;
           expect(data['foo']).to.equal('bar');
         });
     });
 
     it('should set a top level value', () => {
-      let section: IConfigSection;
+      const section: IConfigSection;
       return ConfigSection.create({ name: randomName() })
         .then(s => {
           section = s;
-          let config = new ConfigWithDefaults({ section });
-          let set = config.set('foo', 'bar');
+          const config = new ConfigWithDefaults({ section });
+          const set = config.set('foo', 'bar');
           expect(section.data['foo']).to.equal('bar');
           return set;
         })
@@ -227,13 +227,13 @@ describe('jupyter.services - ConfigWithDefaults', () => {
         });
     });
 
-    it('should fail for an invalid response', done => {
-      let serverSettings = getRequestHandler(200, {});
+    it('should fail for an invalid response', async () => {
+      const serverSettings = getRequestHandler(200, {});
       ConfigSection.create({ name: randomName(), serverSettings })
         .then(section => {
           handleRequest(section, 201, { foo: 'bar' });
-          let config = new ConfigWithDefaults({ section });
-          let set = config.set('foo', 'bar');
+          const config = new ConfigWithDefaults({ section });
+          const set = config.set('foo', 'bar');
           expect(section.data['foo']).to.equal('bar');
           expectFailure(set, done, 'Invalid response: 201 Created');
         })

--- a/packages/services/test/src/contents/index.spec.ts
+++ b/packages/services/test/src/contents/index.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import {
   Contents,
@@ -41,14 +41,14 @@ describe('contents', () => {
   describe('#constructor()', () => {
     it('should accept no options', () => {
       let contents = new ContentsManager();
-      expect(contents).to.be.a(ContentsManager);
+      expect(contents).to.be.an.instanceof(ContentsManager);
     });
 
     it('should accept options', () => {
       let contents = new ContentsManager({
         defaultDrive: new Drive()
       });
-      expect(contents).to.be.a(ContentsManager);
+      expect(contents).to.be.an.instanceof(ContentsManager);
     });
   });
 
@@ -57,10 +57,10 @@ describe('contents', () => {
       let contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
-        expect(sender).to.be(contents);
-        expect(args.type).to.be('new');
-        expect(args.oldValue).to.be(null);
-        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        expect(sender).to.equal(contents);
+        expect(args.type).to.equal('new');
+        expect(args.oldValue).to.be.null;
+        expect(args.newValue.path).to.equal(DEFAULT_FILE.path);
         done();
       });
       contents.newUntitled().catch(done);
@@ -72,7 +72,7 @@ describe('contents', () => {
       contents.addDrive(drive);
       handleRequest(drive, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
-        expect(args.newValue.path).to.be('other:' + DEFAULT_FILE.path);
+        expect(args.newValue.path).to.equal('other:' + DEFAULT_FILE.path);
         done();
       });
       contents.newUntitled({ path: 'other:' }).catch(done);
@@ -82,20 +82,20 @@ describe('contents', () => {
   describe('#isDisposed', () => {
     it('should test whether the manager is disposed', () => {
       let contents = new ContentsManager();
-      expect(contents.isDisposed).to.be(false);
+      expect(contents.isDisposed).to.equal(false);
       contents.dispose();
-      expect(contents.isDisposed).to.be(true);
+      expect(contents.isDisposed).to.equal(true);
     });
   });
 
   describe('#dispose()', () => {
     it('should dispose of the resources used by the manager', () => {
       let contents = new ContentsManager();
-      expect(contents.isDisposed).to.be(false);
+      expect(contents.isDisposed).to.equal(false);
       contents.dispose();
-      expect(contents.isDisposed).to.be(true);
+      expect(contents.isDisposed).to.equal(true);
       contents.dispose();
-      expect(contents.isDisposed).to.be(true);
+      expect(contents.isDisposed).to.equal(true);
     });
   });
 
@@ -114,11 +114,11 @@ describe('contents', () => {
       contents.addDrive(new Drive({ name: 'other' }));
       contents.addDrive(new Drive({ name: 'alternative' }));
 
-      expect(contents.localPath('other:foo/bar/example.txt')).to.be(
+      expect(contents.localPath('other:foo/bar/example.txt')).to.equal(
         'foo/bar/example.txt'
       );
 
-      expect(contents.localPath('alternative:/foo/bar/example.txt')).to.be(
+      expect(contents.localPath('alternative:/foo/bar/example.txt')).to.equal(
         'foo/bar/example.txt'
       );
     });
@@ -129,7 +129,7 @@ describe('contents', () => {
 
       expect(
         contents.localPath('other:foo/odd:directory/example:file.txt')
-      ).to.be('foo/odd:directory/example:file.txt');
+      ).to.equal('foo/odd:directory/example:file.txt');
     });
 
     it('should leave alone names with ":" that are not drive names', () => {
@@ -138,7 +138,7 @@ describe('contents', () => {
 
       expect(
         contents.localPath('which:foo/odd:directory/example:file.txt')
-      ).to.be('which:foo/odd:directory/example:file.txt');
+      ).to.equal('which:foo/odd:directory/example:file.txt');
     });
   });
 
@@ -148,9 +148,9 @@ describe('contents', () => {
       contents.addDrive(new Drive({ name: 'other' }));
       contents.addDrive(new Drive({ name: 'alternative' }));
 
-      expect(contents.driveName('other:foo/bar/example.txt')).to.be('other');
+      expect(contents.driveName('other:foo/bar/example.txt')).to.equal('other');
 
-      expect(contents.driveName('alternative:/foo/bar/example.txt')).to.be(
+      expect(contents.driveName('alternative:/foo/bar/example.txt')).to.equal(
         'alternative'
       );
     });
@@ -161,7 +161,7 @@ describe('contents', () => {
 
       expect(
         contents.driveName('other:foo/odd:directory/example:file.txt')
-      ).to.be('other');
+      ).to.equal('other');
     });
 
     it('should leave alone names with ":" that are not drive names', () => {
@@ -170,7 +170,7 @@ describe('contents', () => {
 
       expect(
         contents.driveName('which:foo/odd:directory/example:file.txt')
-      ).to.be('');
+      ).to.equal('');
     });
   });
 
@@ -180,7 +180,7 @@ describe('contents', () => {
       handleRequest(contents, 200, DEFAULT_FILE);
       let options: Contents.IFetchOptions = { type: 'file' };
       return contents.get('/foo', options).then(model => {
-        expect(model.path).to.be('foo');
+        expect(model.path).to.equal('foo');
       });
     });
 
@@ -189,7 +189,7 @@ describe('contents', () => {
       handleRequest(contents, 200, DEFAULT_DIR);
       let options: Contents.IFetchOptions = { type: 'directory' };
       return contents.get('/foo', options).then(model => {
-        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
@@ -200,7 +200,7 @@ describe('contents', () => {
       handleRequest(drive, 200, DEFAULT_FILE);
       let options: Contents.IFetchOptions = { type: 'file' };
       return contents.get('other:/foo', options).then(model => {
-        expect(model.path).to.be('other:foo');
+        expect(model.path).to.equal('other:foo');
       });
     });
 
@@ -211,7 +211,7 @@ describe('contents', () => {
       handleRequest(drive, 200, DEFAULT_DIR);
       let options: Contents.IFetchOptions = { type: 'directory' };
       return contents.get('other:/foo', options).then(model => {
-        expect(model.content[0].path).to.be('other:foo/bar/buzz.txt');
+        expect(model.content[0].path).to.equal('other:foo/bar/buzz.txt');
       });
     });
 
@@ -235,9 +235,9 @@ describe('contents', () => {
       let test2 = contents.getDownloadUrl('fizz/buzz/bar.txt');
       let test3 = contents.getDownloadUrl('/bar.txt');
       return Promise.all([test1, test2, test3]).then(urls => {
-        expect(urls[0]).to.be('http://foo/files/bar.txt');
-        expect(urls[1]).to.be('http://foo/files/fizz/buzz/bar.txt');
-        expect(urls[2]).to.be('http://foo/files/bar.txt');
+        expect(urls[0]).to.equal('http://foo/files/bar.txt');
+        expect(urls[1]).to.equal('http://foo/files/fizz/buzz/bar.txt');
+        expect(urls[2]).to.equal('http://foo/files/bar.txt');
       });
     });
 
@@ -245,7 +245,7 @@ describe('contents', () => {
       let drive = new Drive({ serverSettings: settings });
       let contents = new ContentsManager({ defaultDrive: drive });
       return contents.getDownloadUrl('b ar?3.txt').then(url => {
-        expect(url).to.be('http://foo/files/b%20ar%3F3.txt');
+        expect(url).to.equal('http://foo/files/b%20ar%3F3.txt');
       });
     });
 
@@ -253,7 +253,7 @@ describe('contents', () => {
       let drive = new Drive({ serverSettings: settings });
       let contents = new ContentsManager({ defaultDrive: drive });
       return contents.getDownloadUrl('fizz/../bar.txt').then(url => {
-        expect(url).to.be('http://foo/files/fizz/../bar.txt');
+        expect(url).to.equal('http://foo/files/fizz/../bar.txt');
       });
     });
 
@@ -265,9 +265,9 @@ describe('contents', () => {
       let test2 = contents.getDownloadUrl('other:fizz/buzz/bar.txt');
       let test3 = contents.getDownloadUrl('other:/bar.txt');
       return Promise.all([test1, test2, test3]).then(urls => {
-        expect(urls[0]).to.be('http://foo/files/bar.txt');
-        expect(urls[1]).to.be('http://foo/files/fizz/buzz/bar.txt');
-        expect(urls[2]).to.be('http://foo/files/bar.txt');
+        expect(urls[0]).to.equal('http://foo/files/bar.txt');
+        expect(urls[1]).to.equal('http://foo/files/fizz/buzz/bar.txt');
+        expect(urls[2]).to.equal('http://foo/files/bar.txt');
       });
     });
   });
@@ -277,7 +277,7 @@ describe('contents', () => {
       let contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       return contents.newUntitled({ path: '/foo' }).then(model => {
-        expect(model.path).to.be('foo/test');
+        expect(model.path).to.equal('foo/test');
       });
     });
 
@@ -289,7 +289,7 @@ describe('contents', () => {
         type: 'directory'
       };
       return contents.newUntitled(options).then(model => {
-        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
@@ -299,7 +299,7 @@ describe('contents', () => {
       contents.addDrive(other);
       handleRequest(other, 201, DEFAULT_FILE);
       return contents.newUntitled({ path: 'other:/foo' }).then(model => {
-        expect(model.path).to.be('other:foo/test');
+        expect(model.path).to.equal('other:foo/test');
       });
     });
 
@@ -313,7 +313,7 @@ describe('contents', () => {
         type: 'directory'
       };
       return contents.newUntitled(options).then(model => {
-        expect(model.path).to.be('other:' + DEFAULT_DIR.path);
+        expect(model.path).to.equal('other:' + DEFAULT_DIR.path);
       });
     });
 
@@ -321,9 +321,9 @@ describe('contents', () => {
       let contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('new');
-        expect(args.oldValue).to.be(null);
-        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        expect(args.type).to.equal('new');
+        expect(args.oldValue).to.be.null;
+        expect(args.newValue.path).to.equal(DEFAULT_FILE.path);
         done();
       });
       contents.newUntitled({ type: 'file', ext: 'test' }).catch(done);
@@ -371,8 +371,8 @@ describe('contents', () => {
       let path = '/foo/bar.txt';
       handleRequest(contents, 204, { path });
       contents.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('delete');
-        expect(args.oldValue.path).to.be('foo/bar.txt');
+        expect(args.type).to.equal('delete');
+        expect(args.oldValue.path).to.equal('foo/bar.txt');
         done();
       });
       contents.delete(path).catch(done);
@@ -406,7 +406,7 @@ describe('contents', () => {
       handleRequest(contents, 200, DEFAULT_FILE);
       let rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
       return rename.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -417,7 +417,7 @@ describe('contents', () => {
       handleRequest(other, 200, DEFAULT_FILE);
       let rename = contents.rename('other:/foo/bar.txt', 'other:/foo/baz.txt');
       return rename.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -425,9 +425,9 @@ describe('contents', () => {
       let contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('rename');
-        expect(args.oldValue.path).to.be('foo/bar.txt');
-        expect(args.newValue.path).to.be('foo/test');
+        expect(args.type).to.equal('rename');
+        expect(args.oldValue.path).to.equal('foo/bar.txt');
+        expect(args.newValue.path).to.equal('foo/test');
         done();
       });
       contents.rename('/foo/bar.txt', '/foo/baz.txt').catch(done);
@@ -456,7 +456,7 @@ describe('contents', () => {
       handleRequest(contents, 200, DEFAULT_FILE);
       let save = contents.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -467,7 +467,7 @@ describe('contents', () => {
       handleRequest(contents, 200, DEFAULT_FILE);
       let save = contents.save('other:/foo', { type: 'file', name: 'test' });
       return save.then(model => {
-        expect(model.path).to.be('other:foo');
+        expect(model.path).to.equal('other:foo');
       });
     });
 
@@ -476,7 +476,7 @@ describe('contents', () => {
       handleRequest(contents, 201, DEFAULT_FILE);
       let save = contents.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -484,9 +484,9 @@ describe('contents', () => {
       let contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('save');
-        expect(args.oldValue).to.be(null);
-        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        expect(args.type).to.equal('save');
+        expect(args.oldValue).to.be.null;
+        expect(args.newValue.path).to.equal(DEFAULT_FILE.path);
         done();
       });
       contents.save('/foo', { type: 'file', name: 'test' }).catch(done);
@@ -514,7 +514,7 @@ describe('contents', () => {
       let contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       return contents.copy('/foo/bar.txt', '/baz').then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -524,7 +524,7 @@ describe('contents', () => {
       contents.addDrive(other);
       handleRequest(other, 201, DEFAULT_FILE);
       return contents.copy('other:/foo/test', 'other:/baz').then(model => {
-        expect(model.path).to.be('other:foo/test');
+        expect(model.path).to.equal('other:foo/test');
       });
     });
 
@@ -532,9 +532,9 @@ describe('contents', () => {
       let contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('new');
-        expect(args.oldValue).to.be(null);
-        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        expect(args.type).to.equal('new');
+        expect(args.oldValue).to.be.null;
+        expect(args.newValue.path).to.equal(DEFAULT_FILE.path);
         done();
       });
       contents.copy('/foo/bar.txt', '/baz').catch(done);
@@ -563,7 +563,7 @@ describe('contents', () => {
       handleRequest(contents, 201, DEFAULT_CP);
       let checkpoint = contents.createCheckpoint('/foo/bar.txt');
       return checkpoint.then(model => {
-        expect(model.last_modified).to.be(DEFAULT_CP.last_modified);
+        expect(model.last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
@@ -574,7 +574,7 @@ describe('contents', () => {
       handleRequest(other, 201, DEFAULT_CP);
       let checkpoint = contents.createCheckpoint('other:/foo/bar.txt');
       return checkpoint.then(model => {
-        expect(model.last_modified).to.be(DEFAULT_CP.last_modified);
+        expect(model.last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
@@ -601,7 +601,7 @@ describe('contents', () => {
       handleRequest(contents, 200, [DEFAULT_CP, DEFAULT_CP]);
       let checkpoints = contents.listCheckpoints('/foo/bar.txt');
       return checkpoints.then(models => {
-        expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
+        expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
@@ -612,7 +612,7 @@ describe('contents', () => {
       handleRequest(other, 200, [DEFAULT_CP, DEFAULT_CP]);
       let checkpoints = contents.listCheckpoints('other:/foo/bar.txt');
       return checkpoints.then(models => {
-        expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
+        expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
@@ -703,14 +703,14 @@ describe('drive', () => {
   describe('#constructor()', () => {
     it('should accept no options', () => {
       let drive = new Drive();
-      expect(drive).to.be.a(Drive);
+      expect(drive).to.be.an.instanceof(Drive);
     });
 
     it('should accept options', () => {
       let drive = new Drive({
         name: 'name'
       });
-      expect(drive).to.be.a(Drive);
+      expect(drive).to.be.an.instanceof(Drive);
     });
   });
 
@@ -719,7 +719,7 @@ describe('drive', () => {
       let drive = new Drive({
         name: 'name'
       });
-      expect(drive.name).to.be('name');
+      expect(drive.name).to.equal('name');
     });
   });
 
@@ -728,10 +728,10 @@ describe('drive', () => {
       let drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
-        expect(sender).to.be(drive);
-        expect(args.type).to.be('new');
-        expect(args.oldValue).to.be(null);
-        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        expect(sender).to.equal(drive);
+        expect(args.type).to.equal('new');
+        expect(args.oldValue).to.be.null;
+        expect(args.newValue.path).to.equal(DEFAULT_FILE.path);
         done();
       });
       drive.newUntitled().catch(done);
@@ -741,20 +741,20 @@ describe('drive', () => {
   describe('#isDisposed', () => {
     it('should test whether the drive is disposed', () => {
       let drive = new Drive();
-      expect(drive.isDisposed).to.be(false);
+      expect(drive.isDisposed).to.equal(false);
       drive.dispose();
-      expect(drive.isDisposed).to.be(true);
+      expect(drive.isDisposed).to.equal(true);
     });
   });
 
   describe('#dispose()', () => {
     it('should dispose of the resources used by the drive', () => {
       let drive = new Drive();
-      expect(drive.isDisposed).to.be(false);
+      expect(drive.isDisposed).to.equal(false);
       drive.dispose();
-      expect(drive.isDisposed).to.be(true);
+      expect(drive.isDisposed).to.equal(true);
       drive.dispose();
-      expect(drive.isDisposed).to.be(true);
+      expect(drive.isDisposed).to.equal(true);
     });
   });
 
@@ -765,7 +765,7 @@ describe('drive', () => {
       let options: Contents.IFetchOptions = { type: 'file' };
       let get = drive.get('/foo', options);
       return get.then(model => {
-        expect(model.path).to.be(DEFAULT_FILE.path);
+        expect(model.path).to.equal(DEFAULT_FILE.path);
       });
     });
 
@@ -775,7 +775,7 @@ describe('drive', () => {
       let options: Contents.IFetchOptions = { type: 'directory' };
       let get = drive.get('/foo', options);
       return get.then(model => {
-        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
@@ -785,7 +785,7 @@ describe('drive', () => {
       let options: Contents.IFetchOptions = { type: 'directory' };
       let get = drive.get('/foo', options);
       return get.then(model => {
-        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
@@ -808,23 +808,23 @@ describe('drive', () => {
       let test2 = drive.getDownloadUrl('fizz/buzz/bar.txt');
       let test3 = drive.getDownloadUrl('/bar.txt');
       return Promise.all([test1, test2, test3]).then(urls => {
-        expect(urls[0]).to.be('http://foo/files/bar.txt');
-        expect(urls[1]).to.be('http://foo/files/fizz/buzz/bar.txt');
-        expect(urls[2]).to.be('http://foo/files/bar.txt');
+        expect(urls[0]).to.equal('http://foo/files/bar.txt');
+        expect(urls[1]).to.equal('http://foo/files/fizz/buzz/bar.txt');
+        expect(urls[2]).to.equal('http://foo/files/bar.txt');
       });
     });
 
     it('should encode characters', () => {
       let drive = new Drive({ serverSettings: settings });
       return drive.getDownloadUrl('b ar?3.txt').then(url => {
-        expect(url).to.be('http://foo/files/b%20ar%3F3.txt');
+        expect(url).to.equal('http://foo/files/b%20ar%3F3.txt');
       });
     });
 
     it('should not handle relative paths', () => {
       let drive = new Drive({ serverSettings: settings });
       return drive.getDownloadUrl('fizz/../bar.txt').then(url => {
-        expect(url).to.be('http://foo/files/fizz/../bar.txt');
+        expect(url).to.equal('http://foo/files/fizz/../bar.txt');
       });
     });
   });
@@ -834,7 +834,7 @@ describe('drive', () => {
       let drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       return drive.newUntitled({ path: '/foo' }).then(model => {
-        expect(model.path).to.be(DEFAULT_FILE.path);
+        expect(model.path).to.equal(DEFAULT_FILE.path);
       });
     });
 
@@ -847,7 +847,7 @@ describe('drive', () => {
       };
       let newDir = drive.newUntitled(options);
       return newDir.then(model => {
-        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
@@ -855,9 +855,9 @@ describe('drive', () => {
       let drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('new');
-        expect(args.oldValue).to.be(null);
-        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        expect(args.type).to.equal('new');
+        expect(args.oldValue).to.be.null;
+        expect(args.newValue.path).to.equal(DEFAULT_FILE.path);
         done();
       });
       drive.newUntitled({ type: 'file', ext: 'test' }).catch(done);
@@ -872,7 +872,7 @@ describe('drive', () => {
         ext: 'txt'
       };
       return drive.newUntitled(options).then(model => {
-        expect(model.content[0].path).to.be(DEFAULT_DIR.content[0].path);
+        expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
@@ -910,8 +910,8 @@ describe('drive', () => {
       let path = '/foo/bar.txt';
       handleRequest(drive, 204, { path });
       drive.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('delete');
-        expect(args.oldValue.path).to.be('/foo/bar.txt');
+        expect(args.type).to.equal('delete');
+        expect(args.oldValue.path).to.equal('/foo/bar.txt');
         done();
       });
       drive.delete(path).catch(done);
@@ -951,7 +951,7 @@ describe('drive', () => {
       handleRequest(drive, 200, DEFAULT_FILE);
       let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
       return rename.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -959,9 +959,9 @@ describe('drive', () => {
       let drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('rename');
-        expect(args.oldValue.path).to.be('/foo/bar.txt');
-        expect(args.newValue.path).to.be('foo/test');
+        expect(args.type).to.equal('rename');
+        expect(args.oldValue.path).to.equal('/foo/bar.txt');
+        expect(args.newValue.path).to.equal('foo/test');
         done();
       });
       drive.rename('/foo/bar.txt', '/foo/baz.txt').catch(done);
@@ -972,7 +972,7 @@ describe('drive', () => {
       handleRequest(drive, 200, DEFAULT_FILE);
       let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
       return rename.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -999,7 +999,7 @@ describe('drive', () => {
       handleRequest(drive, 200, DEFAULT_FILE);
       let save = drive.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -1008,7 +1008,7 @@ describe('drive', () => {
       handleRequest(drive, 201, DEFAULT_FILE);
       let save = drive.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -1016,9 +1016,9 @@ describe('drive', () => {
       let drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('save');
-        expect(args.oldValue).to.be(null);
-        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        expect(args.type).to.equal('save');
+        expect(args.oldValue).to.be.null;
+        expect(args.newValue.path).to.equal(DEFAULT_FILE.path);
         done();
       });
       drive.save('/foo', { type: 'file', name: 'test' }).catch(done);
@@ -1029,7 +1029,7 @@ describe('drive', () => {
       handleRequest(drive, 200, DEFAULT_FILE);
       let save = drive.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -1055,7 +1055,7 @@ describe('drive', () => {
       let drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       return drive.copy('/foo/bar.txt', '/baz').then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -1063,9 +1063,9 @@ describe('drive', () => {
       let drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
-        expect(args.type).to.be('new');
-        expect(args.oldValue).to.be(null);
-        expect(args.newValue.path).to.be(DEFAULT_FILE.path);
+        expect(args.type).to.equal('new');
+        expect(args.oldValue).to.be.null;
+        expect(args.newValue.path).to.equal(DEFAULT_FILE.path);
         done();
       });
       drive.copy('/foo/bar.txt', '/baz').catch(done);
@@ -1075,7 +1075,7 @@ describe('drive', () => {
       let drive = new Drive({ serverSettings });
       handleRequest(drive, 201, DEFAULT_FILE);
       return drive.copy('/foo/bar.txt', '/baz').then(model => {
-        expect(model.created).to.be(DEFAULT_FILE.created);
+        expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
@@ -1102,7 +1102,7 @@ describe('drive', () => {
       handleRequest(drive, 201, DEFAULT_CP);
       let checkpoint = drive.createCheckpoint('/foo/bar.txt');
       return checkpoint.then(model => {
-        expect(model.last_modified).to.be(DEFAULT_CP.last_modified);
+        expect(model.last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
@@ -1111,7 +1111,7 @@ describe('drive', () => {
       handleRequest(drive, 201, DEFAULT_CP);
       let checkpoint = drive.createCheckpoint('/foo/bar.txt');
       return checkpoint.then(model => {
-        expect(model.last_modified).to.be(DEFAULT_CP.last_modified);
+        expect(model.last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
@@ -1138,7 +1138,7 @@ describe('drive', () => {
       handleRequest(drive, 200, [DEFAULT_CP, DEFAULT_CP]);
       let checkpoints = drive.listCheckpoints('/foo/bar.txt');
       return checkpoints.then(models => {
-        expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
+        expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
@@ -1147,7 +1147,7 @@ describe('drive', () => {
       handleRequest(drive, 200, [DEFAULT_CP, DEFAULT_CP]);
       let checkpoints = drive.listCheckpoints('/foo/bar.txt');
       return checkpoints.then(models => {
-        expect(models[0].last_modified).to.be(DEFAULT_CP.last_modified);
+        expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
@@ -1235,7 +1235,7 @@ describe('drive', () => {
           }
         })
         .then(msg => {
-          expect(msg.path).to.be(path);
+          expect(msg.path).to.equal(path);
         });
     });
 
@@ -1248,7 +1248,7 @@ describe('drive', () => {
           return contents.rename(model0.path, 'foo.ipynb');
         })
         .then(model1 => {
-          expect(model1.path).to.be('foo.ipynb');
+          expect(model1.path).to.equal('foo.ipynb');
           return contents.delete('foo.ipynb');
         });
     });
@@ -1276,7 +1276,7 @@ describe('drive', () => {
       return contents
         .save('baz.txt', options)
         .then(model0 => {
-          expect(model0.name).to.be('baz.txt');
+          expect(model0.name).to.equal('baz.txt');
           return contents.createCheckpoint('baz.txt');
         })
         .then(value => {
@@ -1284,7 +1284,7 @@ describe('drive', () => {
           return contents.listCheckpoints('baz.txt');
         })
         .then(checkpoints => {
-          expect(checkpoints[0]).to.eql(checkpoint);
+          expect(checkpoints[0]).to.deep.equal(checkpoint);
           return contents.restoreCheckpoint('baz.txt', checkpoint.id);
         })
         .then(() => {

--- a/packages/services/test/src/contents/index.spec.ts
+++ b/packages/services/test/src/contents/index.spec.ts
@@ -187,7 +187,7 @@ describe('contents', () => {
       expect(model.path).to.equal('foo');
     });
 
-    it('should get a directory', () => {
+    it('should get a directory', async () => {
       const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_DIR);
       const options: Contents.IFetchOptions = { type: 'directory' };
@@ -195,7 +195,7 @@ describe('contents', () => {
       expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
     });
 
-    it('should get a file from an additional drive', () => {
+    it('should get a file from an additional drive', async () => {
       const contents = new ContentsManager();
       const drive = new Drive({ name: 'other' });
       contents.addDrive(drive);
@@ -205,7 +205,7 @@ describe('contents', () => {
       expect(model.path).to.equal('other:foo');
     });
 
-    it('should get a directory from an additional drive', () => {
+    it('should get a directory from an additional drive', async () => {
       const contents = new ContentsManager();
       const drive = new Drive({ name: 'other' });
       contents.addDrive(drive);
@@ -296,7 +296,7 @@ describe('contents', () => {
       expect(model.path).to.equal('other:foo/test');
     });
 
-    it('should create a directory on an additional drive', () => {
+    it('should create a directory on an additional drive', async () => {
       const contents = new ContentsManager();
       const other = new Drive({ name: 'other' });
       contents.addDrive(other);
@@ -458,7 +458,7 @@ describe('contents', () => {
       expect(model.created).to.equal(DEFAULT_FILE.created);
     });
 
-    it('should save a file on an additional drive', () => {
+    it('should save a file on an additional drive', async () => {
       const contents = new ContentsManager();
       const other = new Drive({ name: 'other' });
       contents.addDrive(other);
@@ -468,7 +468,7 @@ describe('contents', () => {
       expect(model.path).to.equal('other:foo');
     });
 
-    it('should create a new file', () => {
+    it('should create a new file', async () => {
       const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       const save = contents.save('/foo', { type: 'file', name: 'test' });
@@ -508,7 +508,7 @@ describe('contents', () => {
   });
 
   describe('#copy()', () => {
-    it('should copy a file', () => {
+    it('should copy a file', async () => {
       const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       const model = await contents.copy('/foo/bar.txt', '/baz');
@@ -592,7 +592,7 @@ describe('contents', () => {
   });
 
   describe('#listCheckpoints()', () => {
-    it('should list the checkpoints', () => {
+    it('should list the checkpoints', async () => {
       const contents = new ContentsManager();
       handleRequest(contents, 200, [DEFAULT_CP, DEFAULT_CP]);
       const checkpoints = contents.listCheckpoints('/foo/bar.txt');
@@ -600,7 +600,7 @@ describe('contents', () => {
       expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
     });
 
-    it('should list the checkpoints on an additional drive', () => {
+    it('should list the checkpoints on an additional drive', async () => {
       const contents = new ContentsManager();
       const other = new Drive({ name: 'other' });
       contents.addDrive(other);
@@ -819,7 +819,7 @@ describe('drive', () => {
     });
   });
 
-  describe('#newUntitled()', () => {
+  describe('#newUntitled()', async () => {
     it('should create a file', async () => {
       const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
@@ -827,7 +827,7 @@ describe('drive', () => {
       expect(model.path).to.equal(DEFAULT_FILE.path);
     });
 
-    it('should create a directory', () => {
+    it('should create a directory', async () => {
       const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_DIR);
       const options: Contents.ICreateOptions = {
@@ -888,10 +888,10 @@ describe('drive', () => {
   });
 
   describe('#delete()', () => {
-    it('should delete a file', () => {
+    it('should delete a file', async () => {
       const drive = new Drive();
       handleRequest(drive, 204, {});
-      return drive.delete('/foo/bar.txt');
+      await drive.delete('/foo/bar.txt');
     });
 
     it('should emit the fileChanged signal', async () => {
@@ -907,10 +907,10 @@ describe('drive', () => {
       await drive.delete(path);
     });
 
-    it('should accept server settings', () => {
+    it('should accept server settings', async () => {
       const drive = new Drive({ serverSettings });
       handleRequest(drive, 204, {});
-      drive.delete('/foo/bar.txt');
+      await drive.delete('/foo/bar.txt');
     });
 
     it('should fail for an incorrect response', async () => {
@@ -984,7 +984,7 @@ describe('drive', () => {
   });
 
   describe('#save()', () => {
-    it('should save a file', () => {
+    it('should save a file', async () => {
       const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
       const save = drive.save('/foo', { type: 'file', name: 'test' });
@@ -992,7 +992,7 @@ describe('drive', () => {
       expect(model.created).to.equal(DEFAULT_FILE.created);
     });
 
-    it('should create a new file', () => {
+    it('should create a new file', async () => {
       const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       const save = drive.save('/foo', { type: 'file', name: 'test' });
@@ -1014,7 +1014,7 @@ describe('drive', () => {
       expect(called).to.equal(true);
     });
 
-    it('should accept server settings', () => {
+    it('should accept server settings', async () => {
       const drive = new Drive({ serverSettings });
       handleRequest(drive, 200, DEFAULT_FILE);
       const save = drive.save('/foo', { type: 'file', name: 'test' });
@@ -1040,7 +1040,7 @@ describe('drive', () => {
   });
 
   describe('#copy()', () => {
-    it('should copy a file', () => {
+    it('should copy a file', async () => {
       const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       const model = await drive.copy('/foo/bar.txt', '/baz');
@@ -1061,7 +1061,7 @@ describe('drive', () => {
       expect(called).to.equal(true);
     });
 
-    it('should accept server settings', () => {
+    it('should accept server settings', async () => {
       const drive = new Drive({ serverSettings });
       handleRequest(drive, 201, DEFAULT_FILE);
       const model = await drive.copy('/foo/bar.txt', '/baz');
@@ -1120,7 +1120,7 @@ describe('drive', () => {
   });
 
   describe('#listCheckpoints()', () => {
-    it('should list the checkpoints', () => {
+    it('should list the checkpoints', async () => {
       const drive = new Drive();
       handleRequest(drive, 200, [DEFAULT_CP, DEFAULT_CP]);
       const checkpoints = drive.listCheckpoints('/foo/bar.txt');
@@ -1128,7 +1128,7 @@ describe('drive', () => {
       expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
     });
 
-    it('should accept server settings', () => {
+    it('should accept server settings', async () => {
       const drive = new Drive({ serverSettings });
       handleRequest(drive, 200, [DEFAULT_CP, DEFAULT_CP]);
       const checkpoints = drive.listCheckpoints('/foo/bar.txt');
@@ -1207,13 +1207,16 @@ describe('drive', () => {
       let path = '';
       const listing = await contents.get('src');
       content = listing.content as Contents.IModel[];
+      let called = false;
       for (let i = 0; i < content.length; i++) {
         if (content[i].type === 'file') {
           path = content[i].path;
-          await contents.get(path, { type: 'file' });
+          const msg = await contents.get(path, { type: 'file' });
+          expect(msg.path).to.equal(path);
+          called = true;
         }
       }
-      expect(msg.path).to.equal(path);
+      expect(called).to.equal(true);
     });
 
     it('should create a new file, rename it, and delete it', async () => {

--- a/packages/services/test/src/contents/index.spec.ts
+++ b/packages/services/test/src/contents/index.spec.ts
@@ -17,7 +17,7 @@ import {
   handleRequest
 } from '../utils';
 
-let DEFAULT_DIR: Contents.IModel = {
+const DEFAULT_DIR: Contents.IModel = {
   name: 'bar',
   path: 'foo/bar',
   type: 'directory',
@@ -32,7 +32,7 @@ let DEFAULT_DIR: Contents.IModel = {
   format: 'json'
 };
 
-let DEFAULT_CP: Contents.ICheckpointModel = {
+const DEFAULT_CP: Contents.ICheckpointModel = {
   id: '1234',
   last_modified: 'yesterday'
 };
@@ -40,12 +40,12 @@ let DEFAULT_CP: Contents.ICheckpointModel = {
 describe('contents', () => {
   describe('#constructor()', () => {
     it('should accept no options', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       expect(contents).to.be.an.instanceof(ContentsManager);
     });
 
     it('should accept options', () => {
-      let contents = new ContentsManager({
+      const contents = new ContentsManager({
         defaultDrive: new Drive()
       });
       expect(contents).to.be.an.instanceof(ContentsManager);
@@ -53,8 +53,8 @@ describe('contents', () => {
   });
 
   describe('#fileChanged', () => {
-    it('should be emitted when a file changes', done => {
-      let contents = new ContentsManager();
+    it('should be emitted when a file changes', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
         expect(sender).to.equal(contents);
@@ -66,9 +66,9 @@ describe('contents', () => {
       contents.newUntitled().catch(done);
     });
 
-    it('should include the full path for additional drives', done => {
-      let contents = new ContentsManager();
-      let drive = new Drive({ name: 'other' });
+    it('should include the full path for additional drives', async () => {
+      const contents = new ContentsManager();
+      const drive = new Drive({ name: 'other' });
       contents.addDrive(drive);
       handleRequest(drive, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
@@ -81,7 +81,7 @@ describe('contents', () => {
 
   describe('#isDisposed', () => {
     it('should test whether the manager is disposed', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       expect(contents.isDisposed).to.equal(false);
       contents.dispose();
       expect(contents.isDisposed).to.equal(true);
@@ -90,7 +90,7 @@ describe('contents', () => {
 
   describe('#dispose()', () => {
     it('should dispose of the resources used by the manager', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       expect(contents.isDisposed).to.equal(false);
       contents.dispose();
       expect(contents.isDisposed).to.equal(true);
@@ -101,7 +101,7 @@ describe('contents', () => {
 
   describe('#addDrive()', () => {
     it('should add a new drive to the manager', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       contents.addDrive(new Drive({ name: 'other' }));
       handleRequest(contents, 200, DEFAULT_FILE);
       return contents.get('other:');
@@ -176,64 +176,64 @@ describe('contents', () => {
 
   describe('#get()', () => {
     it('should get a file', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_FILE);
-      let options: Contents.IFetchOptions = { type: 'file' };
+      const options: Contents.IFetchOptions = { type: 'file' };
       return contents.get('/foo', options).then(model => {
         expect(model.path).to.equal('foo');
       });
     });
 
     it('should get a directory', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_DIR);
-      let options: Contents.IFetchOptions = { type: 'directory' };
+      const options: Contents.IFetchOptions = { type: 'directory' };
       return contents.get('/foo', options).then(model => {
         expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
     it('should get a file from an additional drive', () => {
-      let contents = new ContentsManager();
-      let drive = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const drive = new Drive({ name: 'other' });
       contents.addDrive(drive);
       handleRequest(drive, 200, DEFAULT_FILE);
-      let options: Contents.IFetchOptions = { type: 'file' };
+      const options: Contents.IFetchOptions = { type: 'file' };
       return contents.get('other:/foo', options).then(model => {
         expect(model.path).to.equal('other:foo');
       });
     });
 
     it('should get a directory from an additional drive', () => {
-      let contents = new ContentsManager();
-      let drive = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const drive = new Drive({ name: 'other' });
       contents.addDrive(drive);
       handleRequest(drive, 200, DEFAULT_DIR);
-      let options: Contents.IFetchOptions = { type: 'directory' };
+      const options: Contents.IFetchOptions = { type: 'directory' };
       return contents.get('other:/foo', options).then(model => {
         expect(model.content[0].path).to.equal('other:foo/bar/buzz.txt');
       });
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_DIR);
-      let get = contents.get('/foo');
+      const get = contents.get('/foo');
       expectFailure(get, done, 'Invalid response: 201 Created');
     });
   });
 
   describe('#getDownloadUrl()', () => {
-    let settings = ServerConnection.makeSettings({
+    const settings = ServerConnection.makeSettings({
       baseUrl: 'http://foo'
     });
 
     it('should get the url of a file', () => {
-      let drive = new Drive({ serverSettings: settings });
-      let contents = new ContentsManager({ defaultDrive: drive });
-      let test1 = contents.getDownloadUrl('bar.txt');
-      let test2 = contents.getDownloadUrl('fizz/buzz/bar.txt');
-      let test3 = contents.getDownloadUrl('/bar.txt');
+      const drive = new Drive({ serverSettings: settings });
+      const contents = new ContentsManager({ defaultDrive: drive });
+      const test1 = contents.getDownloadUrl('bar.txt');
+      const test2 = contents.getDownloadUrl('fizz/buzz/bar.txt');
+      const test3 = contents.getDownloadUrl('/bar.txt');
       return Promise.all([test1, test2, test3]).then(urls => {
         expect(urls[0]).to.equal('http://foo/files/bar.txt');
         expect(urls[1]).to.equal('http://foo/files/fizz/buzz/bar.txt');
@@ -242,28 +242,28 @@ describe('contents', () => {
     });
 
     it('should encode characters', () => {
-      let drive = new Drive({ serverSettings: settings });
-      let contents = new ContentsManager({ defaultDrive: drive });
+      const drive = new Drive({ serverSettings: settings });
+      const contents = new ContentsManager({ defaultDrive: drive });
       return contents.getDownloadUrl('b ar?3.txt').then(url => {
         expect(url).to.equal('http://foo/files/b%20ar%3F3.txt');
       });
     });
 
     it('should not handle relative paths', () => {
-      let drive = new Drive({ serverSettings: settings });
-      let contents = new ContentsManager({ defaultDrive: drive });
+      const drive = new Drive({ serverSettings: settings });
+      const contents = new ContentsManager({ defaultDrive: drive });
       return contents.getDownloadUrl('fizz/../bar.txt').then(url => {
         expect(url).to.equal('http://foo/files/fizz/../bar.txt');
       });
     });
 
     it('should get the url of a file from an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other', serverSettings: settings });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other', serverSettings: settings });
       contents.addDrive(other);
-      let test1 = contents.getDownloadUrl('other:bar.txt');
-      let test2 = contents.getDownloadUrl('other:fizz/buzz/bar.txt');
-      let test3 = contents.getDownloadUrl('other:/bar.txt');
+      const test1 = contents.getDownloadUrl('other:bar.txt');
+      const test2 = contents.getDownloadUrl('other:fizz/buzz/bar.txt');
+      const test3 = contents.getDownloadUrl('other:/bar.txt');
       return Promise.all([test1, test2, test3]).then(urls => {
         expect(urls[0]).to.equal('http://foo/files/bar.txt');
         expect(urls[1]).to.equal('http://foo/files/fizz/buzz/bar.txt');
@@ -274,7 +274,7 @@ describe('contents', () => {
 
   describe('#newUntitled()', () => {
     it('should create a file', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       return contents.newUntitled({ path: '/foo' }).then(model => {
         expect(model.path).to.equal('foo/test');
@@ -282,9 +282,9 @@ describe('contents', () => {
     });
 
     it('should create a directory', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_DIR);
-      let options: Contents.ICreateOptions = {
+      const options: Contents.ICreateOptions = {
         path: '/foo',
         type: 'directory'
       };
@@ -294,8 +294,8 @@ describe('contents', () => {
     });
 
     it('should create a file on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 201, DEFAULT_FILE);
       return contents.newUntitled({ path: 'other:/foo' }).then(model => {
@@ -304,11 +304,11 @@ describe('contents', () => {
     });
 
     it('should create a directory on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 201, DEFAULT_DIR);
-      let options: Contents.ICreateOptions = {
+      const options: Contents.ICreateOptions = {
         path: 'other:/foo',
         type: 'directory'
       };
@@ -317,8 +317,8 @@ describe('contents', () => {
       });
     });
 
-    it('should emit the fileChanged signal', done => {
-      let contents = new ContentsManager();
+    it('should emit the fileChanged signal', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('new');
@@ -329,46 +329,46 @@ describe('contents', () => {
       contents.newUntitled({ type: 'file', ext: 'test' }).catch(done);
     });
 
-    it('should fail for an incorrect model', done => {
-      let contents = new ContentsManager();
-      let dir = JSON.parse(JSON.stringify(DEFAULT_DIR));
+    it('should fail for an incorrect model', async () => {
+      const contents = new ContentsManager();
+      const dir = JSON.parse(JSON.stringify(DEFAULT_DIR));
       dir.name = 1;
       handleRequest(contents, 201, dir);
-      let options: Contents.ICreateOptions = {
+      const options: Contents.ICreateOptions = {
         path: '/foo',
         type: 'file',
         ext: 'py'
       };
-      let newFile = contents.newUntitled(options);
+      const newFile = contents.newUntitled(options);
       expectFailure(newFile, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_DIR);
-      let newDir = contents.newUntitled();
+      const newDir = contents.newUntitled();
       expectFailure(newDir, done, 'Invalid response: 200 OK');
     });
   });
 
   describe('#delete()', () => {
     it('should delete a file', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 204, {});
       return contents.delete('/foo/bar.txt');
     });
 
     it('should delete a file on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 204, {});
       return contents.delete('other:/foo/bar.txt');
     });
 
-    it('should emit the fileChanged signal', done => {
-      let contents = new ContentsManager();
-      let path = '/foo/bar.txt';
+    it('should emit the fileChanged signal', async () => {
+      const contents = new ContentsManager();
+      const path = '/foo/bar.txt';
       handleRequest(contents, 204, { path });
       contents.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('delete');
@@ -378,51 +378,54 @@ describe('contents', () => {
       contents.delete(path).catch(done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 200, {});
-      let del = contents.delete('/foo/bar.txt');
+      const del = contents.delete('/foo/bar.txt');
       expectFailure(del, done, 'Invalid response: 200 OK');
     });
 
-    it('should throw a specific error', done => {
-      let contents = new ContentsManager();
+    it('should throw a specific error', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 400, {});
-      let del = contents.delete('/foo/');
+      const del = contents.delete('/foo/');
       expectFailure(del, done, '');
     });
 
-    it('should throw a general error', done => {
-      let contents = new ContentsManager();
+    it('should throw a general error', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 500, {});
-      let del = contents.delete('/foo/');
+      const del = contents.delete('/foo/');
       expectFailure(del, done, '');
     });
   });
 
   describe('#rename()', () => {
     it('should rename a file', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_FILE);
-      let rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
+      const rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
       return rename.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
     it('should rename a file on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 200, DEFAULT_FILE);
-      let rename = contents.rename('other:/foo/bar.txt', 'other:/foo/baz.txt');
+      const rename = contents.rename(
+        'other:/foo/bar.txt',
+        'other:/foo/baz.txt'
+      );
       return rename.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
-    it('should emit the fileChanged signal', done => {
-      let contents = new ContentsManager();
+    it('should emit the fileChanged signal', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('rename');
@@ -433,55 +436,55 @@ describe('contents', () => {
       contents.rename('/foo/bar.txt', '/foo/baz.txt').catch(done);
     });
 
-    it('should fail for an incorrect model', done => {
-      let contents = new ContentsManager();
-      let dir = JSON.parse(JSON.stringify(DEFAULT_FILE));
+    it('should fail for an incorrect model', async () => {
+      const contents = new ContentsManager();
+      const dir = JSON.parse(JSON.stringify(DEFAULT_FILE));
       delete dir.path;
       handleRequest(contents, 200, dir);
-      let rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
+      const rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
       expectFailure(rename, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
-      let rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
+      const rename = contents.rename('/foo/bar.txt', '/foo/baz.txt');
       expectFailure(rename, done, 'Invalid response: 201 Created');
     });
   });
 
   describe('#save()', () => {
     it('should save a file', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_FILE);
-      let save = contents.save('/foo', { type: 'file', name: 'test' });
+      const save = contents.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
     it('should save a file on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(contents, 200, DEFAULT_FILE);
-      let save = contents.save('other:/foo', { type: 'file', name: 'test' });
+      const save = contents.save('other:/foo', { type: 'file', name: 'test' });
       return save.then(model => {
         expect(model.path).to.equal('other:foo');
       });
     });
 
     it('should create a new file', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
-      let save = contents.save('/foo', { type: 'file', name: 'test' });
+      const save = contents.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
-    it('should emit the fileChanged signal', done => {
-      let contents = new ContentsManager();
+    it('should emit the fileChanged signal', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('save');
@@ -492,26 +495,26 @@ describe('contents', () => {
       contents.save('/foo', { type: 'file', name: 'test' }).catch(done);
     });
 
-    it('should fail for an incorrect model', done => {
-      let contents = new ContentsManager();
-      let file = JSON.parse(JSON.stringify(DEFAULT_FILE));
+    it('should fail for an incorrect model', async () => {
+      const contents = new ContentsManager();
+      const file = JSON.parse(JSON.stringify(DEFAULT_FILE));
       delete file.format;
       handleRequest(contents, 200, file);
-      let save = contents.save('/foo', { type: 'file', name: 'test' });
+      const save = contents.save('/foo', { type: 'file', name: 'test' });
       expectFailure(save, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 204, DEFAULT_FILE);
-      let save = contents.save('/foo', { type: 'file', name: 'test' });
+      const save = contents.save('/foo', { type: 'file', name: 'test' });
       expectFailure(save, done, 'Invalid response: 204 No Content');
     });
   });
 
   describe('#copy()', () => {
     it('should copy a file', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       return contents.copy('/foo/bar.txt', '/baz').then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
@@ -519,8 +522,8 @@ describe('contents', () => {
     });
 
     it('should copy a file on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 201, DEFAULT_FILE);
       return contents.copy('other:/foo/test', 'other:/baz').then(model => {
@@ -528,8 +531,8 @@ describe('contents', () => {
       });
     });
 
-    it('should emit the fileChanged signal', done => {
-      let contents = new ContentsManager();
+    it('should emit the fileChanged signal', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_FILE);
       contents.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('new');
@@ -540,110 +543,110 @@ describe('contents', () => {
       contents.copy('/foo/bar.txt', '/baz').catch(done);
     });
 
-    it('should fail for an incorrect model', done => {
-      let contents = new ContentsManager();
-      let file = JSON.parse(JSON.stringify(DEFAULT_FILE));
+    it('should fail for an incorrect model', async () => {
+      const contents = new ContentsManager();
+      const file = JSON.parse(JSON.stringify(DEFAULT_FILE));
       delete file.type;
       handleRequest(contents, 201, file);
-      let copy = contents.copy('/foo/bar.txt', '/baz');
+      const copy = contents.copy('/foo/bar.txt', '/baz');
       expectFailure(copy, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_FILE);
-      let copy = contents.copy('/foo/bar.txt', '/baz');
+      const copy = contents.copy('/foo/bar.txt', '/baz');
       expectFailure(copy, done, 'Invalid response: 200 OK');
     });
   });
 
   describe('#createCheckpoint()', () => {
     it('should create a checkpoint', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 201, DEFAULT_CP);
-      let checkpoint = contents.createCheckpoint('/foo/bar.txt');
+      const checkpoint = contents.createCheckpoint('/foo/bar.txt');
       return checkpoint.then(model => {
         expect(model.last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
     it('should create a checkpoint on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 201, DEFAULT_CP);
-      let checkpoint = contents.createCheckpoint('other:/foo/bar.txt');
+      const checkpoint = contents.createCheckpoint('other:/foo/bar.txt');
       return checkpoint.then(model => {
         expect(model.last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
-    it('should fail for an incorrect model', done => {
-      let contents = new ContentsManager();
-      let cp = JSON.parse(JSON.stringify(DEFAULT_CP));
+    it('should fail for an incorrect model', async () => {
+      const contents = new ContentsManager();
+      const cp = JSON.parse(JSON.stringify(DEFAULT_CP));
       delete cp.last_modified;
       handleRequest(contents, 201, cp);
-      let checkpoint = contents.createCheckpoint('/foo/bar.txt');
+      const checkpoint = contents.createCheckpoint('/foo/bar.txt');
       expectFailure(checkpoint, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 200, DEFAULT_CP);
-      let checkpoint = contents.createCheckpoint('/foo/bar.txt');
+      const checkpoint = contents.createCheckpoint('/foo/bar.txt');
       expectFailure(checkpoint, done, 'Invalid response: 200 OK');
     });
   });
 
   describe('#listCheckpoints()', () => {
     it('should list the checkpoints', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 200, [DEFAULT_CP, DEFAULT_CP]);
-      let checkpoints = contents.listCheckpoints('/foo/bar.txt');
+      const checkpoints = contents.listCheckpoints('/foo/bar.txt');
       return checkpoints.then(models => {
         expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
     it('should list the checkpoints on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 200, [DEFAULT_CP, DEFAULT_CP]);
-      let checkpoints = contents.listCheckpoints('other:/foo/bar.txt');
+      const checkpoints = contents.listCheckpoints('other:/foo/bar.txt');
       return checkpoints.then(models => {
         expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
-    it('should fail for an incorrect model', done => {
-      let contents = new ContentsManager();
-      let cp = JSON.parse(JSON.stringify(DEFAULT_CP));
+    it('should fail for an incorrect model', async () => {
+      const contents = new ContentsManager();
+      const cp = JSON.parse(JSON.stringify(DEFAULT_CP));
       delete cp.id;
       handleRequest(contents, 200, [cp, DEFAULT_CP]);
-      let checkpoints = contents.listCheckpoints('/foo/bar.txt');
-      let second = () => {
+      const checkpoints = contents.listCheckpoints('/foo/bar.txt');
+      const second = () => {
         handleRequest(contents, 200, DEFAULT_CP);
-        let newCheckpoints = contents.listCheckpoints('/foo/bar.txt');
+        const newCheckpoints = contents.listCheckpoints('/foo/bar.txt');
         expectFailure(newCheckpoints, done, 'Invalid Checkpoint list');
       };
 
       expectFailure(checkpoints, second);
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 201, {});
-      let checkpoints = contents.listCheckpoints('/foo/bar.txt');
+      const checkpoints = contents.listCheckpoints('/foo/bar.txt');
       expectFailure(checkpoints, done, 'Invalid response: 201 Created');
     });
   });
 
   describe('#restoreCheckpoint()', () => {
     it('should restore a checkpoint', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 204, {});
-      let checkpoint = contents.restoreCheckpoint(
+      const checkpoint = contents.restoreCheckpoint(
         '/foo/bar.txt',
         DEFAULT_CP.id
       );
@@ -651,21 +654,21 @@ describe('contents', () => {
     });
 
     it('should restore a checkpoint on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 204, {});
-      let checkpoint = contents.restoreCheckpoint(
+      const checkpoint = contents.restoreCheckpoint(
         'other:/foo/bar.txt',
         DEFAULT_CP.id
       );
       return checkpoint;
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 200, {});
-      let checkpoint = contents.restoreCheckpoint(
+      const checkpoint = contents.restoreCheckpoint(
         '/foo/bar.txt',
         DEFAULT_CP.id
       );
@@ -675,39 +678,42 @@ describe('contents', () => {
 
   describe('#deleteCheckpoint()', () => {
     it('should delete a checkpoint', () => {
-      let contents = new ContentsManager();
+      const contents = new ContentsManager();
       handleRequest(contents, 204, {});
       return contents.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
     });
 
     it('should delete a checkpoint on an additional drive', () => {
-      let contents = new ContentsManager();
-      let other = new Drive({ name: 'other' });
+      const contents = new ContentsManager();
+      const other = new Drive({ name: 'other' });
       contents.addDrive(other);
       handleRequest(other, 204, {});
       return contents.deleteCheckpoint('other:/foo/bar.txt', DEFAULT_CP.id);
     });
 
-    it('should fail for an incorrect response', done => {
-      let contents = new ContentsManager();
+    it('should fail for an incorrect response', async () => {
+      const contents = new ContentsManager();
       handleRequest(contents, 200, {});
-      let checkpoint = contents.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
+      const checkpoint = contents.deleteCheckpoint(
+        '/foo/bar.txt',
+        DEFAULT_CP.id
+      );
       expectFailure(checkpoint, done, 'Invalid response: 200 OK');
     });
   });
 });
 
 describe('drive', () => {
-  let serverSettings = makeSettings();
+  const serverSettings = makeSettings();
 
   describe('#constructor()', () => {
     it('should accept no options', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       expect(drive).to.be.an.instanceof(Drive);
     });
 
     it('should accept options', () => {
-      let drive = new Drive({
+      const drive = new Drive({
         name: 'name'
       });
       expect(drive).to.be.an.instanceof(Drive);
@@ -716,7 +722,7 @@ describe('drive', () => {
 
   describe('#name', () => {
     it('should return the name of the drive', () => {
-      let drive = new Drive({
+      const drive = new Drive({
         name: 'name'
       });
       expect(drive.name).to.equal('name');
@@ -724,8 +730,8 @@ describe('drive', () => {
   });
 
   describe('#fileChanged', () => {
-    it('should be emitted when a file changes', done => {
-      let drive = new Drive();
+    it('should be emitted when a file changes', async () => {
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
         expect(sender).to.equal(drive);
@@ -740,7 +746,7 @@ describe('drive', () => {
 
   describe('#isDisposed', () => {
     it('should test whether the drive is disposed', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       expect(drive.isDisposed).to.equal(false);
       drive.dispose();
       expect(drive.isDisposed).to.equal(true);
@@ -749,7 +755,7 @@ describe('drive', () => {
 
   describe('#dispose()', () => {
     it('should dispose of the resources used by the drive', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       expect(drive.isDisposed).to.equal(false);
       drive.dispose();
       expect(drive.isDisposed).to.equal(true);
@@ -760,53 +766,53 @@ describe('drive', () => {
 
   describe('#get()', () => {
     it('should get a file', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
-      let options: Contents.IFetchOptions = { type: 'file' };
-      let get = drive.get('/foo', options);
+      const options: Contents.IFetchOptions = { type: 'file' };
+      const get = drive.get('/foo', options);
       return get.then(model => {
         expect(model.path).to.equal(DEFAULT_FILE.path);
       });
     });
 
     it('should get a directory', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_DIR);
-      let options: Contents.IFetchOptions = { type: 'directory' };
-      let get = drive.get('/foo', options);
+      const options: Contents.IFetchOptions = { type: 'directory' };
+      const get = drive.get('/foo', options);
       return get.then(model => {
         expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 200, DEFAULT_DIR);
-      let options: Contents.IFetchOptions = { type: 'directory' };
-      let get = drive.get('/foo', options);
+      const options: Contents.IFetchOptions = { type: 'directory' };
+      const get = drive.get('/foo', options);
       return get.then(model => {
         expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_DIR);
-      let get = drive.get('/foo');
+      const get = drive.get('/foo');
       expectFailure(get, done, 'Invalid response: 201 Created');
     });
   });
 
   describe('#getDownloadUrl()', () => {
-    let settings = ServerConnection.makeSettings({
+    const settings = ServerConnection.makeSettings({
       baseUrl: 'http://foo'
     });
 
     it('should get the url of a file', () => {
-      let drive = new Drive({ serverSettings: settings });
-      let test1 = drive.getDownloadUrl('bar.txt');
-      let test2 = drive.getDownloadUrl('fizz/buzz/bar.txt');
-      let test3 = drive.getDownloadUrl('/bar.txt');
+      const drive = new Drive({ serverSettings: settings });
+      const test1 = drive.getDownloadUrl('bar.txt');
+      const test2 = drive.getDownloadUrl('fizz/buzz/bar.txt');
+      const test3 = drive.getDownloadUrl('/bar.txt');
       return Promise.all([test1, test2, test3]).then(urls => {
         expect(urls[0]).to.equal('http://foo/files/bar.txt');
         expect(urls[1]).to.equal('http://foo/files/fizz/buzz/bar.txt');
@@ -815,14 +821,14 @@ describe('drive', () => {
     });
 
     it('should encode characters', () => {
-      let drive = new Drive({ serverSettings: settings });
+      const drive = new Drive({ serverSettings: settings });
       return drive.getDownloadUrl('b ar?3.txt').then(url => {
         expect(url).to.equal('http://foo/files/b%20ar%3F3.txt');
       });
     });
 
     it('should not handle relative paths', () => {
-      let drive = new Drive({ serverSettings: settings });
+      const drive = new Drive({ serverSettings: settings });
       return drive.getDownloadUrl('fizz/../bar.txt').then(url => {
         expect(url).to.equal('http://foo/files/fizz/../bar.txt');
       });
@@ -831,7 +837,7 @@ describe('drive', () => {
 
   describe('#newUntitled()', () => {
     it('should create a file', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       return drive.newUntitled({ path: '/foo' }).then(model => {
         expect(model.path).to.equal(DEFAULT_FILE.path);
@@ -839,20 +845,20 @@ describe('drive', () => {
     });
 
     it('should create a directory', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_DIR);
-      let options: Contents.ICreateOptions = {
+      const options: Contents.ICreateOptions = {
         path: '/foo',
         type: 'directory'
       };
-      let newDir = drive.newUntitled(options);
+      const newDir = drive.newUntitled(options);
       return newDir.then(model => {
         expect(model.content[0].path).to.equal(DEFAULT_DIR.content[0].path);
       });
     });
 
-    it('should emit the fileChanged signal', done => {
-      let drive = new Drive();
+    it('should emit the fileChanged signal', async () => {
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('new');
@@ -864,9 +870,9 @@ describe('drive', () => {
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 201, DEFAULT_DIR);
-      let options: Contents.ICreateOptions = {
+      const options: Contents.ICreateOptions = {
         path: '/foo',
         type: 'file',
         ext: 'txt'
@@ -876,38 +882,38 @@ describe('drive', () => {
       });
     });
 
-    it('should fail for an incorrect model', done => {
-      let drive = new Drive();
-      let dir = JSON.parse(JSON.stringify(DEFAULT_DIR));
+    it('should fail for an incorrect model', async () => {
+      const drive = new Drive();
+      const dir = JSON.parse(JSON.stringify(DEFAULT_DIR));
       dir.name = 1;
       handleRequest(drive, 201, dir);
-      let options: Contents.ICreateOptions = {
+      const options: Contents.ICreateOptions = {
         path: '/foo',
         type: 'file',
         ext: 'py'
       };
-      let newFile = drive.newUntitled(options);
+      const newFile = drive.newUntitled(options);
       expectFailure(newFile, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_DIR);
-      let newDir = drive.newUntitled();
+      const newDir = drive.newUntitled();
       expectFailure(newDir, done, 'Invalid response: 200 OK');
     });
   });
 
   describe('#delete()', () => {
     it('should delete a file', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 204, {});
       return drive.delete('/foo/bar.txt');
     });
 
-    it('should emit the fileChanged signal', done => {
-      let drive = new Drive();
-      let path = '/foo/bar.txt';
+    it('should emit the fileChanged signal', async () => {
+      const drive = new Drive();
+      const path = '/foo/bar.txt';
       handleRequest(drive, 204, { path });
       drive.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('delete');
@@ -918,45 +924,45 @@ describe('drive', () => {
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 204, {});
       drive.delete('/foo/bar.txt');
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 200, {});
-      let del = drive.delete('/foo/bar.txt');
+      const del = drive.delete('/foo/bar.txt');
       expectFailure(del, done, 'Invalid response: 200 OK');
     });
 
-    it('should throw a specific error', done => {
-      let drive = new Drive();
+    it('should throw a specific error', async () => {
+      const drive = new Drive();
       handleRequest(drive, 400, {});
-      let del = drive.delete('/foo/');
+      const del = drive.delete('/foo/');
       expectFailure(del, done, '');
     });
 
-    it('should throw a general error', done => {
-      let drive = new Drive();
+    it('should throw a general error', async () => {
+      const drive = new Drive();
       handleRequest(drive, 500, {});
-      let del = drive.delete('/foo/');
+      const del = drive.delete('/foo/');
       expectFailure(del, done, '');
     });
   });
 
   describe('#rename()', () => {
     it('should rename a file', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
-      let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
+      const rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
       return rename.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
-    it('should emit the fileChanged signal', done => {
-      let drive = new Drive();
+    it('should emit the fileChanged signal', async () => {
+      const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('rename');
@@ -968,52 +974,52 @@ describe('drive', () => {
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 200, DEFAULT_FILE);
-      let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
+      const rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
       return rename.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
-    it('should fail for an incorrect model', done => {
-      let drive = new Drive();
-      let dir = JSON.parse(JSON.stringify(DEFAULT_FILE));
+    it('should fail for an incorrect model', async () => {
+      const drive = new Drive();
+      const dir = JSON.parse(JSON.stringify(DEFAULT_FILE));
       delete dir.path;
       handleRequest(drive, 200, dir);
-      let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
+      const rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
       expectFailure(rename, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
-      let rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
+      const rename = drive.rename('/foo/bar.txt', '/foo/baz.txt');
       expectFailure(rename, done, 'Invalid response: 201 Created');
     });
   });
 
   describe('#save()', () => {
     it('should save a file', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
-      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      const save = drive.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
     it('should create a new file', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
-      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      const save = drive.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
-    it('should emit the fileChanged signal', done => {
-      let drive = new Drive();
+    it('should emit the fileChanged signal', async () => {
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('save');
@@ -1025,42 +1031,42 @@ describe('drive', () => {
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 200, DEFAULT_FILE);
-      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      const save = drive.save('/foo', { type: 'file', name: 'test' });
       return save.then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
-    it('should fail for an incorrect model', done => {
-      let drive = new Drive();
-      let file = JSON.parse(JSON.stringify(DEFAULT_FILE));
+    it('should fail for an incorrect model', async () => {
+      const drive = new Drive();
+      const file = JSON.parse(JSON.stringify(DEFAULT_FILE));
       delete file.format;
       handleRequest(drive, 200, file);
-      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      const save = drive.save('/foo', { type: 'file', name: 'test' });
       expectFailure(save, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 204, DEFAULT_FILE);
-      let save = drive.save('/foo', { type: 'file', name: 'test' });
+      const save = drive.save('/foo', { type: 'file', name: 'test' });
       expectFailure(save, done, 'Invalid response: 204 No Content');
     });
   });
 
   describe('#copy()', () => {
     it('should copy a file', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       return drive.copy('/foo/bar.txt', '/baz').then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
-    it('should emit the fileChanged signal', done => {
-      let drive = new Drive();
+    it('should emit the fileChanged signal', async () => {
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_FILE);
       drive.fileChanged.connect((sender, args) => {
         expect(args.type).to.equal('new');
@@ -1072,162 +1078,162 @@ describe('drive', () => {
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 201, DEFAULT_FILE);
       return drive.copy('/foo/bar.txt', '/baz').then(model => {
         expect(model.created).to.equal(DEFAULT_FILE.created);
       });
     });
 
-    it('should fail for an incorrect model', done => {
-      let drive = new Drive();
-      let file = JSON.parse(JSON.stringify(DEFAULT_FILE));
+    it('should fail for an incorrect model', async () => {
+      const drive = new Drive();
+      const file = JSON.parse(JSON.stringify(DEFAULT_FILE));
       delete file.type;
       handleRequest(drive, 201, file);
-      let copy = drive.copy('/foo/bar.txt', '/baz');
+      const copy = drive.copy('/foo/bar.txt', '/baz');
       expectFailure(copy, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_FILE);
-      let copy = drive.copy('/foo/bar.txt', '/baz');
+      const copy = drive.copy('/foo/bar.txt', '/baz');
       expectFailure(copy, done, 'Invalid response: 200 OK');
     });
   });
 
   describe('#createCheckpoint()', () => {
     it('should create a checkpoint', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 201, DEFAULT_CP);
-      let checkpoint = drive.createCheckpoint('/foo/bar.txt');
+      const checkpoint = drive.createCheckpoint('/foo/bar.txt');
       return checkpoint.then(model => {
         expect(model.last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 201, DEFAULT_CP);
-      let checkpoint = drive.createCheckpoint('/foo/bar.txt');
+      const checkpoint = drive.createCheckpoint('/foo/bar.txt');
       return checkpoint.then(model => {
         expect(model.last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
-    it('should fail for an incorrect model', done => {
-      let drive = new Drive();
-      let cp = JSON.parse(JSON.stringify(DEFAULT_CP));
+    it('should fail for an incorrect model', async () => {
+      const drive = new Drive();
+      const cp = JSON.parse(JSON.stringify(DEFAULT_CP));
       delete cp.last_modified;
       handleRequest(drive, 201, cp);
-      let checkpoint = drive.createCheckpoint('/foo/bar.txt');
+      const checkpoint = drive.createCheckpoint('/foo/bar.txt');
       expectFailure(checkpoint, done);
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 200, DEFAULT_CP);
-      let checkpoint = drive.createCheckpoint('/foo/bar.txt');
+      const checkpoint = drive.createCheckpoint('/foo/bar.txt');
       expectFailure(checkpoint, done, 'Invalid response: 200 OK');
     });
   });
 
   describe('#listCheckpoints()', () => {
     it('should list the checkpoints', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 200, [DEFAULT_CP, DEFAULT_CP]);
-      let checkpoints = drive.listCheckpoints('/foo/bar.txt');
+      const checkpoints = drive.listCheckpoints('/foo/bar.txt');
       return checkpoints.then(models => {
         expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 200, [DEFAULT_CP, DEFAULT_CP]);
-      let checkpoints = drive.listCheckpoints('/foo/bar.txt');
+      const checkpoints = drive.listCheckpoints('/foo/bar.txt');
       return checkpoints.then(models => {
         expect(models[0].last_modified).to.equal(DEFAULT_CP.last_modified);
       });
     });
 
-    it('should fail for an incorrect model', done => {
-      let drive = new Drive();
-      let cp = JSON.parse(JSON.stringify(DEFAULT_CP));
+    it('should fail for an incorrect model', async () => {
+      const drive = new Drive();
+      const cp = JSON.parse(JSON.stringify(DEFAULT_CP));
       delete cp.id;
       handleRequest(drive, 200, [cp, DEFAULT_CP]);
-      let checkpoints = drive.listCheckpoints('/foo/bar.txt');
-      let second = () => {
+      const checkpoints = drive.listCheckpoints('/foo/bar.txt');
+      const second = () => {
         handleRequest(drive, 200, DEFAULT_CP);
-        let newCheckpoints = drive.listCheckpoints('/foo/bar.txt');
+        const newCheckpoints = drive.listCheckpoints('/foo/bar.txt');
         expectFailure(newCheckpoints, done, 'Invalid Checkpoint list');
       };
 
       expectFailure(checkpoints, second);
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 201, {});
-      let checkpoints = drive.listCheckpoints('/foo/bar.txt');
+      const checkpoints = drive.listCheckpoints('/foo/bar.txt');
       expectFailure(checkpoints, done, 'Invalid response: 201 Created');
     });
   });
 
   describe('#restoreCheckpoint()', () => {
     it('should restore a checkpoint', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 204, {});
-      let checkpoint = drive.restoreCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
+      const checkpoint = drive.restoreCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
       return checkpoint;
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 204, {});
-      let checkpoint = drive.restoreCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
+      const checkpoint = drive.restoreCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
       return checkpoint;
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 200, {});
-      let checkpoint = drive.restoreCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
+      const checkpoint = drive.restoreCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
       expectFailure(checkpoint, done, 'Invalid response: 200 OK');
     });
   });
 
   describe('#deleteCheckpoint()', () => {
     it('should delete a checkpoint', () => {
-      let drive = new Drive();
+      const drive = new Drive();
       handleRequest(drive, 204, {});
       return drive.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
     });
 
     it('should accept server settings', () => {
-      let drive = new Drive({ serverSettings });
+      const drive = new Drive({ serverSettings });
       handleRequest(drive, 204, {});
       return drive.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
     });
 
-    it('should fail for an incorrect response', done => {
-      let drive = new Drive();
+    it('should fail for an incorrect response', async () => {
+      const drive = new Drive();
       handleRequest(drive, 200, {});
-      let checkpoint = drive.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
+      const checkpoint = drive.deleteCheckpoint('/foo/bar.txt', DEFAULT_CP.id);
       expectFailure(checkpoint, done, 'Invalid response: 200 OK');
     });
   });
 
   describe('integration tests', () => {
     it('should list a directory and get the file contents', () => {
-      let contents = new ContentsManager();
-      let content: Contents.IModel[];
-      let path = '';
+      const contents = new ContentsManager();
+      const content: Contents.IModel[];
+      const path = '';
       return contents
         .get('src')
         .then(listing => {
           content = listing.content as Contents.IModel[];
-          for (let i = 0; i < content.length; i++) {
+          for (const i = 0; i < content.length; i++) {
             if (content[i].type === 'file') {
               path = content[i].path;
               return contents.get(path, { type: 'file' });
@@ -1240,8 +1246,8 @@ describe('drive', () => {
     });
 
     it('should create a new file, rename it, and delete it', () => {
-      let contents = new ContentsManager();
-      let options: Contents.ICreateOptions = { type: 'file', ext: '.ipynb' };
+      const contents = new ContentsManager();
+      const options: Contents.ICreateOptions = { type: 'file', ext: '.ipynb' };
       return contents
         .newUntitled(options)
         .then(model0 => {
@@ -1254,8 +1260,8 @@ describe('drive', () => {
     });
 
     it('should create a file by name and delete it', () => {
-      let contents = new ContentsManager();
-      let options: Partial<Contents.IModel> = {
+      const contents = new ContentsManager();
+      const options: Partial<Contents.IModel> = {
         type: 'file',
         content: '',
         format: 'text'
@@ -1266,13 +1272,13 @@ describe('drive', () => {
     });
 
     it('should exercise the checkpoint API', () => {
-      let contents = new ContentsManager();
-      let options: Partial<Contents.IModel> = {
+      const contents = new ContentsManager();
+      const options: Partial<Contents.IModel> = {
         type: 'file',
         format: 'text',
         content: 'foo'
       };
-      let checkpoint: Contents.ICheckpointModel;
+      const checkpoint: Contents.ICheckpointModel;
       return contents
         .save('baz.txt', options)
         .then(model0 => {

--- a/packages/services/test/src/contents/validate.spec.ts
+++ b/packages/services/test/src/contents/validate.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import {
   validateContentsModel,
@@ -19,13 +19,13 @@ describe('validate', () => {
     it('should fail on missing data', () => {
       let model = JSON.parse(JSON.stringify(DEFAULT_FILE));
       delete model['path'];
-      expect(() => validateContentsModel(model)).to.throwError();
+      expect(() => validateContentsModel(model)).to.throw();
     });
 
     it('should fail on incorrect data', () => {
       let model = JSON.parse(JSON.stringify(DEFAULT_FILE));
       model.type = 1;
-      expect(() => validateContentsModel(model)).to.throwError();
+      expect(() => validateContentsModel(model)).to.throw();
     });
   });
 
@@ -36,12 +36,12 @@ describe('validate', () => {
 
     it('should fail on missing data', () => {
       let model = { id: 'foo' };
-      expect(() => validateCheckpointModel(model as any)).to.throwError();
+      expect(() => validateCheckpointModel(model as any)).to.throw();
     });
 
     it('should fail on incorrect data', () => {
       let model = { id: 1, last_modified: '1' };
-      expect(() => validateCheckpointModel(model as any)).to.throwError();
+      expect(() => validateCheckpointModel(model as any)).to.throw();
     });
   });
 });

--- a/packages/services/test/src/contents/validate.spec.ts
+++ b/packages/services/test/src/contents/validate.spec.ts
@@ -17,13 +17,13 @@ describe('validate', () => {
     });
 
     it('should fail on missing data', () => {
-      let model = JSON.parse(JSON.stringify(DEFAULT_FILE));
+      const model = JSON.parse(JSON.stringify(DEFAULT_FILE));
       delete model['path'];
       expect(() => validateContentsModel(model)).to.throw();
     });
 
     it('should fail on incorrect data', () => {
-      let model = JSON.parse(JSON.stringify(DEFAULT_FILE));
+      const model = JSON.parse(JSON.stringify(DEFAULT_FILE));
       model.type = 1;
       expect(() => validateContentsModel(model)).to.throw();
     });
@@ -35,12 +35,12 @@ describe('validate', () => {
     });
 
     it('should fail on missing data', () => {
-      let model = { id: 'foo' };
+      const model = { id: 'foo' };
       expect(() => validateCheckpointModel(model as any)).to.throw();
     });
 
     it('should fail on incorrect data', () => {
-      let model = { id: 1, last_modified: '1' };
+      const model = { id: 1, last_modified: '1' };
       expect(() => validateCheckpointModel(model as any)).to.throw();
     });
   });

--- a/packages/services/test/src/kernel/comm.spec.ts
+++ b/packages/services/test/src/kernel/comm.spec.ts
@@ -199,15 +199,15 @@ describe('jupyter.services - Comm', () => {
       });
 
       it('should be called when the server side closes', async () => {
-        let called = false;
+        let promise = new PromiseDelegate<void>();
         kernel.registerCommTarget('test', (comm, msg) => {
           comm.onClose = data => {
-            called = true;
+            promise.resolve(void 0);
           };
           comm.send('quit');
         });
         await kernel.requestExecute({ code: SEND }, true).done;
-        expect(called).to.equal(true);
+        await promise.promise;
       });
     });
 

--- a/packages/services/test/src/kernel/comm.spec.ts
+++ b/packages/services/test/src/kernel/comm.spec.ts
@@ -46,10 +46,8 @@ get_ipython().kernel.comm_manager.register_target("test", target_func)
 describe('jupyter.services - Comm', () => {
   let kernel: Kernel.IKernel;
 
-  before(() => {
-    return Kernel.startNew({ name: 'ipython' }).then(k => {
-      kernel = k;
-    });
+  before(async () => {
+    kernel = await Kernel.startNew({ name: 'ipython' });
   });
 
   afterEach(() => {
@@ -133,18 +131,13 @@ describe('jupyter.services - Comm', () => {
         comm.dispose();
       });
 
-      it('should allow an optional target', () => {
-        return kernel
-          .requestExecute({ code: SEND }, true)
-          .done.then(() => {
-            return kernel.requestCommInfo({ target: 'test' });
-          })
-          .then(msg => {
-            const comms = msg.content.comms;
-            for (const id in comms) {
-              expect(comms[id].target_name).to.equal('test');
-            }
-          });
+      it('should allow an optional target', async () => {
+        await kernel.requestExecute({ code: SEND }, true).done;
+        const msg = await kernel.requestCommInfo({ target: 'test' });
+        const comms = msg.content.comms;
+        for (const id in comms) {
+          expect(comms[id].target_name).to.equal('test');
+        }
       });
     });
 

--- a/packages/services/test/src/kernel/comm.spec.ts
+++ b/packages/services/test/src/kernel/comm.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { PromiseDelegate } from '@phosphor/coreutils';
 
@@ -67,20 +67,20 @@ describe('jupyter.services - Comm', () => {
     context('#connectToComm()', () => {
       it('should create an instance of IComm', () => {
         let comm = kernel.connectToComm('test');
-        expect(comm.targetName).to.be('test');
-        expect(typeof comm.commId).to.be('string');
+        expect(comm.targetName).to.equal('test');
+        expect(typeof comm.commId).to.equal('string');
       });
 
       it('should use the given id', () => {
         let comm = kernel.connectToComm('test', '1234');
-        expect(comm.targetName).to.be('test');
-        expect(comm.commId).to.be('1234');
+        expect(comm.targetName).to.equal('test');
+        expect(comm.commId).to.equal('1234');
       });
 
       it('should reuse an existing comm', () => {
         let comm = kernel.connectToComm('test', '1234');
         let comm2 = kernel.connectToComm('test', '1234');
-        expect(comm).to.be(comm2);
+        expect(comm).to.equal(comm2);
       });
     });
 
@@ -99,7 +99,7 @@ describe('jupyter.services - Comm', () => {
 
         // Get the comm.
         let [comm, msg] = await promise.promise;
-        expect(msg.content.data).to.be('hello');
+        expect(msg.content.data).to.equal('hello');
 
         // Clean up
         kernel.removeCommTarget('test', hook);
@@ -126,7 +126,7 @@ describe('jupyter.services - Comm', () => {
 
         // Test to make sure the comm we just created is listed.
         let comms = msg.content.comms;
-        expect(comms[comm.commId].target_name).to.be('test');
+        expect(comms[comm.commId].target_name).to.equal('test');
 
         // Clean up
         kernel.removeCommTarget('test', hook);
@@ -142,7 +142,7 @@ describe('jupyter.services - Comm', () => {
           .then(msg => {
             let comms = msg.content.comms;
             for (let id in comms) {
-              expect(comms[id].target_name).to.be('test');
+              expect(comms[id].target_name).to.equal('test');
             }
           });
       });
@@ -151,18 +151,18 @@ describe('jupyter.services - Comm', () => {
     context('#isDisposed', () => {
       it('should be true after we dispose of the comm', () => {
         let comm = kernel.connectToComm('test');
-        expect(comm.isDisposed).to.be(false);
+        expect(comm.isDisposed).to.equal(false);
         comm.dispose();
-        expect(comm.isDisposed).to.be(true);
+        expect(comm.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
         let comm = kernel.connectToComm('test');
-        expect(comm.isDisposed).to.be(false);
-        expect(comm.isDisposed).to.be(false);
+        expect(comm.isDisposed).to.equal(false);
+        expect(comm.isDisposed).to.equal(false);
         comm.dispose();
-        expect(comm.isDisposed).to.be(true);
-        expect(comm.isDisposed).to.be(true);
+        expect(comm.isDisposed).to.equal(true);
+        expect(comm.isDisposed).to.equal(true);
       });
     });
 
@@ -170,7 +170,7 @@ describe('jupyter.services - Comm', () => {
       it('should dispose of the resources held by the comm', () => {
         let comm = kernel.connectToComm('foo');
         comm.dispose();
-        expect(comm.isDisposed).to.be(true);
+        expect(comm.isDisposed).to.equal(true);
       });
     });
   });
@@ -184,19 +184,19 @@ describe('jupyter.services - Comm', () => {
 
     context('#id', () => {
       it('should be a string', () => {
-        expect(typeof comm.commId).to.be('string');
+        expect(typeof comm.commId).to.equal('string');
       });
     });
 
     context('#name', () => {
       it('should be a string', () => {
-        expect(comm.targetName).to.be('test');
+        expect(comm.targetName).to.equal('test');
       });
     });
 
     context('#onClose', () => {
       it('should be readable and writable function', done => {
-        expect(comm.onClose).to.be(undefined);
+        expect(comm.onClose).to.be.undefined;
         comm.onClose = msg => {
           done();
         };
@@ -219,7 +219,7 @@ describe('jupyter.services - Comm', () => {
         comm.onMsg = msg => {
           done();
         };
-        expect(typeof comm.onMsg).to.be('function');
+        expect(typeof comm.onMsg).to.equal('function');
         let options: KernelMessage.IOptions = {
           msgType: 'comm_msg',
           channel: 'iopub',
@@ -233,7 +233,7 @@ describe('jupyter.services - Comm', () => {
       it('should be called when the server side sends a message', done => {
         kernel.registerCommTarget('test', (comm, msg) => {
           comm.onMsg = msg => {
-            expect(msg.content.data).to.be('hello');
+            expect(msg.content.data).to.equal('hello');
             done();
           };
         });
@@ -287,7 +287,7 @@ describe('jupyter.services - Comm', () => {
           .open()
           .done.then(() => {
             comm.onClose = (msg: KernelMessage.ICommCloseMsg) => {
-              expect(msg.content.data).to.eql({ foo: 'bar' });
+              expect(msg.content.data).to.deep.equal({ foo: 'bar' });
               done();
             };
             let future = comm.close({ foo: 'bar' });
@@ -305,7 +305,7 @@ describe('jupyter.services - Comm', () => {
           .then(() => {
             expect(() => {
               comm.send('test');
-            }).to.throwError();
+            }).to.throw();
           });
       });
     });

--- a/packages/services/test/src/kernel/ifuture.spec.ts
+++ b/packages/services/test/src/kernel/ifuture.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Kernel, KernelMessage } from '../../../lib/kernel';
 
@@ -23,7 +23,7 @@ describe('Kernel.IFuture', () => {
   it('should have a msg attribute', async () => {
     const kernel = await Kernel.startNew();
     const future = kernel.requestExecute({ code: 'print("hello")' });
-    expect(typeof future.msg.header.msg_id).to.be('string');
+    expect(typeof future.msg.header.msg_id).to.equal('string');
     await future.done;
   });
 
@@ -71,11 +71,13 @@ describe('Kernel.IFuture', () => {
           calls.push('first');
           // Check to make sure we actually got the messages we expected.
           if (msg.header.msg_type === 'stream') {
-            expect((msg as KernelMessage.IStreamMsg).content.text).to.be('foo');
+            expect((msg as KernelMessage.IStreamMsg).content.text).to.equal(
+              'foo'
+            );
           } else {
             expect(
               (msg as KernelMessage.IStatusMsg).content.execution_state
-            ).to.be('idle');
+            ).to.equal('idle');
           }
           // not returning should also continue handling
           return void 0;
@@ -91,7 +93,7 @@ describe('Kernel.IFuture', () => {
       await future.done;
 
       // the last hook was called for the stream and the status message.
-      expect(calls).to.eql([
+      expect(calls).to.deep.equal([
         'first',
         'last',
         'iopub',
@@ -159,7 +161,7 @@ describe('Kernel.IFuture', () => {
         })
         .then(() => {
           // the last hook was called for the stream and the status message.
-          expect(calls).to.eql(['first', 'first']);
+          expect(calls).to.deep.equal(['first', 'first']);
         });
     });
 
@@ -217,7 +219,13 @@ describe('Kernel.IFuture', () => {
           return future.done;
         })
         .then(() => {
-          expect(calls).to.eql(['last', 'iopub', 'first', 'last', 'iopub']);
+          expect(calls).to.deep.equal([
+            'last',
+            'iopub',
+            'first',
+            'last',
+            'iopub'
+          ]);
         });
     });
 
@@ -282,7 +290,13 @@ describe('Kernel.IFuture', () => {
           return future.done;
         })
         .then(() => {
-          expect(calls).to.eql(['first', 'delete', 'iopub', 'first', 'iopub']);
+          expect(calls).to.deep.equal([
+            'first',
+            'delete',
+            'iopub',
+            'first',
+            'iopub'
+          ]);
           future.dispose();
           future.removeMessageHook(first);
         });

--- a/packages/services/test/src/kernel/ifuture.spec.ts
+++ b/packages/services/test/src/kernel/ifuture.spec.ts
@@ -8,7 +8,7 @@ import { Kernel, KernelMessage } from '../../../lib/kernel';
 import { KernelTester, createMsg } from '../utils';
 
 describe('Kernel.IFuture', () => {
-  let tester: KernelTester;
+  const tester: KernelTester;
 
   afterEach(() => {
     if (tester) {
@@ -29,7 +29,7 @@ describe('Kernel.IFuture', () => {
 
   describe('Message hooks', () => {
     it('should have the most recently registered hook run first', async () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -37,25 +37,25 @@ describe('Kernel.IFuture', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let calls: string[] = [];
+      const calls: string[] = [];
       tester = new KernelTester();
-      let future: Kernel.IFuture;
-      let kernel: Kernel.IKernel;
+      const future: Kernel.IFuture;
+      const kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
         // send a reply
-        let parentHeader = message.header;
-        let msg = createMsg('shell', parentHeader);
+        const parentHeader = message.header;
+        const msg = createMsg('shell', parentHeader);
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          let msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader);
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          let msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader);
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -104,7 +104,7 @@ describe('Kernel.IFuture', () => {
     });
 
     it('should abort processing if a hook returns false, but the done logic should still work', () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -112,25 +112,25 @@ describe('Kernel.IFuture', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let calls: string[] = [];
+      const calls: string[] = [];
       tester = new KernelTester();
-      let future: Kernel.IFuture;
-      let kernel: Kernel.IKernel;
+      const future: Kernel.IFuture;
+      const kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
         // send a reply
-        let parentHeader = message.header;
-        let msg = createMsg('shell', parentHeader);
+        const parentHeader = message.header;
+        const msg = createMsg('shell', parentHeader);
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          let msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader);
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          let msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader);
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -166,7 +166,7 @@ describe('Kernel.IFuture', () => {
     });
 
     it('should process additions on the next run', () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -174,24 +174,24 @@ describe('Kernel.IFuture', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let calls: string[] = [];
+      const calls: string[] = [];
       tester = new KernelTester();
-      let future: Kernel.IFuture;
+      const future: Kernel.IFuture;
 
       tester.onMessage(message => {
         // send a reply
-        let parentHeader = message.header;
-        let msg = createMsg('shell', parentHeader);
+        const parentHeader = message.header;
+        const msg = createMsg('shell', parentHeader);
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          let msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader);
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          let msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader);
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -230,7 +230,7 @@ describe('Kernel.IFuture', () => {
     });
 
     it('should deactivate message hooks immediately on removal', () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -238,15 +238,15 @@ describe('Kernel.IFuture', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let calls: string[] = [];
+      const calls: string[] = [];
       tester = new KernelTester();
-      let future: Kernel.IFuture;
+      const future: Kernel.IFuture;
 
-      let toDelete = (msg: KernelMessage.IIOPubMessage) => {
+      const toDelete = (msg: KernelMessage.IIOPubMessage) => {
         calls.push('delete');
         return true;
       };
-      let first = (msg: KernelMessage.IIOPubMessage) => {
+      const first = (msg: KernelMessage.IIOPubMessage) => {
         if (calls.length > 0) {
           // delete the hook the second time around
           future.removeMessageHook(toDelete);
@@ -257,18 +257,18 @@ describe('Kernel.IFuture', () => {
 
       tester.onMessage(message => {
         // send a reply
-        let parentHeader = message.header;
-        let msg = createMsg('shell', parentHeader);
+        const parentHeader = message.header;
+        const msg = createMsg('shell', parentHeader);
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          let msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader);
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          let msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader);
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';

--- a/packages/services/test/src/kernel/ikernel.spec.ts
+++ b/packages/services/test/src/kernel/ikernel.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { PageConfig } from '@jupyterlab/coreutils';
 
@@ -49,12 +49,12 @@ describe('Kernel.IKernel', () => {
     it('should be emitted when the kernel is shut down', async () => {
       let called = false;
       defaultKernel.terminated.connect((sender, args) => {
-        expect(sender).to.be(defaultKernel);
-        expect(args).to.be(void 0);
+        expect(sender).to.equal(defaultKernel);
+        expect(args).to.be.undefined;
         called = true;
       });
       await defaultKernel.shutdown();
-      expect(called).to.be(true);
+      expect(called).to.equal(true);
     });
   });
 
@@ -67,7 +67,7 @@ describe('Kernel.IKernel', () => {
         }
       });
       await defaultKernel.requestExecute({ code: 'a=1' }, true).done;
-      expect(called).to.be(true);
+      expect(called).to.equal(true);
     });
   });
 
@@ -78,7 +78,7 @@ describe('Kernel.IKernel', () => {
         called = true;
       });
       await defaultKernel.requestExecute({ code: 'a=1' }, true).done;
-      expect(called).to.be(true);
+      expect(called).to.equal(true);
     });
 
     it('should be emitted regardless of the sender', async () => {
@@ -137,7 +137,7 @@ describe('Kernel.IKernel', () => {
       const msgId = UUID.uuid4();
       const emission = testEmission(kernel.unhandledMessage, {
         test: (k, msg) => {
-          expect(msg.header.msg_id).to.be(msgId);
+          expect(msg.header.msg_id).to.equal(msgId);
         }
       });
 
@@ -166,10 +166,10 @@ describe('Kernel.IKernel', () => {
       const msgId = 'message from right session';
       const emission = testEmission(kernel.unhandledMessage, {
         test: (k, msg) => {
-          expect((msg.parent_header as KernelMessage.IHeader).session).to.be(
+          expect((msg.parent_header as KernelMessage.IHeader).session).to.equal(
             kernel.clientId
           );
-          expect(msg.header.msg_id).to.be(msgId);
+          expect(msg.header.msg_id).to.equal(msgId);
         }
       });
 
@@ -213,9 +213,9 @@ describe('Kernel.IKernel', () => {
 
       const emission = testEmission(kernel.anyMessage, {
         test: (k, args) => {
-          expect(args.msg.header.msg_id).to.be(msgId);
-          expect(args.msg.header.msg_type).to.be('foo');
-          expect(args.direction).to.be('recv');
+          expect(args.msg.header.msg_id).to.equal(msgId);
+          expect(args.msg.header.msg_type).to.equal('foo');
+          expect(args.direction).to.equal('recv');
         }
       });
 
@@ -236,8 +236,8 @@ describe('Kernel.IKernel', () => {
 
       const emission = testEmission(kernel.anyMessage, {
         test: (k, args) => {
-          expect((args.msg.header as any).msg_id).to.be(msgId);
-          expect(args.direction).to.be('recv');
+          expect((args.msg.header as any).msg_id).to.equal(msgId);
+          expect(args.direction).to.equal('recv');
         }
       });
       tester.sendStatus(msgId, 'idle');
@@ -248,8 +248,8 @@ describe('Kernel.IKernel', () => {
       const kernel = await tester.start();
       const emission = testEmission(kernel.anyMessage, {
         test: (k, args) => {
-          expect(args.msg.content.value).to.be('foo');
-          expect(args.direction).to.be('send');
+          expect(args.msg.content.value).to.equal('foo');
+          expect(args.direction).to.equal('send');
         }
       });
       kernel.sendInputReply({ value: 'foo' });
@@ -259,33 +259,33 @@ describe('Kernel.IKernel', () => {
 
   context('#id', () => {
     it('should be a string', () => {
-      expect(typeof defaultKernel.id).to.be('string');
+      expect(typeof defaultKernel.id).to.equal('string');
     });
   });
 
   context('#name', () => {
     it('should be a string', () => {
-      expect(typeof defaultKernel.name).to.be('string');
+      expect(typeof defaultKernel.name).to.equal('string');
     });
   });
 
   context('#model', () => {
     it('should be an IModel', () => {
       let model = defaultKernel.model;
-      expect(typeof model.name).to.be('string');
-      expect(typeof model.id).to.be('string');
+      expect(typeof model.name).to.equal('string');
+      expect(typeof model.id).to.equal('string');
     });
   });
 
   context('#username', () => {
     it('should be a string', () => {
-      expect(typeof defaultKernel.username).to.be('string');
+      expect(typeof defaultKernel.username).to.equal('string');
     });
   });
 
   context('#serverSettings', () => {
     it('should be the server settings', () => {
-      expect(defaultKernel.serverSettings.baseUrl).to.be(
+      expect(defaultKernel.serverSettings.baseUrl).to.equal(
         PageConfig.getBaseUrl()
       );
     });
@@ -293,7 +293,7 @@ describe('Kernel.IKernel', () => {
 
   context('#clientId', () => {
     it('should be a string', () => {
-      expect(typeof defaultKernel.clientId).to.be('string');
+      expect(typeof defaultKernel.clientId).to.equal('string');
     });
   });
 
@@ -355,8 +355,8 @@ describe('Kernel.IKernel', () => {
       await kernel.ready;
       const emission = testEmission(kernel.statusChanged, {
         test: (k, status) => {
-          expect(status).to.be('busy');
-          expect(kernel.status).to.be('busy');
+          expect(status).to.equal('busy');
+          expect(kernel.status).to.equal('busy');
         }
       });
 
@@ -375,23 +375,23 @@ describe('Kernel.IKernel', () => {
     it('should get the kernel info', () => {
       let name = defaultKernel.info.language_info.name;
       let defaultSpecs = specs.kernelspecs[specs.default];
-      expect(name).to.be(defaultSpecs.language);
+      expect(name).to.equal(defaultSpecs.language);
     });
   });
 
   context('#getSpec()', () => {
     it('should resolve with the spec', async () => {
       let spec = await defaultKernel.getSpec();
-      expect(spec.name).to.be(specs.default);
+      expect(spec.name).to.equal(specs.default);
     });
   });
 
   context('#isReady', () => {
     it('should test whether the kernel is ready', async () => {
       let kernel = await Kernel.startNew();
-      expect(kernel.isReady).to.be(false);
+      expect(kernel.isReady).to.equal(false);
       await kernel.ready;
-      expect(kernel.isReady).to.be(true);
+      expect(kernel.isReady).to.equal(true);
       await kernel.shutdown();
     });
   });
@@ -405,18 +405,18 @@ describe('Kernel.IKernel', () => {
   context('#isDisposed', () => {
     it('should be true after we dispose of the kernel', () => {
       let kernel = Kernel.connectTo(defaultKernel.model);
-      expect(kernel.isDisposed).to.be(false);
+      expect(kernel.isDisposed).to.equal(false);
       kernel.dispose();
-      expect(kernel.isDisposed).to.be(true);
+      expect(kernel.isDisposed).to.equal(true);
     });
 
     it('should be safe to call multiple times', () => {
       let kernel = Kernel.connectTo(defaultKernel.model);
-      expect(kernel.isDisposed).to.be(false);
-      expect(kernel.isDisposed).to.be(false);
+      expect(kernel.isDisposed).to.equal(false);
+      expect(kernel.isDisposed).to.equal(false);
       kernel.dispose();
-      expect(kernel.isDisposed).to.be(true);
-      expect(kernel.isDisposed).to.be(true);
+      expect(kernel.isDisposed).to.equal(true);
+      expect(kernel.isDisposed).to.equal(true);
     });
   });
 
@@ -424,21 +424,21 @@ describe('Kernel.IKernel', () => {
     it('should dispose of the resources held by the kernel', () => {
       let kernel = Kernel.connectTo(defaultKernel.model);
       let future = kernel.requestExecute({ code: 'foo' });
-      expect(future.isDisposed).to.be(false);
+      expect(future.isDisposed).to.equal(false);
       kernel.dispose();
-      expect(future.isDisposed).to.be(true);
+      expect(future.isDisposed).to.equal(true);
     });
 
     it('should be safe to call twice', () => {
       const kernel = Kernel.connectTo(defaultKernel.model);
       let future = kernel.requestExecute({ code: 'foo' });
-      expect(future.isDisposed).to.be(false);
+      expect(future.isDisposed).to.equal(false);
       kernel.dispose();
-      expect(future.isDisposed).to.be(true);
-      expect(kernel.isDisposed).to.be(true);
+      expect(future.isDisposed).to.equal(true);
+      expect(kernel.isDisposed).to.equal(true);
       kernel.dispose();
-      expect(future.isDisposed).to.be(true);
-      expect(kernel.isDisposed).to.be(true);
+      expect(future.isDisposed).to.equal(true);
+      expect(kernel.isDisposed).to.equal(true);
     });
   });
 
@@ -451,7 +451,7 @@ describe('Kernel.IKernel', () => {
 
       tester.onMessage(msg => {
         try {
-          expect(msg.header.msg_id).to.be(msgId);
+          expect(msg.header.msg_id).to.equal(msgId);
         } catch (e) {
           done.reject(e);
           throw e;
@@ -483,7 +483,7 @@ describe('Kernel.IKernel', () => {
         try {
           let decoder = new TextDecoder('utf8');
           let item = msg.buffers[0] as DataView;
-          expect(decoder.decode(item)).to.be('hello');
+          expect(decoder.decode(item)).to.equal('hello');
         } catch (e) {
           done.reject(e);
           throw e;
@@ -530,7 +530,7 @@ describe('Kernel.IKernel', () => {
       let msg = KernelMessage.createShellMessage(options);
       expect(() => {
         kernel.sendShellMessage(msg, true);
-      }).to.throwException(/Kernel is dead/);
+      }).to.throw(/Kernel is dead/);
       await tester.shutdown();
       tester.dispose();
     });
@@ -657,8 +657,8 @@ describe('Kernel.IKernel', () => {
       let future = kernel.requestExecute({ code: 'foo' });
       kernel.restart();
       await kernel.ready;
-      expect(future.isDisposed).to.be(true);
-      expect(comm.isDisposed).to.be(true);
+      expect(future.isDisposed).to.equal(true);
+      expect(comm.isDisposed).to.equal(true);
     });
   });
 
@@ -731,8 +731,8 @@ describe('Kernel.IKernel', () => {
       await kernel0.ready;
       await kernel1.ready;
       await kernel0.shutdown();
-      expect(kernel0.isDisposed).to.be(true);
-      expect(kernel1.isDisposed).to.be(true);
+      expect(kernel0.isDisposed).to.equal(true);
+      expect(kernel1.isDisposed).to.equal(true);
     });
   });
 
@@ -740,7 +740,7 @@ describe('Kernel.IKernel', () => {
     it('should resolve the promise', async () => {
       const msg = await defaultKernel.requestKernelInfo();
       let name = msg.content.language_info.name;
-      expect(name).to.be.ok();
+      expect(name).to.be.ok;
     });
   });
 
@@ -815,7 +815,7 @@ describe('Kernel.IKernel', () => {
       const kernel = await tester.start();
       const done = new PromiseDelegate<void>();
       tester.onMessage(msg => {
-        expect(msg.header.msg_type).to.be('input_reply');
+        expect(msg.header.msg_type).to.equal('input_reply');
         done.resolve(null);
       });
       kernel.sendInputReply({ value: 'test' });
@@ -836,7 +836,7 @@ describe('Kernel.IKernel', () => {
       await dead;
       expect(() => {
         kernel.sendInputReply({ value: 'test' });
-      }).to.throwException(/Kernel is dead/);
+      }).to.throw(/Kernel is dead/);
       tester.dispose();
     });
   });
@@ -864,7 +864,7 @@ describe('Kernel.IKernel', () => {
       const tester = new KernelTester();
 
       tester.onMessage(msg => {
-        expect(msg.channel).to.be('shell');
+        expect(msg.channel).to.equal('shell');
 
         // send a reply
         options.channel = 'shell';
@@ -906,7 +906,7 @@ describe('Kernel.IKernel', () => {
       const kernel = await tester.start();
       future = kernel.requestExecute(content);
       await future.done;
-      expect(future.isDisposed).to.be(true);
+      expect(future.isDisposed).to.equal(true);
       await tester.shutdown();
       tester.dispose();
     });
@@ -922,9 +922,9 @@ describe('Kernel.IKernel', () => {
       };
       let future = defaultKernel.requestExecute(options, false);
       await future.done;
-      expect(future.isDisposed).to.be(false);
+      expect(future.isDisposed).to.equal(false);
       future.dispose();
-      expect(future.isDisposed).to.be(true);
+      expect(future.isDisposed).to.equal(true);
     });
   });
 
@@ -985,7 +985,7 @@ describe('Kernel.IKernel', () => {
       future = kernel.requestExecute(options, false);
       await future.done;
       // the last hook was called for the stream and the status message.
-      expect(calls).to.eql([
+      expect(calls).to.deep.equal([
         'first',
         'last',
         'iopub',
@@ -1051,7 +1051,7 @@ describe('Kernel.IKernel', () => {
       future = kernel.requestExecute(options, false);
       await future.done;
       // the last hook was called for the stream and the status message.
-      expect(calls).to.eql(['first', 'first']);
+      expect(calls).to.deep.equal(['first', 'first']);
       await tester.shutdown();
       tester.dispose();
     });
@@ -1107,7 +1107,7 @@ describe('Kernel.IKernel', () => {
       kernel = await tester.start();
       future = kernel.requestExecute(options, false);
       await future.done;
-      expect(calls).to.eql(['last', 'iopub', 'first', 'last', 'iopub']);
+      expect(calls).to.deep.equal(['last', 'iopub', 'first', 'last', 'iopub']);
       await tester.shutdown();
       tester.dispose();
     });
@@ -1168,7 +1168,13 @@ describe('Kernel.IKernel', () => {
       kernel = await tester.start();
       future = kernel.requestExecute(options, false);
       await future.done;
-      expect(calls).to.eql(['first', 'delete', 'iopub', 'first', 'iopub']);
+      expect(calls).to.deep.equal([
+        'first',
+        'delete',
+        'iopub',
+        'first',
+        'iopub'
+      ]);
       await tester.shutdown();
       tester.dispose();
     });
@@ -1354,13 +1360,13 @@ describe('Kernel.IKernel', () => {
       // At this point, the synchronous anyMessage signal should have been
       // emitted for every message, but no actual message handling should have
       // happened.
-      expect(msgSignal).to.eql(msgSignalExpected);
-      expect(calls).to.eql([]);
+      expect(msgSignal).to.deep.equal(msgSignalExpected);
+      expect(calls).to.deep.equal([]);
 
       // Release the lock on message processing.
       handlingBlock.resolve(undefined);
       await future.done;
-      expect(calls).to.eql(callsExpected);
+      expect(calls).to.deep.equal(callsExpected);
 
       await tester.shutdown();
       tester.dispose();

--- a/packages/services/test/src/kernel/ikernel.spec.ts
+++ b/packages/services/test/src/kernel/ikernel.spec.ts
@@ -22,8 +22,8 @@ import {
 } from '../utils';
 
 describe('Kernel.IKernel', () => {
-  const defaultKernel: Kernel.IKernel;
-  const specs: Kernel.ISpecModels;
+  let defaultKernel: Kernel.IKernel;
+  let specs: Kernel.ISpecModels;
 
   before(async () => {
     specs = await Kernel.getSpecs();
@@ -103,7 +103,7 @@ describe('Kernel.IKernel', () => {
   });
 
   context('#unhandledMessage', () => {
-    const tester: KernelTester;
+    let tester: KernelTester;
     beforeEach(() => {
       tester = new KernelTester();
     });
@@ -198,7 +198,7 @@ describe('Kernel.IKernel', () => {
   });
 
   context('#anyMessage', () => {
-    const tester: KernelTester;
+    let tester: KernelTester;
     beforeEach(() => {
       tester = new KernelTester();
     });
@@ -550,7 +550,7 @@ describe('Kernel.IKernel', () => {
       const msg = KernelMessage.createShellMessage(options);
       const future = kernel.sendShellMessage(msg, true);
 
-      const newMsg: KernelMessage.IMessage;
+      let newMsg: KernelMessage.IMessage;
       tester.onMessage(msg => {
         // trigger onDone
         options.msgType = 'status';
@@ -589,13 +589,13 @@ describe('Kernel.IKernel', () => {
         name: defaultKernel.name
       });
       const interrupt = defaultKernel.interrupt();
-      await expectFailure(interrupt, null, 'Invalid response: 200 OK');
+      await expectFailure(interrupt, 'Invalid response: 200 OK');
     });
 
     it('should throw an error for an error response', async () => {
       handleRequest(defaultKernel, 500, {});
       const interrupt = defaultKernel.interrupt();
-      await expectFailure(interrupt, null, '');
+      await expectFailure(interrupt, '');
     });
 
     it('should fail if the kernel is dead', async () => {
@@ -608,7 +608,7 @@ describe('Kernel.IKernel', () => {
       });
       tester.sendStatus(UUID.uuid4(), 'dead');
       await dead;
-      await expectFailure(kernel.interrupt(), null, 'Kernel is dead');
+      await expectFailure(kernel.interrupt(), 'Kernel is dead');
       tester.dispose();
     });
   });
@@ -624,7 +624,7 @@ describe('Kernel.IKernel', () => {
     it('should fail if the kernel does not restart', async () => {
       handleRequest(defaultKernel, 500, {});
       const restart = defaultKernel.restart();
-      await expectFailure(restart, null, '');
+      await expectFailure(restart, '');
     });
 
     it('should throw an error for an invalid response', async () => {
@@ -632,7 +632,6 @@ describe('Kernel.IKernel', () => {
       handleRequest(kernel, 205, { id: kernel.id, name: kernel.name });
       await expectFailure(
         kernel.restart(),
-        null,
         'Invalid response: 205 Reset Content'
       );
     });
@@ -668,7 +667,7 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should emit `"reconnecting"`, then `"connected"` status', async () => {
-      const connectedEmission: Promise<void>;
+      let connectedEmission: Promise<void>;
       const emission = testEmission(defaultKernel.statusChanged, {
         find: () => defaultKernel.status === 'reconnecting',
         test: () => {
@@ -696,7 +695,7 @@ describe('Kernel.IKernel', () => {
         name: 'foo'
       });
       const shutdown = defaultKernel.shutdown();
-      await expectFailure(shutdown, null, 'Invalid response: 200 OK');
+      await expectFailure(shutdown, 'Invalid response: 200 OK');
     });
 
     it('should handle a 404 error', async () => {
@@ -708,7 +707,7 @@ describe('Kernel.IKernel', () => {
     it('should throw an error for an error response', async () => {
       handleRequest(defaultKernel, 500, {});
       const shutdown = defaultKernel.shutdown();
-      await expectFailure(shutdown, null, '');
+      await expectFailure(shutdown, '');
     });
 
     it('should fail if the kernel is dead', async () => {
@@ -721,7 +720,7 @@ describe('Kernel.IKernel', () => {
       });
       tester.sendStatus(UUID.uuid4(), 'dead');
       await dead;
-      await expectFailure(kernel.shutdown(), null, 'Kernel is dead');
+      await expectFailure(kernel.shutdown(), 'Kernel is dead');
       tester.dispose();
     });
 
@@ -767,7 +766,7 @@ describe('Kernel.IKernel', () => {
       });
       tester.sendStatus(UUID.uuid4(), 'dead');
       await dead;
-      expectFailure(kernel.requestComplete(options), null, 'Kernel is dead');
+      await expectFailure(kernel.requestComplete(options), 'Kernel is dead');
       tester.dispose();
     });
   });
@@ -843,7 +842,7 @@ describe('Kernel.IKernel', () => {
 
   context('#requestExecute()', () => {
     it('should send and handle incoming messages', async () => {
-      const newMsg: KernelMessage.IMessage;
+      let newMsg: KernelMessage.IMessage;
       const content: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
@@ -860,7 +859,7 @@ describe('Kernel.IKernel', () => {
         session: defaultKernel.clientId
       };
 
-      const future: Kernel.IFuture;
+      let future: Kernel.IFuture;
       const tester = new KernelTester();
 
       tester.onMessage(msg => {
@@ -939,9 +938,9 @@ describe('Kernel.IKernel', () => {
         stop_on_error: false
       };
       const calls: string[] = [];
-      const future: Kernel.IFuture;
+      let future: Kernel.IFuture;
 
-      const kernel: Kernel.IKernel;
+      let kernel: Kernel.IKernel;
 
       const tester = new KernelTester();
       tester.onMessage(message => {
@@ -1009,8 +1008,8 @@ describe('Kernel.IKernel', () => {
       const calls: string[] = [];
 
       const tester = new KernelTester();
-      const future: Kernel.IFuture;
-      const kernel: Kernel.IKernel;
+      let future: Kernel.IFuture;
+      let kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
         // send a reply
@@ -1067,8 +1066,8 @@ describe('Kernel.IKernel', () => {
       };
       const calls: string[] = [];
       const tester = new KernelTester();
-      const future: Kernel.IFuture;
-      const kernel: Kernel.IKernel;
+      let future: Kernel.IFuture;
+      let kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
         // send a reply
@@ -1123,8 +1122,8 @@ describe('Kernel.IKernel', () => {
       };
       const calls: string[] = [];
       const tester = new KernelTester();
-      const future: Kernel.IFuture;
-      const kernel: Kernel.IKernel;
+      let future: Kernel.IFuture;
+      let kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
         // send a reply

--- a/packages/services/test/src/kernel/ikernel.spec.ts
+++ b/packages/services/test/src/kernel/ikernel.spec.ts
@@ -22,8 +22,8 @@ import {
 } from '../utils';
 
 describe('Kernel.IKernel', () => {
-  let defaultKernel: Kernel.IKernel;
-  let specs: Kernel.ISpecModels;
+  const defaultKernel: Kernel.IKernel;
+  const specs: Kernel.ISpecModels;
 
   before(async () => {
     specs = await Kernel.getSpecs();
@@ -88,7 +88,7 @@ describe('Kernel.IKernel', () => {
       const emission = testEmission(kernel.iopubMessage, {
         find: (k, msg) => msg.header.msg_id === msgId
       });
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'status',
         channel: 'iopub',
         session: tester.serverSessionId,
@@ -103,7 +103,7 @@ describe('Kernel.IKernel', () => {
   });
 
   context('#unhandledMessage', () => {
-    let tester: KernelTester;
+    const tester: KernelTester;
     beforeEach(() => {
       tester = new KernelTester();
     });
@@ -118,7 +118,7 @@ describe('Kernel.IKernel', () => {
       const emission = testEmission(kernel.unhandledMessage, {
         find: (k, msg) => msg.header.msg_id === msgId
       });
-      let msg = KernelMessage.createShellMessage({
+      const msg = KernelMessage.createShellMessage({
         msgType: 'foo',
         channel: 'shell',
         session: tester.serverSessionId,
@@ -145,7 +145,7 @@ describe('Kernel.IKernel', () => {
       tester.sendStatus(UUID.uuid4(), 'idle');
 
       // Send a shell message.
-      let msg = KernelMessage.createShellMessage({
+      const msg = KernelMessage.createShellMessage({
         msgType: 'foo',
         channel: 'shell',
         session: tester.serverSessionId,
@@ -174,7 +174,7 @@ describe('Kernel.IKernel', () => {
       });
 
       // Send a shell message with the wrong client (parent) session.
-      let msg1 = KernelMessage.createShellMessage({
+      const msg1 = KernelMessage.createShellMessage({
         msgType: 'foo',
         channel: 'shell',
         session: tester.serverSessionId,
@@ -184,7 +184,7 @@ describe('Kernel.IKernel', () => {
       tester.send(msg1);
 
       // Send a shell message with the right client (parent) session.
-      let msg2 = KernelMessage.createShellMessage({
+      const msg2 = KernelMessage.createShellMessage({
         msgType: 'foo',
         channel: 'shell',
         session: tester.serverSessionId,
@@ -198,7 +198,7 @@ describe('Kernel.IKernel', () => {
   });
 
   context('#anyMessage', () => {
-    let tester: KernelTester;
+    const tester: KernelTester;
     beforeEach(() => {
       tester = new KernelTester();
     });
@@ -219,7 +219,7 @@ describe('Kernel.IKernel', () => {
         }
       });
 
-      let msg = KernelMessage.createShellMessage({
+      const msg = KernelMessage.createShellMessage({
         msgType: 'foo',
         channel: 'shell',
         session: tester.serverSessionId,
@@ -271,7 +271,7 @@ describe('Kernel.IKernel', () => {
 
   context('#model', () => {
     it('should be an IModel', () => {
-      let model = defaultKernel.model;
+      const model = defaultKernel.model;
       expect(typeof model.name).to.equal('string');
       expect(typeof model.id).to.equal('string');
     });
@@ -373,22 +373,22 @@ describe('Kernel.IKernel', () => {
 
   context('#info', () => {
     it('should get the kernel info', () => {
-      let name = defaultKernel.info.language_info.name;
-      let defaultSpecs = specs.kernelspecs[specs.default];
+      const name = defaultKernel.info.language_info.name;
+      const defaultSpecs = specs.kernelspecs[specs.default];
       expect(name).to.equal(defaultSpecs.language);
     });
   });
 
   context('#getSpec()', () => {
     it('should resolve with the spec', async () => {
-      let spec = await defaultKernel.getSpec();
+      const spec = await defaultKernel.getSpec();
       expect(spec.name).to.equal(specs.default);
     });
   });
 
   context('#isReady', () => {
     it('should test whether the kernel is ready', async () => {
-      let kernel = await Kernel.startNew();
+      const kernel = await Kernel.startNew();
       expect(kernel.isReady).to.equal(false);
       await kernel.ready;
       expect(kernel.isReady).to.equal(true);
@@ -404,14 +404,14 @@ describe('Kernel.IKernel', () => {
 
   context('#isDisposed', () => {
     it('should be true after we dispose of the kernel', () => {
-      let kernel = Kernel.connectTo(defaultKernel.model);
+      const kernel = Kernel.connectTo(defaultKernel.model);
       expect(kernel.isDisposed).to.equal(false);
       kernel.dispose();
       expect(kernel.isDisposed).to.equal(true);
     });
 
     it('should be safe to call multiple times', () => {
-      let kernel = Kernel.connectTo(defaultKernel.model);
+      const kernel = Kernel.connectTo(defaultKernel.model);
       expect(kernel.isDisposed).to.equal(false);
       expect(kernel.isDisposed).to.equal(false);
       kernel.dispose();
@@ -422,8 +422,8 @@ describe('Kernel.IKernel', () => {
 
   context('#dispose()', () => {
     it('should dispose of the resources held by the kernel', () => {
-      let kernel = Kernel.connectTo(defaultKernel.model);
-      let future = kernel.requestExecute({ code: 'foo' });
+      const kernel = Kernel.connectTo(defaultKernel.model);
+      const future = kernel.requestExecute({ code: 'foo' });
       expect(future.isDisposed).to.equal(false);
       kernel.dispose();
       expect(future.isDisposed).to.equal(true);
@@ -431,7 +431,7 @@ describe('Kernel.IKernel', () => {
 
     it('should be safe to call twice', () => {
       const kernel = Kernel.connectTo(defaultKernel.model);
-      let future = kernel.requestExecute({ code: 'foo' });
+      const future = kernel.requestExecute({ code: 'foo' });
       expect(future.isDisposed).to.equal(false);
       kernel.dispose();
       expect(future.isDisposed).to.equal(true);
@@ -445,9 +445,9 @@ describe('Kernel.IKernel', () => {
   context('#sendShellMessage()', () => {
     it('should send a message to the kernel', async () => {
       const tester = new KernelTester();
-      let kernel = await tester.start();
-      let done = new PromiseDelegate<void>();
-      let msgId = UUID.uuid4();
+      const kernel = await tester.start();
+      const done = new PromiseDelegate<void>();
+      const msgId = UUID.uuid4();
 
       tester.onMessage(msg => {
         try {
@@ -459,14 +459,14 @@ describe('Kernel.IKernel', () => {
         done.resolve(null);
       });
 
-      let options: KernelMessage.IOptions = {
+      const options: KernelMessage.IOptions = {
         msgType: 'custom',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId,
         msgId
       };
-      let msg = KernelMessage.createShellMessage(options);
+      const msg = KernelMessage.createShellMessage(options);
       kernel.sendShellMessage(msg, true);
       await done;
       await tester.shutdown();
@@ -475,14 +475,14 @@ describe('Kernel.IKernel', () => {
 
     it('should send a binary message', async () => {
       const tester = new KernelTester();
-      let kernel = await tester.start();
-      let done = new PromiseDelegate<void>();
-      let msgId = UUID.uuid4();
+      const kernel = await tester.start();
+      const done = new PromiseDelegate<void>();
+      const msgId = UUID.uuid4();
 
       tester.onMessage(msg => {
         try {
-          let decoder = new TextDecoder('utf8');
-          let item = msg.buffers[0] as DataView;
+          const decoder = new TextDecoder('utf8');
+          const item = msg.buffers[0] as DataView;
           expect(decoder.decode(item)).to.equal('hello');
         } catch (e) {
           done.reject(e);
@@ -491,16 +491,16 @@ describe('Kernel.IKernel', () => {
         done.resolve(null);
       });
 
-      let options: KernelMessage.IOptions = {
+      const options: KernelMessage.IOptions = {
         msgType: 'custom',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId,
         msgId
       };
-      let encoder = new TextEncoder();
-      let data = encoder.encode('hello');
-      let msg = KernelMessage.createShellMessage(options, {}, {}, [
+      const encoder = new TextEncoder();
+      const data = encoder.encode('hello');
+      const msg = KernelMessage.createShellMessage(options, {}, {}, [
         data,
         data.buffer
       ]);
@@ -512,7 +512,7 @@ describe('Kernel.IKernel', () => {
 
     it('should fail if the kernel is dead', async () => {
       const tester = new KernelTester();
-      let kernel = await tester.start();
+      const kernel = await tester.start();
 
       // Create a promise that resolves when the kernel's status changes to dead
       const dead = testEmission(kernel.statusChanged, {
@@ -521,13 +521,13 @@ describe('Kernel.IKernel', () => {
       tester.sendStatus(UUID.uuid4(), 'dead');
       await dead;
 
-      let options: KernelMessage.IOptions = {
+      const options: KernelMessage.IOptions = {
         msgType: 'custom',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId
       };
-      let msg = KernelMessage.createShellMessage(options);
+      const msg = KernelMessage.createShellMessage(options);
       expect(() => {
         kernel.sendShellMessage(msg, true);
       }).to.throw(/Kernel is dead/);
@@ -539,18 +539,18 @@ describe('Kernel.IKernel', () => {
       // This test that a future.done promise resolves when a status idle and
       // reply come through, even if the status comes first.
       const tester = new KernelTester();
-      let kernel = await tester.start();
+      const kernel = await tester.start();
 
-      let options: KernelMessage.IOptions = {
+      const options: KernelMessage.IOptions = {
         msgType: 'custom',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId
       };
-      let msg = KernelMessage.createShellMessage(options);
-      let future = kernel.sendShellMessage(msg, true);
+      const msg = KernelMessage.createShellMessage(options);
+      const future = kernel.sendShellMessage(msg, true);
 
-      let newMsg: KernelMessage.IMessage;
+      const newMsg: KernelMessage.IMessage;
       tester.onMessage(msg => {
         // trigger onDone
         options.msgType = 'status';
@@ -577,7 +577,7 @@ describe('Kernel.IKernel', () => {
 
   context('#interrupt()', () => {
     it('should interrupt and resolve with a valid server response', async () => {
-      let kernel = await Kernel.startNew();
+      const kernel = await Kernel.startNew();
       await kernel.ready;
       await kernel.interrupt();
       await kernel.shutdown();
@@ -588,13 +588,13 @@ describe('Kernel.IKernel', () => {
         id: defaultKernel.id,
         name: defaultKernel.name
       });
-      let interrupt = defaultKernel.interrupt();
+      const interrupt = defaultKernel.interrupt();
       await expectFailure(interrupt, null, 'Invalid response: 200 OK');
     });
 
     it('should throw an error for an error response', async () => {
       handleRequest(defaultKernel, 500, {});
-      let interrupt = defaultKernel.interrupt();
+      const interrupt = defaultKernel.interrupt();
       await expectFailure(interrupt, null, '');
     });
 
@@ -623,12 +623,12 @@ describe('Kernel.IKernel', () => {
 
     it('should fail if the kernel does not restart', async () => {
       handleRequest(defaultKernel, 500, {});
-      let restart = defaultKernel.restart();
+      const restart = defaultKernel.restart();
       await expectFailure(restart, null, '');
     });
 
     it('should throw an error for an invalid response', async () => {
-      let kernel = defaultKernel;
+      const kernel = defaultKernel;
       handleRequest(kernel, 205, { id: kernel.id, name: kernel.name });
       await expectFailure(
         kernel.restart(),
@@ -639,22 +639,22 @@ describe('Kernel.IKernel', () => {
 
     it('should throw an error for an error response', async () => {
       handleRequest(defaultKernel, 500, {});
-      let restart = defaultKernel.restart();
+      const restart = defaultKernel.restart();
       await expectFailure(restart);
     });
 
     it('should throw an error for an invalid id', async () => {
       handleRequest(defaultKernel, 200, {});
-      let restart = defaultKernel.restart();
+      const restart = defaultKernel.restart();
       await expectFailure(restart);
     });
 
     // TODO: seems to be sporadically timing out if we await the restart. See
     // https://github.com/jupyter/notebook/issues/3705.
     it('should dispose of existing comm and future objects', async () => {
-      let kernel = defaultKernel;
-      let comm = kernel.connectToComm('test');
-      let future = kernel.requestExecute({ code: 'foo' });
+      const kernel = defaultKernel;
+      const comm = kernel.connectToComm('test');
+      const future = kernel.requestExecute({ code: 'foo' });
       kernel.restart();
       await kernel.ready;
       expect(future.isDisposed).to.equal(true);
@@ -668,7 +668,7 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should emit `"reconnecting"`, then `"connected"` status', async () => {
-      let connectedEmission: Promise<void>;
+      const connectedEmission: Promise<void>;
       const emission = testEmission(defaultKernel.statusChanged, {
         find: () => defaultKernel.status === 'reconnecting',
         test: () => {
@@ -686,7 +686,7 @@ describe('Kernel.IKernel', () => {
 
   context('#shutdown()', () => {
     it('should shut down and resolve with a valid server response', async () => {
-      let kernel = await Kernel.startNew();
+      const kernel = await Kernel.startNew();
       await kernel.shutdown();
     });
 
@@ -695,19 +695,19 @@ describe('Kernel.IKernel', () => {
         id: UUID.uuid4(),
         name: 'foo'
       });
-      let shutdown = defaultKernel.shutdown();
+      const shutdown = defaultKernel.shutdown();
       await expectFailure(shutdown, null, 'Invalid response: 200 OK');
     });
 
     it('should handle a 404 error', async () => {
-      let kernel = await Kernel.startNew();
+      const kernel = await Kernel.startNew();
       handleRequest(kernel, 404, {});
       await kernel.shutdown();
     });
 
     it('should throw an error for an error response', async () => {
       handleRequest(defaultKernel, 500, {});
-      let shutdown = defaultKernel.shutdown();
+      const shutdown = defaultKernel.shutdown();
       await expectFailure(shutdown, null, '');
     });
 
@@ -726,8 +726,8 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should dispose of all kernel instances', async () => {
-      let kernel0 = await Kernel.startNew();
-      let kernel1 = Kernel.connectTo(kernel0.model);
+      const kernel0 = await Kernel.startNew();
+      const kernel1 = Kernel.connectTo(kernel0.model);
       await kernel0.ready;
       await kernel1.ready;
       await kernel0.shutdown();
@@ -739,14 +739,14 @@ describe('Kernel.IKernel', () => {
   context('#requestKernelInfo()', () => {
     it('should resolve the promise', async () => {
       const msg = await defaultKernel.requestKernelInfo();
-      let name = msg.content.language_info.name;
+      const name = msg.content.language_info.name;
       expect(name).to.be.ok;
     });
   });
 
   context('#requestComplete()', () => {
     it('should resolve the promise', async () => {
-      let options: KernelMessage.ICompleteRequest = {
+      const options: KernelMessage.ICompleteRequest = {
         code: 'hello',
         cursor_pos: 4
       };
@@ -754,7 +754,7 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should reject the promise if the kernel is dead', async () => {
-      let options: KernelMessage.ICompleteRequest = {
+      const options: KernelMessage.ICompleteRequest = {
         code: 'hello',
         cursor_pos: 4
       };
@@ -774,7 +774,7 @@ describe('Kernel.IKernel', () => {
 
   context('#requestInspect()', () => {
     it('should resolve the promise', async () => {
-      let options: KernelMessage.IInspectRequest = {
+      const options: KernelMessage.IInspectRequest = {
         code: 'hello',
         cursor_pos: 4,
         detail_level: 0
@@ -785,7 +785,7 @@ describe('Kernel.IKernel', () => {
 
   context('#requestIsComplete()', () => {
     it('should resolve the promise', async () => {
-      let options: KernelMessage.IIsCompleteRequest = {
+      const options: KernelMessage.IIsCompleteRequest = {
         code: 'hello'
       };
       await defaultKernel.requestIsComplete(options);
@@ -794,7 +794,7 @@ describe('Kernel.IKernel', () => {
 
   context('#requestHistory()', () => {
     it('should resolve the promise', async () => {
-      let options: KernelMessage.IHistoryRequest = {
+      const options: KernelMessage.IHistoryRequest = {
         output: true,
         raw: true,
         hist_access_type: 'search',
@@ -843,8 +843,8 @@ describe('Kernel.IKernel', () => {
 
   context('#requestExecute()', () => {
     it('should send and handle incoming messages', async () => {
-      let newMsg: KernelMessage.IMessage;
-      let content: KernelMessage.IExecuteRequest = {
+      const newMsg: KernelMessage.IMessage;
+      const content: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -853,14 +853,14 @@ describe('Kernel.IKernel', () => {
         stop_on_error: false
       };
 
-      let options: KernelMessage.IOptions = {
+      const options: KernelMessage.IOptions = {
         msgType: 'custom',
         channel: 'shell',
         username: defaultKernel.username,
         session: defaultKernel.clientId
       };
 
-      let future: Kernel.IFuture;
+      const future: Kernel.IFuture;
       const tester = new KernelTester();
 
       tester.onMessage(msg => {
@@ -884,7 +884,7 @@ describe('Kernel.IKernel', () => {
           // trigger onIOPub with a 'stream' message
           options.channel = 'iopub';
           options.msgType = 'stream';
-          let streamContent: JSONObject = { name: 'stdout', text: '' };
+          const streamContent: JSONObject = { name: 'stdout', text: '' };
           newMsg = KernelMessage.createMessage(options, streamContent);
           newMsg.parent_header = msg.header;
           tester.send(newMsg);
@@ -912,7 +912,7 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should not dispose of KernelFuture when disposeOnDone=false', async () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -920,7 +920,7 @@ describe('Kernel.IKernel', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let future = defaultKernel.requestExecute(options, false);
+      const future = defaultKernel.requestExecute(options, false);
       await future.done;
       expect(future.isDisposed).to.equal(false);
       future.dispose();
@@ -930,7 +930,7 @@ describe('Kernel.IKernel', () => {
 
   context('#registerMessageHook()', () => {
     it('should have the most recently registered hook run first', async () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -938,26 +938,26 @@ describe('Kernel.IKernel', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let calls: string[] = [];
-      let future: Kernel.IFuture;
+      const calls: string[] = [];
+      const future: Kernel.IFuture;
 
-      let kernel: Kernel.IKernel;
+      const kernel: Kernel.IKernel;
 
       const tester = new KernelTester();
       tester.onMessage(message => {
         // send a reply
-        let parentHeader = message.header;
-        let msg = createMsg('shell', parentHeader);
+        const parentHeader = message.header;
+        const msg = createMsg('shell', parentHeader);
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          let msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader);
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          let msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader);
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -998,7 +998,7 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should abort processing if a hook returns false, but the done logic should still work', async () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -1006,26 +1006,26 @@ describe('Kernel.IKernel', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let calls: string[] = [];
+      const calls: string[] = [];
 
       const tester = new KernelTester();
-      let future: Kernel.IFuture;
-      let kernel: Kernel.IKernel;
+      const future: Kernel.IFuture;
+      const kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
         // send a reply
-        let parentHeader = message.header;
-        let msg = createMsg('shell', parentHeader);
+        const parentHeader = message.header;
+        const msg = createMsg('shell', parentHeader);
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          let msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader);
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          let msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader);
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -1057,7 +1057,7 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should process additions on the next run', async () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -1065,25 +1065,25 @@ describe('Kernel.IKernel', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let calls: string[] = [];
+      const calls: string[] = [];
       const tester = new KernelTester();
-      let future: Kernel.IFuture;
-      let kernel: Kernel.IKernel;
+      const future: Kernel.IFuture;
+      const kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
         // send a reply
-        let parentHeader = message.header;
-        let msg = createMsg('shell', parentHeader);
+        const parentHeader = message.header;
+        const msg = createMsg('shell', parentHeader);
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          let msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader);
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          let msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader);
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -1113,7 +1113,7 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should deactivate a hook immediately on removal', async () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -1121,32 +1121,32 @@ describe('Kernel.IKernel', () => {
         allow_stdin: false,
         stop_on_error: false
       };
-      let calls: string[] = [];
+      const calls: string[] = [];
       const tester = new KernelTester();
-      let future: Kernel.IFuture;
-      let kernel: Kernel.IKernel;
+      const future: Kernel.IFuture;
+      const kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
         // send a reply
-        let parentHeader = message.header;
-        let msg = createMsg('shell', parentHeader);
+        const parentHeader = message.header;
+        const msg = createMsg('shell', parentHeader);
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          let msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader);
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          let msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader);
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
           tester.send(msgDone);
         };
 
-        let toDelete = (msg: KernelMessage.IIOPubMessage) => {
+        const toDelete = (msg: KernelMessage.IIOPubMessage) => {
           calls.push('delete');
           return true;
         };
@@ -1186,7 +1186,7 @@ describe('Kernel.IKernel', () => {
     // old session, the comm open should be canceled.
 
     it('should run handlers in order', async () => {
-      let options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -1241,8 +1241,8 @@ describe('Kernel.IKernel', () => {
         msgSignalExpected.push([msgId, 'shell']);
       }
 
-      let anyMessageDone = new PromiseDelegate();
-      let handlingBlock = new PromiseDelegate();
+      const anyMessageDone = new PromiseDelegate();
+      const handlingBlock = new PromiseDelegate();
 
       tester.onMessage(message => {
         tester.onMessage(() => {

--- a/packages/services/test/src/kernel/kernel.spec.ts
+++ b/packages/services/test/src/kernel/kernel.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -87,7 +87,7 @@ describe('kernel', () => {
   describe('Kernel.startNew()', () => {
     it('should create an Kernel.IKernel object', () => {
       return Kernel.startNew({}).then(kernel => {
-        expect(kernel.status).to.be('unknown');
+        expect(kernel.status).to.equal('unknown');
         return kernel.shutdown();
       });
     });
@@ -95,7 +95,7 @@ describe('kernel', () => {
     it('should accept ajax options', () => {
       let serverSettings = makeSettings();
       return Kernel.startNew({ serverSettings }).then(kernel => {
-        expect(kernel.status).to.be('unknown');
+        expect(kernel.status).to.equal('unknown');
         return kernel.shutdown();
       });
     });
@@ -167,7 +167,7 @@ describe('kernel', () => {
     it('should connect to an existing kernel', () => {
       let id = defaultKernel.id;
       const kernel = Kernel.connectTo(defaultKernel.model);
-      expect(kernel.id).to.be(id);
+      expect(kernel.id).to.equal(id);
       kernel.dispose();
     });
 
@@ -175,7 +175,7 @@ describe('kernel', () => {
       let id = defaultKernel.id;
       let serverSettings = makeSettings();
       const kernel = Kernel.connectTo(defaultKernel.model, serverSettings);
-      expect(kernel.id).to.be(id);
+      expect(kernel.id).to.equal(id);
       kernel.dispose();
     });
   });
@@ -195,14 +195,14 @@ describe('kernel', () => {
   describe('Kernel.getSpecs()', () => {
     it('should load the kernelspecs', () => {
       return Kernel.getSpecs().then(specs => {
-        expect(specs.default).to.be.ok();
+        expect(specs.default).to.be.ok;
       });
     });
 
     it('should accept ajax options', () => {
       let serverSettings = makeSettings();
       return Kernel.getSpecs(serverSettings).then(specs => {
-        expect(specs.default).to.be.ok();
+        expect(specs.default).to.be.ok;
       });
     });
 
@@ -211,7 +211,7 @@ describe('kernel', () => {
         kernelspecs: { python: PYTHON_SPEC }
       });
       return Kernel.getSpecs(serverSettings).then(specs => {
-        expect(specs.default).to.be.ok();
+        expect(specs.default).to.be.ok;
       });
     });
 
@@ -234,8 +234,8 @@ describe('kernel', () => {
         }
       });
       return Kernel.getSpecs(serverSettings).then(specs => {
-        expect(specs.default).to.be('python');
-        expect(specs.kernelspecs['R']).to.be(void 0);
+        expect(specs.default).to.equal('python');
+        expect(specs.kernelspecs['R']).to.be.undefined;
       });
     });
 

--- a/packages/services/test/src/kernel/kernel.spec.ts
+++ b/packages/services/test/src/kernel/kernel.spec.ts
@@ -18,14 +18,14 @@ import {
   testEmission
 } from '../utils';
 
-let PYTHON3_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
+const PYTHON3_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
 PYTHON3_SPEC.name = 'Python3';
 PYTHON3_SPEC.display_name = 'python3';
 
 describe('kernel', () => {
-  let defaultKernel: Kernel.IKernel;
-  let specs: Kernel.ISpecModels;
-  let tester: KernelTester;
+  const defaultKernel: Kernel.IKernel;
+  const specs: Kernel.ISpecModels;
+  const tester: KernelTester;
 
   before(() => {
     return Kernel.getSpecs()
@@ -58,28 +58,28 @@ describe('kernel', () => {
     });
 
     it('should accept server settings', () => {
-      let serverSettings = makeSettings();
+      const serverSettings = makeSettings();
       return Kernel.listRunning(serverSettings).then(response => {
         expect(toArray(response).length).to.be.greaterThan(0);
       });
     });
 
-    it('should throw an error for an invalid model', done => {
-      let data = { id: UUID.uuid4(), name: 'test' };
-      let settings = getRequestHandler(200, data);
-      let promise = Kernel.listRunning(settings);
+    it('should throw an error for an invalid model', async () => {
+      const data = { id: UUID.uuid4(), name: 'test' };
+      const settings = getRequestHandler(200, data);
+      const promise = Kernel.listRunning(settings);
       expectFailure(promise, done, 'Invalid kernel list');
     });
 
-    it('should throw an error for an invalid response', done => {
-      let settings = getRequestHandler(201, {});
-      let promise = Kernel.listRunning(settings);
+    it('should throw an error for an invalid response', async () => {
+      const settings = getRequestHandler(201, {});
+      const promise = Kernel.listRunning(settings);
       expectFailure(promise, done, 'Invalid response: 201 Created');
     });
 
-    it('should throw an error for an error response', done => {
-      let settings = getRequestHandler(500, {});
-      let promise = Kernel.listRunning(settings);
+    it('should throw an error for an error response', async () => {
+      const settings = getRequestHandler(500, {});
+      const promise = Kernel.listRunning(settings);
       expectFailure(promise, done, '');
     });
   });
@@ -93,7 +93,7 @@ describe('kernel', () => {
     });
 
     it('should accept ajax options', () => {
-      let serverSettings = makeSettings();
+      const serverSettings = makeSettings();
       return Kernel.startNew({ serverSettings }).then(kernel => {
         expect(kernel.status).to.equal('unknown');
         return kernel.shutdown();
@@ -106,7 +106,7 @@ describe('kernel', () => {
     // kernel typically doesn't immediately send its status, does it? I suppose
     // it should - if we are connecting to an existing kernel, it would be nice
     // to know right off if it's busy/dead/etc.
-    it.skip('should still start if the kernel dies', done => {
+    it.skip('should still start if the kernel dies', async () => {
       tester = new KernelTester();
       tester.initialStatus = 'dead';
       tester
@@ -122,31 +122,31 @@ describe('kernel', () => {
         .catch(done);
     });
 
-    it('should throw an error for an invalid kernel id', done => {
-      let serverSettings = getRequestHandler(201, { id: UUID.uuid4() });
-      let kernelPromise = Kernel.startNew({ serverSettings });
+    it('should throw an error for an invalid kernel id', async () => {
+      const serverSettings = getRequestHandler(201, { id: UUID.uuid4() });
+      const kernelPromise = Kernel.startNew({ serverSettings });
       expectFailure(kernelPromise, done);
     });
 
-    it('should throw an error for another invalid kernel id', done => {
-      let serverSettings = getRequestHandler(201, {
+    it('should throw an error for another invalid kernel id', async () => {
+      const serverSettings = getRequestHandler(201, {
         id: UUID.uuid4(),
         name: 1
       });
-      let kernelPromise = Kernel.startNew({ serverSettings });
+      const kernelPromise = Kernel.startNew({ serverSettings });
       expectFailure(kernelPromise, done);
     });
 
-    it('should throw an error for an invalid response', done => {
-      let data = { id: UUID.uuid4(), name: 'foo' };
-      let serverSettings = getRequestHandler(200, data);
-      let kernelPromise = Kernel.startNew({ serverSettings });
+    it('should throw an error for an invalid response', async () => {
+      const data = { id: UUID.uuid4(), name: 'foo' };
+      const serverSettings = getRequestHandler(200, data);
+      const kernelPromise = Kernel.startNew({ serverSettings });
       expectFailure(kernelPromise, done, 'Invalid response: 200 OK');
     });
 
-    it('should throw an error for an error response', done => {
-      let serverSettings = getRequestHandler(500, {});
-      let kernelPromise = Kernel.startNew({ serverSettings });
+    it('should throw an error for an error response', async () => {
+      const serverSettings = getRequestHandler(500, {});
+      const kernelPromise = Kernel.startNew({ serverSettings });
       expectFailure(kernelPromise, done, '');
     });
 
@@ -165,15 +165,15 @@ describe('kernel', () => {
 
   describe('Kernel.connectTo()', () => {
     it('should connect to an existing kernel', () => {
-      let id = defaultKernel.id;
+      const id = defaultKernel.id;
       const kernel = Kernel.connectTo(defaultKernel.model);
       expect(kernel.id).to.equal(id);
       kernel.dispose();
     });
 
     it('should accept server settings', () => {
-      let id = defaultKernel.id;
-      let serverSettings = makeSettings();
+      const id = defaultKernel.id;
+      const serverSettings = makeSettings();
       const kernel = Kernel.connectTo(defaultKernel.model, serverSettings);
       expect(kernel.id).to.equal(id);
       kernel.dispose();
@@ -200,14 +200,14 @@ describe('kernel', () => {
     });
 
     it('should accept ajax options', () => {
-      let serverSettings = makeSettings();
+      const serverSettings = makeSettings();
       return Kernel.getSpecs(serverSettings).then(specs => {
         expect(specs.default).to.be.ok;
       });
     });
 
     it('should handle a missing default parameter', () => {
-      let serverSettings = getRequestHandler(200, {
+      const serverSettings = getRequestHandler(200, {
         kernelspecs: { python: PYTHON_SPEC }
       });
       return Kernel.getSpecs(serverSettings).then(specs => {
@@ -215,18 +215,18 @@ describe('kernel', () => {
       });
     });
 
-    it('should throw for a missing kernelspecs parameter', done => {
-      let serverSettings = getRequestHandler(200, {
+    it('should throw for a missing kernelspecs parameter', async () => {
+      const serverSettings = getRequestHandler(200, {
         default: PYTHON_SPEC.name
       });
-      let promise = Kernel.getSpecs(serverSettings);
+      const promise = Kernel.getSpecs(serverSettings);
       expectFailure(promise, done, 'No kernelspecs found');
     });
 
     it('should omit an invalid kernelspec', () => {
-      let R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
+      const R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
       R_SPEC.name = 1;
-      let serverSettings = getRequestHandler(200, {
+      const serverSettings = getRequestHandler(200, {
         default: 'python',
         kernelspecs: {
           R: R_SPEC,
@@ -239,64 +239,64 @@ describe('kernel', () => {
       });
     });
 
-    it('should handle an improper name', done => {
-      let R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
+    it('should handle an improper name', async () => {
+      const R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
       R_SPEC.name = 1;
-      let serverSettings = getRequestHandler(200, {
+      const serverSettings = getRequestHandler(200, {
         default: 'R',
         kernelspecs: { R: R_SPEC }
       });
-      let promise = Kernel.getSpecs(serverSettings);
+      const promise = Kernel.getSpecs(serverSettings);
       expectFailure(promise, done, 'No valid kernelspecs found');
     });
 
-    it('should handle an improper language', done => {
-      let R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
+    it('should handle an improper language', async () => {
+      const R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
       R_SPEC.spec.language = 1;
-      let serverSettings = getRequestHandler(200, {
+      const serverSettings = getRequestHandler(200, {
         default: 'R',
         kernelspecs: { R: R_SPEC }
       });
-      let promise = Kernel.getSpecs(serverSettings);
+      const promise = Kernel.getSpecs(serverSettings);
       expectFailure(promise, done, 'No valid kernelspecs found');
     });
 
-    it('should handle an improper argv', done => {
-      let R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
+    it('should handle an improper argv', async () => {
+      const R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
       R_SPEC.spec.argv = 'hello';
-      let serverSettings = getRequestHandler(200, {
+      const serverSettings = getRequestHandler(200, {
         default: 'R',
         kernelspecs: { R: R_SPEC }
       });
-      let promise = Kernel.getSpecs(serverSettings);
+      const promise = Kernel.getSpecs(serverSettings);
       expectFailure(promise, done, 'No valid kernelspecs found');
     });
 
-    it('should handle an improper display_name', done => {
-      let R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
+    it('should handle an improper display_name', async () => {
+      const R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
       R_SPEC.spec.display_name = ['hello'];
-      let serverSettings = getRequestHandler(200, {
+      const serverSettings = getRequestHandler(200, {
         default: 'R',
         kernelspecs: { R: R_SPEC }
       });
-      let promise = Kernel.getSpecs(serverSettings);
+      const promise = Kernel.getSpecs(serverSettings);
       expectFailure(promise, done, 'No valid kernelspecs found');
     });
 
-    it('should handle missing resources', done => {
-      let R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
+    it('should handle missing resources', async () => {
+      const R_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
       delete R_SPEC.resources;
-      let serverSettings = getRequestHandler(200, {
+      const serverSettings = getRequestHandler(200, {
         default: 'R',
         kernelspecs: { R: R_SPEC }
       });
-      let promise = Kernel.getSpecs(serverSettings);
+      const promise = Kernel.getSpecs(serverSettings);
       expectFailure(promise, done, 'No valid kernelspecs found');
     });
 
-    it('should throw an error for an invalid response', done => {
-      let serverSettings = getRequestHandler(201, {});
-      let promise = Kernel.getSpecs(serverSettings);
+    it('should throw an error for an invalid response', async () => {
+      const serverSettings = getRequestHandler(201, {});
+      const promise = Kernel.getSpecs(serverSettings);
       expectFailure(promise, done, 'Invalid response: 201 Created');
     });
   });

--- a/packages/services/test/src/kernel/manager.spec.ts
+++ b/packages/services/test/src/kernel/manager.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { toArray } from '@phosphor/algorithm';
 
@@ -39,7 +39,7 @@ describe('kernel/manager', () => {
 
   beforeEach(() => {
     manager = new KernelManager();
-    expect(manager.specs).to.be(null);
+    expect(manager.specs).to.be.null;
     return manager.ready;
   });
 
@@ -56,7 +56,7 @@ describe('kernel/manager', () => {
       it('should take the options as an argument', () => {
         manager.dispose();
         manager = new KernelManager({ serverSettings: makeSettings() });
-        expect(manager instanceof KernelManager).to.be(true);
+        expect(manager instanceof KernelManager).to.equal(true);
       });
     });
 
@@ -66,14 +66,14 @@ describe('kernel/manager', () => {
         let serverSettings = makeSettings();
         let token = serverSettings.token;
         manager = new KernelManager({ serverSettings });
-        expect(manager.serverSettings.token).to.be(token);
+        expect(manager.serverSettings.token).to.equal(token);
       });
     });
 
     describe('#specs', () => {
       it('should get the kernel specs', () => {
         return manager.ready.then(() => {
-          expect(manager.specs.default).to.be.ok();
+          expect(manager.specs.default).to.be.ok;
         });
       });
     });
@@ -92,8 +92,8 @@ describe('kernel/manager', () => {
         specs.default = 'shell';
         handleRequest(manager, 200, specs);
         manager.specsChanged.connect((sender, args) => {
-          expect(sender).to.be(manager);
-          expect(args.default).to.be(specs.default);
+          expect(sender).to.equal(manager);
+          expect(args.default).to.equal(specs.default);
           done();
         });
         manager.refreshSpecs();
@@ -103,7 +103,7 @@ describe('kernel/manager', () => {
     describe('#runningChanged', () => {
       it('should be emitted in refreshRunning when the running kernels changed', done => {
         manager.runningChanged.connect((sender, args) => {
-          expect(sender).to.be(manager);
+          expect(sender).to.equal(manager);
           expect(toArray(args).length).to.be.greaterThan(0);
           done();
         });
@@ -132,9 +132,9 @@ describe('kernel/manager', () => {
       it('should test whether the manager is ready', () => {
         manager.dispose();
         manager = new KernelManager();
-        expect(manager.isReady).to.be(false);
+        expect(manager.isReady).to.equal(false);
         return manager.ready.then(() => {
-          expect(manager.isReady).to.be(true);
+          expect(manager.isReady).to.equal(true);
         });
       });
     });
@@ -151,7 +151,7 @@ describe('kernel/manager', () => {
         specs.default = 'shell';
         handleRequest(manager, 200, specs);
         return manager.refreshSpecs().then(() => {
-          expect(manager.specs.default).to.be(specs.default);
+          expect(manager.specs.default).to.equal(specs.default);
         });
       });
     });
@@ -181,7 +181,7 @@ describe('kernel/manager', () => {
       it('should find an existing kernel by id', () => {
         let id = kernel.id;
         return manager.findById(id).then(model => {
-          expect(model.id).to.be(id);
+          expect(model.id).to.equal(id);
         });
       });
     });
@@ -190,7 +190,7 @@ describe('kernel/manager', () => {
       it('should connect to an existing kernel', () => {
         let id = kernel.id;
         let newConnection = manager.connectTo(kernel.model);
-        expect(newConnection.model.id).to.be(id);
+        expect(newConnection.model.id).to.equal(id);
       });
 
       it('should emit a runningChanged signal', done => {
@@ -210,14 +210,14 @@ describe('kernel/manager', () => {
         let kernel = await manager.startNew();
         await kernel.ready;
         await manager.shutdown(kernel.id);
-        expect(kernel.isDisposed).to.be(true);
+        expect(kernel.isDisposed).to.equal(true);
       });
 
       it('should emit a runningChanged signal', async () => {
         let kernel = await manager.startNew();
         const emission = testEmission(manager.runningChanged, {
           test: () => {
-            expect(kernel.isDisposed).to.be(false);
+            expect(kernel.isDisposed).to.equal(false);
           }
         });
         await manager.shutdown(kernel.id);

--- a/packages/services/test/src/kernel/manager.spec.ts
+++ b/packages/services/test/src/kernel/manager.spec.ts
@@ -108,7 +108,7 @@ describe('kernel/manager', () => {
       });
 
       it('should be emitted when a kernel is shut down', async () => {
-        kernel = await manager.startNew();
+        const kernel = await manager.startNew();
         let called = false;
         manager.runningChanged.connect(() => {
           manager.dispose();

--- a/packages/services/test/src/kernel/manager.spec.ts
+++ b/packages/services/test/src/kernel/manager.spec.ts
@@ -17,14 +17,14 @@ import {
   testEmission
 } from '../utils';
 
-let PYTHON3_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
+const PYTHON3_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));
 PYTHON3_SPEC.name = 'Python3';
 PYTHON3_SPEC.display_name = 'python3';
 
 describe('kernel/manager', () => {
-  let manager: KernelManager;
-  let specs: Kernel.ISpecModels;
-  let kernel: Kernel.IKernel;
+  const manager: KernelManager;
+  const specs: Kernel.ISpecModels;
+  const kernel: Kernel.IKernel;
 
   before(() => {
     return Kernel.getSpecs()
@@ -63,8 +63,8 @@ describe('kernel/manager', () => {
     describe('#serverSettings', () => {
       it('should get the server settings', () => {
         manager.dispose();
-        let serverSettings = makeSettings();
-        let token = serverSettings.token;
+        const serverSettings = makeSettings();
+        const token = serverSettings.token;
         manager = new KernelManager({ serverSettings });
         expect(manager.serverSettings.token).to.equal(token);
       });
@@ -87,8 +87,8 @@ describe('kernel/manager', () => {
     });
 
     describe('#specsChanged', () => {
-      it('should be emitted when the specs change', done => {
-        let specs = JSONExt.deepCopy(KERNELSPECS) as Kernel.ISpecModels;
+      it('should be emitted when the specs change', async () => {
+        const specs = JSONExt.deepCopy(KERNELSPECS) as Kernel.ISpecModels;
         specs.default = 'shell';
         handleRequest(manager, 200, specs);
         manager.specsChanged.connect((sender, args) => {
@@ -101,7 +101,7 @@ describe('kernel/manager', () => {
     });
 
     describe('#runningChanged', () => {
-      it('should be emitted in refreshRunning when the running kernels changed', done => {
+      it('should be emitted in refreshRunning when the running kernels changed', async () => {
         manager.runningChanged.connect((sender, args) => {
           expect(sender).to.equal(manager);
           expect(toArray(args).length).to.be.greaterThan(0);
@@ -114,7 +114,7 @@ describe('kernel/manager', () => {
           .catch(done);
       });
 
-      it('should be emitted when a kernel is shut down', done => {
+      it('should be emitted when a kernel is shut down', async () => {
         manager
           .startNew()
           .then(kernel => {
@@ -147,7 +147,7 @@ describe('kernel/manager', () => {
 
     describe('#refreshSpecs()', () => {
       it('should update list of kernel specs', () => {
-        let specs = JSONExt.deepCopy(KERNELSPECS) as Kernel.ISpecModels;
+        const specs = JSONExt.deepCopy(KERNELSPECS) as Kernel.ISpecModels;
         specs.default = 'shell';
         handleRequest(manager, 200, specs);
         return manager.refreshSpecs().then(() => {
@@ -169,7 +169,7 @@ describe('kernel/manager', () => {
         return manager.startNew();
       });
 
-      it('should emit a runningChanged signal', done => {
+      it('should emit a runningChanged signal', async () => {
         manager.runningChanged.connect(() => {
           done();
         });
@@ -179,7 +179,7 @@ describe('kernel/manager', () => {
 
     describe('#findById()', () => {
       it('should find an existing kernel by id', () => {
-        let id = kernel.id;
+        const id = kernel.id;
         return manager.findById(id).then(model => {
           expect(model.id).to.equal(id);
         });
@@ -188,12 +188,12 @@ describe('kernel/manager', () => {
 
     describe('#connectTo()', () => {
       it('should connect to an existing kernel', () => {
-        let id = kernel.id;
-        let newConnection = manager.connectTo(kernel.model);
+        const id = kernel.id;
+        const newConnection = manager.connectTo(kernel.model);
         expect(newConnection.model.id).to.equal(id);
       });
 
-      it('should emit a runningChanged signal', done => {
+      it('should emit a runningChanged signal', async () => {
         manager.runningChanged.connect(() => {
           done();
         });
@@ -207,14 +207,14 @@ describe('kernel/manager', () => {
 
     describe('shutdown()', () => {
       it('should shut down a kernel by id', async () => {
-        let kernel = await manager.startNew();
+        const kernel = await manager.startNew();
         await kernel.ready;
         await manager.shutdown(kernel.id);
         expect(kernel.isDisposed).to.equal(true);
       });
 
       it('should emit a runningChanged signal', async () => {
-        let kernel = await manager.startNew();
+        const kernel = await manager.startNew();
         const emission = testEmission(manager.runningChanged, {
           test: () => {
             expect(kernel.isDisposed).to.equal(false);

--- a/packages/services/test/src/kernel/messages.spec.ts
+++ b/packages/services/test/src/kernel/messages.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { KernelMessage } from '../../../lib/kernel';
 
@@ -13,13 +13,13 @@ describe('kernel/messages', () => {
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isStreamMsg(msg)).to.be(true);
+      expect(KernelMessage.isStreamMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isStreamMsg(msg)).to.be(false);
+      expect(KernelMessage.isStreamMsg(msg)).to.equal(false);
     });
   });
 
@@ -30,13 +30,13 @@ describe('kernel/messages', () => {
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isDisplayDataMsg(msg)).to.be(true);
+      expect(KernelMessage.isDisplayDataMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isDisplayDataMsg(msg)).to.be(false);
+      expect(KernelMessage.isDisplayDataMsg(msg)).to.equal(false);
     });
   });
 
@@ -47,13 +47,13 @@ describe('kernel/messages', () => {
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isExecuteInputMsg(msg)).to.be(true);
+      expect(KernelMessage.isExecuteInputMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isExecuteInputMsg(msg)).to.be(false);
+      expect(KernelMessage.isExecuteInputMsg(msg)).to.equal(false);
     });
   });
 
@@ -64,13 +64,13 @@ describe('kernel/messages', () => {
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isExecuteResultMsg(msg)).to.be(true);
+      expect(KernelMessage.isExecuteResultMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isExecuteResultMsg(msg)).to.be(false);
+      expect(KernelMessage.isExecuteResultMsg(msg)).to.equal(false);
     });
   });
 
@@ -81,13 +81,13 @@ describe('kernel/messages', () => {
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isStatusMsg(msg)).to.be(true);
+      expect(KernelMessage.isStatusMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isStatusMsg(msg)).to.be(false);
+      expect(KernelMessage.isStatusMsg(msg)).to.equal(false);
     });
   });
 
@@ -98,13 +98,13 @@ describe('kernel/messages', () => {
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isClearOutputMsg(msg)).to.be(true);
+      expect(KernelMessage.isClearOutputMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isClearOutputMsg(msg)).to.be(false);
+      expect(KernelMessage.isClearOutputMsg(msg)).to.equal(false);
     });
   });
 
@@ -115,13 +115,13 @@ describe('kernel/messages', () => {
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isCommOpenMsg(msg)).to.be(true);
+      expect(KernelMessage.isCommOpenMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isCommOpenMsg(msg)).to.be(false);
+      expect(KernelMessage.isCommOpenMsg(msg)).to.equal(false);
     });
   });
 
@@ -132,13 +132,13 @@ describe('kernel/messages', () => {
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isErrorMsg(msg)).to.be(true);
+      expect(KernelMessage.isErrorMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'iopub',
         session: 'baz'
       });
-      expect(KernelMessage.isErrorMsg(msg)).to.be(false);
+      expect(KernelMessage.isErrorMsg(msg)).to.equal(false);
     });
   });
 
@@ -149,13 +149,13 @@ describe('kernel/messages', () => {
         channel: 'stdin',
         session: 'baz'
       });
-      expect(KernelMessage.isInputRequestMsg(msg)).to.be(true);
+      expect(KernelMessage.isInputRequestMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
         msgType: 'foo',
         channel: 'stdin',
         session: 'baz'
       });
-      expect(KernelMessage.isStatusMsg(msg)).to.be(false);
+      expect(KernelMessage.isStatusMsg(msg)).to.equal(false);
     });
   });
 });

--- a/packages/services/test/src/kernel/messages.spec.ts
+++ b/packages/services/test/src/kernel/messages.spec.ts
@@ -8,7 +8,7 @@ import { KernelMessage } from '../../../lib/kernel';
 describe('kernel/messages', () => {
   describe('KernelMessage.isStreamMsg()', () => {
     it('should check for a stream message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'stream',
         channel: 'iopub',
         session: 'baz'
@@ -25,7 +25,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isDisplayDataMsg()', () => {
     it('should check for a display data message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'display_data',
         channel: 'iopub',
         session: 'baz'
@@ -42,7 +42,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isExecuteInputMsg()', () => {
     it('should check for a execute input message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'execute_input',
         channel: 'iopub',
         session: 'baz'
@@ -59,7 +59,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isExecuteResultMsg()', () => {
     it('should check for an execute result message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'execute_result',
         channel: 'iopub',
         session: 'baz'
@@ -76,7 +76,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isStatusMsg()', () => {
     it('should check for a status message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'status',
         channel: 'iopub',
         session: 'baz'
@@ -93,7 +93,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isClearOutputMsg()', () => {
     it('should check for a clear output message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'clear_output',
         channel: 'iopub',
         session: 'baz'
@@ -110,7 +110,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isCommOpenMsg()', () => {
     it('should check for a comm open message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'comm_open',
         channel: 'iopub',
         session: 'baz'
@@ -127,7 +127,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isErrorMsg()', () => {
     it('should check for an message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'error',
         channel: 'iopub',
         session: 'baz'
@@ -144,7 +144,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isInputRequestMsg()', () => {
     it('should check for an input_request message type', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'input_request',
         channel: 'stdin',
         session: 'baz'

--- a/packages/services/test/src/kernel/messages.spec.ts
+++ b/packages/services/test/src/kernel/messages.spec.ts
@@ -8,7 +8,7 @@ import { KernelMessage } from '../../../lib/kernel';
 describe('kernel/messages', () => {
   describe('KernelMessage.isStreamMsg()', () => {
     it('should check for a stream message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'stream',
         channel: 'iopub',
         session: 'baz'
@@ -25,7 +25,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isDisplayDataMsg()', () => {
     it('should check for a display data message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'display_data',
         channel: 'iopub',
         session: 'baz'
@@ -42,7 +42,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isExecuteInputMsg()', () => {
     it('should check for a execute input message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'execute_input',
         channel: 'iopub',
         session: 'baz'
@@ -59,7 +59,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isExecuteResultMsg()', () => {
     it('should check for an execute result message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'execute_result',
         channel: 'iopub',
         session: 'baz'
@@ -76,7 +76,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isStatusMsg()', () => {
     it('should check for a status message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'status',
         channel: 'iopub',
         session: 'baz'
@@ -93,7 +93,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isClearOutputMsg()', () => {
     it('should check for a clear output message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'clear_output',
         channel: 'iopub',
         session: 'baz'
@@ -110,7 +110,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isCommOpenMsg()', () => {
     it('should check for a comm open message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'comm_open',
         channel: 'iopub',
         session: 'baz'
@@ -127,7 +127,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isErrorMsg()', () => {
     it('should check for an message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'error',
         channel: 'iopub',
         session: 'baz'
@@ -144,7 +144,7 @@ describe('kernel/messages', () => {
 
   describe('KernelMessage.isInputRequestMsg()', () => {
     it('should check for an input_request message type', () => {
-      const msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage({
         msgType: 'input_request',
         channel: 'stdin',
         session: 'baz'

--- a/packages/services/test/src/kernel/validate.spec.ts
+++ b/packages/services/test/src/kernel/validate.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { JSONObject } from '@phosphor/coreutils';
 
@@ -37,7 +37,7 @@ describe('kernel/validate', () => {
         session: 'baz'
       });
       delete msg.channel;
-      expect(() => validateMessage(msg)).to.throwError();
+      expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should throw if a field is invalid', () => {
@@ -47,7 +47,7 @@ describe('kernel/validate', () => {
         session: 'baz'
       });
       (msg as any).header.username = 1;
-      expect(() => validateMessage(msg)).to.throwError();
+      expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should throw if the parent header is given an invalid', () => {
@@ -58,7 +58,7 @@ describe('kernel/validate', () => {
       });
       msg.parent_header = msg.header;
       (msg as any).parent_header.username = 1;
-      expect(() => validateMessage(msg)).to.throwError();
+      expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should throw if the channel is not a string', () => {
@@ -68,7 +68,7 @@ describe('kernel/validate', () => {
         session: 'baz'
       });
       (msg as any).channel = 1;
-      expect(() => validateMessage(msg)).to.throwError();
+      expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should validate an iopub message', () => {
@@ -104,7 +104,7 @@ describe('kernel/validate', () => {
         },
         {}
       );
-      expect(() => validateMessage(msg)).to.throwError();
+      expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should throw on invalid iopub message content', () => {
@@ -116,7 +116,7 @@ describe('kernel/validate', () => {
         },
         { wait: 1 }
       );
-      expect(() => validateMessage(msg)).to.throwError();
+      expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should handle no buffers field', () => {
@@ -148,13 +148,13 @@ describe('kernel/validate', () => {
     it('should fail on missing data', () => {
       let spec = JSON.parse(JSON.stringify(PYTHON_SPEC));
       delete spec['name'];
-      expect(() => validateSpecModel(spec)).to.throwError();
+      expect(() => validateSpecModel(spec)).to.throw();
     });
 
     it('should fail on incorrect data', () => {
       let spec = JSON.parse(JSON.stringify(PYTHON_SPEC));
       spec.spec.language = 1;
-      expect(() => validateSpecModel(spec)).to.throwError();
+      expect(() => validateSpecModel(spec)).to.throw();
     });
   });
 
@@ -173,7 +173,7 @@ describe('kernel/validate', () => {
       const model: any = {
         default: 'python'
       };
-      expect(() => validateSpecModels(model)).to.throwError();
+      expect(() => validateSpecModels(model)).to.throw();
     });
   });
 });

--- a/packages/services/test/src/kernel/validate.spec.ts
+++ b/packages/services/test/src/kernel/validate.spec.ts
@@ -19,7 +19,7 @@ import { PYTHON_SPEC } from '../utils';
 describe('kernel/validate', () => {
   describe('validateMessage', () => {
     it('should pass a valid message', () => {
-      let msg = KernelMessage.createMessage(
+      const msg = KernelMessage.createMessage(
         {
           msgType: 'comm_msg',
           channel: 'iopub',
@@ -31,7 +31,7 @@ describe('kernel/validate', () => {
     });
 
     it('should throw if missing a field', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'comm_msg',
         channel: 'iopub',
         session: 'baz'
@@ -41,7 +41,7 @@ describe('kernel/validate', () => {
     });
 
     it('should throw if a field is invalid', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'comm_msg',
         channel: 'iopub',
         session: 'baz'
@@ -51,7 +51,7 @@ describe('kernel/validate', () => {
     });
 
     it('should throw if the parent header is given an invalid', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'comm_msg',
         channel: 'iopub',
         session: 'baz'
@@ -62,7 +62,7 @@ describe('kernel/validate', () => {
     });
 
     it('should throw if the channel is not a string', () => {
-      let msg = KernelMessage.createMessage({
+      const msg = KernelMessage.createMessage({
         msgType: 'comm_msg',
         channel: 'iopub',
         session: 'baz'
@@ -72,7 +72,7 @@ describe('kernel/validate', () => {
     });
 
     it('should validate an iopub message', () => {
-      let msg = KernelMessage.createMessage(
+      const msg = KernelMessage.createMessage(
         {
           msgType: 'comm_close',
           channel: 'iopub',
@@ -84,7 +84,7 @@ describe('kernel/validate', () => {
     });
 
     it('should ignore on an unknown iopub message type', () => {
-      let msg = KernelMessage.createMessage(
+      const msg = KernelMessage.createMessage(
         {
           msgType: 'foo',
           channel: 'iopub',
@@ -96,7 +96,7 @@ describe('kernel/validate', () => {
     });
 
     it('should throw on missing iopub message content', () => {
-      let msg = KernelMessage.createMessage(
+      const msg = KernelMessage.createMessage(
         {
           msgType: 'error',
           channel: 'iopub',
@@ -108,7 +108,7 @@ describe('kernel/validate', () => {
     });
 
     it('should throw on invalid iopub message content', () => {
-      let msg = KernelMessage.createMessage(
+      const msg = KernelMessage.createMessage(
         {
           msgType: 'clear_output',
           channel: 'iopub',
@@ -120,7 +120,7 @@ describe('kernel/validate', () => {
     });
 
     it('should handle no buffers field', () => {
-      let msg = KernelMessage.createMessage(
+      const msg = KernelMessage.createMessage(
         {
           msgType: 'comm_msg',
           channel: 'iopub',
@@ -135,7 +135,7 @@ describe('kernel/validate', () => {
 
   describe('#validateModel()', () => {
     it('should pass a valid id', () => {
-      let id: Kernel.IModel = { name: 'foo', id: 'baz' };
+      const id: Kernel.IModel = { name: 'foo', id: 'baz' };
       validateModel(id);
     });
   });
@@ -146,13 +146,13 @@ describe('kernel/validate', () => {
     });
 
     it('should fail on missing data', () => {
-      let spec = JSON.parse(JSON.stringify(PYTHON_SPEC));
+      const spec = JSON.parse(JSON.stringify(PYTHON_SPEC));
       delete spec['name'];
       expect(() => validateSpecModel(spec)).to.throw();
     });
 
     it('should fail on incorrect data', () => {
-      let spec = JSON.parse(JSON.stringify(PYTHON_SPEC));
+      const spec = JSON.parse(JSON.stringify(PYTHON_SPEC));
       spec.spec.language = 1;
       expect(() => validateSpecModel(spec)).to.throw();
     });

--- a/packages/services/test/src/manager.spec.ts
+++ b/packages/services/test/src/manager.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ContentsManager } from '../../lib/contents';
 
@@ -30,37 +30,37 @@ describe('manager', () => {
 
     describe('#constructor()', () => {
       it('should create a new service manager', () => {
-        expect(manager).to.be.a(ServiceManager);
+        expect(manager).to.be.an.instanceof(ServiceManager);
       });
     });
 
     describe('#sessions', () => {
       it('should be the sessions manager instance', () => {
-        expect(manager.sessions).to.be.a(SessionManager);
+        expect(manager.sessions).to.be.an.instanceof(SessionManager);
       });
     });
 
     describe('#settings', () => {
       it('should be the setting manager instance', () => {
-        expect(manager.settings).to.be.a(SettingManager);
+        expect(manager.settings).to.be.an.instanceof(SettingManager);
       });
     });
 
     describe('#contents', () => {
       it('should be the content manager instance', () => {
-        expect(manager.contents).to.be.a(ContentsManager);
+        expect(manager.contents).to.be.an.instanceof(ContentsManager);
       });
     });
 
     describe('#terminals', () => {
       it('should be the terminal manager instance', () => {
-        expect(manager.terminals).to.be.a(TerminalManager);
+        expect(manager.terminals).to.be.an.instanceof(TerminalManager);
       });
     });
 
     describe('#workspaces', () => {
       it('should be the workspace manager instance', () => {
-        expect(manager.workspaces).to.be.a(WorkspaceManager);
+        expect(manager.workspaces).to.be.an.instanceof(WorkspaceManager);
       });
     });
 
@@ -68,9 +68,9 @@ describe('manager', () => {
       it('should test whether the manager is ready', () => {
         manager.dispose();
         manager = new ServiceManager();
-        expect(manager.isReady).to.be(false);
+        expect(manager.isReady).to.equal(false);
         return manager.ready.then(() => {
-          expect(manager.isReady).to.be(true);
+          expect(manager.isReady).to.equal(true);
         });
       });
     });

--- a/packages/services/test/src/manager.spec.ts
+++ b/packages/services/test/src/manager.spec.ts
@@ -17,7 +17,7 @@ import { WorkspaceManager } from '../../lib/workspace';
 
 describe('manager', () => {
   describe('ServiceManager', () => {
-    let manager: ServiceManager.IManager;
+    const manager: ServiceManager.IManager;
 
     beforeEach(() => {
       manager = new ServiceManager();

--- a/packages/services/test/src/manager.spec.ts
+++ b/packages/services/test/src/manager.spec.ts
@@ -17,7 +17,7 @@ import { WorkspaceManager } from '../../lib/workspace';
 
 describe('manager', () => {
   describe('ServiceManager', () => {
-    const manager: ServiceManager.IManager;
+    let manager: ServiceManager.IManager;
 
     beforeEach(() => {
       manager = new ServiceManager();
@@ -65,13 +65,12 @@ describe('manager', () => {
     });
 
     describe('#isReady', () => {
-      it('should test whether the manager is ready', () => {
+      it('should test whether the manager is ready', async () => {
         manager.dispose();
         manager = new ServiceManager();
         expect(manager.isReady).to.equal(false);
-        return manager.ready.then(() => {
-          expect(manager.isReady).to.equal(true);
-        });
+        await manager.ready;
+        expect(manager.isReady).to.equal(true);
       });
     });
   });

--- a/packages/services/test/src/serverconnection.spec.ts
+++ b/packages/services/test/src/serverconnection.spec.ts
@@ -13,7 +13,7 @@ describe('@jupyterlab/services', () => {
   describe('ServerConnection', () => {
     describe('.makeRequest()', () => {
       it('should make a request to the server', () => {
-        let settings = getRequestHandler(200, 'hello');
+        const settings = getRequestHandler(200, 'hello');
         return ServerConnection.makeRequest(settings.baseUrl, {}, settings)
           .then(response => {
             expect(response.statusText).to.equal('OK');
@@ -27,23 +27,23 @@ describe('@jupyterlab/services', () => {
 
     describe('.makeSettings()', () => {
       it('should use default settings', () => {
-        let settings = ServerConnection.makeSettings();
+        const settings = ServerConnection.makeSettings();
         expect(settings.baseUrl).to.equal(PageConfig.getBaseUrl());
         expect(settings.wsUrl).to.equal(PageConfig.getWsUrl());
         expect(settings.token).to.equal(PageConfig.getOption('token'));
       });
 
       it('should use baseUrl for wsUrl', () => {
-        let conf: Partial<ServerConnection.ISettings> = {
+        const conf: Partial<ServerConnection.ISettings> = {
           baseUrl: 'https://host/path'
         };
-        let settings = ServerConnection.makeSettings(conf);
+        const settings = ServerConnection.makeSettings(conf);
         expect(settings.baseUrl).to.equal(conf.baseUrl);
         expect(settings.wsUrl).to.equal('wss://host/path');
       });
 
       it('should handle overrides', () => {
-        let defaults: Partial<ServerConnection.ISettings> = {
+        const defaults: Partial<ServerConnection.ISettings> = {
           baseUrl: 'foo',
           wsUrl: 'bar',
           init: {
@@ -51,7 +51,7 @@ describe('@jupyterlab/services', () => {
           },
           token: 'baz'
         };
-        let settings = ServerConnection.makeSettings(defaults);
+        const settings = ServerConnection.makeSettings(defaults);
         expect(settings.baseUrl).to.equal(defaults.baseUrl);
         expect(settings.wsUrl).to.equal(defaults.wsUrl);
         expect(settings.token).to.equal(defaults.token);
@@ -61,14 +61,14 @@ describe('@jupyterlab/services', () => {
 
     describe('.makeError()', () => {
       it('should create a server error from a server response', () => {
-        let settings = getRequestHandler(200, 'hi');
-        let init = { body: 'hi' };
+        const settings = getRequestHandler(200, 'hi');
+        const init = { body: 'hi' };
         return ServerConnection.makeRequest(
           settings.baseUrl,
           init,
           settings
         ).then(response => {
-          let err = new ServerConnection.ResponseError(response);
+          const err = new ServerConnection.ResponseError(response);
           expect(err.message).to.equal('Invalid response: 200 OK');
         });
       });

--- a/packages/services/test/src/serverconnection.spec.ts
+++ b/packages/services/test/src/serverconnection.spec.ts
@@ -12,16 +12,16 @@ import { getRequestHandler } from './utils';
 describe('@jupyterlab/services', () => {
   describe('ServerConnection', () => {
     describe('.makeRequest()', () => {
-      it('should make a request to the server', () => {
+      it('should make a request to the server', async () => {
         const settings = getRequestHandler(200, 'hello');
-        return ServerConnection.makeRequest(settings.baseUrl, {}, settings)
-          .then(response => {
-            expect(response.statusText).to.equal('OK');
-            return response.json();
-          })
-          .then(data => {
-            expect(data).to.equal('hello');
-          });
+        const response = await ServerConnection.makeRequest(
+          settings.baseUrl,
+          {},
+          settings
+        );
+        expect(response.statusText).to.equal('OK');
+        const data = await response.json();
+        expect(data).to.equal('hello');
       });
     });
 
@@ -60,17 +60,16 @@ describe('@jupyterlab/services', () => {
     });
 
     describe('.makeError()', () => {
-      it('should create a server error from a server response', () => {
+      it('should create a server error from a server response', async () => {
         const settings = getRequestHandler(200, 'hi');
         const init = { body: 'hi' };
-        return ServerConnection.makeRequest(
+        const response = await ServerConnection.makeRequest(
           settings.baseUrl,
           init,
           settings
-        ).then(response => {
-          const err = new ServerConnection.ResponseError(response);
-          expect(err.message).to.equal('Invalid response: 200 OK');
-        });
+        );
+        const err = new ServerConnection.ResponseError(response);
+        expect(err.message).to.equal('Invalid response: 200 OK');
       });
     });
   });

--- a/packages/services/test/src/serverconnection.spec.ts
+++ b/packages/services/test/src/serverconnection.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { PageConfig } from '@jupyterlab/coreutils';
 
@@ -16,11 +16,11 @@ describe('@jupyterlab/services', () => {
         let settings = getRequestHandler(200, 'hello');
         return ServerConnection.makeRequest(settings.baseUrl, {}, settings)
           .then(response => {
-            expect(response.statusText).to.be('OK');
+            expect(response.statusText).to.equal('OK');
             return response.json();
           })
           .then(data => {
-            expect(data).to.be('hello');
+            expect(data).to.equal('hello');
           });
       });
     });
@@ -28,9 +28,9 @@ describe('@jupyterlab/services', () => {
     describe('.makeSettings()', () => {
       it('should use default settings', () => {
         let settings = ServerConnection.makeSettings();
-        expect(settings.baseUrl).to.be(PageConfig.getBaseUrl());
-        expect(settings.wsUrl).to.be(PageConfig.getWsUrl());
-        expect(settings.token).to.be(PageConfig.getOption('token'));
+        expect(settings.baseUrl).to.equal(PageConfig.getBaseUrl());
+        expect(settings.wsUrl).to.equal(PageConfig.getWsUrl());
+        expect(settings.token).to.equal(PageConfig.getOption('token'));
       });
 
       it('should use baseUrl for wsUrl', () => {
@@ -38,8 +38,8 @@ describe('@jupyterlab/services', () => {
           baseUrl: 'https://host/path'
         };
         let settings = ServerConnection.makeSettings(conf);
-        expect(settings.baseUrl).to.be(conf.baseUrl);
-        expect(settings.wsUrl).to.be('wss://host/path');
+        expect(settings.baseUrl).to.equal(conf.baseUrl);
+        expect(settings.wsUrl).to.equal('wss://host/path');
       });
 
       it('should handle overrides', () => {
@@ -52,10 +52,10 @@ describe('@jupyterlab/services', () => {
           token: 'baz'
         };
         let settings = ServerConnection.makeSettings(defaults);
-        expect(settings.baseUrl).to.be(defaults.baseUrl);
-        expect(settings.wsUrl).to.be(defaults.wsUrl);
-        expect(settings.token).to.be(defaults.token);
-        expect(settings.init.credentials).to.be(defaults.init.credentials);
+        expect(settings.baseUrl).to.equal(defaults.baseUrl);
+        expect(settings.wsUrl).to.equal(defaults.wsUrl);
+        expect(settings.token).to.equal(defaults.token);
+        expect(settings.init.credentials).to.equal(defaults.init.credentials);
       });
     });
 
@@ -69,7 +69,7 @@ describe('@jupyterlab/services', () => {
           settings
         ).then(response => {
           let err = new ServerConnection.ResponseError(response);
-          expect(err.message).to.be('Invalid response: 200 OK');
+          expect(err.message).to.equal('Invalid response: 200 OK');
         });
       });
     });

--- a/packages/services/test/src/session/manager.spec.ts
+++ b/packages/services/test/src/session/manager.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -38,7 +38,7 @@ describe('session/manager', () => {
 
   beforeEach(() => {
     manager = new SessionManager();
-    expect(manager.specs).to.be(null);
+    expect(manager.specs).to.be.null;
   });
 
   afterEach(() => {
@@ -52,7 +52,7 @@ describe('session/manager', () => {
   describe('SessionManager', () => {
     describe('#constructor()', () => {
       it('should create a new session manager', () => {
-        expect(manager instanceof SessionManager).to.be(true);
+        expect(manager instanceof SessionManager).to.equal(true);
       });
     });
 
@@ -62,14 +62,14 @@ describe('session/manager', () => {
         let serverSettings = ServerConnection.makeSettings();
         let token = serverSettings.token;
         manager = new SessionManager({ serverSettings });
-        expect(manager.serverSettings.token).to.be(token);
+        expect(manager.serverSettings.token).to.equal(token);
       });
     });
 
     describe('#specs', () => {
       it('should be the kernel specs', () => {
         return manager.ready.then(() => {
-          expect(manager.specs.default).to.be.ok();
+          expect(manager.specs.default).to.be.ok;
         });
       });
     });
@@ -78,9 +78,9 @@ describe('session/manager', () => {
       it('should test whether the manager is ready', () => {
         manager.dispose();
         manager = new SessionManager();
-        expect(manager.isReady).to.be(false);
+        expect(manager.isReady).to.equal(false);
         return manager.ready.then(() => {
-          expect(manager.isReady).to.be(true);
+          expect(manager.isReady).to.equal(true);
         });
       });
     });
@@ -106,7 +106,7 @@ describe('session/manager', () => {
         specs.default = 'shell';
         handleRequest(manager, 200, specs);
         manager.specsChanged.connect((sender, args) => {
-          expect(sender).to.be(manager);
+          expect(sender).to.equal(manager);
           if (args.default === specs.default) {
             done();
           }
@@ -119,7 +119,7 @@ describe('session/manager', () => {
       it('should be emitted when the running sessions changed', done => {
         let object = {};
         manager.runningChanged.connect((sender, args) => {
-          expect(sender).to.be(manager);
+          expect(sender).to.equal(manager);
           expect(toArray(args).length).to.be.greaterThan(0);
           Signal.disconnectReceiver(object);
           done();
@@ -138,7 +138,7 @@ describe('session/manager', () => {
             return s.shutdown();
           })
           .then(() => {
-            expect(called).to.be(true);
+            expect(called).to.equal(true);
           });
       });
 
@@ -154,7 +154,7 @@ describe('session/manager', () => {
             return manager.refreshRunning();
           })
           .then(() => {
-            expect(called).to.be(true);
+            expect(called).to.equal(true);
           });
       });
 
@@ -170,7 +170,7 @@ describe('session/manager', () => {
             return manager.refreshRunning();
           })
           .then(() => {
-            expect(called).to.be(true);
+            expect(called).to.equal(true);
           });
       });
     });
@@ -192,7 +192,7 @@ describe('session/manager', () => {
         specs.default = 'shell';
         handleRequest(manager, 200, specs);
         return manager.refreshSpecs().then(() => {
-          expect(manager.specs.default).to.be(specs.default);
+          expect(manager.specs.default).to.equal(specs.default);
         });
       });
     });
@@ -201,7 +201,7 @@ describe('session/manager', () => {
       it('should start a session', async () => {
         let session = await manager.startNew({ path: UUID.uuid4() });
         await session.kernel.ready;
-        expect(session.id).to.be.ok();
+        expect(session.id).to.be.ok;
         return session.shutdown();
       });
 
@@ -212,21 +212,21 @@ describe('session/manager', () => {
         });
         let session = await manager.startNew({ path: UUID.uuid4() });
         await session.kernel.ready;
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#findByPath()', () => {
       it('should find an existing session by path', async () => {
         let newModel = await manager.findByPath(session.path);
-        expect(newModel.id).to.be(session.id);
+        expect(newModel.id).to.equal(session.id);
       });
     });
 
     describe('#findById()', () => {
       it('should find an existing session by id', () => {
         return manager.findById(session.id).then(newModel => {
-          expect(newModel.id).to.be(session.id);
+          expect(newModel.id).to.equal(session.id);
         });
       });
     });
@@ -234,10 +234,10 @@ describe('session/manager', () => {
     describe('#connectTo()', () => {
       it('should connect to a running session', () => {
         const newSession = manager.connectTo(session.model);
-        expect(newSession.id).to.be(session.id);
-        expect(newSession.kernel.id).to.be(session.kernel.id);
-        expect(newSession).to.not.be(session);
-        expect(newSession.kernel).to.not.be(session.kernel);
+        expect(newSession.id).to.equal(session.id);
+        expect(newSession.kernel.id).to.equal(session.kernel.id);
+        expect(newSession).to.not.equal(session);
+        expect(newSession.kernel).to.not.equal(session.kernel);
       });
     });
 
@@ -246,7 +246,7 @@ describe('session/manager', () => {
         let temp = await startNew(manager);
         await temp.kernel.ready;
         await manager.shutdown(temp.id);
-        expect(temp.isDisposed).to.be(true);
+        expect(temp.isDisposed).to.equal(true);
       });
 
       it('should emit a runningChanged signal', async () => {
@@ -261,8 +261,8 @@ describe('session/manager', () => {
         });
 
         await manager.shutdown(session.id);
-        expect(called).to.be(true);
-        expect(session.isDisposed).to.be(true);
+        expect(called).to.equal(true);
+        expect(session.isDisposed).to.equal(true);
       });
     });
   });

--- a/packages/services/test/src/session/manager.spec.ts
+++ b/packages/services/test/src/session/manager.spec.ts
@@ -59,18 +59,17 @@ describe('session/manager', () => {
     describe('#serverSettings', () => {
       it('should get the server settings', () => {
         manager.dispose();
-        let serverSettings = ServerConnection.makeSettings();
-        let token = serverSettings.token;
+        const serverSettings = ServerConnection.makeSettings();
+        const token = serverSettings.token;
         manager = new SessionManager({ serverSettings });
         expect(manager.serverSettings.token).to.equal(token);
       });
     });
 
     describe('#specs', () => {
-      it('should be the kernel specs', () => {
-        return manager.ready.then(() => {
-          expect(manager.specs.default).to.be.ok;
-        });
+      it('should be the kernel specs', async () => {
+        await manager.ready;
+        expect(manager.specs.default).to.be.ok;
       });
     });
 
@@ -94,15 +93,15 @@ describe('session/manager', () => {
     describe('#running()', () => {
       it('should get the running sessions', () => {
         return manager.refreshRunning().then(() => {
-          let running = toArray(manager.running());
+          const running = toArray(manager.running());
           expect(running.length).to.be.greaterThan(0);
         });
       });
     });
 
     describe('#specsChanged', () => {
-      it('should be emitted when the specs change', done => {
-        let specs = JSONExt.deepCopy(KERNELSPECS) as Kernel.ISpecModels;
+      it('should be emitted when the specs change', async () => {
+        const specs = JSONExt.deepCopy(KERNELSPECS) as Kernel.ISpecModels;
         specs.default = 'shell';
         handleRequest(manager, 200, specs);
         manager.specsChanged.connect((sender, args) => {
@@ -116,8 +115,8 @@ describe('session/manager', () => {
     });
 
     describe('#runningChanged', () => {
-      it('should be emitted when the running sessions changed', done => {
-        let object = {};
+      it('should be emitted when the running sessions changed', async () => {
+        const object = {};
         manager.runningChanged.connect((sender, args) => {
           expect(sender).to.equal(manager);
           expect(toArray(args).length).to.be.greaterThan(0);
@@ -180,7 +179,7 @@ describe('session/manager', () => {
       // future is prematurely disposed.
       it('should refresh the list of session ids', () => {
         return manager.refreshRunning().then(() => {
-          let running = toArray(manager.running());
+          const running = toArray(manager.running());
           expect(running.length).to.be.greaterThan(0);
         });
       });
@@ -188,7 +187,7 @@ describe('session/manager', () => {
 
     describe('#refreshSpecs()', () => {
       it('should refresh the specs', () => {
-        let specs = JSONExt.deepCopy(KERNELSPECS) as Kernel.ISpecModels;
+        const specs = JSONExt.deepCopy(KERNELSPECS) as Kernel.ISpecModels;
         specs.default = 'shell';
         handleRequest(manager, 200, specs);
         return manager.refreshSpecs().then(() => {
@@ -199,7 +198,7 @@ describe('session/manager', () => {
 
     describe('#startNew()', () => {
       it('should start a session', async () => {
-        let session = await manager.startNew({ path: UUID.uuid4() });
+        const session = await manager.startNew({ path: UUID.uuid4() });
         await session.kernel.ready;
         expect(session.id).to.be.ok;
         return session.shutdown();
@@ -210,7 +209,7 @@ describe('session/manager', () => {
         manager.runningChanged.connect(() => {
           called = true;
         });
-        let session = await manager.startNew({ path: UUID.uuid4() });
+        const session = await manager.startNew({ path: UUID.uuid4() });
         await session.kernel.ready;
         expect(called).to.equal(true);
       });
@@ -218,7 +217,7 @@ describe('session/manager', () => {
 
     describe('#findByPath()', () => {
       it('should find an existing session by path', async () => {
-        let newModel = await manager.findByPath(session.path);
+        const newModel = await manager.findByPath(session.path);
         expect(newModel.id).to.equal(session.id);
       });
     });
@@ -243,7 +242,7 @@ describe('session/manager', () => {
 
     describe('shutdown()', () => {
       it('should shut down a session by id', async () => {
-        let temp = await startNew(manager);
+        const temp = await startNew(manager);
         await temp.kernel.ready;
         await manager.shutdown(temp.id);
         expect(temp.isDisposed).to.equal(true);
@@ -251,7 +250,7 @@ describe('session/manager', () => {
 
       it('should emit a runningChanged signal', async () => {
         let called = false;
-        let session = await startNew(manager);
+        const session = await startNew(manager);
         await session.kernel.ready;
         manager.runningChanged.connect((sender, sessions) => {
           // Make sure the sessions list does not have our shutdown session in it.

--- a/packages/services/test/src/session/manager.spec.ts
+++ b/packages/services/test/src/session/manager.spec.ts
@@ -207,10 +207,9 @@ describe('session/manager', () => {
     });
 
     describe('#findById()', () => {
-      it('should find an existing session by id', () => {
-        return manager.findById(session.id).then(newModel => {
-          expect(newModel.id).to.equal(session.id);
-        });
+      it('should find an existing session by id', async () => {
+        const newModel = await manager.findById(session.id);
+        expect(newModel.id).to.equal(session.id);
       });
     });
 

--- a/packages/services/test/src/session/session.spec.ts
+++ b/packages/services/test/src/session/session.spec.ts
@@ -119,12 +119,11 @@ describe('session', () => {
       expect(session.id).to.be.ok;
     });
 
-    it('should start even if the websocket fails', () => {
+    it('should start even if the websocket fails', async () => {
       const tester = new SessionTester();
       tester.initialStatus = 'dead';
-      return tester.startSession().then(() => {
-        tester.dispose();
-      });
+      await tester.startSession();
+      tester.dispose();
     });
 
     it('should fail for wrong response status', async () => {
@@ -242,16 +241,15 @@ describe('session', () => {
     });
 
     context('#statusChanged', () => {
-      it('should emit when the kernel status changes', () => {
+      it('should emit when the kernel status changes', async () => {
         let called = false;
         defaultSession.statusChanged.connect((s, status) => {
           if (status === 'busy') {
             called = true;
           }
         });
-        return defaultSession.kernel.requestKernelInfo().then(() => {
-          expect(called).to.equal(true);
-        });
+        await defaultSession.kernel.requestKernelInfo();
+        expect(called).to.equal(true);
       });
     });
 

--- a/packages/services/test/src/session/session.spec.ts
+++ b/packages/services/test/src/session/session.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { PageConfig } from '@jupyterlab/coreutils';
 
@@ -111,7 +111,7 @@ describe('session', () => {
     it('should start a session', async () => {
       return startNew().then(s => {
         session = s;
-        expect(session.id).to.be.ok();
+        expect(session.id).to.be.ok;
       });
     });
 
@@ -120,7 +120,7 @@ describe('session', () => {
       let options: Session.IOptions = { path: UUID.uuid4(), serverSettings };
       Session.startNew(options).then(s => {
         session = s;
-        expect(session.id).to.ok();
+        expect(session.id).to.be.ok;
         done();
       });
     });
@@ -187,16 +187,16 @@ describe('session', () => {
   describe('Session.connectTo()', () => {
     it('should connect to a running session', () => {
       let newSession = Session.connectTo(defaultSession.model);
-      expect(newSession.id).to.be(defaultSession.id);
-      expect(newSession.kernel.id).to.be(defaultSession.kernel.id);
-      expect(newSession).to.not.be(defaultSession);
-      expect(newSession.kernel).to.not.be(defaultSession.kernel);
+      expect(newSession.id).to.equal(defaultSession.id);
+      expect(newSession.kernel.id).to.equal(defaultSession.kernel.id);
+      expect(newSession).to.not.equal(defaultSession);
+      expect(newSession.kernel).to.not.equal(defaultSession.kernel);
     });
 
     it('should accept server settings', () => {
       let serverSettings = makeSettings();
       const session = Session.connectTo(defaultSession.model, serverSettings);
-      expect(session.id).to.be.ok();
+      expect(session.id).to.be.ok;
     });
   });
 
@@ -223,7 +223,7 @@ describe('session', () => {
         });
         await session.shutdown();
         session.dispose();
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
@@ -238,8 +238,8 @@ describe('session', () => {
         let previous = defaultSession.kernel;
         await defaultSession.changeKernel({ name: previous.name });
         await defaultSession.kernel.ready;
-        expect(previous).to.not.be(defaultSession.kernel);
-        expect(called).to.eql({
+        expect(previous).to.not.equal(defaultSession.kernel);
+        expect(called).to.deep.equal({
           oldValue: previous,
           newValue: defaultSession.kernel
         });
@@ -256,7 +256,7 @@ describe('session', () => {
           }
         });
         return defaultSession.kernel.requestKernelInfo().then(() => {
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
         });
       });
     });
@@ -272,7 +272,7 @@ describe('session', () => {
         return defaultSession.kernel
           .requestExecute({ code: 'a=1' }, true)
           .done.then(() => {
-            expect(called).to.be(true);
+            expect(called).to.equal(true);
           });
       });
     });
@@ -306,66 +306,66 @@ describe('session', () => {
         let called = false;
         let object = {};
         defaultSession.propertyChanged.connect((s, type) => {
-          expect(defaultSession.path).to.be(newPath);
-          expect(type).to.be('path');
+          expect(defaultSession.path).to.equal(newPath);
+          expect(type).to.equal('path');
           called = true;
           Signal.disconnectReceiver(object);
         }, object);
         return defaultSession.setPath(newPath).then(() => {
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
         });
       });
     });
 
     context('#id', () => {
       it('should be a string', () => {
-        expect(typeof defaultSession.id).to.be('string');
+        expect(typeof defaultSession.id).to.equal('string');
       });
     });
 
     context('#path', () => {
       it('should be a string', () => {
-        expect(typeof defaultSession.path).to.be('string');
+        expect(typeof defaultSession.path).to.equal('string');
       });
     });
 
     context('#name', () => {
       it('should be a string', () => {
-        expect(typeof defaultSession.name).to.be('string');
+        expect(typeof defaultSession.name).to.equal('string');
       });
     });
 
     context('#type', () => {
       it('should be a string', () => {
-        expect(typeof defaultSession.name).to.be('string');
+        expect(typeof defaultSession.name).to.equal('string');
       });
     });
 
     context('#model', () => {
       it('should be an IModel', () => {
         let model = defaultSession.model;
-        expect(typeof model.id).to.be('string');
-        expect(typeof model.path).to.be('string');
-        expect(typeof model.kernel.name).to.be('string');
-        expect(typeof model.kernel.id).to.be('string');
+        expect(typeof model.id).to.equal('string');
+        expect(typeof model.path).to.equal('string');
+        expect(typeof model.kernel.name).to.equal('string');
+        expect(typeof model.kernel.id).to.equal('string');
       });
     });
 
     context('#kernel', () => {
       it('should be an IKernel object', () => {
-        expect(typeof defaultSession.kernel.id).to.be('string');
+        expect(typeof defaultSession.kernel.id).to.equal('string');
       });
     });
 
     context('#kernel', () => {
       it('should be a delegate to the kernel status', () => {
-        expect(defaultSession.status).to.be(defaultSession.kernel.status);
+        expect(defaultSession.status).to.equal(defaultSession.kernel.status);
       });
     });
 
     context('#serverSettings', () => {
       it('should be the serverSettings', () => {
-        expect(defaultSession.serverSettings.baseUrl).to.be(
+        expect(defaultSession.serverSettings.baseUrl).to.equal(
           PageConfig.getBaseUrl()
         );
       });
@@ -374,18 +374,18 @@ describe('session', () => {
     context('#isDisposed', () => {
       it('should be true after we dispose of the session', () => {
         const session = Session.connectTo(defaultSession.model);
-        expect(session.isDisposed).to.be(false);
+        expect(session.isDisposed).to.equal(false);
         session.dispose();
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
         const session = Session.connectTo(defaultSession.model);
-        expect(session.isDisposed).to.be(false);
-        expect(session.isDisposed).to.be(false);
+        expect(session.isDisposed).to.equal(false);
+        expect(session.isDisposed).to.equal(false);
         session.dispose();
-        expect(session.isDisposed).to.be(true);
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
+        expect(session.isDisposed).to.equal(true);
       });
     });
 
@@ -393,22 +393,22 @@ describe('session', () => {
       it('should dispose of the resources held by the session', () => {
         const session = Session.connectTo(defaultSession.model);
         session.dispose();
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
       });
 
       it('should be safe to call twice', () => {
         const session = Session.connectTo(defaultSession.model);
         session.dispose();
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
         session.dispose();
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
       });
 
       it('should be safe to call if the kernel is disposed', () => {
         const session = Session.connectTo(defaultSession.model);
         session.kernel.dispose();
         session.dispose();
-        expect(session.isDisposed).to.be(true);
+        expect(session.isDisposed).to.equal(true);
       });
     });
 
@@ -416,7 +416,7 @@ describe('session', () => {
       it('should set the path of the session', () => {
         let newPath = UUID.uuid4();
         return defaultSession.setPath(newPath).then(() => {
-          expect(defaultSession.path).to.be(newPath);
+          expect(defaultSession.path).to.equal(newPath);
         });
       });
 
@@ -447,7 +447,7 @@ describe('session', () => {
       it('should set the type of the session', () => {
         let type = UUID.uuid4();
         return defaultSession.setType(type).then(() => {
-          expect(defaultSession.type).to.be(type);
+          expect(defaultSession.type).to.equal(type);
         });
       });
 
@@ -478,7 +478,7 @@ describe('session', () => {
       it('should set the name of the session', () => {
         let name = UUID.uuid4();
         return defaultSession.setName(name).then(() => {
-          expect(defaultSession.name).to.be(name);
+          expect(defaultSession.name).to.equal(name);
         });
       });
 
@@ -512,9 +512,9 @@ describe('session', () => {
         await previous.ready;
         await session.changeKernel({ name: previous.name });
         await session.kernel.ready;
-        expect(session.kernel.name).to.be(previous.name);
-        expect(session.kernel.id).to.not.be(previous.id);
-        expect(session.kernel).to.not.be(previous);
+        expect(session.kernel.name).to.equal(previous.name);
+        expect(session.kernel.id).to.not.equal(previous.id);
+        expect(session.kernel).to.not.equal(previous);
         previous.dispose();
       });
 
@@ -526,9 +526,9 @@ describe('session', () => {
         await kernel.ready;
         await session.changeKernel({ id: kernel.id });
         await session.kernel.ready;
-        expect(session.kernel.id).to.be(kernel.id);
-        expect(session.kernel).to.not.be(previous);
-        expect(session.kernel).to.not.be(kernel);
+        expect(session.kernel.id).to.equal(kernel.id);
+        expect(session.kernel).to.not.equal(previous);
+        expect(session.kernel).to.not.equal(kernel);
         await previous.dispose();
         await kernel.dispose();
       });
@@ -541,8 +541,8 @@ describe('session', () => {
         handleRequest(session, 200, model);
         await session.changeKernel({ name: previous.name });
         await session.kernel.ready;
-        expect(session.kernel.name).to.be(previous.name);
-        expect(session.path).to.be(model.path);
+        expect(session.kernel.name).to.equal(previous.name);
+        expect(session.path).to.equal(model.path);
         previous.dispose();
       });
     });
@@ -564,7 +564,7 @@ describe('session', () => {
             return session.shutdown();
           })
           .then(() => {
-            expect(called).to.be(true);
+            expect(called).to.equal(true);
           });
       });
 
@@ -606,7 +606,7 @@ describe('session', () => {
         let session0 = await startNew();
         let session1 = Session.connectTo(session0.model);
         await session0.shutdown();
-        expect(session1.isDisposed).to.be(true);
+        expect(session1.isDisposed).to.equal(true);
       });
     });
   });

--- a/packages/services/test/src/session/session.spec.ts
+++ b/packages/services/test/src/session/session.spec.ts
@@ -73,101 +73,95 @@ describe('session', () => {
   });
 
   describe('Session.listRunning()', () => {
-    it('should yield a list of valid session models', () => {
-      return Session.listRunning().then(response => {
-        let running = toArray(response);
-        expect(running.length).to.greaterThan(0);
-      });
+    it('should yield a list of valid session models', async () => {
+      const response = await Session.listRunning();
+      const running = toArray(response);
+      expect(running.length).to.greaterThan(0);
     });
 
-    it('should throw an error for an invalid model', done => {
-      let data = { id: '1234', path: 'test' };
-      let serverSettings = getRequestHandler(200, data);
-      let list = Session.listRunning(serverSettings);
-      expectFailure(list, done);
+    it('should throw an error for an invalid model', async () => {
+      const data = { id: '1234', path: 'test' };
+      const serverSettings = getRequestHandler(200, data);
+      const list = Session.listRunning(serverSettings);
+      await expectFailure(list);
     });
 
-    it('should throw an error for another invalid model', done => {
-      let data = [{ id: '1234', kernel: { id: '', name: '' }, path: '' }];
-      let serverSettings = getRequestHandler(200, data);
-      let list = Session.listRunning(serverSettings);
-      expectFailure(list, done);
+    it('should throw an error for another invalid model', async () => {
+      const data = [{ id: '1234', kernel: { id: '', name: '' }, path: '' }];
+      const serverSettings = getRequestHandler(200, data);
+      const list = Session.listRunning(serverSettings);
+      await expectFailure(list);
     });
 
-    it('should fail for wrong response status', done => {
-      let serverSettings = getRequestHandler(201, [createSessionModel()]);
-      let list = Session.listRunning(serverSettings);
-      expectFailure(list, done);
+    it('should fail for wrong response status', async () => {
+      const serverSettings = getRequestHandler(201, [createSessionModel()]);
+      const list = Session.listRunning(serverSettings);
+      await expectFailure(list);
     });
 
-    it('should fail for error response status', done => {
-      let serverSettings = getRequestHandler(500, {});
-      let list = Session.listRunning(serverSettings);
-      expectFailure(list, done, '');
+    it('should fail for error response status', async () => {
+      const serverSettings = getRequestHandler(500, {});
+      const list = Session.listRunning(serverSettings);
+      await expectFailure(list, '');
     });
   });
 
   describe('Session.startNew', () => {
     it('should start a session', async () => {
-      return startNew().then(s => {
-        session = s;
-        expect(session.id).to.be.ok;
-      });
+      session = await startNew();
+      expect(session.id).to.be.ok;
     });
 
-    it('should accept ajax options', done => {
-      let serverSettings = makeSettings();
-      let options: Session.IOptions = { path: UUID.uuid4(), serverSettings };
-      Session.startNew(options).then(s => {
-        session = s;
-        expect(session.id).to.be.ok;
-        done();
-      });
+    it('should accept ajax options', async () => {
+      const serverSettings = makeSettings();
+      const options: Session.IOptions = { path: UUID.uuid4(), serverSettings };
+      session = await Session.startNew(options);
+      expect(session.id).to.be.ok;
     });
 
     it('should start even if the websocket fails', () => {
-      let tester = new SessionTester();
+      const tester = new SessionTester();
       tester.initialStatus = 'dead';
       return tester.startSession().then(() => {
         tester.dispose();
       });
     });
 
-    it('should fail for wrong response status', done => {
-      let sessionModel = createSessionModel();
-      let serverSettings = getRequestHandler(200, sessionModel);
-      let options = createSessionOptions(sessionModel, serverSettings);
-      let sessionPromise = Session.startNew(options);
-      expectFailure(sessionPromise, done);
+    it('should fail for wrong response status', async () => {
+      const sessionModel = createSessionModel();
+      const serverSettings = getRequestHandler(200, sessionModel);
+      const options = createSessionOptions(sessionModel, serverSettings);
+      const sessionPromise = Session.startNew(options);
+      await expectFailure(sessionPromise);
     });
 
-    it('should fail for error response status', done => {
-      let serverSettings = getRequestHandler(500, {});
-      let sessionModel = createSessionModel();
-      let options = createSessionOptions(sessionModel, serverSettings);
-      let sessionPromise = Session.startNew(options);
-      expectFailure(sessionPromise, done, '');
+    it('should fail for error response status', async () => {
+      const serverSettings = getRequestHandler(500, {});
+      const sessionModel = createSessionModel();
+      const options = createSessionOptions(sessionModel, serverSettings);
+      const sessionPromise = Session.startNew(options);
+      await expectFailure(sessionPromise, '');
     });
 
-    it('should fail for wrong response model', done => {
-      let sessionModel = createSessionModel();
+    it('should fail for wrong response model', async () => {
+      const sessionModel = createSessionModel();
       (sessionModel as any).path = 1;
-      let serverSettings = getRequestHandler(201, sessionModel);
-      let options = createSessionOptions(sessionModel, serverSettings);
-      let sessionPromise = Session.startNew(options);
-      let msg = `Property 'path' is not of type 'string'`;
-      expectFailure(sessionPromise, done, msg);
+      const serverSettings = getRequestHandler(201, sessionModel);
+      const options = createSessionOptions(sessionModel, serverSettings);
+      const sessionPromise = Session.startNew(options);
+      const msg = `Property 'path' is not of type 'string'`;
+      await expectFailure(sessionPromise, msg);
     });
 
     it('should handle a deprecated response model', () => {
-      let sessionModel = createSessionModel();
-      let data = {
+      const sessionModel = createSessionModel();
+      const data = {
         id: sessionModel.id,
         kernel: sessionModel.kernel,
         notebook: { path: sessionModel.path }
       };
-      let serverSettings = getRequestHandler(201, data);
-      let options = createSessionOptions(sessionModel, serverSettings);
+      const serverSettings = getRequestHandler(201, data);
+      const options = createSessionOptions(sessionModel, serverSettings);
       return Session.startNew(options);
     });
   });
@@ -186,7 +180,7 @@ describe('session', () => {
 
   describe('Session.connectTo()', () => {
     it('should connect to a running session', () => {
-      let newSession = Session.connectTo(defaultSession.model);
+      const newSession = Session.connectTo(defaultSession.model);
       expect(newSession.id).to.equal(defaultSession.id);
       expect(newSession.kernel.id).to.equal(defaultSession.kernel.id);
       expect(newSession).to.not.equal(defaultSession);
@@ -194,7 +188,7 @@ describe('session', () => {
     });
 
     it('should accept server settings', () => {
-      let serverSettings = makeSettings();
+      const serverSettings = makeSettings();
       const session = Session.connectTo(defaultSession.model, serverSettings);
       expect(session.id).to.be.ok;
     });
@@ -230,12 +224,12 @@ describe('session', () => {
     context('#kernelChanged', () => {
       it('should emit when the kernel changes', async () => {
         let called: Session.IKernelChangedArgs | null = null;
-        let object = {};
+        const object = {};
         defaultSession.kernelChanged.connect((s, args) => {
           called = args;
           Signal.disconnectReceiver(object);
         }, object);
-        let previous = defaultSession.kernel;
+        const previous = defaultSession.kernel;
         await defaultSession.changeKernel({ name: previous.name });
         await defaultSession.kernel.ready;
         expect(previous).to.not.equal(defaultSession.kernel);
@@ -262,18 +256,15 @@ describe('session', () => {
     });
 
     context('#iopubMessage', () => {
-      it('should be emitted for an iopub message', () => {
+      it('should be emitted for an iopub message', async () => {
         let called = false;
         defaultSession.iopubMessage.connect((s, msg) => {
           if (msg.header.msg_type === 'status') {
             called = true;
           }
         });
-        return defaultSession.kernel
-          .requestExecute({ code: 'a=1' }, true)
-          .done.then(() => {
-            expect(called).to.equal(true);
-          });
+        await defaultSession.kernel.requestExecute({ code: 'a=1' }, true).done;
+        expect(called).to.equal(true);
       });
     });
 
@@ -286,7 +277,7 @@ describe('session', () => {
         const emission = testEmission(session.unhandledMessage, {
           find: (k, msg) => msg.header.msg_id === msgId
         });
-        let msg = KernelMessage.createShellMessage({
+        const msg = KernelMessage.createShellMessage({
           msgType: 'foo',
           channel: 'shell',
           session: tester.serverSessionId,
@@ -301,19 +292,18 @@ describe('session', () => {
     });
 
     context('#propertyChanged', () => {
-      it('should be emitted when the session path changes', () => {
-        let newPath = UUID.uuid4();
+      it('should be emitted when the session path changes', async () => {
+        const newPath = UUID.uuid4();
         let called = false;
-        let object = {};
+        const object = {};
         defaultSession.propertyChanged.connect((s, type) => {
           expect(defaultSession.path).to.equal(newPath);
           expect(type).to.equal('path');
           called = true;
           Signal.disconnectReceiver(object);
         }, object);
-        return defaultSession.setPath(newPath).then(() => {
-          expect(called).to.equal(true);
-        });
+        await defaultSession.setPath(newPath);
+        expect(called).to.equal(true);
       });
     });
 
@@ -343,7 +333,7 @@ describe('session', () => {
 
     context('#model', () => {
       it('should be an IModel', () => {
-        let model = defaultSession.model;
+        const model = defaultSession.model;
         expect(typeof model.id).to.equal('string');
         expect(typeof model.path).to.equal('string');
         expect(typeof model.kernel.name).to.equal('string');
@@ -413,102 +403,99 @@ describe('session', () => {
     });
 
     context('#setPath()', () => {
-      it('should set the path of the session', () => {
-        let newPath = UUID.uuid4();
-        return defaultSession.setPath(newPath).then(() => {
-          expect(defaultSession.path).to.equal(newPath);
-        });
+      it('should set the path of the session', async () => {
+        const newPath = UUID.uuid4();
+        await defaultSession.setPath(newPath);
+        expect(defaultSession.path).to.equal(newPath);
       });
 
-      it('should fail for improper response status', done => {
+      it('should fail for improper response status', async () => {
         handleRequest(defaultSession, 201, {});
-        expectFailure(defaultSession.setPath(UUID.uuid4()), done);
+        await expectFailure(defaultSession.setPath(UUID.uuid4()));
       });
 
-      it('should fail for error response status', done => {
+      it('should fail for error response status', async () => {
         handleRequest(defaultSession, 500, {});
-        expectFailure(defaultSession.setPath(UUID.uuid4()), done, '');
+        await expectFailure(defaultSession.setPath(UUID.uuid4()), '');
       });
 
-      it('should fail for improper model', done => {
+      it('should fail for improper model', async () => {
         handleRequest(defaultSession, 200, {});
-        expectFailure(defaultSession.setPath(UUID.uuid4()), done);
+        await expectFailure(defaultSession.setPath(UUID.uuid4()));
       });
 
       it('should fail if the session is disposed', async () => {
         const session = Session.connectTo(defaultSession.model);
         session.dispose();
-        let promise = session.setPath(UUID.uuid4());
-        await expectFailure(promise, null, 'Session is disposed');
+        const promise = session.setPath(UUID.uuid4());
+        await expectFailure(promise, 'Session is disposed');
       });
     });
 
     context('#setType()', () => {
-      it('should set the type of the session', () => {
-        let type = UUID.uuid4();
-        return defaultSession.setType(type).then(() => {
-          expect(defaultSession.type).to.equal(type);
-        });
+      it('should set the type of the session', async () => {
+        const type = UUID.uuid4();
+        await defaultSession.setType(type);
+        expect(defaultSession.type).to.equal(type);
       });
 
-      it('should fail for improper response status', done => {
+      it('should fail for improper response status', async () => {
         handleRequest(defaultSession, 201, {});
-        expectFailure(defaultSession.setType(UUID.uuid4()), done);
+        await expectFailure(defaultSession.setType(UUID.uuid4()));
       });
 
-      it('should fail for error response status', done => {
+      it('should fail for error response status', async () => {
         handleRequest(defaultSession, 500, {});
-        expectFailure(defaultSession.setType(UUID.uuid4()), done, '');
+        await expectFailure(defaultSession.setType(UUID.uuid4()), '');
       });
 
-      it('should fail for improper model', done => {
+      it('should fail for improper model', async () => {
         handleRequest(defaultSession, 200, {});
-        expectFailure(defaultSession.setType(UUID.uuid4()), done);
+        await expectFailure(defaultSession.setType(UUID.uuid4()));
       });
 
       it('should fail if the session is disposed', async () => {
         const session = Session.connectTo(defaultSession.model);
         session.dispose();
-        let promise = session.setPath(UUID.uuid4());
-        await expectFailure(promise, null, 'Session is disposed');
+        const promise = session.setPath(UUID.uuid4());
+        await expectFailure(promise, 'Session is disposed');
       });
     });
 
     context('#setName()', () => {
-      it('should set the name of the session', () => {
-        let name = UUID.uuid4();
-        return defaultSession.setName(name).then(() => {
-          expect(defaultSession.name).to.equal(name);
-        });
+      it('should set the name of the session', async () => {
+        const name = UUID.uuid4();
+        await defaultSession.setName(name);
+        expect(defaultSession.name).to.equal(name);
       });
 
-      it('should fail for improper response status', done => {
+      it('should fail for improper response status', async () => {
         handleRequest(defaultSession, 201, {});
-        expectFailure(defaultSession.setName(UUID.uuid4()), done);
+        await expectFailure(defaultSession.setName(UUID.uuid4()));
       });
 
-      it('should fail for error response status', done => {
+      it('should fail for error response status', async () => {
         handleRequest(defaultSession, 500, {});
-        expectFailure(defaultSession.setName(UUID.uuid4()), done, '');
+        expectFailure(defaultSession.setName(UUID.uuid4()), '');
       });
 
-      it('should fail for improper model', done => {
+      it('should fail for improper model', async () => {
         handleRequest(defaultSession, 200, {});
-        expectFailure(defaultSession.setName(UUID.uuid4()), done);
+        expectFailure(defaultSession.setName(UUID.uuid4()));
       });
 
       it('should fail if the session is disposed', async () => {
         const session = Session.connectTo(defaultSession.model);
         session.dispose();
-        let promise = session.setPath(UUID.uuid4());
-        await expectFailure(promise, null, 'Session is disposed');
+        const promise = session.setPath(UUID.uuid4());
+        await expectFailure(promise, 'Session is disposed');
       });
     });
 
     context('#changeKernel()', () => {
       it('should create a new kernel with the new name', async () => {
         session = await startNew();
-        let previous = session.kernel;
+        const previous = session.kernel;
         await previous.ready;
         await session.changeKernel({ name: previous.name });
         await session.kernel.ready;
@@ -520,9 +507,9 @@ describe('session', () => {
 
       it('should accept the id of the new kernel', async () => {
         session = await startNew();
-        let previous = session.kernel;
+        const previous = session.kernel;
         await previous.ready;
-        let kernel = await Kernel.startNew();
+        const kernel = await Kernel.startNew();
         await kernel.ready;
         await session.changeKernel({ id: kernel.id });
         await session.kernel.ready;
@@ -535,9 +522,9 @@ describe('session', () => {
 
       it('should update the session path if it has changed', async () => {
         session = await startNew();
-        let previous = session.kernel;
+        const previous = session.kernel;
         await previous.ready;
-        let model = { ...session.model, path: 'foo.ipynb' };
+        const model = { ...session.model, path: 'foo.ipynb' };
         handleRequest(session, 200, model);
         await session.changeKernel({ name: previous.name });
         await session.kernel.ready;
@@ -548,63 +535,58 @@ describe('session', () => {
     });
 
     context('#shutdown()', () => {
-      it('should shut down properly', () => {
-        return startNew().then(session => {
-          return session.shutdown();
-        });
+      it('should shut down properly', async () => {
+        session = await startNew();
+        await session.shutdown();
       });
 
-      it('should emit a terminated signal', () => {
+      it('should emit a terminated signal', async () => {
         let called = false;
-        return startNew()
-          .then(session => {
-            session.terminated.connect(() => {
-              called = true;
-            });
-            return session.shutdown();
-          })
-          .then(() => {
-            expect(called).to.equal(true);
-          });
-      });
-
-      it('should fail for an incorrect response status', done => {
-        handleRequest(defaultSession, 200, {});
-        expectFailure(defaultSession.shutdown(), done);
-      });
-
-      it('should handle a 404 status', () => {
-        return startNew().then(session => {
-          handleRequest(session, 404, {});
-          return session.shutdown();
+        session = await startNew();
+        session.terminated.connect(() => {
+          called = true;
         });
+        await session.shutdown();
+        expect(called).to.equal(true);
       });
 
-      it('should handle a specific error status', done => {
+      it('should fail for an incorrect response status', async () => {
+        handleRequest(defaultSession, 200, {});
+        expectFailure(defaultSession.shutdown());
+      });
+
+      it('should handle a 404 status', async () => {
+        session = await startNew();
+        handleRequest(session, 404, {});
+        await session.shutdown();
+      });
+
+      it('should handle a specific error status', async () => {
         handleRequest(defaultSession, 410, {});
-        defaultSession
-          .shutdown()
-          .catch(err => {
-            let text = 'The kernel was deleted but the session was not';
-            expect(err.message).to.contain(text);
-          })
-          .then(done, done);
+        let promise = defaultSession.shutdown();
+        try {
+          await promise;
+          throw Error('should not get here');
+        } catch (err) {
+          const text = 'The kernel was deleted but the session was not';
+          expect(err.message).to.contain(text);
+        }
       });
 
-      it('should fail for an error response status', done => {
+      it('should fail for an error response status', async () => {
         handleRequest(defaultSession, 500, {});
-        expectFailure(defaultSession.shutdown(), done, '');
+        expectFailure(defaultSession.shutdown(), '');
       });
 
       it('should fail if the session is disposed', async () => {
         const session = Session.connectTo(defaultSession.model);
         session.dispose();
-        await expectFailure(session.shutdown(), null, 'Session is disposed');
+        await expectFailure(session.shutdown(), 'Session is disposed');
       });
 
       it('should dispose of all session instances', async () => {
-        let session0 = await startNew();
-        let session1 = Session.connectTo(session0.model);
+        const session0 = await startNew();
+        const session1 = Session.connectTo(session0.model);
         await session0.shutdown();
         expect(session1.isDisposed).to.equal(true);
       });

--- a/packages/services/test/src/session/session.spec.ts
+++ b/packages/services/test/src/session/session.spec.ts
@@ -476,12 +476,12 @@ describe('session', () => {
 
       it('should fail for error response status', async () => {
         handleRequest(defaultSession, 500, {});
-        expectFailure(defaultSession.setName(UUID.uuid4()), '');
+        await expectFailure(defaultSession.setName(UUID.uuid4()), '');
       });
 
       it('should fail for improper model', async () => {
         handleRequest(defaultSession, 200, {});
-        expectFailure(defaultSession.setName(UUID.uuid4()));
+        await expectFailure(defaultSession.setName(UUID.uuid4()));
       });
 
       it('should fail if the session is disposed', async () => {
@@ -552,7 +552,7 @@ describe('session', () => {
 
       it('should fail for an incorrect response status', async () => {
         handleRequest(defaultSession, 200, {});
-        expectFailure(defaultSession.shutdown());
+        await expectFailure(defaultSession.shutdown());
       });
 
       it('should handle a 404 status', async () => {
@@ -575,7 +575,7 @@ describe('session', () => {
 
       it('should fail for an error response status', async () => {
         handleRequest(defaultSession, 500, {});
-        expectFailure(defaultSession.shutdown(), '');
+        await expectFailure(defaultSession.shutdown(), '');
       });
 
       it('should fail if the session is disposed', async () => {

--- a/packages/services/test/src/session/validate.spec.ts
+++ b/packages/services/test/src/session/validate.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Session } from '../../../lib/session';
 
@@ -38,7 +38,7 @@ describe('session/validate', () => {
         path: 'bar',
         name: ''
       };
-      expect(() => validateModel(model)).to.throwError();
+      expect(() => validateModel(model)).to.throw();
     });
   });
 });

--- a/packages/services/test/src/session/validate.spec.ts
+++ b/packages/services/test/src/session/validate.spec.ts
@@ -10,7 +10,7 @@ import { validateModel } from '../../../lib/session/validate';
 describe('session/validate', () => {
   describe('#validateModel()', () => {
     it('should pass a valid model', () => {
-      let model: Session.IModel = {
+      const model: Session.IModel = {
         id: 'foo',
         kernel: { name: 'foo', id: '123' },
         path: 'bar',
@@ -21,7 +21,7 @@ describe('session/validate', () => {
     });
 
     it('should pass a deprecated model', () => {
-      let model = {
+      const model = {
         id: 'foo',
         kernel: { name: 'foo', id: '123' },
         notebook: {
@@ -32,7 +32,7 @@ describe('session/validate', () => {
     });
 
     it('should fail on missing data', () => {
-      let model: any = {
+      const model: any = {
         id: 'foo',
         kernel: { name: 'foo', id: '123' },
         path: 'bar',

--- a/packages/services/test/src/setting/manager.spec.ts
+++ b/packages/services/test/src/setting/manager.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ServerConnection, SettingManager } from '../../../lib';
 
@@ -15,14 +15,14 @@ describe('setting', () => {
     describe('#constructor()', () => {
       it('should accept no options', () => {
         const manager = new SettingManager();
-        expect(manager).to.be.a(SettingManager);
+        expect(manager).to.be.an.instanceof(SettingManager);
       });
 
       it('should accept options', () => {
         const manager = new SettingManager({
           serverSettings: ServerConnection.makeSettings()
         });
-        expect(manager).to.be.a(SettingManager);
+        expect(manager).to.be.an.instanceof(SettingManager);
       });
     });
 
@@ -31,7 +31,7 @@ describe('setting', () => {
         const baseUrl = 'foo';
         const serverSettings = ServerConnection.makeSettings({ baseUrl });
         const manager = new SettingManager({ serverSettings });
-        expect(manager.serverSettings.baseUrl).to.be(baseUrl);
+        expect(manager.serverSettings.baseUrl).to.equal(baseUrl);
       });
     });
   });

--- a/packages/services/test/src/target.ts
+++ b/packages/services/test/src/target.ts
@@ -5,7 +5,7 @@ declare var define: any;
 
 if (typeof define !== 'function') {
   // tslint:disable-next-line
-  let define = require('amdefine')(module);
+  const define = require('amdefine')(module);
 }
 
 module.exports = {

--- a/packages/services/test/src/terminal/manager.spec.ts
+++ b/packages/services/test/src/terminal/manager.spec.ts
@@ -17,10 +17,8 @@ describe('terminal', () => {
   let manager: TerminalSession.IManager;
   let session: TerminalSession.ISession;
 
-  before(() => {
-    return TerminalSession.startNew().then(s => {
-      session = s;
-    });
+  before(async () => {
+    session = await TerminalSession.startNew();
   });
 
   beforeEach(() => {
@@ -56,21 +54,20 @@ describe('terminal', () => {
     describe('#serverSettings', () => {
       it('should get the server settings', () => {
         manager.dispose();
-        let serverSettings = ServerConnection.makeSettings();
-        let token = serverSettings.token;
+        const serverSettings = ServerConnection.makeSettings();
+        const token = serverSettings.token;
         manager = new TerminalManager({ serverSettings });
         expect(manager.serverSettings.token).to.equal(token);
       });
     });
 
     describe('#isReady', () => {
-      it('should test whether the manager is ready', () => {
+      it('should test whether the manager is ready', async () => {
         manager.dispose();
         manager = new TerminalManager();
         expect(manager.isReady).to.equal(false);
-        return manager.ready.then(() => {
-          expect(manager.isReady).to.equal(true);
-        });
+        await manager.ready;
+        expect(manager.isReady).to.equal(true);
       });
     });
 
@@ -87,100 +84,85 @@ describe('terminal', () => {
     });
 
     describe('#running()', () => {
-      it('should give an iterator over the list of running models', () => {
-        return manager.refreshRunning().then(() => {
-          let running = toArray(manager.running());
-          expect(running.length).to.be.greaterThan(0);
-        });
+      it('should give an iterator over the list of running models', async () => {
+        await manager.refreshRunning();
+        const running = toArray(manager.running());
+        expect(running.length).to.be.greaterThan(0);
       });
     });
 
     describe('#startNew()', () => {
-      it('should startNew a new terminal session', () => {
-        return manager.startNew().then(session => {
-          expect(session.name).to.be.ok;
-        });
+      it('should startNew a new terminal session', async () => {
+        session = await manager.startNew();
+        expect(session.name).to.be.ok;
       });
 
-      it('should emit a runningChanged signal', done => {
+      it('should emit a runningChanged signal', async () => {
+        let called = false;
         manager.runningChanged.connect(() => {
-          done();
+          called = true;
         });
-        manager.startNew();
+        await manager.startNew();
+        expect(called).to.equal(true);
       });
     });
 
     describe('#connectTo()', () => {
-      it('should connect to an existing session', () => {
-        let name = session.name;
-        return manager.connectTo(name).then(session => {
-          expect(session.name).to.equal(name);
-        });
+      it('should connect to an existing session', async () => {
+        const name = session.name;
+        session = await manager.connectTo(name);
+        expect(session.name).to.equal(name);
       });
     });
 
     describe('#shutdown()', () => {
-      it('should shut down a session by id', () => {
-        let temp: TerminalSession.ISession;
-        return manager
-          .startNew()
-          .then(s => {
-            temp = s;
-            return manager.shutdown(s.name);
-          })
-          .then(() => {
-            expect(temp.isDisposed).to.equal(true);
-          });
+      it('should shut down a session by id', async () => {
+        const temp = await manager.startNew();
+        await manager.shutdown(temp.name);
+        expect(temp.isDisposed).to.equal(true);
       });
 
-      it('should emit a runningChanged signal', () => {
+      it('should emit a runningChanged signal', async () => {
         let called = false;
-        return manager
-          .startNew()
-          .then(s => {
-            manager.runningChanged.connect((sender, args) => {
-              expect(s.isDisposed).to.equal(false);
-              called = true;
-            });
-            return manager.shutdown(s.name);
-          })
-          .then(() => {
-            expect(called).to.equal(true);
-          });
+        session = await manager.startNew();
+        manager.runningChanged.connect((sender, args) => {
+          expect(session.isDisposed).to.equal(false);
+          called = true;
+        });
+        await manager.shutdown(session.name);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#runningChanged', () => {
-      it('should be emitted when the running terminals changed', done => {
+      it('should be emitted when the running terminals changed', async () => {
+        let called = false;
         manager.runningChanged.connect((sender, args) => {
           expect(sender).to.equal(manager);
           expect(toArray(args).length).to.be.greaterThan(0);
-          done();
+          called = true;
         });
-        manager.startNew().catch(done);
+        await manager.startNew();
+        expect(called).to.equal(true);
       });
     });
 
     describe('#refreshRunning()', () => {
-      it('should update the running session models', () => {
+      it('should update the running session models', async () => {
         let model: TerminalSession.IModel;
-        let before = toArray(manager.running()).length;
-        return TerminalSession.startNew()
-          .then(s => {
-            model = s.model;
-            return manager.refreshRunning();
-          })
-          .then(() => {
-            let running = toArray(manager.running());
-            expect(running.length).to.equal(before + 1);
-            let found = false;
-            running.map(m => {
-              if (m.name === model.name) {
-                found = true;
-              }
-            });
-            expect(found).to.equal(true);
-          });
+        const before = toArray(manager.running()).length;
+        session = await TerminalSession.startNew();
+        model = session.model;
+        await manager.refreshRunning();
+        const running = toArray(manager.running());
+        expect(running.length).to.equal(before + 1);
+        let found = false;
+        running.map(m => {
+          if (m.name === model.name) {
+            found = true;
+          }
+        });
+        expect(found).to.equal(true);
       });
     });
   });

--- a/packages/services/test/src/terminal/manager.spec.ts
+++ b/packages/services/test/src/terminal/manager.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { toArray } from '@phosphor/algorithm';
 
@@ -41,7 +41,7 @@ describe('terminal', () => {
       it('should accept no options', () => {
         manager.dispose();
         manager = new TerminalManager();
-        expect(manager).to.be.a(TerminalManager);
+        expect(manager).to.be.an.instanceof(TerminalManager);
       });
 
       it('should accept options', () => {
@@ -49,7 +49,7 @@ describe('terminal', () => {
         manager = new TerminalManager({
           serverSettings: ServerConnection.makeSettings()
         });
-        expect(manager).to.be.a(TerminalManager);
+        expect(manager).to.be.an.instanceof(TerminalManager);
       });
     });
 
@@ -59,7 +59,7 @@ describe('terminal', () => {
         let serverSettings = ServerConnection.makeSettings();
         let token = serverSettings.token;
         manager = new TerminalManager({ serverSettings });
-        expect(manager.serverSettings.token).to.be(token);
+        expect(manager.serverSettings.token).to.equal(token);
       });
     });
 
@@ -67,9 +67,9 @@ describe('terminal', () => {
       it('should test whether the manager is ready', () => {
         manager.dispose();
         manager = new TerminalManager();
-        expect(manager.isReady).to.be(false);
+        expect(manager.isReady).to.equal(false);
         return manager.ready.then(() => {
-          expect(manager.isReady).to.be(true);
+          expect(manager.isReady).to.equal(true);
         });
       });
     });
@@ -82,7 +82,7 @@ describe('terminal', () => {
 
     describe('#isAvailable()', () => {
       it('should test whether terminal sessions are available', () => {
-        expect(TerminalSession.isAvailable()).to.be(true);
+        expect(TerminalSession.isAvailable()).to.equal(true);
       });
     });
 
@@ -98,7 +98,7 @@ describe('terminal', () => {
     describe('#startNew()', () => {
       it('should startNew a new terminal session', () => {
         return manager.startNew().then(session => {
-          expect(session.name).to.be.ok();
+          expect(session.name).to.be.ok;
         });
       });
 
@@ -114,7 +114,7 @@ describe('terminal', () => {
       it('should connect to an existing session', () => {
         let name = session.name;
         return manager.connectTo(name).then(session => {
-          expect(session.name).to.be(name);
+          expect(session.name).to.equal(name);
         });
       });
     });
@@ -129,7 +129,7 @@ describe('terminal', () => {
             return manager.shutdown(s.name);
           })
           .then(() => {
-            expect(temp.isDisposed).to.be(true);
+            expect(temp.isDisposed).to.equal(true);
           });
       });
 
@@ -139,13 +139,13 @@ describe('terminal', () => {
           .startNew()
           .then(s => {
             manager.runningChanged.connect((sender, args) => {
-              expect(s.isDisposed).to.be(false);
+              expect(s.isDisposed).to.equal(false);
               called = true;
             });
             return manager.shutdown(s.name);
           })
           .then(() => {
-            expect(called).to.be(true);
+            expect(called).to.equal(true);
           });
       });
     });
@@ -153,7 +153,7 @@ describe('terminal', () => {
     describe('#runningChanged', () => {
       it('should be emitted when the running terminals changed', done => {
         manager.runningChanged.connect((sender, args) => {
-          expect(sender).to.be(manager);
+          expect(sender).to.equal(manager);
           expect(toArray(args).length).to.be.greaterThan(0);
           done();
         });
@@ -172,14 +172,14 @@ describe('terminal', () => {
           })
           .then(() => {
             let running = toArray(manager.running());
-            expect(running.length).to.be(before + 1);
+            expect(running.length).to.equal(before + 1);
             let found = false;
             running.map(m => {
               if (m.name === model.name) {
                 found = true;
               }
             });
-            expect(found).to.be(true);
+            expect(found).to.equal(true);
           });
       });
     });

--- a/packages/services/test/src/terminal/terminal.spec.ts
+++ b/packages/services/test/src/terminal/terminal.spec.ts
@@ -11,21 +11,19 @@ import { Signal } from '@phosphor/signaling';
 
 import { TerminalSession } from '../../../lib/terminal';
 
-import { handleRequest } from '../utils';
+import { handleRequest, testEmission } from '../utils';
 
 describe('terminal', () => {
   let defaultSession: TerminalSession.ISession;
   let session: TerminalSession.ISession;
 
-  before(() => {
-    TerminalSession.startNew().then(s => {
-      defaultSession = s;
-    });
+  before(async () => {
+    defaultSession = await TerminalSession.startNew();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (session) {
-      return session.shutdown();
+      await session.shutdown();
     }
   });
 
@@ -37,37 +35,33 @@ describe('terminal', () => {
     });
 
     describe('.startNew()', () => {
-      it('should startNew a terminal session', () => {
-        return TerminalSession.startNew().then(s => {
-          session = s;
-          expect(session.name).to.be.ok;
-        });
+      it('should startNew a terminal session', async () => {
+        session = await TerminalSession.startNew();
+        expect(session.name).to.be.ok;
       });
     });
 
     describe('.connectTo', () => {
-      it('should give back an existing session', () => {
-        return TerminalSession.connectTo(defaultSession.name).then(
-          newSession => {
-            expect(newSession.name).to.equal(defaultSession.name);
-            expect(newSession).to.not.equal(defaultSession);
-          }
-        );
+      it('should give back an existing session', async () => {
+        const newSession = await TerminalSession.connectTo(defaultSession.name);
+        expect(newSession.name).to.equal(defaultSession.name);
+        expect(newSession).to.not.equal(defaultSession);
       });
 
-      it('should reject if the session does not exist on the server', () => {
-        return TerminalSession.connectTo(UUID.uuid4()).then(() => {
+      it('should reject if the session does not exist on the server', async () => {
+        try {
+          await TerminalSession.connectTo(UUID.uuid4());
           throw Error('should not get here');
-        }, () => undefined);
+        } catch (e) {
+          expect(e.message).to.not.equal('should not get here');
+        }
       });
     });
 
     describe('.shutdown()', () => {
-      it('should shut down a terminal session by name', () => {
-        return TerminalSession.startNew().then(s => {
-          session = s;
-          return TerminalSession.shutdown(s.name);
-        });
+      it('should shut down a terminal session by name', async () => {
+        session = await TerminalSession.startNew();
+        await TerminalSession.shutdown(session.name);
       });
 
       it('should handle a 404 status', () => {
@@ -76,46 +70,36 @@ describe('terminal', () => {
     });
 
     describe('.listRunning()', () => {
-      it('should list the running session models', () => {
-        return TerminalSession.listRunning().then(models => {
-          expect(models.length).to.be.greaterThan(0);
-        });
+      it('should list the running session models', async () => {
+        const models = await TerminalSession.listRunning();
+        expect(models.length).to.be.greaterThan(0);
       });
     });
   });
 
   describe('.ISession', () => {
     describe('#terminated', () => {
-      it('should be emitted when the session is shut down', done => {
-        TerminalSession.startNew()
-          .then(s => {
-            session = s;
-            session.terminated.connect((sender, args) => {
-              expect(sender).to.equal(session);
-              expect(args).to.be.undefined;
-              done();
-            });
-            return session.shutdown();
-          })
-          .catch(done);
+      it('should be emitted when the session is shut down', async () => {
+        session = await TerminalSession.startNew();
+        let called = false;
+        session.terminated.connect((sender, args) => {
+          expect(sender).to.equal(session);
+          expect(args).to.be.undefined;
+          called = true;
+        });
+        await session.shutdown();
+        expect(called).to.equal(true);
       });
     });
 
     describe('#messageReceived', () => {
-      it('should be emitted when a message is received', done => {
-        const object = {};
-        TerminalSession.startNew()
-          .then(s => {
-            session = s;
-            session.messageReceived.connect((sender, msg) => {
-              expect(sender).to.equal(session);
-              if (msg.type === 'stdout') {
-                Signal.disconnectReceiver(object);
-                done();
-              }
-            }, object);
-          })
-          .catch(done);
+      it('should be emitted when a message is received', async () => {
+        session = await TerminalSession.startNew();
+        await testEmission(session.messageReceived, {
+          test: (sender, msg) => {
+            return msg.type === 'stdout';
+          }
+        });
       });
     });
 
@@ -134,49 +118,41 @@ describe('terminal', () => {
     });
 
     describe('#isDisposed', () => {
-      it('should test whether the object is disposed', () => {
-        return TerminalSession.startNew().then(session => {
-          let name = session.name;
-          expect(session.isDisposed).to.equal(false);
-          session.dispose();
-          expect(session.isDisposed).to.equal(true);
-          return TerminalSession.shutdown(name);
-        });
+      it('should test whether the object is disposed', async () => {
+        session = await TerminalSession.startNew();
+        const name = session.name;
+        expect(session.isDisposed).to.equal(false);
+        session.dispose();
+        expect(session.isDisposed).to.equal(true);
+        await TerminalSession.shutdown(name);
       });
     });
 
     describe('#dispose()', () => {
-      it('should dispose of the resources used by the session', () => {
-        TerminalSession.startNew().then(session => {
-          let name = session.name;
-          session.dispose();
-          expect(session.isDisposed).to.equal(true);
-          return TerminalSession.shutdown(name);
-        });
+      it('should dispose of the resources used by the session', async () => {
+        session = await TerminalSession.startNew();
+        const name = session.name;
+        session.dispose();
+        expect(session.isDisposed).to.equal(true);
+        await TerminalSession.shutdown(name);
       });
 
-      it('should be safe to call more than once', () => {
-        TerminalSession.startNew().then(s => {
-          let name = session.name;
-          session.dispose();
-          session.dispose();
-          expect(session.isDisposed).to.equal(true);
-          return TerminalSession.shutdown(name);
-        });
+      it('should be safe to call more than once', async () => {
+        session = await TerminalSession.startNew();
+        const name = session.name;
+        session.dispose();
+        session.dispose();
+        expect(session.isDisposed).to.equal(true);
+        await TerminalSession.shutdown(name);
       });
     });
 
     context('#isReady', () => {
-      it('should test whether the terminal is ready', () => {
-        return TerminalSession.startNew()
-          .then(s => {
-            session = s;
-            expect(session.isReady).to.equal(false);
-            return session.ready;
-          })
-          .then(() => {
-            expect(session.isReady).to.equal(true);
-          });
+      it('should test whether the terminal is ready', async () => {
+        session = await TerminalSession.startNew();
+        expect(session.isReady).to.equal(false);
+        await session.ready;
+        expect(session.isReady).to.equal(true);
       });
     });
 
@@ -187,34 +163,26 @@ describe('terminal', () => {
     });
 
     describe('#send()', () => {
-      it('should send a message to the socket', () => {
-        return defaultSession.ready.then(() => {
-          session.send({ type: 'stdin', content: [1, 2] });
-        });
+      it('should send a message to the socket', async () => {
+        await defaultSession.ready;
+        session.send({ type: 'stdin', content: [1, 2] });
       });
     });
 
     describe('#reconnect()', () => {
-      it('should reconnect to the socket', () => {
-        let session: TerminalSession.ISession;
-        return TerminalSession.startNew()
-          .then(s => {
-            session = s;
-            let promise = session.reconnect();
-            expect(session.isReady).to.equal(false);
-            return promise;
-          })
-          .then(() => {
-            expect(session.isReady).to.equal(true);
-          });
+      it('should reconnect to the socket', async () => {
+        const session = await TerminalSession.startNew();
+        const promise = session.reconnect();
+        expect(session.isReady).to.equal(false);
+        await promise;
+        expect(session.isReady).to.equal(true);
       });
     });
 
     describe('#shutdown()', () => {
-      it('should shut down the terminal session', () => {
-        TerminalSession.startNew().then(session => {
-          return session.shutdown();
-        });
+      it('should shut down the terminal session', async () => {
+        session = await TerminalSession.startNew();
+        await session.shutdown();
       });
 
       it('should handle a 404 status', () => {

--- a/packages/services/test/src/terminal/terminal.spec.ts
+++ b/packages/services/test/src/terminal/terminal.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { PageConfig } from '@jupyterlab/coreutils';
 
@@ -32,7 +32,7 @@ describe('terminal', () => {
   describe('TerminalSession', () => {
     describe('.isAvailable()', () => {
       it('should test whether terminal sessions are available', () => {
-        expect(TerminalSession.isAvailable()).to.be(true);
+        expect(TerminalSession.isAvailable()).to.equal(true);
       });
     });
 
@@ -40,7 +40,7 @@ describe('terminal', () => {
       it('should startNew a terminal session', () => {
         return TerminalSession.startNew().then(s => {
           session = s;
-          expect(session.name).to.be.ok();
+          expect(session.name).to.be.ok;
         });
       });
     });
@@ -49,8 +49,8 @@ describe('terminal', () => {
       it('should give back an existing session', () => {
         return TerminalSession.connectTo(defaultSession.name).then(
           newSession => {
-            expect(newSession.name).to.be(defaultSession.name);
-            expect(newSession).to.not.be(defaultSession);
+            expect(newSession.name).to.equal(defaultSession.name);
+            expect(newSession).to.not.equal(defaultSession);
           }
         );
       });
@@ -91,8 +91,8 @@ describe('terminal', () => {
           .then(s => {
             session = s;
             session.terminated.connect((sender, args) => {
-              expect(sender).to.be(session);
-              expect(args).to.be(void 0);
+              expect(sender).to.equal(session);
+              expect(args).to.be.undefined;
               done();
             });
             return session.shutdown();
@@ -108,7 +108,7 @@ describe('terminal', () => {
           .then(s => {
             session = s;
             session.messageReceived.connect((sender, msg) => {
-              expect(sender).to.be(session);
+              expect(sender).to.equal(session);
               if (msg.type === 'stdout') {
                 Signal.disconnectReceiver(object);
                 done();
@@ -121,13 +121,13 @@ describe('terminal', () => {
 
     describe('#name', () => {
       it('should be the name of the session', () => {
-        expect(defaultSession.name).to.be.ok();
+        expect(defaultSession.name).to.be.ok;
       });
     });
 
     context('#serverSettings', () => {
       it('should be the server settings of the server', () => {
-        expect(defaultSession.serverSettings.baseUrl).to.be(
+        expect(defaultSession.serverSettings.baseUrl).to.equal(
           PageConfig.getBaseUrl()
         );
       });
@@ -137,9 +137,9 @@ describe('terminal', () => {
       it('should test whether the object is disposed', () => {
         return TerminalSession.startNew().then(session => {
           let name = session.name;
-          expect(session.isDisposed).to.be(false);
+          expect(session.isDisposed).to.equal(false);
           session.dispose();
-          expect(session.isDisposed).to.be(true);
+          expect(session.isDisposed).to.equal(true);
           return TerminalSession.shutdown(name);
         });
       });
@@ -150,7 +150,7 @@ describe('terminal', () => {
         TerminalSession.startNew().then(session => {
           let name = session.name;
           session.dispose();
-          expect(session.isDisposed).to.be(true);
+          expect(session.isDisposed).to.equal(true);
           return TerminalSession.shutdown(name);
         });
       });
@@ -160,7 +160,7 @@ describe('terminal', () => {
           let name = session.name;
           session.dispose();
           session.dispose();
-          expect(session.isDisposed).to.be(true);
+          expect(session.isDisposed).to.equal(true);
           return TerminalSession.shutdown(name);
         });
       });
@@ -171,11 +171,11 @@ describe('terminal', () => {
         return TerminalSession.startNew()
           .then(s => {
             session = s;
-            expect(session.isReady).to.be(false);
+            expect(session.isReady).to.equal(false);
             return session.ready;
           })
           .then(() => {
-            expect(session.isReady).to.be(true);
+            expect(session.isReady).to.equal(true);
           });
       });
     });
@@ -201,11 +201,11 @@ describe('terminal', () => {
           .then(s => {
             session = s;
             let promise = session.reconnect();
-            expect(session.isReady).to.be(false);
+            expect(session.isReady).to.equal(false);
             return promise;
           })
           .then(() => {
-            expect(session.isReady).to.be(true);
+            expect(session.isReady).to.equal(true);
           });
       });
     });

--- a/packages/services/test/src/utils.spec.ts
+++ b/packages/services/test/src/utils.spec.ts
@@ -12,9 +12,9 @@ import { expectFailure, isFulfilled, testEmission } from './utils';
 describe('test/utils', () => {
   context('testEmission', () => {
     it('should resolve to the given value', async () => {
-      let owner = {};
-      let x = new Signal<{}, number>(owner);
-      let emission = testEmission(x, {
+      const owner = {};
+      const x = new Signal<{}, number>(owner);
+      const emission = testEmission(x, {
         value: 'done'
       });
       x.emit(0);
@@ -22,9 +22,9 @@ describe('test/utils', () => {
     });
 
     it('should find the given emission', async () => {
-      let owner = {};
-      let x = new Signal<{}, number>(owner);
-      let emission = testEmission(x, {
+      const owner = {};
+      const x = new Signal<{}, number>(owner);
+      const emission = testEmission(x, {
         find: (a, b) => b === 1,
         value: 'done'
       });
@@ -35,9 +35,9 @@ describe('test/utils', () => {
     });
 
     it('should reject if the test throws an error', async () => {
-      let owner = {};
-      let x = new Signal<{}, number>(owner);
-      let emission = testEmission(x, {
+      const owner = {};
+      const x = new Signal<{}, number>(owner);
+      const emission = testEmission(x, {
         find: (a, b) => b === 1,
         test: (a, b) => {
           throw new Error('my error');
@@ -47,13 +47,13 @@ describe('test/utils', () => {
       x.emit(0);
       expect(await isFulfilled(emission)).to.equal(false);
       x.emit(1);
-      await expectFailure(emission, null, 'my error');
+      await expectFailure(emission, 'my error');
     });
 
     it('should resolve if the test succeeds', async () => {
-      let owner = {};
-      let x = new Signal<{}, number>(owner);
-      let emission = testEmission(x, {
+      const owner = {};
+      const x = new Signal<{}, number>(owner);
+      const emission = testEmission(x, {
         find: (a, b) => b === 1,
         test: (a, b) => {
           expect(b).to.equal(1);
@@ -69,14 +69,14 @@ describe('test/utils', () => {
 
   context('isFulfilled', () => {
     it('should resolve to true only after a promise is fulfilled', async () => {
-      let p = new PromiseDelegate<number>();
+      const p = new PromiseDelegate<number>();
       expect(await isFulfilled(p.promise)).to.equal(false);
       p.resolve(10);
       expect(await isFulfilled(p.promise)).to.equal(true);
     });
 
     it('should resolve to true even if the promise is rejected', async () => {
-      let p = new PromiseDelegate<number>();
+      const p = new PromiseDelegate<number>();
       expect(await isFulfilled(p.promise)).to.equal(false);
       p.reject(new Error('my error'));
       expect(await isFulfilled(p.promise)).to.equal(true);

--- a/packages/services/test/src/utils.spec.ts
+++ b/packages/services/test/src/utils.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect from 'expect.js';
+import { expect } from 'chai';
 
 import { PromiseDelegate } from '@phosphor/coreutils';
 

--- a/packages/services/test/src/utils.spec.ts
+++ b/packages/services/test/src/utils.spec.ts
@@ -18,7 +18,7 @@ describe('test/utils', () => {
         value: 'done'
       });
       x.emit(0);
-      expect(await emission).to.be('done');
+      expect(await emission).to.equal('done');
     });
 
     it('should find the given emission', async () => {
@@ -29,9 +29,9 @@ describe('test/utils', () => {
         value: 'done'
       });
       x.emit(0);
-      expect(await isFulfilled(emission)).to.be(false);
+      expect(await isFulfilled(emission)).to.equal(false);
       x.emit(1);
-      expect(await emission).to.be('done');
+      expect(await emission).to.equal('done');
     });
 
     it('should reject if the test throws an error', async () => {
@@ -45,7 +45,7 @@ describe('test/utils', () => {
         value: 'done'
       });
       x.emit(0);
-      expect(await isFulfilled(emission)).to.be(false);
+      expect(await isFulfilled(emission)).to.equal(false);
       x.emit(1);
       await expectFailure(emission, null, 'my error');
     });
@@ -56,30 +56,30 @@ describe('test/utils', () => {
       let emission = testEmission(x, {
         find: (a, b) => b === 1,
         test: (a, b) => {
-          expect(b).to.be(1);
+          expect(b).to.equal(1);
         },
         value: 'done'
       });
       x.emit(0);
-      expect(await isFulfilled(emission)).to.be(false);
+      expect(await isFulfilled(emission)).to.equal(false);
       x.emit(1);
-      expect(await emission).to.be('done');
+      expect(await emission).to.equal('done');
     });
   });
 
   context('isFulfilled', () => {
     it('should resolve to true only after a promise is fulfilled', async () => {
       let p = new PromiseDelegate<number>();
-      expect(await isFulfilled(p.promise)).to.be(false);
+      expect(await isFulfilled(p.promise)).to.equal(false);
       p.resolve(10);
-      expect(await isFulfilled(p.promise)).to.be(true);
+      expect(await isFulfilled(p.promise)).to.equal(true);
     });
 
     it('should resolve to true even if the promise is rejected', async () => {
       let p = new PromiseDelegate<number>();
-      expect(await isFulfilled(p.promise)).to.be(false);
+      expect(await isFulfilled(p.promise)).to.equal(false);
       p.reject(new Error('my error'));
-      expect(await isFulfilled(p.promise)).to.be(true);
+      expect(await isFulfilled(p.promise)).to.equal(true);
     });
   });
 });

--- a/packages/services/test/src/utils.ts
+++ b/packages/services/test/src/utils.ts
@@ -144,12 +144,12 @@ export function getRequestHandler(
   status: number,
   body: any
 ): ServerConnection.ISettings {
-  let fetch = (info: RequestInfo, init: RequestInit) => {
+  const fetch = (info: RequestInfo, init: RequestInit) => {
     // Normalize the body.
     body = JSON.stringify(body);
 
     // Create the response and return it as a promise.
-    let response = new Response(body, { status });
+    const response = new Response(body, { status });
     return Promise.resolve(response as any);
   };
   return ServerConnection.makeSettings({ fetch });
@@ -167,10 +167,10 @@ export interface IService {
  */
 export function handleRequest(item: IService, status: number, body: any) {
   // Store the existing fetch function.
-  let oldFetch = item.serverSettings.fetch;
+  const oldFetch = item.serverSettings.fetch;
 
   // A single use callback.
-  let temp = (info: RequestInfo, init: RequestInit) => {
+  const temp = (info: RequestInfo, init: RequestInit) => {
     // Restore fetch.
     (item.serverSettings as any).fetch = oldFetch;
 
@@ -180,7 +180,7 @@ export function handleRequest(item: IService, status: number, body: any) {
     }
 
     // Create the response and return it as a promise.
-    let response = new Response(body, { status });
+    const response = new Response(body, { status });
     return Promise.resolve(response as any);
   };
 
@@ -193,10 +193,9 @@ export function handleRequest(item: IService, status: number, body: any) {
  */
 export async function expectFailure(
   promise: Promise<any>,
-  done?: () => void,
   message?: string
 ): Promise<any> {
-  let result = promise.then(
+  const result = promise.then(
     (msg: any) => {
       throw Error('Expected failure did not occur');
     },
@@ -207,7 +206,7 @@ export async function expectFailure(
     }
   );
 
-  return done ? result.then(done, done) : result;
+  return result;
 }
 
 /**
@@ -236,7 +235,7 @@ class SocketTester implements IService {
       this._ws = ws;
       this.onSocket(ws);
       this._ready.resolve(undefined);
-      let connect = this._onConnect;
+      const connect = this._onConnect;
       if (connect) {
         connect(ws);
       }
@@ -449,7 +448,7 @@ export class KernelTester extends SocketTester {
     content: any
   ) {
     options.session = this.serverSessionId;
-    let msg = KernelMessage.createMessage(
+    const msg = KernelMessage.createMessage(
       options as KernelMessage.IOptions,
       content
     );
@@ -473,7 +472,7 @@ export class KernelTester extends SocketTester {
     handleRequest(this, 201, { name: 'test', id: UUID.uuid4() });
 
     // Construct a new kernel.
-    let serverSettings = this.serverSettings;
+    const serverSettings = this.serverSettings;
     this._kernel = await Kernel.startNew({ serverSettings });
     await this.ready;
     await this._kernel.ready;
@@ -520,7 +519,7 @@ export class KernelTester extends SocketTester {
       if (msg instanceof Buffer) {
         msg = new Uint8Array(msg).buffer;
       }
-      let data = deserialize(msg);
+      const data = deserialize(msg);
       if (data.header.msg_type === 'kernel_info_request') {
         // First send status busy message.
         this.parentHeader = data.header;
@@ -533,7 +532,7 @@ export class KernelTester extends SocketTester {
         this.sendStatus(UUID.uuid4(), 'idle');
         this.parentHeader = undefined;
       } else {
-        let onMessage = this._onMessage;
+        const onMessage = this._onMessage;
         if (onMessage) {
           onMessage(data);
         }
@@ -577,7 +576,7 @@ export class SessionTester extends SocketTester {
    */
   async startSession(): Promise<Session.ISession> {
     handleRequest(this, 201, createSessionModel());
-    let serverSettings = this.serverSettings;
+    const serverSettings = this.serverSettings;
     this._session = await Session.startNew({
       path: UUID.uuid4(),
       serverSettings
@@ -610,12 +609,14 @@ export class SessionTester extends SocketTester {
    * Send the status from the server to the client.
    */
   sendStatus(status: string, parentHeader?: KernelMessage.IHeader) {
-    let options: KernelMessage.IOptions = {
+    const options: KernelMessage.IOptions = {
       msgType: 'status',
       channel: 'iopub',
       session: this.serverSessionId
     };
-    let msg = KernelMessage.createMessage(options, { execution_state: status });
+    const msg = KernelMessage.createMessage(options, {
+      execution_state: status
+    });
     if (parentHeader) {
       msg.parent_header = parentHeader;
     }
@@ -645,25 +646,25 @@ export class SessionTester extends SocketTester {
       if (msg instanceof Buffer) {
         msg = new Uint8Array(msg).buffer;
       }
-      let data = deserialize(msg);
+      const data = deserialize(msg);
       if (data.header.msg_type === 'kernel_info_request') {
         // First send status busy message.
         this.sendStatus('busy', data.header);
 
         // Then send the kernel_info_reply message.
-        let options: KernelMessage.IOptions = {
+        const options: KernelMessage.IOptions = {
           msgType: 'kernel_info_reply',
           channel: 'shell',
           session: this.serverSessionId
         };
-        let msg = KernelMessage.createMessage(options, EXAMPLE_KERNEL_INFO);
+        const msg = KernelMessage.createMessage(options, EXAMPLE_KERNEL_INFO);
         msg.parent_header = data.header;
         this.send(msg);
 
         // Then send status idle message.
         this.sendStatus('idle', data.header);
       } else {
-        let onMessage = this._onMessage;
+        const onMessage = this._onMessage;
         if (onMessage) {
           onMessage(data);
         }
@@ -691,10 +692,10 @@ export class TerminalTester extends SocketTester {
   protected onSocket(sock: WebSocket): void {
     super.onSocket(sock);
     sock.on('message', (msg: any) => {
-      let onMessage = this._onMessage;
+      const onMessage = this._onMessage;
       if (onMessage) {
-        let data = JSON.parse(msg) as JSONPrimitive[];
-        let termMsg: TerminalSession.IMessage = {
+        const data = JSON.parse(msg) as JSONPrimitive[];
+        const termMsg: TerminalSession.IMessage = {
           type: data[0] as TerminalSession.MessageType,
           content: data.slice(1)
         };
@@ -765,8 +766,8 @@ export async function testEmission<T, U, V>(
  * false if the promise is still pending.
  */
 export async function isFulfilled<T>(p: PromiseLike<T>): Promise<boolean> {
-  let x = Object.create(null);
-  let result = await Promise.race([p, x]).catch(() => false);
+  const x = Object.create(null);
+  const result = await Promise.race([p, x]).catch(() => false);
   return result !== x;
 }
 
@@ -778,7 +779,7 @@ export async function isFulfilled<T>(p: PromiseLike<T>): Promise<boolean> {
  *
  * interface A {a: number, b: string}
  * type B = MakeOptional<A, 'a'>
- * let x: B = {b: 'test'}
+ * const x: B = {b: 'test'}
  */
 type MakeOptional<T, K> = Pick<T, Exclude<keyof T, K>> &
   { [P in Extract<keyof T, K>]?: T[P] };

--- a/packages/services/test/src/utils.ts
+++ b/packages/services/test/src/utils.ts
@@ -5,7 +5,7 @@ import encoding from 'text-encoding';
 
 import WebSocket from 'ws';
 
-import expect from 'expect.js';
+import { expect } from 'chai';
 
 import { UUID } from '@phosphor/coreutils';
 

--- a/packages/services/test/src/utils.ts
+++ b/packages/services/test/src/utils.ts
@@ -194,26 +194,24 @@ export function handleRequest(item: IService, status: number, body: any) {
 export async function expectFailure(
   promise: Promise<any>,
   message?: string
-): Promise<any> {
-  const result = promise.then(
-    (msg: any) => {
-      throw Error('Expected failure did not occur');
-    },
-    (error: Error) => {
-      if (message && error.message.indexOf(message) === -1) {
-        throw Error(`Error "${message}" not in: "${error.message}"`);
-      }
+): Promise<void> {
+  let called = false;
+  try {
+    await promise;
+    called = true;
+  } catch (err) {
+    if (message && err.message.indexOf(message) === -1) {
+      throw Error(`Error "${message}" not in: "${err.message}"`);
     }
-  );
-
-  return result;
+  }
 }
 
 /**
  * Do something in the future ensuring total ordering wrt to Promises.
  */
-export function doLater(cb: () => void): void {
-  Promise.resolve().then(cb);
+export async function doLater(cb: () => void): Promise<void> {
+  await Promise.resolve(void 0);
+  cb();
 }
 
 /**

--- a/packages/services/test/src/workspace/manager.spec.ts
+++ b/packages/services/test/src/workspace/manager.spec.ts
@@ -56,7 +56,7 @@ describe('workspace', () => {
         ids.forEach(async id => {
           await manager.save(id, { data: {}, metadata: { id } });
         });
-        expect((await manager.list()).sort()).to.eql(ids.sort());
+        expect((await manager.list()).sort()).to.deep.equal(ids.sort());
       });
     });
 

--- a/tests/convert-to-chai.js
+++ b/tests/convert-to-chai.js
@@ -43,5 +43,7 @@ glob.sync(path.join(target, 'src', '*.ts*')).forEach(function(filePath) {
   src = src.split('to.be.a(').join('to.be.an.instanceof(');
   src = src.split('to.be.an(').join('to.be.an.instanceof(');
   src = src.split(').to.be.empty()').join('.length).to.equal(0)');
+  src = src.split('let ').join('const ');
+  src = src.split('const called').join('let called');
   fs.writeFileSync(filePath, src, 'utf8');
 });

--- a/tests/test-coreutils/src/settingregistry.spec.ts
+++ b/tests/test-coreutils/src/settingregistry.spec.ts
@@ -25,7 +25,7 @@ export class TestConnector extends StateDB
   }
 
   async fetch(id: string): Promise<ISettingRegistry.IPlugin | null> {
-    const data: string = await super.fetch(id);
+    const data = await super.fetch(id);
     if (!data && !this.schemas[id]) {
       return null;
     }
@@ -33,10 +33,8 @@ export class TestConnector extends StateDB
     const schema = this.schemas[id] || { type: 'object' };
     const composite = {};
     const user = {};
-    const raw = data || '{ }';
-    const result = { id, data: { composite, user }, raw, schema };
-
-    return result;
+    const raw = (data as string) || '{ }';
+    return { id, data: { composite, user }, raw, schema };
   }
 }
 

--- a/tests/test-coreutils/src/settingregistry.spec.ts
+++ b/tests/test-coreutils/src/settingregistry.spec.ts
@@ -24,20 +24,19 @@ export class TestConnector extends StateDB
     super({ namespace: 'setting-registry-tests' });
   }
 
-  fetch(id: string): Promise<ISettingRegistry.IPlugin | null> {
-    return super.fetch(id).then((data: string) => {
-      if (!data && !this.schemas[id]) {
-        return null;
-      }
+  async fetch(id: string): Promise<ISettingRegistry.IPlugin | null> {
+    const data: string = await super.fetch(id);
+    if (!data && !this.schemas[id]) {
+      return null;
+    }
 
-      const schema = this.schemas[id] || { type: 'object' };
-      const composite = {};
-      const user = {};
-      const raw = data || '{ }';
-      const result = { id, data: { composite, user }, raw, schema };
+    const schema = this.schemas[id] || { type: 'object' };
+    const composite = {};
+    const user = {};
+    const raw = data || '{ }';
+    const result = { id, data: { composite, user }, raw, schema };
 
-      return result;
-    });
+    return result;
   }
 }
 

--- a/tests/test-coreutils/src/statedb.spec.ts
+++ b/tests/test-coreutils/src/statedb.spec.ts
@@ -51,18 +51,12 @@ describe('StateDB', () => {
       let value = 'qux';
 
       // By sharing a namespace, the two databases will share data.
-      let promise = prepopulate
-        .save('foo', 'bar')
-        .then(() => db.fetch('foo'))
-        .then(saved => {
-          expect(saved).to.equal('bar');
-        })
-        .then(() => db.fetch(key))
-        .then(saved => {
-          expect(saved).to.equal(value);
-        });
+      await prepopulate.save('foo', 'bar');
+      let saved = await db.fetch('foo');
+      expect(saved).to.equal('bar');
       transform.resolve({ type: 'merge', contents: { [key]: value } });
-      await promise;
+      saved = await db.fetch(key);
+      expect(saved).to.equal(value);
       await db.clear();
     });
   });

--- a/tests/test-coreutils/src/statedb.spec.ts
+++ b/tests/test-coreutils/src/statedb.spec.ts
@@ -52,9 +52,9 @@ describe('StateDB', () => {
 
       // By sharing a namespace, the two databases will share data.
       await prepopulate.save('foo', 'bar');
+      transform.resolve({ type: 'merge', contents: { [key]: value } });
       let saved = await db.fetch('foo');
       expect(saved).to.equal('bar');
-      transform.resolve({ type: 'merge', contents: { [key]: value } });
       saved = await db.fetch(key);
       expect(saved).to.equal(value);
       await db.clear();

--- a/tests/test-csvviewer/src/model.spec.ts
+++ b/tests/test-csvviewer/src/model.spec.ts
@@ -324,7 +324,7 @@ describe('csvviewer/model', () => {
       ]);
     });
 
-    it('handles delayed parsing of rows past the initial rows', () => {
+    it('handles delayed parsing of rows past the initial rows', async () => {
       const d = new DSVModel({
         data: `a,b,c\nc,d,e\nf,g,h\ni,j,k`,
         delimiter: ',',
@@ -348,30 +348,31 @@ describe('csvviewer/model', () => {
       ]);
 
       // Check everything is in order after all the data has been parsed asynchronously.
-      return d.ready.then(() => {
-        expect(d.rowCount('column-header')).to.equal(1);
-        expect(d.rowCount('body')).to.equal(3);
-        expect(d.columnCount('row-header')).to.equal(1);
-        expect(d.columnCount('body')).to.equal(3);
-        expect([0, 1, 2].map(i => d.data('column-header', 0, i))).to.deep.equal(
-          ['a', 'b', 'c']
-        );
-        expect([0, 1, 2].map(i => d.data('body', 0, i))).to.deep.equal([
-          'c',
-          'd',
-          'e'
-        ]);
-        expect([0, 1, 2].map(i => d.data('body', 1, i))).to.deep.equal([
-          'f',
-          'g',
-          'h'
-        ]);
-        expect([0, 1, 2].map(i => d.data('body', 2, i))).to.deep.equal([
-          'i',
-          'j',
-          'k'
-        ]);
-      });
+      await d.ready;
+      expect(d.rowCount('column-header')).to.equal(1);
+      expect(d.rowCount('body')).to.equal(3);
+      expect(d.columnCount('row-header')).to.equal(1);
+      expect(d.columnCount('body')).to.equal(3);
+      expect([0, 1, 2].map(i => d.data('column-header', 0, i))).to.deep.equal([
+        'a',
+        'b',
+        'c'
+      ]);
+      expect([0, 1, 2].map(i => d.data('body', 0, i))).to.deep.equal([
+        'c',
+        'd',
+        'e'
+      ]);
+      expect([0, 1, 2].map(i => d.data('body', 1, i))).to.deep.equal([
+        'f',
+        'g',
+        'h'
+      ]);
+      expect([0, 1, 2].map(i => d.data('body', 2, i))).to.deep.equal([
+        'i',
+        'j',
+        'k'
+      ]);
     });
   });
 });

--- a/tests/test-imageviewer/src/widget.spec.ts
+++ b/tests/test-imageviewer/src/widget.spec.ts
@@ -138,13 +138,12 @@ describe('ImageViewer', () => {
   });
 
   describe('#onUpdateRequest()', () => {
-    it('should render the image', () => {
+    it('should render the image', async () => {
       const img: HTMLImageElement = widget.node.querySelector('img');
-      return widget.ready.then(() => {
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(widget.methods).to.contain('onUpdateRequest');
-        expect(img.src).to.contain(IMAGE.content);
-      });
+      await widget.ready;
+      MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+      expect(widget.methods).to.contain('onUpdateRequest');
+      expect(img.src).to.contain(IMAGE.content);
     });
   });
 

--- a/tests/test-notebook/package.json
+++ b/tests/test-notebook/package.json
@@ -28,10 +28,11 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1",
+    "chai": "~4.1.2",
     "simulate-event": "~1.4.0"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ClientSession } from '@jupyterlab/apputils';
 
@@ -53,7 +53,7 @@ describe('@jupyterlab/notebook', () => {
         contentFactory: NBTestUtils.createNotebookFactory(),
         mimeTypeService: NBTestUtils.mimeTypeService
       });
-      let model = new NotebookModel();
+      const model = new NotebookModel();
       model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
       widget.model = model;
 
@@ -71,8 +71,8 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#executed', () => {
       it('should emit when Markdown and code cells are run', () => {
-        let cell = widget.activeCell as CodeCell;
-        let next = widget.widgets[1] as MarkdownCell;
+        const cell = widget.activeCell as CodeCell;
+        const next = widget.widgets[1] as MarkdownCell;
         let emitted = 0;
 
         widget.select(next);
@@ -83,35 +83,35 @@ describe('@jupyterlab/notebook', () => {
         });
 
         return NotebookActions.run(widget, session).then(result => {
-          expect(emitted).to.be(2);
-          expect(next.rendered).to.be(true);
+          expect(emitted).to.equal(2);
+          expect(next.rendered).to.equal(true);
         });
       });
     });
 
     describe('#splitCell({})', () => {
       it('should split the active cell into two cells', () => {
-        let cell = widget.activeCell;
-        let source = 'thisisasamplestringwithnospaces';
+        const cell = widget.activeCell;
+        const source = 'thisisasamplestringwithnospaces';
         cell.model.value.text = source;
-        let index = widget.activeCellIndex;
-        let editor = cell.editor;
+        const index = widget.activeCellIndex;
+        const editor = cell.editor;
         editor.setCursorPosition(editor.getPositionAt(10));
         NotebookActions.splitCell(widget);
-        let cells = widget.model.cells;
-        let newSource =
+        const cells = widget.model.cells;
+        const newSource =
           cells.get(index).value.text + cells.get(index + 1).value.text;
-        expect(newSource).to.be(source);
+        expect(newSource).to.equal(source);
       });
 
       it('should preserve leading white space in the second cell', () => {
-        let cell = widget.activeCell;
-        let source = 'this\n\n   is a test';
+        const cell = widget.activeCell;
+        const source = 'this\n\n   is a test';
         cell.model.value.text = source;
-        let editor = cell.editor;
+        const editor = cell.editor;
         editor.setCursorPosition(editor.getPositionAt(4));
         NotebookActions.splitCell(widget);
-        expect(widget.activeCell.model.value.text).to.be('   is a test');
+        expect(widget.activeCell.model.value.text).to.equal('   is a test');
       });
 
       it('should clear the existing selection', () => {
@@ -123,53 +123,53 @@ describe('@jupyterlab/notebook', () => {
           if (i === widget.activeCellIndex) {
             continue;
           }
-          expect(widget.isSelected(widget.widgets[i])).to.be(false);
+          expect(widget.isSelected(widget.widgets[i])).to.equal(false);
         }
       });
 
       it('should activate the second cell', () => {
         NotebookActions.splitCell(widget);
-        expect(widget.activeCellIndex).to.be(1);
+        expect(widget.activeCellIndex).to.equal(1);
       });
 
       it('should preserve the types of each cell', () => {
         NotebookActions.changeCellType(widget, 'markdown');
         NotebookActions.splitCell(widget);
-        expect(widget.activeCell).to.be.a(MarkdownCell);
-        let prev = widget.widgets[0];
-        expect(prev).to.be.a(MarkdownCell);
+        expect(widget.activeCell).to.be.an.instanceof(MarkdownCell);
+        const prev = widget.widgets[0];
+        expect(prev).to.be.an.instanceof(MarkdownCell);
       });
 
       it('should create two empty cells if there is no content', () => {
         widget.activeCell.model.value.text = '';
         NotebookActions.splitCell(widget);
-        expect(widget.activeCell.model.value.text).to.be('');
-        let prev = widget.widgets[0];
-        expect(prev.model.value.text).to.be('');
+        expect(widget.activeCell.model.value.text).to.equal('');
+        const prev = widget.widgets[0];
+        expect(prev.model.value.text).to.equal('');
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.splitCell(widget);
-        expect(widget.activeCell).to.be(void 0);
+        expect(widget.activeCell).to.be.undefined;
       });
 
       it('should preserve the widget mode', () => {
         NotebookActions.splitCell(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.splitCell(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should be undo-able', () => {
-        let source = widget.activeCell.model.value.text;
-        let count = widget.widgets.length;
+        const source = widget.activeCell.model.value.text;
+        const count = widget.widgets.length;
         NotebookActions.splitCell(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count);
-        let cell = widget.widgets[0];
-        expect(cell.model.value.text).to.be(source);
+        expect(widget.widgets.length).to.equal(count);
+        const cell = widget.widgets[0];
+        expect(cell.model.value.text).to.equal(source);
       });
     });
 
@@ -182,49 +182,49 @@ describe('@jupyterlab/notebook', () => {
         next = widget.widgets[2];
         widget.select(next);
         source += next.model.value.text;
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.mergeCells(widget);
-        expect(widget.widgets.length).to.be(count - 2);
-        expect(widget.activeCell.model.value.text).to.be(source);
+        expect(widget.widgets.length).to.equal(count - 2);
+        expect(widget.activeCell.model.value.text).to.equal(source);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.mergeCells(widget);
-        expect(widget.activeCell).to.be(void 0);
+        expect(widget.activeCell).to.be.undefined;
       });
 
       it('should select the next cell if there is only one cell selected', () => {
         let source = widget.activeCell.model.value.text + '\n\n';
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         source += next.model.value.text;
         NotebookActions.mergeCells(widget);
-        expect(widget.activeCell.model.value.text).to.be(source);
+        expect(widget.activeCell.model.value.text).to.equal(source);
       });
 
       it('should clear the outputs of a code cell', () => {
         NotebookActions.mergeCells(widget);
-        let cell = widget.activeCell as CodeCell;
-        expect(cell.model.outputs.length).to.be(0);
+        const cell = widget.activeCell as CodeCell;
+        expect(cell.model.outputs.length).to.equal(0);
       });
 
       it('should preserve the widget mode', () => {
         widget.mode = 'edit';
         NotebookActions.mergeCells(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
         widget.mode = 'command';
         NotebookActions.mergeCells(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
 
       it('should be undo-able', () => {
-        let source = widget.activeCell.model.value.text;
-        let count = widget.widgets.length;
+        const source = widget.activeCell.model.value.text;
+        const count = widget.widgets.length;
         NotebookActions.mergeCells(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count);
-        let cell = widget.widgets[0];
-        expect(cell.model.value.text).to.be(source);
+        expect(widget.widgets.length).to.equal(count);
+        const cell = widget.widgets[0];
+        expect(cell.model.value.text).to.equal(source);
       });
 
       it('should unrender a markdown cell', () => {
@@ -233,51 +233,51 @@ describe('@jupyterlab/notebook', () => {
         cell.rendered = true;
         NotebookActions.mergeCells(widget);
         cell = widget.activeCell as MarkdownCell;
-        expect(cell.rendered).to.be(false);
-        expect(widget.mode).to.be('command');
+        expect(cell.rendered).to.equal(false);
+        expect(widget.mode).to.equal('command');
       });
 
       it('should preserve the cell type of the active cell', () => {
         NotebookActions.changeCellType(widget, 'raw');
         NotebookActions.mergeCells(widget);
-        expect(widget.activeCell).to.be.a(RawCell);
-        expect(widget.mode).to.be('command');
+        expect(widget.activeCell).to.be.an.instanceof(RawCell);
+        expect(widget.mode).to.equal('command');
       });
     });
 
     describe('#deleteCells()', () => {
       it('should delete the selected cells', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.deleteCells(widget);
-        expect(widget.widgets.length).to.be(count - 2);
+        expect(widget.widgets.length).to.equal(count - 2);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.deleteCells(widget);
-        expect(widget.activeCell).to.be(void 0);
+        expect(widget.activeCell).to.be.undefined;
       });
 
       it('should switch to command mode', () => {
         widget.mode = 'edit';
         NotebookActions.deleteCells(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
 
       it('should activate the cell after the last selected cell', () => {
         widget.activeCellIndex = 4;
-        let prev = widget.widgets[2];
+        const prev = widget.widgets[2];
         widget.select(prev);
         NotebookActions.deleteCells(widget);
-        expect(widget.activeCellIndex).to.be(3);
+        expect(widget.activeCellIndex).to.equal(3);
       });
 
       it('should select the previous cell if the last cell is deleted', () => {
         widget.select(widget.widgets[widget.widgets.length - 1]);
         NotebookActions.deleteCells(widget);
-        expect(widget.activeCellIndex).to.be(widget.widgets.length - 1);
+        expect(widget.activeCellIndex).to.equal(widget.widgets.length - 1);
       });
 
       it('should add a code cell if all cells are deleted', async () => {
@@ -286,63 +286,63 @@ describe('@jupyterlab/notebook', () => {
         }
         NotebookActions.deleteCells(widget);
         await sleep();
-        expect(widget.widgets.length).to.be(1);
-        expect(widget.activeCell).to.be.a(CodeCell);
+        expect(widget.widgets.length).to.equal(1);
+        expect(widget.activeCell).to.be.an.instanceof(CodeCell);
       });
 
       it('should be undo-able', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
-        let source = widget.activeCell.model.value.text;
-        let count = widget.widgets.length;
+        const source = widget.activeCell.model.value.text;
+        const count = widget.widgets.length;
         NotebookActions.deleteCells(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count);
-        let cell = widget.widgets[0];
-        expect(cell.model.value.text).to.be(source);
+        expect(widget.widgets.length).to.equal(count);
+        const cell = widget.widgets[0];
+        expect(cell.model.value.text).to.equal(source);
       });
 
       it('should be undo-able if all the cells are deleted', () => {
         for (let i = 0; i < widget.widgets.length; i++) {
           widget.select(widget.widgets[i]);
         }
-        let count = widget.widgets.length;
-        let source = widget.widgets[1].model.value.text;
+        const count = widget.widgets.length;
+        const source = widget.widgets[1].model.value.text;
         NotebookActions.deleteCells(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count);
-        expect(widget.widgets[1].model.value.text).to.be(source);
+        expect(widget.widgets.length).to.equal(count);
+        expect(widget.widgets[1].model.value.text).to.equal(source);
       });
     });
 
     describe('#insertAbove()', () => {
       it('should insert a code cell above the active cell', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.insertAbove(widget);
-        expect(widget.activeCellIndex).to.be(0);
-        expect(widget.widgets.length).to.be(count + 1);
-        expect(widget.activeCell).to.be.a(CodeCell);
+        expect(widget.activeCellIndex).to.equal(0);
+        expect(widget.widgets.length).to.equal(count + 1);
+        expect(widget.activeCell).to.be.an.instanceof(CodeCell);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.insertAbove(widget);
-        expect(widget.activeCell).to.be(void 0);
+        expect(widget.activeCell).to.be.undefined;
       });
 
       it('should widget mode should be preserved', () => {
         NotebookActions.insertAbove(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.insertAbove(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should be undo-able', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.insertAbove(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count);
+        expect(widget.widgets.length).to.equal(count);
       });
 
       it('should clear the existing selection', () => {
@@ -354,44 +354,44 @@ describe('@jupyterlab/notebook', () => {
           if (i === widget.activeCellIndex) {
             continue;
           }
-          expect(widget.isSelected(widget.widgets[i])).to.be(false);
+          expect(widget.isSelected(widget.widgets[i])).to.equal(false);
         }
       });
 
       it('should be the new active cell', () => {
         NotebookActions.insertAbove(widget);
-        expect(widget.activeCell.model.value.text).to.be('');
+        expect(widget.activeCell.model.value.text).to.equal('');
       });
     });
 
     describe('#insertBelow()', () => {
       it('should insert a code cell below the active cell', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.insertBelow(widget);
-        expect(widget.activeCellIndex).to.be(1);
-        expect(widget.widgets.length).to.be(count + 1);
-        expect(widget.activeCell).to.be.a(CodeCell);
+        expect(widget.activeCellIndex).to.equal(1);
+        expect(widget.widgets.length).to.equal(count + 1);
+        expect(widget.activeCell).to.be.an.instanceof(CodeCell);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.insertBelow(widget);
-        expect(widget.activeCell).to.be(void 0);
+        expect(widget.activeCell).to.be.undefined;
       });
 
       it('should widget mode should be preserved', () => {
         NotebookActions.insertBelow(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.insertBelow(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should be undo-able', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.insertBelow(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count);
+        expect(widget.widgets.length).to.equal(count);
       });
 
       it('should clear the existing selection', () => {
@@ -403,13 +403,13 @@ describe('@jupyterlab/notebook', () => {
           if (i === widget.activeCellIndex) {
             continue;
           }
-          expect(widget.isSelected(widget.widgets[i])).to.be(false);
+          expect(widget.isSelected(widget.widgets[i])).to.equal(false);
         }
       });
 
       it('should be the new active cell', () => {
         NotebookActions.insertBelow(widget);
-        expect(widget.activeCell.model.value.text).to.be('');
+        expect(widget.activeCell.model.value.text).to.equal('');
       });
     });
 
@@ -418,30 +418,30 @@ describe('@jupyterlab/notebook', () => {
         let next = widget.widgets[1];
         widget.select(next);
         NotebookActions.changeCellType(widget, 'raw');
-        expect(widget.activeCell).to.be.a(RawCell);
+        expect(widget.activeCell).to.be.an.instanceof(RawCell);
         next = widget.widgets[widget.activeCellIndex + 1];
-        expect(next).to.be.a(RawCell);
+        expect(next).to.be.an.instanceof(RawCell);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.changeCellType(widget, 'code');
-        expect(widget.activeCell).to.be(void 0);
+        expect(widget.activeCell).to.be.undefined;
       });
 
       it('should preserve the widget mode', () => {
         NotebookActions.changeCellType(widget, 'code');
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.changeCellType(widget, 'raw');
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should be undo-able', () => {
         NotebookActions.changeCellType(widget, 'raw');
         NotebookActions.undo(widget);
-        let cell = widget.widgets[0];
-        expect(cell).to.be.a(CodeCell);
+        const cell = widget.widgets[0];
+        expect(cell).to.be.an.instanceof(CodeCell);
       });
 
       it('should clear the existing selection', () => {
@@ -453,70 +453,70 @@ describe('@jupyterlab/notebook', () => {
           if (i === widget.activeCellIndex) {
             continue;
           }
-          expect(widget.isSelected(widget.widgets[i])).to.be(false);
+          expect(widget.isSelected(widget.widgets[i])).to.equal(false);
         }
       });
 
       it('should unrender markdown cells', () => {
         NotebookActions.changeCellType(widget, 'markdown');
-        let cell = widget.activeCell as MarkdownCell;
-        expect(cell.rendered).to.be(false);
+        const cell = widget.activeCell as MarkdownCell;
+        expect(cell.rendered).to.equal(false);
       });
     });
 
     describe('#run()', () => {
       it('should run the selected cells', () => {
-        let next = widget.widgets[1] as MarkdownCell;
+        const next = widget.widgets[1] as MarkdownCell;
         widget.select(next);
-        let cell = widget.activeCell as CodeCell;
+        const cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
         next.rendered = false;
         return NotebookActions.run(widget, session).then(result => {
-          expect(result).to.be(true);
+          expect(result).to.equal(true);
           expect(cell.model.outputs.length).to.be.above(0);
-          expect(next.rendered).to.be(true);
+          expect(next.rendered).to.equal(true);
         });
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         return NotebookActions.run(widget, session).then(result => {
-          expect(result).to.be(false);
+          expect(result).to.equal(false);
         });
       });
 
       it('should activate the last selected cell', () => {
-        let other = widget.widgets[2];
+        const other = widget.widgets[2];
         widget.select(other);
         other.model.value.text = 'a = 1';
         return NotebookActions.run(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.activeCell).to.be(other);
+          expect(result).to.equal(true);
+          expect(widget.activeCell).to.equal(other);
         });
       });
 
       it('should clear the selection', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
         return NotebookActions.run(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.isSelected(widget.widgets[0])).to.be(false);
+          expect(result).to.equal(true);
+          expect(widget.isSelected(widget.widgets[0])).to.equal(false);
         });
       });
 
       it('should change to command mode', () => {
         widget.mode = 'edit';
         return NotebookActions.run(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.mode).to.be('command');
+          expect(result).to.equal(true);
+          expect(widget.mode).to.equal('command');
         });
       });
 
       it('should handle no session', () => {
         return NotebookActions.run(widget, null).then(result => {
-          expect(result).to.be(true);
-          let cell = widget.activeCell as CodeCell;
-          expect(cell.model.executionCount).to.be(null);
+          expect(result).to.equal(true);
+          const cell = widget.activeCell as CodeCell;
+          expect(cell.model.executionCount).to.be.null;
         });
       });
 
@@ -529,22 +529,22 @@ describe('@jupyterlab/notebook', () => {
         widget.model.cells.push(cell);
         widget.select(widget.widgets[widget.widgets.length - 1]);
         return NotebookActions.run(widget, ipySession).then(result => {
-          expect(result).to.be(false);
-          expect(cell.executionCount).to.be(null);
+          expect(result).to.equal(false);
+          expect(cell.executionCount).to.be.null;
           return ipySession.kernel.restart();
         });
       });
 
       it('should render all markdown cells on an error', () => {
-        let cell = widget.model.contentFactory.createMarkdownCell({});
+        const cell = widget.model.contentFactory.createMarkdownCell({});
         widget.model.cells.push(cell);
-        let child = widget.widgets[widget.widgets.length - 1] as MarkdownCell;
+        const child = widget.widgets[widget.widgets.length - 1] as MarkdownCell;
         child.rendered = false;
         widget.select(child);
         widget.activeCell.model.value.text = ERROR_INPUT;
         return NotebookActions.run(widget, ipySession).then(result => {
-          expect(result).to.be(false);
-          expect(child.rendered).to.be(true);
+          expect(result).to.equal(false);
+          expect(child.rendered).to.equal(true);
           return ipySession.kernel.restart();
         });
       });
@@ -552,32 +552,32 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#runAndAdvance()', () => {
       it('should run the selected cells ', () => {
-        let next = widget.widgets[1] as MarkdownCell;
+        const next = widget.widgets[1] as MarkdownCell;
         widget.select(next);
-        let cell = widget.activeCell as CodeCell;
+        const cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
         next.rendered = false;
         return NotebookActions.runAndAdvance(widget, session).then(result => {
-          expect(result).to.be(true);
+          expect(result).to.equal(true);
           expect(cell.model.outputs.length).to.be.above(0);
-          expect(next.rendered).to.be(true);
+          expect(next.rendered).to.equal(true);
         });
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         return NotebookActions.runAndAdvance(widget, session).then(result => {
-          expect(result).to.be(false);
+          expect(result).to.equal(false);
         });
       });
 
       it('should clear the existing selection', () => {
-        let next = widget.widgets[2];
+        const next = widget.widgets[2];
         widget.select(next);
         return NotebookActions.runAndAdvance(widget, ipySession).then(
           result => {
-            expect(result).to.be(false);
-            expect(widget.isSelected(widget.widgets[0])).to.be(false);
+            expect(result).to.equal(false);
+            expect(widget.isSelected(widget.widgets[0])).to.equal(false);
             return ipySession.kernel.restart();
           }
         );
@@ -586,50 +586,50 @@ describe('@jupyterlab/notebook', () => {
       it('should change to command mode', () => {
         widget.mode = 'edit';
         return NotebookActions.runAndAdvance(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.mode).to.be('command');
+          expect(result).to.equal(true);
+          expect(widget.mode).to.equal('command');
         });
       });
 
       it('should activate the cell after the last selected cell', () => {
-        let next = widget.widgets[3] as MarkdownCell;
+        const next = widget.widgets[3] as MarkdownCell;
         widget.select(next);
         return NotebookActions.runAndAdvance(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.activeCellIndex).to.be(4);
+          expect(result).to.equal(true);
+          expect(widget.activeCellIndex).to.equal(4);
         });
       });
 
       it('should create a new code cell in edit mode if necessary', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         widget.activeCellIndex = count - 1;
         return NotebookActions.runAndAdvance(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.widgets.length).to.be(count + 1);
-          expect(widget.activeCell).to.be.a(CodeCell);
-          expect(widget.mode).to.be('edit');
+          expect(result).to.equal(true);
+          expect(widget.widgets.length).to.equal(count + 1);
+          expect(widget.activeCell).to.be.an.instanceof(CodeCell);
+          expect(widget.mode).to.equal('edit');
         });
       });
 
       it('should allow an undo of the new cell', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         widget.activeCellIndex = count - 1;
         return NotebookActions.runAndAdvance(widget, session).then(result => {
-          expect(result).to.be(true);
+          expect(result).to.equal(true);
           NotebookActions.undo(widget);
-          expect(widget.widgets.length).to.be(count);
+          expect(widget.widgets.length).to.equal(count);
         });
       });
 
       it('should stop executing code cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.model.contentFactory.createCodeCell({});
+        const cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
         widget.select(widget.widgets[widget.widgets.length - 1]);
         return NotebookActions.runAndAdvance(widget, ipySession).then(
           result => {
-            expect(result).to.be(false);
-            expect(cell.executionCount).to.be(null);
+            expect(result).to.equal(false);
+            expect(cell.executionCount).to.be.null;
             return ipySession.kernel.restart();
           }
         );
@@ -637,14 +637,14 @@ describe('@jupyterlab/notebook', () => {
 
       it('should render all markdown cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.widgets[1] as MarkdownCell;
+        const cell = widget.widgets[1] as MarkdownCell;
         cell.rendered = false;
         widget.select(cell);
         return NotebookActions.runAndAdvance(widget, ipySession).then(
           result => {
-            expect(result).to.be(false);
-            expect(cell.rendered).to.be(true);
-            expect(widget.activeCellIndex).to.be(2);
+            expect(result).to.equal(false);
+            expect(cell.rendered).to.equal(true);
+            expect(widget.activeCellIndex).to.equal(2);
             return ipySession.kernel.restart();
           }
         );
@@ -653,80 +653,80 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#runAndInsert()', () => {
       it('should run the selected cells ', () => {
-        let next = widget.widgets[1] as MarkdownCell;
+        const next = widget.widgets[1] as MarkdownCell;
         widget.select(next);
-        let cell = widget.activeCell as CodeCell;
+        const cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
         next.rendered = false;
         return NotebookActions.runAndInsert(widget, session).then(result => {
-          expect(result).to.be(true);
+          expect(result).to.equal(true);
           expect(cell.model.outputs.length).to.be.above(0);
-          expect(next.rendered).to.be(true);
+          expect(next.rendered).to.equal(true);
         });
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         return NotebookActions.runAndInsert(widget, session).then(result => {
-          expect(result).to.be(false);
+          expect(result).to.equal(false);
         });
       });
 
       it('should clear the existing selection', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
         return NotebookActions.runAndInsert(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.isSelected(widget.widgets[0])).to.be(false);
+          expect(result).to.equal(true);
+          expect(widget.isSelected(widget.widgets[0])).to.equal(false);
         });
       });
 
       it('should insert a new code cell in edit mode after the last selected cell', () => {
-        let next = widget.widgets[2];
+        const next = widget.widgets[2];
         widget.select(next);
         next.model.value.text = 'a = 1';
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         return NotebookActions.runAndInsert(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.activeCell).to.be.a(CodeCell);
-          expect(widget.mode).to.be('edit');
-          expect(widget.widgets.length).to.be(count + 1);
+          expect(result).to.equal(true);
+          expect(widget.activeCell).to.be.an.instanceof(CodeCell);
+          expect(widget.mode).to.equal('edit');
+          expect(widget.widgets.length).to.equal(count + 1);
         });
       });
 
       it('should allow an undo of the cell insert', () => {
-        let next = widget.widgets[2];
+        const next = widget.widgets[2];
         widget.select(next);
         next.model.value.text = 'a = 1';
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         return NotebookActions.runAndInsert(widget, session).then(result => {
-          expect(result).to.be(true);
+          expect(result).to.equal(true);
           NotebookActions.undo(widget);
-          expect(widget.widgets.length).to.be(count);
+          expect(widget.widgets.length).to.equal(count);
         });
       });
 
       it('should stop executing code cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.model.contentFactory.createCodeCell({});
+        const cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
         widget.select(widget.widgets[widget.widgets.length - 1]);
         return NotebookActions.runAndInsert(widget, ipySession).then(result => {
-          expect(result).to.be(false);
-          expect(cell.executionCount).to.be(null);
+          expect(result).to.equal(false);
+          expect(cell.executionCount).to.be.null;
           return ipySession.kernel.restart();
         });
       });
 
       it('should render all markdown cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.widgets[1] as MarkdownCell;
+        const cell = widget.widgets[1] as MarkdownCell;
         cell.rendered = false;
         widget.select(cell);
         return NotebookActions.runAndInsert(widget, ipySession).then(result => {
-          expect(result).to.be(false);
-          expect(cell.rendered).to.be(true);
-          expect(widget.activeCellIndex).to.be(2);
+          expect(result).to.equal(false);
+          expect(cell.rendered).to.equal(true);
+          expect(widget.activeCellIndex).to.equal(2);
           return ipySession.kernel.restart();
         });
       });
@@ -739,66 +739,66 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should run all of the cells in the notebok', () => {
-        let next = widget.widgets[1] as MarkdownCell;
-        let cell = widget.activeCell as CodeCell;
+        const next = widget.widgets[1] as MarkdownCell;
+        const cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
         next.rendered = false;
         return NotebookActions.runAll(widget, session).then(result => {
-          expect(result).to.be(true);
+          expect(result).to.equal(true);
           expect(cell.model.outputs.length).to.be.above(0);
-          expect(next.rendered).to.be(true);
+          expect(next.rendered).to.equal(true);
         });
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         return NotebookActions.runAll(widget, session).then(result => {
-          expect(result).to.be(false);
+          expect(result).to.equal(false);
         });
       });
 
       it('should change to command mode', () => {
         widget.mode = 'edit';
         return NotebookActions.runAll(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.mode).to.be('command');
+          expect(result).to.equal(true);
+          expect(widget.mode).to.equal('command');
         });
       });
 
       it('should clear the existing selection', () => {
-        let next = widget.widgets[2];
+        const next = widget.widgets[2];
         widget.select(next);
         return NotebookActions.runAll(widget, session).then(result => {
-          expect(result).to.be(true);
-          expect(widget.isSelected(widget.widgets[2])).to.be(false);
+          expect(result).to.equal(true);
+          expect(widget.isSelected(widget.widgets[2])).to.equal(false);
         });
       });
 
       it('should activate the last cell', () => {
         return NotebookActions.runAll(widget, session).then(result => {
-          expect(widget.activeCellIndex).to.be(widget.widgets.length - 1);
+          expect(widget.activeCellIndex).to.equal(widget.widgets.length - 1);
         });
       });
 
       it('should stop executing code cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.model.contentFactory.createCodeCell({});
+        const cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
         return NotebookActions.runAll(widget, ipySession).then(result => {
-          expect(result).to.be(false);
-          expect(cell.executionCount).to.be(null);
-          expect(widget.activeCellIndex).to.be(widget.widgets.length - 1);
+          expect(result).to.equal(false);
+          expect(cell.executionCount).to.be.null;
+          expect(widget.activeCellIndex).to.equal(widget.widgets.length - 1);
           return ipySession.kernel.restart();
         });
       });
 
       it('should render all markdown cells on an error', () => {
         widget.activeCell.model.value.text = ERROR_INPUT;
-        let cell = widget.widgets[1] as MarkdownCell;
+        const cell = widget.widgets[1] as MarkdownCell;
         cell.rendered = false;
         return NotebookActions.runAll(widget, ipySession).then(result => {
-          expect(result).to.be(false);
-          expect(cell.rendered).to.be(true);
+          expect(result).to.equal(false);
+          expect(cell.rendered).to.equal(true);
           return ipySession.kernel.restart();
         });
       });
@@ -808,55 +808,55 @@ describe('@jupyterlab/notebook', () => {
       it('should select the cell above the active cell', () => {
         widget.activeCellIndex = 1;
         NotebookActions.selectAbove(widget);
-        expect(widget.activeCellIndex).to.be(0);
+        expect(widget.activeCellIndex).to.equal(0);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.selectAbove(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should not wrap around to the bottom', () => {
         NotebookActions.selectAbove(widget);
-        expect(widget.activeCellIndex).to.be(0);
+        expect(widget.activeCellIndex).to.equal(0);
       });
 
       it('should preserve the mode', () => {
         widget.activeCellIndex = 2;
         NotebookActions.selectAbove(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.selectAbove(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
     });
 
     describe('#selectBelow()', () => {
       it('should select the cell below the active cell', () => {
         NotebookActions.selectBelow(widget);
-        expect(widget.activeCellIndex).to.be(1);
+        expect(widget.activeCellIndex).to.equal(1);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.selectBelow(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should not wrap around to the top', () => {
         widget.activeCellIndex = widget.widgets.length - 1;
         NotebookActions.selectBelow(widget);
-        expect(widget.activeCellIndex).to.not.be(0);
+        expect(widget.activeCellIndex).to.not.equal(0);
       });
 
       it('should preserve the mode', () => {
         widget.activeCellIndex = 2;
         NotebookActions.selectBelow(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.selectBelow(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
     });
 
@@ -864,106 +864,106 @@ describe('@jupyterlab/notebook', () => {
       it('should extend the selection to the cell above', () => {
         widget.activeCellIndex = 1;
         NotebookActions.extendSelectionAbove(widget);
-        expect(widget.isSelected(widget.widgets[0])).to.be(true);
+        expect(widget.isSelected(widget.widgets[0])).to.equal(true);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.extendSelectionAbove(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should change to command mode if there is a selection', () => {
         widget.mode = 'edit';
         widget.activeCellIndex = 1;
         NotebookActions.extendSelectionAbove(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
 
       it('should not wrap around to the bottom', () => {
         widget.mode = 'edit';
         NotebookActions.extendSelectionAbove(widget);
-        expect(widget.activeCellIndex).to.be(0);
-        let last = widget.widgets[widget.widgets.length - 1];
-        expect(widget.isSelected(last)).to.be(false);
+        expect(widget.activeCellIndex).to.equal(0);
+        const last = widget.widgets[widget.widgets.length - 1];
+        expect(widget.isSelected(last)).to.equal(false);
         expect(widget.mode).to.equal('edit');
       });
 
       it('should deselect the current cell if the cell above is selected', () => {
         NotebookActions.extendSelectionBelow(widget);
         NotebookActions.extendSelectionBelow(widget);
-        let cell = widget.activeCell;
+        const cell = widget.activeCell;
         NotebookActions.extendSelectionAbove(widget);
-        expect(widget.isSelected(cell)).to.be(false);
+        expect(widget.isSelected(cell)).to.equal(false);
       });
 
       it('should select only the first cell if we move from the second to first', () => {
         NotebookActions.extendSelectionBelow(widget);
-        let cell = widget.activeCell;
+        const cell = widget.activeCell;
         NotebookActions.extendSelectionAbove(widget);
-        expect(widget.isSelected(cell)).to.be(false);
-        expect(widget.activeCellIndex).to.be(0);
+        expect(widget.isSelected(cell)).to.equal(false);
+        expect(widget.activeCellIndex).to.equal(0);
       });
 
       it('should activate the cell', () => {
         widget.activeCellIndex = 1;
         NotebookActions.extendSelectionAbove(widget);
-        expect(widget.activeCellIndex).to.be(0);
+        expect(widget.activeCellIndex).to.equal(0);
       });
     });
 
     describe('#extendSelectionBelow()', () => {
       it('should extend the selection to the cell below', () => {
         NotebookActions.extendSelectionBelow(widget);
-        expect(widget.isSelected(widget.widgets[0])).to.be(true);
-        expect(widget.isSelected(widget.widgets[1])).to.be(true);
+        expect(widget.isSelected(widget.widgets[0])).to.equal(true);
+        expect(widget.isSelected(widget.widgets[1])).to.equal(true);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.extendSelectionBelow(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should change to command mode if there is a selection', () => {
         widget.mode = 'edit';
         NotebookActions.extendSelectionBelow(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
 
       it('should not wrap around to the top', () => {
-        let last = widget.widgets.length - 1;
+        const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
         widget.mode = 'edit';
         NotebookActions.extendSelectionBelow(widget);
-        expect(widget.activeCellIndex).to.be(last);
-        expect(widget.isSelected(widget.widgets[0])).to.be(false);
+        expect(widget.activeCellIndex).to.equal(last);
+        expect(widget.isSelected(widget.widgets[0])).to.equal(false);
         expect(widget.mode).to.equal('edit');
       });
 
       it('should deselect the current cell if the cell below is selected', () => {
-        let last = widget.widgets.length - 1;
+        const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
         NotebookActions.extendSelectionAbove(widget);
         NotebookActions.extendSelectionAbove(widget);
-        let current = widget.activeCell;
+        const current = widget.activeCell;
         NotebookActions.extendSelectionBelow(widget);
-        expect(widget.isSelected(current)).to.be(false);
+        expect(widget.isSelected(current)).to.equal(false);
       });
 
       it('should select only the last cell if we move from the second last to last', () => {
-        let last = widget.widgets.length - 1;
+        const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
         NotebookActions.extendSelectionAbove(widget);
-        let current = widget.activeCell;
+        const current = widget.activeCell;
         NotebookActions.extendSelectionBelow(widget);
-        expect(widget.isSelected(current)).to.be(false);
-        expect(widget.activeCellIndex).to.be(last);
+        expect(widget.isSelected(current)).to.equal(false);
+        expect(widget.activeCellIndex).to.equal(last);
       });
 
       it('should activate the cell', () => {
         NotebookActions.extendSelectionBelow(widget);
-        expect(widget.activeCellIndex).to.be(1);
+        expect(widget.activeCellIndex).to.equal(1);
       });
     });
 
@@ -972,31 +972,31 @@ describe('@jupyterlab/notebook', () => {
         widget.activeCellIndex = 2;
         NotebookActions.extendSelectionAbove(widget);
         NotebookActions.moveUp(widget);
-        expect(widget.isSelected(widget.widgets[0])).to.be(true);
-        expect(widget.isSelected(widget.widgets[1])).to.be(true);
-        expect(widget.isSelected(widget.widgets[2])).to.be(false);
-        expect(widget.activeCellIndex).to.be(0);
+        expect(widget.isSelected(widget.widgets[0])).to.equal(true);
+        expect(widget.isSelected(widget.widgets[1])).to.equal(true);
+        expect(widget.isSelected(widget.widgets[2])).to.equal(false);
+        expect(widget.activeCellIndex).to.equal(0);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.moveUp(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should not wrap around to the bottom', () => {
-        expect(widget.activeCellIndex).to.be(0);
+        expect(widget.activeCellIndex).to.equal(0);
         NotebookActions.moveUp(widget);
-        expect(widget.activeCellIndex).to.be(0);
+        expect(widget.activeCellIndex).to.equal(0);
       });
 
       it('should be undo-able', () => {
         widget.activeCellIndex++;
-        let source = widget.activeCell.model.value.text;
+        const source = widget.activeCell.model.value.text;
         NotebookActions.moveUp(widget);
-        expect(widget.model.cells.get(0).value.text).to.be(source);
+        expect(widget.model.cells.get(0).value.text).to.equal(source);
         NotebookActions.undo(widget);
-        expect(widget.model.cells.get(1).value.text).to.be(source);
+        expect(widget.model.cells.get(1).value.text).to.equal(source);
       });
     });
 
@@ -1004,82 +1004,86 @@ describe('@jupyterlab/notebook', () => {
       it('should move the selected cells down', () => {
         NotebookActions.extendSelectionBelow(widget);
         NotebookActions.moveDown(widget);
-        expect(widget.isSelected(widget.widgets[0])).to.be(false);
-        expect(widget.isSelected(widget.widgets[1])).to.be(true);
-        expect(widget.isSelected(widget.widgets[2])).to.be(true);
-        expect(widget.activeCellIndex).to.be(2);
+        expect(widget.isSelected(widget.widgets[0])).to.equal(false);
+        expect(widget.isSelected(widget.widgets[1])).to.equal(true);
+        expect(widget.isSelected(widget.widgets[2])).to.equal(true);
+        expect(widget.activeCellIndex).to.equal(2);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.moveUp(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should not wrap around to the top', () => {
         widget.activeCellIndex = widget.widgets.length - 1;
         NotebookActions.moveDown(widget);
-        expect(widget.activeCellIndex).to.be(widget.widgets.length - 1);
+        expect(widget.activeCellIndex).to.equal(widget.widgets.length - 1);
       });
 
       it('should be undo-able', () => {
-        let source = widget.activeCell.model.value.text;
+        const source = widget.activeCell.model.value.text;
         NotebookActions.moveDown(widget);
-        expect(widget.model.cells.get(1).value.text).to.be(source);
+        expect(widget.model.cells.get(1).value.text).to.equal(source);
         NotebookActions.undo(widget);
-        expect(widget.model.cells.get(0).value.text).to.be(source);
+        expect(widget.model.cells.get(0).value.text).to.equal(source);
       });
     });
 
     describe('#copy()', () => {
       it('should copy the selected cells to a NBTestUtils.clipboard', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
         NotebookActions.copy(widget);
-        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.be(true);
-        let data = NBTestUtils.clipboard.getData(JUPYTER_CELL_MIME);
-        expect(data.length).to.be(2);
+        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
+        const data = NBTestUtils.clipboard.getData(JUPYTER_CELL_MIME);
+        expect(data.length).to.equal(2);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.copy(widget);
-        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.be(false);
+        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(
+          false
+        );
       });
 
       it('should change to command mode', () => {
         widget.mode = 'edit';
         NotebookActions.copy(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
     });
 
     describe('#cut()', () => {
       it('should cut the selected cells to a NBTestUtils.clipboard', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.cut(widget);
-        expect(widget.widgets.length).to.be(count - 2);
+        expect(widget.widgets.length).to.equal(count - 2);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.cut(widget);
-        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.be(false);
+        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(
+          false
+        );
       });
 
       it('should change to command mode', () => {
         widget.mode = 'edit';
         NotebookActions.cut(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
 
       it('should be undo-able', () => {
-        let source = widget.activeCell.model.value.text;
+        const source = widget.activeCell.model.value.text;
         NotebookActions.cut(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets[0].model.value.text).to.be(source);
+        expect(widget.widgets[0].model.value.text).to.equal(source);
       });
 
       it('should add a new code cell if all cells were cut', async () => {
@@ -1088,154 +1092,154 @@ describe('@jupyterlab/notebook', () => {
         }
         NotebookActions.cut(widget);
         await sleep();
-        expect(widget.widgets.length).to.be(1);
-        expect(widget.activeCell).to.be.a(CodeCell);
+        expect(widget.widgets.length).to.equal(1);
+        expect(widget.activeCell).to.be.an.instanceof(CodeCell);
       });
     });
 
     describe('#paste()', () => {
       it('should paste cells from a NBTestUtils.clipboard', () => {
-        let source = widget.activeCell.model.value.text;
-        let next = widget.widgets[1];
+        const source = widget.activeCell.model.value.text;
+        const next = widget.widgets[1];
         widget.select(next);
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.cut(widget);
         widget.activeCellIndex = 1;
         NotebookActions.paste(widget);
-        expect(widget.widgets.length).to.be(count);
-        expect(widget.widgets[2].model.value.text).to.be(source);
-        expect(widget.activeCellIndex).to.be(3);
+        expect(widget.widgets.length).to.equal(count);
+        expect(widget.widgets[2].model.value.text).to.equal(source);
+        expect(widget.activeCellIndex).to.equal(3);
       });
 
       it('should be a no-op if there is no model', () => {
         NotebookActions.copy(widget);
         widget.model = null;
         NotebookActions.paste(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should be a no-op if there is no cell data on the NBTestUtils.clipboard', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.paste(widget);
-        expect(widget.widgets.length).to.be(count);
+        expect(widget.widgets.length).to.equal(count);
       });
 
       it('should change to command mode', () => {
         widget.mode = 'edit';
         NotebookActions.cut(widget);
         NotebookActions.paste(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
 
       it('should be undo-able', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.cut(widget);
         widget.activeCellIndex = 1;
         NotebookActions.paste(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count - 2);
+        expect(widget.widgets.length).to.equal(count - 2);
       });
     });
 
     describe('#undo()', () => {
       it('should undo a cell action', () => {
-        let count = widget.widgets.length;
-        let next = widget.widgets[1];
+        const count = widget.widgets.length;
+        const next = widget.widgets[1];
         widget.select(next);
         NotebookActions.deleteCells(widget);
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count);
+        expect(widget.widgets.length).to.equal(count);
       });
 
       it('should switch the widget to command mode', () => {
         widget.mode = 'edit';
         NotebookActions.undo(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.undo(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should be a no-op if there are no cell actions to undo', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.deleteCells(widget);
         widget.model.cells.clearUndo();
         NotebookActions.undo(widget);
-        expect(widget.widgets.length).to.be(count - 1);
+        expect(widget.widgets.length).to.equal(count - 1);
       });
     });
 
     describe('#redo()', () => {
       it('should redo a cell action', () => {
-        let count = widget.widgets.length;
-        let next = widget.widgets[1];
+        const count = widget.widgets.length;
+        const next = widget.widgets[1];
         widget.select(next);
         NotebookActions.deleteCells(widget);
         NotebookActions.undo(widget);
         NotebookActions.redo(widget);
-        expect(widget.widgets.length).to.be(count - 2);
+        expect(widget.widgets.length).to.equal(count - 2);
       });
 
       it('should switch the widget to command mode', () => {
         NotebookActions.undo(widget);
         widget.mode = 'edit';
         NotebookActions.redo(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
       });
 
       it('should be a no-op if there is no model', () => {
         NotebookActions.undo(widget);
         widget.model = null;
         NotebookActions.redo(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should be a no-op if there are no cell actions to redo', () => {
-        let count = widget.widgets.length;
+        const count = widget.widgets.length;
         NotebookActions.redo(widget);
-        expect(widget.widgets.length).to.be(count);
+        expect(widget.widgets.length).to.equal(count);
       });
     });
 
     describe('#toggleAllLineNumbers()', () => {
       it('should toggle line numbers on all cells', () => {
-        let state = widget.activeCell.editor.getOption('lineNumbers');
+        const state = widget.activeCell.editor.getOption('lineNumbers');
         NotebookActions.toggleAllLineNumbers(widget);
         for (let i = 0; i < widget.widgets.length; i++) {
-          let lineNumbers = widget.widgets[i].editor.getOption('lineNumbers');
-          expect(lineNumbers).to.be(!state);
+          const lineNumbers = widget.widgets[i].editor.getOption('lineNumbers');
+          expect(lineNumbers).to.equal(!state);
         }
       });
 
       it('should be based on the state of the active cell', () => {
-        let state = widget.activeCell.editor.getOption('lineNumbers');
+        const state = widget.activeCell.editor.getOption('lineNumbers');
         for (let i = 1; i < widget.widgets.length; i++) {
           widget.widgets[i].editor.setOption('lineNumbers', !state);
         }
         NotebookActions.toggleAllLineNumbers(widget);
         for (let i = 0; i < widget.widgets.length; i++) {
-          let lineNumbers = widget.widgets[i].editor.getOption('lineNumbers');
-          expect(lineNumbers).to.be(!state);
+          const lineNumbers = widget.widgets[i].editor.getOption('lineNumbers');
+          expect(lineNumbers).to.equal(!state);
         }
       });
 
       it('should preserve the widget mode', () => {
         NotebookActions.toggleAllLineNumbers(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.toggleAllLineNumbers(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.toggleAllLineNumbers(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
     });
 
@@ -1244,7 +1248,7 @@ describe('@jupyterlab/notebook', () => {
         // Select the next code cell that has outputs.
         let index = 0;
         for (let i = 1; i < widget.widgets.length; i++) {
-          let cell = widget.widgets[i];
+          const cell = widget.widgets[i];
           if (cell instanceof CodeCell && cell.model.outputs.length) {
             widget.select(cell);
             index = i;
@@ -1253,51 +1257,51 @@ describe('@jupyterlab/notebook', () => {
         }
         NotebookActions.clearOutputs(widget);
         let cell = widget.widgets[0] as CodeCell;
-        expect(cell.model.outputs.length).to.be(0);
+        expect(cell.model.outputs.length).to.equal(0);
         cell = widget.widgets[index] as CodeCell;
-        expect(cell.model.outputs.length).to.be(0);
+        expect(cell.model.outputs.length).to.equal(0);
       });
 
       it('should preserve the widget mode', () => {
         NotebookActions.clearOutputs(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.clearOutputs(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.clearOutputs(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
     });
 
     describe('#clearAllOutputs()', () => {
       it('should clear the outputs on all cells', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
         NotebookActions.clearAllOutputs(widget);
         for (let i = 0; i < widget.widgets.length; i++) {
-          let cell = widget.widgets[i];
+          const cell = widget.widgets[i];
           if (cell instanceof CodeCell) {
-            expect(cell.model.outputs.length).to.be(0);
+            expect(cell.model.outputs.length).to.equal(0);
           }
         }
       });
 
       it('should preserve the widget mode', () => {
         NotebookActions.clearAllOutputs(widget);
-        expect(widget.mode).to.be('command');
+        expect(widget.mode).to.equal('command');
         widget.mode = 'edit';
         NotebookActions.clearAllOutputs(widget);
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.clearAllOutputs(widget);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
     });
 
@@ -1313,14 +1317,14 @@ describe('@jupyterlab/notebook', () => {
         NotebookActions.persistViewState(widget);
         for (const cell of widget.widgets) {
           if (cell instanceof CodeCell) {
-            expect(cell.model.metadata.get('collapsed')).to.be(true);
-            expect(cell.model.metadata.get('scrolled')).to.be(true);
-            expect(cell.model.metadata.get('jupyter')).to.eql({
+            expect(cell.model.metadata.get('collapsed')).to.equal(true);
+            expect(cell.model.metadata.get('scrolled')).to.equal(true);
+            expect(cell.model.metadata.get('jupyter')).to.deep.equal({
               source_hidden: true,
               outputs_hidden: true
             });
           } else {
-            expect(cell.model.metadata.get('jupyter')).to.eql({
+            expect(cell.model.metadata.get('jupyter')).to.deep.equal({
               source_hidden: true
             });
           }
@@ -1338,10 +1342,10 @@ describe('@jupyterlab/notebook', () => {
         NotebookActions.persistViewState(widget);
         for (const cell of widget.widgets) {
           if (cell instanceof CodeCell) {
-            expect(cell.model.metadata.has('collapsed')).to.be(false);
-            expect(cell.model.metadata.has('scrolled')).to.be(false);
+            expect(cell.model.metadata.has('collapsed')).to.equal(false);
+            expect(cell.model.metadata.has('scrolled')).to.equal(false);
           }
-          expect(cell.model.metadata.has('jupyter')).to.be(false);
+          expect(cell.model.metadata.has('jupyter')).to.equal(false);
         }
       });
 
@@ -1356,10 +1360,10 @@ describe('@jupyterlab/notebook', () => {
         NotebookActions.persistViewState(widget);
         for (const cell of widget.widgets) {
           if (cell instanceof CodeCell) {
-            expect(cell.model.metadata.has('collapsed')).to.be(false);
-            expect(cell.model.metadata.has('scrolled')).to.be(false);
+            expect(cell.model.metadata.has('collapsed')).to.equal(false);
+            expect(cell.model.metadata.has('scrolled')).to.equal(false);
           }
-          expect(cell.model.metadata.get('jupyter')).to.eql({
+          expect(cell.model.metadata.get('jupyter')).to.deep.equal({
             source_hidden: true
           });
         }
@@ -1368,69 +1372,71 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#setMarkdownHeader()', () => {
       it('should set the markdown header level of selected cells', () => {
-        let next = widget.widgets[1];
+        const next = widget.widgets[1];
         widget.select(next);
         NotebookActions.setMarkdownHeader(widget, 2);
-        expect(widget.activeCell.model.value.text.slice(0, 3)).to.be('## ');
-        expect(next.model.value.text.slice(0, 3)).to.be('## ');
+        expect(widget.activeCell.model.value.text.slice(0, 3)).to.equal('## ');
+        expect(next.model.value.text.slice(0, 3)).to.equal('## ');
       });
 
       it('should convert the cells to markdown type', () => {
         NotebookActions.setMarkdownHeader(widget, 2);
-        expect(widget.activeCell).to.be.a(MarkdownCell);
+        expect(widget.activeCell).to.be.an.instanceof(MarkdownCell);
       });
 
       it('should be clamped between 1 and 6', () => {
         NotebookActions.setMarkdownHeader(widget, -1);
-        expect(widget.activeCell.model.value.text.slice(0, 2)).to.be('# ');
+        expect(widget.activeCell.model.value.text.slice(0, 2)).to.equal('# ');
         NotebookActions.setMarkdownHeader(widget, 10);
-        expect(widget.activeCell.model.value.text.slice(0, 7)).to.be('###### ');
+        expect(widget.activeCell.model.value.text.slice(0, 7)).to.equal(
+          '###### '
+        );
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
         NotebookActions.setMarkdownHeader(widget, 1);
-        expect(widget.activeCellIndex).to.be(-1);
+        expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should replace an existing header', () => {
         widget.activeCell.model.value.text = '# foo';
         NotebookActions.setMarkdownHeader(widget, 2);
-        expect(widget.activeCell.model.value.text).to.be('## foo');
+        expect(widget.activeCell.model.value.text).to.equal('## foo');
       });
 
       it('should replace leading white space', () => {
         widget.activeCell.model.value.text = '      foo';
         NotebookActions.setMarkdownHeader(widget, 2);
-        expect(widget.activeCell.model.value.text).to.be('## foo');
+        expect(widget.activeCell.model.value.text).to.equal('## foo');
       });
 
       it('should unrender the cells', () => {
         NotebookActions.setMarkdownHeader(widget, 1);
-        expect((widget.activeCell as MarkdownCell).rendered).to.be(false);
+        expect((widget.activeCell as MarkdownCell).rendered).to.equal(false);
       });
     });
 
     describe('#trust()', () => {
       it('should trust the notebook cells if the user accepts', done => {
-        let model = widget.model;
+        const model = widget.model;
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        let cell = model.cells.get(0);
-        expect(cell.trusted).to.not.be(true);
+        const cell = model.cells.get(0);
+        expect(cell.trusted).to.not.equal(true);
         NotebookActions.trust(widget).then(() => {
-          expect(cell.trusted).to.be(true);
+          expect(cell.trusted).to.equal(true);
           done();
         });
         acceptDialog();
       });
 
       it('should not trust the notebook cells if the user aborts', done => {
-        let model = widget.model;
+        const model = widget.model;
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        let cell = model.cells.get(0);
-        expect(cell.trusted).to.not.be(true);
+        const cell = model.cells.get(0);
+        expect(cell.trusted).to.not.equal(true);
         NotebookActions.trust(widget).then(() => {
-          expect(cell.trusted).to.not.be(true);
+          expect(cell.trusted).to.not.equal(true);
           done();
         });
         dismissDialog();
@@ -1444,11 +1450,11 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should show a dialog if all cells are trusted', done => {
-        let model = widget.model;
+        const model = widget.model;
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         for (let i = 0; i < model.cells.length; i++) {
-          let cell = model.cells.get(i);
+          const cell = model.cells.get(i);
           cell.trusted = true;
         }
         NotebookActions.trust(widget).then(() => {

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -604,7 +604,7 @@ describe('@jupyterlab/notebook', () => {
         const cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
         widget.select(widget.widgets[widget.widgets.length - 1]);
-        const result = await NotebookActions.runAndAdvance(widget, session);
+        const result = await NotebookActions.runAndAdvance(widget, ipySession);
         expect(result).to.equal(false);
         expect(cell.executionCount).to.be.null;
         await ipySession.kernel.restart();
@@ -615,7 +615,7 @@ describe('@jupyterlab/notebook', () => {
         const cell = widget.widgets[1] as MarkdownCell;
         cell.rendered = false;
         widget.select(cell);
-        const result = await NotebookActions.runAndAdvance(widget, session);
+        const result = await NotebookActions.runAndAdvance(widget, ipySession);
         expect(result).to.equal(false);
         expect(cell.rendered).to.equal(true);
         expect(widget.activeCellIndex).to.equal(2);
@@ -1381,8 +1381,9 @@ describe('@jupyterlab/notebook', () => {
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         const cell = model.cells.get(0);
         expect(cell.trusted).to.not.equal(true);
-        await NotebookActions.trust(widget);
+        let promise = NotebookActions.trust(widget);
         await acceptDialog();
+        await promise;
         expect(cell.trusted).to.equal(true);
       });
 
@@ -1397,7 +1398,7 @@ describe('@jupyterlab/notebook', () => {
         expect(cell.trusted).to.not.equal(true);
       });
 
-      it('should bail if the model is `null`', async () => {
+      it('should be a no-op if the model is `null`', async () => {
         widget.model = null;
         await NotebookActions.trust(widget);
       });
@@ -1410,7 +1411,7 @@ describe('@jupyterlab/notebook', () => {
           const cell = model.cells.get(i);
           cell.trusted = true;
         }
-        const promise = await NotebookActions.trust(widget);
+        const promise = NotebookActions.trust(widget);
         await acceptDialog();
         await promise;
       });

--- a/tests/test-notebook/src/celltools.spec.ts
+++ b/tests/test-notebook/src/celltools.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Message } from '@phosphor/messaging';
 
@@ -121,39 +121,43 @@ describe('@jupyterlab/notebook', () => {
     describe('CellTools', () => {
       describe('#constructor()', () => {
         it('should create a celltools object', () => {
-          expect(celltools).to.be.a(CellTools);
+          expect(celltools).to.be.an.instanceof(CellTools);
         });
       });
 
       describe('#activeCell', () => {
         it('should be the active cell', () => {
-          expect(celltools.activeCell).to.be(panel1.content.activeCell);
+          expect(celltools.activeCell).to.equal(panel1.content.activeCell);
           tabpanel.currentIndex = 0;
           simulate(panel0.node, 'focus');
-          expect(celltools.activeCell).to.be(panel0.content.activeCell);
+          expect(celltools.activeCell).to.equal(panel0.content.activeCell);
         });
       });
 
       describe('#selectedCells', () => {
         it('should be the currently selected cells', () => {
-          expect(celltools.selectedCells).to.eql([panel1.content.activeCell]);
+          expect(celltools.selectedCells).to.deep.equal([
+            panel1.content.activeCell
+          ]);
           tabpanel.currentIndex = 0;
           simulate(panel0.node, 'focus');
-          expect(celltools.selectedCells).to.eql([panel0.content.activeCell]);
+          expect(celltools.selectedCells).to.deep.equal([
+            panel0.content.activeCell
+          ]);
           panel0.content.select(panel0.content.widgets[1]);
-          expect(celltools.selectedCells.length).to.be(2);
+          expect(celltools.selectedCells.length).to.equal(2);
         });
       });
 
       describe('#addItem()', () => {
         it('should add a cell tool item', () => {
-          let tool = new CellTools.Tool();
+          const tool = new CellTools.Tool();
           celltools.addItem({ tool });
           tool.dispose();
         });
 
         it('should accept a rank', () => {
-          let tool = new CellTools.Tool();
+          const tool = new CellTools.Tool();
           celltools.addItem({ tool, rank: 100 });
           tool.dispose();
         });
@@ -163,22 +167,22 @@ describe('@jupyterlab/notebook', () => {
     describe('CellTools.Tool', () => {
       describe('#constructor', () => {
         it('should create a new base tool', () => {
-          let tool = new CellTools.Tool();
-          expect(tool).to.be.a(CellTools.Tool);
+          const tool = new CellTools.Tool();
+          expect(tool).to.be.an.instanceof(CellTools.Tool);
         });
       });
 
       describe('#parent', () => {
         it('should be the celltools object used by the tool', () => {
-          let tool = new CellTools.Tool({});
+          const tool = new CellTools.Tool({});
           celltools.addItem({ tool });
-          expect(tool.parent).to.be(celltools);
+          expect(tool.parent).to.equal(celltools);
         });
       });
 
       describe('#onActiveCellChanged()', () => {
         it('should be called when the active cell changes', () => {
-          let tool = new LogTool({});
+          const tool = new LogTool({});
           celltools.addItem({ tool });
           tool.methods = [];
           simulate(panel0.node, 'focus');
@@ -188,10 +192,10 @@ describe('@jupyterlab/notebook', () => {
 
       describe('#onSelectionChanged()', () => {
         it('should be called when the selection changes', () => {
-          let tool = new LogTool({});
+          const tool = new LogTool({});
           celltools.addItem({ tool });
           tool.methods = [];
-          let current = tracker.currentWidget;
+          const current = tracker.currentWidget;
           current.content.select(current.content.widgets[1]);
           expect(tool.methods).to.contain('onSelectionChanged');
         });
@@ -199,10 +203,10 @@ describe('@jupyterlab/notebook', () => {
 
       describe('#onMetadataChanged()', () => {
         it('should be called when the metadata changes', () => {
-          let tool = new LogTool({});
+          const tool = new LogTool({});
           celltools.addItem({ tool });
           tool.methods = [];
-          let metadata = celltools.activeCell.model.metadata;
+          const metadata = celltools.activeCell.model.metadata;
           metadata.set('foo', 1);
           metadata.set('foo', 2);
           expect(tool.methods).to.contain('onMetadataChanged');
@@ -212,49 +216,49 @@ describe('@jupyterlab/notebook', () => {
 
     describe('CellTools.ActiveCellTool', () => {
       it('should create a new active cell tool', () => {
-        let tool = new CellTools.ActiveCellTool();
+        const tool = new CellTools.ActiveCellTool();
         celltools.addItem({ tool });
-        expect(tool).to.be.a(CellTools.ActiveCellTool);
+        expect(tool).to.be.an.instanceof(CellTools.ActiveCellTool);
       });
 
       it('should handle a change to the active cell', () => {
-        let tool = new CellTools.ActiveCellTool();
+        const tool = new CellTools.ActiveCellTool();
         celltools.addItem({ tool });
-        let widget = tracker.currentWidget;
+        const widget = tracker.currentWidget;
         widget.content.activeCellIndex++;
         widget.content.activeCell.model.metadata.set('bar', 1);
-        expect(tool.node.querySelector('.jp-InputArea-editor')).to.be.ok();
+        expect(tool.node.querySelector('.jp-InputArea-editor')).to.be.ok;
       });
     });
 
     describe('CellTools.MetadataEditorTool', () => {
-      let editorServices = new CodeMirrorEditorFactory();
+      const editorServices = new CodeMirrorEditorFactory();
       const editorFactory = editorServices.newInlineEditor.bind(editorServices);
 
       it('should create a new metadata editor tool', () => {
-        let tool = new CellTools.MetadataEditorTool({ editorFactory });
-        expect(tool).to.be.a(CellTools.MetadataEditorTool);
+        const tool = new CellTools.MetadataEditorTool({ editorFactory });
+        expect(tool).to.be.an.instanceof(CellTools.MetadataEditorTool);
       });
 
       it('should handle a change to the active cell', () => {
-        let tool = new CellTools.MetadataEditorTool({ editorFactory });
+        const tool = new CellTools.MetadataEditorTool({ editorFactory });
         celltools.addItem({ tool });
-        let model = tool.editor.model;
-        expect(JSON.stringify(model.value.text)).to.ok();
-        let widget = tracker.currentWidget;
+        const model = tool.editor.model;
+        expect(JSON.stringify(model.value.text)).to.be.ok;
+        const widget = tracker.currentWidget;
         widget.content.activeCellIndex++;
         widget.content.activeCell.model.metadata.set('bar', 1);
         expect(JSON.stringify(model.value.text)).to.contain('bar');
       });
 
       it('should handle a change to the metadata', () => {
-        let tool = new CellTools.MetadataEditorTool({ editorFactory });
+        const tool = new CellTools.MetadataEditorTool({ editorFactory });
         celltools.addItem({ tool });
-        let model = tool.editor.model;
-        let previous = model.value.text;
-        let metadata = celltools.activeCell.model.metadata;
+        const model = tool.editor.model;
+        const previous = model.value.text;
+        const metadata = celltools.activeCell.model.metadata;
         metadata.set('foo', 1);
-        expect(model.value.text).to.not.be(previous);
+        expect(model.value.text).to.not.equal(previous);
       });
     });
 
@@ -280,165 +284,167 @@ describe('@jupyterlab/notebook', () => {
 
       describe('#constructor()', () => {
         it('should create a new key selector', () => {
-          expect(tool).to.be.a(CellTools.KeySelector);
+          expect(tool).to.be.an.instanceof(CellTools.KeySelector);
         });
       });
 
       describe('#key', () => {
         it('should be the key used by the selector', () => {
-          expect(tool.key).to.be('foo');
+          expect(tool.key).to.equal('foo');
         });
       });
 
       describe('#selectNode', () => {
         it('should be the select node', () => {
-          expect(tool.selectNode.localName).to.be('select');
+          expect(tool.selectNode.localName).to.equal('select');
         });
       });
 
       describe('#handleEvent()', () => {
         context('change', () => {
           it('should update the metadata', () => {
-            let select = tool.selectNode;
+            const select = tool.selectNode;
             simulate(select, 'focus');
             select.selectedIndex = 1;
             simulate(select, 'change');
             expect(tool.events).to.contain('change');
-            let metadata = celltools.activeCell.model.metadata;
-            expect(metadata.get('foo')).to.eql([1, 2, 'a']);
+            const metadata = celltools.activeCell.model.metadata;
+            expect(metadata.get('foo')).to.deep.equal([1, 2, 'a']);
           });
         });
 
         context('focus', () => {
           it('should add the focused class to the wrapper node', () => {
-            let select = tool.selectNode;
+            const select = tool.selectNode;
             simulate(select, 'focus');
-            let selector = '.jp-mod-focused';
-            expect(tool.node.querySelector(selector)).to.be.ok();
+            const selector = '.jp-mod-focused';
+            expect(tool.node.querySelector(selector)).to.be.ok;
           });
         });
 
         context('blur', () => {
           it('should remove the focused class from the wrapper node', () => {
-            let select = tool.selectNode;
+            const select = tool.selectNode;
             simulate(select, 'focus');
             simulate(select, 'blur');
-            let selector = '.jp-mod-focused';
-            expect(tool.node.querySelector(selector)).to.not.be.ok();
+            const selector = '.jp-mod-focused';
+            expect(tool.node.querySelector(selector)).to.not.be.ok;
           });
         });
       });
 
       describe('#onAfterAttach()', () => {
         it('should add event listeners', () => {
-          let select = tool.selectNode;
+          const select = tool.selectNode;
           expect(tool.methods).to.contain('onAfterAttach');
           simulate(select, 'focus');
           simulate(select, 'blur');
           select.selectedIndex = 0;
           simulate(select, 'change');
-          expect(tool.events).to.eql(['change']);
+          expect(tool.events).to.deep.equal(['change']);
         });
       });
 
       describe('#onBeforeDetach()', () => {
         it('should remove event listeners', () => {
-          let select = tool.selectNode;
+          const select = tool.selectNode;
           celltools.dispose();
           expect(tool.methods).to.contain('onBeforeDetach');
           simulate(select, 'focus');
           simulate(select, 'blur');
           simulate(select, 'change');
-          expect(tool.events).to.eql([]);
+          expect(tool.events).to.deep.equal([]);
         });
       });
 
       describe('#onValueChanged()', () => {
         it('should update the metadata', () => {
-          let select = tool.selectNode;
+          const select = tool.selectNode;
           simulate(select, 'focus');
           select.selectedIndex = 1;
           simulate(select, 'change');
           expect(tool.methods).to.contain('onValueChanged');
-          let metadata = celltools.activeCell.model.metadata;
-          expect(metadata.get('foo')).to.eql([1, 2, 'a']);
+          const metadata = celltools.activeCell.model.metadata;
+          expect(metadata.get('foo')).to.deep.equal([1, 2, 'a']);
         });
       });
 
       describe('#onActiveCellChanged()', () => {
         it('should update the select value', () => {
-          let cell = panel0.content.model.cells.get(1);
+          const cell = panel0.content.model.cells.get(1);
           cell.metadata.set('foo', 1);
           panel0.content.activeCellIndex = 1;
           expect(tool.methods).to.contain('onActiveCellChanged');
-          expect(tool.selectNode.value).to.be('1');
+          expect(tool.selectNode.value).to.equal('1');
         });
       });
 
       describe('#onMetadataChanged()', () => {
         it('should update the select value', () => {
-          let metadata = celltools.activeCell.model.metadata;
+          const metadata = celltools.activeCell.model.metadata;
           metadata.set('foo', 1);
           expect(tool.methods).to.contain('onMetadataChanged');
-          expect(tool.selectNode.value).to.be('1');
+          expect(tool.selectNode.value).to.equal('1');
         });
       });
     });
 
     describe('CellTools.createSlideShowSelector()', () => {
       it('should create a slide show selector', () => {
-        let tool = CellTools.createSlideShowSelector();
+        const tool = CellTools.createSlideShowSelector();
         tool.selectNode.selectedIndex = -1;
         celltools.addItem({ tool });
         simulate(panel0.node, 'focus');
         tabpanel.currentIndex = 2;
-        expect(tool).to.be.a(CellTools.KeySelector);
-        expect(tool.key).to.be('slideshow');
-        let select = tool.selectNode;
-        expect(select.value).to.be('');
-        let metadata = celltools.activeCell.model.metadata;
-        expect(metadata.get('slideshow')).to.be(void 0);
+        expect(tool).to.be.an.instanceof(CellTools.KeySelector);
+        expect(tool.key).to.equal('slideshow');
+        const select = tool.selectNode;
+        expect(select.value).to.equal('');
+        const metadata = celltools.activeCell.model.metadata;
+        expect(metadata.get('slideshow')).to.be.undefined;
         simulate(select, 'focus');
         tool.selectNode.selectedIndex = 1;
         simulate(select, 'change');
-        expect(metadata.get('slideshow')).to.eql({ slide_type: 'slide' });
+        expect(metadata.get('slideshow')).to.deep.equal({
+          slide_type: 'slide'
+        });
       });
     });
 
     describe('CellTools.createNBConvertSelector()', () => {
       it('should create a raw mimetype selector', () => {
-        let tool = CellTools.createNBConvertSelector();
+        const tool = CellTools.createNBConvertSelector();
         tool.selectNode.selectedIndex = -1;
         celltools.addItem({ tool });
         simulate(panel0.node, 'focus');
         NotebookActions.changeCellType(panel0.content, 'raw');
         tabpanel.currentIndex = 2;
-        expect(tool).to.be.a(CellTools.KeySelector);
-        expect(tool.key).to.be('raw_mimetype');
-        let select = tool.selectNode;
-        expect(select.value).to.be('');
+        expect(tool).to.be.an.instanceof(CellTools.KeySelector);
+        expect(tool.key).to.equal('raw_mimetype');
+        const select = tool.selectNode;
+        expect(select.value).to.equal('');
 
-        let metadata = celltools.activeCell.model.metadata;
-        expect(metadata.get('raw_mimetype')).to.be(void 0);
+        const metadata = celltools.activeCell.model.metadata;
+        expect(metadata.get('raw_mimetype')).to.be.undefined;
         simulate(select, 'focus');
         tool.selectNode.selectedIndex = 2;
         simulate(select, 'change');
-        expect(metadata.get('raw_mimetype')).to.be('text/restructuredtext');
+        expect(metadata.get('raw_mimetype')).to.equal('text/restructuredtext');
       });
 
       it('should have no effect on a code cell', () => {
-        let tool = CellTools.createNBConvertSelector();
+        const tool = CellTools.createNBConvertSelector();
         tool.selectNode.selectedIndex = -1;
         celltools.addItem({ tool });
         simulate(panel0.node, 'focus');
         NotebookActions.changeCellType(panel0.content, 'code');
 
         tabpanel.currentIndex = 2;
-        expect(tool).to.be.a(CellTools.KeySelector);
-        expect(tool.key).to.be('raw_mimetype');
-        let select = tool.selectNode;
-        expect(select.disabled).to.be(true);
-        expect(select.value).to.be('');
+        expect(tool).to.be.an.instanceof(CellTools.KeySelector);
+        expect(tool.key).to.equal('raw_mimetype');
+        const select = tool.selectNode;
+        expect(select.disabled).to.equal(true);
+        expect(select.value).to.equal('');
       });
     });
   });

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { toArray } from '@phosphor/algorithm';
 
@@ -49,7 +49,7 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#createSaveButton()', () => {
       it('should save when clicked', done => {
-        let button = ToolbarItems.createSaveButton(panel);
+        const button = ToolbarItems.createSaveButton(panel);
         Widget.attach(button, document.body);
         context.fileChanged.connect(() => {
           button.dispose();
@@ -59,83 +59,83 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it("should have the `'jp-SaveIcon'` class", () => {
-        let button = ToolbarItems.createSaveButton(panel);
-        expect(button.hasClass('jp-SaveIcon')).to.be(true);
+        const button = ToolbarItems.createSaveButton(panel);
+        expect(button.hasClass('jp-SaveIcon')).to.equal(true);
       });
     });
 
     describe('#createInsertButton()', () => {
       it('should insert below when clicked', () => {
-        let button = ToolbarItems.createInsertButton(panel);
+        const button = ToolbarItems.createInsertButton(panel);
         Widget.attach(button, document.body);
         button.node.click();
-        expect(panel.content.activeCellIndex).to.be(1);
-        expect(panel.content.activeCell).to.be.a(CodeCell);
+        expect(panel.content.activeCellIndex).to.equal(1);
+        expect(panel.content.activeCell).to.be.an.instanceof(CodeCell);
         button.dispose();
       });
 
       it("should have the `'jp-AddIcon'` class", () => {
-        let button = ToolbarItems.createInsertButton(panel);
-        expect(button.hasClass('jp-AddIcon')).to.be(true);
+        const button = ToolbarItems.createInsertButton(panel);
+        expect(button.hasClass('jp-AddIcon')).to.equal(true);
       });
     });
 
     describe('#createCutButton()', () => {
       it('should cut when clicked', () => {
-        let button = ToolbarItems.createCutButton(panel);
-        let count = panel.content.widgets.length;
+        const button = ToolbarItems.createCutButton(panel);
+        const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         button.node.click();
-        expect(panel.content.widgets.length).to.be(count - 1);
-        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.be(true);
+        expect(panel.content.widgets.length).to.equal(count - 1);
+        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
         button.dispose();
       });
 
       it("should have the `'jp-CutIcon'` class", () => {
-        let button = ToolbarItems.createCutButton(panel);
-        expect(button.hasClass('jp-CutIcon')).to.be(true);
+        const button = ToolbarItems.createCutButton(panel);
+        expect(button.hasClass('jp-CutIcon')).to.equal(true);
       });
     });
 
     describe('#createCopyButton()', () => {
       it('should copy when clicked', () => {
-        let button = ToolbarItems.createCopyButton(panel);
-        let count = panel.content.widgets.length;
+        const button = ToolbarItems.createCopyButton(panel);
+        const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         button.node.click();
-        expect(panel.content.widgets.length).to.be(count);
-        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.be(true);
+        expect(panel.content.widgets.length).to.equal(count);
+        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
         button.dispose();
       });
 
       it("should have the `'jp-CopyIcon'` class", () => {
-        let button = ToolbarItems.createCopyButton(panel);
-        expect(button.hasClass('jp-CopyIcon')).to.be(true);
+        const button = ToolbarItems.createCopyButton(panel);
+        expect(button.hasClass('jp-CopyIcon')).to.equal(true);
       });
     });
 
     describe('#createPasteButton()', () => {
       it('should paste when clicked', async () => {
-        let button = ToolbarItems.createPasteButton(panel);
-        let count = panel.content.widgets.length;
+        const button = ToolbarItems.createPasteButton(panel);
+        const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         NotebookActions.copy(panel.content);
         button.node.click();
         await sleep();
-        expect(panel.content.widgets.length).to.be(count + 1);
+        expect(panel.content.widgets.length).to.equal(count + 1);
         button.dispose();
       });
 
       it("should have the `'jp-PasteIcon'` class", () => {
-        let button = ToolbarItems.createPasteButton(panel);
-        expect(button.hasClass('jp-PasteIcon')).to.be(true);
+        const button = ToolbarItems.createPasteButton(panel);
+        expect(button.hasClass('jp-PasteIcon')).to.equal(true);
       });
     });
 
     describe('#createRunButton()', () => {
       it('should run and advance when clicked', async () => {
-        let button = ToolbarItems.createRunButton(panel);
-        let widget = panel.content;
+        const button = ToolbarItems.createRunButton(panel);
+        const widget = panel.content;
 
         // Clear and select the first two cells.
         const codeCell = widget.widgets[0] as CodeCell;
@@ -153,7 +153,7 @@ describe('@jupyterlab/notebook', () => {
         context.session.statusChanged.connect((sender, status) => {
           // Find the right status idle message
           if (status === 'idle' && codeCell.model.outputs.length > 0) {
-            expect(mdCell.rendered).to.be(true);
+            expect(mdCell.rendered).to.equal(true);
             expect(widget.activeCellIndex).to.equal(2);
             button.dispose();
             p.resolve(0);
@@ -164,49 +164,49 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it("should have the `'jp-RunIcon'` class", () => {
-        let button = ToolbarItems.createRunButton(panel);
-        expect(button.hasClass('jp-RunIcon')).to.be(true);
+        const button = ToolbarItems.createRunButton(panel);
+        expect(button.hasClass('jp-RunIcon')).to.equal(true);
       });
     });
 
     describe('#createCellTypeItem()', () => {
       it('should track the cell type of the current cell', () => {
-        let item = ToolbarItems.createCellTypeItem(panel);
-        let node = item.node.getElementsByTagName(
+        const item = ToolbarItems.createCellTypeItem(panel);
+        const node = item.node.getElementsByTagName(
           'select'
         )[0] as HTMLSelectElement;
-        expect(node.value).to.be('code');
+        expect(node.value).to.equal('code');
         panel.content.activeCellIndex++;
-        expect(node.value).to.be('markdown');
+        expect(node.value).to.equal('markdown');
       });
 
       it("should display `'-'` if multiple cell types are selected", () => {
-        let item = ToolbarItems.createCellTypeItem(panel);
-        let node = item.node.getElementsByTagName(
+        const item = ToolbarItems.createCellTypeItem(panel);
+        const node = item.node.getElementsByTagName(
           'select'
         )[0] as HTMLSelectElement;
-        expect(node.value).to.be('code');
+        expect(node.value).to.equal('code');
         panel.content.select(panel.content.widgets[1]);
-        expect(node.value).to.be('-');
+        expect(node.value).to.equal('-');
       });
 
       it('should display the active cell type if multiple cells of the same type are selected', () => {
-        let item = ToolbarItems.createCellTypeItem(panel);
-        let node = item.node.getElementsByTagName(
+        const item = ToolbarItems.createCellTypeItem(panel);
+        const node = item.node.getElementsByTagName(
           'select'
         )[0] as HTMLSelectElement;
-        expect(node.value).to.be('code');
-        let cell = panel.model.contentFactory.createCodeCell({});
+        expect(node.value).to.equal('code');
+        const cell = panel.model.contentFactory.createCodeCell({});
         panel.model.cells.insert(1, cell);
         panel.content.select(panel.content.widgets[1]);
-        expect(node.value).to.be('code');
+        expect(node.value).to.equal('code');
       });
     });
 
     describe('#populateDefaults()', () => {
       it('should add the default items to the panel toolbar', () => {
         ToolbarItems.populateDefaults(panel);
-        expect(toArray(panel.toolbar.names())).to.eql([
+        expect(toArray(panel.toolbar.names())).to.deep.equal([
           'save',
           'insert',
           'cut',

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -23,6 +23,7 @@ import { NotebookPanel } from '@jupyterlab/notebook';
 
 import {
   createNotebookContext,
+  signalToPromise,
   sleep,
   NBTestUtils
 } from '@jupyterlab/testutils';
@@ -48,14 +49,13 @@ describe('@jupyterlab/notebook', () => {
     });
 
     describe('#createSaveButton()', () => {
-      it('should save when clicked', done => {
+      it('should save when clicked', async () => {
         const button = ToolbarItems.createSaveButton(panel);
         Widget.attach(button, document.body);
-        context.fileChanged.connect(() => {
-          button.dispose();
-          done();
-        });
+        let promise = signalToPromise(context.fileChanged);
         button.node.click();
+        await promise;
+        button.dispose();
       });
 
       it("should have the `'jp-SaveIcon'` class", () => {

--- a/tests/test-notebook/src/model.spec.ts
+++ b/tests/test-notebook/src/model.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ArrayExt, toArray } from '@phosphor/algorithm';
 
@@ -19,28 +19,28 @@ describe('@jupyterlab/notebook', () => {
   describe('NotebookModel', () => {
     describe('#constructor()', () => {
       it('should create a notebook model', () => {
-        let model = new NotebookModel();
-        expect(model).to.be.a(NotebookModel);
+        const model = new NotebookModel();
+        expect(model).to.be.an.instanceof(NotebookModel);
       });
 
       it('should accept an optional language preference', () => {
-        let model = new NotebookModel({ languagePreference: 'python' });
-        let lang = model.metadata.get(
+        const model = new NotebookModel({ languagePreference: 'python' });
+        const lang = model.metadata.get(
           'language_info'
         ) as nbformat.ILanguageInfoMetadata;
-        expect(lang.name).to.be('python');
+        expect(lang.name).to.equal('python');
       });
 
       it('should add a single code cell by default', () => {
-        let model = new NotebookModel();
-        expect(model.cells.length).to.be(1);
-        expect(model.cells.get(0)).to.be.a(CodeCellModel);
+        const model = new NotebookModel();
+        expect(model.cells.length).to.equal(1);
+        expect(model.cells.get(0)).to.be.an.instanceof(CodeCellModel);
       });
 
       it('should accept an optional factory', () => {
-        let contentFactory = new NotebookModel.ContentFactory({});
-        let model = new NotebookModel({ contentFactory });
-        expect(model.contentFactory.codeCellContentFactory).to.be(
+        const contentFactory = new NotebookModel.ContentFactory({});
+        const model = new NotebookModel({ contentFactory });
+        expect(model.contentFactory.codeCellContentFactory).to.equal(
           contentFactory.codeCellContentFactory
         );
       });
@@ -48,87 +48,87 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#metadataChanged', () => {
       it('should be emitted when a metadata field changes', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         let called = false;
         model.metadata.changed.connect((sender, args) => {
-          expect(sender).to.be(model.metadata);
-          expect(args.key).to.be('foo');
-          expect(args.oldValue).to.be(void 0);
-          expect(args.newValue).to.be(1);
+          expect(sender).to.equal(model.metadata);
+          expect(args.key).to.equal('foo');
+          expect(args.oldValue).to.be.undefined;
+          expect(args.newValue).to.equal(1);
           called = true;
         });
         model.metadata.set('foo', 1);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should not be emitted when the value does not change', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         let called = false;
         model.metadata.set('foo', 1);
         model.metadata.changed.connect(() => {
           called = true;
         });
         model.metadata.set('foo', 1);
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
     });
 
     describe('#cells', () => {
       it('should add an empty code cell by default', () => {
-        let model = new NotebookModel();
-        expect(model.cells.length).to.be(1);
-        expect(model.cells.get(0)).to.be.a(CodeCellModel);
+        const model = new NotebookModel();
+        expect(model.cells.length).to.equal(1);
+        expect(model.cells.get(0)).to.be.an.instanceof(CodeCellModel);
       });
 
       it('should be reset when loading from disk', () => {
-        let model = new NotebookModel();
-        let cell = model.contentFactory.createCodeCell({});
+        const model = new NotebookModel();
+        const cell = model.contentFactory.createCodeCell({});
         model.cells.push(cell);
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(ArrayExt.firstIndexOf(toArray(model.cells), cell)).to.be(-1);
-        expect(model.cells.length).to.be(6);
+        expect(ArrayExt.firstIndexOf(toArray(model.cells), cell)).to.equal(-1);
+        expect(model.cells.length).to.equal(6);
       });
 
       it('should allow undoing a change', () => {
-        let model = new NotebookModel();
-        let cell = model.contentFactory.createCodeCell({});
+        const model = new NotebookModel();
+        const cell = model.contentFactory.createCodeCell({});
         cell.value.text = 'foo';
         model.cells.push(cell);
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         model.cells.undo();
-        expect(model.cells.length).to.be(2);
-        expect(model.cells.get(1).value.text).to.be('foo');
-        expect(model.cells.get(1)).to.be(cell); // should be ===.
+        expect(model.cells.length).to.equal(2);
+        expect(model.cells.get(1).value.text).to.equal('foo');
+        expect(model.cells.get(1)).to.equal(cell); // should be ===.
       });
 
       context('cells `changed` signal', () => {
         it('should emit a `contentChanged` signal upon cell addition', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
+          const model = new NotebookModel();
+          const cell = model.contentFactory.createCodeCell({});
           let called = false;
           model.contentChanged.connect(() => {
             called = true;
           });
           model.cells.push(cell);
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
         });
 
         it('should emit a `contentChanged` signal upon cell removal', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
+          const model = new NotebookModel();
+          const cell = model.contentFactory.createCodeCell({});
           model.cells.push(cell);
           let called = false;
           model.contentChanged.connect(() => {
             called = true;
           });
           model.cells.remove(0);
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
         });
 
         it('should emit a `contentChanged` signal upon cell move', () => {
-          let model = new NotebookModel();
-          let cell0 = model.contentFactory.createCodeCell({});
-          let cell1 = model.contentFactory.createCodeCell({});
+          const model = new NotebookModel();
+          const cell0 = model.contentFactory.createCodeCell({});
+          const cell1 = model.contentFactory.createCodeCell({});
           model.cells.push(cell0);
           model.cells.push(cell1);
           let called = false;
@@ -136,60 +136,60 @@ describe('@jupyterlab/notebook', () => {
             called = true;
           });
           model.cells.move(0, 1);
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
         });
 
         it('should set the dirty flag', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
+          const model = new NotebookModel();
+          const cell = model.contentFactory.createCodeCell({});
           model.cells.push(cell);
-          expect(model.dirty).to.be(true);
+          expect(model.dirty).to.equal(true);
         });
 
         it('should add a new code cell when cells are cleared', async () => {
-          let model = new NotebookModel();
+          const model = new NotebookModel();
           model.cells.clear();
           await sleep();
-          expect(model.cells.length).to.be(1);
-          expect(model.cells.get(0)).to.be.a(CodeCellModel);
+          expect(model.cells.length).to.equal(1);
+          expect(model.cells.get(0)).to.be.an.instanceof(CodeCellModel);
         });
       });
 
       describe('cell `changed` signal', () => {
         it('should be called when a cell content changes', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
+          const model = new NotebookModel();
+          const cell = model.contentFactory.createCodeCell({});
           model.cells.push(cell);
           cell.value.text = 'foo';
         });
 
         it('should emit the `contentChanged` signal', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
+          const model = new NotebookModel();
+          const cell = model.contentFactory.createCodeCell({});
           model.cells.push(cell);
           let called = false;
           model.contentChanged.connect(() => {
             called = true;
           });
           model.metadata.set('foo', 'bar');
-          expect(called).to.be(true);
+          expect(called).to.equal(true);
         });
 
         it('should set the dirty flag', () => {
-          let model = new NotebookModel();
-          let cell = model.contentFactory.createCodeCell({});
+          const model = new NotebookModel();
+          const cell = model.contentFactory.createCodeCell({});
           model.cells.push(cell);
           model.dirty = false;
           cell.value.text = 'foo';
-          expect(model.dirty).to.be(true);
+          expect(model.dirty).to.equal(true);
         });
       });
     });
 
     describe('#contentFactory', () => {
       it('should be the cell model factory used by the model', () => {
-        let model = new NotebookModel();
-        expect(model.contentFactory.codeCellContentFactory).to.be(
+        const model = new NotebookModel();
+        expect(model.contentFactory.codeCellContentFactory).to.equal(
           NotebookModel.defaultContentFactory.codeCellContentFactory
         );
       });
@@ -197,157 +197,157 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#nbformat', () => {
       it('should get the major version number of the nbformat', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(model.nbformat).to.be(NBTestUtils.DEFAULT_CONTENT.nbformat);
+        expect(model.nbformat).to.equal(NBTestUtils.DEFAULT_CONTENT.nbformat);
       });
     });
 
     describe('#nbformatMinor', () => {
       it('should get the minor version number of the nbformat', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(model.nbformatMinor).to.be(nbformat.MINOR_VERSION);
+        expect(model.nbformatMinor).to.equal(nbformat.MINOR_VERSION);
       });
     });
 
     describe('#defaultKernelName()', () => {
       it('should get the default kernel name of the document', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.metadata.set('kernelspec', { name: 'python3' });
-        expect(model.defaultKernelName).to.be('python3');
+        expect(model.defaultKernelName).to.equal('python3');
       });
 
       it('should default to an empty string', () => {
-        let model = new NotebookModel();
-        expect(model.defaultKernelName).to.be('');
+        const model = new NotebookModel();
+        expect(model.defaultKernelName).to.equal('');
       });
     });
 
     describe('#defaultKernelLanguage', () => {
       it('should get the default kernel language of the document', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.metadata.set('language_info', { name: 'python' });
-        expect(model.defaultKernelLanguage).to.be('python');
+        expect(model.defaultKernelLanguage).to.equal('python');
       });
 
       it('should default to an empty string', () => {
-        let model = new NotebookModel();
-        expect(model.defaultKernelLanguage).to.be('');
+        const model = new NotebookModel();
+        expect(model.defaultKernelLanguage).to.equal('');
       });
 
       it('should be set from the constructor arg', () => {
-        let model = new NotebookModel({ languagePreference: 'foo' });
-        expect(model.defaultKernelLanguage).to.be('foo');
+        const model = new NotebookModel({ languagePreference: 'foo' });
+        expect(model.defaultKernelLanguage).to.equal('foo');
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the model', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         model.dispose();
-        expect(model.cells).to.be(null);
-        expect(model.isDisposed).to.be(true);
+        expect(model.cells).to.be.null;
+        expect(model.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.dispose();
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
     });
 
     describe('#toString()', () => {
       it('should serialize the model to a string', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        let text = model.toString();
-        let data = JSON.parse(text);
-        expect(data.cells.length).to.be(6);
+        const text = model.toString();
+        const data = JSON.parse(text);
+        expect(data.cells.length).to.equal(6);
       });
     });
 
     describe('#fromString()', () => {
       it('should deserialize the model from a string', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.fromString(JSON.stringify(NBTestUtils.DEFAULT_CONTENT));
-        expect(model.cells.length).to.be(6);
+        expect(model.cells.length).to.equal(6);
       });
 
       it('should set the dirty flag', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.dirty = false;
         model.fromString(JSON.stringify(NBTestUtils.DEFAULT_CONTENT));
-        expect(model.dirty).to.be(true);
+        expect(model.dirty).to.equal(true);
       });
     });
 
     describe('#toJSON()', () => {
       it('should serialize the model to JSON', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        let data = model.toJSON();
-        expect(data.cells.length).to.be(6);
+        const data = model.toJSON();
+        expect(data.cells.length).to.equal(6);
       });
     });
 
     describe('#fromJSON()', () => {
       it('should serialize the model from JSON', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(model.cells.length).to.be(6);
-        expect(model.nbformat).to.be(NBTestUtils.DEFAULT_CONTENT.nbformat);
-        expect(model.nbformatMinor).to.be(nbformat.MINOR_VERSION);
+        expect(model.cells.length).to.equal(6);
+        expect(model.nbformat).to.equal(NBTestUtils.DEFAULT_CONTENT.nbformat);
+        expect(model.nbformatMinor).to.equal(nbformat.MINOR_VERSION);
       });
 
       it('should set the dirty flag', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         model.dirty = false;
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(model.dirty).to.be(true);
+        expect(model.dirty).to.equal(true);
       });
     });
 
     describe('#metadata', () => {
       it('should have default values', () => {
-        let model = new NotebookModel();
-        let metadata = model.metadata;
+        const model = new NotebookModel();
+        const metadata = model.metadata;
         expect(metadata.has('kernelspec'));
         expect(metadata.has('language_info'));
-        expect(metadata.size).to.be(2);
+        expect(metadata.size).to.equal(2);
       });
 
       it('should set the dirty flag when changed', () => {
-        let model = new NotebookModel();
-        expect(model.dirty).to.be(false);
+        const model = new NotebookModel();
+        expect(model.dirty).to.equal(false);
         model.metadata.set('foo', 'bar');
-        expect(model.dirty).to.be(true);
+        expect(model.dirty).to.equal(true);
       });
 
       it('should emit the `contentChanged` signal', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         let called = false;
         model.contentChanged.connect(() => {
           called = true;
         });
         model.metadata.set('foo', 'bar');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should emit the `metadataChanged` signal', () => {
-        let model = new NotebookModel();
+        const model = new NotebookModel();
         let called = false;
         model.metadata.changed.connect((sender, args) => {
-          expect(sender).to.be(model.metadata);
-          expect(args.key).to.be('foo');
-          expect(args.oldValue).to.be(void 0);
-          expect(args.newValue).to.be('bar');
+          expect(sender).to.equal(model.metadata);
+          expect(args.key).to.equal('foo');
+          expect(args.oldValue).to.be.undefined;
+          expect(args.newValue).to.equal('bar');
           called = true;
         });
         model.metadata.set('foo', 'bar');
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
@@ -356,104 +356,106 @@ describe('@jupyterlab/notebook', () => {
 
       context('#codeCellContentFactory', () => {
         it('should be a code cell content factory', () => {
-          expect(factory.codeCellContentFactory).to.be(
+          expect(factory.codeCellContentFactory).to.equal(
             CodeCellModel.defaultContentFactory
           );
         });
 
         it('should be settable in the constructor', () => {
-          let codeCellContentFactory = new CodeCellModel.ContentFactory();
+          const codeCellContentFactory = new CodeCellModel.ContentFactory();
           factory = new NotebookModel.ContentFactory({
             codeCellContentFactory
           });
-          expect(factory.codeCellContentFactory).to.be(codeCellContentFactory);
+          expect(factory.codeCellContentFactory).to.equal(
+            codeCellContentFactory
+          );
         });
       });
 
       context('#createCodeCell()', () => {
         it('should create a new code cell', () => {
-          let cell = factory.createCodeCell({});
-          expect(cell.type).to.be('code');
+          const cell = factory.createCodeCell({});
+          expect(cell.type).to.equal('code');
         });
 
         it('should clone an existing code cell', () => {
-          let orig = factory.createCodeCell({});
+          const orig = factory.createCodeCell({});
           orig.value.text = 'foo';
-          let cell = orig.toJSON();
-          let newCell = factory.createCodeCell({ cell });
-          expect(newCell.value.text).to.be('foo');
+          const cell = orig.toJSON();
+          const newCell = factory.createCodeCell({ cell });
+          expect(newCell.value.text).to.equal('foo');
         });
 
         it('should clone an existing raw cell', () => {
-          let orig = factory.createRawCell({});
+          const orig = factory.createRawCell({});
           orig.value.text = 'foo';
-          let cell = orig.toJSON();
-          let newCell = factory.createCodeCell({ cell });
-          expect(newCell.value.text).to.be('foo');
+          const cell = orig.toJSON();
+          const newCell = factory.createCodeCell({ cell });
+          expect(newCell.value.text).to.equal('foo');
         });
       });
 
       context('#createRawCell()', () => {
         it('should create a new raw cell', () => {
-          let cell = factory.createRawCell({});
-          expect(cell.type).to.be('raw');
+          const cell = factory.createRawCell({});
+          expect(cell.type).to.equal('raw');
         });
 
         it('should clone an existing raw cell', () => {
-          let orig = factory.createRawCell({});
+          const orig = factory.createRawCell({});
           orig.value.text = 'foo';
-          let cell = orig.toJSON();
-          let newCell = factory.createRawCell({ cell });
-          expect(newCell.value.text).to.be('foo');
+          const cell = orig.toJSON();
+          const newCell = factory.createRawCell({ cell });
+          expect(newCell.value.text).to.equal('foo');
         });
 
         it('should clone an existing code cell', () => {
-          let orig = factory.createCodeCell({});
+          const orig = factory.createCodeCell({});
           orig.value.text = 'foo';
-          let cell = orig.toJSON();
-          let newCell = factory.createRawCell({ cell });
-          expect(newCell.value.text).to.be('foo');
+          const cell = orig.toJSON();
+          const newCell = factory.createRawCell({ cell });
+          expect(newCell.value.text).to.equal('foo');
         });
       });
 
       describe('#createMarkdownCell()', () => {
         it('should create a new markdown cell', () => {
-          let cell = factory.createMarkdownCell({});
-          expect(cell.type).to.be('markdown');
+          const cell = factory.createMarkdownCell({});
+          expect(cell.type).to.equal('markdown');
         });
 
         it('should clone an existing markdown cell', () => {
-          let orig = factory.createMarkdownCell({});
+          const orig = factory.createMarkdownCell({});
           orig.value.text = 'foo';
-          let cell = orig.toJSON();
-          let newCell = factory.createMarkdownCell({ cell });
-          expect(newCell.value.text).to.be('foo');
+          const cell = orig.toJSON();
+          const newCell = factory.createMarkdownCell({ cell });
+          expect(newCell.value.text).to.equal('foo');
         });
 
         it('should clone an existing raw cell', () => {
-          let orig = factory.createRawCell({});
+          const orig = factory.createRawCell({});
           orig.value.text = 'foo';
-          let cell = orig.toJSON();
-          let newCell = factory.createMarkdownCell({ cell });
-          expect(newCell.value.text).to.be('foo');
+          const cell = orig.toJSON();
+          const newCell = factory.createMarkdownCell({ cell });
+          expect(newCell.value.text).to.equal('foo');
         });
       });
 
       describe('#modelDB', () => {
         it('should be undefined by default', () => {
-          expect(factory.modelDB).to.be(undefined);
+          expect(factory.modelDB).to.be.undefined;
         });
       });
 
       describe('#clone()', () => {
         it('should create a new content factory with a new IModelDB', () => {
-          let modelDB = new ModelDB();
-          let factory = new NotebookModel.ContentFactory({ modelDB });
-          expect(factory.modelDB).to.be(modelDB);
-          let newModelDB = new ModelDB();
-          let newFactory = factory.clone(newModelDB);
-          expect(newFactory.modelDB).to.be(newModelDB);
-          expect(newFactory.codeCellContentFactory).to.be(
+          const modelDB = new ModelDB();
+          const factory = new NotebookModel.ContentFactory({ modelDB });
+          expect(factory.modelDB).to.equal(modelDB);
+          const newModelDB = new ModelDB();
+          const newFactory = factory.clone(newModelDB);
+          expect(newFactory.modelDB).to.equal(newModelDB);
+          expect(newFactory.codeCellContentFactory).to.equal(
             factory.codeCellContentFactory
           );
         });
@@ -462,7 +464,7 @@ describe('@jupyterlab/notebook', () => {
 
     describe('.defaultContentFactory', () => {
       it('should be a ContentFactory', () => {
-        expect(NotebookModel.defaultContentFactory).to.be.a(
+        expect(NotebookModel.defaultContentFactory).to.be.an.instanceof(
           NotebookModel.ContentFactory
         );
       });

--- a/tests/test-notebook/src/modelfactory.spec.ts
+++ b/tests/test-notebook/src/modelfactory.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CodeCellModel } from '@jupyterlab/cells';
 
@@ -13,103 +13,105 @@ describe('@jupyterlab/notebook', () => {
   describe('NotebookModelFactory', () => {
     describe('#constructor', () => {
       it('should create a new notebook model factory', () => {
-        let factory = new NotebookModelFactory({});
-        expect(factory).to.be.a(NotebookModelFactory);
+        const factory = new NotebookModelFactory({});
+        expect(factory).to.be.an.instanceof(NotebookModelFactory);
       });
 
       it('should accept a code cell content factory', () => {
-        let codeCellContentFactory = new CodeCellModel.ContentFactory();
-        let factory = new NotebookModelFactory({ codeCellContentFactory });
-        expect(factory.contentFactory.codeCellContentFactory).to.be(
+        const codeCellContentFactory = new CodeCellModel.ContentFactory();
+        const factory = new NotebookModelFactory({ codeCellContentFactory });
+        expect(factory.contentFactory.codeCellContentFactory).to.equal(
           codeCellContentFactory
         );
       });
 
       it('should accept a notebook model content factory', () => {
-        let contentFactory = new NotebookModel.ContentFactory({});
-        let factory = new NotebookModelFactory({ contentFactory });
-        expect(factory.contentFactory).to.be(contentFactory);
+        const contentFactory = new NotebookModel.ContentFactory({});
+        const factory = new NotebookModelFactory({ contentFactory });
+        expect(factory.contentFactory).to.equal(contentFactory);
       });
     });
 
     describe('#contentFactory', () => {
       it('should be the content factory used by the model factory', () => {
-        let factory = new NotebookModelFactory({});
-        expect(factory.contentFactory).to.be.a(NotebookModel.ContentFactory);
+        const factory = new NotebookModelFactory({});
+        expect(factory.contentFactory).to.be.an.instanceof(
+          NotebookModel.ContentFactory
+        );
       });
     });
 
     describe('#name', () => {
       it('should get the name of the model factory', () => {
-        let factory = new NotebookModelFactory({});
-        expect(factory.name).to.be('notebook');
+        const factory = new NotebookModelFactory({});
+        expect(factory.name).to.equal('notebook');
       });
     });
 
     describe('#contentType', () => {
       it('should get the file type', () => {
-        let factory = new NotebookModelFactory({});
-        expect(factory.contentType).to.be('notebook');
+        const factory = new NotebookModelFactory({});
+        expect(factory.contentType).to.equal('notebook');
       });
     });
 
     describe('#fileFormat', () => {
       it('should get the file format', () => {
-        let factory = new NotebookModelFactory({});
-        expect(factory.fileFormat).to.be('json');
+        const factory = new NotebookModelFactory({});
+        expect(factory.fileFormat).to.equal('json');
       });
     });
 
     describe('#isDisposed', () => {
       it('should get whether the factory is disposed', () => {
-        let factory = new NotebookModelFactory({});
-        expect(factory.isDisposed).to.be(false);
+        const factory = new NotebookModelFactory({});
+        expect(factory.isDisposed).to.equal(false);
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the model factory', () => {
-        let factory = new NotebookModelFactory({});
+        const factory = new NotebookModelFactory({});
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let factory = new NotebookModelFactory({});
+        const factory = new NotebookModelFactory({});
         factory.dispose();
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
     });
 
     describe('#createNew()', () => {
       it('should create a new model for a given path', () => {
-        let factory = new NotebookModelFactory({});
-        let model = factory.createNew();
-        expect(model).to.be.a(NotebookModel);
+        const factory = new NotebookModelFactory({});
+        const model = factory.createNew();
+        expect(model).to.be.an.instanceof(NotebookModel);
       });
 
       it('should add an empty code cell by default', () => {
-        let factory = new NotebookModelFactory({});
-        let model = factory.createNew();
-        expect(model.cells.length).to.be(1);
-        expect(model.cells.get(0).type).to.be('code');
+        const factory = new NotebookModelFactory({});
+        const model = factory.createNew();
+        expect(model.cells.length).to.equal(1);
+        expect(model.cells.get(0).type).to.equal('code');
       });
 
       it('should accept a language preference', () => {
-        let factory = new NotebookModelFactory({});
-        let model = factory.createNew('foo');
-        expect(model.defaultKernelLanguage).to.be('foo');
+        const factory = new NotebookModelFactory({});
+        const model = factory.createNew('foo');
+        expect(model.defaultKernelLanguage).to.equal('foo');
       });
     });
 
     describe('#preferredLanguage()', () => {
       it('should always return an empty string', () => {
-        let factory = new NotebookModelFactory({});
-        expect(factory.preferredLanguage('')).to.be('');
-        expect(factory.preferredLanguage('.ipynb')).to.be('');
+        const factory = new NotebookModelFactory({});
+        expect(factory.preferredLanguage('')).to.equal('');
+        expect(factory.preferredLanguage('.ipynb')).to.equal('');
       });
     });
   });

--- a/tests/test-notebook/src/panel.spec.ts
+++ b/tests/test-notebook/src/panel.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Context } from '@jupyterlab/docregistry';
 
@@ -33,13 +33,13 @@ describe('@jupyterlab/notebook', () => {
       it('should create a notebook panel', () => {
         const content = NBTestUtils.createNotebook();
         const panel = new NotebookPanel({ context, content });
-        expect(panel).to.be.a(NotebookPanel);
+        expect(panel).to.be.an.instanceof(NotebookPanel);
       });
 
       it('should change notebook to edit mode if we have a single empty code cell', async () => {
         const panel = NBTestUtils.createNotebookPanel(context);
         const model = panel.content.model;
-        expect(model).to.be(context.model);
+        expect(model).to.equal(context.model);
         await context.initialize(true);
         await context.ready;
         expect(panel.content.mode).to.equal('edit');
@@ -48,58 +48,60 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#toolbar', () => {
       it('should be the toolbar used by the widget', () => {
-        let panel = NBTestUtils.createNotebookPanel(context);
-        expect(panel.toolbar).to.be.a(Toolbar);
+        const panel = NBTestUtils.createNotebookPanel(context);
+        expect(panel.toolbar).to.be.an.instanceof(Toolbar);
       });
     });
 
     describe('#content', () => {
       it('should be the notebook content widget', () => {
-        let panel = NBTestUtils.createNotebookPanel(context);
-        expect(panel.content).to.be.a(Notebook);
+        const panel = NBTestUtils.createNotebookPanel(context);
+        expect(panel.content).to.be.an.instanceof(Notebook);
       });
     });
 
     describe('#context', () => {
       it('should get the document context for the widget', () => {
-        let panel = NBTestUtils.createNotebookPanel(context);
-        expect(panel.context).to.be(context);
+        const panel = NBTestUtils.createNotebookPanel(context);
+        expect(panel.context).to.equal(context);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources used by the widget', () => {
-        let panel = NBTestUtils.createNotebookPanel(context);
+        const panel = NBTestUtils.createNotebookPanel(context);
         panel.dispose();
-        expect(panel.isDisposed).to.be(true);
+        expect(panel.isDisposed).to.equal(true);
       });
 
       it('should be safe to call more than once', () => {
-        let panel = NBTestUtils.createNotebookPanel(context);
+        const panel = NBTestUtils.createNotebookPanel(context);
         panel.dispose();
         panel.dispose();
-        expect(panel.isDisposed).to.be(true);
+        expect(panel.isDisposed).to.equal(true);
       });
     });
 
     describe('.ContentFactory', () => {
       describe('#constructor', () => {
         it('should create a new ContentFactory', () => {
-          let factory = new NotebookPanel.ContentFactory({
+          const factory = new NotebookPanel.ContentFactory({
             editorFactory: NBTestUtils.editorFactory
           });
-          expect(factory).to.be.a(NotebookPanel.ContentFactory);
+          expect(factory).to.be.an.instanceof(NotebookPanel.ContentFactory);
         });
       });
 
       describe('#NBTestUtils.createNotebook()', () => {
         it('should create a notebook widget', () => {
-          let options = {
+          const options = {
             contentFactory: contentFactory,
             rendermime: NBTestUtils.defaultRenderMime(),
             mimeTypeService: NBTestUtils.mimeTypeService
           };
-          expect(contentFactory.createNotebook(options)).to.be.a(Notebook);
+          expect(contentFactory.createNotebook(options)).to.be.an.instanceof(
+            Notebook
+          );
         });
       });
     });

--- a/tests/test-notebook/src/tracker.spec.ts
+++ b/tests/test-notebook/src/tracker.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Cell } from '@jupyterlab/cells';
 
@@ -41,56 +41,56 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#constructor()', () => {
       it('should create a NotebookTracker', () => {
-        let tracker = new NotebookTracker({ namespace });
-        expect(tracker).to.be.a(NotebookTracker);
+        const tracker = new NotebookTracker({ namespace });
+        expect(tracker).to.be.an.instanceof(NotebookTracker);
       });
     });
 
     describe('#activeCell', () => {
       it('should be `null` if there is no tracked notebook panel', () => {
-        let tracker = new NotebookTracker({ namespace });
-        expect(tracker.activeCell).to.be(null);
+        const tracker = new NotebookTracker({ namespace });
+        expect(tracker.activeCell).to.be.null;
       });
 
       it('should be `null` if a tracked notebook has no active cell', () => {
-        let tracker = new NotebookTracker({ namespace });
-        let panel = NBTestUtils.createNotebookPanel(context);
+        const tracker = new NotebookTracker({ namespace });
+        const panel = NBTestUtils.createNotebookPanel(context);
         panel.content.model.cells.clear();
         tracker.add(panel);
-        expect(tracker.activeCell).to.be(null);
+        expect(tracker.activeCell).to.be.null;
       });
 
       it('should be the active cell if a tracked notebook has one', () => {
-        let tracker = new NotebookTracker({ namespace });
-        let panel = NBTestUtils.createNotebookPanel(context);
+        const tracker = new NotebookTracker({ namespace });
+        const panel = NBTestUtils.createNotebookPanel(context);
         tracker.add(panel);
         panel.content.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(tracker.activeCell).to.be.a(Cell);
+        expect(tracker.activeCell).to.be.an.instanceof(Cell);
         panel.dispose();
       });
     });
 
     describe('#activeCellChanged', () => {
       it('should emit a signal when the active cell changes', () => {
-        let tracker = new NotebookTracker({ namespace });
-        let panel = NBTestUtils.createNotebookPanel(context);
+        const tracker = new NotebookTracker({ namespace });
+        const panel = NBTestUtils.createNotebookPanel(context);
         let count = 0;
         tracker.activeCellChanged.connect(() => {
           count++;
         });
         panel.content.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         tracker.add(panel);
-        expect(count).to.be(1);
+        expect(count).to.equal(1);
         panel.content.activeCellIndex = 1;
-        expect(count).to.be(2);
+        expect(count).to.equal(2);
         panel.dispose();
       });
     });
 
     describe('#onCurrentChanged()', () => {
       it('should be called when the active cell changes', () => {
-        let tracker = new TestTracker({ namespace });
-        let panel = NBTestUtils.createNotebookPanel(context);
+        const tracker = new TestTracker({ namespace });
+        const panel = NBTestUtils.createNotebookPanel(context);
         tracker.add(panel);
         expect(tracker.methods).to.contain('onCurrentChanged');
       });

--- a/tests/test-notebook/src/widget.spec.ts
+++ b/tests/test-notebook/src/widget.spec.ts
@@ -1314,15 +1314,6 @@ describe('@jupyter/notebook', () => {
         expect(document.activeElement).to.equal(widget.node);
         widget.dispose();
       });
-
-      it('should post an `update-request', async () => {
-        const widget = createActiveWidget();
-        MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
-        expect(widget.methods).to.contain('onActivateRequest');
-        await sleep();
-        expect(widget.methods).to.contain('onUpdateRequest');
-        widget.dispose();
-      });
     });
 
     describe('#onUpdateRequest()', () => {

--- a/tests/test-notebook/src/widget.spec.ts
+++ b/tests/test-notebook/src/widget.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { MessageLoop, Message } from '@phosphor/messaging';
 
@@ -37,8 +37,8 @@ const options: Notebook.IOptions = {
 };
 
 function createWidget(): LogStaticNotebook {
-  let model = new NotebookModel();
-  let widget = new LogStaticNotebook(options);
+  const model = new NotebookModel();
+  const widget = new LogStaticNotebook(options);
   widget.model = model;
   return widget;
 }
@@ -127,8 +127,8 @@ class LogNotebook extends Notebook {
 }
 
 function createActiveWidget(): LogNotebook {
-  let model = new NotebookModel();
-  let widget = new LogNotebook(options);
+  const model = new NotebookModel();
+  const widget = new LogNotebook(options);
   widget.model = model;
   return widget;
 }
@@ -148,119 +148,119 @@ describe('@jupyter/notebook', () => {
   describe('StaticNotebook', () => {
     describe('#constructor()', () => {
       it('should create a notebook widget', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget).to.be.a(StaticNotebook);
+        const widget = new StaticNotebook(options);
+        expect(widget).to.be.an.instanceof(StaticNotebook);
       });
 
       it('should add the `jp-Notebook` class', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget.hasClass('jp-Notebook')).to.be(true);
+        const widget = new StaticNotebook(options);
+        expect(widget.hasClass('jp-Notebook')).to.equal(true);
       });
 
       it('should accept an optional render', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget.contentFactory).to.be(contentFactory);
+        const widget = new StaticNotebook(options);
+        expect(widget.contentFactory).to.equal(contentFactory);
       });
 
       it('should accept an optional editor config', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget.editorConfig).to.be(editorConfig);
+        const widget = new StaticNotebook(options);
+        expect(widget.editorConfig).to.equal(editorConfig);
       });
     });
 
     describe('#modelChanged', () => {
       it('should be emitted when the model changes', () => {
-        let widget = new StaticNotebook(options);
-        let model = new NotebookModel();
+        const widget = new StaticNotebook(options);
+        const model = new NotebookModel();
         let called = false;
         widget.modelChanged.connect((sender, args) => {
-          expect(sender).to.be(widget);
-          expect(args).to.be(void 0);
+          expect(sender).to.equal(widget);
+          expect(args).to.be.undefined;
           called = true;
         });
         widget.model = model;
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#modelContentChanged', () => {
       it('should be emitted when a cell is added', () => {
-        let widget = new StaticNotebook(options);
+        const widget = new StaticNotebook(options);
         widget.model = new NotebookModel();
         let called = false;
         widget.modelContentChanged.connect(() => {
           called = true;
         });
-        let cell = widget.model.contentFactory.createCodeCell({});
+        const cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.push(cell);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should be emitted when metadata is set', () => {
-        let widget = new StaticNotebook(options);
+        const widget = new StaticNotebook(options);
         widget.model = new NotebookModel();
         let called = false;
         widget.modelContentChanged.connect(() => {
           called = true;
         });
         widget.model.metadata.set('foo', 1);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#model', () => {
       it('should get the model for the widget', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget.model).to.be(null);
+        const widget = new StaticNotebook(options);
+        expect(widget.model).to.be.null;
       });
 
       it('should set the model for the widget', () => {
-        let widget = new StaticNotebook(options);
-        let model = new NotebookModel();
+        const widget = new StaticNotebook(options);
+        const model = new NotebookModel();
         widget.model = model;
-        expect(widget.model).to.be(model);
+        expect(widget.model).to.equal(model);
       });
 
       it('should emit the `modelChanged` signal', () => {
-        let widget = new StaticNotebook(options);
-        let model = new NotebookModel();
+        const widget = new StaticNotebook(options);
+        const model = new NotebookModel();
         widget.model = model;
         let called = false;
         widget.modelChanged.connect(() => {
           called = true;
         });
         widget.model = new NotebookModel();
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should be a no-op if the value does not change', () => {
-        let widget = new StaticNotebook(options);
-        let model = new NotebookModel();
+        const widget = new StaticNotebook(options);
+        const model = new NotebookModel();
         widget.model = model;
         let called = false;
         widget.modelChanged.connect(() => {
           called = true;
         });
         widget.model = model;
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
 
       it('should add the model cells to the layout', () => {
-        let widget = new LogStaticNotebook(options);
-        let model = new NotebookModel();
+        const widget = new LogStaticNotebook(options);
+        const model = new NotebookModel();
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.model = model;
-        expect(widget.widgets.length).to.be(6);
+        expect(widget.widgets.length).to.equal(6);
       });
 
       it('should set the mime types of the cell widgets', () => {
-        let widget = new LogStaticNotebook(options);
-        let model = new NotebookModel();
-        let value = { name: 'python', codemirror_mode: 'python' };
+        const widget = new LogStaticNotebook(options);
+        const model = new NotebookModel();
+        const value = { name: 'python', codemirror_mode: 'python' };
         model.metadata.set('language_info', value);
         widget.model = model;
-        let child = widget.widgets[0];
-        expect(child.model.mimeType).to.be('text/x-python');
+        const child = widget.widgets[0];
+        expect(child.model.mimeType).to.equal('text/x-python');
       });
 
       context('`cells.changed` signal', () => {
@@ -279,66 +279,68 @@ describe('@jupyter/notebook', () => {
           widget = createWidget();
           widget.model.cells.clear();
           await sleep();
-          expect(widget.widgets.length).to.be(1);
+          expect(widget.widgets.length).to.equal(1);
         });
 
         it('should handle a remove', () => {
-          let cell = widget.model.cells.get(1);
-          let child = widget.widgets[1];
+          const cell = widget.model.cells.get(1);
+          const child = widget.widgets[1];
           widget.model.cells.removeValue(cell);
-          expect(cell.isDisposed).to.be(false);
-          expect(child.isDisposed).to.be(true);
+          expect(cell.isDisposed).to.equal(false);
+          expect(child.isDisposed).to.equal(true);
         });
 
         it('should handle an add', () => {
-          let cell = widget.model.contentFactory.createCodeCell({});
+          const cell = widget.model.contentFactory.createCodeCell({});
           widget.model.cells.push(cell);
-          expect(widget.widgets.length).to.be(7);
-          let child = widget.widgets[0];
-          expect(child.hasClass('jp-Notebook-cell')).to.be(true);
+          expect(widget.widgets.length).to.equal(7);
+          const child = widget.widgets[0];
+          expect(child.hasClass('jp-Notebook-cell')).to.equal(true);
         });
 
         it('should handle a move', () => {
-          let child = widget.widgets[1];
+          const child = widget.widgets[1];
           widget.model.cells.move(1, 2);
-          expect(widget.widgets[2]).to.be(child);
+          expect(widget.widgets[2]).to.equal(child);
         });
 
         it('should handle a clear', () => {
-          let cell = widget.model.contentFactory.createCodeCell({});
+          const cell = widget.model.contentFactory.createCodeCell({});
           widget.model.cells.push(cell);
           widget.model.cells.clear();
-          expect(widget.widgets.length).to.be(0);
+          expect(widget.widgets.length).to.equal(0);
         });
       });
     });
 
     describe('#rendermime', () => {
       it('should be the rendermime instance used by the widget', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget.rendermime).to.be(rendermime);
+        const widget = new StaticNotebook(options);
+        expect(widget.rendermime).to.equal(rendermime);
       });
     });
 
     describe('#contentFactory', () => {
       it('should be the cell widget contentFactory used by the widget', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget.contentFactory).to.be.a(StaticNotebook.ContentFactory);
+        const widget = new StaticNotebook(options);
+        expect(widget.contentFactory).to.be.an.instanceof(
+          StaticNotebook.ContentFactory
+        );
       });
     });
 
     describe('#editorConfig', () => {
       it('should be the cell widget contentFactory used by the widget', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget.editorConfig).to.be(options.editorConfig);
+        const widget = new StaticNotebook(options);
+        expect(widget.editorConfig).to.equal(options.editorConfig);
       });
 
       it('should be settable', () => {
-        let widget = createWidget();
-        expect(widget.widgets[0].editor.getOption('autoClosingBrackets')).to.be(
-          true
-        );
-        let newConfig = {
+        const widget = createWidget();
+        expect(
+          widget.widgets[0].editor.getOption('autoClosingBrackets')
+        ).to.equal(true);
+        const newConfig = {
           raw: editorConfig.raw,
           markdown: editorConfig.markdown,
           code: {
@@ -347,73 +349,73 @@ describe('@jupyter/notebook', () => {
           }
         };
         widget.editorConfig = newConfig;
-        expect(widget.widgets[0].editor.getOption('autoClosingBrackets')).to.be(
-          false
-        );
+        expect(
+          widget.widgets[0].editor.getOption('autoClosingBrackets')
+        ).to.equal(false);
       });
     });
 
     describe('#codeMimetype', () => {
       it('should get the mime type for code cells', () => {
-        let widget = new StaticNotebook(options);
-        expect(widget.codeMimetype).to.be('text/plain');
+        const widget = new StaticNotebook(options);
+        expect(widget.codeMimetype).to.equal('text/plain');
       });
 
       it('should be set from language metadata', () => {
-        let widget = new LogStaticNotebook(options);
-        let model = new NotebookModel();
-        let value = { name: 'python', codemirror_mode: 'python' };
+        const widget = new LogStaticNotebook(options);
+        const model = new NotebookModel();
+        const value = { name: 'python', codemirror_mode: 'python' };
         model.metadata.set('language_info', value);
         widget.model = model;
-        expect(widget.codeMimetype).to.be('text/x-python');
+        expect(widget.codeMimetype).to.equal('text/x-python');
       });
     });
 
     describe('#widgets', () => {
       it('should get the child widget at a specified index', () => {
-        let widget = createWidget();
-        let child = widget.widgets[0];
-        expect(child).to.be.a(CodeCell);
+        const widget = createWidget();
+        const child = widget.widgets[0];
+        expect(child).to.be.an.instanceof(CodeCell);
       });
 
       it('should return `undefined` if out of range', () => {
-        let widget = createWidget();
-        let child = widget.widgets[1];
-        expect(child).to.be(void 0);
+        const widget = createWidget();
+        const child = widget.widgets[1];
+        expect(child).to.be.undefined;
       });
 
       it('should get the number of child widgets', () => {
-        let widget = createWidget();
-        expect(widget.widgets.length).to.be(1);
+        const widget = createWidget();
+        expect(widget.widgets.length).to.equal(1);
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(widget.widgets.length).to.be(6);
+        expect(widget.widgets.length).to.equal(6);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the widget', () => {
-        let widget = createWidget();
+        const widget = createWidget();
         widget.dispose();
-        expect(widget.isDisposed).to.be(true);
+        expect(widget.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let widget = createWidget();
+        const widget = createWidget();
         widget.dispose();
         widget.dispose();
-        expect(widget.isDisposed).to.be(true);
+        expect(widget.isDisposed).to.equal(true);
       });
     });
 
     describe('#onModelChanged()', () => {
       it('should be called when the model changes', () => {
-        let widget = new LogStaticNotebook(options);
+        const widget = new LogStaticNotebook(options);
         widget.model = new NotebookModel();
         expect(widget.methods).to.contain('onModelChanged');
       });
 
       it('should not be called if the model does not change', () => {
-        let widget = createWidget();
+        const widget = createWidget();
         widget.methods = [];
         widget.model = widget.model;
         expect(widget.methods).to.not.contain('onModelChanged');
@@ -422,32 +424,32 @@ describe('@jupyter/notebook', () => {
 
     describe('#onMetadataChanged()', () => {
       it('should be called when the metadata on the notebook changes', () => {
-        let widget = createWidget();
+        const widget = createWidget();
         widget.model.metadata.set('foo', 1);
         expect(widget.methods).to.contain('onMetadataChanged');
       });
 
       it('should update the `codeMimetype`', () => {
-        let widget = createWidget();
-        let value = { name: 'python', codemirror_mode: 'python' };
+        const widget = createWidget();
+        const value = { name: 'python', codemirror_mode: 'python' };
         widget.model.metadata.set('language_info', value);
         expect(widget.methods).to.contain('onMetadataChanged');
-        expect(widget.codeMimetype).to.be('text/x-python');
+        expect(widget.codeMimetype).to.equal('text/x-python');
       });
 
       it('should update the cell widget mimetype', () => {
-        let widget = createWidget();
-        let value = { name: 'python', mimetype: 'text/x-python' };
+        const widget = createWidget();
+        const value = { name: 'python', mimetype: 'text/x-python' };
         widget.model.metadata.set('language_info', value);
         expect(widget.methods).to.contain('onMetadataChanged');
-        let child = widget.widgets[0];
-        expect(child.model.mimeType).to.be('text/x-python');
+        const child = widget.widgets[0];
+        expect(child.model.mimeType).to.equal('text/x-python');
       });
     });
 
     describe('#onCellInserted()', () => {
       it('should be called when a cell is inserted', () => {
-        let widget = createWidget();
+        const widget = createWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         expect(widget.methods).to.contain('onCellInserted');
       });
@@ -455,7 +457,7 @@ describe('@jupyter/notebook', () => {
 
     describe('#onCellMoved()', () => {
       it('should be called when a cell is moved', () => {
-        let widget = createWidget();
+        const widget = createWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.model.cells.move(0, 1);
         expect(widget.methods).to.contain('onCellMoved');
@@ -464,8 +466,8 @@ describe('@jupyter/notebook', () => {
 
     describe('#onCellRemoved()', () => {
       it('should be called when a cell is removed', () => {
-        let widget = createWidget();
-        let cell = widget.model.cells.get(0);
+        const widget = createWidget();
+        const cell = widget.model.cells.get(0);
         widget.model.cells.removeValue(cell);
         expect(widget.methods).to.contain('onCellRemoved');
       });
@@ -475,41 +477,41 @@ describe('@jupyter/notebook', () => {
       describe('#constructor', () => {
         it('should create a new ContentFactory', () => {
           const editorFactory = NBTestUtils.editorFactory;
-          let factory = new StaticNotebook.ContentFactory({ editorFactory });
-          expect(factory).to.be.a(StaticNotebook.ContentFactory);
+          const factory = new StaticNotebook.ContentFactory({ editorFactory });
+          expect(factory).to.be.an.instanceof(StaticNotebook.ContentFactory);
         });
       });
 
       describe('#createCodeCell({})', () => {
         it('should create a `CodeCell`', () => {
-          let contentFactory = new StaticNotebook.ContentFactory();
-          let model = new CodeCellModel({});
-          let codeOptions = { model, rendermime, contentFactory };
-          let parent = new StaticNotebook(options);
-          let widget = contentFactory.createCodeCell(codeOptions, parent);
-          expect(widget).to.be.a(CodeCell);
+          const contentFactory = new StaticNotebook.ContentFactory();
+          const model = new CodeCellModel({});
+          const codeOptions = { model, rendermime, contentFactory };
+          const parent = new StaticNotebook(options);
+          const widget = contentFactory.createCodeCell(codeOptions, parent);
+          expect(widget).to.be.an.instanceof(CodeCell);
         });
       });
 
       describe('#createMarkdownCell({})', () => {
         it('should create a `MarkdownCell`', () => {
-          let contentFactory = new StaticNotebook.ContentFactory();
-          let model = new MarkdownCellModel({});
-          let mdOptions = { model, rendermime, contentFactory };
-          let parent = new StaticNotebook(options);
-          let widget = contentFactory.createMarkdownCell(mdOptions, parent);
-          expect(widget).to.be.a(MarkdownCell);
+          const contentFactory = new StaticNotebook.ContentFactory();
+          const model = new MarkdownCellModel({});
+          const mdOptions = { model, rendermime, contentFactory };
+          const parent = new StaticNotebook(options);
+          const widget = contentFactory.createMarkdownCell(mdOptions, parent);
+          expect(widget).to.be.an.instanceof(MarkdownCell);
         });
       });
 
       describe('#createRawCell()', () => {
         it('should create a `RawCell`', () => {
-          let contentFactory = new StaticNotebook.ContentFactory();
-          let model = new RawCellModel({});
-          let rawOptions = { model, contentFactory };
-          let parent = new StaticNotebook(options);
-          let widget = contentFactory.createRawCell(rawOptions, parent);
-          expect(widget).to.be.a(RawCell);
+          const contentFactory = new StaticNotebook.ContentFactory();
+          const model = new RawCellModel({});
+          const rawOptions = { model, contentFactory };
+          const parent = new StaticNotebook(options);
+          const widget = contentFactory.createRawCell(rawOptions, parent);
+          expect(widget).to.be.an.instanceof(RawCell);
         });
       });
     });
@@ -518,62 +520,62 @@ describe('@jupyter/notebook', () => {
   describe('Notebook', () => {
     describe('#stateChanged', () => {
       it('should be emitted when the state of the notebook changes', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         let called = false;
         widget.stateChanged.connect((sender, args) => {
-          expect(sender).to.be(widget);
-          expect(args.name).to.be('mode');
-          expect(args.oldValue).to.be('command');
-          expect(args.newValue).to.be('edit');
+          expect(sender).to.equal(widget);
+          expect(args.name).to.equal('mode');
+          expect(args.oldValue).to.equal('command');
+          expect(args.newValue).to.equal('edit');
           called = true;
         });
         widget.mode = 'edit';
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#activeCellChanged', () => {
       it('should be emitted when the active cell changes', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         let called = false;
         widget.activeCellChanged.connect((sender, args) => {
-          expect(sender).to.be(widget);
-          expect(args).to.be(widget.activeCell);
+          expect(sender).to.equal(widget);
+          expect(args).to.equal(widget.activeCell);
           called = true;
         });
         widget.activeCellIndex++;
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should not be emitted when the active cell does not change', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         let called = false;
         widget.activeCellChanged.connect(() => {
           called = true;
         });
         widget.activeCellIndex = widget.activeCellIndex;
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
     });
 
     describe('#selectionChanged', () => {
       it('should be emitted when the selection changes', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         let called = false;
         widget.selectionChanged.connect((sender, args) => {
-          expect(sender).to.be(widget);
-          expect(args).to.be(void 0);
+          expect(sender).to.equal(widget);
+          expect(args).to.be.undefined;
           called = true;
         });
         widget.select(widget.widgets[1]);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should not be emitted when the selection does not change', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         let called = false;
         widget.select(widget.widgets[1]);
@@ -581,130 +583,130 @@ describe('@jupyter/notebook', () => {
           called = true;
         });
         widget.select(widget.widgets[1]);
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
     });
 
     describe('#mode', () => {
       it('should get the interactivity mode of the notebook', () => {
-        let widget = createActiveWidget();
-        expect(widget.mode).to.be('command');
+        const widget = createActiveWidget();
+        expect(widget.mode).to.equal('command');
       });
 
       it('should set the interactivity mode of the notebook', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.mode = 'edit';
-        expect(widget.mode).to.be('edit');
+        expect(widget.mode).to.equal('edit');
       });
 
       it('should emit the `stateChanged` signal', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         let called = false;
         widget.stateChanged.connect((sender, args) => {
-          expect(sender).to.be(widget);
-          expect(args.name).to.be('mode');
-          expect(args.oldValue).to.be('command');
-          expect(args.newValue).to.be('edit');
+          expect(sender).to.equal(widget);
+          expect(args.name).to.equal('mode');
+          expect(args.oldValue).to.equal('command');
+          expect(args.newValue).to.equal('edit');
           called = true;
         });
         widget.mode = 'edit';
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should be a no-op if the value does not change', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         let called = false;
         widget.stateChanged.connect(() => {
           called = true;
         });
         widget.mode = 'command';
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
 
       it('should post an update request', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.mode = 'edit';
         await sleep();
         expect(widget.methods).to.contain('onUpdateRequest');
       });
 
       it('should deselect all cells if switching to edit mode', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         Widget.attach(widget, document.body);
         await sleep();
         widget.extendContiguousSelectionTo(widget.widgets.length - 1);
-        let selectedRange = Array.from(Array(widget.widgets.length).keys());
-        expect(selected(widget)).to.eql(selectedRange);
+        const selectedRange = Array.from(Array(widget.widgets.length).keys());
+        expect(selected(widget)).to.deep.equal(selectedRange);
         widget.mode = 'edit';
-        expect(selected(widget)).to.eql([]);
+        expect(selected(widget)).to.deep.equal([]);
         widget.dispose();
       });
 
       it('should unrender a markdown cell when switching to edit mode', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         Widget.attach(widget, document.body);
         MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
-        let cell = widget.model.contentFactory.createMarkdownCell({});
+        const cell = widget.model.contentFactory.createMarkdownCell({});
         widget.model.cells.push(cell);
-        let child = widget.widgets[widget.widgets.length - 1] as MarkdownCell;
-        expect(child.rendered).to.be(true);
+        const child = widget.widgets[widget.widgets.length - 1] as MarkdownCell;
+        expect(child.rendered).to.equal(true);
         widget.activeCellIndex = widget.widgets.length - 1;
         widget.mode = 'edit';
-        expect(child.rendered).to.be(false);
+        expect(child.rendered).to.equal(false);
       });
     });
 
     describe('#activeCellIndex', () => {
       it('should get the active cell index of the notebook', () => {
-        let widget = createActiveWidget();
-        expect(widget.activeCellIndex).to.be(0);
+        const widget = createActiveWidget();
+        expect(widget.activeCellIndex).to.equal(0);
       });
 
       it('should set the active cell index of the notebook', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.activeCellIndex = 1;
-        expect(widget.activeCellIndex).to.be(1);
+        expect(widget.activeCellIndex).to.equal(1);
       });
 
       it('should clamp the index to the bounds of the notebook cells', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.activeCellIndex = -2;
-        expect(widget.activeCellIndex).to.be(0);
+        expect(widget.activeCellIndex).to.equal(0);
         widget.activeCellIndex = 100;
-        expect(widget.activeCellIndex).to.be(5);
+        expect(widget.activeCellIndex).to.equal(5);
       });
 
       it('should emit the `stateChanged` signal', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         let called = false;
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.stateChanged.connect((sender, args) => {
-          expect(sender).to.be(widget);
-          expect(args.name).to.be('activeCellIndex');
-          expect(args.oldValue).to.be(0);
-          expect(args.newValue).to.be(1);
+          expect(sender).to.equal(widget);
+          expect(args.name).to.equal('activeCellIndex');
+          expect(args.oldValue).to.equal(0);
+          expect(args.newValue).to.equal(1);
           called = true;
         });
         widget.activeCellIndex = 1;
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
 
       it('should be a no-op if the value does not change', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         let called = false;
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.stateChanged.connect(() => {
           called = true;
         });
         widget.activeCellIndex = 0;
-        expect(called).to.be(false);
+        expect(called).to.equal(false);
       });
 
       it('should post an update request', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         await sleep();
         expect(widget.methods).to.contain('onUpdateRequest');
@@ -712,99 +714,99 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should update the active cell if necessary', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.activeCellIndex = 1;
-        expect(widget.activeCell).to.be(widget.widgets[1]);
+        expect(widget.activeCell).to.equal(widget.widgets[1]);
       });
     });
 
     describe('#activeCell', () => {
       it('should get the active cell widget', () => {
-        let widget = createActiveWidget();
-        expect(widget.activeCell).to.be(widget.widgets[0]);
+        const widget = createActiveWidget();
+        expect(widget.activeCell).to.equal(widget.widgets[0]);
       });
     });
 
     describe('#select()', () => {
       it('should select a cell widget', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        let cell = widget.widgets[0];
+        const cell = widget.widgets[0];
         widget.select(cell);
-        expect(widget.isSelected(cell)).to.be(true);
+        expect(widget.isSelected(cell)).to.equal(true);
       });
 
       it('should allow multiple widgets to be selected', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.widgets.forEach(cell => {
           widget.select(cell);
         });
-        let expectSelected = Array.from(Array(widget.widgets.length).keys());
-        expect(selected(widget)).to.eql(expectSelected);
+        const expectSelected = Array.from(Array(widget.widgets.length).keys());
+        expect(selected(widget)).to.deep.equal(expectSelected);
       });
     });
 
     describe('#deselect()', () => {
       it('should deselect a cell', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         for (let i = 0; i < widget.widgets.length; i++) {
-          let cell = widget.widgets[i];
+          const cell = widget.widgets[i];
           widget.select(cell);
-          expect(widget.isSelected(cell)).to.be(true);
+          expect(widget.isSelected(cell)).to.equal(true);
           widget.deselect(cell);
-          expect(widget.isSelected(cell)).to.be(false);
+          expect(widget.isSelected(cell)).to.equal(false);
         }
       });
 
-      it('should let the active cell be deselected', () => {
-        let widget = createActiveWidget();
+      it('should const the active cell be deselected', () => {
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        let cell = widget.activeCell;
+        const cell = widget.activeCell;
         widget.select(cell);
-        expect(widget.isSelected(cell)).to.be(true);
+        expect(widget.isSelected(cell)).to.equal(true);
         widget.deselect(cell);
-        expect(widget.isSelected(cell)).to.be(false);
+        expect(widget.isSelected(cell)).to.equal(false);
       });
     });
 
     describe('#isSelected()', () => {
       it('should get whether the cell is selected', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.select(widget.widgets[0]);
         widget.select(widget.widgets[2]);
-        expect(selected(widget)).to.eql([0, 2]);
+        expect(selected(widget)).to.deep.equal([0, 2]);
       });
 
       it('reports selection whether or not cell is active', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(selected(widget)).to.eql([]);
+        expect(selected(widget)).to.deep.equal([]);
         widget.select(widget.activeCell);
-        expect(selected(widget)).to.eql([widget.activeCellIndex]);
+        expect(selected(widget)).to.deep.equal([widget.activeCellIndex]);
       });
     });
 
     describe('#deselectAll()', () => {
       it('should deselect all cells', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.select(widget.widgets[0]);
         widget.select(widget.widgets[2]);
         widget.select(widget.widgets[3]);
         widget.select(widget.widgets[4]);
-        expect(selected(widget)).to.eql([0, 2, 3, 4]);
+        expect(selected(widget)).to.deep.equal([0, 2, 3, 4]);
         widget.deselectAll();
-        expect(selected(widget)).to.eql([]);
+        expect(selected(widget)).to.deep.equal([]);
       });
     });
 
     describe('#extendContiguousSelectionTo()', () => {
       // Test a permutation for extending a selection.
-      let checkSelection = (
+      const checkSelection = (
         widget: Notebook,
         anchor: number,
         head: number,
@@ -831,7 +833,7 @@ describe('@jupyter/notebook', () => {
 
         // Set up a selection event listener.
         let selectionChanged = 0;
-        let countSelectionChanged = (sender: Notebook, args: void) => {
+        const countSelectionChanged = (sender: Notebook, args: void) => {
           selectionChanged += 1;
         };
         widget.selectionChanged.connect(countSelectionChanged);
@@ -839,11 +841,11 @@ describe('@jupyter/notebook', () => {
         // Check the contiguous selection.
         let selection = widget.getContiguousSelection();
         if (select) {
-          expect(selection.anchor).to.be(anchor);
-          expect(selection.head).to.be(head);
+          expect(selection.anchor).to.equal(anchor);
+          expect(selection.head).to.equal(head);
         } else {
-          expect(selection.anchor).to.be(null);
-          expect(selection.head).to.be(null);
+          expect(selection.anchor).to.be.null;
+          expect(selection.head).to.be.null;
         }
 
         // Extend the selection.
@@ -862,12 +864,12 @@ describe('@jupyter/notebook', () => {
         if (head === index) {
           if (index === anchor && select) {
             // we should have collapsed the single cell selection
-            expect(selectionChanged).to.be(1);
+            expect(selectionChanged).to.equal(1);
           } else {
-            expect(selectionChanged).to.be(0);
+            expect(selectionChanged).to.equal(0);
           }
         } else {
-          expect(selectionChanged).to.be(1);
+          expect(selectionChanged).to.equal(1);
         }
 
         if (anchor !== index) {
@@ -886,7 +888,7 @@ describe('@jupyter/notebook', () => {
       };
 
       // Lists are of the form [anchor, head, index].
-      let permutations = [
+      const permutations = [
         // Anchor, head, and index are distinct
         [1, 3, 5],
         [1, 5, 3],
@@ -905,7 +907,7 @@ describe('@jupyter/notebook', () => {
       ];
 
       it('should work in each permutation of anchor, head, and index', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         permutations.forEach(p => {
@@ -914,7 +916,7 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should work when we only have an active cell, with no existing selection', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         permutations.forEach(p => {
@@ -925,7 +927,7 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should clip when the index is greater than the last index', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         permutations.forEach(p => {
@@ -934,7 +936,7 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should clip when the index is greater than the last index with no existing selection', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         permutations.forEach(p => {
@@ -945,7 +947,7 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should clip when the index is less than 0', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         permutations.forEach(p => {
@@ -954,7 +956,7 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should clip when the index is less than 0 with no existing selection', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         permutations.forEach(p => {
@@ -965,9 +967,9 @@ describe('@jupyter/notebook', () => {
       });
 
       it('handles the case of no cells', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.cells.clear();
-        expect(widget.widgets.length).to.be(0);
+        expect(widget.widgets.length).to.equal(0);
 
         // Set up a selection event listener.
         let selectionChanged = 0;
@@ -977,27 +979,27 @@ describe('@jupyter/notebook', () => {
 
         widget.extendContiguousSelectionTo(3);
 
-        expect(widget.activeCellIndex).to.be(-1);
-        expect(selectionChanged).to.be(0);
+        expect(widget.activeCellIndex).to.equal(-1);
+        expect(selectionChanged).to.equal(0);
       });
     });
 
     describe('#getContiguousSelection()', () => {
       it('throws an error when the selection is not contiguous', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         widget.select(widget.widgets[1]);
         widget.select(widget.widgets[3]);
         widget.activeCellIndex = 3;
 
-        expect(() => widget.getContiguousSelection()).to.throwError(
+        expect(() => widget.getContiguousSelection()).to.throw(
           /Selection not contiguous/
         );
       });
 
       it('throws an error if the active cell is not at an endpoint', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         widget.select(widget.widgets[1]);
@@ -1006,36 +1008,36 @@ describe('@jupyter/notebook', () => {
 
         // Check if active cell is outside selection.
         widget.activeCellIndex = 0;
-        expect(() => widget.getContiguousSelection()).to.throwError(
+        expect(() => widget.getContiguousSelection()).to.throw(
           /Active cell not at endpoint of selection/
         );
 
         // Check if active cell is inside selection.
         widget.activeCellIndex = 2;
-        expect(() => widget.getContiguousSelection()).to.throwError(
+        expect(() => widget.getContiguousSelection()).to.throw(
           /Active cell not at endpoint of selection/
         );
       });
 
       it('returns null values if there is no selection', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
-        let selection = widget.getContiguousSelection();
-        expect(selection).to.eql({ head: null, anchor: null });
+        const selection = widget.getContiguousSelection();
+        expect(selection).to.deep.equal({ head: null, anchor: null });
       });
 
       it('handles the case of no cells', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.cells.clear();
-        expect(widget.widgets.length).to.be(0);
+        expect(widget.widgets.length).to.equal(0);
 
-        let selection = widget.getContiguousSelection();
-        expect(selection).to.eql({ head: null, anchor: null });
+        const selection = widget.getContiguousSelection();
+        expect(selection).to.deep.equal({ head: null, anchor: null });
       });
 
       it('works if head is before the anchor', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         widget.select(widget.widgets[1]);
@@ -1043,12 +1045,12 @@ describe('@jupyter/notebook', () => {
         widget.select(widget.widgets[3]);
         widget.activeCellIndex = 1;
 
-        let selection = widget.getContiguousSelection();
-        expect(selection).to.eql({ head: 1, anchor: 3 });
+        const selection = widget.getContiguousSelection();
+        expect(selection).to.deep.equal({ head: 1, anchor: 3 });
       });
 
       it('works if head is after the anchor', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         widget.select(widget.widgets[1]);
@@ -1056,19 +1058,19 @@ describe('@jupyter/notebook', () => {
         widget.select(widget.widgets[3]);
         widget.activeCellIndex = 3;
 
-        let selection = widget.getContiguousSelection();
-        expect(selection).to.eql({ head: 3, anchor: 1 });
+        const selection = widget.getContiguousSelection();
+        expect(selection).to.deep.equal({ head: 3, anchor: 1 });
       });
 
       it('works if head and anchor are the same', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
 
         widget.select(widget.widgets[3]);
         widget.activeCellIndex = 3;
 
-        let selection = widget.getContiguousSelection();
-        expect(selection).to.eql({ head: 3, anchor: 3 });
+        const selection = widget.getContiguousSelection();
+        expect(selection).to.deep.equal({ head: 3, anchor: 3 });
       });
     });
 
@@ -1088,28 +1090,28 @@ describe('@jupyter/notebook', () => {
 
       context('mousedown', () => {
         it('should set the active cell index', () => {
-          let child = widget.widgets[1];
+          const child = widget.widgets[1];
           simulate(child.node, 'mousedown');
           expect(widget.events).to.contain('mousedown');
-          expect(widget.isSelected(widget.widgets[0])).to.be(false);
-          expect(widget.activeCellIndex).to.be(1);
+          expect(widget.isSelected(widget.widgets[0])).to.equal(false);
+          expect(widget.activeCellIndex).to.equal(1);
         });
 
         it('should be a no-op if not not a cell', () => {
           simulate(widget.node, 'mousedown');
           expect(widget.events).to.contain('mousedown');
-          expect(widget.activeCellIndex).to.be(0);
+          expect(widget.activeCellIndex).to.equal(0);
         });
 
         it('should preserve "command" mode if in a markdown cell', () => {
-          let cell = widget.model.contentFactory.createMarkdownCell({});
+          const cell = widget.model.contentFactory.createMarkdownCell({});
           widget.model.cells.push(cell);
-          let count = widget.widgets.length;
-          let child = widget.widgets[count - 1] as MarkdownCell;
-          expect(child.rendered).to.be(true);
+          const count = widget.widgets.length;
+          const child = widget.widgets[count - 1] as MarkdownCell;
+          expect(child.rendered).to.equal(true);
           simulate(child.node, 'mousedown');
-          expect(child.rendered).to.be(true);
-          expect(widget.activeCell).to.be(child);
+          expect(child.rendered).to.equal(true);
+          expect(widget.activeCell).to.equal(child);
         });
 
         it('should extend selection if invoked with shift', () => {
@@ -1117,71 +1119,71 @@ describe('@jupyter/notebook', () => {
 
           // shift click below
           simulate(widget.widgets[4].node, 'mousedown', { shiftKey: true });
-          expect(widget.activeCellIndex).to.be(4);
-          expect(selected(widget)).to.eql([3, 4]);
+          expect(widget.activeCellIndex).to.equal(4);
+          expect(selected(widget)).to.deep.equal([3, 4]);
 
           // shift click above
           simulate(widget.widgets[1].node, 'mousedown', { shiftKey: true });
-          expect(widget.activeCellIndex).to.be(1);
-          expect(selected(widget)).to.eql([1, 2, 3]);
+          expect(widget.activeCellIndex).to.equal(1);
+          expect(selected(widget)).to.deep.equal([1, 2, 3]);
 
           // shift click expand
           simulate(widget.widgets[0].node, 'mousedown', { shiftKey: true });
-          expect(widget.activeCellIndex).to.be(0);
-          expect(selected(widget)).to.eql([0, 1, 2, 3]);
+          expect(widget.activeCellIndex).to.equal(0);
+          expect(selected(widget)).to.deep.equal([0, 1, 2, 3]);
 
           // shift click contract
           simulate(widget.widgets[2].node, 'mousedown', { shiftKey: true });
-          expect(widget.activeCellIndex).to.be(2);
-          expect(selected(widget)).to.eql([2, 3]);
+          expect(widget.activeCellIndex).to.equal(2);
+          expect(selected(widget)).to.deep.equal([2, 3]);
         });
 
         it('should leave a markdown cell rendered', () => {
-          let code = widget.model.contentFactory.createCodeCell({});
-          let md = widget.model.contentFactory.createMarkdownCell({});
+          const code = widget.model.contentFactory.createCodeCell({});
+          const md = widget.model.contentFactory.createMarkdownCell({});
           widget.model.cells.push(code);
           widget.model.cells.push(md);
-          let count = widget.widgets.length;
-          let codeChild = widget.widgets[count - 2];
-          let mdChild = widget.widgets[count - 1] as MarkdownCell;
+          const count = widget.widgets.length;
+          const codeChild = widget.widgets[count - 2];
+          const mdChild = widget.widgets[count - 1] as MarkdownCell;
           widget.select(codeChild);
           widget.select(mdChild);
           widget.activeCellIndex = count - 2;
-          expect(mdChild.rendered).to.be(true);
+          expect(mdChild.rendered).to.equal(true);
           simulate(codeChild.editorWidget.node, 'mousedown');
           simulate(codeChild.editorWidget.node, 'focusin');
-          expect(mdChild.rendered).to.be(true);
-          expect(widget.activeCell).to.be(codeChild);
-          expect(widget.mode).to.be('edit');
+          expect(mdChild.rendered).to.equal(true);
+          expect(widget.activeCell).to.equal(codeChild);
+          expect(widget.mode).to.equal('edit');
         });
 
         it('should remove selection and switch to command mode', () => {
-          let code = widget.model.contentFactory.createCodeCell({});
-          let md = widget.model.contentFactory.createMarkdownCell({});
+          const code = widget.model.contentFactory.createCodeCell({});
+          const md = widget.model.contentFactory.createMarkdownCell({});
           widget.model.cells.push(code);
           widget.model.cells.push(md);
-          let count = widget.widgets.length;
-          let codeChild = widget.widgets[count - 2];
-          let mdChild = widget.widgets[count - 1] as MarkdownCell;
+          const count = widget.widgets.length;
+          const codeChild = widget.widgets[count - 2];
+          const mdChild = widget.widgets[count - 1] as MarkdownCell;
           widget.select(codeChild);
           widget.select(mdChild);
           widget.activeCellIndex = count - 2;
           simulate(codeChild.editorWidget.node, 'mousedown');
           simulate(codeChild.editorWidget.node, 'focusin');
-          expect(widget.mode).to.be('edit');
+          expect(widget.mode).to.equal('edit');
           simulate(codeChild.editorWidget.node, 'mousedown', { button: 2 });
-          expect(widget.isSelected(mdChild)).to.be(false);
-          expect(widget.mode).to.be('command');
+          expect(widget.isSelected(mdChild)).to.equal(false);
+          expect(widget.mode).to.equal('command');
         });
 
         it('should have no effect on shift right click', () => {
-          let code = widget.model.contentFactory.createCodeCell({});
-          let md = widget.model.contentFactory.createMarkdownCell({});
+          const code = widget.model.contentFactory.createCodeCell({});
+          const md = widget.model.contentFactory.createMarkdownCell({});
           widget.model.cells.push(code);
           widget.model.cells.push(md);
-          let count = widget.widgets.length;
-          let codeChild = widget.widgets[count - 2];
-          let mdChild = widget.widgets[count - 1] as MarkdownCell;
+          const count = widget.widgets.length;
+          const codeChild = widget.widgets[count - 2];
+          const mdChild = widget.widgets[count - 1] as MarkdownCell;
           widget.select(codeChild);
           widget.select(mdChild);
           widget.activeCellIndex = count - 2;
@@ -1189,41 +1191,43 @@ describe('@jupyter/notebook', () => {
             shiftKey: true,
             button: 2
           });
-          expect(widget.isSelected(mdChild)).to.be(true);
-          expect(widget.mode).to.be('command');
+          expect(widget.isSelected(mdChild)).to.equal(true);
+          expect(widget.mode).to.equal('command');
         });
       });
 
       context('dblclick', () => {
         it('should unrender a markdown cell', () => {
-          let cell = widget.model.contentFactory.createMarkdownCell({});
+          const cell = widget.model.contentFactory.createMarkdownCell({});
           widget.model.cells.push(cell);
-          let child = widget.widgets[widget.widgets.length - 1] as MarkdownCell;
-          expect(child.rendered).to.be(true);
-          expect(widget.mode).to.be('command');
+          const child = widget.widgets[
+            widget.widgets.length - 1
+          ] as MarkdownCell;
+          expect(child.rendered).to.equal(true);
+          expect(widget.mode).to.equal('command');
           simulate(child.node, 'dblclick');
-          expect(widget.mode).to.be('command');
-          expect(child.rendered).to.be(false);
+          expect(widget.mode).to.equal('command');
+          expect(child.rendered).to.equal(false);
         });
       });
 
       context('focusin', () => {
         it('should change to edit mode if a child cell takes focus', () => {
-          let child = widget.widgets[0];
+          const child = widget.widgets[0];
           simulate(child.editorWidget.node, 'focusin');
           expect(widget.events).to.contain('focusin');
-          expect(widget.mode).to.be('edit');
+          expect(widget.mode).to.equal('edit');
         });
 
         it('should change to command mode if the widget takes focus', () => {
-          let child = widget.widgets[0];
+          const child = widget.widgets[0];
           simulate(child.editorWidget.node, 'focusin');
           expect(widget.events).to.contain('focusin');
-          expect(widget.mode).to.be('edit');
+          expect(widget.mode).to.equal('edit');
           widget.events = [];
           simulate(widget.node, 'focusin');
           expect(widget.events).to.contain('focusin');
-          expect(widget.mode).to.be('command');
+          expect(widget.mode).to.equal('command');
         });
       });
 
@@ -1231,32 +1235,32 @@ describe('@jupyter/notebook', () => {
         it('should switch to command mode', () => {
           simulate(widget.node, 'focusin');
           widget.mode = 'edit';
-          let event = generate('focusout');
+          const event = generate('focusout');
           (event as any).relatedTarget = document.body;
           widget.node.dispatchEvent(event);
-          expect(widget.mode).to.be('command');
+          expect(widget.mode).to.equal('command');
           MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
-          expect(widget.mode).to.be('command');
-          expect(widget.activeCell.editor.hasFocus()).to.be(false);
+          expect(widget.mode).to.equal('command');
+          expect(widget.activeCell.editor.hasFocus()).to.equal(false);
         });
 
         it('should set command mode', () => {
           simulate(widget.node, 'focusin');
           widget.mode = 'edit';
-          let evt = generate('focusout');
+          const evt = generate('focusout');
           (evt as any).relatedTarget = widget.activeCell.node;
           widget.node.dispatchEvent(evt);
-          expect(widget.mode).to.be('command');
+          expect(widget.mode).to.equal('command');
         });
       });
     });
 
     describe('#onAfterAttach()', () => {
       it('should add event listeners', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         Widget.attach(widget, document.body);
-        let child = widget.widgets[0];
+        const child = widget.widgets[0];
         await sleep();
         expect(widget.methods).to.contain('onAfterAttach');
         simulate(widget.node, 'mousedown');
@@ -1269,7 +1273,7 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should post an update request', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         Widget.attach(widget, document.body);
         await sleep();
@@ -1282,10 +1286,10 @@ describe('@jupyter/notebook', () => {
 
     describe('#onBeforeDetach()', () => {
       it('should remove event listeners', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         Widget.attach(widget, document.body);
-        let child = widget.widgets[0];
+        const child = widget.widgets[0];
         await sleep();
         Widget.detach(widget);
         expect(widget.methods).to.contain('onBeforeDetach');
@@ -1302,17 +1306,17 @@ describe('@jupyter/notebook', () => {
 
     describe('#onActivateRequest()', () => {
       it('should focus the node after an update', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         Widget.attach(widget, document.body);
         MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
         expect(widget.methods).to.contain('onActivateRequest');
         await sleep();
-        expect(document.activeElement).to.be(widget.node);
+        expect(document.activeElement).to.equal(widget.node);
         widget.dispose();
       });
 
       it('should post an `update-request', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
         expect(widget.methods).to.contain('onActivateRequest');
         await sleep();
@@ -1337,40 +1341,40 @@ describe('@jupyter/notebook', () => {
 
       it('should apply the command class if in command mode', () => {
         expect(widget.methods).to.contain('onUpdateRequest');
-        expect(widget.hasClass('jp-mod-commandMode')).to.be(true);
+        expect(widget.hasClass('jp-mod-commandMode')).to.equal(true);
       });
 
       it('should apply the edit class if in edit mode', async () => {
         widget.mode = 'edit';
         await sleep();
-        expect(widget.hasClass('jp-mod-editMode')).to.be(true);
+        expect(widget.hasClass('jp-mod-editMode')).to.equal(true);
       });
 
       it('should add the active class to the active widget', () => {
-        let cell = widget.widgets[widget.activeCellIndex];
-        expect(cell.hasClass('jp-mod-active')).to.be(true);
+        const cell = widget.widgets[widget.activeCellIndex];
+        expect(cell.hasClass('jp-mod-active')).to.equal(true);
       });
 
       it('should set the selected class on the selected widgets', async () => {
         widget.select(widget.widgets[1]);
         await sleep();
         for (let i = 0; i < 2; i++) {
-          let cell = widget.widgets[i];
-          expect(cell.hasClass('jp-mod-selected')).to.be(true);
+          const cell = widget.widgets[i];
+          expect(cell.hasClass('jp-mod-selected')).to.equal(true);
         }
       });
 
       it('should add the multi select class if there is more than one widget', async () => {
         widget.select(widget.widgets[1]);
-        expect(widget.hasClass('jp-mod-multSelected')).to.be(false);
+        expect(widget.hasClass('jp-mod-multSelected')).to.equal(false);
         await sleep();
-        expect(widget.hasClass('jp-mod-multSelected')).to.be(false);
+        expect(widget.hasClass('jp-mod-multSelected')).to.equal(false);
       });
     });
 
     describe('#onCellInserted()', () => {
       it('should post an `update-request', async () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         expect(widget.methods).to.contain('onCellInserted');
         await sleep();
@@ -1378,46 +1382,46 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should update the active cell if necessary', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        expect(widget.activeCell).to.be(widget.widgets[0]);
+        expect(widget.activeCell).to.equal(widget.widgets[0]);
       });
 
       it('should keep the currently active cell active', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.activeCellIndex = 1;
-        let cell = widget.model.contentFactory.createCodeCell({});
+        const cell = widget.model.contentFactory.createCodeCell({});
         widget.model.cells.insert(1, cell);
-        expect(widget.activeCell).to.be(widget.widgets[2]);
+        expect(widget.activeCell).to.equal(widget.widgets[2]);
       });
 
       context('`edgeRequested` signal', () => {
         it('should activate the previous cell if top is requested', () => {
-          let widget = createActiveWidget();
+          const widget = createActiveWidget();
           widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
           widget.activeCellIndex = 1;
-          let child = widget.widgets[widget.activeCellIndex];
+          const child = widget.widgets[widget.activeCellIndex];
           (child.editor.edgeRequested as any).emit('top');
-          expect(widget.activeCellIndex).to.be(0);
+          expect(widget.activeCellIndex).to.equal(0);
         });
 
         it('should activate the next cell if bottom is requested', () => {
-          let widget = createActiveWidget();
+          const widget = createActiveWidget();
           widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-          let child = widget.widgets[widget.activeCellIndex];
+          const child = widget.widgets[widget.activeCellIndex];
           (child.editor.edgeRequested as any).emit('bottom');
-          expect(widget.activeCellIndex).to.be(1);
+          expect(widget.activeCellIndex).to.equal(1);
         });
       });
     });
 
     describe('#onCellMoved()', () => {
       it('should update the active cell index if necessary', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
 
         // [fromIndex, toIndex, activeIndex], starting with activeIndex=3.
-        let moves = [
+        const moves = [
           [0, 2, 3],
           [0, 3, 2],
           [0, 4, 2],
@@ -1430,21 +1434,21 @@ describe('@jupyter/notebook', () => {
         ];
 
         moves.forEach(m => {
-          let [fromIndex, toIndex, activeIndex] = m;
+          const [fromIndex, toIndex, activeIndex] = m;
           widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-          let cell = widget.widgets[3];
+          const cell = widget.widgets[3];
           widget.activeCellIndex = 3;
           widget.model.cells.move(fromIndex, toIndex);
-          expect(widget.activeCellIndex).to.be(activeIndex);
-          expect(widget.widgets[activeIndex]).to.be(cell);
+          expect(widget.activeCellIndex).to.equal(activeIndex);
+          expect(widget.widgets[activeIndex]).to.equal(cell);
         });
       });
     });
 
     describe('#onCellRemoved()', () => {
       it('should post an `update-request', async () => {
-        let widget = createActiveWidget();
-        let cell = widget.model.cells.get(0);
+        const widget = createActiveWidget();
+        const cell = widget.model.cells.get(0);
         widget.model.cells.removeValue(cell);
         expect(widget.methods).to.contain('onCellRemoved');
         await sleep();
@@ -1452,18 +1456,18 @@ describe('@jupyter/notebook', () => {
       });
 
       it('should update the active cell if necessary', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.model.cells.remove(0);
-        expect(widget.activeCell).to.be(widget.widgets[0]);
+        expect(widget.activeCell).to.equal(widget.widgets[0]);
       });
 
       it('should keep the currently active cell active', () => {
-        let widget = createActiveWidget();
+        const widget = createActiveWidget();
         widget.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         widget.activeCellIndex = 2;
         widget.model.cells.remove(1);
-        expect(widget.activeCell).to.be(widget.widgets[1]);
+        expect(widget.activeCell).to.equal(widget.widgets[1]);
       });
     });
   });

--- a/tests/test-notebook/src/widgetfactory.spec.ts
+++ b/tests/test-notebook/src/widgetfactory.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { toArray } from '@phosphor/algorithm';
 
@@ -44,74 +44,74 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#constructor()', () => {
       it('should create a notebook widget factory', () => {
-        let factory = createFactory();
-        expect(factory).to.be.a(NotebookWidgetFactory);
+        const factory = createFactory();
+        expect(factory).to.be.an.instanceof(NotebookWidgetFactory);
       });
     });
 
     describe('#isDisposed', () => {
       it('should get whether the factory has been disposed', () => {
-        let factory = createFactory();
-        expect(factory.isDisposed).to.be(false);
+        const factory = createFactory();
+        expect(factory.isDisposed).to.equal(false);
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
     });
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the factory', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
-        let factory = createFactory();
+        const factory = createFactory();
         factory.dispose();
         factory.dispose();
-        expect(factory.isDisposed).to.be(true);
+        expect(factory.isDisposed).to.equal(true);
       });
     });
 
     describe('#editorConfig', () => {
       it('should be the editor config passed into the constructor', () => {
-        let factory = createFactory();
-        expect(factory.editorConfig).to.be(NBTestUtils.defaultEditorConfig);
+        const factory = createFactory();
+        expect(factory.editorConfig).to.equal(NBTestUtils.defaultEditorConfig);
       });
 
       it('should be settable', () => {
-        let factory = createFactory();
-        let newConfig = { ...NBTestUtils.defaultEditorConfig };
+        const factory = createFactory();
+        const newConfig = { ...NBTestUtils.defaultEditorConfig };
         factory.editorConfig = newConfig;
-        expect(factory.editorConfig).to.be(newConfig);
+        expect(factory.editorConfig).to.equal(newConfig);
       });
     });
 
     describe('#createNew()', () => {
       it('should create a new `NotebookPanel` widget', () => {
-        let factory = createFactory();
-        let panel = factory.createNew(context);
-        expect(panel).to.be.a(NotebookPanel);
+        const factory = createFactory();
+        const panel = factory.createNew(context);
+        expect(panel).to.be.an.instanceof(NotebookPanel);
       });
 
       it('should create a clone of the rendermime', () => {
-        let factory = createFactory();
-        let panel = factory.createNew(context);
-        expect(panel.rendermime).to.not.be(rendermime);
+        const factory = createFactory();
+        const panel = factory.createNew(context);
+        expect(panel.rendermime).to.not.equal(rendermime);
       });
 
       it('should pass the editor config to the notebook', () => {
-        let factory = createFactory();
-        let panel = factory.createNew(context);
-        expect(panel.content.editorConfig).to.be(
+        const factory = createFactory();
+        const panel = factory.createNew(context);
+        expect(panel.content.editorConfig).to.equal(
           NBTestUtils.defaultEditorConfig
         );
       });
 
       it('should populate the default toolbar items', () => {
-        let factory = createFactory();
-        let panel = factory.createNew(context);
-        let items = toArray(panel.toolbar.names());
+        const factory = createFactory();
+        const panel = factory.createNew(context);
+        const items = toArray(panel.toolbar.names());
         expect(items).to.contain('save');
         expect(items).to.contain('restart');
         expect(items).to.contain('kernelStatus');

--- a/tests/test-outputarea/package.json
+++ b/tests/test-outputarea/package.json
@@ -23,9 +23,10 @@
     "@jupyterlab/testutils": "^0.1.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1"
+    "chai": "~4.1.2"
   },
   "devDependencies": {
+    "@types/chai": "~4.0.10",
     "karma": "~2.0.4",
     "karma-chrome-launcher": "~2.2.0",
     "puppeteer": "^1.5.0",

--- a/tests/test-outputarea/src/model.spec.ts
+++ b/tests/test-outputarea/src/model.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { OutputModel } from '@jupyterlab/rendermime';
 
@@ -23,18 +23,18 @@ describe('outputarea/model', () => {
   describe('OutputAreaModel', () => {
     describe('#constructor()', () => {
       it('should create an output area model', () => {
-        expect(model).to.be.an(OutputAreaModel);
+        expect(model).to.be.an.instanceof(OutputAreaModel);
       });
 
       it('should accept options', () => {
-        let contentFactory = new OutputAreaModel.ContentFactory();
+        const contentFactory = new OutputAreaModel.ContentFactory();
         model = new OutputAreaModel({
           values: NBTestUtils.DEFAULT_OUTPUTS,
           contentFactory,
           trusted: true
         });
-        expect(model.contentFactory).to.be(contentFactory);
-        expect(model.trusted).to.be(true);
+        expect(model.contentFactory).to.equal(contentFactory);
+        expect(model.trusted).to.equal(true);
       });
     });
 
@@ -42,15 +42,15 @@ describe('outputarea/model', () => {
       it('should be emitted when the model changes', () => {
         let called = false;
         model.changed.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args.type).to.be('add');
-          expect(args.oldIndex).to.be(-1);
-          expect(args.newIndex).to.be(0);
-          expect(args.oldValues.length).to.be(0);
+          expect(sender).to.equal(model);
+          expect(args.type).to.equal('add');
+          expect(args.oldIndex).to.equal(-1);
+          expect(args.newIndex).to.equal(0);
+          expect(args.oldValues.length).to.equal(0);
           called = true;
         });
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
@@ -59,27 +59,27 @@ describe('outputarea/model', () => {
         let called = false;
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
         model.stateChanged.connect((sender, args) => {
-          expect(sender).to.be(model);
-          expect(args).to.be(void 0);
+          expect(sender).to.equal(model);
+          expect(args).to.be.undefined;
           called = true;
         });
-        let output = model.get(0);
+        const output = model.get(0);
         output.setData({ ...output.data });
-        expect(called).to.be(true);
+        expect(called).to.equal(true);
       });
     });
 
     describe('#length', () => {
       it('should get the length of the items in the model', () => {
-        expect(model.length).to.be(0);
+        expect(model.length).to.equal(0);
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
-        expect(model.length).to.be(1);
+        expect(model.length).to.equal(1);
       });
     });
 
     describe('#trusted', () => {
       it('should be the trusted state of the model', () => {
-        expect(model.trusted).to.be(false);
+        expect(model.trusted).to.equal(false);
       });
 
       it('should cause all of the cells to `set`', () => {
@@ -90,13 +90,13 @@ describe('outputarea/model', () => {
           called++;
         });
         model.trusted = true;
-        expect(called).to.be(2);
+        expect(called).to.equal(2);
       });
     });
 
     describe('#contentFactory', () => {
       it('should be the content factory used by the model', () => {
-        expect(model.contentFactory).to.be(
+        expect(model.contentFactory).to.equal(
           OutputAreaModel.defaultContentFactory
         );
       });
@@ -104,9 +104,9 @@ describe('outputarea/model', () => {
 
     describe('#isDisposed', () => {
       it('should test whether the model is disposed', () => {
-        expect(model.isDisposed).to.be(false);
+        expect(model.isDisposed).to.equal(false);
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
     });
 
@@ -114,60 +114,62 @@ describe('outputarea/model', () => {
       it('should dispose of the resources used by the model', () => {
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
         model.dispose();
-        expect(model.isDisposed).to.be(true);
-        expect(model.length).to.be(0);
+        expect(model.isDisposed).to.equal(true);
+        expect(model.length).to.equal(0);
       });
 
       it('should be safe to call more than once', () => {
         model.dispose();
         model.dispose();
-        expect(model.isDisposed).to.be(true);
+        expect(model.isDisposed).to.equal(true);
       });
     });
 
     describe('#get()', () => {
       it('should get the item at the specified index', () => {
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
-        let output = model.get(0);
-        expect(output.type).to.be(NBTestUtils.DEFAULT_OUTPUTS[0].output_type);
+        const output = model.get(0);
+        expect(output.type).to.equal(
+          NBTestUtils.DEFAULT_OUTPUTS[0].output_type
+        );
       });
 
       it('should return `undefined` if out of range', () => {
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
-        expect(model.get(1)).to.be(void 0);
+        expect(model.get(1)).to.be.undefined;
       });
     });
 
     describe('#add()', () => {
       it('should add an output', () => {
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
-        expect(model.length).to.be(1);
+        expect(model.length).to.equal(1);
       });
 
       it('should consolidate consecutive stream outputs of the same kind', () => {
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
         model.add(NBTestUtils.DEFAULT_OUTPUTS[1]);
-        expect(model.length).to.be(2);
+        expect(model.length).to.equal(2);
         model.add(NBTestUtils.DEFAULT_OUTPUTS[2]);
-        expect(model.length).to.be(2);
+        expect(model.length).to.equal(2);
       });
     });
 
     describe('#clear()', () => {
       it('should clear all of the output', () => {
-        for (let output of NBTestUtils.DEFAULT_OUTPUTS) {
+        for (const output of NBTestUtils.DEFAULT_OUTPUTS) {
           model.add(output);
         }
         model.clear();
-        expect(model.length).to.be(0);
+        expect(model.length).to.equal(0);
       });
 
       it('should wait for next add if requested', () => {
         model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
         model.clear(true);
-        expect(model.length).to.be(1);
+        expect(model.length).to.equal(1);
         model.add(NBTestUtils.DEFAULT_OUTPUTS[1]);
-        expect(model.length).to.be(1);
+        expect(model.length).to.equal(1);
       });
     });
 
@@ -175,15 +177,15 @@ describe('outputarea/model', () => {
       it('should deserialize the model from JSON', () => {
         model.clear();
         model.fromJSON(NBTestUtils.DEFAULT_OUTPUTS);
-        expect(model.toJSON().length).to.be(5);
+        expect(model.toJSON().length).to.equal(5);
       });
     });
 
     describe('#toJSON()', () => {
       it('should serialize the model to JSON', () => {
-        expect(model.toJSON()).to.eql([]);
+        expect(model.toJSON()).to.deep.equal([]);
         model.fromJSON(NBTestUtils.DEFAULT_OUTPUTS);
-        expect(model.toJSON().length).to.be(5);
+        expect(model.toJSON().length).to.equal(5);
       });
     });
   });
@@ -191,18 +193,18 @@ describe('outputarea/model', () => {
   describe('.ContentFactory', () => {
     describe('#createOutputModel()', () => {
       it('should create an output model', () => {
-        let factory = new OutputAreaModel.ContentFactory();
-        let model = factory.createOutputModel({
+        const factory = new OutputAreaModel.ContentFactory();
+        const model = factory.createOutputModel({
           value: NBTestUtils.DEFAULT_OUTPUTS[0]
         });
-        expect(model).to.be.an(OutputModel);
+        expect(model).to.be.an.instanceof(OutputModel);
       });
     });
   });
 
   describe('.defaultContentFactory', () => {
     it('should be an instance of ContentFactory', () => {
-      expect(OutputAreaModel.defaultContentFactory).to.be.an(
+      expect(OutputAreaModel.defaultContentFactory).to.be.an.instanceof(
         OutputAreaModel.ContentFactory
       );
     });

--- a/tests/test-outputarea/src/widget.spec.ts
+++ b/tests/test-outputarea/src/widget.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { ClientSession } from '@jupyterlab/apputils';
 
@@ -67,91 +67,82 @@ describe('outputarea/widget', () => {
   describe('OutputArea', () => {
     describe('#constructor()', () => {
       it('should create an output area widget', () => {
-        expect(widget).to.be.an(OutputArea);
-        expect(widget.hasClass('jp-OutputArea')).to.be(true);
+        expect(widget).to.be.an.instanceof(OutputArea);
+        expect(widget.hasClass('jp-OutputArea')).to.equal(true);
       });
 
       it('should take an optional contentFactory', () => {
-        let contentFactory = Object.create(OutputArea.defaultContentFactory);
-        let widget = new OutputArea({ rendermime, contentFactory, model });
-        expect(widget.contentFactory).to.be(contentFactory);
+        const contentFactory = Object.create(OutputArea.defaultContentFactory);
+        const widget = new OutputArea({ rendermime, contentFactory, model });
+        expect(widget.contentFactory).to.equal(contentFactory);
       });
     });
 
     describe('#model', () => {
       it('should be the model used by the widget', () => {
-        expect(widget.model).to.be(model);
+        expect(widget.model).to.equal(model);
       });
     });
 
     describe('#rendermime', () => {
       it('should be the rendermime instance used by the widget', () => {
-        expect(widget.rendermime).to.be(rendermime);
+        expect(widget.rendermime).to.equal(rendermime);
       });
     });
 
     describe('#contentFactory', () => {
       it('should be the contentFactory used by the widget', () => {
-        expect(widget.contentFactory).to.be(OutputArea.defaultContentFactory);
+        expect(widget.contentFactory).to.equal(
+          OutputArea.defaultContentFactory
+        );
       });
     });
 
     describe('#widgets', () => {
       it('should get the child widget at the specified index', () => {
-        expect(widget.widgets[0]).to.be.a(Widget);
+        expect(widget.widgets[0]).to.be.an.instanceof(Widget);
       });
 
       it('should get the number of child widgets', () => {
-        expect(widget.widgets.length).to.be(
+        expect(widget.widgets.length).to.equal(
           NBTestUtils.DEFAULT_OUTPUTS.length - 1
         );
         widget.model.clear();
-        expect(widget.widgets.length).to.be(0);
+        expect(widget.widgets.length).to.equal(0);
       });
     });
 
     describe('#future', () => {
       let session: ClientSession;
 
-      beforeEach(() => {
-        return createClientSession().then(s => {
-          session = s;
-          return session.initialize();
-        });
+      beforeEach(async () => {
+        session = await createClientSession();
+        await session.initialize();
       });
 
-      afterEach(() => {
-        return session.shutdown().then(() => {
-          session.dispose();
-        });
+      afterEach(async () => {
+        await session.shutdown();
+        session.dispose();
       });
 
-      it('should execute code on a kernel and send outputs to the model', () => {
-        return session.kernel.ready
-          .then(() => {
-            let future = session.kernel.requestExecute({ code: CODE });
-            widget.future = future;
-            return future.done;
-          })
-          .then(reply => {
-            expect(reply.content.execution_count).to.be.ok();
-            expect(reply.content.status).to.be('ok');
-            expect(model.length).to.be(1);
-          });
+      it('should execute code on a kernel and send outputs to the model', async () => {
+        await session.kernel.ready;
+        const future = session.kernel.requestExecute({ code: CODE });
+        widget.future = future;
+        const reply = await future.done;
+        expect(reply.content.execution_count).to.be.ok;
+        expect(reply.content.status).to.equal('ok');
+        expect(model.length).to.equal(1);
       });
 
-      it('should clear existing outputs', () => {
+      it('should clear existing outputs', async () => {
         widget.model.fromJSON(NBTestUtils.DEFAULT_OUTPUTS);
-        return session.kernel.ready
-          .then(() => {
-            let future = session.kernel.requestExecute({ code: CODE });
-            widget.future = future;
-            return future.done;
-          })
-          .then(reply => {
-            expect(reply.content.execution_count).to.be.ok();
-            expect(model.length).to.be(1);
-          });
+        await session.kernel.ready;
+        const future = session.kernel.requestExecute({ code: CODE });
+        widget.future = future;
+        const reply = await future.done;
+        expect(reply.content.execution_count).to.be.ok;
+        expect(model.length).to.equal(1);
       });
     });
 
@@ -161,7 +152,7 @@ describe('outputarea/widget', () => {
         widget.methods = [];
         widget.model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
         expect(widget.methods).to.contain('onModelChanged');
-        expect(widget.widgets.length).to.be(1);
+        expect(widget.widgets.length).to.equal(1);
       });
 
       it('should handle a clear', () => {
@@ -169,7 +160,7 @@ describe('outputarea/widget', () => {
         widget.methods = [];
         widget.model.clear();
         expect(widget.methods).to.contain('onModelChanged');
-        expect(widget.widgets.length).to.be(0);
+        expect(widget.widgets.length).to.equal(0);
       });
 
       it('should handle a set', () => {
@@ -178,53 +169,47 @@ describe('outputarea/widget', () => {
         widget.methods = [];
         widget.model.add(NBTestUtils.DEFAULT_OUTPUTS[0]);
         expect(widget.methods).to.contain('onModelChanged');
-        expect(widget.widgets.length).to.be(1);
+        expect(widget.widgets.length).to.equal(1);
       });
     });
 
     describe('.execute()', () => {
       let session: ClientSession;
 
-      beforeEach(() => {
-        return createClientSession().then(s => {
-          session = s;
-          return session.initialize();
-        });
+      beforeEach(async () => {
+        session = await createClientSession();
+        await session.initialize();
       });
 
-      afterEach(() => {
-        return session.shutdown().then(() => {
-          session.dispose();
-        });
+      afterEach(async () => {
+        await session.shutdown();
+        session.dispose();
       });
 
-      it('should execute code on a kernel and send outputs to the model', () => {
-        return session.kernel.ready.then(() => {
-          return OutputArea.execute(CODE, widget, session).then(reply => {
-            expect(reply.content.execution_count).to.be.ok();
-            expect(reply.content.status).to.be('ok');
-            expect(model.length).to.be(1);
-          });
-        });
+      it('should execute code on a kernel and send outputs to the model', async () => {
+        await session.kernel.ready;
+        const reply = await OutputArea.execute(CODE, widget, session);
+        expect(reply.content.execution_count).to.be.ok;
+        expect(reply.content.status).to.equal('ok');
+        expect(model.length).to.equal(1);
       });
 
-      it('should clear existing outputs', () => {
+      it('should clear existing outputs', async () => {
         widget.model.fromJSON(NBTestUtils.DEFAULT_OUTPUTS);
-        return OutputArea.execute(CODE, widget, session).then(reply => {
-          expect(reply.content.execution_count).to.be.ok();
-          expect(model.length).to.be(1);
-        });
+        const reply = await OutputArea.execute(CODE, widget, session);
+        expect(reply.content.execution_count).to.be.ok;
+        expect(model.length).to.equal(1);
       });
 
-      it('should handle routing of display messages', () => {
-        let model0 = new OutputAreaModel({ trusted: true });
-        let widget0 = new LogOutputArea({ rendermime, model: model0 });
-        let model1 = new OutputAreaModel({ trusted: true });
-        let widget1 = new LogOutputArea({ rendermime, model: model1 });
-        let model2 = new OutputAreaModel({ trusted: true });
-        let widget2 = new LogOutputArea({ rendermime, model: model2 });
+      it('should handle routing of display messages', async () => {
+        const model0 = new OutputAreaModel({ trusted: true });
+        const widget0 = new LogOutputArea({ rendermime, model: model0 });
+        const model1 = new OutputAreaModel({ trusted: true });
+        const widget1 = new LogOutputArea({ rendermime, model: model1 });
+        const model2 = new OutputAreaModel({ trusted: true });
+        const widget2 = new LogOutputArea({ rendermime, model: model2 });
 
-        let code0 = [
+        const code0 = [
           'ip = get_ipython()',
           'from IPython.display import display',
           'def display_with_id(obj, display_id, update=False):',
@@ -236,76 +221,68 @@ describe('outputarea/widget', () => {
           '  msg_type = "update_display_data" if update else "display_data"',
           '  session.send(iopub, msg_type, content, parent=ip.parent_header)'
         ].join('\n');
-        let code1 = [
+        const code1 = [
           'display("above")',
           'display_with_id(1, "here")',
           'display("below")'
         ].join('\n');
-        let code2 = [
+        const code2 = [
           'display_with_id(2, "here")',
           'display_with_id(3, "there")',
           'display_with_id(4, "here")'
         ].join('\n');
 
         let ipySession: ClientSession;
-        return createClientSession({ kernelPreference: { name: 'ipython' } })
-          .then(s => {
-            ipySession = s;
-            return s.initialize();
-          })
-          .then(() => {
-            let promise0 = OutputArea.execute(code0, widget0, ipySession);
-            let promise1 = OutputArea.execute(code1, widget1, ipySession);
-            return Promise.all([promise0, promise1]);
-          })
-          .then(() => {
-            expect(model1.length).to.be(3);
-            expect(model1.toJSON()[1].data).to.eql({ 'text/plain': '1' });
-            return OutputArea.execute(code2, widget2, ipySession);
-          })
-          .then(() => {
-            expect(model1.length).to.be(3);
-            expect(model1.toJSON()[1].data).to.eql({ 'text/plain': '4' });
-            expect(model2.length).to.be(3);
-            let outputs = model2.toJSON();
-            expect(outputs[0].data).to.eql({ 'text/plain': '4' });
-            expect(outputs[1].data).to.eql({ 'text/plain': '3' });
-            expect(outputs[2].data).to.eql({ 'text/plain': '4' });
-            return ipySession.shutdown();
-          });
+        ipySession = await createClientSession({
+          kernelPreference: { name: 'ipython' }
+        });
+        await ipySession.initialize();
+        const promise0 = OutputArea.execute(code0, widget0, ipySession);
+        const promise1 = OutputArea.execute(code1, widget1, ipySession);
+        await Promise.all([promise0, promise1]);
+        expect(model1.length).to.equal(3);
+        expect(model1.toJSON()[1].data).to.deep.equal({ 'text/plain': '1' });
+        await OutputArea.execute(code2, widget2, ipySession);
+
+        expect(model1.length).to.equal(3);
+        expect(model1.toJSON()[1].data).to.deep.equal({ 'text/plain': '4' });
+        expect(model2.length).to.equal(3);
+        const outputs = model2.toJSON();
+        expect(outputs[0].data).to.deep.equal({ 'text/plain': '4' });
+        expect(outputs[1].data).to.deep.equal({ 'text/plain': '3' });
+        expect(outputs[2].data).to.deep.equal({ 'text/plain': '4' });
+        await ipySession.shutdown();
       });
     });
 
     describe('.ContentFactory', () => {
       describe('#createOutputPrompt()', () => {
         it('should create an output prompt', () => {
-          let factory = new OutputArea.ContentFactory();
-          expect(factory.createOutputPrompt().executionCount).to.be(null);
+          const factory = new OutputArea.ContentFactory();
+          expect(factory.createOutputPrompt().executionCount).to.be.null;
         });
       });
 
       describe('#createStdin()', () => {
-        it('should create a stdin widget', () => {
-          return Kernel.startNew().then(kernel => {
-            let factory = new OutputArea.ContentFactory();
-            let future = kernel.requestExecute({ code: CODE });
-            let options = {
-              prompt: 'hello',
-              password: false,
-              future
-            };
-            expect(factory.createStdin(options)).to.be.a(Widget);
-            return kernel.shutdown().then(() => {
-              kernel.dispose();
-            });
-          });
+        it('should create a stdin widget', async () => {
+          const kernel = await Kernel.startNew();
+          const factory = new OutputArea.ContentFactory();
+          const future = kernel.requestExecute({ code: CODE });
+          const options = {
+            prompt: 'hello',
+            password: false,
+            future
+          };
+          expect(factory.createStdin(options)).to.be.an.instanceof(Widget);
+          await kernel.shutdown();
+          kernel.dispose();
         });
       });
     });
 
     describe('.defaultContentFactory', () => {
       it('should be a `contentFactory` instance', () => {
-        expect(OutputArea.defaultContentFactory).to.be.an(
+        expect(OutputArea.defaultContentFactory).to.be.an.instanceof(
           OutputArea.ContentFactory
         );
       });

--- a/tests/test-rendermime/src/registry.spec.ts
+++ b/tests/test-rendermime/src/registry.spec.ts
@@ -99,14 +99,13 @@ describe('rendermime/registry', () => {
         }).to.throw();
       });
 
-      it('should render json data', () => {
+      it('should render json data', async () => {
         const model = createModel({
           'application/json': { foo: 1 }
         });
         const w = r.createRenderer('application/json');
-        return w.renderModel(model).then(() => {
-          expect(w.node.textContent).to.equal('{\n  "foo": 1\n}');
-        });
+        await w.renderModel(model);
+        expect(w.node.textContent).to.equal('{\n  "foo": 1\n}');
       });
 
       it('should send a url resolver', async () => {


### PR DESCRIPTION
Fixes #4727. 

- Converted to `chai`
- Eradicated `.then()` and `done()` from tests in favor of `await`, helper functions, or `called` tricks
- Used `const` where appropriate