### PR TITLE
make jupyterlab default ui when running jupyter-labhub

### DIFF
--- a/jupyterlab/labhubapp.py
+++ b/jupyterlab/labhubapp.py
@@ -1,4 +1,7 @@
 import os
+
+from traitlets import default
+
 from .labapp import LabApp
 
 try:
@@ -8,6 +11,11 @@ except ImportError:
     raise ImportError('You must have jupyterhub installed for this to work.')
 else:
     class SingleUserLabApp(SingleUserNotebookApp, LabApp):
+
+        @default("default_url")
+        def _default_url(self):
+            """when using jupyter-labhub, jupyterlab is default ui"""
+            return "/lab"
 
         def init_webapp(self, *args, **kwargs):
             super().init_webapp(*args, **kwargs)


### PR DESCRIPTION
instead of "/tree"

This allows jupyterhub deployments to enable labhub with one line of config, instead of two:

    c.Spawner.cmd = 'jupyter-labhub'

rather than additionally needing to set default_url, which is the current case:

    c.Spawner.default_url = '/lab'