### PR TITLE
Fix command header style

### DIFF
--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -93,8 +93,13 @@
 | Results
 |----------------------------------------------------------------------------*/
 
+.p-CommandPalette-header:first-child {
+  margin-top: 0px;
+}
+
 .p-CommandPalette-header {
-  padding: 8px 0 8px 22px;
+  margin-top: 8px;
+  padding: 8px 0 8px 12px;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size0);
   font-weight: 600;


### PR DESCRIPTION
The command headers were left-padded 22px whereas other headers are just left-padded 12px. This makes it hard to distinguish the header from the commands. This PR chages the left-padding to 12px. Also, it adds a 8px margin to the top of the header (except for the first header) to better separte the command groups.

---

### Current style:

![grafik](https://user-images.githubusercontent.com/2836374/47115798-f4778600-d25f-11e8-9963-f96f5a13d4b0.png)

---

### Proposed style:

![grafik](https://user-images.githubusercontent.com/2836374/47115646-83d06980-d25f-11e8-9aee-a550f657be06.png)
