### PR TITLE
Delete unnecessary call to adoptWidget

### DIFF
--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -197,7 +197,6 @@ export class DocumentWidgetManager implements IDisposable {
       return undefined;
     }
     let newWidget = this.createWidget(factory, context);
-    this.adoptWidget(context, newWidget);
     return newWidget;
   }
 


### PR DESCRIPTION
The createWidget method already calls adoptWidget, so no need to call it again.
