### PR TITLE
use target=_blank for download links

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -321,7 +321,7 @@ export class FileBrowserModel implements IDisposable {
       let element = document.createElement('a');
       document.body.appendChild(element);
       element.setAttribute('href', url);
-      element.setAttribute('download', '');
+      element.setAttribute('target', '_blank');
       element.click();
       document.body.removeChild(element);
       return void 0;


### PR DESCRIPTION
instead of `download` which unsets the Referer on Chrome, which in turn fails XSSI checks in notebook >= 5.7.6.

The server already sets the disposition-attachment, which should cause a download anyway.


Fixes #6106

[More info on the security issue](https://blog.jupyter.org/jupyter-notebook-xssi-security-fix-546cd95babb0)