### PR TITLE
CSV fragment

### DIFF
--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -272,12 +272,12 @@ export class CSVViewer extends Widget {
    * Go to line
    */
   goToLine(lineNumber: number) {
-    let scrollY = this._grid.scrollY;
+    let scrollY = 0;
     /* The lines might not all have uniform height, so we can't just scroll to lineNumber * this._grid.baseRowSize
     see https://github.com/jupyterlab/jupyterlab/pull/5523#issuecomment-432621391 for discussions around
     this. It would be nice if DataGrid had a method to scroll to cell, which could be implemented more efficiently
     because datagrid knows more about the shape of the cells. */
-    for (let i = scrollY; i < lineNumber - 1; i++) {
+    for (let i = 0; i < lineNumber - 1; i++) {
       scrollY += this._grid.sectionSize('row', i);
     }
     this._grid.scrollTo(this._grid.scrollX, scrollY);

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -370,8 +370,10 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
     console.log(top_row);
 
     // go to that row
-    this.content.goToLine(Number(top_row));
-    this.update();
+    this._context.ready.then(() => {
+      this.content.goToLine(Number(top_row));
+      // this.update();
+    });
   }
 }
 

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -369,7 +369,7 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
     topRow = topRow.split('-')[0];
 
     // go to that row
-    this._context.ready.then(() => {
+    this.context.ready.then(() => {
       this.content.goToLine(Number(topRow));
     });
     this.update();

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -348,6 +348,29 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
       }
     );
   }
+
+  /**
+   * Set URI fragment identifier for rows
+   */
+  setFragment(fragment: string): void {
+    // console.log('In setFragment');
+    console.log(fragment);
+    // // TODO: expand to allow columns and cells to be selected
+    // // reference: https://tools.ietf.org/html/rfc7111#section-3
+    // let parse_fragments = fragment.split('=');
+    // console.log(parse_fragments);
+    // if (parse_fragments[0] !== 'row') {
+    //   return;
+    // }
+    // // multiple rows, separated by semi-colons can be provided, we will just
+    // // go to the top one
+    // let top_row = ((parse_fragments[0].split(';'))[0]);
+    // // a range of rows can be provided, we will take the first value
+    // top_row = ((top_row.split('-'))[0]);
+    // // go to that row
+    // (this.content as CSVViewer).goToLine(Number(top_row));
+    // this.update();
+  }
 }
 
 export namespace CSVDocumentWidget {

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -353,23 +353,25 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
    * Set URI fragment identifier for rows
    */
   setFragment(fragment: string): void {
-    // console.log('In setFragment');
-    console.log(fragment);
-    // // TODO: expand to allow columns and cells to be selected
-    // // reference: https://tools.ietf.org/html/rfc7111#section-3
-    // let parse_fragments = fragment.split('=');
-    // console.log(parse_fragments);
-    // if (parse_fragments[0] !== 'row') {
-    //   return;
-    // }
-    // // multiple rows, separated by semi-colons can be provided, we will just
-    // // go to the top one
-    // let top_row = ((parse_fragments[0].split(';'))[0]);
-    // // a range of rows can be provided, we will take the first value
-    // top_row = ((top_row.split('-'))[0]);
-    // // go to that row
-    // (this.content as CSVViewer).goToLine(Number(top_row));
-    // this.update();
+    let parse_fragments = fragment.split('=');
+
+    // TODO: expand to allow columns and cells to be selected
+    // reference: https://tools.ietf.org/html/rfc7111#section-3
+    if (parse_fragments[0] !== '#row') {
+      console.log('not row');
+      return;
+    }
+
+    // multiple rows, separated by semi-colons can be provided, we will just
+    // go to the top one
+    let top_row = parse_fragments[1].split(';')[0];
+
+    // a range of rows can be provided, we will take the first value
+    top_row = top_row.split('-')[0];
+    console.log(top_row);
+
+    // go to that row
+    this.content.goToLine(Number(top_row));
   }
 }
 

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -353,27 +353,26 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
    * Set URI fragment identifier for rows
    */
   setFragment(fragment: string): void {
-    let parse_fragments = fragment.split('=');
+    let parseFragments = fragment.split('=');
 
     // TODO: expand to allow columns and cells to be selected
     // reference: https://tools.ietf.org/html/rfc7111#section-3
-    if (parse_fragments[0] !== '#row') {
+    if (parseFragments[0] !== '#row') {
       return;
     }
 
     // multiple rows, separated by semi-colons can be provided, we will just
     // go to the top one
-    let top_row = parse_fragments[1].split(';')[0];
+    let topRow = parseFragments[1].split(';')[0];
 
     // a range of rows can be provided, we will take the first value
-    top_row = top_row.split('-')[0];
-    console.log(top_row);
+    topRow = topRow.split('-')[0];
 
     // go to that row
     this._context.ready.then(() => {
-      this.content.goToLine(Number(top_row));
-      // this.update();
+      this.content.goToLine(Number(topRow));
     });
+    this.update();
   }
 }
 

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -358,7 +358,6 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
     // TODO: expand to allow columns and cells to be selected
     // reference: https://tools.ietf.org/html/rfc7111#section-3
     if (parse_fragments[0] !== '#row') {
-      console.log('not row');
       return;
     }
 
@@ -372,6 +371,7 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
 
     // go to that row
     this.content.goToLine(Number(top_row));
+    this.update();
   }
 }
 

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -372,7 +372,6 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
     this.context.ready.then(() => {
       this.content.goToLine(Number(topRow));
     });
-    this.update();
   }
 }
 


### PR DESCRIPTION
Fixes #5720 

Implement a CSV `setFragment` function that scrolls to the requested row of a csv file. 

![sfqbu3vik9](https://user-images.githubusercontent.com/6361812/49537011-b1f42200-f87c-11e8-8586-8d56b63ecc4e.gif)

Currently only supports `row` requests (not`col` or `cell`, https://tools.ietf.org/html/rfc7111#section-3)

## TODO / Question:

If the CSV file is already open, this does not update which row is at the top, so I think I am missing a refresh or update step... Any pointers?

![nj4nxaznkt](https://user-images.githubusercontent.com/6361812/49538470-5e83d300-f880-11e8-8f8e-10793eaebaf1.gif)


## Thanks! 

Thanks @ian-r-rose, @jasongrout, @ellisonbg, @AlbertHilb for patiently answering my questions 😄    
