### PR TITLE
cursor drag & drop

### DIFF
--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -162,6 +162,7 @@
 .jp-DirListing.jp-mod-native-drop .jp-DirListing-content {
   outline: 5px dashed rgba(128, 128, 128, 0.5);
   outline-offset: -10px;
+  cursor: copy;
 }
 
 .jp-DirListing-item {


### PR DESCRIPTION
Set cursor to copy when dragging and dropping to the file explorer

Fixes #3072
