### PR TITLE
Optimize editor refresh on notebook show

### DIFF
--- a/packages/cells/src/inputarea.ts
+++ b/packages/cells/src/inputarea.ts
@@ -56,7 +56,11 @@ export class InputArea extends Widget {
     prompt.addClass(INPUT_AREA_PROMPT_CLASS);
 
     // Editor
-    let editorOptions = { model, factory: contentFactory.editorFactory };
+    let editorOptions = {
+      model,
+      factory: contentFactory.editorFactory,
+      updateOnShow: options.updateOnShow
+    };
     let editor = (this._editor = new CodeEditorWrapper(editorOptions));
     editor.addClass(INPUT_AREA_EDITOR_CLASS);
 
@@ -164,6 +168,11 @@ export namespace InputArea {
      * Defaults to one that uses CodeMirror.
      */
     contentFactory?: IContentFactory;
+
+    /**
+     * Whether to send an update request to the editor when it is shown.
+     */
+    updateOnShow?: boolean;
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -177,7 +177,11 @@ export class Cell extends Widget {
     inputWrapper.addClass(CELL_INPUT_WRAPPER_CLASS);
     let inputCollapser = new InputCollapser();
     inputCollapser.addClass(CELL_INPUT_COLLAPSER_CLASS);
-    let input = (this._input = new InputArea({ model, contentFactory }));
+    let input = (this._input = new InputArea({
+      model,
+      contentFactory,
+      updateOnShow: options.updateEditorOnShow
+    }));
     input.addClass(CELL_INPUT_AREA_CLASS);
     inputWrapper.addWidget(inputCollapser);
     inputWrapper.addWidget(input);
@@ -404,6 +408,11 @@ export namespace Cell {
      * The configuration options for the text editor widget.
      */
     editorConfig?: Partial<CodeEditor.IConfig>;
+
+    /**
+     * Whether to send an update request to the editor when it is shown.
+     */
+    updateEditorOnShow?: boolean;
   }
 
   /**

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -52,6 +52,7 @@ export class CodeEditorWrapper extends Widget {
       this._onSelectionsChanged,
       this
     );
+    this._updateOnShow = options.updateOnShow !== false;
   }
 
   /**
@@ -143,7 +144,9 @@ export class CodeEditorWrapper extends Widget {
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
-    this.update();
+    if (this._updateOnShow) {
+      this.update();
+    }
   }
 
   /**
@@ -273,6 +276,8 @@ export class CodeEditorWrapper extends Widget {
     const offset = this.editor.getOffsetAt(position);
     this.model.value.insert(offset, data);
   }
+
+  private _updateOnShow: boolean;
 }
 
 /**
@@ -311,6 +316,11 @@ export namespace CodeEditorWrapper {
      * The default selection style for the editor.
      */
     selectionStyle?: CodeEditor.ISelectionStyle;
+
+    /**
+     * Whether to send an update request to the editor when it is shown.
+     */
+    updateOnShow?: boolean;
   }
 }
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -468,7 +468,13 @@ export class StaticNotebook extends Widget {
     let rendermime = this.rendermime;
     let contentFactory = this.contentFactory;
     const editorConfig = this.editorConfig.code;
-    let options = { editorConfig, model, rendermime, contentFactory };
+    let options = {
+      editorConfig,
+      model,
+      rendermime,
+      contentFactory,
+      updateEditorOnShow: false
+    };
     return this.contentFactory.createCodeCell(options, this);
   }
 
@@ -479,7 +485,13 @@ export class StaticNotebook extends Widget {
     let rendermime = this.rendermime;
     let contentFactory = this.contentFactory;
     const editorConfig = this.editorConfig.markdown;
-    let options = { editorConfig, model, rendermime, contentFactory };
+    let options = {
+      editorConfig,
+      model,
+      rendermime,
+      contentFactory,
+      updateEditorOnShow: false
+    };
     return this.contentFactory.createMarkdownCell(options, this);
   }
 
@@ -489,7 +501,12 @@ export class StaticNotebook extends Widget {
   private _createRawCell(model: IRawCellModel): RawCell {
     let contentFactory = this.contentFactory;
     const editorConfig = this.editorConfig.raw;
-    let options = { editorConfig, model, contentFactory };
+    let options = {
+      editorConfig,
+      model,
+      contentFactory,
+      updateEditorOnShow: false
+    };
     return this.contentFactory.createRawCell(options, this);
   }
 
@@ -568,6 +585,7 @@ export class StaticNotebook extends Widget {
       Object.keys(config).forEach((key: keyof CodeEditor.IConfig) => {
         cell.editor.setOption(key, config[key]);
       });
+      cell.editor.refresh();
     }
   }
 
@@ -1267,6 +1285,49 @@ export class Notebook extends StaticNotebook {
     node.removeEventListener('p-drop', this, true);
     document.removeEventListener('mousemove', this, true);
     document.removeEventListener('mouseup', this, true);
+  }
+
+  /**
+   * A message handler invoked on an `'after-show'` message.
+   */
+  protected onAfterShow(msg: Message): void {
+    this._checkCacheOnNextResize = true;
+  }
+
+  /**
+   * A message handler invoked on a `'resize'` message.
+   */
+  protected onResize(msg: Widget.ResizeMessage): void {
+    if (!this._checkCacheOnNextResize) {
+      return super.onResize(msg);
+    }
+    this._checkCacheOnNextResize = false;
+    const cache = this._cellLayoutStateCache;
+    const width = parseInt(this.node.style.width, 10);
+    if (cache) {
+      if (width === cache.width) {
+        // Cache identical, do nothing
+        return;
+      }
+    }
+    // Update cache
+    this._cellLayoutStateCache = { width };
+
+    // Fallback:
+    for (let w of this.widgets) {
+      if (w instanceof Cell) {
+        w.editorWidget.update();
+      }
+    }
+  }
+
+  /**
+   * A message handler invoked on an `'before-hide'` message.
+   */
+  protected onBeforeHide(msg: Message): void {
+    // Update cache
+    const width = parseInt(this.node.style.width, 10);
+    this._cellLayoutStateCache = { width };
   }
 
   /**
@@ -2034,6 +2095,10 @@ export class Notebook extends StaticNotebook {
   private _activeCellChanged = new Signal<this, Cell>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);
   private _selectionChanged = new Signal<this, void>(this);
+
+  // Attributes for optimized cell refresh:
+  private _cellLayoutStateCache?: { width: number };
+  private _checkCacheOnNextResize = false;
 }
 
 /**


### PR DESCRIPTION
- Adds an option to the editor to prevent automatic refresh on show.
- Adds logic to notebook widget to selectivly refresh cell editors on show.

Fixes #2639. Fixes #4292 (duplicate of 2639?). At least it helps improve the experience.

@sccolbert: Any gotchas for the phoshpor messaging I'm missing? I'm assuming the following:
- When in a layout with fixed sizes, the width style attribute is set.
- The before-show message triggers an update (queued).
- The update triggers a resize message (if the size has changed since it was hidden).