### PR TITLE
Read return code in  jupyterlab.commands._node_check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Documentation Status](https://readthedocs.org/projects/jupyterlab/badge/?version=stable)](http://jupyterlab.readthedocs.io/en/stable/)
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
 [![Join the Gitter Chat](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/jupyterlab/jupyterlab)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/81cc2c75bc8e2647578c232f5a38fe5539651ba4?urlpath=lab%2Ftree%2Fdemo%2FLorenz.ipynb)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/0b0bb42e3e43ee2ebe1c0424d3a88a9b9edcd055?urlpath=lab%2Ftree%2Fdemo%2FLorenz.ipynb)
 
 An extensible environment for interactive and reproducible computing, based on the
 Jupyter Notebook and Architecture. [Currently ready for users.](https://blog.jupyter.org/jupyterlab-is-ready-for-users-5a6f039b8906)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,7 +56,7 @@ jlpm run build:update
 * Create the Python release artifacts:
 
 ```bash
-rm -rf dist
+rm -rf dist build
 python setup.py sdist
 python setup.py bdist_wheel --universal
 twine upload dist/*

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -215,7 +215,7 @@
       "url-parse",
       "xterm"
     ],
-    "version": "0.33.6",
+    "version": "0.34.0a0",
     "linkedPackages": {
       "@jupyterlab/application": "../packages/application",
       "@jupyterlab/application-extension": "../packages/application-extension",

--- a/jupyterlab/_version.py
+++ b/jupyterlab/_version.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 
 VersionInfo = namedtuple('VersionInfo', ['major', 'minor', 'micro', 'releaselevel', 'serial'])
 
-version_info = VersionInfo(0, 33, 6, 'final', 0)
+version_info = VersionInfo(0, 34, 0, 'alpha', 0)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1471,10 +1471,9 @@ class _AppHandler(object):
 def _node_check():
     """Check for the existence of nodejs with the correct version.
     """
-    try:
-        proc = Process(['node', 'node-version-check.js'], cwd=HERE, quiet=True)
-        proc.wait()
-    except Exception:
+    proc = Process(['node', 'node-version-check.js'], cwd=HERE, quiet=True)
+    return_code = proc.wait()
+    if return_code == 1:
         msg = 'Please install nodejs 5+ and npm before continuing. nodejs may be installed using conda or directly from the nodejs website.'
         raise ValueError(msg)
 

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1069,8 +1069,16 @@ class _AppHandler(object):
             name = data['name']
             jlab = data.get('jupyterlab', dict())
             path = osp.realpath(target)
+            # homepage, repository  are optional
+            if 'homepage' in data:
+                url = data['homepage']
+            elif 'repository' in data:
+                url = data['repository'].get('url', '')
+            else:
+                url = ''
             extensions[name] = dict(path=path,
                                     filename=osp.basename(path),
+                                    url=url,
                                     version=data['version'],
                                     jupyterlab=jlab,
                                     dependencies=deps,

--- a/jupyterlab/extension_manager_handler.py
+++ b/jupyterlab/extension_manager_handler.py
@@ -20,12 +20,13 @@ from .commands import (
 )
 
 
-def _make_extension_entry(name, description, enabled, core, latest_version,
+def _make_extension_entry(name, description, url, enabled, core, latest_version,
                           installed_version, status, installed=None):
     """Create an extension entry that can be sent to the client"""
     ret = dict(
         name=name,
         description=description,
+        url=url,
         enabled=enabled,
         core=core,
         latest_version=latest_version,
@@ -93,6 +94,7 @@ class ExtensionManager(object):
             extensions.append(_make_extension_entry(
                 name=name,
                 description=pkg_info['description'],
+                url=data['url'],
                 enabled=(name not in info['disabled']),
                 core=False,
                 # Use wanted version to ensure we limit ourselves
@@ -107,6 +109,7 @@ class ExtensionManager(object):
                 extensions.append(_make_extension_entry(
                     name=name,
                     description=data['description'],
+                    url=data.get('homepage', ''),
                     installed=False,
                     enabled=False,
                     core=False,

--- a/packages/application/style/sidepanel.css
+++ b/packages/application/style/sidepanel.css
@@ -66,6 +66,16 @@
   overflow: visible;
 }
 
+.jp-SideBar .p-TabBar-tab.p-mod-current {
+  min-height: calc(
+    var(--jp-private-sidebar-tab-width) + var(--jp-border-width)
+  );
+  max-height: calc(
+    var(--jp-private-sidebar-tab-width) + var(--jp-border-width)
+  );
+  transform: translateY(var(--jp-border-width));
+}
+
 .jp-SideBar .p-TabBar-tab:not(.p-mod-current) {
   background: var(--jp-layout-color2);
 }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -797,7 +797,9 @@ export namespace CodeCell {
     cell.setPrompt('*');
     model.trusted = true;
 
-    return OutputArea.execute(code, cell.outputArea, session)
+    return OutputArea.execute(code, cell.outputArea, session, {
+      cellId: model.id
+    })
       .then(msg => {
         model.executionCount = msg.content.execution_count;
         return msg;

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -13,6 +13,17 @@ import { CodeEditor } from './';
 const HAS_SELECTION_CLASS = 'jp-mod-has-primary-selection';
 
 /**
+ * The class name added to an editor widget that has a cursor/selection
+ * within the whitespace at the beginning of a line
+ */
+const HAS_IN_LEADING_WHITESPACE_CLASS = 'jp-mod-in-leading-whitespace';
+
+/**
+ * RegExp to test for leading whitespace
+ */
+const leadingWhitespaceRe = /^\s+$/;
+
+/**
  * A widget which hosts a code editor.
  */
 export class CodeEditorWrapper extends Widget {
@@ -103,9 +114,23 @@ export class CodeEditorWrapper extends Widget {
     const { start, end } = this.editor.getSelection();
 
     if (start.column !== end.column || start.line !== end.line) {
+      // a selection was made
       this.addClass(HAS_SELECTION_CLASS);
+      this.removeClass(HAS_IN_LEADING_WHITESPACE_CLASS);
     } else {
+      // the cursor was placed
       this.removeClass(HAS_SELECTION_CLASS);
+
+      if (
+        this.editor
+          .getLine(end.line)
+          .slice(0, end.column)
+          .match(leadingWhitespaceRe)
+      ) {
+        this.addClass(HAS_IN_LEADING_WHITESPACE_CLASS);
+      } else {
+        this.removeClass(HAS_IN_LEADING_WHITESPACE_CLASS);
+      }
     }
   }
 }

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -34,6 +34,11 @@ export interface IEntry {
   description: string;
 
   /**
+   * A representative link of the package.
+   */
+  url: string;
+
+  /**
    * Whether the extension is currently installed.
    */
   installed: boolean;
@@ -72,6 +77,11 @@ export interface IInstalledEntry {
    * A short description of the extension.
    */
   description: string;
+
+  /**
+   * A representative link of the package.
+   */
+  url: string;
 
   /**
    * Whether the extension is currently installed.
@@ -180,6 +190,10 @@ export class ListModel extends VDomModel {
       entries[pkg.name] = {
         name: pkg.name,
         description: pkg.description,
+        url:
+          'homepage' in pkg.links
+            ? pkg.links.homepage
+            : 'repository' in pkg.links ? pkg.links.repository : pkg.links.npm,
         installed: false,
         enabled: false,
         status: null,
@@ -206,6 +220,7 @@ export class ListModel extends VDomModel {
           entries[pkg.name] = {
             name: pkg.name,
             description: pkg.description,
+            url: pkg.url,
             installed: pkg.installed !== false,
             enabled: pkg.enabled,
             status: pkg.status,

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -163,7 +163,8 @@ export class ListModel extends VDomModel {
   }
 
   /**
-   * Translate search results from an npm repository query into entries.
+   * Translate search results from an npm repository query into entries
+   * and remove entries with 'deprecated' in the keyword list
    *
    * @param res Promise to an npm query result.
    */
@@ -173,6 +174,9 @@ export class ListModel extends VDomModel {
     let entries: { [key: string]: IEntry } = {};
     for (let obj of (await res).objects) {
       let pkg = obj.package;
+      if (pkg.keywords.indexOf('deprecated') >= 0) {
+        continue;
+      }
       entries[pkg.name] = {
         name: pkg.name,
         description: pkg.description,

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -162,7 +162,11 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
       title={title}
     >
       <div className="jp-extensionmanager-entry-title">
-        <div className="jp-extensionmanager-entry-name">{entry.name}</div>
+        <div className="jp-extensionmanager-entry-name">
+          <a href={entry.url} target="_blank">
+            {entry.name}
+          </a>
+        </div>
         <div className="jp-extensionmanager-entry-jupyter-org" />
       </div>
       <div className="jp-extensionmanager-entry-content">

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -29,9 +29,9 @@ import { ISignal, Signal } from '@phosphor/signaling';
 import { showDialog, Dialog } from '@jupyterlab/apputils';
 
 /**
- * The duration of auto-refresh in ms.
+ * The default duration of the auto-refresh in ms
  */
-const REFRESH_DURATION = 10000;
+const DEFAULT_REFRESH_INTERVAL = 10000;
 
 /**
  * The enforced time between refreshes in ms.
@@ -86,6 +86,8 @@ export class FileBrowserModel implements IDisposable {
       format: 'text'
     };
     this._state = options.state || null;
+    this._baseRefreshDuration =
+      options.refreshInterval || DEFAULT_REFRESH_INTERVAL;
 
     const { services } = options.manager;
     services.contents.fileChanged.connect(this._onFileChanged, this);
@@ -262,7 +264,7 @@ export class FileBrowserModel implements IDisposable {
         if (this.isDisposed) {
           return;
         }
-        this._refreshDuration = REFRESH_DURATION;
+        this._refreshDuration = this._baseRefreshDuration;
         this._handleContents(contents);
         this._pendingPath = null;
         if (oldValue !== newValue) {
@@ -288,7 +290,7 @@ export class FileBrowserModel implements IDisposable {
           this._connectionFailure.emit(error);
           this.cd('/');
         } else {
-          this._refreshDuration = REFRESH_DURATION * 10;
+          this._refreshDuration = this._baseRefreshDuration * 10;
           this._connectionFailure.emit(error);
         }
       });
@@ -625,7 +627,8 @@ export class FileBrowserModel implements IDisposable {
   private _sessions: Session.IModel[] = [];
   private _state: IStateDB | null = null;
   private _timeoutId = -1;
-  private _refreshDuration = REFRESH_DURATION;
+  private _refreshDuration: number;
+  private _baseRefreshDuration: number;
   private _driveName: string;
   private _isDisposed = false;
   private _restored = new PromiseDelegate<void>();
@@ -659,6 +662,11 @@ export namespace FileBrowserModel {
      * folder was last opened when it is restored.
      */
     state?: IStateDB;
+
+    /**
+     * The time interval for browser refreshing, in ms.
+     */
+    refreshInterval?: number;
   }
 }
 

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -31,6 +31,7 @@
   border-bottom: none;
   height: auto;
   margin: var(--jp-toolbar-header-margin);
+  box-shadow: none;
 }
 
 .jp-BreadCrumbs {

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -531,7 +531,8 @@ export namespace OutputArea {
   export function execute(
     code: string,
     output: OutputArea,
-    session: IClientSession
+    session: IClientSession,
+    metadata?: JSONObject
   ): Promise<KernelMessage.IExecuteReplyMsg> {
     // Override the default for `stop_on_error`.
     let content: KernelMessage.IExecuteRequest = {
@@ -542,7 +543,7 @@ export namespace OutputArea {
     if (!session.kernel) {
       return Promise.reject('Session has no kernel.');
     }
-    let future = session.kernel.requestExecute(content, false);
+    let future = session.kernel.requestExecute(content, false, metadata);
     output.future = future;
     return future.done as Promise<KernelMessage.IExecuteReplyMsg>;
   }

--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -164,3 +164,16 @@ body.p-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-Stdin-input:focus {
   box-shadow: none;
 }
+
+/*-----------------------------------------------------------------------------
+| Output Area View
+|----------------------------------------------------------------------------*/
+
+.jp-LinkedOutputView .jp-OutputArea {
+  height: calc(100%);
+  display: block;
+}
+
+.jp-LinkedOutputView .jp-OutputArea-child:only-child {
+  height: calc(100%);
+}

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -130,11 +130,12 @@ type SessionProps<M> = {
 function Item<M>(props: SessionProps<M> & { model: M }) {
   const { model } = props;
   return (
-    <li className={ITEM_CLASS} onClick={() => props.openRequested.emit(model)}>
+    <li className={ITEM_CLASS}>
       <span className={`${ITEM_ICON_CLASS} ${props.iconClass(model)}`} />
       <span
         className={ITEM_LABEL_CLASS}
         title={props.labelTitle ? props.labelTitle(model) : ''}
+        onClick={() => props.openRequested.emit(model)}
       >
         {props.label(model)}
       </span>

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -515,7 +515,8 @@ export class DefaultKernel implements Kernel.IKernel {
    */
   requestExecute(
     content: KernelMessage.IExecuteRequest,
-    disposeOnDone: boolean = true
+    disposeOnDone: boolean = true,
+    metadata?: JSONObject
   ): Kernel.IFuture {
     let options: KernelMessage.IOptions = {
       msgType: 'execute_request',
@@ -531,7 +532,7 @@ export class DefaultKernel implements Kernel.IKernel {
       stop_on_error: false
     };
     content = { ...defaults, ...content };
-    let msg = KernelMessage.createShellMessage(options, content);
+    let msg = KernelMessage.createShellMessage(options, content, metadata);
     return this.sendShellMessage(msg, true, disposeOnDone);
   }
 

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -266,7 +266,8 @@ export namespace Kernel {
      */
     requestExecute(
       content: KernelMessage.IExecuteRequest,
-      disposeOnDone?: boolean
+      disposeOnDone?: boolean,
+      metadata?: JSONObject
     ): Kernel.IFuture;
 
     /**

--- a/packages/services/test/src/kernel/ikernel.spec.ts
+++ b/packages/services/test/src/kernel/ikernel.spec.ts
@@ -13,6 +13,8 @@ import { Signal } from '@phosphor/signaling';
 
 import { Kernel, KernelMessage } from '../../../lib/kernel';
 
+import { Cell } from '@jupyterlab/cells';
+
 import {
   expectFailure,
   KernelTester,
@@ -924,6 +926,23 @@ describe('Kernel.IKernel', () => {
       expect(future.isDisposed).to.equal(false);
       future.dispose();
       expect(future.isDisposed).to.equal(true);
+    });
+  });
+
+  context('#checkExecuteMetadata()', () => {
+    it('should accept cell metadata as part of request', async () => {
+      let options: KernelMessage.IExecuteRequest = {
+        code: 'test',
+        silent: false,
+        store_history: true,
+        user_expressions: {},
+        allow_stdin: false,
+        stop_on_error: false
+      };
+      let metadata = { cellId: 'test' };
+      let future = defaultKernel.requestExecute(options, false, metadata);
+      await future.done;
+      expect((future.msg.metadata = metadata));
     });
   });
 

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -974,7 +974,7 @@
         "keys": { "default": ["Shift Tab"] },
         "selector": {
           "default":
-            ".jp-CodeConsole-promptCell .jp-InputArea-editor:not(.jp-mod-has-primary-selection)"
+            ".jp-CodeConsole-promptCell .jp-InputArea-editor:not(.jp-mod-has-primary-selection):not(.jp-mod-in-leading-whitespace)"
         },
         "title": { "default": "Invoke Completer" },
         "category": { "default": "Tooltips" }
@@ -988,7 +988,7 @@
         "keys": { "default": ["Shift Tab"] },
         "selector": {
           "default":
-            ".jp-Notebook.jp-mod-editMode .jp-InputArea-editor:not(.jp-mod-has-primary-selection)"
+            ".jp-Notebook.jp-mod-editMode .jp-InputArea-editor:not(.jp-mod-has-primary-selection):not(.jp-mod-in-leading-whitespace)"
         },
         "title": { "default": "Invoke Completer" },
         "category": { "default": "Tooltips" }

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -162,6 +162,17 @@
       },
       "type": "object"
     },
+    "docmanager:save-as": {
+      "default": {},
+      "properties": {
+        "command": { "default": "docmanager:save-as" },
+        "keys": { "default": ["Accel Shift S"] },
+        "selector": { "default": "body" },
+        "title": { "default": "Save As" },
+        "category": { "default": "File Operations" }
+      },
+      "type": "object"
+    },
     "editmenu:undo": {
       "default": {},
       "properties": {


### PR DESCRIPTION
I constantly received the ValueError
'Please install nodejs 5+ and npm before continuing. nodejs may be installed using conda or directly from the nodejs website.' 
even though I had nodejs 9 installed. _node_check uses jupyterlab_launcher.process.Process. My problem was located there (my old version of subprocess32 was incompatible) but the try-except raised the nodejs error mentioned above instead of propagating the correct error.

Replacing the try-except with an evaluation of the return code (which we know will be 1 if the nodejs version is below 5 from jupyterlab/node-version-check.js) avoids raising the wrong error/shows the user the correct error if there is one.

https://github.com/jupyterlab/jupyterlab/issues/3640 is related since users will experience the same error message (although the solution was different for the OP and others in this discussion).