### PR TITLE
Add "Go to Line" and "Find" capabilities to csvviewer

### DIFF
--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -717,6 +717,76 @@ export namespace Dialog {
    * The default renderer instance.
    */
   export const defaultRenderer = new Renderer();
+
+  /** A simple type for prompt widget */
+  type PromptValueType = string | number | boolean;
+  /**
+   * Create and show a prompt dialog
+   */
+  class PromptWidget<T extends PromptValueType> extends Widget {
+    constructor(value: T) {
+      let body = document.createElement('div');
+      let input = document.createElement('input');
+      if (typeof value === 'string') {
+        input.type = 'text';
+        if (value) {
+          input.value = value;
+        }
+      }
+      if (typeof value === 'number') {
+        input.type = 'number';
+        if (value) {
+          input.value = value.toFixed(2);
+        }
+      }
+      if (typeof value === 'boolean') {
+        input.type = 'checkbox';
+        input.checked = value;
+      }
+      body.appendChild(input);
+      super({ node: body });
+    }
+
+    /**
+     * Get the input text node.
+     */
+    get inputNode(): HTMLInputElement {
+      return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
+    }
+
+    /**
+     * Get the value of the widget.
+     */
+    getValue(): T {
+      if (this.inputNode.type === 'number') {
+        // In this branch T extends number.
+        return parseFloat(this.inputNode.value) as T;
+      }
+      if (this.inputNode.type === 'checkbox') {
+        // In this branch T extends boolean.
+        return this.inputNode.checked as T;
+      }
+      return this.inputNode.value as T;
+    }
+  }
+
+  /**
+   * Simple dialog to prompt for a value
+   * @param prompt Text to show on the prompt
+   * @param defaultValue Initial value
+   * @returns a Promise which will resolve with the value entered by user.
+   */
+  export function prompt<T extends PromptValueType>(
+    prompt: string,
+    defaultValue: PromptValueType
+  ): Promise<Dialog.IResult<T>> {
+    return showDialog({
+      title: prompt,
+      body: new PromptWidget<T>(defaultValue as T),
+      buttons: [Dialog.cancelButton(), Dialog.okButton()],
+      focusNodeSelector: 'input'
+    });
+  }
 }
 
 /**

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -327,10 +327,6 @@ function activateEditorCommands(
   // Add go to line capabilities to the edit menu.
   mainMenu.editMenu.goToLiners.add({
     tracker,
-    find: (widget: IDocumentWidget<FileEditor>) => {
-      let editor = widget.content.editor as CodeMirrorEditor;
-      editor.execCommand('jumpToLine');
-    },
     goToLine: (widget: IDocumentWidget<FileEditor>) => {
       let editor = widget.content.editor as CodeMirrorEditor;
       editor.execCommand('jumpToLine');

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -34,7 +34,9 @@
     "@jupyterlab/apputils": "^0.19.1",
     "@jupyterlab/csvviewer": "^0.19.1",
     "@jupyterlab/docregistry": "^0.19.1",
-    "@phosphor/datagrid": "^0.1.6"
+    "@jupyterlab/mainmenu": "^0.8.1",
+    "@phosphor/datagrid": "^0.1.6",
+    "@phosphor/widgets": "^1.6.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -7,12 +7,7 @@ import {
   JupyterLabPlugin
 } from '@jupyterlab/application';
 
-import {
-  InstanceTracker,
-  IThemeManager,
-  showDialog,
-  Dialog
-} from '@jupyterlab/apputils';
+import { InstanceTracker, IThemeManager, Dialog } from '@jupyterlab/apputils';
 
 import {
   CSVViewer,
@@ -24,7 +19,6 @@ import {
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 
 import { DataGrid } from '@phosphor/datagrid';
-import { Widget } from '@phosphor/widgets';
 
 import { IMainMenu, IEditMenu } from '@jupyterlab/mainmenu';
 
@@ -33,40 +27,6 @@ import { IMainMenu, IEditMenu } from '@jupyterlab/mainmenu';
  */
 const FACTORY_CSV = 'CSVTable';
 const FACTORY_TSV = 'TSVTable';
