### PR TITLE
Speed up switching to a tab containing a markdown document.

### DIFF
--- a/packages/mathjax2/src/index.ts
+++ b/packages/mathjax2/src/index.ts
@@ -25,6 +25,19 @@ export class MathJaxTypesetter implements IRenderMime.ILatexTypesetter {
   }
 
   /**
+   * Remove typeset math from a node
+   */
+  removeOutput(node: HTMLElement) {
+    if (!this._initialized) {
+      return;
+    }
+    const jaxs = MathJax.Hub.getAllJax(node);
+    for (const jax of jaxs) {
+      jax.Remove();
+    }
+  }
+
+  /**
    * Typeset the math in a node.
    *
    * #### Notes

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -301,6 +301,16 @@ export namespace IRenderMime {
      * The LaTeX typesetter.
      */
     latexTypesetter: ILatexTypesetter | null;
+
+    /**
+     * Whether the LaTeX typeset should be incremental.
+     */
+    incrementalTypeset?: boolean;
+
+    /**
+     * Whether the typeset math should be removed when the widget is hidden.
+     */
+    removeMathOnHide?: boolean;
   }
 
   /**
@@ -372,5 +382,13 @@ export namespace IRenderMime {
      * own typesetter may replace that on the global `lab.rendermime`.
      */
     typeset(element: HTMLElement): void;
+
+    /**
+     * Remove typeset math from a DOM element.
+     *
+     * @param element - the DOM element from which typeset math should
+     *   be removed.
+     */
+    removeOutput(element: HTMLElement): void;
   }
 }

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -62,6 +62,8 @@ export class RenderMimeRegistry {
     this.linkHandler = options.linkHandler || null;
     this.latexTypesetter = options.latexTypesetter || null;
     this.sanitizer = options.sanitizer || defaultSanitizer;
+    this.incrementalTypeset = options.incrementalTypeset || false;
+    this.removeMathOnHide = options.removeMathOnHide || false;
 
     // Add the initial factories.
     if (options.initialFactories) {
@@ -90,6 +92,16 @@ export class RenderMimeRegistry {
    * The LaTeX typesetter for the rendermime.
    */
   readonly latexTypesetter: IRenderMime.ILatexTypesetter | null;
+
+  /**
+   * Whether the LaTeX typeset should be incremental.
+   */
+  readonly incrementalTypeset: boolean;
+
+  /**
+   * Whether the typeset math should be removed when the widget is hidden.
+   */
+  readonly removeMathOnHide: boolean;
 
   /**
    * The ordered list of mimeTypes.
@@ -158,7 +170,9 @@ export class RenderMimeRegistry {
       resolver: this.resolver,
       sanitizer: this.sanitizer,
       linkHandler: this.linkHandler,
-      latexTypesetter: this.latexTypesetter
+      latexTypesetter: this.latexTypesetter,
+      incrementalTypeset: this.incrementalTypeset,
+      removeMathOnHide: this.removeMathOnHide
     });
   }
 
@@ -186,7 +200,9 @@ export class RenderMimeRegistry {
       resolver: options.resolver || this.resolver || undefined,
       sanitizer: options.sanitizer || this.sanitizer || undefined,
       linkHandler: options.linkHandler || this.linkHandler || undefined,
-      latexTypesetter: options.latexTypesetter || this.latexTypesetter
+      latexTypesetter: options.latexTypesetter || this.latexTypesetter,
+      incrementalTypeset: options.incrementalTypeset || this.incrementalTypeset,
+      removeMathOnHide: options.removeMathOnHide || this.removeMathOnHide
     });
 
     // Clone the internal state.
@@ -321,6 +337,16 @@ export namespace RenderMimeRegistry {
      * An optional LaTeX typesetter.
      */
     latexTypesetter?: IRenderMime.ILatexTypesetter;
+
+    /**
+     * Whether the LaTeX typeset should be incremental.
+     */
+    incrementalTypeset?: boolean;
+
+    /**
+     * Whether the typeset math should be removed when the widget is hidden.
+     */
+    removeMathOnHide?: boolean;
   }
 
   /**
@@ -346,6 +372,16 @@ export namespace RenderMimeRegistry {
      * The new LaTeX typesetter.
      */
     latexTypesetter?: IRenderMime.ILatexTypesetter;
+
+    /**
+     * Whether the LaTeX typeset should be incremental.
+     */
+    incrementalTypeset?: boolean;
+
+    /**
+     * Whether the typeset math should be removed when the widget is hidden.
+     */
+    removeMathOnHide?: boolean;
   }
 
   /**

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -29,6 +29,8 @@ export abstract class RenderedCommon extends Widget
     this.resolver = options.resolver;
     this.linkHandler = options.linkHandler;
     this.latexTypesetter = options.latexTypesetter;
+    this.incrementalTypeset = options.incrementalTypeset;
+    this.removeMathOnHide = options.removeMathOnHide;
     this.node.dataset['mimeType'] = this.mimeType;
   }
 
@@ -56,6 +58,16 @@ export abstract class RenderedCommon extends Widget
    * The latexTypesetter.
    */
   readonly latexTypesetter: IRenderMime.ILatexTypesetter;
+
+  /**
+   * Whether the LaTeX typeset should be incremental.
+   */
+  readonly incrementalTypeset: boolean;
+
+  /**
+   * Whether the typeset math should be removed when the widget is hidden.
+   */
+  readonly removeMathOnHide: boolean;
 
   /**
    * Render a mime model.
@@ -165,7 +177,11 @@ export class RenderedHTML extends RenderedHTMLCommon {
    */
   onAfterAttach(msg: Message): void {
     if (this.latexTypesetter) {
-      this.latexTypesetter.typeset(this.node);
+      renderers.typesetLatex({
+        host: this.node,
+        incrementalTypeset: this.incrementalTypeset,
+        latexTypesetter: this.latexTypesetter
+      });
     }
   }
 }
