### PR TITLE
Let an output overflow with scrollbars in both directions.

### DIFF
--- a/packages/outputarea/style/index.css
+++ b/packages/outputarea/style/index.css
@@ -48,7 +48,7 @@
 
 .jp-OutputArea-output {
   height: auto;
-  overflow-x: auto;
+  overflow: auto;
   user-select: text;
   -moz-user-select: text;
   -webkit-user-select: text;


### PR DESCRIPTION
In linked views, CSS at the end of this file was setting the height to 100% if the output was the only child. Without an overflow-y setting, this was hiding content without a scrollbar. You can see it in the following example:

```python
for i in range(1000):
    print(i)
```

and “Create new view for output” (a linked output cell). With a single output, the vertical scrollbar does not appear in this new view, and we cannot see the bottom of the output.


Rather than just fixing that one case of an only child in a linked output view, we make this change, following the principle that output contents should always be accessible and not hidden.

**Screenshots**
Before:
<img width="862" alt="Screen Shot 2019-03-19 at 12 46 41 PM" src="https://user-images.githubusercontent.com/192614/54637098-c8b33300-4a7f-11e9-8725-87554c7fe719.png">

After:
<img width="861" alt="Screen Shot 2019-03-19 at 12 45 01 PM" src="https://user-images.githubusercontent.com/192614/54637122-d10b6e00-4a7f-11e9-9c8d-ed46e5d6d98f.png">
