### PR TITLE
Increase z-index of search overlay

### DIFF
--- a/packages/documentsearch/style/index.css
+++ b/packages/documentsearch/style/index.css
@@ -17,7 +17,7 @@
   border-bottom-left-radius: var(--jp-border-radius);
   top: 0;
   right: 0;
-  z-index: 5;
+  z-index: 7;
   min-width: 300px;
   padding: 2px;
   font-size: var(--jp-ui-font-size1);


### PR DESCRIPTION
This bumps the z-index of the ctrl-f search overlay from 5 to 7.  The CodeMirror horizontal scroll bar has a z-index of 6, so it was appearing on top of the search overlay.

Before:
![search overlay obstructed](https://user-images.githubusercontent.com/1820420/53273955-6ba7a580-36aa-11e9-977e-c0a60300c524.png)

After:
![search overlay in the clear](https://user-images.githubusercontent.com/1820420/53273949-664a5b00-36aa-11e9-9762-f4dd0df1cec2.png)

