### PR TITLE
Clear * prompt from console cells that are not going to be executed

### DIFF
--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -524,6 +524,12 @@ export class CodeConsole extends Widget {
             cell.model.value.text = text;
           }
         }
+      } else if (value && value.content.status === 'error') {
+        each(this._cells, (cell: CodeCell) => {
+          if (cell.model.executionCount === null) {
+            cell.setPrompt('');
+          }
+        });
       }
       cell.model.contentChanged.disconnect(this.update, this);
       this.update();


### PR DESCRIPTION
Fixes #4916 , uses basically the same approach as https://github.com/jupyterlab/jupyterlab/pull/5423

Before:
<img width="665" alt="screen shot 2018-10-29 at 9 12 45 pm" src="https://user-images.githubusercontent.com/12180828/47689618-fbd45300-dbc0-11e8-99e7-95b0fe4fbf0f.png">

After:
<img width="662" alt="screen shot 2018-10-29 at 9 14 43 pm" src="https://user-images.githubusercontent.com/12180828/47689622-fe36ad00-dbc0-11e8-944b-b7dc2c28bd37.png">