### PR TITLE
Implement saving signal

### DIFF
--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -41,11 +41,11 @@ def _create_notebook_dir():
     with open(osp.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
         fid.write('hello')
 
-    readonly_filpath = osp.join(root_dir, 'src', 'readonly-temp.txt')
-    with open(readonly_filpath, 'w') as fid:
+    readonly_filepath = osp.join(root_dir, 'src', 'readonly-temp.txt')
+    with open(readonly_filepath, 'w') as fid:
         fid.write('hello from a readonly file')
 
-    os.chmod(readonly_filpath, S_IRUSR|S_IRGRP|S_IROTH)
+    os.chmod(readonly_filepath, S_IRUSR|S_IRGRP|S_IROTH)
     atexit.register(lambda: shutil.rmtree(root_dir, True))
     return root_dir
 

--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -5,6 +5,7 @@ from __future__ import print_function, absolute_import
 
 from os import path as osp
 from os.path import join as pjoin
+from stat import S_IRUSR, S_IRGRP, S_IROTH
 import argparse
 import atexit
 import glob
@@ -39,6 +40,12 @@ def _create_notebook_dir():
     os.mkdir(osp.join(root_dir, 'src'))
     with open(osp.join(root_dir, 'src', 'temp.txt'), 'w') as fid:
         fid.write('hello')
+
+    readonly_filpath = osp.join(root_dir, 'src', 'readonly-temp.txt')
+    with open(readonly_filpath, 'w') as fid:
+        fid.write('hello from a readonly file')
+
+    os.chmod(readonly_filpath, S_IRUSR|S_IRGRP|S_IROTH)
     atexit.register(lambda: shutil.rmtree(root_dir, True))
     return root_dir
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -96,10 +96,10 @@ export class Context<T extends DocumentRegistry.IModel>
   }
 
   /**
-   * A signal emitted on the start and end of a saving operation
+   * A signal emitted on the start and end of a saving operation.
    */
-  get saving(): ISignal<this, DocumentRegistry.SaveState> {
-    return this._fileSaving;
+  get saveState(): ISignal<this, DocumentRegistry.SaveState> {
+    return this._saveState;
   }
 
   /**
@@ -458,7 +458,7 @@ export class Context<T extends DocumentRegistry.IModel>
    * Save the document contents to disk.
    */
   private _save(): Promise<void> {
-    this._fileSaving.emit('started');
+    this._saveState.emit('started');
     let model = this._model;
     let content: JSONValue;
     if (this._factory.fileFormat === 'json') {
@@ -508,13 +508,13 @@ export class Context<T extends DocumentRegistry.IModel>
       })
       .then(
         value => {
-          // Capture all sucess paths and emit completion
-          this._fileSaving.emit('completed');
+          // Capture all success paths and emit completion.
+          this._saveState.emit('completed');
           return value;
         },
         err => {
-          // Capture all error paths and emit failure
-          this._fileSaving.emit('failed');
+          // Capture all error paths and emit failure.
+          this._saveState.emit('failed');
           throw err;
         }
       )
@@ -768,7 +768,7 @@ export class Context<T extends DocumentRegistry.IModel>
   private _isDisposed = false;
   private _pathChanged = new Signal<this, string>(this);
   private _fileChanged = new Signal<this, Contents.IModel>(this);
-  private _fileSaving = new Signal<this, DocumentRegistry.SaveState>(this);
+  private _saveState = new Signal<this, DocumentRegistry.SaveState>(this);
   private _disposed = new Signal<this, void>(this);
 }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -233,8 +233,6 @@ export class Context<T extends DocumentRegistry.IModel>
    */
   save(): Promise<void> {
     return this.ready.then(() => {
-      this._fileSaving.emit('starting');
-
       return this._save();
     });
   }
