### PR TITLE
Update workspaces list method to conform to IDataConnector list method.

### DIFF
--- a/packages/services/src/workspace/index.ts
+++ b/packages/services/src/workspace/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { URLExt } from '@jupyterlab/coreutils';
+import { DataConnector, URLExt } from '@jupyterlab/coreutils';
 
 import { ReadonlyJSONObject } from '@phosphor/coreutils';
 
@@ -15,11 +15,12 @@ const SERVICE_WORKSPACES_URL = 'api/workspaces';
 /**
  * The workspaces API service manager.
  */
-export class WorkspaceManager {
+export class WorkspaceManager extends DataConnector<Workspace.IWorkspace> {
   /**
    * Create a new workspace manager.
    */
   constructor(options: WorkspaceManager.IOptions = {}) {
+    super();
     this.serverSettings =
       options.serverSettings || ServerConnection.makeSettings();
   }
@@ -56,7 +57,7 @@ export class WorkspaceManager {
    *
    * @returns A promise that resolves if successful.
    */
-  async list(): Promise<string[]> {
+  async list(): Promise<{ ids: string[]; values: Workspace.IWorkspace[] }> {
     const { serverSettings } = this;
     const { baseUrl, pageUrl } = serverSettings;
     const { makeRequest, ResponseError } = ServerConnection;

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup_args = dict(
 
 setup_args['install_requires'] = [
     'notebook>=4.3.1',
-    'jupyterlab_server>=0.2.0,<0.3.0'
+    'jupyterlab_server>=0.3.0,<0.4.0'
 ]
 
 setup_args['extras_require'] = {

--- a/tests/test-services/src/workspace/manager.spec.ts
+++ b/tests/test-services/src/workspace/manager.spec.ts
@@ -49,16 +49,17 @@ describe('workspace', () => {
       });
     });
 
-    // describe('#list()', async () => {
-    //   it('should fetch a workspace list supporting arbitrary IDs', async () => {
-    //     const ids = ['foo', 'bar', 'baz', 'f/o/o', 'b/a/r', 'b/a/z'];
+    describe('#list()', async () => {
+      it('should fetch a workspace list supporting arbitrary IDs', async () => {
+        const ids = ['foo', 'bar', 'baz', 'f/o/o', 'b/a/r', 'b/a/z'];
+        const promises = ids.map(id =>
+          manager.save(id, { data: {}, metadata: { id } })
+        );
 
-    //     ids.forEach(async id => {
-    //       await manager.save(id, { data: {}, metadata: { id } });
-    //     });
-    //     expect((await manager.list()).sort()).to.deep.equal(ids.sort());
-    //   });
-    // });
+        await Promise.all(promises);
+        expect((await manager.list()).ids.sort()).to.deep.equal(ids.sort());
+      });
+    });
 
     describe('#remove()', () => {
       it('should remove a workspace', async () => {


### PR DESCRIPTION
The `list()` method of the workspace service is updated to conform to the `IDataConnector` interface. While it is probably the case that nobody was using this method, since this is a backward-incompatible change, it requires a major version bump.

**NB** This PR has a hard dependency on https://github.com/jupyterlab/jupyterlab_server/pull/61, which means its tests will fail until a new version of `jupyterlab_server` is published and the dependency is bumped in this branch.