### PR TITLE
Allow passing "-" as a file to jupyter workspaces import

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -187,19 +187,12 @@ class LabWorkspaceImportApp(JupyterApp):
             print('One argument is required for workspace import.')
             sys.exit(1)
 
-        file_name = self.extra_args[0]
-        file_path = os.path.abspath(file_name)
-
-        if not os.path.exists(file_path):
-            print('%s does not exist.' % file_name)
-            sys.exit(1)
-
         workspace = dict()
-        with open(file_path) as fid:
+        with self._smart_open() as fid:
             try:  # to load, parse, and validate the workspace file.
                 workspace = self._validate(fid, base_url, page_url, workspaces_url)
             except Exception as e:
-                print('%s is not a valid workspace:\n%s' % (file_name, e))
+                print('%s is not a valid workspace:\n%s' % (fid.name, e))
                 sys.exit(1)
 
         if not os.path.exists(directory):
@@ -217,6 +210,20 @@ class LabWorkspaceImportApp(JupyterApp):
             fid.write(json.dumps(workspace))
 
         print('Saved workspace: %s' % workspace_path)
+
+    def _smart_open(self):
+        file_name = self.extra_args[0]
+
+        if file_name == '-':
+            return sys.stdin
+        else:
+            file_path = os.path.abspath(file_name)
+
+            if not os.path.exists(file_path):
+                print('%s does not exist.' % file_name)
+                sys.exit(1)
+            
+            return open(file_path)
 
     def _validate(self, data, base_url, page_url, workspaces_url):
         workspace = json.load(data)


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/6272

## Code changes

Check for "-" as a file name, and use stdin instead

## User-facing changes

User will be able to pass - to mean that they want to load from stdin instead of a file
From:
`jupyter lab workspaces import ./workspace.json`

To:
`cat workspace.json | jupyter lab workspaces import -- -`

Note: the -- is necessary to tell the jupyter lab command tool to not take - as a parameter.

## Backwards-incompatible changes

None
