### PR TITLE
Prevent focus loss on `input` elements inside toolbar.

### DIFF
--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -154,7 +154,8 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget {
           this._content &&
           this.toolbar.node.contains(document.activeElement) &&
           target.tagName !== 'SELECT' &&
-          target.tagName !== 'OPTION'
+          target.tagName !== 'OPTION' &&
+          target.tagName !== 'INPUT'
         ) {
           this._focusContent();
         }


### PR DESCRIPTION
As in #5324, but for `input` elements.
I need it for a widget you can use to get and set current page number in the [jupyterlab-latex][1] PDF viewer.

Cheers

[1]: https://github.com/jupyterlab/jupyterlab-latex