### PR TITLE
Use the `mousedown` event to trigger toolbar button actions.

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -434,7 +434,11 @@ export namespace ToolbarButtonComponent {
  * @param props - The props for ToolbarButtonComponent.
  */
 export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
-  const handleClick = (event: React.MouseEvent) => {
+  // The default action on `mousedown` event moves the focus from the main
+  // content to the button. To avoid this we call `preventDefault`.
+  // However, preventing `mousedown` default action stops `click` event from
+  // firing as well. So we have to bind button action to `mousedown`.
+  const handleMouseDown = (event: React.MouseEvent) => {
     event.preventDefault();
     props.onClick();
   };
@@ -454,7 +458,7 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
           : 'jp-ToolbarButtonComponent'
       }
       disabled={props.enabled === false}
-      onClick={handleClick}
+      onMouseDown={handleMouseDown}
       onKeyDown={handleKeyDown}
       title={props.tooltip || props.iconLabel}
       minimal

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -434,10 +434,10 @@ export namespace ToolbarButtonComponent {
  * @param props - The props for ToolbarButtonComponent.
  */
 export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
-  // The default action on `mousedown` event moves the focus from the main
-  // content to the button. To avoid this we call `preventDefault`.
-  // However, preventing `mousedown` default action stops `click` event from
-  // firing as well. So we have to bind button action to `mousedown`.
+  // In some browsers, a button click event moves the focus from the main
+  // content to the button (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus). 
+  // We avoid a click event by calling preventDefault in mousedown, and
+  // we bind the button action to `mousedown`.
   const handleMouseDown = (event: React.MouseEvent) => {
     event.preventDefault();
     props.onClick();

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -417,7 +417,7 @@ describe('@jupyterlab/apputils', () => {
           });
           Widget.attach(button, document.body);
           await framePromise();
-          simulate(button.node.firstChild as HTMLElement, 'click');
+          simulate(button.node.firstChild as HTMLElement, 'mousedown');
           expect(called).to.equal(true);
           button.dispose();
         });

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -54,7 +54,7 @@ describe('@jupyterlab/notebook', () => {
         Widget.attach(button, document.body);
         let promise = signalToPromise(context.fileChanged);
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'click');
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         await promise;
         button.dispose();
       });
@@ -72,7 +72,7 @@ describe('@jupyterlab/notebook', () => {
         const button = ToolbarItems.createInsertButton(panel);
         Widget.attach(button, document.body);
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'click');
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         expect(panel.content.activeCellIndex).to.equal(1);
         expect(panel.content.activeCell).to.be.an.instanceof(CodeCell);
         button.dispose();
@@ -92,7 +92,7 @@ describe('@jupyterlab/notebook', () => {
         const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'click');
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         expect(panel.content.widgets.length).to.equal(count - 1);
         expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
         button.dispose();
@@ -112,7 +112,7 @@ describe('@jupyterlab/notebook', () => {
         const count = panel.content.widgets.length;
         Widget.attach(button, document.body);
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'click');
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         expect(panel.content.widgets.length).to.equal(count);
         expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
         button.dispose();
@@ -133,7 +133,7 @@ describe('@jupyterlab/notebook', () => {
         Widget.attach(button, document.body);
         await framePromise();
         NotebookActions.copy(panel.content);
-        simulate(button.node.firstChild as HTMLElement, 'click');
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         await sleep();
         expect(panel.content.widgets.length).to.equal(count + 1);
         button.dispose();
@@ -175,7 +175,7 @@ describe('@jupyterlab/notebook', () => {
           }
         });
         await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'click');
+        simulate(button.node.firstChild as HTMLElement, 'mousedown');
         await p.promise;
       }).timeout(30000); // Allow for slower CI
 


### PR DESCRIPTION
Fixes #6077.

Cheers
