### PR TITLE
Add node dependencies and a browser field to services for the ws and node-fetch packages

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -36,6 +36,10 @@
     "prepublishOnly": "jlpm run build && webpack",
     "watch": "tsc -b --watch"
   },
+  "browser": {
+    "node-fetch": false,
+    "ws": false
+  },
   "dependencies": {
     "@jupyterlab/coreutils": "^3.0.0-alpha.1",
     "@jupyterlab/observables": "^2.2.0-alpha.1",
@@ -43,8 +47,8 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "node-fetch": "^2.3.0",
-    "ws": "^6.1.3"
+    "node-fetch": "~2.2.0",
+    "ws": "~6.0.0"
   },
   "devDependencies": {
     "@types/node": "~8.0.47",
@@ -55,10 +59,6 @@
     "typescript": "~3.3.1",
     "webpack": "~4.12.0",
     "webpack-cli": "^3.0.3"
-  },
-  "browser": {
-    "node-fetch": false,
-    "ws": false
   },
   "publishConfig": {
     "access": "public"

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -42,7 +42,9 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
-    "@phosphor/signaling": "^1.2.2"
+    "@phosphor/signaling": "^1.2.2",
+    "node-fetch": "^2.3.0",
+    "ws": "^6.1.3"
   },
   "devDependencies": {
     "@types/node": "~8.0.47",
@@ -53,6 +55,10 @@
     "typescript": "~3.3.1",
     "webpack": "~4.12.0",
     "webpack-cli": "^3.0.3"
+  },
+  "browser": {
+    "node-fetch": false,
+    "ws": false
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6989,6 +6989,10 @@ node-fetch@^2.1.2, node-fetch@~2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
 
+node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+
 node-gyp@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
@@ -10768,6 +10772,12 @@ write@^0.2.1:
 ws@^5.1.1, ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.3.tgz#d2d2e5f0e3c700ef2de89080ebc0ac6e1bf3a72d"
   dependencies:
     async-limiter "~1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6989,10 +6989,6 @@ node-fetch@^2.1.2, node-fetch@~2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
 
-node-fetch@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
-
 node-gyp@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
@@ -10772,12 +10768,6 @@ write@^0.2.1:
 ws@^5.1.1, ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  dependencies:
-    async-limiter "~1.0.0"
-
-ws@^6.1.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.3.tgz#d2d2e5f0e3c700ef2de89080ebc0ac6e1bf3a72d"
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
Webpack should ignore our import of the ws and node-fetch nodejs packages because of the browser field (see https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module).

Fixes #5856