### PR TITLE
Refractor updating notebook settings for opened widgets

### DIFF
--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -17,7 +17,7 @@ import { RenderMimeRegistry } from '@jupyterlab/rendermime';
 
 import { INotebookModel } from './model';
 
-import { Notebook } from './widget';
+import { Notebook, StaticNotebook } from './widget';
 
 /**
  * The class name added to notebook panels.
@@ -109,6 +109,22 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
   }
 
   /**
+   * Update the options for the current notebook panel.
+   *
+   * @param config new options to set
+   */
+  setConfig(config: NotebookPanel.IConfig): void {
+    this.content.editorConfig = config.editorConfig;
+    this.content.notebookConfig = config.notebookConfig;
+    // Update kernel shutdown behavior
+    const kernelPreference = this.context.session.kernelPreference;
+    this.context.session.kernelPreference = {
+      ...kernelPreference,
+      shutdownOnClose: config.kernelShutdown
+    };
+  }
+
+  /**
    * Set URI fragment identifier.
    */
   setFragment(fragment: string) {
@@ -184,6 +200,24 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
  * A namespace for `NotebookPanel` statics.
  */
 export namespace NotebookPanel {
+  /**
+   * Notebook config interface for NotebookPanel
+   */
+  export interface IConfig {
+    /**
+     * A config object for cell editors
+     */
+    editorConfig: StaticNotebook.IEditorConfig;
+    /**
+     * A config object for notebook widget
+     */
+    notebookConfig: StaticNotebook.INotebookConfig;
+    /**
+     * Whether to shut down the kernel when closing the panel or not
+     */
+    kernelShutdown: boolean;
+  }
+
   /**
    * A content factory interface for NotebookPanel.
    */


### PR DESCRIPTION
## References

Closes #6274 

## Code changes

* Hide the update widget actions in a new method `NotebookPanel.setConfig`
* Change `updateTracker` signature to receive directly the new settings to set.

## User-facing changes

None
