### PR TITLE
Fix PDF scroll position on Firefox.

### DIFF
--- a/packages/pdf-extension/src/index.ts
+++ b/packages/pdf-extension/src/index.ts
@@ -95,7 +95,7 @@ export class RenderedPDF extends Widget implements IRenderMime.IRenderer {
    */
   protected onBeforeHide(): void {
     // Dispose of any URL fragment before hiding the widget
-    // so that it is not rememberd upon show. Only Firefox
+    // so that it is not remembered upon show. Only Firefox
     // seems to have a problem with this.
     if (Private.IS_FIREFOX) {
       this._object.data = this._object.data.split('#')[0];

--- a/packages/pdf-extension/src/index.ts
+++ b/packages/pdf-extension/src/index.ts
@@ -91,6 +91,18 @@ export class RenderedPDF extends Widget implements IRenderMime.IRenderer {
   }
 
   /**
+   * Handle a `before-hide` message.
+   */
+  protected onBeforeHide(): void {
+    // Dispose of any URL fragment before hiding the widget
+    // so that it is not rememberd upon show. Only Firefox
+    // seems to have a problem with this.
+    if (Private.IS_FIREFOX) {
+      this._object.data = this._object.data.split('#')[0];
+    }
+  }
+
+  /**
    * Dispose of the resources held by the pdf widget.
    */
   dispose() {

--- a/packages/pdf-extension/src/index.ts
+++ b/packages/pdf-extension/src/index.ts
@@ -58,6 +58,12 @@ export class RenderedPDF extends Widget implements IRenderMime.IRenderer {
         const url = this._object.data;
         this._object.data = `${url.split('#')[0]}${model.metadata.fragment}`;
       }
+      // For some opaque reason, Firefox seems to loose its scroll position
+      // upon unhiding a PDF. But triggering a refresh of the URL makes it
+      // find it again. No idea what the reason for this is.
+      if (Private.IS_FIREFOX) {
+        this._object.data = this._object.data;
+      }
       return Promise.resolve(void 0);
     }
     this._base64 = data;
@@ -140,6 +146,14 @@ export default extensions;
  * A namespace for PDF widget private data.
  */
 namespace Private {
+  /**
+   * A flag for determining whether the user is using Firefox.
+   * There are some different PDF viewer behaviors on Firefox,
+   * and we try to address them with this. User agent string parsing
+   * is *not* reliable, so this should be considered a best-effort test.
+   */
+  export const IS_FIREFOX: boolean = /Firefox/.test(navigator.userAgent);
+
   /**
    * Convert a base64 encoded string to a Blob object.
    * Modified from a snippet found here:


### PR DESCRIPTION
@jasongrout and I had thought that the DOM structure changes from #6255 were responsible for a regression in the PDF.js viewer on Firefox where it lost its scroll position upon unhiding. I did some more testing on this, however, and as far as I can tell it was not the DOM changes, but instead was the re-setting of the data URL.

So before we try a ton of user-agent testing and building out a DOM-structure-matrix, I'd like to try this more limited fix. For me, on Ubuntu+Firefox/Chrome, it seems to behave reasonably. I have no idea why this fixes the PDF.js issue, but overall browser PDF behavior is not something that we can control too much.

I'd appreciate if folks with other OS/browser combinations could test this:
1. Does a PDF render correctly?
1. Does the PDF retain its position upon unhiding or moving?
1. Do markdown links to the document with page fragments work? (e.g. `#page=10`).