### PR TITLE
Reject InstanceTracker#add() if added widget is already disposed.

### DIFF
--- a/packages/apputils/src/instancetracker.ts
+++ b/packages/apputils/src/instancetracker.ts
@@ -180,8 +180,13 @@ export class InstanceTracker<T extends Widget>
    * @param widget - The widget being added.
    */
   add(widget: T): Promise<void> {
+    if (widget.isDisposed) {
+      const warning = `${widget.id} is disposed and cannot be tracked.`;
+      console.warn(warning);
+      return Promise.reject(warning);
+    }
     if (this._tracker.has(widget)) {
-      let warning = `${widget.id} already exists in the tracker.`;
+      const warning = `${widget.id} already exists in the tracker.`;
       console.warn(warning);
       return Promise.reject(warning);
     }

--- a/tests/test-apputils/src/instancetracker.spec.ts
+++ b/tests/test-apputils/src/instancetracker.spec.ts
@@ -197,18 +197,47 @@ describe('@jupyterlab/apputils', () => {
     });
 
     describe('#add()', () => {
-      it('should add a widget to the tracker', () => {
+      it('should add a widget to the tracker', async () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widget = new Widget();
         expect(tracker.has(widget)).to.equal(false);
-        tracker.add(widget);
+        await tracker.add(widget);
         expect(tracker.has(widget)).to.equal(true);
       });
 
-      it('should remove an added widget if it is disposed', () => {
+      it('should reject a widget that already exists', async () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widget = new Widget();
-        tracker.add(widget);
+        let failed = false;
+        expect(tracker.has(widget)).to.equal(false);
+        await tracker.add(widget);
+        expect(tracker.has(widget)).to.equal(true);
+        try {
+          await tracker.add(widget);
+        } catch (error) {
+          failed = true;
+        }
+        expect(failed).to.equal(true);
+      });
+
+      it('should reject a widget that is disposed', async () => {
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
+        let failed = false;
+        expect(tracker.has(widget)).to.equal(false);
+        widget.dispose();
+        try {
+          await tracker.add(widget);
+        } catch (error) {
+          failed = true;
+        }
+        expect(failed).to.equal(true);
+      });
+
+      it('should remove an added widget if it is disposed', async () => {
+        const tracker = new InstanceTracker<Widget>({ namespace });
+        const widget = new Widget();
+        await tracker.add(widget);
         expect(tracker.has(widget)).to.equal(true);
         widget.dispose();
         expect(tracker.has(widget)).to.equal(false);

--- a/tests/test-mainmenu/src/edit.spec.ts
+++ b/tests/test-mainmenu/src/edit.spec.ts
@@ -22,13 +22,14 @@ describe('@jupyterlab/mainmenu', () => {
     let commands: CommandRegistry;
     let menu: EditMenu;
     let tracker: InstanceTracker<Wodget>;
-    const wodget = new Wodget();
+    let wodget: Wodget;
 
     beforeAll(() => {
       commands = new CommandRegistry();
     });
 
     beforeEach(() => {
+      wodget = new Wodget();
       menu = new EditMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
       tracker.add(wodget);

--- a/tests/test-mainmenu/src/file.spec.ts
+++ b/tests/test-mainmenu/src/file.spec.ts
@@ -22,13 +22,14 @@ describe('@jupyterlab/mainmenu', () => {
     let commands: CommandRegistry;
     let menu: FileMenu;
     let tracker: InstanceTracker<Wodget>;
-    const wodget = new Wodget();
+    let wodget: Wodget;
 
     beforeAll(() => {
       commands = new CommandRegistry();
     });
 
     beforeEach(() => {
+      wodget = new Wodget();
       menu = new FileMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
       tracker.add(wodget);

--- a/tests/test-mainmenu/src/kernel.spec.ts
+++ b/tests/test-mainmenu/src/kernel.spec.ts
@@ -22,13 +22,14 @@ describe('@jupyterlab/mainmenu', () => {
     let commands: CommandRegistry;
     let menu: KernelMenu;
     let tracker: InstanceTracker<Wodget>;
-    const wodget = new Wodget();
+    let wodget: Wodget;
 
     beforeAll(() => {
       commands = new CommandRegistry();
     });
 
     beforeEach(() => {
+      wodget = new Wodget();
       menu = new KernelMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
       tracker.add(wodget);

--- a/tests/test-mainmenu/src/run.spec.ts
+++ b/tests/test-mainmenu/src/run.spec.ts
@@ -22,13 +22,14 @@ describe('@jupyterlab/mainmenu', () => {
     let commands: CommandRegistry;
     let menu: RunMenu;
     let tracker: InstanceTracker<Wodget>;
-    const wodget = new Wodget();
+    let wodget: Wodget;
 
     beforeAll(() => {
       commands = new CommandRegistry();
     });
 
     beforeEach(() => {
+      wodget = new Wodget();
       menu = new RunMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
       tracker.add(wodget);


### PR DESCRIPTION
If a widget being added to an instance tracker has been disposed before it is even added, the tracker should reject its addition.