### PR TITLE
Unpin yet again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,8 @@ setup_args = dict(
 
 
 setup_args['install_requires'] = [
-    'notebook>=4.3.1,<5.7.5',
+    'notebook>=4.3.1',
+    'tornado<6',
     'jupyterlab_server>=0.3.0,<0.4.0'
 ]
 
@@ -140,8 +141,7 @@ setup_args['extras_require'] = {
     'test': [
         'pytest',
         'pytest-check-links',
-        'requests',
-        'tornado<6.0',
+        'requests'
     ],
     'docs': [
         'sphinx',

--- a/tests/test-application/src/shell.spec.ts
+++ b/tests/test-application/src/shell.spec.ts
@@ -24,6 +24,12 @@ class ContentWidget extends Widget {
 describe('LabShell', () => {
   let shell: LabShell;
 
+  beforeAll(() => {
+    console.log(
+      'Expecting 5 console errors logged in this suite: "Widgets added to app shell must have unique id property."'
+    );
+  });
+
   beforeEach(() => {
     shell = new LabShell();
     Widget.attach(shell, document.body);

--- a/tests/test-apputils/src/clientsession.spec.ts
+++ b/tests/test-apputils/src/clientsession.spec.ts
@@ -207,7 +207,8 @@ describe('@jupyterlab/apputils', () => {
         session = new ClientSession({ manager, kernelPreference });
         await session.initialize();
         expect(session.kernel.id).to.equal(other.kernel.id);
-        await other.shutdown();
+        // We don't call other.shutdown() here because that
+        // is handled by the afterEach() handler above.
         other.dispose();
       });
 

--- a/tests/test-codeeditor/src/editor.spec.ts
+++ b/tests/test-codeeditor/src/editor.spec.ts
@@ -5,6 +5,8 @@ import { expect } from 'chai';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
+import { IObservableString } from '@jupyterlab/observables';
+
 describe('CodeEditor.Model', () => {
   let model: CodeEditor.Model;
 
@@ -58,37 +60,52 @@ describe('CodeEditor.Model', () => {
   describe('#value', () => {
     it('should be the observable value of the model', () => {
       let called = false;
-      model.value.changed.connect((sender, args) => {
+      const handler = (
+        sender: IObservableString,
+        args: IObservableString.IChangedArgs
+      ) => {
         expect(sender).to.equal(model.value);
         expect(args.type).to.equal('set');
         expect(args.value).to.equal('foo');
         called = true;
-      });
+      };
+      model.value.changed.connect(handler);
       model.value.text = 'foo';
       expect(called).to.be.true;
+      model.value.changed.disconnect(handler);
     });
 
     it('should handle an insert', () => {
       let called = false;
-      model.value.changed.connect((sender, args) => {
+      const handler = (
+        sender: IObservableString,
+        args: IObservableString.IChangedArgs
+      ) => {
         expect(args.type).to.equal('insert');
         expect(args.value).to.equal('foo');
         called = true;
-      });
+      };
+      model.value.changed.connect(handler);
       model.value.insert(0, 'foo');
       expect(called).to.be.true;
+      model.value.changed.disconnect(handler);
     });
 
     it('should handle a remove', () => {
       let called = false;
       model.value.text = 'foo';
-      model.value.changed.connect((sender, args) => {
+      const handler = (
+        sender: IObservableString,
+        args: IObservableString.IChangedArgs
+      ) => {
         expect(args.type).to.equal('remove');
         expect(args.value).to.equal('f');
         called = true;
-      });
+      };
+      model.value.changed.connect(handler);
       model.value.remove(0, 1);
       expect(called).to.be.true;
+      model.value.changed.disconnect(handler);
     });
   });
 


### PR DESCRIPTION
Once more, an attempt to fix #6131.

This represents a compromise solution. I think that notebook 5.7.8 fixes some of the issues we were seeing, so we can unpin that. However, we are still having troubles with tornado 6, so I have kept that constraint. This allows users to gain the benefits of recent security patches to the notebook server.

It also cherry-picks some (but not all) of the stuff from #6174 .