### PR TITLE
Show correct file type for Reload and Revert dialogs

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -556,7 +556,7 @@ function addCommands(
           return;
         }
         return showDialog({
-          title: 'Revert notebook to checkpoint',
+          title: `Revert ${fileType()} to checkpoint`,
           body: new RevertConfirmWidget(lastCheckpoint),
           buttons: [
             Dialog.cancelButton(),

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -524,10 +524,11 @@ function addCommands(
         return;
       }
       const context = docManager.contextForWidget(shell.currentWidget);
+      const type = fileType();
       return showDialog({
-        title: 'Reload Notebook from Disk',
+        title: `Reload ${type} from Disk`,
         body: `Are you sure you want to reload
-          the notebook from the disk?`,
+          the ${type} from the disk?`,
         buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Reload' })]
       }).then(result => {
         if (result.button.accept && !context.isDisposed) {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -247,8 +247,11 @@ class RevertConfirmWidget extends Widget {
   /**
    * Construct a new revert confirmation widget.
    */
-  constructor(checkpoint: Contents.ICheckpointModel) {
-    super({ node: Private.createRevertConfirmNode(checkpoint) });
+  constructor(
+    checkpoint: Contents.ICheckpointModel,
+    fileType: string = 'notebook'
+  ) {
+    super({ node: Private.createRevertConfirmNode(checkpoint, fileType) });
   }
 }
 
@@ -555,9 +558,10 @@ function addCommands(
         if (!lastCheckpoint) {
           return;
         }
+        const type = fileType();
         return showDialog({
-          title: `Revert ${fileType()} to checkpoint`,
-          body: new RevertConfirmWidget(lastCheckpoint),
+          title: `Revert ${type} to checkpoint`,
+          body: new RevertConfirmWidget(lastCheckpoint, type),
           buttons: [
             Dialog.cancelButton(),
             Dialog.warnButton({ label: 'Revert' })
@@ -822,12 +826,13 @@ namespace Private {
   export let id = 0;
 
   export function createRevertConfirmNode(
-    checkpoint: Contents.ICheckpointModel
+    checkpoint: Contents.ICheckpointModel,
+    fileType: string
   ): HTMLElement {
     let body = document.createElement('div');
     let confirmMessage = document.createElement('p');
     let confirmText = document.createTextNode(`Are you sure you want to revert
-      the notebook to the latest checkpoint? `);
+      the ${fileType} to the latest checkpoint? `);
     let cannotUndoText = document.createElement('strong');
     cannotUndoText.textContent = 'This cannot be undone.';
 


### PR DESCRIPTION
The "Reload" and "Revert" dialogs were showing "notebook" for non-notebook files.

This change should fix that by retrieving the file type for the current widget before constructing the dialogs.

### Before

![image](https://user-images.githubusercontent.com/591645/49751003-9f2e8280-fcac-11e8-9132-a19496fb1320.png)

![image](https://user-images.githubusercontent.com/591645/49751012-a6ee2700-fcac-11e8-98c6-47a7d85ee847.png)


### After

![image](https://user-images.githubusercontent.com/591645/49750805-1e6f8680-fcac-11e8-85d1-54a3e6eb9d6c.png)

![image](https://user-images.githubusercontent.com/591645/49750978-9178fd00-fcac-11e8-999d-9567102cb721.png)

