### PR TITLE
Default cell type

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -284,6 +284,13 @@
         "codeFolding": false
       }
     },
+    "defaultCell": {
+      "title": "Default cell type",
+      "description": "The default type (markdown, code, or raw) for new cells",
+      "type": "string",
+      "enum": ["code", "markdown", "raw"],
+      "default": "code"
+    },
     "kernelShutdown": {
       "title": "Shut down kernel",
       "description": "Whether to shut down or not the kernel when closing a notebook.",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -23,6 +23,7 @@ import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 import {
   ISettingRegistry,
   IStateDB,
+  nbformat,
   PageConfig,
   URLExt
 } from '@jupyterlab/coreutils';
@@ -626,7 +627,8 @@ function activateNotebookHandler(
     });
     factory.editorConfig = { code, markdown, raw };
     factory.notebookConfig = {
-      scrollPastEnd: settings.get('scrollPastEnd').composite as boolean
+      scrollPastEnd: settings.get('scrollPastEnd').composite as boolean,
+      defaultCell: settings.get('defaultCell').composite as nbformat.CellType
     };
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -262,7 +262,7 @@ export namespace NotebookActions {
 
     const state = Private.getState(notebook);
     const model = notebook.model;
-    const cell = model.contentFactory.createCodeCell({});
+    const cell = model.contentFactory.createCell(model.defaultCell, {});
     const active = notebook.activeCellIndex;
 
     model.cells.insert(active, cell);
@@ -291,7 +291,7 @@ export namespace NotebookActions {
 
     const state = Private.getState(notebook);
     const model = notebook.model;
-    const cell = model.contentFactory.createCodeCell({});
+    const cell = model.contentFactory.createCell(model.defaultCell, {});
 
     model.cells.insert(notebook.activeCellIndex + 1, cell);
 
@@ -446,7 +446,7 @@ export namespace NotebookActions {
     const model = notebook.model;
 
     if (notebook.activeCellIndex === notebook.widgets.length - 1) {
-      const cell = model.contentFactory.createCodeCell({});
+      const cell = model.contentFactory.createCell(model.defaultCell, {});
 
       model.cells.push(cell);
       notebook.activeCellIndex++;
@@ -484,7 +484,7 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
     const promise = Private.runSelected(notebook, session);
     const model = notebook.model;
-    const cell = model.contentFactory.createCodeCell({});
+    const cell = model.contentFactory.createCell(model.defaultCell, {});
 
     model.cells.insert(notebook.activeCellIndex + 1, cell);
     notebook.activeCellIndex++;
@@ -1658,7 +1658,7 @@ namespace Private {
       // within the compound operation to make the deletion of
       // a notebook's last cell undoable.
       if (!cells.length) {
-        cells.push(model.contentFactory.createCodeCell({}));
+        cells.push(model.contentFactory.createCell(model.defaultCell, {}));
       }
       cells.endCompoundOperation();
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -294,7 +294,10 @@ export namespace NotebookActions {
 
     const state = Private.getState(notebook);
     const model = notebook.model;
-    const cell = model.contentFactory.createCell(model.defaultCell, {});
+    const cell = model.contentFactory.createCell(
+      notebook.notebookConfig.defaultCell,
+      {}
+    );
 
     model.cells.insert(notebook.activeCellIndex + 1, cell);
 
@@ -449,7 +452,10 @@ export namespace NotebookActions {
     const model = notebook.model;
 
     if (notebook.activeCellIndex === notebook.widgets.length - 1) {
-      const cell = model.contentFactory.createCell(model.defaultCell, {});
+      const cell = model.contentFactory.createCell(
+        notebook.notebookConfig.defaultCell,
+        {}
+      );
 
       model.cells.push(cell);
       notebook.activeCellIndex++;
@@ -487,7 +493,10 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
     const promise = Private.runSelected(notebook, session);
     const model = notebook.model;
-    const cell = model.contentFactory.createCell(model.defaultCell, {});
+    const cell = model.contentFactory.createCell(
+      notebook.notebookConfig.defaultCell,
+      {}
+    );
 
     model.cells.insert(notebook.activeCellIndex + 1, cell);
     notebook.activeCellIndex++;
@@ -1661,7 +1670,12 @@ namespace Private {
       // within the compound operation to make the deletion of
       // a notebook's last cell undoable.
       if (!cells.length) {
-        cells.push(model.contentFactory.createCell(model.defaultCell, {}));
+        cells.push(
+          model.contentFactory.createCell(
+            notebook.notebookConfig.defaultCell,
+            {}
+          )
+        );
       }
       cells.endCompoundOperation();
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -262,7 +262,10 @@ export namespace NotebookActions {
 
     const state = Private.getState(notebook);
     const model = notebook.model;
-    const cell = model.contentFactory.createCell(model.defaultCell, {});
+    const cell = model.contentFactory.createCell(
+      notebook.notebookConfig.defaultCell,
+      {}
+    );
     const active = notebook.activeCellIndex;
 
     model.cells.insert(active, cell);

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -386,6 +386,19 @@ export namespace NotebookModel {
     modelDB: IModelDB;
 
     /**
+     * Create a new cell by cell type.
+     *
+     * @param type:  the type of the cell to create.
+     *
+     * @param options: the cell creation options.
+     *
+     * #### Notes
+     * This method is intended to be a convenience method to programmaticaly
+     * call the other cell creation methods in the factory.
+     */
+    createCell(type: nbformat.CellType, opts: CellModel.IOptions): ICellModel;
+
+    /**
      * Create a new code cell.
      *
      * @param options - The options used to create the cell.
@@ -443,6 +456,31 @@ export namespace NotebookModel {
      * The IModelDB in which to put the notebook data.
      */
     readonly modelDB: IModelDB | undefined;
+
+    /**
+     * Create a new cell by cell type.
+     *
+     * @param type:  the type of the cell to create.
+     *
+     * @param options: the cell creation options.
+     *
+     * #### Notes
+     * This method is intended to be a convenience method to programmaticaly
+     * call the other cell creation methods in the factory.
+     */
+    createCell(type: nbformat.CellType, opts: CellModel.IOptions): ICellModel {
+      switch (type) {
+        case 'code':
+          return this.createCodeCell(opts);
+          break;
+        case 'markdown':
+          return this.createMarkdownCell(opts);
+          break;
+        case 'raw':
+        default:
+          return this.createRawCell(opts);
+      }
+    }
 
     /**
      * Create a new code cell.

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -214,6 +214,7 @@ export class StaticNotebook extends Widget {
     }
     let oldValue = this._model;
     this._model = newValue;
+    this._model.defaultCell = this._notebookConfig.defaultCell;
 
     if (oldValue && oldValue.modelDB.isCollaborative) {
       void oldValue.modelDB.connected.then(() => {
@@ -599,7 +600,9 @@ export class StaticNotebook extends Widget {
       'jp-mod-scrollPastEnd',
       this._notebookConfig.scrollPastEnd
     );
-    this._model.defaultCell = this._notebookConfig.defaultCell;
+    if (this._model) {
+      this._model.defaultCell = this._notebookConfig.defaultCell;
+    }
   }
 
   private _editorConfig = StaticNotebook.defaultEditorConfig;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -599,6 +599,7 @@ export class StaticNotebook extends Widget {
       'jp-mod-scrollPastEnd',
       this._notebookConfig.scrollPastEnd
     );
+    this._model.defaultCell = this._notebookConfig.defaultCell;
   }
 
   private _editorConfig = StaticNotebook.defaultEditorConfig;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -417,7 +417,7 @@ export class StaticNotebook extends Widget {
         each(args.oldValues, value => {
           this._removeCell(args.oldIndex);
         });
-        // Add code cell if there are no cells remaining.
+        // Add default cell if there are no cells remaining.
         if (!sender.length) {
           const model = this.model;
           // Add the cell in a new context to avoid triggering another

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -443,6 +443,9 @@ export class StaticNotebook extends Widget {
         break;
       case 'markdown':
         widget = this._createMarkdownCell(cell as IMarkdownCellModel);
+        if (cell.value.text === '') {
+          (widget as MarkdownCell).rendered = false;
+        }
         break;
       default:
         widget = this._createRawCell(cell as IRawCellModel);

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -730,12 +730,18 @@ export namespace StaticNotebook {
      * Enable scrolling past the last cell
      */
     scrollPastEnd: boolean;
+
+    /**
+     * The default type for new notebook cells.
+     */
+    defaultCell: nbformat.CellType;
   }
   /**
    * Default configuration options for notebooks.
    */
   export const defaultNotebookConfig: INotebookConfig = {
-    scrollPastEnd: true
+    scrollPastEnd: true,
+    defaultCell: 'code'
   };
 
   /**

--- a/tests/test-notebook/src/model.spec.ts
+++ b/tests/test-notebook/src/model.spec.ts
@@ -13,11 +13,7 @@ import { NotebookModel } from '@jupyterlab/notebook';
 
 import { ModelDB } from '@jupyterlab/observables';
 
-import {
-  signalToPromise,
-  NBTestUtils,
-  acceptDialog
-} from '@jupyterlab/testutils';
+import { acceptDialog, NBTestUtils } from '@jupyterlab/testutils';
 
 describe('@jupyterlab/notebook', () => {
   describe('NotebookModel', () => {
@@ -33,12 +29,6 @@ describe('@jupyterlab/notebook', () => {
           'language_info'
         ) as nbformat.ILanguageInfoMetadata;
         expect(lang.name).to.equal('python');
-      });
-
-      it('should add a single code cell by default', () => {
-        const model = new NotebookModel();
-        expect(model.cells.length).to.equal(1);
-        expect(model.cells.get(0)).to.be.an.instanceof(CodeCellModel);
       });
 
       it('should accept an optional factory', () => {
@@ -78,12 +68,6 @@ describe('@jupyterlab/notebook', () => {
     });
 
     describe('#cells', () => {
-      it('should add an empty code cell by default', () => {
-        const model = new NotebookModel();
-        expect(model.cells.length).to.equal(1);
-        expect(model.cells.get(0)).to.be.an.instanceof(CodeCellModel);
-      });
-
       it('should be reset when loading from disk', () => {
         const model = new NotebookModel();
         const cell = model.contentFactory.createCodeCell({});
@@ -100,7 +84,7 @@ describe('@jupyterlab/notebook', () => {
         model.cells.push(cell);
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         model.cells.undo();
-        expect(model.cells.length).to.equal(2);
+        expect(model.cells.length).to.equal(1);
         expect(model.cells.get(1).value.text).to.equal('foo');
         expect(model.cells.get(1)).to.equal(cell); // should be ===.
       });
@@ -148,17 +132,6 @@ describe('@jupyterlab/notebook', () => {
           const cell = model.contentFactory.createCodeCell({});
           model.cells.push(cell);
           expect(model.dirty).to.equal(true);
-        });
-
-        it('should add a new code cell when cells are cleared', async () => {
-          const model = new NotebookModel();
-          let promise = signalToPromise(model.cells.changed);
-          model.cells.clear();
-          await promise;
-          expect(model.cells.length).to.equal(0);
-          await signalToPromise(model.cells.changed);
-          expect(model.cells.length).to.equal(1);
-          expect(model.cells.get(0)).to.be.an.instanceof(CodeCellModel);
         });
       });
 
@@ -390,6 +363,23 @@ describe('@jupyterlab/notebook', () => {
           expect(factory.codeCellContentFactory).to.equal(
             codeCellContentFactory
           );
+        });
+      });
+
+      context('#createCell()', () => {
+        it('should create a new code cell', () => {
+          const cell = factory.createCell('code', {});
+          expect(cell.type).to.equal('code');
+        });
+
+        it('should create a new code cell', () => {
+          const cell = factory.createCell('markdown', {});
+          expect(cell.type).to.equal('markdown');
+        });
+
+        it('should create a new code cell', () => {
+          const cell = factory.createCell('raw', {});
+          expect(cell.type).to.equal('raw');
         });
       });
 

--- a/tests/test-notebook/src/model.spec.ts
+++ b/tests/test-notebook/src/model.spec.ts
@@ -85,8 +85,8 @@ describe('@jupyterlab/notebook', () => {
         model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         model.cells.undo();
         expect(model.cells.length).to.equal(1);
-        expect(model.cells.get(1).value.text).to.equal('foo');
-        expect(model.cells.get(1)).to.equal(cell); // should be ===.
+        expect(model.cells.get(0).value.text).to.equal('foo');
+        expect(model.cells.get(0)).to.equal(cell); // should be ===.
       });
 
       context('cells `changed` signal', () => {

--- a/tests/test-notebook/src/modelfactory.spec.ts
+++ b/tests/test-notebook/src/modelfactory.spec.ts
@@ -93,13 +93,6 @@ describe('@jupyterlab/notebook', () => {
         expect(model).to.be.an.instanceof(NotebookModel);
       });
 
-      it('should add an empty code cell by default', () => {
-        const factory = new NotebookModelFactory({});
-        const model = factory.createNew();
-        expect(model.cells.length).to.equal(1);
-        expect(model.cells.get(0).type).to.equal('code');
-      });
-
       it('should accept a language preference', () => {
         const factory = new NotebookModelFactory({});
         const model = factory.createNew('foo');

--- a/tests/test-notebook/src/widget.spec.ts
+++ b/tests/test-notebook/src/widget.spec.ts
@@ -321,6 +321,19 @@ describe('@jupyter/notebook', () => {
           expect(child.hasClass('jp-Notebook-cell')).to.equal(true);
         });
 
+        it('should initially render markdown cells with content', () => {
+          const cell1 = widget.model.contentFactory.createMarkdownCell({});
+          const cell2 = widget.model.contentFactory.createMarkdownCell({});
+          cell1.value.text = '# Hello';
+          widget.model.cells.push(cell1);
+          widget.model.cells.push(cell2);
+          expect(widget.widgets.length).to.equal(8);
+          const child1 = widget.widgets[6] as MarkdownCell;
+          const child2 = widget.widgets[7] as MarkdownCell;
+          expect(child1.rendered).to.equal(true);
+          expect(child2.rendered).to.equal(false);
+        });
+
         it('should handle a move', () => {
           const child = widget.widgets[1];
           widget.model.cells.move(1, 2);
@@ -686,6 +699,7 @@ describe('@jupyter/notebook', () => {
         Widget.attach(widget, document.body);
         MessageLoop.sendMessage(widget, Widget.Msg.ActivateRequest);
         const cell = widget.model.contentFactory.createMarkdownCell({});
+        cell.value.text = '# Hello'; // Should be rendered with content.
         widget.model.cells.push(cell);
         const child = widget.widgets[widget.widgets.length - 1] as MarkdownCell;
         expect(child.rendered).to.equal(true);
@@ -1143,6 +1157,7 @@ describe('@jupyter/notebook', () => {
 
         it('should preserve "command" mode if in a markdown cell', () => {
           const cell = widget.model.contentFactory.createMarkdownCell({});
+          cell.value.text = '# Hello'; // Should be rendered with content.
           widget.model.cells.push(cell);
           const count = widget.widgets.length;
           const child = widget.widgets[count - 1] as MarkdownCell;
@@ -1194,6 +1209,7 @@ describe('@jupyter/notebook', () => {
         it('should leave a markdown cell rendered', () => {
           const code = widget.model.contentFactory.createCodeCell({});
           const md = widget.model.contentFactory.createMarkdownCell({});
+          md.value.text = '# Hello'; // Should be rendered with content.
           widget.model.cells.push(code);
           widget.model.cells.push(md);
           const count = widget.widgets.length;
@@ -1252,6 +1268,7 @@ describe('@jupyter/notebook', () => {
       context('dblclick', () => {
         it('should unrender a markdown cell', () => {
           const cell = widget.model.contentFactory.createMarkdownCell({});
+          cell.value.text = '# Hello'; // Should be rendered with content.
           widget.model.cells.push(cell);
           const child = widget.widgets[
             widget.widgets.length - 1


### PR DESCRIPTION
I'm not sure whether folks will like this idea, but I wanted to experiment with it and open this for discussion. It's motivated by some of the work done by @acrule, as well as my personal experience. Many (most?) notebooks have little to no explanatory text in the form of markdown cells, which fails to use one of the primary selling points of the notebook platform: literate programming.

The idea here is to allow users to select a different default cell type for notebooks. If every new cell we see is a markdown cell, maybe that will encourage us all to write more narrative documentation for our notebooks. For people who don't want this feature, there should be no changes.

If folks like the feature, I can wrap this up with some tests, but I thought I'd let people take a look now for some feedback.

## References

#5839 
https://blog.jupyter.org/we-analyzed-1-million-jupyter-notebooks-now-you-can-too-guest-post-8116a964b536
![](https://cdn-images-1.medium.com/max/1600/1*0O1x_D0FTRUwX-6qdo1whA.png)
## Code changes

Some internal restructuring of notebook widget and model logic.
In particular, I've made the notebook model no longer responsible for adding a new cell when it is empty. This is now the responsibility of the notebook widget (which holds the default cell type), and the model is perfectly happy to have no cells.

## User-facing changes

A new option for default cell types.

## Backwards-incompatible changes

Notebook content factories are expected to have a `createCell` function that delegates to the more specific versions (`createCodeCell`, `createMarkdownCell`, `createRawCell`).
People using the `NotebookModel` without a `Notebook` widget will find that it no longer adds a new cell when empty.