### PR TITLE
Fixed documentation formatting issue

### DIFF
--- a/docs/source/developer/css.rst
+++ b/docs/source/developer/css.rst
@@ -203,6 +203,7 @@ to invoke when a keyboard shortcut is used. The following common CSS selectors a
 intended to be used for adding context menu items and keyboard shortcuts.
 
 **CSS classes that target widgets and their children**
+
 -  ``jp-Activity``: applied to elements in the main work area
 -  ``jp-Cell``: applied to cells
 -  ``jp-CodeCell``: applied to code cells
@@ -218,7 +219,9 @@ intended to be used for adding context menu items and keyboard shortcuts.
 -  ``jp-SettingEditor``: applied to setting editors
 -  ``jp-SideBar``: applied to sidebars
 -  ``jp-Terminal``: applied to terminals
+
 **CSS classes that describe the state of a widget**
+
 -  ``jp-mod-current``: applied to elements on the current document only
 -  ``jp-mod-completer-enabled``: applied to ediors that can host a completer
 -  ``jp-mod-commandMode``: applied to a notebook in command mode
@@ -226,7 +229,9 @@ intended to be used for adding context menu items and keyboard shortcuts.
 -  ``jp-mod-has-primary-selection``: applied to editors that have a primary selection
 -  ``jp-mod-in-leading-whitespace``: applied to editors that have a selection within the beginning whitespace of a line
 -  ``jp-mod-tooltip``: applied to the body when a tooltip exists on the page
+
 **CSS selectors that target data attributes**
+
 -  ``[data-jp-code-runner]``: applied to widgets that can run code
 -  ``[data-jp-interaction-mode="terminal"]``: applied when a code console is in terminal mode
 -  ``[data-jp-interaction-mode="notebook"]``: applied when a code console is in notebook mode


### PR DESCRIPTION
Fixes a formatting issue in the new CSS documentation that was preventing bullets from being displayed.