### PR TITLE
Support windows-like paths

### DIFF
--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -183,7 +183,12 @@ export function getOpenPath(contentsManager: any): Promise<string | undefined> {
   }).then((result: any) => {
     if (result.button.label === 'OPEN') {
       let str = result.value;
-      let value = str.replace(/\\/g, '/');
+      var value = str;
+
+      if (navigator.appVersion.indexOf('Win') != -1) {
+        value = str.replace(/\\/g, '/');
+      }
+
       return value;
     }
     return;

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -182,17 +182,8 @@ export function getOpenPath(contentsManager: any): Promise<string | undefined> {
     focusNodeSelector: 'input'
   }).then((result: any) => {
     if (result.button.label === 'OPEN') {
-      var str = result.value;
+      let str = result.value;
       let value = str.replace(/\\/g, '/');
-
-      /* USED FOR TESTING *
-      showDialog({
-        title: 'RESULT',
-        body: new OpenDirectWidget(),
-        buttons: [Dialog.cancelButton({ label: (value) }), Dialog.okButton({ label: (value) })]
-      });
-      /**/
-
       return value;
     }
     return;

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -182,7 +182,18 @@ export function getOpenPath(contentsManager: any): Promise<string | undefined> {
     focusNodeSelector: 'input'
   }).then((result: any) => {
     if (result.button.label === 'OPEN') {
-      return result.value;
+      var str = result.value;
+      let value = str.replace(/\\/g, '/');
+
+      /* USED FOR TESTING *
+      showDialog({
+        title: 'RESULT',
+        body: new OpenDirectWidget(),
+        buttons: [Dialog.cancelButton({ label: (value) }), Dialog.okButton({ label: (value) })]
+      });
+      /**/
+
+      return value;
     }
     return;
   });


### PR DESCRIPTION
Fixes #5051

BEFORE: 
When you open a file from `File > Open From Path...`, if the path uses backslashes `\` (e.g. Windows paths) the filename displays the whole file path instead of just the name of the file.
![shutter_005](https://user-images.githubusercontent.com/26393657/48517386-62917780-e823-11e8-8986-5bc349a3f427.png)

AFTER: 
Even if you use backslashes, the filename displays only the name and not the whole file path.
![shutter_003](https://user-images.githubusercontent.com/26393657/48517460-9b315100-e823-11e8-8c58-50844858963e.png)
![shutter_004](https://user-images.githubusercontent.com/26393657/48517464-9e2c4180-e823-11e8-9c2b-e07a58270248.png)

Tested in:
Windows 10 - Google Chrome
Ubuntu 18.04.1 - Google Chrome

