### PR TITLE
Update Poll#schedule() semantics.

### DIFF
--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -358,9 +358,7 @@ export class Poll<T = any, U = any> implements IDisposable, IPoll<T, U> {
    * schedule poll ticks.
    */
   protected async schedule(
-    next: Partial<
-      IPoll.State & { cancel: ((last: IPoll.State) => boolean) }
-    > = {}
+    next: Partial<IPoll.State & { cancel: (last: IPoll.State) => boolean }> = {}
   ): Promise<void> {
     if (this.isDisposed) {
       return;
@@ -417,8 +415,8 @@ export class Poll<T = any, U = any> implements IDisposable, IPoll<T, U> {
       state.interval === Private.IMMEDIATE
         ? requestAnimationFrame(execute)
         : state.interval === Private.NEVER
-          ? -1
-          : setTimeout(execute, state.interval);
+        ? -1
+        : setTimeout(execute, state.interval);
   }
 
   /**

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -9,9 +9,7 @@ import { sleep } from '@jupyterlab/testutils';
 
 class TestPoll extends Poll {
   schedule(
-    next: Partial<
-      IPoll.State & { cancel: ((last: IPoll.State) => boolean) }
-    > = {}
+    next: Partial<IPoll.State & { cancel: (last: IPoll.State) => boolean }> = {}
   ): Promise<void> {
     return super.schedule(next);
   }

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -229,16 +229,16 @@ describe('Poll', () => {
       });
       const ticker: IPoll.Phase[] = [];
       const tocker: IPoll.Phase[] = [];
-      poll.ticked.connect((_, state) => {
+      poll.ticked.connect(async (_, state) => {
         ticker.push(state.phase);
         expect(ticker.length).to.equal(tocker.length + 1);
       });
-      const tock = (poll: IPoll) => {
+      const tock = async (poll: IPoll) => {
         tocker.push(poll.state.phase);
         expect(ticker.join(' ')).to.equal(tocker.join(' '));
         poll.tick.then(tock).catch(() => undefined);
       };
-      void poll.tick.then(tock);
+      await poll.tick.then(tock);
       await poll.stop();
       await poll.start();
       await poll.tick;


### PR DESCRIPTION
This PR implements some ideas that came out of conversations with @jasongrout  during initial implementation:
* Updates `Poll#schedule()` to accept `Partial` next state data and automatically defaults the state to known defaults:
  ```typescript
  {
    interval: this.frequency.interval,
    payload: null,
    phase: 'standby',
    timestamp: new Date().getTime(),
  }
  ```
* Removes `Poll#ready` in favor of automatically handling ready status.
* Allows passing a `cancel` function along with next state data to cancel the phase transition if it is unnecessary. This is useful for *e.g.,* conflating phases or ignoring unnecessary transitions.
* Updates `Poll#schedule()` to be asynchronous.