### PR TITLE
Add setting to close kernel with console panel

### DIFF
--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -35,6 +35,12 @@
       "type": "string",
       "enum": ["notebook", "terminal"],
       "default": "notebook"
+    },
+    "kernelShutdown": {
+      "title": "Shut down kernel",
+      "description": "Whether to shut down or not the kernel when closing a console.",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -111,6 +111,20 @@ export class ConsolePanel extends Panel {
     return this._session;
   }
 
+  setConfig(config: ConsolePanel.IConsoleConfig): void {
+    this.console.node.dataset.jpInteractionMode = config.interactionMode;
+    let shutdownOnClose = config.kernelShutdown;
+    // Dirty fix to turn off kernel shutdown for console open on a notebook
+    if (PathExt.extname(this.session.path) === '.ipynb') {
+      shutdownOnClose = false;
+    }
+    const kernelPreference = this.session.kernelPreference;
+    this.session.kernelPreference = {
+      ...kernelPreference,
+      shutdownOnClose
+    };
+  }
+
   /**
    * Dispose of the resources held by the widget.
    */
@@ -216,6 +230,28 @@ export namespace ConsolePanel {
      */
     setBusy?: () => IDisposable;
   }
+
+  /**
+   * A config object for the console
+   */
+  export interface IConsoleConfig {
+    /**
+     * User preferred interaction mode
+     */
+    interactionMode: 'notebook' | 'terminal';
+    /**
+     * Whether shut down the kernel when the widget is closed or not
+     */
+    kernelShutdown: boolean;
+  }
+
+  /**
+   * The default configuration options for a console
+   */
+  export const defaultConfig: IConsoleConfig = {
+    interactionMode: 'notebook',
+    kernelShutdown: false
+  };
 
   /**
    * The console panel renderer.


### PR DESCRIPTION
## References

Related issue: #5241 
This is a follow up of #6275 

## Code changes

Transmit a new `kernelShutdown` setting to the `shutdownOnClose` option of `ClientSession` `kernelPreference` to link tab disposal with kernel shutdown.

Nota: following the comment of @jasongrout in #6275, a dirty fix is in place to deactivate `shutdownOnClose` if the console is opened on a notebook. If someone can point me out to a nicer solution than looking at the path extension, I happily change the current code.

## User-facing changes

Add setting:
*Console* -> *Shut down kernel*
