### PR TITLE
CSS: Add alert, alert-info and alert-warning styles

### DIFF
--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -445,7 +445,36 @@
 }
 
 .jp-RenderedHTMLCommon .alert {
+  padding: var(--jp-notebook-padding);
+  border: var(--jp-border-width) solid transparent;
+  border-radius: var(--jp-border-radius);
   margin-bottom: 1em;
+}
+
+.jp-RenderedHTMLCommon .alert-info {
+  color: var(--jp-info-color0);
+  background-color: var(--jp-info-color3);
+  border-color: var(--jp-info-color2);
+}
+.jp-RenderedHTMLCommon .alert-info hr {
+  border-color: var(--jp-info-color3);
+}
+.jp-RenderedHTMLCommon .alert-info > p:last-child,
+.jp-RenderedHTMLCommon .alert-info > ul:last-child {
+  margin-bottom: 0;
+}
+
+.jp-RenderedHTMLCommon .alert-warning {
+  color: var(--jp-warn-color0);
+  background-color: var(--jp-warn-color3);
+  border-color: var(--jp-warn-color2);
+}
+.jp-RenderedHTMLCommon .alert-warning hr {
+  border-color: var(--jp-warn-color3);
+}
+.jp-RenderedHTMLCommon .alert-warning > p:last-child,
+.jp-RenderedHTMLCommon .alert-warning > ul:last-child {
+  margin-bottom: 0;
 }
 
 .jp-RenderedHTMLCommon blockquote {

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -477,6 +477,32 @@
   margin-bottom: 0;
 }
 
+.jp-RenderedHTMLCommon .alert-success {
+  color: var(--jp-success-color0);
+  background-color: var(--jp-success-color3);
+  border-color: var(--jp-success-color2);
+}
+.jp-RenderedHTMLCommon .alert-success hr {
+  border-color: var(--jp-success-color3);
+}
+.jp-RenderedHTMLCommon .alert-success > p:last-child,
+.jp-RenderedHTMLCommon .alert-success > ul:last-child {
+  margin-bottom: 0;
+}
+
+.jp-RenderedHTMLCommon .alert-danger {
+  color: var(--jp-error-color0);
+  background-color: var(--jp-error-color3);
+  border-color: var(--jp-error-color2);
+}
+.jp-RenderedHTMLCommon .alert-danger hr {
+  border-color: var(--jp-error-color3);
+}
+.jp-RenderedHTMLCommon .alert-danger > p:last-child,
+.jp-RenderedHTMLCommon .alert-danger > ul:last-child {
+  margin-bottom: 0;
+}
+
 .jp-RenderedHTMLCommon blockquote {
   margin: 1em 2em;
   padding: 0 1em;


### PR DESCRIPTION
A first attempt to kinda re-introduce the bootstrap "alert" CSS styles.

This is inspired by the bootstrap styles (https://github.com/twbs/bootstrap/blob/master/less/alerts.less and https://github.com/twbs/bootstrap/blob/master/less/mixins/alerts.less), but it isn't an exact copy, so I guess there are no copyright problems.

It turned out there were already Jupyter color definitions I could use for that, which is great!

For now, I've only added `alert-info` and `alert-warning`, because that's all I need.

If requested, I could further add `alert-success` using `--jp-success-colorX` and `alert-danger` using `--jp-error-colorX`.

This is a bit repetitive, but  there are currently no tools available to automate this, right?

There are of course some arbitrary choices in there, feel free to suggest/make whatever changes you like.

See #2693.