### PR TITLE
Change background when hovering over filebrowser breadcrumbs

### DIFF
--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -40,8 +40,14 @@
 }
 
 .jp-BreadCrumbs-item {
-  margin: 0px 4px;
+  margin: 0px 2px;
+  padding: 0px 2px;
+  border-radius: var(--jp-border-radius);
   cursor: pointer;
+}
+
+.jp-BreadCrumbs-item:hover {
+  background-color: var(--jp-layout-color2);
 }
 
 .jp-BreadCrumbs-item:first-child {


### PR DESCRIPTION
So far, there is no visual response from a breadcrumb in the filebrowser when the mouse hovering over it.

As suggested in https://github.com/jupyterlab/jupyterlab/issues/3502#issuecomment-376828659, this PR changes the background of the breadcrumb when the mouse hovers over it (as is already the case for other buttons, e.g. the "new folder" button above"). This makes it more clear that the breadcrumbs are actually clickable buttons.

Example: Mouse hovering over "jupyterlab":

![grafik](https://user-images.githubusercontent.com/2836374/46586918-54fb0c00-ca85-11e8-820d-71b870039e77.png)

