### PR TITLE
[WIP] Limit overly aggressive API polling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# need sudo to remove yarn from path
+# https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
+sudo: required
+dist: trusty
+
+language: python
+python: 3.6
+cache:
+  pip: true
+  directories:
+    - /home/travis/.yarn-cache/
+matrix:
+  include:
+  - env: GROUP=js
+  - env: GROUP=integrity
+  - env: GROUP=python
+  - env: GROUP=cli
+    python: 3.5
+  - env: GROUP=docs
+env:
+  global:
+    - GH_REF=github.com/jupyterlab/jupyterlab.git
+    - YARN_CACHE_FOLDER=/home/travis/.yarn-cache/
+    - secure: MWpTI6cj3/Bnmtrr0Oqlp2JeWqDneB9aEjlQDaRxLOkqVbxhqDcYW9qAgZZP+sq29vT5oVMWzyCirteKxJfG2vy3HQE1XNLhz82Sf/7sE6DQ51gohl0CcOeA/uA8hCXEw97hneFWsZgHKqSoch7nVDsE3qfYgO+930jHlnxYApJGP9hZFv2Q2NVa6+99kipEYS4BY/yBDYKy6/t4kXcnBrUlNaPtdjnXcrY9esLZ7EQtkaG5VqcQVIBaLJKGF5Q7Aufj5nCFaZ6hZDF1Bi/AbmIbVWFyiT+22i8DZK6YwenECckyzoWkl+bEhYepWsgBKh/BDgPBAmPWKHgU5V4apDaGqZBhF7FP6H02AdZYYuCwl47jyakqvWLZW7oDmorL+HsWG5HQ3m0tMT2ywdbwNOiD39tiPPXjsvROh5ys9vL6NzQvxILCeEOnzcZrFuxi2LGEZfnlqRIjkh1llUAvNc3mOycRLWDOwVQa2+U59qDRXCSY2RD+MOfcdFUGengVujTMaAPMBUa3E33/ZIOOKJtR5TIajYZvd9B2uDlz02QfvTK+hrTaNYJjRZ8WCaeSM/CIKdoLw+29MNO6eqtchw0/vNvM8c9EkhrhMQKcY04OecVhmZkemFhd4SD5l92VX3z3xSxLkmazfNkj3CigWDXNxfDd2ORoGjA46Pga8RM=
+install:
+- bash ./scripts/travis_install.sh
+script:
+- bash ./scripts/travis_script.sh
+after_success:
+- bash ./scripts/travis_after_success.sh

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -3,6 +3,8 @@
 
 import { ArrayExt, each, map, toArray } from '@phosphor/algorithm';
 
+import { DisposableSet } from '@phosphor/disposable';
+
 import { PromiseDelegate } from '@phosphor/coreutils';
 
 import { Message, MessageLoop } from '@phosphor/messaging';
