### PR TITLE
Hide quit entry for older notebook versions.

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -205,11 +205,7 @@ class LabApp(NotebookApp):
             settings['page_config_data'] = {}
 
         # Handle quit button with support for Notebook < 5.6
-        if hasattr(self, 'quit_button'):
-            quit_button = self.quit_button
-        else:
-            quit_button = True
-        settings['page_config_data']['quit_button'] = quit_button
+        settings['page_config_data']['quit_button'] = getattr(self, 'quit_button', False)
 
     def init_server_extensions(self):
         """Load any extensions specified by config.


### PR DESCRIPTION
Remove quit entry for older notebook versions instead of turning it on as introduced in #5252.

Reason: API end point `api/shutdown` is not existing for version prior to 5.1 and the option `quit_button` and the addition of a button in the UI was introduced in 5.5. So with this modification, the quit entry is only present for notebook >=5.5.