### PR TITLE
Point to Discourse instead of Gitter

### DIFF
--- a/.github/ISSUE_TEMPLATE/installation-and-configuration-issues.md
+++ b/.github/ISSUE_TEMPLATE/installation-and-configuration-issues.md
@@ -3,4 +3,4 @@ name: Installation and configuration issues
 about: Installation and configuration assistance
 ---
 
-If you are having issues with installation or configuration, you may ask for help on the [JupyterLab Gitter channel](https://gitter.im/jupyterlab/jupyterlab) or file an issue here.
+If you are having issues with installation or configuration, we encourage you to post in the [Jupyter Discourse forum](https://discourse.jupyter.org/c/jupyterlab).

--- a/.github/ISSUE_TEMPLATE/installation-and-configuration-issues.md
+++ b/.github/ISSUE_TEMPLATE/installation-and-configuration-issues.md
@@ -3,4 +3,4 @@ name: Installation and configuration issues
 about: Installation and configuration assistance
 ---
 
-If you are having issues with installation or configuration, we encourage you to post in the [Jupyter Discourse forum](https://discourse.jupyter.org/c/jupyterlab).
+If you are having issues with installation or configuration, we encourage you to post in the [Jupyter Discourse forum](https://discourse.jupyter.org/c/jupyterlab) or file an issue here.


### PR DESCRIPTION
Aligns communication suggestions in JupyterLab's readme as suggested we do by @gnestor 

Please feel free to add commits, I just wanted to followup with something basic.