### PR TITLE
Use new Poll class for filebrowser contents polling.

### DIFF
--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -309,6 +309,11 @@ export class Poll<T = any, U = any> implements IDisposable, IPoll<T, U> {
    * Refreshes the poll. Schedules `refreshed` tick if necessary.
    *
    * @returns A promise that resolves after tick is scheduled and never rejects.
+   *
+   * #### Notes
+   * The returned promise resolves after the tick is scheduled, but before
+   * the polling action is run. To wait until after the poll action executes,
+   * await the `poll.tick` promise: `await poll.refresh(); await poll.tick;`
    */
   refresh(): Promise<void> {
     return this.schedule({

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -36,11 +36,6 @@ import { showDialog, Dialog } from '@jupyterlab/apputils';
 const DEFAULT_REFRESH_INTERVAL = 10000;
 
 /**
- * The enforced time between refreshes in ms.
- */
-const MIN_REFRESH = 1000;
-
-/**
  * The maximum upload size (in bytes) for notebook version < 5.1.0
  */
 export const LARGE_FILE_SIZE = 15 * 1024 * 1024;
@@ -104,13 +99,7 @@ export class FileBrowserModel implements IDisposable {
     };
     window.addEventListener('beforeunload', this._unloadEventListener);
     this._poll = new Poll({
-      factory: async () => {
-        const date = new Date().getTime();
-        if (date - this._lastRefresh < MIN_REFRESH) {
-          return;
-        }
-        return this.refresh();
-      },
+      factory: () => this.cd('.'),
       frequency: {
         interval: refreshInterval,
         backoff: true,
@@ -239,8 +228,7 @@ export class FileBrowserModel implements IDisposable {
    * Force a refresh of the directory contents.
    */
   refresh(): Promise<void> {
-    this._lastRefresh = new Date().getTime();
-    return this.cd('.');
+    return this._poll.refresh();
   }
 
   /**
@@ -625,7 +613,6 @@ export class FileBrowserModel implements IDisposable {
   private _pending: Promise<void> | null = null;
   private _pendingPath: string | null = null;
   private _refreshed = new Signal<this, void>(this);
-  private _lastRefresh = -1;
   private _sessions: Session.IModel[] = [];
   private _state: IStateDB | null = null;
   private _driveName: string;

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -586,7 +586,7 @@ export class FileBrowserModel implements IDisposable {
 
     // If either the old value or the new value is in the current path, update.
     if (value) {
-      this._poll.refresh();
+      void this._poll.refresh();
       this._populateSessions(sessions.running());
       this._fileChanged.emit(change);
       return;

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -227,8 +227,8 @@ export class FileBrowserModel implements IDisposable {
   /**
    * Force a refresh of the directory contents.
    */
-  refresh(): Promise<void> {
-    return this._poll.refresh();
+  async refresh(): Promise<void> {
+    await this.cd('.');
   }
 
   /**
@@ -271,6 +271,7 @@ export class FileBrowserModel implements IDisposable {
         }
         this._handleContents(contents);
         this._pendingPath = null;
+        this._pending = null;
         if (oldValue !== newValue) {
           // If there is a state database and a unique key, save the new path.
           // We don't need to wait on the save to continue.

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -228,7 +228,8 @@ export class FileBrowserModel implements IDisposable {
    * Force a refresh of the directory contents.
    */
   async refresh(): Promise<void> {
-    await this.cd('.');
+    await this._poll.refresh();
+    await this._poll.tick;
   }
 
   /**

--- a/tests/test-filebrowser/src/model.spec.ts
+++ b/tests/test-filebrowser/src/model.spec.ts
@@ -26,7 +26,8 @@ import {
 import {
   acceptDialog,
   dismissDialog,
-  signalToPromises
+  signalToPromises,
+  sleep
 } from '@jupyterlab/testutils';
 import { toArray } from '@phosphor/algorithm';
 
@@ -259,18 +260,15 @@ describe('filebrowser/model', () => {
           opener,
           manager: delayedServiceManager
         });
-        model = new FileBrowserModel({ manager, state });
+        model = new FileBrowserModel({ manager, state }); // Should delay 1000ms
 
-        const paths: string[] = [];
         // An initial refresh is called in the constructor.
         // If it is too slow, it can come in after the directory change,
         // causing a directory set by, e.g., the tree handler to be wrong.
         // This checks to make sure we are handling that case correctly.
-        const refresh = model.refresh().then(() => paths.push(model.path));
-        const cd = model.cd('src').then(() => paths.push(model.path));
-        await Promise.all([refresh, cd]);
+        await model.cd('src'); // should delay 500ms
+        await sleep(2000);
         expect(model.path).to.equal('src');
-        expect(paths).to.eql(['', 'src']);
 
         manager.dispose();
         delayedServiceManager.contents.dispose();


### PR DESCRIPTION
Uses the `Poll` class for the filebrowser refresh scheduling.

## References

Fixes #6157.

## Code changes

Internal changes to polling logic of the filebrowser. Replaces some crude backoff logic with the smarter `Poll`.

## User-facing changes

Some differences in how polling backs off upon failures to connect, but the user would have to be looking very hard to see it.

## Backwards-incompatible changes

None