### PR TITLE
Add release script for checking the milestone PRs against the commit history

### DIFF
--- a/scripts/milestone_check.py
+++ b/scripts/milestone_check.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2018 Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# Generate a GitHub token at https://github.com/settings/tokens
+# Invoke this script using something like:
+# python scripts/milestone_check.py
+
+import subprocess
+import requests
+import os
+
+# Get authentication token
+import getpass
+token = getpass.getpass('GitHub token:')
+
+MILESTONE=18
+
+ranges = {
+    18: 'origin/master --not origin/0.34.x' #0.35.0
+}
+
+out = subprocess.run("git log {} --format='%H,%cE,%s'".format(ranges[MILESTONE]), shell=True, encoding='utf8', stdout=subprocess.PIPE)
+commits = {i[0]: (i[1], i[2]) for i in (x.split(',',2) for x in out.stdout.splitlines())}
+
+
+url = 'https://api.github.com/graphql'
+json = { 'query' : """
+query test($milestone: Int!) {
+    repository(owner:"jupyterlab" name:"jupyterlab") {
+      milestone(number:$milestone) {
+        title
+        pullRequests(first:100 states:[MERGED]) {
+          nodes {
+            title
+            number
+            mergeCommit {
+              oid
+            }
+            commits(first:100) {
+              nodes {
+                commit {
+                  oid
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+""",
+       'variables': {
+           'milestone': MILESTONE
+       }
+       }
+
+api_token = os.environ['GITHUB_TOKEN']
+headers = {'Authorization': 'token %s' % api_token}
+
+r = requests.post(url=url, json=json, headers=headers)
+milestone_data = r.json()['data']['repository']['milestone']
+pr_list = milestone_data['pullRequests']['nodes']
+
+# construct a commit to PR dictionary
+prs = {}
+for pr in pr_list:
+    prs[pr['number']] = {'mergeCommit': pr['mergeCommit']['oid'],
+                        'commits': set(i['commit']['oid'] for i in pr['commits']['nodes'])}
+    
+# Reverse dictionary
+commits_to_prs={}
+for key,value in prs.items():
+    commits_to_prs[value['mergeCommit']]=key
+    for c in value['commits']:
+        commits_to_prs[c]=key
+
+# Check to see if commits in the repo are represented in PRs
+good = set()
+notfound = set()
+for c in commits:
+    if c in commits_to_prs:
+        good.add(commits_to_prs[c])
+    else:
+        notfound.add(c)
+
+prs_not_represented = set(prs.keys()) - good
+
+print("Milestone: %s, %d merged PRs"%(milestone_data['title'], len(milestone_data['pullRequests']['nodes'])))
+print("""
+PRs that are in the milestone, but have no commits in the version range. 
+These PRs probably belong in a different milestone.
+""")
+print('\n'.join('https://github.com/jupyterlab/jupyterlab/pull/%d'%i for i in prs_not_represented))
+
+print('-'*40)
+
+print("""
+Commits that are not included in any PR on this milestone.
+This probably means the commit's PR needs to be assigned to this milestone,
+or the commit was pushed to master directly.
+""")
+print('\n'.join('%s %s %s'%(c, commits[c][0], commits[c][1]) for c in notfound))


### PR DESCRIPTION
This script compares the actual version history against the PRs in a milestone, and identifies:

1. merged PRs in the milestone that have no commits in the version range for the milestone, which probably need to be moved to a different milestone
2. commits in the version range that are not in any milestone PR, which signify PRs that need to be moved into the milestone, or commits that were pushed directly to master without being in a PR.

This led to finding several misclassified PRs in 0.34.x, 0.35, and 1.0 milestones.

The python is somewhat messy, but I figure we can improve it as time goes on.

Output of the script now is:

```
Milestone: 0.35, 62 merged PRs

PRs that are in the milestone, but have no commits in the version range. 
These PRs probably belong in a different milestone.


----------------------------------------

Commits that are not included in any PR on this milestone.
This probably means the commit's PR needs to be assigned to this milestone,
or the commit was pushed to master directly.

f015066f0ae80ddb5ab2fb3ecbfbf193e380260d steven.silvester@ieee.org Merge branch 'master' of https://github.com/jupyterlab/jupyterlab
7d7b8ca3d713469fb28a8a7c202defb4aba40448 steven.silvester@ieee.org Update versions
31a384ea7949ad1b67a7382eb6937cb63fe98632 steven.silvester@ieee.org Switch to dev mode
c5d3db53c84622ec3e582dfa521a5857c2469198 steven.silvester@ieee.org Release 0.35.0rc2
9d6193d318872a4a3600ee96fe6f3996312ffe07 steven.silvester@ieee.org "Publish"
37b0a5bce5e7212ae94deb0bcc17cbfd9eea7903 steven.silvester@ieee.org integrity
783fe738ca38bcd041f2e1444ddc5046eeeafc2b steven.silvester@ieee.org bump to rc
9cef810f2a137d79f7adf7238aba8cfbdc5cff8f steven.silvester@ieee.org integrity
4c52c9e3a07ed372f0082aaf4ed15381f528dab3 steven.silvester@ieee.org Bump mainmenu version
8d52a016a279f2a93de03f56ed0bca0d940b352c steven.silvester@ieee.org Release 0.35.0rc0
2b934966793a5145935505148a814cafcb27acc3 steven.silvester@ieee.org bump filebrowser
d246453e0bb944ee9eaf532f7f5a7815fc9d51f2 steven.silvester@ieee.org Release 0.35.0rc1
a8b918fe0e2735c6b61e3aadf9ab0b20bda43a93 steven.silvester@ieee.org Merge branch 'master' of https://github.com/jupyterlab/jupyterlab into ts-3.0
fcce939a164baea27e20956f532c48d22e2d6b3e steven.silvester@ieee.org Buildutils 0.10.0
6c3140dc9b295733e5e659df8d2aa1f222eda52a steven.silvester@ieee.org "Publish"
6350ef9907460d49e81389113da9a3a03a7846d2 steven.silvester@ieee.org Release 0.35.0rc1
```
Looks like there were a number of commits pushed directly to master.