### PR TITLE
Passing 'noopener' to window.open() always returns null, breaking exporting

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1037,7 +1037,7 @@ function addCommands(
           args['format'] as string,
           notebookPath
         ) + '?download=true';
-      const child = window.open('', '_blank', 'noopener');
+      const child = window.open('', '_blank');
       const { context } = current;
 
       child.opener = null;


### PR DESCRIPTION
Fixes exports, which seem to have been broken by https://github.com/jupyterlab/jupyterlab/pull/5656.

Using any of the ``Export Notebook As`` options in master throws error 
``Cannot set property 'opener' of null``