@@ -275,7 +291,8 @@ export class RenderedMarkdown extends RenderedHTMLCommon {
       sanitizer: this.sanitizer,
       linkHandler: this.linkHandler,
       shouldTypeset: this.isAttached,
-      latexTypesetter: this.latexTypesetter
+      latexTypesetter: this.latexTypesetter,
+      incrementalTypeset: this.incrementalTypeset
     });
   }
 
@@ -284,7 +301,27 @@ export class RenderedMarkdown extends RenderedHTMLCommon {
    */
   onAfterAttach(msg: Message): void {
     if (this.latexTypesetter) {
-      this.latexTypesetter.typeset(this.node);
+      renderers.typesetLatex({
+        host: this.node,
+        incrementalTypeset: this.incrementalTypeset,
+        latexTypesetter: this.latexTypesetter
+      });
+    }
+  }
+
+  onAfterHide(msg: Message): void {
+    if (this.latexTypesetter && this.removeMathOnHide) {
+      this.latexTypesetter.removeOutput(this.node);
+    }
+  }
+
+  onAfterShow(msg: Message): void {
+    if (this.latexTypesetter && this.removeMathOnHide) {
+      renderers.typesetLatex({
+        host: this.node,
+        incrementalTypeset: this.incrementalTypeset,
+        latexTypesetter: this.latexTypesetter
+      });
     }
   }
 }


### PR DESCRIPTION
It has been reported (#4292) that switching to a tab with a big notebook is slow. The same is true if the tab contains a complex (with a lot of math) markdown document.
For instance, switching to a tab containing the notebook [Rigid-body transformations in three-dimensions][1] by Marcos Duarte converted to a markdown document, takes about 4 seconds on my old laptop.
Most of that time is spent by the browser to recalculate the page layout.

To mitigate this issue I added a new method to `ILatexTypesetter`

~~~
removeOutput(node: HTMLElement): void
~~~

and a new optional property to `IRendermime.IRenderOptions`

~~~
removeMathOnHide?: boolean
~~~

When a markdown renderer, created with the option `removeMathOnHide` set to `true`, receives an `after-hide` message, it uses `removeOutput` to wipe the typeset math off the document. Later when the renderer is shown again the math is typeset afresh.

In this way, at the time the tab returns visible, the document DOM structure is hugely simpler and the browser workload much lighter. So much lighter that, once applied these changes, switching to the tab with the Duarte's document becomes almost instantaneous.

The obvious downside of this approach is the need to typeset the math again each time. Although the typeset does not block the UI, it makes the UI sluggish for a long time if the document is large and the LaTeX renderer is slow (MathJax 2).

To reduce the UI lags, I added a new function to the `rendermime` plugin

~~~
typesetLatex(options: typesetLatex.IOptions): void
~~~

As suggested by its name, `typesetLatex` should be used by renderers to typeset math in a DOM node. It has two working mode: in normal mode, it typesets all the pieces of math at once; in incremental mode, instead, exploiting the [intersection observer api][2], it renders them gradually, as they enter the document viewport.

The working mode, normal or incremental, is controlled by another optional property added to `IRendermime.IRenderOptions`

~~~
incrementalTypeset?: boolean;
~~~

It's worth noting that incremental typesetting is convenient in other cases too. For example, previewing a document being edited. In such a circumstance, one is, generally, just interested to the area he is working on. So there is no real need to render the math throughout the whole document.

In addition, I managed to avoid unneeded renderings. Not every time the markdown renderer receives an `update-request`, a new rendering of the document is necessary (for example if the document has not changed since last rendering), nor should the renderer update each time the document changes (for example it shouldn't if it is hidden).

To this aim, I added a `_dirty` flag to `markdownviewer`; I connected the `activityStopped` signal to a new private method, `_setDirty`, which takes care to set the `_dirty` flag and to request an update of the widget; and, finally, I put constraints on the widget update: it is performed only if the widget is visible and dirty.

I'd like to hear your opinion on my approach to the issue before carry on with the work.

Cheers


[1]: http://nbviewer.jupyter.org/github/demotu/BMC/blob/master/notebooks/Transformation3D.ipynb
[2]: https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
