### PR TITLE
add ability to toggle status bar visibility

### DIFF
--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -37,8 +37,10 @@
     "@jupyterlab/apputils": "^1.0.0-alpha.3",
     "@jupyterlab/cells": "^1.0.0-alpha.3",
     "@jupyterlab/console": "^1.0.0-alpha.3",
+    "@jupyterlab/coreutils": "^3.0.0-alpha.3",
     "@jupyterlab/docregistry": "^1.0.0-alpha.3",
     "@jupyterlab/fileeditor": "^1.0.0-alpha.3",
+    "@jupyterlab/mainmenu": "^1.0.0-alpha.3",
     "@jupyterlab/notebook": "^1.0.0-alpha.4",
     "@jupyterlab/statusbar": "^1.0.0-alpha.3",
     "@phosphor/widgets": "^1.6.0"

--- a/packages/statusbar-extension/schema/plugin.json
+++ b/packages/statusbar-extension/schema/plugin.json
@@ -25,7 +25,7 @@
     "visible": {
       "type": "boolean",
       "title": "Status Bar Visibility",
-      "description": "Whether to show status bar at launch",
+      "description": "Whether to show status bar or not",
       "default": true
     }
   },

--- a/packages/statusbar-extension/schema/plugin.json
+++ b/packages/statusbar-extension/schema/plugin.json
@@ -21,6 +21,12 @@
         "memory-usage-item",
         "saving-status-item"
       ]
+    },
+    "visible": {
+      "type": "boolean",
+      "title": "Status Bar Visibility",
+      "description": "Whether to show status bar at launch",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -70,7 +70,7 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
     }
 
     const category: string = 'Main Area';
-    const command: string = 'toggle-jp-main-statusbar';
+    const command: string = 'statusbar:toggle';
 
     app.commands.addCommand(command, {
       label: 'Show Status Bar',

--- a/packages/statusbar-extension/tsconfig.json
+++ b/packages/statusbar-extension/tsconfig.json
@@ -19,10 +19,16 @@
       "path": "../console"
     },
     {
+      "path": "../coreutils"
+    },
+    {
       "path": "../docregistry"
     },
     {
       "path": "../fileeditor"
+    },
+    {
+      "path": "../mainmenu"
     },
     {
       "path": "../notebook"


### PR DESCRIPTION
Fixes #5982 

- Adds a menu item into View menu and a Command Palette command to toggle Status Bar visibility
- Selection is persisted using `settingRegistry`

![status-bar-toggle](https://user-images.githubusercontent.com/40003442/52827524-0b957b80-307a-11e9-8bc5-ca812d3fdce3.png)

