### PR TITLE
remove In and Out from all prompts in jupyterlab

### DIFF
--- a/packages/cells/src/inputarea.ts
+++ b/packages/cells/src/inputarea.ts
@@ -291,7 +291,7 @@ export class InputPrompt extends Widget implements IInputPrompt {
     if (value === null) {
       this.node.textContent = ' ';
     } else {
-      this.node.textContent = `In [${value || ' '}]:`;
+      this.node.textContent = `[${value || ' '}]:`;
     }
   }
 

--- a/packages/console/style/index.css
+++ b/packages/console/style/index.css
@@ -46,12 +46,12 @@
 
 .jp-CodeConsole-content .jp-Cell:not(.jp-mod-active) .jp-InputPrompt {
   opacity: var(--jp-cell-prompt-not-active-opacity);
-  color: var(--jp-cell-prompt-not-active-font-color);
+  color: var(--jp-cell-inprompt-font-color);
 }
 
 .jp-CodeConsole-content .jp-Cell:not(.jp-mod-active) .jp-OutputPrompt {
   opacity: var(--jp-cell-prompt-not-active-opacity);
-  color: var(--jp-cell-prompt-not-active-font-color);
+  color: var(--jp-cell-outprompt-font-color);
 }
 
 /* This rule is for styling cell run by another activity in this console */

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -628,7 +628,7 @@ export class OutputPrompt extends Widget implements IOutputPrompt {
     if (value === null) {
       this.node.textContent = '';
     } else {
-      this.node.textContent = `Out[${value}]:`;
+      this.node.textContent = `[${value}]:`;
     }
   }
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -28,7 +28,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Elevation
    *
    * We style box-shadows using Material Design's idea of elevation. These particular numbers are taken from here:
-   * 
+   *
    * https://github.com/material-components/material-components-web
    * https://material-components-web.appspot.com/elevation.html
    */
@@ -173,9 +173,9 @@ all of MD as it is not optimized for dense, information rich UIs.
     Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol';
 
-  /* 
+  /*
    * Code Fonts
-   * 
+   *
    * Code font variables are used for typography of code and other monospaces content.
    */
 
@@ -247,7 +247,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-active-background: var(--jp-layout-color0);
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
 
-  --jp-cell-prompt-width: 90px;
+  --jp-cell-prompt-width: 64px;
   --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1;

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -251,10 +251,19 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1;
-  --jp-cell-prompt-not-active-opacity: 0.5;
+  --jp-cell-prompt-not-active-opacity: 1;
   --jp-cell-prompt-not-active-font-color: var(--md-grey-300);
-  --jp-cell-inprompt-font-color: var(--md-grey-50);
-  --jp-cell-outprompt-font-color: var(--md-grey-50);
+  /* --jp-cell-inprompt-font-color: var(--md-grey-50);
+  --jp-cell-outprompt-font-color: var(--md-grey-50); */
+
+
+  /* A custom blend of MD grey and blue 600
+   * See https://meyerweb.com/eric/tools/color-blend/#546E7A:1E88E5:5:hex */
+  --jp-cell-inprompt-font-color: #307fc1;
+  /* A custom blend of MD grey and orange 600
+   * https://meyerweb.com/eric/tools/color-blend/#546E7A:F4511E:5:hex */
+  --jp-cell-outprompt-font-color: #bf5b3d;
+
 
   /* Notebook specific styles */
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -253,9 +253,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-prompt-opacity: 1;
   --jp-cell-prompt-not-active-opacity: 1;
   --jp-cell-prompt-not-active-font-color: var(--md-grey-300);
-  /* --jp-cell-inprompt-font-color: var(--md-grey-50);
-  --jp-cell-outprompt-font-color: var(--md-grey-50); */
-
 
   /* A custom blend of MD grey and blue 600
    * See https://meyerweb.com/eric/tools/color-blend/#546E7A:1E88E5:5:hex */
@@ -263,7 +260,6 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* A custom blend of MD grey and orange 600
    * https://meyerweb.com/eric/tools/color-blend/#546E7A:F4511E:5:hex */
   --jp-cell-outprompt-font-color: #bf5b3d;
-
 
   /* Notebook specific styles */
 

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -28,7 +28,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Elevation
    *
    * We style box-shadows using Material Design's idea of elevation. These particular numbers are taken from here:
-   * 
+   *
    * https://github.com/material-components/material-components-web
    * https://material-components-web.appspot.com/elevation.html
    */
@@ -171,9 +171,9 @@ all of MD as it is not optimized for dense, information rich UIs.
     Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol';
 
-  /* 
+  /*
    * Code Fonts
-   * 
+   *
    * Code font variables are used for typography of code and other monospaces content.
    */
 
@@ -245,7 +245,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-active-background: var(--jp-layout-color0);
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
 
-  --jp-cell-prompt-width: 90px;
+  --jp-cell-prompt-width: 64px;
   --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1;


### PR DESCRIPTION
Pinging @ellisonbg. 

We talked about recovering some horizontal space in notebooks and consoles by removing the `In` and `Out` prefixes in all cell prompts. 

Here, I've done the following:
1. Removed `In`/`Out` prefixes 
1. Shrunk the prompt width from 90px to 64px. 
![notebook](https://user-images.githubusercontent.com/2791223/43982988-331f588a-9cad-11e8-9b9a-fea1a2b7aa98.png)
1. In the light theme, I set the prompt colors of *executed* console cells to *active* prompt colors, but reduced their opacity to **0.5**. 
*Why?* This visually separates the In vs. Out areas and communicates to the user that those cells have been executed and cannot be edited.  
![light-theme](https://user-images.githubusercontent.com/2791223/43982700-0498e72a-9cac-11e8-9600-0430270e3c5f.png)
1.  In the dark theme, I set the prompt colors of *executed* console cells to *active* prompt colors, but set their opacity to **1**. 
*Why?* I chose colors for the same reason as the point above. I *did not* reduce the opacity of executed cells, because it becomes too hard to see with the dark background. The dark theme visually separates the executed cells already, because active cells are a lighter color than inactive cells. 
![dark-theme](https://user-images.githubusercontent.com/2791223/43982706-0ddcc950-9cac-11e8-9ebf-f090ad84f349.png)

This PR follows up on the conversation in #1692 about prompt design. 