### PR TITLE
set font color according to theme in text matching command palette

### DIFF
--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -114,6 +114,7 @@
 .p-CommandPalette-header > mark {
   background-color: transparent;
   font-weight: bold;
+  color: var(--jp-ui-font-color1);
 }
 
 .p-CommandPalette-item {


### PR DESCRIPTION
I set font color according to the theme in text matching command palette. 

Fixes #5561