### PR TITLE
Typo in `jupyter lab paths` output, missing colon.

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -105,7 +105,7 @@ class LabPathApp(JupyterApp):
     def start(self):
         print('Application directory:   %s' % get_app_dir())
         print('User Settings directory: %s' % get_user_settings_dir())
-        print('Workspaces directory %s' % get_workspaces_dir())
+        print('Workspaces directory: %s' % get_workspaces_dir())
 
 
 lab_aliases = dict(aliases)


### PR DESCRIPTION
One character PR.