### PR TITLE
Exclude extensions with "deprecated" in keyword list

### DIFF
--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -163,7 +163,8 @@ export class ListModel extends VDomModel {
   }
 
   /**
-   * Translate search results from an npm repository query into entries.
+   * Translate search results from an npm repository query into entries
+   * and remove entries with 'deprecated' in the keyword list
    *
    * @param res Promise to an npm query result.
    */
@@ -173,6 +174,9 @@ export class ListModel extends VDomModel {
     let entries: { [key: string]: IEntry } = {};
     for (let obj of (await res).objects) {
       let pkg = obj.package;
+      if (pkg.keywords.indexOf('deprecated') < 0) {
+        continue;
+      }
       entries[pkg.name] = {
         name: pkg.name,
         description: pkg.description,

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -174,7 +174,7 @@ export class ListModel extends VDomModel {
     let entries: { [key: string]: IEntry } = {};
     for (let obj of (await res).objects) {
       let pkg = obj.package;
-      if (pkg.keywords.indexOf('deprecated') < 0) {
+      if (pkg.keywords.indexOf('deprecated') >= 0) {
         continue;
       }
       entries[pkg.name] = {


### PR DESCRIPTION
#5057

This PR excludes packages from the extensionmanager if it has `deprecated` in its keyword list. This effectively removes my outdated `sos-extension` extension from the list.

There can be other criteria such as no valid homepage url, even inaccessible homepage url, or comparing `depends` with current JLab version, but looking for `deprecated` is the easiest one and we can implement other criteria later.