### PR TITLE
Fix "Rename CSV File"

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -586,7 +586,7 @@ function addLabCommands(
       return labShell.currentWidget;
     }
     const pathMatch = node['title'].match(pathRe);
-    return docManager.findWidget(pathMatch[1]);
+    return docManager.findWidget(pathMatch[1], null);
   };
 
   // Returns `true` if the current widget has a document context.


### PR DESCRIPTION
Fixes an issue when renaming a file open with a factory that is not the default one.

For example when a CSV file is open with `Editor` instead of `CSVTable` (its default)

## References

This was already addressed in https://github.com/jupyterlab/jupyterlab/pull/5758, but it looks like part of this change has been reverted since.

## Code changes

Re-introduce the default `null` parameter to the `docManager.findWidget()` method.

## User-facing changes

### Before

![rename-csv](https://user-images.githubusercontent.com/591645/57401455-f8f09580-71d5-11e9-9cf4-353e3491aa36.gif)

### After

![rename-csv-fixed](https://user-images.githubusercontent.com/591645/57401465-fe4de000-71d5-11e9-8152-7389de09b318.gif)

## Backwards-incompatible changes

N/A