### PR TITLE
Fix alignment of latex/mathjax output cells

### DIFF
--- a/packages/mathjax2/style/index.css
+++ b/packages/mathjax2/style/index.css
@@ -5,10 +5,12 @@
 
 /* Left-justify the MathJax preview in cell outputs. */
 .jp-OutputArea-output.jp-RenderedLatex .MathJax_Preview .MJXp-display {
+  padding: var(--jp-code-padding);
   text-align: left !important;
 }
 
 /* Left-justify the MathJax display equation in cell outputs. */
 .jp-OutputArea-output.jp-RenderedLatex .MathJax_Display {
+  padding: var(--jp-code-padding);
   text-align: left !important;
 }

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -10,7 +10,6 @@
 .jp-RenderedText {
   text-align: left;
   padding-left: var(--jp-code-padding);
-  font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
   font-family: var(--jp-code-font-family);
 }
@@ -19,6 +18,7 @@
 .jp-RenderedJavaScript pre,
 .jp-RenderedHTMLCommon pre {
   color: var(--jp-content-font-color1);
+  font-size: var(--jp-code-font-size);
   border: none;
   margin: 0px;
   padding: 0px;
@@ -156,6 +156,7 @@
 
 /* Left-justify outputs.*/
 .jp-OutputArea-output.jp-RenderedLatex {
+  padding: var(--jp-code-padding);
   text-align: left;
 }
 


### PR DESCRIPTION
Addresses alignment bug when rendering math output by using the standard padding for latex/mathjax outputs.

Fixes #5276

**Regular rendered text**

Before:
<img width="535" alt="text_before" src="https://user-images.githubusercontent.com/7255416/47605241-f0164000-d9b8-11e8-9e12-3b56052b5989.png">

After:
<img width="527" alt="text_after" src="https://user-images.githubusercontent.com/7255416/47605244-f9071180-d9b8-11e8-937f-99053544816e.png">

Note: alignment still doesn't look perfect, but that is because we use different fonts for the prompt vs the output cell (notebook classic uses the same font for the prompt and the output). I assume the selection of different fonts was intentional, so I do not change the font-family in this PR.

**Latex/Math**

 Before:
<img width="534" alt="latex_before" src="https://user-images.githubusercontent.com/7255416/47605245-fe645c00-d9b8-11e8-9324-7a1926ad0c6a.png">

After:
<img width="532" alt="latex_after" src="https://user-images.githubusercontent.com/7255416/47605251-045a3d00-d9b9-11e8-9c4f-a5dd1f3d54d3.png">

Again, alignment still doesn't look perfect, but given the range of possible sizes of latex output, it's not clear what "perfect" alignment would look like. This now matches what is in notebook classic.

**Misc HTML (unaffected)** 

Before:
<img width="536" alt="misc_html_before" src="https://user-images.githubusercontent.com/7255416/47605256-091ef100-d9b9-11e8-92e9-e3824dd4d3ae.png">

After (no change):
<img width="533" alt="misc_html_after" src="https://user-images.githubusercontent.com/7255416/47605258-0d4b0e80-d9b9-11e8-8e59-d71748749664.png">

Note: Textual output in HTML looks misaligned, but styling of HTML should be left to the caller.