@@ -460,6 +458,7 @@ export class Context<T extends DocumentRegistry.IModel>
    * Save the document contents to disk.
    */
   private _save(): Promise<void> {
+    this._fileSaving.emit('starting');
     let model = this._model;
     let content: JSONValue;
     if (this._factory.fileFormat === 'json') {

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -96,6 +96,13 @@ export class Context<T extends DocumentRegistry.IModel>
   }
 
   /**
+   * A signal emitted on the start and end of a saving operation
+   */
+  get saving(): ISignal<this, DocumentRegistry.SaveState> {
+    return this._fileSaving;
+  }
+
+  /**
    * A signal emitted when the context is disposed.
    */
   get disposed(): ISignal<this, void> {
@@ -226,6 +233,8 @@ export class Context<T extends DocumentRegistry.IModel>
    */
   save(): Promise<void> {
     return this.ready.then(() => {
+      this._fileSaving.emit('starting');
+
       return this._save();
     });
   }
@@ -476,6 +485,8 @@ export class Context<T extends DocumentRegistry.IModel>
         if (this.isDisposed) {
           return;
         }
+
+        this._fileSaving.emit('ending');
         model.dirty = false;
         this._updateContentsModel(value);
 
@@ -746,6 +757,7 @@ export class Context<T extends DocumentRegistry.IModel>
   private _isDisposed = false;
   private _pathChanged = new Signal<this, string>(this);
   private _fileChanged = new Signal<this, Contents.IModel>(this);
+  private _fileSaving = new Signal<this, DocumentRegistry.SaveState>(this);
   private _disposed = new Signal<this, void>(this);
 }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -485,7 +485,6 @@ export class Context<T extends DocumentRegistry.IModel>
           return;
         }
 
-        this._fileSaving.emit('ending');
         model.dirty = false;
         this._updateContentsModel(value);
 
@@ -506,6 +505,16 @@ export class Context<T extends DocumentRegistry.IModel>
         const name = PathExt.basename(localPath);
         this._handleError(err, `File Save Error for ${name}`);
         throw err;
+      })
+      .catch(err => {
+        // Capture all error paths and confirm failure
+        this._fileSaving.emit('failed');
+        throw err;
+      })
+      .then(value => {
+        // Capture all sucess paths and emit completion
+        this._fileSaving.emit('completed');
+        return value;
       });
   }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -458,7 +458,7 @@ export class Context<T extends DocumentRegistry.IModel>
    * Save the document contents to disk.
    */
   private _save(): Promise<void> {
-    this._fileSaving.emit('starting');
+    this._fileSaving.emit('started');
     let model = this._model;
     let content: JSONValue;
     if (this._factory.fileFormat === 'json') {
@@ -506,16 +506,19 @@ export class Context<T extends DocumentRegistry.IModel>
         this._handleError(err, `File Save Error for ${name}`);
         throw err;
       })
-      .catch(err => {
-        // Capture all error paths and confirm failure
-        this._fileSaving.emit('failed');
-        throw err;
-      })
-      .then(value => {
-        // Capture all sucess paths and emit completion
-        this._fileSaving.emit('completed');
-        return value;
-      });
+      .then(
+        value => {
+          // Capture all sucess paths and emit completion
+          this._fileSaving.emit('completed');
+          return value;
+        },
+        err => {
+          // Capture all error paths and emit failure
+          this._fileSaving.emit('failed');
+          throw err;
+        }
+      )
+      .catch();
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -866,7 +866,7 @@ export namespace DocumentRegistry {
     addSibling(widget: Widget, options?: IOpenOptions): IDisposable;
   }
 
-  export type SaveState = 'starting' | 'ending';
+  export type SaveState = 'starting' | 'completed' | 'failed';
 
   /**
    * A type alias for a context.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -745,6 +745,11 @@ export namespace DocumentRegistry {
     fileChanged: ISignal<this, Contents.IModel>;
 
     /**
+     * A signal emitted on the start and end of a saving operation
+     */
+    saving: ISignal<this, SaveState>;
+
+    /**
      * A signal emitted when the context is disposed.
      */
     disposed: ISignal<this, void>;
@@ -860,6 +865,8 @@ export namespace DocumentRegistry {
      */
     addSibling(widget: Widget, options?: IOpenOptions): IDisposable;
   }
+
+  export type SaveState = 'starting' | 'ending';
 
   /**
    * A type alias for a context.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -745,9 +745,9 @@ export namespace DocumentRegistry {
     fileChanged: ISignal<this, Contents.IModel>;
 
     /**
-     * A signal emitted on the start and end of a saving operation
+     * A signal emitted on the start and end of a saving operation.
      */
