### PR TITLE
Remove initialCommand from args of terminal creation.

### DIFF
--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -203,8 +203,7 @@ export function addCommands(
     iconClass: args => (args['isPalette'] ? '' : TERMINAL_ICON_CLASS),
     execute: args => {
       const name = args['name'] as string;
-      const initialCommand = args['initialCommand'] as string;
-      const term = new Terminal({ initialCommand });
+      const term = new Terminal();
       const promise = name
         ? services.terminals.connectTo(name)
         : services.terminals.startNew();


### PR DESCRIPTION
I don't think we need to remove it from the terminal API, just from the command args.