### PR TITLE
Updated xkcd tutorial for correct change emphasis

### DIFF
--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -446,7 +446,7 @@ function to apply the CSS classes and add the attribution badge markup.
 The beginning of the function should read like the following:
 
 .. code-block:: typescript
-      :emphasize-lines: 9,13,16-22
+      :emphasize-lines: 9,13,16-23
 
       activate: (app: JupyterLab, palette: ICommandPalette) => {
         console.log('JupyterLab extension jupyterlab_xkcd is activated!');


### PR DESCRIPTION
**Screenshots**
Currently, the end of the added function is not highlighted
![image](https://user-images.githubusercontent.com/1813603/50597053-130b1780-0e74-11e9-8315-2216fd68e050.png)
