### PR TITLE
Account for tree URLs when there is a workspace collision.

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -642,7 +642,6 @@ namespace Private {
       focusNodeSelector: 'input',
       buttons: [Dialog.okButton({ label: 'Switch Workspace' })]
     });
-
     const result = await dialog.launch();
 
     dialog.dispose();
@@ -651,8 +650,13 @@ namespace Private {
     }
 
     // Navigate to a new workspace URL and abandon this session altogether.
+    const page = PageConfig.getOption('pageUrl');
     const workspaces = PageConfig.getOption('workspacesUrl');
-    const url = URLExt.join(workspaces, result.value);
+    const match = router.current.path.match(Patterns.workspace);
+    const workspace = (match && decodeURIComponent(match[1])) || '';
+    const prefix = (workspace ? workspaces : page).length + workspace.length;
+    const rest = router.current.request.substring(prefix);
+    const url = URLExt.join(workspaces, result.value, rest);
 
     router.navigate(url, { hard: true, silent: true });
 


### PR DESCRIPTION
This change accounts for tree URLs when there is a workspace collision, but more specifically, it passes through the entire "rest" of the URL after the page / workspace URL components have been replaced.

Fixes https://github.com/jupyterlab/jupyterlab/issues/5214