### PR TITLE
adding nbconvert to services and using to load exporter list from nbconvert

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -334,16 +334,16 @@ function activateCellTools(
         }
       });
       const nbConvert = CellTools.createNBConvertSelector(optionsMap);
-      celltools.title.iconClass = 'jp-BuildIcon jp-SideBar-tabIcon';
-      celltools.title.caption = 'Cell Inspector';
-      celltools.id = id;
-      celltools.addItem({ tool: activeCellTool, rank: 1 });
-      celltools.addItem({ tool: slideShow, rank: 2 });
       celltools.addItem({ tool: nbConvert, rank: 3 });
-      celltools.addItem({ tool: metadataEditor, rank: 4 });
-      MessageLoop.installMessageHook(celltools, hook);
     }
   });
+  celltools.title.iconClass = 'jp-BuildIcon jp-SideBar-tabIcon';
+  celltools.title.caption = 'Cell Inspector';
+  celltools.id = id;
+  celltools.addItem({ tool: activeCellTool, rank: 1 });
+  celltools.addItem({ tool: slideShow, rank: 2 });
+  celltools.addItem({ tool: metadataEditor, rank: 4 });
+  MessageLoop.installMessageHook(celltools, hook);
 
   // Wait until the application has finished restoring before rendering.
   Promise.all([state.fetch(id), app.restored]).then(([args]) => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1613,7 +1613,6 @@ function populatePalette(
   services.nbconvert.getExportFormats().then(response => {
     if (response.exportList) {
       // convert exportList to palette items
-      console.error(response.exportList);
       const formatList = Object.keys(response.exportList);
       formatList.forEach(function(key) {
         let labelStr = FORMAT_LABEL[key] ? FORMAT_LABEL[key] : key;
@@ -1758,7 +1757,6 @@ function populateMenus(
   services.nbconvert.getExportFormats().then(response => {
     if (response.exportList) {
       // convert exportList to palette items
-      console.error(response.exportList);
       const formatList = Object.keys(response.exportList);
       formatList.forEach(function(key) {
         let labelStr = FORMAT_LABEL[key] ? FORMAT_LABEL[key] : key;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1611,9 +1611,9 @@ function populatePalette(
   });
 
   services.nbconvert.getExportFormats().then(response => {
-    if (response.exportList) {
+    if (response) {
       // convert exportList to palette items
-      const formatList = Object.keys(response.exportList);
+      const formatList = Object.keys(response);
       formatList.forEach(function(key) {
         let labelStr = FORMAT_LABEL[key] ? FORMAT_LABEL[key] : key;
         let args = {
@@ -1755,9 +1755,9 @@ function populateMenus(
   let exportTo = new Menu({ commands });
   exportTo.title.label = 'Export Notebook As…';
   services.nbconvert.getExportFormats().then(response => {
-    if (response.exportList) {
+    if (response) {
       // convert exportList to palette items
-      const formatList = Object.keys(response.exportList);
+      const formatList = Object.keys(response);
       formatList.forEach(function(key) {
         let labelStr = FORMAT_LABEL[key] ? FORMAT_LABEL[key] : key;
         let args = {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -393,7 +393,7 @@ function activateNotebookHandler(
   registry.addWidgetFactory(factory);
 
   addCommands(app, services, tracker);
-  populatePalette(palette);
+  populatePalette(palette, services);
 
   let id = 0; // The ID counter for notebook panels.
 
@@ -1569,7 +1569,10 @@ function addCommands(
 /**
  * Populate the application's command palette with notebook commands.
  */
-function populatePalette(palette: ICommandPalette): void {
+function populatePalette(
+  palette: ICommandPalette,
+  services: ServiceManager
+): void {
   let category = 'Notebook Operations';
   [
     CommandIDs.interrupt,
@@ -1601,6 +1604,14 @@ function populatePalette(palette: ICommandPalette): void {
     args: { isPalette: true }
   });
 
+  services.nbconvert.getExportFormats().then(response => {
+    console.log('dumping exportlistformat');
+    console.log(response); // TODO - remove this dump
+    if (response.exportList) {
+      // convert exportList to palette items
+      console.log(response.exportList);
+    }
+  });
   EXPORT_TO_FORMATS.forEach(exportToFormat => {
     let args = {
       format: exportToFormat['format'],

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -300,7 +300,6 @@ function activateCellTools(
   const celltools = new CellTools({ tracker });
   const activeCellTool = new CellTools.ActiveCellTool();
   const slideShow = CellTools.createSlideShowSelector();
-  // const nbConvert = CellTools.createNBConvertSelector();
   const editorFactory = editorServices.factoryService.newInlineEditor;
   const metadataEditor = new CellTools.MetadataEditorTool({ editorFactory });
   const services = app.serviceManager;

--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -662,14 +662,6 @@ export namespace CellTools {
       key: 'raw_mimetype',
       title: 'Raw NBConvert Format',
       optionsMap: optionsMap,
-      // optionsMap: {
-      //   None: '-',
-      //   LaTeX: 'text/latex',
-      //   reST: 'text/restructuredtext',
-      //   HTML: 'text/html',
-      //   Markdown: 'text/markdown',
-      //   Python: 'text/x-python'
-      // },
       validCellTypes: ['raw']
     });
   }

--- a/packages/notebook/src/celltools.ts
+++ b/packages/notebook/src/celltools.ts
@@ -655,18 +655,21 @@ export namespace CellTools {
   /**
    * Create an nbcovert selector.
    */
-  export function createNBConvertSelector(): KeySelector {
+  export function createNBConvertSelector(optionsMap: {
+    [key: string]: JSONValue;
+  }): KeySelector {
     return new KeySelector({
       key: 'raw_mimetype',
       title: 'Raw NBConvert Format',
-      optionsMap: {
-        None: '-',
-        LaTeX: 'text/latex',
-        reST: 'text/restructuredtext',
-        HTML: 'text/html',
-        Markdown: 'text/markdown',
-        Python: 'text/x-python'
-      },
+      optionsMap: optionsMap,
+      // optionsMap: {
+      //   None: '-',
+      //   LaTeX: 'text/latex',
+      //   reST: 'text/restructuredtext',
+      //   HTML: 'text/html',
+      //   Markdown: 'text/markdown',
+      //   Python: 'text/x-python'
+      // },
       validCellTypes: ['raw']
     });
   }

--- a/packages/services/src/builder/index.ts
+++ b/packages/services/src/builder/index.ts
@@ -11,7 +11,7 @@ import { ServerConnection } from '../serverconnection';
 const BUILD_SETTINGS_URL = 'lab/api/build';
 
 /**
- * The static namespace for `BuildManager`.
+ * The build API service manager.
  */
 export class BuildManager {
   /**

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -10,5 +10,6 @@ export * from './session';
 export * from './setting';
 export * from './terminal';
 export * from './workspace';
+export * from './nbconvert';
 
 export { Builder } from './builder';

--- a/packages/services/src/manager.ts
+++ b/packages/services/src/manager.ts
@@ -7,6 +7,8 @@ import { ISignal, Signal } from '@phosphor/signaling';
 
 import { Builder, BuildManager } from './builder';
 
+import { Nbconvert, NbconvertManager } from './nbconvert';
+
 import { Contents, ContentsManager } from './contents';
 
 import { Kernel } from './kernel';
@@ -38,6 +40,7 @@ export class ServiceManager implements ServiceManager.IManager {
     this.terminals = new TerminalManager(options);
     this.builder = new BuildManager(options);
     this.workspaces = new WorkspaceManager(options);
+    this.nbconvert = new NbconvertManager(options);
 
     this.sessions.specsChanged.connect((sender, specs) => {
       this._specsChanged.emit(specs);
@@ -125,6 +128,11 @@ export class ServiceManager implements ServiceManager.IManager {
   readonly workspaces: WorkspaceManager;
 
   /**
+   * Get the nbconvert manager instance.
+   */
+  readonly nbconvert: NbconvertManager;
+
+  /**
    * Test whether the manager is ready.
    */
   get isReady(): boolean {
@@ -206,6 +214,11 @@ export namespace ServiceManager {
      * The workspace manager for the manager.
      */
     readonly workspaces: Workspace.IManager;
+
+    /**
+     * The nbconvert manager for the manager.
+     */
+    readonly nbconvert: Nbconvert.IManager;
   }
 
   /**

--- a/packages/services/src/manager.ts
+++ b/packages/services/src/manager.ts
@@ -7,7 +7,7 @@ import { ISignal, Signal } from '@phosphor/signaling';
 
 import { Builder, BuildManager } from './builder';
 
-import { Nbconvert, NbconvertManager } from './nbconvert';
+import { NbConvert, NbConvertManager } from './nbconvert';
 
 import { Contents, ContentsManager } from './contents';
 
@@ -40,7 +40,7 @@ export class ServiceManager implements ServiceManager.IManager {
     this.terminals = new TerminalManager(options);
     this.builder = new BuildManager(options);
     this.workspaces = new WorkspaceManager(options);
-    this.nbconvert = new NbconvertManager(options);
+    this.nbconvert = new NbConvertManager(options);
 
     this.sessions.specsChanged.connect((sender, specs) => {
       this._specsChanged.emit(specs);
@@ -130,7 +130,7 @@ export class ServiceManager implements ServiceManager.IManager {
   /**
    * Get the nbconvert manager instance.
    */
-  readonly nbconvert: NbconvertManager;
+  readonly nbconvert: NbConvertManager;
 
   /**
    * Test whether the manager is ready.
@@ -218,7 +218,7 @@ export namespace ServiceManager {
     /**
      * The nbconvert manager for the manager.
      */
-    readonly nbconvert: Nbconvert.IManager;
+    readonly nbconvert: NbConvert.IManager;
   }
 
   /**

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -11,13 +11,13 @@ import { ServerConnection } from '../serverconnection';
 const NBCONVERT_SETTINGS_URL = 'api/nbconvert';
 
 /**
- * The static namespace for `NbconvertManager`.
+ * The nbconvert API service manager.
  */
-export class NbconvertManager {
+export class NbConvertManager {
   /**
    * Create a new nbconvert manager.
    */
-  constructor(options: NbconvertManager.IOptions = {}) {
+  constructor(options: NbConvertManager.IOptions = {}) {
     this.serverSettings =
       options.serverSettings || ServerConnection.makeSettings();
   }
@@ -30,7 +30,7 @@ export class NbconvertManager {
   /**
    * Get whether the application should be built.
    */
-  getExportFormats(): Promise<NbconvertManager.IExportFormats> {
+  getExportFormats(): Promise<NbConvertManager.IExportFormats> {
     const base = this.serverSettings.baseUrl;
     const url = URLExt.join(base, NBCONVERT_SETTINGS_URL);
     const { serverSettings } = this;
@@ -45,71 +45,15 @@ export class NbconvertManager {
         return response.json();
       })
       .then(data => {
-        /* TODO: should we add a type check here?
-            or just return the export list object unmodified:
-         {
-            "custom": {
-              "output_mimetype": ""
-            },
-            "html": {
-              "output_mimetype": "text/html"
-            },
-            "slides": {
-              "output_mimetype": "text/html"
-           },
-
-            ...
-          }
-       */
-        return { exportList: data };
+        return data;
       });
-  }
-
-  /**
-   * Build the application.
-   */
-  build(): Promise<void> {
-    const base = this.serverSettings.baseUrl;
-    const url = URLExt.join(base, NBCONVERT_SETTINGS_URL);
-    const { serverSettings } = this;
-    const init = { method: 'POST' };
-    const promise = ServerConnection.makeRequest(url, init, serverSettings);
-
-    return promise.then(response => {
-      if (response.status === 400) {
-        throw new ServerConnection.ResponseError(response, 'Build aborted');
-      }
-      if (response.status !== 200) {
-        let message = `Build failed with ${
-          response.status
-        }, please run 'jupyter lab build' on the server for full output`;
-        throw new ServerConnection.ResponseError(response, message);
-      }
-    });
-  }
-
-  /**
-   * Cancel an active build.
-   */
-  cancel(): Promise<void> {
-    const base = this.serverSettings.baseUrl;
-    const url = URLExt.join(base, NBCONVERT_SETTINGS_URL);
-    const { serverSettings } = this;
-    const init = { method: 'DELETE' };
-    const promise = ServerConnection.makeRequest(url, init, serverSettings);
-
-    return promise.then(response => {
-      if (response.status !== 204) {
-        throw new ServerConnection.ResponseError(response);
-      }
-    });
   }
 }
 
 /**
  * A namespace for `BuildManager` statics.
  */
-export namespace NbconvertManager {
+export namespace NbConvertManager {
   /**
    * The instantiation options for a setting manager.
    */
@@ -121,7 +65,7 @@ export namespace NbconvertManager {
   }
 
   /**
-   * The build status response from the server.
+   * A namespace for nbconvert API interfaces.
    */
   export interface IExportFormats {
     /**
@@ -129,16 +73,16 @@ export namespace NbconvertManager {
      */
     // TODO: should this stay a string, or a typed object
     // that includes an 'output_mimetype' string?
-    readonly exportList: string;
+    [key: string]: { output_mimetype: string };
   }
 }
 
 /**
  * A namespace for builder API interfaces.
  */
-export namespace Nbconvert {
+export namespace NbConvert {
   /**
    * The interface for the build manager.
    */
-  export interface IManager extends NbconvertManager {}
+  export interface IManager extends NbConvertManager {}
 }

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -8,7 +8,7 @@ import { ServerConnection } from '../serverconnection';
 /**
  * The url for the lab nbconvert service.
  */
-const NBCONVERT_SETTINGS_URL = 'lab/api/nbconvert';
+const NBCONVERT_SETTINGS_URL = 'api/nbconvert';
 
 /**
  * The static namespace for `NbconvertManager`.
@@ -45,12 +45,22 @@ export class NbconvertManager {
         return response.json();
       })
       .then(data => {
-        // if (typeof data.status !== 'string') {
-        //   throw new Error('Invalid data');
-        // }
-        // if (typeof data.message !== 'string') {
-        //   throw new Error('Invalid data');
-        // }
+        /* TODO: should we add a type check here?
+            or just return the export list object unmodified:
+         {
+            "custom": {
+              "output_mimetype": ""
+            },
+            "html": {
+              "output_mimetype": "text/html"
+            },
+            "slides": {
+              "output_mimetype": "text/html"
+           },
+
+            ...
+          }
+       */
         return { exportList: data };
       });
   }
@@ -117,6 +127,8 @@ export namespace NbconvertManager {
     /**
      * The list of supported export formats.
      */
+    // TODO: should this stay a string, or a typed object
+    // that includes an 'output_mimetype' string?
     readonly exportList: string;
   }
 }

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -1,0 +1,132 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+
+import { ServerConnection } from '../serverconnection';
+
+/**
+ * The url for the lab nbconvert service.
+ */
+const NBCONVERT_SETTINGS_URL = 'lab/api/nbconvert';
+
+/**
+ * The static namespace for `NbconvertManager`.
+ */
+export class NbconvertManager {
+  /**
+   * Create a new nbconvert manager.
+   */
+  constructor(options: NbconvertManager.IOptions = {}) {
+    this.serverSettings =
+      options.serverSettings || ServerConnection.makeSettings();
+  }
+
+  /**
+   * The server settings used to make API requests.
+   */
+  readonly serverSettings: ServerConnection.ISettings;
+
+  /**
+   * Get whether the application should be built.
+   */
+  getExportFormats(): Promise<NbconvertManager.IExportFormats> {
+    const base = this.serverSettings.baseUrl;
+    const url = URLExt.join(base, NBCONVERT_SETTINGS_URL);
+    const { serverSettings } = this;
+    const promise = ServerConnection.makeRequest(url, {}, serverSettings);
+
+    return promise
+      .then(response => {
+        if (response.status !== 200) {
+          throw new ServerConnection.ResponseError(response);
+        }
+
+        return response.json();
+      })
+      .then(data => {
+        if (typeof data.status !== 'string') {
+          throw new Error('Invalid data');
+        }
+        if (typeof data.message !== 'string') {
+          throw new Error('Invalid data');
+        }
+        return data;
+      });
+  }
+
+  /**
+   * Build the application.
+   */
+  build(): Promise<void> {
+    const base = this.serverSettings.baseUrl;
+    const url = URLExt.join(base, NBCONVERT_SETTINGS_URL);
+    const { serverSettings } = this;
+    const init = { method: 'POST' };
+    const promise = ServerConnection.makeRequest(url, init, serverSettings);
+
+    return promise.then(response => {
+      if (response.status === 400) {
+        throw new ServerConnection.ResponseError(response, 'Build aborted');
+      }
+      if (response.status !== 200) {
+        let message = `Build failed with ${
+          response.status
+        }, please run 'jupyter lab build' on the server for full output`;
+        throw new ServerConnection.ResponseError(response, message);
+      }
+    });
+  }
+
+  /**
+   * Cancel an active build.
+   */
+  cancel(): Promise<void> {
+    const base = this.serverSettings.baseUrl;
+    const url = URLExt.join(base, NBCONVERT_SETTINGS_URL);
+    const { serverSettings } = this;
+    const init = { method: 'DELETE' };
+    const promise = ServerConnection.makeRequest(url, init, serverSettings);
+
+    return promise.then(response => {
+      if (response.status !== 204) {
+        throw new ServerConnection.ResponseError(response);
+      }
+    });
+  }
+}
+
+/**
+ * A namespace for `BuildManager` statics.
+ */
+export namespace NbconvertManager {
+  /**
+   * The instantiation options for a setting manager.
+   */
+  export interface IOptions {
+    /**
+     * The server settings used to make API requests.
+     */
+    serverSettings?: ServerConnection.ISettings;
+  }
+
+  /**
+   * The build status response from the server.
+   */
+  export interface IExportFormats {
+    /**
+     * The list of supported export formats. TODO: pre-process this in getExportFormats?
+     */
+    readonly exportList: string;
+  }
+}
+
+/**
+ * A namespace for builder API interfaces.
+ */
+export namespace Nbconvert {
+  /**
+   * The interface for the build manager.
+   */
+  export interface IManager extends NbconvertManager {}
+}

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -77,8 +77,6 @@ export namespace NbConvertManager {
     /**
      * The list of supported export formats.
      */
-    // TODO: should this stay a string, or a typed object
-    // that includes an 'output_mimetype' string?
     [key: string]: { output_mimetype: string };
   }
 }

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -45,7 +45,13 @@ export class NbConvertManager {
         return response.json();
       })
       .then(data => {
-        return data;
+        let exportList: NbConvertManager.IExportFormats = {};
+        let keys = Object.keys(data);
+        keys.forEach(function(key) {
+          let mimeType: string = data[key].output_mimetype;
+          exportList[key] = { output_mimetype: mimeType };
+        });
+        return exportList;
       });
   }
 }

--- a/packages/services/src/nbconvert/index.ts
+++ b/packages/services/src/nbconvert/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { URLExt } from '@jupyterlab/coreutils';
 
 import { ServerConnection } from '../serverconnection';
 
@@ -45,13 +45,13 @@ export class NbconvertManager {
         return response.json();
       })
       .then(data => {
-        if (typeof data.status !== 'string') {
-          throw new Error('Invalid data');
-        }
-        if (typeof data.message !== 'string') {
-          throw new Error('Invalid data');
-        }
-        return data;
+        // if (typeof data.status !== 'string') {
+        //   throw new Error('Invalid data');
+        // }
+        // if (typeof data.message !== 'string') {
+        //   throw new Error('Invalid data');
+        // }
+        return { exportList: data };
       });
   }
 
@@ -115,7 +115,7 @@ export namespace NbconvertManager {
    */
   export interface IExportFormats {
     /**
-     * The list of supported export formats. TODO: pre-process this in getExportFormats?
+     * The list of supported export formats.
      */
     readonly exportList: string;
   }

--- a/tests/test-notebook/src/celltools.spec.ts
+++ b/tests/test-notebook/src/celltools.spec.ts
@@ -7,6 +7,8 @@ import { Message } from '@phosphor/messaging';
 
 import { TabPanel, Widget } from '@phosphor/widgets';
 
+import { JSONValue } from '@phosphor/coreutils';
+
 import { simulate } from 'simulate-event';
 
 import { CodeMirrorEditorFactory } from '@jupyterlab/codemirror';
@@ -413,7 +415,16 @@ describe('@jupyterlab/notebook', () => {
 
     describe('CellTools.createNBConvertSelector()', () => {
       it('should create a raw mimetype selector', () => {
-        const tool = CellTools.createNBConvertSelector();
+        let optionsMap: { [key: string]: JSONValue } = {
+          None: '-',
+          LaTeX: 'text/latex',
+          reST: 'text/restructuredtext',
+          HTML: 'text/html',
+          Markdown: 'text/markdown',
+          Python: 'text/x-python'
+        };
+        optionsMap.None = '-';
+        const tool = CellTools.createNBConvertSelector(optionsMap);
         tool.selectNode.selectedIndex = -1;
         celltools.addItem({ tool });
         simulate(panel0.node, 'focus');
@@ -433,7 +444,15 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should have no effect on a code cell', () => {
-        const tool = CellTools.createNBConvertSelector();
+        let optionsMap: { [key: string]: JSONValue } = {
+          None: '-',
+          LaTeX: 'text/latex',
+          reST: 'text/restructuredtext',
+          HTML: 'text/html',
+          Markdown: 'text/markdown',
+          Python: 'text/x-python'
+        };
+        const tool = CellTools.createNBConvertSelector(optionsMap);
         tool.selectNode.selectedIndex = -1;
         celltools.addItem({ tool });
         simulate(panel0.node, 'focus');


### PR DESCRIPTION
first pass at changes for https://github.com/jupyterlab/jupyterlab/issues/5015
I've added nbconvert to services, and hooked this up in notebook-extensions to start (going to making/testing equivalent change in the [cell inspector](https://github.com/jupyterlab/jupyterlab/blob/e33fcb9238230696e782c6d734888a71fac09d02/packages/notebook/src/celltools.ts#L658) (for setting the drop down items in the 'Raw NBConvert Format' combo box)

a couple of things that need polishing during this review: 
- should I add any type checking or formatting in NbconvertManager's getExportFormats? Right now, I'm just passing through the object that the api/nbonvert root endpoint returns. 
- I'm leaving in an object to map the exporter key/name to the label that shows up in the command/menu item (wasn't sure if that should live in a more shared utility or in the nbconvert services logic?)
- I've added a 'black list' of sorts to the notebook-extension logic to prevent notebook/python/custom from showing up as export options, not sure if that's the cleanest way to filter out these options. For reference, this is the current default exporter list that gets returned by the endpoint:

{
  "custom": {
    "output_mimetype": ""
  },
  "html": {
    "output_mimetype": "text/html"
  },
  "slides": {
    "output_mimetype": "text/html"
  },
  "latex": {
    "output_mimetype": "text/latex"
  },
  "pdf": {
    "output_mimetype": "text/latex"
  },
  "markdown": {
    "output_mimetype": "text/markdown"
  },
  "python": {
    "output_mimetype": "text/x-python"
  },
  "rst": {
    "output_mimetype": "text/restructuredtext"
  },
  "notebook": {
    "output_mimetype": "application/json"
  },
  "script": {
    "output_mimetype": ""
  }
}