### PR TITLE
Add a notebook metadata editor to the cell tools panel.

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -394,7 +394,14 @@ function activateCellTools(
   const activeCellTool = new CellTools.ActiveCellTool();
   const slideShow = CellTools.createSlideShowSelector();
   const editorFactory = editorServices.factoryService.newInlineEditor;
-  const metadataEditor = new CellTools.MetadataEditorTool({ editorFactory });
+  const cellMetadataEditor = new CellTools.CellMetadataEditorTool({
+    title: 'Edit Cell Metadata',
+    editorFactory
+  });
+  const notebookMetadataEditor = new CellTools.NotebookMetadataEditorTool({
+    title: 'Edit Notebook Metadata',
+    editorFactory
+  });
   const services = app.serviceManager;
 
   // Create message hook for triggers to save to the database.
@@ -435,7 +442,8 @@ function activateCellTools(
   celltools.id = id;
   celltools.addItem({ tool: activeCellTool, rank: 1 });
   celltools.addItem({ tool: slideShow, rank: 2 });
-  celltools.addItem({ tool: metadataEditor, rank: 4 });
+  celltools.addItem({ tool: cellMetadataEditor, rank: 4 });
+  celltools.addItem({ tool: notebookMetadataEditor, rank: 5 });
   MessageLoop.installMessageHook(celltools, hook);
 
   // Wait until the application has finished restoring before rendering.

--- a/tests/test-notebook/src/celltools.spec.ts
+++ b/tests/test-notebook/src/celltools.spec.ts
@@ -136,6 +136,15 @@ describe('@jupyterlab/notebook', () => {
         });
       });
 
+      describe('#activeNotebook', () => {
+        it('should be the active notebook', () => {
+          expect(celltools.activeNotebook).to.equal(panel1);
+          tabpanel.currentIndex = 0;
+          simulate(panel0.node, 'focus');
+          expect(celltools.activeNotebook).to.equal(panel0);
+        });
+      });
+
       describe('#selectedCells', () => {
         it('should be the currently selected cells', () => {
           expect(celltools.selectedCells).to.deep.equal([
@@ -233,17 +242,17 @@ describe('@jupyterlab/notebook', () => {
       });
     });
 
-    describe('CellTools.MetadataEditorTool', () => {
+    describe('CellTools.CellMetadataEditorTool', () => {
       const editorServices = new CodeMirrorEditorFactory();
       const editorFactory = editorServices.newInlineEditor.bind(editorServices);
 
       it('should create a new metadata editor tool', () => {
-        const tool = new CellTools.MetadataEditorTool({ editorFactory });
-        expect(tool).to.be.an.instanceof(CellTools.MetadataEditorTool);
+        const tool = new CellTools.CellMetadataEditorTool({ editorFactory });
+        expect(tool).to.be.an.instanceof(CellTools.CellMetadataEditorTool);
       });
 
       it('should handle a change to the active cell', () => {
-        const tool = new CellTools.MetadataEditorTool({ editorFactory });
+        const tool = new CellTools.CellMetadataEditorTool({ editorFactory });
         celltools.addItem({ tool });
         const model = tool.editor.model;
         expect(JSON.stringify(model.value.text)).to.be.ok;
@@ -254,11 +263,50 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should handle a change to the metadata', () => {
-        const tool = new CellTools.MetadataEditorTool({ editorFactory });
+        const tool = new CellTools.CellMetadataEditorTool({ editorFactory });
         celltools.addItem({ tool });
         const model = tool.editor.model;
         const previous = model.value.text;
         const metadata = celltools.activeCell.model.metadata;
+        metadata.set('foo', 1);
+        expect(model.value.text).to.not.equal(previous);
+      });
+    });
+
+    describe('CellTools.NotebookMetadataEditorTool', () => {
+      const editorServices = new CodeMirrorEditorFactory();
+      const editorFactory = editorServices.newInlineEditor.bind(editorServices);
+
+      it('should create a new metadata editor tool', () => {
+        const tool = new CellTools.NotebookMetadataEditorTool({
+          editorFactory
+        });
+        expect(tool).to.be.an.instanceof(CellTools.NotebookMetadataEditorTool);
+      });
+
+      it('should handle a change to the active notebook', async () => {
+        const tool = new CellTools.NotebookMetadataEditorTool({
+          editorFactory
+        });
+        celltools.addItem({ tool });
+        const model = tool.editor.model;
+        expect(JSON.stringify(model.value.text)).to.be.ok;
+        expect(tracker.currentWidget).to.equal(panel1);
+        tabpanel.currentIndex = 0;
+        simulate(panel0.node, 'focus');
+        expect(tracker.currentWidget).to.equal(panel0);
+        panel0.content.model.metadata.set('bar', 1);
+        expect(JSON.stringify(model.value.text)).to.contain('bar');
+      });
+
+      it('should handle a change to the metadata', () => {
+        const tool = new CellTools.NotebookMetadataEditorTool({
+          editorFactory
+        });
+        celltools.addItem({ tool });
+        const model = tool.editor.model;
+        const previous = model.value.text;
+        const metadata = celltools.activeNotebook.model.metadata;
         metadata.set('foo', 1);
         expect(model.value.text).to.not.equal(previous);
       });


### PR DESCRIPTION
Fixes #1308.

This is a pretty minimal UI, it just adds another JSON editor which is close-to-identical to the cell metadata editor. A more featureful set of editors might do some schema checking, but this is what we need right now for feature parity.
![image](https://user-images.githubusercontent.com/5728311/53125480-ef2e8e80-3512-11e9-98fe-85b3f3778b1e.png)
