### PR TITLE
Add MathJax "begingroup" extension

### DIFF
--- a/packages/mathjax2/src/index.ts
+++ b/packages/mathjax2/src/index.ts
@@ -94,6 +94,9 @@ export class MathJaxTypesetter implements IRenderMime.ILatexTypesetter {
         styles: { '.MathJax_Display': { margin: 0 } },
         linebreaks: { automatic: true }
       },
+      TeX: {
+        extensions: ['newcommand.js', 'begingroup.js'] // Support for \gdef
+      },
       skipStartupTypeset: true
     });
     MathJax.Hub.Configured();


### PR DESCRIPTION
This enables support for `\gdef`, which allows defining LaTeX macros that also work when exported to LaTeX.

This was already suggested in this very old issue from the Classic Notebook: https://github.com/jupyter/notebook/issues/490#issuecomment-151687209

The MathJax docs only mention `\def`: http://docs.mathjax.org/en/latest/tex.html#defining-tex-macros

But when processed with LaTeX, if `\def` is enclosed in `$` signs, it doesn't have an effect outside the current math expression.

Therefore, when exporting to LaTeX/PDF, the equations are broken.

In LaTeX, one would normally use `\def` without wrapping it in `$`signs, but this doesn't work in MathJax.

The solution is to use `\gdef`, which makes the definitions visible in the following math expressions.

Sadly, support for `\gdef` isn't enabled by default in MathJax, that's where my PR comes in.

Here's an example for a definition that works in JupyterLab and in the exported PDF file, too:

```
<div hidden>

$\gdef\vec#1{\boldsymbol{#1}}$

\vskip-\parskip
\vskip-\baselineskip

</div>
```

A usage of this definition could e.g. look like: `$\vec{a}$`.

This is a bit complicated, but it is the easiest way I could come up with that allows using the same definition in HTML and PDF.

If anybody knows an easier way how to achieve that, please let me know!