### PR TITLE
[WIP] Use lab's css variables for statusbar colors

### DIFF
--- a/packages/statusbar/src/style/variables.ts
+++ b/packages/statusbar/src/style/variables.ts
@@ -2,12 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 export default {
-  hoverColor: '#8a8a8a',
-  clickColor: '#a6a6a6',
-  backgroundColor: '#757575',
+  hoverColor: 'var(--jp-layout-color2)',
+  clickColor: 'var(--jp-brand-color1)',
+  backgroundColor: 'var(--jp-layout-color1)',
   height: '24px',
   fontSize: 'var(--jp-ui-font-size1)',
-  textColor: '#EEEEEE',
+  textColor: 'var(--jp-ui-font-color1)',
   itemMargin: '2px',
   itemPadding: '6px',
   textIconHalfSpacing: '3px',


### PR DESCRIPTION
The statusbar's colors are currently hard-coded so they won't necessarily place nice with themes in the future. 

Dark theme before:

![image](https://user-images.githubusercontent.com/512354/52431381-f8ecd680-2abc-11e9-8e3e-bfe7d40e079f.png)

Dark theme after:

![image](https://user-images.githubusercontent.com/512354/52431304-cfcc4600-2abc-11e9-98e7-1c5dbf7e5442.png)

Atom dark theme (in development) before:

![image](https://user-images.githubusercontent.com/512354/52431415-0ace7980-2abd-11e9-91c7-61381cef84d4.png)

Atom dark theme (in development) after:

![image](https://user-images.githubusercontent.com/512354/52431261-bf1bd000-2abc-11e9-8e0d-a8c4faf407b3.png)
