### PR TITLE
@jupyterlab/buildutils v0.10.2

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/buildutils",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "JupyterLab - Build Utilities",
   "homepage": "https://github.com/jupyterlab/jupyterlab",
   "bugs": {

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -105,7 +105,7 @@
     "xterm": "~3.3.0"
   },
   "devDependencies": {
-    "@jupyterlab/buildutils": "^0.10.0",
+    "@jupyterlab/buildutils": "^0.10.2",
     "css-loader": "~0.28.7",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "file-loader": "~1.1.11",

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -11,7 +11,7 @@
     "@jupyterlab/application": "^0.18.4",
     "@jupyterlab/application-extension": "^0.18.5",
     "@jupyterlab/apputils-extension": "^0.18.4",
-    "@jupyterlab/buildutils": "^0.10.0",
+    "@jupyterlab/buildutils": "^0.10.2",
     "@jupyterlab/codemirror-extension": "^0.18.4",
     "@jupyterlab/completer-extension": "^0.18.4",
     "@jupyterlab/console-extension": "^0.18.4",

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -104,7 +104,7 @@
     "xterm": "~3.3.0"
   },
   "devDependencies": {
-    "@jupyterlab/buildutils": "^0.9.4",
+    "@jupyterlab/buildutils": "^0.10.2",
     "css-loader": "~0.28.7",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "file-loader": "~1.1.11",


### PR DESCRIPTION
Bumps @jupyterlab/buildutils version to `0.10.2`.

This version is published: [@jupyterlab/buildutils v0.10.2 on NPM](https://www.npmjs.com/package/@jupyterlab/buildutils/v/0.10.2)