### PR TITLE
Remove items from the Toolbar

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -5,7 +5,7 @@ import { UseSignal, ReactWidget } from './vdom';
 
 import { Button } from '@jupyterlab/ui-components';
 
-import { IIterator, find, map, some } from '@phosphor/algorithm';
+import { IIterator, find, map, some, toArray } from '@phosphor/algorithm';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -214,6 +214,25 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   addItem(name: string, widget: T): boolean {
     let layout = this.layout as ToolbarLayout;
     return this.insertItem(layout.widgets.length, name, widget);
+  }
+
+  /**
+   * Remove an item from the toolbar.
+   *
+   * @param name - The name of the widget to remove from the toolbar.
+   *
+   * @returns Whether the item was removed from the toolbar. Returns false if
+   *   the item is not in the toolbar.
+   *
+   */
+  removeItem(name: string): boolean {
+    let layout = this.layout as ToolbarLayout;
+    const pos = toArray(this.names()).indexOf(name);
+    if (pos === -1) {
+      return false;
+    }
+    layout.removeWidgetAt(pos);
+    return true;
   }
 
   /**

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -226,11 +226,11 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
    *
    */
   removeItem(name: string): boolean {
-    let layout = this.layout as ToolbarLayout;
     const pos = toArray(this.names()).indexOf(name);
     if (pos === -1) {
       return false;
     }
+    let layout = this.layout as ToolbarLayout;
     layout.removeWidgetAt(pos);
     return true;
   }

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -5,7 +5,7 @@ import { UseSignal, ReactWidget } from './vdom';
 
 import { Button } from '@jupyterlab/ui-components';
 
-import { IIterator, find, map, some, toArray } from '@phosphor/algorithm';
+import { IIterator, find, map, some } from '@phosphor/algorithm';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -217,7 +217,7 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   }
 
   /**
-   * Remove an item from the toolbar.
+   * Remove an item from the toolbar given a name.
    *
    * @param name - The name of the widget to remove from the toolbar.
    *
@@ -226,12 +226,32 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
    *
    */
   removeItem(name: string): boolean {
-    const pos = toArray(this.names()).indexOf(name);
-    if (pos === -1) {
+    let widget = find(
+      this.children(),
+      widget => Private.nameProperty.get(widget) === name
+    );
+    if (!widget) {
       return false;
     }
-    let layout = this.layout as ToolbarLayout;
-    layout.removeWidgetAt(pos);
+    widget.parent = null;
+    return true;
+  }
+
+  /**
+   * Remove an item from the toolbar given a position.
+   *
+   * @param index - The position of the widget to remove from the toolbar.
+   *
+   * @returns Whether the item was removed from the toolbar. Returns false if
+   *   the item is not in the toolbar.
+   *
+   */
+  removeItemAt(index: number): boolean {
+    let widget = find(this.children(), (_, i) => i === index);
+    if (!widget) {
+      return false;
+    }
+    widget.parent = null;
     return true;
   }
 

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -95,6 +95,22 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
+    describe('#removeItemAt()', () => {
+      it('should remove an item from the toolbar given an index', () => {
+        widget.addItem('a', new Widget());
+        widget.addItem('b', new Widget());
+        widget.addItem('c', new Widget());
+        expect(widget.removeItemAt(1)).to.equal(true);
+        expect(toArray(widget.names())).to.deep.equal(['a', 'c']);
+      });
+
+      it('should return false if the index is out of bounds', () => {
+        widget.addItem('a', new Widget());
+        widget.addItem('b', new Widget());
+        expect(widget.removeItemAt(2)).to.equal(false);
+      });
+    });
+
     describe('#insertItem()', () => {
       it('should insert the item into the toolbar', () => {
         widget.addItem('a', new Widget());

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -81,6 +81,20 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
+    describe('#removeItem()', () => {
+      it('should remove an item from the toolbar', () => {
+        const item = new Widget();
+        expect(widget.addItem('test', item)).to.equal(true);
+        expect(widget.removeItem('test')).to.equal(true);
+        expect(toArray(widget.names())).to.be.empty;
+      });
+
+      it('should return false if the item is not in the toolbar', () => {
+        widget.addItem('foo', new Widget());
+        expect(widget.removeItem('bar')).to.equal(false);
+      });
+    });
+
     describe('#insertItem()', () => {
       it('should insert the item into the toolbar', () => {
         widget.addItem('a', new Widget());


### PR DESCRIPTION
Hi,

I'm currently working on a [third-party extension](https://github.com/jtpio/jupyterlab-topbar) that makes use of the [`Toolbar`](https://github.com/jupyterlab/jupyterlab/blob/91af807f8422ba846bb295c3c87a6c60e05e5869/packages/apputils/src/toolbar.tsx#L177) from `@jupyterlab/apputils`.

For now the `Toolbar` interface lets users add items with a name and insert items at specific locations.

But it would also be useful to be able to remove items from a `Toolbar`, either by providing a name or an index.

It is already possible to set the parent of the item to `null` to remove it from the toolbar, but it requires keeping track of the Widget itself. 

So having methods such as `removeItem` or `removeItemAt` would give more control over the `Toolbar` layout to developers working on third-party extensions, and avoid having to use the lower level `layout.removeWidget` and `layout.removeWidgetAt`.

This change adds `removeItem(name: string)`, but there are other methods to consider:

```typescript
removeItemAt(pos: number)
// not about removing items but also useful for dynamic toolbars
swapItems(first: number, second: number)
swapItems(first: string, second: string)
```

Opening the PR early so this can be discussed before digging into it any further.