### PR TITLE
Simplify PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,13 @@
-<!-- Thanks for contributing to JupyterLab! Please fill out the following items to submit a pull request. -->
+<!--
+Thanks for contributing to JupyterLab!
+Please fill out the following items to submit a pull request.
+See the contributing guidelines for more information:
+https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
+-->
 
 ## References
 
-<!-- Note here issue numbers this pull request addresses. -->
+<!-- Note here issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
 
 <!-- Note here any other pull requests that address this issue and how this pull request is different. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 
 <!-- Describe here any visual or user interaction changes and how they address the issue. -->
 
-<!-- For user interface changes, include before/after screenshots here. -->
+<!-- For visual changes, include before and after screenshots here. -->
 
 ## Backwards-incompatible changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,11 @@
+<!-- 
 Hi! Thanks for contributing to JupyterLab.
 Please look through the checklist below before submitting your pull request.
+-->
 
 - [ ] Look through open pull requests to see if someone has already started working on this.
-- [ ] Note what issue(s) this pull request addresses. (We strongly encourage the community to open an issue describing proposed work before opening a pull request.)
-- [ ] Provide a detailed description of the pull request. (Why are these changes necessary? How have they been implemented?)
-- [ ] For UI/UX changes, include before/after screenshots
-- [ ] Include a narrative description of visual or user interaction changes. How does your design effectively address the problem?
-- [ ] Provide a list of Jupyterlab packages the pull request modifies.
-- [ ] Describe any backwards incompatible changes to Jupyterlab’s public APIs.
+- [ ] Note what issue(s) this pull request addresses.
+- [ ] Describe the changes and reasons for them in this pull request.
+- [ ] Describe visual or user interaction changes in sentences. How does your design effectively address the problem?
+- [ ] For user interface changes, include before/after screenshots
+- [ ] Describe any backwards-incompatible changes to JupyterLab public APIs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,20 +7,20 @@ https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
 
 ## References
 
-<!-- Note here issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
+<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
 
-<!-- Note here any other pull requests that address this issue and how this pull request is different. -->
+<!-- Note any other pull requests that address this issue and how this pull request is different. -->
 
 ## Code changes
 
-<!-- Describe here the code changes and how they address the issue. -->
+<!-- Describe the code changes and how they address the issue. -->
 
 ## User-facing changes
 
-<!-- Describe here any visual or user interaction changes and how they address the issue. -->
+<!-- Describe any visual or user interaction changes and how they address the issue. -->
 
 <!-- For visual changes, include before and after screenshots here. -->
 
 ## Backwards-incompatible changes
 
-<!-- Describe here any backwards-incompatible changes to JupyterLab public APIs. -->
+<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,21 @@
-<!--
-Hi! Thanks for contributing to JupyterLab.
-Please look through the checklist below before submitting your pull request.
--->
+<!-- Thanks for contributing to JupyterLab! Please fill out the following items to submit a pull request. -->
 
 ## References
-<!-- Note here issue numbers this pull request addresses. -->
 
+<!-- Note here issue numbers this pull request addresses. -->
 
 <!-- Note here any other pull requests that address this issue and how this pull request is different. -->
 
-
 ## Code changes
+
 <!-- Describe here the code changes and how they address the issue. -->
 
-
 ## User-facing changes
-<!-- Describe here any visual or user interaction changes and how they address the issue. -->
 
+<!-- Describe here any visual or user interaction changes and how they address the issue. -->
 
 <!-- For user interface changes, include before/after screenshots here. -->
 
-
 ## Backwards incompatibe changes
+
 <!-- Describe here any backwards-incompatible changes to JupyterLab public APIs. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
-<!-- 
+<!--
 Hi! Thanks for contributing to JupyterLab.
 Please look through the checklist below before submitting your pull request.
 -->
 
-- [ ] Look through open pull requests to see if someone has already started working on this.
-- [ ] Note what issue(s) this pull request addresses.
-- [ ] Describe the changes and reasons for them in this pull request.
-- [ ] Describe visual or user interaction changes in sentences. How does your design effectively address the problem?
+- [ ] Note the issue numbers this pull request addresses.
+- [ ] Note any other pull requests that address this issue and how this pull request is different.
+- [ ] Describe in sentences the code changes and how they address the issue.
+- [ ] Describe in sentences the visual or user interaction changes and how they address the issue.
+- [ ] Describe in sentences any backwards-incompatible changes to JupyterLab public APIs.
 - [ ] For user interface changes, include before/after screenshots
