### PR TITLE
Clean up schemas, setting editor toolbar.

### DIFF
--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -7,6 +7,7 @@
     "theme": {
       "type": "string",
       "title": "Selected Theme",
+      "description": "Application-level visual styling theme",
       "default": "JupyterLab Light"
     }
   },

--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -31,7 +31,7 @@
   "properties": {
     "interactionMode": {
       "title": "Interaction mode",
-      "description": "Whether the console interaction mimics the notebook or terminal keyboard shortcuts.",
+      "description": "Whether the console interaction mimics the notebook\nor terminal keyboard shortcuts.",
       "type": "string",
       "enum": ["notebook", "terminal"],
       "default": "notebook"

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -1306,7 +1306,7 @@ export namespace Private {
       prefix(description || nondescript),
       prefix(line(length)),
       '',
-      keys.map(key => defaultDocumentedValue(schema, key)).join(',\n\n'),
+      join(keys.map(key => defaultDocumentedValue(schema, key))),
       '}'
     ].join('\n');
   }
@@ -1333,9 +1333,7 @@ export namespace Private {
       prefix(description || nondescript),
       prefix(line(length)),
       '',
-      keys
-        .map(key => documentedValue(plugin.schema, key, data[key]))
-        .join(',\n\n'),
+      join(keys.map(key => documentedValue(plugin.schema, key, data[key]))),
       '}'
     ].join('\n');
   }
@@ -1348,21 +1346,18 @@ export namespace Private {
     schema: ISettingRegistry.ISchema,
     key: string
   ): string {
-    const props = schema.properties && schema.properties[key];
-    const description = (props && props['description']) || nondescript;
-    const title = (props && props['title']) || untitled;
+    const props = (schema.properties && schema.properties[key]) || {};
+    const type = props['type'];
+    const description = props['description'] || nondescript;
+    const title = props['title'] || '';
     const reified = reifyDefault(schema, key);
     const spaces = indent.length;
     const defaults =
       reified !== undefined
         ? prefix(`"${key}": ${JSON.stringify(reified, null, spaces)}`, indent)
-        : '';
+        : prefix(`"${key}": ${type}`);
 
-    return [
-      prefix(`${title || untitled}`),
-      prefix(description || nondescript),
-      defaults
-    ]
+    return [prefix(title), prefix(description), defaults]
       .filter(str => str.length)
       .join('\n');
   }
@@ -1386,6 +1381,22 @@ export namespace Private {
 
     return [prefix(title), prefix(description), attribute].join('\n');
   }
+
+  /**
+   * Returns a joined string with line breaks and commas where appropriate.
+   */
+  function join(body: string[]): string {
+    return body.reduce((acc, val, idx) => {
+      const rows = val.split('\n');
+      const last = rows[rows.length - 1];
+      const comment = last.trim().indexOf('//') === 0;
+      const comma = comment || idx === body.length - 1 ? '' : ',';
+      const separator = idx === body.length - 1 ? '' : '\n\n';
+
+      return acc + val + comma + separator;
+    }, '');
+  }
+
   /**
    * Returns a line of a specified length.
    */
@@ -1396,7 +1407,7 @@ export namespace Private {
   /**
    * Returns a documentation string with a comment prefix added on every line.
    */
-  function prefix(source: string, pre = `${indent}\/\/ `): string {
+  function prefix(source: string, pre = `${indent}// `): string {
     return pre + source.split('\n').join(`\n${pre}`);
   }
 

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -1284,11 +1284,6 @@ export namespace Private {
   const nondescript = '[missing schema description]';
 
   /**
-   * Replacement text for schema properties missing a `default` field.
-   */
-  const undefaulted = '[missing schema default]';
-
-  /**
    * Replacement text for schema properties missing a `title` field.
    */
   const untitled = '[missing schema title]';
@@ -1359,15 +1354,17 @@ export namespace Private {
     const reified = reifyDefault(schema, key);
     const spaces = indent.length;
     const defaults =
-      reified === undefined
-        ? prefix(`"${key}": ${undefaulted}`)
-        : prefix(`"${key}": ${JSON.stringify(reified, null, spaces)}`, indent);
+      reified !== undefined
+        ? prefix(`"${key}": ${JSON.stringify(reified, null, spaces)}`, indent)
+        : '';
 
     return [
       prefix(`${title || untitled}`),
       prefix(description || nondescript),
       defaults
-    ].join('\n');
+    ]
+      .filter(Boolean)
+      .join('\n');
   }
 
   /**

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -1363,7 +1363,7 @@ export namespace Private {
       prefix(description || nondescript),
       defaults
     ]
-      .filter(Boolean)
+      .filter(str => str.length)
       .join('\n');
   }
 

--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -18,7 +18,7 @@
   "properties": {
     "navigateToCurrentDirectory": {
       "type": "boolean",
-      "title": "Navigate to document's current directory",
+      "title": "Navigate to current directory",
       "description": "Whether to automatically navigate to a document's current directory",
       "default": false
     }

--- a/packages/fileeditor-extension/schema/plugin.json
+++ b/packages/fileeditor-extension/schema/plugin.json
@@ -50,7 +50,7 @@
   "properties": {
     "editorConfig": {
       "title": "Editor Configuration",
-      "description": "The configuration for all text editors.\nIf `fontFamily`, `fontSize` or `lineHeight` are `null`, values from\ncurrent theme are used.",
+      "description": "The configuration for all text editors.\nIf `fontFamily`, `fontSize` or `lineHeight` are `null`,\nvalues from current theme are used.",
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": true,

--- a/packages/settingeditor/style/settingeditor.css
+++ b/packages/settingeditor/style/settingeditor.css
@@ -151,11 +151,19 @@
   max-height: var(--jp-private-settingeditor-toolbar-height);
 }
 
+#setting-editor
+  .jp-SettingsRawEditor
+  .jp-Toolbar
+  .jp-ToolbarButtonComponent-label {
+  display: none;
+}
+
 #setting-editor .jp-SettingsRawEditor .jp-Toolbar-item {
   margin-top: 2px;
 }
 
-#setting-editor
+.jp-ToolbarButtonComponent-label
+  #setting-editor
   .jp-SettingsRawEditor.jp-mod-error
   .jp-Toolbar-item.jp-BugIcon::after {
   color: red;


### PR DESCRIPTION
Fixes #5372

* Hides the toolbar button labels in the setting editor.
* Removes "missing schema default" comments in setting editor. If a default value is not set the field name and its type are show so that users can set an override even if there is no default value.
* Cleans up some schema descriptions.