### PR TITLE
Raw input fields have increased to 50 percent.

### DIFF
--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -152,7 +152,7 @@ body.p-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   font-size: inherit;
   color: inherit;
   background-color: inherit;
-  width: auto;
+  width: 50%;
   /* make sure input baseline aligns with prompt */
   vertical-align: baseline;
   /* padding + margin = 0.5em between prompt and cursor */


### PR DESCRIPTION
Fixes #4880 by simply increasing the raw input field width to 50%. The request of emulating the shell's ability to write to stdout would require much more effort.

![raw_input_before](https://user-images.githubusercontent.com/3829329/47592613-fcab8180-d941-11e8-9f0b-a0396b70b50b.png)
![raw_input_after](https://user-images.githubusercontent.com/3829329/47592614-fe754500-d941-11e8-89fa-c960547ab17c.png)


