### PR TITLE
Add getInitialQuery to documentsearch interface

### DIFF
--- a/packages/csvviewer-extension/src/searchprovider.ts
+++ b/packages/csvviewer-extension/src/searchprovider.ts
@@ -18,6 +18,17 @@ export class CSVSearchProvider implements ISearchProvider {
   }
 
   /**
+   * Get an initial query value if applicable so that it can be entered
+   * into the search box as an initial query
+   *
+   * @returns Initial value used to populate the search box.
+   */
+  getInitialQuery(searchTarget: IDocumentWidget<CSVViewer>): any {
+    // CSV Viewer does not support selection
+    return null;
+  }
+
+  /**
    * Initialize the search using the provided options.  Should update the UI
    * to highlight all matches and "select" whatever the first match should be.
    *

--- a/packages/documentsearch/src/interfaces.ts
+++ b/packages/documentsearch/src/interfaces.ts
@@ -107,6 +107,15 @@ export interface ISearchProviderConstructor {
 
 export interface ISearchProvider {
   /**
+   * Get an initial query value if applicable so that it can be entered
+   * into the search box as an initial query
+   *
+   * @param searchTarget The widget to be searched
+   *
+   * @returns Initial value used to populate the search box.
+   */
+  getInitialQuery(searchTarget: Widget): any;
+  /**
    * Initialize the search using the provided options.  Should update the UI
    * to highlight all matches and "select" whatever the first match should be.
    *

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -45,6 +45,21 @@ type MatchMap = { [key: number]: { [key: number]: ISearchMatch } };
 
 export class CodeMirrorSearchProvider implements ISearchProvider {
   /**
+   * Get an initial query value if applicable so that it can be entered
+   * into the search box as an initial query
+   *
+   * @returns Initial value used to populate the search box.
+   */
+  getInitialQuery(searchTarget: Widget): any {
+    const target = searchTarget as MainAreaWidget;
+    const content = target.content as FileEditor;
+    const cm = content.editor as CodeMirrorEditor;
+    const selection = cm.doc.getSelection();
+    // if there are newlines, just return empty string
+    return selection.search(/\r?\n|\r/g) === -1 ? selection : '';
+  }
+
+  /**
    * Initialize the search using the provided options.  Should update the UI
    * to highlight all matches and "select" whatever the first match should be.
    *
@@ -63,8 +78,8 @@ export class CodeMirrorSearchProvider implements ISearchProvider {
 
     // Extract the codemirror object from the editor widget. Each of these casts
     // is justified by the canSearchOn call above.
-    let target = searchTarget as MainAreaWidget;
-    let content = target.content as FileEditor;
+    const target = searchTarget as MainAreaWidget;
+    const content = target.content as FileEditor;
     this._cm = content.editor as CodeMirrorEditor;
     return this._startQuery(query);
   }

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -18,6 +18,19 @@ interface ICellSearchPair {
 
 export class NotebookSearchProvider implements ISearchProvider {
   /**
+   * Get an initial query value if applicable so that it can be entered
+   * into the search box as an initial query
+   *
+   * @returns Initial value used to populate the search box.
+   */
+  getInitialQuery(searchTarget: NotebookPanel): any {
+    const activeCell = searchTarget.content.activeCell;
+    const selection = (activeCell.editor as CodeMirrorEditor).doc.getSelection();
+    // if there are newlines, just return empty string
+    return selection.search(/\r?\n|\r/g) === -1 ? selection : '';
+  }
+
+  /**
    * Initialize the search using the provided options.  Should update the UI
    * to highlight all matches and "select" whatever the first match should be.
    *

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -17,6 +17,9 @@ export class SearchInstance implements IDisposable {
     this._widget = widget;
     this._activeProvider = searchProvider;
 
+    const initialQuery = this._activeProvider.getInitialQuery(this._widget);
+    this._displayState.searchText = initialQuery || '';
+
     this._searchWidget = createSearchOverlay({
       widgetChanged: this._displayUpdateSignal,
       overlayState: this._displayState,

--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -243,6 +243,12 @@ class SearchOverlay extends React.Component<
     this.state = props.overlayState;
   }
 
+  componentDidMount() {
+    if (this.state.searchText) {
+      this._executeSearch(true, this.state.searchText);
+    }
+  }
+
   private _onSearchChange(event: React.ChangeEvent) {
     const searchText = (event.target as HTMLInputElement).value;
     this.setState({ searchText: searchText });


### PR DESCRIPTION
As suggested on #6081 by @gabegrand, this adds `getInitialQuery` to the `ISearchProvider` interface.  This allows the `SearchInstance` to get the initial query (set as `any` because it could be any type of object in the future when we support other search widgets), populate the search box and start a search.  To the user, this means that if you have a word selected and press <kbd>ctrl</kbd> + <kbd>f</kbd>, a search box will open populated with that word, all of the matches will be highlighted, and the selected match will be in yellow.  This logic only activates when the search box is initially created, so it won't ever clobber existing text in the search box.  Lastly, because search doesn't support newlines, if a selection contains newlines at the time of search box creation, the box will not be populated. @jasongrout 