### PR TITLE
Add docstring for mergeReplies method.

### DIFF
--- a/packages/completer/src/connector.ts
+++ b/packages/completer/src/connector.ts
@@ -39,9 +39,7 @@ export class CompletionConnector extends DataConnector<
     return Promise.all([
       this._kernel.fetch(request),
       this._context.fetch(request)
-    ]).then(([kernelReply, contextReply]) => {
-      return Private.mergeReplies(kernelReply, contextReply);
-    });
+    ]).then(([kernel, context]) => Private.mergeReplies(kernel, context));
   }
 
   private _kernel: KernelConnector;
@@ -64,6 +62,18 @@ export namespace CompletionConnector {
 namespace Private {
   /**
    * Merge results from kernel and context completions.
+   *
+   * @param kernel - The kernel reply being merged.
+   *
+   * @param context - The context reply being merged.
+   *
+   * @returns A reply with a superset of kernel and context matches.
+   *
+   * #### Notes
+   * The kernel and context matches are merged with a preference for kernel
+   * results. Both lists are known to contain unique, non-repeating items;
+   * so this function returns a non-repeating superset by filtering out
+   * duplicates from the context list that appear in the kernel list.
    */
   export function mergeReplies(
     kernel: CompletionHandler.IReply,
@@ -75,11 +85,6 @@ namespace Private {
     } else if (context.matches.length === 0) {
       return kernel;
     }
-
-    // They both have matches, merge them with a preference for the kernel
-    // result. Both lists are known to contain unique, non-repeating items,
-    // so return a non-repeating superset by filtering out duplicates from
-    // the context list that appear in the kernel list.
 
     // Populate the result with a copy of the kernel matches.
     const matches = kernel.matches.slice();


### PR DESCRIPTION
Adds a docstring for private `mergeReplies` function to expose comments that were embedded in the source code.