### PR TITLE
fixes issue #6296 markdown

### DIFF
--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -322,7 +322,7 @@
 .jp-RenderedHTMLCommon pre,
 .jp-RenderedHTMLCommon code {
   border: 0;
-  background-color: var(--jp-line-color0);
+  background-color: var(--jp-layout-color0);
   color: var(--jp-content-font-color1);
   font-family: var(--jp-code-font-family);
   font-size: inherit;
@@ -331,8 +331,8 @@
   white-space: pre-wrap;
 }
 
-.jp-RenderedHTMLCommon code {
-  background-color: var(--jp-line-color2);
+.jp-RenderedHTMLCommon :not(pre) > code {
+  background-color: var(--jp-layout-color2);
   padding: 1px 5px;
 }
 

--- a/packages/rendermime/style/index.css
+++ b/packages/rendermime/style/index.css
@@ -322,7 +322,7 @@
 .jp-RenderedHTMLCommon pre,
 .jp-RenderedHTMLCommon code {
   border: 0;
-  background-color: var(--jp-layout-color0);
+  background-color: var(--jp-line-color0);
   color: var(--jp-content-font-color1);
   font-family: var(--jp-code-font-family);
   font-size: inherit;
@@ -332,7 +332,7 @@
 }
 
 .jp-RenderedHTMLCommon code {
-  background-color: var(--jp-layout-color2);
+  background-color: var(--jp-line-color2);
   padding: 1px 5px;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

issue #6296

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Fixes in-line code background. 

Before: 

<img width="698" alt="57052750-55dcd080-6c57-11e9-982b-3a3bba832384" src="https://user-images.githubusercontent.com/17151787/57184963-9cb60a80-6e91-11e9-9edc-6aeb894c944b.png">

With this fix: 

<img width="466" alt="Screen Shot 2019-05-04 at 5 21 57 PM" src="https://user-images.githubusercontent.com/17151787/57184943-52348e00-6e91-11e9-972b-e8ee101f2289.png">

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
