### PR TITLE
Use setRelativeSizes to set initial width of side panel.

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -124,7 +124,7 @@ export class ApplicationShell extends Widget {
     rootLayout.spacing = 0; // TODO make this configurable?
     // Use relative sizing to set the width of the side panels.
     // This will still respect the min-size of children widget in the stacked panel.
-    hsplitPanel.setRelativeSizes([1, 3, 0]);
+    hsplitPanel.setRelativeSizes([1, 2.5, 1]);
 
     BoxLayout.setStretch(topPanel, 0);
     BoxLayout.setStretch(hboxPanel, 1);

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -122,6 +122,9 @@ export class ApplicationShell extends Widget {
 
     rootLayout.direction = 'top-to-bottom';
     rootLayout.spacing = 0; // TODO make this configurable?
+    // Use relative sizing to set the width of the side panels.
+    // This will still respect the min-size of children widget in the stacked panel.
+    hsplitPanel.setRelativeSizes([1, 3, 0]);
 
     BoxLayout.setStretch(topPanel, 0);
     BoxLayout.setStretch(hboxPanel, 1);

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -352,5 +352,5 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Sidebar-related styles */
 
-  --jp-sidebar-min-width: 150px;
+  --jp-sidebar-min-width: 180px;
 }

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -352,5 +352,5 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Sidebar-related styles */
 
-  --jp-sidebar-min-width: 250px;
+  --jp-sidebar-min-width: 150px;
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -349,5 +349,5 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Sidebar-related styles */
 
-  --jp-sidebar-min-width: 250px;
+  --jp-sidebar-min-width: 150px;
 }

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -349,5 +349,5 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Sidebar-related styles */
 
-  --jp-sidebar-min-width: 150px;
+  --jp-sidebar-min-width: 180px;
 }


### PR DESCRIPTION
Fixes #5314

This makes the initial width of the L sidebar separate from its minimum size:

* Uses `SplitPanel.setRelativeSizes` to size the L panel and dock panel using relative sizes. The current ratio or 1:3, which makes the L sidebar around 300px on a 1280 wide screen (close to what 0.34 was).
* Users can make it narrower, down to the max of the min-size of the stacked panel children. This does mean that extensions can create sidebar content that has a larger min-size and that will be respected (this PR doesn't change that, just clarifying).
* This sizing approach should only be used the first time a user loads lab. From then on, the application state should save the width the user has set interactively (there is a separate bug preventing this from working).
* Ran into a couple of other bugs in the sidebar related to this that I will open issues for (they were pre-existing).

Future things to investigate:

* Do some actual design work to answer the underlying questions:
  - What are the design considerations for setting the initial width of the L/R sidebar?
  - What is an appropriate static or relative width based on those considerations?
  - Should different sidebar panels have different min-size values?
  - Is static or relative sizing more appropriate?
* Implementation question:
  - How to set the initial width of the R side panel in a relative manner?
* Fix pre-existing bugs:
  - Width of side panels is not preserved in the application state
  - Moving a panel to the R side collapses the L one

**Screenshots**

Current master with a 250px sidebar width on a 1280px wide MacBook Pro screen:

<img width="1280" alt="screen shot 2018-10-02 at 12 49 36 pm" src="https://user-images.githubusercontent.com/27600/46373216-41dddb80-c642-11e8-99e0-c4635b6ac609.png">

Proposed change on a 1280px wide MacBook Pro Screen (this is very close to the 300px width from previous versions of lab):

<img width="1280" alt="screen shot 2018-10-02 at 12 50 08 pm" src="https://user-images.githubusercontent.com/27600/46373491-01329200-c643-11e8-8d93-89f1a62d2f0a.png">

Proposed change on a crazy wide browser window to show how the relative sizing is working:

![screen shot 2018-10-02 at 12 52 05 pm](https://user-images.githubusercontent.com/27600/46373523-160f2580-c643-11e8-9dbf-83f8473623d5.png)

