### PR TITLE
Refresh the editor when switching a Markdown cell to edit mode.

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -898,6 +898,12 @@ export class MarkdownCell extends Cell {
     }
     this._rendered = value;
     this._handleRendered();
+    // Refreshing an editor can be really expensive, so we don't call it from
+    // _handleRendered, since _handledRendered is also called on every update
+    // request.
+    if (!this._rendered) {
+      this.editor.refresh();
+    }
   }
 
   /**


### PR DESCRIPTION
In ad2d92278c82fca57eddc32628add597269575eb (#5700), editor refreshing is eliminated in AfterShow messages for cells. This means when opening a notebook with a rendered Markdown, double-clicking to edit the Markdown cell now no longer refreshes the editor, which means the editor initially is the wrong height (often zero height). This changes forces an editor refresh explicitly in this case.
