### PR TITLE
Polish update-dist-tag

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -21,7 +21,8 @@
   "bin": {
     "get-dependency": "./lib/get-dependency.js",
     "remove-dependency": "./lib/remove-dependency.js",
-    "update-dependency": "./lib/update-dependency.js"
+    "update-dependency": "./lib/update-dependency.js",
+    "update-dist-tag": "./lib/update-dist-tag.js"
   },
   "directories": {
     "lib": "lib/"

--- a/buildutils/src/update-dist-tag.ts
+++ b/buildutils/src/update-dist-tag.ts
@@ -75,8 +75,10 @@ commander
       cmds = await Promise.all(paths.map(handlePackage));
     }
     cmds.push(await handlePackage(basePath));
-
-    console.log(flatten(cmds).join('\n'));
+    let out = flatten(cmds).join('\n');
+    if (out) {
+      console.log(out);
+    }
   });
 
 commander.parse(process.argv);

--- a/buildutils/src/update-dist-tag.ts
+++ b/buildutils/src/update-dist-tag.ts
@@ -40,15 +40,12 @@ async function handlePackage(packagePath: string): Promise<string[]> {
   let next = semver.prerelease(versions[0]) ? versions[0] : undefined;
   let latest = versions.find(i => !semver.prerelease(i));
 
-  // If the tag is defined, but not supposed to be, remove it. If the tag is
-  // supposed to be defined, but is not the same as what is currently there,
-  // change it.
-  if (!latest && tags.latest) {
-    cmds.push(`npm dist-tag rm ${pkg} latest`);
-  } else if (latest && latest !== tags.latest) {
+  if (latest && latest !== tags.latest) {
     cmds.push(`npm dist-tag add ${pkg}@${latest} latest`);
   }
 
+  // If next is defined, but not supposed to be, remove it. If next is supposed
+  // to be defined, but is not the same as the current next, change it.
   if (!next && tags.next) {
     cmds.push(`npm dist-tag rm ${pkg} next`);
   } else if (next && next !== tags.next) {

--- a/buildutils/src/update-dist-tag.ts
+++ b/buildutils/src/update-dist-tag.ts
@@ -61,7 +61,9 @@ function flatten(a: any[]) {
 
 commander
   .description(
-    'Print out commands to update npm latest and next tags appropriately'
+    `Print out commands to update npm 'latest' and 'next' dist-tags
+so that 'latest' points to the latest stable release and 'next'
+points to the latest prerelease after it.`
   )
   // .option('--dry-run', 'Do not perform actions, just print output')
   .option('--lerna', 'Update dist-tags in all lerna packages')

--- a/buildutils/src/update-dist-tag.ts
+++ b/buildutils/src/update-dist-tag.ts
@@ -65,7 +65,6 @@ commander
 so that 'latest' points to the latest stable release and 'next'
 points to the latest prerelease after it.`
   )
-  // .option('--dry-run', 'Do not perform actions, just print output')
   .option('--lerna', 'Update dist-tags in all lerna packages')
   .option('--path [path]', 'Path to package or monorepo to update')
   .action(async (args: any) => {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prettier": "prettier --write '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
     "prettier:check": "prettier --list-different '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
     "update:dependency": "node buildutils/lib/update-dependency.js --lerna",
-    "update:dist-tag": "node buildutils/lib/update-dist-tag.js",
+    "update:dist-tag": "node buildutils/lib/update-dist-tag.js --lerna",
     "update:local": "node buildutils/lib/update-local.js",
     "watch": "run-p watch:dev watch:themes",
     "watch:dev": "python scripts/watch_dev.py",

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -34,7 +34,6 @@
     "@jupyterlab/apputils": "^0.19.1-alpha.0",
     "@jupyterlab/coreutils": "^2.2.1-alpha.0",
     "@jupyterlab/docmanager": "^0.19.1-alpha.0",
-    "@jupyterlab/docregistry": "^0.19.1-alpha.0",
     "@jupyterlab/filebrowser": "^0.19.1-alpha.0",
     "@jupyterlab/launcher": "^0.19.1-alpha.0",
     "@jupyterlab/services": "^3.2.1-alpha.0",

--- a/packages/filebrowser-extension/tsconfig.json
+++ b/packages/filebrowser-extension/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../docmanager"
     },
     {
-      "path": "../docregistry"
-    },
-    {
       "path": "../filebrowser"
     },
     {


### PR DESCRIPTION
This updates update-dist-tag so the logic is clearer, and uses command and package-json to be much more polished.

Here's the output now, showing some of the issues we currently have with our dist-tags:

```
% node ./buildutils/lib/update-dist-tag.js --lerna
npm dist-tag add @jupyterlab/buildutils@0.10.2 latest
npm dist-tag add @jupyterlab/buildutils@0.11.1-alpha.0 next
npm dist-tag add @jupyterlab/template@0.6.4 latest
npm dist-tag add @jupyterlab/template@0.7.1-alpha.0 next
npm dist-tag add @jupyterlab/json-extension@0.17.4 latest
npm dist-tag add @jupyterlab/json-extension@0.18.1-alpha.0 next
npm dist-tag rm @jupyterlab/mathjax2 latest
npm dist-tag add @jupyterlab/pdf-extension@0.9.4 latest
npm dist-tag add @jupyterlab/pdf-extension@0.10.1-alpha.0 next
npm dist-tag add @jupyterlab/rendermime-interfaces@1.1.7 latest
npm dist-tag add @jupyterlab/rendermime-interfaces@1.2.1-alpha.0 next
```
