### PR TITLE
JupyterFrontend cleanup

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -82,25 +82,26 @@ their source) is shown here: |dependencies|
 Application Object
 ~~~~~~~~~~~~~~~~~~
 
-The JupyterLab Application object is given to each plugin in its
-``activate()`` function. The Application object has a:
+A Jupyter front-end application object is given to each plugin in its
+``activate()`` function. The application object has:
 
 -  commands - used to add and execute commands in the application.
 -  keymap - used to add keyboard shortcuts to the application.
--  shell - a JupyterLab shell instance.
+-  shell - a generic Jupyter front-end shell instance.
 
-JupyterLab Shell
-~~~~~~~~~~~~~~~~
+Jupyter Front-End Shell
+~~~~~~~~~~~~~~~~~~~~~~~
 
-The JupyterLab
-`shell <https://jupyterlab.github.io/jupyterlab/application/classes/applicationshell.html>`__
-is used to add and interact with content in the application. The
-application consists of:
+The Jupyter front-end
+`shell <https://jupyterlab.github.io/jupyterlab/application/interfaces/jupyterfrontend.ishell.html>`__
+is used to add and interact with content in the application. The ``IShell``
+interface provides an ``add()`` method for adding widgets to the application.
+In JupyterLab, the application shell consists of:
 
--  A top area for things like top level menus and toolbars
--  Left and right side bar areas for collapsible content
--  A main work area for user activity.
--  A bottom area for things like status bars
+-  A ``top`` area for things like top level menus and toolbars
+-  ``left`` and ``right`` side bar areas for collapsible content
+-  A ``main`` work area for user activity.
+-  A ``bottom`` area for things like status bars
 
 Phosphor
 ~~~~~~~~

--- a/docs/source/developer/notebook.rst
+++ b/docs/source/developer/notebook.rst
@@ -176,7 +176,7 @@ Copy the following to ``src/index.ts``:
     } from '@phosphor/disposable';
 
     import {
-      JupyterLab, JupyterFrontEndPlugin
+      JupyterFrontEnd, JupyterFrontEndPlugin
     } from '@jupyterlab/application';
 
     import {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -135,7 +135,15 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
     });
 
     // Register the file operations commands.
-    addCommands(app, docManager, settingRegistry, labShell, palette, mainMenu);
+    addCommands(
+      app,
+      docManager,
+      opener,
+      settingRegistry,
+      labShell,
+      palette,
+      mainMenu
+    );
 
     // Keep up to date with the settings registry.
     const onSettingsUpdated = (settings: ISettingRegistry.ISettings) => {
@@ -266,6 +274,7 @@ function fileType(widget: Widget, docManager: IDocumentManager): string {
 function addCommands(
   app: JupyterFrontEnd,
   docManager: IDocumentManager,
+  opener: DocumentManager.IWidgetOpener,
   settingRegistry: ISettingRegistry,
   labShell: ILabShell | null,
   palette: ICommandPalette | null,
@@ -293,7 +302,7 @@ function addCommands(
 
   // If inside a rich application like JupyterLab, add additional functionality.
   if (labShell) {
-    addLabCommands(app, docManager, labShell, palette);
+    addLabCommands(app, docManager, labShell, opener, palette);
   }
 
   commands.addCommand(CommandIDs.close, {
@@ -603,6 +612,7 @@ function addLabCommands(
   app: JupyterFrontEnd,
   docManager: IDocumentManager,
   labShell: ILabShell,
+  opener: DocumentManager.IWidgetOpener,
   palette: ICommandPalette | null
 ): void {
   const { commands } = app;

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -17,7 +17,7 @@ can be used to polyfill browsers that do not support the `fetch` API.
 **Prerequisites**
 
 - [node](http://nodejs.org/)
-- [python](https://www.anaconda.com/download)
+- [python](https://www.anaconda.com/distribution/)
 
 ```bash
 npm install --save @jupyterlab/services
@@ -30,7 +30,7 @@ conda install notebook  # notebook 4.3+ required
 
 - [git](http://git-scm.com/)
 - [node 0.12+](http://nodejs.org/)
-- [python](https://www.anaconda.com/download)
+- [python](https://www.anaconda.com/distribution/)
 
 ```bash
 git clone https://github.com/jupyterlab/jupyterlab.git

--- a/packages/settingeditor/src/inspector.ts
+++ b/packages/settingeditor/src/inspector.ts
@@ -85,6 +85,9 @@ class InspectorConnector extends DataConnector<
 
   private _validate(raw: string): ISchemaValidator.IError[] | null {
     const editor = this._editor;
+    if (!editor.settings) {
+      return null;
+    }
     const { id, schema, version } = editor.settings;
     const data = { composite: {}, user: {} };
     const validator = editor.registry.validator;


### PR DESCRIPTION
Some falllout from #5845.

* Threads opener into docmanager commands: `tsc` didn't catch this because `window.opener` exists.
* Documentation links went out of date because APIs were changed and the old links broke the docs build.
* Defensively check for whether setting editor has setting selected.