### PR TITLE
Set tab bar icon background size so SVGs of other sizes may be used.

### DIFF
--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -137,6 +137,7 @@
   width: 14px;
   background-position: left center;
   background-repeat: no-repeat;
+  background-size: 14px;
   margin-right: 4px;
 }
 


### PR DESCRIPTION
Fixes #5718 

## References

#5718

## Code changes

Just some CSS

## User-facing changes

SVGs of various sizes can now be used as icons in tab bars.

Before:
![image](https://user-images.githubusercontent.com/5728311/57173262-f3640b80-6de1-11e9-93b5-7cb5dc18aaeb.png)

After:
![image](https://user-images.githubusercontent.com/5728311/57173272-0b3b8f80-6de2-11e9-87a9-32b3c865ca8d.png)


## Backwards-incompatible changes
None