-
-/**
- * A widget used to prompt for a simple value.
- */
-class PromptWidget extends Widget {
-  constructor(labelText: string, inputType: string, value?: string) {
-    let body = document.createElement('div');
-    let label = document.createElement('label');
-    label.textContent = labelText;
-    let input = document.createElement('input');
-    input.type = inputType;
-    if (value) {
-      input.value = value;
-    }
-    body.appendChild(label);
-    body.appendChild(input);
-
-    super({ node: body });
-  }
-
-  /**
-   * Get the input text node.
-   */
-  get inputNode(): HTMLInputElement {
-    return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
-  }
-
-  /**
-   * Get the value of the widget.
-   */
-  getValue(): string {
-    return this.inputNode.value;
-  }
-}
 
 /**
  * The CSV file handler extension.
@@ -99,21 +59,11 @@ function addMenuEntries(
   mainMenu.editMenu.findReplacers.add({
     tracker,
     find: (widget: IDocumentWidget<CSVViewer>) => {
-      const buttons = {
-        Cancel: Dialog.cancelButton(),
-        OK: Dialog.okButton({ label: 'Find' })
-      };
-      return showDialog({
-        title: 'Find...',
-        body: new PromptWidget(
-          'Search Text',
-          'text',
-          widget.content.searchService.searchText
-        ),
-        buttons: [buttons.Cancel, buttons.OK],
-        focusNodeSelector: 'input'
-      }).then(value => {
-        if (value.button === buttons.OK) {
+      return Dialog.prompt<string>(
+        'Search Text',
+        widget.content.searchService.searchText
+      ).then(value => {
+        if (value.button.accept) {
           widget.content.searchService.find(value.value);
         }
       });
@@ -124,18 +74,9 @@ function addMenuEntries(
   mainMenu.editMenu.goToLiners.add({
     tracker,
     goToLine: (widget: IDocumentWidget<CSVViewer>) => {
-      const buttons = {
-        Cancel: Dialog.cancelButton(),
-        OK: Dialog.okButton({ label: 'Go To Line' })
-      };
-      return showDialog({
-        title: 'Go to Line',
-        body: new PromptWidget('Line Number', 'number'),
-        buttons: [buttons.Cancel, buttons.OK],
-        focusNodeSelector: 'input'
-      }).then(value => {
-        if (value.button === buttons.OK) {
-          widget.content.goToLine(parseInt(value.value, 10));
+      return Dialog.prompt<number>('Go to Line', 0).then(value => {
+        if (value.button.accept) {
+          widget.content.goToLine(value.value);
         }
       });
     }

--- a/packages/csvviewer-extension/tsconfig.json
+++ b/packages/csvviewer-extension/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../docregistry"
+    },
+    {
+      "path": "../mainmenu"
     }
   ]
 }

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -136,6 +136,16 @@ export class CSVViewer extends Widget {
   }
 
   /**
+   * Go to line
+   */
+  goToLine(lineNumber: number) {
+    this._grid.scrollTo(
+      this._grid.scrollX,
+      this._grid.baseRowSize * (lineNumber - 1)
+    );
+  }
+
+  /**
    * Handle `'activate-request'` messages.
    */
   protected onActivateRequest(msg: Message): void {

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -130,10 +130,16 @@ export class GridSearchService {
           this._grid.repaint();
           if (!isMatchInViewport()) {
             // scroll the matching cell into view
-            this._grid.scrollTo(
-              this._grid.baseColumnSize * this._column,
-              this._grid.baseRowSize * this._row
-            );
+            let scrollX = this._grid.scrollX;
+            let scrollY = this._grid.scrollY;
+            /* see also https://github.com/jupyterlab/jupyterlab/pull/5523#issuecomment-432621391 */
+            for (let i = scrollY; i < this._row - 1; i++) {
+              scrollY += this._grid.sectionSize('row', i);
+            }
+            for (let j = scrollX; j < this._column - 1; j++) {
+              scrollX += this._grid.sectionSize('column', j);
+            }
+            this._grid.scrollTo(scrollX, scrollY);
           }
           return;
         }
@@ -266,10 +272,15 @@ export class CSVViewer extends Widget {
    * Go to line
    */
   goToLine(lineNumber: number) {
-    this._grid.scrollTo(
-      this._grid.scrollX,
-      this._grid.baseRowSize * (lineNumber - 1)
-    );
+    let scrollY = this._grid.scrollY;
+    /* The lines might not all have uniform height, so we can't just scroll to lineNumber * this._grid.baseRowSize
+    see https://github.com/jupyterlab/jupyterlab/pull/5523#issuecomment-432621391 for discussions around
+    this. It would be nice if DataGrid had a method to scroll to cell, which could be implemented more efficiently
+    because datagrid knows more about the shape of the cells. */
+    for (let i = scrollY; i < lineNumber - 1; i++) {
+      scrollY += this._grid.sectionSize('row', i);
+    }
+    this._grid.scrollTo(this._grid.scrollX, scrollY);
   }
 
   /**

--- a/tests/test-csvviewer/package.json
+++ b/tests/test-csvviewer/package.json
@@ -21,6 +21,7 @@
     "@jupyterlab/services": "^3.2.1",
     "@jupyterlab/testutils": "^0.3.1",
     "@phosphor/coreutils": "^1.3.0",
+    "@phosphor/datagrid": "^0.1.6",
     "@phosphor/widgets": "^1.6.0",
     "chai": "~4.1.2",
     "csv-spectrum": "~1.0.0",


### PR DESCRIPTION

## Go to Line

![jupyterlab-csvviewer-go-to-line](https://user-images.githubusercontent.com/521510/47326190-8c330500-d6a2-11e8-8454-da5bffe2d820.gif)


## Find
![jupyterlab-csvviewer-find](https://user-images.githubusercontent.com/521510/47274195-609a1700-d5dd-11e8-9e64-2ebc17e1353f.gif)

Some notes about *find* implementation: 
 * So that we can configure the colours for "cell matching search" and "current cell matching search", I had to refactor a bit to replace the `TextRender`s created for the theme by some `TextRenderConfig` that would allow the search service to build a `TextRenderer` which style the matching cells accordingly.
 * added a unit test faking the cell renderer service to check that the cell matching search text are highlighted.

At the same time, I add a fixup commit for a mistake in #5377