### PR TITLE
Deleted metadata in cell copy

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -22,6 +22,8 @@ import {
 
 import { ArrayExt, each, toArray } from '@phosphor/algorithm';
 
+import { JSONObject } from '@phosphor/coreutils';
+
 import { ElementExt } from '@phosphor/domutils';
 
 import { ISignal, Signal } from '@phosphor/signaling';
@@ -31,7 +33,6 @@ import * as React from 'react';
 import { INotebookModel } from './model';
 
 import { Notebook } from './widget';
-import { JSONObject } from '../../../node_modules/@phosphor/coreutils';
 
 // The message to display to the user when prompting to trust the notebook.
 const TRUST_MESSAGE = (

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -31,6 +31,7 @@ import * as React from 'react';
 import { INotebookModel } from './model';
 
 import { Notebook } from './widget';
+import { JSONObject } from '../../../node_modules/@phosphor/coreutils';
 
 // The message to display to the user when prompting to trust the notebook.
 const TRUST_MESSAGE = (
@@ -1542,9 +1543,15 @@ namespace Private {
     notebook.mode = 'command';
     clipboard.clear();
 
-    const data = notebook.widgets
+    let data = notebook.widgets
       .filter(cell => notebook.isSelectedOrActive(cell))
-      .map(cell => cell.model.toJSON());
+      .map(cell => cell.model.toJSON())
+      .map(cellJSON => {
+        if ((cellJSON.metadata as JSONObject).deletable !== undefined) {
+          delete (cellJSON.metadata as JSONObject).deletable;
+        }
+        return cellJSON;
+      });
 
     clipboard.setData(JUPYTER_CELL_MIME, data);
     if (cut) {

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -22,6 +22,10 @@ import {
   sleep,
   NBTestUtils
 } from '@jupyterlab/testutils';
+import {
+  JSONObject,
+  JSONArray
+} from '../../../node_modules/@phosphor/coreutils';
 
 const ERROR_INPUT = 'a = foo';
 
@@ -1011,6 +1015,20 @@ describe('@jupyterlab/notebook', () => {
         widget.mode = 'edit';
         NotebookActions.copy(widget);
         expect(widget.mode).to.equal('command');
+      });
+
+      it('should delete metadata.deletable', () => {
+        const next = widget.widgets[1];
+        widget.select(next);
+        next.model.metadata.set('deletable', false);
+        NotebookActions.copy(widget);
+        const data = NBTestUtils.clipboard.getData(
+          JUPYTER_CELL_MIME
+        ) as JSONArray;
+        data.map(cell => {
+          expect(((cell as JSONObject).metadata as JSONObject).deletable).to.be
+            .undefined;
+        });
       });
     });
 

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -22,10 +22,7 @@ import {
   sleep,
   NBTestUtils
 } from '@jupyterlab/testutils';
-import {
-  JSONObject,
-  JSONArray
-} from '../../../node_modules/@phosphor/coreutils';
+import { JSONObject, JSONArray } from '@phosphor/coreutils';
 
 const ERROR_INPUT = 'a = foo';
 


### PR DESCRIPTION
Cell metadata can have a `deletable` attribute that controls whether or not a cell can be deleted. In the classic notebook this metadata attribute is omitted when a cell is copied. The logic is that the original cell can't be deleted, but copies of it should be deletable. In the classic notebook this logic is here:

https://github.com/jupyter/notebook/blob/master/notebook/static/notebook/js/notebook.js#L1653

I ran into this inconsistency in using nbgrader, which marks cell and `deletable=false`. Students would make copies of those cells (which is fine) but then be totally confused when the copies couldn't be deleted.