### PR TITLE
Fix #5181: Remove maxlength so as to not cut off kernel name in kernel selector dialog.

### DIFF
--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -1055,7 +1055,6 @@ namespace Private {
     while (node.firstChild) {
       node.removeChild(node.firstChild);
     }
-    let maxLength = 10;
 
     let { preference, sessions, specs } = options;
     let { name, id, language, canStart, shouldStart } = preference;
@@ -1075,7 +1074,6 @@ namespace Private {
     for (let name in specs.kernelspecs) {
       let spec = specs.kernelspecs[name];
       displayNames[name] = spec.display_name;
-      maxLength = Math.max(maxLength, displayNames[name].length);
       languages[name] = spec.language;
     }
 
@@ -1174,7 +1172,7 @@ namespace Private {
 
       each(matchingSessions, session => {
         let name = displayNames[session.kernel.name];
-        matching.appendChild(optionForSession(session, name, maxLength));
+        matching.appendChild(optionForSession(session, name));
       });
     }
 
@@ -1189,9 +1187,7 @@ namespace Private {
 
       each(otherSessions, session => {
         let name = displayNames[session.kernel.name] || session.kernel.name;
-        otherSessionsNode.appendChild(
-          optionForSession(session, name, maxLength)
-        );
+        otherSessionsNode.appendChild(optionForSession(session, name));
       });
     }
   }
@@ -1237,14 +1233,10 @@ namespace Private {
    */
   function optionForSession(
     session: Session.IModel,
-    displayName: string,
-    maxLength: number
+    displayName: string
   ): HTMLOptionElement {
     let option = document.createElement('option');
     let sessionName = session.name || PathExt.basename(session.path);
-    if (sessionName.length > maxLength) {
-      sessionName = sessionName.slice(0, maxLength - 3) + '...';
-    }
     option.text = sessionName;
     option.value = JSON.stringify({ id: session.kernel.id });
     option.title =


### PR DESCRIPTION
This PR fix #5181 

Removed `maxLength` variable so as to remove the concept of trimming the kernel name and appending `...` in it. Now the kernel name appears without any trimming in kernel selector dialog.