### PR TITLE
Opening console from fileeditor context menu and from tab context menu not coherent

### DIFF
--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -45,6 +45,7 @@
     "@jupyterlab/services": "^4.0.0-alpha.6",
     "@jupyterlab/statusbar": "^1.0.0-alpha.6",
     "@phosphor/algorithm": "^1.1.2",
+    "@phosphor/commands": "^1.6.1",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",


### PR DESCRIPTION
## References

Closes #6284 

## Code changes

Use common `createConsole` function to open a console on a notebook tab by using file editor context menu and tab title context menu.

As different implementation were also used for notebook tabs, I also refractored the code in notebook-extension.

## User-facing changes

Opening a console for a file from the file editor context menu or from the tab title context menu will act similarly; i.e. open a console in a tab included in `split-bottom` mode and titled with the file name.
