### PR TITLE
Fix border of active tab in L/R sidebar

### DIFF
--- a/packages/application/style/sidepanel.css
+++ b/packages/application/style/sidepanel.css
@@ -66,6 +66,12 @@
   overflow: visible;
 }
 
+.jp-SideBar .p-TabBar-tab.p-mod-current {
+  min-height: calc(var(--jp-private-sidebar-tab-width) + var(--jp-border-width));
+  max-height: calc(var(--jp-private-sidebar-tab-width) + var(--jp-border-width));
+  transform: translateY(var(--jp-border-width));
+}
+
 .jp-SideBar .p-TabBar-tab:not(.p-mod-current) {
   background: var(--jp-layout-color2);
 }

--- a/packages/application/style/sidepanel.css
+++ b/packages/application/style/sidepanel.css
@@ -67,8 +67,12 @@
 }
 
 .jp-SideBar .p-TabBar-tab.p-mod-current {
-  min-height: calc(var(--jp-private-sidebar-tab-width) + var(--jp-border-width));
-  max-height: calc(var(--jp-private-sidebar-tab-width) + var(--jp-border-width));
+  min-height: calc(
+    var(--jp-private-sidebar-tab-width) + var(--jp-border-width)
+  );
+  max-height: calc(
+    var(--jp-private-sidebar-tab-width) + var(--jp-border-width)
+  );
   transform: translateY(var(--jp-border-width));
 }
 

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -31,6 +31,7 @@
   border-bottom: none;
   height: auto;
   margin: var(--jp-toolbar-header-margin);
+  box-shadow: none;
 }
 
 .jp-BreadCrumbs {


### PR DESCRIPTION
Previously, there was a border on the active tab of the L/R sidebar that made it look less "tab-like." This fixes that issue.

Before:

<img width="368" alt="screen shot 2018-08-02 at 10 08 44 pm" src="https://user-images.githubusercontent.com/27600/43625213-a4c49224-96a0-11e8-9564-7b87756e63a3.png">

After:

<img width="368" alt="screen shot 2018-08-02 at 10 06 17 pm" src="https://user-images.githubusercontent.com/27600/43625207-98af041a-96a0-11e8-9848-00bfe6c55bfe.png">

@tgeorgeux 