### PR TITLE
Update Typescript target to es2017

### DIFF
--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -6,7 +6,6 @@
     "esModuleInterop": true,
     "incremental": true,
     "jsx": "react",
-    "lib": ["dom", "es2015"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
@@ -14,7 +13,7 @@
     "noUnusedLocals": true,
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
-    "target": "es2015",
+    "target": "es2017",
     "types": []
   }
 }


### PR DESCRIPTION
Right now we have our typescript target as es2015:

https://github.com/jupyterlab/jupyterlab/blob/1c534338943034550636da829708242a008ee490/tsconfigbase.json#L17

According to http://kangax.github.io/compat-table/es2016plus/, all supported browsers have basically everything from es2017 (at least everything we use, I think), even going back as far as FF 60 (ESR). Upgrading our target to es2017 means that we can support native async/await, instead of transpiling down to the iterators, which should make debugging easier.

If we do decide to switch the target, I think it should be before 1.0 so that we can maintain compatibility after 1.0 with that target. I also think we should do another prerelease so that we can catch any issues with switching the target before 1.0.