### PR TITLE
Skip processing svg anchor elements

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -628,15 +628,21 @@ namespace Private {
     // Handle anchor elements.
     let anchors = node.getElementsByTagName('a');
     for (let i = 0; i < anchors.length; i++) {
-      let path = anchors[i].href || '';
+      const el = anchors[i];
+      // skip when processing a elements inside svg
+      // which are of type SVGAnimatedString
+      if (!(el instanceof HTMLAnchorElement)) {
+        continue;
+      }
+      let path = el.href;
       const isLocal =
         resolver && resolver.isLocal
           ? resolver.isLocal(path)
           : URLExt.isLocal(path);
       if (isLocal) {
-        anchors[i].target = '_self';
+        el.target = '_self';
       } else {
-        anchors[i].target = '_blank';
+        el.target = '_blank';
       }
     }
 


### PR DESCRIPTION
**EDIT**: Also fixes #5610

Fixes https://github.com/jupyterlab/jupyterlab/issues/5589 by skipping
processing of a elements that are not `HTMLAnchorElement`s, including
those within SVG elements. Currently, if you have a `a` element
inside an SVG element it will break HTML rendering since that element
does not have a `href` like other `a` elements do.


**Screenshots**

Before, this code (from issue #5589) will end up raising an exception while rendering and so will display no output:

```python
from IPython.display import display, SVG

class A:
    def __init__(self):
        print("init A")
        
    def _repr_html_(self):
        return """
<svg height="44pt" viewBox="0.00 0.00 62.00 44.00" width="62pt">
<g class="graph" id="graph0" transform="scale(1 1) rotate(0) translate(4 40)">
<g class="node" id="node1">
<title>a</title>
<g id="a_node1"><a xlink:title="(0) a">
<ellipse cx="27" cy="-18" fill="#444444" rx="27" ry="18" stroke="#000000"/>
<text fill="#ffffff" font-family="Times,serif" font-size="14.00" text-anchor="middle" x="27" y="-14.3">A</text>
</a>
</g>
</g>
</g>
</svg>
"""
    
a=A()
a
```

<img width="1540" alt="screen shot 2018-11-11 at 10 25 34 am" src="https://user-images.githubusercontent.com/1186124/48314774-5d6ec700-e59c-11e8-8415-286dc439ad51.png">

After, this exception will not be raised since we skip processing the `a` elements in the `svg` element and so  it will render correctly, as it does in Jupyter Notebook

<img width="1519" alt="screen shot 2018-11-11 at 10 25 09 am" src="https://user-images.githubusercontent.com/1186124/48314782-78413b80-e59c-11e8-9810-256ea23baeed.png">


