### PR TITLE
More yarn deduplicating

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -91,6 +91,13 @@ def get_app_dir():
 
 
 def dedupe_yarn(path, logger=None):
+    """ `yarn-deduplicate` with the `fewer` strategy to minimize total
+        packages installed in a given staging directory
+
+        This means a extension (or dependency) _could_ cause a downgrade of an
+        version expected at publication time, but core should aggressively set
+        pins above, for example, known-bad versions
+    """
     had_dupes = Process(
         ['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer', '--fail'],
         cwd=path, logger=logger

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -90,6 +90,17 @@ def get_app_dir():
     return osp.abspath(app_dir)
 
 
+def dedupe_yarn(path, logger=None):
+    had_dupes = Process(
+        ['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer', '--fail'],
+        cwd=path, logger=logger
+    ).wait() != 0
+
+    if had_dupes:
+        yarn_proc = Process(['node', YARN_PATH], cwd=path, logger=logger)
+        yarn_proc.wait()
+
+
 def ensure_dev(logger=None):
     """Ensure that the dev assets are available.
     """
@@ -99,12 +110,7 @@ def ensure_dev(logger=None):
         yarn_proc = Process(['node', YARN_PATH], cwd=parent, logger=logger)
         yarn_proc.wait()
 
-        yarn_proc = Process(['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer', '--fail'],
-                            cwd=parent, logger=logger)
-        had_dupes = yarn_proc.wait() != 0
-        if had_dupes:
-            yarn_proc = Process(['node', YARN_PATH], cwd=parent, logger=logger)
-            yarn_proc.wait()
+        dedupe_yarn(parent, logger)
 
     if not osp.exists(pjoin(parent, 'dev_mode', 'static')):
         yarn_proc = Process(['node', YARN_PATH, 'build'], cwd=parent,
@@ -125,12 +131,7 @@ def ensure_core(logger=None):
         yarn_proc = Process(['node', YARN_PATH], cwd=staging, logger=logger)
         yarn_proc.wait()
 
-        yarn_proc = Process(['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer', '--fail'],
-                            cwd=staging, logger=logger)
-        had_dupes = yarn_proc.wait() != 0
-        if had_dupes:
-            yarn_proc = Process(['node', YARN_PATH], cwd=staging, logger=logger)
-            yarn_proc.wait()
+        dedupe_yarn(staging, logger)
 
     if not osp.exists(pjoin(HERE, 'static')):
         yarn_proc = Process(['node', YARN_PATH, 'build'], cwd=staging,
@@ -156,12 +157,7 @@ def watch_packages(logger=None):
         yarn_proc = Process(['node', YARN_PATH], cwd=parent, logger=logger)
         yarn_proc.wait()
 
-        yarn_proc = Process(['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer', '--fail'],
-                            cwd=parent, logger=logger)
-        had_dupes = yarn_proc.wait() != 0
-        if had_dupes:
-            yarn_proc = Process(['node', YARN_PATH], cwd=parent, logger=logger)
-            yarn_proc.wait()
+        dedupe_yarn(parent, logger)
 
     logger = _ensure_logger(logger)
     ts_dir = osp.abspath(osp.join(HERE, '..', 'packages', 'metapackage'))
@@ -468,11 +464,8 @@ class _AppHandler(object):
             msg = 'npm dependencies failed to install'
             self.logger.error(msg)
             raise RuntimeError(msg)
-        had_dupes = 0 != self._run(
-            ['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer', '--fail'],
-            cwd=staging)
-        if had_dupes:
-            self._run(['node', YARN_PATH, 'install'], cwd=staging)
+
+        dedupe_yarn(staging, self.logger)
 
         # Build the app.
         ret = self._run(['node', YARN_PATH, 'run', command], cwd=staging)
@@ -491,11 +484,7 @@ class _AppHandler(object):
 
         # Make sure packages are installed.
         self._run(['node', YARN_PATH, 'install'], cwd=staging)
-        had_dupes = 0 != self._run(
-            ['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer', '--fail'],
-            cwd=staging)
-        if had_dupes:
-            self._run(['node', YARN_PATH, 'install'], cwd=staging)
+        dedupe_yarn(staging, self.logger)
 
         proc = WatchHelper(['node', YARN_PATH, 'run', 'watch'],
                            cwd=pjoin(self.app_dir, 'staging'),
@@ -978,6 +967,11 @@ class _AppHandler(object):
         pkg_path = pjoin(staging, 'package.json')
         with open(pkg_path, 'w') as fid:
             json.dump(data, fid, indent=4)
+
+        # copy known-good yarn.lock if missing
+        lock_path = pjoin(staging, 'yarn.lock')
+        if not osp.exists(lock_path):
+            shutil.copy(pjoin(HERE, 'staging', 'yarn.lock'), lock_path)
 
     def _get_package_template(self, silent=False):
         """Get the template the for staging package.json file.

--- a/jupyterlab/staging/yarn.lock
+++ b/jupyterlab/staging/yarn.lock
@@ -1995,7 +1995,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-commander@2, commander@^2.19.0, commander@^2.5.0, commander@~2.20.0:
+commander@2, commander@^2.10.0, commander@^2.19.0, commander@^2.5.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -2277,12 +2277,12 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-d3-array@1, d3-array@^1.1.1:
+d3-array@1, d3-array@^1.1.1, "d3-array@^1.2.0 || 2":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
-"d3-array@^1.2.0 || 2", d3-array@^2.0.3:
+d3-array@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.0.3.tgz#9c0531eda701e416f28a030e3d4e6179ba74f19f"
   integrity sha512-C7g4aCOoJa+/K5hPVqZLG8wjYHsTUROTk7Z1Ep9F4P5l+WVrvV0+6nAZ1wKTRLMhFWpGbozxUpyjIPZYAaLi+g==
@@ -3855,15 +3855,10 @@ lower-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
-lowercase-keys@1.0.0:
+lowercase-keys@1.0.0, lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
   integrity sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=
-
-lowercase-keys@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -4014,7 +4009,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
@@ -4023,11 +4018,6 @@ minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.2.1, minipass@^2.3.4:
   version "2.3.5"
@@ -4739,15 +4729,10 @@ pumpify@^1.3.3:
     inherits "^2.0.3"
     pump "^2.0.0"
 
-punycode@1.3.2:
+punycode@1.3.2, punycode@^1.2.4:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
-punycode@^1.2.4:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -5477,14 +5462,7 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string_decoder@^1.0.0, string_decoder@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
-  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
-  dependencies:
-    safe-buffer "~5.1.0"
-
-string_decoder@~1.1.1:
+string_decoder@^1.0.0, string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
@@ -5733,20 +5711,12 @@ ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
   integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
-uglify-js@3.4.x:
+uglify-js@3.4.x, uglify-js@^3.1.4:
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"
   integrity sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==
   dependencies:
     commander "~2.19.0"
-    source-map "~0.6.1"
-
-uglify-js@^3.1.4:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.4.tgz#4a64d57f590e20a898ba057f838dcdfb67a939b9"
-  integrity sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==
-  dependencies:
-    commander "~2.20.0"
     source-map "~0.6.1"
 
 union-value@^1.0.0:
@@ -5873,19 +5843,12 @@ util.promisify@1.0.0, util.promisify@~1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-util@0.10.3:
+util@0.10.3, util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   integrity sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
   dependencies:
     inherits "2.0.1"
-
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
 
 util@^0.11.0:
   version "0.11.1"
@@ -6440,3 +6403,12 @@ yargs@~13.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.0.0"
+
+yarn-deduplicate@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-1.1.1.tgz#19b4a87654b66f55bf3a4bd6b153b4e4ab1b6e6d"
+  integrity sha512-2FDJ1dFmtvqhRmfja89ohYzpaheCYg7BFBSyaUq+kxK0y61C9oHv1XaQovCWGJtP2WU8PksQOgzMVV7oQOobzw==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    commander "^2.10.0"
+    semver "^5.3.0"


### PR DESCRIPTION
Kind of a discussion PR, but do think it's a good idea. Newer and more simultaneous versions of node packages aren't necessarily better!

## References
- builds on #5775 (thanks @vidartf for bringing that :house: !)

## Code changes
- copies the tested, known-good `yarn.lock` into `$PREFIX/share/jupyter/lab/staging` if there is no `yarn.lock` in a staging directory (e.g. on first extension install or after an upgrade)
- refactors invocation of `yarn-deduplicate` so the flags are only set once (`commands.py` is pretty long as it is) and logging is more consistent (this doesn't seem like a thing to be silent about)
  - there are a few other places in js/json where the strategy is specified... just have to be careful, i guess

## User-facing changes
- an initial "pointless" build of core with no added extensions will be faster, as no work will be performed (p.j and y.l will agree)
- every user build will start from the versions we rigorously test, not Whatever's On NPM Today.
  - it's _possible_ an extension could cause a downgrade
   - installing @jupyter-widgets/jupyterlab-manager latest, for example, downgrades `commander`

## Backwards-incompatible changes
- some duplicates are gone :crying_cat_face: 
  - ...but i think that's the point

If our `yarn.lock` didn't contain the build chain, i would be +:100: getting the `yarn.lock` into the static directory so that there was something more predictable... but then it would also be accessible from the browser, which is maybe Not So Good.