### PR TITLE
Make sure API docs are output to the right directory.

### DIFF
--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -130,6 +130,15 @@ export async function ensurePackage(
     }
   });
 
+  // Handle typedoc config output.
+  const tdOptionsPath = path.join(pkgPath, 'tdoptions.json');
+  if (fs.existsSync(tdOptionsPath)) {
+    const tdConfigData = utils.readJSONFile(tdOptionsPath);
+    const pkgDirName = pkgPath.split('/').pop();
+    tdConfigData['out'] = `../../docs/api/${pkgDirName}`;
+    utils.writeJSONFile(tdOptionsPath, tdConfigData);
+  }
+
   // Handle references.
   let references: { [key: string]: string } = Object.create(null);
   Object.keys(deps).forEach(name => {

--- a/packages/htmlviewer-extension/tdoptions.json
+++ b/packages/htmlviewer-extension/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/observables",
+  "out": "../../docs/api/htmlviewer-extension",
   "baseUrl": ".",
   "paths": {
     "@jupyterlab/*": ["../packages/*"]

--- a/packages/htmlviewer/tdoptions.json
+++ b/packages/htmlviewer/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/observables",
+  "out": "../../docs/api/htmlviewer",
   "baseUrl": ".",
   "paths": {
     "@jupyterlab/*": ["../packages/*"]

--- a/packages/markdownviewer/tdoptions.json
+++ b/packages/markdownviewer/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/imageviewer",
+  "out": "../../docs/api/markdownviewer",
   "baseUrl": ".",
   "paths": {
     "@jupyterlab/*": ["../packages/*"]

--- a/packages/statusbar/tdoptions.json
+++ b/packages/statusbar/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/statusbar-extension",
+  "out": "../../docs/api/statusbar",
   "baseUrl": ".",
   "paths": {
     "@jupyterlab/*": ["../packages/*"]


### PR DESCRIPTION
Some new packages were outputting the API docs to the wrong directories, which, in addition to being wrong, was breaking CI. This fixes those places and adds a check in the integrity script.