### PR TITLE
DOC: add tips and tricks

### DIFF
--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -21,3 +21,10 @@ Development
 -  `How can you
    contribute? <https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`__
 -  :ref:`How can you extend or customize JupyterLab? <user_extensions>`
+
+Tips and Tricks
+---------------
+
+- How to start JupyterLab with a clean workspace?
+
+Add `'c.NotebookApp.default_url = '/lab?reset'` to your `jupyter_notebook_config.py`. See [How to create a jupyter_notebook_config.py](https://jupyter-notebook.readthedocs.io/en/stable/config.html) for more information.

--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -25,6 +25,6 @@ Development
 Tips and Tricks
 ---------------
 
-- How to start JupyterLab with a clean workspace?
+- How do I start JupyterLab with a clean workspace every time?
 
 Add `'c.NotebookApp.default_url = '/lab?reset'` to your `jupyter_notebook_config.py`. See [How to create a jupyter_notebook_config.py](https://jupyter-notebook.readthedocs.io/en/stable/config.html) for more information.


### PR DESCRIPTION
Fixes #5926 

This an up updated version of https://github.com/jupyterlab/jupyterlab/pull/5939
I apologize for opening a new PR but it was easier to start from scratch.

I moved the text to the file but I wonder if we want to hyperlink to somewhere else with the information? I couldn't find anywhere obvious in the jupterlab docs.

We could add it to  https://github.com/jupyter/notebook/blob/b26221ad44037f16610db0234ef109d7879ab437/notebook/notebookapp.py#L651
but then we are encroaching on the jupyter notebook docs
