### PR TITLE
Prevent tooltip flicker in Safari.

### DIFF
--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -64,6 +64,7 @@ export class Tooltip extends Widget {
 
     this.anchor = options.anchor;
     this.addClass(TOOLTIP_CLASS);
+    this.hide();
     this._editor = options.editor;
     this._rendermime = options.rendermime;
 
@@ -168,6 +169,9 @@ export class Tooltip extends Widget {
    * Handle `'update-request'` messages.
    */
   protected onUpdateRequest(msg: Message): void {
+    if (this.isHidden) {
+      this.show();
+    }
     this._setGeometry();
     super.onUpdateRequest(msg);
   }


### PR DESCRIPTION
## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/6091

## Code changes

The tooltip widget is hidden when it is instantiated and only shown on update request.

## User-facing changes

Prevents a flicker when the tooltip is first invoked in Safari.

**before**
![flicker](https://user-images.githubusercontent.com/159529/57014082-50a36580-6c06-11e9-8f27-e16394feebb7.gif)

**after**
![no-flicker](https://user-images.githubusercontent.com/159529/57014111-7cbee680-6c06-11e9-9c4d-d687fbe3a844.gif)


## Backwards-incompatible changes

N/A
