### PR TITLE
Start a new terminal if connecting to an old one fails.

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -146,10 +146,16 @@ async function activateConsole(
 
   // Handle state restoration.
   restorer.restore(tracker, {
-    command: CommandIDs.open,
+    command: CommandIDs.create,
     args: panel => ({
       path: panel.console.session.path,
-      name: panel.console.session.name
+      name: panel.console.session.name,
+      kernelPreference: {
+        name: panel.console.session.kernel && panel.console.session.kernel.name,
+        language:
+          panel.console.session.language &&
+          panel.console.session.kernel.language
+      }
     }),
     name: panel => panel.console.session.path,
     when: manager.ready

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -209,7 +209,9 @@ export function addCommands(
       const initialCommand = args['initialCommand'] as string;
       const term = new Terminal({ initialCommand });
       const promise = name
-        ? serviceManager.terminals.connectTo(name)
+        ? serviceManager.terminals
+            .connectTo(name)
+            .catch(() => serviceManager.terminals.startNew())
         : serviceManager.terminals.startNew();
 
       term.title.icon = TERMINAL_ICON_CLASS;


### PR DESCRIPTION
This makes starting a new terminal a bit more fault-tolerant. It fixes a bug that can be reproduced by the following:

1. Launch a new terminal.
2. Close the terminal session from the running panel without closing the terminal panel.
3. Refresh the page -- the terminal widget will fail to restore.

Now, the above description is not a huge deal, but the broken restoration also makes workspace files that are less portable: if you try to launch from an existing workspace (e.g., on binder), terminals will not restart because they try to connect to a nonexistent session and fail.