### PR TITLE
BUG @types/react not as devDependency in apputils

### DIFF
--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -43,12 +43,12 @@
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.6.0",
-    "@types/react": "~16.4.13",
     "react": "~16.4.2",
     "react-dom": "~16.4.2",
     "sanitize-html": "~1.18.2"
   },
   "devDependencies": {
+    "@types/react": "~16.4.13",
     "@types/react-dom": "~16.0.7",
     "@types/sanitize-html": "~1.18.0",
     "rimraf": "~2.6.2",


### PR DESCRIPTION
Correct: @types/react not as devDependency in apputils
