### PR TITLE
Change "the next-generation ... interface" to "a next-generation ... interface"

### DIFF
--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -3,7 +3,7 @@
 Overview
 --------
 
-JupyterLab is the next-generation web-based user interface for Project Jupyter.
+JupyterLab is a next-generation web-based user interface for Project Jupyter.
 
 .. image:: ../user/images/interface_jupyterlab.png
    :align: center


### PR DESCRIPTION
We help the community of frontends to grow and mature by saying "a ... interface" rather than an exclusive "the ... interface".
