### PR TITLE
Fix LineCol Functionality

### DIFF
--- a/packages/statusbar/src/components/hover.tsx
+++ b/packages/statusbar/src/components/hover.tsx
@@ -146,7 +146,6 @@ export class Popup extends Widget {
   }
 
   private _setGeometry(): void {
-    this._setGeometry();
     let aligned = 0;
     const anchorRect = this._anchor.node.getBoundingClientRect();
     const bodyRect = this._body.node.getBoundingClientRect();


### PR DESCRIPTION
Recursive call in _setGeometry was probably a mistake, caused 'RangeError: maximum call stack size exceeded'