### PR TITLE
Assign keyboard shortcut C-S-Enter to notebook:run-in-console

### DIFF
--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -791,6 +791,17 @@
       },
       "type": "object"
     },
+    "notebook:run-in-console": {
+      "default": {},
+      "properties": {
+        "command": { "default": "notebook:run-in-console" },
+        "keys": { "default": ["Ctrl Shift Enter"] },
+        "selector": { "default": ".jp-Notebook.jp-mod-editMode" },
+        "title": { "default": "Run In Console" },
+        "category": { "default": "Notebook Cell Operations" }
+      },
+      "type": "object"
+    },
     "notebook:run-cell-and-select-next": {
       "default": {},
       "properties": {

--- a/packages/shortcuts-extension/schema/plugin.json
+++ b/packages/shortcuts-extension/schema/plugin.json
@@ -795,7 +795,7 @@
       "default": {},
       "properties": {
         "command": { "default": "notebook:run-in-console" },
-        "keys": { "default": ["Ctrl Shift Enter"] },
+        "keys": { "default": [""] },
         "selector": { "default": ".jp-Notebook.jp-mod-editMode" },
         "title": { "default": "Run In Console" },
         "category": { "default": "Notebook Cell Operations" }


### PR DESCRIPTION
`notebook:run-in-console` has been tested for a while and we have at least one user who [confirmed the usefulness and asked how to enable a shortcut](https://github.com/jupyterlab/jupyterlab/pull/4330#issuecomment-409892805). I am wondering if a default shortcut `C-S-Enter` could be assigned to this action now, mostly because this action and associated shortcut `C-S-Enter` has been used by [the SoS jupyter extension](https://vatlab.github.io) for a while. I am presenting SoS next week at JupyterCon, and the worst could happen is that JLab later assigns another shortcut to this action and I have to change the shortcut for SoS for classic Jupyter for consistency. 

As I have discussed in [another thread](https://github.com/jupyterlab/jupyterlab/pull/4558#issuecomment-409272224), `notebook:run-in-console` deserves a keyboard shortcut because it tends to be used repeatedly to step through cell content. I chose this shortcut because it is in line with `C-Enter` and `S-Enter` and because users tend to use this shortcut to step through a cell for debugging, and then use`C-Enter` or `S-Enter` to actually execute the cell. The finger switch between `C-S-Enter` and `C-Enter` or `S-Enter` is very natural.