### PR TITLE
Add "New Text File" and "New Markdown File" to the palette

### DIFF
--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -512,13 +512,14 @@ function activate(
   }
 
   if (palette) {
+    const category = 'Text Editor';
     let args: JSONObject = {
       insertSpaces: false,
       size: 4,
       name: 'Indent with Tab'
     };
     let command = 'fileeditor:change-tabs';
-    palette.addItem({ command, args, category: 'Text Editor' });
+    palette.addItem({ command, args, category });
 
     for (let size of [1, 2, 4, 8]) {
       let args: JSONObject = {
@@ -526,20 +527,20 @@ function activate(
         size,
         name: `Spaces: ${size} `
       };
-      palette.addItem({ command, args, category: 'Text Editor' });
+      palette.addItem({ command, args, category });
     }
 
     args = { isPalette: true };
     command = CommandIDs.createNew;
-    palette.addItem({ command, args, category: 'Text Editor' });
+    palette.addItem({ command, args, category });
 
     args = { name: 'Increase Font Size', delta: 1 };
     command = CommandIDs.changeFontSize;
-    palette.addItem({ command, args, category: 'Text Editor' });
+    palette.addItem({ command, args, category });
 
     args = { name: 'Decrease Font Size', delta: -1 };
     command = CommandIDs.changeFontSize;
-    palette.addItem({ command, args, category: 'Text Editor' });
+    palette.addItem({ command, args, category });
   }
 
   if (menu) {

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -440,11 +440,12 @@ function activate(
 
   // Function to create a new untitled text file, given
   // the current working directory.
-  const createNew = (cwd: string) => {
+  const createNew = (cwd: string, ext: string = 'txt') => {
     return commands
       .execute('docmanager:new-untitled', {
         path: cwd,
-        type: 'file'
+        type: 'file',
+        ext
       })
       .then(model => {
         return commands.execute('docmanager:open', {
@@ -465,32 +466,6 @@ function activate(
     }
   });
 
-  // Add a launcher item if the launcher is available.
-  if (launcher) {
-    launcher.add({
-      command: CommandIDs.createNew,
-      category: 'Other',
-      rank: 1
-    });
-  }
-
-  // Function to create a new untitled markdown file, given
-  // the current working directory.
-  const createNewMarkdown = (cwd: string) => {
-    return commands
-      .execute('docmanager:new-untitled', {
-        path: cwd,
-        type: 'file',
-        ext: 'md'
-      })
-      .then(model => {
-        return commands.execute('docmanager:open', {
-          path: model.path,
-          factory: FACTORY
-        });
-      });
-  };
-
   // Add a command for creating a new Markdown file.
   commands.addCommand(CommandIDs.createNewMarkdown, {
     label: args => (args['isPalette'] ? 'New Markdown File' : 'Markdown File'),
@@ -498,12 +473,18 @@ function activate(
     iconClass: args => (args['isPalette'] ? '' : MARKDOWN_ICON_CLASS),
     execute: args => {
       let cwd = args['cwd'] || browserFactory.defaultBrowser.model.path;
-      return createNewMarkdown(cwd as string);
+      return createNew(cwd as string, 'md');
     }
   });
 
   // Add a launcher item if the launcher is available.
   if (launcher) {
+    launcher.add({
+      command: CommandIDs.createNew,
+      category: 'Other',
+      rank: 1
+    });
+
     launcher.add({
       command: CommandIDs.createNewMarkdown,
       category: 'Other',

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -493,9 +493,9 @@ function activate(
 
   // Add a command for creating a new Markdown file.
   commands.addCommand(CommandIDs.createNewMarkdown, {
-    label: 'Markdown File',
+    label: args => (args['isPalette'] ? 'New Markdown File' : 'Markdown File'),
     caption: 'Create a new markdown file',
-    iconClass: MARKDOWN_ICON_CLASS,
+    iconClass: args => (args['isPalette'] ? '' : MARKDOWN_ICON_CLASS),
     execute: args => {
       let cwd = args['cwd'] || browserFactory.defaultBrowser.model.path;
       return createNewMarkdown(cwd as string);
@@ -532,6 +532,10 @@ function activate(
 
     args = { isPalette: true };
     command = CommandIDs.createNew;
+    palette.addItem({ command, args, category });
+
+    args = { isPalette: true };
+    command = CommandIDs.createNewMarkdown;
     palette.addItem({ command, args, category });
 
     args = { name: 'Increase Font Size', delta: 1 };

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -456,9 +456,9 @@ function activate(
 
   // Add a command for creating a new text file.
   commands.addCommand(CommandIDs.createNew, {
-    label: 'Text File',
+    label: args => (args['isPalette'] ? 'New Text File' : 'Text File'),
     caption: 'Create a new text file',
-    iconClass: EDITOR_ICON_CLASS,
+    iconClass: args => (args['isPalette'] ? '' : EDITOR_ICON_CLASS),
     execute: args => {
       let cwd = args['cwd'] || browserFactory.defaultBrowser.model.path;
       return createNew(cwd as string);
@@ -528,6 +528,10 @@ function activate(
       };
       palette.addItem({ command, args, category: 'Text Editor' });
     }
+
+    args = { isPalette: true };
+    command = CommandIDs.createNew;
+    palette.addItem({ command, args, category: 'Text Editor' });
 
     args = { name: 'Increase Font Size', delta: 1 };
     command = CommandIDs.changeFontSize;


### PR DESCRIPTION
To keep parity with "New Console", "New Terminal" and "New Notebook", which can be found both in "New > File > ..." and in the palette.

![new-text-md-file-palette](https://user-images.githubusercontent.com/591645/47239636-316d8500-d3e6-11e8-821f-a70a593ff554.gif)