### PR TITLE
CodeMirror gutter restyling

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -51,8 +51,8 @@ pre.CodeMirror-line {
   padding: 0 var(--jp-code-padding);
 }
 
-.CodeMirror-linenumbers {
-  padding: 0 4px 0 4px;
+.CodeMirror-linenumber {
+  padding: 0 8px;
 }
 
 .jp-CodeMirrorEditor-static {
@@ -90,11 +90,7 @@ pre.CodeMirror-line {
 
 .CodeMirror-gutters {
   border-right: 1px solid var(--jp-border-color2);
-  background-color: var(--jp-layout-color2);
-}
-
-.CodeMirror-gutter-wrapper {
-  margin-left: calc(-1 * var(--jp-code-padding));
+  background-color: var(--jp-layout-color0);
 }
 
 .jp-CollaboratorCursor {


### PR DESCRIPTION
This fixes #6121.
Moreover, it restores the line number position, which, as side effect of #6032, had been pushed on the left side, in the center of the gutter.
  
The editor before:

![before](https://user-images.githubusercontent.com/1220427/55289159-0dfe2b80-53c3-11e9-9816-9f472dfabb4f.png)

and after these changes:

![after](https://user-images.githubusercontent.com/1220427/55289164-1e160b00-53c3-11e9-9d39-a7b82d3aee8d.png)

Cheers