### PR TITLE
Fix select focus

### DIFF
--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -144,12 +144,17 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget {
     switch (event.type) {
       case 'mouseup':
       case 'mouseout':
+        // Refocus the content if we are done interacting with the toolabar.
+        // An exception is if we are in a dropdown select menu, since mouse
+        // interactions can leave the toolbar area even when we are still
+        // interacting with it.
         let target = event.target as HTMLElement;
         if (
           this._isRevealed &&
           this._content &&
           this.toolbar.node.contains(document.activeElement) &&
-          target.tagName !== 'SELECT'
+          target.tagName !== 'SELECT' &&
+          target.tagName !== 'OPTION'
         ) {
           this._focusContent();
         }

--- a/packages/notebook/style/toolbar.css
+++ b/packages/notebook/style/toolbar.css
@@ -36,5 +36,5 @@
   border: none;
   border-radius: 0;
   outline: none;
-  background-color: transparent;
+  background-color: var(--jp-layout-color1);
 }


### PR DESCRIPTION
Fixes #2995. This is tricky: Firefox apparently uses two different code-paths for select elements depending on whether multiprocessing is enabled. In one of the codepaths, events are fired slighly differently, where the target is the `SELECT` in one and the `OPTION` in the other. We were defocusing the `SELECT` inadvertently in one of the codepaths.

Also fixes #5168. Straightforward CSS change.