### PR TITLE
Add @jupyterlab/ui-components package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,6 @@ examples/app/themes
 examples/app/schemas
 
 lerna-debug.log
+yarn-error.log
 
 junit.xml

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -75,6 +75,7 @@
     "@jupyterlab/theme-light-extension": "^0.19.1",
     "@jupyterlab/tooltip": "^0.19.1",
     "@jupyterlab/tooltip-extension": "^0.19.1",
+    "@jupyterlab/ui-components": "^0.0.1",
     "@jupyterlab/vdom-extension": "^0.18.1",
     "@jupyterlab/vega4-extension": "^0.18.1",
     "@phosphor/algorithm": "^1.1.2",
@@ -290,6 +291,7 @@
       "@jupyterlab/theme-light-extension": "../packages/theme-light-extension",
       "@jupyterlab/tooltip": "../packages/tooltip",
       "@jupyterlab/tooltip-extension": "../packages/tooltip-extension",
+      "@jupyterlab/ui-components": "../packages/ui-components",
       "@jupyterlab/vdom-extension": "../packages/vdom-extension",
       "@jupyterlab/vega4-extension": "../packages/vega4-extension"
     }

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@jupyterlab/coreutils": "^2.2.1",
     "@jupyterlab/services": "^3.2.1",
+    "@jupyterlab/ui-components": "^0.0.1",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/commands": "^1.6.1",
     "@phosphor/coreutils": "^1.3.0",

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -3,6 +3,8 @@
 
 import { UseSignal, ReactWidget } from './vdom';
 
+import { Button } from '@jupyterlab/ui-components';
+
 import { IIterator, find, map, some } from '@phosphor/algorithm';
 
 import { CommandRegistry } from '@phosphor/commands';
