### PR TITLE
Remove notion of default search providers

### DIFF
--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -12,7 +12,9 @@ import { ICommandPalette } from '@jupyterlab/apputils';
 import {
   ISearchProviderRegistry,
   SearchInstance,
-  SearchProviderRegistry
+  SearchProviderRegistry,
+  CodeMirrorSearchProvider,
+  NotebookSearchProvider
 } from '@jupyterlab/documentsearch';
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
@@ -79,8 +81,10 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
   ) => {
     // Create registry, retrieve all default providers
     const registry: SearchProviderRegistry = new SearchProviderRegistry();
-    // TODO: Should register the default providers, with an application-specific
-    // enabler.
+
+    // Register default implementations of the Notebook and CodeMirror search providers
+    registry.register('jp-notebookSearchProvider', NotebookSearchProvider);
+    registry.register('jp-codeMirrorSearchProvider', CodeMirrorSearchProvider);
 
     const activeSearches = new Map<string, SearchInstance>();
 

--- a/packages/documentsearch/src/searchproviderregistry.ts
+++ b/packages/documentsearch/src/searchproviderregistry.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 import { ISearchProvider, ISearchProviderConstructor } from './interfaces';
-import { CodeMirrorSearchProvider } from './providers/codemirrorsearchprovider';
-import { NotebookSearchProvider } from './providers/notebooksearchprovider';
 
 import { Token } from '@phosphor/coreutils';
 import { Widget } from '@phosphor/widgets';
@@ -43,17 +41,6 @@ export interface ISearchProviderRegistry {
 }
 
 export class SearchProviderRegistry implements ISearchProviderRegistry {
-  constructor() {
-    this._registerDefaultProviders(
-      'jl-defaultNotebookSearchProvider',
-      NotebookSearchProvider
-    );
-    this._registerDefaultProviders(
-      'jl-defaultCodeMirrorSearchProvider',
-      CodeMirrorSearchProvider
-    );
-  }
-
   /**
    * Add a provider to the registry.
    *
@@ -61,10 +48,10 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
    * @returns A disposable delegate that, when disposed, deregisters the given search provider
    */
   register(key: string, provider: ISearchProviderConstructor): IDisposable {
-    this._customProviders.set(key, provider);
+    this._providerMap.set(key, provider);
     this._changed.emit();
     return new DisposableDelegate(() => {
-      this._customProviders.delete(key);
+      this._providerMap.delete(key);
       this._changed.emit();
     });
   }
@@ -76,10 +63,7 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
    * @returns the search provider, or undefined if none exists.
    */
   getProviderForWidget(widget: Widget): ISearchProvider | undefined {
-    return (
-      this._findMatchingProvider(this._customProviders, widget) ||
-      this._findMatchingProvider(this._defaultProviders, widget)
-    );
+    return this._findMatchingProvider(this._providerMap, widget);
   }
 
   /**
@@ -88,13 +72,6 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
    */
   get changed(): ISignal<this, void> {
     return this._changed;
-  }
-
-  private _registerDefaultProviders(
-    key: string,
-    provider: ISearchProviderConstructor
-  ): void {
-    this._defaultProviders.set(key, provider);
   }
 
   private _findMatchingProvider(
@@ -112,11 +89,7 @@ export class SearchProviderRegistry implements ISearchProviderRegistry {
   }
 
   private _changed = new Signal<this, void>(this);
-  private _defaultProviders: Private.ProviderMap = new Map<
-    string,
-    ISearchProviderConstructor
-  >();
-  private _customProviders: Private.ProviderMap = new Map<
+  private _providerMap: Private.ProviderMap = new Map<
     string,
     ISearchProviderConstructor
   >();


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes third point brought up in #6217 by @afshin 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This removes the notion of default search providers in the `documentsearch` package.  Instead of importing and registering the default notebook and codemirror search providers directly in the constructor of the `SearchProviderRegistry`, the two default search provider implementations are imported by the `documentsearch-extension` package and registered there.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
There are no user facing or interface changes here.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None!
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
