### PR TITLE
Follow file path between file browser and editor

### DIFF
--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -1,6 +1,8 @@
 {
+  "jupyter.lab.setting-icon-class": "jp-FileIcon",
+  "jupyter.lab.setting-icon-label": "File Browser",
   "title": "File Browser",
-  "description": "File browser settings.",
+  "description": "File Browser settings.",
   "jupyter.lab.shortcuts": [
     {
       "command": "filebrowser:create-main-launcher",
@@ -13,7 +15,14 @@
       "selector": "body"
     }
   ],
-  "properties": {},
+  "properties": {
+    "navigateToCurrentDirectory": {
+      "type": "boolean",
+      "title": "Navigate to document's current directory",
+      "description": "Whether to automatically navigate to a document's current directory",
+      "default": false
+    }
+  },
   "additionalProperties": false,
   "type": "object"
 }

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -275,23 +275,30 @@ function activateBrowser(
       maybeCreate();
     });
 
+    let navigateToCurrentDirectory: boolean = false;
+
+    settingRegistry
+      .load('@jupyterlab/filebrowser-extension:browser')
+      .then(settings => {
+        settings.changed.connect(settings => {
+          navigateToCurrentDirectory = settings.get(
+            'navigateToCurrentDirectory'
+          ).composite as boolean;
+        });
+        navigateToCurrentDirectory = settings.get('navigateToCurrentDirectory')
+          .composite as boolean;
+      });
+
     // Whether to automatically navigate to a document's current directory
     shell.currentChanged.connect((shell, change) => {
-      settingRegistry
-        .load('@jupyterlab/filebrowser-extension:browser')
-        .then(settings => {
-          const navigateToCurrentDirectory = settings.get(
-            'navigateToCurrentDirectory'
-          ).composite as boolean | null;
-          if (navigateToCurrentDirectory) {
-            const { newValue } = change;
-            const context = docManager.contextForWidget(newValue);
-            if (context) {
-              commands.execute('filebrowser:activate', { path: context.path });
-              commands.execute('filebrowser:navigate', { path: context.path });
-            }
-          }
-        });
+      if (navigateToCurrentDirectory) {
+        const { newValue } = change;
+        const context = docManager.contextForWidget(newValue);
+        if (context) {
+          commands.execute('filebrowser:activate', { path: context.path });
+          commands.execute('filebrowser:navigate', { path: context.path });
+        }
+      }
     });
 
     maybeCreate();

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -94,7 +94,7 @@ namespace CommandIDs {
 const browser: JupyterLabPlugin<void> = {
   activate: activateBrowser,
   id: '@jupyterlab/filebrowser-extension:browser',
-  requires: [IFileBrowserFactory, ILayoutRestorer],
+  requires: [IFileBrowserFactory, ILayoutRestorer, IDocumentManager],
   autoStart: true
 };
 
@@ -223,7 +223,8 @@ function activateFactory(
 function activateBrowser(
   app: JupyterLab,
   factory: IFileBrowserFactory,
-  restorer: ILayoutRestorer
+  restorer: ILayoutRestorer,
+  docManager: IDocumentManager
 ): void {
   const browser = factory.defaultBrowser;
   const { commands, shell } = app;
@@ -261,6 +262,17 @@ function activateBrowser(
     shell.layoutModified.connect(() => {
       maybeCreate();
     });
+
+    // Keep the session object on the status item up-to-date.
+    shell.currentChanged.connect((shell, change) => {
+      const { newValue } = change;
+      const context = docManager.contextForWidget(newValue);
+      // const path = `/${PathExt.dirname(context.path)}`;
+      // browser.model.cd(path);
+      commands.execute('filebrowser:activate', { path: context.path });
+      commands.execute('filebrowser:navigate', { path: context.path });
+    });
+
     maybeCreate();
   });
 }


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/4258

![](http://g.recordit.co/9ca5XWWx2E.gif)

This adds the File Browser to the Settings and introduces a "navigateToCurrentDirectory" option that, when enabled, will navigate the file browser to the CWD (current working directory) of the current document. 

![image](https://user-images.githubusercontent.com/512354/49238226-96dd6a00-f3c5-11e8-8606-88ddcc80c2f2.png)
