### PR TITLE
Cherry pick #6139 to 0.35.x: use target=_blank for download links

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -321,7 +321,7 @@ export class FileBrowserModel implements IDisposable {
       let element = document.createElement('a');
       document.body.appendChild(element);
       element.setAttribute('href', url);
-      element.setAttribute('download', '');
+      element.setAttribute('target', '_blank');
       element.click();
       document.body.removeChild(element);
       return void 0;


### PR DESCRIPTION
Cherry-pick of #6139 to 0.35.x. This is a regression on Chrome since 0.34.x

Fixes #6106
