### PR TITLE
Fix focus issues when focusing away from a notebook in edit mode.

### DIFF
--- a/docs/source/developer/adding_content.rst
+++ b/docs/source/developer/adding_content.rst
@@ -17,7 +17,7 @@ As an example: Add a leaflet viewer plugin for geoJSON files.
    file that exports functions is
    `codemirror <https://github.com/jupyterlab/jupyterlab/blob/master/packages/codemirror/typings/codemirror/codemirror.d.ts>`__.
    An example with a class is
-   `xterm <https://github.com/jupyterlab/jupyterlab/blob/master/packages/terminal/src/xterm.d.ts>`__.
+   `vdom <https://github.com/jupyterlab/jupyterlab/blob/master/packages/vdom-extension/src/transform-vdom.d.ts>`__.
 
 -  Add a reference to the new library in ``src/typings.d.ts``.
 

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -2056,8 +2056,16 @@ export class Notebook extends StaticNotebook {
       }
     }
 
-    // Otherwise enter command mode.
-    this.mode = 'command';
+    // Otherwise enter command mode if not already.
+    if (this.mode !== 'command') {
+      this.mode = 'command';
+
+      // Switching to command mode currently focuses the notebook element, so
+      // refocus the relatedTarget so the focus actually switches as intended.
+      if (relatedTarget) {
+        relatedTarget.focus();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
To see the problem, edit a cell in a notebook, then click on the command palette search box. The focus does not end up at the search box, but instead ends up on the notebook node.

Perhaps the one setting the mode should be in charge of setting the focus?
