### PR TITLE
[WIP] Add logout button

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -352,7 +352,7 @@ export function createFileMenu(
     caption: 'Shut down JupyterLab',
     execute: () => {
       return showDialog({
-        title: 'Shut down confirmation',
+        title: 'Shutdown confirmation',
         body: 'Please confirm you want to shut down JupyterLab.',
         buttons: [
           Dialog.cancelButton(),


### PR DESCRIPTION
Fixes #5966 

Is there an easy way to change the order a phosphor widget is inserted ? I've not been able to find a trivial way to add it to the end of the shell's top area - so it shows up at top left of the screen.
