### PR TITLE
Allow registering additional CodeMirror mode loaders

### DIFF
--- a/tests/test-codemirror/package.json
+++ b/tests/test-codemirror/package.json
@@ -16,6 +16,7 @@
     "@jupyterlab/codemirror": "^0.19.1",
     "@jupyterlab/testutils": "^0.3.1",
     "chai": "~4.1.2",
+    "codemirror": "~5.42.0",
     "jest": "^23.5.0",
     "jest-junit": "^5.2.0",
     "simulate-event": "~1.4.0",

--- a/tests/test-codemirror/src/mode.spec.ts
+++ b/tests/test-codemirror/src/mode.spec.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect } from 'chai';
+
+import CodeMirror from 'codemirror';
+
+import { Mode } from '@jupyterlab/codemirror/src/mode';
+
+function fakeMode(name: string) {
+  return {
+    mode: name,
+    ext: [name],
+    mime: `text/${name}`,
+    name: name.toUpperCase()
+  };
+}
+
+describe('Mode', () => {
+  describe('#ensure', () => {
+    it('should load a defined spec', async () => {
+      CodeMirror.modeInfo.push(fakeMode('foo'));
+      CodeMirror.defineMode('foo', () => null);
+      let spec = await Mode.ensure('text/foo');
+      expect(spec.name).to.equal('FOO');
+    });
+
+    it('should load a bundled spec', async () => {
+      let spec = await Mode.ensure('application/json');
+      expect(spec.name).to.equal('JSON');
+    });
+
+    it('should add a spec loader', async () => {
+      let called = 0;
+      let loaded = 0;
+
+      Mode.addSpecLoader(async spec => {
+        called++;
+        if (spec.mode !== 'bar') {
+          return false;
+        }
+        loaded++;
+        return true;
+      }, 42);
+
+      CodeMirror.modeInfo.push(fakeMode('bar'));
+
+      let spec = await Mode.ensure('bar');
+      expect(called).to.equal(1);
+      expect(loaded).to.equal(1);
+      expect(spec.name).to.equal('BAR');
+
+      spec = await Mode.ensure('python');
+      expect(called).to.equal(1);
+      expect(loaded).to.equal(1);
+
+      try {
+        spec = await Mode.ensure('APL');
+      } catch (err) {
+        // apparently one cannot use webpack `require` in jest
+      }
+      expect(called).to.equal(2);
+      expect(loaded).to.equal(1);
+    });
+
+    it('should default to plain text', async () => {
+      let spec = await Mode.ensure('this is not a mode');
+      expect(spec.name).to.equal('Plain Text');
+    });
+  });
+});


### PR DESCRIPTION
At present, the options for resolving a CodeMirror mode are:
- no-op, the full mode implementation was already `defineMode`d  and/or `defineMIME`d and `modeInfo.push`d
- the mode is `require`d from the "big-ol-bundle of modes which will never get any bigger"
- fails with a a console error and returns "plain text"

This adds a rankable extension point to `Mode` for alternate CodeMirror mode loaders, as well as some tests for `Mode`, which revealed some surprises like not being able to use webpack's `require` in jest. 

## motivation
Concretely, https://github.com/jupyterlab/jupyterlab/issues/5504#issuecomment-450854288 is experimenting with [codemirror-textmate](https://github.com/NeekSandhu/codemirror-textmate) which has a heavy-duty (500kb) dependency on [onigasm](https://github.com/NeekSandhu/onigasm). To achieve the initial demo (stan, stata and sql) without loading `onigasm` and all the JSON on first load, I've monkeypatched `Mode.ensure`, but having a first-class way to provide more modes would be _much_ better.

There are other goodies in that repo, including a [schema for simplemode](https://codemirror.net/demo/simplemode.html), icons, etc. but the marquee feature is definitely the tmlanguage stuff.

![stan in the place your live](https://user-images.githubusercontent.com/45380/50625415-acc2db00-0eed-11e9-9267-cba898fd4e7e.png)

## challenges
There are a number of additional issues like having to patch [mimetypes](https://github.com/deathbeds/jupyterlab-simple-syntax/blob/master/jupyter_static_syntax/serverextension.py#L22) to serve wasm, and just the size of `onigasm`, but...  

## payoff
...the upside is there are probably **thousands** of existing textmate/sublime/vscode modes defined as static, [schema-conforming](https://github.com/martinring/tmlanguage) JSON (or equivalent plist or CSON or XML) which could be added to a user's environment **without a rebuild** and **minimal maintenance**. These can also be used with monaco (indeed, the implementation already has [monaco-textmate](https://github.com/NeekSandhu/monaco-textmate) as a dependency).
