### PR TITLE
[WIP] Implementation of go-to-definition functionality

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -600,7 +600,7 @@ export namespace CodeEditor {
     getTokens(): IToken[];
 
     /**
-     * Finds definitions of variable or function, depending on given type.
+     * Finds definitions of variable or function matching given name.
      */
     findDefinitions(name: string): Array<IToken>;
   }

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -150,6 +150,31 @@ export namespace CodeEditor {
   }
 
   /**
+   * An interface for jump-to-definition event.
+   *
+   * #### Notes
+   * Combination of target and mouseEvent are used to determine clicked cell,
+   * instead of CodeEditor instance which is being passed, as its host attribute
+   * behaves non-reliably when clicking on a cell different form the current one.
+   */
+  export interface IJump {
+    /**
+     * The token of origin (variable/function usage).
+     */
+    token: IToken;
+    /**
+     * The clicked (or active) element of origin used to find the cell from which
+     * the request originated.
+     */
+    origin: HTMLElement;
+    /**
+     * Optional mouse event used as a fallback to determine the cell of origin in
+     * Firefox 57.
+     */
+    mouseEvent?: MouseEvent;
+  }
+
+  /**
    * An interface to manage selections by selection owners.
    *
    * #### Definitions
@@ -387,6 +412,11 @@ export namespace CodeEditor {
     readonly edgeRequested: ISignal<IEditor, EdgeLocation>;
 
     /**
+     * A signal emitted when the jump to definition (go to definition) is requested.
+     */
+    readonly jumpRequested: ISignal<IEditor, IJump>;
+
+    /**
      * The default selection style for the editor.
      */
     selectionStyle: CodeEditor.ISelectionStyle;
