### PR TITLE
Change documentsearch shortcut selector to searchable class

### DIFF
--- a/examples/notebook/index.css
+++ b/examples/notebook/index.css
@@ -20,3 +20,7 @@ body {
 .jp-NotebookPanel {
   border-bottom: 1px solid #e0e0e0;
 }
+
+.notebookCommandPalette {
+  min-width: 225px;
+}

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -12,6 +12,7 @@
     "@jupyterlab/completer": "^1.0.0-alpha.6",
     "@jupyterlab/docmanager": "^1.0.0-alpha.6",
     "@jupyterlab/docregistry": "^1.0.0-alpha.6",
+    "@jupyterlab/documentsearch": "^1.0.0-alpha.7",
     "@jupyterlab/mathjax2": "^1.0.0-alpha.6",
     "@jupyterlab/notebook": "^1.0.0-alpha.7",
     "@jupyterlab/rendermime": "^1.0.0-alpha.6",

--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -4,6 +4,10 @@
 import { CommandRegistry } from '@phosphor/commands';
 import { CompletionHandler } from '@jupyterlab/completer';
 import { NotebookPanel, NotebookActions } from '@jupyterlab/notebook';
+import {
+  SearchInstance,
+  NotebookSearchProvider
+} from '@jupyterlab/documentsearch';
 import { CommandPalette } from '@phosphor/widgets';
 
 /**
@@ -14,6 +18,9 @@ const cmdIds = {
   select: 'completer:select',
   invokeNotebook: 'completer:invoke-notebook',
   selectNotebook: 'completer:select-notebook',
+  startSearch: 'documentsearch:start-search',
+  findNext: 'documentsearch:find-next',
+  findPrevious: 'documentsearch:find-previous',
   save: 'notebook:save',
   interrupt: 'notebook:interrupt-kernel',
   restart: 'notebook:restart-kernel',
@@ -66,6 +73,49 @@ export const SetupCommands = (
   commands.addCommand(cmdIds.save, {
     label: 'Save',
     execute: () => nbWidget.context.save()
+  });
+
+  let searchInstance: SearchInstance;
+  commands.addCommand(cmdIds.startSearch, {
+    label: 'Find...',
+    execute: () => {
+      if (searchInstance) {
+        searchInstance.focusInput();
+        return;
+      }
+      const provider = new NotebookSearchProvider();
+      searchInstance = new SearchInstance(nbWidget, provider);
+      searchInstance.disposed.connect(() => {
+        searchInstance = undefined;
+        // find next and previous are now not enabled
+        commands.notifyCommandChanged();
+      });
+      // find next and previous are now enabled
+      commands.notifyCommandChanged();
+      searchInstance.focusInput();
+    }
+  });
+  commands.addCommand(cmdIds.findNext, {
+    label: 'Find Next',
+    isEnabled: () => !!searchInstance,
+    execute: async () => {
+      if (!searchInstance) {
+        return;
+      }
+      await searchInstance.provider.highlightNext();
+      searchInstance.updateIndices();
+    }
+  });
+  commands.addCommand(cmdIds.findPrevious, {
+    label: 'Find Previous',
+    isEnabled: () => !!searchInstance,
+    execute: async () => {
+      if (!searchInstance) {
+        return;
+      }
+      await searchInstance.provider.highlightPrevious();
+      searchInstance.updateIndices();
+    }
   });
   commands.addCommand(cmdIds.interrupt, {
     label: 'Interrupt',
@@ -143,7 +193,10 @@ export const SetupCommands = (
     cmdIds.restart,
     cmdIds.editMode,
     cmdIds.commandMode,
-    cmdIds.switchKernel
+    cmdIds.switchKernel,
+    cmdIds.startSearch,
+    cmdIds.findNext,
+    cmdIds.findPrevious
   ].forEach(command => palette.addItem({ command, category }));
 
   category = 'Notebook Cell Operations';
@@ -179,6 +232,21 @@ export const SetupCommands = (
       selector: '.jp-Notebook',
       keys: ['Accel S'],
       command: cmdIds.save
+    },
+    {
+      selector: '.jp-Notebook',
+      keys: ['Accel F'],
+      command: cmdIds.startSearch
+    },
+    {
+      selector: '.jp-Notebook',
+      keys: ['Accel G'],
+      command: cmdIds.findNext
+    },
+    {
+      selector: '.jp-Notebook',
+      keys: ['Accel Shift G'],
+      command: cmdIds.findPrevious
     },
     {
       selector: '.jp-Notebook.jp-mod-commandMode:focus',

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -101,6 +101,7 @@ function createApp(manager: ServiceManager.IManager): void {
   let notebookPath = PageConfig.getOption('notebookPath');
   let nbWidget = docManager.open(notebookPath) as NotebookPanel;
   let palette = new CommandPalette({ commands });
+  palette.addClass('notebookCommandPalette');
 
   const editor =
     nbWidget.content.activeCell && nbWidget.content.activeCell.editor;

--- a/examples/notebook/test.ipynb
+++ b/examples/notebook/test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "tags": []
    },
@@ -137,7 +137,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": []
@@ -146,7 +149,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -160,9 +163,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/notebook/test.ipynb
+++ b/examples/notebook/test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
@@ -137,10 +137,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    }
+    "collapsed": true
    },
    "outputs": [],
    "source": []
@@ -149,7 +146,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -163,9 +160,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 1
 }

--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -5,17 +5,17 @@
     {
       "command": "documentsearch:start",
       "keys": ["Accel F"],
-      "selector": "body"
+      "selector": ".jp-mod-searchable"
     },
     {
       "command": "documentsearch:highlightNext",
       "keys": ["Accel G"],
-      "selector": "body"
+      "selector": ".jp-mod-searchable"
     },
     {
       "command": "documentsearch:highlightPrevious",
       "keys": ["Accel Shift G"],
-      "selector": "body"
+      "selector": ".jp-mod-searchable"
     }
   ],
   "properties": {},

--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -3,7 +3,8 @@
 
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
+  ILabShell
 } from '@jupyterlab/application';
 
 import { ICommandPalette } from '@jupyterlab/apputils';
@@ -16,18 +17,21 @@ import {
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
 
+const SEARCHABLE_CLASS = 'jp-mod-searchable';
+
 /**
  * Initialization data for the document-search extension.
  */
 const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
   id: '@jupyterlab/documentsearch:plugin',
   provides: ISearchProviderRegistry,
-  requires: [ICommandPalette],
+  requires: [ICommandPalette, ILabShell],
   optional: [IMainMenu],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     palette: ICommandPalette,
+    labShell: ILabShell,
     mainMenu: IMainMenu | null
   ) => {
     // Create registry, retrieve all default providers
@@ -36,6 +40,17 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
     // enabler.
 
     const activeSearches = new Map<string, SearchInstance>();
+
+    labShell.activeChanged.connect((_, args) => {
+      const newWidget = args.newValue;
+      if (
+        newWidget &&
+        !newWidget.hasClass(SEARCHABLE_CLASS) &&
+        registry.getProviderForWidget(newWidget) !== undefined
+      ) {
+        newWidget.addClass(SEARCHABLE_CLASS);
+      }
+    });
 
     const startCommand: string = 'documentsearch:start';
     const nextCommand: string = 'documentsearch:highlightNext';

--- a/packages/documentsearch/src/index.ts
+++ b/packages/documentsearch/src/index.ts
@@ -6,3 +6,5 @@ import '../style/index.css';
 export * from './interfaces';
 export * from './searchinstance';
 export * from './searchproviderregistry';
+export * from './providers/codemirrorsearchprovider';
+export * from './providers/notebooksearchprovider';

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -35,6 +35,7 @@ export class SearchInstance implements IDisposable {
       this.dispose();
     });
     this._searchWidget.disposed.connect(() => {
+      this._widget.activate();
       this.dispose();
     });
 


### PR DESCRIPTION
This addresses bullet 1 in #6217.  When the active widget changes, the documentsearch extension checks if it is searchable and applies the `jp-mod-searchable` class if it doesn't have it already.  Then the `Accel F` and other shortcuts are scoped to only this class, so that they'll pass through to the browser when the focus is outside a searchable widget.

@afshin @jasongrout 