### PR TITLE
Change jp-CellTools CSS class to block and add scrolling

### DIFF
--- a/packages/notebook/style/index.css
+++ b/packages/notebook/style/index.css
@@ -194,14 +194,14 @@
 |----------------------------------------------------------------------------*/
 
 .jp-CellTools {
-  display: flex;
-  flex-direction: column;
+  display: block;
   min-width: var(--jp-sidebar-min-width);
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
   /* This is needed so that all font sizing of children done in ems is
    * relative to this base size */
   font-size: var(--jp-ui-font-size1);
+  overflow: auto;
 }
 
 .jp-ActiveCellTool {


### PR DESCRIPTION
Fixes #5685 

Adds scrolling to the entire Cell Inspector panel. In the event that there is lots of text in the Edit Cell Metadata box, the entire panel will become scrollable rather than shrinking the widgets in a strange way.

**Screenshots**
![image](https://user-images.githubusercontent.com/8410871/49300845-dd47cd00-f488-11e8-93e8-8bb7c00211da.png)