@@ -412,7 +442,7 @@ export namespace CodeEditor {
     readonly charWidth: number;
 
     /**
-     * Get the number of lines in the eidtor.
+     * Get the number of lines in the editor.
      */
     readonly lineCount: number;
 
@@ -568,6 +598,11 @@ export namespace CodeEditor {
      * Gets the list of tokens for the editor model.
      */
     getTokens(): IToken[];
+
+    /**
+     * Finds definitions of variable or function, depending on given type.
+     */
+    findDefinitions(name: string): Array<IToken>;
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -209,7 +209,10 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
               token = {
                 value: target.textContent,
                 offset: 0, // dummy offset
-                type: 'variable'
+                type:
+                  target.className.indexOf('cm-variable') !== -1
+                    ? 'variable'
+                    : 'property'
               };
             }
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -135,8 +135,8 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
         let target = event.target as HTMLElement;
         const { button, altKey } = event;
         if (altKey && button === 0) {
-          // offset is needed to handle same-cell jumping
-          // to get offset we could either derive it from the DOM
+          // Offset is needed to handle same-cell jumping.
+          // To get offset we could either derive it from the DOM
           // or from the tokens. Tokens sound better, but there is
           // no direct link between DOM and tokens.
           // This can be worked around using:
@@ -167,10 +167,10 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
               let nextSibling = sibling.previousSibling;
 
               if (nextSibling == null) {
-                // try to traverse to previous line, if there is one
+                // Try to traverse to previous line (if there is one).
 
-                // the additional parent/child which is traversed
-                // both ways is a non-relevant presentation container
+                // The additional parent (child) which is traversed
+                // both ways is a non-relevant presentation container.
                 let thisLine = sibling.parentNode.parentNode as HTMLElement;
                 let previousLine = thisLine.previousElementSibling;
 
@@ -642,7 +642,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   }
 
   /**
-   * Find definitions using the HTML nodes from source tokenized and classed by CodeMirror.
+   * Find definitions among tokens of this editor instance.
    */
   findDefinitions(name: string): Array<CodeEditor.IToken> {
     // try to find variable assignment
@@ -653,7 +653,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
         return false;
       }
       if (token.type === 'variable') {
-        // matching variable assignment
+        // Matching variable assignment.
         let nextMeaningfulToken = null;
         while (nextMeaningfulToken == null) {
           if (i >= cellTokens.length - 1) {
@@ -672,8 +672,9 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
           nextToken && nextToken.type === 'operator' && nextToken.value === '='
         );
       } else if (token.type === 'def') {
-        // matching function definition
-        // we could double-check that an opening parenthesis follows,
+        // Matching function definition.
+
+        // We could double-check that an opening parenthesis follows,
         // but we can assume that it is the responsibility of CodeMirror.
         return true;
       } else {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1705,7 +1705,7 @@ export class Notebook extends StaticNotebook {
 
     for (
       let offset = testedToken.offset + 1;
-      offset < originToken.offset;
+      offset < originToken.offset + 1;
       offset++
     ) {
       let position = cell.editor.getPositionAt(offset);
@@ -1749,7 +1749,9 @@ export class Notebook extends StaticNotebook {
       }
       // empty string is used as a token representing new-line
       let terminator = token.value === ';' || token.value === '';
-      if (openedBrackets === 0 && terminator) {
+      // if there is a closing bracket, completing a previously opened one,
+      // which proceeds the token of origin, that is fine too (hence <= 0)
+      if (openedBrackets <= 0 && terminator) {
         terminatingTokens.push(token);
       }
     }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1722,15 +1722,15 @@ export class Notebook extends StaticNotebook {
       token => token.type === 'operator' && token.value.indexOf('=') !== -1
     );
     if (!assignments.length) {
-      return true;
+      return false;
     }
 
     let firstAssignment = assignments.sort(
       (a, b) => (a.offset > b.offset ? 1 : -1)
     )[0];
 
-    // Select terminating tokens
-    // ';' and new line (which are locally outside of brackets)
+    // Select terminating tokens:
+    // semicolons and new lines (which are locally outside of brackets)
     let terminatingTokens = [];
     let openedBrackets = 0;
     const openingBrackets = '([{';
@@ -1747,7 +1747,7 @@ export class Notebook extends StaticNotebook {
           continue;
         }
       }
-      // empty string is used by as a token representing new-line
+      // empty string is used as a token representing new-line
       let terminator = token.value === ';' || token.value === '';
       if (openedBrackets === 0 && terminator) {
         terminatingTokens.push(token);


### PR DESCRIPTION
Dear maintainers, please have a look at this proposed implementation of go-to-definition functionality.
With this changes, alt-click on a variable will make the cursor jump to the last definition of such variable that is contained in the same notebook. I will appreciate any feedback. Fixes #4562. 

**Screenshots**
![alt-click-opt](https://user-images.githubusercontent.com/5832902/47969769-616a8880-e074-11e8-9da3-6aed3ff9182a.gif)

**Technical overview**
I propose to add a new `jumpRequested` signal which would be emitted with information about the definition sought by the user (packed inside a new `IJump` interface). Emission of the new signal by the editor would be optional, and therefore the new functionality will be editor-agnostic and won't interfere with any other (potentially existing) implementations of `CodeEditor`.

When the editor emits `jumpRequested` signal, the `notebook` package would intercept it, and iteratively ask the editors of every single cell above the clicked one (assumption; the definition comes before usage) whether it has any definitions matching the requested one (`findDefinitions` function).

Then the notebook would choose the last definition which comes before the clicked variable usage - both in terms of cells and offset (see `_findLastDefinition`) - and switch the active cell to the one containing the chosen definition and place cursor just before definition token.

**Rationale**
- it is currently difficult to find a variable defined early in a long notebook,
- many IDEs support this function out-of-box,
- this feature was proposed in #4562 (6 thumbs up) and earlier in https://github.com/jupyter/jupyter/issues/271 (22 thumbs up).

I have chosen to use <kbd>alt</kbd> + <kbd>click</kbd> for compatibility reasons, as <kbd>ctrl</kbd> + <kbd>click</kbd> is already used for placing multiple cursors.

**Plans for this PR**

- [ ] discuss how and if to move the code into an extension with members of JupyterLab organization
- [ ] write tests
- [ ] split the code into more manageable functions
- [ ] allow to customize the trigger (to use <kbd>ctrl</kbd> instead of <kbd>alt</kbd>)

**Support for non-trivial language constructs**
- [x] loops - e.g. having `for i in range(10)`, click on `i` inside loop should jump to the loop definition,
- [x] comprehensions (a special case of loops; additionally in this case the definition comes after usage)
- [ ] basic namespaces (currently there is no distinction between method `x` and variable `x`)
- [x] reference to previous value in reassignment (`a = a + 1`, click on second `a` should jump the previous definition of `a`, not to the beginning of the line).
- [ ] lambda expressions
- [x] imports
- [x] `as` keyword (exceptions and context managers)
- [ ] IPython magic?
- [x] tuple/list unpacking in assignments `x, y = 1, 2`, click on `x` in subsequent lines should jump to `x`

**Limitations**
Support for advanced namespace/scope handling is not planned for this PR as it requires fully fledged language parsing support. Support for kernels other than Python is not guaranteed, however, the reliance on CodeEditor tokens (in default implementation generated by CodeMirror) for the detection of definitions should make it work on a basic lavel with most C-like languages.