### PR TITLE
Add exit entry to File menu

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -198,6 +198,13 @@ class LabApp(NotebookApp):
     watch = Bool(False, config=True,
         help="Whether to serve the app in watch mode")
 
+    def init_webapp(self, *args, **kwargs):
+        super().init_webapp(*args, **kwargs)
+        settings = self.web_app.settings
+        if 'page_config_data' not in settings:
+            settings['page_config_data'] = {}
+        settings['page_config_data']['quit_button'] = self.quit_button
+
     def init_server_extensions(self):
         """Load any extensions specified by config.
 

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -30,7 +30,9 @@
   "dependencies": {
     "@jupyterlab/application": "^0.18.4",
     "@jupyterlab/apputils": "^0.18.4",
+    "@jupyterlab/coreutils": "^2.1.3",
     "@jupyterlab/mainmenu": "^0.7.4",
+    "@jupyterlab/services": "^3.1.3",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/widgets": "^1.6.0"

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -30,9 +30,9 @@
   "dependencies": {
     "@jupyterlab/application": "^0.18.4",
     "@jupyterlab/apputils": "^0.18.4",
-    "@jupyterlab/coreutils": "^2.1.3",
+    "@jupyterlab/coreutils": "^2.1.4",
     "@jupyterlab/mainmenu": "^0.7.4",
-    "@jupyterlab/services": "^3.1.3",
+    "@jupyterlab/services": "^3.1.4",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/widgets": "^1.6.0"

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -53,7 +53,7 @@ export namespace CommandIDs {
 
   export const createConsole = 'filemenu:create-console';
 
-  export const quit = 'filemenu:exit';
+  export const quit = 'filemenu:quit';
 
   export const interruptKernel = 'kernelmenu:interrupt';
 
@@ -268,13 +268,13 @@ export function createFileMenu(app: JupyterLab, menu: FileMenu): void {
   });
 
   commands.addCommand(CommandIDs.quit, {
-    label: 'Exit',
-    caption: 'Exit JupyterLab',
+    label: 'Quit',
+    caption: 'Quit JupyterLab',
     execute: () => {
       showDialog({
-        title: 'Exit confirmation',
+        title: 'Quit confirmation',
         body: 'Please confirm you want to quit JupyterLab.',
-        buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Exit' })]
+        buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Quit' })]
       }).then(result => {
         if (result.button.accept) {
           let setting = ServerConnection.makeSettings();
@@ -345,7 +345,7 @@ export function createFileMenu(app: JupyterLab, menu: FileMenu): void {
   });
 
   // Add the quit group.
-  const quitGroup = [{ command: 'filemenu:exit' }];
+  const quitGroup = [{ command: 'filemenu:quit' }];
 
   menu.addGroup(newGroup, 0);
   menu.addGroup(newViewGroup, 1);

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -112,6 +112,13 @@ const menuPlugin: JupyterLabPlugin<IMainMenu> = {
     createViewMenu(app, menu.viewMenu);
     createTabsMenu(app, menu.tabsMenu);
 
+    if (menu.fileMenu.quitEntry) {
+      palette.addItem({
+        command: CommandIDs.quit,
+        category: 'Main Area'
+      });
+    }
+
     palette.addItem({
       command: CommandIDs.shutdownAllKernels,
       category: 'Kernel Operations'

--- a/packages/mainmenu/src/file.ts
+++ b/packages/mainmenu/src/file.ts
@@ -10,6 +10,11 @@ import { IJupyterLabMenu, IMenuExtender, JupyterLabMenu } from './labmenu';
  */
 export interface IFileMenu extends IJupyterLabMenu {
   /**
+   * Option to add a `Quit` entry in the File menu
+   */
+  quitEntry: boolean;
+
+  /**
    * A submenu for creating new files/launching new activities.
    */
   readonly newMenu: IJupyterLabMenu;
@@ -38,6 +43,8 @@ export class FileMenu extends JupyterLabMenu implements IFileMenu {
     super(options);
 
     this.menu.title.label = 'File';
+
+    this.quitEntry = false;
 
     // Create the "New" submenu.
     this.newMenu = new JupyterLabMenu(options, false);
@@ -75,6 +82,11 @@ export class FileMenu extends JupyterLabMenu implements IFileMenu {
     this.consoleCreators.clear();
     super.dispose();
   }
+
+  /**
+   * Option to add a `Quit` entry in File menu
+   */
+  public quitEntry: boolean;
 }
 
 /**


### PR DESCRIPTION
Fix for #4647 

Introduction of a *Exit* entry in the *File* menu. The entry can be removed through the *LabApp.quit_button* configuration option introduced by the notebook server.

Questions:
- I named the entry *Exit* as it seems more used than *Quit* in desktop applications. Should I keep *Quit* for consistency with the classical notebook?
- Should the new command be added to the palette?
- I like to add unit test for this. Could somebody point me to some resources to test the presence of the entry depending on the configuration option?