### PR TITLE
Add shutdown on close capability for terminals

### DIFF
--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -53,6 +53,12 @@
       "description": "The amount of scrollback beyond initial viewport",
       "$ref": "#/definitions/lineHeight",
       "default": 1000
+    },
+    "shutdownOnClose": {
+      "title": "Shut down on close",
+      "description": "Whether to shut down or not the session when closing the terminal.",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/terminal/src/constants.ts
+++ b/packages/terminal/src/constants.ts
@@ -83,6 +83,11 @@ export namespace ITerminal {
     scrollback: number | null;
 
     /**
+     * Whether to shut down the session when closing a terminal or not.
+     */
+    shutdownOnClose: boolean;
+
+    /**
      * Whether to blink the cursor.  Can only be set at startup.
      */
     cursorBlink: boolean;
@@ -102,6 +107,7 @@ export namespace ITerminal {
     fontSize: 13,
     lineHeight: 1.0,
     scrollback: 1000,
+    shutdownOnClose: false,
     cursorBlink: true,
     initialCommand: ''
   };

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -107,6 +107,8 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
     this._options[option] = value;
 
     switch (option) {
+      case 'shutdownOnClose': // Do not transmit to XTerm
+        break;
       case 'theme':
         this._term.setOption(
           'theme',
@@ -126,6 +128,13 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
    * Dispose of the resources held by the terminal widget.
    */
   dispose(): void {
+    if (this._session) {
+      if (this.getOption('shutdownOnClose')) {
+        this._session.shutdown().catch(reason => {
+          console.error(`Terminal not shut down: ${reason}`);
+        });
+      }
+    }
     this._session = null;
     this._term.dispose();
     super.dispose();


### PR DESCRIPTION
## References

Related issue: #5241 
This is a follow-up of #6275 for terminals.

## Code changes

Add option `shutdownOnClose` for `ITerminal.IOptions`.
If this is true, the session will be shut down when a terminal tab is closed.

## User-facing changes

New settings:
*Terminal* -> *Shut down on close*
