### PR TITLE
fixes #4803: shift-tab in leading whitespace unindents a line (parity with classic notebook)

### DIFF
--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -13,6 +13,17 @@ import { CodeEditor } from './';
 const HAS_SELECTION_CLASS = 'jp-mod-has-primary-selection';
 
 /**
+ * The class name added to an editor widget that has a cursor/selection
+ * within the whitespace at the beginning of a line
+ */
+const HAS_IN_LEADING_WHITESPACE_CLASS = 'jp-mod-in-leading-whitespace';
+
+/**
+ * RegExp to test for leading whitespace
+ */
+const leadingWhitespaceRe = /^\s+$/;
+
+/**
  * A widget which hosts a code editor.
  */
 export class CodeEditorWrapper extends Widget {
@@ -103,9 +114,23 @@ export class CodeEditorWrapper extends Widget {
     const { start, end } = this.editor.getSelection();
 
     if (start.column !== end.column || start.line !== end.line) {
+      // a selection was made
       this.addClass(HAS_SELECTION_CLASS);
+      this.removeClass(HAS_IN_LEADING_WHITESPACE_CLASS);
     } else {
+      // the cursor was placed
       this.removeClass(HAS_SELECTION_CLASS);
+
+      if (
+        this.editor
+          .getLine(end.line)
+          .slice(0, end.column)
+          .match(leadingWhitespaceRe)
+      ) {
+        this.addClass(HAS_IN_LEADING_WHITESPACE_CLASS);
+      } else {
+        this.removeClass(HAS_IN_LEADING_WHITESPACE_CLASS);
+      }
     }
   }
 }

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -974,7 +974,7 @@
         "keys": { "default": ["Shift Tab"] },
         "selector": {
           "default":
-            ".jp-CodeConsole-promptCell .jp-InputArea-editor:not(.jp-mod-has-primary-selection)"
+            ".jp-CodeConsole-promptCell .jp-InputArea-editor:not(.jp-mod-has-primary-selection):not(.jp-mod-in-leading-whitespace)"
         },
         "title": { "default": "Invoke Completer" },
         "category": { "default": "Tooltips" }
@@ -988,7 +988,7 @@
         "keys": { "default": ["Shift Tab"] },
         "selector": {
           "default":
-            ".jp-Notebook.jp-mod-editMode .jp-InputArea-editor:not(.jp-mod-has-primary-selection)"
+            ".jp-Notebook.jp-mod-editMode .jp-InputArea-editor:not(.jp-mod-has-primary-selection):not(.jp-mod-in-leading-whitespace)"
         },
         "title": { "default": "Invoke Completer" },
         "category": { "default": "Tooltips" }


### PR DESCRIPTION
Fixes the issue mentioned in #4803:

>In the classic Jupyter notebook when unindenting a line it was enough to have your text cursor somewhere in the empty space before the code.
>
>So anywhere the arrows are

```
↓↓↓↓
    some_code
```
>With Jupyterlab you need to select at least one charactar in that line when clicking Shift + Tab.

Basically, the problem was that the doc/tooltip shortcuts (which also use Shift + Tab) were overriding the unindent shortcut. With the changes I made, codeeditor widgets now get a `jp-mod-in-leading-whitespace` css class when they have a cursor placed in the leading whitespace of a line. I also modified the selectors of the doc/tooltip shortcuts to exclude widgets with that new css class.