### PR TITLE
"Close all" command refers to tabs, not widgets

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -452,7 +452,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
 
   command = CommandIDs.closeAll;
   app.commands.addCommand(command, {
-    label: 'Close All Widgets',
+    label: 'Close All Tabs',
     execute: () => {
       app.shell.closeAll();
     }


### PR DESCRIPTION
Users are unaware of the JupyterLab "widget" nomenclature (which is
also overloaded in many contexts). The other Main Area commands
currently refer to "Activate Next Tab" and "Activate Previous Tab", so
having "Close All Tabs" seems like a more natural name for the
operation.