### PR TITLE
Prevent focus loss on `mouseout` for `input` elements inside toolbar

### DIFF
--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -155,7 +155,7 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget {
           this.toolbar.node.contains(document.activeElement) &&
           target.tagName !== 'SELECT' &&
           target.tagName !== 'OPTION' &&
-          target.tagName !== 'INPUT'
+          document.activeElement.tagName !== 'INPUT'
         ) {
           this._focusContent();
         }

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -131,57 +131,6 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget {
   }
 
   /**
-   * Handle the DOM events for the widget.
-   *
-   * @param event - The DOM event sent to the widget.
-   *
-   * #### Notes
-   * This method implements the DOM `EventListener` interface and is
-   * called in response to events on the main area widget's node. It should
-   * not be called directly by user code.
-   */
-  handleEvent(event: Event): void {
-    switch (event.type) {
-      case 'mouseup':
-      case 'mouseout':
-        // Refocus the content if we are done interacting with the toolabar.
-        // An exception is if we are in a dropdown select menu, since mouse
-        // interactions can leave the toolbar area even when we are still
-        // interacting with it.
-        let target = event.target as HTMLElement;
-        if (
-          this._isRevealed &&
-          this._content &&
-          this.toolbar.node.contains(document.activeElement) &&
-          target.tagName !== 'SELECT' &&
-          target.tagName !== 'OPTION' &&
-          document.activeElement.tagName !== 'INPUT'
-        ) {
-          this._focusContent();
-        }
-        break;
-      default:
-        break;
-    }
-  }
-
-  /**
-   * Handle `after-attach` messages for the widget.
-   */
-  protected onAfterAttach(msg: Message): void {
-    this.toolbar.node.addEventListener('mouseup', this);
-    this.toolbar.node.addEventListener('mouseout', this);
-  }
-
-  /**
-   * Handle `before-detach` messages for the widget.
-   */
-  protected onBeforeDetach(msg: Message): void {
-    this.toolbar.node.removeEventListener('mouseup', this);
-    this.toolbar.node.removeEventListener('mouseout', this);
-  }
-
-  /**
    * Handle `'activate-request'` messages.
    */
   protected onActivateRequest(msg: Message): void {

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -374,6 +374,11 @@ export namespace ToolbarButtonComponent {
  * @param props - The props for ToolbarButtonComponent.
  */
 export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
+  const handleMouseDown = (event: React.MouseEvent) => {
+    event.preventDefault();
+    props.onClick();
+  };
+
   return (
     <button
       className={
@@ -382,7 +387,7 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
           : 'jp-ToolbarButtonComponent'
       }
       disabled={props.enabled === false}
-      onClick={props.onClick}
+      onMouseDown={handleMouseDown}
       title={props.tooltip || props.iconLabel}
     >
       {props.iconClassName && (

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -403,7 +403,7 @@ describe('@jupyterlab/apputils', () => {
           });
           Widget.attach(button, document.body);
           await framePromise();
-          simulate(button.node.firstChild as HTMLElement, 'click');
+          simulate(button.node.firstChild as HTMLElement, 'mousedown');
           expect(called).to.equal(true);
           button.dispose();
         });

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -3,6 +3,8 @@
 
 import { expect } from 'chai';
 
+import { simulate } from 'simulate-event';
+
 import { toArray } from '@phosphor/algorithm';
 
 import { PromiseDelegate } from '@phosphor/coreutils';
@@ -55,7 +57,7 @@ describe('@jupyterlab/notebook', () => {
         Widget.attach(button, document.body);
         let promise = signalToPromise(context.fileChanged);
         await framePromise();
-        (button.node.firstChild as HTMLElement).click();
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         await promise;
         button.dispose();
       });
@@ -77,7 +79,7 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createInsertButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        (button.node.firstChild as HTMLElement).click();
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         expect(panel.content.activeCellIndex).to.equal(1);
         expect(panel.content.activeCell).to.be.an.instanceof(CodeCell);
         button.dispose();
@@ -101,7 +103,7 @@ describe('@jupyterlab/notebook', () => {
         const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         await framePromise();
-        (button.node.firstChild as HTMLElement).click();
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         expect(panel.content.widgets.length).to.equal(count - 1);
         expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
         button.dispose();
@@ -125,7 +127,7 @@ describe('@jupyterlab/notebook', () => {
         const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         await framePromise();
-        (button.node.firstChild as HTMLElement).click();
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         expect(panel.content.widgets.length).to.equal(count);
         expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
         button.dispose();
@@ -150,7 +152,7 @@ describe('@jupyterlab/notebook', () => {
         Widget.attach(button, document.body);
         await framePromise();
         NotebookActions.copy(panel.content);
-        (button.node.firstChild as HTMLElement).click();
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         await sleep();
         expect(panel.content.widgets.length).to.equal(count + 1);
         button.dispose();
@@ -196,7 +198,7 @@ describe('@jupyterlab/notebook', () => {
           }
         });
         await framePromise();
-        (button.node.firstChild as HTMLElement).click();
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         await p.promise;
       }).timeout(30000); // Allow for slower CI
 


### PR DESCRIPTION
This is a refinement of PR #5328.
The code introduced there prevents focus loss caused by `mouseup`, but not by `mouseout`.
This fix works in either case.

Cheers