### PR TITLE
Upgrade CodeMirror from 5.42.0 to 5.46.0

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -99,7 +99,7 @@
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.6.0",
     "ajv": "^6.5.5",
-    "codemirror": "~5.42.0",
+    "codemirror": "~5.46.0",
     "comment-json": "^1.1.3",
     "es6-promise": "~4.1.1",
     "marked": "0.5.1",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/mainmenu": "^1.0.0-alpha.6",
     "@jupyterlab/statusbar": "^1.0.0-alpha.6",
     "@phosphor/widgets": "^1.6.0",
-    "codemirror": "~5.42.0"
+    "codemirror": "~5.46.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -42,7 +42,7 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "codemirror": "~5.42.0",
+    "codemirror": "~5.46.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -38,7 +38,7 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "codemirror": "~5.42.0",
+    "codemirror": "~5.46.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/tests/test-codemirror/package.json
+++ b/tests/test-codemirror/package.json
@@ -16,7 +16,7 @@
     "@jupyterlab/codemirror": "^1.0.0-alpha.6",
     "@jupyterlab/testutils": "^1.0.0-alpha.6",
     "chai": "~4.1.2",
-    "codemirror": "~5.42.0",
+    "codemirror": "~5.46.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",
     "simulate-event": "~1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3220,9 +3220,10 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror@~5.42.0:
-  version "5.42.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.42.0.tgz#2d5b640ed009e89dee9ed8a2a778e2a25b65f9eb"
+codemirror@~5.46.0:
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.46.0.tgz#be3591572f88911e0105a007c324856a9ece0fb7"
+  integrity sha512-3QpMge0vg4QEhHW3hBAtCipJEWjTJrqLLXdIaWptJOblf1vHFeXLNtFhPai/uX2lnFCehWNk4yOdaMR853Z02w==
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## References

Addresses https://github.com/jupyterlab/jupyterlab/issues/6313.

## Code changes

CodeMirror was bumped from version 5.42.0 to 5.46.0 by running the command
```
jlpm run update:dependency codemirror ~latest
```
Thanks @jasongrout for making it clear how to do this.

## User-facing changes

Fixes indentation issues with julia (see https://github.com/jupyterlab/jupyterlab/issues/5797). For example, typing if/elseif/else blocks now works as follows:
![2019-05-07 17 22 05](https://user-images.githubusercontent.com/1733389/57334123-db93cc80-70ec-11e9-9ce6-5ee537ec4dde.gif)