### PR TITLE
Improvement on inspector to allow easier updates of inspector

### DIFF
--- a/packages/inspector-extension/src/manager.ts
+++ b/packages/inspector-extension/src/manager.ts
@@ -71,6 +71,14 @@ export class InspectorManager implements IInspector {
   }
 
   /**
+   * Pass onInspectorUpdate to the underlying panel, which allows
+   * an IInspectable to connect to an inspector directly.
+   */
+  onInspectorUpdate(sender: any, args: IInspector.IInspectorUpdate): void {
+    this._inspector.onInspectorUpdate(sender, args);
+  }
+
+  /**
    * Handle the source disposed signal.
    */
   private _onSourceDisposed() {

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -67,6 +67,11 @@ export interface IInspector {
    * The source of events the inspector listens for.
    */
   source: IInspector.IInspectable | null;
+
+  /**
+   * IInspector reacts to IInspectorUpdate
+   */
+  onInspectorUpdate(sender: any, args: IInspector.IInspectorUpdate): void;
 }
 
 /**
@@ -148,6 +153,23 @@ export namespace IInspector {
      * The type of the inspector being updated.
      */
     type: string;
+
+    /**
+     * The optional class name added to the inspector child widget
+     * if a new inspector is created.
+     */
+    className?: string;
+
+    /**
+     * The rank order of display priority for inspector updates. A lower rank
+     * denotes a higher display priority. Used if a new inspector is created.
+     */
+    rank?: number;
+
+    /**
+     * The display name of the inspector child if a new inspector is created.
+     */
+    name?: string;
   }
 }
 
@@ -264,13 +286,16 @@ export class InspectorPanel extends TabPanel implements IInspector {
   /**
    * Handle inspector update signals.
    */
-  protected onInspectorUpdate(
-    sender: any,
-    args: IInspector.IInspectorUpdate
-  ): void {
+  onInspectorUpdate(sender: any, args: IInspector.IInspectorUpdate): void {
     let widget = this._items[args.type];
     if (!widget) {
-      return;
+      this.add({
+        className: args.className,
+        name: args.name,
+        rank: args.rank,
+        type: args.type
+      });
+      widget = this._items[args.type];
     }
 
     // Update the content of the inspector widget.
@@ -282,7 +307,7 @@ export class InspectorPanel extends TabPanel implements IInspector {
     if (args.content) {
       for (let type in items) {
         let inspector = this._items[type];
-        if (inspector.rank < widget.rank && inspector.content) {
+        if (inspector.rank > widget.rank && inspector.content) {
           return;
         }
       }

--- a/tests/test-inspector/src/inspector.spec.ts
+++ b/tests/test-inspector/src/inspector.spec.ts
@@ -12,7 +12,7 @@ import { IInspector, InspectorPanel } from '@jupyterlab/inspector/src';
 class TestInspectorPanel extends InspectorPanel {
   methods: string[] = [];
 
-  protected onInspectorUpdate(
+  public onInspectorUpdate(
     sender: any,
     args: IInspector.IInspectorUpdate
   ): void {


### PR DESCRIPTION
This is a subset of pull request #4879, which extends the inspect widget and allows the implementation of #4879 in an extension.

More specifically,

1. It exposes `onInspectorUpdate` of `InspectorManager` so that it can be updated by an extension.
2. It adds fields `className`, `rank`, and `name` to `IInspector.IInspectorUpdate` and changes the logic of `onInspectorUpdate` so that a new tab will be created if no existing tab with `type` exists. Items 1 and 2 make it easier to add new tabs to the inspector panel.
3. It fixes a bug in the handling of `rank` of inspector panel.

@afshin Could you have a look at this?
