### PR TITLE
Inherit terminal theme from lab theme

### DIFF
--- a/docs/source/developer/adding_content.rst
+++ b/docs/source/developer/adding_content.rst
@@ -16,8 +16,6 @@ As an example: Add a leaflet viewer plugin for geoJSON files.
 -  If there are no typings, we must create our own. An example typings
    file that exports functions is
    `codemirror <https://github.com/jupyterlab/jupyterlab/blob/master/packages/codemirror/typings/codemirror/codemirror.d.ts>`__.
-   An example with a class is
-   `vdom <https://github.com/jupyterlab/jupyterlab/blob/master/packages/vdom-extension/src/transform-vdom.d.ts>`__.
 
 -  Add a reference to the new library in ``src/typings.d.ts``.
 

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -36,7 +36,8 @@
     "@jupyterlab/coreutils": "^3.0.0-alpha.3",
     "@jupyterlab/launcher": "^1.0.0-alpha.3",
     "@jupyterlab/mainmenu": "^1.0.0-alpha.3",
-    "@jupyterlab/terminal": "^1.0.0-alpha.3"
+    "@jupyterlab/terminal": "^1.0.0-alpha.3",
+    "@phosphor/widgets": "^1.6.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -42,12 +42,6 @@
       "$ref": "#/definitions/lineHeight",
       "default": 1.0
     },
