### PR TITLE
Convert from uglifyjs to terser for js minification.

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -131,7 +131,7 @@
     "svg-url-loader": "~2.3.2",
     "svgo": "~1.2.1",
     "svgo-loader": "~2.2.0",
-    "uglifyjs-webpack-plugin": "~2.1.2",
+    "terser-webpack-plugin": "~1.2.3",
     "url-loader": "~1.1.2",
     "webpack": "~4.29.6",
     "webpack-cli": "^3.3.0",

--- a/dev_mode/webpack.prod.config.js
+++ b/dev_mode/webpack.prod.config.js
@@ -1,4 +1,4 @@
-var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 var merge = require('webpack-merge');
 var config = require('./webpack.config');
 
@@ -7,15 +7,17 @@ config[0] = merge(config[0], {
   devtool: 'source-map',
   optimization: {
     minimizer: [
-      new UglifyJsPlugin({
+      new TerserPlugin({
         parallel: true,
         sourceMap: true,
-        uglifyOptions: {
-          beautify: false,
-          comments: false,
+        terserOptions: {
           compress: false,
           ecma: 6,
-          mangle: true
+          mangle: true,
+          output: {
+            beautify: false,
+            comments: false
+          }
         },
         cache: process.platform !== 'win32'
       })

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -130,7 +130,7 @@
     "svg-url-loader": "~2.3.1",
     "svgo": "~1.0.4",
     "svgo-loader": "~2.1.0",
-    "uglifyjs-webpack-plugin": "~1.2.5",
+    "terser-webpack-plugin": "~1.2.3",
     "url-loader": "~1.0.1",
     "webpack": "~4.12.0",
     "webpack-cli": "^3.0.3",

--- a/jupyterlab/staging/webpack.prod.config.js
+++ b/jupyterlab/staging/webpack.prod.config.js
@@ -1,4 +1,4 @@
-var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 var merge = require('webpack-merge');
 var config = require('./webpack.config');
 
@@ -7,15 +7,17 @@ config[0] = merge(config[0], {
   devtool: 'source-map',
   optimization: {
     minimizer: [
-      new UglifyJsPlugin({
+      new TerserPlugin({
         parallel: true,
         sourceMap: true,
-        uglifyOptions: {
-          beautify: false,
-          comments: false,
+        terserOptions: {
           compress: false,
           ecma: 6,
-          mangle: true
+          mangle: true,
+          output: {
+            beautify: false,
+            comments: false
+          }
         },
         cache: process.platform !== 'win32'
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,7 +2403,7 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
-cacache@^11.0.1, cacache@^11.0.2, cacache@^11.2.0, cacache@^11.3.2:
+cacache@^11.0.1, cacache@^11.0.2, cacache@^11.3.2:
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
   integrity sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==
@@ -9990,7 +9990,7 @@ temp-write@^3.4.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
-terser-webpack-plugin@^1.1.0:
+terser-webpack-plugin@^1.1.0, terser-webpack-plugin@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz#3f98bc902fac3e5d0de730869f50668561262ec8"
   integrity sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==
@@ -10364,27 +10364,13 @@ uglify-js@3.4.x:
     commander "~2.17.1"
     source-map "~0.6.1"
 
-uglify-js@^3.0.0, uglify-js@^3.1.4:
+uglify-js@^3.1.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.4.tgz#4a64d57f590e20a898ba057f838dcdfb67a939b9"
   integrity sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
-
-uglifyjs-webpack-plugin@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.1.2.tgz#70e5c38fb2d35ee887949c2a0adb2656c23296d5"
-  integrity sha512-G1fJx2uOAAfvdZ77SVCzmFo6mv8uKaHoZBL9Qq/ciC8r6p0ANOL1uY85fIUiyWXKw5RzAaJYZfNSL58Or2hQ0A==
-  dependencies:
-    cacache "^11.2.0"
-    find-cache-dir "^2.0.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.4.0"
-    source-map "^0.6.1"
-    uglify-js "^3.0.0"
-    webpack-sources "^1.1.0"
-    worker-farm "^1.5.2"
 
 uid-number@0.0.6:
   version "0.0.6"


### PR DESCRIPTION
terser understands es6 syntax, and is more supported moving forward.

See also https://github.com/webpack-contrib/terser-webpack-plugin/issues/15 for more background.