### PR TITLE
[master] adding 'writable' checks to some of the menu and toolbar options

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -189,17 +189,15 @@ function addCommands(
 
   const isWritable = () => {
     const { currentWidget } = shell;
-    if (currentWidget) {
-      const context = docManager.contextForWidget(currentWidget);
-      return !!(
-        currentWidget &&
-        context &&
-        context.contentsModel &&
-        context.contentsModel.writable
-      );
-    } else {
+    if (!currentWidget) {
       return false;
     }
+    const context = docManager.contextForWidget(currentWidget);
+    return !!(
+      context &&
+      context.contentsModel &&
+      context.contentsModel.writable
+    );
   };
 
   // fetches the doc widget associated with the most recent contextmenu event
@@ -561,7 +559,7 @@ function addCommands(
   commands.addCommand(CommandIDs.saveAs, {
     label: () => `Save ${fileType()} As…`,
     caption: 'Save with new path',
-    isEnabled: isWritable,
+    isEnabled,
     execute: () => {
       if (isEnabled()) {
         let context = docManager.contextForWidget(shell.currentWidget);

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -522,7 +522,6 @@ function addCommands(
     isEnabled: () => {
       const iterator = shell.widgets('main');
       let widget = iterator.next();
-      let anyWritable = false;
       while (widget) {
         if (docManager.contextForWidget(widget)) {
           let context = docManager.contextForWidget(widget);
@@ -531,14 +530,14 @@ function addCommands(
             context.contentsModel &&
             context.contentsModel.writable
           ) {
-            anyWritable = true;
+            return true;
           }
         }
         widget = iterator.next();
       }
       // disable saveAll if all of the widgets models
       // have writable === false
-      return anyWritable;
+      return false;
     },
     execute: () => {
       const iterator = shell.widgets('main');

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -187,6 +187,17 @@ function addCommands(
     return !!(currentWidget && docManager.contextForWidget(currentWidget));
   };
 
+  const isWritable = () => {
+    const { currentWidget } = shell;
+    const context = docManager.contextForWidget(currentWidget);
+    return !!(
+      currentWidget &&
+      context &&
+      context.contentsModel &&
+      context.contentsModel.writable
+    );
+  };
+
   // fetches the doc widget associated with the most recent contextmenu event
   const contextMenuWidget = (): Widget => {
     let pathRe = /[Pp]ath:\s?(.*)\n?/;
@@ -480,7 +491,7 @@ function addCommands(
   commands.addCommand(CommandIDs.save, {
     label: () => `Save ${fileType()}`,
     caption: 'Save and create checkpoint',
-    isEnabled,
+    isEnabled: isWritable,
     execute: () => {
       if (isEnabled()) {
         let context = docManager.contextForWidget(shell.currentWidget);
@@ -539,7 +550,7 @@ function addCommands(
   commands.addCommand(CommandIDs.saveAs, {
     label: () => `Save ${fileType()} As…`,
     caption: 'Save with new path',
-    isEnabled,
+    isEnabled: isWritable,
     execute: () => {
       if (isEnabled()) {
         let context = docManager.contextForWidget(shell.currentWidget);
@@ -550,7 +561,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.rename, {
     label: () => `Rename ${fileType(contextMenuWidget())}…`,
-    isEnabled,
+    isEnabled: isWritable,
     execute: () => {
       if (isEnabled()) {
         let context = docManager.contextForWidget(contextMenuWidget());

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -189,13 +189,17 @@ function addCommands(
 
   const isWritable = () => {
     const { currentWidget } = shell;
-    const context = docManager.contextForWidget(currentWidget);
-    return !!(
-      currentWidget &&
-      context &&
-      context.contentsModel &&
-      context.contentsModel.writable
-    );
+    if (currentWidget) {
+      const context = docManager.contextForWidget(currentWidget);
+      return !!(
+        currentWidget &&
+        context &&
+        context.contentsModel &&
+        context.contentsModel.writable
+      );
+    } else {
+      return false;
+    }
   };
 
   // fetches the doc widget associated with the most recent contextmenu event
@@ -523,15 +527,13 @@ function addCommands(
       const iterator = shell.widgets('main');
       let widget = iterator.next();
       while (widget) {
-        if (docManager.contextForWidget(widget)) {
-          let context = docManager.contextForWidget(widget);
-          if (
-            context &&
-            context.contentsModel &&
-            context.contentsModel.writable
-          ) {
-            return true;
-          }
+        let context = docManager.contextForWidget(widget);
+        if (
+          context &&
+          context.contentsModel &&
+          context.contentsModel.writable
+        ) {
+          return true;
         }
         widget = iterator.next();
       }

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -522,13 +522,23 @@ function addCommands(
     isEnabled: () => {
       const iterator = shell.widgets('main');
       let widget = iterator.next();
+      let anyWritable = false;
       while (widget) {
         if (docManager.contextForWidget(widget)) {
-          return true;
+          let context = docManager.contextForWidget(widget);
+          if (
+            context &&
+            context.contentsModel &&
+            context.contentsModel.writable
+          ) {
+            anyWritable = true;
+          }
         }
         widget = iterator.next();
       }
-      return false;
+      // disable saveAll if all of the widgets models
+      // have writable === false
+      return anyWritable;
     },
     execute: () => {
       const iterator = shell.widgets('main');

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -570,7 +570,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.rename, {
     label: () => `Rename ${fileType(contextMenuWidget())}…`,
-    isEnabled: isWritable,
+    isEnabled,
     execute: () => {
       if (isEnabled()) {
         let context = docManager.contextForWidget(contextMenuWidget());

--- a/packages/notebook/src/default-toolbar.ts
+++ b/packages/notebook/src/default-toolbar.ts
@@ -85,7 +85,8 @@ export namespace ToolbarItems {
           }
         });
       },
-      tooltip: 'Save the notebook contents and create checkpoint'
+      tooltip: 'Save the notebook contents and create checkpoint',
+      enabled: panel.context.contentsModel.writable
     });
   }
 

--- a/packages/notebook/src/default-toolbar.ts
+++ b/packages/notebook/src/default-toolbar.ts
@@ -86,7 +86,12 @@ export namespace ToolbarItems {
         });
       },
       tooltip: 'Save the notebook contents and create checkpoint',
-      enabled: panel.context.contentsModel.writable
+      enabled: !!(
+        panel &&
+        panel.context &&
+        panel.context.contentsModel &&
+        panel.context.contentsModel.writable
+      )
     });
   }
 


### PR DESCRIPTION
adding logic to check 'writable' for the following menu items:
- Save
- Save As ...
- Save All .. (only disabling if ALL files are not writable)
- Rename

toolbar items:
- Save

as a followup to this PR, when the refactoring that @jasongrout  is working on around 'Save Notebook with Extras' lands, I'm hoping to add a similar 'writable' check (tricky to do that now without adding cyclic dependencies between the docmanager and mainmenu extensions)
