### PR TITLE
Fix syntax highlighting for markdown lists.

### DIFF
--- a/packages/codemirror/src/codemirror-ipythongfm.ts
+++ b/packages/codemirror/src/codemirror-ipythongfm.ts
@@ -19,7 +19,11 @@ import 'codemirror/addon/mode/multiplex';
 CodeMirror.defineMode(
   'ipythongfm',
   (config: CodeMirror.EditorConfiguration, modeOptions?: any) => {
-    let gfmMode = CodeMirror.getMode(config, 'gfm');
+    let gfmMode = CodeMirror.getMode(config, {
+      name: 'gfm',
+      // Override list3 with an under-used token, rather than `keyword`
+      tokenTypeOverrides: { list3: 'string-2' }
+    });
     let texMode = CodeMirror.getMode(config, {
       name: 'stex',
       inMathMode: true

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -326,14 +326,14 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-mirror-editor-number-color: var(--md-green-400);
   --jp-mirror-editor-def-color: var(--md-blue-600);
   --jp-mirror-editor-variable-color: var(--md-grey-300);
-  --jp-mirror-editor-variable-2-color: var(--md-grey-500);
-  --jp-mirror-editor-variable-3-color: var(--md-grey-600);
+  --jp-mirror-editor-variable-2-color: var(--md-blue-400);
+  --jp-mirror-editor-variable-3-color: var(--md-green-600);
   --jp-mirror-editor-punctuation-color: var(--md-blue-400);
   --jp-mirror-editor-property-color: var(--md-blue-400);
   --jp-mirror-editor-operator-color: #aa22ff;
   --jp-mirror-editor-comment-color: #408080;
   --jp-mirror-editor-string-color: #ba2121;
-  --jp-mirror-editor-string-2-color: #f50;
+  --jp-mirror-editor-string-2-color: var(--md-purple-300);
   --jp-mirror-editor-meta-color: #aa22ff;
   --jp-mirror-editor-qualifier-color: #555;
   --jp-mirror-editor-builtin-color: var(--md-green-600);

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -323,14 +323,14 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-mirror-editor-number-color: #080;
   --jp-mirror-editor-def-color: #00f;
   --jp-mirror-editor-variable-color: var(--md-grey-900);
-  --jp-mirror-editor-variable-2-color: var(--md-grey-800);
-  --jp-mirror-editor-variable-3-color: var(--md-grey-700);
+  --jp-mirror-editor-variable-2-color: #05a;
+  --jp-mirror-editor-variable-3-color: #085;
   --jp-mirror-editor-punctuation-color: #05a;
   --jp-mirror-editor-property-color: #05a;
   --jp-mirror-editor-operator-color: #aa22ff;
   --jp-mirror-editor-comment-color: #408080;
   --jp-mirror-editor-string-color: #ba2121;
-  --jp-mirror-editor-string-2-color: #f50;
+  --jp-mirror-editor-string-2-color: #708;
   --jp-mirror-editor-meta-color: #aa22ff;
   --jp-mirror-editor-qualifier-color: #555;
   --jp-mirror-editor-builtin-color: #008000;


### PR DESCRIPTION
Fixes #2741. This necessitated a deeper dive into codemirror themes than expected.

Before:
![image](https://user-images.githubusercontent.com/5728311/45436475-bdfa8a00-b667-11e8-9346-ae8964db526b.png)

![image](https://user-images.githubusercontent.com/5728311/45436445-aae7ba00-b667-11e8-9930-83cb1df959d9.png)


After:
![image](https://user-images.githubusercontent.com/5728311/45436332-6c51ff80-b667-11e8-9fc4-5ba12e028aec.png)
![image](https://user-images.githubusercontent.com/5728311/45436356-7aa01b80-b667-11e8-875a-1463c89c31ce.png)
