### PR TITLE
Once more with carriage returns

### DIFF
--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -394,20 +394,14 @@ export class OutputAreaModel implements IOutputAreaModel {
    * carriage return characters.
    */
   private _fixCarriageReturn(txt: string): string {
-    let tmp = txt;
-    // Handle multiple carriage returns before a newline
-    tmp = tmp.replace(/\r\r+\n/gm, '\r\n');
-    // Remove chunks that should be overridden by carriage returns
-    do {
-      // Remove any chunks preceding a carriage return unless carriage
-      // return followed by a newline
-      tmp = tmp.replace(/^[^\n]*(?:\r(?!\n))+/gm, '');
-    } while (tmp.search(/\r(?!\n)/) > -1);
-    do {
-      // Replace remaining \r\n characters with a newline
-      tmp = tmp.replace(/\r\n/gm, '\n');
-    } while (tmp.indexOf('\r\n') > -1);
-    return tmp;
+    txt = txt.replace(/\r+\n/gm, '\n'); // \r followed by \n --> newline
+    while (txt.search(/\r[^$]/g) > -1) {
+      const base = txt.match(/^(.*)\r+/m)[1];
+      let insert = txt.match(/\r+(.*)$/m)[1];
+      insert = insert + base.slice(insert.length, base.length);
+      txt = txt.replace(/\r+.*$/m, '\r').replace(/^.*\r/m, insert);
+    }
+    return txt;
   }
 
   /*

--- a/tests/test-outputarea/src/model.spec.ts
+++ b/tests/test-outputarea/src/model.spec.ts
@@ -153,6 +153,29 @@ describe('outputarea/model', () => {
         model.add(NBTestUtils.DEFAULT_OUTPUTS[2]);
         expect(model.length).to.equal(2);
       });
+
+      it('should remove carriage returns and backspaces from streams', () => {
+        model.add({
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['Jupyter\rj']
+        });
+        expect(model.get(0).toJSON().text).to.equal('jupyter');
+        model.add({
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['\njj\bupyter']
+        });
+        expect(model.get(0).toJSON().text).to.equal('jupyter\njupyter');
+        model.add({
+          name: 'stdout',
+          output_type: 'stream',
+          text: ['\r\r\njupyter']
+        });
+        expect(model.get(0).toJSON().text).to.equal(
+          'jupyter\njupyter\njupyter'
+        );
+      });
     });
 
     describe('#clear()', () => {


### PR DESCRIPTION
Fixes #4822.

There were some minor differences in the regexes used in JupyterLab and classic notebook for overwriting `\r` and `\b`. This just copies the classic notebook implementation directly and includes a new test.