### PR TITLE
Don't set execution count on markdown cells.

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1421,9 +1421,12 @@ namespace Private {
       })
       .catch(reason => {
         if (reason.message === 'KernelReplyNotOK') {
-          selected.map((cell: CodeCell) => {
+          selected.map(cell => {
             // Remove '*' prompt from cells that didn't execute
-            if (cell.model.executionCount == null) {
+            if (
+              cell.model.type === 'code' &&
+              (cell as CodeCell).model.executionCount == null
+            ) {
               cell.setPrompt('');
             }
           });


### PR DESCRIPTION
Fixes #5669.

I considered removing the ability to set a prompt on non-code cells all-together, but thought that extension authors might want the ability to have some kind of lightweight annotation mechanism?