### PR TITLE
Fix logic bug in poll promise/signal sync.

### DIFF
--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -364,12 +364,10 @@ export class Poll<T = any, U = any> implements IDisposable, IPoll<T, U> {
       return;
     }
 
-    const pending = this._tick;
-
     // The `when` promise in the constructor options acts as a gate.
     if (this.state.phase === 'constructed') {
       if (next.phase !== 'when-rejected' && next.phase !== 'when-resolved') {
-        await pending.promise;
+        await this.tick;
       }
     }
 
@@ -380,6 +378,7 @@ export class Poll<T = any, U = any> implements IDisposable, IPoll<T, U> {
 
     // Update poll state.
     const last = this.state;
+    const pending = this._tick;
     const scheduled = new PromiseDelegate<this>();
     const state: IPoll.State<T, U> = {
       interval: this.frequency.interval,

--- a/tests/test-coreutils/src/poll.spec.ts
+++ b/tests/test-coreutils/src/poll.spec.ts
@@ -236,7 +236,9 @@ describe('Poll', () => {
         expect(ticker.join(' ')).to.equal(tocker.join(' '));
         poll.tick.then(tock).catch(() => undefined);
       };
-      await poll.tick.then(tock);
+      // Kick off the promise listener, but void its settlement to verify that
+      // the poll's internal sync of the promise and the signal is correct.
+      void poll.tick.then(tock);
       await poll.stop();
       await poll.start();
       await poll.tick;


### PR DESCRIPTION
Fixes incorrectly cached pending in async function (`Poll#schedule()`).

If a `Poll` is instantiated and its public methods are *immediately* invoked by a client without waiting for the first tick, one promise was accidentally skipped. This fixes that.