### PR TITLE
Remove deregisterProvider from SearchProviderRegistry interface

### DIFF
--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -139,7 +139,7 @@ function activateCsv(
 
   addMenuEntries(mainMenu, tracker);
   if (searchregistry) {
-    searchregistry.registerProvider('csv', CSVSearchProvider);
+    searchregistry.register('csv', CSVSearchProvider);
   }
 }
 
@@ -209,7 +209,7 @@ function activateTsv(
 
   addMenuEntries(mainMenu, tracker);
   if (searchregistry) {
-    searchregistry.registerProvider('tsv', CSVSearchProvider);
+    searchregistry.register('tsv', CSVSearchProvider);
   }
 }
 

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -32,7 +32,8 @@
     "@jupyterlab/application": "^1.0.0-alpha.6",
     "@jupyterlab/apputils": "^1.0.0-alpha.6",
     "@jupyterlab/documentsearch": "^1.0.0-alpha.7",
-    "@jupyterlab/mainmenu": "^1.0.0-alpha.6"
+    "@jupyterlab/mainmenu": "^1.0.0-alpha.6",
+    "@phosphor/widgets": "^1.6.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/documentsearch/src/searchproviderregistry.ts
+++ b/packages/documentsearch/src/searchproviderregistry.ts
@@ -23,6 +23,7 @@ export interface ISearchProviderRegistry {
    * Add a provider to the registry.
    *
    * @param key - The provider key.
+   * @returns A disposable delegate that, when disposed, deregisters the given search provider
    */
   register(key: string, provider: ISearchProviderConstructor): IDisposable;
 
@@ -57,6 +58,7 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
    * Add a provider to the registry.
    *
    * @param key - The provider key.
+   * @returns A disposable delegate that, when disposed, deregisters the given search provider
    */
   register(key: string, provider: ISearchProviderConstructor): IDisposable {
     this._customProviders.set(key, provider);
@@ -80,6 +82,10 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
     );
   }
 
+  /**
+   * Signal that emits when a new search provider has been registered
+   * or removed.
+   */
   get changed(): ISignal<this, void> {
     return this._changed;
   }

--- a/packages/documentsearch/src/searchproviderregistry.ts
+++ b/packages/documentsearch/src/searchproviderregistry.ts
@@ -6,6 +6,7 @@ import { NotebookSearchProvider } from './providers/notebooksearchprovider';
 
 import { Token } from '@phosphor/coreutils';
 import { Widget } from '@phosphor/widgets';
+import { IDisposable, DisposableDelegate } from '@phosphor/disposable';
 
 /* tslint:disable */
 /**
@@ -22,15 +23,7 @@ export interface ISearchProviderRegistry {
    *
    * @param key - The provider key.
    */
-  registerProvider(key: string, provider: ISearchProviderConstructor): void;
-
-  /**
-   * Remove provider from registry.
-   *
-   * @param key - The provider key.
-   * @returns true if removed, false if key did not exist in map.
-   */
-  deregisterProvider(key: string): boolean;
+  register(key: string, provider: ISearchProviderConstructor): IDisposable;
 
   /**
    * Returns a matching provider for the widget.
@@ -58,18 +51,11 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
    *
    * @param key - The provider key.
    */
-  registerProvider(key: string, provider: ISearchProviderConstructor): void {
+  register(key: string, provider: ISearchProviderConstructor): IDisposable {
     this._customProviders.set(key, provider);
-  }
-
-  /**
-   * Remove provider from registry.
-   *
-   * @param key - The provider key.
-   * @returns true if removed, false if key did not exist in map.
-   */
-  deregisterProvider(key: string): boolean {
-    return this._customProviders.delete(key);
+    return new DisposableDelegate(() => {
+      this._customProviders.delete(key);
+    });
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Addresses an issue brought up in #6217.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
This removes the `deregisterProvider` function on `ISearchProviderRegistry`, renames `registerProvider` to simply `register` and returns a `DisposableDelegate`, and adds a `changed` signal to `ISearchProviderRegistry` that emits when a provider has been registered or disposed (and effectively deregistered).  The goal here was to allow extensions to only 'deregister' the providers that they provide and no others.

Also, with the new signal, we can ensure that the `jp-mod-searchable` class that controls the <kbd>ctrl</kbd> + <kbd>f</kbd> and other search-related keybindings is added to and removed from active widgets only when they have a registered search provider.
## User-facing changes
There should be no user-facing changes here, other than a slightly tighter control on when the search keybindings are routed to the browser vs a search provider when providers are registered/deregistered.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
This makes three breaking changes to the `ISearchProviderRegistry` interface, as described above:
1. Rename `registerProvider` -> `register` and it now returns an `IDisposable`
2. Remove `deregisterProvider`
3. Add `changed` signal
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
