### PR TITLE
Switch left right panel

### DIFF
--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -11,7 +11,8 @@
   "files": [
     "lib/*.d.ts",
     "lib/*.js.map",
-    "lib/*.js"
+    "lib/*.js",
+    "schema/*.json"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -32,6 +33,7 @@
     "@jupyterlab/application": "^0.18.4",
     "@jupyterlab/apputils": "^0.18.4",
     "@jupyterlab/coreutils": "^2.1.4",
+    "@phosphor/algorithm": "^1.1.2",
     "react": "~16.4.2"
   },
   "devDependencies": {
@@ -39,6 +41,7 @@
     "typescript": "~2.9.2"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "schemaDir": "schema"
   }
 }

--- a/packages/application-extension/schema/sidebar.json
+++ b/packages/application-extension/schema/sidebar.json
@@ -1,0 +1,20 @@
+{
+  "jupyter.lab.setting-icon-class": "jp-FileIcon",
+  "jupyter.lab.setting-icon-label": "Sidebar",
+  "title": "Sidebar",
+  "description": "Sidebar layout settings.",
+  "properties": {
+    "overrides": {
+      "type": "object",
+      "title": "Overrides",
+      "description": "Overrides for where to show sidebar items",
+      "properties": {},
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["left", "right"]
+      }
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -53,6 +53,8 @@ namespace CommandIDs {
     'application:toggle-presentation-mode';
 
   export const tree: string = 'router:tree';
+
+  export const switchSidebar = 'sidebar:switch';
 }
 
 /**
@@ -326,11 +328,13 @@ const busy: JupyterLabPlugin<void> = {
   autoStart: true
 };
 
+const SIDEBAR_ID = '@jupyterlab/application-extension:sidebar';
+
 /**
  * Keep user settings for where to show the side panels.
  */
 const sidebar: JupyterLabPlugin<void> = {
-  id: '@jupyterlab/application-extension:sidebar',
+  id: SIDEBAR_ID,
   activate: (app: JupyterLab, settingRegistry: ISettingRegistry) => {
     type overrideMap = { [id: string]: 'left' | 'right' };
     let overrides: overrideMap = {};
@@ -348,15 +352,59 @@ const sidebar: JupyterLabPlugin<void> = {
     };
     app.shell.layoutModified.connect(handleLayoutOverrides);
     // Fetch overrides from the settings system.
-    Promise.all([
-      settingRegistry.load('@jupyterlab/application-extension:sidebar'),
-      app.restored
-    ]).then(([settings]) => {
-      overrides = (settings.get('overrides').composite as overrideMap) || {};
-      settings.changed.connect(settings => {
+    Promise.all([settingRegistry.load(SIDEBAR_ID), app.restored]).then(
+      ([settings]) => {
         overrides = (settings.get('overrides').composite as overrideMap) || {};
-        handleLayoutOverrides();
-      });
+        settings.changed.connect(settings => {
+          overrides =
+            (settings.get('overrides').composite as overrideMap) || {};
+          handleLayoutOverrides();
+        });
+      }
+    );
+
+    // Add a command to switch a side panels's side
+    app.commands.addCommand(CommandIDs.switchSidebar, {
+      label: 'Switch Sidebar Side',
+      execute: () => {
+        // First, try to find the right panel based on the
+        // application context menu click,
+        // If we can't find it there, look for use the active
+        // left/right widgets.
+        const contextNode: HTMLElement = app.contextMenuFirst(
+          node => !!node.dataset.id
+        );
+        let id: string;
+        let side: 'left' | 'right';
+        if (contextNode) {
+          id = contextNode.dataset['id'];
+          const leftPanel = document.getElementById('jp-left-stack');
+          const node = document.getElementById(id);
+          if (leftPanel && node && leftPanel.contains(node)) {
+            side = 'right';
+          } else {
+            side = 'left';
+          }
+        } else if (document.body.dataset.leftSidebarWidget) {
+          id = document.body.dataset.leftSidebarWidget;
+          side = 'right';
+        } else if (document.body.dataset.rightSidebarWidget) {
+          id = document.body.dataset.rightSidebarWidget;
+          side = 'left';
+        }
+
+        // Move the panel to the other side.
+        const newOverrides = { ...overrides };
+        newOverrides[id] = side;
+        settingRegistry.set(SIDEBAR_ID, 'overrides', newOverrides);
+      }
+    });
+
+    // Add a context menu item to sidebar tabs.
+    app.contextMenu.addItem({
+      command: CommandIDs.switchSidebar,
+      selector: '.jp-SideBar .p-TabBar-tab',
+      rank: 500
     });
   },
   requires: [ISettingRegistry],

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -332,7 +332,8 @@ const busy: JupyterLabPlugin<void> = {
 const sidebar: JupyterLabPlugin<void> = {
   id: '@jupyterlab/application-extension:sidebar',
   activate: (app: JupyterLab, settingRegistry: ISettingRegistry) => {
-    let overrides: { [id: string]: 'left' | 'right' } = {};
+    type overrideMap = { [id: string]: 'left' | 'right' };
+    let overrides: overrideMap = {};
     const handleLayoutOverrides = () => {
       each(app.shell.widgets('left'), widget => {
         if (overrides[widget.id] && overrides[widget.id] === 'right') {
@@ -351,11 +352,9 @@ const sidebar: JupyterLabPlugin<void> = {
       settingRegistry.load('@jupyterlab/application-extension:sidebar'),
       app.restored
     ]).then(([settings]) => {
+      overrides = (settings.get('overrides').composite as overrideMap) || {};
       settings.changed.connect(settings => {
-        overrides =
-          (settings.get('overrides').composite as {
-            [id: string]: 'left' | 'right';
-          }) || {};
+        overrides = (settings.get('overrides').composite as overrideMap) || {};
         handleLayoutOverrides();
       });
     });

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -224,25 +224,15 @@ export class JupyterLab extends Application<ApplicationShell> {
    * in the node hierarchy returned by contextMenuNodes.
    * Optionally, gets the first value that matches a passed-in RegExp
    */
-  contextMenuFirst(prop: string, regexp: RegExp | null = null): any | null {
-    if (regexp) {
-      for (let node of this.contextMenuNodes as any[]) {
-        if (prop in node && node[prop]) {
-          let match = node[prop].match(regexp);
-          if (match) {
-            return match;
-          }
-        }
-      }
-    } else {
-      for (let node of this.contextMenuNodes as any[]) {
-        if (prop in node && node[prop]) {
-          return node[prop];
-        }
+  contextMenuFirst(
+    test: (node: HTMLElement) => boolean
+  ): HTMLElement | undefined {
+    for (let node of this.contextMenuNodes as HTMLElement[]) {
+      if (test(node)) {
+        return node;
       }
     }
-
-    return;
+    return null;
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -399,12 +399,14 @@ export class ApplicationShell extends Widget {
    */
   addToLeftArea(
     widget: Widget,
-    options: ApplicationShell.ISideAreaOptions = {}
+    options?: ApplicationShell.ISideAreaOptions
   ): void {
     if (!widget.id) {
       console.error('Widgets added to app shell must have unique id property.');
       return;
     }
+    options = options || this._sideOptionsCache.get(widget) || {};
+    this._sideOptionsCache.set(widget, options);
     let rank = 'rank' in options ? options.rank : DEFAULT_RANK;
     this._leftHandler.addWidget(widget, rank!);
     this._onLayoutModified();
@@ -462,12 +464,14 @@ export class ApplicationShell extends Widget {
    */
   addToRightArea(
     widget: Widget,
-    options: ApplicationShell.ISideAreaOptions = {}
+    options?: ApplicationShell.ISideAreaOptions
   ): void {
     if (!widget.id) {
       console.error('Widgets added to app shell must have unique id property.');
       return;
     }
+    options = options || this._sideOptionsCache.get(widget) || {};
+    this._sideOptionsCache.set(widget, options);
     let rank = 'rank' in options ? options.rank : DEFAULT_RANK;
     this._rightHandler.addWidget(widget, rank!);
     this._onLayoutModified();
@@ -811,6 +815,10 @@ export class ApplicationShell extends Widget {
   private _addOptionsCache = new Map<
     Widget,
     ApplicationShell.IMainAreaOptions
+  >();
+  private _sideOptionsCache = new Map<
+    Widget,
+    ApplicationShell.ISideAreaOptions
   >();
 }
 

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1072,7 +1072,10 @@ namespace Private {
       let index = this._findInsertIndex(item);
       ArrayExt.insert(this._items, index, item);
       this._stackedPanel.insertWidget(index, widget);
-      this._sideBar.insertTab(index, widget.title);
+      const title = this._sideBar.insertTab(index, widget.title);
+      // Store the parent id in the title dataset
+      // in order to dispatch click events to the right widget.
+      title.dataset = { id: widget.id };
       this._refreshVisibility();
     }
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -189,14 +189,16 @@ function addCommands(
 
   // fetches the doc widget associated with the most recent contextmenu event
   const contextMenuWidget = (): Widget => {
-    let pathRe = /[Pp]ath:\s?(.*)\n?/;
-    let pathMatch = app.contextMenuFirst('title', pathRe);
+    const pathRe = /[Pp]ath:\s?(.*)\n?/;
+    const test = (node: HTMLElement) =>
+      node['title'] && !!node['title'].match(pathRe);
+    const node = app.contextMenuFirst(test);
 
-    if (!pathMatch) {
+    if (!node) {
       // fall back to active doc widget if path cannot be obtained from event
       return app.shell.currentWidget;
     }
-
+    const pathMatch = node['title'].match(pathRe);
     return docManager.findWidget(pathMatch[1]);
   };
 


### PR DESCRIPTION
Alternative to #5104 
Fixes #5054. Fixes #3707 

This adds a new plugin that tracks, via the settings system, a set of overrides for left-ness or right-ness of sidebar items. It is relatively self-contained, and available as a context-menu item on the tabs.