### PR TITLE
Issue 2346

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -375,7 +375,7 @@ export namespace CodeEditor {
   /**
    * The location of requested edges.
    */
-  export type EdgeLocation = 'top' | 'bottom';
+  export type EdgeLocation = 'top' | 'topLine' | 'bottom';
 
   /**
    * A widget that provides a code editor.

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -554,6 +554,13 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       return false;
     }
 
+    if (line === 0 && event.keyCode === UP_ARROW) {
+      if (!event.shiftKey) {
+        this.edgeRequested.emit('topLine');
+      }
+      return false;
+    }
+
     let lastLine = this.lineCount - 1;
     let lastCh = this.getLine(lastLine)!.length;
     if (

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -98,7 +98,6 @@ export class ConsoleHistory implements IConsoleHistory {
     return this._editor;
   }
   set editor(value: CodeEditor.IEditor | null) {
-    console.log('console/history:ConsoleHistory.set editor() called');
     if (this._editor === value) {
       return;
     }

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -98,6 +98,7 @@ export class ConsoleHistory implements IConsoleHistory {
     return this._editor;
   }
   set editor(value: CodeEditor.IEditor | null) {
+    console.log('console/history:ConsoleHistory.set editor() called');
     if (this._editor === value) {
       return;
     }
@@ -264,7 +265,7 @@ export class ConsoleHistory implements IConsoleHistory {
     let model = editor.model;
     let source = model.value.text;
 
-    if (location === 'top') {
+    if (location === 'top' || location === 'topLine') {
       this.back(source).then(value => {
         if (this.isDisposed || !value) {
           return;
@@ -274,7 +275,12 @@ export class ConsoleHistory implements IConsoleHistory {
         }
         this._setByHistory = true;
         model.value.text = value;
-        editor.setCursorPosition({ line: 0, column: 0 });
+        let columnPos = 0;
+        columnPos = value.indexOf('\n');
+        if (columnPos < 0) {
+          columnPos = value.length;
+        }
+        editor.setCursorPosition({ line: 0, column: columnPos });
       });
     } else {
       this.forward(source).then(value => {


### PR DESCRIPTION
Fixes #2346

Pressing the up arrow in the console cell recalls the previous history and places the cursor at the end of the first line. A new signal was implemented so that any editor that wants can respond to. The console editor responds to this new signal to implement this behavior. The down arrow behavior remains unchanged.

**Screenshots**
None available that can demonstrate the implemented behavior.
