### PR TITLE
Add tab navigation to the search box

### DIFF
--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -78,7 +78,7 @@ class SearchEntry extends React.Component<ISearchEntryProps> {
           ref="searchInputNode"
         />
         <button
-          className={`${BUTTON_WRAPPER_CLASS}`}
+          className={BUTTON_WRAPPER_CLASS}
           onClick={() => this.props.onCaseSensitiveToggled()}
           tabIndex={2}
         >

--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -78,18 +78,24 @@ class SearchEntry extends React.Component<ISearchEntryProps> {
           ref="searchInputNode"
         />
         <button
-          className={`${caseButtonToggleClass} ${BUTTON_WRAPPER_CLASS}`}
+          className={`${BUTTON_WRAPPER_CLASS}`}
           onClick={() => this.props.onCaseSensitiveToggled()}
           tabIndex={2}
         >
-          <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+          <span
+            className={`${caseButtonToggleClass} ${BUTTON_CONTENT_CLASS}`}
+            tabIndex={-1}
+          />
         </button>
         <button
-          className={`${regexButtonToggleClass} ${BUTTON_WRAPPER_CLASS}`}
+          className={BUTTON_WRAPPER_CLASS}
           onClick={() => this.props.onRegexToggled()}
           tabIndex={3}
         >
-          <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+          <span
+            className={`${regexButtonToggleClass} ${BUTTON_CONTENT_CLASS}`}
+            tabIndex={-1}
+          />
         </button>
       </div>
     );
@@ -105,18 +111,24 @@ function UpDownButtons(props: IUpDownProps) {
   return (
     <div className={UP_DOWN_BUTTON_WRAPPER_CLASS}>
       <button
-        className={`${UP_BUTTON_CLASS} ${BUTTON_WRAPPER_CLASS}`}
+        className={BUTTON_WRAPPER_CLASS}
         onClick={() => props.onHighlightPrevious()}
         tabIndex={4}
       >
-        <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+        <span
+          className={`${UP_BUTTON_CLASS} ${BUTTON_CONTENT_CLASS}`}
+          tabIndex={-1}
+        />
       </button>
       <button
-        className={`${DOWN_BUTTON_CLASS} ${BUTTON_WRAPPER_CLASS}`}
+        className={BUTTON_WRAPPER_CLASS}
         onClick={() => props.onHightlightNext()}
         tabIndex={5}
       >
-        <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+        <span
+          className={`${DOWN_BUTTON_CLASS} ${BUTTON_CONTENT_CLASS}`}
+          tabIndex={-1}
+        />
       </button>
     </div>
   );
@@ -235,12 +247,15 @@ class SearchOverlay extends React.Component<
         key={2}
       />,
       <button
-        className={`${CLOSE_BUTTON_CLASS} ${BUTTON_WRAPPER_CLASS}`}
+        className={BUTTON_WRAPPER_CLASS}
         onClick={() => this.onClose()}
         tabIndex={6}
         key={3}
       >
-        <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+        <span
+          className={`${CLOSE_BUTTON_CLASS} ${BUTTON_CONTENT_CLASS}`}
+          tabIndex={-1}
+        />
       </button>,
       <div
         className={REGEX_ERROR_CLASS}

--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -26,6 +26,9 @@ const DOWN_BUTTON_CLASS = 'jp-DocumentSearch-down-button';
 const CLOSE_BUTTON_CLASS = 'jp-DocumentSearch-close-button';
 const REGEX_ERROR_CLASS = 'jp-DocumentSearch-regex-error';
 
+const BUTTON_CONTENT_CLASS = 'jp-DocumentSearch-button-content';
+const BUTTON_WRAPPER_CLASS = 'jp-DocumentSearch-button-wrapper';
+
 interface ISearchEntryProps {
   onCaseSensitiveToggled: Function;
   onRegexToggled: Function;
@@ -71,16 +74,23 @@ class SearchEntry extends React.Component<ISearchEntryProps> {
           value={this.props.inputText}
           onChange={e => this.props.onChange(e)}
           onKeyDown={e => this.props.onKeydown(e)}
+          tabIndex={1}
           ref="searchInputNode"
         />
         <button
-          className={caseButtonToggleClass}
+          className={`${caseButtonToggleClass} ${BUTTON_WRAPPER_CLASS}`}
           onClick={() => this.props.onCaseSensitiveToggled()}
-        />
+          tabIndex={2}
+        >
+          <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+        </button>
         <button
-          className={regexButtonToggleClass}
+          className={`${regexButtonToggleClass} ${BUTTON_WRAPPER_CLASS}`}
           onClick={() => this.props.onRegexToggled()}
-        />
+          tabIndex={3}
+        >
+          <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+        </button>
       </div>
     );
   }
@@ -95,13 +105,19 @@ function UpDownButtons(props: IUpDownProps) {
   return (
     <div className={UP_DOWN_BUTTON_WRAPPER_CLASS}>
       <button
-        className={UP_BUTTON_CLASS}
+        className={`${UP_BUTTON_CLASS} ${BUTTON_WRAPPER_CLASS}`}
         onClick={() => props.onHighlightPrevious()}
-      />
+        tabIndex={4}
+      >
+        <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+      </button>
       <button
-        className={DOWN_BUTTON_CLASS}
+        className={`${DOWN_BUTTON_CLASS} ${BUTTON_WRAPPER_CLASS}`}
         onClick={() => props.onHightlightNext()}
-      />
+        tabIndex={5}
+      >
+        <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+      </button>
     </div>
   );
 }
@@ -218,11 +234,14 @@ class SearchOverlay extends React.Component<
         onHightlightNext={() => this._executeSearch(true)}
         key={2}
       />,
-      <div
-        className={CLOSE_BUTTON_CLASS}
+      <button
+        className={`${CLOSE_BUTTON_CLASS} ${BUTTON_WRAPPER_CLASS}`}
         onClick={() => this.onClose()}
+        tabIndex={6}
         key={3}
-      />,
+      >
+        <span className={BUTTON_CONTENT_CLASS} tabIndex={-1} />
+      </button>,
       <div
         className={REGEX_ERROR_CLASS}
         hidden={this.state.errorMessage && this.state.errorMessage.length === 0}

--- a/packages/documentsearch/style/index.css
+++ b/packages/documentsearch/style/index.css
@@ -6,6 +6,7 @@
   border: none;
   outline: none;
   font-size: var(--jp-ui-font-size1);
+  background-color: var(--jp-layout-color0);
 }
 
 .jp-DocumentSearch-overlay {
@@ -29,25 +30,40 @@
   color: var(--jp-ui-font-color0);
 }
 
-.jp-DocumentSearch-input-wrapper {
-  border: var(--jp-border-width) solid var(--jp-border-color0);
-  border-radius: var(--jp-border-radius);
-  display: flex;
-  background-color: var(--jp-layout-color0);
+.jp-DocumentSearch-button-content {
+  display: inline-block;
+  cursor: pointer;
+  width: 80%;
+  height: 80%;
+  margin: 10%;
+  background-color: none;
 }
 
-.jp-DocumentSearch-input-wrapper * {
-  background-color: var(--jp-layout-color0);
-}
-
-.jp-DocumentSearch-input-wrapper button {
+.jp-DocumentSearch-button-wrapper {
+  all: initial;
+  display: inline-block;
   outline: 0;
   border: none;
   width: 20px;
   height: 20px;
   box-sizing: border-box;
-  background-color: var(--jp-layout-color0);
   background-repeat: no-repeat;
+}
+
+.jp-DocumentSearch-button-wrapper:focus > .jp-DocumentSearch-button-content {
+  box-shadow: 0 0 2px 2px #51a7e8;
+}
+
+.jp-DocumentSearch-button-wrapper,
+.jp-DocumentSearch-button-content:focus {
+  outline: none;
+}
+
+.jp-DocumentSearch-input-wrapper {
+  border: var(--jp-border-width) solid var(--jp-border-color0);
+  border-radius: var(--jp-border-radius);
+  display: flex;
+  background-color: var(--jp-layout-color0);
 }
 
 .jp-DocumentSearch-regex-button {
@@ -88,13 +104,8 @@
 }
 
 .jp-DocumentSearch-up-down-wrapper button {
-  outline: 0;
-  border: none;
-  width: 20px;
-  height: 20px;
   padding-bottom: 5px;
   background-color: var(--jp-layout-color0);
-  background-repeat: no-repeat;
 }
 
 .jp-DocumentSearch-up-button {
@@ -113,7 +124,6 @@
   width: 16px;
   background-image: var(--jp-icon-close);
   background-position: center;
-  background-repeat: no-repeat;
 }
 
 .jp-DocumentSearch-close-button:hover {

--- a/packages/documentsearch/style/index.css
+++ b/packages/documentsearch/style/index.css
@@ -28,19 +28,20 @@
 
 .jp-DocumentSearch-overlay * {
   color: var(--jp-ui-font-color0);
+  background-position: center;
 }
 
 .jp-DocumentSearch-button-content {
   display: inline-block;
   cursor: pointer;
-  width: 80%;
-  height: 80%;
-  margin: 10%;
-  background-color: none;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
 }
 
 .jp-DocumentSearch-button-wrapper {
   all: initial;
+  overflow: hidden;
   display: inline-block;
   outline: 0;
   border: none;
@@ -50,8 +51,10 @@
   background-repeat: no-repeat;
 }
 
-.jp-DocumentSearch-button-wrapper:focus > .jp-DocumentSearch-button-content {
-  box-shadow: 0 0 2px 2px #51a7e8;
+.jp-DocumentSearch-button-wrapper:focus {
+  outline: var(--jp-border-width) solid
+    var(--jp-cell-editor-active-border-color);
+  outline-offset: -1px;
 }
 
 .jp-DocumentSearch-button-wrapper,
@@ -104,8 +107,9 @@
 }
 
 .jp-DocumentSearch-up-down-wrapper button {
-  padding-bottom: 5px;
   background-color: var(--jp-layout-color0);
+  vertical-align: middle;
+  background-position: center;
 }
 
 .jp-DocumentSearch-up-button {
@@ -118,12 +122,11 @@
 
 .jp-DocumentSearch-close-button {
   display: inline-block;
-  margin-left: 4px;
   background-size: 16px;
-  height: 16px;
-  width: 16px;
   background-image: var(--jp-icon-close);
+  background-repeat: no-repeat;
   background-position: center;
+  vertical-align: middle;
 }
 
 .jp-DocumentSearch-close-button:hover {


### PR DESCRIPTION
This adds a tab index to the entry and each button/toggle in the search box.  Now you can navigate from the search input to any of the buttons using the tab key and activate them with enter.  This also adds a box shadow to the buttons when you navigate to them via the keyboard (but not when you click on them).  Lastly, this changes the cursor to the pointer on the buttons.

I couldn't really find any similar UX in JupyterLab but this seemed like it'd be useful.  I started to do this in search & replace (#6081), where it will be necessary to move between the two boxes, but I figured it'd be worth putting in early and separate.  Any suggestions on improving the CSS or the look of the box shadow would be much appreciated.

Gif demo using tab and shift+tab to navigate, enter to activate the buttons:
![ctrl-f-tab-index](https://user-images.githubusercontent.com/1820420/54466950-87e5b200-473f-11e9-91d8-0a376f81c1b5.gif)

