### PR TITLE
Make sure `composite` is set to `true` when adding a sibling.

### DIFF
--- a/buildutils/src/add-sibling.ts
+++ b/buildutils/src/add-sibling.ts
@@ -53,9 +53,11 @@ if (fs.existsSync(path.join(packagePath, 'node_modules'))) {
 
 // Make sure composite is set to true in the new package.
 let packageTsconfigPath = path.join(packagePath, 'tsconfig.json');
-let packageTsconfig = utils.readJSONFile(packageTsconfigPath);
-packageTsconfig.compilerOptions.composite = true;
-utils.writeJSONFile(packageTsconfigPath, packageTsconfig);
+if (fs.existsSync(packageTsconfigPath)) {
+  let packageTsconfig = utils.readJSONFile(packageTsconfigPath);
+  packageTsconfig.compilerOptions.composite = true;
+  utils.writeJSONFile(packageTsconfigPath, packageTsconfig);
+}
 
 // Get the package.json of the extension.
 let pkgJSONPath = path.join(packagePath, 'package.json');

--- a/buildutils/src/add-sibling.ts
+++ b/buildutils/src/add-sibling.ts
@@ -35,6 +35,7 @@ if (fs.existsSync(packagePath)) {
   // Copy the package directory contents to the sibling package.
   let newPackagePath = path.join(basePath, 'packages', packageDirName);
   fs.copySync(packagePath, newPackagePath);
+  packagePath = newPackagePath;
 } else {
   // Otherwise treat it as a git reposotory and try to add it.
   packageDirName = target
@@ -49,6 +50,12 @@ if (fs.existsSync(packagePath)) {
 if (fs.existsSync(path.join(packagePath, 'node_modules'))) {
   fs.removeSync(path.join(packagePath, 'node_modules'));
 }
+
+// Make sure composite is set to true in the new package.
+let packageTsconfigPath = path.join(packagePath, 'tsconfig.json');
+let packageTsconfig = utils.readJSONFile(packageTsconfigPath);
+packageTsconfig.compilerOptions.composite = true;
+utils.writeJSONFile(packageTsconfigPath, packageTsconfig);
 
 // Get the package.json of the extension.
 let pkgJSONPath = path.join(packagePath, 'package.json');


### PR DESCRIPTION
This removes a bit of friction that was introduced by the new TS projects setup, which requires that this key is set in the `tsconfig.json` of subpackages.