### PR TITLE
add 'name' flag to workspaces import CLI

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -164,13 +164,16 @@ class LabWorkspaceImportApp(JupyterApp):
         file must be the same as what the export functionality emits.
     """
     workspace_name = Unicode(
-        config=True, 
+        None,
+        config=True,
+        allow_none=True,
         help="""
-        Workspace name. If given, the workspace ID in the imported 
-        file will be replaced with a new ID pointing to this 
+        Workspace name. If given, the workspace ID in the imported
+        file will be replaced with a new ID pointing to this
         workspace name.
         """
     )
+
     aliases = {
         'name': 'LabWorkspaceImportApp.workspace_name'
     }
@@ -225,7 +228,7 @@ class LabWorkspaceImportApp(JupyterApp):
             raise Exception('The `data` field is missing.')
 
         # See if workspace name is given, inject into workspace.
-        if self.workspace_name != '':
+        if self.workspace_name is not None:
             workspace_id = ujoin(base_url, workspaces_url, self.workspace_name)
             workspace['metadata'] = {'id': workspace_id}
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -227,19 +227,23 @@ class LabWorkspaceImportApp(JupyterApp):
         if 'data' not in workspace:
             raise Exception('The `data` field is missing.')
 
-        # See if workspace name is given, inject into workspace.
+        # If workspace_name is set in config, inject the
+        # name into the workspace metadata.
         if self.workspace_name is not None:
-            workspace_id = ujoin(base_url, workspaces_url, self.workspace_name)
+            if self.workspace_name == "":
+                workspace_id = ujoin(base_url, 'lab')
+            else:
+                workspace_id = ujoin(base_url, workspaces_url, self.workspace_name)
             workspace['metadata'] = {'id': workspace_id}
-
-        elif 'id' not in workspace['metadata']:
-            raise Exception('The `id` field is missing in `metadata`.')
-
+        # else check that the workspace_id is valid.
         else:
-            id = workspace['metadata']['id']
-            if id != ujoin(base_url, page_url) and not id.startswith(ujoin(base_url, workspaces_url)):
-                error = '%s does not match page_url or start with workspaces_url.'
-                raise Exception(error % id)
+            if 'id' not in workspace['metadata']:
+                raise Exception('The `id` field is missing in `metadata`.')
+            else:
+                id = workspace['metadata']['id']
+                if id != ujoin(base_url, page_url) and not id.startswith(ujoin(base_url, workspaces_url)):
+                    error = '%s does not match page_url or start with workspaces_url.'
+                    raise Exception(error % id)
 
         return workspace
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -231,7 +231,7 @@ class LabWorkspaceImportApp(JupyterApp):
         # name into the workspace metadata.
         if self.workspace_name is not None:
             if self.workspace_name == "":
-                workspace_id = ujoin(base_url, 'lab')
+                workspace_id = ujoin(base_url, page_url)
             else:
                 workspace_id = ujoin(base_url, workspaces_url, self.workspace_name)
             workspace['metadata'] = {'id': workspace_id}


### PR DESCRIPTION
Fixes #5694

This adds a `--name` argument to the `jupyter lab workspaces import` command. The workspace name can now be set from the command line. 

