### PR TITLE
Exclude node-fetch and ws from webpack and use require instead of eval

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -208,6 +208,7 @@ module.exports = [
     },
     bail: true,
     devtool: 'source-map',
+    externals: ['node-fetch', 'ws'],
     plugins: [
       new DuplicatePackageCheckerPlugin({
         verbose: true,

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -45,7 +45,7 @@
     "@phosphor/signaling": "^1.2.2"
   },
   "devDependencies": {
-    "@types/node": "^10.12.10",
+    "@types/node": "~8.0.47",
     "@types/text-encoding": "0.0.33",
     "rimraf": "~2.6.2",
     "text-encoding": "~0.5.5",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -45,6 +45,7 @@
     "@phosphor/signaling": "^1.2.2"
   },
   "devDependencies": {
+    "@types/node": "^10.12.10",
     "@types/text-encoding": "0.0.33",
     "rimraf": "~2.6.2",
     "text-encoding": "~0.5.5",

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -17,11 +17,11 @@ if (typeof window === 'undefined') {
   // Mangle the require statements so it does not get picked up in the
   // browser assets.
   /* tslint:disable */
-  let fetchMod = eval('require')('node-fetch');
+  let fetchMod = require('node-fetch');
   FETCH = global.fetch || fetchMod;
   REQUEST = global.Request || fetchMod.Request;
   HEADERS = global.Headers || fetchMod.Headers;
-  WEBSOCKET = global.WebSocket || eval('require')('ws');
+  WEBSOCKET = global.WebSocket || require('ws');
   /* tslint:enable */
 } else {
   FETCH = fetch;

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "references": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,6 +763,10 @@
   version "8.0.58"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.58.tgz#5b3881c0be3a646874803fee3197ea7f1ed6df90"
 
+"@types/node@^10.12.10":
+  version "10.12.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.10.tgz#4fa76e6598b7de3f0cb6ec3abacc4f59e5b3a2ce"
+
 "@types/prop-types@*":
   version "15.5.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.5.tgz#17038dd322c2325f5da650a94d5f9974943625e3"


### PR DESCRIPTION
Fixes #5651
