### PR TITLE
Pin pytest until we can update pytest-link-check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,11 @@ setup_args['install_requires'] = [
 ]
 
 setup_args['extras_require'] = {
-    'test': ['pytest', 'requests', 'pytest-check-links'],
+    'test': [
+        'pytest==4.0',
+        'requests',
+        'pytest-check-links'
+    ],
     'docs': [
         'sphinx',
         'recommonmark',


### PR DESCRIPTION
pytest 4.1 broke our link checker (https://github.com/minrk/pytest-check-links/pull/5).
This pins to the previous version until we can publish a new version of that.
