### PR TITLE
Update yarn.lock for correct typescript semver range.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9990,7 +9990,7 @@ typescript@3.2.x:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
 
-typescript@^3.3.1:
+typescript@~3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
 


### PR DESCRIPTION
Completes the update from 1203700 (#5929)