### PR TITLE
Fixes #5765 Improved header anchors

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -649,7 +649,7 @@ namespace Private {
       let headers = node.getElementsByTagName(headerType);
       for (let i = 0; i < headers.length; i++) {
         let header = headers[i];
-        header.id = encodeURIComponent(header.innerHTML.replace(/ /g, '-'));
+        header.id = header.textContent.replace(/ /g, '-');
         let anchor = document.createElement('a');
         anchor.target = '_self';
         anchor.textContent = '¶';


### PR DESCRIPTION
Fixes #5765 

Now uses `textContent` rather than `innerHTML`