-- [ ] Describe any backwards-incompatible changes to JupyterLab public APIs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,23 @@ Hi! Thanks for contributing to JupyterLab.
 Please look through the checklist below before submitting your pull request.
 -->
 
-- [ ] Note the issue numbers this pull request addresses.
-- [ ] Note any other pull requests that address this issue and how this pull request is different.
-- [ ] Describe in sentences the code changes and how they address the issue.
-- [ ] Describe in sentences the visual or user interaction changes and how they address the issue.
-- [ ] Describe in sentences any backwards-incompatible changes to JupyterLab public APIs.
-- [ ] For user interface changes, include before/after screenshots
+## References
+<!-- Note here issue numbers this pull request addresses. -->
+
+
+<!-- Note here any other pull requests that address this issue and how this pull request is different. -->
+
+
+## Code changes
+<!-- Describe here the code changes and how they address the issue. -->
+
+
+## User-facing changes
+<!-- Describe here any visual or user interaction changes and how they address the issue. -->
+
+
+<!-- For user interface changes, include before/after screenshots here. -->
+
+
+## Backwards incompatibe changes
+<!-- Describe here any backwards-incompatible changes to JupyterLab public APIs. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,6 @@
 
 <!-- For user interface changes, include before/after screenshots here. -->
 
-## Backwards incompatibe changes
+## Backwards-incompatible changes
 
 <!-- Describe here any backwards-incompatible changes to JupyterLab public APIs. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ If you're reading this section, you're probably interested in contributing to
 JupyterLab. Welcome and thanks for your interest in contributing!
 
 Please take a look at the Contributor documentation, familiarize yourself with
-using JupyterLab, and introduce yourself on the mailing list and share
-what area of the project you are interested in working on. Please see also the
-Jupyter [Community Guides](https://jupyter.readthedocs.io/en/latest/community/content-community.html).
+using JupyterLab, and introduce yourself to the community (on the mailing list
+or discourse) and share what area of the project you are interested in working
+on. Please also see the Jupyter [Community Guides](https://jupyter.readthedocs.io/en/latest/community/content-community.html).
 
 We have labeled some issues as [good first issue](https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) or [help wanted](https://github.com/jupyterlab/jupyterlab/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 that we believe are good examples of small, self-contained changes.
@@ -19,11 +19,7 @@ Jupyter project, please report it to
 security reports, you can use [this PGP public
 key](https://jupyter-notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc).
 
-## Tag Issues with Labels
-
-Users without the commit rights to the jupyterlab repository can also tag the issues with labels. For example: To apply the label `foo` and `bar baz` to an issue, comment `@meeseeksdev tag foo "bar baz"` on the issue.
-
-## General Guidelines
+## General Guidelines for Contributing
 
 For general documentation about contributing to Jupyter projects, see the
 [Project Jupyter Contributor Documentation](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html) and [Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md).
@@ -44,6 +40,21 @@ You may also use the prettier npm script (e.g. `npm run prettier` or `yarn prett
 installing a prettier
 extension for your code editor and configuring it to format your code with
 a keyboard shortcut or automatically on save.
+
+## Submitting a Pull Request Contribution
+
+Generally, an issue should be opened describing a piece of proposed work and the
+issues it solves before a pull request is opened. This lets community members
+participate in the design discussion, makes others aware of work being done, and
+sets the stage for a fruitful community interaction. A pull request should
+reference the issue it is addressing.
+
+### Tag Issues with Labels
+
+Users without the commit rights to the JupyterLab repository can tag issues with
+labels using the `@meeseeksdev` bot. For example: To apply the label `foo` and
+`bar baz` to an issue, comment `@meeseeksdev tag foo "bar baz"` on the issue.
+
 
 ## Setting Up a Development Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,6 @@ Users without the commit rights to the JupyterLab repository can tag issues with
 labels using the `@meeseeksdev` bot. For example: To apply the label `foo` and
 `bar baz` to an issue, comment `@meeseeksdev tag foo "bar baz"` on the issue.
 
-
 ## Setting Up a Development Environment
 
 You can launch a binder with the latest JupyterLab master to test something (this may take a few minutes to load): [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab/master?urlpath=lab-dev/)


### PR DESCRIPTION
* I put the note to the author in an HTML comment so it doesn’t appear in the PR description.
* I simplified the language to be more direct about what the user should do.
* I took out “We strongly encourage the community to open an issue … before a PR” since at this point, their PR is open and work is done already. If this is our stance, we should tell people before this stage.
* I took out “Provide a list of packages” since that should just be automated from the files that are touched.
* I reworded a few points to be more direct and shorter and use simpler language.

CC @richagadgil 