### PR TITLE
Update launcher on specs change

### DIFF
--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -41,6 +41,7 @@
     "@jupyterlab/rendermime": "^0.19.1",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
+    "@phosphor/disposable": "^1.1.2",
     "@phosphor/properties": "^1.1.2",
     "@phosphor/widgets": "^1.6.0"
   },

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -781,7 +781,8 @@ export class DirListing extends Widget {
 
       node.classList.add(RUNNING_CLASS);
       if (specs) {
-        name = specs.kernelspecs[name].display_name;
+        const spec = specs.kernelspecs[name];
+        name = spec ? spec.display_name : 'unknown';
       }
       node.title = `${node.title}\nKernel: ${name}`;
     });

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -207,6 +207,9 @@ function activate(
       // Add the kernel banner to the Help Menu.
       const bannerCommand = `help-menu-${name}:banner`;
       const spec = serviceManager.specs.kernelspecs[name];
+      if (!spec) {
+        return;
+      }
       const kernelName = spec.display_name;
       let kernelIconUrl = spec.resources['logo-64x64'];
       if (kernelIconUrl) {

--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -76,13 +76,6 @@ export interface ILauncher {
  */
 export class LauncherModel extends VDomModel implements ILauncher {
   /**
-   * Create a new launcher model.
-   */
-  constructor() {
-    super();
-  }
-
-  /**
    * Add a command item to the launcher, and trigger re-render event for parent
    * widget.
    *

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -44,6 +44,7 @@
     "@jupyterlab/services": "^3.2.1",
     "@jupyterlab/statusbar": "^0.7.1",
     "@phosphor/coreutils": "^1.3.0",
+    "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0"
   },

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -267,7 +267,8 @@ function RunningSessionsComponent({
         labelTitle={m => {
           let kernelName = m.kernel.name;
           if (manager.specs) {
-            kernelName = manager.specs.kernelspecs[kernelName].display_name;
+            const spec = manager.specs.kernelspecs[kernelName];
+            kernelName = spec ? spec.display_name : 'unknown';
           }
           return `Path: ${m.path}\nKernel: ${kernelName}`;
         }}


### PR DESCRIPTION
Fixes #5676.

Reacts to kernel specs changing, and is a bit more defensive in a few places if a kernel spec has been removed.
