### PR TITLE
Add a insert new markdown icon to notebook toolbar

### DIFF
--- a/packages/application/style/icons.css
+++ b/packages/application/style/icons.css
@@ -43,6 +43,10 @@
   background-image: var(--jp-icon-add);
 }
 
+.jp-AddMarkdownIcon {
+  background-image: var(--jp-icon-add-markdown);
+}
+
 .jp-BugIcon {
   background-image: var(--jp-icon-bug);
 }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -302,6 +302,34 @@ export namespace NotebookActions {
   }
 
   /**
+   * Insert a new markdown cell below the active cell.
+   *
+   * @param notebook - The target notebook widget.
+   *
+   * #### Notes
+   * The widget mode will be preserved.
+   * This action can be undone.
+   * The existing selection will be cleared.
+   * The new cell will be the active cell.
+   */
+  export function insertMarkdownBelow(notebook: Notebook): void {
+    if (!notebook.model || !notebook.activeCell) {
+      return;
+    }
+
+    const state = Private.getState(notebook);
+    const model = notebook.model;
+    const cell = model.contentFactory.createMarkdownCell({});
+
+    model.cells.insert(notebook.activeCellIndex + 1, cell);
+
+    // Make the newly inserted cell active.
+    notebook.activeCellIndex++;
+    notebook.deselectAll();
+    Private.handleState(notebook, state, true);
+  }
+
+  /**
    * Move the selected cell(s) down.
    *
    * @param notebook = The target notebook widget.

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -40,6 +40,11 @@ const TOOLBAR_SAVE_CLASS = 'jp-SaveIcon';
 const TOOLBAR_INSERT_CLASS = 'jp-AddIcon';
 
 /**
+ * The class name added to toolbar insert button.
+ */
+const TOOLBAR_INSERT_MARKDOWN_CLASS = 'jp-AddMarkdownIcon';
+
+/**
  * The class name added to toolbar cut button.
  */
 const TOOLBAR_CUT_CLASS = 'jp-CutIcon';
