### PR TITLE
Carriage return perf

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -469,11 +469,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     }
     executionCount.changed.connect(this._onExecutionCountChanged, this);
 
-    this._outputs = factory.createOutputArea({
-      trusted,
-      values: outputs,
-      modelDB: this.modelDB
-    });
+    this._outputs = factory.createOutputArea({ trusted, values: outputs });
     this._outputs.changed.connect(this.onGenericChange, this);
 
     // We keep `collapsed` and `jupyter.outputs_hidden` metadata in sync, since

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -9,11 +9,7 @@ import { ISignal, Signal } from '@phosphor/signaling';
 
 import { nbformat } from '@jupyterlab/coreutils';
 
-import {
-  IObservableList,
-  ObservableList,
-  IModelDB
-} from '@jupyterlab/observables';
+import { IObservableList, ObservableList } from '@jupyterlab/observables';
 
 import { IOutputModel, OutputModel } from '@jupyterlab/rendermime';
 
@@ -110,11 +106,6 @@ export namespace IOutputAreaModel {
      * If not given, a default factory will be used.
      */
     contentFactory?: IContentFactory;
-
-    /**
-     * An optional IModelDB to store the output area model.
-     */
-    modelDB?: IModelDB;
   }
 
   /**

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -317,6 +317,7 @@ export class OutputAreaModel implements IOutputAreaModel {
       this._lastStream += value.text as string;
       value.text = this._lastStream;
       this._removeOverwrittenChars(value);
+      this._lastStream = value.text;
       let item = this._createItem({ value, trusted });
       let index = this.length - 1;
       let prev = this.list.get(index);


### PR DESCRIPTION
Fixes #4202, for real this time. Boy, it's kind of tricky to debug something for which the test case locks up the browser. The problem was essentially a bad cached value. We were overwriting carriage returns and backspaces correctly, but then not updating the cached value of the overwritten output stream. This meant that we were doing the same work, over, and over, and over, in a quadratically growing fashion.

The real fix for this is a one-liner in b899ab0 . The rest of this PR is just some cleanup.

## References

#4202.

## Code changes

Restructuring of private functionality.

## User-facing changes

None, except that the browser won't lock up when using progress bars.

## Backwards-incompatible changes

Removal of `IModelDB` from output area input options. So far as I know, this was only used by the now-broken Google RTC.