### PR TITLE
Avoid activating the non-current widget after navigating to cwd

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -301,7 +301,7 @@ function activateBrowser(
           const { path } = context;
           Private.navigateToPath(path, factory)
             .then(() => {
-              docManager.findWidget(path).activate();
+              labShell.currentWidget.activate();
             })
             .catch((reason: any) => {
               console.warn(


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/5987