@@ -95,6 +97,8 @@ export class Dialog<T> extends Widget {
 
     this._primary = this._buttonNodes[this._defaultButton];
     this._focusNodeSelector = options.focusNodeSelector;
+
+    Private.register(this);
   }
 
   /**
@@ -336,7 +340,7 @@ export class Dialog<T> extends Widget {
   private _promise: PromiseDelegate<Dialog.IResult<T>> | null;
   private _defaultButton: number;
   private _host: HTMLElement;
-  private _body: Dialog.BodyType<T>;
+  private _body: Dialog.Body<T>;
   private _focusNodeSelector = '';
 }
 
@@ -345,55 +349,28 @@ export class Dialog<T> extends Widget {
  */
 export namespace Dialog {
   /**
-   * The options used to create a dialog.
+   * The body input types.
    */
-  export interface IOptions<T> {
-    /**
-     * The top level text for the dialog.  Defaults to an empty string.
-     */
-    title: HeaderType;
+  export type Body<T> = IBodyWidget<T> | React.ReactElement<any> | string;
 
-    /**
-     * The main body element for the dialog or a message to display.
-     * Defaults to an empty string.
-     *
-     * #### Notes
-     * If a widget is given as the body, it will be disposed after the
-     * dialog is resolved.  If the widget has a `getValue()` method,
-     * the method will be called prior to disposal and the value
-     * will be provided as part of the dialog result.
-     * A string argument will be used as raw `textContent`.
-     * All `input` and `select` nodes will be wrapped and styled.
-     */
-    body: BodyType<T>;
+  /**
+   * The header input types.
+   */
+  export type Header = React.ReactElement<any> | string;
 
-    /**
-     * The host element for the dialog. Defaults to `document.body`.
-     */
-    host: HTMLElement;
+  /**
+   * A simple type for prompt widget
+   */
+  type PromptValue = string | number | boolean;
 
+  /**
+   * A widget used as a dialog body.
+   */
+  export interface IBodyWidget<T = string> extends Widget {
     /**
-     * The to buttons to display. Defaults to cancel and accept buttons.
+     * Get the serialized value of the widget.
      */
-    buttons: ReadonlyArray<IButton>;
-
-    /**
-     * The index of the default button.  Defaults to the last button.
-     */
-    defaultButton: number;
-
-    /**
-     * A selector for the primary element that should take focus in the dialog.
-     * Defaults to an empty string, causing the [[defaultButton]] to take
-     * focus.
-     */
-    focusNodeSelector: string;
-
-    /**
-     * An optional renderer for dialog items.  Defaults to a shared
-     * default renderer.
-     */
-    renderer: IRenderer;
+    getValue?(): T;
   }
 
   /**
@@ -437,84 +414,55 @@ export namespace Dialog {
   }
 
   /**
-   * The options used to create a button.
+   * The options used to create a dialog.
    */
-  export type ButtonOptions = Partial<IButton>;
-
-  /**
-   * The header input types.
-   */
-  export type HeaderType = React.ReactElement<any> | string;
-
-  /**
-   * The result of a dialog.
-   */
-  export interface IResult<T> {
+  export interface IOptions<T> {
     /**
-     * The button that was pressed.
+     * The top level text for the dialog.  Defaults to an empty string.
      */
-    button: IButton;
+    title: Header;
 
     /**
-     * The value retrieved from `.getValue()` if given on the widget.
+     * The main body element for the dialog or a message to display.
+     * Defaults to an empty string.
+     *
+     * #### Notes
+     * If a widget is given as the body, it will be disposed after the
+     * dialog is resolved.  If the widget has a `getValue()` method,
+     * the method will be called prior to disposal and the value
+     * will be provided as part of the dialog result.
+     * A string argument will be used as raw `textContent`.
+     * All `input` and `select` nodes will be wrapped and styled.
      */
-    value: T | null;
-  }
+    body: Body<T>;
 
-  /**
-   * A widget used as a dialog body.
-   */
-  export interface IBodyWidget<T = string> extends Widget {
     /**
-     * Get the serialized value of the widget.
+     * The host element for the dialog. Defaults to `document.body`.
      */
-    getValue?(): T;
-  }
+    host: HTMLElement;
 
-  /**
-   * The body input types.
-   */
-  export type BodyType<T> = IBodyWidget<T> | React.ReactElement<any> | string;
+    /**
+     * The to buttons to display. Defaults to cancel and accept buttons.
+     */
+    buttons: ReadonlyArray<IButton>;
 
-  /**
-   * Create an accept button.
-   */
-  export function okButton(options: ButtonOptions = {}): Readonly<IButton> {
-    options.accept = true;
-    return createButton(options);
-  }
+    /**
+     * The index of the default button.  Defaults to the last button.
+     */
+    defaultButton: number;
 
-  /**
-   * Create a reject button.
-   */
-  export function cancelButton(options: ButtonOptions = {}): Readonly<IButton> {
-    options.accept = false;
-    return createButton(options);
-  }
+    /**
+     * A selector for the primary element that should take focus in the dialog.
+     * Defaults to an empty string, causing the [[defaultButton]] to take
+     * focus.
+     */
+    focusNodeSelector: string;
 
-  /**
-   * Create a warn button.
-   */
-  export function warnButton(options: ButtonOptions = {}): Readonly<IButton> {
-    options.displayType = 'warn';
-    return createButton(options);
-  }
-
-  /**
-   * Create a button item.
-   */
-  export function createButton(value: Dialog.ButtonOptions): Readonly<IButton> {
-    value.accept = value.accept !== false;
-    let defaultLabel = value.accept ? 'OK' : 'CANCEL';
-    return {
-      label: value.label || defaultLabel,
-      iconClass: value.iconClass || '',
-      iconLabel: value.iconLabel || '',
-      caption: value.caption || '',
-      className: value.className || '',
-      accept: value.accept,
-      displayType: value.displayType || 'default'
-    };
+    /**
+     * An optional renderer for dialog items.  Defaults to a shared
+     * default renderer.
+     */
+    renderer: IRenderer;
   }
 
   /**
@@ -528,7 +476,7 @@ export namespace Dialog {
      *
      * @returns A widget for the dialog header.
      */
-    createHeader(title: HeaderType): Widget;
+    createHeader(title: Header): Widget;
 
     /**
      * Create the body of the dialog.
@@ -537,7 +485,7 @@ export namespace Dialog {
      *
      * @returns A widget for the body.
      */
-    createBody(body: BodyType<any>): Widget;
+    createBody(body: Body<any>): Widget;
 
     /**
      * Create the footer of the dialog.
@@ -559,6 +507,145 @@ export namespace Dialog {
   }
 
   /**
+   * The result of a dialog.
+   */
+  export interface IResult<T> {
+    /**
+     * The button that was pressed.
+     */
+    button: IButton;
+
+    /**
+     * The value retrieved from `.getValue()` if given on the widget.
+     */
+    value: T | null;
+  }
+
+  /**
+   * Create a button item.
+   */
+  export function createButton(value: Partial<IButton>): Readonly<IButton> {
+    value.accept = value.accept !== false;
+    let defaultLabel = value.accept ? 'OK' : 'CANCEL';
+    return {
+      label: value.label || defaultLabel,
+      iconClass: value.iconClass || '',
+      iconLabel: value.iconLabel || '',
+      caption: value.caption || '',
+      className: value.className || '',
+      accept: value.accept,
+      displayType: value.displayType || 'default'
+    };
+  }
+
+  /**
+   * Create a reject button.
+   */
+  export function cancelButton(
+    options: Partial<IButton> = {}
+  ): Readonly<IButton> {
+    options.accept = false;
+    return createButton(options);
+  }
+
+  /**
+   * Create an accept button.
+   */
+  export function okButton(options: Partial<IButton> = {}): Readonly<IButton> {
+    options.accept = true;
+    return createButton(options);
+  }
+
+  /**
+   * Create a warn button.
+   */
+  export function warnButton(
+    options: Partial<IButton> = {}
+  ): Readonly<IButton> {
+    options.displayType = 'warn';
+    return createButton(options);
+  }
+
+  /**
+   * Simple dialog to prompt for a value
+   * @param prompt Text to show on the prompt
+   * @param defaultValue Initial value
+   * @returns a Promise which will resolve with the value entered by user.
+   */
+  export function prompt<T extends PromptValue>(
+    prompt: string,
+    defaultValue: PromptValue
+  ): Promise<Dialog.IResult<T>> {
+    return showDialog({
+      title: prompt,
+      body: new PromptWidget<T>(defaultValue as T),
+      buttons: [Dialog.cancelButton(), Dialog.okButton()],
+      focusNodeSelector: 'input'
+    });
+  }
+
+  /**
+   * Disposes all dialog instances.
+   *
+   * #### Notes
+   * This function should only be used in tests or cases where application state
+   * may be discarded.
+   */
+  export function nuke(): void {
+    Private.nuke();
+  }
+
+  /**
+   * Create and show a prompt dialog
+   */
+  class PromptWidget<T extends PromptValue> extends Widget {
+    constructor(value: T) {
+      let body = document.createElement('div');
+      let input = document.createElement('input');
+      if (typeof value === 'string') {
+        input.type = 'text';
+        if (value) {
+          input.value = value;
+        }
+      }
+      if (typeof value === 'number') {
+        input.type = 'number';
+        if (value) {
+          input.value = value.toFixed(2);
+        }
+      }
+      if (typeof value === 'boolean') {
+        input.type = 'checkbox';
+        input.checked = value;
+      }
+      body.appendChild(input);
+      super({ node: body });
+    }
+
+    /**
+     * Get the input text node.
+     */
+    get inputNode(): HTMLInputElement {
+      return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
+    }
+
+    /**
+     * Get the value of the widget.
+     */
+    getValue(): T {
+      if (this.inputNode.type === 'number') {
+        // In this branch T extends number.
+        return parseFloat(this.inputNode.value) as T;
+      }
+      if (this.inputNode.type === 'checkbox') {
+        // In this branch T extends boolean.
+        return this.inputNode.checked as T;
+      }
+      return this.inputNode.value as T;
+    }
+  }
+
+  /**
    * The default implementation of a dialog renderer.
    */
   export class Renderer {
@@ -569,7 +656,7 @@ export namespace Dialog {
      *
      * @returns A widget for the dialog header.
      */
-    createHeader(title: HeaderType): Widget {
+    createHeader(title: Header): Widget {
       let header: Widget;
       if (typeof title === 'string') {
         header = new Widget({ node: document.createElement('span') });
@@ -589,7 +676,7 @@ export namespace Dialog {
      *
      * @returns A widget for the body.
      */
-    createBody(value: BodyType<any>): Widget {
+    createBody(value: Body<any>): Widget {
       let body: Widget;
       if (typeof value === 'string') {
         body = new Widget({ node: document.createElement('span') });
@@ -717,82 +804,17 @@ export namespace Dialog {
    * The default renderer instance.
    */
   export const defaultRenderer = new Renderer();
-
-  /** A simple type for prompt widget */
-  type PromptValueType = string | number | boolean;
-  /**
-   * Create and show a prompt dialog
-   */
-  class PromptWidget<T extends PromptValueType> extends Widget {
-    constructor(value: T) {
-      let body = document.createElement('div');
-      let input = document.createElement('input');
-      if (typeof value === 'string') {
-        input.type = 'text';
-        if (value) {
-          input.value = value;
-        }
-      }
-      if (typeof value === 'number') {
-        input.type = 'number';
-        if (value) {
-          input.value = value.toFixed(2);
-        }
-      }
-      if (typeof value === 'boolean') {
-        input.type = 'checkbox';
-        input.checked = value;
-      }
-      body.appendChild(input);
-      super({ node: body });
-    }
-
-    /**
-     * Get the input text node.
-     */
-    get inputNode(): HTMLInputElement {
-      return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
-    }
-
-    /**
-     * Get the value of the widget.
-     */
-    getValue(): T {
-      if (this.inputNode.type === 'number') {
-        // In this branch T extends number.
-        return parseFloat(this.inputNode.value) as T;
-      }
-      if (this.inputNode.type === 'checkbox') {
-        // In this branch T extends boolean.
-        return this.inputNode.checked as T;
-      }
-      return this.inputNode.value as T;
-    }
-  }
-
-  /**
-   * Simple dialog to prompt for a value
-   * @param prompt Text to show on the prompt
-   * @param defaultValue Initial value
-   * @returns a Promise which will resolve with the value entered by user.
-   */
-  export function prompt<T extends PromptValueType>(
-    prompt: string,
-    defaultValue: PromptValueType
-  ): Promise<Dialog.IResult<T>> {
-    return showDialog({
-      title: prompt,
-      body: new PromptWidget<T>(defaultValue as T),
-      buttons: [Dialog.cancelButton(), Dialog.okButton()],
-      focusNodeSelector: 'input'
-    });
-  }
 }
 
 /**
  * The namespace for module private data.
  */
 namespace Private {
+  /**
+   * The collection of outstanding dialog instances.
+   */
+  export let dialogs: DisposableSet | null = null;
+
   /**
    * The queue for launching dialogs.
    */
@@ -837,5 +859,32 @@ namespace Private {
       '[tabindex]'
     ].join(',');
     return node.querySelectorAll(candidateSelectors)[0] as HTMLElement;
+  }
+
+  /**
+   * Disposes all outstanding dialog instances.
+   */
+  export function nuke(): void {
+    if (dialogs) {
+      dialogs.dispose();
+      dialogs = null;
+    }
+  }
+
+  /**
+   * Tracks a new dialog instance.
+   *
+   * @param dialog - The dialog being added.
+   */
+  export function register(dialog: Dialog<any>): void {
+    if (!dialogs) {
+      dialogs = new DisposableSet();
+    }
+    dialogs.add(dialog);
+    dialog.disposed.connect(() => {
+      if (dialogs) {
+        dialogs.remove(dialog);
+      }
+    });
   }
 }

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -591,8 +591,8 @@ export namespace Dialog {
    * This function should only be used in tests or cases where application state
    * may be discarded.
    */
-  export function nuke(): void {
-    Private.nuke();
+  export function flush(): void {
+    Private.flush();
   }
 
   /**
@@ -864,7 +864,7 @@ namespace Private {
   /**
    * Disposes all outstanding dialog instances.
    */
-  export function nuke(): void {
+  export function flush(): void {
     if (dialogs) {
       dialogs.dispose();
       dialogs = null;

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -55,7 +55,7 @@ export namespace PageConfig {
     let found = false;
 
     // Use script tag if available.
-    if (typeof document !== 'undefined') {
+    if (typeof document !== 'undefined' && document) {
       const el = document.getElementById('jupyter-config-data');
 
       if (el) {

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -88,7 +88,7 @@ export class Poll implements IDisposable {
 
           // Check if this is a reconnection before setting connected state.
           if (!this._connected) {
-            console.log(`Poll ${this.name} reconnected.`);
+            console.log(`Poll (${this.name}) reconnected.`);
           }
           this._connected = true;
 
@@ -108,7 +108,7 @@ export class Poll implements IDisposable {
           console.warn(
             `Poll (${
               this.name
-            }) failed, increasing interval from ${old} to ${interval}`,
+            }) failed, increasing interval from ${old} to ${interval}.`,
             error
           );
         }

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -97,17 +97,20 @@ export class Poll<T = any> implements IDisposable {
    * A handle to the next link in the poll promise chain.
    */
   get next(): Poll.Next {
+    // If polling has begun return the outstanding promise or schedule one.
     if (this._isReady) {
       return this._outstanding || this._schedule(this.interval);
     }
+
+    // Return a proxy to the ready promise.
     const ready = this._ready;
-    const delegate = new PromiseDelegate<Poll.Next>();
+    const proxy = new PromiseDelegate<Poll.Next>();
 
     ready.then(next => {
-      delegate.resolve(next);
+      proxy.resolve(next);
     });
 
-    return delegate;
+    return proxy;
   }
 
   /**

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -58,7 +58,7 @@ export class Poll<T = any, U = any> implements IDisposable {
         this._resolve(this._tick, {
           interval: this.interval,
           payload: null,
-          phase: 'when-resolved',
+          phase: 'instantiated-resolved',
           timestamp: new Date().getTime()
         });
       })
@@ -72,7 +72,7 @@ export class Poll<T = any, U = any> implements IDisposable {
         this._resolve(this._tick, {
           interval: this.interval,
           payload: null,
-          phase: 'when-rejected',
+          phase: 'instantiated-rejected',
           timestamp: new Date().getTime()
         });
 
@@ -338,15 +338,15 @@ export namespace Poll {
    */
   export type Phase =
     | 'instantiated'
+    | 'instantiated-rejected'
+    | 'instantiated-resolved'
     | 'reconnected'
     | 'refreshed'
     | 'rejected'
     | 'resolved'
     | 'standby'
     | 'started'
-    | 'stopped'
-    | 'when-rejected'
-    | 'when-resolved';
+    | 'stopped';
 
   /**
    * Definition of poll state at any given tick.

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -190,6 +190,9 @@ export class Poll implements IDisposable {
   private _outstanding: PromiseDelegate<Poll.Next> | null = null;
 }
 
+/**
+ * A namespace for `Poll` class statics, types, and interfaces.
+ */
 export namespace Poll {
   /**
    * Definition of poll state that gets passed into the poll promise factory.
@@ -229,8 +232,8 @@ export namespace Poll {
      * The millisecond interval between poll requests.
      *
      * #### Notes
-     * If set to `0`, the poll will schedule an animation frame after promise
-     * resolution.
+     * If set to `0`, the poll will schedule an animation frame after each
+     * promise resolution.
      */
     interval: number;
 

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -246,7 +246,7 @@ export class Poll<T = any, U = any> implements IDisposable {
     const { max, min, variance } = this;
 
     // Reschedule without executing poll promise if application is hidden.
-    if (typeof document !== 'undefined' && document.hidden) {
+    if (typeof document !== 'undefined' && document && document.hidden) {
       this._resolve(poll, {
         interval: Private.jitter(this.interval, variance, min, max),
         payload: null,

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -169,14 +169,14 @@ export class Poll<T = any, U = any> implements IDisposable {
   /**
    * Refresh the poll.
    */
-  refresh(): this {
+  refresh(): Promise<this> {
     this._schedule({
       interval: 0,
       payload: null,
       phase: 'override',
       tick: new Date().getTime()
     });
-    return this;
+    return this.next;
   }
 
   /**

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -80,14 +80,14 @@ export class Poll implements IDisposable {
   /**
    * Refresh the poll.
    */
-  refresh(): Promise<Poll.Next> {
+  refresh(): Poll.Next {
     return this._poll(0, true);
   }
 
   /**
    * Schedule a poll request.
    */
-  private _poll(interval: number, override = false): Promise<Poll.Next> {
+  private _poll(interval: number, override = false): Poll.Next {
     // If poll is being overridden, generate a new poll.
     if (override && this._outstanding) {
       // Reset the previously outstanding poll and generate the next poll.
@@ -214,7 +214,12 @@ export namespace Poll {
   /**
    * A poll promise that resolves to the next scheduled poll promise.
    */
-  export type Next = Private.INext;
+  export type Next = INextPromise;
+
+  /**
+   * A poll promise that resolves to the next scheduled poll promise.
+   */
+  interface INextPromise extends Promise<Next> {}
 
   /**
    * Instantiation options for polls.
@@ -262,11 +267,6 @@ export namespace Poll {
  * A namespace for private module data.
  */
 namespace Private {
-  /**
-   * A poll promise that resolves to the next scheduled poll promise.
-   */
-  export interface INext extends Promise<INext> {}
-
   /**
    * Returns a randomly jittered integer value.
    *

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -226,15 +226,17 @@ export class Poll<T = any, U = any> implements IDisposable {
     }
 
     if (this._state.phase === 'stopped') {
-      return this._tick.promise;
+      return this;
     }
 
-    return this._resolve(this._tick, {
+    this._resolve(this._tick, {
       interval: Infinity, // Never.
       payload: null,
       phase: 'stopped',
       timestamp: new Date().getTime()
-    }).promise;
+    });
+
+    return this;
   }
 
   /**

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -83,6 +83,13 @@ export class Poll<T = any> implements IDisposable {
   readonly variance: number;
 
   /**
+   * Whether the last poll request succeeded.
+   */
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  /**
    * A signal emitted when the poll is disposed.
    */
   get disposed(): ISignal<this, void> {
@@ -175,8 +182,7 @@ export class Poll<T = any> implements IDisposable {
     }
 
     const { max, min, variance } = this;
-    const connected = this._connected;
-    const promise = this._factory({ connected, interval, schedule });
+    const promise = this._factory({ interval, schedule });
 
     promise
       .then((payload: T) => {
@@ -329,11 +335,6 @@ export namespace Poll {
    * Definition of poll state that gets passed into the poll promise factory.
    */
   export type State = {
-    /**
-     * Whether the last poll succeeded.
-     */
-    readonly connected: boolean;
-
     /**
      * The number of milliseconds that elapsed since the last poll.
      */

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -237,25 +237,15 @@ export class Poll<T = any, U = any> implements IDisposable {
         }
 
         // Schedule the next poll.
-        const old = this._state;
-        const increased = Math.min(old.interval * 2, max);
-        const updated: Poll.State<T, U> = {
+        const increased = Math.min(this._state.interval * 2, max);
+        this._next = null;
+        this._schedule({
           interval: Private.jitter(increased, variance, min, max),
           payload: rejected,
           phase: 'rejected',
           tick: new Date().getTime()
-        };
-        this._next = null;
-        this._schedule(updated);
+        });
         this._resolve(poll);
-
-        // Warn that the poll request was rejected.
-        console.warn(
-          `Poll (${this.name}) failed, changing interval from ${
-            old.interval
-          } to ${updated.interval}.`,
-          rejected
-        );
       });
   }
 

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -179,7 +179,7 @@ export class Poll<T = any> implements IDisposable {
   private _execute(
     delegate: PromiseDelegate<Poll.Next>,
     interval: number,
-    schedule: Poll.Schedule
+    origin: Poll.Origin
   ): void {
     if (this._isDisposed) {
       return;
@@ -193,7 +193,7 @@ export class Poll<T = any> implements IDisposable {
     }
 
     const { max, min, variance } = this;
-    const promise = this._factory({ interval, schedule });
+    const promise = this._factory({ interval, origin });
 
     promise
       .then((payload: T) => {
@@ -278,15 +278,15 @@ export class Poll<T = any> implements IDisposable {
    */
   private _schedule(
     interval: number,
-    schedule: Poll.Schedule = 'automatic'
+    origin: Poll.Origin = 'automatic'
   ): Poll.Next {
     const outstanding = this._outstanding;
 
     // If poll is being overridden, generate a new poll.
-    if (schedule === 'override' && outstanding) {
+    if (origin === 'override' && outstanding) {
       // Reset the previously outstanding poll and generate the next poll.
       this._outstanding = null;
-      const next = this._schedule(0, 'override');
+      const next = this._schedule(0, origin);
 
       // Short-circuit the previous poll promise and return a reference to the
       // next poll promise (which supersedes it) scheduled to run immediately.
@@ -311,7 +311,7 @@ export class Poll<T = any> implements IDisposable {
         if (this._isDisposed) {
           return;
         }
-        this._execute(next, interval, schedule);
+        this._execute(next, interval, origin);
       }, interval);
     } else {
       requestAnimationFrame(() => {
@@ -319,7 +319,7 @@ export class Poll<T = any> implements IDisposable {
         if (this._isDisposed) {
           return;
         }
-        this._execute(next, interval, schedule);
+        this._execute(next, interval, origin);
       });
     }
 
@@ -347,9 +347,9 @@ export namespace Poll {
   export type Next = { promise: Promise<Next> };
 
   /**
-   * Whether polling was scheduled automatically, overridden, or from standby.
+   * The origin of a scheduled poll request.
    */
-  export type Schedule = 'automatic' | 'override' | 'standby';
+  export type Origin = 'automatic' | 'override' | 'standby';
   /**
    * Definition of poll state that gets passed into the poll promise factory.
    */
@@ -360,9 +360,9 @@ export namespace Poll {
     readonly interval: number;
 
     /**
-     * Whether polling was scheduled automatically, overridden, or from standby.
+     * The origin of a scheduled poll request.
      */
-    readonly schedule: Schedule;
+    readonly origin: Origin;
   };
 
   /**

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -10,6 +10,10 @@ import { ISignal, Signal } from '@phosphor/signaling';
 /**
  * A class that wraps an asynchronous function to poll at a regular interval
  * with exponential increases to the interval length if the poll fails.
+ *
+ * #### Notes
+ * The generic argument `T` indicates the resolved type of the promises returned
+ * by the poll's promise factory.
  */
 export class Poll<T = any> implements IDisposable {
   /**

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -115,7 +115,7 @@ export class Poll<T = any> implements IDisposable {
    * A handle to the next link in the poll promise chain.
    */
   get next(): Poll.Next {
-    return this._outstanding || this._schedule(this.interval);
+    return this._schedule(this.interval);
   }
 
   /**

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -241,19 +241,19 @@ export class Poll<T = any> implements IDisposable {
           }
           this._connected = true;
 
-          // Record and emit the current tick.
-          this._tick = new Date().getTime();
-          this._ticked.emit(this._tick);
-
           // The poll succeeded. Reset the interval.
           interval = Private.jitter(this.interval, variance, min, max);
-
-          // Emit the promise resolution's payload.
-          this._resolved.emit(payload);
 
           // Schedule the next poll.
           this._outstanding = null;
           delegate.resolve(this._poll(interval));
+
+          // Record and emit the current tick.
+          this._tick = new Date().getTime();
+          this._ticked.emit(this._tick);
+
+          // Emit the promise resolution's payload.
+          this._resolved.emit(payload);
         })
         .catch((reason: any) => {
           // Bail if disposed while poll promise was in flight.
@@ -280,16 +280,16 @@ export class Poll<T = any> implements IDisposable {
             reason
           );
 
+          // Schedule the next poll.
+          this._outstanding = null;
+          delegate.resolve(this._poll(interval));
+
           // Record and emit the current tick.
           this._tick = new Date().getTime();
           this._ticked.emit(this._tick);
 
           // Emit the promise rejection's error payload.
           this._rejected.emit(reason);
-
-          // Schedule the next poll.
-          this._outstanding = null;
-          delegate.resolve(this._poll(interval));
         });
     }
   }

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -14,7 +14,7 @@ export class Poll implements IDisposable {
    * @param options - The poll instantiation options.
    */
   constructor(options: Poll.IOptions) {
-    const { interval, max, name, poll } = options;
+    const { interval, max, name, poll, when } = options;
 
     if (interval > max) {
       throw new Error('Poll interval cannot exceed max interval length');
@@ -24,7 +24,13 @@ export class Poll implements IDisposable {
 
     // Cache the original interval length and start polling.
     this._interval = interval;
-    this._poll(poll, interval, max);
+    (when || Promise.resolve())
+      .then(() => {
+        this._poll(poll, interval, max);
+      })
+      .catch(() => {
+        this._poll(poll, interval, max);
+      });
   }
 
   /**
@@ -118,5 +124,10 @@ export namespace Poll {
      * A function that returns a poll promise.
      */
     poll: () => Promise<any>;
+
+    /**
+     * If set, a promise which must resolve (or reject) before polling begins.
+     */
+    when?: Promise<any>;
   }
 }

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -354,11 +354,11 @@ export namespace Poll {
     | 'when-resolved';
 
   /**
-   * Definition of poll state that gets passed into the poll promise factory.
+   * Definition of poll state at any given tick.
    */
   export type State<T, U> = {
     /**
-     * The number of milliseconds that elapsed since the last poll.
+     * The number of milliseconds until the next poll request.
      */
     readonly interval: number;
 
@@ -366,14 +366,13 @@ export namespace Poll {
      * The payload of the last poll resolution or rejection.
      *
      * #### Notes
-     * Payload is `null` unless the phase is `resolved` or `rejected`.
-     * It is of type `T` for resolutions and `U` for rejections.
+     * `payload` is `null` unless the `phase` is `'resolved'` or `'rejected'`.
+     * `payload` is of type `T` for resolutions and `U` for rejections.
      */
     readonly payload: T | U | null;
 
     /**
-     * The phase of tbe poll when the current request was scheduled, i.e. the end
-     * state of the immediately preceding link of the promise chain.
+     * The current poll phase.
      */
     readonly phase: Phase;
 
@@ -393,13 +392,13 @@ export namespace Poll {
    */
   export interface IOptions<T, U> {
     /**
-     * The millisecond interval between poll requests.
+     * The millisecond interval between poll requests. Defaults to `1000`.
      *
      * #### Notes
      * If set to `0`, the poll will schedule an animation frame after each
      * promise resolution.
      */
-    interval: number;
+    interval?: number;
 
     /**
      * The maximum interval to wait between polls. Defaults to `10 * interval`.

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -41,12 +41,12 @@ export class Poll<T = any> implements IDisposable {
         this._connected = true;
         this._isReady = true;
         this._ready = null;
-        return this._poll(interval);
+        return this._schedule(interval);
       })
       .catch(() => {
         this._isReady = true;
         this._ready = null;
-        return this._poll(interval);
+        return this._schedule(interval);
       });
   }
 
@@ -94,7 +94,7 @@ export class Poll<T = any> implements IDisposable {
    */
   get next(): Poll.Next {
     if (this._isReady) {
-      return this._outstanding || this._poll(this.interval);
+      return this._outstanding || this._schedule(this.interval);
     }
     const ready = this._ready;
     const delegate = new PromiseDelegate<Poll.Next>();
@@ -155,7 +155,103 @@ export class Poll<T = any> implements IDisposable {
    * Refresh the poll.
    */
   refresh(): Poll.Next {
-    return this._poll(0, true);
+    return this._schedule(0, true);
+  }
+
+  /**
+   * Execute a poll request.
+   */
+  private _execute(
+    delegate: PromiseDelegate<Poll.Next>,
+    interval: number,
+    override: boolean
+  ): void {
+    if (this._isDisposed) {
+      return;
+    }
+
+    // Reschedule without executing poll promise if application is hidden.
+    if (typeof document !== 'undefined' && document.hidden) {
+      this._outstanding = null;
+      delegate.resolve(this._schedule(interval));
+      return;
+    }
+
+    const { max, min, variance } = this;
+    const connected = this._connected;
+    const schedule = override ? 'override' : 'automatic';
+    const promise = this._factory({ connected, interval, schedule });
+
+    promise
+      .then((payload: T) => {
+        // Bail if disposed while poll promise was in flight.
+        if (this._isDisposed) {
+          return;
+        }
+
+        // Bail if this promise has already been superseded.
+        if (this._outstanding !== delegate) {
+          return;
+        }
+
+        // Note if this is a reconnection.
+        if (!this._connected) {
+          console.log(`Poll (${this.name}) reconnected.`);
+        }
+
+        // Set current poll state.
+        this._connected = true;
+        this._outstanding = null;
+        this._tick = new Date().getTime();
+
+        // The poll succeeded. Reset the interval.
+        interval = Private.jitter(this.interval, variance, min, max);
+
+        // Schedule the next poll.
+        delegate.resolve(this._schedule(interval));
+
+        // Emit the current tick.
+        this._ticked.emit(this._tick);
+
+        // Emit the promise resolution's payload.
+        this._resolved.emit(payload);
+      })
+      .catch((reason: any) => {
+        // Bail if disposed while poll promise was in flight.
+        if (this._isDisposed) {
+          return;
+        }
+
+        // Bail if this promise has already been superseded.
+        if (this._outstanding !== delegate) {
+          return;
+        }
+
+        // Set current poll state.
+        this._connected = false;
+        this._outstanding = null;
+        this._tick = new Date().getTime();
+
+        // The poll failed. Increase the interval.
+        const old = interval;
+        const increased = Math.min(interval * 2, max);
+        interval = Private.jitter(increased, variance, min, max);
+        console.warn(
+          `Poll (${
+            this.name
+          }) failed, increasing interval from ${old} to ${interval}.`,
+          reason
+        );
+
+        // Schedule the next poll.
+        delegate.resolve(this._schedule(interval));
+
+        // Emit the current tick.
+        this._ticked.emit(this._tick);
+
+        // Emit the promise rejection's error payload.
+        this._rejected.emit(reason);
+      });
   }
 
   /**
@@ -166,14 +262,14 @@ export class Poll<T = any> implements IDisposable {
    * The next poll promise returned is guaranteed to always resolve with a
    * handle on the correct next link in the poll promise chain.
    */
-  private _poll(interval: number, override = false): Poll.Next {
+  private _schedule(interval: number, override = false): Poll.Next {
     const outstanding = this._outstanding;
 
     // If poll is being overridden, generate a new poll.
     if (override && outstanding) {
       // Reset the previously outstanding poll and generate the next poll.
       this._outstanding = null;
-      const next = this._poll(0, override);
+      const next = this._schedule(0, override);
 
       // Short-circuit the previous poll promise and return a reference to the
       // next poll promise (which supersedes it) scheduled to run immediately.
@@ -203,101 +299,6 @@ export class Poll<T = any> implements IDisposable {
     }
 
     return delegate;
-  }
-
-  /**
-   * Execute a poll request.
-   */
-  private _execute(
-    delegate: PromiseDelegate<Poll.Next>,
-    interval: number,
-    override: boolean
-  ): void {
-    if (this._isDisposed) {
-      return;
-    }
-
-    // Do not execute promise if application is currently not visible.
-    if (typeof document !== 'undefined' && document.hidden) {
-      // Schedule the next poll.
-      this._outstanding = null;
-      delegate.resolve(this._poll(interval));
-      return;
-    }
-
-    const { max, min, variance } = this;
-    const connected = this._connected;
-    const schedule = override ? 'override' : 'automatic';
-    const promise = this._factory({ connected, interval, schedule });
-
-    promise
-      .then((payload: T) => {
-        // Bail if disposed while poll promise was in flight.
-        if (this._isDisposed) {
-          return;
-        }
-
-        // Bail if this promise has already been superseded.
-        if (this._outstanding !== delegate) {
-          return;
-        }
-
-        // Check if this is a reconnection before setting connected state.
-        if (!this._connected) {
-          console.log(`Poll (${this.name}) reconnected.`);
-        }
-        this._connected = true;
-
-        // The poll succeeded. Reset the interval.
-        interval = Private.jitter(this.interval, variance, min, max);
-
-        // Schedule the next poll.
-        this._outstanding = null;
-        delegate.resolve(this._poll(interval));
-
-        // Record and emit the current tick.
-        this._tick = new Date().getTime();
-        this._ticked.emit(this._tick);
-
-        // Emit the promise resolution's payload.
-        this._resolved.emit(payload);
-      })
-      .catch((reason: any) => {
-        // Bail if disposed while poll promise was in flight.
-        if (this._isDisposed) {
-          return;
-        }
-
-        // Bail if this promise has already been superseded.
-        if (this._outstanding !== delegate) {
-          return;
-        }
-
-        // Set connected state.
-        this._connected = false;
-
-        // The poll failed. Increase the interval.
-        const old = interval;
-        const increased = Math.min(interval * 2, max);
-        interval = Private.jitter(increased, variance, min, max);
-        console.warn(
-          `Poll (${
-            this.name
-          }) failed, increasing interval from ${old} to ${interval}.`,
-          reason
-        );
-
-        // Schedule the next poll.
-        this._outstanding = null;
-        delegate.resolve(this._poll(interval));
-
-        // Record and emit the current tick.
-        this._tick = new Date().getTime();
-        this._ticked.emit(this._tick);
-
-        // Emit the promise rejection's error payload.
-        this._rejected.emit(reason);
-      });
   }
 
   private _connected = false;

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -17,7 +17,7 @@ export namespace URLExt {
    * @returns A URL object.
    */
   export function parse(url: string): IUrl {
-    if (typeof document !== 'undefined') {
+    if (typeof document !== 'undefined' && document) {
       let a = document.createElement('a');
       a.href = url;
       return a;

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -145,7 +145,7 @@ export class KernelManager implements Kernel.IManager {
    * manager maintains its own internal state.
    */
   async refreshRunning(): Promise<void> {
-    await this._pollModels.refresh().promise;
+    await this._pollModels.refresh();
   }
 
   /**
@@ -158,7 +158,7 @@ export class KernelManager implements Kernel.IManager {
    * since the manager maintains its internal state.
    */
   async refreshSpecs(): Promise<void> {
-    await this._pollSpecs.refresh().promise;
+    await this._pollSpecs.refresh();
   }
 
   /**

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -38,6 +38,7 @@ export class KernelManager implements Kernel.IManager {
       max: 300 * 1000,
       min: 100,
       name: `@jupyterlab/services:KernelManager#models`,
+      standby: options.standby || 'when-hidden',
       when: this._readyPromise
     });
     this._pollSpecs = new Poll({
@@ -46,6 +47,7 @@ export class KernelManager implements Kernel.IManager {
       max: 300 * 1000,
       min: 100,
       name: `@jupyterlab/services:KernelManager#specs`,
+      standby: options.standby || 'when-hidden',
       when: this._readyPromise
     });
   }
@@ -350,5 +352,10 @@ export namespace KernelManager {
      * The server settings for the manager.
      */
     serverSettings?: ServerConnection.ISettings;
+
+    /**
+     * When the manager stops polling the API. Defaults to `when-hidden`.
+     */
+    standby?: Poll.Standby;
   }
 }

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -35,11 +35,13 @@ export class KernelManager implements Kernel.IManager {
     this._pollModels = new Poll({
       interval: 10 * 1000,
       max: 300 * 1000,
+      name: `@jupyterlab/services:KernelManager#models`,
       poll: () => this._refreshRunning()
     });
     this._pollSpecs = new Poll({
       interval: 61 * 1000,
       max: 300 * 1000,
+      name: `@jupyterlab/services:KernelManager#specs`,
       poll: () => this._refreshSpecs()
     });
   }

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -33,17 +33,19 @@ export class KernelManager implements Kernel.IManager {
 
     // Start model and specs polling with exponential backoff.
     this._pollModels = new Poll({
+      factory: () => this._refreshRunning(),
       interval: 10 * 1000,
       max: 300 * 1000,
+      min: 100,
       name: `@jupyterlab/services:KernelManager#models`,
-      poll: () => this._refreshRunning(),
       when: this._readyPromise
     });
     this._pollSpecs = new Poll({
+      factory: () => this._refreshSpecs(),
       interval: 61 * 1000,
       max: 300 * 1000,
+      min: 100,
       name: `@jupyterlab/services:KernelManager#specs`,
-      poll: () => this._refreshSpecs(),
       when: this._readyPromise
     });
   }

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -203,11 +203,11 @@ export class KernelManager implements Kernel.IManager {
       }
     });
 
-    // Emit the new model list without waiting for API request.
-    this._runningChanged.emit(models.slice());
-
     // Shut down the remote session.
     await Kernel.shutdown(id, this.serverSettings);
+
+    // Emit the new model list.
+    this._runningChanged.emit(models.slice());
   }
 
   /**

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -27,22 +27,24 @@ export class KernelManager implements Kernel.IManager {
       options.serverSettings || ServerConnection.makeSettings();
 
     // Initialize internal data.
-    this._readyPromise = this._refreshSpecs().then(() => {
-      return this._refreshRunning();
-    });
+    this._readyPromise = this._refreshSpecs().then(() =>
+      this._refreshRunning()
+    );
 
     // Start model and specs polling with exponential backoff.
     this._pollModels = new Poll({
       interval: 10 * 1000,
       max: 300 * 1000,
       name: `@jupyterlab/services:KernelManager#models`,
-      poll: () => this._refreshRunning()
+      poll: () => this._refreshRunning(),
+      when: this._readyPromise
     });
     this._pollSpecs = new Poll({
       interval: 61 * 1000,
       max: 300 * 1000,
       name: `@jupyterlab/services:KernelManager#specs`,
-      poll: () => this._refreshSpecs()
+      poll: () => this._refreshSpecs(),
+      when: this._readyPromise
     });
   }
 

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -245,22 +245,24 @@ namespace Private {
 
     // Use explicit cache buster when `no-store` is set since
     // not all browsers use it properly.
-    let cache = init.cache || settings.init.cache;
+    const cache = init.cache || settings.init.cache;
     if (cache === 'no-store') {
       // https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache
       url += (/\?/.test(url) ? '&' : '?') + new Date().getTime();
     }
 
-    let request = new settings.Request(url, { ...settings.init, ...init });
+    const request = new settings.Request(url, { ...settings.init, ...init });
 
-    // Handle authentication.
+    // Handle authentication. Authentication can be overdetermined by
+    // settings token and XSRF token.
     let authenticated = false;
     if (settings.token) {
       authenticated = true;
       request.headers.append('Authorization', `token ${settings.token}`);
-    } else if (typeof document !== 'undefined' && document.cookie) {
-      let xsrfToken = getCookie('_xsrf');
-      if (xsrfToken !== void 0) {
+    }
+    if (typeof document !== 'undefined' && document.cookie) {
+      const xsrfToken = getCookie('_xsrf');
+      if (xsrfToken !== undefined) {
         authenticated = true;
         request.headers.append('X-XSRFToken', xsrfToken);
       }
@@ -282,9 +284,9 @@ namespace Private {
   /**
    * Get a cookie from the document.
    */
-  function getCookie(name: string) {
-    // from tornado docs: http://www.tornadoweb.org/en/stable/guide/security.html
-    let r = document.cookie.match('\\b' + name + '=([^;]*)\\b');
-    return r ? r[1] : void 0;
+  function getCookie(name: string): string | undefined {
+    // From http://www.tornadoweb.org/en/stable/guide/security.html
+    const matches = document.cookie.match('\\b' + name + '=([^;]*)\\b');
+    return matches ? matches[1] : undefined;
   }
 }

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -260,7 +260,7 @@ namespace Private {
       authenticated = true;
       request.headers.append('Authorization', `token ${settings.token}`);
     }
-    if (typeof document !== 'undefined' && document.cookie) {
+    if (typeof document !== 'undefined' && document && document.cookie) {
       const xsrfToken = getCookie('_xsrf');
       if (xsrfToken !== undefined) {
         authenticated = true;

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -40,6 +40,7 @@ export class SessionManager implements Session.IManager {
       max: 300 * 1000,
       min: 100,
       name: `@jupyterlab/services:SessionManager#models`,
+      standby: options.standby || 'when-hidden',
       when: this._readyPromise
     });
     this._pollSpecs = new Poll({
@@ -48,6 +49,7 @@ export class SessionManager implements Session.IManager {
       max: 300 * 1000,
       min: 100,
       name: `@jupyterlab/services:SessionManager#specs`,
+      standby: options.standby || 'when-hidden',
       when: this._readyPromise
     });
   }
@@ -362,5 +364,10 @@ export namespace SessionManager {
      * The server settings for the manager.
      */
     serverSettings?: ServerConnection.ISettings;
+
+    /**
+     * When the manager stops polling the API. Defaults to `when-hidden`.
+     */
+    standby?: Poll.Standby;
   }
 }

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -37,11 +37,13 @@ export class SessionManager implements Session.IManager {
     this._pollModels = new Poll({
       interval: 10 * 1000,
       max: 300 * 1000,
+      name: `@jupyterlab/services:SessionManager#models`,
       poll: () => this._refreshRunning()
     });
     this._pollSpecs = new Poll({
       interval: 61 * 1000,
       max: 300 * 1000,
+      name: `@jupyterlab/services:SessionManager#specs`,
       poll: () => this._refreshSpecs()
     });
   }

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -29,22 +29,24 @@ export class SessionManager implements Session.IManager {
       options.serverSettings || ServerConnection.makeSettings();
 
     // Initialize internal data.
-    this._readyPromise = this._refreshSpecs().then(() => {
-      return this._refreshRunning();
-    });
+    this._readyPromise = this._refreshSpecs().then(() =>
+      this._refreshRunning()
+    );
 
     // Start model and specs polling with exponential backoff.
     this._pollModels = new Poll({
       interval: 10 * 1000,
       max: 300 * 1000,
       name: `@jupyterlab/services:SessionManager#models`,
-      poll: () => this._refreshRunning()
+      poll: () => this._refreshRunning(),
+      when: this._readyPromise
     });
     this._pollSpecs = new Poll({
       interval: 61 * 1000,
       max: 300 * 1000,
       name: `@jupyterlab/services:SessionManager#specs`,
-      poll: () => this._refreshSpecs()
+      poll: () => this._refreshSpecs(),
+      when: this._readyPromise
     });
   }
 
@@ -237,7 +239,7 @@ export class SessionManager implements Session.IManager {
     const models = this._models;
 
     if (models.length) {
-      this._models = [];
+      this._models.length = 0;
     }
 
     await this._refreshRunning();

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -35,17 +35,19 @@ export class SessionManager implements Session.IManager {
 
     // Start model and specs polling with exponential backoff.
     this._pollModels = new Poll({
+      factory: () => this._refreshRunning(),
       interval: 10 * 1000,
       max: 300 * 1000,
+      min: 100,
       name: `@jupyterlab/services:SessionManager#models`,
-      poll: () => this._refreshRunning(),
       when: this._readyPromise
     });
     this._pollSpecs = new Poll({
+      factory: () => this._refreshSpecs(),
       interval: 61 * 1000,
       max: 300 * 1000,
+      min: 100,
       name: `@jupyterlab/services:SessionManager#specs`,
-      poll: () => this._refreshSpecs(),
       when: this._readyPromise
     });
   }

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -167,7 +167,6 @@ export class TerminalManager implements TerminalSession.IManager {
     const models = this._models;
     const sessions = this._sessions;
     const index = ArrayExt.findFirstIndex(models, model => model.name === name);
-
     if (index === -1) {
       return;
     }
@@ -183,11 +182,11 @@ export class TerminalManager implements TerminalSession.IManager {
       }
     });
 
-    // Emit the new model list without waiting for API request.
-    this._runningChanged.emit(models.slice());
-
     // Shut down the remote session.
     await TerminalSession.shutdown(name, this.serverSettings);
+
+    // Emit the model list.
+    this._runningChanged.emit(models.slice());
   }
 
   /**

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -30,10 +30,11 @@ export class TerminalManager implements TerminalSession.IManager {
 
       // Start polling with exponential backoff.
       this._pollModels = new Poll({
+        factory: () => this._refreshRunning(),
         interval: 10 * 1000,
         max: 300 * 1000,
+        min: 100,
         name: `@jupyterlab/services:TerminalManager#models`,
-        poll: () => this._refreshRunning(),
         when: this._readyPromise
       });
     }

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -147,6 +147,15 @@ export class TerminalManager implements TerminalSession.IManager {
   }
 
   /**
+   * Force a refresh of the running sessions.
+   */
+  async refreshRunning(): Promise<void> {
+    if (this._pollModels) {
+      await this._pollModels.refresh().promise;
+    }
+  }
+
+  /**
    * Shut down a terminal session by name.
    */
   async shutdown(name: string): Promise<void> {
@@ -218,19 +227,6 @@ export class TerminalManager implements TerminalSession.IManager {
     if (error) {
       throw error;
     }
-  }
-
-  /**
-   * Force a refresh of the running sessions.
-   *
-   * @returns A promise that with the list of running sessions.
-   *
-   * #### Notes
-   * This is not typically meant to be called by the user, since the
-   * manager maintains its own internal state.
-   */
-  refreshRunning(): Promise<void> {
-    return this._refreshRunning();
   }
 
   /**

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -30,23 +30,12 @@ export class TerminalManager implements TerminalSession.IManager {
 
       // Start polling with exponential backoff.
       this._pollModels = new Poll({
-        factory: state => {
-          // console.log('generating poll promise...', state);
-          return this._refreshRunning();
-        },
+        factory: () => this._refreshRunning(),
         interval: 10 * 1000,
         max: 300 * 1000,
         min: 100,
         name: `@jupyterlab/services:TerminalManager#models`,
         when: this._readyPromise
-      });
-      const handle = (poll: Poll) => {
-        console.log(`#next`, poll.state);
-        poll.next.then(handle);
-      };
-      this._pollModels.next.then(handle);
-      this._pollModels.ticked.connect(sender => {
-        console.warn(`#ticked`, sender.state);
       });
     }
   }

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -35,6 +35,7 @@ export class TerminalManager implements TerminalSession.IManager {
         max: 300 * 1000,
         min: 100,
         name: `@jupyterlab/services:TerminalManager#models`,
+        standby: options.standby || 'when-hidden',
         when: this._readyPromise
       });
     }
@@ -318,5 +319,10 @@ export namespace TerminalManager {
      * The server settings used by the manager.
      */
     serverSettings?: ServerConnection.ISettings;
+
+    /**
+     * When the manager stops polling the API. Defaults to `when-hidden`.
+     */
+    standby?: Poll.Standby;
   }
 }

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -10,6 +10,7 @@ import { ISignal, Signal } from '@phosphor/signaling';
 import { ServerConnection } from '..';
 
 import { TerminalSession } from './terminal';
+import { Poll } from '@jupyterlab/coreutils';
 
 /**
  * A terminal session manager.
@@ -27,14 +28,13 @@ export class TerminalManager implements TerminalSession.IManager {
       // Initialize internal data.
       this._readyPromise = this._refreshRunning();
 
-      // Set up polling.
-      this._refreshTimer = (setInterval as any)(() => {
-        if (typeof document !== 'undefined' && document.hidden) {
-          // Don't poll when nobody's looking.
-          return;
-        }
-        this._refreshRunning();
-      }, 10000);
+      // Start polling with exponential backoff.
+      this._pollRunning = new Poll({
+        interval: 10 * 1000,
+        max: 300 * 1000,
+        name: `@jupyterlab/services:TerminalManager#models`,
+        poll: () => this._refreshRunning()
+      });
     }
   }
 
@@ -72,9 +72,9 @@ export class TerminalManager implements TerminalSession.IManager {
       return;
     }
     this._isDisposed = true;
-    clearInterval(this._refreshTimer);
+    this._models.length = 0;
+    this._pollRunning.dispose();
     Signal.clearData(this);
-    this._models = [];
   }
 
   /**
@@ -259,25 +259,21 @@ export class TerminalManager implements TerminalSession.IManager {
   /**
    * Refresh the running sessions.
    */
-  private _refreshRunning(): Promise<void> {
-    return TerminalSession.listRunning(this.serverSettings).then(models => {
-      this._isReady = true;
-      if (!JSONExt.deepEqual(models, this._models)) {
-        let names = models.map(r => r.name);
-        let toRemove: TerminalSession.ISession[] = [];
-        this._sessions.forEach(s => {
-          if (names.indexOf(s.name) === -1) {
-            s.dispose();
-            toRemove.push(s);
-          }
-        });
-        toRemove.forEach(s => {
-          this._sessions.delete(s);
-        });
-        this._models = models.slice();
-        this._runningChanged.emit(models);
-      }
-    });
+  private async _refreshRunning(): Promise<void> {
+    const models = await TerminalSession.listRunning(this.serverSettings);
+    this._isReady = true;
+    if (!JSONExt.deepEqual(models, this._models)) {
+      const names = models.map(model => model.name);
+      const sessions = this._sessions;
+      sessions.forEach(session => {
+        if (names.indexOf(session.name) === -1) {
+          session.dispose();
+          sessions.delete(session);
+        }
+      });
+      this._models = models.slice();
+      this._runningChanged.emit(models);
+    }
   }
 
   /**
@@ -289,11 +285,11 @@ export class TerminalManager implements TerminalSession.IManager {
     return { ...options, serverSettings: this.serverSettings };
   }
 
-  private _models: TerminalSession.IModel[] = [];
-  private _sessions = new Set<TerminalSession.ISession>();
   private _isDisposed = false;
   private _isReady = false;
-  private _refreshTimer = -1;
+  private _models: TerminalSession.IModel[] = [];
+  private _pollRunning: Poll;
+  private _sessions = new Set<TerminalSession.ISession>();
   private _readyPromise: Promise<void>;
   private _runningChanged = new Signal<this, TerminalSession.IModel[]>(this);
 }

--- a/packages/statusbar/src/defaults/memoryUsage.tsx
+++ b/packages/statusbar/src/defaults/memoryUsage.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { VDomModel, VDomRenderer } from '@jupyterlab/apputils';
 
-import { URLExt } from '@jupyterlab/coreutils';
+import { URLExt, Poll } from '@jupyterlab/coreutils';
 
 import { TextItem } from '..';
 
@@ -20,9 +20,7 @@ export class MemoryUsage extends VDomRenderer<MemoryUsage.Model> {
    */
   constructor() {
     super();
-    this.model = new MemoryUsage.Model({
-      refreshRate: 5000
-    });
+    this.model = new MemoryUsage.Model({ refreshRate: 5000 });
   }
 
   /**
@@ -63,13 +61,30 @@ export namespace MemoryUsage {
      */
     constructor(options: Model.IOptions) {
       super();
+      this._poll = new Poll<Private.IMetricRequestResult | null>({
+        factory: () => Private.factory(),
+        interval: options.refreshRate,
+        name: '@jupyterlab/statusbar:MemoryUsage#metrics'
+      });
+      this._poll.ticked.connect(poll => {
+        const { payload, phase } = poll.state;
+        if (phase === 'resolved') {
+          this._updateMetricsValues(payload);
+          return;
+        }
+        if (phase === 'rejected') {
+          const oldMetricsAvailable = this._metricsAvailable;
+          this._metricsAvailable = false;
+          this._currentMemory = 0;
+          this._memoryLimit = null;
+          this._units = 'B';
 
-      this._refreshRate = options.refreshRate;
-
-      this._intervalId = setInterval(
-        () => this._makeMetricRequest(),
-        this._refreshRate
-      );
+          if (oldMetricsAvailable) {
+            this.stateChanged.emit();
+          }
+          return;
+        }
+      });
     }
 
     /**
@@ -105,43 +120,11 @@ export namespace MemoryUsage {
      */
     dispose(): void {
       super.dispose();
-      clearInterval(this._intervalId);
+      this._poll.dispose();
     }
 
     /**
-     * Make a request to the metrics backend and update the model.
-     */
-    private _makeMetricRequest(): Promise<void> {
-      return Private.makeMetricsRequest()
-        .then(response => {
-          if (response.ok) {
-            try {
-              return response.json();
-            } catch (err) {
-              return null;
-            }
-          } else {
-            return null;
-          }
-        })
-        .then(data => this._updateMetricsValues(data))
-        .catch(err => {
-          const oldMetricsAvailable = this._metricsAvailable;
-          this._metricsAvailable = false;
-          this._currentMemory = 0;
-          this._memoryLimit = null;
-          this._units = 'B';
-          clearInterval(this._intervalId);
-
-          if (oldMetricsAvailable) {
-            this.stateChanged.emit(void 0);
-          }
-        });
-    }
-
-    /**
-     * Given the results of the metrics request, update
-     * model values.
+     * Given the results of the metrics request, update model values.
      */
     private _updateMetricsValues(
       value: Private.IMetricRequestResult | null
@@ -156,8 +139,6 @@ export namespace MemoryUsage {
         this._currentMemory = 0;
         this._memoryLimit = null;
         this._units = 'B';
-
-        clearInterval(this._intervalId);
       } else {
         const numBytes = value.rss;
         const memoryLimit = value.limits.memory
@@ -171,13 +152,6 @@ export namespace MemoryUsage {
         this._memoryLimit = memoryLimit
           ? memoryLimit / Private.MEMORY_UNIT_LIMITS[units]
           : null;
-
-        if (!oldMetricsAvailable) {
-          this._intervalId = setInterval(
-            () => this._makeMetricRequest(),
-            this._refreshRate
-          );
-        }
       }
 
       if (
@@ -190,12 +164,11 @@ export namespace MemoryUsage {
       }
     }
 
-    private _metricsAvailable: boolean = false;
     private _currentMemory: number = 0;
     private _memoryLimit: number | null = null;
+    private _metricsAvailable: boolean = false;
+    private _poll: Poll<Response>;
     private _units: MemoryUnit = 'B';
-    private _intervalId: any;
-    private _refreshRate: number;
   }
 
   /**
@@ -302,13 +275,22 @@ namespace Private {
   /**
    * Make a request to the backend.
    */
-  export function makeMetricsRequest(): Promise<Response> {
+  export async function factory(): Promise<IMetricRequestResult | null> {
     const request = ServerConnection.makeRequest(
       METRIC_URL,
       {},
       SERVER_CONNECTION_SETTINGS
     );
+    const response = await request;
 
-    return request;
+    if (response.ok) {
+      try {
+        return await response.json();
+      } catch (error) {
+        throw error;
+      }
+    }
+
+    return null;
   }
 }

--- a/tests/test-apputils/src/clientsession.spec.ts
+++ b/tests/test-apputils/src/clientsession.spec.ts
@@ -5,7 +5,11 @@ import { expect } from 'chai';
 
 import { SessionManager } from '@jupyterlab/services';
 
-import { ClientSession, IClientSession } from '@jupyterlab/apputils/src';
+import {
+  ClientSession,
+  Dialog,
+  IClientSession
+} from '@jupyterlab/apputils/src';
 
 import { UUID } from '@phosphor/coreutils';
 
@@ -28,6 +32,7 @@ describe('@jupyterlab/apputils', () => {
     afterEach(async () => {
       await session.shutdown();
       session.dispose();
+      Dialog.nuke();
     });
 
     describe('#constructor()', () => {

--- a/tests/test-apputils/src/clientsession.spec.ts
+++ b/tests/test-apputils/src/clientsession.spec.ts
@@ -32,7 +32,7 @@ describe('@jupyterlab/apputils', () => {
     afterEach(async () => {
       await session.shutdown();
       session.dispose();
-      Dialog.nuke();
+      Dialog.flush();
     });
 
     describe('#constructor()', () => {

--- a/tests/test-completer/src/widget.spec.ts
+++ b/tests/test-completer/src/widget.spec.ts
@@ -18,6 +18,7 @@ import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import { Completer, CompleterModel } from '@jupyterlab/completer/src';
 
 import { framePromise, sleep } from '@jupyterlab/testutils';
+
 const TEST_ITEM_CLASS = 'jp-TestItem';
 
 const ITEM_CLASS = 'jp-Completer-item';

--- a/tests/test-console/src/panel.spec.ts
+++ b/tests/test-console/src/panel.spec.ts
@@ -38,7 +38,7 @@ const contentFactory = createConsolePanelFactory();
 
 describe('console/panel', () => {
   let panel: TestPanel;
-  const manager = new ServiceManager();
+  const manager = new ServiceManager({ standby: 'never' });
 
   before(() => {
     return manager.ready;

--- a/tests/test-console/src/widget.spec.ts
+++ b/tests/test-console/src/widget.spec.ts
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 
-import { Message } from '@phosphor/messaging';
+import { Message, MessageLoop } from '@phosphor/messaging';
 
 import { Widget } from '@phosphor/widgets';
 
@@ -18,7 +18,7 @@ import {
   RawCell
 } from '@jupyterlab/cells';
 
-import { createClientSession, NBTestUtils, sleep } from '@jupyterlab/testutils';
+import { createClientSession, NBTestUtils } from '@jupyterlab/testutils';
 
 import {
   createConsoleFactory,
@@ -273,13 +273,11 @@ describe('console/widget', () => {
     });
 
     describe('#onActivateRequest()', () => {
-      it('should focus the prompt editor', async () => {
+      it('should focus the prompt editor', () => {
         expect(widget.promptCell).to.not.be.ok;
         expect(widget.methods).to.not.contain('onActivateRequest');
         Widget.attach(widget, document.body);
-        widget.activate();
-        // Because test browser may be in a hidden tab, use sleep.
-        await sleep(1000);
+        MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
         expect(widget.methods).to.contain('onActivateRequest');
         expect(widget.promptCell.editor.hasFocus()).to.equal(true);
       });

--- a/tests/test-console/src/widget.spec.ts
+++ b/tests/test-console/src/widget.spec.ts
@@ -18,11 +18,7 @@ import {
   RawCell
 } from '@jupyterlab/cells';
 
-import {
-  createClientSession,
-  framePromise,
-  NBTestUtils
-} from '@jupyterlab/testutils';
+import { createClientSession, NBTestUtils, sleep } from '@jupyterlab/testutils';
 
 import {
   createConsoleFactory,
@@ -35,23 +31,23 @@ class TestConsole extends CodeConsole {
   methods: string[] = [];
 
   protected newPromptCell(): void {
-    super.newPromptCell();
     this.methods.push('newPromptCell');
+    super.newPromptCell();
   }
 
   protected onActivateRequest(msg: Message): void {
-    super.onActivateRequest(msg);
     this.methods.push('onActivateRequest');
+    super.onActivateRequest(msg);
   }
 
   protected onAfterAttach(msg: Message): void {
-    super.onAfterAttach(msg);
     this.methods.push('onAfterAttach');
+    super.onAfterAttach(msg);
   }
 
   protected onUpdateRequest(msg: Message): void {
-    super.onUpdateRequest(msg);
     this.methods.push('onUpdateRequest');
+    super.onUpdateRequest(msg);
   }
 }
 
@@ -281,9 +277,9 @@ describe('console/widget', () => {
         expect(widget.promptCell).to.not.be.ok;
         expect(widget.methods).to.not.contain('onActivateRequest');
         Widget.attach(widget, document.body);
-        await framePromise();
         widget.activate();
-        await framePromise();
+        // Because test browser may be in a hidden tab, use sleep.
+        await sleep(1000);
         expect(widget.methods).to.contain('onActivateRequest');
         expect(widget.promptCell.editor.hasFocus()).to.equal(true);
       });

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -285,4 +285,22 @@ describe('Poll', () => {
       expect(poll.isDisposed).to.equal(true);
     });
   });
+
+  describe('#refresh()', () => {
+    it('should refresh the poll', async () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#dispose()-1',
+        interval: 200,
+        factory: () => Promise.resolve()
+      });
+      const expected = 'instantiated-resolved refreshed resolved';
+      const ticker: Poll.Phase[] = [];
+
+      poll.ticked.connect((_, tick) => {
+        ticker.push(tick.phase);
+      });
+      await poll.refresh();
+      expect(ticker.join(' ')).to.equal(expected);
+    });
+  });
 });

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -32,7 +32,7 @@ describe('Poll', () => {
 
       expect(poll.state.phase).to.equal('instantiated');
       await promise;
-      expect(poll.state.phase).to.equal('when-resolved');
+      expect(poll.state.phase).to.equal('instantiated-resolved');
       poll.dispose();
     });
 
@@ -47,7 +47,7 @@ describe('Poll', () => {
 
       expect(poll.state.phase).to.equal('instantiated');
       await promise.catch(() => undefined);
-      expect(poll.state.phase).to.equal('when-rejected');
+      expect(poll.state.phase).to.equal('instantiated-rejected');
       poll.dispose();
     });
   });
@@ -200,7 +200,7 @@ describe('Poll', () => {
         factory: () => Promise.resolve(),
         variance: 0
       });
-      const expected = 'when-resolved resolved';
+      const expected = 'instantiated-resolved resolved';
       const ticker: Poll.Phase[] = [];
       const tock = (poll: Poll) => {
         ticker.push(poll.state.phase);
@@ -222,7 +222,7 @@ describe('Poll', () => {
         factory: () => Promise.resolve(),
         variance: 0
       });
-      const expected = 'when-resolved resolved';
+      const expected = 'instantiated-resolved resolved';
       const ticker: Poll.Phase[] = [];
 
       poll.ticked.connect(() => {
@@ -242,7 +242,7 @@ describe('Poll', () => {
         variance: 0,
         when: promise
       });
-      const expected = 'when-rejected resolved';
+      const expected = 'instantiated-rejected resolved';
       const ticker: Poll.Phase[] = [];
 
       poll.ticked.connect(() => {

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -289,7 +289,7 @@ describe('Poll', () => {
   describe('#refresh()', () => {
     it('should refresh the poll', async () => {
       const poll = new Poll({
-        name: '@jupyterlab/test-coreutils:Poll#dispose()-1',
+        name: '@jupyterlab/test-coreutils:Poll#refresh()-1',
         interval: 200,
         factory: () => Promise.resolve()
       });
@@ -300,6 +300,93 @@ describe('Poll', () => {
         ticker.push(tick.phase);
       });
       await poll.refresh();
+      expect(ticker.join(' ')).to.equal(expected);
+    });
+
+    it('should not refresh multiple times if refresh is pending', async () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#refresh()-2',
+        interval: 200,
+        factory: () => Promise.resolve()
+      });
+      const expected = 'instantiated-resolved refreshed resolved';
+      const ticker: Poll.Phase[] = [];
+
+      poll.ticked.connect((_, tick) => {
+        ticker.push(tick.phase);
+      });
+      poll.refresh();
+      await poll.refresh();
+      expect(ticker.join(' ')).to.equal(expected);
+    });
+  });
+
+  describe('#start()', () => {
+    it('should start the poll if it is stopped', async () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#start()-1',
+        interval: 200,
+        factory: () => Promise.resolve()
+      });
+      const expected = 'instantiated-resolved stopped started resolved';
+      const ticker: Poll.Phase[] = [];
+
+      poll.ticked.connect((_, tick) => {
+        ticker.push(tick.phase);
+      });
+      await poll.stop();
+      await poll.start();
+      expect(ticker.join(' ')).to.equal(expected);
+    });
+
+    it('should not start the poll if it is already running', async () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#start()-2',
+        interval: 200,
+        factory: () => Promise.resolve()
+      });
+      const expected = 'instantiated-resolved resolved';
+      const ticker: Poll.Phase[] = [];
+
+      poll.ticked.connect((_, tick) => {
+        ticker.push(tick.phase);
+      });
+      await poll.start();
+      expect(ticker.join(' ')).to.equal(expected);
+    });
+  });
+
+  describe('#stop()', () => {
+    it('should stop the poll', async () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#stop()-1',
+        interval: 200,
+        factory: () => Promise.resolve()
+      });
+      const expected = 'instantiated-resolved stopped';
+      const ticker: Poll.Phase[] = [];
+
+      poll.ticked.connect((_, tick) => {
+        ticker.push(tick.phase);
+      });
+      await poll.stop();
+      expect(ticker.join(' ')).to.equal(expected);
+    });
+
+    it('should not stop the poll if it is already stopped', async () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#stop()-2',
+        interval: 200,
+        factory: () => Promise.resolve()
+      });
+      const expected = 'instantiated-resolved stopped';
+      const ticker: Poll.Phase[] = [];
+
+      poll.ticked.connect((_, tick) => {
+        ticker.push(tick.phase);
+      });
+      poll.stop();
+      await poll.stop();
       expect(ticker.join(' ')).to.equal(expected);
     });
   });

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -5,22 +5,244 @@ import { expect } from 'chai';
 
 import { Poll } from '@jupyterlab/coreutils/src';
 
+import { sleep } from '@jupyterlab/testutils';
+
 describe('Poll', () => {
-  let poll: Poll | null;
-
-  afterEach(() => {
-    poll.dispose();
-    poll = null;
-  });
-
   describe('#constructor()', () => {
     it('should create a poll', () => {
-      poll = new Poll({
+      const poll = new Poll({
         interval: 1000,
         factory: () => Promise.resolve(),
         when: new Promise(() => undefined) // Never.
       });
+
       expect(poll).to.be.an.instanceof(Poll);
+      poll.dispose();
+    });
+
+    it('should tick if `when` promise resolves', async () => {
+      const promise = Promise.resolve();
+      const poll = new Poll({
+        interval: 1000,
+        factory: () => Promise.resolve(),
+        when: promise
+      });
+
+      expect(poll.state.phase).to.equal('instantiated');
+      await promise;
+      expect(poll.state.phase).to.equal('when-resolved');
+      poll.dispose();
+    });
+
+    it('should tick if `when` promise rejects', async () => {
+      const promise = Promise.reject();
+      const poll = new Poll({
+        interval: 1000,
+        factory: () => Promise.resolve(),
+        when: promise
+      });
+
+      expect(poll.state.phase).to.equal('instantiated');
+      await promise.catch(() => undefined);
+      expect(poll.state.phase).to.equal('when-rejected');
+      poll.dispose();
+    });
+  });
+
+  describe('#interval', () => {
+    it('should be set to value passed in during instantation', () => {
+      const poll = new Poll({
+        interval: 9000,
+        factory: () => Promise.resolve()
+      });
+
+      expect(poll.interval).to.equal(9000);
+      poll.dispose();
+    });
+
+    it('should default to `1000`', () => {
+      const poll = new Poll({ factory: () => Promise.resolve() });
+
+      expect(poll.interval).to.equal(1000);
+      poll.dispose();
+    });
+  });
+
+  describe('#max', () => {
+    it('should be set to value passed in during instantation', () => {
+      const poll = new Poll({
+        max: 200000,
+        factory: () => Promise.resolve()
+      });
+
+      expect(poll.max).to.equal(200000);
+      poll.dispose();
+    });
+
+    it('should default to 10x the interval', () => {
+      const poll = new Poll({
+        interval: 500,
+        factory: () => Promise.resolve()
+      });
+
+      expect(poll.max).to.equal(10 * 500);
+      poll.dispose();
+    });
+  });
+
+  describe('#min', () => {
+    it('should be set to value passed in during instantation', () => {
+      const poll = new Poll({
+        min: 250,
+        factory: () => Promise.resolve()
+      });
+
+      expect(poll.min).to.equal(250);
+      poll.dispose();
+    });
+
+    it('should default to `100`', () => {
+      const poll = new Poll({ factory: () => Promise.resolve() });
+
+      expect(poll.min).to.equal(100);
+      poll.dispose();
+    });
+  });
+
+  describe('#name', () => {
+    it('should be set to value passed in during instantation', () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#name',
+        factory: () => Promise.resolve()
+      });
+
+      expect(poll.name).to.equal('@jupyterlab/test-coreutils:Poll#name');
+      poll.dispose();
+    });
+
+    it('should default to `unknown`', () => {
+      const poll = new Poll({ factory: () => Promise.resolve() });
+
+      expect(poll.name).to.equal('unknown');
+      poll.dispose();
+    });
+  });
+
+  describe('#variance', () => {
+    it('should be set to value passed in during instantation', () => {
+      const poll = new Poll({
+        variance: 0.5,
+        factory: () => Promise.resolve()
+      });
+
+      expect(poll.variance).to.equal(0.5);
+      poll.dispose();
+    });
+
+    it('should default to `0.2`', () => {
+      const poll = new Poll({ factory: () => Promise.resolve() });
+
+      expect(poll.variance).to.equal(0.2);
+      poll.dispose();
+    });
+  });
+
+  describe('#disposed', () => {
+    it('should emit when the poll is disposed', () => {
+      const poll = new Poll({ factory: () => Promise.resolve() });
+      let disposed = false;
+
+      poll.disposed.connect(() => {
+        disposed = true;
+      });
+      poll.dispose();
+      expect(disposed).to.equal(true);
+      poll.dispose();
+    });
+  });
+
+  describe('#isDisposed', () => {
+    it('should indicate whether the poll is disposed', () => {
+      const poll = new Poll({ factory: () => Promise.resolve() });
+
+      expect(poll.isDisposed).to.equal(false);
+      poll.dispose();
+      expect(poll.isDisposed).to.equal(true);
+    });
+  });
+
+  describe('#tick', () => {
+    it('should resolve after a tick', async () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#tick',
+        interval: 400,
+        factory: () => Promise.resolve(),
+        variance: 0
+      });
+      const expected = 'when-resolved resolved';
+      const ticker: Poll.Phase[] = [];
+      const tock = (poll: Poll) => {
+        ticker.push(poll.state.phase);
+        poll.tick.then(tock).catch(() => undefined);
+      };
+
+      poll.tick.then(tock);
+      await sleep(750);
+      expect(ticker.join(' ')).to.eql(expected);
+      poll.dispose();
+    });
+  });
+
+  describe('#ticked', () => {
+    it('should emit when the poll ticks after `when` resolves', async () => {
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#ticked-1',
+        interval: 400,
+        factory: () => Promise.resolve(),
+        variance: 0
+      });
+      const expected = 'when-resolved resolved';
+      const ticker: Poll.Phase[] = [];
+
+      poll.ticked.connect(() => {
+        ticker.push(poll.state.phase);
+      });
+      await sleep(750);
+      expect(ticker.join(' ')).to.eql(expected);
+      poll.dispose();
+    });
+
+    it('should emit when the poll ticks after `when` rejects', async () => {
+      const promise = Promise.reject();
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#ticked-2',
+        interval: 400,
+        factory: () => Promise.resolve(),
+        variance: 0,
+        when: promise
+      });
+      const expected = 'when-rejected resolved';
+      const ticker: Poll.Phase[] = [];
+
+      poll.ticked.connect(() => {
+        ticker.push(poll.state.phase);
+      });
+      await promise.catch(() => undefined);
+      await sleep(750);
+      expect(ticker.join(' ')).to.eql(expected);
+      poll.dispose();
+    });
+  });
+
+  describe('#dispose()', () => {
+    it('should dispose the poll and be safe to call repeatedly', () => {
+      const poll = new Poll({ factory: () => Promise.resolve() });
+
+      expect(poll.isDisposed).to.equal(false);
+      poll.dispose();
+      expect(poll.isDisposed).to.equal(true);
+      poll.dispose();
+      expect(poll.isDisposed).to.equal(true);
     });
   });
 });

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -11,6 +11,7 @@ describe('Poll', () => {
   describe('#constructor()', () => {
     it('should create a poll', () => {
       const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#constructor()-1',
         interval: 1000,
         factory: () => Promise.resolve(),
         when: new Promise(() => undefined) // Never.
@@ -20,9 +21,10 @@ describe('Poll', () => {
       poll.dispose();
     });
 
-    it('should tick if `when` promise resolves', async () => {
+    it('should be `instantiated` and tick after `when` resolves', async () => {
       const promise = Promise.resolve();
       const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#constructor()-2',
         interval: 1000,
         factory: () => Promise.resolve(),
         when: promise
@@ -34,9 +36,10 @@ describe('Poll', () => {
       poll.dispose();
     });
 
-    it('should tick if `when` promise rejects', async () => {
+    it('should be `instantiated` and tick after `when` rejects', async () => {
       const promise = Promise.reject();
       const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#constructor()-3',
         interval: 1000,
         factory: () => Promise.resolve(),
         when: promise
@@ -52,6 +55,7 @@ describe('Poll', () => {
   describe('#interval', () => {
     it('should be set to value passed in during instantation', () => {
       const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#interval-1',
         interval: 9000,
         factory: () => Promise.resolve()
       });
@@ -61,7 +65,10 @@ describe('Poll', () => {
     });
 
     it('should default to `1000`', () => {
-      const poll = new Poll({ factory: () => Promise.resolve() });
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#interval-2',
+        factory: () => Promise.resolve()
+      });
 
       expect(poll.interval).to.equal(1000);
       poll.dispose();
@@ -71,6 +78,7 @@ describe('Poll', () => {
   describe('#max', () => {
     it('should be set to value passed in during instantation', () => {
       const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#max-1',
         max: 200000,
         factory: () => Promise.resolve()
       });
@@ -81,6 +89,7 @@ describe('Poll', () => {
 
     it('should default to 10x the interval', () => {
       const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#max-2',
         interval: 500,
         factory: () => Promise.resolve()
       });
@@ -93,6 +102,7 @@ describe('Poll', () => {
   describe('#min', () => {
     it('should be set to value passed in during instantation', () => {
       const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#min-1',
         min: 250,
         factory: () => Promise.resolve()
       });
@@ -102,7 +112,10 @@ describe('Poll', () => {
     });
 
     it('should default to `100`', () => {
-      const poll = new Poll({ factory: () => Promise.resolve() });
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#min-2',
+        factory: () => Promise.resolve()
+      });
 
       expect(poll.min).to.equal(100);
       poll.dispose();
@@ -111,12 +124,10 @@ describe('Poll', () => {
 
   describe('#name', () => {
     it('should be set to value passed in during instantation', () => {
-      const poll = new Poll({
-        name: '@jupyterlab/test-coreutils:Poll#name',
-        factory: () => Promise.resolve()
-      });
+      const name = '@jupyterlab/test-coreutils:Poll#name-1';
+      const poll = new Poll({ name, factory: () => Promise.resolve() });
 
-      expect(poll.name).to.equal('@jupyterlab/test-coreutils:Poll#name');
+      expect(poll.name).to.equal(name);
       poll.dispose();
     });
 
@@ -131,6 +142,7 @@ describe('Poll', () => {
   describe('#variance', () => {
     it('should be set to value passed in during instantation', () => {
       const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#variance-1',
         variance: 0.5,
         factory: () => Promise.resolve()
       });
@@ -140,7 +152,10 @@ describe('Poll', () => {
     });
 
     it('should default to `0.2`', () => {
-      const poll = new Poll({ factory: () => Promise.resolve() });
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#variance-2',
+        factory: () => Promise.resolve()
+      });
 
       expect(poll.variance).to.equal(0.2);
       poll.dispose();
@@ -149,7 +164,10 @@ describe('Poll', () => {
 
   describe('#disposed', () => {
     it('should emit when the poll is disposed', () => {
-      const poll = new Poll({ factory: () => Promise.resolve() });
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#disposed-1',
+        factory: () => Promise.resolve()
+      });
       let disposed = false;
 
       poll.disposed.connect(() => {
@@ -163,7 +181,10 @@ describe('Poll', () => {
 
   describe('#isDisposed', () => {
     it('should indicate whether the poll is disposed', () => {
-      const poll = new Poll({ factory: () => Promise.resolve() });
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#isDisposed-1',
+        factory: () => Promise.resolve()
+      });
 
       expect(poll.isDisposed).to.equal(false);
       poll.dispose();
@@ -174,7 +195,7 @@ describe('Poll', () => {
   describe('#tick', () => {
     it('should resolve after a tick', async () => {
       const poll = new Poll({
-        name: '@jupyterlab/test-coreutils:Poll#tick',
+        name: '@jupyterlab/test-coreutils:Poll#tick-1',
         interval: 400,
         factory: () => Promise.resolve(),
         variance: 0
@@ -195,7 +216,7 @@ describe('Poll', () => {
 
   describe('#ticked', () => {
     it('should emit when the poll ticks after `when` resolves', async () => {
-      const poll = new Poll({
+      const poll = new Poll<void, void>({
         name: '@jupyterlab/test-coreutils:Poll#ticked-1',
         interval: 400,
         factory: () => Promise.resolve(),
@@ -232,11 +253,30 @@ describe('Poll', () => {
       expect(ticker.join(' ')).to.eql(expected);
       poll.dispose();
     });
+
+    it('should emit a tick identical to the poll state', async () => {
+      const poll = new Poll<void, void>({
+        name: '@jupyterlab/test-coreutils:Poll#ticked-3',
+        interval: 100,
+        factory: () => Promise.resolve(),
+        variance: 0
+      });
+
+      poll.ticked.connect((sender: Poll, tick: Poll.Tick<void, void>) => {
+        expect(sender).to.equal(poll);
+        expect(tick).to.equal(poll.state);
+      });
+      await sleep(250);
+      poll.dispose();
+    });
   });
 
   describe('#dispose()', () => {
     it('should dispose the poll and be safe to call repeatedly', () => {
-      const poll = new Poll({ factory: () => Promise.resolve() });
+      const poll = new Poll({
+        name: '@jupyterlab/test-coreutils:Poll#dispose()-1',
+        factory: () => Promise.resolve()
+      });
 
       expect(poll.isDisposed).to.equal(false);
       poll.dispose();

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { expect } from 'chai';
+
+import { Poll } from '@jupyterlab/coreutils/src';
+
+describe('Poll', () => {
+  let poll: Poll | null;
+
+  afterEach(() => {
+    poll.dispose();
+    poll = null;
+  });
+
+  describe('#constructor()', () => {
+    it('should create a poll', () => {
+      poll = new Poll({
+        interval: 1000,
+        factory: () => Promise.resolve(),
+        when: new Promise(() => undefined) // Never.
+      });
+      expect(poll).to.be.an.instanceof(Poll);
+    });
+  });
+});

--- a/tests/test-csvviewer/src/widget.spec.ts
+++ b/tests/test-csvviewer/src/widget.spec.ts
@@ -18,7 +18,7 @@ import { JSONModel, DataGrid, CellRenderer } from '@phosphor/datagrid';
 
 function createContext(): Context<DocumentRegistry.IModel> {
   const factory = new TextModelFactory();
-  const manager = new ServiceManager();
+  const manager = new ServiceManager({ standby: 'never' });
   const path = UUID.uuid4() + '.csv';
   return new Context({ factory, manager, path });
 }

--- a/tests/test-docmanager/src/manager.spec.ts
+++ b/tests/test-docmanager/src/manager.spec.ts
@@ -44,7 +44,7 @@ describe('@jupyterlab/docmanager', () => {
   });
 
   before(() => {
-    services = new ServiceManager();
+    services = new ServiceManager({ standby: 'never' });
     return services.ready;
   });
 

--- a/tests/test-docmanager/src/savehandler.spec.ts
+++ b/tests/test-docmanager/src/savehandler.spec.ts
@@ -29,7 +29,7 @@ describe('docregistry/savehandler', () => {
   let handler: SaveHandler;
 
   before(() => {
-    manager = new ServiceManager();
+    manager = new ServiceManager({ standby: 'never' });
     return manager.ready;
   });
 

--- a/tests/test-docmanager/src/widgetmanager.spec.ts
+++ b/tests/test-docmanager/src/widgetmanager.spec.ts
@@ -70,7 +70,7 @@ describe('@jupyterlab/docmanager', () => {
   });
 
   before(() => {
-    services = new ServiceManager();
+    services = new ServiceManager({ standby: 'never' });
   });
 
   beforeEach(() => {

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -30,7 +30,7 @@ describe('docregistry/context', () => {
   const factory = new TextModelFactory();
 
   beforeAll(() => {
-    manager = new ServiceManager();
+    manager = new ServiceManager({ standby: 'never' });
     return manager.ready;
   });
 

--- a/tests/test-docregistry/src/default.spec.ts
+++ b/tests/test-docregistry/src/default.spec.ts
@@ -544,7 +544,7 @@ describe('docregistry/default', () => {
     };
 
     beforeAll(async () => {
-      manager = new ServiceManager();
+      manager = new ServiceManager({ standby: 'never' });
       await manager.ready;
     });
 

--- a/tests/test-filebrowser/src/crumbs.spec.ts
+++ b/tests/test-filebrowser/src/crumbs.spec.ts
@@ -67,7 +67,7 @@ describe('filebrowser/model', () => {
     registry = new DocumentRegistry({
       textModelFactory: new TextModelFactory()
     });
-    serviceManager = new ServiceManager();
+    serviceManager = new ServiceManager({ standby: 'never' });
     manager = new DocumentManager({
       registry,
       opener,

--- a/tests/test-filebrowser/src/model.spec.ts
+++ b/tests/test-filebrowser/src/model.spec.ts
@@ -71,7 +71,7 @@ describe('filebrowser/model', () => {
     registry = new DocumentRegistry({
       textModelFactory: new TextModelFactory()
     });
-    serviceManager = new ServiceManager();
+    serviceManager = new ServiceManager({ standby: 'never' });
     manager = new DocumentManager({
       registry,
       opener,
@@ -252,7 +252,7 @@ describe('filebrowser/model', () => {
       });
 
       it('should be resilient to a slow initial fetch', async () => {
-        let delayedServiceManager = new ServiceManager();
+        let delayedServiceManager = new ServiceManager({ standby: 'never' });
         (delayedServiceManager as any).contents = new DelayedContentsManager();
         let manager = new DocumentManager({
           registry,

--- a/tests/test-fileeditor/src/widget.spec.ts
+++ b/tests/test-fileeditor/src/widget.spec.ts
@@ -67,7 +67,7 @@ describe('fileeditorcodewrapper', () => {
   let manager: ServiceManager.IManager;
 
   beforeAll(() => {
-    manager = new ServiceManager();
+    manager = new ServiceManager({ standby: 'never' });
     return manager.ready;
   });
 

--- a/tests/test-imageviewer/src/widget.spec.ts
+++ b/tests/test-imageviewer/src/widget.spec.ts
@@ -62,7 +62,7 @@ describe('ImageViewer', () => {
   let widget: LogImage;
 
   beforeAll(async () => {
-    manager = new ServiceManager();
+    manager = new ServiceManager({ standby: 'never' });
     await manager.ready;
     return manager.contents.save(IMAGE.path, IMAGE);
   });

--- a/tests/test-rendermime/src/factories.spec.ts
+++ b/tests/test-rendermime/src/factories.spec.ts
@@ -228,19 +228,19 @@ describe('rendermime/factories', () => {
       });
 
       // TODO we are disabling script execution for now.
-      // it('should execute a script tag when attached', () => {
-      //   const source = '<script>window.y=3;</script>';
-      //   const f = htmlRendererFactory;
-      //   const mimeType = 'text/html';
-      //   const model = createModel(mimeType, source, true);
-      //   const w = f.createRenderer({ mimeType, ...defaultOptions });
-      //   return w.renderModel(model).then(() => {
-      //     expect((window as any).y).to.be.undefined;
-      //     Widget.attach(w, document.body);
-      //     expect((window as any).y).to.equal(3);
-      //     w.dispose();
-      //   });
-      // });
+      it.skip('should execute a script tag when attached', () => {
+        const source = '<script>window.y=3;</script>';
+        const f = htmlRendererFactory;
+        const mimeType = 'text/html';
+        const model = createModel(mimeType, source, true);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        return w.renderModel(model).then(() => {
+          expect((window as any).y).to.be.undefined;
+          Widget.attach(w, document.body);
+          expect((window as any).y).to.equal(3);
+          w.dispose();
+        });
+      });
 
       it('should sanitize when untrusted', async () => {
         const source = '<pre><script>window.y=3;</script></pre>';

--- a/tests/test-rendermime/src/registry.spec.ts
+++ b/tests/test-rendermime/src/registry.spec.ts
@@ -304,7 +304,7 @@ describe('rendermime/registry', () => {
       const urlParent = encodeURI(pathParent);
 
       before(async () => {
-        const manager = new ServiceManager();
+        const manager = new ServiceManager({ standby: 'never' });
         const drive = new Drive({ name: 'extra' });
         const path = pathParent + '/pr%25 ' + UUID.uuid4();
         contents = manager.contents;

--- a/tests/test-services/src/kernel/manager.spec.ts
+++ b/tests/test-services/src/kernel/manager.spec.ts
@@ -30,7 +30,7 @@ describe('kernel/manager', () => {
   });
 
   beforeEach(() => {
-    manager = new KernelManager();
+    manager = new KernelManager({ standby: 'never' });
     expect(manager.specs).to.be.null;
     return manager.ready;
   });
@@ -47,7 +47,10 @@ describe('kernel/manager', () => {
     describe('#constructor()', () => {
       it('should take the options as an argument', () => {
         manager.dispose();
-        manager = new KernelManager({ serverSettings: makeSettings() });
+        manager = new KernelManager({
+          serverSettings: makeSettings(),
+          standby: 'never'
+        });
         expect(manager instanceof KernelManager).to.equal(true);
       });
     });
@@ -56,8 +59,9 @@ describe('kernel/manager', () => {
       it('should get the server settings', () => {
         manager.dispose();
         const serverSettings = makeSettings();
+        const standby = 'never';
         const token = serverSettings.token;
-        manager = new KernelManager({ serverSettings });
+        manager = new KernelManager({ serverSettings, standby });
         expect(manager.serverSettings.token).to.equal(token);
       });
     });
@@ -120,7 +124,7 @@ describe('kernel/manager', () => {
     describe('#isReady', () => {
       it('should test whether the manager is ready', async () => {
         manager.dispose();
-        manager = new KernelManager();
+        manager = new KernelManager({ standby: 'never' });
         expect(manager.isReady).to.equal(false);
         await manager.ready;
         expect(manager.isReady).to.equal(true);

--- a/tests/test-services/src/kernel/manager.spec.ts
+++ b/tests/test-services/src/kernel/manager.spec.ts
@@ -207,7 +207,7 @@ describe('kernel/manager', () => {
         const kernel = await manager.startNew();
         const emission = testEmission(manager.runningChanged, {
           test: () => {
-            expect(kernel.isDisposed).to.equal(false);
+            expect(kernel.isDisposed).to.equal(true);
           }
         });
         await manager.shutdown(kernel.id);

--- a/tests/test-services/src/manager.spec.ts
+++ b/tests/test-services/src/manager.spec.ts
@@ -20,7 +20,7 @@ describe('manager', () => {
     let manager: ServiceManager.IManager;
 
     beforeEach(() => {
-      manager = new ServiceManager();
+      manager = new ServiceManager({ standby: 'never' });
       return manager.ready;
     });
 
@@ -67,7 +67,7 @@ describe('manager', () => {
     describe('#isReady', () => {
       it('should test whether the manager is ready', async () => {
         manager.dispose();
-        manager = new ServiceManager();
+        manager = new ServiceManager({ standby: 'never' });
         expect(manager.isReady).to.equal(false);
         await manager.ready;
         expect(manager.isReady).to.equal(true);

--- a/tests/test-services/src/terminal/manager.spec.ts
+++ b/tests/test-services/src/terminal/manager.spec.ts
@@ -20,7 +20,7 @@ describe('terminal', () => {
   });
 
   beforeEach(() => {
-    manager = new TerminalManager();
+    manager = new TerminalManager({ standby: 'never' });
     return manager.ready;
   });
 
@@ -36,14 +36,15 @@ describe('terminal', () => {
     describe('#constructor()', () => {
       it('should accept no options', () => {
         manager.dispose();
-        manager = new TerminalManager();
+        manager = new TerminalManager({ standby: 'never' });
         expect(manager).to.be.an.instanceof(TerminalManager);
       });
 
       it('should accept options', () => {
         manager.dispose();
         manager = new TerminalManager({
-          serverSettings: ServerConnection.makeSettings()
+          serverSettings: ServerConnection.makeSettings(),
+          standby: 'never'
         });
         expect(manager).to.be.an.instanceof(TerminalManager);
       });
@@ -53,8 +54,9 @@ describe('terminal', () => {
       it('should get the server settings', () => {
         manager.dispose();
         const serverSettings = ServerConnection.makeSettings();
+        const standby = 'never';
         const token = serverSettings.token;
-        manager = new TerminalManager({ serverSettings });
+        manager = new TerminalManager({ serverSettings, standby });
         expect(manager.serverSettings.token).to.equal(token);
       });
     });
@@ -62,7 +64,7 @@ describe('terminal', () => {
     describe('#isReady', () => {
       it('should test whether the manager is ready', async () => {
         manager.dispose();
-        manager = new TerminalManager();
+        manager = new TerminalManager({ standby: 'never' });
         expect(manager.isReady).to.equal(false);
         await manager.ready;
         expect(manager.isReady).to.equal(true);

--- a/tests/test-services/src/terminal/manager.spec.ts
+++ b/tests/test-services/src/terminal/manager.spec.ts
@@ -126,7 +126,7 @@ describe('terminal', () => {
         let called = false;
         session = await manager.startNew();
         manager.runningChanged.connect((sender, args) => {
-          expect(session.isDisposed).to.equal(false);
+          expect(session.isDisposed).to.equal(true);
           called = true;
         });
         await manager.shutdown(session.name);

--- a/testutils/src/index.ts
+++ b/testutils/src/index.ts
@@ -302,7 +302,7 @@ namespace Private {
    */
   export function getManager(): ServiceManager {
     if (!manager) {
-      manager = new ServiceManager();
+      manager = new ServiceManager({ standby: 'never' });
     }
     return manager;
   }


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/3929

* Adds a `Poll` class to `@jupyterlab/coreutils` to abstract polling and exponentially backing off in case of failure.
* Adds `Poll` class tests.
* Cleans up doc strings in the running extension.
* Updates different ad hoc polls to use the `Poll` class:
    * `@jupyterlab/services:KernelManager#models`
    * `@jupyterlab/services:KernelManager#specs`
    * `@jupyterlab/services:SessionManager#models`
    * `@jupyterlab/services:SessionManager#specs`
    * `@jupyterlab/services:TerminalManager#models`
    * `@jupyterlab/statusbar:MemoryUsage#metrics`
* Switches kernel manager and session manager to `async`.
* A future enhancement of the `Poll` class that is possible is adding `Poll[Symbol.asyncIterator]`, `Poll#return()`, and `Poll#next()` methods to make the poll an `async` iterator.
* Updates tests and switches some previously asynchronous tests to synchronous (as long as the semantics are not modified).