### PR TITLE
Evaluate return code in jupyterlab.commands._node_check

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1463,10 +1463,9 @@ class _AppHandler(object):
 def _node_check():
     """Check for the existence of nodejs with the correct version.
     """
-    try:
-        proc = Process(['node', 'node-version-check.js'], cwd=HERE, quiet=True)
-        proc.wait()
-    except Exception:
+    proc = Process(['node', 'node-version-check.js'], cwd=HERE, quiet=True)
+    return_code = proc.wait()
+    if return_code == 1:
         msg = 'Please install nodejs 5+ and npm before continuing. nodejs may be installed using conda or directly from the nodejs website.'
         raise ValueError(msg)
 


### PR DESCRIPTION
Trying to install jupyterlab extensions I constantly received 

`ValueError('Please install nodejs 5+ and npm before continuing. nodejs may be installed using conda or directly from the nodejs website.')`

even though I had nodejs 9 installed. jupyterlab.commands._node_check uses jupyterlab_launcher.process.Process. My problem was located there (my old version of subprocess32 was incompatible) but the try-except raised the nodejs error mentioned above instead of propagating the correct error.

Replacing the try-except with an evaluation of the return code (which we know equals 1 if the nodejs version is below 5 from jupyterlab/node-version-check.js) avoids raising the wrong error/shows the user the correct error if there is one.

Out of curiosity I downgraded nodejs to 4.5, with the try-except implementation I don't get the expected ValueError. Evaluating the return code I do get it. 

#3640 is related since users will experience the same error message (although the solution was different for the OP and others in this discussion).