### PR TITLE
Remove '*' prompt from cells that don't execute after an exception

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -701,7 +701,7 @@ export namespace NotebookActions {
   /**
    * Select all of the cells of the notebook.
    *
-   * @param notebook - the targe notebook widget.
+   * @param notebook - the target notebook widget.
    */
   export function selectAll(notebook: Notebook): void {
     if (!notebook.model || !notebook.activeCell) {
@@ -1408,18 +1408,26 @@ namespace Private {
     notebook.activeCellIndex = lastIndex;
     notebook.deselectAll();
 
-    return Promise.all(
-      selected.map(child => runCell(notebook, child, session))
-    ).then(results => {
-      if (notebook.isDisposed) {
+    return Promise.all(selected.map(child => runCell(notebook, child, session)))
+      .then(results => {
+        if (notebook.isDisposed) {
+          return false;
+        }
+
+        // Post an update request.
+        notebook.update();
+
+        return results.every(result => result);
+      })
+      .catch(err => {
+        selected.map((cell: CodeCell) => {
+          // Remove '*' prompt from cells that didn't execute
+          if (cell.model.executionCount == null) {
+            cell.setPrompt('');
+          }
+        });
         return false;
-      }
-
-      // Post an update request.
-      notebook.update();
-
-      return results.every(result => result);
-    });
+      });
   }
 
   /**
@@ -1462,9 +1470,9 @@ namespace Private {
                 }
 
                 return true;
+              } else {
+                throw new Error('Kernel reply status was not ok');
               }
-
-              return false;
             })
             .catch(reason => {
               if (reason.message !== 'Canceled') {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1431,6 +1431,8 @@ namespace Private {
           throw reason;
         }
 
+        notebook.update();
+
         return false;
       });
   }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1420,7 +1420,7 @@ namespace Private {
         return results.every(result => result);
       })
       .catch(reason => {
-        if (reason.message == 'KernelReplyNotOK') {
+        if (reason.message === 'KernelReplyNotOK') {
           selected.map((cell: CodeCell) => {
             // Remove '*' prompt from cells that didn't execute
             if (cell.model.executionCount == null) {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1419,13 +1419,18 @@ namespace Private {
 
         return results.every(result => result);
       })
-      .catch(err => {
-        selected.map((cell: CodeCell) => {
-          // Remove '*' prompt from cells that didn't execute
-          if (cell.model.executionCount == null) {
-            cell.setPrompt('');
-          }
-        });
+      .catch(reason => {
+        if (reason.message == 'KernelReplyNotOK') {
+          selected.map((cell: CodeCell) => {
+            // Remove '*' prompt from cells that didn't execute
+            if (cell.model.executionCount == null) {
+              cell.setPrompt('');
+            }
+          });
+        } else {
+          throw reason;
+        }
+
         return false;
       });
   }
@@ -1471,7 +1476,7 @@ namespace Private {
 
                 return true;
               } else {
-                throw new Error('Kernel reply status was not ok');
+                throw new Error('KernelReplyNotOK');
               }
             })
             .catch(reason => {


### PR DESCRIPTION
Fixes #5366 and fixes #4916 

This PR is based on the [proposed fix here](https://github.com/jupyterlab/jupyterlab/issues/5366#issuecomment-424286069).