### PR TITLE
add more test for deprecated response model

### DIFF
--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -631,8 +631,8 @@ namespace Private {
         return response.json();
       })
       .then(data => {
-        validate.validateModel(data);
-        return updateFromServer(data, settings!.baseUrl);
+        const model = validate.validateModel(data);
+        return updateFromServer(model, settings!.baseUrl);
       });
   }
 
@@ -675,7 +675,7 @@ namespace Private {
           throw new Error('Invalid Session list');
         }
         for (let i = 0; i < data.length; i++) {
-          validate.validateModel(data[i]);
+          data[i] = validate.validateModel(data[i]);
         }
         return updateRunningSessions(data, settings!.baseUrl);
       });
@@ -765,8 +765,8 @@ namespace Private {
         return response.json();
       })
       .then(data => {
-        validate.validateModel(data);
-        return updateFromServer(data, settings.baseUrl);
+        const model = validate.validateModel(data);
+        return updateFromServer(model, settings.baseUrl);
       });
   }
 

--- a/packages/services/test/src/session/session.spec.ts
+++ b/packages/services/test/src/session/session.spec.ts
@@ -152,7 +152,7 @@ describe('session', () => {
       await expectFailure(sessionPromise, msg);
     });
 
-    it('should handle a deprecated response model', () => {
+    it('should handle a deprecated response model', async () => {
       const sessionModel = createSessionModel();
       const data = {
         id: sessionModel.id,
@@ -161,7 +161,8 @@ describe('session', () => {
       };
       const serverSettings = getRequestHandler(201, data);
       const options = createSessionOptions(sessionModel, serverSettings);
-      return Session.startNew(options);
+      const model = await Session.startNew(options);
+      expect(model.path).not.empty;
     });
   });
 


### PR DESCRIPTION
add more test for deprecated response model for `session`, which should not failed, since `model.path` should not be absence.

Fixes https://github.com/jupyter/kernel_gateway/issues/306

This will ensure the old deprecated model from other backends like [kernel_gateway](https://github.com/jupyter/kernel_gateway) also work correctly.


