### PR TITLE
Update to prettier 1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lerna": "^3.13.2",
     "lint-staged": "^8.1.5",
     "opn-cli": "^4.1.0",
-    "prettier": "^1.16.4",
+    "prettier": "^1.17.0",
     "tslint": "^5.15.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",

--- a/packages/apputils/src/vdom.ts
+++ b/packages/apputils/src/vdom.ts
@@ -26,11 +26,11 @@ export abstract class ReactWidget extends Widget {
    * @param element React element to render.
    */
   static create(element: ReactRenderElement): ReactWidget {
-    return new class extends ReactWidget {
+    return new (class extends ReactWidget {
       render() {
         return element;
       }
-    }();
+    })();
   }
 
   /**

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -421,7 +421,7 @@ function activateNotebookTools(
   };
   let optionsMap: { [key: string]: JSONValue } = {};
   optionsMap.None = null;
-  services.nbconvert.getExportFormats().then(response => {
+  void services.nbconvert.getExportFormats().then(response => {
     if (response) {
       // convert exportList to palette and menu items
       const formatList = Object.keys(response);

--- a/packages/vdom-extension/src/index.ts
+++ b/packages/vdom-extension/src/index.ts
@@ -91,9 +91,9 @@ const plugin: JupyterFrontEndPlugin<IVDOMTracker> = {
 
     factory.widgetCreated.connect((sender, widget) => {
       widget.context.pathChanged.connect(() => {
-        tracker.save(widget);
+        void tracker.save(widget);
       });
-      tracker.add(widget);
+      void tracker.add(widget);
     });
 
     // Add widget factory to document registry.

--- a/yarn.lock
+++ b/yarn.lock
@@ -8355,10 +8355,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
+  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
prettier 1.17 was released hours after we upgraded to 1.16. Luckily, there was only one place where our formatting changed. I also fixed two places where we had a dangling promise noted by tslint.