### PR TITLE
Fix missing declaration block in docs CSS rules

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -15,7 +15,6 @@ div.wy-side-nav-search {
   height: 1em !important;
 }
 
-.wy
 /* Elevation
   *
   * We style box-shadows using Material Design's idea of elevation. These particular numbers are taken from here:


### PR DESCRIPTION
The `wy` rule had no declaration block, so it was being parsed as part of the
rule below it. Because of this, drop shadows weren't getting applied to
screenshots.

This was introduced by `d59b172e`, and looks erroneous so I removed the rule.

Fixes #5730