### PR TITLE
Tweak the dark splash screen to be a bit darker.

### DIFF
--- a/packages/apputils-extension/style/splash.css
+++ b/packages/apputils-extension/style/splash.css
@@ -20,7 +20,7 @@
 }
 
 #jupyterlab-splash.dark {
-  background-color: var(--md-grey-800);
+  background-color: var(--md-grey-900);
 }
 
 .splash-fade {


### PR DESCRIPTION
This is a followup of #5339, making the dark splash screen a bit darker. I found over time that the lighter grey still looked out of place when fading to a much darker theme.

CC @ellisonbg, @tgeorgeux 

**Screenshots**
Old:
![olddarksplash](https://user-images.githubusercontent.com/192614/46227626-a7655b80-c314-11e8-85b9-5febd4af1cdc.gif)


New:
![darksplash](https://user-images.githubusercontent.com/192614/46227389-e8a93b80-c313-11e8-8788-0bbf4960fce6.gif)
