### PR TITLE
Fix re-focus on ctrl+f when search overlay is already open

### DIFF
--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -67,9 +67,11 @@ export class SearchInstance implements IDisposable {
    */
   focusInput(): void {
     this._displayState.forceFocus = true;
+    this._displayState.searchInputFocused = true;
 
     // Trigger a rerender without resetting the forceFocus.
     this._displayUpdateSignal.emit(this._displayState);
+    this._displayState.forceFocus = false;
   }
 
   /**

--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -73,7 +73,7 @@ class SearchEntry extends React.Component<ISearchEntryProps> {
   }
 
   componentDidUpdate() {
-    if (this.props.forceFocus && this.props.inputFocused) {
+    if (this.props.forceFocus) {
       this.focusInput();
     }
   }


### PR DESCRIPTION
This is a quick fix to the documentsearch package.  Right now, pressing ctrl+f when your focus is in the document and the search box is already open does nothing.  This fix refocuses the search box when you press ctrl+f again.  This was broken in #6159.