### PR TITLE
Don't sort extension search alphabetically

### DIFF
--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -738,7 +738,8 @@ namespace Private {
     let testB = isJupyterOrg(b.name);
 
     if (testA === testB) {
-      return a.name.localeCompare(b.name);
+      // Retain sort-order from API
+      return 0;
     } else if (testA && !testB) {
       return -1;
     } else {


### PR DESCRIPTION
Sorting the extensions alphabetically will artificially give more visibility to packages early in the alphabet. Instead, retain the sort order from the registry, which is based on a composite score including:
- How well the package matches the search text.
- A [package "score"](https://docs.npmjs.com/searching-for-and-choosing-packages-to-download#package-search-rank-criteria).