### PR TITLE
Skip collapsed cells when selecting

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -644,6 +644,7 @@ export namespace NotebookActions {
    * #### Notes
    * The widget mode will be preserved.
    * This is a no-op if the first cell is the active cell.
+   * This will skip any collapsed cells.
    * The existing selection will be cleared.
    */
   export function selectAbove(notebook: Notebook): void {
@@ -654,9 +655,22 @@ export namespace NotebookActions {
       return;
     }
 
+    let possibleNextCell = notebook.activeCellIndex - 1;
+
+    // find first non hidden cell above current cell
+    if (notebook.mode === 'edit') {
+      while (notebook.widgets[possibleNextCell].inputHidden) {
+        // If we are at the top cell, we cannot change selection.
+        if (possibleNextCell === 0) {
+          return;
+        }
+        possibleNextCell -= 1;
+      }
+    }
+
     const state = Private.getState(notebook);
 
-    notebook.activeCellIndex -= 1;
+    notebook.activeCellIndex = possibleNextCell;
     notebook.deselectAll();
     Private.handleState(notebook, state, true);
   }
@@ -669,19 +683,34 @@ export namespace NotebookActions {
    * #### Notes
    * The widget mode will be preserved.
    * This is a no-op if the last cell is the active cell.
+   * This will skip any collapsed cells.
    * The existing selection will be cleared.
    */
   export function selectBelow(notebook: Notebook): void {
     if (!notebook.model || !notebook.activeCell) {
       return;
     }
-    if (notebook.activeCellIndex === notebook.widgets.length - 1) {
+    const maxCellIndex = notebook.widgets.length - 1;
+    if (notebook.activeCellIndex === maxCellIndex) {
       return;
+    }
+
+    let possibleNextCell = notebook.activeCellIndex + 1;
+
+    // find first non hidden cell below current cell
+    if (notebook.mode === 'edit') {
+      while (notebook.widgets[possibleNextCell].inputHidden) {
+        // If we are at the bottom cell, we cannot change selection.
+        if (possibleNextCell === maxCellIndex) {
+          return;
+        }
+        possibleNextCell += 1;
+      }
     }
 
     const state = Private.getState(notebook);
 
-    notebook.activeCellIndex += 1;
+    notebook.activeCellIndex = possibleNextCell;
     notebook.deselectAll();
     Private.handleState(notebook, state, true);
   }

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -797,7 +797,7 @@ describe('@jupyterlab/notebook', () => {
       }).timeout(60000); // Allow for slower CI
     });
 
-    describe('#selectAbove(`)', () => {
+    describe('#selectAbove()', () => {
       it('should select the cell above the active cell', () => {
         widget.activeCellIndex = 1;
         NotebookActions.selectAbove(widget);
@@ -887,25 +887,25 @@ describe('@jupyterlab/notebook', () => {
         widget.widgets[2].inputHidden = true;
         widget.widgets[3].inputHidden = false;
         NotebookActions.selectBelow(widget);
-        expect(widget.activeCellIndex).to.equal(4);
+        expect(widget.activeCellIndex).to.equal(3);
       });
 
       it('should not change if in edit mode and no non-collapsed cells below', () => {
-        widget.activeCellIndex = 0;
-        widget.mode = 'edit';
-        widget.widgets[1].inputHidden = true;
-        widget.widgets[2].inputHidden = true;
-        widget.widgets[3].inputHidden = false;
-        NotebookActions.selectBelow(widget);
-        expect(widget.activeCellIndex).to.equal(4);
-      });
-
-      it('should not skip collapsed cells and in command mode', () => {
         widget.activeCellIndex = widget.widgets.length - 2;
         widget.mode = 'edit';
         widget.widgets[widget.widgets.length - 1].inputHidden = true;
         NotebookActions.selectBelow(widget);
         expect(widget.activeCellIndex).to.equal(widget.widgets.length - 2);
+      });
+
+      it('should not skip collapsed cells and in command mode', () => {
+        widget.activeCellIndex = 0;
+        widget.mode = 'command';
+        widget.widgets[1].inputHidden = true;
+        widget.widgets[2].inputHidden = true;
+        widget.widgets[3].inputHidden = false;
+        NotebookActions.selectBelow(widget);
+        expect(widget.activeCellIndex).to.equal(1);
       });
     });
 

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -834,6 +834,14 @@ describe('@jupyterlab/notebook', () => {
         expect(widget.activeCellIndex).to.equal(0);
       });
 
+      it('should not change if in edit mode and no non-collapsed cells above', () => {
+        widget.activeCellIndex = 1;
+        widget.mode = 'edit';
+        widget.widgets[0].inputHidden = true;
+        NotebookActions.selectAbove(widget);
+        expect(widget.activeCellIndex).to.equal(1);
+      });
+
       it('should not skip collapsed cells and in command mode', () => {
         widget.activeCellIndex = 3;
         widget.mode = 'command';
@@ -882,12 +890,22 @@ describe('@jupyterlab/notebook', () => {
         expect(widget.activeCellIndex).to.equal(4);
       });
 
-      it('should not skip collapsed cells and in command mode', () => {
+      it('should not change if in edit mode and no non-collapsed cells below', () => {
         widget.activeCellIndex = 0;
-        widget.mode = 'command';
+        widget.mode = 'edit';
         widget.widgets[1].inputHidden = true;
+        widget.widgets[2].inputHidden = true;
+        widget.widgets[3].inputHidden = false;
         NotebookActions.selectBelow(widget);
-        expect(widget.activeCellIndex).to.equal(1);
+        expect(widget.activeCellIndex).to.equal(4);
+      });
+
+      it('should not skip collapsed cells and in command mode', () => {
+        widget.activeCellIndex = widget.widgets.length - 2;
+        widget.mode = 'edit';
+        widget.widgets[widget.widgets.length - 1].inputHidden = true;
+        NotebookActions.selectBelow(widget);
+        expect(widget.activeCellIndex).to.equal(widget.widgets.length - 2);
       });
     });
 

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -823,6 +823,26 @@ describe('@jupyterlab/notebook', () => {
         NotebookActions.selectAbove(widget);
         expect(widget.mode).to.equal('edit');
       });
+
+      it('should skip collapsed cells in edit mode', () => {
+        widget.activeCellIndex = 3;
+        widget.mode = 'edit';
+        widget.widgets[1].inputHidden = true;
+        widget.widgets[2].inputHidden = true;
+        widget.widgets[3].inputHidden = false;
+        NotebookActions.selectAbove(widget);
+        expect(widget.activeCellIndex).to.equal(0);
+      });
+
+      it('should not skip collapsed cells and in command mode', () => {
+        widget.activeCellIndex = 3;
+        widget.mode = 'command';
+        widget.widgets[1].inputHidden = true;
+        widget.widgets[2].inputHidden = true;
+        widget.widgets[3].inputHidden = false;
+        NotebookActions.selectAbove(widget);
+        expect(widget.activeCellIndex).to.equal(2);
+      });
     });
 
     describe('#selectBelow()', () => {
@@ -850,6 +870,24 @@ describe('@jupyterlab/notebook', () => {
         widget.mode = 'edit';
         NotebookActions.selectBelow(widget);
         expect(widget.mode).to.equal('edit');
+      });
+
+      it('should skip collapsed cells in edit mode', () => {
+        widget.activeCellIndex = 0;
+        widget.mode = 'edit';
+        widget.widgets[1].inputHidden = true;
+        widget.widgets[2].inputHidden = true;
+        widget.widgets[3].inputHidden = false;
+        NotebookActions.selectBelow(widget);
+        expect(widget.activeCellIndex).to.equal(4);
+      });
+
+      it('should not skip collapsed cells and in command mode', () => {
+        widget.activeCellIndex = 0;
+        widget.mode = 'command';
+        widget.widgets[1].inputHidden = true;
+        NotebookActions.selectBelow(widget);
+        expect(widget.activeCellIndex).to.equal(1);
       });
     });
 


### PR DESCRIPTION

- [x] Add test when there is no non-collapsed cell that selection stays the same
- [x] Change behavior to skip collapsed cells


## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/3233
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update `NotebookActions.selectBelow` and `NotebookActions.selectAbove` to skip over collapsed cells.


## User-facing changes

When the user is in edit mode, and the select a cell above or below, the selection changes to first non collapsed cell. 

## Backwards-incompatible changes

None.