### PR TITLE
Application theme info

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -190,6 +190,14 @@ const themes: JupyterLabPlugin<IThemeManager> = {
     // can lead to an incorrect toggle on the currently used theme.
     let currentTheme: string;
 
+    // Set data attributes on the application shell for the current theme.
+    manager.themeChanged.connect((sender, args) => {
+      currentTheme = args.newValue;
+      app.shell.dataset.themeLight = String(manager.isLight(currentTheme));
+      app.shell.dataset.themeName = currentTheme;
+      commands.notifyCommandChanged(CommandIDs.changeTheme);
+    });
+
     commands.addCommand(CommandIDs.changeTheme, {
       label: args => {
         const theme = args['theme'] as string;
@@ -201,9 +209,7 @@ const themes: JupyterLabPlugin<IThemeManager> = {
         if (theme === manager.theme) {
           return;
         }
-        currentTheme = theme;
         manager.setTheme(theme);
-        commands.notifyCommandChanged(CommandIDs.changeTheme);
       }
     });
 

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -142,6 +142,13 @@ export class ThemeManager {
   }
 
   /**
+   * Test whether a given theme is light.
+   */
+  isLight(name: string): boolean {
+    return this._themes[name].isLight;
+  }
+
+  /**
    * Handle the current settings.
    */
   private _loadSettings(): void {
@@ -313,6 +320,13 @@ export namespace ThemeManager {
      * The display name of the theme.
      */
     name: string;
+
+    /**
+     * Whether the theme is light or dark. Downstream authors
+     * of extensions can use this information to customize their
+     * UI depending upon the current theme.
+     */
+    isLight: boolean;
 
     /**
      * Load the theme.

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ISettingRegistry, URLExt } from '@jupyterlab/coreutils';
+import { IChangedArgs, ISettingRegistry, URLExt } from '@jupyterlab/coreutils';
 
 import { each } from '@phosphor/algorithm';
 
@@ -10,6 +10,8 @@ import { Token } from '@phosphor/coreutils';
 import { DisposableDelegate, IDisposable } from '@phosphor/disposable';
 
 import { Widget } from '@phosphor/widgets';
+
+import { ISignal, Signal } from '@phosphor/signaling';
 
 import { Dialog, showDialog } from './dialog';
 
@@ -73,6 +75,13 @@ export class ThemeManager {
    */
   get themes(): ReadonlyArray<string> {
     return Object.keys(this._themes);
+  }
+
+  /**
+   * A signal fired when the application theme changes.
+   */
+  get themeChanged(): ISignal<this, IChangedArgs<string>> {
+    return this._themeChanged;
   }
 
   /**
@@ -226,6 +235,11 @@ export class ThemeManager {
         this._current = theme;
         Private.fitAll(this._host);
         splash.dispose();
+        this._themeChanged.emit({
+          name: 'theme',
+          oldValue: current,
+          newValue: theme
+        });
       })
       .catch(reason => {
         this._onError(reason);
@@ -254,6 +268,7 @@ export class ThemeManager {
   private _settings: ISettingRegistry.ISettings;
   private _splash: ISplashScreen;
   private _themes: { [key: string]: ThemeManager.ITheme } = {};
+  private _themeChanged = new Signal<this, IChangedArgs<string>>(this);
 }
 
 /**

--- a/packages/theme-dark-extension/src/index.ts
+++ b/packages/theme-dark-extension/src/index.ts
@@ -16,6 +16,7 @@ const plugin: JupyterLabPlugin<void> = {
 
     manager.register({
       name: 'JupyterLab Dark',
+      isLight: false,
       load: () => manager.loadCSS(style),
       unload: () => Promise.resolve(undefined)
     });

--- a/packages/theme-light-extension/src/index.ts
+++ b/packages/theme-light-extension/src/index.ts
@@ -16,6 +16,7 @@ const plugin: JupyterLabPlugin<void> = {
 
     manager.register({
       name: 'JupyterLab Light',
+      isLight: true,
       load: () => manager.loadCSS(style),
       unload: () => Promise.resolve(undefined)
     });


### PR DESCRIPTION
cf. discussions in #5069, #3855, #3681, #3458,  jupyterlab/jupyterlab-github#30

This adds a `themeChanged` signal to the  application theme manager. It also adds HTML data attributes to the application shell corresponding to the current theme name, as well as whether the theme declares itself to be light or dark. This will allow extension authors to distribute different icons, UI elements, and respond to the current theme.