### PR TITLE
Mirrored output takes all available vertical space when there is only one output

### DIFF
--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -164,3 +164,16 @@ body.p-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-Stdin-input:focus {
   box-shadow: none;
 }
+
+/*-----------------------------------------------------------------------------
+| Output Area View
+|----------------------------------------------------------------------------*/
+
+.jp-LinkedOutputView .jp-OutputArea {
+  height: calc(100%);
+  display: block;
+}
+
+.jp-LinkedOutputView .jp-OutputArea-child:only-child {
+  height: calc(100%);
+}


### PR DESCRIPTION
(This was in the 0.32 series but was removed inadvertently during a refactoring.)

Allows for e.g. ipyleaflet maps to take all vertical space in mirrored output.
