### PR TITLE
Test stability

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -207,12 +207,17 @@ export async function ensureIntegrity(): Promise<boolean> {
 
   // Validate each package.
   for (let name in pkgData) {
+    let unused = UNUSED[name] || [];
+    // Allow jest-junit to be unused in the test suite.
+    if (name.indexOf('@jupyterlab/test-') === 0) {
+      unused.push('jest-junit');
+    }
     let options: IEnsurePackageOptions = {
       pkgPath: pkgPaths[name],
       data: pkgData[name],
       depCache,
       missing: MISSING[name],
-      unused: UNUSED[name],
+      unused,
       locals
     };
 

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -35,7 +35,6 @@
     "@jupyterlab/coreutils": "^2.2.1",
     "@jupyterlab/launcher": "^0.19.1",
     "@jupyterlab/mainmenu": "^0.8.1",
-    "@jupyterlab/services": "^3.2.1",
     "@jupyterlab/terminal": "^0.19.1"
   },
   "devDependencies": {

--- a/packages/terminal-extension/tsconfig.json
+++ b/packages/terminal-extension/tsconfig.json
@@ -22,9 +22,6 @@
       "path": "../mainmenu"
     },
     {
-      "path": "../services"
-    },
-    {
       "path": "../terminal"
     }
   ]

--- a/tests/test-console/src/foreign.spec.ts
+++ b/tests/test-console/src/foreign.spec.ts
@@ -208,7 +208,7 @@ describe('@jupyterlab/console', () => {
           promise.resolve(void 0);
         });
         await foreign.kernel.requestExecute({ code, stop_on_error: true }).done;
-        await promise;
+        await promise.promise;
         expect(called).to.equal(true);
       });
 
@@ -225,7 +225,7 @@ describe('@jupyterlab/console', () => {
           promise.resolve(void 0);
         });
         await foreign.kernel.requestExecute({ code, stop_on_error: true }).done;
-        await promise;
+        await promise.promise;
         expect(called).to.equal(true);
       });
 
@@ -244,7 +244,7 @@ describe('@jupyterlab/console', () => {
           }
         });
         await foreign.kernel.requestExecute({ code, stop_on_error: true }).done;
-        await promise;
+        await promise.promise;
         expect(called).to.equal(true);
       });
     });

--- a/tests/test-coreutils/src/statedb.spec.ts
+++ b/tests/test-coreutils/src/statedb.spec.ts
@@ -37,7 +37,8 @@ describe('StateDB', () => {
       await prepopulate.save(key, incorrect);
       let value = await prepopulate.fetch(key);
       expect(value).to.equal(incorrect);
-      await transform.resolve(transformation);
+      transform.resolve(transformation);
+      await transform.promise;
       value = await db.fetch(key);
       expect(value).to.equal(correct);
       await db.clear();

--- a/tests/test-outputarea/src/widget.spec.ts
+++ b/tests/test-outputarea/src/widget.spec.ts
@@ -270,6 +270,7 @@ describe('outputarea/widget', () => {
       describe('#createStdin()', () => {
         it('should create a stdin widget', async () => {
           const kernel = await Kernel.startNew();
+          await kernel.ready;
           const factory = new OutputArea.ContentFactory();
           const future = kernel.requestExecute({ code: CODE });
           const options = {

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -465,7 +465,7 @@ describe('Kernel.IKernel', () => {
       };
       const msg = KernelMessage.createShellMessage(options);
       kernel.sendShellMessage(msg, true);
-      await done;
+      await done.promise;
       await tester.shutdown();
       tester.dispose();
     });
@@ -502,7 +502,7 @@ describe('Kernel.IKernel', () => {
         data.buffer
       ]);
       kernel.sendShellMessage(msg, true);
-      await done;
+      await done.promise;
       await tester.shutdown();
       tester.dispose();
     });
@@ -817,7 +817,7 @@ describe('Kernel.IKernel', () => {
         done.resolve(null);
       });
       kernel.sendInputReply({ value: 'test' });
-      await done;
+      await done.promise;
       await tester.shutdown();
       tester.dispose();
     });

--- a/tests/test-services/src/kernel/manager.spec.ts
+++ b/tests/test-services/src/kernel/manager.spec.ts
@@ -186,7 +186,7 @@ describe('kernel/manager', () => {
           called = true;
         });
         const k = await Kernel.startNew();
-        await manager.connectTo(k.model);
+        manager.connectTo(k.model);
         expect(called).to.equal(true);
       });
     });

--- a/tests/test-services/src/session/isession.spec.ts
+++ b/tests/test-services/src/session/isession.spec.ts
@@ -366,8 +366,8 @@ describe('session', () => {
         expect(session.kernel.id).to.equal(kernel.id);
         expect(session.kernel).to.not.equal(previous);
         expect(session.kernel).to.not.equal(kernel);
-        await previous.dispose();
-        await kernel.dispose();
+        previous.dispose();
+        kernel.dispose();
       });
 
       it('should update the session path if it has changed', async () => {


### PR DESCRIPTION
This splits out the non-API-changing stuff from #5860 to just fix some bugs in the tests: mostly around awaiting the wrong things.