### PR TITLE
Allow Extensions to Specify loader overrides

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,6 @@
   },
   "rules": {
     "prettier/prettier": ["error", { "singleQuote": true }],
-    "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
     "no-console": ["error", { "allow": ["warn", "error"] }]
   }

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -147,43 +147,41 @@ module.exports = {
     }
   },
   module: {
-    rules:
-      custom_loaders +
-      [
-        { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-        { test: /\.md$/, use: 'raw-loader' },
-        { test: /\.txt$/, use: 'raw-loader' },
-        {
-          test: /\.js$/,
-          use: ['source-map-loader'],
-          enforce: 'pre',
-          // eslint-disable-next-line no-undef
-          exclude: /node_modules/
-        },
-        { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
-        { test: /\.js.map$/, use: 'file-loader' },
-        {
-          test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=application/font-woff'
-        },
-        {
-          test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=application/font-woff'
-        },
-        {
-          test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=application/octet-stream'
-        },
-        {
-          test: /\.otf(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=application/octet-stream'
-        },
-        { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
-        {
-          test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=image/svg+xml'
-        }
-      ]
+    rules: custom_loaders.concat([
+      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+      { test: /\.md$/, use: 'raw-loader' },
+      { test: /\.txt$/, use: 'raw-loader' },
+      {
+        test: /\.js$/,
+        use: ['source-map-loader'],
+        enforce: 'pre',
+        // eslint-disable-next-line no-undef
+        exclude: /node_modules/
+      },
+      { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
+      { test: /\.js.map$/, use: 'file-loader' },
+      {
+        test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
+        use: 'url-loader?limit=10000&mimetype=application/font-woff'
+      },
+      {
+        test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+        use: 'url-loader?limit=10000&mimetype=application/font-woff'
+      },
+      {
+        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+        use: 'url-loader?limit=10000&mimetype=application/octet-stream'
+      },
+      {
+        test: /\.otf(\?v=\d+\.\d+\.\d+)?$/,
+        use: 'url-loader?limit=10000&mimetype=application/octet-stream'
+      },
+      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+      {
+        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+        use: 'url-loader?limit=10000&mimetype=image/svg+xml'
+      }
+    ])
   },
   watchOptions: {
     ignored: function(localPath) {

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -39,11 +39,6 @@ allExtensions.forEach(function(extension) {
       case 'file':
         use = 'file-loader';
         break;
-      case 'css':
-        use = ['style-loader', 'css-loader'];
-        break;
-      default:
-        break;
     }
     for (var file_path of loaders[loader]) {
       file_path = extData.name + '/' + file_path;

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -46,11 +46,6 @@
   },
   "jupyterlab": {
     "extension": true,
-    "schemaDir": "schema",
-    "loaders": {
-      "file": [
-        "lib/foo"
-      ]
-    }
+    "schemaDir": "schema"
   }
 }

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -48,7 +48,9 @@
     "extension": true,
     "schemaDir": "schema",
     "loaders": {
-      "file": ["lib/foo"]
+      "file": [
+        "lib/foo"
+      ]
     }
   }
 }

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -46,6 +46,9 @@
   },
   "jupyterlab": {
     "extension": true,
-    "schemaDir": "schema"
+    "schemaDir": "schema",
+    "loaders": {
+      "file": ["lib/foo"]
+    }
   }
 }


### PR DESCRIPTION
Fixes #4406.

- Extension authors can declare `jupyterlab: loaders` metadata with `raw`, `file`, and `url` options.
- The specified paths must start with either the extension package name or a dependent package name and can include wildcards.
- We are trying to be as generic as possible for when we potentially switch to using browser module import logic instead of webpack.

cc @gnestor, @SimonBiggs 