### PR TITLE
Open file in separate panel on clicking "New View for File"

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -616,7 +616,8 @@ function addCommands(
       }
       return commands.execute('docmanager:open', {
         path,
-        factory: MARKDOWN_FACTORY
+        factory: MARKDOWN_FACTORY,
+        options: args['options']
       });
     }
   });

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -564,8 +564,9 @@ function addCommands(
     isEnabled,
     execute: args => {
       const widget = contextMenuWidget();
-      const options =
-        (args['options'] as DocumentRegistry.IOpenOptions) || void 0;
+      const options = (args['options'] as DocumentRegistry.IOpenOptions) || {
+        mode: 'split-right'
+      };
       if (!widget) {
         return;
       }

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -407,7 +407,12 @@ function activate(
         return;
       }
       let path = widget.context.path;
-      return commands.execute('markdownviewer:open', { path });
+      return commands.execute('markdownviewer:open', {
+        path,
+        options: {
+          mode: 'split-right'
+        }
+      });
     },
     isVisible: () => {
       let widget = tracker.currentWidget;


### PR DESCRIPTION
@jasongrout @ivanov @ian-r-rose This sets the open mode to 'split-right' for the 'New View for <file>' command. Closes #4256. Please let me know if there's a different way this should be done. Thank you!