### PR TITLE
Rulers

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -660,7 +660,7 @@ export namespace CodeEditor {
     insertSpaces: true,
     matchBrackets: true,
     autoClosingBrackets: true,
-    rulers: [88]
+    rulers: []
   };
 
   /**

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -638,6 +638,11 @@ export namespace CodeEditor {
      * The column where to break text line.
      */
     wordWrapColumn: number;
+
+    /**
+     * Column index at which rulers should be added.
+     */
+    rulers: Array<number>;
   }
 
   /**
@@ -654,7 +659,8 @@ export namespace CodeEditor {
     tabSize: 4,
     insertSpaces: true,
     matchBrackets: true,
-    autoClosingBrackets: true
+    autoClosingBrackets: true,
+    rulers: [88]
   };
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1132,8 +1132,6 @@ export namespace CodeMirrorEditor {
      */
     scrollPastEnd?: boolean;
 
-    rulers?: Array<any>;
-
     /**
      * Whether to give the wrapper of the line that contains the cursor the class
      * CodeMirror-activeline, adds a background with the class
@@ -1180,12 +1178,7 @@ export namespace CodeMirrorEditor {
     styleActiveLine: false,
     styleSelectedText: false,
     selectionPointer: false,
-    rulers: [{
-      column: 79,
-      color: 'red',
-      lineStyle: 'dashed',
-      width: 5
-    }]
+    rulers: [88]
   };
 
   /**
@@ -1326,8 +1319,6 @@ namespace Private {
   }
 
   /**
-    case 'rulers':
-      return editor.getOption('rulers');
    * Set a config option for the editor.
    */
   export function setOption<K extends keyof CodeMirrorEditor.IConfig>(
@@ -1365,9 +1356,18 @@ namespace Private {
         break;
       case 'autoClosingBrackets':
         editor.setOption('autoCloseBrackets', value);
-      break;
-    case 'rulers':
-      editor.setOption('rulers', value);
+        break;
+      case 'rulers':
+        let rulers = value as Array<number>;
+        editor.setOption(
+          'rulers',
+          rulers.map(column => {
+            return {
+              column,
+              className: 'jp-CodeMirror-ruler'
+            };
+          })
+        );
         break;
       case 'readOnly':
         el.classList.toggle(READ_ONLY_CLASS, value);

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1178,7 +1178,7 @@ export namespace CodeMirrorEditor {
     styleActiveLine: false,
     styleSelectedText: false,
     selectionPointer: false,
-    rulers: [88]
+    rulers: []
   };
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -26,6 +26,7 @@ import {
 import { Mode } from './mode';
 
 import 'codemirror/addon/comment/comment.js';
+import 'codemirror/addon/display/rulers.js';
 import 'codemirror/addon/edit/matchbrackets.js';
 import 'codemirror/addon/edit/closebrackets.js';
 import 'codemirror/addon/scroll/scrollpastend.js';
@@ -1131,6 +1132,8 @@ export namespace CodeMirrorEditor {
      */
     scrollPastEnd?: boolean;
 
+    rulers?: Array<any>;
+
     /**
      * Whether to give the wrapper of the line that contains the cursor the class
      * CodeMirror-activeline, adds a background with the class
@@ -1176,7 +1179,13 @@ export namespace CodeMirrorEditor {
     scrollPastEnd: false,
     styleActiveLine: false,
     styleSelectedText: false,
-    selectionPointer: false
+    selectionPointer: false,
+    rulers: [{
+      column: 79,
+      color: 'red',
+      lineStyle: 'dashed',
+      width: 5
+    }]
   };
 
   /**
@@ -1317,6 +1326,8 @@ namespace Private {
   }
 
   /**
+    case 'rulers':
+      return editor.getOption('rulers');
    * Set a config option for the editor.
    */
   export function setOption<K extends keyof CodeMirrorEditor.IConfig>(
@@ -1354,6 +1365,9 @@ namespace Private {
         break;
       case 'autoClosingBrackets':
         editor.setOption('autoCloseBrackets', value);
+      break;
+    case 'rulers':
+      editor.setOption('rulers', value);
         break;
       case 'readOnly':
         el.classList.toggle(READ_ONLY_CLASS, value);

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -122,6 +122,10 @@
   white-space: nowrap;
 }
 
+.jp-CodeMirror-ruler {
+  border-left: 1px dashed var(--jp-border-color2);
+}
+
 /**
  * Here is our jupyter theme for CodeMirror syntax highlighting
  * This is used in our marked.js syntax highlighting and CodeMirror itself

--- a/packages/fileeditor-extension/schema/plugin.json
+++ b/packages/fileeditor-extension/schema/plugin.json
@@ -41,6 +41,12 @@
         },
         "wordWrapColumn": {
           "type": "integer"
+        },
+        "rulers": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
         }
       },
       "additionalProperties": false,
@@ -63,7 +69,8 @@
         "readOnly": false,
         "insertSpaces": true,
         "tabSize": 4,
-        "wordWrapColumn": 80
+        "wordWrapColumn": 80,
+        "rulers": [88]
       }
     }
   },

--- a/packages/fileeditor-extension/schema/plugin.json
+++ b/packages/fileeditor-extension/schema/plugin.json
@@ -70,7 +70,7 @@
         "insertSpaces": true,
         "tabSize": 4,
         "wordWrapColumn": 80,
-        "rulers": [88]
+        "rulers": []
       }
     }
   },

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -277,7 +277,7 @@
         "insertSpaces": true,
         "tabSize": 4,
         "wordWrapColumn": 80,
-        "rulers": [88]
+        "rulers": []
       }
     },
     "markdownCellConfig": {
@@ -295,7 +295,8 @@
         "readOnly": false,
         "insertSpaces": true,
         "tabSize": 4,
-        "wordWrapColumn": 80
+        "wordWrapColumn": 80,
+        "rulers": []
       }
     },
     "rawCellConfig": {
@@ -313,7 +314,8 @@
         "readOnly": false,
         "insertSpaces": true,
         "tabSize": 4,
-        "wordWrapColumn": 80
+        "wordWrapColumn": 80,
+        "rulers": []
       }
     },
     "scrollPastEnd": {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -248,6 +248,12 @@
         },
         "wordWrapColumn": {
           "type": "integer"
+        },
+        "rulers": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
         }
       },
       "additionalProperties": false,
@@ -270,7 +276,8 @@
         "readOnly": false,
         "insertSpaces": true,
         "tabSize": 4,
-        "wordWrapColumn": 80
+        "wordWrapColumn": 80,
+        "rulers": [88]
       }
     },
     "markdownCellConfig": {


### PR DESCRIPTION
Fixes #4179 by building on #4294

Styling of the rulers is done through a class `jp-CodeMirror-ruler` which is set to 
```css
.jp-CodeMirror-ruler {
  border-left: 1px dashed var(--jp-border-color2);
}
```

**Screenshots**
![image](https://user-images.githubusercontent.com/8435071/49765757-baf94f00-fcd3-11e8-88b4-c6b686064c7f.png)


