### PR TITLE
Make persist and save use save enabled

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -231,11 +231,15 @@ export function createFileMenu(app: JupyterLab, menu: FileMenu): void {
       const name = Private.delegateLabel(app, menu.persistAndSavers, 'name');
       return `Save ${name} ${action || 'with Extras'}`;
     },
-    isEnabled: Private.delegateEnabled(
-      app,
-      menu.persistAndSavers,
-      'persistAndSave'
-    ),
+    isEnabled: args => {
+      return (
+        Private.delegateEnabled(
+          app,
+          menu.persistAndSavers,
+          'persistAndSave'
+        )() && commands.isEnabled('docmanager:save', args)
+      );
+    },
     execute: Private.delegateExecute(
       app,
       menu.persistAndSavers,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1562,7 +1562,9 @@ function addCommands(
         app.commands.execute('docmanager:save');
       }
     },
-    isEnabled
+    isEnabled: args => {
+      return isEnabled() && commands.isEnabled('docmanager:save', args);
+    }
   });
 }
 


### PR DESCRIPTION
This changes the persist and save command in the filemenu and the persist notebook state command to be enabled only if the `docmanager:save` is command is enabled.

Now https://github.com/jupyterlab/jupyterlab/pull/5376 should also work for the persist and save file menu action, so that if the file is readonly it will be greyed out.