### PR TITLE
Use `MarkdownDocument` as document widget for `MarkdownViewer`.

### DIFF
--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -312,7 +312,7 @@ export class MarkdownViewerFactory extends ABCWidgetFactory<MarkdownDocument> {
     const content = new MarkdownViewer({ context, renderer });
     content.title.iconClass = this._fileType.iconClass;
     content.title.iconLabel = this._fileType.iconLabel;
-    const widget = new DocumentWidget({ content, context });
+    const widget = new MarkdownDocument({ content, context });
 
     return widget;
   }


### PR DESCRIPTION
`MarkdownDocument` extends `DocumentWidget` adding an handler for markdown URI fragment.
It was already part of #5901, but at the end, I forgot to use it. :grimacing:

Cheers