-    saving: ISignal<this, SaveState>;
+    saveState: ISignal<this, SaveState>;
 
     /**
      * A signal emitted when the context is disposed.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -866,7 +866,7 @@ export namespace DocumentRegistry {
     addSibling(widget: Widget, options?: IOpenOptions): IDisposable;
   }
 
-  export type SaveState = 'starting' | 'completed' | 'failed';
+  export type SaveState = 'started' | 'completed' | 'failed';
 
   /**
    * A type alias for a context.

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -90,6 +90,45 @@ describe('docregistry/context', () => {
       });
     });
 
+    describe('#saving', () => {
+      it("should emit 'starting' when the file starts saving", async () => {
+        let called = false;
+        let checked = false;
+        context.saving.connect((sender, args) => {
+          if (!called) {
+            expect(sender).to.equal(context);
+            expect(args).to.equal('starting');
+
+            checked = true;
+          }
+
+          called = true;
+        });
+
+        await context.initialize(true);
+        expect(called).to.be.true;
+        expect(checked).to.be.true;
+      });
+
+      it("should emit 'ending' when the file ends saving", async () => {
+        let called = 0;
+        let checked = false;
+        context.saving.connect((sender, args) => {
+          if (called > 0) {
+            expect(sender).to.equal(context);
+            expect(args).to.equal('ending');
+            checked = true;
+          }
+
+          called += 1;
+        });
+
+        await context.initialize(true);
+        expect(called).to.equal(2);
+        expect(checked).to.be.true;
+      });
+    });
+
     describe('#isReady', () => {
       it('should indicate whether the context is ready', async () => {
         expect(context.isReady).to.equal(false);

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -97,7 +97,7 @@ describe('docregistry/context', () => {
         context.saving.connect((sender, args) => {
           if (!called) {
             expect(sender).to.equal(context);
-            expect(args).to.equal('starting');
+            expect(args).to.equal('started');
 
             checked = true;
           }
@@ -126,6 +126,36 @@ describe('docregistry/context', () => {
         await context.initialize(true);
         expect(called).to.equal(2);
         expect(checked).to.be.true;
+      });
+
+      it("should emit 'failed' when the save operation fails out", async () => {
+        context = new Context({
+          manager,
+          factory,
+          path: 'src/readonly-temp.txt'
+        });
+
+        let called = 0;
+        let checked;
+        context.saving.connect((sender, args) => {
+          if (called > 0) {
+            expect(sender).to.equal(context);
+            checked = args;
+          }
+
+          called += 1;
+        });
+
+        try {
+          await context.initialize(true);
+        } catch (err) {
+          expect(err.message).to.contain('Invalid response: 403 Forbidden');
+        }
+
+        expect(called).to.equal(2);
+        expect(checked).to.equal('failed');
+
+        await acceptDialog();
       });
     });
 

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -110,13 +110,13 @@ describe('docregistry/context', () => {
         expect(checked).to.be.true;
       });
 
-      it("should emit 'ending' when the file ends saving", async () => {
+      it("should emit 'completed' when the file ends saving", async () => {
         let called = 0;
         let checked = false;
         context.saving.connect((sender, args) => {
           if (called > 0) {
             expect(sender).to.equal(context);
-            expect(args).to.equal('ending');
+            expect(args).to.equal('completed');
             checked = true;
           }
 

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -94,7 +94,7 @@ describe('docregistry/context', () => {
       it("should emit 'starting' when the file starts saving", async () => {
         let called = false;
         let checked = false;
-        context.saving.connect((sender, args) => {
+        context.saveState.connect((sender, args) => {
           if (!called) {
             expect(sender).to.equal(context);
             expect(args).to.equal('started');
@@ -113,7 +113,7 @@ describe('docregistry/context', () => {
       it("should emit 'completed' when the file ends saving", async () => {
         let called = 0;
         let checked = false;
-        context.saving.connect((sender, args) => {
+        context.saveState.connect((sender, args) => {
           if (called > 0) {
             expect(sender).to.equal(context);
             expect(args).to.equal('completed');
@@ -137,7 +137,7 @@ describe('docregistry/context', () => {
 
         let called = 0;
         let checked;
-        context.saving.connect((sender, args) => {
+        context.saveState.connect((sender, args) => {
           if (called > 0) {
             expect(sender).to.equal(context);
             checked = args;


### PR DESCRIPTION
Added a signal to the `DocumentRegistry.IContext` that will trigger on the beginning of a save operation and again on completion or error. 

Added tests for the start and completed signal values, but I was unable to come up with a test that would trigger a error while saving.

@ellisonbg 