### PR TITLE
Fix deleting a tab by using the indentUnit option

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1364,7 +1364,7 @@ namespace Private {
       return;
     }
     let cur = doc.getCursor();
-    let tabsize = cm.getOption('tabSize');
+    let tabsize = cm.getOption('indentUnit');
     let chToPrevTabStop = cur.ch - (Math.ceil(cur.ch / tabsize) - 1) * tabsize;
     from = { ch: cur.ch - chToPrevTabStop, line: cur.line };
     let select = doc.getRange(from, cur);


### PR DESCRIPTION
Fixes #5992

Setting tabSize to 2 and deleting an indentation level will now remove 2 spaces and not 4
