### PR TITLE
Expose an instance tracker token for the HTML viewer.

### DIFF
--- a/packages/htmlviewer-extension/src/index.tsx
+++ b/packages/htmlviewer-extension/src/index.tsx
@@ -13,7 +13,11 @@ import { ICommandPalette, InstanceTracker } from '@jupyterlab/apputils';
 
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 
-import { HTMLViewer, HTMLViewerFactory } from '@jupyterlab/htmlviewer';
+import {
+  HTMLViewer,
+  HTMLViewerFactory,
+  IHTMLViewerTracker
+} from '@jupyterlab/htmlviewer';
 
 /**
  * The CSS class for an HTML5 icon.
@@ -32,9 +36,10 @@ namespace CommandIDs {
 /**
  * The HTML file handler extension.
  */
-const htmlPlugin: JupyterFrontEndPlugin<void> = {
+const htmlPlugin: JupyterFrontEndPlugin<IHTMLViewerTracker> = {
   activate: activateHTMLViewer,
   id: '@jupyterlab/htmlviewer-extension:plugin',
+  provides: IHTMLViewerTracker,
   optional: [ICommandPalette, ILayoutRestorer],
   autoStart: true
 };
@@ -46,7 +51,7 @@ function activateHTMLViewer(
   app: JupyterFrontEnd,
   palette: ICommandPalette | null,
   restorer: ILayoutRestorer | null
-): void {
+): IHTMLViewerTracker {
   // Add an HTML file type to the docregistry.
   const ft: DocumentRegistry.IFileType = {
     name: 'html',
@@ -126,6 +131,8 @@ function activateHTMLViewer(
       category: 'File Operations'
     });
   }
+
+  return tracker;
 }
 /**
  * Export the plugins as default.

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -31,6 +31,7 @@
     "@jupyterlab/apputils": "^1.0.0-alpha.3",
     "@jupyterlab/coreutils": "^3.0.0-alpha.3",
     "@jupyterlab/docregistry": "^1.0.0-alpha.3",
+    "@phosphor/coreutils": "^1.3.0",
     "@phosphor/signaling": "^1.2.2",
     "react": "~16.4.2"
   },

--- a/packages/htmlviewer/src/index.tsx
+++ b/packages/htmlviewer/src/index.tsx
@@ -5,6 +5,7 @@
 
 import {
   IFrame,
+  IInstanceTracker,
   ReactWidget,
   ToolbarButton,
   ToolbarButtonComponent,
@@ -20,12 +21,25 @@ import {
   IDocumentWidget
 } from '@jupyterlab/docregistry';
 
+import { Token } from '@phosphor/coreutils';
+
 import { ISignal, Signal } from '@phosphor/signaling';
 
 import * as React from 'react';
 
 import '../style/index.css';
 
+/**
+ * A class that tracks HTML viewer widgets.
+ */
+export interface IHTMLViewerTracker extends IInstanceTracker<HTMLViewer> {}
+
+/**
+ * The HTML viewer tracker token.
+ */
+export const IHTMLViewerTracker = new Token<IHTMLViewerTracker>(
+  '@jupyterlab/htmlviewer:IHTMLViewerTracker'
+);
 /**
  * The timeout to wait for change activity to have ceased before rendering.
  */


### PR DESCRIPTION
Follow up to #5855. Exposes a tracker token so extensions can interact with these documents.