### PR TITLE
Make codemirror use contenteditable mode everywhere

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1293,6 +1293,7 @@ namespace Private {
       indentUnit: tabSize,
       indentWithTabs: !insertSpaces,
       lineWrapping: lineWrap === 'off' ? false : true,
+      inputStyle: 'contenteditable',
       readOnly,
       ...otherOptions
     };


### PR DESCRIPTION
This makes accessibility for screen readers
and other accessibility devices better than
it is now. It still isn't fully functional or
usable, but much better than what it is now.

From http://www.w4a.info/2019/hackathon/