@@ -128,6 +133,19 @@ export namespace ToolbarItems {
   }
 
   /**
+   * Create an insert toolbar item.
+   */
+  export function createInsertMarkdownButton(panel: NotebookPanel): Widget {
+    return new ToolbarButton({
+      iconClassName: TOOLBAR_INSERT_MARKDOWN_CLASS + ' jp-Icon jp-Icon-16',
+      onClick: () => {
+        NotebookActions.insertMarkdownBelow(panel.content);
+      },
+      tooltip: 'Insert a markdown cell below'
+    });
+  }
+
+  /**
    * Create a cut toolbar item.
    */
   export function createCutButton(panel: NotebookPanel): Widget {
@@ -203,6 +221,7 @@ export namespace ToolbarItems {
     return [
       { name: 'save', widget: createSaveButton(panel) },
       { name: 'insert', widget: createInsertButton(panel) },
+      { name: 'insertMarkdown', widget: createInsertMarkdownButton(panel) },
       { name: 'cut', widget: createCutButton(panel) },
       { name: 'copy', widget: createCopyButton(panel) },
       { name: 'paste', widget: createPasteButton(panel) },

--- a/packages/theme-dark-extension/style/icons/md/ic_add_markdown_24px.svg
+++ b/packages/theme-dark-extension/style/icons/md/ic_add_markdown_24px.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#E0E0E0;stroke-width:0.9346;}
+	.st1{fill:#E0E0E0;}
+</style>
+<path class="st0" d="M3.8,6.7h16.4c0.5,0,0.9,0.4,0.9,0.9V17c0,0.5-0.4,0.9-0.9,0.9H3.8c-0.5,0-0.9-0.4-0.9-0.9V7.7
+	C2.9,7.1,3.3,6.7,3.8,6.7z"/>
+<path class="st1" d="M5.2,15.5V9.1H7l1.8,2.4l1.8-2.4h1.8v6.4h-1.8v-3.7l-1.8,2.4L7,11.8v3.7H5.2z M16.7,15.5l-2.8-3.1h1.8V9.1h1.8
+	v3.3h1.8L16.7,15.5z"/>
+</svg>

--- a/packages/theme-dark-extension/style/urls.css
+++ b/packages/theme-dark-extension/style/urls.css
@@ -32,6 +32,7 @@
   --jp-about-header-logo: url('icons/jupyter/jupyter.svg');
   --jp-about-header-wordmark: url('images/jupyterlab-wordmark.svg');
   --jp-icon-add: url('icons/md/ic_add_24px.svg');
+  --jp-icon-add-markdown: url('icons/md/ic_add_markdown_24px.svg');
   --jp-icon-book-selected: url('icons/jupyter/book_selected.svg');
   --jp-icon-book: url('icons/jupyter/book.svg');
   --jp-icon-bug: url('icons/md/bug.svg');

--- a/packages/theme-light-extension/style/icons/md/ic_add_markdown_24px.svg
+++ b/packages/theme-light-extension/style/icons/md/ic_add_markdown_24px.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#616161;stroke-width:0.9346;}
+	.st1{fill:#616161;}
+</style>
+<path class="st0" d="M3.8,6.7h16.4c0.5,0,0.9,0.4,0.9,0.9V17c0,0.5-0.4,0.9-0.9,0.9H3.8c-0.5,0-0.9-0.4-0.9-0.9V7.7
+	C2.9,7.1,3.3,6.7,3.8,6.7z"/>
+<path class="st1" d="M5.2,15.5V9.1H7l1.8,2.4l1.8-2.4h1.8v6.4h-1.8v-3.7l-1.8,2.4L7,11.8v3.7H5.2z M16.7,15.5l-2.8-3.1h1.8V9.1h1.8
+	v3.3h1.8L16.7,15.5z"/>
+</svg>

--- a/packages/theme-light-extension/style/urls.css
+++ b/packages/theme-light-extension/style/urls.css
@@ -31,6 +31,7 @@
   --jp-about-header-logo: url('icons/jupyter/jupyter.svg');
   --jp-about-header-wordmark: url('images/jupyterlab-wordmark.svg');
   --jp-icon-add: url('icons/md/ic_add_24px.svg');
+  --jp-icon-add-markdown: url('icons/md/ic_add_markdown_24px.svg');
   --jp-icon-book-selected: url('icons/jupyter/book_selected.svg');
   --jp-icon-book: url('icons/jupyter/book.svg');
   --jp-icon-bug: url('icons/md/bug.svg');

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -94,6 +94,29 @@ describe('@jupyterlab/notebook', () => {
       });
     });
 
+    describe('#createInsertMarkdownButton()', () => {
+      it('should insert markdown below when clicked', async () => {
+        const button = ToolbarItems.createInsertMarkdownButton(panel);
+        Widget.attach(button, document.body);
+        await framePromise();
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
+        expect(panel.content.activeCellIndex).to.equal(1);
+        expect(panel.content.activeCell).to.be.an.instanceof(MarkdownCell);
+        button.dispose();
+      });
+
+      it("should have the `'jp-AddMarkdownIcon'` class", async () => {
+        const button = ToolbarItems.createInsertMarkdownButton(panel);
+        Widget.attach(button, document.body);
+        await framePromise();
+        expect(
+          (button.node.firstChild.firstChild as HTMLElement).classList.contains(
+            'jp-AddMarkdownIcon'
+          )
+        ).to.equal(true);
+      });
+    });
+
     describe('#createCutButton()', () => {
       it('should cut when clicked', async () => {
         const button = ToolbarItems.createCutButton(panel);


### PR DESCRIPTION
Fixes #5839

Adds an "add markdown cell" icon next to new cell, which reduces the insertion of new markdown cell from a two-step process to one. The icon is currently a scaled version of the official markdown icon, but I can modify it to add a "+" somewhere to indicate "new cell".

![image](https://user-images.githubusercontent.com/9889312/50743940-2eaf4e80-11e3-11e9-95b5-ccdbbb5fdb82.png)

![image](https://user-images.githubusercontent.com/9889312/50743983-b006e100-11e3-11e9-960e-f70685d1b55c.png)
