### PR TITLE
Makes matplotlib figs with dark text legible in the dark theme (and related fixes)

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -161,7 +161,15 @@ export function renderImage(
   options: renderImage.IRenderOptions
 ): Promise<void> {
   // Unpack the options.
-  let { host, mimeType, source, width, height, unconfined } = options;
+  let {
+    host,
+    mimeType,
+    source,
+    width,
+    height,
+    needsBackground,
+    unconfined
+  } = options;
 
   // Clear the content in the host.
   host.textContent = '';
@@ -178,6 +186,12 @@ export function renderImage(
   }
   if (typeof width === 'number') {
     img.width = width;
+  }
+
+  if (needsBackground === 'light') {
+    img.classList.add('jp-needs-light-background');
+  } else if (needsBackground === 'dark') {
+    img.classList.add('jp-needs-dark-background');
   }
 
   if (unconfined === true) {
@@ -223,6 +237,11 @@ export namespace renderImage {
      * The optional height for the image.
      */
     height?: number;
+
+    /**
+     * Whether an image requires a background for legibility.
+     */
+    needsBackground?: string;
 
     /**
      * Whether the image should be unconfined.

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -212,6 +212,7 @@ export class RenderedImage extends RenderedCommon {
       source: String(model.data[this.mimeType]),
       width: metadata && (metadata.width as number | undefined),
       height: metadata && (metadata.height as number | undefined),
+      needsBackground: model.metadata['needs_background'] as string | undefined,
       unconfined: metadata && (metadata.unconfined as boolean | undefined)
     });
   }

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -396,6 +396,17 @@
   margin-bottom: 1em;
 }
 
+/* Change color behind transparent images if they need it... */
+[data-theme-light="false"] .jp-RenderedImage img.jp-needs-light-background {
+  background-color: var(--jp-inverse-layout-color1);
+}
+[data-theme-light="true"] .jp-RenderedImage img.jp-needs-dark-background {
+  background-color: var(--jp-inverse-layout-color1);
+}
+/* ...or leave it untouched if they don't */
+[data-theme-light="false"] .jp-RenderedImage img.jp-needs-dark-background {}
+[data-theme-light="true"] .jp-RenderedImage img.jp-needs-light-background {}
+
 .jp-RenderedHTMLCommon img,
 .jp-RenderedImage img,
 .jp-RenderedHTMLCommon svg,

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -397,15 +397,17 @@
 }
 
 /* Change color behind transparent images if they need it... */
-[data-theme-light="false"] .jp-RenderedImage img.jp-needs-light-background {
+[data-theme-light='false'] .jp-RenderedImage img.jp-needs-light-background {
   background-color: var(--jp-inverse-layout-color1);
 }
-[data-theme-light="true"] .jp-RenderedImage img.jp-needs-dark-background {
+[data-theme-light='true'] .jp-RenderedImage img.jp-needs-dark-background {
   background-color: var(--jp-inverse-layout-color1);
 }
 /* ...or leave it untouched if they don't */
-[data-theme-light="false"] .jp-RenderedImage img.jp-needs-dark-background {}
-[data-theme-light="true"] .jp-RenderedImage img.jp-needs-light-background {}
+[data-theme-light='false'] .jp-RenderedImage img.jp-needs-dark-background {
+}
+[data-theme-light='true'] .jp-RenderedImage img.jp-needs-light-background {
+}
 
 .jp-RenderedHTMLCommon img,
 .jp-RenderedImage img,

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -200,6 +200,18 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-layout-color3: var(--md-grey-700);
   --jp-layout-color4: var(--md-grey-600);
 
+  /* Inverse Layout
+   *
+   * The following are the inverse layout colors use in JupyterLab. In a light
+   * theme these would go from dark to light.
+   */
+
+  --jp-inverse-layout-color0: white;
+  --jp-inverse-layout-color1: white;
+  --jp-inverse-layout-color2: var(--md-grey-200);
+  --jp-inverse-layout-color3: var(--md-grey-400);
+  --jp-inverse-layout-color4: var(--md-grey-600);
+
   /* Brand/accent */
 
   --jp-brand-color0: var(--md-blue-700);

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -198,6 +198,18 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-layout-color3: var(--md-grey-400);
   --jp-layout-color4: var(--md-grey-600);
 
+  /* Inverse Layout
+   *
+   * The following are the inverse layout colors use in JupyterLab. In a light
+   * theme these would go from dark to light.
+   */
+
+  --jp-inverse-layout-color0: #111111;
+  --jp-inverse-layout-color1: var(--md-grey-900);
+  --jp-inverse-layout-color2: var(--md-grey-800);
+  --jp-inverse-layout-color3: var(--md-grey-700);
+  --jp-inverse-layout-color4: var(--md-grey-600);
+
   /* Brand/accent */
 
   --jp-brand-color0: var(--md-blue-700);


### PR DESCRIPTION
This is the sister PR of ipython/ipykernel#336.

This PR fixes a number of Matplotlib/Jupyterlab legibility issues. Given appropriate metadata (which the sister PR adds to ipykernel), Jupyterlab will now, if needed, set a background behind figures based on the luminance (ie light or dark) of the colors of its tick labels. This fix does not monkeypatch or change the actual figure in any way.

Based on the value of the `needs-background` metadata entry, Jupyterlab will now add either a `needs-light-background` or a `needs-dark-background` class (or nothing, if `needs-background` is not passed) to the img node that displays the figure. The background of the img node is then styled using a CSS selector that matches on the light/dark nature of the current theme and on the `needs-x-background` class. This is nice, since it means that the figure backgrounds will update as needed if the theme changes.

Here's what the fix looks like in action:

## Light theme
### Pre-fix
![image](https://user-images.githubusercontent.com/2263641/44753528-63e8b900-aaec-11e8-8255-a3bd49675829.png)

### Post-fix
![image](https://user-images.githubusercontent.com/2263641/44753664-d6f22f80-aaec-11e8-8d11-0c8385640d28.png)

## Dark theme
### Pre-fix
![image](https://user-images.githubusercontent.com/2263641/44753573-909cd080-aaec-11e8-8ef6-df504e686e55.png)

### Post-fix
![image](https://user-images.githubusercontent.com/2263641/44753706-fee19300-aaec-11e8-92aa-b093c2abf02e.png)

## What happens when the ticks have different colors?

This PR is meant to fix the Jupyterlab dark theme/Matplotlib default style conflict, and also to deal with any similar issues. This fix is not meant to cover ever possible visibility/legibility edge case out there. In particular, when the ticks of a figure have different colors, a background is added only if all of the ticks are light or if all are dark:

![image](https://user-images.githubusercontent.com/2263641/44754396-a95ab580-aaef-11e8-80c6-68176cdfd628.png)

If the luminance of the ticks does not match, then no background is added:

![image](https://user-images.githubusercontent.com/2263641/44754631-972d4700-aaf0-11e8-9904-013a694694f4.png)


Thanks to @bollwyvl, @Carreau, and @ian-r-rose for helping me figure out all of the moving parts needed for this fix during the Jupytercon sprint. This PR has a dependency on the extra figure metadata (`'needs-background'`) added by ipython/ipykernel#336. If, for whatever reason, `'needs-background'` is not present in the metadata, the current Jupyterlab behavior is left completely unchanged.