### PR TITLE
Rename package.json to package.json.orig when copying schemas.

### DIFF
--- a/buildutils/src/build.ts
+++ b/buildutils/src/build.ts
@@ -110,7 +110,7 @@ export namespace Build {
         // Remove the existing directory if necessary.
         if (fs.existsSync(destination)) {
           try {
-            const oldPackagePath = path.join(destination, 'package.json');
+            const oldPackagePath = path.join(destination, 'package.json.orig');
             const oldPackageData = utils.readJSONFile(oldPackagePath);
             if (oldPackageData.version === packageData.version) {
               fs.removeSync(destination);
@@ -126,16 +126,13 @@ export namespace Build {
         // Copy schemas.
         schemas.forEach(schema => {
           const file = path.basename(schema);
-          if (file === 'package.json') {
-            throw new Error('Cannot use name "package.json" for schema file');
-          }
           fs.copySync(schema, path.join(destination, file));
         });
 
         // Write the package.json file for future comparison.
         fs.copySync(
           path.join(packageDir, 'package.json'),
-          path.join(destination, 'package.json')
+          path.join(destination, 'package.json.orig')
         );
       }
 
@@ -147,10 +144,9 @@ export namespace Build {
         // Remove the existing directory if necessary.
         if (fs.existsSync(destination)) {
           try {
-            const oldPackageData = require(path.join(
-              destination,
-              'package.json'
-            ));
+            const oldPackageData = utils.readJSONFile(
+              path.join(destination, 'package.json.orig')
+            );
             if (oldPackageData.version === packageData.version) {
               fs.removeSync(destination);
             }
@@ -168,7 +164,7 @@ export namespace Build {
         // Write the package.json file for future comparison.
         fs.copySync(
           path.join(packageDir, 'package.json'),
-          path.join(destination, 'package.json')
+          path.join(destination, 'package.json.orig')
         );
       }
     });

--- a/jupyterlab/staging/yarn.lock
+++ b/jupyterlab/staging/yarn.lock
@@ -1178,6 +1178,10 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
+array-uniq@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
@@ -3218,6 +3222,10 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
 lodash.curry@^4.0.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
@@ -3234,9 +3242,21 @@ lodash.flow@^3.3.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.mergewith@^4.6.0:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -4092,9 +4112,9 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.1:
+postcss@^6.0.1, postcss@^6.0.14:
   version "6.0.23"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   dependencies:
     chalk "^2.4.1"
     source-map "^0.6.1"
@@ -4541,6 +4561,21 @@ sanitize-html@~1.14.3:
     lodash.escaperegexp "^4.1.2"
     xtend "^4.0.0"
 
+sanitize-html@~1.18.2:
+  version "1.18.4"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.18.4.tgz#ffdeea13b555dd5e872e9a68b79e5e716cd8c543"
+  dependencies:
+    chalk "^2.3.0"
+    htmlparser2 "^3.9.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.mergewith "^4.6.0"
+    postcss "^6.0.14"
+    srcset "^1.0.0"
+    xtend "^4.0.0"
+
 sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -4708,6 +4743,13 @@ split-string@^3.0.1, split-string@^3.0.2:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+srcset@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-1.0.0.tgz#a5669de12b42f3b1d5e83ed03c71046fc48f41ef"
+  dependencies:
+    array-uniq "^1.0.2"
+    number-is-nan "^1.0.0"
 
 ssri@^5.2.4:
   version "5.3.0"


### PR DESCRIPTION
This way, even a schema called `package.json` will not collide with the package definition file.