### PR TITLE
FileModel Upload Progress Patch

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -17,7 +17,8 @@ import {
   each,
   find,
   IIterator,
-  IterableOrArrayLike
+  IterableOrArrayLike,
+  ArrayExt
 } from '@phosphor/algorithm';
 
 import { PromiseDelegate, ReadonlyJSONObject } from '@phosphor/coreutils';
@@ -173,15 +174,9 @@ export class FileBrowserModel implements IDisposable {
   }
 
   uploadFailed(file: File) {
-    console.log(this._uploads);
-    let index = 0;
-    this._uploads.forEach(upload => {
-      if (upload.path !== file.name) {
-        index = index + 1;
-      }
+    ArrayExt.removeFirstWhere(this._uploads, uploadIndex => {
+      return file.name === uploadIndex.path;
     });
-    this._uploads.splice(index, 1);
-    console.log(this._uploads);
   }
   /**
    * Create an iterator over the status of all in progress uploads.
@@ -480,7 +475,6 @@ export class FileBrowserModel implements IDisposable {
       const newUpload = { path, progress: start / file.size };
       this._uploads.splice(this._uploads.indexOf(upload));
       this._uploads.push(newUpload);
-      console.log(this._uploads);
       this._uploadChanged.emit({
         name: 'update',
         newValue: newUpload,

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -172,6 +172,17 @@ export class FileBrowserModel implements IDisposable {
     return this._uploadChanged;
   }
 
+  uploadFailed(file: File) {
+    console.log(this._uploads);
+    let index = 0;
+    this._uploads.forEach(upload => {
+      if (upload.path !== file.name) {
+        index = index + 1;
+      }
+    });
+    this._uploads.splice(index, 1);
+    console.log(this._uploads);
+  }
   /**
    * Create an iterator over the status of all in progress uploads.
    */
@@ -437,6 +448,7 @@ export class FileBrowserModel implements IDisposable {
           reject(`Failed to upload "${file.name}":` + event);
       });
       await this._uploadCheckDisposed();
+
       let model: Partial<Contents.IModel> = {
         type,
         format,
@@ -468,6 +480,7 @@ export class FileBrowserModel implements IDisposable {
       const newUpload = { path, progress: start / file.size };
       this._uploads.splice(this._uploads.indexOf(upload));
       this._uploads.push(newUpload);
+      console.log(this._uploads);
       this._uploadChanged.emit({
         name: 'update',
         newValue: newUpload,

--- a/packages/filebrowser/src/upload.ts
+++ b/packages/filebrowser/src/upload.ts
@@ -70,6 +70,7 @@ export class Uploader extends ToolbarButton {
     let pending = files.map(file => this.model.upload(file));
     Promise.all(pending).catch(error => {
       showErrorMessage('Upload Error', error);
+      files.forEach(file => this.model.uploadFailed(file));
     });
   };
 

--- a/packages/filebrowser/src/upload.ts
+++ b/packages/filebrowser/src/upload.ts
@@ -70,7 +70,6 @@ export class Uploader extends ToolbarButton {
     let pending = files.map(file => this.model.upload(file));
     Promise.all(pending).catch(error => {
       showErrorMessage('Upload Error', error);
-      files.forEach(file => this.model.uploadFailed(file));
     });
   };
 


### PR DESCRIPTION
When a file upload errors, it stays in the in-progress uploads array until another file is uploaded or chunked. This patch would ensure that a file upload error would result in that file being removed from the `model._uploads` array immediately. This patch would improve the ability of the status bar file upload widget to correctly update when an upload is occurring and hide when it is not. @ellisonbg 