### PR TITLE
Fix codemirror styling

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -365,6 +365,14 @@ export class Cell extends Widget {
   }
 
   /**
+   * Handle `fit-request` messages.
+   */
+  protected onFitRequest(msg: Message): void {
+    // need this for for when a theme changes font size
+    this.editor.refresh();
+  }
+
+  /**
    * Handle `update-request` messages.
    */
   protected onUpdateRequest(msg: Message): void {

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -43,7 +43,12 @@
 /* This causes https://github.com/jupyter/jupyterlab/issues/522 */
 /* May not cause it not because we changed it! */
 .CodeMirror-lines {
-  padding: var(--jp-code-padding);
+  padding: var(--jp-code-padding) 0;
+}
+
+/* Set horizontal padding on line nodes for correct margins */
+pre.CodeMirror-line {
+  padding: 0 var(--jp-code-padding);
 }
 
 .CodeMirror-linenumbers {
@@ -153,7 +158,7 @@
 }
 
 .cm-s-jupyter .CodeMirror-cursor {
-  border-left: 1.4px solid var(--jp-editor-cursor-color);
+  border-left: var(--jp-code-cursor-width0) solid var(--jp-editor-cursor-color);
 }
 .cm-s-jupyter span.cm-keyword {
   color: var(--jp-mirror-editor-keyword-color);


### PR DESCRIPTION
In the course of my recent work on theme stuff, I found and fixed a number of bugs in the Codemirror styling. Here's the contents of the PR:

- Fixed the right margin of code cells:
    - Before
![image](https://user-images.githubusercontent.com/2263641/53304836-05588980-3848-11e9-8974-cd14294b5a45.png)
    - After
![image](https://user-images.githubusercontent.com/2263641/53304965-7187bd00-3849-11e9-85aa-36d9762ce50f.png)

- The editors were left in a bad state after a theme changed the font size, fixed it:
    - Before (notice that the cursor isn't aligned to the text)
![image](https://user-images.githubusercontent.com/2263641/53304911-3be2d400-3849-11e9-8d51-71d18f827481.png)
    - After
![image](https://user-images.githubusercontent.com/2263641/53304980-9ed46b00-3849-11e9-93e8-c41af3f758c9.png)

- When I set up the theme variables for cursor width, I missed a line of CSS in which the width was still hardcoded. Fixed that.