### PR TITLE
Fix TypeError when canceling file renaming dialog

### DIFF
--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -50,6 +50,9 @@ export function renameDialog(
     focusNodeSelector: 'input',
     buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'RENAME' })]
   }).then(result => {
+    if (!result.value) {
+      return;
+    }
     if (!isValidFileName(result.value)) {
       showErrorMessage(
         'Rename Error',


### PR DESCRIPTION
It appears that `result.value` is `null` when canceling a Rename Dialog and checking for the file name, resulting in:
```
Uncaught (in promise) TypeError: Cannot read property 'length' of null
```

This change adds a check against `result.value` and returns fast if the value is falsy.

### Before

![cancel_valid_file_name_before](https://user-images.githubusercontent.com/591645/45909649-4e249600-be03-11e8-878f-4b0f0c005108.gif)

### After

![cancel_valid_file_name_after](https://user-images.githubusercontent.com/591645/45909650-51b81d00-be03-11e8-8726-00a9fedde6ea.gif)
