### PR TITLE
fix python versions of build wheels by removing the universal flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal=1
-
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
Hi,
currently the built wheel files still have the extension `py2.py3-none-any.whl` indicating python2 and python3 compatibility (for example jupyterlab-0.34.8-py2.py3-none-any.whl). As jupyterlab is python3 only since https://github.com/jupyterlab/jupyterlab/commit/40530f84b86f096ca9d83a25fe0139c3209d621c this pull requests removes the universal flag as it indicates that both versions are supported (see https://wheel.readthedocs.io/en/stable/#defining-the-python-version).
This will result in wheels like `jupyterlab-0.35.0a0-py3-none-any.whl`.