### PR TITLE
Add exclude list to the clean:slate script

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -13,6 +13,11 @@ if os.name == 'nt':
             dnames.remove('node_modules')
 
 
-subprocess.check_call(['git', 'clean', '-dfx'], cwd=here)
+git_clean_exclude = [
+    '-e',
+    '/.vscode',
+]
+git_clean_command = ['git', 'clean', '-dfx'] + git_clean_exclude
+subprocess.check_call(git_clean_command, cwd=here)
 
 subprocess.call('python -m pip uninstall -y jupyterlab'.split(), cwd=here)


### PR DESCRIPTION
The `clean:slate` script might be a little bit too aggressive, as it runs `git clean -dfx` under the hood.

I lost my VS code configuration (`launch.json` and `settings.json`) several times after cleaning the repository with `jlpm run clean:slate` :).

This change adds a whitelist of files / folders to keep on disk whenever we execute this script. For now it only has `.vscode` but can of course be extended.