### PR TITLE
Allow "Run All Code"/ "Restart Kernel and Run All Code" when editting Text File

### DIFF
--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -498,9 +498,21 @@ function activate(
         return;
       }
 
+      let code = '';
       let editor = widget.editor;
-      let code = editor.model.value.text;
+      let text = editor.model.value.text;
       let path = widget.context.path;
+      let extension = PathExt.extname(path);
+
+      if (MarkdownCodeBlocks.isMarkdown(extension)) {
+        // For Markdown files, run only code blocks.
+        const blocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(text);
+        for (let block of blocks) {
+          code += block.code;
+        }
+      } else {
+        code = text;
+      }
 
       const activate = false;
       if (code) {

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -85,6 +85,8 @@ namespace CommandIDs {
 
   export const runCode = 'fileeditor:run-code';
 
+  export const runAllCode = 'fileeditor:run-all';
+
   export const markdownPreview = 'fileeditor:markdown-preview';
 }
 
@@ -488,6 +490,29 @@ function activate(
     label: 'Run Code'
   });
 
+  commands.addCommand(CommandIDs.runAllCode, {
+    execute: () => {
+      let widget = tracker.currentWidget.content;
+
+      if (!widget) {
+        return;
+      }
+
+      let editor = widget.editor;
+      let code = editor.model.value.text;
+      let path = widget.context.path;
+
+      const activate = false;
+      if (code) {
+        return commands.execute('console:inject', { activate, code, path });
+      } else {
+        return Promise.resolve(void 0);
+      }
+    },
+    isEnabled,
+    label: 'Run All Code'
+  });
+
   commands.addCommand(CommandIDs.markdownPreview, {
     execute: () => {
       let widget = tracker.currentWidget;
@@ -708,7 +733,16 @@ function activate(
         });
         return found;
       },
-      run: () => commands.execute(CommandIDs.runCode)
+      run: () => commands.execute(CommandIDs.runCode),
+      runAll: () => commands.execute(CommandIDs.runAllCode),
+      restartAndRunAll: current => {
+        return current.context.session.restart().then(restarted => {
+          if (restarted) {
+            commands.execute(CommandIDs.runAllCode);
+          }
+          return restarted;
+        });
+      }
     } as IRunMenu.ICodeRunner<IDocumentWidget<FileEditor>>);
   }
 


### PR DESCRIPTION
Fixes #5579
- Add "Run All Code"/"Restart Kernel and Run All Code" in Run menu.
- For Markdown files, only run code blocks.

**Screenshots**
Text file
![run_all](https://user-images.githubusercontent.com/1594393/48669655-c2e22b00-eb3b-11e8-887c-b5a23797b0c1.gif)

Markdown file
![md_run_all](https://user-images.githubusercontent.com/1594393/48669650-acd46a80-eb3b-11e8-8608-768776361201.gif)