### PR TITLE
Doc links

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = JupyterLab
 SOURCEDIR     = source

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
 - python=3.5
-- sphinx
+- sphinx>=1.8
 - sphinx_rtd_theme
 - recommonmark

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -232,6 +232,10 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 # https://github.com/rtfd/recommonmark/blob/master/docs/conf.py#L296
 github_doc_root = 'https://github.com/jupyterlab/jupyterlab/tree/master/docs/'
 
+# We can't rely on anchors because GitHub dynamically renders them for
+# markdown documents.
+linkcheck_anchors = False
+
 def setup(app):
     app.add_config_value('recommonmark_config', {
         'url_resolver': lambda url: github_doc_root + url,

--- a/docs/source/developer/adding_content.rst
+++ b/docs/source/developer/adding_content.rst
@@ -29,7 +29,7 @@ As an example: Add a leaflet viewer plugin for geoJSON files.
 
 -  The ``index.ts`` file should have the core logic for the plugin. In
    this case, it should create a widget and widget factory for rendering
-   geojson files (see `Documents <documents.html>`__).
+   geojson files (see :ref:`documents`).
 
 -  The ``plugin.ts`` file should create the extension and add the
    content to the application. In this case registering the widget

--- a/docs/source/developer/adding_content.rst
+++ b/docs/source/developer/adding_content.rst
@@ -15,7 +15,7 @@ As an example: Add a leaflet viewer plugin for geoJSON files.
 
 -  If there are no typings, we must create our own. An example typings
    file that exports functions is
-   `path-posix <https://github.com/jupyterlab/jupyterlab/blob/master/packages/coreutils/typings/path-posix/path-posix.d.ts>`__.
+   `codemirror <https://github.com/jupyterlab/jupyterlab/blob/master/packages/codemirror/typings/codemirror/codemirror.d.ts>`__.
    An example with a class is
    `xterm <https://github.com/jupyterlab/jupyterlab/blob/master/packages/terminal/src/xterm.d.ts>`__.
 

--- a/docs/source/developer/documents.rst
+++ b/docs/source/developer/documents.rst
@@ -18,21 +18,21 @@ is backed by a file stored on disk (i.e. uses Contents API).
 Overview of document architecture
 ---------------------------------
 
-A 'document' in JupyterLab is represented by a model instance implementing the `IModel <http://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_registry_.documentregistry.imodel.html>`__ interface. The model interface is intentionally fairly small, and concentrates on representing the data in the document and signaling changes to that data. Each model has an associated `context <http://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_registry_.documentregistry.icontext.html>`__ instance as well. The context for a model is the bridge between the internal data of the document, stored in the model, and the file metadata and operations possible on the file, such as save and revert. Since many objects will need both the context and the model, the context contains a reference to the model as its `.model` attribute.
+A 'document' in JupyterLab is represented by a model instance implementing the `IModel <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.imodel.html>`__ interface. The model interface is intentionally fairly small, and concentrates on representing the data in the document and signaling changes to that data. Each model has an associated `context <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.icontext.html>`__ instance as well. The context for a model is the bridge between the internal data of the document, stored in the model, and the file metadata and operations possible on the file, such as save and revert. Since many objects will need both the context and the model, the context contains a reference to the model as its `.model` attribute.
 
 A single file path can have multiple different models (and hence different contexts) representing the file. For example, a notebook can be opened with a notebook model and with a text model. Different models for the same file path do not directly communicate with each other.
 
-`Document widgets <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html>`__ represent a view of a document model. There can be multiple document widgets associated with a single document model, and they naturally stay in sync with each other since they are views on the same underlying data model.
+`Document widgets <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html>`__ represent a view of a document model. There can be multiple document widgets associated with a single document model, and they naturally stay in sync with each other since they are views on the same underlying data model.
 
 
 The `Document
-Registry <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html>`__
+Registry <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html>`__
 is where document types and factories are registered. Plugins can
 require a document registry instance and register their content types
 and providers.
 
 The `Document
-Manager <http://jupyterlab.github.io/jupyterlab/classes/_docmanager_src_manager_.documentmanager.html>`__
+Manager <https://jupyterlab.github.io/jupyterlab/docmanager/classes/documentmanager.html>`__
 uses the Document Registry to create models and widgets for documents.
 The Document Manager is only meant to be accessed by the File Browser
 itself.
@@ -48,8 +48,8 @@ Document Registry
 -  widget extension factories
 -  file creators
 
-`Widget Factories <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html#addwidgetfactory>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Widget Factories <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html#addwidgetfactory>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Create a widget for a given file.
 
@@ -57,16 +57,16 @@ Create a widget for a given file.
 
 -  The notebook widget factory that creates NotebookPanel widgets.
 
-`Model Factories <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html#addmodelfactory>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Model Factories <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html#addmodelfactory>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Create a model for a given file.
 
 Models are generally differentiated by the contents options used to
 fetch the model (e.g. text, base64, notebook).
 
-`Widget Extension Factories <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html#addwidgetextension>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Widget Extension Factories <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html#addwidgetextension>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Adds additional functionality to a widget type. An extension instance is
 created for each widget instance, enabling the extension to add
@@ -77,14 +77,14 @@ functionality to each widget or observe the widget and/or its context.
 -  The ipywidgets extension that is created for NotebookPanel widgets.
 -  Adding a button to the toolbar of each NotebookPanel widget.
 
-`File Types <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html#addfiletype>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`File Types <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html#addfiletype>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Intended to be used in a "Create New" dialog, providing a list of known
 file types.
 
-`File Creators <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`File Creators <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Intended for create quick launch file creators.
 
@@ -92,8 +92,8 @@ The default use will be for the "create new" dropdown in the file
 browser, giving list of items that can be created with default options
 (e.g. "Python 3 Notebook").
 
-`Document Models <http://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_registry_.documentregistry.imodel.html>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Document Models <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.imodel.html>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Created by the model factories and passed to widget factories and widget
 extension factories. Models are the way in which we interact with the
@@ -101,8 +101,8 @@ data of a document. For a simple text file, we typically only use the
 ``to/fromString()`` methods. A more complex document like a Notebook
 contains more points of interaction like the Notebook metadata.
 
-`Document Contexts <http://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_registry_.documentregistry.icontext.html>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Document Contexts <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.icontext.html>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Created by the Document Manager and passed to widget factories and
 widget extensions. The context contains the model as one of its

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -23,10 +23,6 @@ JupyterLab can be extended in four ways via:
 
 See :ref:`xkcd_extension_tutorial` to learn how to make a simple JupyterLab extension.
 
-To understand how to wrap an **Angular** application as a JupyterLab extension,
-see the `"Create your own Angular JupyerLab extension" <https://github.com/SimonBiggs/scriptedforms/blob/master/scriptedforms/docs/create-your-own-angular-jupyterlab-extension.md#create-your-own-angular-jupyerlab-extension>`_ guide provided by
-`Scripted Forms <https://github.com/SimonBiggs/scriptedforms>`_.
-
 A JupyterLab application is comprised of:
 
 -  A core Application object
@@ -43,7 +39,7 @@ A plugin adds a core functionality to the application:
 -  Plugins require and provide ``Token`` objects, which are used to
    provide a typed value to the plugin's ``activate()`` method.
 -  The module providing plugin(s) must meet the
-   `JupyterLab.IPluginModule <http://jupyterlab.github.io/jupyterlab/interfaces/_application_src_index_.jupyterlab.ipluginmodule.html>`__
+   `JupyterLab.IPluginModule <https://jupyterlab.github.io/jupyterlab/application/interfaces/jupyterlab.ipluginmodule.html>`__
    interface, by exporting a plugin object or array of plugin objects as
    the default export.
 
@@ -97,7 +93,7 @@ JupyterLab Shell
 ~~~~~~~~~~~~~~~~
 
 The JupyterLab
-`shell <http://jupyterlab.github.io/jupyterlab/classes/_application_src_shell_.applicationshell.html>`__
+`shell <https://jupyterlab.github.io/jupyterlab/application/classes/applicationshell.html>`__
 is used to add and interact with content in the application. The
 application consists of:
 
@@ -237,7 +233,7 @@ Mime renderer extensions are more declarative than standard extensions.
 The extension is treated the same from the command line perspective
 (``jupyter labextension install`` ), but it does not directly create
 JupyterLab plugins. Instead it exports an interface given in the
-`rendermime-interfaces <http://jupyterlab.github.io/jupyterlab/interfaces/_rendermime_interfaces_src_index_.irendermime.iextension.html>`__
+`rendermime-interfaces <https://jupyterlab.github.io/jupyterlab/rendermime-interfaces/interfaces/irendermime.iextension.html>`__
 package.
 
 The JupyterLab repo has an example mime renderer extension for
@@ -282,7 +278,7 @@ you must compile them to CSS and point JupyterLab to the CSS files.
 
 To quickly create a theme based on the JupyterLab Light Theme, follow
 the instructions in the `contributing
-guide <https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md#setting-up-a-development-environment>`__ and
+guide <https://github.com/jupyterlab/jupyterlab/blob/d9bbf0822be5309d063249da6776e640dba7984c/CONTRIBUTING.md#setting-up-a-development-environment>`__ and
 then run ``jlpm run create:theme`` from the repository root directory.
 Once you select a name, title and a description, a new theme folder will
 be created in the current directory. You can move that new folder to a
@@ -469,13 +465,13 @@ Context Menus
 
 JupyterLab has an application-wide context menu available as
 ``app.contextMenu``. See the Phosphor
-`docs <http://phosphorjs.github.io/phosphor/api/widgets/interfaces/contextmenu.iitemoptions.html>`__
+`docs <https://phosphorjs.github.io/phosphor/api/widgets/interfaces/contextmenu.iitemoptions.html>`__
 for the item creation options. If you wish to preempt the
 application context menu, you can use a 'contextmenu' event listener and
 call ``event.stopPropagation`` to prevent the application context menu
 handler from being called (it is listening in the bubble phase on the
 ``document``). At this point you could show your own Phosphor
-`contextMenu <http://phosphorjs.github.io/phosphor/api/widgets/classes/contextmenu.html>`__,
+`contextMenu <https://phosphorjs.github.io/phosphor/api/widgets/classes/contextmenu.html>`__,
 or simply stop propagation and let the system context menu be shown.
 This would look something like the following in a ``Widget`` subclass:
 

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -385,8 +385,8 @@ might want to use them in your extensions.
 Standard Extension Example
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For a concrete example of a standard extension, see `How to Extend the Notebook
-Plugin <https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/developer/notebook.rst#how-to-extend-the-notebook-plugin>`__. Notice that the mime renderer and themes extensions above use a limited,
+For a concrete example of a standard extension, see :ref:`How to extend the Notebook plugin <extend-notebook-plugin>`.
+Notice that the mime renderer and themes extensions above use a limited,
 simplified interface to JupyterLab's extension system. Modifying the
 notebook plugin requires the full, general-purpose interface to the
 extension system.

--- a/docs/source/developer/notebook.rst
+++ b/docs/source/developer/notebook.rst
@@ -19,9 +19,9 @@ The most complicated plugin included in the **JupyterLab application**
 is the **Notebook plugin**.
 
 The
-`NotebookWidgetFactory <http://jupyterlab.github.io/jupyterlab/classes/_notebook_src_widgetfactory_.notebookwidgetfactory.html>`__
+`NotebookWidgetFactory <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebookwidgetfactory.html>`__
 constructs a new
-`NotebookPanel <http://jupyterlab.github.io/jupyterlab/classes/_notebook_src_panel_.notebookpanel.html>`__
+`NotebookPanel <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebookpanel.html>`__
 from a model and populates the toolbar with default widgets.
 
 Structure of the Notebook plugin
@@ -34,11 +34,11 @@ Model
 ^^^^^
 
 The
-`NotebookModel <http://jupyterlab.github.io/jupyterlab/classes/_notebook_src_model_.notebookmodel.html>`__
+`NotebookModel <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebookmodel.html>`__
 contains an observable list of cells.
 
 A `cell
-model <http://jupyterlab.github.io/jupyterlab/modules/_cells_src_model_.html>`__
+model <https://jupyterlab.github.io/jupyterlab/cells/classes/cellmodel.html>`__
 can be:
 
 -  a code cell
@@ -65,7 +65,7 @@ Metadata
 
 The notebook model and the cell model (i.e. notebook cells) support
 getting and setting metadata through an
-`IObservableJSON <http://jupyterlab.github.io/jupyterlab/modules/_observables_src_observablejson_.iobservablejson.html>`__
+`IObservableJSON <https://jupyterlab.github.io/jupyterlab/observables/modules/iobservablejson.html>`__
 object. You can use this to get and set notebook/cell metadata,
 as well as subscribe to changes to it.
 
@@ -77,9 +77,9 @@ a new NotebookPanel from the model. The NotebookPanel widget is added to
 the DockPanel. The **NotebookPanel** contains:
 
 -  a
-   `Toolbar <http://jupyterlab.github.io/jupyterlab/modules/_apputils_src_toolbar_.html>`__
+   `Toolbar <https://jupyterlab.github.io/jupyterlab/apputils/classes/toolbar.html>`__
 -  a `Notebook
-   widget <http://jupyterlab.github.io/jupyterlab/classes/_notebook_src_widget_.notebook.html>`__.
+   widget <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebook.html>`__.
 
 The NotebookPanel also adds completion logic.
 
@@ -96,7 +96,7 @@ Higher level actions using NotebookActions
 ''''''''''''''''''''''''''''''''''''''''''
 
 Higher-level actions are contained in the
-`NotebookActions <http://jupyterlab.github.io/jupyterlab/classes/_notebook_src_actions_.notebookactions.html>`__
+`NotebookActions <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebookactions.html>`__
 namespace, which has functions, when given a notebook widget, to run a
 cell and select the next cell, merge or split cells at the cursor,
 delete selected cells, etc.
@@ -105,25 +105,25 @@ Widget hierarchy
 ''''''''''''''''
 
 A Notebook widget contains a list of `cell
-widgets <http://jupyterlab.github.io/jupyterlab/modules/_cells_src_widget_.html>`__,
+widgets <https://jupyterlab.github.io/jupyterlab/cells/classes/cell.html>`__,
 corresponding to the cell models in its cell list.
 
 -  Each cell widget contains an
-   `InputArea <http://jupyterlab.github.io/jupyterlab/classes/_cells_src_inputarea_.inputarea.html>`__,
+   `InputArea <https://jupyterlab.github.io/jupyterlab/cells/classes/inputarea.html>`__,
 
    -  which contains n
-      `CodeEditorWrapper <http://jupyterlab.github.io/jupyterlab/classes/_codeeditor_src_widget_.codeeditorwrapper.html>`__,
+      `CodeEditorWrapper <https://jupyterlab.github.io/jupyterlab/codeeditor/classes/codeeditorwrapper.html>`__,
 
       -  which contains a JavaScript CodeMirror instance.
 
 A
-`CodeCell <http://jupyterlab.github.io/jupyterlab/classes/_cells_src_widget_.codecell.html>`__
+`CodeCell <https://jupyterlab.github.io/jupyterlab/cells/classes/codecell.html>`__
 also contains an
-`OutputArea <http://jupyterlab.github.io/jupyterlab/classes/_outputarea_src_widget_.outputarea.html>`__.
+`OutputArea <https://jupyterlab.github.io/jupyterlab/outputarea/classes/outputarea.html>`__.
 An OutputArea is responsible for rendering the outputs in the
-`OutputAreaModel <http://jupyterlab.github.io/jupyterlab/classes/_outputarea_src_model_.outputareamodel.html>`__
+`OutputAreaModel <https://jupyterlab.github.io/jupyterlab/outputarea/classes/outputareamodel.html>`__
 list. An OutputArea uses a notebook-specific
-`RenderMimeRegistry <http://jupyterlab.github.io/jupyterlab/classes/_rendermime_src_registry_.rendermimeregistry.html>`__
+`RenderMimeRegistry <https://jupyterlab.github.io/jupyterlab/rendermime/classes/rendermimeregistry.html>`__
 object to render ``display_data`` output messages.
 
 Rendering output messages
@@ -262,9 +262,9 @@ intrinsic relation between *phosphor widgets* and *ipython widgets*.
 
 The *ipywidgets* extension registers a factory for a notebook *widget*
 extension using the `Document
-Registry <http://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_registry_.documentregistry.html>`__.
+Registry <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html>`__.
 The ``createNew()`` function is called with a NotebookPanel and
-`DocumentContext <http://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_registry_.documentregistry.icontext.html>`__.
+`DocumentContext <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.icontext.html>`__.
 The plugin then creates a ipywidget manager (which uses the context to
 interact the kernel and kernel's comm manager). The plugin then
 registers an ipywidget renderer with the notebook instance's rendermime

--- a/docs/source/developer/notebook.rst
+++ b/docs/source/developer/notebook.rst
@@ -139,6 +139,8 @@ The ipywidgets widget manager is an example of an extension that adds a
 notebook-specific renderer, since rendering a widget depends on
 notebook-specific widget state.
 
+.. _extend-notebook-plugin:
+
 How to extend the Notebook plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developer/virtualdom.rst
+++ b/docs/source/developer/virtualdom.rst
@@ -1,7 +1,7 @@
 Virtual DOM and React
 ---------------------
 
-JupyterLab is based on `PhosphorJS <http://phosphorjs.github.io/>`__,
+JupyterLab is based on `PhosphorJS <https://phosphorjs.github.io/>`__,
 which provides a flexible ``Widget`` class that handles the following:
 
 -  Resize events that propagate down the Widget hierarchy.

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -856,8 +856,8 @@ learning, here are some suggestions about what to try next:
 -  Make the image a link to the comic on https://xkcd.com.
 -  Push your extension git repository to GitHub.
 -  Give users the ability to pin comics in separate, permanent panels.
--  Learn how to write `other kinds of
-   extensions <./extension_dev.html>`__.
+-  Learn how to write :ref:`other kinds of
+   extensions <developer_extensions>`.
 
 .. |Completed xkcd extension screenshot| image:: xkcd_tutorial_complete.png
 .. |Empty xkcd extension panel| image:: xkcd_tutorial_empty.png

--- a/docs/source/getting_started/changelog.rst
+++ b/docs/source/getting_started/changelog.rst
@@ -248,8 +248,8 @@ Workspaces
 ^^^^^^^^^^
 
 We added new workspace support, which enables you to have multiple saved
-layouts, including in different browser windows. See the `workspace
-documentation <https://jupyterlab.readthedocs.io/en/stable/user/urls.html>`__
+layouts, including in different browser windows. See the
+:ref:`workspace documentation <url-workspaces-ui>`
 for more details.
 (`#4502 <https://github.com/jupyterlab/jupyterlab/issues/4502>`__,
 `#4708 <https://github.com/jupyterlab/jupyterlab/pull/4708>`__,

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -88,5 +88,5 @@ Earlier browser versions may also work, but come with no guarantees.
 JupyterLab uses CSS Variables for styling, which is one reason for the
 minimum versions listed above.  IE 11+ or Edge 14 do not support
 CSS Variables, and are not directly supported at this time.
-A tool like `postcss <http://postcss.org/>`__ can be used to convert the CSS files in the
+A tool like `postcss <https://postcss.org/>`__ can be used to convert the CSS files in the
 ``jupyterlab/build`` directory manually if desired.

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -44,7 +44,7 @@ of JupyterLab, including new themes, file editors, and custom components.
 
 JupyterLab is served from the same `server
 <https://jupyter-notebook.readthedocs.io/en/stable/>`__ and uses the same
-`notebook document format <http://nbformat.readthedocs.io/en/latest/>`__ as the
+`notebook document format <https://nbformat.readthedocs.io/en/latest/>`__ as the
 classic Jupyter Notebook.
 
 .. _releases:

--- a/docs/source/getting_started/starting.rst
+++ b/docs/source/getting_started/starting.rst
@@ -13,7 +13,7 @@ JupyterLab will open automatically in your browser.
 
 You may access JupyterLab by entering the notebook server's :ref:`URL <urls>`
 into the browser. JupyterLab sessions always reside in a
-:ref:`workspace <url-workspaces>`. The default workspace is the main ``/lab`` URL:
+:ref:`workspace <url-workspaces-ui>`. The default workspace is the main ``/lab`` URL:
 
 .. code-block:: none
 
@@ -27,7 +27,7 @@ Like the classic notebook,
 JupyterLab provides a way for users to copy URLs that
 :ref:`open a specific notebook or file <url-tree>`. Additionally,
 JupyterLab URLs are an advanced part of the user interface that allows for
-managing :ref:`workspaces <url-workspaces>`. To learn more about URLs in
+managing :ref:`workspaces <url-workspaces-ui>`. To learn more about URLs in
 Jupyterlab, visit :ref:`urls`.
 
 To open the classic Notebook from JupyterLab, select "Launch Classic Notebook"

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -15,7 +15,7 @@ or privileged than any custom extension.
 JupyterLab extensions are `npm <https://www.npmjs.com/>`__ packages (the
 standard package format in Javascript development). You can search for the
 keyword `jupyterlab-extension
-<https://www.npmjs.com/search?q=keywords%3Ajupyterlab-extension`__ on the
+<https://www.npmjs.com/search?q=keywords%3Ajupyterlab-extension>`__ on the
 npm registry to find extensions. For information about developing extensions,
 see the :ref:`developer documentation <developer_extensions>`.
 
@@ -147,15 +147,15 @@ Companion packages
 
 During installation of an extension, JupyterLab will inspect the package
 metadata for any
-:ref:`instructions on companion packages<ext-author-companion-packages>`.
+:ref:`instructions on companion packages <ext-author-companion-packages>`.
 Companion packages can be:
 
    - Notebook server extensions (or any other packages that need to be
      installed on the Notebook server).
    - Kernel packages. An example of companion packages for the
-     kernel are Jupyter Widget packages, like the `ipywidgets`_
+     kernel are Jupyter Widget packages, like the `ipywidgets <https://ipywidgets.readthedocs.io/en/stable>`__
      Python package for the
-     `@jupyter-widgets/jupyterlab-manager package`_.
+     `@jupyter-widgets/jupyterlab-manager package <https://www.npmjs.com/package/@jupyter-widgets/jupyterlab-manager>`__.
 
 If JupyterLab finds instructions for companion packages, it will present
 a dialog to notify you about these. These are informational only, and it

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -19,11 +19,11 @@ cell tools inspector <notebook>`, and the :ref:`tabs list <tabs>`.
    :align: center
    :class: jp-screenshot
 
-JupyterLab sessions always reside in a :ref:`workspace <url-workspaces>`.
+JupyterLab sessions always reside in a :ref:`workspace <url-workspaces-ui>`.
 Workspaces contain the state of JupyterLab: the files that are currently open,
 the layout of the application areas and tabs, etc.
 Workspaces can be saved on the server with
-:ref:`named workspace URLs <url-workspaces>`.
+:ref:`named workspace URLs <url-workspaces-ui>`.
 To learn more about URLs in Jupyterlab, visit :ref:`urls`.
 
 

--- a/docs/source/user/notebook.rst
+++ b/docs/source/user/notebook.rst
@@ -12,7 +12,7 @@ visualizations and other rich output:
    :class: jp-screenshot
 
 **Jupyter notebooks (.ipynb files) are fully supported in JupyterLab.** The
-`notebook document format <http://nbformat.readthedocs.io/en/latest/>`__ used in
+`notebook document format <https://nbformat.readthedocs.io/en/latest/>`__ used in
 JupyterLab is the same as in the classic Jupyter Notebook. Your existing notebooks
 should open correctly in JupyterLab. If they don’t, please open an issue on our
 `GitHub issues <https://github.com/jupyterlab/jupyterlab/issues>`__ page.
@@ -120,7 +120,7 @@ information about the types of the matched items:
 
 Note: IPython 6.3.1 has temporarily disabled type annotations.
 To re-enable them, add ``c.Completer.use_jedi = True`` to an
-`ipython_config.py <http://ipython.readthedocs.io/en/stable/development/config.html>`__ file. 
+`ipython_config.py <https://ipython.readthedocs.io/en/stable/development/config.html>`__ file. 
 
 .. _tooltip:
 

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -41,7 +41,8 @@ if [[ $GROUP == docs ]]; then
 
     # Verify tutorial docs build
     pushd docs
-    pip install "sphinx<1.8" sphinx_rtd_theme recommonmark
+    pip install sphinx sphinx_rtd_theme recommonmark
+    make linkcheck
     make html
     popd
 fi


### PR DESCRIPTION
Fixes a lot of broken links in the documentation, as well as adding a step checking them in our CI.


Also fixes https://github.com/jupyterlab/jupyterlab/issues/5602