### PR TITLE
Use yarn-deduplicate instead of cleaning

### DIFF
--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -35,6 +35,12 @@ utils.writePackageData(path.join(staging, 'package.json'), data);
 // Create a new yarn.lock file to ensure it is correct.
 fs.removeSync(path.join(staging, 'yarn.lock'));
 utils.run('jlpm', { cwd: staging });
+try {
+  utils.run('jlpm yarn-deduplicate -s fewer --fail', { cwd: staging });
+} catch {
+  // re-run install if we deduped packages!
+  utils.run('jlpm', { cwd: staging });
+}
 
 // Build the core assets.
 utils.run('jlpm run build:prod', { cwd: staging });

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -136,7 +136,8 @@
     "webpack": "~4.29.6",
     "webpack-cli": "^3.3.0",
     "webpack-merge": "^4.2.1",
-    "webpack-visualizer-plugin": "^0.1.11"
+    "webpack-visualizer-plugin": "^0.1.11",
+    "yarn-deduplicate": "^1.1.1"
   },
   "engines": {
     "node": ">=6.11.5"

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -60,8 +60,8 @@ class LabBuildApp(JupyterApp):
     dev_build = Bool(True, config=True,
         help="Whether to build in dev mode (defaults to dev mode)")
 
-    pre_clean = Bool(True, config=True,
-        help="Whether to clean before building (defaults to True)")
+    pre_clean = Bool(False, config=True,
+        help="Whether to clean before building (defaults to False)")
 
     def start(self):
         command = 'build:prod' if not self.dev_build else 'build'

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -136,7 +136,8 @@
     "webpack": "~4.29.6",
     "webpack-cli": "^3.3.0",
     "webpack-merge": "^4.2.1",
-    "webpack-visualizer-plugin": "^0.1.11"
+    "webpack-visualizer-plugin": "^0.1.11",
+    "yarn-deduplicate": "^1.1.1"
   },
   "engines": {
     "node": ">=6.11.5"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "analyze:dev": "cd dev_mode && jlpm run build --analyze && opn static/stats.html",
     "analyze:prod": "cd dev_mode && jlpm run build:prod --analyze && opn static/stats.html",
     "build": "jlpm run build:dev",
-    "build:core": "cd jupyterlab/staging && jlpm && jlpm run build",
+    "build:core": "cd jupyterlab/staging && jlpm && (jlpm yarn-deduplicate -s fewer --fail || jlpm) && jlpm run build",
     "build:dev": "jlpm run integrity && jlpm run build:packages && cd dev_mode && jlpm run build",
     "build:dev:prod": "jlpm run integrity && jlpm run build:packages && cd dev_mode && jlpm run build:prod",
     "build:examples": "lerna run build --scope \"@jupyterlab/example-*\"",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3264,7 +3264,7 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5, combined-
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@^2.12.1, commander@^2.14.1, commander@^2.19.0, commander@^2.5.0, commander@^2.9.0, commander@~2.20.0:
+commander@2, commander@^2.10.0, commander@^2.12.1, commander@^2.14.1, commander@^2.19.0, commander@^2.5.0, commander@^2.9.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -11850,6 +11850,15 @@ yargs@~13.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.0.0"
+
+yarn-deduplicate@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-1.1.1.tgz#19b4a87654b66f55bf3a4bd6b153b4e4ab1b6e6d"
+  integrity sha512-2FDJ1dFmtvqhRmfja89ohYzpaheCYg7BFBSyaUq+kxK0y61C9oHv1XaQovCWGJtP2WU8PksQOgzMVV7oQOobzw==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    commander "^2.10.0"
+    semver "^5.3.0"
 
 yarn@1.15.2:
   version "1.15.2"


### PR DESCRIPTION
Speed up lab build by using [yarn-deduplicate](https://github.com/atlassian/yarn-deduplicate) instead of cleaning out yarn lock every build.

Question: There were previously two cleaning steps involved, the `pre_clean` and the explicit removal of a yarn lock file in staging. The PR changes the default of `pre_clean` to `False`, and removes the yarn lock clean step. While the yarn lock step should now be safe, some care should be taken to ensure that changing the `pre_clean` default doesn't surface any other issues.