### PR TITLE
Migrate filebrowser contextmenu to application-wide contextmenu

### DIFF
--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -410,63 +410,12 @@ export class DocumentRegistry implements IDisposable {
   /**
    * Create an iterator over the widget factories that have been registered.
    *
-   * @param preferredOrder - If this flag is set, the return value will
-   * iterate over the widget factories using the same ordering as
-   * [[preferredWidgetFactories]].
-   *
    * @returns A new iterator of widget factories.
    */
-  widgetFactories(
-    preferredOrder: boolean = false
-  ): IIterator<DocumentRegistry.WidgetFactory> {
-    if (preferredOrder) {
-      let factoryNames = new Set<string>();
-
-      // Start with the file type default factoryNames.
-      Object.keys(this._defaultWidgetFactories).forEach(name => {
-        factoryNames.add(this._defaultWidgetFactories[name]);
-      });
-
-      // Add the file type default rendered factoryNames.
-      Object.keys(this._defaultRenderedWidgetFactories).forEach(name => {
-        factoryNames.add(this._defaultRenderedWidgetFactories[name]);
-      });
-
-      // Add the global default factory.
-      if (this._defaultWidgetFactory) {
-        factoryNames.add(this._defaultWidgetFactory);
-      }
-
-      // Add the file type factoryNames in registration order.
-      Object.keys(this._widgetFactoryExtensions).forEach(name => {
-        each(this._widgetFactoryExtensions[name], n => {
-          factoryNames.add(n);
-        });
-      });
-
-      // Add the rest of the global factoryNames, in registration order.
-      if ('*' in this._widgetFactoryExtensions) {
-        each(this._widgetFactoryExtensions['*'], n => {
-          factoryNames.add(n);
-        });
-      }
-
-      // Convert the set of factory names to an array of factories
-      let factories: DocumentRegistry.WidgetFactory[] = [];
-      factoryNames.forEach(name => {
-        let factory = this._widgetFactories[name];
-        if (!factory) {
-          return;
-        }
-        factories.push(factory);
-      });
-
-      return new ArrayIterator(factories);
-    } else {
-      return map(Object.keys(this._widgetFactories), name => {
-        return this._widgetFactories[name];
-      });
-    }
+  widgetFactories(): IIterator<DocumentRegistry.WidgetFactory> {
+    return map(Object.keys(this._widgetFactories), name => {
+      return this._widgetFactories[name];
+    });
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -410,12 +410,63 @@ export class DocumentRegistry implements IDisposable {
   /**
    * Create an iterator over the widget factories that have been registered.
    *
+   * @param preferredOrder - If this flag is set, the return value will
+   * iterate over the widget factories using the same ordering as
+   * [[preferredWidgetFactories]].
+   *
    * @returns A new iterator of widget factories.
    */
-  widgetFactories(): IIterator<DocumentRegistry.WidgetFactory> {
-    return map(Object.keys(this._widgetFactories), name => {
-      return this._widgetFactories[name];
-    });
+  widgetFactories(
+    preferredOrder: boolean = false
+  ): IIterator<DocumentRegistry.WidgetFactory> {
+    if (preferredOrder) {
+      let factoryNames = new Set<string>();
+
+      // Start with the file type default factoryNames.
+      Object.keys(this._defaultWidgetFactories).forEach(name => {
+        factoryNames.add(this._defaultWidgetFactories[name]);
+      });
+
+      // Add the file type default rendered factoryNames.
+      Object.keys(this._defaultRenderedWidgetFactories).forEach(name => {
+        factoryNames.add(this._defaultRenderedWidgetFactories[name]);
+      });
+
+      // Add the global default factory.
+      if (this._defaultWidgetFactory) {
+        factoryNames.add(this._defaultWidgetFactory);
+      }
+
+      // Add the file type factoryNames in registration order.
+      Object.keys(this._widgetFactoryExtensions).forEach(name => {
+        each(this._widgetFactoryExtensions[name], n => {
+          factoryNames.add(n);
+        });
+      });
+
+      // Add the rest of the global factoryNames, in registration order.
+      if ('*' in this._widgetFactoryExtensions) {
+        each(this._widgetFactoryExtensions['*'], n => {
+          factoryNames.add(n);
+        });
+      }
+
+      // Convert the set of factory names to an array of factories
+      let factories: DocumentRegistry.WidgetFactory[] = [];
+      factoryNames.forEach(name => {
+        let factory = this._widgetFactories[name];
+        if (!factory) {
+          return;
+        }
+        factories.push(factory);
+      });
+
+      return new ArrayIterator(factories);
+    } else {
+      return map(Object.keys(this._widgetFactories), name => {
+        return this._widgetFactories[name];
+      });
+    }
   }
 
   /**

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -40,6 +40,7 @@
     "@jupyterlab/services": "^3.2.1-alpha.0",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/commands": "^1.6.1",
+    "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0"
   },
   "devDependencies": {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -366,7 +366,22 @@ function addCommands(
         )
       );
     },
-    iconClass: 'jp-MaterialIcon jp-OpenFolderIcon',
+    iconClass: args => {
+      const factory = (args['factory'] as string) || void 0;
+      if (factory) {
+        // if an explicit factory is passed...
+        const ft = registry.getFileType(factory);
+        if (ft) {
+          // ...set an icon if the factory name corresponds to a file type name...
+          return ft.iconClass;
+        } else {
+          // ...or leave the icon blank
+          return '';
+        }
+      } else {
+        return 'jp-MaterialIcon jp-OpenFolderIcon';
+      }
+    },
     label: args => (args['label'] || args['factory'] || 'Open') as string,
     mnemonic: 0
   });

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -754,6 +754,13 @@ export class DirListing extends Widget {
           node.classList.add(CUT_CLASS);
         }
       }
+
+      // add metadata to the node
+      node.setAttribute(
+        'data-isdir',
+        item.type === 'directory' ? 'filebrowser-true' : 'filebrowser-false'
+      );
+      node.setAttribute('data-path', item.path);
     });
 
     // Handle the selectors on the widget node.
@@ -1625,6 +1632,7 @@ export namespace DirListing {
       let header = document.createElement('div');
       let content = document.createElement('ul');
       content.className = CONTENT_CLASS;
+      content.setAttribute('data-widget', 'filebrowser');
       header.className = HEADER_CLASS;
       node.appendChild(header);
       node.appendChild(content);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -93,6 +93,8 @@ const ITEM_ICON_CLASS = 'jp-DirListing-itemIcon';
  */
 const ITEM_MODIFIED_CLASS = 'jp-DirListing-itemModified';
 
+const DEAD_SPACE_CLASS = 'jp-DirListing-deadSpace';
+
 /**
  * The class name added to the dir listing editor node.
  */
@@ -758,9 +760,8 @@ export class DirListing extends Widget {
       // add metadata to the node
       node.setAttribute(
         'data-isdir',
-        item.type === 'directory' ? 'filebrowser-true' : 'filebrowser-false'
+        item.type === 'directory' ? 'true' : 'false'
       );
-      node.setAttribute('data-path', item.path);
     });
 
     // Handle the selectors on the widget node.
@@ -1631,11 +1632,13 @@ export namespace DirListing {
       let node = document.createElement('div');
       let header = document.createElement('div');
       let content = document.createElement('ul');
+      let deadSpace = document.createElement('ul');
       content.className = CONTENT_CLASS;
-      content.setAttribute('data-widget', 'filebrowser');
+      deadSpace.className = DEAD_SPACE_CLASS;
       header.className = HEADER_CLASS;
       node.appendChild(header);
       node.appendChild(content);
+      node.appendChild(deadSpace);
       node.tabIndex = 1;
       return node;
     }

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -144,7 +144,7 @@
 
 /* increase specificity to override bundled default */
 .jp-DirListing-content {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -267,6 +267,15 @@
   border-radius: 0px;
   color: var(--jp-ui-font-color1);
   transform: translateX(-40%) translateY(-58%);
+}
+
+.jp-DirListing-deadSpace {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  overflow: auto;
+  background-color: var(--jp-layout-color1);
 }
 
 .jp-Document {


### PR DESCRIPTION
Fixes #4529.

This PR address the remaining unresolved issue from #4529 (paging @ian-r-rose): migrating the "special case" contextmenu that the filebrowser currently uses to the application-wide contextmenu that Phosphor provides.

90% of the migration was doable via built-in Phosphor stuff (ie the CSS menu item selector system). The final ~10% required a couple of more significant tweaks:
- A transparent `jp-DirListing-deadSpace` node was added to the filebrowser layout. This node automatically takes up all of the empty space at the end of filebrowser listings, and is needed in order to distinguish clicks on item/not-an-item using CSS selectors alone.
- The "open with..." submenu is implemented via a subclass `OpenwithMenu` of the Phosphor `Menu` widget. The subclass was needed in order to completely reproduce the behavior of the extant "open with..." submenu.

This patch leaves the current behavior of the filebrowser contextmenu virtually untouched. The only change I made was to implement more sensible behavior in "open with..." when you have multiple items selected in the filebrowser. Now "open with..." will show the widget factories that can be used to open all of the items in a selection (ie the intersection of the factories of each item). If you click on one of the factories, that factory will then be used to open every item in the selection. Previously, "open with..." would only act on the item under the cursor, instead of all of the items in a selection.