### PR TITLE
Add autoredirect query string parameter to generate new workspaces.

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -256,11 +256,10 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
         // If the user has requested `autoredirect` create a new workspace name.
         if ('autoredirect' in query) {
           const { base, workspaces } = paths.urls;
-          const auto = `auto-${Private.token(6)}`;
-          const path = URLExt.join(base, workspaces, auto);
-
-          // Maintain the query string parameters but remove `autoredirect`.
-          delete query['autoredirect'];
+          const pool =
+            'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+          const random = pool[Math.floor(Math.random() * pool.length)];
+          const path = URLExt.join(base, workspaces, `auto-${random}`);
 
           // Clone the originally requested workspace after redirecting.
           query['clone'] = workspace;
@@ -789,29 +788,5 @@ namespace Private {
         }
       });
     });
-  }
-
-  /**
-   * Returns a random string composed of characters in the range [A-Z,a-z].
-   *
-   * @param length - The desired length of the random token.
-   */
-  export function token(length: number): string {
-    const start = 'A'.charCodeAt(0);
-    const end = 'Z'.charCodeAt(0);
-    const delta = end - start;
-
-    return ' '
-      .repeat(length)
-      .split('')
-      .reduce(acc => {
-        // Pick a random character from range [start-end], inclusively.
-        const char = String.fromCharCode(
-          start + Math.round(Math.random() * delta)
-        );
-
-        // Switch case half the time and append to accumulator.
-        return acc + (Math.random() < 0.5 ? char : char.toLocaleLowerCase());
-      }, '');
   }
 }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -265,7 +265,7 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
           // Clone the originally requested workspace after redirecting.
           query['clone'] = workspace;
 
-          // Change the URL and trigger the router by triggering a hard reload.
+          // Change the URL and trigger a hard reload to re-route.
           const url = path + URLExt.objectToQueryString(query) + (hash || '');
           router.navigate(url, { hard: true, silent: true });
           return;

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -52,6 +52,12 @@ import '../style/index.css';
 const WORKSPACE_SAVE_DEBOUNCE_INTERVAL = 750;
 
 /**
+ * The query string parameter indicating that a workspace name should be
+ * automatically generated if the current request collides with an open session.
+ */
+const WORKSPACE_RESOLVE = 'resolve-workspace';
+
+/**
  * The interval in milliseconds before recover options appear during splash.
  */
 const SPLASH_RECOVER_TIMEOUT = 12000;
@@ -253,8 +259,8 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
       // that never resolves to prevent the application from loading plugins
       // that rely on `IWindowResolver`.
       return new Promise<IWindowResolver>(() => {
-        // If the user has requested `autoredirect` create a new workspace name.
-        if ('autoredirect' in query) {
+        // If the user has requested workspace resolution create a new one.
+        if (WORKSPACE_RESOLVE in query) {
           const { base, workspaces } = paths.urls;
           const pool =
             'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
@@ -276,10 +282,9 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
       });
     }
 
-    // If the user has requested `autoredirect` remove the query parameter.
-    if ('autoredirect' in query) {
-      // Maintain the query string parameters but remove `autoredirect`.
-      delete query['autoredirect'];
+    // If the user has requested workspace resolution remove the query param.
+    if (WORKSPACE_RESOLVE in query) {
+      delete query[WORKSPACE_RESOLVE];
 
       // Silently scrub the URL.
       const url = path + URLExt.objectToQueryString(query) + (hash || '');

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -456,8 +456,7 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
     commands.addCommand(CommandIDs.autoRedirect, {
       label: 'Redirect to New Workspace',
       execute: (args: IRouter.ILocation) => {
-        const { hash, search } = args;
-        const query = URLExt.queryStringToObject(search || '');
+        const query = URLExt.queryStringToObject(args.search || '');
         const autoredirect = 'autoredirect' in query;
 
         if (!autoredirect) {
@@ -468,15 +467,12 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
         delete query['autoredirect'];
 
         const { base, workspaces } = paths.urls;
-        const workspace = `auto-${Private.token(6)}`;
         const url =
-          URLExt.join(base, workspaces, workspace) +
+          URLExt.join(base, workspaces, `auto-${Private.token(6)}`) +
           URLExt.objectToQueryString(query) +
-          hash;
-        const hard = true;
-        const silent = true;
+          (args.hash || '');
 
-        router.navigate(url, { hard, silent });
+        router.navigate(url, { hard: true, silent: true });
       }
     });
 


### PR DESCRIPTION
This adds support for a query string parameter called `autoredirect` which will redirect the user to a randomly generated workspace name of the form `auto-x` where `x` is randomly drawn from [A-Z,a-z,0-9].

The semantics of this functionality are:
* If `autoredirect` is added to the query string and there is no workspace collision, the user is not redirected. The `autoredirect` query string parameter is silently removed from the URL.
* If `autoredirect` is added to the query string and there is a workspace collision, the user is redirected to an auto-generated workspace. In this case, the originally requested workspace is cloned into the new auto-generated one. Afterward, the `autoredirect` parameter is scrubbed from the URL.
* The combination of these two behaviors means that if an auto-generated name `auto-A` already exists, another auto-generated name will be picked at random. The pathological case is if the user has 62 randomly generated tabs open. The 63rd randomly generated tab will get stuck in an endless loop of trying to create an auto-generated name. This seems like an acceptable outcome. The benefit of this is that all auto-generated names are very short.

Fixes https://github.com/jupyterlab/jupyterlab/issues/5854