### PR TITLE
Add 'scroll past end' notebook setting

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -101,6 +101,12 @@
         "tabSize": 4,
         "wordWrapColumn": 80
       }
+    },
+    "scrollPastEnd": {
+      "title": "Scroll past last cell",
+      "description": "Whether to be able to scroll so the last cell is at the top of the panel",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -465,6 +465,7 @@ function activateNotebookHandler(
   const services = app.serviceManager;
   // An object for tracking the current notebook settings.
   let editorConfig = StaticNotebook.defaultEditorConfig;
+  let notebookConfig = StaticNotebook.defaultNotebookConfig;
   const factory = new NotebookWidgetFactory({
     name: FACTORY,
     fileTypes: ['notebook'],
@@ -475,6 +476,7 @@ function activateNotebookHandler(
     rendermime: rendermime,
     contentFactory,
     editorConfig,
+    notebookConfig,
     mimeTypeService: editorServices.mimeTypeService
   });
   const { commands, restored } = app;
@@ -544,6 +546,9 @@ function activateNotebookHandler(
           : cached[key];
     });
     factory.editorConfig = editorConfig = { code, markdown, raw };
+    factory.notebookConfig = notebookConfig = {
+      scrollPastEnd: settings.get('scrollPastEnd').composite as boolean
+    };
   }
 
   /**
@@ -552,6 +557,7 @@ function activateNotebookHandler(
   function updateTracker(): void {
     tracker.forEach(widget => {
       widget.content.editorConfig = editorConfig;
+      widget.content.notebookConfig = notebookConfig;
     });
   }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -169,6 +169,8 @@ export class StaticNotebook extends Widget {
       options.contentFactory || StaticNotebook.defaultContentFactory;
     this.editorConfig =
       options.editorConfig || StaticNotebook.defaultEditorConfig;
+    this.notebookConfig =
+      options.notebookConfig || StaticNotebook.defaultNotebookConfig;
     this._mimetypeService = options.mimeTypeService;
   }
 
@@ -259,6 +261,17 @@ export class StaticNotebook extends Widget {
   set editorConfig(value: StaticNotebook.IEditorConfig) {
     this._editorConfig = value;
     this._updateEditorConfig();
+  }
+
+  /**
+   * A configuration object for notebook settings.
+   */
+  get notebookConfig(): StaticNotebook.INotebookConfig {
+    return this._notebookConfig;
+  }
+  set notebookConfig(value: StaticNotebook.INotebookConfig) {
+    this._notebookConfig = value;
+    this._updateNotebookConfig();
   }
 
   /**
@@ -558,7 +571,18 @@ export class StaticNotebook extends Widget {
     }
   }
 
+  /**
+   * Update editor settings for notebook.
+   */
+  private _updateNotebookConfig() {
+    this.toggleClass(
+      'jp-mod-scrollPastEnd',
+      this._notebookConfig.scrollPastEnd
+    );
+  }
+
   private _editorConfig = StaticNotebook.defaultEditorConfig;
+  private _notebookConfig = StaticNotebook.defaultNotebookConfig;
   private _mimetype = 'text/plain';
   private _model: INotebookModel = null;
   private _mimetypeService: IEditorMimeTypeService;
@@ -593,6 +617,11 @@ export namespace StaticNotebook {
      * A configuration object for the cell editor settings.
      */
     editorConfig?: IEditorConfig;
+
+    /**
+     * A configuration object for notebook settings.
+     */
+    notebookConfig?: INotebookConfig;
 
     /**
      * The service used to look up mime types.
@@ -671,6 +700,22 @@ export namespace StaticNotebook {
       matchBrackets: false,
       autoClosingBrackets: false
     }
+  };
+
+  /**
+   * A config object for the notebook widget
+   */
+  export interface INotebookConfig {
+    /**
+     * Enable scrolling past the last cell
+     */
+    scrollPastEnd: boolean;
+  }
+  /**
+   * Default configuration options for notebooks.
+   */
+  export const defaultNotebookConfig: INotebookConfig = {
+    scrollPastEnd: true
   };
 
   /**

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -35,6 +35,8 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
     this.mimeTypeService = options.mimeTypeService;
     this._editorConfig =
       options.editorConfig || StaticNotebook.defaultEditorConfig;
+    this._notebookConfig =
+      options.notebookConfig || StaticNotebook.defaultNotebookConfig;
   }
 
   /*
@@ -63,6 +65,16 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
   }
 
   /**
+   * A configuration object for notebook settings.
+   */
+  get notebookConfig(): StaticNotebook.INotebookConfig {
+    return this._notebookConfig;
+  }
+  set notebookConfig(value: StaticNotebook.INotebookConfig) {
+    this._notebookConfig = value;
+  }
+
+  /**
    * Create a new widget.
    *
    * #### Notes
@@ -77,7 +89,8 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
       rendermime,
       contentFactory: this.contentFactory,
       mimeTypeService: this.mimeTypeService,
-      editorConfig: this._editorConfig
+      editorConfig: this._editorConfig,
+      notebookConfig: this._notebookConfig
     };
     let content = this.contentFactory.createNotebook(nbOptions);
 
@@ -94,6 +107,7 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
   }
 
   private _editorConfig: StaticNotebook.IEditorConfig;
+  private _notebookConfig: StaticNotebook.INotebookConfig;
 }
 
 /**
@@ -124,5 +138,10 @@ export namespace NotebookWidgetFactory {
      * The notebook cell editor configuration.
      */
     editorConfig?: StaticNotebook.IEditorConfig;
+
+    /**
+     * The notebook configuration.
+     */
+    notebookConfig?: StaticNotebook.INotebookConfig;
   }
 }

