### PR TITLE
Refactor the share link command to separate plugin

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -104,6 +104,24 @@ const factory: JupyterLabPlugin<IFileBrowserFactory> = {
 };
 
 /**
+ * The default file browser share-file plugin
+ *
+ * This extension adds a "Copy Shareable Link" command that generates a copy-
+ * pastable URL. This url can be used to open a particular file in JupyterLab,
+ * handy for emailing links or bookmarking for reference.
+ *
+ * If you need to change how this link is generated (for instance, to copy a
+ * /user-redirect URL for JupyterHub), disable this plugin and replace it
+ * with another implementation.
+ */
+const shareFile: JupyterLabPlugin<void> = {
+  activate: activateShareFile,
+  id: '@jupyterlab/filebrowser-extension:share-file',
+  requires: [IFileBrowserFactory],
+  autoStart: true
+};
+
+/**
  * The file browser namespace token.
  */
 const namespace = 'filebrowser';
@@ -111,7 +129,7 @@ const namespace = 'filebrowser';
 /**
  * Export the plugins as default.
  */
-const plugins: JupyterLabPlugin<any>[] = [factory, browser];
+const plugins: JupyterLabPlugin<any>[] = [factory, browser, shareFile];
 export default plugins;
 
 /**
@@ -205,6 +223,32 @@ function activateBrowser(
       maybeCreate();
     });
     maybeCreate();
+  });
+}
+
+function activateShareFile(
+  app: JupyterLab,
+  factory: IFileBrowserFactory
+): void {
+  const { commands } = app;
+  const { tracker } = factory;
+
+  commands.addCommand(CommandIDs.share, {
+    execute: () => {
+      const widget = tracker.currentWidget;
+      if (!widget) {
+        return;
+      }
+      const path = encodeURI(widget.selectedItems().next().path);
+      const tree = PageConfig.getTreeUrl({ workspace: true });
+
+      Clipboard.copyToSystem(URLExt.join(tree, path));
+    },
+    isVisible: () =>
+      tracker.currentWidget &&
+      toArray(tracker.currentWidget.selectedItems()).length === 1,
+    iconClass: 'jp-MaterialIcon jp-LinkIcon',
+    label: 'Copy Shareable Link'
   });
 }
 
@@ -448,24 +492,6 @@ function addCommands(
     iconClass: 'jp-MaterialIcon jp-EditIcon',
     label: 'Rename',
     mnemonic: 0
-  });
-
-  commands.addCommand(CommandIDs.share, {
-    execute: () => {
-      const widget = tracker.currentWidget;
-      if (!widget) {
-        return;
-      }
-      const path = encodeURI(widget.selectedItems().next().path);
-      const tree = PageConfig.getTreeUrl({ workspace: true });
-
-      Clipboard.copyToSystem(URLExt.join(tree, path));
-    },
-    isVisible: () =>
-      tracker.currentWidget &&
-      toArray(tracker.currentWidget.selectedItems()).length === 1,
-    iconClass: 'jp-MaterialIcon jp-LinkIcon',
-    label: 'Copy Shareable Link'
   });
 
   commands.addCommand(CommandIDs.copyPath, {


### PR DESCRIPTION
Fixes #5388

As per the discussion on the ticket, I created another `JupyterLabPlugin` in the same package (`@jupyterlab/filebrowser-extension`). There's some things we could expand on (such as making it a more configurable link handler), but this will at least solve the immediate need and hopefully generate some user stories as to what more could be done for sharability.

This is my first PR to this project, so if you have any concerns (even if they're really minor!) please don't hesitate to share them.