### PR TITLE
Delete session from Set on terminated

### DIFF
--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -291,6 +291,12 @@ export class TerminalManager implements TerminalSession.IManager {
       this._models.splice(index, 1);
       this._runningChanged.emit(this._models.slice());
     }
+    const sessions = this._sessions;
+    sessions.forEach(session => {
+      if (session.name === name) {
+        sessions.delete(session);
+      }
+    });
   }
 
   private _isDisposed = false;


### PR DESCRIPTION
## References

Fix #6363 

## Code changes

Delete session from `TerminalManager` sessions `Set` in `_onTerminated`.

## User-facing changes

None

## Backwards-incompatible changes

None