--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -41,7 +41,7 @@
   background: var(--jp-layout-color0);
 }
 
-.jp-Notebook::after {
+.jp-Notebook.jp-mod-scrollPastEnd::after {
   display: block;
   content: '';
   min-height: var(--jp-notebook-scroll-padding);

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -277,9 +277,16 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Notebook specific styles */
 
   --jp-notebook-padding: 10px;
-  --jp-notebook-scroll-padding: 50%;
   --jp-notebook-select-background: var(--jp-layout-color1);
   --jp-notebook-multiselected-color: rgba(33, 150, 243, 0.24);
+
+  /* The scroll padding is calculated to fill enough space at the bottom of the
+  notebook to show one single-line cell (with appropriate padding) at the top
+  when the notebook is scrolled all the way to the bottom. We also subtract one
+  pixel so that no scrollbar appears if we have just one single-line cell in the
+  notebook. This padding is to enable a 'scroll past end' feature in a notebook.
+  */
+  --jp-notebook-scroll-padding: calc(100% - var(--jp-code-font-size)*var(--jp-code-line-height) - var(--jp-code-padding) - var(--jp-cell-padding) - 1px);
 
   /* Rendermime styles */
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -286,7 +286,10 @@ all of MD as it is not optimized for dense, information rich UIs.
   pixel so that no scrollbar appears if we have just one single-line cell in the
   notebook. This padding is to enable a 'scroll past end' feature in a notebook.
   */
-  --jp-notebook-scroll-padding: calc(100% - var(--jp-code-font-size)*var(--jp-code-line-height) - var(--jp-code-padding) - var(--jp-cell-padding) - 1px);
+  --jp-notebook-scroll-padding: calc(
+    100% - var(--jp-code-font-size) * var(--jp-code-line-height) -
+      var(--jp-code-padding) - var(--jp-cell-padding) - 1px
+  );
 
   /* Rendermime styles */
 

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -283,7 +283,10 @@ all of MD as it is not optimized for dense, information rich UIs.
   pixel so that no scrollbar appears if we have just one single-line cell in the
   notebook. This padding is to enable a 'scroll past end' feature in a notebook.
   */
-  --jp-notebook-scroll-padding: calc(100% - var(--jp-code-font-size)*var(--jp-code-line-height) - var(--jp-code-padding) - var(--jp-cell-padding) - 1px);
+  --jp-notebook-scroll-padding: calc(
+    100% - var(--jp-code-font-size) * var(--jp-code-line-height) -
+      var(--jp-code-padding) - var(--jp-cell-padding) - 1px
+  );
 
   /* Rendermime styles */
 

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -274,9 +274,16 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* Notebook specific styles */
 
   --jp-notebook-padding: 10px;
-  --jp-notebook-scroll-padding: 50%;
   --jp-notebook-select-background: var(--jp-layout-color1);
   --jp-notebook-multiselected-color: var(--md-blue-50);
+
+  /* The scroll padding is calculated to fill enough space at the bottom of the
+  notebook to show one single-line cell (with appropriate padding) at the top
+  when the notebook is scrolled all the way to the bottom. We also subtract one
+  pixel so that no scrollbar appears if we have just one single-line cell in the
+  notebook. This padding is to enable a 'scroll past end' feature in a notebook.
+  */
+  --jp-notebook-scroll-padding: calc(100% - var(--jp-code-font-size)*var(--jp-code-line-height) - var(--jp-code-padding) - var(--jp-cell-padding) - 1px);
 
   /* Rendermime styles */
 


### PR DESCRIPTION
This PR tries to address #5271 more completely than currently is in master. It (a) adds a CSS calculation to let you basically scroll the bottom cell to the top of the screen, and (b) adds an advanced notebook setting controlling this 'scroll past end' behavior, defaulting to letting you scroll past the end of the notebook.

Fixes #897 as well (which addresses https://github.com/jupyterlab/jupyterlab/issues/488#issuecomment-234154514)

(See also #5542 for previous work on a scroll-past-end feature)

**Screenshots**
With the setting set to true (left is single cell notebook, right is scrolled to the bottom):
<img width="726" alt="screen shot 2018-11-09 at 1 02 19 pm" src="https://user-images.githubusercontent.com/192614/48288093-db599380-e41f-11e8-90fb-ff3d80dfc1f9.png">

with the setting set to false (left is single cell notebook, right is scrolled to the bottom):
<img width="724" alt="screen shot 2018-11-09 at 1 02 47 pm" src="https://user-images.githubusercontent.com/192614/48288146-fa582580-e41f-11e8-9aee-3833414aa9b5.png">
