### PR TITLE
Don't force table alignment.

### DIFF
--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -354,6 +354,12 @@
   max-width: none;
 }
 
+:not(.jp-RenderedMarkdown).jp-RenderedHTMLCommon td,
+:not(.jp-RenderedMarkdown).jp-RenderedHTMLCommon th,
+:not(.jp-RenderedMarkdown).jp-RenderedHTMLCommon tr {
+  text-align: right;
+}
+
 .jp-RenderedHTMLCommon th {
   font-weight: bold;
 }

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -341,7 +341,6 @@
 .jp-RenderedHTMLCommon td,
 .jp-RenderedHTMLCommon th,
 .jp-RenderedHTMLCommon tr {
-  text-align: right;
   vertical-align: middle;
   padding: 0.5em 0.5em;
   line-height: normal;


### PR DESCRIPTION
Fixes #3180.

Styles are now allowed to pass thanks to #5012, but we were still overriding table alignment attributes with our own CSS. This allows marked and others to set their own alignment for tables.