### PR TITLE
decode url link targets

### DIFF
--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -318,14 +318,14 @@ export namespace IRenderMime {
    */
   export interface IResolver {
     /**
-     * Resolve a relative url to a correct server path.
+     * Resolve a relative url to an absolute url path.
      */
     resolveUrl(url: string): Promise<string>;
 
     /**
-     * Get the download url of a given absolute server path.
+     * Get the download url for a given absolute url path.
      */
-    getDownloadUrl(path: string): Promise<string>;
+    getDownloadUrl(url: string): Promise<string>;
 
     /**
      * Whether the URL should be handled by the resolver

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -361,24 +361,25 @@ export namespace RenderMimeRegistry {
     }
 
     /**
-     * Resolve a relative url to a correct server path.
+     * Resolve a relative url to an absolute url path.
      */
     resolveUrl(url: string): Promise<string> {
       if (this.isLocal(url)) {
-        let cwd = PathExt.dirname(this._session.path);
+        const cwd = encodeURI(PathExt.dirname(this._session.path));
         url = PathExt.resolve(cwd, url);
       }
       return Promise.resolve(url);
     }
 
     /**
-     * Get the download url of a given absolute server path.
+     * Get the download url of a given absolute url path.
      */
-    getDownloadUrl(path: string): Promise<string> {
-      if (this.isLocal(path)) {
-        return this._contents.getDownloadUrl(path);
+    getDownloadUrl(url: string): Promise<string> {
+      if (this.isLocal(url)) {
+        // decode url->path before passing to contents api
+        return this._contents.getDownloadUrl(decodeURI(url));
       }
-      return Promise.resolve(path);
+      return Promise.resolve(url);
     }
 
     /**
@@ -392,7 +393,8 @@ export namespace RenderMimeRegistry {
      * manager.
      */
     isLocal(url: string): boolean {
-      return URLExt.isLocal(url) || !!this._contents.driveName(url);
+      const path = decodeURI(url);
+      return URLExt.isLocal(url) || !!this._contents.driveName(path);
     }
 
     private _session: Session.ISession | IClientSession;

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -732,8 +732,8 @@ namespace Private {
     node.setAttribute(name, '');
     return resolver
       .resolveUrl(source)
-      .then(path => {
-        return resolver.getDownloadUrl(path);
+      .then(urlPath => {
+        return resolver.getDownloadUrl(urlPath);
       })
       .then(url => {
         // Check protocol again in case it changed:
@@ -783,13 +783,15 @@ namespace Private {
     // Get the appropriate file path.
     return resolver
       .resolveUrl(href)
-      .then(path => {
+      .then(urlPath => {
+        // decode encoded url from url to api path
+        const path = decodeURI(urlPath);
         // Handle the click override.
         if (linkHandler) {
           linkHandler.handleLink(anchor, path, hash);
         }
         // Get the appropriate file download path.
-        return resolver.getDownloadUrl(path);
+        return resolver.getDownloadUrl(urlPath);
       })
       .then(url => {
         // Set the visible anchor.


### PR DESCRIPTION
link targets can be escaped urls, but APIs expect unescaped "API path" strings

Example valid and correct markdown links that didn't resolve, but do now:

```markdown
- [link](has%20space) (should resolve to "has space")
- [link](has%25percent) (should resolve to "has%percent")
```

Fixes #5153

I'd love to add a test, but I couldn't figure out how.