### PR TITLE
 Add jp-Icon and jp-Icon-16 classnames to ToolbarButtons with icons

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -461,7 +461,10 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
     >
       {props.iconClassName && (
         <span
-          className={props.iconClassName + ' jp-ToolbarButtonComponent-icon'}
+          className={
+            props.iconClassName +
+            ' jp-ToolbarButtonComponent-icon jp-Icon jp-Icon-16'
+          }
         />
       )}
       {props.label && (

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -346,7 +346,7 @@ export namespace Toolbar {
    */
   export function createInterruptButton(session: IClientSession): Widget {
     return new ToolbarButton({
-      iconClassName: 'jp-StopIcon jp-Icon jp-Icon-16',
+      iconClassName: 'jp-StopIcon',
       onClick: () => {
         if (session.kernel) {
           session.kernel.interrupt();
@@ -361,7 +361,7 @@ export namespace Toolbar {
    */
   export function createRestartButton(session: IClientSession): Widget {
     return new ToolbarButton({
-      iconClassName: 'jp-RefreshIcon jp-Icon jp-Icon-16',
+      iconClassName: 'jp-RefreshIcon',
       onClick: () => {
         session.restart();
       },

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -344,10 +344,9 @@ export class CollapsibleSection extends React.Component<
         <header>
           <ToolbarButtonComponent
             iconClassName={
-              'jp-Icon jp-Icon-16 ' +
-              (this.state.isOpen
+              this.state.isOpen
                 ? 'jp-extensionmanager-expandIcon'
-                : 'jp-extensionmanager-collapseIcon')
+                : 'jp-extensionmanager-collapseIcon'
             }
             onClick={() => {
               this.handleCollapse();
@@ -539,7 +538,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
             <ToolbarButtonComponent
               key="refresh-button"
               className="jp-extensionmanager-refresh"
-              iconClassName="jp-RefreshIcon jp-Icon jp-Icon-16"
+              iconClassName="jp-RefreshIcon"
               onClick={() => {
                 model.refreshInstalled();
               }}

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -212,7 +212,7 @@ function activateFactory(
 
     // Add a launcher toolbar item.
     let launcher = new ToolbarButton({
-      iconClassName: 'jp-AddIcon jp-Icon jp-Icon-16',
+      iconClassName: 'jp-AddIcon',
       onClick: () => {
         return Private.createLauncher(commands, widget);
       },

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -70,7 +70,7 @@ export class FileBrowser extends Widget {
 
     this._directoryPending = false;
     let newFolder = new ToolbarButton({
-      iconClassName: 'jp-NewFolderIcon jp-Icon jp-Icon-16',
+      iconClassName: 'jp-NewFolderIcon',
       onClick: () => {
         this.createNewDirectory();
       },
@@ -80,7 +80,7 @@ export class FileBrowser extends Widget {
     let uploader = new Uploader({ model });
 
     let refresher = new ToolbarButton({
-      iconClassName: 'jp-RefreshIcon jp-Icon jp-Icon-16',
+      iconClassName: 'jp-RefreshIcon',
       onClick: () => {
         model.refresh();
       },

--- a/packages/filebrowser/src/upload.ts
+++ b/packages/filebrowser/src/upload.ts
@@ -14,7 +14,7 @@ export class Uploader extends ToolbarButton {
    */
   constructor(options: Uploader.IOptions) {
     super({
-      iconClassName: 'jp-FileUploadIcon jp-Icon jp-Icon-16',
+      iconClassName: 'jp-FileUploadIcon',
       onClick: () => {
         this._input.click();
       },

--- a/packages/htmlviewer/src/index.tsx
+++ b/packages/htmlviewer/src/index.tsx
@@ -92,7 +92,7 @@ export class HTMLViewer extends DocumentWidget<IFrame>
     this.toolbar.addItem(
       'refresh',
       new ToolbarButton({
-        iconClassName: 'jp-RefreshIcon jp-Icon jp-Icon-16',
+        iconClassName: 'jp-RefreshIcon',
         onClick: () => {
           this.content.url = this.content.url;
         },

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -95,7 +95,7 @@ export namespace ToolbarItems {
         <UseSignal signal={panel.context.fileChanged}>
           {() => (
             <ToolbarButtonComponent
-              iconClassName={TOOLBAR_SAVE_CLASS + ' jp-Icon jp-Icon-16'}
+              iconClassName={TOOLBAR_SAVE_CLASS}
               onClick={onClick}
               tooltip="Save the notebook contents and create checkpoint"
               enabled={
@@ -118,7 +118,7 @@ export namespace ToolbarItems {
    */
   export function createInsertButton(panel: NotebookPanel): Widget {
     return new ToolbarButton({
-      iconClassName: TOOLBAR_INSERT_CLASS + ' jp-Icon jp-Icon-16',
+      iconClassName: TOOLBAR_INSERT_CLASS,
       onClick: () => {
         NotebookActions.insertBelow(panel.content);
       },
@@ -131,7 +131,7 @@ export namespace ToolbarItems {
    */
   export function createCutButton(panel: NotebookPanel): Widget {
     return new ToolbarButton({
-      iconClassName: TOOLBAR_CUT_CLASS + ' jp-Icon jp-Icon-16',
+      iconClassName: TOOLBAR_CUT_CLASS,
       onClick: () => {
         NotebookActions.cut(panel.content);
       },
@@ -144,7 +144,7 @@ export namespace ToolbarItems {
    */
   export function createCopyButton(panel: NotebookPanel): Widget {
     return new ToolbarButton({
-      iconClassName: TOOLBAR_COPY_CLASS + ' jp-Icon jp-Icon-16',
+      iconClassName: TOOLBAR_COPY_CLASS,
       onClick: () => {
         NotebookActions.copy(panel.content);
       },
@@ -157,7 +157,7 @@ export namespace ToolbarItems {
    */
   export function createPasteButton(panel: NotebookPanel): Widget {
     return new ToolbarButton({
-      iconClassName: TOOLBAR_PASTE_CLASS + ' jp-Icon jp-Icon-16',
+      iconClassName: TOOLBAR_PASTE_CLASS,
       onClick: () => {
         NotebookActions.paste(panel.content);
       },
@@ -170,7 +170,7 @@ export namespace ToolbarItems {
    */
   export function createRunButton(panel: NotebookPanel): Widget {
     return new ToolbarButton({
-      iconClassName: TOOLBAR_RUN_CLASS + ' jp-Icon jp-Icon-16',
+      iconClassName: TOOLBAR_RUN_CLASS,
       onClick: () => {
         NotebookActions.runAndAdvance(panel.content, panel.session);
       },

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -197,7 +197,7 @@ function Section<M>(props: SessionProps<M>) {
             <h2>{props.name} Sessions</h2>
             <ToolbarButtonComponent
               tooltip={`Shutdown All ${props.name} Sessions…`}
-              iconClassName="jp-CloseIcon jp-Icon jp-Icon-16"
+              iconClassName="jp-CloseIcon"
               onClick={onShutdown}
             />
           </header>
@@ -229,7 +229,7 @@ function RunningSessionsComponent({
       <div className={HEADER_CLASS}>
         <ToolbarButtonComponent
           tooltip="Refresh List"
-          iconClassName="jp-RefreshIcon jp-Icon jp-Icon-16"
+          iconClassName="jp-RefreshIcon"
           onClick={() => {
             if (terminalsAvailable) {
               manager.terminals.refreshRunning();


### PR DESCRIPTION
Fixes #5971

Without the `jp-Icon` and `jp-Icon-16` classnames, icons will not display in `ToolbarButton`s. This adds those classnames by default to avoid confusion. Additionally, it cleans up instances (in core packages) where those classnames are passed to `ToolbarButton`.

We _could_ prevent duplicate classnames (e.g. from non-core extensions passing in those classnames), by stripping out these classnames from the component's props.