### PR TITLE
Find Editor widgets

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -297,7 +297,7 @@ function addCommands(
       return app.shell.currentWidget;
     }
     const pathMatch = node['title'].match(pathRe);
-    return docManager.findWidget(pathMatch[1]);
+    return docManager.findWidget(pathMatch[1], null);
   };
 
   // operates on active widget by default

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -290,18 +290,19 @@ export class DocumentManager implements IDisposable {
     widgetName = 'default'
   ): IDocumentWidget | undefined {
     let newPath = PathExt.normalize(path);
+    let widgetNames = [widgetName];
     if (widgetName === 'default') {
-      let factory = this.registry.defaultWidgetFactory(newPath);
-      if (!factory) {
-        return undefined;
-      }
-      widgetName = factory.name;
+      widgetNames = this.registry
+        .preferredWidgetFactories(newPath)
+        .map(f => f.name);
     }
 
     for (let context of this._contextsForPath(newPath)) {
-      let widget = this._widgetManager.findWidget(context, widgetName);
-      if (widget) {
-        return widget;
+      for (const widgetName of widgetNames) {
+        let widget = this._widgetManager.findWidget(context, widgetName);
+        if (widget) {
+          return widget;
+        }
       }
     }
     return undefined;

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -287,11 +287,17 @@ export class DocumentManager implements IDisposable {
    */
   findWidget(
     path: string,
-    widgetName = 'default'
+    widgetName: string | null = 'default'
   ): IDocumentWidget | undefined {
     let newPath = PathExt.normalize(path);
     let widgetNames = [widgetName];
     if (widgetName === 'default') {
+      let factory = this.registry.defaultWidgetFactory(newPath);
+      if (!factory) {
+        return undefined;
+      }
+      widgetNames = [factory.name];
+    } else if (widgetName === null) {
       widgetNames = this.registry
         .preferredWidgetFactories(newPath)
         .map(f => f.name);

--- a/tests/test-docmanager/src/manager.spec.ts
+++ b/tests/test-docmanager/src/manager.spec.ts
@@ -252,6 +252,35 @@ describe('@jupyterlab/docmanager', () => {
       it('should fail to find a widget', () => {
         expect(manager.findWidget('foo')).to.be.undefined;
       });
+
+      it('should fail to find a widget with non default factory and the default widget name', async () => {
+        const widgetFactory2 = new WidgetFactory({
+          name: 'test2',
+          fileTypes: ['text']
+        });
+        manager.registry.addWidgetFactory(widgetFactory2);
+        const model = await services.contents.newUntitled({
+          type: 'file',
+          ext: '.txt'
+        });
+        widget = manager.createNew(model.path, 'test2');
+        expect(manager.findWidget(model.path)).to.be.undefined;
+      });
+
+      it('should find a widget with non default factory given a file and a null widget name', async () => {
+        const widgetFactory2 = new WidgetFactory({
+          name: 'test2',
+          fileTypes: ['text']
+        });
+        manager.registry.addWidgetFactory(widgetFactory2);
+        const model = await services.contents.newUntitled({
+          type: 'file',
+          ext: '.txt'
+        });
+        widget = manager.createNew(model.path, 'test2');
+        expect(manager.findWidget(model.path, null)).to.equal(widget);
+        await dismissDialog();
+      });
     });
 
     describe('#contextForWidget()', () => {


### PR DESCRIPTION
This is an attempt at fixing the following behavior:

![show_in_files_bug](https://user-images.githubusercontent.com/591645/49905820-ac479f00-fe6f-11e8-8800-835e04f560ab.gif)

In this case, when a widget is created with a factory that is not the default one (with `Editor` and not `CSVTable`), attempting to "Rename File" or "Show in File Browser" will fail silently (but with an error in the dev tools).

With this change:

![show_in_files_fix](https://user-images.githubusercontent.com/591645/49905821-aea9f900-fe6f-11e8-9ccf-e01d182a0285.gif)

This adds an interesting side-effect as well: once a document is open (with the `Editor` for example), opening it again from the file browser (double click) will bring the focus back the widget, instead of trying to reopen it with the default factory (`CSVTable` in this example).