### PR TITLE
Adding white-space pre-wrap to code snippets in markdown.

### DIFF
--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -328,6 +328,7 @@
   font-size: inherit;
   line-height: var(--jp-code-line-height);
   padding: 0;
+  white-space: pre-wrap;
 }
 
 .jp-RenderedHTMLCommon code {


### PR DESCRIPTION
Fixes # n/a
Code snippets in markdown were not wrapping. 

**Screenshots**
Before:
<img width="453" alt="wrap_before" src="https://user-images.githubusercontent.com/11672891/48677823-be5b4980-eb1e-11e8-8a59-36b3d175cf29.png">


After:
<img width="458" alt="wrap_after" src="https://user-images.githubusercontent.com/11672891/48677846-23af3a80-eb1f-11e8-8549-4b5fce5e1ed9.png">

