### PR TITLE
Make button parameterized in showError

### DIFF
--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -37,13 +37,19 @@ export function showDialog<T>(
  * @param error - the error to show in the dialog body (either a string
  *   or an object with a string `message` property).
  */
-export function showErrorMessage(title: string, error: any): Promise<void> {
+export function showErrorMessage(
+  title: string,
+  error: any,
+  buttons: ReadonlyArray<Dialog.IButton> = [
+    Dialog.okButton({ label: 'DISMISS' })
+  ]
+): Promise<void> {
   console.warn('Showing error:', error);
 
   return showDialog({
     title: title,
     body: error.message || title,
-    buttons: [Dialog.okButton({ label: 'DISMISS' })]
+    buttons: buttons
   }).then(() => {
     /* no-op */
   });


### PR DESCRIPTION
The error message is defaulting to using the OK button scheme. In some cases, the WARN button scheme will be a better fit to make it clear to the user about the status.

Still defaults to using 1 OK button.

