### PR TITLE
Add a command to enable the extension manager

### DIFF
--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -35,7 +35,8 @@
     "@jupyterlab/application": "^1.0.0-alpha.6",
     "@jupyterlab/apputils": "^1.0.0-alpha.6",
     "@jupyterlab/coreutils": "^3.0.0-alpha.6",
-    "@jupyterlab/extensionmanager": "^1.0.0-alpha.6"
+    "@jupyterlab/extensionmanager": "^1.0.0-alpha.6",
+    "@jupyterlab/mainmenu": "^1.0.0-alpha.6"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -81,7 +81,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     });
 
     commands.addCommand(CommandIDs.toggle, {
-      label: 'Enable Extension Manager',
+      label: 'Enable Extension Manager (experimental)',
       execute: () => {
         if (registry) {
           registry.set(plugin.id, 'enabled', !enabled);

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -27,14 +27,11 @@ namespace CommandIDs {
   export const show = 'extensionmanager:activate-main';
 }
 
-export const EXTENSION_MANAGER_PLUGIN_ID =
-  '@jupyterlab/extensionmanager-extension:plugin';
-
 /**
  * The extension manager plugin.
  */
 const plugin: JupyterFrontEndPlugin<void> = {
-  id: EXTENSION_MANAGER_PLUGIN_ID,
+  id: '@jupyterlab/extensionmanager-extension:plugin',
   autoStart: true,
   requires: [ISettingRegistry],
   optional: [ILabShell, ILayoutRestorer, IMainMenu, ICommandPalette],
@@ -91,7 +88,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       label: 'Enable Extension Manager',
       execute: () => {
         if (registry) {
-          registry.set(EXTENSION_MANAGER_PLUGIN_ID, 'enabled', !enabled);
+          registry.set(plugin.id, 'enabled', !enabled);
         }
       },
       isToggled: () => enabled

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -87,7 +87,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
           registry.set(plugin.id, 'enabled', !enabled);
         }
       },
-      isToggled: () => enabled
+      isToggled: () => enabled,
+      isEnabled: () => serviceManager.builder.isAvailable
     });
 
     const category = 'Extension Manager';

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -21,10 +21,6 @@ import { ExtensionView } from '@jupyterlab/extensionmanager';
  */
 namespace CommandIDs {
   export const toggle = 'extensionmanager:toggle';
-
-  export const hide = 'extensionmanager:hide-main';
-
-  export const show = 'extensionmanager:activate-main';
 }
 
 /**
@@ -103,38 +99,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
     if (mainMenu) {
       mainMenu.settingsMenu.addGroup([{ command }], 100);
     }
-
-    addCommands(app, view, labShell);
   }
 };
-
-/**
- * Add the main file view commands to the application's command registry.
- */
-function addCommands(
-  app: JupyterFrontEnd,
-  view: ExtensionView,
-  labShell: ILabShell | null
-): void {
-  const { commands, shell } = app;
-
-  commands.addCommand(CommandIDs.show, {
-    label: 'Show Extension Manager',
-    execute: () => {
-      shell.activateById(view.id);
-    }
-  });
-
-  commands.addCommand(CommandIDs.hide, {
-    execute: () => {
-      if (labShell && !view.isHidden) {
-        labShell.collapseLeft();
-      }
-    }
-  });
-
-  // TODO: Also add to command palette.
-}
 
 /**
  * Export the plugin as the default.

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -88,7 +88,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     });
 
     commands.addCommand(CommandIDs.toggle, {
-      label: 'Toggle Extension Manager',
+      label: 'Enable Extension Manager',
       execute: () => {
         if (registry) {
           registry.set(EXTENSION_MANAGER_PLUGIN_ID, 'enabled', !enabled);

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -12,6 +12,8 @@ import { Dialog, showDialog, ICommandPalette } from '@jupyterlab/apputils';
 
 import { ISettingRegistry } from '@jupyterlab/coreutils';
 
+import { IMainMenu } from '@jupyterlab/mainmenu';
+
 import { ExtensionView } from '@jupyterlab/extensionmanager';
 
 /**
@@ -35,12 +37,13 @@ const plugin: JupyterFrontEndPlugin<void> = {
   id: EXTENSION_MANAGER_PLUGIN_ID,
   autoStart: true,
   requires: [ISettingRegistry],
-  optional: [ILabShell, ILayoutRestorer, ICommandPalette],
+  optional: [ILabShell, ILayoutRestorer, IMainMenu, ICommandPalette],
   activate: async (
     app: JupyterFrontEnd,
     registry: ISettingRegistry,
     labShell: ILabShell | null,
     restorer: ILayoutRestorer | null,
+    mainMenu: IMainMenu | null,
     palette: ICommandPalette | null
   ) => {
     const settings = await registry.load(plugin.id);
@@ -90,12 +93,18 @@ const plugin: JupyterFrontEndPlugin<void> = {
         if (registry) {
           registry.set(EXTENSION_MANAGER_PLUGIN_ID, 'enabled', !enabled);
         }
-      }
+      },
+      isToggled: () => enabled
     });
 
-    const category: string = 'Extension Manager';
+    const category = 'Extension Manager';
+    const command = CommandIDs.toggle;
     if (palette) {
-      palette.addItem({ command: CommandIDs.toggle, category });
+      palette.addItem({ command, category });
+    }
+
+    if (mainMenu) {
+      mainMenu.settingsMenu.addGroup([{ command }], 100);
     }
 
     addCommands(app, view, labShell);

--- a/packages/extensionmanager-extension/tsconfig.json
+++ b/packages/extensionmanager-extension/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../extensionmanager"
+    },
+    {
+      "path": "../mainmenu"
     }
   ]
 }


### PR DESCRIPTION
This adds the `Enable Extension Manager` command to the command palette and the main menu.

![extension-manager-cmd](https://user-images.githubusercontent.com/591645/56099448-7eea2b00-5f0d-11e9-8696-1a4f8af27fd0.gif)

It can sometimes be a bit difficult to figure out how to enable the extension manager.
Having it exposed as a command should make it more accessible and simplify [the steps listed in the docs](https://jupyterlab.readthedocs.io/en/latest/user/extensions.html?#using-the-extension-manager).