### PR TITLE
Fix regression: terminal should default to configured monospace font

### DIFF
--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -28,7 +28,7 @@
       "title": "Font family",
       "description": "The font family used to render text.",
       "$ref": "#/definitions/fontFamily",
-      "default": "courier-new, courier, monospace"
+      "default": "monospace"
     },
     "fontSize": {
       "title": "Font size",


### PR DESCRIPTION
And not courier

See earlier issue #1317, and PR #1377

**Screenshots**
Before:

![screenshot_2018-12-06 jupyterlab](https://user-images.githubusercontent.com/9155111/49600938-645ede80-f97c-11e8-9649-9872f7d9f000.png)

After:
![screenshot_2018-12-06 jupyterlab_after](https://user-images.githubusercontent.com/9155111/49600940-67f26580-f97c-11e8-9c22-5db2df375c59.png)

No settings:
![screenshot_2018-12-06 jupyterlab_settings](https://user-images.githubusercontent.com/9155111/49600963-7771ae80-f97c-11e8-8af7-b26969841311.png)
