### PR TITLE
Add geojson support to json-extension

### DIFF
--- a/packages/json-extension/src/index.tsx
+++ b/packages/json-extension/src/index.tsx
@@ -86,7 +86,7 @@ const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
     documentWidgetFactoryOptions: {
       name: 'JSON',
       primaryFileType: 'json',
-      fileTypes: ['json', 'notebook'],
+      fileTypes: ['json', 'notebook', 'geojson'],
       defaultFor: ['json']
     }
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/451#issuecomment-491402703

## Code changes

Add `geojson` filetype to json-extension

## User-facing changes

Allow users to open `.geojson` files with json-extension.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
