### PR TITLE
Remove extraneous 'Find and Replace...' item from the edit menu and codemirror

### DIFF
--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -42,8 +42,6 @@ namespace CommandIDs {
 
   export const find = 'codemirror:find';
 
-  export const findAndReplace = 'codemirror:find-and-replace';
-
   export const goToLine = 'codemirror:go-to-line';
 }
 
@@ -284,19 +282,6 @@ function activateEditorCommands(
     isEnabled
   });
 
-  commands.addCommand(CommandIDs.findAndReplace, {
-    label: 'Find and Replace...',
-    execute: () => {
-      let widget = tracker.currentWidget;
-      if (!widget) {
-        return;
-      }
-      let editor = widget.content.editor as CodeMirrorEditor;
-      editor.execCommand('replace');
-    },
-    isEnabled
-  });
-
   commands.addCommand(CommandIDs.goToLine, {
     label: 'Go to Line...',
     execute: () => {
@@ -394,15 +379,6 @@ function activateEditorCommands(
 
     // Add the syntax highlighting submenu to the `View` menu.
     mainMenu.viewMenu.addGroup([{ type: 'submenu', submenu: modeMenu }], 40);
-
-    // Add find-replace capabilities to the edit menu.
-    mainMenu.editMenu.findReplacers.add({
-      tracker,
-      findAndReplace: (widget: IDocumentWidget<FileEditor>) => {
-        let editor = widget.content.editor as CodeMirrorEditor;
-        editor.execCommand('replace');
-      }
-    } as IEditMenu.IFindReplacer<IDocumentWidget<FileEditor>>);
 
     // Add go to line capabilities to the edit menu.
     mainMenu.editMenu.goToLiners.add({

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -51,8 +51,6 @@ export namespace CommandIDs {
 
   export const find = 'editmenu:find';
 
-  export const findAndReplace = 'editmenu:find-and-replace';
-
   export const goToLine = 'editmenu:go-to-line';
 
   export const openFile = 'filemenu:open';
@@ -280,20 +278,6 @@ export function createEditMenu(app: JupyterFrontEnd, menu: EditMenu): void {
     10
   );
 
-  // Add the find-replace command to the Edit menu.
-  commands.addCommand(CommandIDs.findAndReplace, {
-    label: 'Find and Replace…',
-    isEnabled: Private.delegateEnabled(
-      app,
-      menu.findReplacers,
-      'findAndReplace'
-    ),
-    execute: Private.delegateExecute(app, menu.findReplacers, 'findAndReplace')
-  });
-  menu.addGroup(
-    [{ command: CommandIDs.find }, { command: CommandIDs.findAndReplace }],
-    200
-  );
   commands.addCommand(CommandIDs.goToLine, {
     label: 'Go to Line…',
     isEnabled: Private.delegateEnabled(app, menu.goToLiners, 'goToLine'),

--- a/packages/mainmenu/src/edit.ts
+++ b/packages/mainmenu/src/edit.ts
@@ -20,11 +20,6 @@ export interface IEditMenu extends IJupyterLabMenu {
   readonly clearers: Set<IEditMenu.IClearer<Widget>>;
 
   /**
-   * A set storing IFindReplacers for the Edit menu.
-   */
-  readonly findReplacers: Set<IEditMenu.IFindReplacer<Widget>>;
-
-  /**
    * A set storing IGoToLiners for the Edit menu.
    */
   readonly goToLiners: Set<IEditMenu.IGoToLiner<Widget>>;
@@ -45,8 +40,6 @@ export class EditMenu extends JupyterLabMenu implements IEditMenu {
 
     this.clearers = new Set<IEditMenu.IClearer<Widget>>();
 
-    this.findReplacers = new Set<IEditMenu.IFindReplacer<Widget>>();
-
     this.goToLiners = new Set<IEditMenu.IGoToLiner<Widget>>();
   }
 
@@ -61,11 +54,6 @@ export class EditMenu extends JupyterLabMenu implements IEditMenu {
   readonly clearers: Set<IEditMenu.IClearer<Widget>>;
 
   /**
-   * A set storing IFindReplacers for the Edit menu.
-   */
-  readonly findReplacers: Set<IEditMenu.IFindReplacer<Widget>>;
-
-  /**
    * A set storing IGoToLiners for the Edit menu.
    */
   readonly goToLiners: Set<IEditMenu.IGoToLiner<Widget>>;
@@ -76,7 +64,6 @@ export class EditMenu extends JupyterLabMenu implements IEditMenu {
   dispose(): void {
     this.undoers.clear();
     this.clearers.clear();
-    this.findReplacers.clear();
     super.dispose();
   }
 }
@@ -123,16 +110,6 @@ export namespace IEditMenu {
      * A function to clear all of an activity.
      */
     clearAll?: (widget: T) => void;
-  }
-
-  /**
-   * Interface for an activity that uses Find/Find+Replace.
-   */
-  export interface IFindReplacer<T extends Widget> extends IMenuExtender<T> {
-    /**
-     * Execute a find/replace command for the activity.
-     */
-    findAndReplace?: (widget: T) => void;
   }
 
   /**

--- a/tests/test-mainmenu/src/edit.spec.ts
+++ b/tests/test-mainmenu/src/edit.spec.ts
@@ -90,20 +90,5 @@ describe('@jupyterlab/mainmenu', () => {
         expect(wodget.state).to.equal('clearAll');
       });
     });
-
-    describe('#findReplacers', () => {
-      it('should allow setting of an IFindReplacer', () => {
-        const finder: IEditMenu.IFindReplacer<Wodget> = {
-          tracker,
-          findAndReplace: widget => {
-            widget.state = 'findAndReplace';
-            return;
-          }
-        };
-        menu.findReplacers.add(finder);
-        void delegateExecute(wodget, menu.findReplacers, 'findAndReplace');
-        expect(wodget.state).to.equal('findAndReplace');
-      });
-    });
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6322 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This removes the `IFindReplacer` interface and all `findReplacers` logic from the Edit menu.  It also removes the Find and Replace command added by the CodeMirror extension.  These are being removed in favor of the new interfaces provided by the documentsearch package.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Removes the `Find and Replace` item from the edit menu in favor of the `Find` option which provides replace functionality as well.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
This removes the `findReplacers` property from the `editMenu`.  Extensions that would like to add Find or Find and Replace functionality should use the documentsearch package instead.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
