### PR TITLE
[mathjax2] Set charset attribute explicitly

### DIFF
--- a/packages/mathjax2/src/index.ts
+++ b/packages/mathjax2/src/index.ts
@@ -60,7 +60,8 @@ export class MathJaxTypesetter implements IRenderMime.ILatexTypesetter {
     script.type = 'text/javascript';
     script.src = `${this._url}?config=${
       this._config
-    }&amp;delayStartupUntil=configured" charset="utf-8"`;
+    }&amp;delayStartupUntil=configured`;
+    script.charset = 'utf-8';
     head.appendChild(script);
     script.addEventListener('load', () => {
       this._onLoad();


### PR DESCRIPTION
In my browser, the entire url is serialized, *including*
the charset= line. This makes a URL like
https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured%22%20charset=%22utf-8%22,
which fails to load.

Discovered in the course of #5833 