### PR TITLE
Fix un-styled different workspace dialog.

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -119,15 +119,13 @@ const settings: JupyterFrontEndPlugin<ISettingRegistry> = {
  */
 const themes: JupyterFrontEndPlugin<IThemeManager> = {
   id: '@jupyterlab/apputils-extension:themes',
-  requires: [ISettingRegistry, JupyterFrontEnd.IPaths, ISplashScreen],
-  optional: [ICommandPalette, IMainMenu],
+  requires: [ISettingRegistry, JupyterFrontEnd.IPaths],
+  optional: [ISplashScreen],
   activate: (
     app: JupyterFrontEnd,
     settings: ISettingRegistry,
     paths: JupyterFrontEnd.IPaths,
-    splash: ISplashScreen | null,
-    palette: ICommandPalette | null,
-    mainMenu: IMainMenu | null
+    splash: ISplashScreen | null
   ): IThemeManager => {
     const host = app.shell;
     const commands = app.commands;
@@ -163,6 +161,32 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
       }
     });
 
+    return manager;
+  },
+  autoStart: true,
+  provides: IThemeManager
+};
+
+/**
+ * The default theme manager's UI command palette and main menu functionality.
+ *
+ * #### Notes
+ * This plugin loads separately from the theme manager plugin in order to
+ * prevent blocking of the theme manager while it waits for the command palette
+ * and main menu to become available.
+ */
+const themesPaletteMenu: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/apputils-extension:themes-palette-menu',
+  requires: [IThemeManager],
+  optional: [ICommandPalette, IMainMenu],
+  activate: (
+    app: JupyterFrontEnd,
+    manager: IThemeManager,
+    palette: ICommandPalette | null,
+    mainMenu: IMainMenu | null
+  ): void => {
+    const commands = app.commands;
+
     // If we have a main menu, add the theme manager to the settings menu.
     if (mainMenu) {
       const themeMenu = new Menu({ commands });
@@ -192,18 +216,14 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
         const category = 'Settings';
         const command = CommandIDs.changeTheme;
         const isPalette = true;
-        currentTheme = manager.theme;
 
         manager.themes.forEach(theme => {
           palette.addItem({ command, args: { isPalette, theme }, category });
         });
       });
     }
-
-    return manager;
   },
-  autoStart: true,
-  provides: IThemeManager
+  autoStart: true
 };
 
 /**
@@ -532,7 +552,8 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   settings,
   state,
   splash,
-  themes
+  themes,
+  themesPaletteMenu
 ];
 export default plugins;
 

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -54,7 +54,7 @@ export class ThemeManager {
 
     this._base = url;
     this._host = host;
-    this._splash = splash;
+    this._splash = splash || null;
 
     registry.load(key).then(settings => {
       this._settings = settings;
@@ -227,7 +227,9 @@ export class ThemeManager {
     const current = this._current;
     const links = this._links;
     const themes = this._themes;
-    const splash = this._splash.show(themes[theme].isLight);
+    const splash = this._splash
+      ? this._splash.show(themes[theme].isLight)
+      : new DisposableDelegate(() => undefined);
 
     // Unload any CSS files that have been loaded.
     links.forEach(link => {
@@ -276,7 +278,7 @@ export class ThemeManager {
   private _pending = 0;
   private _requests: { [theme: string]: number } = {};
   private _settings: ISettingRegistry.ISettings;
-  private _splash: ISplashScreen;
+  private _splash: ISplashScreen | null;
   private _themes: { [key: string]: ThemeManager.ITheme } = {};
   private _themeChanged = new Signal<this, IChangedArgs<string>>(this);
 }
@@ -307,7 +309,7 @@ export namespace ThemeManager {
     /**
      * The splash screen to show when loading themes.
      */
-    splash: ISplashScreen;
+    splash?: ISplashScreen;
 
     /**
      * The url for local theme loading.


### PR DESCRIPTION
The different workspace dialog was un-styled. Now it looks like this again:

![screen shot 2019-02-04 at 18 24 33](https://user-images.githubusercontent.com/159529/52228390-27df2e80-28aa-11e9-9ce6-229173de42ba.png)
