### PR TITLE
Add more information to documentation about how to package extensions with Conda

### DIFF
--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -104,10 +104,17 @@ all of MD as it is not optimized for dense, information rich UIs.
    */
 
   --jp-ui-font-scale-factor: 1.2;
-  --jp-ui-font-size0: 0.83333em;
+  --jp-ui-font-size0: 1.2em;
   --jp-ui-font-size1: 13px; /* Base font size */
-  --jp-ui-font-size2: 1.2em;
-  --jp-ui-font-size3: 1.44em;
+  --jp-ui-font-size2: 0.83333em;
+  --jp-ui-font-size3: 0.69444em;
+
+  /* or maybe instead?
+  --jp-ui-font-scale-factor: 1.2;
+  --jp-ui-font-size0: 1.44 em;
+  --jp-ui-font-size1: 1.2 em;
+  --jp-ui-font-size2: 13px;
+  --jp-ui-font-size3: 0.83333em; */
 
   --jp-ui-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';


### PR DESCRIPTION
Because JupyterLab extensions can consist of both Python and TypeScript/Javascript code, and may conceivably begin to frequently use other JupyterLab extensions as dependencies in the future, it seems important that tools be made available to use a language-agnostic package manager to distribute JupyterLab extensions.

The only such package manager I know of is conda, so I have attempted to add information to the developer documentation about how one might package their extensions with conda. I also [added a repository to GitHub containing examples](https://github.com/krinsman/conda_recipes/tree/master/Jupyter/labextensions) but did not want to reference that repository within the documentation itself, because it is not an official part of the Jupyter project, and I wanted to avoid the appearance of self-promotion.

My primary concern is that attempting to distribute JupyterLab extensions primarily via NPM and pip separately will lead to a dependency nightmare which creates among other things (1) a lack of reproducibility when using JupyterLab extensions (2) unnecessary difficulty for end users when installing JupyterLab extensions. Since the extensibility of JupyterLab is one of its most important features, it seems very important to me that JupyterLab extensions be as easy to distribute and install as possible, and this seems like a step in the right direction for that.

Note that the templates I added are _not_ fool proof. In particular, there are several examples of where I was unable to get them to work, although these may require only small changes to fix. (Or maybe they require major changes? I don't know either way.) See [this conda build issue](https://github.com/conda/conda-build/issues/3064) and [this other conda build issue](https://github.com/conda/conda-build/issues/3065).

Any feedback or suggestions you may have would be greatly appreciated. I think adding more guidelines about how to distribute JupyterLab extensions as packages to the documentation could end up being greatly beneficial to the JupyterLab ecosystem as a whole, in ways which are impossible to foresee entirely in advance. My goal is to see this project succeed and to encounter as few barriers and obstacles to widespread adoption as possible.

See also: https://github.com/jupyterlab/jupyterlab/issues/5074