### PR TITLE
Bring back the settings table picker button

### DIFF
--- a/packages/settingeditor/style/settingeditor.css
+++ b/packages/settingeditor/style/settingeditor.css
@@ -72,6 +72,7 @@
   top: 1px;
   left: 0;
   right: 0;
+  display: flex;
 }
 
 #setting-editor .jp-PluginList-switcher button {
@@ -82,7 +83,7 @@
   margin: 0;
   padding: 0;
   height: var(--jp-private-settingeditor-switcher-height);
-  width: 50%;
+  flex: 1;
 }
 
 #setting-editor .jp-PluginList-switcher button:first-child {


### PR DESCRIPTION
Fixes #5874.

**Screenshots**
> `master`
![Screenshot from 2019-04-16 23-32-57](https://user-images.githubusercontent.com/45380/56259397-e2f12880-60a0-11e9-9c03-08c2cab13d42.png)

> after
![Screenshot from 2019-04-16 23-37-27](https://user-images.githubusercontent.com/45380/56259396-e2589200-60a0-11e9-84e9-d1fcf8c9f505.png)
