### PR TITLE
Remove extra padding from Mathjax display math.

### DIFF
--- a/packages/mathjax2/style/index.css
+++ b/packages/mathjax2/style/index.css
@@ -11,6 +11,5 @@
 
 /* Left-justify the MathJax display equation in cell outputs. */
 .jp-OutputArea-output.jp-RenderedLatex .MathJax_Display {
-  padding: var(--jp-code-padding);
   text-align: left !important;
 }


### PR DESCRIPTION
This fixes #5949 removing extra padding added to Mathjax display math by mathjax2 package stylesheet.

Cheers

