### PR TITLE
Enhance extension errors without network traffic

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1071,7 +1071,7 @@ class _AppHandler(object):
             # homepage, repository  are optional
             if 'homepage' in data:
                 url = data['homepage']
-            elif 'repository' in data:
+            elif 'repository' in data and isinstance(data['repository'], dict):
                 url = data['repository'].get('url', '')
             else:
                 url = ''


### PR DESCRIPTION
While the errors in #5174 were helpful, the added network error slows down the process. Also, it did not change the errors for `jupyter labextension list`. This PR replaces the changes of #5174 with the following behavior:
 - For any outdated extension (all singleton deps are older than current lab versions), it prints `[LabBuildApp] WARNING | The extension "<ext name>" is outdated.`
 - For any othe type of incompatibility, it prints the compatibility table as previous to #5147.

Additionally, for `jupyter labextension list`, it now reports all the incompatibilities after the extension list:
```
> jupyter labextension list
JupyterLab v0.34.1
Known labextensions:
   app dir: c:\miniconda3\share\jupyter\lab
        @jupyter-widgets/jupyterlab-manager v0.37.2 enabled  
        @jupyterlab/github v0.7.2 enabled   X
        jupyter-threejs v1.1.0 enabled  ok*
        jupyterlab-kernelspy v0.1.3 enabled   X
        jupyterlab-toc v0.2.1 enabled   X

   The following extension are outdated:
        @jupyterlab/github
        jupyterlab-kernelspy
        jupyterlab-toc

   Consider running "jupyter labextension update --all" to check for updates.

   < any non-outdated incompatibilities will be printed here with full table >

   local extensions:
        ...
```

Fixes #5187.