### PR TITLE
Fix Copyright year in Jupyterlab help menu

### DIFF
--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -300,9 +300,11 @@ function activate(
           </a>
         </span>
       );
+
+      let currentYear = new Date().getFullYear();
       let copyright = (
         <span className="jp-About-copyright">
-          © 2015 Project Jupyter Contributors
+          © {currentYear} Project Jupyter Contributors
         </span>
       );
       let body = (


### PR DESCRIPTION
Update Copyright year in the Jupyterlab Help menu from `2015` to current year.
