### PR TITLE
[WIP] Keep autoscroll behavior when clearing cell output.

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -758,10 +758,6 @@ export class CodeCell extends Cell {
   private _outputLengthHandler(sender: OutputArea, args: number) {
     let force = args === 0 ? true : false;
     this.toggleClass(NO_OUTPUTS_CLASS, force);
-    /* Turn off scrolling outputs if there are none */
-    if (force) {
-      this.outputsScrolled = false;
-    }
   }
 
   private _rendermime: RenderMimeRegistry = null;


### PR DESCRIPTION
Fixes #4028

* [ ] Add tests
* [ ] Add screenshot to this PR
* [ ] Investigate saving the scrolled state by default, instead of only with the 'save with view state' menu item.

CC @ellisonbg, @saulshanabrook 
