### PR TITLE
Set the CodeMirror-activeline-background and CodeMirror-gutter backgr…

### DIFF
--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -249,3 +249,8 @@ pre.CodeMirror-line {
   background-position: right;
   background-repeat: no-repeat;
 }
+
+.cm-s-jupyter .CodeMirror-activeline-background,
+.cm-s-jupyter .CodeMirror-gutter {
+  background-color: var(--jp-layout-color2);
+}


### PR DESCRIPTION
Set the CodeMirror-activeline-background and CodeMirror-gutter background-color to jp-layout-color
This resolves the CodeMirror ActiveLine highlight issue from issue #6053

This modifies the codemirror package

- [x] Look through open pull requests to see if someone has already started working on this.
- [x] Note what issue(s) this pull request addresses. (We strongly encourage the community to open an issue describing proposed work before opening a pull request.)
- [x] Provide a detailed description of the pull request. (Why are these changes necessary? How have they been implemented?)
- [x] For UI/UX changes, include before/after screenshots
- [x] Include a narrative description of visual or user interaction changes. How does your design effectively address the problem?
- [x] Provide a list of Jupyterlab packages the pull request modifies.
- [x] Describe any backwards incompatible changes to Jupyterlab’s public APIs.

Before

![Before](https://user-images.githubusercontent.com/26635592/56843283-92ca5100-686c-11e9-92fd-73de0c9d1b3f.png)

After

![After](https://user-images.githubusercontent.com/26635592/56843292-a970a800-686c-11e9-86e8-6100c88c1786.png)
