### PR TITLE
Text editor menu settings are always enabled

### DIFF
--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -317,7 +317,6 @@ function activate(
           console.error(`Failed to set ${id}: ${reason.message}`);
         });
     },
-    //isEnabled,
     label: args => args['name'] as string
   });
 
@@ -366,7 +365,6 @@ function activate(
           console.error(`Failed to set ${id}: ${reason.message}`);
         });
     },
-    //isEnabled,
     isToggled: args => {
       const insertSpaces = !!args['insertSpaces'];
       const size = (args['size'] as number) || 4;
@@ -398,7 +396,6 @@ function activate(
         });
     },
     label: 'Auto Close Brackets for Text Editor',
-    //isEnabled,
     isToggled: () => config.autoClosingBrackets
   });
 

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -317,7 +317,7 @@ function activate(
           console.error(`Failed to set ${id}: ${reason.message}`);
         });
     },
-    isEnabled,
+    //isEnabled,
     label: args => args['name'] as string
   });
 
@@ -366,7 +366,7 @@ function activate(
           console.error(`Failed to set ${id}: ${reason.message}`);
         });
     },
-    isEnabled,
+    //isEnabled,
     isToggled: args => {
       const insertSpaces = !!args['insertSpaces'];
       const size = (args['size'] as number) || 4;
@@ -398,7 +398,7 @@ function activate(
         });
     },
     label: 'Auto Close Brackets for Text Editor',
-    isEnabled,
+    //isEnabled,
     isToggled: () => config.autoClosingBrackets
   });
 


### PR DESCRIPTION
Fixes #5580 

now text editor options are always enabled, the way I archived this was by removing the isEnabled option in the addCommand method.

![screenshot from 2018-11-05 10-54-26](https://user-images.githubusercontent.com/16631761/48016588-38380f80-e0e9-11e8-85a5-d4ffe6f6a403.png)