-    "theme": {
-      "title": "Theme",
-      "description": "The theme for the terminal.",
-      "$ref": "#/definitions/theme",
-      "default": "dark"
-    },
     "scrollback": {
       "title": "Scrollback Buffer",
       "description": "The amount of scrollback beyond initial viewport",

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -17,7 +17,7 @@
       "minimum": 1.0
     },
     "theme": {
-      "enum": ["dark", "light"]
+      "enum": ["dark", "light", "inherit"]
     },
     "scrollback": {
       "type": "number"
@@ -41,6 +41,12 @@
       "description": "The line height used to render text.",
       "$ref": "#/definitions/lineHeight",
       "default": 1.0
+    },
+    "theme": {
+      "title": "Theme",
+      "description": "The theme for the terminal.",
+      "$ref": "#/definitions/theme",
+      "default": "inherit"
     },
     "scrollback": {
       "title": "Scrollback Buffer",

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -10,6 +10,7 @@ import {
 import {
   ICommandPalette,
   InstanceTracker,
+  IThemeManager,
   MainAreaWidget
 } from '@jupyterlab/apputils';
 
@@ -51,7 +52,13 @@ const plugin: JupyterFrontEndPlugin<ITerminalTracker> = {
   id: '@jupyterlab/terminal-extension:plugin',
   provides: ITerminalTracker,
   requires: [ISettingRegistry],
-  optional: [ICommandPalette, ILauncher, ILayoutRestorer, IMainMenu],
+  optional: [
+    ICommandPalette,
+    ILauncher,
+    ILayoutRestorer,
+    IMainMenu,
+    IThemeManager
+  ],
   autoStart: true
 };
 
@@ -69,7 +76,8 @@ function activate(
   palette: ICommandPalette | null,
   launcher: ILauncher | null,
   restorer: ILayoutRestorer | null,
-  mainMenu: IMainMenu | null
+  mainMenu: IMainMenu | null,
+  themeManager: IThemeManager
 ): ITerminalTracker {
   const { serviceManager } = app;
   const category = 'Terminal';
@@ -140,6 +148,14 @@ function activate(
     .catch((reason: Error) => {
       console.error(reason.message);
     });
+
+  // Subscribe to changes in theme.
+  themeManager.themeChanged.connect((sender, args) => {
+    tracker.forEach(widget => {
+      const terminal = widget.content;
+      terminal.setOption('theme', args.newValue as 'light' | 'dark');
+    });
+  });
 
   addCommands(app, tracker, settingRegistry);
 

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -35,8 +35,6 @@ namespace CommandIDs {
   export const increaseFont = 'terminal:increase-font';
 
   export const decreaseFont = 'terminal:decrease-font';
-
-  export const toggleTheme = 'terminal:toggle-theme';
 }
 
 /**
@@ -161,13 +159,11 @@ function activate(
 
   if (mainMenu) {
     // Add some commands to the application view menu.
-    const viewGroup = [
-      CommandIDs.increaseFont,
-      CommandIDs.decreaseFont,
-      CommandIDs.toggleTheme
-    ].map(command => {
-      return { command };
-    });
+    const viewGroup = [CommandIDs.increaseFont, CommandIDs.decreaseFont].map(
+      command => {
+        return { command };
+      }
+    );
     mainMenu.settingsMenu.addGroup(viewGroup, 40);
 
     // Add terminal creation to the file menu.
@@ -180,8 +176,7 @@ function activate(
       CommandIDs.createNew,
       CommandIDs.refresh,
       CommandIDs.increaseFont,
-      CommandIDs.decreaseFont,
-      CommandIDs.toggleTheme
+      CommandIDs.decreaseFont
     ].forEach(command => {
       palette.addItem({ command, category, args: { isPalette: true } });
     });
@@ -309,20 +304,6 @@ export function addCommands(
           .set(plugin.id, 'fontSize', fontSize - 1)
           .catch(showErrorMessage);
       }
-    }
-  });
-
-  commands.addCommand(CommandIDs.toggleTheme, {
-    label: 'Use Dark Terminal Theme',
-    caption: 'Whether to use the dark terminal theme',
-    isToggled: () => Terminal.defaultOptions.theme === 'dark',
-    execute: () => {
-      let { theme } = Terminal.defaultOptions;
-      theme = theme === 'dark' ? 'light' : 'dark';
-      return settingRegistry
-        .set(plugin.id, 'theme', theme)
-        .then(() => commands.notifyCommandChanged(CommandIDs.toggleTheme))
-        .catch(showErrorMessage);
     }
   });
 }

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -37,14 +37,9 @@ export class Terminal extends Widget {
     this._options = { ...Terminal.defaultOptions, ...options };
 
     const { initialCommand, theme, ...other } = this._options;
-    const { lightTheme, darkTheme } = Private;
-    const xtermTheme = theme === 'light' ? lightTheme : darkTheme;
-    const xtermOptions = { theme: xtermTheme, ...other };
+    const xtermOptions = { theme: Private.getCurrentTheme(), ...other };
 
     this.addClass(TERMINAL_CLASS);
-    if (theme === 'light') {
-      this.addClass('jp-mod-light');
-    }
 
     // Create the xterm.
     this._term = new Xterm(xtermOptions);
@@ -114,13 +109,7 @@ export class Terminal extends Widget {
     }
 
     if (option === 'theme') {
-      if (value === 'light') {
-        this.addClass('jp-mod-light');
-        this._term.setOption('theme', Private.lightTheme);
-      } else {
-        this.removeClass('jp-mod-light');
-        this._term.setOption('theme', Private.darkTheme);
-      }
+      this._term.setOption('theme', Private.getCurrentTheme());
     } else {
       this._term.setOption(option, value);
       this._needsResize = true;
@@ -332,7 +321,7 @@ export namespace Terminal {
     /**
      * The theme of the terminal.
      */
-    theme: Theme;
+    theme: 'light' | 'dark' | ITheme;
 
     /**
      * The amount of buffer scrollback to be used
@@ -355,7 +344,7 @@ export namespace Terminal {
    * The default options used for creating terminals.
    */
   export const defaultOptions: IOptions = {
-    theme: 'dark',
+    theme: 'light',
     fontFamily: 'courier-new, courier, monospace',
     fontSize: 13,
     lineHeight: 1.0,
@@ -367,7 +356,13 @@ export namespace Terminal {
   /**
    * A type for the terminal theme.
    */
-  export type Theme = 'light' | 'dark';
+  export interface ITheme {
+    foreground: string;
+    background: string;
+    cursor: string;
+    cursorAccent: string;
+    selection: string;
+  }
 }
 
 /**
@@ -380,24 +375,25 @@ namespace Private {
   export let id = 0;
 
   /**
-   * The light terminal theme.
+   * The current theme.
    */
-  export const lightTheme = {
-    foreground: '#000',
-    background: '#fff',
-    cursor: '#616161', // md-grey-700
-    cursorAccent: '#F5F5F5', // md-grey-100
-    selection: 'rgba(97, 97, 97, 0.3)' // md-grey-700
-  };
-
-  /**
-   * The dark terminal theme.
-   */
-  export const darkTheme = {
-    foreground: '#fff',
-    background: '#000',
-    cursor: '#fff',
-    cursorAccent: '#000',
-    selection: 'rgba(255, 255, 255, 0.3)'
-  };
+  export function getCurrentTheme(): Terminal.ITheme {
+    return {
+      foreground: getComputedStyle(document.body).getPropertyValue(
+        '--jp-ui-font-color0'
+      ),
+      background: getComputedStyle(document.body).getPropertyValue(
+        '--jp-layout-color0'
+      ),
+      cursor: getComputedStyle(document.body).getPropertyValue(
+        '--jp-ui-font-color1'
+      ),
+      cursorAccent: getComputedStyle(document.body).getPropertyValue(
+        '--jp-ui-inverse-font-color0'
+      ),
+      selection: getComputedStyle(document.body).getPropertyValue(
+        '--jp-ui-font-color3'
+      )
+    };
+  }
 }

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -358,7 +358,7 @@ export namespace Terminal {
   /**
    * A type for the terminal theme.
    */
-  export type ITheme = 'light' | 'dark' | 'inherit' | string;
+  export type ITheme = 'light' | 'dark' | 'inherit';
 
   /**
    * A type for the terminal theme.

--- a/packages/terminal/style/index.css
+++ b/packages/terminal/style/index.css
@@ -8,11 +8,6 @@
 .jp-Terminal {
   min-width: 240px;
   min-height: 120px;
-  background: black;
-}
-
-.jp-Terminal.jp-mod-light {
-  background: white;
 }
 
 .jp-Terminal-body {

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -120,10 +120,10 @@ all of MD as it is not optimized for dense, information rich UIs.
    */
 
   /* Defaults use Material Design specification */
-  --jp-ui-font-color0: white;
-  --jp-ui-font-color1: var(--md-grey-300);
-  --jp-ui-font-color2: var(--md-grey-500);
-  --jp-ui-font-color3: var(--md-grey-700);
+  --jp-ui-font-color0: rgba(255, 255, 255, 1);
+  --jp-ui-font-color1: rgba(255, 255, 255, 0.87);
+  --jp-ui-font-color2: rgba(255, 255, 255, 0.54);
+  --jp-ui-font-color3: rgba(255, 255, 255, 0.38);
 
   /*
    * Use these against the brand/accent/warn/error colors.

--- a/tests/test-terminal/src/terminal.spec.ts
+++ b/tests/test-terminal/src/terminal.spec.ts
@@ -105,8 +105,8 @@ describe('terminal/index', () => {
     });
 
     describe('#theme', () => {
-      it('should be dark by default', () => {
-        expect(widget.getOption('theme')).to.equal('dark');
+      it('should be set to inherit by default', () => {
+        expect(widget.getOption('theme')).to.equal('inherit');
       });
 
       it('should be light if we change it', () => {
@@ -180,7 +180,7 @@ describe('terminal/index', () => {
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
         expect(widget.methods).to.contain('onUpdateRequest');
         const style = window.getComputedStyle(widget.node);
-        expect(style.backgroundColor).to.equal('rgb(0, 0, 0)');
+        expect(style.backgroundColor).to.equal('rgba(0, 0, 0, 0)');
       });
     });
 


### PR DESCRIPTION
This provides the terminal with a theme based on the current lab theme's CSS variables and removes the setting, command, and menu item for toggling the terminal theme light/dark. This simplifies things for the user and has the added benefit of the terminal theme playing nice with themes other than the official light/dark.

Another option: We can provide a new CSS variable or set of variables for the terminal theme. This would allow themes to have a little more control over the terminal theme (vs. defaulting to general variables like `--jp-layout-color0` and `--jp-font-color0`). I'm starting work on refactoring the CSS theme variables (https://github.com/jupyterlab/jupyterlab/issues/5549) and this may be a good place to refactor. 

![](http://g.recordit.co/oIZkvzHZqv.gif)