### PR TITLE
Add git config option for disabling hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && jlpm run integrity"
+      "pre-commit": "node scripts/precommit-disabled || (lint-staged && jlpm run integrity)"
     }
   },
   "workspaces": [

--- a/scripts/precommit-disabled.js
+++ b/scripts/precommit-disabled.js
@@ -1,0 +1,23 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/*
+Exits with a return code of 1 if hooks are *not* disabled.
+*/
+
+var childProcess = require('child_process');
+
+try {
+  var output = childProcess.execSync(
+    'git config --bool --get husky.disableHooks',
+    { encoding: 'utf8' }
+  );
+} catch (e) {
+  process.exit(1);
+}
+
+if (output.trim() !== 'true') {
+  process.exit(1);
+}


### PR DESCRIPTION
The pre-commit hooks can sometimes be quite intrusive in the development process (and slow). With this PR, by adding the git config option `husky.disableHooks = true`, pre-commit hooks will be disabled.

Example use: `git config --replace-all husky.disableHooks true`
To restore hooks: `git config --unset husky.disableHooks`