### PR TITLE
Add links to extensions listed in extension manager

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1069,10 +1069,16 @@ class _AppHandler(object):
             name = data['name']
             jlab = data.get('jupyterlab', dict())
             path = osp.realpath(target)
+            # homepage, repository  are optional
+            if 'homepage' in data:
+                url = data['homepage']
+            elif 'repository' in data:
+                url = data['repository'].get('url', '')
+            else:
+                url = ''
             extensions[name] = dict(path=path,
                                     filename=osp.basename(path),
-                                    link=data.get('homepage',
-                                        data.get('repository')['url']),
+                                    url=url,
                                     version=data['version'],
                                     jupyterlab=jlab,
                                     dependencies=deps,

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1071,6 +1071,8 @@ class _AppHandler(object):
             path = osp.realpath(target)
             extensions[name] = dict(path=path,
                                     filename=osp.basename(path),
+                                    link=data.get('homepage',
+                                        data.get('repository')['url']),
                                     version=data['version'],
                                     jupyterlab=jlab,
                                     dependencies=deps,

--- a/jupyterlab/extension_manager_handler.py
+++ b/jupyterlab/extension_manager_handler.py
@@ -20,12 +20,13 @@ from .commands import (
 )
 
 
-def _make_extension_entry(name, description, enabled, core, latest_version,
+def _make_extension_entry(name, description, link, enabled, core, latest_version,
                           installed_version, status, installed=None):
     """Create an extension entry that can be sent to the client"""
     ret = dict(
         name=name,
         description=description,
+        link=link,
         enabled=enabled,
         core=core,
         latest_version=latest_version,
@@ -93,6 +94,7 @@ class ExtensionManager(object):
             extensions.append(_make_extension_entry(
                 name=name,
                 description=pkg_info['description'],
+                link=pkg_info['homepage'],
                 enabled=(name not in info['disabled']),
                 core=False,
                 # Use wanted version to ensure we limit ourselves
@@ -107,6 +109,7 @@ class ExtensionManager(object):
                 extensions.append(_make_extension_entry(
                     name=name,
                     description=data['description'],
+                    link=data['link'],
                     installed=False,
                     enabled=False,
                     core=False,

--- a/jupyterlab/extension_manager_handler.py
+++ b/jupyterlab/extension_manager_handler.py
@@ -20,13 +20,13 @@ from .commands import (
 )
 
 
-def _make_extension_entry(name, description, link, enabled, core, latest_version,
+def _make_extension_entry(name, description, url, enabled, core, latest_version,
                           installed_version, status, installed=None):
     """Create an extension entry that can be sent to the client"""
     ret = dict(
         name=name,
         description=description,
-        link=link,
+        url=url,
         enabled=enabled,
         core=core,
         latest_version=latest_version,
@@ -94,7 +94,7 @@ class ExtensionManager(object):
             extensions.append(_make_extension_entry(
                 name=name,
                 description=pkg_info['description'],
-                link=pkg_info['homepage'],
+                url=data['url'],
                 enabled=(name not in info['disabled']),
                 core=False,
                 # Use wanted version to ensure we limit ourselves
@@ -109,7 +109,7 @@ class ExtensionManager(object):
                 extensions.append(_make_extension_entry(
                     name=name,
                     description=data['description'],
-                    link=data['link'],
+                    url=data['url'],
                     installed=False,
                     enabled=False,
                     core=False,

--- a/jupyterlab/extension_manager_handler.py
+++ b/jupyterlab/extension_manager_handler.py
@@ -109,7 +109,7 @@ class ExtensionManager(object):
                 extensions.append(_make_extension_entry(
                     name=name,
                     description=data['description'],
-                    url=data['url'],
+                    url=data.get('homepage', ''),
                     installed=False,
                     enabled=False,
                     core=False,

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -36,7 +36,7 @@ export interface IEntry {
   /**
    * A representative link of the package.
    */
-  link: string;
+  url: string;
 
   /**
    * Whether the extension is currently installed.
@@ -81,7 +81,7 @@ export interface IInstalledEntry {
   /**
    * A representative link of the package.
    */
-  link: string;
+  url: string;
 
   /**
    * Whether the extension is currently installed.
@@ -186,7 +186,7 @@ export class ListModel extends VDomModel {
       entries[pkg.name] = {
         name: pkg.name,
         description: pkg.description,
-        link:
+        url:
           'homepage' in pkg.links
             ? pkg.links.homepage
             : 'repository' in pkg.links ? pkg.links.repository : pkg.links.npm,
@@ -216,7 +216,7 @@ export class ListModel extends VDomModel {
           entries[pkg.name] = {
             name: pkg.name,
             description: pkg.description,
-            link: pkg.link,
+            url: pkg.url,
             installed: pkg.installed !== false,
             enabled: pkg.enabled,
             status: pkg.status,

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -34,6 +34,11 @@ export interface IEntry {
   description: string;
 
   /**
+   * A representative link of the package.
+   */
+  link: string;
+
+  /**
    * Whether the extension is currently installed.
    */
   installed: boolean;
@@ -72,6 +77,11 @@ export interface IInstalledEntry {
    * A short description of the extension.
    */
   description: string;
+
+  /**
+   * A representative link of the package.
+   */
+  link: string;
 
   /**
    * Whether the extension is currently installed.
@@ -176,6 +186,10 @@ export class ListModel extends VDomModel {
       entries[pkg.name] = {
         name: pkg.name,
         description: pkg.description,
+        link:
+          'homepage' in pkg.links
+            ? pkg.links.homepage
+            : 'repository' in pkg.links ? pkg.links.repository : pkg.links.npm,
         installed: false,
         enabled: false,
         status: null,
@@ -202,6 +216,7 @@ export class ListModel extends VDomModel {
           entries[pkg.name] = {
             name: pkg.name,
             description: pkg.description,
+            link: pkg.link,
             installed: pkg.installed !== false,
             enabled: pkg.enabled,
             status: pkg.status,

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -162,7 +162,11 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
       title={title}
     >
       <div className="jp-extensionmanager-entry-title">
-        <div className="jp-extensionmanager-entry-name">{entry.name}</div>
+        <div className="jp-extensionmanager-entry-name">
+          <a href={entry.link} target="_blank">
+            {entry.name}
+          </a>
+        </div>
         <div className="jp-extensionmanager-entry-jupyter-org" />
       </div>
       <div className="jp-extensionmanager-entry-content">
@@ -328,7 +332,12 @@ export class ExtensionView extends VDomRenderer<ListModel> {
   protected render(): React.ReactElement<any>[] {
     const model = this.model!;
     let pages = Math.ceil(model.totalEntries / model.pagination);
-    let elements = [<SearchBar key="searchbar" placeholder="SEARCH" />];
+    let elements = [
+      <SearchBar
+        key="searchbar"
+        placeholder="SEARCH (enter space to list all)"
+      />
+    ];
     if (model.promptBuild) {
       elements.push(
         <BuildPrompt

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -163,7 +163,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
     >
       <div className="jp-extensionmanager-entry-title">
         <div className="jp-extensionmanager-entry-name">
-          <a href={entry.link} target="_blank">
+          <a href={entry.url} target="_blank">
             {entry.name}
           </a>
         </div>

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -332,12 +332,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
   protected render(): React.ReactElement<any>[] {
     const model = this.model!;
     let pages = Math.ceil(model.totalEntries / model.pagination);
-    let elements = [
-      <SearchBar
-        key="searchbar"
-        placeholder="SEARCH (enter space to list all)"
-      />
-    ];
+    let elements = [<SearchBar key="searchbar" placeholder="SEARCH" />];
     if (model.promptBuild) {
       elements.push(
         <BuildPrompt


### PR DESCRIPTION
 #5053

This PR adds homepage links to extensions so that users can check the details of the extensions.

For npm-returned extensions, it is easy to get the information from package info. However, for installed packages, the information is passed from the server extension where `link` is not part of the information returned so I had to change the information returned by server extension.

![image](https://user-images.githubusercontent.com/9889312/43689712-2884a098-98c4-11e8-87f2-25f2604db84c.png)


![image](https://user-images.githubusercontent.com/9889312/43689697-058f4246-98c4-11e8-84d6-234bfcde5541.png)



cc: @vidartf @afshin 
