### PR TITLE
Make environment.yml dev-mode focused

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,40 @@
+#   A JupyterLab development environment for Windows, Linux and MacOSX
+
+name: jupyterlab-dev
+
+#   conda env update -p .env                # Install/update the env
+#   conda activate -p .env                  # Activate the env
+#   pip install -e .                        # Install source in local python
+#   jupyter serverextension enable --py jupyterlab --sys-prefix  # serverextension
+#   jlpm                                    # Install frontend build dependencies
+#   jlpm build                              # Build the dev mode assets
+#   jupyter lab --debug --dev-mode --watch  # Serve & watch/rebuild (optional)
+                                            #
+# We recommend conda-forge for developing Lab in conda
+channels:
+- conda-forge
+
+dependencies:
+## Serving
+- python >=3.7,<3.8
+- notebook >=4.3.1
+- jupyterlab_server >=0.2,<0.3
+
+## Frontend Building
+- nodejs >10,<11
+
+## Testing
+- pytest >=4.0,<5
+- requests
+
+## Documenting
+- sphinx
+- recommonmark
+- sphinx_rtd_theme
+# - graphviz                                # for buildutils/src/dependency-graph.ts
+
+
+## Not yet available from conda-forge
+- pip:
+  # Docs
+  - pytest-check-links


### PR DESCRIPTION
From https://github.com/jupyterlab/jupyterlab/pull/5952#discussion_r254558076

Adding a `/binder` directory over in that PR leaves the `environment.yml` free to be something more useful. @yuvipanda raises the point that we want that to be lean-and-mean, such that you would use it in the PR process, so every minute counts. Since we already _know_ binder has a usable environment (minus a few pip packages, and 700mb of `node_modules`, and a few minutes of webpack), it is unnecessary to even invoke the conda solver.

I'm not telling anyone they _have_ to use conda, and I know a number of core devs have some history with the brand, but we can't in good faith just have a `requirements.txt` or anticipate that new developers will wade through the CONTRIBUTING choose-you-own-adventure. And yes, you _could_ do this in a (docker|vagrant)file, but _I'm_ not going to write/maintain them :)

@ian-r-rose raises the point that this could easily stale: I'd see adding a `master`-only CI job that runs the env through its paces on linux/windows/osx, and could also add on this PR... but would use templates, so would like some feedback on where we'd want to put them. Anyhow, by being the master build, this would affect the badge, which would keep us honest.

A few remaining things I'd consider adding in:
- sphinx-auto-build
- graphviz (for `dependency-graph.ts`)