### PR TITLE
Change file mod time hover to use local/locale time format

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1759,7 +1759,7 @@ export namespace DirListing {
       let modTitle = '';
       if (model.last_modified) {
         modText = Time.formatHuman(new Date(model.last_modified));
-        modTitle = Time.format(new Date(model.last_modified));
+        modTitle = Time.format(new Date(model.last_modified), 'lll');
       }
       modified.textContent = modText;
       modified.title = modTitle;


### PR DESCRIPTION
In the file browser:  change the "title" attribute to use times formatted with the user's locale, so that mouse hover text (the file mod time) is shown in that format.  

(vs the fixed format 'YYYY-MM-DD HH:mm' set in coreutils/src/time.ts).
