### PR TITLE
Catch `copytree` error on NFS drives (#4738).

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -875,7 +875,15 @@ class _AppHandler(object):
         templates = pjoin(staging, 'templates')
         if osp.exists(templates):
             shutil.rmtree(templates)
-        shutil.copytree(pjoin(HERE, 'staging', 'templates'), templates)
+
+        try:
+            shutil.copytree(pjoin(HERE, 'staging', 'templates'), templates)
+        except shutil.Error as error:
+            # `copytree` throws an error if copying to + from NFS even though
+            # the copy is successful (see https://bugs.python.org/issue24564)
+
+            if '[Errno 22]' not in str(error) or not osp.exists(templates):
+                raise
 
         # Ensure a clean linked packages directory.
         linked_dir = pjoin(staging, 'linked_packages')


### PR DESCRIPTION
During build, `shutil.copytree` can throw an error when copying over the template directories even if the copy was successful. This only occurs when copying to + from an NFS drive (see https://bugs.python.org/issue24564). If this specific error is thrown (identified by "Errno 22" in the error string and a new templates directory having been generated), we catch it.