### PR TITLE
Add transient_display_data message type and display such messages in console window

### DIFF
--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -63,6 +63,12 @@ const BANNER_CLASS = 'jp-CodeConsole-banner';
 const FOREIGN_CELL_CLASS = 'jp-CodeConsole-foreignCell';
 
 /**
+ * The class name of a cell with output from transient_display_message.
+ */
+const TRANSIENT_CELL_CLASS = 'jp-CodeConsole-transientCell';
+
+
+/**
  * The class name of the active prompt cell.
  */
 const PROMPT_CLASS = 'jp-CodeConsole-promptCell';
@@ -125,7 +131,7 @@ export class CodeConsole extends Widget {
     this._foreignHandler = new ForeignHandler({
       session: this.session,
       parent: this,
-      cellFactory: () => this._createCodeCell()
+      cellFactory: (transient: boolean = false) => this._createCodeCell(transient)
     });
 
     this._history = new ConsoleHistory({
@@ -560,13 +566,13 @@ export class CodeConsole extends Widget {
   /**
    * Create a new foreign cell.
    */
-  private _createCodeCell(): CodeCell {
+  private _createCodeCell(transient: boolean = false): CodeCell {
     let factory = this.contentFactory;
     let options = this._createCodeCellOptions();
     let cell = factory.createCodeCell(options);
     cell.readOnly = true;
     cell.model.mimeType = this._mimetype;
-    cell.addClass(FOREIGN_CELL_CLASS);
+    cell.addClass(transient ? TRANSIENT_CELL_CLASS : FOREIGN_CELL_CLASS);
     return cell;
   }
 

--- a/packages/console/style/index.css
+++ b/packages/console/style/index.css
@@ -58,6 +58,14 @@
 .jp-CodeConsole-content .jp-Cell.jp-CodeConsole-foreignCell {
 }
 
+/* hide input of transient cells without input */
+.jp-CodeConsole-content .jp-Cell.jp-CodeConsole-transientCell
+.jp-Cell-inputWrapper,
+.jp-CodeConsole-content .jp-Cell.jp-CodeConsole-transientCell
+.jp-OutputPrompt {
+  display: none;
+}
+
 .jp-CodeConsole-content .jp-InputArea-editor.jp-InputArea-editor {
   background: transparent;
   border: 1px solid transparent;

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -166,6 +166,22 @@ export namespace KernelMessage {
   }
 
   /**
+   * Test whether a kernel message is an `'transient_display_data'` message.
+   */
+  export function isTransientDisplayDataMsg (
+    msg: IMessage
+  ): msg is ITransientDisplayDataMsg {
+    return msg.header.msg_type === 'transient_display_data';
+  }
+
+  /**
+   * A `'transient_display_data'` message on the `'iopub'` channel.
+   */
+  export interface ITransientDisplayDataMsg extends IDisplayDataMsg {
+    content: IDisplayDataMsg['content'];
+  }
+
+  /**
    * An `'execute_input'` message on the `'iopub'` channel.
    *
    * See [Code inputs](https://jupyter-client.readthedocs.io/en/latest/messaging.html#code-inputs).


### PR DESCRIPTION
Re-implementation of PR #4879, reincarnation proposal (#4550) on the display of `transient_display_data` (jupyter/jupyter_client#378), it  basically **provides a way to send `display_data` that is displayed in console windows, not in notebook**.


What this PR does:
1. Add a new message type `transient_display_data`, which is derived directly from `display_data` with no additional field. 
2. Allow `ForeignHandler` of console to 
  * When `Show All Kernel Activity` is turned on, `transient_display_data` will be treated just like a `display_data`. 
  * When `Show All Kernel Activity` is turned off, a new `CodeCell` will be created with hidden input to display only the `transient_display_data`.

![image](https://user-images.githubusercontent.com/9889312/49237111-2df4f280-f3c3-11e8-92eb-6693659bf38f.png)

What this means:

1. Everything will be the same for kernels that do not support the `transient_display_data` message.
2. For kernels that supports this message type, it can send `display_data` for messages that are displayed in notebook (and console window if `Show All Kernel Activity` is enabled), and it can send `transient_display_data` for messages that will only be displayed in the console.

As stated in [the `transient_display_data` PR](https://github.com/jupyter/jupyter_client/pull/378#issuecomment-386760939), this message type can be used to send arbitrary information that should not be stored in the main notebook permanently. Obvious examples include additional debug messages and progress information.

@afshin Let me know if this makes sense to you.
