### PR TITLE
fix _changeKernel bug when session dead

### DIFF
--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -569,7 +569,7 @@ export class ClientSession implements IClientSession {
       return Promise.reject('Disposed');
     }
     let session = this._session;
-    if (session) {
+    if (session && session.status !== 'dead') {
       return session.changeKernel(options);
     } else {
       return this._startSession(options);


### PR DESCRIPTION
Fixes: when `session` is dead, should not `changeKernel`

Change a **dead** session just throw in server side, and should be avoid.

**Server Throw error when change a dead session**

```
{
  "message": "Unhandled error",
  "reason": null,
  "traceback": "Traceback (most recent call last):\n  File \"/opt/conda/lib/python3.6/site-packages/tornado/web.py\", line 1512, in _execute\n    result = yield result\n  File \"/opt/conda/lib/python3.6/site-packages/tornado/gen.py\", line 1055, in run\n    value = future.result()\n  File \"/opt/conda/lib/python3.6/site-packages/tornado/concurrent.py\", line 238, in result\n    raise_exc_info(self._exc_info)\n  File \"<string>\", line 4, in raise_exc_info\n  File \"/opt/conda/lib/python3.6/site-packages/tornado/gen.py\", line 307, in wrapper\n    yielded = next(result)\n  File \"/opt/conda/lib/python3.6/site-packages/notebook/services/sessions/handlers.py\", line 114, in patch\n    before = yield gen.maybe_future(sm.get_session(session_id=session_id))\n  File \"/opt/conda/lib/python3.6/site-packages/kernel_gateway/services/sessions/sessionmanager.py\", line 162, in get_session\n    return self.row_to_model(row)\n  File \"/opt/conda/lib/python3.6/site-packages/kernel_gateway/services/sessions/sessionmanager.py\", line 216, in row_to_model\n    raise KeyError\nKeyError\n"
}
```

