### PR TITLE
Build and publish script cleanup

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -3,15 +3,6 @@
     "**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}": [
       "prettier --write",
       "git add"
-    ],
-    "**/*{.ts,.tsx}": [
-      "tslint --fix -c tslint.json",
-      "git add"
-    ],
-    "**/*{.js,.jsx}": [
-      "eslint --fix",
-      "git add"
     ]
-  },
-  "concurrent": false
+  }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Notes:
   local version of `yarn` in `jupyterlab/yarn.js` when run in the repository or
   a built application directory.
 
-- At times, it may be necessary to clean your local repo with the command `jlpm run clean:slate`. This will clean the repository, and re-install and
+- At times, it may be necessary to clean your local repo with the command `npm run clean:slate`. This will clean the repository, and re-install and
   rebuild.
 
 - If `pip` gives a `VersionConflict` error, it usually means that the installed

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -253,7 +253,8 @@ export async function ensureIntegrity(): Promise<boolean> {
       process.exit(1);
     }
     utils.run('jlpm install');
-    console.log('\n\nPlease commit the changes by running:');
+    console.log('\n\nMade integrity changes!');
+    console.log('Please commit the changes by running:');
     console.log('git commit -a -m "Package integrity updates"');
     return false;
   }

--- a/buildutils/src/prepublish.ts
+++ b/buildutils/src/prepublish.ts
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 import * as utils from './utils';
 
-utils.run('jlpm run clean:slate');
+utils.run('npm run clean:slate');
 utils.run('jlpm run build:packages');
 utils.run('jlpm run build:themes');
 utils.run('jlpm integrity');

--- a/clean.py
+++ b/clean.py
@@ -14,3 +14,5 @@ if os.name == 'nt':
 
 
 subprocess.check_call(['git', 'clean', '-dfx'], cwd=here)
+
+subprocess.call('python -m pip uninstall -y jupyterlab'.split(), cwd=here)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "pre-publish": "cd buildutils && npm run build && cd .. && node buildutils/lib/prepublish.js",
+    "pre-publish": "jlpm && cd buildutils && npm run build && cd .. && node buildutils/lib/prepublish.js",
     "add:sibling": "node buildutils/lib/add-sibling.js",
     "build": "jlpm run build:dev",
     "build:core": "cd jupyterlab/staging && jlpm && jlpm run build",
@@ -20,7 +20,7 @@
     "clean:dev": "cd dev_mode && jlpm run clean",
     "clean:examples": "node buildutils/lib/clean-packages.js examples",
     "clean:packages": "node buildutils/lib/clean-packages.js packages",
-    "clean:slate": "python clean.py && python -m pip uninstall -y jupyterlab && python -m pip install -v -e .",
+    "clean:slate": "python clean.py && python -m pip install -v -e .",
     "clean:src": "jlpm run clean",
     "clean:test": "lerna run clean --scope \"@jupyterlab/test-*\"",
     "clean:utils": "cd buildutils && jlpm run clean",
@@ -79,7 +79,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "jlpm run integrity && lint-staged"
+      "pre-commit": "lint-staged",
+      "pre-push": "jlpm run integrity"
     }
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clean:dev": "cd dev_mode && jlpm run clean",
     "clean:examples": "node buildutils/lib/clean-packages.js examples",
     "clean:packages": "node buildutils/lib/clean-packages.js packages",
-    "clean:slate": "python clean.py && pip install -v -e .",
+    "clean:slate": "python clean.py && python -m pip uninstall -y jupyterlab && python -m pip install -v -e .",
     "clean:src": "jlpm run clean",
     "clean:test": "lerna run clean --scope \"@jupyterlab/test-*\"",
     "clean:utils": "cd buildutils && jlpm run clean",

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -42,6 +42,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -52,5 +52,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -50,6 +50,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -54,5 +54,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -42,5 +42,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -51,5 +51,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -45,5 +45,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -46,6 +46,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -46,5 +46,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -44,6 +44,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -47,5 +47,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -48,6 +48,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -49,5 +49,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -47,5 +47,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -41,6 +41,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -46,5 +46,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -47,6 +47,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -46,5 +46,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -50,5 +50,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -42,6 +42,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -44,5 +44,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/faq-extension/package.json
+++ b/packages/faq-extension/package.json
@@ -43,6 +43,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -47,6 +47,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -50,5 +50,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -49,6 +49,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -42,5 +42,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -44,6 +44,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -40,6 +40,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -42,5 +42,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -42,6 +42,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -45,5 +45,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -38,6 +38,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "mimeExtension": true
   }

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -47,6 +47,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "mimeExtension": true
   }

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -43,6 +43,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -45,5 +45,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -43,6 +43,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -41,5 +41,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -38,6 +38,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "mimeExtension": true
   }

--- a/packages/mathjax2-extension/package.json
+++ b/packages/mathjax2-extension/package.json
@@ -39,6 +39,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -36,5 +36,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -99,5 +99,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -51,6 +51,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -54,5 +54,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -39,5 +39,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -48,5 +48,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -39,6 +39,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "mimeExtension": true
   }

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -38,6 +38,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -37,5 +37,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -50,5 +50,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -38,6 +38,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -45,5 +45,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -69,5 +69,8 @@
     "webpack": "~4.12.0",
     "webpack-cli": "^3.0.3",
     "ws": "~6.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -43,6 +43,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -49,5 +49,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -42,6 +42,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "schemaDir": "schema"

--- a/packages/tabmanager-extension/package.json
+++ b/packages/tabmanager-extension/package.json
@@ -40,6 +40,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -42,6 +42,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -42,5 +42,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -57,6 +57,9 @@
     "webpack": "~4.12.0",
     "webpack-cli": "^3.0.3"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "themeDir": "static"

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -56,6 +56,9 @@
     "webpack": "~4.12.0",
     "webpack-cli": "^3.0.3"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true,
     "themeDir": "static"

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -48,6 +48,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -43,5 +43,8 @@
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/vdom-extension/package.json
+++ b/packages/vdom-extension/package.json
@@ -43,6 +43,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "mimeExtension": true
   }

--- a/packages/vega4-extension/package.json
+++ b/packages/vega4-extension/package.json
@@ -42,6 +42,9 @@
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": {
     "mimeExtension": true
   }


### PR DESCRIPTION
- Fixes `clean:slate` on Windows
- Ensures all of our packages are published as public
- Only run prettier on git commit
- Run integrity on push
