### PR TITLE
Ignore editor temp files for file watching in dev mode

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -49,7 +49,7 @@ Object.keys(jlab.linkedPackages).forEach(function(name) {
   var localPath = require.resolve(path.join(name, 'package.json'));
   localLinked[name] = path.dirname(localPath);
 });
-var ignorePatterns = [/^\.\#/];
+var ignorePatterns = [/^\.\#/]; // eslint-disable-line
 
 /**
  * Sync a local path to a linked package path if they are files and differ.
@@ -164,7 +164,7 @@ module.exports = [
         }
 
         // Ignore files with certain patterns
-        var baseName = localPath.replace(/^.*[\\\/]/, '');
+        var baseName = localPath.replace(/^.*[\\\/]/, ''); // eslint-disable-line
         if (
           ignorePatterns.some(function(rexp) {
             return baseName.match(rexp);

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -49,6 +49,7 @@ Object.keys(jlab.linkedPackages).forEach(function(name) {
   var localPath = require.resolve(path.join(name, 'package.json'));
   localLinked[name] = path.dirname(localPath);
 });
+var ignorePatterns = [/^\.\#/];
 
 /**
  * Sync a local path to a linked package path if they are files and differ.
@@ -161,6 +162,17 @@ module.exports = [
         if (localPath in ignoreCache) {
           return ignoreCache[localPath];
         }
+
+        // Ignore files with certain patterns
+        var baseName = localPath.replace(/^.*[\\\/]/, '');
+        if (
+          ignorePatterns.some(function(rexp) {
+            return baseName.match(rexp);
+          })
+        ) {
+          return true;
+        }
+
         // Limit the watched files to those in our local linked package dirs.
         var ignore = true;
         Object.keys(localLinked).some(function(name) {


### PR DESCRIPTION
Add support for a list of filename patterns (as regular expressions) that webpack will ignore during --watch mode and --dev_mode

This prevents spurious errors during file editing where an editor (e.g. emacs) creates temporary files that webpack then tries to build.  