### PR TITLE
Fix completer regression

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -241,6 +241,17 @@ export class Completer extends Widget {
       return;
     }
 
+    // If there is only one option, signal and bail.
+    // We don't test the filtered `items`, as that
+    // is too aggressive of completer behavior, it can
+    // lead to double typing of an option.
+    const options = toArray(model.options());
+    if (options.length === 1) {
+      this._selected.emit(options[0]);
+      this.reset();
+      return;
+    }
+
     // Clear the node.
     let node = this.node;
     node.textContent = '';

--- a/tests/test-completer/src/widget.spec.ts
+++ b/tests/test-completer/src/widget.spec.ts
@@ -615,6 +615,43 @@ describe('completer/widget', () => {
     });
 
     describe('#onUpdateRequest()', () => {
+      it('should emit a selection if there is only one match', () => {
+        let anchor = createEditorWidget();
+        let model = new CompleterModel();
+        let coords = { left: 0, right: 0, top: 100, bottom: 120 };
+        let request: Completer.ITextState = {
+          column: 0,
+          lineHeight: 0,
+          charWidth: 0,
+          line: 0,
+          coords: coords as CodeEditor.ICoordinate,
+          text: 'f'
+        };
+
+        let value = '';
+        let options: Completer.IOptions = {
+          editor: anchor.editor,
+          model
+        };
+        let listener = (sender: any, selected: string) => {
+          value = selected;
+        };
+
+        Widget.attach(anchor, document.body);
+        model.original = request;
+        model.setOptions(['foo']);
+
+        let widget = new Completer(options);
+        widget.selected.connect(listener);
+        Widget.attach(widget, document.body);
+
+        expect(value).to.equal('');
+        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+        expect(value).to.equal('foo');
+        widget.dispose();
+        anchor.dispose();
+      });
+
       it('should do nothing if a model does not exist', () => {
         let widget = new LogWidget({ editor: null });
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);


### PR DESCRIPTION
Fixes a regression in completer behavior from #5858. This partially reverts ca49864, which prevented completion from taking place when there was only one match. The desired behavior, which this now implements, is:
1. If there is *exactly one* in the completion request, automatically complete with that.
2. If there are multiple matches, but they are filtered down to one by subsequent typing, don't complete with that unless the user explicitly selects it.

