### PR TITLE
Make super-primary elements have the largest text and tertiary the smallest text

### DIFF
--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -104,10 +104,17 @@ all of MD as it is not optimized for dense, information rich UIs.
    */
 
   --jp-ui-font-scale-factor: 1.2;
-  --jp-ui-font-size0: 0.83333em;
+  --jp-ui-font-size0: 1.2em;
   --jp-ui-font-size1: 13px; /* Base font size */
-  --jp-ui-font-size2: 1.2em;
-  --jp-ui-font-size3: 1.44em;
+  --jp-ui-font-size2: 0.83333em;
+  --jp-ui-font-size3: 0.69444em;
+
+  /* or maybe instead?
+  --jp-ui-font-scale-factor: 1.2;
+  --jp-ui-font-size0: 1.44 em;
+  --jp-ui-font-size1: 1.2 em;
+  --jp-ui-font-size2: 13px;
+  --jp-ui-font-size3: 0.83333em; */
 
   --jp-ui-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';


### PR DESCRIPTION
Changed font size section to conform to the '0: super-primary, 1: primary, 2: secondary, 3: tertiary' convention laid out at the top of the CSS file.

Right now the 'super-primary' elements of the page have the smallest font size, and the 'tertiary' elements of the page have the largest font size. This seems possibly backwards to me.