### PR TITLE
Added theme css classes to shell body

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -195,6 +195,13 @@ const themes: JupyterLabPlugin<IThemeManager> = {
       currentTheme = args.newValue;
       app.shell.dataset.themeLight = String(manager.isLight(currentTheme));
       app.shell.dataset.themeName = currentTheme;
+      if (currentTheme === 'JupyterLab Light') {
+        app.shell.toggleClass('jp-mod-light', true);
+        app.shell.toggleClass('jp-mod-dark', false);
+      } else {
+        app.shell.toggleClass('jp-mod-dark', true);
+        app.shell.toggleClass('jp-mod-light', false);
+      }
       commands.notifyCommandChanged(CommandIDs.changeTheme);
     });
 


### PR DESCRIPTION
Building off of #5078. Being in dark or light theme now adds a class to the body of JupyerLab, letting developers style based on the current theme in CSS.