### PR TITLE
Don't display any output if Javascript output is empty

### DIFF
--- a/packages/javascript-extension/src/index.ts
+++ b/packages/javascript-extension/src/index.ts
@@ -23,13 +23,6 @@ export class ExperimentalRenderedJavascript extends RenderedJavaScript {
       try {
         const data = model.data[this.mimeType] as string;
         evalInContext(data, this.node, document, window);
-        // If output is empty after evaluating, render the plain text value
-        if (this.node.innerHTML === '') {
-          const text = model.data['text/plain'] as string;
-          const output = document.createElement('pre');
-          output.textContent = text;
-          this.node.appendChild(output);
-        }
         return Promise.resolve();
       } catch (error) {
         return Promise.reject(error);


### PR DESCRIPTION
Fixes #5404 

Before: 

![image](https://user-images.githubusercontent.com/512354/49298986-4711a800-f484-11e8-926f-e973703b1eef.png)

After:

![image](https://user-images.githubusercontent.com/512354/49298898-15004600-f484-11e8-89ea-fe67acf7e726.png)

