### PR TITLE
Add a note about WebPack and watches to the extension dev docs

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -165,7 +165,8 @@ the CSS files) are watched by the WebPack process. This means that if
 your extension is in TypeScript you'll have to run a ``jlpm run build``
 before the changes will be reflected in JupyterLab. To avoid this step
 you can also watch the TypeScript sources in your extension which is
-usually assigned to the ``tsc -w`` shortcut.
+usually assigned to the ``tsc -w`` shortcut. If WebPack doesn't seem to
+detect the changes, this can be related to `the number of available watches <https://github.com/webpack/docs/wiki/troubleshooting#not-enough-watchers>`__.
 
 Note that the application is built against **released** versions of the
 core JupyterLab extensions. If your extension depends on JupyterLab


### PR DESCRIPTION
Add a note to the Extension Developer Guide about the number of file watches and WebPack.

The default limit can be reached when working on several extensions at the same time, and the problem might not be self-evident.
