### PR TITLE
Build cleanup

### DIFF
--- a/dev_mode/webpack.prod.config.js
+++ b/dev_mode/webpack.prod.config.js
@@ -16,7 +16,8 @@ module.exports = merge(common, {
           compress: false,
           ecma: 6,
           mangle: true
-        }
+        },
+        cache: process.platform !== 'win32'
       })
     ]
   }

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -13,7 +13,7 @@ from ._version import __version__
 from .extension import load_jupyter_server_extension
 from .commands import (
     build, clean, get_app_dir, get_user_settings_dir, get_app_version,
-    get_workspaces_dir
+    get_workspaces_dir, get_app_dir
 )
 
 
@@ -55,12 +55,15 @@ class LabBuildApp(JupyterApp):
     version = Unicode('', config=True,
         help="The version of the built application")
 
-    dev_build = Bool(False, config=True,
-        help="Whether to build in dev mode (defaults to production mode)")
+    dev_build = Bool(True, config=True,
+        help="Whether to build in dev mode (defaults to dev mode)")
 
     def start(self):
         command = 'build:prod' if not self.dev_build else 'build'
-        build(app_dir=self.app_dir, name=self.name, version=self.version,
+        app_dir = self.app_dir or get_app_dir()
+        self.log.info('JupyterLab %s', version)
+        self.log.info('Building in %s', app_dir)
+        build(app_dir=app_dir, name=self.name, version=self.version,
               command=command, logger=self.log)
 
 

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -66,8 +66,8 @@ class BaseExtensionApp(JupyterApp):
     should_build = Bool(True, config=True,
         help="Whether to build the app after the action")
 
-    dev_build = Bool(False, config=True,
-        help="Whether to build in dev mode (defaults to production mode)")
+    dev_build = Bool(True, config=True,
+        help="Whether to build in dev mode (defaults to dev mode)")
 
     should_clean = Bool(False, config=True,
         help="Whether temporary files should be cleaned up after building jupyterlab")

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:examples": "lerna run build --scope \"@jupyterlab/example-*\"",
     "build:packages": "cd packages/metapackage && jlpm run build",
     "build:src": "lerna run build --scope \"@jupyterlab/!(test-|example-)*\"",
-    "build:test": "jlpm run build:testutils && lerna run build:test",
+    "build:test": "jlpm run build:testutils && lerna run build:test && lerna run build --scope \"@jupyterlab/test-*\"",
     "build:testutils": "cd testutils && jlpm run build",
     "build:themes": "lerna run build:webpack --scope \"@jupyterlab/theme-*-extension\"",
     "build:update": "node buildutils/lib/update-core-mode.js",

--- a/tests/test-apputils/src/instancetracker.spec.ts
+++ b/tests/test-apputils/src/instancetracker.spec.ts
@@ -62,7 +62,8 @@ describe('@jupyterlab/apputils', () => {
         const widget = new Widget();
         let promise = signalToPromise(tracker.widgetAdded);
         tracker.add(widget);
-        const args = (await promise)[1];
+        const [sender, args] = await promise;
+        expect(sender).to.equal(tracker);
         expect(args).to.equal(widget);
       });
 

--- a/tests/test-codeeditor/package.json
+++ b/tests/test-codeeditor/package.json
@@ -22,6 +22,7 @@
     "@jupyterlab/testutils": "^0.1.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
+    "chai": "~4.1.2",
     "simulate-event": "~1.4.0"
   },
   "devDependencies": {

--- a/tests/test-codeeditor/package.json
+++ b/tests/test-codeeditor/package.json
@@ -22,7 +22,6 @@
     "@jupyterlab/testutils": "^0.1.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "expect.js": "~0.3.1",
     "simulate-event": "~1.4.0"
   },
   "devDependencies": {

--- a/tests/test-codeeditor/src/editor.spec.ts
+++ b/tests/test-codeeditor/src/editor.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
@@ -18,13 +18,13 @@ describe('CodeEditor.Model', () => {
 
   describe('#constructor()', () => {
     it('should create a CodeEditor Model', () => {
-      expect(model).to.be.a(CodeEditor.Model);
+      expect(model).to.be.an.instanceof(CodeEditor.Model);
       expect(model.value.text).to.equal('');
     });
 
     it('should create a CodeEditor Model with an initial value', () => {
       let other = new CodeEditor.Model({ value: 'Initial text here' });
-      expect(other).to.be.a(CodeEditor.Model);
+      expect(other).to.be.an.instanceof(CodeEditor.Model);
       expect(other.value.text).to.equal('Initial text here');
       other.dispose();
     });
@@ -34,7 +34,7 @@ describe('CodeEditor.Model', () => {
         value: 'import this',
         mimeType: 'text/x-python'
       });
-      expect(other).to.be.a(CodeEditor.Model);
+      expect(other).to.be.an.instanceof(CodeEditor.Model);
       expect(other.mimeType).to.equal('text/x-python');
       expect(other.value.text).to.equal('import this');
       other.dispose();
@@ -45,13 +45,13 @@ describe('CodeEditor.Model', () => {
     it('should be emitted when the mime type changes', () => {
       let called = false;
       model.mimeTypeChanged.connect((sender, args) => {
-        expect(sender).to.be(model);
-        expect(args.oldValue).to.be('text/plain');
-        expect(args.newValue).to.be('text/foo');
+        expect(sender).to.equal(model);
+        expect(args.oldValue).to.equal('text/plain');
+        expect(args.newValue).to.equal('text/foo');
         called = true;
       });
       model.mimeType = 'text/foo';
-      expect(called).to.be(true);
+      expect(called).to.be.true;
     });
   });
 
@@ -60,64 +60,64 @@ describe('CodeEditor.Model', () => {
       let called = false;
       model.value.changed.connect((sender, args) => {
         console.log('hi', args.value);
-        expect(sender).to.be(model.value);
-        expect(args.type).to.be('set');
-        expect(args.value).to.be('foo');
+        expect(sender).to.equal(model.value);
+        expect(args.type).to.equal('set');
+        expect(args.value).to.equal('foo');
         called = true;
       });
       model.value.text = 'foo';
-      expect(called).to.be(true);
+      expect(called).to.be.true;
     });
 
     it('should handle an insert', () => {
       let called = false;
       model.value.changed.connect((sender, args) => {
-        expect(args.type).to.be('insert');
-        expect(args.value).to.be('foo');
+        expect(args.type).to.equal('insert');
+        expect(args.value).to.equal('foo');
         called = true;
       });
       model.value.insert(0, 'foo');
-      expect(called).to.be(true);
+      expect(called).to.be.true;
     });
 
     it('should handle a remove', () => {
       let called = false;
       model.value.text = 'foo';
       model.value.changed.connect((sender, args) => {
-        expect(args.type).to.be('remove');
-        expect(args.value).to.be('f');
+        expect(args.type).to.equal('remove');
+        expect(args.value).to.equal('f');
         called = true;
       });
       model.value.remove(0, 1);
-      expect(called).to.be(true);
+      expect(called).to.be.true;
     });
   });
 
   describe('#selections', () => {
     it('should be the selections associated with the model', () => {
-      expect(model.selections.keys().length).to.be(0);
+      expect(model.selections.keys().length).to.equal(0);
     });
   });
 
   describe('#mimeType', () => {
     it('should be the mime type of the model', () => {
-      expect(model.mimeType).to.be('text/plain');
+      expect(model.mimeType).to.equal('text/plain');
       model.mimeType = 'text/foo';
-      expect(model.mimeType).to.be('text/foo');
+      expect(model.mimeType).to.equal('text/foo');
     });
   });
 
   describe('#modelDB', () => {
     it('should get the modelDB object associated with the model', () => {
-      expect(model.modelDB.has('value')).to.be(true);
+      expect(model.modelDB.has('value')).to.be.true;
     });
   });
 
   describe('#isDisposed', () => {
     it('should test whether the model is disposed', () => {
-      expect(model.isDisposed).to.be(false);
+      expect(model.isDisposed).to.be.false;
       model.dispose();
-      expect(model.isDisposed).to.be(true);
+      expect(model.isDisposed).to.be.true;
     });
   });
 });

--- a/tests/test-codeeditor/src/jsoneditor.spec.ts
+++ b/tests/test-codeeditor/src/jsoneditor.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { CodeMirrorEditorFactory } from '@jupyterlab/codemirror';
 
@@ -65,34 +65,34 @@ describe('apputils', () => {
     describe('#constructor', () => {
       it('should create a new metadata editor', () => {
         let newEditor = new JSONEditor({ editorFactory });
-        expect(newEditor).to.be.a(JSONEditor);
+        expect(newEditor).to.be.an.instanceof(JSONEditor);
       });
     });
 
     describe('#collapsible', () => {
       it('should default to false', () => {
-        expect(editor.collapsible).to.be(false);
+        expect(editor.collapsible).to.be.false;
       });
 
       it('should be settable in the constructor', () => {
         let newEditor = new JSONEditor({ editorFactory, collapsible: true });
-        expect(newEditor.collapsible).to.be(true);
+        expect(newEditor.collapsible).to.be.true;
       });
     });
 
     describe('#editorTitle', () => {
       it('should default to empty string', () => {
-        expect(editor.editorTitle).to.be('');
+        expect(editor.editorTitle).to.equal('');
       });
 
       it('should be settable in the constructor', () => {
         let newEditor = new JSONEditor({ editorFactory, title: 'foo' });
-        expect(newEditor.editorTitle).to.be('foo');
+        expect(newEditor.editorTitle).to.equal('foo');
       });
 
       it('should be settable', () => {
         editor.editorTitle = 'foo';
-        expect(editor.editorTitle).to.be('foo');
+        expect(editor.editorTitle).to.equal('foo');
       });
     });
 
@@ -142,69 +142,69 @@ describe('apputils', () => {
 
     describe('#source', () => {
       it('should be the source of the metadata', () => {
-        expect(editor.source).to.be(null);
+        expect(editor.source).to.equal(null);
       });
 
       it('should be settable', () => {
         let source = new ObservableJSON();
         editor.source = source;
-        expect(editor.source).to.be(source);
+        expect(editor.source).to.equal(source);
       });
 
       it('should update the text area value', () => {
         let model = editor.model;
-        expect(model.value.text).to.be('No data!');
+        expect(model.value.text).to.equal('No data!');
         editor.source = new ObservableJSON();
-        expect(model.value.text).to.be('{}');
+        expect(model.value.text).to.equal('{}');
       });
     });
 
     describe('#isDirty', () => {
       it('should test whether the editor value is dirty', () => {
-        expect(editor.isDirty).to.be(false);
+        expect(editor.isDirty).to.be.false;
         Widget.attach(editor, document.body);
         editor.model.value.text = 'a';
-        expect(editor.isDirty).to.be(true);
+        expect(editor.isDirty).to.be.true;
       });
 
       it('should be dirty if the value changes while focused', () => {
         editor.source = new ObservableJSON();
         Widget.attach(editor, document.body);
         editor.editor.focus();
-        expect(editor.isDirty).to.be(false);
+        expect(editor.isDirty).to.be.false;
         editor.source.set('foo', 1);
-        expect(editor.isDirty).to.be(true);
+        expect(editor.isDirty).to.be.true;
       });
 
       it('should not be set if not focused', () => {
         editor.source = new ObservableJSON();
         Widget.attach(editor, document.body);
-        expect(editor.isDirty).to.be(false);
+        expect(editor.isDirty).to.be.false;
         editor.source.set('foo', 1);
-        expect(editor.isDirty).to.be(false);
+        expect(editor.isDirty).to.be.false;
       });
     });
 
     context('model.value.changed', () => {
       it('should add the error flag if invalid JSON', () => {
         editor.model.value.text = 'foo';
-        expect(editor.hasClass('jp-mod-error')).to.be(true);
+        expect(editor.hasClass('jp-mod-error')).to.be.true;
       });
 
       it('should show the commit button if the value has changed', () => {
         editor.model.value.text = '{"foo": 2}';
         editor.model.value.text = '{"foo": 1}';
-        expect(editor.commitButtonNode.hidden).to.be(false);
+        expect(editor.commitButtonNode.hidden).to.be.false;
       });
 
       it('should not show the commit button if the value is invalid', () => {
         editor.model.value.text = 'foo';
-        expect(editor.commitButtonNode.hidden).to.be(true);
+        expect(editor.commitButtonNode.hidden).to.be.true;
       });
 
       it('should show the revert button if the value has changed', () => {
         editor.model.value.text = 'foo';
-        expect(editor.revertButtonNode.hidden).to.be(false);
+        expect(editor.revertButtonNode.hidden).to.be.false;
       });
     });
 
@@ -225,9 +225,9 @@ describe('apputils', () => {
           editor.editor.focus();
           editor.source.set('foo', 1);
           let model = editor.model;
-          expect(model.value.text).to.be('{}');
+          expect(model.value.text).to.equal('{}');
           simulate(editor.editorHostNode, 'blur');
-          expect(model.value.text).to.be('{\n    "foo": 1\n}');
+          expect(model.value.text).to.equal('{\n    "foo": 1\n}');
         });
 
         it('should not revert to current data if there was a change', () => {
@@ -235,11 +235,11 @@ describe('apputils', () => {
           editor.model.value.text = 'foo';
           editor.source.set('foo', 1);
           let model = editor.model;
-          expect(model.value.text).to.be('foo');
+          expect(model.value.text).to.equal('foo');
           simulate(editor.editorHostNode, 'blur');
-          expect(model.value.text).to.be('foo');
-          expect(editor.commitButtonNode.hidden).to.be(true);
-          expect(editor.revertButtonNode.hidden).to.be(false);
+          expect(model.value.text).to.equal('foo');
+          expect(editor.commitButtonNode.hidden).to.be.true;
+          expect(editor.revertButtonNode.hidden).to.be.false;
         });
       });
 
@@ -253,7 +253,7 @@ describe('apputils', () => {
           editor.source = new ObservableJSON();
           editor.model.value.text = 'foo';
           simulate(editor.revertButtonNode, 'click');
-          expect(editor.model.value.text).to.be('{}');
+          expect(editor.model.value.text).to.equal('{}');
         });
 
         it('should handle programmatic changes', () => {
@@ -261,7 +261,7 @@ describe('apputils', () => {
           editor.model.value.text = 'foo';
           editor.source.set('foo', 1);
           simulate(editor.revertButtonNode, 'click');
-          expect(editor.model.value.text).to.be('{\n    "foo": 1\n}');
+          expect(editor.model.value.text).to.equal('{\n    "foo": 1\n}');
         });
 
         it('should handle click events on the commit button', () => {
@@ -274,7 +274,7 @@ describe('apputils', () => {
           editor.model.value.text = 'foo';
           editor.source.set('foo', 1);
           simulate(editor.commitButtonNode, 'click');
-          expect(editor.model.value.text).to.be('foo');
+          expect(editor.model.value.text).to.equal('foo');
         });
 
         it('should override a key that was set programmatically', () => {
@@ -282,7 +282,7 @@ describe('apputils', () => {
           editor.model.value.text = '{"foo": 2}';
           editor.source.set('foo', 1);
           simulate(editor.commitButtonNode, 'click');
-          expect(editor.model.value.text).to.be('{\n    "foo": 2\n}');
+          expect(editor.model.value.text).to.equal('{\n    "foo": 2\n}');
         });
 
         it('should allow a programmatic key to update', () => {
@@ -293,7 +293,7 @@ describe('apputils', () => {
           editor.source.set('foo', 2);
           simulate(editor.commitButtonNode, 'click');
           let expected = '{\n    "foo": 2,\n    "bar": 2\n}';
-          expect(editor.model.value.text).to.be(expected);
+          expect(editor.model.value.text).to.equal(expected);
         });
 
         it('should allow a key to be added by the user', () => {
@@ -304,7 +304,7 @@ describe('apputils', () => {
           editor.source.set('foo', 2);
           simulate(editor.commitButtonNode, 'click');
           let value = '{\n    "foo": 2,\n    "bar": 2,\n    "baz": 3\n}';
-          expect(editor.model.value.text).to.be(value);
+          expect(editor.model.value.text).to.equal(value);
         });
 
         it('should allow a key to be removed by the user', () => {
@@ -313,7 +313,7 @@ describe('apputils', () => {
           editor.source.set('bar', 1);
           editor.model.value.text = '{"foo": 1}';
           simulate(editor.commitButtonNode, 'click');
-          expect(editor.model.value.text).to.be('{\n    "foo": 1\n}');
+          expect(editor.model.value.text).to.equal('{\n    "foo": 1\n}');
         });
 
         it('should allow a key to be removed programmatically that was not set by the user', () => {
@@ -323,7 +323,7 @@ describe('apputils', () => {
           editor.model.value.text = '{"foo": 1, "bar": 3}';
           editor.source.delete('foo');
           simulate(editor.commitButtonNode, 'click');
-          expect(editor.model.value.text).to.be('{\n    "bar": 3\n}');
+          expect(editor.model.value.text).to.equal('{\n    "bar": 3\n}');
         });
 
         it('should keep a key that was removed programmatically that was changed by the user', () => {
@@ -334,7 +334,7 @@ describe('apputils', () => {
           editor.source.set('foo', null);
           simulate(editor.commitButtonNode, 'click');
           let expected = '{\n    "foo": 2,\n    "bar": 3\n}';
-          expect(editor.model.value.text).to.be(expected);
+          expect(editor.model.value.text).to.equal(expected);
         });
 
         it('should collapse the editor', () => {
@@ -395,7 +395,7 @@ describe('apputils', () => {
       it('should update the value', () => {
         editor.source = new ObservableJSON();
         editor.source.set('foo', 1);
-        expect(editor.model.value.text).to.be('{\n    "foo": 1\n}');
+        expect(editor.model.value.text).to.equal('{\n    "foo": 1\n}');
       });
 
       it('should bail if the input is dirty', () => {
@@ -403,7 +403,7 @@ describe('apputils', () => {
         editor.source = new ObservableJSON();
         editor.model.value.text = 'ha';
         editor.source.set('foo', 2);
-        expect(editor.model.value.text).to.be('ha');
+        expect(editor.model.value.text).to.equal('ha');
       });
 
       it('should bail if the input is focused', () => {
@@ -412,7 +412,7 @@ describe('apputils', () => {
         editor.source = new ObservableJSON();
         editor.editor.focus();
         editor.source.set('foo', 2);
-        expect(editor.model.value.text).to.be('{}');
+        expect(editor.model.value.text).to.equal('{}');
       });
     });
   });

--- a/tests/test-codeeditor/src/jsoneditor.spec.ts
+++ b/tests/test-codeeditor/src/jsoneditor.spec.ts
@@ -48,7 +48,7 @@ class LogEditor extends JSONEditor {
   }
 }
 
-describe('apputils', () => {
+describe('codeeditor', () => {
   describe('JSONEditor', () => {
     let editor: LogEditor;
     let editorServices = new CodeMirrorEditorFactory();
@@ -98,19 +98,23 @@ describe('apputils', () => {
 
     describe('#headerNode', () => {
       it('should be the header node used by the editor', () => {
-        expect(editor.headerNode.classList).to.contain('jp-JSONEditor-header');
+        expect(Array.from(editor.headerNode.classList)).to.contain(
+          'jp-JSONEditor-header'
+        );
       });
     });
 
     describe('#titleNode', () => {
       it('should be the title node used by the editor', () => {
-        expect(editor.titleNode.classList).to.contain('jp-JSONEditor-title');
+        expect(Array.from(editor.titleNode.classList)).to.contain(
+          'jp-JSONEditor-title'
+        );
       });
     });
 
     describe('#collapserNode', () => {
       it('should be the collapser node used by the editor', () => {
-        expect(editor.collapserNode.classList).to.contain(
+        expect(Array.from(editor.collapserNode.classList)).to.contain(
           'jp-JSONEditor-collapser'
         );
       });
@@ -118,7 +122,7 @@ describe('apputils', () => {
 
     describe('#editorHostNode', () => {
       it('should be the editor host node used by the editor', () => {
-        expect(editor.editorHostNode.classList).to.contain(
+        expect(Array.from(editor.editorHostNode.classList)).to.contain(
           'jp-JSONEditor-host'
         );
       });
@@ -126,7 +130,7 @@ describe('apputils', () => {
 
     describe('#revertButtonNode', () => {
       it('should be the revert button node used by the editor', () => {
-        expect(editor.revertButtonNode.classList).to.contain(
+        expect(Array.from(editor.revertButtonNode.classList)).to.contain(
           'jp-JSONEditor-revertButton'
         );
       });
@@ -134,7 +138,7 @@ describe('apputils', () => {
 
     describe('#commitButtonNode', () => {
       it('should be the commit button node used by the editor', () => {
-        expect(editor.commitButtonNode.classList).to.contain(
+        expect(Array.from(editor.commitButtonNode.classList)).to.contain(
           'jp-JSONEditor-commitButton'
         );
       });
@@ -342,14 +346,14 @@ describe('apputils', () => {
           editor = new LogEditor({ editorFactory, collapsible: true });
           Widget.attach(editor, document.body);
           simulate(editor.titleNode, 'click');
-          expect(editor.editorHostNode.classList).to.contain(
+          expect(Array.from(editor.editorHostNode.classList)).to.contain(
             'jp-mod-collapsed'
           );
         });
 
         it('should have no effect if the editor is not collapsible', () => {
           simulate(editor.titleNode, 'click');
-          expect(editor.editorHostNode.classList).to.not.contain(
+          expect(Array.from(editor.editorHostNode.classList)).to.not.contain(
             'jp-mod-collapsed'
           );
         });

--- a/tests/test-codeeditor/src/widget.spec.ts
+++ b/tests/test-codeeditor/src/widget.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import expect = require('expect.js');
+import { expect } from 'chai';
 
 import { Message, MessageLoop } from '@phosphor/messaging';
 
@@ -82,7 +82,7 @@ describe('CodeEditorWrapper', () => {
 
   describe('#constructor()', () => {
     it('should be a CodeEditorWrapper', () => {
-      expect(widget).to.be.a(CodeEditorWrapper);
+      expect(widget).to.be.an.instanceof(CodeEditorWrapper);
     });
 
     it('should add a focus listener', () => {
@@ -95,24 +95,24 @@ describe('CodeEditorWrapper', () => {
 
   describe('#editor', () => {
     it('should be a a code editor', () => {
-      expect(widget.editor.getOption('lineNumbers')).to.be(false);
+      expect(widget.editor.getOption('lineNumbers')).to.be.false;
     });
   });
 
   describe('#dispose()', () => {
     it('should dispose of the resources used by the widget', () => {
-      expect(widget.isDisposed).to.be(false);
+      expect(widget.isDisposed).to.be.false;
       widget.dispose();
-      expect(widget.isDisposed).to.be(true);
+      expect(widget.isDisposed).to.be.true;
       widget.dispose();
-      expect(widget.isDisposed).to.be(true);
+      expect(widget.isDisposed).to.be.true;
     });
 
     it('should remove the focus listener', () => {
       let editor = widget.editor as LogEditor;
-      expect(editor.isDisposed).to.be(false);
+      expect(editor.isDisposed).to.be.false;
       widget.dispose();
-      expect(editor.isDisposed).to.be(true);
+      expect(editor.isDisposed).to.be.true;
 
       widget.node.tabIndex = -1;
       simulate(widget.node, 'focus');
@@ -136,7 +136,7 @@ describe('CodeEditorWrapper', () => {
         MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
         editor.methods = [];
         simulate(editor.editor.getInputField(), 'focus');
-        expect(editor.methods).to.eql(['refresh']);
+        expect(editor.methods).to.deep.equal(['refresh']);
       });
     });
   });
@@ -146,7 +146,7 @@ describe('CodeEditorWrapper', () => {
       Widget.attach(widget, document.body);
       MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
       expect(widget.methods).to.contain('onActivateRequest');
-      expect(widget.editor.hasFocus()).to.be(true);
+      expect(widget.editor.hasFocus()).to.be.true;
     });
   });
 

--- a/tests/test-completer/src/handler.spec.ts
+++ b/tests/test-completer/src/handler.spec.ts
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 
-import { IClientSession } from '@jupyterlab/apputils';
+import { ClientSession, IClientSession } from '@jupyterlab/apputils';
 
 import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
@@ -60,7 +60,7 @@ describe('@jupyterlab/completer', () => {
 
   before(async () => {
     session = await createClientSession();
-    await session.initialize();
+    await (session as ClientSession).initialize();
     connector = new KernelConnector({ session });
   });
 


### PR DESCRIPTION
Fixes #5017 

- Do not cache during uglify on Windows to avoid creating long paths
- Use `dev_mode` by default when building (but ship prod mode files)
- Run the test builds directly, since a failing TS build does not stop the build, cf https://github.com/webpack-contrib/karma-webpack/issues/66.  Fixes the errors that running the builds directly exposed.
- Display the version and app directory when building