### PR TITLE
Make dev build arg an alias instead of flag

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -26,7 +26,7 @@ build_aliases = dict(base_aliases)
 build_aliases['app-dir'] = 'LabBuildApp.app_dir'
 build_aliases['name'] = 'LabBuildApp.name'
 build_aliases['version'] = 'LabBuildApp.version'
-build_aliases['dev'] = 'LabBuildApp.dev_build'
+build_aliases['dev-build'] = 'LabBuildApp.dev_build'
 
 build_flags = dict(flags)
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -26,12 +26,9 @@ build_aliases = dict(base_aliases)
 build_aliases['app-dir'] = 'LabBuildApp.app_dir'
 build_aliases['name'] = 'LabBuildApp.name'
 build_aliases['version'] = 'LabBuildApp.version'
+build_aliases['dev'] = 'LabBuildApp.dev_build'
 
 build_flags = dict(flags)
-build_flags['dev'] = (
-    {'LabBuildApp': {'dev_build': True}},
-    "Build in Development mode"
-)
 
 version = __version__
 app_version = get_app_version()

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -26,10 +26,6 @@ flags['no-build'] = (
     {'BaseExtensionApp': {'should_build': False}},
     "Defer building the app after the action."
 )
-flags['dev-build'] = (
-    {'BaseExtensionApp': {'dev_build': True}},
-    "Build in Development mode"
-)
 flags['clean'] = (
     {'BaseExtensionApp': {'should_clean': True}},
     "Cleanup intermediate files after the action."
@@ -49,6 +45,7 @@ update_flags['all'] = (
 
 aliases = dict(base_aliases)
 aliases['app-dir'] = 'BaseExtensionApp.app_dir'
+aliases['dev-build'] = 'BaseExtensionApp.dev_build'
 
 VERSION = get_app_version()
 


### PR DESCRIPTION
Fixes #5661.

Changes the type of the `--dev` argument to an alias instead of a flag. While this fixes the issue, it does entail that any commands that currently pass the flag `--dev` will now fail. Alternatively, we could add another flag `--prod`, that sets the `dev_build` to `False`. Thoughts?