### PR TITLE
Moved onClick to open model to item label, fixes #5065

### DIFF
--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -130,11 +130,12 @@ type SessionProps<M> = {
 function Item<M>(props: SessionProps<M> & { model: M }) {
   const { model } = props;
   return (
-    <li className={ITEM_CLASS} onClick={() => props.openRequested.emit(model)}>
+    <li className={ITEM_CLASS}>
       <span className={`${ITEM_ICON_CLASS} ${props.iconClass(model)}`} />
       <span
         className={ITEM_LABEL_CLASS}
         title={props.labelTitle ? props.labelTitle(model) : ''}
+        onClick={() => props.openRequested.emit(model)}
       >
         {props.label(model)}
       </span>


### PR DESCRIPTION
Originally clicking anywhere on an item in the running menu caused the notebook/terminal to be reopened due to onClicks for the reopen and shutdown being stacked. Moved onClick to the item label as it highlights when hovered thus making more sense from a UI design point of view to change the functionality this way whilst fixing the bug at the same time.

fixes #5065 