### PR TITLE
Log out and Shut down are two words when used as verbs

### DIFF
--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -194,7 +194,7 @@ function createApp(manager: ServiceManager.IManager): void {
     }
   });
   commands.addCommand('file-shutdown-kernel', {
-    label: 'Shutdown Kernel',
+    label: 'Shut Down Kernel',
     icon: 'fa fa-stop-circle-o',
     execute: () => {
       return fbWidget.shutdownKernels();

--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -370,7 +370,7 @@ export class ClientSession implements IClientSession {
     if (this._session) {
       if (this.kernelPreference.shutdownOnClose) {
         this._session.shutdown().catch(reason => {
-          console.error(`Kernel not shutdown ${reason}`);
+          console.error(`Kernel not shut down ${reason}`);
         });
       }
       this._session = null;

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -428,14 +428,14 @@ async function activateConsole(
   });
 
   commands.addCommand(CommandIDs.closeAndShutdown, {
-    label: 'Close and Shutdown…',
+    label: 'Close and Shut Down…',
     execute: args => {
       const current = getCurrent(args);
       if (!current) {
         return;
       }
       return showDialog({
-        title: 'Shutdown the console?',
+        title: 'Shut down the console?',
         body: `Are you sure you want to close "${current.title.label}"?`,
         buttons: [Dialog.cancelButton(), Dialog.warnButton()]
       }).then(result => {
@@ -509,7 +509,7 @@ async function activateConsole(
     name: 'Console',
     closeAndCleanup: (current: ConsolePanel) => {
       return showDialog({
-        title: 'Shutdown the console?',
+        title: 'Shut Down the console?',
         body: `Are you sure you want to close "${current.title.label}"?`,
         buttons: [Dialog.cancelButton(), Dialog.warnButton()]
       }).then(result => {

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -509,7 +509,7 @@ async function activateConsole(
     name: 'Console',
     closeAndCleanup: (current: ConsolePanel) => {
       return showDialog({
-        title: 'Shut Down the console?',
+        title: 'Shut down the console?',
         body: `Are you sure you want to close "${current.title.label}"?`,
         buttons: [Dialog.cancelButton(), Dialog.warnButton()]
       }).then(result => {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -625,7 +625,7 @@ function addCommands(
       }
     },
     iconClass: 'jp-MaterialIcon jp-StopIcon',
-    label: 'Shutdown Kernel'
+    label: 'Shut Down Kernel'
   });
 
   commands.addCommand(CommandIDs.toggleBrowser, {

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -440,7 +440,7 @@ export class DirListing extends Widget {
         return undefined;
       })
       .catch(error => {
-        void showErrorMessage('Shutdown kernel', error);
+        void showErrorMessage('Shut down kernel', error);
       });
   }
 

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -348,7 +348,7 @@ export function createFileMenu(
   });
 
   commands.addCommand(CommandIDs.shutdown, {
-    label: 'Shutdown',
+    label: 'Shut Down',
     caption: 'Shut down JupyterLab',
     execute: () => {
       return showDialog({
@@ -392,7 +392,7 @@ export function createFileMenu(
   });
 
   commands.addCommand(CommandIDs.logout, {
-    label: 'Logout',
+    label: 'Log Out',
     caption: 'Log out of JupyterLab',
     execute: () => {
       router.navigate('/logout', { hard: true });

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -211,7 +211,6 @@ const plugin: JupyterFrontEndPlugin<IMainMenu> = {
         command: CommandIDs.logout,
         category: 'Main Area'
       });
-
     }
 
     palette.addItem({
@@ -511,23 +510,23 @@ export function createKernelMenu(app: JupyterFrontEnd, menu: KernelMenu): void {
   });
 
   commands.addCommand(CommandIDs.shutdownKernel, {
-    label: 'Shutdown Kernel',
+    label: 'Shut Down Kernel',
     isEnabled: Private.delegateEnabled(app, menu.kernelUsers, 'shutdownKernel'),
     execute: Private.delegateExecute(app, menu.kernelUsers, 'shutdownKernel')
   });
 
   commands.addCommand(CommandIDs.shutdownAllKernels, {
-    label: 'Shutdown All Kernels…',
+    label: 'Shut Down All Kernels…',
     isEnabled: () => {
       return app.serviceManager.sessions.running().next() !== undefined;
     },
     execute: () => {
       return showDialog({
-        title: 'Shutdown All?',
+        title: 'Shut Down All?',
         body: 'Shut down all kernels?',
         buttons: [
           Dialog.cancelButton(),
-          Dialog.warnButton({ label: 'SHUTDOWN' })
+          Dialog.warnButton({ label: 'SHUT DOWN ALL' })
         ]
       }).then(result => {
         if (result.button.accept) {

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -207,6 +207,11 @@ const plugin: JupyterFrontEndPlugin<IMainMenu> = {
         command: CommandIDs.shutdown,
         category: 'Main Area'
       });
+      palette.addItem({
+        command: CommandIDs.logout,
+        category: 'Main Area'
+      });
+
     }
 
     palette.addItem({

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1089,7 +1089,7 @@ function addCommands(
     isEnabled
   });
   commands.addCommand(CommandIDs.closeAndShutdown, {
-    label: 'Close and Shutdown',
+    label: 'Close and Shut Down',
     execute: args => {
       const current = getCurrent(args);
 
@@ -1100,7 +1100,7 @@ function addCommands(
       const fileName = current.title.label;
 
       return showDialog({
-        title: 'Shutdown the notebook?',
+        title: 'Shut down the notebook?',
         body: `Are you sure you want to close "${fileName}"?`,
         buttons: [Dialog.cancelButton(), Dialog.warnButton()]
       }).then(result => {
@@ -1927,7 +1927,7 @@ function populateMenus(
     closeAndCleanup: (current: NotebookPanel) => {
       const fileName = current.title.label;
       return showDialog({
-        title: 'Shutdown the notebook?',
+        title: 'Shut down the notebook?',
         body: `Are you sure you want to close "${fileName}"?`,
         buttons: [Dialog.cancelButton(), Dialog.warnButton()]
       }).then(result => {

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -173,7 +173,7 @@ function Item<M>(props: SessionProps<M> & { model: M }) {
         className={`${SHUTDOWN_BUTTON_CLASS} jp-mod-styled`}
         onClick={() => props.shutdown(model)}
       >
-        SHUTDOWN
+        SHUT DOWN
       </button>
     </li>
   );
@@ -221,7 +221,7 @@ function Section<M>(props: SessionProps<M>) {
       title: `Shut Down All ${props.name} Sessions?`,
       buttons: [
         Dialog.cancelButton(),
-        Dialog.warnButton({ label: 'SHUT DOWN' })
+        Dialog.warnButton({ label: 'SHUT DOWN ALL' })
       ]
     }).then(result => {
       if (result.button.accept) {

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -218,8 +218,11 @@ function List<M>(props: SessionProps<M>) {
 function Section<M>(props: SessionProps<M>) {
   function onShutdown() {
     void showDialog({
-      title: `Shutdown All ${props.name} Sessions?`,
-      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'SHUTDOWN' })]
+      title: `Shut Down All ${props.name} Sessions?`,
+      buttons: [
+        Dialog.cancelButton(),
+        Dialog.warnButton({ label: 'SHUT DOWN' })
+      ]
     }).then(result => {
       if (result.button.accept) {
         props.manager.shutdownAll();
@@ -233,7 +236,7 @@ function Section<M>(props: SessionProps<M>) {
           <header className={SECTION_HEADER_CLASS}>
             <h2>{props.name} Sessions</h2>
             <ToolbarButtonComponent
-              tooltip={`Shutdown All ${props.name} Sessions…`}
+              tooltip={`Shut Down All ${props.name} Sessions…`}
               iconClassName="jp-CloseIcon"
               onClick={onShutdown}
             />


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Expands on #6087 

## Code changes

Log out is added to the command palette.

## User-facing changes


Log out and shut down are two words when used as a verb/action. This sweeps through the codebase attempting to correct our use of these terms.

<!-- For visual changes, include before and after screenshots here. -->


## Backwards-incompatible changes

N/A

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
