### PR TITLE
Left-align equations in cell outputs.

### DIFF
--- a/packages/mathjax2-extension/src/index.ts
+++ b/packages/mathjax2-extension/src/index.ts
@@ -16,6 +16,8 @@ import { PromiseDelegate } from '@phosphor/coreutils';
 // Stub for window MathJax.
 declare var MathJax: any;
 
+import '../style/index.css';
+
 /**
  * The MathJax latexTypesetter plugin.
  */

--- a/packages/mathjax2-extension/style/index.css
+++ b/packages/mathjax2-extension/style/index.css
@@ -1,0 +1,14 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/* Left-justify the MathJax preview in cell outputs. */
+.jp-OutputArea-output.jp-RenderedLatex .MathJax_Preview .MJXp-display {
+  text-align: left !important;
+}
+
+/* Left-justify the MathJax display equation in cell outputs. */
+.jp-OutputArea-output.jp-RenderedLatex .MathJax_Display {
+  text-align: left !important;
+}

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -140,6 +140,11 @@
   line-height: var(--jp-content-line-height);
 }
 
+/* Left-justify outputs.*/
+.jp-OutputArea-output.jp-RenderedLatex {
+  text-align: left;
+}
+
 /*-----------------------------------------------------------------------------
 | RenderedHTML
 |----------------------------------------------------------------------------*/
@@ -151,10 +156,6 @@
   line-height: var(--jp-content-line-height);
   /* Give a bit more R padding on Markdown text to keep line lengths reasonable */
   padding-right: 20px;
-}
-
-.jp-RenderedHTMLCommon .MathJax_Display {
-  margin: 0;
 }
 
 .jp-RenderedHTMLCommon em {


### PR DESCRIPTION
Fixes #5107. I think this used to be correct in some previous version, but the left-aligning was lost in some refactoring along the line.

Also attempts to clean up a bit of outdated MathJax-related CSS.