### PR TITLE
Allow other files to Open With -> Notebook

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -548,6 +548,13 @@ function createContextMenu(
   const path = model.path;
   if (model.type !== 'directory') {
     const factories = registry.preferredWidgetFactories(path).map(f => f.name);
+    const notebookFactory = registry.getWidgetFactory('notebook').name;
+    if (
+      model.type === 'notebook' &&
+      factories.indexOf(notebookFactory) === -1
+    ) {
+      factories.unshift(notebookFactory);
+    }
     if (path && factories.length > 1) {
       const command = 'docmanager:open';
       const openWith = new Menu({ commands });


### PR DESCRIPTION
Text-files, that can be interpreted as notebook by an alternative
ContentManager get an 'Open With' -> 'Notebook' entry
in the FileManager context menu.

Fixes #4924.