### PR TITLE
Strict promises

### DIFF
--- a/buildutils/src/create-package.ts
+++ b/buildutils/src/create-package.ts
@@ -21,7 +21,7 @@ let questions = [
   }
 ];
 
-inquirer.prompt(questions).then(answers => {
+void inquirer.prompt(questions).then(answers => {
   let { name, description } = answers;
   let dest = path.resolve(path.join('.', 'packages', name));
   if (fs.existsSync(dest)) {

--- a/buildutils/src/create-test-package.ts
+++ b/buildutils/src/create-test-package.ts
@@ -33,5 +33,5 @@ if (require.main === module) {
   }
   data.name = name;
   utils.writePackageData(jsonPath, data);
-  fs.ensureDir(path.join(dest, 'src'));
+  fs.ensureDirSync(path.join(dest, 'src'));
 }

--- a/buildutils/src/create-theme.ts
+++ b/buildutils/src/create-theme.ts
@@ -57,7 +57,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
 export default plugin;
 `;
 
-inquirer.prompt(questions).then(answers => {
+void inquirer.prompt(questions).then(answers => {
   let { name, title, description } = answers;
   let dest = path.resolve(path.join('.', name));
   if (fs.existsSync(dest)) {
@@ -81,7 +81,7 @@ inquirer.prompt(questions).then(answers => {
   ['lib', 'node_modules', 'static'].forEach(folder => {
     let folderPath = path.join('.', name, folder);
     if (fs.existsSync(folderPath)) {
-      fs.remove(folderPath);
+      fs.removeSync(folderPath);
     }
   });
 

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -268,5 +268,5 @@ export async function ensureIntegrity(): Promise<boolean> {
 }
 
 if (require.main === module) {
-  ensureIntegrity();
+  void ensureIntegrity();
 }

--- a/buildutils/src/get-dependency.ts
+++ b/buildutils/src/get-dependency.ts
@@ -84,7 +84,7 @@ if (require.main === module) {
     process.exit(1);
   }
   let name = process.argv[2];
-  getDependency(name).then(version => {
+  void getDependency(name).then(version => {
     console.log('dependency of: ', allDeps);
     console.log('devDependency of:', allDevDeps);
     console.log(`\n    "${name}": "${version}"`);

--- a/examples/cell/src/index.ts
+++ b/examples/cell/src/index.ts
@@ -58,7 +58,7 @@ function main(): void {
 
   // Handle the mimeType for the current kernel.
   session.kernelChanged.connect(() => {
-    session.kernel.ready.then(() => {
+    void session.kernel.ready.then(() => {
       const lang = session.kernel.info.language_info;
       const mimeType = mimeService.getMimeTypeByLanguage(lang);
       cellWidget.model.mimeType = mimeType;
@@ -67,7 +67,7 @@ function main(): void {
 
   // Start the default kernel.
   session.kernelPreference = { autoStartDefault: true };
-  session.initialize();
+  void session.initialize();
 
   // Set up a completer.
   const editor = cellWidget.editor;

--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -42,7 +42,7 @@ function main(): void {
   }
 
   let manager = new ServiceManager();
-  manager.ready.then(() => {
+  void manager.ready.then(() => {
     startApp(path, manager);
   });
 }
@@ -109,7 +109,7 @@ function startApp(path: string, manager: ServiceManager.IManager) {
   commands.addCommand(command, {
     label: 'Execute Prompt',
     execute: () => {
-      consolePanel.console.execute();
+      return consolePanel.console.execute();
     }
   });
   palette.addItem({ command, category });
@@ -119,7 +119,7 @@ function startApp(path: string, manager: ServiceManager.IManager) {
   commands.addCommand(command, {
     label: 'Execute Cell (forced)',
     execute: () => {
-      consolePanel.console.execute(true);
+      return consolePanel.console.execute(true);
     }
   });
   palette.addItem({ command, category });

--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -32,7 +32,7 @@ import { FileEditorFactory } from '@jupyterlab/fileeditor';
 
 function main(): void {
   let manager = new ServiceManager();
-  manager.ready.then(() => {
+  void manager.ready.then(() => {
     createApp(manager);
   });
 }
@@ -91,7 +91,7 @@ function createApp(manager: ServiceManager.IManager): void {
   let creator = new ToolbarButton({
     iconClassName: 'jp-AddIcon jp-Icon jp-Icon-16',
     onClick: () => {
-      docManager
+      void docManager
         .newUntitled({
           type: 'file',
           path: fbModel.path
@@ -138,13 +138,13 @@ function createApp(manager: ServiceManager.IManager): void {
     icon: 'fa fa-edit',
     mnemonic: 0,
     execute: () => {
-      fbWidget.rename();
+      return fbWidget.rename();
     }
   });
   commands.addCommand('file-save', {
     execute: () => {
       let context = docManager.contextForWidget(activeWidget);
-      context.save();
+      return context.save();
     }
   });
   commands.addCommand('file-cut', {
@@ -167,7 +167,7 @@ function createApp(manager: ServiceManager.IManager): void {
     icon: 'fa fa-remove',
     mnemonic: 0,
     execute: () => {
-      fbWidget.delete();
+      return fbWidget.delete();
     }
   });
   commands.addCommand('file-duplicate', {
@@ -175,7 +175,7 @@ function createApp(manager: ServiceManager.IManager): void {
     icon: 'fa fa-copy',
     mnemonic: 0,
     execute: () => {
-      fbWidget.duplicate();
+      return fbWidget.duplicate();
     }
   });
   commands.addCommand('file-paste', {
@@ -183,21 +183,21 @@ function createApp(manager: ServiceManager.IManager): void {
     icon: 'fa fa-paste',
     mnemonic: 0,
     execute: () => {
-      fbWidget.paste();
+      return fbWidget.paste();
     }
   });
   commands.addCommand('file-download', {
     label: 'Download',
     icon: 'fa fa-download',
     execute: () => {
-      fbWidget.download();
+      return fbWidget.download();
     }
   });
   commands.addCommand('file-shutdown-kernel', {
     label: 'Shutdown Kernel',
     icon: 'fa fa-stop-circle-o',
     execute: () => {
-      fbWidget.shutdownKernels();
+      return fbWidget.shutdownKernels();
     }
   });
   commands.addCommand('file-dialog-demo', {
@@ -210,7 +210,7 @@ function createApp(manager: ServiceManager.IManager): void {
     label: 'Info Demo',
     execute: () => {
       let msg = 'The quick brown fox jumped over the lazy dog';
-      showDialog({
+      void showDialog({
         title: 'Cool Title',
         body: msg,
         buttons: [Dialog.okButton()]
@@ -282,7 +282,7 @@ function dialogDemo(): void {
   selector.appendChild(option1);
   body.appendChild(input);
   body.appendChild(selector);
-  showDialog({
+  void showDialog({
     title: 'Create new notebook'
   });
 }

--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -69,9 +69,9 @@ export const SetupCommands = (
   });
   commands.addCommand(cmdIds.interrupt, {
     label: 'Interrupt',
-    execute: () => {
+    execute: async () => {
       if (nbWidget.context.session.kernel) {
-        nbWidget.context.session.kernel.interrupt();
+        await nbWidget.context.session.kernel.interrupt();
       }
     }
   });
@@ -86,7 +86,10 @@ export const SetupCommands = (
   commands.addCommand(cmdIds.runAndAdvance, {
     label: 'Run and Advance',
     execute: () => {
-      NotebookActions.runAndAdvance(nbWidget.content, nbWidget.context.session);
+      return NotebookActions.runAndAdvance(
+        nbWidget.content,
+        nbWidget.context.session
+      );
     }
   });
   commands.addCommand(cmdIds.editMode, {

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -41,7 +41,7 @@ import { SetupCommands } from './commands';
 
 function main(): void {
   let manager = new ServiceManager();
-  manager.ready.then(() => {
+  void manager.ready.then(() => {
     createApp(manager);
   });
 }

--- a/examples/terminal/src/index.ts
+++ b/examples/terminal/src/index.ts
@@ -16,10 +16,10 @@ function main(): void {
   let term1 = new Terminal({ theme: 'light' });
   let term2 = new Terminal({ theme: 'dark' });
 
-  TerminalSession.startNew().then(session => {
+  void TerminalSession.startNew().then(session => {
     term1.session = session;
   });
-  TerminalSession.startNew().then(session => {
+  void TerminalSession.startNew().then(session => {
     term2.session = session;
   });
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:chrome-headless": "lerna run test:chrome-headless --scope \"@jupyterlab/test-*\" --concurrency 1 --stream",
     "test:firefox": "lerna run test:firefox --scope \"@jupyterlab/test-*\" --concurrency 1 --stream",
     "test:ie": "lerna run test:ie --scope \"@jupyterlab/test-*\" --concurrency 1 --stream",
-    "tslint": "tslint --fix -c tslint.json '**/*{.ts,.tsx}'",
+    "tslint": "tslint --fix -c tslint.json --project tsconfigbase.json '**/*{.ts,.tsx}'",
     "tslint:check": "tslint -c tslint.json '**/*{.ts,.tsx}'",
     "prettier": "prettier --write '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
     "prettier:check": "prettier --list-different '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -89,7 +89,7 @@ const main: JupyterFrontEndPlugin<void> = {
         <pre>{app.registerPluginErrors.map(e => e.message).join('\n')}</pre>
       );
 
-      showErrorMessage('Error Registering Plugins', { message: body });
+      void showErrorMessage('Error Registering Plugins', { message: body });
     }
 
     addCommands(app, palette);
@@ -120,14 +120,14 @@ const main: JupyterFrontEndPlugin<void> = {
           }
         })
         .catch(err => {
-          showErrorMessage('Build Failed', {
+          void showErrorMessage('Build Failed', {
             message: <pre>{err.message}</pre>
           });
         });
     };
 
     if (builder.isAvailable && builder.shouldCheck) {
-      builder.getStatus().then(response => {
+      void builder.getStatus().then(response => {
         if (response.status === 'building') {
           return build();
         }
@@ -144,7 +144,7 @@ const main: JupyterFrontEndPlugin<void> = {
           </div>
         );
 
-        showDialog({
+        void showDialog({
           title: 'Build Recommended',
           body,
           buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'BUILD' })]
@@ -181,10 +181,10 @@ const layout: JupyterFrontEndPlugin<ILayoutRestorer> = {
     const registry = app.commands;
     const restorer = new LayoutRestorer({ first, registry, state });
 
-    restorer.fetch().then(saved => {
+    void restorer.fetch().then(saved => {
       labShell.restoreLayout(saved);
       labShell.layoutModified.connect(() => {
-        restorer.save(labShell.saveLayout());
+        void restorer.save(labShell.saveLayout());
       });
     });
 
@@ -205,13 +205,13 @@ const router: JupyterFrontEndPlugin<IRouter> = {
     const base = paths.urls.base;
     const router = new Router({ base, commands });
 
-    app.started.then(() => {
+    void app.started.then(() => {
       // Route the very first request on load.
-      router.route();
+      void router.route();
 
       // Route all pop state events.
       window.addEventListener('popstate', () => {
-        router.route();
+        void router.route();
       });
     });
 
@@ -300,7 +300,7 @@ const notfound: JupyterFrontEndPlugin<void> = {
     // URL change to the browser history.
     router.navigate('', { silent: true });
 
-    showErrorMessage('Path Not Found', { message });
+    void showErrorMessage('Path Not Found', { message });
   },
   autoStart: true
 };
@@ -367,7 +367,7 @@ const sidebar: JupyterFrontEndPlugin<void> = {
     };
     labShell.layoutModified.connect(handleLayoutOverrides);
     // Fetch overrides from the settings system.
-    Promise.all([settingRegistry.load(SIDEBAR_ID), app.restored]).then(
+    void Promise.all([settingRegistry.load(SIDEBAR_ID), app.restored]).then(
       ([settings]) => {
         overrides = (settings.get('overrides').composite as overrideMap) || {};
         settings.changed.connect(settings => {
@@ -411,7 +411,7 @@ const sidebar: JupyterFrontEndPlugin<void> = {
         // Move the panel to the other side.
         const newOverrides = { ...overrides };
         newOverrides[id] = side;
-        settingRegistry.set(SIDEBAR_ID, 'overrides', newOverrides);
+        return settingRegistry.set(SIDEBAR_ID, 'overrides', newOverrides);
       }
     });
 

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -154,7 +154,7 @@ export class LayoutRestorer implements ILayoutRestorer {
     this._state = options.state;
     this._first = options.first;
 
-    this._first
+    void this._first
       .then(() => {
         this._firstDone = true;
       })

--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -149,9 +149,9 @@ export function createRendermimePlugin(
           Private.factoryNameProperty.set(widget, factory.name);
           // Notify the instance tracker if restore data needs to update.
           widget.context.pathChanged.connect(() => {
-            tracker.save(widget);
+            void tracker.save(widget);
           });
-          tracker.add(widget);
+          void tracker.add(widget);
         });
       });
     }

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -235,7 +235,7 @@ export class Router implements IRouter {
     // Because a `route()` call may still be in the stack after having received
     // a `stop` token, wait for the next stack frame before calling `route()`.
     requestAnimationFrame(() => {
-      this.route();
+      void this.route();
     });
   }
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -163,7 +163,7 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
         if (theme === manager.theme) {
           return;
         }
-        manager.setTheme(theme);
+        return manager.setTheme(theme);
       }
     });
 
@@ -197,7 +197,7 @@ const themesPaletteMenu: JupyterFrontEndPlugin<void> = {
     if (mainMenu) {
       const themeMenu = new Menu({ commands });
       themeMenu.title.label = 'JupyterLab Theme';
-      app.restored.then(() => {
+      void app.restored.then(() => {
         const command = CommandIDs.changeTheme;
         const isPalette = false;
 
@@ -218,7 +218,7 @@ const themesPaletteMenu: JupyterFrontEndPlugin<void> = {
 
     // If we have a command palette, add theme switching options to it.
     if (palette) {
-      app.restored.then(() => {
+      void app.restored.then(() => {
         const category = 'Settings';
         const command = CommandIDs.changeTheme;
         const isPalette = true;
@@ -278,7 +278,7 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
 
         // Launch a dialog to ask the user for a new workspace name.
         console.warn('Window resolution failed:', error);
-        Private.redirect(router, paths, workspace);
+        return Private.redirect(router, paths, workspace);
       });
     }
 
@@ -412,7 +412,7 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
     });
 
     const listener = (sender: any, change: StateDB.Change) => {
-      commands.execute(CommandIDs.saveState);
+      return commands.execute(CommandIDs.saveState);
     };
 
     commands.addCommand(CommandIDs.loadState, {
@@ -474,7 +474,7 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
             .then(() => router.stop);
 
           // After the state has been cloned, navigate to the URL.
-          cloned.then(() => {
+          void cloned.then(() => {
             router.navigate(url, { silent: true });
           });
 
@@ -538,11 +538,11 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
 
         // After the state has been reset, navigate to the URL.
         if (clone) {
-          cleared.then(() => {
+          void cleared.then(() => {
             router.navigate(url, { silent, hard });
           });
         } else {
-          cleared.then(() => {
+          void cleared.then(() => {
             router.navigate(url, { silent });
             loading.dispose();
           });
@@ -766,7 +766,7 @@ namespace Private {
     debouncer = window.setTimeout(() => {
       if (commands.hasCommand(recovery)) {
         recover(() => {
-          commands.execute(recovery);
+          return commands.execute(recovery);
         });
       }
     }, SPLASH_RECOVER_TIMEOUT);
@@ -774,7 +774,7 @@ namespace Private {
     document.body.appendChild(splash);
 
     return new DisposableDelegate(() => {
-      ready.then(() => {
+      void ready.then(() => {
         if (--splashCount === 0) {
           if (debouncer) {
             window.clearTimeout(debouncer);

--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -523,7 +523,8 @@ export class ClientSession implements IClientSession {
         let session = manager.connectTo(model);
         this._handleNewSession(session);
       } catch (err) {
-        this._handleSessionError(err);
+        void this._handleSessionError(err);
+        return Promise.reject(err);
       }
     }
     await this._startIfNecessary();
@@ -641,7 +642,7 @@ export class ClientSession implements IClientSession {
         return this._handleNewSession(session);
       })
       .catch(err => {
-        this._handleSessionError(err);
+        void this._handleSessionError(err);
         return Promise.reject(err);
       });
   }

--- a/packages/apputils/src/commandlinker.ts
+++ b/packages/apputils/src/commandlinker.ts
@@ -182,7 +182,7 @@ export class CommandLinker implements IDisposable {
         if (argsValue) {
           args = JSON.parse(argsValue);
         }
-        this._commands.execute(command, args);
+        void this._commands.execute(command, args);
         return;
       }
       target = target.parentElement;

--- a/packages/apputils/src/instancetracker.ts
+++ b/packages/apputils/src/instancetracker.ts
@@ -318,9 +318,9 @@ export class InstanceTracker<T extends Widget>
    * for layout and state restoration in addition to injecting its widgets into
    * the parent plugin's instance tracker.
    */
-  inject(widget: T): void {
+  inject(widget: T): Promise<void> {
     Private.injectedProperty.set(widget, true);
-    this.add(widget);
+    return this.add(widget);
   }
 
   /**
@@ -380,7 +380,7 @@ export class InstanceTracker<T extends Widget>
    *
    * @param widget - The widget being saved.
    */
-  save(widget: T): void {
+  async save(widget: T): Promise<void> {
     const injected = Private.injectedProperty.get(widget);
 
     if (!this._restore || !this.has(widget) || injected) {
@@ -393,7 +393,7 @@ export class InstanceTracker<T extends Widget>
     const newName = widgetName ? `${this.namespace}:${widgetName}` : '';
 
     if (oldName && oldName !== newName) {
-      state.remove(oldName);
+      await state.remove(oldName);
     }
 
     // Set the name property irrespective of whether the new name is null.
@@ -401,7 +401,7 @@ export class InstanceTracker<T extends Widget>
 
     if (newName) {
       const data = this._restore.args(widget);
-      state.save(newName, { data });
+      await state.save(newName, { data });
     }
 
     if (oldName !== newName) {
@@ -468,7 +468,7 @@ export class InstanceTracker<T extends Widget>
     const name = Private.nameProperty.get(widget);
 
     if (name) {
-      state.remove(name);
+      void state.remove(name);
     }
   }
 

--- a/packages/apputils/src/instancetracker.ts
+++ b/packages/apputils/src/instancetracker.ts
@@ -198,6 +198,12 @@ export class InstanceTracker<T extends Widget>
    * Add a new widget to the tracker.
    *
    * @param widget - The widget being added.
+   *
+   * #### Notes
+   * When a widget is added its state is saved to the state database.
+   * This function returns a promise that is resolved when that saving
+   * is completed. However, the widget is added to the in-memory tracker
+   * synchronously, and is available to use before the promise is resolved.
    */
   add(widget: T): Promise<void> {
     if (widget.isDisposed) {
@@ -318,9 +324,9 @@ export class InstanceTracker<T extends Widget>
    * for layout and state restoration in addition to injecting its widgets into
    * the parent plugin's instance tracker.
    */
-  inject(widget: T): Promise<void> {
+  inject(widget: T): void {
     Private.injectedProperty.set(widget, true);
-    return this.add(widget);
+    void this.add(widget);
   }
 
   /**

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -56,7 +56,7 @@ export class ThemeManager {
     this._host = host;
     this._splash = splash || null;
 
-    registry.load(key).then(settings => {
+    void registry.load(key).then(settings => {
       this._settings = settings;
       this._settings.changed.connect(
         this._loadSettings,
@@ -263,7 +263,7 @@ export class ThemeManager {
    * Handle a theme error.
    */
   private _onError(reason: any): void {
-    showDialog({
+    void showDialog({
       title: 'Error Loading Theme',
       body: String(reason),
       buttons: [Dialog.okButton({ label: 'OK' })]

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -349,7 +349,7 @@ export namespace Toolbar {
       iconClassName: 'jp-StopIcon jp-Icon jp-Icon-16',
       onClick: () => {
         if (session.kernel) {
-          session.kernel.interrupt();
+          void session.kernel.interrupt();
         }
       },
       tooltip: 'Interrupt the kernel'
@@ -363,7 +363,7 @@ export namespace Toolbar {
     return new ToolbarButton({
       iconClassName: 'jp-RefreshIcon jp-Icon jp-Icon-16',
       onClick: () => {
-        session.restart();
+        void session.restart();
       },
       tooltip: 'Restart the kernel'
     });
@@ -579,7 +579,7 @@ namespace Private {
     }
     const tooltip = commands.caption(id) || label || iconLabel;
     const onClick = () => {
-      commands.execute(id);
+      void commands.execute(id);
     };
     const enabled = commands.isEnabled(id);
     return { className, iconClassName, tooltip, onClick, enabled, label };

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -874,7 +874,7 @@ export class MarkdownCell extends Cell {
       this
     );
 
-    this._updateRenderedInput().then(() => {
+    void this._updateRenderedInput().then(() => {
       this._ready.resolve(void 0);
     });
     this.renderInput(this._renderer);
@@ -946,7 +946,9 @@ export class MarkdownCell extends Cell {
     if (!this._rendered) {
       this.showEditor();
     } else {
-      this._updateRenderedInput();
+      // TODO: It would be nice for the cell to provide a way for
+      // its consumers to hook into when the rendering is done.
+      void this._updateRenderedInput();
       this.renderInput(this._renderer);
     }
   }

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -124,7 +124,7 @@ const id = commands.id;
  */
 function activateEditorServices(app: JupyterFrontEnd): IEditorServices {
   CodeMirror.prototype.save = () => {
-    app.commands.execute('docmanager:save');
+    void app.commands.execute('docmanager:save');
   };
   return editorServices;
 }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -672,7 +672,9 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   private _onMimeTypeChanged(): void {
     const mime = this._model.mimeType;
     let editor = this._editor;
-    Mode.ensure(mime).then(spec => {
+    // TODO: should we provide a hook for when the
+    // mode is done being set?
+    void Mode.ensure(mime).then(spec => {
       editor.setOption('mode', spec.mime);
     });
     let extraKeys = editor.getOption('extraKeys') || {};
@@ -1029,7 +1031,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       return;
     }
 
-    showDialog({
+    void showDialog({
       title: 'Code Editor out of Sync',
       body:
         'Please open your browser JavaScript console for bug report instructions'

--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -302,7 +302,7 @@ const files: JupyterFrontEndPlugin<void> = {
           }
         }
       };
-      Session.listRunning().then(models => {
+      void Session.listRunning().then(models => {
         onRunningChanged(sessions, models);
       });
       sessions.runningChanged.connect(onRunningChanged);

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -163,7 +163,7 @@ async function activateConsole(
 
   // Add a launcher item if the launcher is available.
   if (launcher) {
-    manager.ready.then(() => {
+    void manager.ready.then(() => {
       let disposables: DisposableSet | null = null;
       const onSpecsChanged = () => {
         if (disposables) {
@@ -245,10 +245,8 @@ async function activateConsole(
     )).composite as string;
     panel.console.node.dataset.jpInteractionMode = interactionMode;
 
-    await panel.session.ready;
-
-    // Add the console panel to the tracker.
-    tracker.add(panel);
+    // Add the console panel to the tracker and wait for it to be ready.
+    await Promise.all([tracker.add(panel), panel.session.ready]);
     panel.session.propertyChanged.connect(() => tracker.save(panel));
 
     shell.add(panel, 'main', {
@@ -270,7 +268,7 @@ async function activateConsole(
   }
   settingRegistry.pluginChanged.connect((sender, plugin) => {
     if (plugin === pluginId) {
-      updateSettings();
+      void updateSettings();
     }
   });
   await updateSettings();
@@ -385,7 +383,7 @@ async function activateConsole(
       if (!current) {
         return;
       }
-      current.console.execute(true);
+      return current.console.execute(true);
     },
     isEnabled
   });
@@ -442,8 +440,9 @@ async function activateConsole(
         buttons: [Dialog.cancelButton(), Dialog.warnButton()]
       }).then(result => {
         if (result.button.accept) {
-          current.console.session.shutdown().then(() => {
+          return current.console.session.shutdown().then(() => {
             current.dispose();
+            return true;
           });
         } else {
           return false;
@@ -461,7 +460,7 @@ async function activateConsole(
           if (args['activate'] !== false) {
             shell.activateById(widget.id);
           }
-          widget.console.inject(args['code'] as string);
+          void widget.console.inject(args['code'] as string);
           return true;
         }
         return false;
@@ -512,7 +511,7 @@ async function activateConsole(
         buttons: [Dialog.cancelButton(), Dialog.warnButton()]
       }).then(result => {
         if (result.button.accept) {
-          current.console.session.shutdown().then(() => {
+          return current.console.session.shutdown().then(() => {
             current.dispose();
           });
         } else {

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -79,7 +79,7 @@ export class ConsoleHistory implements IConsoleHistory {
    */
   constructor(options: ConsoleHistory.IOptions) {
     this.session = options.session;
-    this._handleKernel();
+    void this._handleKernel();
     this.session.kernelChanged.connect(
       this._handleKernel,
       this
@@ -265,7 +265,7 @@ export class ConsoleHistory implements IConsoleHistory {
     let source = model.value.text;
 
     if (location === 'top' || location === 'topLine') {
-      this.back(source).then(value => {
+      void this.back(source).then(value => {
         if (this.isDisposed || !value) {
           return;
         }
@@ -282,7 +282,7 @@ export class ConsoleHistory implements IConsoleHistory {
         editor.setCursorPosition({ line: 0, column: columnPos });
       });
     } else {
-      this.forward(source).then(value => {
+      void this.forward(source).then(value => {
         if (this.isDisposed) {
           return;
         }
@@ -303,14 +303,14 @@ export class ConsoleHistory implements IConsoleHistory {
   /**
    * Handle the current kernel changing.
    */
-  private _handleKernel(): void {
+  private async _handleKernel(): Promise<void> {
     let kernel = this.session.kernel;
     if (!kernel) {
       this._history.length = 0;
       return;
     }
 
-    kernel.requestHistory(Private.initialRequest).then(v => {
+    return kernel.requestHistory(Private.initialRequest).then(v => {
       this.onHistory(v);
     });
   }

--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -79,7 +79,7 @@ export class ConsolePanel extends Panel {
     });
     this.addWidget(this.console);
 
-    session.initialize().then(() => {
+    void session.initialize().then(() => {
       this._connected = new Date();
       this._updateTitle();
     });

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -460,14 +460,18 @@ export class CodeConsole extends Widget {
         event.clientY
       )
     ) {
-      this._startDrag(data.index, event.clientX, event.clientY);
+      void this._startDrag(data.index, event.clientX, event.clientY);
     }
   }
 
   /**
    * Start a drag event
    */
-  private _startDrag(index: number, clientX: number, clientY: number) {
+  private _startDrag(
+    index: number,
+    clientX: number,
+    clientY: number
+  ): Promise<void> {
     const cellModel = this._focusedCell.model as ICodeCellModel;
     let selected: nbformat.ICell[] = [cellModel.toJSON()];
 
@@ -492,7 +496,7 @@ export class CodeConsole extends Widget {
 
     document.removeEventListener('mousemove', this, true);
     document.removeEventListener('mouseup', this, true);
-    this._drag.start(clientX, clientY).then(() => {
+    return this._drag.start(clientX, clientY).then(() => {
       if (this.isDisposed) {
         return;
       }

--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -108,10 +108,10 @@ function activateCsv(
   let ft = app.docRegistry.getFileType('csv');
   factory.widgetCreated.connect((sender, widget) => {
     // Track the widget.
-    tracker.add(widget);
+    void tracker.add(widget);
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => {
-      tracker.save(widget);
+      void tracker.save(widget);
     });
 
     if (ft) {
@@ -178,10 +178,10 @@ function activateTsv(
   let ft = app.docRegistry.getFileType('tsv');
   factory.widgetCreated.connect((sender, widget) => {
     // Track the widget.
-    tracker.add(widget);
+    void tracker.add(widget);
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => {
-      tracker.save(widget);
+      void tracker.save(widget);
     });
 
     if (ft) {

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -247,7 +247,7 @@ export class CSVViewer extends Widget {
 
     this._searchService = new GridSearchService(this._grid);
 
-    this._context.ready.then(() => {
+    void this._context.ready.then(() => {
       this._updateGrid();
       this._revealed.resolve(undefined);
       // Throttle the rendering rate of the widget.
@@ -431,7 +431,7 @@ export class CSVDocumentWidget extends DocumentWidget<CSVViewer> {
     topRow = topRow.split('-')[0];
 
     // go to that row
-    this.context.ready.then(() => {
+    void this.context.ready.then(() => {
       this.content.goToLine(Number(topRow));
     });
   }

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -766,15 +766,15 @@ function addLabCommands(
   commands.addCommand(CommandIDs.showInFileBrowser, {
     label: () => `Show in File Browser`,
     isEnabled,
-    execute: () => {
+    execute: async () => {
       let context = docManager.contextForWidget(contextMenuWidget());
       if (!context) {
         return;
       }
 
       // 'activate' is needed if this command is selected in the "open tabs" sidebar
-      commands.execute('filebrowser:activate', { path: context.path });
-      commands.execute('filebrowser:navigate', { path: context.path });
+      await commands.execute('filebrowser:activate', { path: context.path });
+      await commands.execute('filebrowser:navigate', { path: context.path });
     }
   });
 
@@ -835,7 +835,7 @@ function handleContext(
       }
     }
   };
-  context.ready.then(() => {
+  void context.ready.then(() => {
     context.model.stateChanged.connect(onStateChanged);
     if (context.model.dirty) {
       disposable = status.setDirty();

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -54,7 +54,7 @@ export function renameDialog(
       return;
     }
     if (!isValidFileName(result.value)) {
-      showErrorMessage(
+      void showErrorMessage(
         'Rename Error',
         Error(
           `"${result.value}" is not a valid name for a file. ` +

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -151,7 +151,7 @@ export class DocumentManager implements IDisposable {
 
     // Close all the widgets for our contexts and dispose the widget manager.
     this._contexts.forEach(context => {
-      this._widgetManager.closeWidgets(context);
+      return this._widgetManager.closeWidgets(context);
     });
     this._widgetManager.dispose();
 
@@ -485,7 +485,7 @@ export class DocumentManager implements IDisposable {
       saveInterval: this.autosaveInterval
     });
     Private.saveHandlerProperty.set(context, handler);
-    context.ready.then(() => {
+    void context.ready.then(() => {
       if (this.autosave) {
         handler.start();
       }

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -107,8 +107,8 @@ export class DocumentWidgetManager implements IDisposable {
       this._onPathChanged,
       this
     );
-    context.ready.then(() => {
-      this.setCaption(widget);
+    void context.ready.then(() => {
+      void this.setCaption(widget);
     });
     return widget;
   }
@@ -238,7 +238,7 @@ export class DocumentWidgetManager implements IDisposable {
   messageHook(handler: IMessageHandler, msg: Message): boolean {
     switch (msg.type) {
       case 'close-request':
-        this.onClose(handler as Widget);
+        void this.onClose(handler as Widget);
         return false;
       case 'activate-request':
         let context = this.contextForWidget(handler as Widget);
@@ -257,7 +257,7 @@ export class DocumentWidgetManager implements IDisposable {
    *
    * @param widget - The target widget.
    */
-  protected setCaption(widget: Widget): void {
+  protected setCaption(widget: Widget): Promise<void> {
     let context = Private.contextProperty.get(widget);
     if (!context) {
       return;
@@ -267,7 +267,7 @@ export class DocumentWidgetManager implements IDisposable {
       widget.title.caption = '';
       return;
     }
-    context
+    return context
       .listCheckpoints()
       .then((checkpoints: Contents.ICheckpointModel[]) => {
         if (widget.isDisposed) {
@@ -397,7 +397,7 @@ export class DocumentWidgetManager implements IDisposable {
   private _onFileChanged(context: DocumentRegistry.Context): void {
     let widgets = Private.widgetsProperty.get(context);
     each(widgets, widget => {
-      this.setCaption(widget);
+      void this.setCaption(widget);
     });
   }
 
@@ -407,7 +407,7 @@ export class DocumentWidgetManager implements IDisposable {
   private _onPathChanged(context: DocumentRegistry.Context): void {
     let widgets = Private.widgetsProperty.get(context);
     each(widgets, widget => {
-      this.setCaption(widget);
+      void this.setCaption(widget);
     });
   }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -223,7 +223,7 @@ export class Context<T extends DocumentRegistry.IModel>
       return this._modelDB.connected.then(() => {
         if (this._modelDB.isPrepopulated) {
           this._model.initialize();
-          this._save();
+          void this._save();
           return void 0;
         } else {
           return this._revert(true);
@@ -387,13 +387,13 @@ export class Context<T extends DocumentRegistry.IModel>
         };
       }
       this._path = newPath;
-      this.session.setPath(newPath);
+      void this.session.setPath(newPath);
       const updateModel = {
         ...this._contentsModel,
         ...changeModel
       };
       const localPath = this._manager.contents.localPath(newPath);
-      this.session.setName(PathExt.basename(localPath));
+      void this.session.setName(PathExt.basename(localPath));
       this._updateContentsModel(updateModel as Contents.IModel);
       this._pathChanged.emit(this._path);
     }
@@ -456,7 +456,10 @@ export class Context<T extends DocumentRegistry.IModel>
         name,
         language: this._model.defaultKernelLanguage
       };
-      this.session.initialize();
+      // Note: we don't wait on the session to initialize
+      // so that the user can be shown the content before
+      // any kernel has started.
+      void this.session.initialize();
     });
   }
 
@@ -512,7 +515,7 @@ export class Context<T extends DocumentRegistry.IModel>
         // Otherwise show an error message and throw the error.
         const localPath = this._manager.contents.localPath(this._path);
         const name = PathExt.basename(localPath);
-        this._handleError(err, `File Save Error for ${name}`);
+        void this._handleError(err, `File Save Error for ${name}`);
         throw err;
       })
       .then(
@@ -585,7 +588,7 @@ export class Context<T extends DocumentRegistry.IModel>
         if (err.message === 'Invalid response: 400 bad format') {
           err = new Error('JupyterLab is unable to open this file type.');
         }
-        this._handleError(err, `File Load Error for ${name}`);
+        void this._handleError(err, `File Load Error for ${name}`);
         throw err;
       });
   }
@@ -629,27 +632,28 @@ export class Context<T extends DocumentRegistry.IModel>
   /**
    * Handle a save/load error with a dialog.
    */
-  private _handleError(
+  private async _handleError(
     err: Error | ServerConnection.ResponseError,
     title: string
-  ): void {
+  ): Promise<void> {
     let buttons = [Dialog.okButton()];
 
     // Check for a more specific error message.
     if (err instanceof ServerConnection.ResponseError) {
-      err.response.text().then(text => {
-        let body = '';
-        try {
-          body = JSON.parse(text).message;
-        } catch (e) {
-          body = text;
-        }
-        body = body || err.message;
-        showDialog({ title, body, buttons });
-      });
+      const text = await err.response.text();
+      let body = '';
+      try {
+        body = JSON.parse(text).message;
+      } catch (e) {
+        body = text;
+      }
+      body = body || err.message;
+      await showDialog({ title, body, buttons });
+      return;
     } else {
       let body = err.message;
-      showDialog({ title, body, buttons });
+      await showDialog({ title, body, buttons });
+      return;
     }
   }
 
@@ -739,7 +743,7 @@ export class Context<T extends DocumentRegistry.IModel>
       }
       if (result.button.label === 'OVERWRITE') {
         return this._manager.contents.delete(path).then(() => {
-          this._finishSaveAs(path);
+          return this._finishSaveAs(path);
         });
       }
     });
@@ -753,7 +757,7 @@ export class Context<T extends DocumentRegistry.IModel>
     return this.session
       .setPath(newPath)
       .then(() => {
-        this.session.setName(newPath.split('/').pop()!);
+        void this.session.setName(newPath.split('/').pop()!);
         return this.save();
       })
       .then(() => {

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -458,7 +458,7 @@ export class DocumentWidget<
       this._onModelStateChanged,
       this
     );
-    this.context.ready.then(() => {
+    void this.context.ready.then(() => {
       this._handleDirtyState();
     });
   }

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -69,7 +69,10 @@ export class MimeContent extends Widget {
         requestAnimationFrame(() => {
           this.dispose();
         });
-        showErrorMessage(`Renderer Failure: ${this._context.path}`, reason);
+        void showErrorMessage(
+          `Renderer Failure: ${this._context.path}`,
+          reason
+        );
       });
   }
 
@@ -112,7 +115,7 @@ export class MimeContent extends Widget {
    */
   protected onUpdateRequest(msg: Message): void {
     if (this._context.isReady) {
-      this._render();
+      void this._render();
       this._fragment = '';
     }
   }
@@ -163,7 +166,7 @@ export class MimeContent extends Widget {
       requestAnimationFrame(() => {
         this.dispose();
       });
-      showErrorMessage(`Renderer Failure: ${context.path}`, reason);
+      void showErrorMessage(`Renderer Failure: ${context.path}`, reason);
     }
   }
 

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -126,7 +126,7 @@ export class CodeMirrorSearchProvider implements ISearchProvider {
     if (!this.isSubProvider) {
       this._cm.focus();
     }
-    this.endQuery();
+    return this.endQuery();
   }
 
   /**

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -114,8 +114,9 @@ export class NotebookSearchProvider implements ISearchProvider {
    * begin a new search.
    */
   async endQuery(): Promise<void> {
+    const queriesEnded: Promise<void>[] = [];
     this._cmSearchProviders.forEach(({ provider }) => {
-      provider.endQuery();
+      queriesEnded.push(provider.endQuery());
       provider.changed.disconnect(this._onCmSearchProviderChanged, this);
     });
     Signal.disconnectBetween(this._searchTarget.model.cells, this);
@@ -128,6 +129,7 @@ export class NotebookSearchProvider implements ISearchProvider {
       }
     });
     this._unRenderedMarkdownCells = [];
+    await Promise.all(queriesEnded);
   }
 
   /**
@@ -139,8 +141,9 @@ export class NotebookSearchProvider implements ISearchProvider {
     Signal.disconnectBetween(this._searchTarget.model.cells, this);
 
     const index = this._searchTarget.content.activeCellIndex;
+    const searchEnded: Promise<void>[] = [];
     this._cmSearchProviders.forEach(({ provider }) => {
-      provider.endSearch();
+      searchEnded.push(provider.endSearch());
       provider.changed.disconnect(this._onCmSearchProviderChanged, this);
     });
 
@@ -154,6 +157,7 @@ export class NotebookSearchProvider implements ISearchProvider {
     this._searchTarget.content.mode = 'edit';
     this._searchTarget = null;
     this._currentMatch = null;
+    await Promise.all(searchEnded);
   }
 
   /**

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -114,7 +114,7 @@ export class SearchInstance implements IDisposable {
 
     // If a query hasn't been executed yet, no need to call endSearch
     if (this._displayState.query) {
-      this._activeProvider.endSearch();
+      void this._activeProvider.endSearch();
     }
 
     this._searchWidget.dispose();

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -65,13 +65,13 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     // If the extension is enabled or disabled,
     // add or remove it from the left area.
-    app.restored.then(() => {
+    void app.restored.then(() => {
       settings.changed.connect(async () => {
         enabled = settings.composite['enabled'] === true;
         if (enabled && (!view || (view && !view.isAttached))) {
           const accepted = await Private.showWarning();
           if (!accepted) {
-            settings.set('enabled', false);
+            void settings.set('enabled', false);
             return;
           }
           view = view || createView();

--- a/packages/extensionmanager/src/build-helper.tsx
+++ b/packages/extensionmanager/src/build-helper.tsx
@@ -32,7 +32,7 @@ export function doBuild(builder: Builder.IManager): Promise<void> {
         }
       })
       .catch(err => {
-        showDialog({
+        void showDialog({
           title: 'Build Failed',
           body: <pre>{err.message}</pre>
         });

--- a/packages/extensionmanager/src/dialog.tsx
+++ b/packages/extensionmanager/src/dialog.tsx
@@ -29,7 +29,7 @@ export function reportInstallError(name: string, errorMessage?: string) {
     );
   }
   let body = <div className="jp-extensionmanager-dialog">{entries}</div>;
-  showDialog({
+  void showDialog({
     title: 'Extension Installation Error',
     body,
     buttons: [Dialog.warnButton({ label: 'OK' })]

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -170,7 +170,7 @@ export class ListModel extends VDomModel {
   }
   set query(value: string | null) {
     this._query = value;
-    this.update();
+    void this.update();
   }
 
   /**
@@ -186,7 +186,7 @@ export class ListModel extends VDomModel {
   }
   set page(value: number) {
     this._page = value;
-    this.update();
+    void this.update();
   }
 
   /**
@@ -202,7 +202,7 @@ export class ListModel extends VDomModel {
   }
   set pagination(value: number) {
     this._pagination = value;
-    this.update();
+    void this.update();
   }
 
   /**
@@ -215,8 +215,8 @@ export class ListModel extends VDomModel {
   /**
    * Initialize the model.
    */
-  initialize() {
-    this.update()
+  initialize(): Promise<void> {
+    return this.update()
       .then(() => {
         this.initialized = true;
         this.stateChanged.emit(undefined);
@@ -239,23 +239,23 @@ export class ListModel extends VDomModel {
    *
    * @param entry An entry indicating which extension to install.
    */
-  install(entry: IEntry) {
+  async install(entry: IEntry): Promise<void> {
     if (entry.installed) {
       // Updating
-      return this._performAction('install', entry).then(data => {
+      await this._performAction('install', entry).then(data => {
         if (data.status !== 'ok') {
           reportInstallError(entry.name, data.message);
         }
-        this.update();
+        return this.update();
       });
     }
-    this.checkCompanionPackages(entry).then(shouldInstall => {
+    await this.checkCompanionPackages(entry).then(shouldInstall => {
       if (shouldInstall) {
         return this._performAction('install', entry).then(data => {
           if (data.status !== 'ok') {
             reportInstallError(entry.name, data.message);
           }
-          this.update();
+          return this.update();
         });
       }
     });
@@ -266,13 +266,12 @@ export class ListModel extends VDomModel {
    *
    * @param entry An entry indicating which extension to uninstall.
    */
-  uninstall(entry: IEntry) {
+  async uninstall(entry: IEntry): Promise<void> {
     if (!entry.installed) {
       throw new Error(`Not installed, cannot uninstall: ${entry.name}`);
     }
-    this._performAction('uninstall', entry).then(data => {
-      this.update();
-    });
+    await this._performAction('uninstall', entry);
+    return this.update();
   }
 
   /**
@@ -280,13 +279,12 @@ export class ListModel extends VDomModel {
    *
    * @param entry An entry indicating which extension to enable.
    */
-  enable(entry: IEntry) {
+  async enable(entry: IEntry): Promise<void> {
     if (entry.enabled) {
       throw new Error(`Already enabled: ${entry.name}`);
     }
-    this._performAction('enable', entry).then(data => {
-      this.update();
-    });
+    await this._performAction('enable', entry);
+    await this.update();
   }
 
   /**
@@ -294,13 +292,12 @@ export class ListModel extends VDomModel {
    *
    * @param entry An entry indicating which extension to disable.
    */
-  disable(entry: IEntry) {
+  async disable(entry: IEntry): Promise<void> {
     if (!entry.enabled) {
       throw new Error(`Already disabled: ${entry.name}`);
     }
-    this._performAction('disable', entry).then(data => {
-      this.update();
-    });
+    await this._performAction('disable', entry);
+    await this.update();
   }
 
   /**

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -475,7 +475,7 @@ export class ExtensionView extends VDomRenderer<ListModel> {
     );
     const content = [];
     if (!model.initialized) {
-      model.initialize();
+      void model.initialize();
       content.push(
         <div key="loading-placeholder" className="jp-extensionmanager-loader">
           Updating extensions list

--- a/packages/faq-extension/src/index.ts
+++ b/packages/faq-extension/src/index.ts
@@ -77,7 +77,7 @@ function activate(
     const model = rendermime.createModel({
       data: { 'text/markdown': SOURCE }
     });
-    content.renderModel(model);
+    void content.renderModel(model);
     content.addClass('jp-FAQ-content');
     let widget = new MainAreaWidget({ content });
     widget.addClass('jp-FAQ');
@@ -94,7 +94,7 @@ function activate(
         widget = createWidget();
       }
       if (!tracker.has(widget)) {
-        tracker.add(widget);
+        void tracker.add(widget);
         shell.add(widget, 'main', { activate: false });
       }
       shell.activateById(widget.id);

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -221,7 +221,7 @@ function activateFactory(
     widget.toolbar.insertItem(0, 'launch', launcher);
 
     // Track the newly created file browser.
-    tracker.add(widget);
+    void tracker.add(widget);
 
     return widget;
   };
@@ -259,17 +259,17 @@ function activateBrowser(
   labShell.add(browser, 'left', { rank: 100 });
 
   // If the layout is a fresh session without saved data, open file browser.
-  labShell.restored.then(layout => {
+  void labShell.restored.then(layout => {
     if (layout.fresh) {
-      commands.execute(CommandIDs.showBrowser, void 0);
+      void commands.execute(CommandIDs.showBrowser, void 0);
     }
   });
 
-  Promise.all([app.restored, browser.model.restored]).then(() => {
+  void Promise.all([app.restored, browser.model.restored]).then(() => {
     function maybeCreate() {
       // Create a launcher if there are no open items.
       if (labShell.isEmpty('main')) {
-        Private.createLauncher(commands, browser);
+        void Private.createLauncher(commands, browser);
       }
     }
 
@@ -280,7 +280,7 @@ function activateBrowser(
 
     let navigateToCurrentDirectory: boolean = false;
 
-    settingRegistry
+    void settingRegistry
       .load('@jupyterlab/filebrowser-extension:browser')
       .then(settings => {
         settings.changed.connect(settings => {
@@ -432,9 +432,9 @@ function addCommands(
   commands.addCommand(CommandIDs.navigate, {
     execute: args => {
       const path = (args.path as string) || '';
-      Private.navigateToPath(path, factory)
+      return Private.navigateToPath(path, factory)
         .then(() => {
-          commands.execute('docmanager:open', { path });
+          return commands.execute('docmanager:open', { path });
         })
         .catch((reason: any) => {
           console.warn(

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -82,7 +82,7 @@ export class FileBrowser extends Widget {
     let refresher = new ToolbarButton({
       iconClassName: 'jp-RefreshIcon jp-Icon jp-Icon-16',
       onClick: () => {
-        model.refresh();
+        void model.refresh();
       },
       tooltip: 'Refresh File List'
     });
@@ -103,7 +103,7 @@ export class FileBrowser extends Widget {
     layout.addWidget(this._listing);
 
     this.layout = layout;
-    model.restore(this.id);
+    void model.restore(this.id);
   }
 
   /**
@@ -165,13 +165,18 @@ export class FileBrowser extends Widget {
       return;
     }
     this._directoryPending = true;
-    this._manager
+    // TODO: We should provide a hook into when the
+    // directory is done being created. This probably
+    // means storing a pendingDirectory promise and
+    // returning that if there is already a directory
+    // request.
+    void this._manager
       .newUntitled({
         path: this.model.path,
         type: 'directory'
       })
-      .then(model => {
-        this._listing.selectItemByName(model.name);
+      .then(async model => {
+        await this._listing.selectItemByName(model.name);
         this._directoryPending = false;
       })
       .catch(err => {
@@ -200,8 +205,8 @@ export class FileBrowser extends Widget {
   /**
    * Download the currently selected item(s).
    */
-  download(): void {
-    this._listing.download();
+  download(): Promise<void> {
+    return this._listing.download();
   }
 
   /**
@@ -263,7 +268,7 @@ export class FileBrowser extends Widget {
       }
     }
 
-    showErrorMessage(title, args).then(() => {
+    void showErrorMessage(title, args).then(() => {
       this._showingError = false;
     });
   }

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -272,8 +272,8 @@ export class BreadCrumbs extends Widget {
       let newPath = PathExt.join(path, name);
       promises.push(renameFile(manager, oldPath, newPath));
     }
-    Promise.all(promises).catch(err => {
-      showErrorMessage('Move Error', err);
+    void Promise.all(promises).catch(err => {
+      return showErrorMessage('Move Error', err);
     });
   }
 

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -359,7 +359,7 @@ export class DirListing extends Widget {
         return undefined;
       })
       .catch(error => {
-        showErrorMessage('Paste Error', error);
+        void showErrorMessage('Paste Error', error);
       });
   }
 
@@ -415,19 +415,19 @@ export class DirListing extends Widget {
         return undefined;
       })
       .catch(error => {
-        showErrorMessage('Duplicate file', error);
+        void showErrorMessage('Duplicate file', error);
       });
   }
 
   /**
    * Download the currently selected item(s).
    */
-  download(): void {
-    each(this.selectedItems(), item => {
-      if (item.type !== 'directory') {
-        this._model.download(item.path);
-      }
-    });
+  async download(): Promise<void> {
+    await Promise.all(
+      toArray(this.selectedItems())
+        .filter(item => item.type !== 'directory')
+        .map(item => this._model.download(item.path))
+    );
   }
 
   /**
@@ -452,7 +452,7 @@ export class DirListing extends Widget {
         return undefined;
       })
       .catch(error => {
-        showErrorMessage('Shutdown kernel', error);
+        void showErrorMessage('Shutdown kernel', error);
       });
   }
 
@@ -1023,7 +1023,7 @@ export class DirListing extends Widget {
     }
     event.preventDefault();
     for (let i = 0; i < files.length; i++) {
-      this._model.upload(files[i]);
+      void this._model.upload(files[i]);
     }
   }
 
@@ -1136,7 +1136,7 @@ export class DirListing extends Widget {
       }
     }
     Promise.all(promises).catch(error => {
-      showErrorMessage('Error while copying/moving files', error);
+      void showErrorMessage('Error while copying/moving files', error);
     });
   }
 
@@ -1197,7 +1197,7 @@ export class DirListing extends Widget {
         }
         if (otherPaths.length) {
           const firstWidgetPlaced = new PromiseDelegate<void>();
-          firstWidgetPlaced.promise.then(() => {
+          void firstWidgetPlaced.promise.then(() => {
             let prevWidget = widget;
             otherPaths.forEach(path => {
               const options: DocumentRegistry.IOpenOptions = {
@@ -1223,7 +1223,7 @@ export class DirListing extends Widget {
     document.removeEventListener('mousemove', this, true);
     document.removeEventListener('mouseup', this, true);
     clearTimeout(this._selectTimer);
-    this._drag.start(clientX, clientY).then(action => {
+    void this._drag.start(clientX, clientY).then(action => {
       this._drag = null;
       clearTimeout(this._selectTimer);
     });
@@ -1332,7 +1332,7 @@ export class DirListing extends Widget {
     for (let name of names) {
       let newPath = PathExt.join(basePath, name);
       let promise = this._model.manager.deleteFile(newPath).catch(err => {
-        showErrorMessage('Delete Failed', err);
+        void showErrorMessage('Delete Failed', err);
       });
       promises.push(promise);
     }
@@ -1360,7 +1360,7 @@ export class DirListing extends Widget {
         return original;
       }
       if (!isValidFileName(newName)) {
-        showErrorMessage(
+        void showErrorMessage(
           'Rename Error',
           Error(
             `"${newName}" is not a valid name for a file. ` +
@@ -1384,7 +1384,7 @@ export class DirListing extends Widget {
       return promise
         .catch(error => {
           if (error !== 'File not renamed') {
-            showErrorMessage('Rename Error', error);
+            void showErrorMessage('Rename Error', error);
           }
           this._inRename = false;
           return original;
@@ -1396,7 +1396,7 @@ export class DirListing extends Widget {
           }
           if (this._inRename) {
             // No need to catch because `newName` will always exit.
-            this.selectItemByName(newName);
+            void this.selectItemByName(newName);
           }
           this._inRename = false;
           return newName;
@@ -1466,10 +1466,10 @@ export class DirListing extends Widget {
       return;
     }
 
-    this.selectItemByName(name)
+    void this.selectItemByName(name)
       .then(() => {
         if (!this.isDisposed && newValue.type === 'directory') {
-          this._doRename();
+          return this._doRename();
         }
       })
       .catch(() => {

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -280,8 +280,9 @@ export class FileBrowserModel implements IDisposable {
         this._pendingPath = null;
         if (oldValue !== newValue) {
           // If there is a state database and a unique key, save the new path.
+          // We don't need to wait on the save to continue.
           if (this._state && this._key) {
-            this._state.save(this._key, { path: newValue });
+            void this._state.save(this._key, { path: newValue });
           }
 
           this._pathChanged.emit({
@@ -616,7 +617,7 @@ export class FileBrowserModel implements IDisposable {
   private _startTimer(): void {
     this._timeoutId = window.setInterval(() => {
       if (this._requested) {
-        this.refresh();
+        void this.refresh();
         return;
       }
       if (document.hidden) {
@@ -625,7 +626,7 @@ export class FileBrowserModel implements IDisposable {
       }
       let date = new Date().getTime();
       if (date - this._lastRefresh > this._refreshDuration) {
-        this.refresh();
+        void this.refresh();
       }
     }, MIN_REFRESH);
   }
@@ -636,7 +637,7 @@ export class FileBrowserModel implements IDisposable {
   private _scheduleUpdate(): void {
     let date = new Date().getTime();
     if (date - this._lastRefresh > MIN_REFRESH) {
-      this.refresh();
+      void this.refresh();
     } else {
       this._requested = true;
     }

--- a/packages/filebrowser/src/upload.ts
+++ b/packages/filebrowser/src/upload.ts
@@ -39,8 +39,8 @@ export class Uploader extends ToolbarButton {
   private _onInputChanged = () => {
     let files = Array.prototype.slice.call(this._input.files) as File[];
     let pending = files.map(file => this.fileBrowserModel.upload(file));
-    Promise.all(pending).catch(error => {
-      showErrorMessage('Upload Error', error);
+    void Promise.all(pending).catch(error => {
+      void showErrorMessage('Upload Error', error);
     });
   };
 

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -154,7 +154,7 @@ export const tabSpaceStatus: JupyterFrontEndPlugin<void> = {
       };
       item.model!.config = config;
     };
-    Promise.all([
+    void Promise.all([
       settingRegistry.load('@jupyterlab/fileeditor-extension:plugin'),
       app.restored
     ]).then(([settings]) => {
@@ -283,9 +283,9 @@ function activate(
 
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => {
-      tracker.save(widget);
+      void tracker.save(widget);
     });
-    tracker.add(widget);
+    void tracker.add(widget);
     updateWidget(widget.content);
   });
   app.docRegistry.addWidgetFactory(factory);
@@ -749,7 +749,7 @@ function activate(
       restartAndRunAll: current => {
         return current.context.session.restart().then(restarted => {
           if (restarted) {
-            commands.execute(CommandIDs.runAllCode);
+            void commands.execute(CommandIDs.runAllCode);
           }
           return restarted;
         });

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -52,13 +52,13 @@ export class FileEditorCodeWrapper extends CodeEditorWrapper {
     this.node.dataset[UNDOER] = 'true';
 
     editor.model.value.text = context.model.toString();
-    context.ready.then(() => {
+    void context.ready.then(() => {
       this._onContextReady();
     });
 
     if (context.model.modelDB.isCollaborative) {
       let modelDB = context.model.modelDB;
-      modelDB.connected.then(() => {
+      void modelDB.connected.then(() => {
         let collaborators = modelDB.collaborators;
         if (!collaborators) {
           return;

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -181,7 +181,7 @@ function activate(
       return;
     }
     const session = serviceManager.sessions.connectTo(sessionModel);
-    session.kernel.ready.then(() => {
+    void session.kernel.ready.then(() => {
       // Check the cache second time so that, if two callbacks get scheduled,
       // they don't try to add the same commands.
       if (kernelInfoCache.has(sessionModel.kernel.name)) {
@@ -240,7 +240,7 @@ function activate(
           const banner = <pre>{kernelInfo.banner}</pre>;
           let body = <div className="jp-About-body">{banner}</div>;
 
-          showDialog({
+          return showDialog({
             title,
             body,
             buttons: [
@@ -263,7 +263,7 @@ function activate(
           isVisible: usesKernel,
           isEnabled: usesKernel,
           execute: () => {
-            commands.execute(CommandIDs.open, link);
+            return commands.execute(CommandIDs.open, link);
           }
         });
         kernelGroup.push({ command: commandId });
@@ -333,7 +333,7 @@ function activate(
         </div>
       );
 
-      showDialog({
+      return showDialog({
         title,
         body,
         buttons: [
@@ -359,8 +359,9 @@ function activate(
       }
 
       let widget = newHelpWidget(url, text);
-      tracker.add(widget);
+      void tracker.add(widget);
       shell.add(widget, 'main');
+      return widget;
     }
   });
 

--- a/packages/htmlviewer-extension/src/index.tsx
+++ b/packages/htmlviewer-extension/src/index.tsx
@@ -89,10 +89,10 @@ function activateHTMLViewer(
   app.docRegistry.addWidgetFactory(factory);
   factory.widgetCreated.connect((sender, widget) => {
     // Track the widget.
-    tracker.add(widget);
+    void tracker.add(widget);
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => {
-      tracker.save(widget);
+      void tracker.save(widget);
     });
     // Notify the application when the trust state changes so it
     // can update any renderings of the trust command.

--- a/packages/htmlviewer/src/index.tsx
+++ b/packages/htmlviewer/src/index.tsx
@@ -75,7 +75,7 @@ export class HTMLViewer extends DocumentWidget<IFrame>
     });
     this.content.addClass(CSS_CLASS);
 
-    this.context.ready.then(() => {
+    void this.context.ready.then(() => {
       this.update();
       // Throttle the rendering rate of the widget.
       this._monitor = new ActivityMonitor({
@@ -155,7 +155,7 @@ export class HTMLViewer extends DocumentWidget<IFrame>
       return;
     }
     this._renderPending = true;
-    this._renderModel().then(() => (this._renderPending = false));
+    void this._renderModel().then(() => (this._renderPending = false));
   }
 
   /**

--- a/packages/imageviewer-extension/src/index.ts
+++ b/packages/imageviewer-extension/src/index.ts
@@ -98,9 +98,9 @@ function activate(
   factory.widgetCreated.connect((sender, widget) => {
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => {
-      tracker.save(widget);
+      void tracker.save(widget);
     });
-    tracker.add(widget);
+    void tracker.add(widget);
 
     const types = app.docRegistry.getFileTypesForPath(widget.context.path);
 

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -43,7 +43,7 @@ export class ImageViewer extends Widget {
       this
     );
 
-    context.ready.then(() => {
+    void context.ready.then(() => {
       if (this.isDisposed) {
         return;
       }

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -64,7 +64,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         inspector = new MainAreaWidget({ content: new InspectorPanel() });
         inspector.id = 'jp-inspector';
         inspector.title.label = title;
-        tracker.add(inspector);
+        void tracker.add(inspector);
         source = source && !source.isDisposed ? source : null;
         inspector.content.source = source;
       }

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -147,7 +147,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
 
     const pending = ++this._pending;
 
-    this._connector
+    void this._connector
       .fetch({ offset, text })
       .then(reply => {
         // If handler has been disposed or a newer request is pending, bail.
@@ -163,7 +163,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
           const widget = this._rendermime.createRenderer(mimeType);
           const model = new MimeModel({ data });
 
-          widget.renderModel(model);
+          void widget.renderModel(model);
           update.content = widget;
         }
 

--- a/packages/javascript-extension/src/index.ts
+++ b/packages/javascript-extension/src/index.ts
@@ -34,7 +34,7 @@ export class ExperimentalRenderedJavascript extends RenderedJavaScript {
       <button>Run</button>`;
       this.node.querySelector('button').onclick = event => {
         this.node.innerHTML = '';
-        renderJavascript();
+        void renderJavascript();
       };
       return Promise.resolve();
     }

--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -359,7 +359,7 @@ function Card(
       return;
     }
     launcher.pending = true;
-    commands
+    void commands
       .execute(command, {
         ...item.args,
         cwd: launcher.cwd
@@ -373,7 +373,7 @@ function Card(
       })
       .catch(err => {
         launcher.pending = false;
-        showErrorMessage('Launcher Error', err);
+        void showErrorMessage('Launcher Error', err);
       });
   };
 

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -375,7 +375,7 @@ export function createFileMenu(
     label: 'Quit',
     caption: 'Quit JupyterLab',
     execute: () => {
-      showDialog({
+      return showDialog({
         title: 'Quit confirmation',
         body: 'Please confirm you want to quit JupyterLab.',
         buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Quit' })]
@@ -383,14 +383,18 @@ export function createFileMenu(
         if (result.button.accept) {
           let setting = ServerConnection.makeSettings();
           let apiURL = URLExt.join(setting.baseUrl, 'api/shutdown');
-          ServerConnection.makeRequest(apiURL, { method: 'POST' }, setting)
+          return ServerConnection.makeRequest(
+            apiURL,
+            { method: 'POST' },
+            setting
+          )
             .then(result => {
               if (result.ok) {
                 // Close this window if the shutdown request has been successful
                 let body = document.createElement('div');
                 body.innerHTML = `<p>You have shut down the Jupyter server. You can now close this tab.</p>
                   <p>To use JupyterLab again, you will need to relaunch it.</p>`;
-                showDialog({
+                void showDialog({
                   title: 'Server stopped',
                   body: new Widget({ node: body }),
                   buttons: []
@@ -524,7 +528,7 @@ export function createKernelMenu(app: JupyterFrontEnd, menu: KernelMenu): void {
       return app.serviceManager.sessions.running().next() !== undefined;
     },
     execute: () => {
-      showDialog({
+      return showDialog({
         title: 'Shutdown All?',
         body: 'Shut down all kernels?',
         buttons: [
@@ -762,7 +766,7 @@ export function createTabsMenu(
   });
 
   if (labShell) {
-    app.restored.then(() => {
+    void app.restored.then(() => {
       // Iterate over the current widgets in the
       // main area, and add them to the tab group
       // of the menu.

--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -112,11 +112,11 @@ function activate(
   factory.widgetCreated.connect((sender, widget) => {
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => {
-      tracker.save(widget);
+      void tracker.save(widget);
     });
     // Handle the settings of new widgets.
     updateWidget(widget.content);
-    tracker.add(widget);
+    void tracker.add(widget);
   });
   docRegistry.addWidgetFactory(factory);
 

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -52,7 +52,7 @@ export class MarkdownViewer extends Widget {
     const layout = (this.layout = new StackedLayout());
     layout.addWidget(this.renderer);
 
-    this.context.ready.then(async () => {
+    void this.context.ready.then(async () => {
       await this._render();
 
       // Throttle the rendering rate of the widget.
@@ -141,7 +141,7 @@ export class MarkdownViewer extends Widget {
    */
   protected onUpdateRequest(msg: Message): void {
     if (this.context.isReady && !this.isDisposed) {
-      this._render();
+      void this._render();
       this._fragment = '';
     }
   }
@@ -198,7 +198,7 @@ export class MarkdownViewer extends Widget {
       requestAnimationFrame(() => {
         this.dispose();
       });
-      showErrorMessage(`Renderer Failure: ${context.path}`, reason);
+      void showErrorMessage(`Renderer Failure: ${context.path}`, reason);
     }
   }
 

--- a/packages/mathjax2/src/index.ts
+++ b/packages/mathjax2/src/index.ts
@@ -36,7 +36,7 @@ export class MathJaxTypesetter implements IRenderMime.ILatexTypesetter {
     if (!this._initialized) {
       this._init();
     }
-    this._initPromise.promise.then(() => {
+    void this._initPromise.promise.then(() => {
       MathJax.Hub.Queue(['Typeset', MathJax.Hub, node]);
       try {
         MathJax.Hub.Queue(

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -401,11 +401,11 @@ function activateCellTools(
   const hook = (sender: any, message: Message): boolean => {
     switch (message.type) {
       case 'activate-request':
-        state.save(id, { open: true });
+        void state.save(id, { open: true });
         break;
       case 'after-hide':
       case 'close-request':
-        state.remove(id);
+        void state.remove(id);
         break;
       default:
         break;
@@ -414,7 +414,7 @@ function activateCellTools(
   };
   let optionsMap: { [key: string]: JSONValue } = {};
   optionsMap.None = '-';
-  services.nbconvert.getExportFormats().then(response => {
+  void services.nbconvert.getExportFormats().then(response => {
     if (response) {
       // convert exportList to palette and menu items
       const formatList = Object.keys(response);
@@ -439,7 +439,7 @@ function activateCellTools(
   MessageLoop.installMessageHook(celltools, hook);
 
   // Wait until the application has finished restoring before rendering.
-  Promise.all([state.fetch(id), app.restored]).then(([value]) => {
+  void Promise.all([state.fetch(id), app.restored]).then(([value]) => {
     const open = !!(
       value && ((value as ReadonlyJSONObject)['open'] as boolean)
     );
@@ -557,10 +557,10 @@ function activateNotebookHandler(
     widget.title.icon = NOTEBOOK_ICON_CLASS;
     // Notify the instance tracker if restore data needs to update.
     widget.context.pathChanged.connect(() => {
-      tracker.save(widget);
+      void tracker.save(widget);
     });
     // Add the notebook panel to the tracker.
-    tracker.add(widget);
+    void tracker.add(widget);
   });
 
   /**
@@ -675,7 +675,7 @@ function activateNotebookHandler(
 
   // Add a launcher item if the launcher is available.
   if (launcher) {
-    services.ready.then(() => {
+    void services.ready.then(() => {
       let disposables: DisposableSet | null = null;
       const onSpecsChanged = () => {
         if (disposables) {
@@ -1147,7 +1147,7 @@ function addCommands(
 
         return session.restart().then(restarted => {
           if (restarted) {
-            NotebookActions.runAll(content, context.session);
+            void NotebookActions.runAll(content, context.session);
           }
           return restarted;
         });
@@ -1543,13 +1543,13 @@ function addCommands(
       });
 
       const updateCloned = () => {
-        clonedOutputs.save(widget);
+        void clonedOutputs.save(widget);
       };
       current.context.pathChanged.connect(updateCloned);
       current.content.model.cells.changed.connect(updateCloned);
 
       // Add the cloned output to the output instance tracker.
-      clonedOutputs.add(widget);
+      void clonedOutputs.add(widget);
 
       // Remove the output view if the parent notebook is closed.
       current.content.disposed.connect(() => {
@@ -1760,12 +1760,12 @@ function addCommands(
   });
   commands.addCommand(CommandIDs.saveWithView, {
     label: 'Save Notebook with View State',
-    execute: args => {
+    execute: async args => {
       const current = getCurrent(args);
 
       if (current) {
         NotebookActions.persistViewState(current.content);
-        app.commands.execute('docmanager:save');
+        return app.commands.execute('docmanager:save');
       }
     },
     isEnabled: args => {
@@ -1935,7 +1935,7 @@ function populateMenus(
   // Add a notebook group to the File menu.
   let exportTo = new Menu({ commands });
   exportTo.title.label = 'Export Notebook As…';
-  services.nbconvert.getExportFormats().then(response => {
+  void services.nbconvert.getExportFormats().then(response => {
     if (response) {
       // Convert export list to palette and menu items.
       const formatList = Object.keys(response);
@@ -2066,7 +2066,7 @@ function populateMenus(
       const { context, content } = current;
       return context.session.restart().then(restarted => {
         if (restarted) {
-          NotebookActions.runAll(content, context.session);
+          void NotebookActions.runAll(content, context.session);
         }
         return restarted;
       });
@@ -2163,7 +2163,7 @@ namespace Private {
 
       // Wait for the notebook to be loaded before
       // cloning the output area.
-      this._notebook.context.ready.then(() => {
+      void this._notebook.context.ready.then(() => {
         if (!this._cell) {
           this._cell = this._notebook.content.widgets[this._index] as CodeCell;
         }

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -84,7 +84,7 @@ export namespace ToolbarItems {
           buttons: [Dialog.okButton()]
         });
       }
-      panel.context.save().then(() => {
+      void panel.context.save().then(() => {
         if (!panel.isDisposed) {
           return panel.context.createCheckpoint();
         }
@@ -172,7 +172,7 @@ export namespace ToolbarItems {
     return new ToolbarButton({
       iconClassName: TOOLBAR_RUN_CLASS + ' jp-Icon jp-Icon-16',
       onClick: () => {
-        NotebookActions.runAndAdvance(panel.content, panel.session);
+        void NotebookActions.runAndAdvance(panel.content, panel.session);
       },
       tooltip: 'Run the selected cells and advance'
     });

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -54,7 +54,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       this
     );
 
-    this.revealed.then(() => {
+    void this.revealed.then(() => {
       // Set the document edit mode on initial open if it looks like a new document.
       if (this.content.widgets.length === 1) {
         let cellModel = this.content.widgets[0].model;
@@ -115,7 +115,7 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
    * Set URI fragment identifier.
    */
   setFragment(fragment: string) {
-    this.context.ready.then(() => {
+    void this.context.ready.then(() => {
       this.content.setFragment(fragment);
     });
   }
@@ -149,12 +149,12 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       return;
     }
     let { newValue } = args;
-    newValue.ready.then(() => {
+    void newValue.ready.then(() => {
       if (this.model) {
         this._updateLanguage(newValue.info.language_info);
       }
     });
-    this._updateSpec(newValue);
+    void this._updateSpec(newValue);
   }
 
   /**
@@ -167,8 +167,8 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
   /**
    * Update the kernel spec.
    */
-  private _updateSpec(kernel: Kernel.IKernelConnection): void {
-    kernel.getSpec().then(spec => {
+  private _updateSpec(kernel: Kernel.IKernelConnection): Promise<void> {
+    return kernel.getSpec().then(spec => {
       if (this.isDisposed) {
         return;
       }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -216,7 +216,7 @@ export class StaticNotebook extends Widget {
     this._model = newValue;
 
     if (oldValue && oldValue.modelDB.isCollaborative) {
-      oldValue.modelDB.connected.then(() => {
+      void oldValue.modelDB.connected.then(() => {
         oldValue.modelDB.collaborators.changed.disconnect(
           this._onCollaboratorsChanged,
           this
@@ -224,7 +224,7 @@ export class StaticNotebook extends Widget {
       });
     }
     if (newValue && newValue.modelDB.isCollaborative) {
-      newValue.modelDB.connected.then(() => {
+      void newValue.modelDB.connected.then(() => {
         newValue.modelDB.collaborators.changed.connect(
           this._onCollaboratorsChanged,
           this
@@ -1183,7 +1183,7 @@ export class Notebook extends StaticNotebook {
    */
   setFragment(fragment: string): void {
     // Wait all cells are rendered then set fragment and update.
-    Promise.all(this.widgets.map(widget => widget.ready)).then(() => {
+    void Promise.all(this.widgets.map(widget => widget.ready)).then(() => {
       this._fragment = fragment;
       this.update();
     });
@@ -1402,7 +1402,7 @@ export class Notebook extends StaticNotebook {
   protected onCellInserted(index: number, cell: Cell): void {
     if (this.model && this.model.modelDB.isCollaborative) {
       let modelDB = this.model.modelDB;
-      modelDB.connected.then(() => {
+      void modelDB.connected.then(() => {
         if (!cell.isDisposed) {
           // Setup the selection style for collaborators.
           let localCollaborator = modelDB.collaborators.localCollaborator;
@@ -1996,7 +1996,7 @@ export class Notebook extends StaticNotebook {
     document.removeEventListener('mousemove', this, true);
     document.removeEventListener('mouseup', this, true);
     this._mouseMode = null;
-    this._drag.start(clientX, clientY).then(action => {
+    void this._drag.start(clientX, clientY).then(action => {
       if (this.isDisposed) {
         return;
       }

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -308,7 +308,7 @@ export class OutputArea extends Widget {
      * Wait for the stdin to complete, add it to the model (so it persists)
      * and remove the stdin widget.
      */
-    input.value.then(value => {
+    void input.value.then(value => {
       // Use stdin as the stream so it does not get combined with stdout.
       this.model.add({
         output_type: 'stream',
@@ -329,7 +329,7 @@ export class OutputArea extends Widget {
       ? panel.widgets[1]
       : panel) as IRenderMime.IRenderer;
     if (renderer.renderModel) {
-      renderer.renderModel(model);
+      void renderer.renderModel(model);
     } else {
       layout.widgets[index].dispose();
       this._insertOutput(index, model);

--- a/packages/running-extension/src/index.ts
+++ b/packages/running-extension/src/index.ts
@@ -46,14 +46,14 @@ function activate(
   running.sessionOpenRequested.connect((sender, model) => {
     let path = model.path;
     if (model.type.toLowerCase() === 'console') {
-      app.commands.execute('console:open', { path });
+      void app.commands.execute('console:open', { path });
     } else {
-      app.commands.execute('docmanager:open', { path });
+      void app.commands.execute('docmanager:open', { path });
     }
   });
 
   running.terminalOpenRequested.connect((sender, model) => {
-    app.commands.execute('terminal:open', { name: model.name });
+    void app.commands.execute('terminal:open', { name: model.name });
   });
 
   // Rank has been chosen somewhat arbitrarily to give priority to the running

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -180,7 +180,7 @@ function List<M>(props: SessionProps<M>) {
  */
 function Section<M>(props: SessionProps<M>) {
   function onShutdown() {
-    showDialog({
+    void showDialog({
       title: `Shutdown All ${props.name} Sessions?`,
       buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'SHUTDOWN' })]
     }).then(result => {
@@ -232,9 +232,9 @@ function RunningSessionsComponent({
           iconClassName="jp-RefreshIcon jp-Icon jp-Icon-16"
           onClick={() => {
             if (terminalsAvailable) {
-              manager.terminals.refreshRunning();
+              void manager.terminals.refreshRunning();
             }
-            manager.sessions.refreshRunning();
+            void manager.sessions.refreshRunning();
           }}
         />
       </div>

--- a/packages/services/examples/typescript-browser-with-output/index.ts
+++ b/packages/services/examples/typescript-browser-with-output/index.ts
@@ -31,7 +31,7 @@ function main() {
   const rendermime = new RenderMimeRegistry({ initialFactories });
   const outputArea = new OutputArea({ model, rendermime });
 
-  Kernel.startNew().then(kernel => {
+  void Kernel.startNew().then(kernel => {
     outputArea.future = kernel.requestExecute({ code });
     document.getElementById('outputarea').appendChild(outputArea.node);
   });

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -947,6 +947,7 @@ export class DefaultKernel implements Kernel.IKernel {
     this._unregisterComm(comm.commId);
     let onClose = comm.onClose;
     if (onClose) {
+      // tslint:disable-next-line:await-promise
       await onClose(msg);
     }
     (comm as CommHandler).dispose();
@@ -964,6 +965,7 @@ export class DefaultKernel implements Kernel.IKernel {
     }
     let onMsg = comm.onMsg;
     if (onMsg) {
+      // tslint:disable-next-line:await-promise
       await onMsg(msg);
     }
   }

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -229,7 +229,9 @@ export class DefaultKernel implements Kernel.IKernel {
     this._isDisposed = true;
     this._terminated.emit(void 0);
     this._status = 'dead';
-    this._clearState();
+    // TODO: Kernel status rework should avoid doing
+    // anything asynchronous in the disposal.
+    void this._clearState();
     this._clearSocket();
     this._kernelSession = '';
     this._msgChain = null;
@@ -1544,7 +1546,7 @@ namespace Private {
     // Reconnect the other kernels asynchronously, but don't wait for them.
     each(runningKernels, k => {
       if (k !== kernel && k.id === kernel.id) {
-        k.reconnect();
+        void k.reconnect();
       }
     });
     await kernel.reconnect();

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -213,6 +213,7 @@ export class KernelFutureHandler extends DisposableDelegate
   private async _handleReply(msg: KernelMessage.IShellMessage): Promise<void> {
     let reply = this._reply;
     if (reply) {
+      // tslint:disable-next-line:await-promise
       await reply(msg);
     }
     this._replyMsg = msg;
@@ -225,6 +226,7 @@ export class KernelFutureHandler extends DisposableDelegate
   private async _handleStdin(msg: KernelMessage.IStdinMessage): Promise<void> {
     let stdin = this._stdin;
     if (stdin) {
+      // tslint:disable-next-line:await-promise
       await stdin(msg);
     }
   }
@@ -233,6 +235,7 @@ export class KernelFutureHandler extends DisposableDelegate
     let process = await this._hooks.process(msg);
     let iopub = this._iopub;
     if (process && iopub) {
+      // tslint:disable-next-line:await-promise
       await iopub(msg);
     }
     if (
@@ -375,6 +378,7 @@ namespace Private {
 
         // Execute the hook and log any errors.
         try {
+          // tslint:disable-next-line:await-promise
           continueHandling = await hook(msg);
         } catch (err) {
           continueHandling = true;

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -35,14 +35,14 @@ export class KernelManager implements Kernel.IManager {
         // Don't poll when nobody's looking.
         return;
       }
-      this._refreshRunning();
+      return this._refreshRunning();
     }, 10000);
     this._specsTimer = (setInterval as any)(() => {
       if (typeof document !== 'undefined' && document.hidden) {
         // Don't poll when nobody's looking.
         return;
       }
-      this._refreshSpecs();
+      return this._refreshSpecs();
     }, 61000);
   }
 

--- a/packages/services/src/manager.ts
+++ b/packages/services/src/manager.ts
@@ -50,7 +50,7 @@ export class ServiceManager implements ServiceManager.IManager {
         return this.terminals.ready;
       }
     });
-    this._readyPromise.then(() => {
+    void this._readyPromise.then(() => {
       this._isReady = true;
     });
   }

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -37,14 +37,14 @@ export class SessionManager implements Session.IManager {
         // Don't poll when nobody's looking.
         return;
       }
-      this._refreshRunning();
+      return this._refreshRunning();
     }, 10000);
     this._specsTimer = (setInterval as any)(() => {
       if (typeof document !== 'undefined' && document.hidden) {
         // Don't poll when nobody's looking.
         return;
       }
-      this._refreshSpecs();
+      return this._refreshSpecs();
     }, 61000);
   }
 

--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -121,7 +121,7 @@ export class DefaultTerminalSession implements TerminalSession.ISession {
       return;
     }
 
-    this.ready.then(() => {
+    void this.ready.then(() => {
       const socket = this._ws;
 
       if (socket) {

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -33,7 +33,7 @@ export class TerminalManager implements TerminalSession.IManager {
           // Don't poll when nobody's looking.
           return;
         }
-        this._refreshRunning();
+        return this._refreshRunning();
       }, 10000);
     }
   }

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -133,7 +133,7 @@ function activate(
       editor.title.iconClass = 'jp-SettingsIcon';
 
       let main = new MainAreaWidget({ content: editor });
-      tracker.add(main);
+      void tracker.add(main);
       shell.add(main);
     },
     label: 'Advanced Settings Editor'

--- a/packages/settingeditor/src/plugineditor.ts
+++ b/packages/settingeditor/src/plugineditor.ts
@@ -260,7 +260,7 @@ namespace Private {
   export function onSaveError(reason: any): void {
     console.error(`Saving setting editor value failed: ${reason.message}`);
 
-    showDialog({
+    void showDialog({
       title: 'Your changes were not saved.',
       body: reason.message,
       buttons: [Dialog.okButton()]

--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -80,7 +80,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         });
 
         // Save the reconciled list.
-        settings.set('shortcuts', shortcuts);
+        void settings.set('shortcuts', shortcuts);
       };
 
       if (!keys.length) {
@@ -101,7 +101,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       port(deprecated);
 
       // Remove all old shortcuts;
-      old.save('{}');
+      void old.save('{}');
     } catch (error) {
       console.error(`Loading ${plugin.id} failed.`, error);
     }

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -79,7 +79,7 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
       execute: (args: any) => {
         statusBar.setHidden(statusBar.isVisible);
         if (settingRegistry) {
-          settingRegistry.set(
+          void settingRegistry.set(
             STATUSBAR_PLUGIN_ID,
             'visible',
             statusBar.isVisible
@@ -136,11 +136,11 @@ export const kernelStatus: JupyterFrontEndPlugin<void> = {
     // When the status item is clicked, launch the kernel
     // selection dialog for the current session.
     let currentSession: IClientSession | null = null;
-    const changeKernel = () => {
+    const changeKernel = async () => {
       if (!currentSession) {
         return;
       }
-      currentSession.selectKernel();
+      await currentSession.selectKernel();
     };
 
     // Create the status item.

--- a/packages/tabmanager-extension/src/index.ts
+++ b/packages/tabmanager-extension/src/index.ts
@@ -39,7 +39,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     tabs.node.insertBefore(header, tabs.contentNode);
     shell.add(tabs, 'left', { rank: 600 });
 
-    app.restored.then(() => {
+    void app.restored.then(() => {
       const populate = () => {
         tabs.clearTabs();
         each(shell.widgets('main'), widget => {

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -221,7 +221,7 @@ export function addCommands(
       return promise
         .then(session => {
           term.session = session;
-          tracker.add(main);
+          void tracker.add(main);
           app.shell.activateById(main.id);
 
           return main;

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -68,7 +68,7 @@ export class Terminal extends Widget {
     if (!value) {
       return;
     }
-    value.ready.then(() => {
+    void value.ready.then(() => {
       if (this.isDisposed || value !== this._session) {
         return;
       }

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -207,7 +207,7 @@ const files: JupyterFrontEndPlugin<void> = {
         }
       });
     };
-    Session.listRunning().then(models => {
+    void Session.listRunning().then(models => {
       onRunningChanged(sessions, models);
     });
     sessions.runningChanged.connect(onRunningChanged);

--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -74,7 +74,7 @@ export class Tooltip extends Widget {
     }
 
     this._content = this._rendermime.createRenderer(mimeType);
-    this._content.renderModel(model);
+    void this._content.renderModel(model);
     this._content.addClass(CONTENT_CLASS);
     layout.addWidget(this._content);
   }

--- a/tests/test-apputils/src/dialog.spec.tsx
+++ b/tests/test-apputils/src/dialog.spec.tsx
@@ -87,7 +87,7 @@ describe('@jupyterlab/apputils', () => {
         const dialog = new TestDialog({ host });
 
         document.body.appendChild(host);
-        dialog.launch();
+        void dialog.launch();
         await waitForDialog();
         expect(host.firstChild).to.equal(dialog.node);
         dialog.dispose();

--- a/tests/test-apputils/src/instancetracker.spec.ts
+++ b/tests/test-apputils/src/instancetracker.spec.ts
@@ -50,7 +50,7 @@ describe('@jupyterlab/apputils', () => {
         Widget.attach(widget, document.body);
         widget.node.focus();
         simulate(widget.node, 'focus');
-        tracker.add(widget);
+        void tracker.add(widget);
         await promise;
         Widget.detach(widget);
       });
@@ -61,7 +61,7 @@ describe('@jupyterlab/apputils', () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widget = new Widget();
         let promise = signalToPromise(tracker.widgetAdded);
-        tracker.add(widget);
+        void tracker.add(widget);
         const [sender, args] = await promise;
         expect(sender).to.equal(tracker);
         expect(args).to.equal(widget);
@@ -81,7 +81,7 @@ describe('@jupyterlab/apputils', () => {
             return total === 1;
           }
         });
-        tracker.add(one);
+        void tracker.add(one);
         tracker.inject(two);
         Widget.attach(two, document.body);
         two.node.focus();
@@ -101,7 +101,7 @@ describe('@jupyterlab/apputils', () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widget = new Widget();
         widget.node.tabIndex = -1;
-        tracker.add(widget);
+        void tracker.add(widget);
         expect(tracker.currentWidget).to.equal(widget);
         widget.dispose();
       });
@@ -110,9 +110,9 @@ describe('@jupyterlab/apputils', () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const panel = new Panel();
         const widget0 = createWidget();
-        tracker.add(widget0);
+        void tracker.add(widget0);
         const widget1 = createWidget();
-        tracker.add(widget1);
+        void tracker.add(widget1);
         panel.addWidget(widget0);
         panel.addWidget(widget1);
         Widget.attach(panel, document.body);
@@ -128,9 +128,9 @@ describe('@jupyterlab/apputils', () => {
       it('should revert to the previously added widget on widget disposal', () => {
         const tracker = new TestTracker<Widget>({ namespace });
         const widget0 = new Widget();
-        tracker.add(widget0);
+        void tracker.add(widget0);
         const widget1 = new Widget();
-        tracker.add(widget1);
+        void tracker.add(widget1);
         expect(tracker.currentWidget).to.equal(widget1);
         widget1.dispose();
         expect(tracker.currentWidget).to.equal(widget0);
@@ -141,7 +141,7 @@ describe('@jupyterlab/apputils', () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widgets = [createWidget(), createWidget(), createWidget()];
         each(widgets, widget => {
-          tracker.add(widget);
+          void tracker.add(widget);
           panel.addWidget(widget);
         });
         Widget.attach(panel, document.body);
@@ -168,7 +168,7 @@ describe('@jupyterlab/apputils', () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widgets = [createWidget(), createWidget(), createWidget()];
         each(widgets, widget => {
-          tracker.add(widget);
+          void tracker.add(widget);
           panel.addWidget(widget);
         });
         Widget.attach(panel, document.body);
@@ -270,9 +270,9 @@ describe('@jupyterlab/apputils', () => {
         widgetA.id = 'A';
         widgetB.id = 'B';
         widgetC.id = 'C';
-        tracker.add(widgetA);
-        tracker.add(widgetB);
-        tracker.add(widgetC);
+        void tracker.add(widgetA);
+        void tracker.add(widgetB);
+        void tracker.add(widgetC);
         expect(tracker.find(widget => widget.id === 'B')).to.equal(widgetB);
       });
 
@@ -284,9 +284,9 @@ describe('@jupyterlab/apputils', () => {
         widgetA.id = 'A';
         widgetB.id = 'B';
         widgetC.id = 'C';
-        tracker.add(widgetA);
-        tracker.add(widgetB);
-        tracker.add(widgetC);
+        void tracker.add(widgetA);
+        void tracker.add(widgetB);
+        void tracker.add(widgetC);
         expect(tracker.find(widget => widget.id === 'D')).to.not.be.ok;
       });
     });
@@ -300,9 +300,9 @@ describe('@jupyterlab/apputils', () => {
         widgetA.id = 'include-A';
         widgetB.id = 'include-B';
         widgetC.id = 'exclude-C';
-        tracker.add(widgetA);
-        tracker.add(widgetB);
-        tracker.add(widgetC);
+        void tracker.add(widgetA);
+        void tracker.add(widgetB);
+        void tracker.add(widgetC);
         const list = tracker.filter(
           widget => widget.id.indexOf('include') !== -1
         );
@@ -319,9 +319,9 @@ describe('@jupyterlab/apputils', () => {
         widgetA.id = 'A';
         widgetB.id = 'B';
         widgetC.id = 'C';
-        tracker.add(widgetA);
-        tracker.add(widgetB);
-        tracker.add(widgetC);
+        void tracker.add(widgetA);
+        void tracker.add(widgetB);
+        void tracker.add(widgetC);
         expect(tracker.filter(widget => widget.id === 'D').length).to.equal(0);
       });
     });
@@ -335,9 +335,9 @@ describe('@jupyterlab/apputils', () => {
         widgetA.id = 'A';
         widgetB.id = 'B';
         widgetC.id = 'C';
-        tracker.add(widgetA);
-        tracker.add(widgetB);
-        tracker.add(widgetC);
+        void tracker.add(widgetA);
+        void tracker.add(widgetB);
+        void tracker.add(widgetC);
         tracker.forEach(widget => {
           visited += widget.id;
         });
@@ -350,7 +350,7 @@ describe('@jupyterlab/apputils', () => {
         const tracker = new InstanceTracker<Widget>({ namespace });
         const widget = new Widget();
         expect(tracker.has(widget)).to.equal(false);
-        tracker.add(widget);
+        void tracker.add(widget);
         expect(tracker.has(widget)).to.equal(true);
       });
     });
@@ -378,7 +378,7 @@ describe('@jupyterlab/apputils', () => {
       it('should be called when the current widget is changed', () => {
         const tracker = new TestTracker<Widget>({ namespace });
         const widget = new Widget();
-        tracker.add(widget);
+        void tracker.add(widget);
         expect(tracker.methods).to.contain('onCurrentChanged');
       });
     });

--- a/tests/test-console/src/history.spec.ts
+++ b/tests/test-console/src/history.spec.ts
@@ -55,9 +55,7 @@ describe('console/history', () => {
     session = await createClientSession();
   });
 
-  after(() => {
-    session.shutdown();
-  });
+  after(() => session.shutdown());
 
   describe('ConsoleHistory', () => {
     describe('#constructor()', () => {

--- a/tests/test-console/src/panel.spec.ts
+++ b/tests/test-console/src/panel.spec.ts
@@ -87,7 +87,7 @@ describe('console/panel', () => {
     });
 
     describe('#onAfterAttach()', () => {
-      it('should start the session', () => {
+      it('should start the session', async () => {
         Widget.attach(panel, document.body);
         await dismissDialog();
         return panel.session.ready;

--- a/tests/test-console/src/panel.spec.ts
+++ b/tests/test-console/src/panel.spec.ts
@@ -89,7 +89,7 @@ describe('console/panel', () => {
     describe('#onAfterAttach()', () => {
       it('should start the session', () => {
         Widget.attach(panel, document.body);
-        dismissDialog();
+        await dismissDialog();
         return panel.session.ready;
       });
     });

--- a/tests/test-docmanager/src/widgetmanager.spec.ts
+++ b/tests/test-docmanager/src/widgetmanager.spec.ts
@@ -43,9 +43,9 @@ class LoggingManager extends DocumentWidgetManager {
     return super.messageHook(handler, msg);
   }
 
-  setCaption(widget: Widget): void {
+  setCaption(widget: Widget): Promise<void> {
     this.methods.push('setCaption');
-    super.setCaption(widget);
+    return super.setCaption(widget);
   }
 
   onClose(widget: Widget): Promise<boolean> {

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -251,7 +251,7 @@ describe('docregistry/context', () => {
       it('should be set after population', async () => {
         const { path } = context;
 
-        context.initialize(true);
+        void context.initialize(true);
         await context.ready;
         expect(context.contentsModel.path).to.equal(path);
       });

--- a/tests/test-docregistry/src/default.spec.ts
+++ b/tests/test-docregistry/src/default.spec.ts
@@ -587,7 +587,7 @@ describe('docregistry/default', () => {
         // Our promise should resolve before the widget reveal promise.
         expect(await Promise.race([widget.revealed, reveal])).to.equal(x);
         // The context ready promise should also resolve first.
-        context.initialize(true);
+        void context.initialize(true);
         expect(
           await Promise.race([widget.revealed, contextReady])
         ).to.deep.equal([undefined, x]);

--- a/tests/test-docregistry/src/mimedocument.spec.ts
+++ b/tests/test-docregistry/src/mimedocument.spec.ts
@@ -100,7 +100,7 @@ describe('docregistry/mimedocument', () => {
           renderTimeout: 1000,
           dataType: 'string'
         });
-        dContext.initialize(true);
+        void dContext.initialize(true);
         await widget.ready;
         const layout = widget.layout as BoxLayout;
         expect(layout.widgets.length).to.equal(1);

--- a/tests/test-filebrowser/src/model.spec.ts
+++ b/tests/test-filebrowser/src/model.spec.ts
@@ -42,7 +42,7 @@ class DelayedContentsManager extends ContentsManager {
     return new Promise<Contents.IModel>(resolve => {
       const delay = this._delay;
       this._delay -= 500;
-      super.get(path, options).then(contents => {
+      void super.get(path, options).then(contents => {
         setTimeout(() => {
           resolve(contents);
         }, Math.max(delay, 0));
@@ -81,7 +81,7 @@ describe('filebrowser/model', () => {
   });
 
   beforeEach(async () => {
-    state.clear();
+    await state.clear();
     model = new FileBrowserModel({ manager, state });
     const contents = await manager.newUntitled({ type: 'file' });
     name = contents.name;
@@ -444,7 +444,7 @@ describe('filebrowser/model', () => {
             4
           );
 
-          model.upload(file);
+          const uploaded = model.upload(file);
           expect(toArray(model.uploads())).to.deep.equal([]);
           expect(await start).to.deep.equal([
             model,
@@ -488,6 +488,7 @@ describe('filebrowser/model', () => {
             }
           ]);
           expect(toArray(model.uploads())).to.deep.equal([]);
+          await uploaded;
         });
 
         after(() => {

--- a/tests/test-mainmenu/src/edit.spec.ts
+++ b/tests/test-mainmenu/src/edit.spec.ts
@@ -32,7 +32,7 @@ describe('@jupyterlab/mainmenu', () => {
       wodget = new Wodget();
       menu = new EditMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
-      tracker.add(wodget);
+      void tracker.add(wodget);
     });
 
     afterEach(() => {
@@ -62,9 +62,9 @@ describe('@jupyterlab/mainmenu', () => {
           }
         };
         menu.undoers.add(undoer);
-        delegateExecute(wodget, menu.undoers, 'undo');
+        void delegateExecute(wodget, menu.undoers, 'undo');
         expect(wodget.state).to.equal('undo');
-        delegateExecute(wodget, menu.undoers, 'redo');
+        void delegateExecute(wodget, menu.undoers, 'redo');
         expect(wodget.state).to.equal('redo');
       });
     });
@@ -84,9 +84,9 @@ describe('@jupyterlab/mainmenu', () => {
           }
         };
         menu.clearers.add(clearer);
-        delegateExecute(wodget, menu.clearers, 'clearCurrent');
+        void delegateExecute(wodget, menu.clearers, 'clearCurrent');
         expect(wodget.state).to.equal('clearCurrent');
-        delegateExecute(wodget, menu.clearers, 'clearAll');
+        void delegateExecute(wodget, menu.clearers, 'clearAll');
         expect(wodget.state).to.equal('clearAll');
       });
     });
@@ -101,7 +101,7 @@ describe('@jupyterlab/mainmenu', () => {
           }
         };
         menu.findReplacers.add(finder);
-        delegateExecute(wodget, menu.findReplacers, 'findAndReplace');
+        void delegateExecute(wodget, menu.findReplacers, 'findAndReplace');
         expect(wodget.state).to.equal('findAndReplace');
       });
     });

--- a/tests/test-mainmenu/src/file.spec.ts
+++ b/tests/test-mainmenu/src/file.spec.ts
@@ -32,7 +32,7 @@ describe('@jupyterlab/mainmenu', () => {
       wodget = new Wodget();
       menu = new FileMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
-      tracker.add(wodget);
+      void tracker.add(wodget);
     });
 
     afterEach(() => {
@@ -66,7 +66,7 @@ describe('@jupyterlab/mainmenu', () => {
           }
         };
         menu.closeAndCleaners.add(cleaner);
-        delegateExecute(wodget, menu.closeAndCleaners, 'closeAndCleanup');
+        void delegateExecute(wodget, menu.closeAndCleaners, 'closeAndCleanup');
         expect(wodget.state).to.equal('clean');
       });
     });
@@ -83,7 +83,7 @@ describe('@jupyterlab/mainmenu', () => {
           }
         };
         menu.persistAndSavers.add(persistAndSaver);
-        delegateExecute(wodget, menu.persistAndSavers, 'persistAndSave');
+        void delegateExecute(wodget, menu.persistAndSavers, 'persistAndSave');
         expect(wodget.state).to.equal('saved');
       });
     });
@@ -99,7 +99,7 @@ describe('@jupyterlab/mainmenu', () => {
           }
         };
         menu.consoleCreators.add(creator);
-        delegateExecute(wodget, menu.consoleCreators, 'createConsole');
+        void delegateExecute(wodget, menu.consoleCreators, 'createConsole');
         expect(wodget.state).to.equal('create');
       });
     });

--- a/tests/test-mainmenu/src/kernel.spec.ts
+++ b/tests/test-mainmenu/src/kernel.spec.ts
@@ -32,7 +32,7 @@ describe('@jupyterlab/mainmenu', () => {
       wodget = new Wodget();
       menu = new KernelMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
-      tracker.add(wodget);
+      void tracker.add(wodget);
     });
 
     afterEach(() => {
@@ -75,15 +75,15 @@ describe('@jupyterlab/mainmenu', () => {
           }
         };
         menu.kernelUsers.add(user);
-        delegateExecute(wodget, menu.kernelUsers, 'interruptKernel');
+        void delegateExecute(wodget, menu.kernelUsers, 'interruptKernel');
         expect(wodget.state).to.equal('interrupt');
-        delegateExecute(wodget, menu.kernelUsers, 'restartKernel');
+        void delegateExecute(wodget, menu.kernelUsers, 'restartKernel');
         expect(wodget.state).to.equal('restart');
-        delegateExecute(wodget, menu.kernelUsers, 'restartKernelAndClear');
+        void delegateExecute(wodget, menu.kernelUsers, 'restartKernelAndClear');
         expect(wodget.state).to.equal('restartAndClear');
-        delegateExecute(wodget, menu.kernelUsers, 'changeKernel');
+        void delegateExecute(wodget, menu.kernelUsers, 'changeKernel');
         expect(wodget.state).to.equal('change');
-        delegateExecute(wodget, menu.kernelUsers, 'shutdownKernel');
+        void delegateExecute(wodget, menu.kernelUsers, 'shutdownKernel');
         expect(wodget.state).to.equal('shutdown');
       });
     });

--- a/tests/test-mainmenu/src/run.spec.ts
+++ b/tests/test-mainmenu/src/run.spec.ts
@@ -32,7 +32,7 @@ describe('@jupyterlab/mainmenu', () => {
       wodget = new Wodget();
       menu = new RunMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
-      tracker.add(wodget);
+      void tracker.add(wodget);
     });
 
     afterEach(() => {
@@ -67,11 +67,11 @@ describe('@jupyterlab/mainmenu', () => {
           }
         };
         menu.codeRunners.add(runner);
-        delegateExecute(wodget, menu.codeRunners, 'run');
+        void delegateExecute(wodget, menu.codeRunners, 'run');
         expect(wodget.state).to.equal('run');
-        delegateExecute(wodget, menu.codeRunners, 'runAll');
+        void delegateExecute(wodget, menu.codeRunners, 'runAll');
         expect(wodget.state).to.equal('runAll');
-        delegateExecute(wodget, menu.codeRunners, 'restartAndRunAll');
+        void delegateExecute(wodget, menu.codeRunners, 'restartAndRunAll');
         expect(wodget.state).to.equal('restartAndRunAll');
       });
     });

--- a/tests/test-mainmenu/src/view.spec.ts
+++ b/tests/test-mainmenu/src/view.spec.ts
@@ -34,7 +34,7 @@ describe('@jupyterlab/mainmenu', () => {
       wodget = new Wodget();
       menu = new ViewMenu({ commands });
       tracker = new InstanceTracker<Wodget>({ namespace: 'wodget' });
-      tracker.add(wodget);
+      void tracker.add(wodget);
     });
 
     afterEach(() => {
@@ -82,9 +82,9 @@ describe('@jupyterlab/mainmenu', () => {
           delegateToggled(wodget, menu.editorViewers, 'lineNumbersToggled')
         ).to.equal(false);
 
-        delegateExecute(wodget, menu.editorViewers, 'toggleLineNumbers');
-        delegateExecute(wodget, menu.editorViewers, 'toggleMatchBrackets');
-        delegateExecute(wodget, menu.editorViewers, 'toggleWordWrap');
+        void delegateExecute(wodget, menu.editorViewers, 'toggleLineNumbers');
+        void delegateExecute(wodget, menu.editorViewers, 'toggleMatchBrackets');
+        void delegateExecute(wodget, menu.editorViewers, 'toggleWordWrap');
 
         expect(
           delegateToggled(wodget, menu.editorViewers, 'matchBracketsToggled')

--- a/tests/test-notebook/Untitled.ipynb
+++ b/tests/test-notebook/Untitled.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test-notebook/src/celltools.spec.ts
+++ b/tests/test-notebook/src/celltools.spec.ts
@@ -102,8 +102,8 @@ describe('@jupyterlab/notebook', () => {
       NBTestUtils.populateNotebook(panel1.content);
 
       tracker = new NotebookTracker({ namespace: 'notebook' });
-      tracker.add(panel0);
-      tracker.add(panel1);
+      await tracker.add(panel0);
+      await tracker.add(panel1);
       celltools = new CellTools({ tracker });
       tabpanel = new TabPanel();
       tabpanel.addWidget(panel0);

--- a/tests/test-notebook/src/tracker.spec.ts
+++ b/tests/test-notebook/src/tracker.spec.ts
@@ -56,14 +56,14 @@ describe('@jupyterlab/notebook', () => {
         const tracker = new NotebookTracker({ namespace });
         const panel = NBTestUtils.createNotebookPanel(context);
         panel.content.model.cells.clear();
-        tracker.add(panel);
+        void tracker.add(panel);
         expect(tracker.activeCell).to.be.null;
       });
 
       it('should be the active cell if a tracked notebook has one', () => {
         const tracker = new NotebookTracker({ namespace });
         const panel = NBTestUtils.createNotebookPanel(context);
-        tracker.add(panel);
+        void tracker.add(panel);
         panel.content.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         expect(tracker.activeCell).to.be.an.instanceof(Cell);
         panel.dispose();
@@ -79,7 +79,7 @@ describe('@jupyterlab/notebook', () => {
           count++;
         });
         panel.content.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-        tracker.add(panel);
+        void tracker.add(panel);
         expect(count).to.equal(1);
         panel.content.activeCellIndex = 1;
         expect(count).to.equal(2);
@@ -91,7 +91,7 @@ describe('@jupyterlab/notebook', () => {
       it('should be called when the active cell changes', () => {
         const tracker = new TestTracker({ namespace });
         const panel = NBTestUtils.createNotebookPanel(context);
-        tracker.add(panel);
+        void tracker.add(panel);
         expect(tracker.methods).to.contain('onCurrentChanged');
       });
     });

--- a/tests/test-services/src/kernel/ifuture.spec.ts
+++ b/tests/test-services/src/kernel/ifuture.spec.ts
@@ -61,6 +61,7 @@ describe('Kernel.IFuture', () => {
         };
 
         future.registerMessageHook(async msg => {
+          // tslint:disable-next-line:await-promise
           await calls.push('last');
           return true;
         });

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -981,6 +981,7 @@ describe('Kernel.IKernel', () => {
 
         kernel.registerMessageHook(parentHeader.msg_id, async msg => {
           // Make this hook call asynchronous
+          // tslint:disable-next-line:await-promise
           await calls.push('last');
           return true;
         });
@@ -1058,6 +1059,7 @@ describe('Kernel.IKernel', () => {
         });
 
         future.onIOPub = async () => {
+          // tslint:disable-next-line:await-promise
           await calls.push('iopub');
         };
       });
@@ -1325,6 +1327,7 @@ describe('Kernel.IKernel', () => {
 
       kernel.registerMessageHook(future.msg.header.msg_id, async msg => {
         // Make this hook call asynchronous
+        // tslint:disable-next-line:await-promise
         await calls.push([msg.header.msg_id, 'kernel hook b']);
         return true;
       });
@@ -1335,17 +1338,21 @@ describe('Kernel.IKernel', () => {
       });
 
       kernel.registerCommTarget('commtarget', async (comm, msg) => {
+        // tslint:disable-next-line:await-promise
         await calls.push([msg.header.msg_id, 'comm open']);
 
         comm.onMsg = async msg => {
+          // tslint:disable-next-line:await-promise
           await calls.push([msg.header.msg_id, 'comm msg']);
         };
         comm.onClose = async msg => {
+          // tslint:disable-next-line:await-promise
           await calls.push([msg.header.msg_id, 'comm close']);
         };
       });
 
       future.registerMessageHook(async msg => {
+        // tslint:disable-next-line:await-promise
         await calls.push([msg.header.msg_id, 'future hook b']);
         return true;
       });
@@ -1353,19 +1360,23 @@ describe('Kernel.IKernel', () => {
       future.registerMessageHook(async msg => {
         // Delay processing until after we've checked the anyMessage results.
         await handlingBlock.promise;
+        // tslint:disable-next-line:await-promise
         await calls.push([msg.header.msg_id, 'future hook a']);
         return true;
       });
 
       future.onIOPub = async msg => {
+        // tslint:disable-next-line:await-promise
         await calls.push([msg.header.msg_id, 'iopub']);
       };
 
       future.onStdin = async msg => {
+        // tslint:disable-next-line:await-promise
         await calls.push([msg.header.msg_id, 'stdin']);
       };
 
       future.onReply = async msg => {
+        // tslint:disable-next-line:await-promise
         await calls.push([msg.header.msg_id, 'reply']);
       };
 

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "prettier": [true, { "singleQuote": true }],
     "align": [true, "parameters", "statements"],
+    "await-promise": true,
     "ban": [
       true,
       ["_", "forEach"],
@@ -36,6 +37,7 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
+    "no-floating-promises": true,
     "no-inferrable-types": false,
     "no-internal-module": true,
     "no-invalid-this": [true, "check-function-in-method"],


### PR DESCRIPTION
This is an attempt to cut down on async errors in our test suite. It enables two new rules in our `tslint` settings.
1. `'no-floating-promises'`: All promises and async functions *must* be handled. This catches bugs where promises were intended to be chained but were not, or things were intended to be awaited but were not. It *does* force some extra care around "fire-and-forget" promises. In that case, we must consume the result using the `void` operator.
Probably two-thirds of this PR is annontating fire-and-forget promises with `void` to indicate that. It adds some visual noise, and takes some getting used-to, but I think it is overall a good thing. We *should* take extra note of those cases, and sometimes they are not intentional, or are indicative of API awkwardness.
2. `'await-promise'`: All things which are awaited *must* be promises. This should be uncontroversial, but there is one place in the API where we are intentionally awaiting things that may not be promises: `Comms`. In that case, we are awaiting `void | PromiseLike<void>`. @jasongrout has indicated that he may want to revisit that later, but for now I have disabled the linter in those places.

Most of this PR is pretty mechanical. The majority of it is annotating intentional fire-and-forget promises with `void`. A solid chunk of it is changing some functions to return promises instead of `void` when that is more appropriate. There is a handful of places where there were real bugs. I will try to flag those, as well as API changes in the comments.
