### PR TITLE
Add a time zone conversion link to the dev meeting time

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,6 @@ We have videoconference meetings every week where we discuss what we have been w
 
 Anyone is welcome to attend, if they would like to discuss a topic or just to listen in.
 
-- When: Wednesdays 9AM PT
+- When: Wednesdays [9AM Pacific Time](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=San%20Francisco&)
 - Where: [`calpoly/jupyter` Zoom](https://calpoly.zoom.us/my/jupyter)
 - What: [Meeting notes on Dropbox Paper](https://paper.dropbox.com/doc/JLab-Dev-Meeting-Minutes-2019--AZlv6L3jnv8ntl6kJK88y5M5Ag-Lj0P4kI2JrbA0eXHZSdY5)


### PR DESCRIPTION
This just adds a convenient link to a website to do the time zone conversion in case people want it.