### PR TITLE
Retain crlf

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -471,6 +471,9 @@ export class Context<T extends DocumentRegistry.IModel>
       content = model.toJSON();
     } else {
       content = model.toString();
+      if (this._useCRLF) {
+        content = content.replace(/\n/g, '\r\n');
+      }
     }
 
     let options = {
@@ -560,8 +563,10 @@ export class Context<T extends DocumentRegistry.IModel>
           // Convert line endings if necessary, marking the file
           // as dirty.
           if (content.indexOf('\r') !== -1) {
-            dirty = true;
-            content = content.replace(/\r\n|\r/g, '\n');
+            this._useCRLF = true;
+            content = content.replace(/\r\n/g, '\n');
+          } else {
+            this._useCRLF = false;
           }
           model.fromString(content);
           if (initializeModel) {
@@ -765,6 +770,7 @@ export class Context<T extends DocumentRegistry.IModel>
   private _model: T;
   private _modelDB: IModelDB;
   private _path = '';
+  private _useCRLF = false;
   private _factory: DocumentRegistry.IModelFactory<T>;
   private _contentsModel: Contents.IModel | null = null;
   private _readyPromise: Promise<void>;

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -297,6 +297,42 @@ describe('docregistry/context', () => {
         expect(model.content).to.equal('foo');
         await dismissDialog();
       });
+
+      it('should should preserve LF line endings upon save', async () => {
+        await context.initialize(true);
+        await manager.contents.save(context.path, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo\nbar'
+        });
+        await context.revert();
+        await context.save();
+        const opts: Contents.IFetchOptions = {
+          format: factory.fileFormat,
+          type: factory.contentType,
+          content: true
+        };
+        const model = await manager.contents.get(context.path, opts);
+        expect(model.content).to.equal('foo\nbar');
+      });
+
+      it('should should preserve CRLF line endings upon save', async () => {
+        await context.initialize(true);
+        await manager.contents.save(context.path, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo\r\nbar'
+        });
+        await context.revert();
+        await context.save();
+        const opts: Contents.IFetchOptions = {
+          format: factory.fileFormat,
+          type: factory.contentType,
+          content: true
+        };
+        const model = await manager.contents.get(context.path, opts);
+        expect(model.content).to.equal('foo\r\nbar');
+      });
     });
 
     describe('#saveAs()', () => {
@@ -385,6 +421,17 @@ describe('docregistry/context', () => {
         context.model.fromString('bar');
         await context.revert();
         expect(context.model.toString()).to.equal('foo');
+      });
+
+      it('should normalize CRLF line endings to LF', async () => {
+        await context.initialize(true);
+        await manager.contents.save(context.path, {
+          type: factory.contentType,
+          format: factory.fileFormat,
+          content: 'foo\r\nbar'
+        });
+        await context.revert();
+        expect(context.model.toString()).to.equal('foo\nbar');
       });
     });
 


### PR DESCRIPTION
Fixes #3901, fixes #4464, fixes #3706.

This stores whether CRLF line endings were detected upon loading a text file in the `Context`. If so, it replaces them upon serialization. I considered adding CRLF vs LF knowledget to the text model, but decided that was opening us up to heartache as soon as we have multiple people collaborating on the same text model. Instead, I think it is better to standardize entirely on LF in our in-memory text models and only do the conversion upon serialization.

Currently the `_useCRLF` property is a private member of the `Context`. If we expose it, we could consider making CRLF something that we display in the status bar, as @t-makaro suggested. There was some talk in #3901 about making this user-configurable, but I think we may want to give this a shot in the wild, and see if people complain :)