### PR TITLE
commandpalette highlight fix

### DIFF
--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -150,7 +150,7 @@
 }
 
 .p-CommandPalette-item.p-mod-disabled mark {
-  color: rgba(0, 0, 0, 0.4);
+  color: rgba(131, 131, 131, 0.863);
 }
 
 .p-CommandPalette-item.p-mod-toggled .p-CommandPalette-itemIcon {


### PR DESCRIPTION
Fixes #5561

**Screenshots**
Inicial state as in #5561
![screenshot from 2018-11-01 09-47-50](https://user-images.githubusercontent.com/16631761/47866224-64871f80-ddbb-11e8-9f74-5bd57ed19c22.png)

New Look 
![screenshot from 2018-11-01 09-50-08](https://user-images.githubusercontent.com/16631761/47866284-8da7b000-ddbb-11e8-826e-75f200b3c13a.png)
![screenshot from 2018-11-01 09-48-52](https://user-images.githubusercontent.com/16631761/47866291-900a0a00-ddbb-11e8-84b5-4d51c68b82b6.png)

I think this is a bigger problem, the fix I did was moving the rgba value at commandpalette.css line 153, but I believe this should be a variable defined somewhere in the themes variables. I would like more information on that THX 