### PR TITLE
Added vars to themes in order to support larger fonts

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -60,20 +60,22 @@
 }
 
 .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
-  border-left: 1.4px solid var(--jp-editor-cursor-color);
+  border-left: var(--jp-code-cursor-width0) solid var(--jp-editor-cursor-color);
 }
 
 /* When zoomed out 67% and 33% on a screen of 1440 width x 900 height */
 @media screen and (min-width: 2138px) and (max-width: 4319px) {
   .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
-    border-left: 2px solid var(--jp-editor-cursor-color);
+    border-left: var(--jp-code-cursor-width1) solid
+      var(--jp-editor-cursor-color);
   }
 }
 
 /* When zoomed out less than 33% */
 @media screen and (min-width: 4320px) {
   .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
-    border-left: 4px solid var(--jp-editor-cursor-color);
+    border-left: var(--jp-code-cursor-width2) solid
+      var(--jp-editor-cursor-color);
   }
 }
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -262,12 +262,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-background: var(--jp-layout-color1);
   --jp-cell-editor-border-color: var(--md-grey-700);
   --jp-cell-editor-box-shadow: inset 0 0 2px var(--md-blue-300);
-  --jp-cell-editor-active-background: rgba(
-    33,
-    33,
-    33,
-    1
-  ); /*var(--jp-layout-color0);*/
+  --jp-cell-editor-active-background: var(--jp-layout-color0);
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
 
   --jp-cell-prompt-width: 64px;
@@ -335,12 +330,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* General editor styles */
 
-  --jp-editor-selected-background: rgba(
-    33,
-    66,
-    131,
-    0.5
-  ); /*var(--jp-layout-color2);*/
+  --jp-editor-selected-background: var(--jp-layout-color2);
   --jp-editor-selected-focused-background: rgba(33, 150, 243, 0.24);
   --jp-editor-cursor-color: var(--jp-ui-font-color0);
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -188,6 +188,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* This gives a magnification of about 125% in presentation mode over normal. */
   --jp-code-presentation-font-size: 16px;
 
+  /* may need to tweak cursor width if you change font size */
+  --jp-code-cursor-width0: 1.4px;
+  --jp-code-cursor-width1: 2px;
+  --jp-code-cursor-width2: 4px;
+
   /* Layout
    *
    * The following are the main layout colors use in JupyterLab. In a light
@@ -257,7 +262,12 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-background: var(--jp-layout-color1);
   --jp-cell-editor-border-color: var(--md-grey-700);
   --jp-cell-editor-box-shadow: inset 0 0 2px var(--md-blue-300);
-  --jp-cell-editor-active-background: var(--jp-layout-color0);
+  --jp-cell-editor-active-background: rgba(
+    33,
+    33,
+    33,
+    1
+  ); /*var(--jp-layout-color0);*/
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
 
   --jp-cell-prompt-width: 64px;
@@ -325,7 +335,12 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* General editor styles */
 
-  --jp-editor-selected-background: var(--jp-layout-color2);
+  --jp-editor-selected-background: rgba(
+    33,
+    66,
+    131,
+    0.5
+  ); /*var(--jp-layout-color2);*/
   --jp-editor-selected-focused-background: rgba(33, 150, 243, 0.24);
   --jp-editor-cursor-color: var(--jp-ui-font-color0);
 

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -186,6 +186,11 @@ all of MD as it is not optimized for dense, information rich UIs.
   /* This gives a magnification of about 125% in presentation mode over normal. */
   --jp-code-presentation-font-size: 16px;
 
+  /* may need to tweak cursor width if you change font size */
+  --jp-code-cursor-width0: 1.4px;
+  --jp-code-cursor-width1: 2px;
+  --jp-code-cursor-width2: 4px;
+
   /* Layout
    *
    * The following are the main layout colors use in JupyterLab. In a light


### PR DESCRIPTION
I recently made a theme that uses a code font that's slightly larger than the default (I think Consolas looks best in `15px`). In addition to the font size, I also had to change a whole bunch of hard coded spacing and padding variables to match the larger font size. Most of these are already exposed as variables in the theme css, but the variables controlling the scaling of the code cursor were not.

This pull request exposes the code cursor widths as css variables, and moves them in to the themes. Without these vars, the cursor was too skinny and hard to see.