### PR TITLE
Honor body data upon first call to PageConfig.getOption()

### DIFF
--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -97,7 +97,7 @@ export namespace PageConfig {
           .join('"');
       }
     }
-    return configData![name] || '';
+    return configData![name] || Private.getBodyData(name);
   }
 
   /**


### PR DESCRIPTION
Closes #5799. See the issue for context.

Note: this is a totally naive and untested attempt to fix the problem! But I'm pretty sure it's correct.