### PR TITLE
Clean up browser DOM for when it is narrow.

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -67,9 +67,6 @@ namespace CommandIDs {
 
   export const paste = 'filebrowser:paste';
 
-  // paste command used when user did not click on an item
-  export const pasteNotItem = 'filebrowser:paste-not-item';
-
   export const rename = 'filebrowser:rename';
 
   // For main browser only.
@@ -616,17 +613,18 @@ function addCommands(
     }
   }
 
-  // matches anywhere on filebrowser that is not an item
-  const selectorDeadSpace = '.jp-DirListing-deadSpace';
+  // matches anywhere on filebrowser
+  const selectorContent = '.jp-DirListing-content';
   // matches all filebrowser items
   const selectorItem = '.jp-DirListing-item[data-isdir]';
   // matches only non-directory items
   const selectorNotDir = '.jp-DirListing-item[data-isdir="false"]';
 
-  // If the user did not click on any file, we still want to show paste
+  // If the user did not click on any file, we still want to show paste,
+  // so target the content rather than an item.
   app.contextMenu.addItem({
     command: CommandIDs.paste,
-    selector: selectorDeadSpace,
+    selector: selectorContent,
     rank: 1
   });
 
@@ -671,12 +669,6 @@ function addCommands(
     command: CommandIDs.copy,
     selector: selectorNotDir,
     rank: 7
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.paste,
-    selector: selectorItem,
-    rank: 8
   });
 
   app.contextMenu.addItem({

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -93,8 +93,6 @@ const ITEM_ICON_CLASS = 'jp-DirListing-itemIcon';
  */
 const ITEM_MODIFIED_CLASS = 'jp-DirListing-itemModified';
 
-const DEAD_SPACE_CLASS = 'jp-DirListing-deadSpace';
-
 /**
  * The class name added to the dir listing editor node.
  */
@@ -1632,13 +1630,10 @@ export namespace DirListing {
       let node = document.createElement('div');
       let header = document.createElement('div');
       let content = document.createElement('ul');
-      let deadSpace = document.createElement('ul');
       content.className = CONTENT_CLASS;
-      deadSpace.className = DEAD_SPACE_CLASS;
       header.className = HEADER_CLASS;
       node.appendChild(header);
       node.appendChild(content);
-      node.appendChild(deadSpace);
       node.tabIndex = 1;
       return node;
     }

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -144,7 +144,7 @@
 
 /* increase specificity to override bundled default */
 .jp-DirListing-content {
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   margin: 0;
   padding: 0;
   list-style-type: none;


### PR DESCRIPTION
#5409 interacted poorly with #5314 when the side panel is narrow, putting a scrollbar in the wrong place. This fixes that behavior.

**Screenshots**
If applicable, add before and after screenshots to help show the issue being fixed, or the appearance of a new feature.

Before:
![image](https://user-images.githubusercontent.com/5728311/46554023-e440cd80-c893-11e8-94f3-3e8280fdc512.png)

After: 
![image](https://user-images.githubusercontent.com/5728311/46553965-b3f92f00-c893-11e8-8d19-4066ca35a37a.png)
