### PR TITLE
remove In from prompts in notebook/widget

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2052,7 +2052,7 @@ namespace Private {
               { className: DRAG_IMAGE_CLASS },
               h.span(
                 { className: CELL_DRAG_PROMPT_CLASS },
-                'In [' + promptNumber + ']:'
+                '[' + promptNumber + ']:'
               ),
               h.span({ className: CELL_DRAG_CONTENT_CLASS }, cellContent)
             ),
@@ -2079,7 +2079,7 @@ namespace Private {
               { className: `${DRAG_IMAGE_CLASS} ${SINGLE_DRAG_IMAGE_CLASS}` },
               h.span(
                 { className: CELL_DRAG_PROMPT_CLASS },
-                'In [' + promptNumber + ']:'
+                '[' + promptNumber + ']:'
               ),
               h.span({ className: CELL_DRAG_CONTENT_CLASS }, cellContent)
             )


### PR DESCRIPTION
@ellisonbg We're removing all `In` and `Out` text from cell prompts. I missed one of the prompts in #5097. This PR removes it. 