@@ -376,7 +378,7 @@ export namespace ToolbarButtonComponent {
  * @param props - The props for ToolbarButtonComponent.
  */
 export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
-  const handleMouseDown = (event: React.MouseEvent) => {
+  const handleClick = (event: React.MouseEvent) => {
     event.preventDefault();
     props.onClick();
   };
@@ -389,16 +391,17 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
   };
 
   return (
-    <button
+    <Button
       className={
         props.className
           ? props.className + ' jp-ToolbarButtonComponent'
           : 'jp-ToolbarButtonComponent'
       }
       disabled={props.enabled === false}
-      onMouseDown={handleMouseDown}
+      onClick={handleClick}
       onKeyDown={handleKeyDown}
       title={props.tooltip || props.iconLabel}
+      minimal
     >
       {props.iconClassName && (
         <span
@@ -408,7 +411,7 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
       {props.label && (
         <span className="jp-ToolbarButtonComponent-label">{props.label}</span>
       )}
-    </button>
+    </Button>
   );
 }
 

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -29,7 +29,7 @@
 |----------------------------------------------------------------------------*/
 
 .p-CommandPalette-search {
-  padding: 8px;
+  padding: 4px;
   background-color: var(--jp-layout-color1);
   z-index: 2;
 }
@@ -37,14 +37,13 @@
 .p-CommandPalette-wrapper {
   overflow: overlay;
   padding: 0px 8px;
-  border: 1px solid var(--jp-border-color0);
   background-color: var(--jp-input-active-background);
   height: 30px;
 }
 
 .p-CommandPalette.p-mod-focused .p-CommandPalette-wrapper {
-  border: var(--jp-border-width) solid var(--md-blue-500);
-  box-shadow: inset 0 0 4px var(--md-blue-300);
+  box-shadow: inset 0 0 0 1px rgba(19, 124, 189, 0.3),
+    inset 0 0 0 3px rgba(19, 124, 189, 0.3);
 }
 
 .p-CommandPalette-wrapper::after {
@@ -52,11 +51,11 @@
   color: white;
   background-color: var(--jp-brand-color1);
   position: absolute;
-  top: 8px;
-  right: 8px;
-  height: 32px;
-  width: 12px;
-  padding: 0px 12px;
+  top: 4px;
+  right: 4px;
+  height: 30px;
+  width: 10px;
+  padding: 0px 10px;
   background-image: var(--jp-icon-search-white);
   background-size: 20px;
   background-repeat: no-repeat;
@@ -74,16 +73,8 @@
   line-height: var(--jp-private-commandpalette-search-height);
 }
 
-.p-CommandPalette-input::-webkit-input-placeholder {
-  color: var(--jp-ui-font-color3);
-  font-size: var(--jp-ui-font-size1);
-}
-
-.p-CommandPalette-input::-moz-placeholder {
-  color: var(--jp-ui-font-color3);
-  font-size: var(--jp-ui-font-size1);
-}
-
+.p-CommandPalette-input::-webkit-input-placeholder,
+.p-CommandPalette-input::-moz-placeholder,
 .p-CommandPalette-input:-ms-input-placeholder {
   color: var(--jp-ui-font-color3);
   font-size: var(--jp-ui-font-size1);

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -36,9 +36,10 @@
 
 .p-CommandPalette-wrapper {
   overflow: overlay;
-  padding: 0px 8px;
+  padding: 0px 9px;
   background-color: var(--jp-input-active-background);
   height: 30px;
+  box-shadow: inset 0 0 0 var(--jp-border-width) var(--jp-input-border-color);
 }
 
 .p-CommandPalette.p-mod-focused .p-CommandPalette-wrapper {

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -77,18 +77,10 @@ button.jp-ToolbarButtonComponent {
   border-radius: var(--jp-border-radius);
   display: flex;
   align-items: center;
-}
-
-button.jp-ToolbarButtonComponent:focus {
-  background: var(--jp-layout-color2);
-}
-
-button.jp-ToolbarButtonComponent:enabled:hover {
-  background: var(--jp-layout-color2);
-}
-
-button.jp-ToolbarButtonComponent:enabled:active {
-  background: var(--jp-layout-color3);
+  text-align: center;
+  font-size: 14px;
+  min-width: unset;
+  min-height: unset;
 }
 
 button.jp-ToolbarButtonComponent:disabled {

--- a/packages/apputils/tsconfig.json
+++ b/packages/apputils/tsconfig.json
@@ -11,6 +11,9 @@
     },
     {
       "path": "../services"
+    },
+    {
+      "path": "../ui-components"
     }
   ]
 }

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^0.19.1",
     "@jupyterlab/services": "^3.2.1",
+    "@jupyterlab/ui-components": "^0.0.1",
     "@phosphor/messaging": "^1.2.2",
     "react": "~16.4.2",
     "react-paginate": "^5.2.3",

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -7,6 +7,8 @@ import { ServiceManager } from '@jupyterlab/services';
 
 import { Message } from '@phosphor/messaging';
 
+import { Button, InputGroup, Collapse } from '@jupyterlab/ui-components';
+
 import * as React from 'react';
 
 import ReactPaginate from 'react-paginate';
@@ -37,15 +39,14 @@ export class SearchBar extends React.Component<
   render(): React.ReactNode {
     return (
       <div className="jp-extensionmanager-search-bar">
-        <div className="jp-extensionmanager-search-wrapper">
-          <input
-            type="text"
-            className="jp-extensionmanager-input"
-            placeholder={this.props.placeholder}
-            onChange={this.handleChange.bind(this)}
-            value={this.state.value}
-          />
-        </div>
+        <InputGroup
+          className="jp-extensionmanager-search-wrapper"
+          type="text"
+          placeholder={this.props.placeholder}
+          onChange={this.handleChange}
+          value={this.state.value}
+          rightIcon="search"
+        />
       </div>
     );
   }
@@ -53,12 +54,12 @@ export class SearchBar extends React.Component<
   /**
    * Handler for search input changes.
    */
-  handleChange(e: KeyboardEvent) {
+  handleChange = (e: React.FormEvent<HTMLElement>) => {
     let target = e.target as HTMLInputElement;
     this.setState({
       value: target.value
     });
-  }
+  };
 }
 
 /**
@@ -97,18 +98,12 @@ function BuildPrompt(props: BuildPrompt.IProperties): React.ReactElement<any> {
       <div className="jp-extensionmanager-buildmessage">
         A build is needed to include the latest changes
       </div>
-      <button
-        className="jp-extensionmanager-rebuild"
-        onClick={props.performBuild}
-      >
+      <Button onClick={props.performBuild} minimal small>
         Rebuild
-      </button>
-      <button
-        className="jp-extensionmanager-ignorebuild"
-        onClick={props.ignoreBuild}
-      >
+      </Button>
+      <Button onClick={props.ignoreBuild} minimal small>
         Ignore
-      </button>
+      </Button>
     </div>
   );
 }
@@ -139,15 +134,6 @@ namespace BuildPrompt {
 function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
   const { entry } = props;
   const flagClasses = [];
-  if (entry.installed) {
-    flagClasses.push('jp-extensionmanager-entry-installed');
-  }
-  if (entry.enabled) {
-    flagClasses.push('jp-extensionmanager-entry-enabled');
-  }
-  if (ListModel.entryHasUpdate(entry)) {
-    flagClasses.push('jp-extensionmanager-entry-update');
-  }
   if (entry.status && ['ok', 'warning', 'error'].indexOf(entry.status) !== -1) {
     flagClasses.push(`jp-extensionmanager-entry-${entry.status}`);
   }
@@ -174,37 +160,51 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
           {entry.description}
         </div>
         <div className="jp-extensionmanager-entry-buttons">
-          <button
-            className="jp-extensionmanager-install"
-            onClick={() => props.performAction('install', entry)}
-          >
-            Install
-          </button>
-          <button
-            className="jp-extensionmanager-update"
-            // An install action will update the extension:
-            onClick={() => props.performAction('install', entry)}
-          >
-            Update
-          </button>
-          <button
-            className="jp-extensionmanager-uninstall"
-            onClick={() => props.performAction('uninstall', entry)}
-          >
-            Uninstall
-          </button>
-          <button
-            className="jp-extensionmanager-enable"
-            onClick={() => props.performAction('enable', entry)}
-          >
-            Enable
-          </button>
-          <button
-            className="jp-extensionmanager-disable"
-            onClick={() => props.performAction('disable', entry)}
-          >
-            Disable
-          </button>
+          {!entry.installed && (
+            <Button
+              onClick={() => props.performAction('install', entry)}
+              minimal
+              small
+            >
+              Install
+            </Button>
+          )}
+          {ListModel.entryHasUpdate(entry) && (
+            <Button
+              onClick={() => props.performAction('install', entry)}
+              minimal
+              small
+            >
+              Update
+            </Button>
+          )}
+          {entry.installed && (
+            <Button
+              onClick={() => props.performAction('uninstall', entry)}
+              minimal
+              small
+            >
+              Uninstall
+            </Button>
+          )}
+          {entry.enabled && (
+            <Button
+              onClick={() => props.performAction('enable', entry)}
+              minimal
+              small
+            >
+              Enable
+            </Button>
+          )}
+          {!entry.enabled && (
+            <Button
+              onClick={() => props.performAction('disable', entry)}
+              minimal
+              small
+            >
+              Disable
+            </Button>
+          )}
         </div>
       </div>
     </li>
@@ -307,32 +307,6 @@ export namespace ListView {
   }
 }
 
-/**
- *
- *
- * @param {RefreshButton.IProperties} props
- * @returns {React.ReactElement<any>}
- */
-function RefreshButton(
-  props: RefreshButton.IProperties
-): React.ReactElement<any> {
-  return (
-    <ToolbarButtonComponent
-      key="refreshButton"
-      className="jp-extensionmanager-refresh"
-      iconClassName="jp-RefreshIcon jp-Icon jp-Icon-16"
-      onClick={props.onClick}
-      tooltip="Refresh extension list"
-    />
-  );
-}
-
-namespace RefreshButton {
-  export interface IProperties {
-    onClick: () => void;
-  }
-}
-
 function ErrorMessage(props: ErrorMessage.IProperties) {
   return (
     <div key="error-msg" className="jp-extensionmanager-error">
@@ -357,7 +331,7 @@ export class CollapsibleSection extends React.Component<
   constructor(props: CollapsibleSection.IProperties) {
     super(props);
     this.state = {
-      collapsed: props.startCollapsed
+      isOpen: props.isOpen || true
     };
   }
 
@@ -365,49 +339,44 @@ export class CollapsibleSection extends React.Component<
    * Render the collapsible section using the virtual DOM.
    */
   render(): React.ReactNode {
-    const elements: Array<React.ReactNode> = [
-      <header key="header">
-        <ToolbarButtonComponent
-          key="collapser"
-          iconClassName={
-            'jp-Icon jp-Icon-16 ' +
-            (this.state.collapsed
-              ? 'jp-extensionmanager-collapseIcon'
-              : 'jp-extensionmanager-expandIcon')
-          }
-          className={'jp-collapser-button'}
-          onClick={() => {
-            this.onCollapse();
-          }}
-        />
-        <span className="jp-extensionmanager-headerText">
-          {this.props.header}
-        </span>
-        {this.props.headerElements}
-      </header>
-    ];
-
-    if (!this.state.collapsed) {
-      if (Array.isArray(this.props.children)) {
-        elements.push(...this.props.children);
-      } else {
-        elements.push(this.props.children);
-      }
-    }
-
-    return elements;
+    return (
+      <>
+        <header>
+          <ToolbarButtonComponent
+            iconClassName={
+              'jp-Icon jp-Icon-16 ' +
+              (this.state.isOpen
+                ? 'jp-extensionmanager-expandIcon'
+                : 'jp-extensionmanager-collapseIcon')
+            }
+            onClick={() => {
+              this.handleCollapse();
+            }}
+          />
+          <span className="jp-extensionmanager-headerText">
+            {this.props.header}
+          </span>
+          {this.props.headerElements}
+        </header>
+        <Collapse isOpen={this.state.isOpen}>{this.props.children}</Collapse>
+      </>
+    );
   }
 
   /**
    * Handler for search input changes.
    */
-  onCollapse() {
-    if (this.props.onCollapse !== undefined) {
-      this.props.onCollapse(!this.state.collapsed);
-    }
-    this.setState({
-      collapsed: !this.state.collapsed
-    });
+  handleCollapse() {
+    this.setState(
+      {
+        isOpen: !this.state.isOpen
+      },
+      () => {
+        if (this.props.onCollapse) {
+          this.props.onCollapse(this.state.isOpen);
+        }
+      }
+    );
   }
 }
 
@@ -425,14 +394,14 @@ export namespace CollapsibleSection {
     header: string;
 
     /**
-     * Whether the view will be collapsed initially or not.
+     * Whether the view will be expanded or collapsed initially, defaults to open.
      */
-    startCollapsed: boolean;
+    isOpen?: boolean;
 
     /**
-     * Callback for collapse action.
+     * Handle collapse event.
      */
-    onCollapse?: (collapsed: boolean) => void;
+    onCollapse?: (isOpen: boolean) => void;
 
     /**
      * Any additional elements to add to the header.
@@ -450,9 +419,9 @@ export namespace CollapsibleSection {
    */
   export interface IState {
     /**
-     * Whther the section is collapsed or not.
+     * Whether the section is expanded or collapsed.
      */
-    collapsed: boolean;
+    isOpen: boolean;
   }
 }
 
@@ -470,9 +439,9 @@ export class ExtensionView extends VDomRenderer<ListModel> {
    * The search input node.
    */
   get inputNode(): HTMLInputElement {
-    return this.node.getElementsByClassName(
-      'jp-extensionmanager-input'
-    )[0] as HTMLInputElement;
+    return this.node.querySelector(
+      '.jp-extensionmanager-search-wrapper input'
+    ) as HTMLInputElement;
   }
 
   /**
@@ -526,7 +495,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
       );
     } else if (model.serverRequirementsError !== null) {
       content.push(
-        <ErrorMessage key="error-msg">
+        <ErrorMessage key="server-requirements-error">
           <p>
             The server has some missing requirements for installing extensions.
           </p>
@@ -541,7 +510,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
       let installedContent = [];
       if (model.installedError !== null) {
         installedContent.push(
-          <ErrorMessage>
+          <ErrorMessage key="install-error">
             {`Error querying installed extensions${
               model.installedError ? `: ${model.installedError}` : '.'
             }`}
@@ -550,7 +519,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
       } else {
         installedContent.push(
           <ListView
-            key="list-view"
+            key="installed-items"
             entries={model.installed}
             numPages={1}
             onPage={value => {
@@ -563,14 +532,18 @@ export class ExtensionView extends VDomRenderer<ListModel> {
 
       content.push(
         <CollapsibleSection
-          header="Installed"
           key="installed-section"
-          startCollapsed={false}
+          isOpen={true}
+          header="Installed"
           headerElements={
-            <RefreshButton
+            <ToolbarButtonComponent
+              key="refresh-button"
+              className="jp-extensionmanager-refresh"
+              iconClassName="jp-RefreshIcon jp-Icon jp-Icon-16"
               onClick={() => {
                 model.refreshInstalled();
               }}
+              tooltip="Refresh extension list"
             />
           }
         >
@@ -581,7 +554,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
       let searchContent = [];
       if (model.searchError !== null) {
         searchContent.push(
-          <ErrorMessage>
+          <ErrorMessage key="search-error">
             {`Error searching for extensions${
               model.searchError ? `: ${model.searchError}` : '.'
             }`}
@@ -590,7 +563,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
       } else {
         searchContent.push(
           <ListView
-            key="list-view"
+            key="search-items"
             // Filter out installed extensions:
             entries={model.searchResult.filter(
               entry => model.installed.indexOf(entry) === -1
@@ -606,11 +579,11 @@ export class ExtensionView extends VDomRenderer<ListModel> {
 
       content.push(
         <CollapsibleSection
-          header={model.query ? 'Search Results' : 'Discover'}
           key="search-section"
-          startCollapsed={true}
-          onCollapse={(collapsed: boolean) => {
-            if (!collapsed && model.query === null) {
+          isOpen={false}
+          header={model.query ? 'Search Results' : 'Discover'}
+          onCollapse={(isOpen: boolean) => {
+            if (isOpen && model.query === null) {
               model.query = '';
             }
           }}

--- a/packages/extensionmanager/style/index.css
+++ b/packages/extensionmanager/style/index.css
@@ -13,6 +13,7 @@
 
 .jp-extensionmanager-content {
   overflow: auto;
+  overflow-x: hidden;
 }
 
 /*
@@ -22,7 +23,7 @@
 .jp-extensionmanager-listview-wrapper {
   margin: 0;
   padding: 0;
-  padding-bottom: 5px;
+  padding-bottom: 8px;
   display: flex;
   flex-direction: column;
   flex: 0 0 auto;
@@ -44,7 +45,7 @@
   justify-content: space-between;
   flex: 0 0 auto;
   margin: 0px;
-  padding: 8px 12px;
+  padding-bottom: 8px;
   font-weight: 600;
   text-transform: uppercase;
   border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
@@ -52,6 +53,7 @@
   font-size: var(--jp-ui-font-size0);
   line-height: 24px;
   height: 24px;
+  padding: 4px;
 }
 
 .jp-extensionmanager-view header > .jp-ToolbarButtonComponent {
@@ -60,7 +62,7 @@
 
 .jp-extensionmanager-view header .jp-extensionmanager-headerText {
   flex: 1 0 auto;
-  margin: 0px 2px;
+  margin: 0px 4px;
 }
 
 .jp-extensionmanager-view header > .jp-ToolbarButtonComponent {
@@ -70,7 +72,7 @@
 }
 
 .jp-extensionmanager-view header > .jp-ToolbarButtonComponent:hover {
-  border: 1px solid var(--jp-brand-color1);
+  /* border: 1px solid var(--jp-brand-color1); */
 }
 
 /*
@@ -85,50 +87,21 @@
 */
 
 .jp-extensionmanager-search-bar {
-  padding: 8px 8px 0px 8px;
-  background-color: var(--jp-layout-color1);
-  z-index: 2;
-  flex: 0 0 auto;
+  padding: 4px;
 }
 
-.jp-extensionmanager-input {
+.jp-extensionmanager-search-wrapper input {
   background: transparent;
-  width: calc(100% - 18px);
-  float: left;
-  border: none;
-  outline: none;
   font-size: var(--jp-ui-font-size1);
   color: var(--jp-ui-font-color0);
   line-height: var(--jp-private-commandpalette-search-height);
+  box-sizing: border-box;
+  border-radius: 0;
 }
 
-.jp-extensionmanager-search-wrapper {
-  overflow: overlay;
-  padding: 0px 8px;
-  border: 1px solid var(--jp-border-color0);
-  background-color: var(--jp-input-active-background);
-  height: 30px;
-}
-
-.jp-extensionmanager-search-wrapper::after {
-  content: ' ';
-  color: var(--jp-ui-inverse-font-color1);
-  background-color: var(--jp-brand-color1);
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  height: 32px;
-  width: 12px;
-  padding: 0px 12px;
-  background-image: var(--jp-icon-search-white);
-  background-size: 20px;
-  background-repeat: no-repeat;
-  background-position: center;
-}
-
-.jp-extensionmanager-view.p-mod-focused .jp-extensionmanager-search-wrapper {
-  border: var(--jp-border-width) solid var(--jp-brand-color1);
-  box-shadow: inset 0 0 4px var(--jp-brand-color2);
+.jp-extensionmanager-search-wrapper input:focus {
+  box-shadow: inset 0 0 0 1px rgba(19, 124, 189, 0.3),
+    inset 0 0 0 3px rgba(19, 124, 189, 0.3);
 }
 
 /*
@@ -153,46 +126,12 @@
   display: flex;
   justify-content: center;
 }
-
-/*
-  Entry buttons visibility
-*/
-
-.jp-extensionmanager-entry .jp-extensionmanager-install,
-.jp-extensionmanager-entry.jp-extensionmanager-entry-update
-  .jp-extensionmanager-update,
-.jp-extensionmanager-entry.jp-extensionmanager-entry-installed
-  .jp-extensionmanager-uninstall {
-  display: inline-block;
-}
-
-.jp-extensionmanager-entry .jp-extensionmanager-update,
-.jp-extensionmanager-entry .jp-extensionmanager-uninstall,
-.jp-extensionmanager-entry.jp-extensionmanager-entry-installed
-  .jp-extensionmanager-install {
-  display: none;
-}
-
-.jp-extensionmanager-entry .jp-extensionmanager-enable,
-.jp-extensionmanager-entry .jp-extensionmanager-disable,
-.jp-extensionmanager-entry.jp-extensionmanager-entry-installed.jp-extensionmanager-entry-enabled
-  .jp-extensionmanager-enable {
-  display: none;
-}
-
-.jp-extensionmanager-entry.jp-extensionmanager-entry-installed
-  .jp-extensionmanager-enable,
-.jp-extensionmanager-entry.jp-extensionmanager-entry-installed.jp-extensionmanager-entry-enabled
-  .jp-extensionmanager-disable {
-  display: inline-block;
-}
-
 /*
   Entry layout and styling
 */
 
 .jp-extensionmanager-entry {
-  padding: 4px 12px;
+  padding: 8px;
   border-bottom: solid var(--jp-border-width) var(--jp-border-color2);
 }
 
@@ -270,7 +209,7 @@
 
 .jp-extensionmanager-entry-content {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: space-between;
 }
 
@@ -294,7 +233,7 @@
   left: -200px;
   width: 200px;
   height: 4px;
-  border-radius: 5px;
+  border-radius: 4px;
   background-color: var(--jp-brand-color1);
   animation: loading 2s linear infinite;
 }
@@ -327,38 +266,8 @@
 
 .jp-extensionmanager-entry-buttons {
   display: flex;
-  flex-direction: column;
-}
-
-.jp-extensionmanager-entry button {
-  border: solid var(--jp-border-width) var(--jp-border-color2);
-  font-size: var(--jp-ui-font-size0);
-  margin-top: 1px;
-  margin-bottom: 1px;
-  margin-right: 0px;
-  margin-left: 3px;
-  color: var(--jp-ui-font-color1);
-  background-color: var(--jp-layout-color2);
-}
-
-.jp-extensionmanager-entry button.jp-extensionmanager-uninstall:hover {
-  background-color: var(--jp-error-color2);
-}
-
-.jp-extensionmanager-entry button.jp-extensionmanager-disable:hover {
-  background-color: var(--jp-error-color3);
-}
-
-.jp-extensionmanager-entry button.jp-extensionmanager-install:hover {
-  background-color: var(--jp-success-color2);
-}
-
-.jp-extensionmanager-entry button.jp-extensionmanager-enable:hover {
-  background-color: var(--jp-success-color3);
-}
-
-.jp-extensionmanager-entry button.jp-extensionmanager-update:hover {
-  background-color: var(--jp-brand-color3);
+  flex-direction: row;
+  padding-top: 4px;
 }
 
 /*
@@ -380,7 +289,7 @@
   font-size: var(--jp-ui-font-size1);
   font-weight: 600;
   float: right;
-  margin: 3px;
+  margin: 4px;
 }
 
 /*

--- a/packages/extensionmanager/tsconfig.json
+++ b/packages/extensionmanager/tsconfig.json
@@ -11,6 +11,9 @@
     },
     {
       "path": "../services"
+    },
+    {
+      "path": "../ui-components"
     }
   ]
 }

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -71,8 +71,12 @@
   justify-content: space-evenly;
 }
 
+.jp-FileBrowser-toolbar.jp-Toolbar .jp-Toolbar-item {
+  flex: 1;
+}
+
 .jp-FileBrowser-toolbar.jp-Toolbar .jp-ToolbarButtonComponent {
-  padding: 0px 16px;
+  width: 100%;
 }
 
 /*-----------------------------------------------------------------------------

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^1.2.1",
+    "@jupyterlab/ui-components": "^0.0.1",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -3,15 +3,13 @@
 
 import * as React from 'react';
 
-import * as ReactDOM from 'react-dom';
-
 import Highlight from 'react-highlighter';
 
 import JSONTree from 'react-json-tree';
 
-import { InputGroup } from '@jupyterlab/ui-components';
-
 import { JSONArray, JSONObject, JSONValue } from '@phosphor/coreutils';
+
+import { InputGroup } from '@jupyterlab/ui-components';
 
 /**
  * The properties for the JSON tree component.
@@ -19,7 +17,6 @@ import { JSONArray, JSONObject, JSONValue } from '@phosphor/coreutils';
 export interface IProps {
   data: JSONValue;
   metadata?: JSONObject;
-  theme?: string;
 }
 
 /**
@@ -35,30 +32,17 @@ export interface IState {
  */
 export class Component extends React.Component<IProps, IState> {
   state = { filter: '', value: '' };
+
   timer: number = 0;
 
-  componentDidMount() {
-    /**
-     * Stop propagation of keyboard events to JupyterLab
-     */
-    ReactDOM.findDOMNode(this.input).addEventListener(
-      'keydown',
-      (event: Event) => {
-        event.stopPropagation();
-      },
-      false
-    );
-  }
-
-  componentWillUnmount() {
-    ReactDOM.findDOMNode(this.input).removeEventListener(
-      'keydown',
-      (event: Event) => {
-        event.stopPropagation();
-      },
-      false
-    );
-  }
+  handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+    this.setState({ value });
+    window.clearTimeout(this.timer);
+    this.timer = window.setTimeout(() => {
+      this.setState({ filter: value });
+    }, 300);
+  };
 
   render() {
     const { data, metadata } = this.props;
@@ -81,34 +65,25 @@ export class Component extends React.Component<IProps, IState> {
           collectionLimit={100}
           theme={{
             extend: theme,
-            // TODO: Use Jupyter Notebook's current CodeMirror theme vs. 'cm-s-ipython'
-            tree: `CodeMirror ${this.props.theme || 'cm-s-ipython'}`,
-            // valueLabel: 'cm-variable',
+            valueLabel: 'cm-variable',
             valueText: 'cm-string',
-            // nestedNodeLabel: 'cm-variable-2',
-            nestedNodeItemString: 'cm-comment',
-            // value: {},
-            // label: {},
-            // itemRange: {},
-            // nestedNode: {},
-            // nestedNodeItemType: {},
-            // nestedNodeChildren: {},
-            // rootNodeChildren: {},
-            arrowSign: { color: 'cm-variable' }
+            nestedNodeItemString: 'cm-comment'
           }}
           invertTheme={false}
           keyPath={[root]}
           labelRenderer={([label, type]) => {
-            let className = 'cm-variable';
-            // if (type === 'root') className = 'cm-variable-2';
-            if (type === 'array') {
-              className = 'cm-variable-2';
-            }
-            if (type === 'object') {
-              className = 'cm-variable-3';
-            }
+            // let className = 'cm-variable';
+            // if (type === 'root') {
+            //   className = 'cm-variable-2';
+            // }
+            // if (type === 'array') {
+            //   className = 'cm-variable-2';
+            // }
+            // if (type === 'Object') {
+            //   className = 'cm-variable-3';
+            // }
             return (
-              <span className={className}>
+              <span className="cm-keyword">
                 <Highlight
                   search={this.state.filter}
                   matchStyle={{ backgroundColor: 'yellow' }}
@@ -148,24 +123,26 @@ export class Component extends React.Component<IProps, IState> {
   }
 }
 
+// Provide an invalid theme object (this is on purpose!) to invalidate the
+// react-json-tree's inline styles that override CodeMirror CSS classes
 const theme = {
   scheme: 'jupyter',
-  base00: '#fff',
-  base01: '#fff',
-  base02: '#d7d4f0',
-  base03: '#408080',
-  base04: '#b4b7b4',
-  base05: '#c5c8c6',
-  base06: '#d7d4f0',
-  base07: '#fff',
-  base08: '#000',
-  base09: '#080',
-  base0A: '#fba922',
-  base0B: '#408080',
-  base0C: '#aa22ff',
-  base0D: '#00f',
-  base0E: '#008000',
-  base0F: '#00f'
+  base00: 'invalid',
+  base01: 'invalid',
+  base02: 'invalid',
+  base03: 'invalid',
+  base04: 'invalid',
+  base05: 'invalid',
+  base06: 'invalid',
+  base07: 'invalid',
+  base08: 'invalid',
+  base09: 'invalid',
+  base0A: 'invalid',
+  base0B: 'invalid',
+  base0C: 'invalid',
+  base0D: 'invalid',
+  base0E: 'invalid',
+  base0F: 'invalid'
 };
 
 function objectIncludes(data: JSONValue, query: string): boolean {

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -9,6 +9,8 @@ import Highlight from 'react-highlighter';
 
 import JSONTree from 'react-json-tree';
 
+import { InputGroup } from '@jupyterlab/ui-components';
+
 import { JSONArray, JSONObject, JSONValue } from '@phosphor/coreutils';
 
 /**
@@ -25,14 +27,14 @@ export interface IProps {
  */
 export interface IState {
   filter?: string;
+  value: string;
 }
 
 /**
  * A component that renders JSON data as a collapsible tree.
  */
 export class Component extends React.Component<IProps, IState> {
-  state = { filter: '' };
-  input: Element = null;
+  state = { filter: '', value: '' };
   timer: number = 0;
 
   componentDidMount() {
@@ -65,31 +67,14 @@ export class Component extends React.Component<IProps, IState> {
       ? filterPaths(data, this.state.filter, [root])
       : [root];
     return (
-      <div style={{ position: 'relative', width: '100%' }}>
-        <input
-          ref={ref => (this.input = ref)}
-          onChange={event => {
-            if (this.timer) {
-              window.clearTimeout(this.timer);
-            }
-            const filter = event.target.value;
-            this.timer = window.setTimeout(() => {
-              this.setState({ filter } as IState);
-              this.timer = 0;
-            }, 300);
-          }}
-          style={{
-            position: 'absolute',
-            top: 0,
-            right: 0,
-            width: '33%',
-            maxWidth: 150,
-            zIndex: 10,
-            fontSize: 13,
-            padding: '4px 2px'
-          }}
+      <div className="container">
+        <InputGroup
+          className="filter"
           type="text"
           placeholder="Filter..."
+          onChange={this.handleChange}
+          value={this.state.value}
+          rightIcon="search"
         />
         <JSONTree
           data={data}

--- a/packages/json-extension/src/index.tsx
+++ b/packages/json-extension/src/index.tsx
@@ -35,6 +35,8 @@ export class RenderedJSON extends Widget implements IRenderMime.IRenderer {
   constructor(options: IRenderMime.IRendererOptions) {
     super();
     this.addClass(CSS_CLASS);
+    this.addClass('CodeMirror');
+    this.addClass('cm-s-jupyter');
     this._mimeType = options.mimeType;
   }
 
@@ -44,14 +46,14 @@ export class RenderedJSON extends Widget implements IRenderMime.IRenderer {
   renderModel(model: IRenderMime.IMimeModel): Promise<void> {
     const data = model.data[this._mimeType] as any;
     const metadata = (model.metadata[this._mimeType] as any) || {};
-    const props = { data, metadata, theme: 'cm-s-jupyter' };
-
     return new Promise<void>((resolve, reject) => {
-      const component = <Component {...props} />;
-
-      ReactDOM.render(component, this.node, () => {
-        resolve();
-      });
+      ReactDOM.render(
+        <Component data={data} metadata={metadata} />,
+        this.node,
+        () => {
+          resolve();
+        }
+      );
     });
   }
 

--- a/packages/json-extension/style/index.css
+++ b/packages/json-extension/style/index.css
@@ -3,11 +3,6 @@
   Distributed under the terms of the Modified BSD License.
 */
 
-/* Add CSS variables to :root */
-:root {
-  /*--jp-private-json-variable: 16px;*/
-}
-
 /* Base styles */
 .jp-RenderedJSON {
   width: 100%;
@@ -16,20 +11,36 @@
   overflow: hidden;
 }
 
-/* Patch for default ul.CodeMirror styles */
-.jp-RenderedJSON ul.CodeMirror {
-  list-style: none;
-  padding-left: 0;
-  margin: 0;
+/* Override react-json-tree inline styles */
+.jp-RenderedJSON *:not(mark) {
+  background-color: transparent !important;
+}
+
+.jp-RenderedJSON ul {
+  margin: 0 !important;
+}
+
+.jp-RenderedJSON .container {
+  position: relative;
+  width: 100%;
+}
+
+.jp-RenderedJSON .filter {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 33%;
+  max-width: 150px;
+  z-index: 10;
 }
 
 /* Document styles */
 .jp-MimeDocument .jp-RenderedJSON {
-  padding: 5px;
-  padding-top: 0;
+  padding: 5px 5px 5px 20px;
   overflow-y: auto;
 }
 
 /* Output styles */
-.jp-OutputArea .jp-RenderedJSON {
-}
+/* .jp-OutputArea .jp-RenderedJSON {
+
+} */

--- a/packages/json-extension/tsconfig.json
+++ b/packages/json-extension/tsconfig.json
@@ -8,6 +8,9 @@
   "references": [
     {
       "path": "../rendermime-interfaces"
+    },
+    {
+      "path": "../ui-components"
     }
   ]
 }

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -93,6 +93,7 @@
     "@jupyterlab/theme-light-extension": "^0.19.1",
     "@jupyterlab/tooltip": "^0.19.1",
     "@jupyterlab/tooltip-extension": "^0.19.1",
+    "@jupyterlab/ui-components": "^0.0.1",
     "@jupyterlab/vdom-extension": "^0.18.1",
     "@jupyterlab/vega4-extension": "^0.18.1"
   },

--- a/packages/metapackage/src/index.ts
+++ b/packages/metapackage/src/index.ts
@@ -63,5 +63,6 @@ import '@jupyterlab/theme-dark-extension';
 import '@jupyterlab/theme-light-extension';
 import '@jupyterlab/tooltip';
 import '@jupyterlab/tooltip-extension';
+import '@jupyterlab/ui-components';
 import '@jupyterlab/vdom-extension';
 import '@jupyterlab/vega4-extension';

--- a/packages/metapackage/tsconfig.json
+++ b/packages/metapackage/tsconfig.json
@@ -196,6 +196,9 @@
       "path": "../tooltip-extension"
     },
     {
+      "path": "../ui-components"
+    },
+    {
       "path": "../vdom-extension"
     },
     {

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -40,6 +40,7 @@
     "@jupyterlab/rendermime": "^0.19.1",
     "@jupyterlab/services": "^3.2.1",
     "@jupyterlab/statusbar": "^0.7.1",
+    "@jupyterlab/ui-components": "^0.0.1",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/domutils": "^1.1.2",

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -278,6 +278,14 @@ export class CellTypeSwitcher extends ReactWidget {
     if (this._notebook.activeCell) {
       value = this._notebook.activeCell.model.type;
     }
+    for (let widget of this._notebook.widgets) {
+      if (this._notebook.isSelectedOrActive(widget)) {
+        if (widget.model.type !== value) {
+          value = '-';
+          break;
+        }
+      }
+    }
     return (
       <HTMLSelect
         className={TOOLBAR_CELLTYPE_DROPDOWN_CLASS}
@@ -286,6 +294,7 @@ export class CellTypeSwitcher extends ReactWidget {
         value={value}
         minimal
       >
+        <option value="-">-</option>
         <option value="code">Code</option>
         <option value="markdown">Markdown</option>
         <option value="raw">Raw</option>

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -5,8 +5,6 @@ import * as React from 'react';
 
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 
-import { Message } from '@phosphor/messaging';
-
 import { Widget } from '@phosphor/widgets';
 
 import { NotebookActions } from './actions';
@@ -14,7 +12,6 @@ import { NotebookActions } from './actions';
 import {
   showDialog,
   Dialog,
-  Styling,
   Toolbar,
   ToolbarButtonComponent,
   UseSignal,
@@ -24,6 +21,8 @@ import {
 } from '@jupyterlab/apputils';
 
 import { nbformat } from '@jupyterlab/coreutils';
+
+import { HTMLSelect } from '@jupyterlab/ui-components';
 
 import { NotebookPanel } from './panel';
 
@@ -232,151 +231,67 @@ export namespace ToolbarItems {
 /**
  * A toolbar widget that switches cell types.
  */
-class CellTypeSwitcher extends Widget {
+export class CellTypeSwitcher extends ReactWidget {
   /**
    * Construct a new cell type switcher.
    */
   constructor(widget: Notebook) {
-    super({ node: createCellTypeSwitcherNode() });
+    super();
     this.addClass(TOOLBAR_CELLTYPE_CLASS);
-
-    this._select = this.node.firstChild as HTMLSelectElement;
-    Styling.wrapSelect(this._select);
-    this._wildCard = document.createElement('option');
-    this._wildCard.value = '-';
-    this._wildCard.textContent = '-';
     this._notebook = widget;
-
-    // Set the initial value.
     if (widget.model) {
-      this._updateValue();
+      this.update();
     }
-
-    // Follow the type of the active cell.
     widget.activeCellChanged.connect(
-      this._updateValue,
+      this.update,
       this
     );
-
     // Follow a change in the selection.
     widget.selectionChanged.connect(
-      this._updateValue,
+      this.update,
       this
     );
   }
 
   /**
-   * Handle the DOM events for the widget.
-   *
-   * @param event - The DOM event sent to the widget.
-   *
-   * #### Notes
-   * This method implements the DOM `EventListener` interface and is
-   * called in response to events on the dock panel's node. It should
-   * not be called directly by user code.
+   * Handle `change` events for the HTMLSelect component.
    */
-  handleEvent(event: Event): void {
-    switch (event.type) {
-      case 'change':
-        this._evtChange(event);
-        break;
-      case 'keydown':
-        this._evtKeyDown(event as KeyboardEvent);
-        break;
-      default:
-        break;
-    }
-  }
-
-  /**
-   * Handle `after-attach` messages for the widget.
-   */
-  protected onAfterAttach(msg: Message): void {
-    this._select.addEventListener('change', this);
-    this._select.addEventListener('keydown', this);
-  }
-
-  /**
-   * Handle `before-detach` messages for the widget.
-   */
-  protected onBeforeDetach(msg: Message): void {
-    this._select.removeEventListener('change', this);
-    this._select.removeEventListener('keydown', this);
-  }
-
-  /**
-   * Handle `changed` events for the widget.
-   */
-  private _evtChange(event: Event): void {
-    let select = this._select;
-    let widget = this._notebook;
-    if (select.value === '-') {
-      return;
-    }
-    if (!this._changeGuard) {
-      let value = select.value as nbformat.CellType;
-      NotebookActions.changeCellType(widget, value);
-      widget.activate();
-    }
-  }
-
-  /**
-   * Handle `keydown` events for the widget.
-   */
-  private _evtKeyDown(event: KeyboardEvent): void {
-    if (event.keyCode === 13) {
-      // Enter
+  handleChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+    if (event.target.value !== '-') {
+      NotebookActions.changeCellType(this._notebook, event.target
+        .value as nbformat.CellType);
       this._notebook.activate();
     }
-  }
+  };
 
   /**
-   * Update the value of the dropdown from the widget state.
+   * Handle `keydown` events for the HTMLSelect component.
    */
-  private _updateValue(): void {
-    let widget = this._notebook;
-    let select = this._select;
-    if (!widget.activeCell) {
-      return;
+  handleKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.keyCode === 13) {
+      this._notebook.activate();
     }
-    let mType: string = widget.activeCell.model.type;
-    for (let i = 0; i < widget.widgets.length; i++) {
-      let child = widget.widgets[i];
-      if (widget.isSelectedOrActive(child)) {
-        if (child.model.type !== mType) {
-          mType = '-';
-          select.appendChild(this._wildCard);
-          break;
-        }
-      }
+  };
+
+  render() {
+    let value = '-';
+    if (this._notebook.activeCell) {
+      value = this._notebook.activeCell.model.type;
     }
-    if (mType !== '-') {
-      select.remove(3);
-    }
-    this._changeGuard = true;
-    select.value = mType;
-    this._changeGuard = false;
+    return (
+      <HTMLSelect
+        className={TOOLBAR_CELLTYPE_DROPDOWN_CLASS}
+        onChange={this.handleChange}
+        onKeyDown={this.handleKeyDown}
+        value={value}
+        minimal
+      >
+        <option value="code">Code</option>
+        <option value="markdown">Markdown</option>
+        <option value="raw">Raw</option>
+      </HTMLSelect>
+    );
   }
 
-  private _changeGuard = false;
-  private _wildCard: HTMLOptionElement = null;
-  private _select: HTMLSelectElement = null;
   private _notebook: Notebook = null;
-}
-
-/**
- * Create the node for the cell type switcher.
- */
-function createCellTypeSwitcherNode(): HTMLElement {
-  let div = document.createElement('div');
-  let select = document.createElement('select');
-  for (let t of ['Code', 'Markdown', 'Raw']) {
-    let option = document.createElement('option');
-    option.value = t.toLowerCase();
-    option.textContent = t;
-    select.appendChild(option);
-  }
-  select.className = TOOLBAR_CELLTYPE_DROPDOWN_CLASS;
-  div.appendChild(select);
-  return div;
 }

--- a/packages/notebook/style/toolbar.css
+++ b/packages/notebook/style/toolbar.css
@@ -17,24 +17,19 @@
   padding: 2px;
 }
 
-/* select wrapper */
-.jp-Toolbar-item.jp-Notebook-toolbarCellType > .jp-select-wrapper {
-  height: 100%;
-  background-color: var(--jp-notebook-select-background);
-}
-
 .jp-Toolbar-item.jp-Notebook-toolbarCellType .jp-select-wrapper.jp-mod-focused {
   border: none;
   box-shadow: none;
 }
 
-/* Actual select element */
-.jp-Notebook-toolbarCellType select.jp-Notebook-toolbarCellTypeDropdown {
+.jp-Notebook-toolbarCellTypeDropdown select {
+  height: 24px;
   font-size: var(--jp-ui-font-size1);
-  background-size: 16px;
-  padding-right: 16px;
-  border: none;
+  line-height: 14px;
   border-radius: 0;
-  outline: none;
-  background-color: var(--jp-layout-color1);
+  display: block;
+}
+
+.jp-Notebook-toolbarCellTypeDropdown span {
+  top: 5px !important;
 }

--- a/packages/notebook/tsconfig.json
+++ b/packages/notebook/tsconfig.json
@@ -32,6 +32,9 @@
     },
     {
       "path": "../statusbar"
+    },
+    {
+      "path": "../ui-components"
     }
   ]
 }

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -1,0 +1,3 @@
+# @jupyterlab/ui-components
+
+A JupyterLab package that provides React UI components to core JupyterLab packages and third-party extensions.

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@jupyterlab/ui-components",
+  "version": "0.0.1",
+  "description": "JupyterLab - UI components written in React",
+  "homepage": "https://github.com/jupyterlab/jupyterlab",
+  "bugs": {
+    "url": "https://github.com/jupyterlab/jupyterlab/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Project Jupyter",
+  "files": [
+    "lib/*.d.ts",
+    "lib/*.js.map",
+    "lib/*.js",
+    "style/*.css"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "directories": {
+    "lib": "lib/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jupyterlab/jupyterlab.git"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf lib",
+    "docs": "typedoc --options tdoptions.json --theme ../../typedoc-theme src",
+    "prepublishOnly": "npm run build",
+    "watch": "tsc -b --watch"
+  },
+  "dependencies": {
+    "@blueprintjs/core": "^3.9.0",
+    "@blueprintjs/icons": "^3.3.0",
+    "@blueprintjs/select": "^3.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "~16.4.13",
+    "react": "~16.4.2",
+    "rimraf": "~2.6.2",
+    "typedoc": "~0.12.0",
+    "typescript": "~3.1.1"
+  },
+  "peerDependencies": {
+    "react": "~16.4.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -33,11 +33,11 @@
   "dependencies": {
     "@blueprintjs/core": "^3.9.0",
     "@blueprintjs/icons": "^3.3.0",
-    "@blueprintjs/select": "^3.3.0"
+    "@blueprintjs/select": "^3.3.0",
+    "react": "~16.4.2"
   },
   "devDependencies": {
     "@types/react": "~16.4.13",
-    "react": "~16.4.2",
     "rimraf": "~2.6.2",
     "typedoc": "~0.12.0",
     "typescript": "~3.1.1"

--- a/packages/ui-components/src/index.tsx
+++ b/packages/ui-components/src/index.tsx
@@ -4,17 +4,28 @@
 import * as React from 'react';
 import {
   Button as BPButton,
-  IButtonProps as IBPButtonProps,
-  InputGroup as BPInputGroup,
-  IInputGroupProps as IBPInputGroupProps,
+  IButtonProps as IBPButtonProps
+} from '@blueprintjs/core/lib/esm/components/button/buttons';
+import {
   Icon as BPIcon,
-  IIconProps,
+  IIconProps
+} from '@blueprintjs/core/lib/esm/components/icon/icon';
+import {
   Collapse as BPCollapse,
-  HTMLSelect as BPHTMLSelect,
-  IHTMLSelectProps,
   ICollapseProps
-} from '@blueprintjs/core';
-import { Select as BPSelect, ISelectProps } from '@blueprintjs/select';
+} from '@blueprintjs/core/lib/esm/components/collapse/collapse';
+import {
+  InputGroup as BPInputGroup,
+  IInputGroupProps as IBPInputGroupProps
+} from '@blueprintjs/core/lib/esm/components/forms/inputGroup';
+import {
+  HTMLSelect as BPHTMLSelect,
+  IHTMLSelectProps
+} from '@blueprintjs/core/lib/esm/components/html-select/htmlSelect';
+import {
+  Select as BPSelect,
+  ISelectProps
+} from '@blueprintjs/select/lib/esm/components/select/select';
 import '@blueprintjs/icons/lib/css/blueprint-icons.css';
 import '@blueprintjs/core/lib/css/blueprint.css';
 import '../style/index.css';

--- a/packages/ui-components/src/index.tsx
+++ b/packages/ui-components/src/index.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import * as React from 'react';
+import {
+  Button as BPButton,
+  IButtonProps as IBPButtonProps,
+  InputGroup as BPInputGroup,
+  IInputGroupProps as IBPInputGroupProps,
+  Icon as BPIcon,
+  IIconProps,
+  Collapse as BPCollapse,
+  HTMLSelect as BPHTMLSelect,
+  IHTMLSelectProps,
+  ICollapseProps
+} from '@blueprintjs/core';
+import { Select as BPSelect, ISelectProps } from '@blueprintjs/select';
+import '@blueprintjs/icons/lib/css/blueprint-icons.css';
+import '@blueprintjs/core/lib/css/blueprint.css';
+import '../style/index.css';
+
+export { Intent } from '@blueprintjs/core/lib/esm/common/intent';
+
+interface IButtonProps extends IBPButtonProps {
+  title?: string;
+}
+
+interface IInputGroupProps extends IBPInputGroupProps {
+  rightIcon?: IIconProps['icon'];
+}
+
+export const Button = (props: IButtonProps) => (
+  <BPButton
+    className={props.minimal ? 'jp-Button minimal' : 'jp-Button'}
+    {...props}
+  />
+);
+
+export const InputGroup = (props: IInputGroupProps) => {
+  if (props.rightIcon) {
+    return (
+      <BPInputGroup
+        className="jp-InputGroup"
+        rightElement={
+          <div className="jp-InputGroupAction right">
+            <Icon className="jp-Icon" icon={props.rightIcon} />
+          </div>
+        }
+        {...props}
+      />
+    );
+  }
+  return <BPInputGroup className="jp-InputGroup" {...props} />;
+};
+
+export const Icon = (props: IIconProps) => (
+  <BPIcon className="jp-Icon" {...props} />
+);
+
+export const Collapse = (props: ICollapseProps) => <BPCollapse {...props} />;
+
+export const HTMLSelect = (props: IHTMLSelectProps) => (
+  <BPHTMLSelect className="jp-HTMLSelect" {...props} />
+);
+
+export const Select = (props: ISelectProps<any>) => (
+  <BPSelect className="jp-Select" {...props} />
+);

--- a/packages/ui-components/src/index.tsx
+++ b/packages/ui-components/src/index.tsx
@@ -29,6 +29,7 @@ import {
 import '@blueprintjs/icons/lib/css/blueprint-icons.css';
 import '@blueprintjs/core/lib/css/blueprint.css';
 import '../style/index.css';
+import { combineClassNames } from './utils';
 
 export { Intent } from '@blueprintjs/core/lib/esm/common/intent';
 
@@ -42,8 +43,12 @@ interface IInputGroupProps extends IBPInputGroupProps {
 
 export const Button = (props: IButtonProps) => (
   <BPButton
-    className={props.minimal ? 'jp-Button minimal' : 'jp-Button'}
     {...props}
+    className={combineClassNames(
+      props.className,
+      props.minimal && 'minimal',
+      'jp-Button'
+    )}
   />
 );
 
@@ -51,29 +56,43 @@ export const InputGroup = (props: IInputGroupProps) => {
   if (props.rightIcon) {
     return (
       <BPInputGroup
-        className="jp-InputGroup"
+        {...props}
+        className={combineClassNames(props.className, 'jp-InputGroup')}
         rightElement={
-          <div className="jp-InputGroupAction right">
+          <div className="jp-InputGroupAction">
             <Icon className="jp-Icon" icon={props.rightIcon} />
           </div>
         }
-        {...props}
       />
     );
   }
-  return <BPInputGroup className="jp-InputGroup" {...props} />;
+  return (
+    <BPInputGroup
+      {...props}
+      className={combineClassNames(props.className, 'jp-InputGroup')}
+    />
+  );
 };
 
 export const Icon = (props: IIconProps) => (
-  <BPIcon className="jp-Icon" {...props} />
+  <BPIcon
+    {...props}
+    className={combineClassNames(props.className, 'jp-Icon')}
+  />
 );
 
 export const Collapse = (props: ICollapseProps) => <BPCollapse {...props} />;
 
 export const HTMLSelect = (props: IHTMLSelectProps) => (
-  <BPHTMLSelect className="jp-HTMLSelect" {...props} />
+  <BPHTMLSelect
+    {...props}
+    className={combineClassNames(props.className, 'jp-HTMLSelect')}
+  />
 );
 
 export const Select = (props: ISelectProps<any>) => (
-  <BPSelect className="jp-Select" {...props} />
+  <BPSelect
+    {...props}
+    className={combineClassNames(props.className, 'jp-Select')}
+  />
 );

--- a/packages/ui-components/src/index.tsx
+++ b/packages/ui-components/src/index.tsx
@@ -5,33 +5,33 @@ import * as React from 'react';
 import {
   Button as BPButton,
   IButtonProps as IBPButtonProps
-} from '@blueprintjs/core/lib/esm/components/button/buttons';
+} from '@blueprintjs/core/lib/cjs/components/button/buttons';
 import {
   Icon as BPIcon,
   IIconProps
-} from '@blueprintjs/core/lib/esm/components/icon/icon';
+} from '@blueprintjs/core/lib/cjs/components/icon/icon';
 import {
   Collapse as BPCollapse,
   ICollapseProps
-} from '@blueprintjs/core/lib/esm/components/collapse/collapse';
+} from '@blueprintjs/core/lib/cjs/components/collapse/collapse';
 import {
   InputGroup as BPInputGroup,
   IInputGroupProps as IBPInputGroupProps
-} from '@blueprintjs/core/lib/esm/components/forms/inputGroup';
+} from '@blueprintjs/core/lib/cjs/components/forms/inputGroup';
 import {
   HTMLSelect as BPHTMLSelect,
   IHTMLSelectProps
-} from '@blueprintjs/core/lib/esm/components/html-select/htmlSelect';
+} from '@blueprintjs/core/lib/cjs/components/html-select/htmlSelect';
 import {
   Select as BPSelect,
   ISelectProps
-} from '@blueprintjs/select/lib/esm/components/select/select';
+} from '@blueprintjs/select/lib/cjs/components/select/select';
 import '@blueprintjs/icons/lib/css/blueprint-icons.css';
 import '@blueprintjs/core/lib/css/blueprint.css';
 import '../style/index.css';
 import { combineClassNames } from './utils';
 
-export { Intent } from '@blueprintjs/core/lib/esm/common/intent';
+export { Intent } from '@blueprintjs/core/lib/cjs/common/intent';
 
 interface IButtonProps extends IBPButtonProps {
   title?: string;

--- a/packages/ui-components/src/index.tsx
+++ b/packages/ui-components/src/index.tsx
@@ -41,7 +41,9 @@ interface IInputGroupProps extends IBPInputGroupProps {
   rightIcon?: IIconProps['icon'];
 }
 
-export const Button = (props: IButtonProps) => (
+type CommonProps<T> = React.DOMAttributes<T>;
+
+export const Button = (props: IButtonProps & CommonProps<any>) => (
   <BPButton
     {...props}
     className={combineClassNames(
@@ -52,7 +54,7 @@ export const Button = (props: IButtonProps) => (
   />
 );
 
-export const InputGroup = (props: IInputGroupProps) => {
+export const InputGroup = (props: IInputGroupProps & CommonProps<any>) => {
   if (props.rightIcon) {
     return (
       <BPInputGroup
@@ -81,16 +83,18 @@ export const Icon = (props: IIconProps) => (
   />
 );
 
-export const Collapse = (props: ICollapseProps) => <BPCollapse {...props} />;
+export const Collapse = (props: ICollapseProps & CommonProps<any>) => (
+  <BPCollapse {...props} />
+);
 
-export const HTMLSelect = (props: IHTMLSelectProps) => (
+export const HTMLSelect = (props: IHTMLSelectProps & CommonProps<any>) => (
   <BPHTMLSelect
     {...props}
     className={combineClassNames(props.className, 'jp-HTMLSelect')}
   />
 );
 
-export const Select = (props: ISelectProps<any>) => (
+export const Select = (props: ISelectProps<any> & CommonProps<any>) => (
   <BPSelect
     {...props}
     className={combineClassNames(props.className, 'jp-Select')}

--- a/packages/ui-components/src/utils.ts
+++ b/packages/ui-components/src/utils.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+export function combineClassNames(...classNames: (string | undefined)[]) {
+  return classNames.join(' ');
+}

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -4,7 +4,54 @@
 |----------------------------------------------------------------------------*/
 
 .jp-Button {
+  border-radius: var(--jp-border-radius);
+  padding: 0px 12px;
+  font-size: var(--jp-ui-font-size1);
+  text-transform: uppercase;
 }
 
-.jp-Select {
+.jp-Button.minimal {
+  color: unset !important;
 }
+
+.jp-InputGroup {
+  border-radius: 0;
+}
+
+.jp-InputGroup input {
+  box-sizing: border-box;
+}
+
+.jp-InputGroup input:focus {
+  box-shadow: inset 0 0 0 1px rgba(19, 124, 189, 0.3),
+    inset 0 0 0 3px rgba(19, 124, 189, 0.3);
+}
+
+.jp-Icon {
+  color: var(--jp-layout-color4);
+}
+
+.jp-InputGroupAction {
+  line-height: 24px;
+  font-size: 20px;
+}
+
+.jp-InputGroupAction.left {
+  padding-left: 8px;
+}
+
+.jp-InputGroupAction.right {
+  padding-right: 8px;
+}
+
+.jp-HTMLSelect select {
+  height: 24;
+  font-size: var(--jp-ui-font-size1);
+  line-height: 14px;
+  border-radius: 0;
+  display: block;
+}
+
+/* .jp-Select {
+
+} */

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -49,17 +49,27 @@ strong {
   color: unset !important;
 }
 
-.jp-InputGroup {
-  border-radius: 0;
-}
+/* .jp-InputGroup {
+
+} */
 
 .jp-InputGroup input {
   box-sizing: border-box;
+  border-radius: 0;
+  background-color: transparent;
+  color: var(--jp-ui-font-color0);
+  box-shadow: inset 0 0 0 var(--jp-border-width) var(--jp-input-border-color);
 }
 
 .jp-InputGroup input:focus {
-  box-shadow: inset 0 0 0 1px rgba(19, 124, 189, 0.3),
+  /* box-shadow: inset 0 0 0 var(--jp-border-width) var(--jp-input-active-border-color),
+    inset 0 0 0 3px rgba(19, 124, 189, 0.3); */
+  box-shadow: inset 0 0 0 var(--jp-border-width) rgba(19, 124, 189, 0.3),
     inset 0 0 0 3px rgba(19, 124, 189, 0.3);
+}
+
+.jp-InputGroup input::placeholder {
+  color: var(--jp-ui-font-color3);
 }
 
 .jp-Icon {
@@ -67,16 +77,7 @@ strong {
 }
 
 .jp-InputGroupAction {
-  line-height: 24px;
-  font-size: 20px;
-}
-
-.jp-InputGroupAction.left {
-  padding-left: 8px;
-}
-
-.jp-InputGroupAction.right {
-  padding-right: 8px;
+  padding: 5px;
 }
 
 .jp-HTMLSelect select {
@@ -85,6 +86,11 @@ strong {
   line-height: 14px;
   border-radius: 0;
   display: block;
+  color: var(--jp-ui-font-color0);
+}
+
+.jp-HTMLSelect select:hover {
+  color: var(--jp-ui-font-color0);
 }
 
 /* .jp-Select {

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -3,6 +3,41 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+/* Override Blueprint's _reset.scss styles */
+html {
+  box-sizing: unset;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: unset;
+}
+
+body {
+  color: #182026;
+  font-family: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', 'Helvetica Neue', 'Icons16',
+    sans-serif;
+}
+
+p {
+  margin-top: unset;
+  margin-bottom: unset;
+}
+
+small {
+  font-size: unset;
+}
+
+strong {
+  font-weight: unset;
+}
+
+::selection {
+  background: unset;
+}
+
 .jp-Button {
   border-radius: var(--jp-border-radius);
   padding: 0px 12px;

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -1,0 +1,10 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-Button {
+}
+
+.jp-Select {
+}

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -16,9 +16,7 @@ html {
 
 body {
   color: #182026;
-  font-family: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto',
-    'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans', 'Helvetica Neue', 'Icons16',
-    sans-serif;
+  font-family: var(--jp-ui-font-family);
 }
 
 p {
@@ -35,7 +33,24 @@ strong {
 }
 
 ::selection {
-  background: unset;
+  /* background: unset; */
+}
+
+a {
+  text-decoration: unset;
+  color: unset;
+}
+
+a:hover {
+  cursor: unset;
+  text-decoration: unset;
+  color: unset;
+}
+
+:focus {
+  outline: unset;
+  outline-offset: unset;
+  -moz-outline-radius: unset;
 }
 
 .jp-Button {
@@ -47,6 +62,10 @@ strong {
 
 .jp-Button.minimal {
   color: unset !important;
+}
+
+.jp-Button.jp-ToolbarButtonComponent {
+  text-transform: none;
 }
 
 /* .jp-InputGroup {
@@ -68,7 +87,8 @@ strong {
     inset 0 0 0 3px rgba(19, 124, 189, 0.3);
 }
 
-.jp-InputGroup input::placeholder {
+.jp-InputGroup input::placeholder,
+input::placeholder {
   color: var(--jp-ui-font-color3);
 }
 
@@ -77,7 +97,7 @@ strong {
 }
 
 .jp-InputGroupAction {
-  padding: 5px;
+  padding: 6px;
 }
 
 .jp-HTMLSelect select {
@@ -96,3 +116,7 @@ strong {
 /* .jp-Select {
 
 } */
+
+select {
+  box-sizing: border-box;
+}

--- a/packages/ui-components/tdoptions.json
+++ b/packages/ui-components/tdoptions.json
@@ -1,0 +1,20 @@
+{
+  "excludeNotExported": true,
+  "mode": "file",
+  "target": "es5",
+  "module": "es5",
+  "lib": [
+    "lib.es2015.d.ts",
+    "lib.es2015.collection.d.ts",
+    "lib.es2015.promise.d.ts",
+    "lib.dom.d.ts"
+  ],
+  "out": "../../docs/api/ui-components",
+  "baseUrl": ".",
+  "paths": {
+    "@jupyterlab/*": ["../packages/*"]
+  },
+  "esModuleInterop": true,
+  "jsx": "react",
+  "types": ["webpack-env"]
+}

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfigbase",
+  "compilerOptions": {
+    "outDir": "lib",
+    "types": ["webpack-env"],
+    "rootDir": "src"
+  },
+  "include": ["src/*"],
+  "references": []
+}

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -153,7 +153,8 @@ describe('@jupyterlab/apputils', () => {
         await render(button);
         const buttonNode = button.node.firstChild as HTMLButtonElement;
         expect(buttonNode.title).to.equal('Test log command caption');
-        const iconNode = buttonNode.firstChild as HTMLElement;
+        const wrapperNode = buttonNode.firstChild as HTMLElement;
+        const iconNode = wrapperNode.firstChild as HTMLElement;
         expect(iconNode.classList.contains('test-icon-class')).to.equal(true);
         button.dispose();
       });
@@ -238,7 +239,8 @@ describe('@jupyterlab/apputils', () => {
         iconClassValue = 'updated-icon-class';
         commands.notifyCommandChanged(id);
         await render(button);
-        const iconNode = buttonNode.firstChild as HTMLElement;
+        const wrapperNode = buttonNode.firstChild as HTMLElement;
+        const iconNode = wrapperNode.firstChild as HTMLElement;
         expect(iconNode.classList.contains(iconClassValue)).to.equal(true);
 
         cmd.dispose();

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -250,11 +250,7 @@ describe('@jupyterlab/apputils', () => {
         const button = Toolbar.createInterruptButton(session);
         Widget.attach(button, document.body);
         await framePromise();
-        expect(
-          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
-            'jp-StopIcon'
-          )
-        ).to.equal(true);
+        expect(button.node.querySelector('.jp-StopIcon')).to.exist;
       });
     });
 
@@ -263,11 +259,7 @@ describe('@jupyterlab/apputils', () => {
         const button = Toolbar.createRestartButton(session);
         Widget.attach(button, document.body);
         await framePromise();
-        expect(
-          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
-            'jp-RefreshIcon'
-          )
-        ).to.equal(true);
+        expect(button.node.querySelector('.jp-RefreshIcon')).to.exist;
       });
     });
 
@@ -358,9 +350,7 @@ describe('@jupyterlab/apputils', () => {
         await framePromise();
         const button = widget.node.firstChild as HTMLElement;
         expect(button.classList.contains('foo')).to.equal(true);
-        expect(
-          (button.firstChild as HTMLElement).classList.contains('iconFoo')
-        ).to.equal(true);
+        expect(button.querySelector('.iconFoo')).to.exist;
         expect(button.title).to.equal('bar');
       });
     });
@@ -391,7 +381,7 @@ describe('@jupyterlab/apputils', () => {
           });
           Widget.attach(button, document.body);
           await framePromise();
-          simulate(button.node.firstChild as HTMLElement, 'mousedown');
+          simulate(button.node.firstChild as HTMLElement, 'click');
           expect(called).to.equal(true);
           button.dispose();
         });

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -190,28 +190,34 @@ describe('@jupyterlab/notebook', () => {
     describe('#createCellTypeItem()', () => {
       it('should track the cell type of the current cell', async () => {
         const item = ToolbarItems.createCellTypeItem(panel);
+        Widget.attach(item, document.body);
+        await framePromise();
         const node = item.node.getElementsByTagName(
           'select'
         )[0] as HTMLSelectElement;
-        await framePromise();
         expect(node.value).to.equal('code');
         panel.content.activeCellIndex++;
         await framePromise();
         expect(node.value).to.equal('markdown');
       });
 
-      it("should display `'-'` if multiple cell types are selected", () => {
+      it("should display `'-'` if multiple cell types are selected", async () => {
         const item = ToolbarItems.createCellTypeItem(panel);
+        Widget.attach(item, document.body);
+        await framePromise();
         const node = item.node.getElementsByTagName(
           'select'
         )[0] as HTMLSelectElement;
         expect(node.value).to.equal('code');
         panel.content.select(panel.content.widgets[1]);
+        await framePromise();
         expect(node.value).to.equal('-');
       });
 
-      it('should display the active cell type if multiple cells of the same type are selected', () => {
+      it('should display the active cell type if multiple cells of the same type are selected', async () => {
         const item = ToolbarItems.createCellTypeItem(panel);
+        Widget.attach(item, document.body);
+        await framePromise();
         const node = item.node.getElementsByTagName(
           'select'
         )[0] as HTMLSelectElement;
@@ -219,6 +225,7 @@ describe('@jupyterlab/notebook', () => {
         const cell = panel.model.contentFactory.createCodeCell({});
         panel.model.cells.insert(1, cell);
         panel.content.select(panel.content.widgets[1]);
+        await framePromise();
         expect(node.value).to.equal('code');
       });
     });

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -54,7 +54,7 @@ describe('@jupyterlab/notebook', () => {
         Widget.attach(button, document.body);
         let promise = signalToPromise(context.fileChanged);
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
+        simulate(button.node.firstChild as HTMLElement, 'click');
         await promise;
         button.dispose();
       });
@@ -63,11 +63,7 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createSaveButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        expect(
-          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
-            'jp-SaveIcon'
-          )
-        ).to.equal(true);
+        expect(button.node.querySelector('.jp-SaveIcon')).to.exist;
       });
     });
 
@@ -76,7 +72,7 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createInsertButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
+        simulate(button.node.firstChild as HTMLElement, 'click');
         expect(panel.content.activeCellIndex).to.equal(1);
         expect(panel.content.activeCell).to.be.an.instanceof(CodeCell);
         button.dispose();
@@ -86,11 +82,7 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createInsertButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        expect(
-          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
-            'jp-AddIcon'
-          )
-        ).to.equal(true);
+        expect(button.node.querySelector('.jp-AddIcon')).to.exist;
       });
     });
 
@@ -100,7 +92,7 @@ describe('@jupyterlab/notebook', () => {
         const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
+        simulate(button.node.firstChild as HTMLElement, 'click');
         expect(panel.content.widgets.length).to.equal(count - 1);
         expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
         button.dispose();
@@ -110,11 +102,7 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createCutButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        expect(
-          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
-            'jp-CutIcon'
-          )
-        ).to.equal(true);
+        expect(button.node.querySelector('.jp-CutIcon')).to.exist;
       });
     });
 
@@ -124,7 +112,7 @@ describe('@jupyterlab/notebook', () => {
         const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
+        simulate(button.node.firstChild as HTMLElement, 'click');
         expect(panel.content.widgets.length).to.equal(count);
         expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
         button.dispose();
@@ -134,11 +122,7 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createCopyButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        expect(
-          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
-            'jp-CopyIcon'
-          )
-        ).to.equal(true);
+        expect(button.node.querySelector('.jp-CopyIcon')).to.exist;
       });
     });
 
@@ -149,7 +133,7 @@ describe('@jupyterlab/notebook', () => {
         Widget.attach(button, document.body);
         await framePromise();
         NotebookActions.copy(panel.content);
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
+        simulate(button.node.firstChild as HTMLElement, 'click');
         await sleep();
         expect(panel.content.widgets.length).to.equal(count + 1);
         button.dispose();
@@ -159,11 +143,7 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createPasteButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        expect(
-          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
-            'jp-PasteIcon'
-          )
-        ).to.equal(true);
+        expect(button.node.querySelector('.jp-PasteIcon')).to.exist;
       });
     });
 
@@ -195,7 +175,7 @@ describe('@jupyterlab/notebook', () => {
           }
         });
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
+        simulate(button.node.firstChild as HTMLElement, 'click');
         await p.promise;
       }).timeout(30000); // Allow for slower CI
 
@@ -203,22 +183,20 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createRunButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        expect(
-          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
-            'jp-RunIcon'
-          )
-        ).to.equal(true);
+        expect(button.node.querySelector('.jp-RunIcon')).to.exist;
       });
     });
 
     describe('#createCellTypeItem()', () => {
-      it('should track the cell type of the current cell', () => {
+      it('should track the cell type of the current cell', async () => {
         const item = ToolbarItems.createCellTypeItem(panel);
         const node = item.node.getElementsByTagName(
           'select'
         )[0] as HTMLSelectElement;
+        await framePromise();
         expect(node.value).to.equal('code');
         panel.content.activeCellIndex++;
+        await framePromise();
         expect(node.value).to.equal('markdown');
       });
 

--- a/tslint.json
+++ b/tslint.json
@@ -98,7 +98,8 @@
       true,
       "check-format",
       "allow-leading-underscore",
-      "ban-keywords"
+      "ban-keywords",
+      "allow-pascal-case"
     ],
     "whitespace": [
       true,

--- a/tslint.json
+++ b/tslint.json
@@ -110,6 +110,11 @@
     ]
   },
   "linterOptions": {
-    "exclude": ["node_modules/**/*.ts", "**/*.d.ts", "jupyterlab/**/*.ts"]
+    "exclude": [
+      "node_modules/**/*.ts",
+      "node_modules/**/*.tsx",
+      "**/*.d.ts",
+      "jupyterlab/**/*.ts"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,36 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@blueprintjs/core@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/core/-/core-3.9.0.tgz#60f10908227de8260be920a529bc67efbe9eb686"
+  dependencies:
+    "@blueprintjs/icons" "^3.3.0"
+    "@types/dom4" "^2.0.0"
+    classnames "^2.2"
+    dom4 "^2.0.1"
+    normalize.css "^8.0.0"
+    popper.js "^1.14.1"
+    react-popper "^1.0.0"
+    react-transition-group "^2.2.1"
+    resize-observer-polyfill "^1.5.0"
+    tslib "^1.9.0"
+
+"@blueprintjs/icons@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/icons/-/icons-3.3.0.tgz#d7f203ea97df79cb8f085b7468c516ff15332bea"
+  dependencies:
+    classnames "^2.2"
+    tslib "^1.9.0"
+
+"@blueprintjs/select@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/select/-/select-3.3.0.tgz#e5ff961a846a9e90ca627b58912bda5058518941"
+  dependencies:
+    "@blueprintjs/core" "^3.9.0"
+    classnames "^2.2"
+    tslib "^1.9.0"
+
 "@lerna/add@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.4.1.tgz#d41068317e30f530df48220d256b5e79690b1877"
@@ -669,6 +699,10 @@
 "@types/comment-json@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/comment-json/-/comment-json-1.1.1.tgz#b4ae889912a93e64619f97989aecaff8ce889dca"
+
+"@types/dom4@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.1.tgz#506d5781b9bcab81bd9a878b198aec7dee2a6033"
 
 "@types/events@*":
   version "1.2.0"
@@ -1560,7 +1594,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.0.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
+babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -2189,6 +2223,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 clean-css@4.2.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
@@ -2607,6 +2645,13 @@ create-react-class@^15.6.2:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+create-react-context@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -3191,6 +3236,10 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
+dom-helpers@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
+
 dom-serialize@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/dom-serialize/-/dom-serialize-2.2.1.tgz#562ae8999f44be5ea3076f5419dcd59eb43ac95b"
@@ -3206,6 +3255,10 @@ dom-serializer@0:
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
+
+dom4@^2.0.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/dom4/-/dom4-2.1.3.tgz#f71808fe1f141e4da4ebc43ad5ddb3dd521f2767"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -3845,7 +3898,7 @@ fb-watchman@^2.0.0:
 
 fbjs@^0.6.1:
   version "0.6.1"
-  resolved "http://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz#9636b7705f5ba9684d44b72f78321254afc860f7"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.6.1.tgz#9636b7705f5ba9684d44b72f78321254afc860f7"
   dependencies:
     core-js "^1.0.0"
     loose-envify "^1.0.0"
@@ -3853,7 +3906,7 @@ fbjs@^0.6.1:
     ua-parser-js "^0.7.9"
     whatwg-fetch "^0.9.0"
 
-fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -4415,6 +4468,10 @@ growl@1.9.2:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.6, handlebars@~4.0.11:
   version "4.0.11"
@@ -6436,7 +6493,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -7107,6 +7164,10 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+normalize.css@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.0.tgz#14ac5e461612538a4ce9be90a7da23f86e718493"
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
@@ -7706,6 +7767,10 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
 
+popper.js@^1.14.1:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -8052,7 +8117,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -8292,11 +8357,35 @@ react-json-tree@^0.11.0:
     prop-types "^15.5.8"
     react-base16-styling "^0.5.1"
 
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+
 react-paginate@^5.2.3:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/react-paginate/-/react-paginate-5.2.4.tgz#0a4d6d468ebb1795d0581bd4fc930ad57a86ae14"
   dependencies:
     prop-types "^15.6.1"
+
+react-popper@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.2.tgz#0e72f338b7f15ab9f9ec884e36ae0dad78a3e301"
+  dependencies:
+    babel-runtime "6.x.x"
+    create-react-context "^0.2.1"
+    popper.js "^1.14.1"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.5"
+    warning "^3.0.0"
+
+react-transition-group@^2.2.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
 
 react@^0.14.0:
   version "0.14.9"
@@ -8693,6 +8782,10 @@ require-uncached@^1.0.3:
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -9859,6 +9952,10 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
+typed-styles@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.5.tgz#a60df245d482a9b1adf9c06c078d0f06085ed1cf"
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -10424,6 +10521,12 @@ walker@~1.0.5:
   resolved "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"


### PR DESCRIPTION
This work is a first shot at https://github.com/jupyterlab/jupyterlab/issues/5170 and continuation of https://github.com/jupyterlab/jupyterlab/pull/4234

This package will provide React components that other lab extensions can consume to easily create UIs within lab. 

Initially, this PR:

* Imports [blueprint](https://github.com/palantir/blueprint) components and exports them with a CSS class name applied 
* Imports the blueprint CSS and a custom CSS file that will allow us to define styles for individual components (e.g. `jp-Button`). We don't have to define styles from scratch since the blueprint CSS is applied, we just need to override styles in our own classes.

To contribute to this PR:

* Add my remote/fork: `git remote add gnestor https://github.com/gnestor/jupyterlab.git`
* Fetch my remote: `git fetch gnestor`
* Checkout this branch: `git checkout gnestor/ui-components`
* Install dependencies: `jlpm`
* Watch the source: `jlpm watch`
* Launch lab in dev and watch mode: `jupyter lab --dev --watch`