### PR TITLE
Extensions manager results sections

### DIFF
--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -348,9 +348,16 @@ export class ListModel extends VDomModel {
       this.pagination
     );
     let searchMapPromise = this.translateSearchResult(search);
-    let installedMap = await this.translateInstalled(
-      this.fetchInstalled(refreshInstalled)
-    );
+    let installedMap;
+    try {
+      installedMap = await this.translateInstalled(
+        this.fetchInstalled(refreshInstalled)
+      );
+      this.installedError = null;
+    } catch (reason) {
+      installedMap = {};
+      this.installedError = reason.toString();
+    }
     let searchMap;
     try {
       searchMap = await searchMapPromise;
@@ -604,7 +611,12 @@ export class ListModel extends VDomModel {
   }
 
   /**
-   * Contains an error message if an error occurred when updating the model.
+   * Contains an error message if an error occurred when querying installed extensions.
+   */
+  installedError: string | null = null;
+
+  /**
+   * Contains an error message if an error occurred when searching for extensions.
    */
   searchError: string | null = null;
 

--- a/packages/extensionmanager/style/index.css
+++ b/packages/extensionmanager/style/index.css
@@ -11,10 +11,6 @@
   font-size: var(--jp-ui-font-size1);
 }
 
-.jp-extensionmanager-view > header > .jp-ToolbarButtonComponent {
-  padding: 0px 16px;
-}
-
 .jp-extensionmanager-content {
   overflow: auto;
 }
@@ -38,6 +34,46 @@
   padding: 0;
   min-height: 0;
 }
+
+/*
+  Section headers
+*/
+
+.jp-extensionmanager-view header {
+  display: flex;
+  justify-content: space-between;
+  flex: 0 0 auto;
+  margin: 0px;
+  padding: 8px 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
+  letter-spacing: 1px;
+  font-size: var(--jp-ui-font-size0);
+  line-height: 24px;
+  height: 24px;
+}
+
+
+.jp-extensionmanager-view header > .jp-ToolbarButtonComponent {
+  padding: 0px 4px;
+}
+
+.jp-extensionmanager-view header .jp-extensionmanager-headerText {
+  flex: 1 0 auto;
+  margin: 0px 2px;
+}
+
+.jp-extensionmanager-view header > .jp-ToolbarButtonComponent {
+  border: 1px solid transparent;
+  background-color: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
+}
+
+.jp-extensionmanager-view header > .jp-ToolbarButtonComponent:hover {
+  border: 1px solid var(--jp-brand-color1);
+}
+
 
 /*
   Error messages
@@ -120,30 +156,6 @@
   justify-content: center;
 }
 
-.jp-extensionmanager-view header {
-  display: flex;
-  justify-content: space-between;
-  flex: 0 0 auto;
-  margin: 0px;
-  padding: 8px 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
-  letter-spacing: 1px;
-  font-size: var(--jp-ui-font-size0);
-  line-height: 24px;
-  height: 24px;
-}
-
-.jp-extensionmanager-view header button.jp-extensionmanager-refresh {
-  border: 1px solid transparent;
-  background-color: var(--jp-layout-color1);
-  color: var(--jp-ui-font-color1);
-}
-
-.jp-extensionmanager-view header button.jp-extensionmanager-refresh:hover {
-  border: 1px solid var(--jp-brand-color1);
-}
 
 /*
   Entry buttons visibility
@@ -274,6 +286,7 @@
   width: 100%;
   position: relative;
   overflow: hidden;
+  flex: 0 0 auto;
   background-color: var(--jp-layout-color1);
 }
 
@@ -391,4 +404,13 @@ input[type='checkbox'] {
   font-size: var(--jp-ui-font-size1);
   font-weight: 600;
   color: var(--jp-ui-font-color0);
+}
+
+
+.jp-extensionmanager-collapseIcon {
+  background-image: var(--jp-image-caretright);
+}
+
+.jp-extensionmanager-expandIcon {
+  background-image: var(--jp-image-caretdown);
 }

--- a/packages/extensionmanager/style/index.css
+++ b/packages/extensionmanager/style/index.css
@@ -54,7 +54,6 @@
   height: 24px;
 }
 
-
 .jp-extensionmanager-view header > .jp-ToolbarButtonComponent {
   padding: 0px 4px;
 }
@@ -73,7 +72,6 @@
 .jp-extensionmanager-view header > .jp-ToolbarButtonComponent:hover {
   border: 1px solid var(--jp-brand-color1);
 }
-
 
 /*
   Error messages
@@ -155,7 +153,6 @@
   display: flex;
   justify-content: center;
 }
-
 
 /*
   Entry buttons visibility
@@ -405,7 +402,6 @@ input[type='checkbox'] {
   font-weight: 600;
   color: var(--jp-ui-font-color0);
 }
-
 
 .jp-extensionmanager-collapseIcon {
   background-image: var(--jp-image-caretright);

--- a/packages/extensionmanager/tsconfig.json
+++ b/packages/extensionmanager/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "outDir": "./lib",
-    "jsx": "react",
-    "strictNullChecks": true
+    "jsx": "react"
   },
   "include": ["src/*"]
 }

--- a/packages/extensionmanager/tsconfig.json
+++ b/packages/extensionmanager/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "outDir": "./lib",
-    "jsx": "react"
+    "jsx": "react",
+    "strictNullChecks": true
   },
   "include": ["src/*"]
 }


### PR DESCRIPTION
- Fixes error handling during install (the await had gotten outside a try/catch block).
- Split extension view into two lists: One section for installed extensions, one for discovery (search results). To lessen registry hits, discovery is initially collapsed, and is not populated until expanded.

Closes #5042. Addresses discussion in #5055.