### PR TITLE
Context menu hint

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -55,8 +55,6 @@ namespace CommandIDs {
   export const togglePresentationMode: string =
     'application:toggle-presentation-mode';
 
-  export const contextMenuInfo = 'application:context-menu-info';
-
   export const tree: string = 'router:tree';
 
   export const switchSidebar = 'sidebar:switch';
@@ -537,18 +535,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     }
   });
   palette.addItem({ command, category });
-
-  app.commands.addCommand(CommandIDs.contextMenuInfo, {
-    label: 'Shift+Right Click for Browser Menu',
-    isEnabled: () => false,
-    execute: () => void 0
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.contextMenuInfo,
-    selector: 'body',
-    rank: 9999
-  });
 }
 
 /**

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -55,6 +55,8 @@ namespace CommandIDs {
   export const togglePresentationMode: string =
     'application:toggle-presentation-mode';
 
+  export const contextMenuInfo = 'application:context-menu-info';
+
   export const tree: string = 'router:tree';
 
   export const switchSidebar = 'sidebar:switch';
@@ -535,6 +537,18 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     }
   });
   palette.addItem({ command, category });
+
+  app.commands.addCommand(CommandIDs.contextMenuInfo, {
+    label: 'Shift+Right Click for Browser Menu',
+    isEnabled: () => false,
+    execute: () => void 0
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.contextMenuInfo,
+    selector: 'body',
+    rank: 9999
+  });
 }
 
 /**

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -59,6 +59,18 @@ export abstract class JupyterFrontEnd<
       options.restored ||
       this.started.then(() => restored).catch(() => restored);
     this.serviceManager = options.serviceManager || new ServiceManager();
+
+    this.commands.addCommand(Private.CONTEXT_MENU_INFO, {
+      label: 'Shift+Right Click for Browser Menu',
+      isEnabled: () => false,
+      execute: () => void 0
+    });
+
+    this.contextMenu.addItem({
+      command: Private.CONTEXT_MENU_INFO,
+      selector: 'body',
+      rank: Infinity
+    });
   }
 
   /**
@@ -154,7 +166,7 @@ export abstract class JupyterFrontEnd<
       // allow the native one to open.
       if (
         items.length === 1 &&
-        items[0].command === 'application:context-menu-info'
+        items[0].command === Private.CONTEXT_MENU_INFO
       ) {
         this.contextMenu.menu.close();
         return;
@@ -282,4 +294,15 @@ export namespace JupyterFrontEnd {
       readonly workspaces: string;
     };
   }
+}
+
+/**
+ * A namespace for module-private functionality.
+ */
+namespace Private {
+  /**
+   * An id for a private context-menu-info
+   * ersatz command.
+   */
+  export const CONTEXT_MENU_INFO = '__internal:context-menu-info';
 }

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -143,7 +143,26 @@ export abstract class JupyterFrontEnd<
    */
   protected evtContextMenu(event: MouseEvent): void {
     this._contextMenuEvent = event;
-    super.evtContextMenu(event);
+    if (event.shiftKey) {
+      return;
+    }
+    const opened = this.contextMenu.open(event);
+    if (opened) {
+      const items = this.contextMenu.menu.items;
+      // If only the context menu information will be shown,
+      // with no real commands, close the context menu and
+      // allow the native one to open.
+      if (
+        items.length === 1 &&
+        items[0].command === 'application:context-menu-info'
+      ) {
+        this.contextMenu.menu.close();
+        return;
+      }
+      // Stop propagation and allow the application context menu to show.
+      event.preventDefault();
+      event.stopPropagation();
+    }
   }
 
   private _contextMenuEvent: MouseEvent;


### PR DESCRIPTION
Fixes #4023.

This adds a new context menu item to `body` which instructs the user how to open the native browser menu.

There is one outstanding issue to figure out: currently, if the application context menu has no items in it, the native one is shown. Since this adds an item to `body` that is always visible, that makes the native context menu *always* invisible without `Shift`, at least by default.

I have added some additional logic to catch this case. If only the "context menu info" item is showing, this instead closes the application context menu and allows the native one to open. I am not sure whether this is a good idea: it may be better to just always show the application one. In that case, we only want the first commit of this PR.

cc @tgeorgeux @afshin 