### PR TITLE
add sidebar min-width css variable

### DIFF
--- a/packages/application/style/sidepanel.css
+++ b/packages/application/style/sidepanel.css
@@ -176,7 +176,7 @@
 
 #jp-left-stack > .p-Widget,
 #jp-right-stack > .p-Widget {
-  min-width: 300px;
+  min-width: var(--jp-sidebar-min-width);
 }
 
 #jp-right-stack {

--- a/packages/inspector/style/index.css
+++ b/packages/inspector/style/index.css
@@ -42,7 +42,7 @@
 |----------------------------------------------------------------------------*/
 
 .jp-Inspector .p-TabBar {
-  min-width: 300px;
+  min-width: var(--jp-sidebar-min-width);
   min-height: var(--jp-private-inspector-tab-height);
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -196,7 +196,7 @@
 .jp-CellTools {
   display: flex;
   flex-direction: column;
-  min-width: 300px;
+  min-width: var(--jp-sidebar-min-width);
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
   /* This is needed so that all font sizing of children done in ems is

--- a/packages/running/style/index.css
+++ b/packages/running/style/index.css
@@ -17,7 +17,7 @@
 .jp-RunningSessions {
   display: flex;
   flex-direction: column;
-  min-width: 300px;
+  min-width: var(--jp-sidebar-min-width);
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
   /* This is needed so that all font sizing of children done in ems is

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -349,4 +349,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Vega extension styles */
 
   --jp-vega-background: var(--md-grey-400);
+
+  /* Sidebar-related styles */
+
+  --jp-sidebar-min-width: 250px;
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -346,4 +346,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Vega extension styles */
 
   --jp-vega-background: white;
+
+  /* Sidebar-related styles */
+
+  --jp-sidebar-min-width: 250px;
 }


### PR DESCRIPTION
Sets it to 250px instead of the 300px that it used to be.

Down the line, it would be nice to have a minimum width that is separate from the default width, but I have not been able to make that work so just submitting this as is. 

Also, there is flexbox css stuff that should get cleaned up because the last modified elements eat too much into the filename, but, again, separate PRs for that in the future.