### PR TITLE
Restore cloned output

### DIFF
--- a/packages/apputils/src/instancetracker.ts
+++ b/packages/apputils/src/instancetracker.ts
@@ -53,6 +53,19 @@ export interface IInstanceTracker<T extends Widget> extends IDisposable {
   readonly size: number;
 
   /**
+   * A promise that is resolved when the instance tracker has been
+   * restored from a serialized state.
+   *
+   * #### Notes
+   * Most client code will not need to use this, since they can wait
+   * for the whole application to restore. However, if an extension
+   * wants to perform actions during the application restoration, but
+   * after the restoration of another instance tracker, they can use
+   * this promise.
+   */
+  readonly restored: Promise<void>;
+
+  /**
    * Find the first widget in the tracker that satisfies a filter function.
    *
    * @param - fn The filter function to call on each widget.

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -44,10 +44,10 @@
     "@jupyterlab/rendermime": "^1.0.0-alpha.3",
     "@jupyterlab/services": "^4.0.0-alpha.3",
     "@jupyterlab/statusbar": "^1.0.0-alpha.3",
+    "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/properties": "^1.1.2",
     "@phosphor/widgets": "^1.6.0"
   },
   "devDependencies": {

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -36,6 +36,7 @@
     "@jupyterlab/cells": "^1.0.0-alpha.3",
     "@jupyterlab/codeeditor": "^1.0.0-alpha.3",
     "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+    "@jupyterlab/docmanager": "^1.0.0-alpha.3",
     "@jupyterlab/filebrowser": "^1.0.0-alpha.3",
     "@jupyterlab/launcher": "^1.0.0-alpha.3",
     "@jupyterlab/mainmenu": "^1.0.0-alpha.3",
@@ -46,6 +47,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
+    "@phosphor/properties": "^1.1.2",
     "@phosphor/widgets": "^1.6.0"
   },
   "devDependencies": {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -535,7 +535,7 @@ function activateNotebookHandler(
         path: widget.content.path,
         index: widget.content.index
       }),
-      name: widget => `${widget.path}:${widget.index}`,
+      name: widget => `${widget.content.path}:${widget.content.index}`,
       when: tracker.restored
     });
   }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -536,7 +536,7 @@ function activateNotebookHandler(
         index: widget.content.index
       }),
       name: widget => `${widget.content.path}:${widget.content.index}`,
-      when: tracker.restored
+      when: tracker.restored // After the notebook widgets (but not contents).
     });
   }
 

--- a/packages/notebook-extension/tsconfig.json
+++ b/packages/notebook-extension/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../coreutils"
     },
     {
+      "path": "../docmanager"
+    },
+    {
       "path": "../filebrowser"
     },
     {


### PR DESCRIPTION
Fixes #5976.

This restores cloned output areas. It is kind of a tricky proposition, since the output areas are not available to clone until the notebook is actually loaded. Furthermore, if there are unsaved changes in the notebook (especially cell reorderings), this will restore the wrong output area, or none at all. So really, this should be considered as fixing #5976 on a reasonably-good-effort basis. It's not particularly clean, but it should work for the most common use-cases.