### PR TITLE
Fix navigate behavior

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -294,11 +294,11 @@ function activateBrowser(
 
     // Whether to automatically navigate to a document's current directory
     labShell.currentChanged.connect((_, change) => {
-      if (navigateToCurrentDirectory) {
+      if (navigateToCurrentDirectory && change.newValue) {
         const { newValue } = change;
         const context = docManager.contextForWidget(newValue);
-        const { path } = context;
         if (context) {
+          const { path } = context;
           factory.defaultBrowser;
           Private.navigateToPath(path, factory)
             .then(() => {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -252,7 +252,7 @@ function activateBrowser(
   // responsible for their own restoration behavior, if any.
   restorer.add(browser, namespace);
 
-  addCommands(app, factory.tracker, browser, labShell);
+  addCommands(app, factory.tracker, browser, labShell, docManager);
 
   browser.title.iconClass = 'jp-FolderIcon jp-SideBar-tabIcon';
   browser.title.caption = 'File Browser';
@@ -342,7 +342,8 @@ function addCommands(
   app: JupyterFrontEnd,
   tracker: InstanceTracker<FileBrowser>,
   browser: FileBrowser,
-  labShell: ILabShell
+  labShell: ILabShell,
+  docManager: IDocumentManager
 ): void {
   const registry = app.docRegistry;
 
@@ -461,7 +462,9 @@ function addCommands(
 
           return restored
             .then(() => model.cd(`/${PathExt.dirname(localPath)}`))
-            .then(() => commands.execute('docmanager:open', { path: path }));
+            .then(() => {
+              docManager.findWidget(path).activate();
+            });
         })
         .catch(failure);
     }

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -299,7 +299,6 @@ function activateBrowser(
         const context = docManager.contextForWidget(newValue);
         if (context) {
           const { path } = context;
-          factory.defaultBrowser;
           Private.navigateToPath(path, factory)
             .then(() => {
               docManager.findWidget(path).activate();
@@ -435,7 +434,7 @@ function addCommands(
       const path = (args.path as string) || '';
       Private.navigateToPath(path, factory)
         .then(() => {
-          docManager.findWidget(path).activate();
+          commands.execute('docmanager:open', { path });
         })
         .catch((reason: any) => {
           console.warn(
@@ -844,8 +843,7 @@ namespace Private {
     path: string,
     factory: IFileBrowserFactory
   ): FileBrowser {
-    const { defaultBrowser: browser } = factory;
-    const { tracker } = factory;
+    const { defaultBrowser: browser, tracker } = factory;
     const driveName = browser.model.manager.services.contents.driveName(path);
 
     if (driveName) {
@@ -876,7 +874,7 @@ namespace Private {
     factory: IFileBrowserFactory
   ): Promise<any> {
     const browserForPath = Private.getBrowserForPath(path, factory);
-    const { services } = factory.defaultBrowser.model.manager;
+    const { services } = browserForPath.model.manager;
     const localPath = services.contents.localPath(path);
 
     return services.ready

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -299,7 +299,6 @@ function activateBrowser(
         const context = docManager.contextForWidget(newValue);
         const { path } = context;
         if (context) {
-          commands.execute('filebrowser:activate', { path: path });
           factory.defaultBrowser;
           Private.navigateToPath(path, factory)
             .then(() => {


### PR DESCRIPTION
To reproduce:

1. Enable the _navigateToCurrentDirectory_ setting in File Browser settings
2. Open a notebook document with the JSON renderer or any non-default renderer
3. It will open the document with the JSON renderer and notebook renderer and switch to notebook tab
4. Try clicking on the JSON tab and it will keep switching back to the notebook tab

or 

1. Disable the _navigateToCurrentDirectory_ setting in File Browser settings
2. Open a notebook document with the JSON renderer or any non-default renderer
3. Right-click the JSON tab and click "Show in File Browser" and it will open the notebook renderer and jump to that tab

![](http://g.recordit.co/nwgOOvJVrF.gif)

This fixes that by calling `docWidget.activate()` vs. `commands.execute('docmanager:open', { path }))` which was in turn calling `docManager.openOrReveal(path, factory, kernel, options)` where `factory` is the default factory, not the JSON one like expected.