### PR TITLE
add 'New Folder' item to filebrowser context menu

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -67,6 +67,8 @@ namespace CommandIDs {
 
   export const paste = 'filebrowser:paste';
 
+  export const createNewDirectory = 'filebrowser:create-new-directory';
+
   export const rename = 'filebrowser:rename';
 
   // For main browser only.
@@ -437,6 +439,18 @@ function addCommands(
     mnemonic: 0
   });
 
+  commands.addCommand(CommandIDs.createNewDirectory, {
+    execute: () => {
+      const widget = tracker.currentWidget;
+
+      if (widget) {
+        return widget.createNewDirectory();
+      }
+    },
+    iconClass: 'jp-MaterialIcon jp-NewFolderIcon',
+    label: 'New Folder'
+  });
+
   commands.addCommand(CommandIDs.rename, {
     execute: args => {
       const widget = tracker.currentWidget;
@@ -620,12 +634,18 @@ function addCommands(
   // matches only non-directory items
   const selectorNotDir = '.jp-DirListing-item[data-isdir="false"]';
 
-  // If the user did not click on any file, we still want to show paste,
+  // If the user did not click on any file, we still want to show paste and new folder,
   // so target the content rather than an item.
+  app.contextMenu.addItem({
+    command: CommandIDs.createNewDirectory,
+    selector: selectorContent,
+    rank: 1
+  });
+
   app.contextMenu.addItem({
     command: CommandIDs.paste,
     selector: selectorContent,
-    rank: 1
+    rank: 2
   });
 
   app.contextMenu.addItem({
@@ -674,33 +694,33 @@ function addCommands(
   app.contextMenu.addItem({
     command: CommandIDs.duplicate,
     selector: selectorNotDir,
-    rank: 9
+    rank: 8
   });
   app.contextMenu.addItem({
     command: CommandIDs.download,
     selector: selectorNotDir,
-    rank: 10
+    rank: 9
   });
   app.contextMenu.addItem({
     command: CommandIDs.shutdown,
     selector: selectorNotDir,
-    rank: 11
+    rank: 10
   });
 
   app.contextMenu.addItem({
     command: CommandIDs.share,
     selector: selectorItem,
-    rank: 12
+    rank: 11
   });
   app.contextMenu.addItem({
     command: CommandIDs.copyPath,
     selector: selectorItem,
-    rank: 13
+    rank: 12
   });
   app.contextMenu.addItem({
     command: CommandIDs.copyDownloadLink,
     selector: selectorItem,
-    rank: 14
+    rank: 13
   });
 }
 

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -70,26 +70,11 @@ export class FileBrowser extends Widget {
     this._crumbs = new BreadCrumbs({ model });
     this.toolbar = new Toolbar<Widget>();
 
-    let directoryPending = false;
+    this._directoryPending = false;
     let newFolder = new ToolbarButton({
       iconClassName: 'jp-NewFolderIcon jp-Icon jp-Icon-16',
       onClick: () => {
-        if (directoryPending === true) {
-          return;
-        }
-        directoryPending = true;
-        this._manager
-          .newUntitled({
-            path: model.path,
-            type: 'directory'
-          })
-          .then(model => {
-            this._listing.selectItemByName(model.name);
-            directoryPending = false;
-          })
-          .catch(err => {
-            directoryPending = false;
-          });
+        this.createNewDirectory();
       },
       tooltip: 'New Folder'
     });
@@ -172,6 +157,28 @@ export class FileBrowser extends Widget {
    */
   paste(): Promise<void> {
     return this._listing.paste();
+  }
+
+  /**
+   * Create a new directory
+   */
+  createNewDirectory(): void {
+    if (this._directoryPending === true) {
+      return;
+    }
+    this._directoryPending = true;
+    this._manager
+      .newUntitled({
+        path: this.model.path,
+        type: 'directory'
+      })
+      .then(model => {
+        this._listing.selectItemByName(model.name);
+        this._directoryPending = false;
+      })
+      .catch(err => {
+        this._directoryPending = false;
+      });
   }
 
   /**
@@ -267,6 +274,7 @@ export class FileBrowser extends Widget {
   private _listing: DirListing;
   private _manager: DocumentManager;
   private _showingError = false;
+  private _directoryPending: boolean;
 }
 
 /**


### PR DESCRIPTION
Adds a “New Folder” item to the file browser context menu (addresses half of https://github.com/jupyterlab/jupyterlab/issues/4280).

<img width="336" alt="screen shot 2018-10-06 at 1 07 50 am" src="https://user-images.githubusercontent.com/12180828/46567847-cfeae800-c908-11e8-8ab6-aea3e7553959.png">
<img width="338" alt="screen shot 2018-10-06 at 1 08 04 am" src="https://user-images.githubusercontent.com/12180828/46567846-ce212480-c908-11e8-9d3d-b9d7648f9e3f.png">


