### PR TITLE
Example tests for default toolbar items that do not succeed.

### DIFF
--- a/tests/test-docregistry/src/default.spec.ts
+++ b/tests/test-docregistry/src/default.spec.ts
@@ -178,22 +178,28 @@ describe('docregistry/default', () => {
       });
 
       it('should have toolbar items', () => {
+        const buttons = [new Widget(), new Widget()];
         const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text'],
           toolbarItems: [
             {
               name: 'foo',
-              widget: new Widget()
+              widget: buttons[0]
             },
             {
               name: 'bar',
-              widget: new Widget()
+              widget: buttons[1]
             }
           ]
         });
-        const widget = factory.createNew(createFileContext());
+        const context = createFileContext();
+        const widget = factory.createNew(context);
+        const widget2 = factory.createNew(context);
         expect(toArray(widget.toolbar.names())).to.deep.equal(['foo', 'bar']);
+        expect(toArray(widget2.toolbar.names())).to.deep.equal(['foo', 'bar']);
+        expect(toArray(widget.toolbar.children())).to.deep.equal(buttons);
+        expect(toArray(widget2.toolbar.children())).to.deep.equal(buttons);
       });
     });
 

--- a/tests/test-notebook/src/widgetfactory.spec.ts
+++ b/tests/test-notebook/src/widgetfactory.spec.ts
@@ -121,14 +121,18 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should populate the customized toolbar items', () => {
+        const buttons = [new ToolbarButton(), new ToolbarButton()];
         const toolbars = [
-          { name: 'foo', widget: new ToolbarButton() },
-          { name: 'bar', widget: new ToolbarButton() }
+          { name: 'foo', widget: buttons[0] },
+          { name: 'bar', widget: buttons[1] }
         ];
         const factory = createFactory(toolbars);
         const panel = factory.createNew(context);
-        const items = toArray(panel.toolbar.names());
-        expect(items).to.deep.equal(['foo', 'bar']);
+        const panel2 = factory.createNew(context);
+        expect(toArray(panel.toolbar.names())).to.deep.equal(['foo', 'bar']);
+        expect(toArray(panel2.toolbar.names())).to.deep.equal(['foo', 'bar']);
+        expect(toArray(panel.toolbar.children())).to.deep.equal(buttons);
+        expect(toArray(panel2.toolbar.children())).to.deep.equal(buttons);
       });
     });
   });


### PR DESCRIPTION
Here are some tweaks of the tests for #5370 that fail, and illustrate we need to do a bit more work on this.

Because a phosphor widget can only have one parent, it doesn't work to pass in specific widgets that will be used in multiple panels created. This means that if I pass in some toolbar items to a widget factory, then create two widgets, the second widget will effectively steal the toolbar items from the first widget.
