### PR TITLE
DirListing: Correct undefined `name` variable

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1460,6 +1460,7 @@ export class DirListing extends Widget {
       return;
     }
 
+    let name = newValue.name;
     if (args.type !== 'new' || !name) {
       return;
     }


### PR DESCRIPTION
Fixes #5666 

**Screenshots**

Before
![newfolder_before](https://user-images.githubusercontent.com/8435071/48967752-c6ffc400-efe5-11e8-84b7-09e36e5ebe89.gif)

After
![newfolder_after](https://user-images.githubusercontent.com/8435071/48967754-d0892c00-efe5-11e8-83bf-b3905e9cc902.gif)


