### PR TITLE
Add to file menu

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -389,8 +389,8 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.openDirect, {
-    label: () => 'Open from Path',
-    caption: 'Open from path',
+    label: () => 'Open File...',
+    caption: 'Open file',
     isEnabled: () => true,
     execute: () => {
       return getOpenPath(docManager.services.contents).then(path => {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -389,8 +389,8 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.openDirect, {
-    label: () => 'Open File...',
-    caption: 'Open file',
+    label: () => 'Open From Path...',
+    caption: 'Open from path',
     isEnabled: () => true,
     execute: () => {
       return getOpenPath(docManager.services.contents).then(path => {

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -266,7 +266,8 @@ export function createFileMenu(app: JupyterLab, menu: FileMenu): void {
 
   const newViewGroup = [
     { command: 'docmanager:clone' },
-    { command: CommandIDs.createConsole }
+    { command: CommandIDs.createConsole },
+    { command: 'docmanager:open-direct' }
   ];
 
   // Add the close group


### PR DESCRIPTION
fixes #5050 

I wasn't sure if this was the right place in the menu.
![image](https://user-images.githubusercontent.com/2541209/43997356-6523cfd8-9d8d-11e8-803c-f9d0a9dd5ab6.png)


I also am not sure if this will confuse users, who are looking for a dialog that allows for more than just a file path. (i.e. "Why can't I select my file to open?") I wonder if "Open from path" is a more descriptive name. (Users already open files from the Files tab... )

Happy to update whichever way you all decide.