### PR TITLE
Remove `commands` in `FileBrowser` constructor

### DIFF
--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -84,7 +84,6 @@ function createApp(manager: ServiceManager.IManager): void {
   let fbModel = new FileBrowserModel({ manager: docManager });
   let fbWidget = new FileBrowser({
     id: 'filebrowser',
-    commands,
     model: fbModel
   });
 

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -194,8 +194,7 @@ function activateFactory(
     });
     const widget = new FileBrowser({
       id,
-      model,
-      commands: options.commands || commands
+      model
     });
 
     // Add a launcher toolbar item.

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -38,7 +38,6 @@
     "@jupyterlab/services": "^3.2.1",
     "@jupyterlab/statusbar": "^0.7.1",
     "@phosphor/algorithm": "^1.1.2",
-    "@phosphor/commands": "^1.6.1",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/domutils": "^1.1.2",

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -9,8 +9,6 @@ import { Contents, ServerConnection } from '@jupyterlab/services';
 
 import { IIterator } from '@phosphor/algorithm';
 
-import { CommandRegistry } from '@phosphor/commands';
-
 import { PanelLayout, Widget } from '@phosphor/widgets';
 
 import { BreadCrumbs } from './crumbs';
@@ -285,11 +283,6 @@ export namespace FileBrowser {
    * An options object for initializing a file browser widget.
    */
   export interface IOptions {
-    /**
-     * The command registry for use with the file browser.
-     */
-    commands: CommandRegistry;
-
     /**
      * The widget/DOM id of the file browser.
      */

--- a/packages/filebrowser/src/factory.ts
+++ b/packages/filebrowser/src/factory.ts
@@ -5,8 +5,6 @@ import { InstanceTracker } from '@jupyterlab/apputils';
 
 import { IStateDB } from '@jupyterlab/coreutils';
 
-import { CommandRegistry } from '@phosphor/commands';
-
 import { Token } from '@phosphor/coreutils';
 
 import { FileBrowser } from './browser';
@@ -73,14 +71,6 @@ export namespace IFileBrowserFactory {
    * state database.
    */
   export interface IOptions {
-    /**
-     * The command registry used by the file browser.
-     *
-     * #### Notes
-     * If no command registry is provided, the application default will be used.
-     */
-    commands?: CommandRegistry;
-
     /**
      * An optional `Contents.IDrive` name for the model.
      * If given, the model will prepend `driveName:` to


### PR DESCRIPTION
Commands registry is not consumed by the `FileBrowser` constructor. This PR removes it from the associated interfaces.