### PR TITLE
Clean up handling of launch assets

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -273,8 +273,7 @@ site-specific directory prefix of the current Python environment. You
 can query the current application path by running ``jupyter lab path``.
 Note that the application directory is expected to contain the JupyterLab
 static assets (e.g. `static/index.html`).  If JupyterLab is launched
-and the static assets are not present, it will attempt to build if
-`node` is available, or raise an error during startup.
+and the static assets are not present, it will display an error in the console and in the browser.
 
 JupyterLab Build Process
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -271,6 +271,10 @@ environment variable. If not specified, it will default to
 ``<sys-prefix>/share/jupyter/lab``, where ``<sys-prefix>`` is the
 site-specific directory prefix of the current Python environment. You
 can query the current application path by running ``jupyter lab path``.
+Note that the application directory is expected to contain the JupyterLab
+static assets (e.g. `static/index.html`).  If JupyterLab is launched
+and the static assets are not present, it will attempt to build if
+`node` is available, or raise an error during startup.
 
 JupyterLab Build Process
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -149,7 +149,8 @@ def ensure_core(logger=None):
 
     # Determine whether to build.
     target = pjoin(HERE, 'static', 'index.html')
-    if ensure_node_modules(staging, logger) or not osp.exists(target):
+    if not osp.exists(target):
+        ensure_node_modules(staging, logger)
         yarn_proc = Process(['node', YARN_PATH, 'build'], cwd=staging,
                             logger=logger)
         yarn_proc.wait()

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -156,19 +156,17 @@ def ensure_core(logger=None):
         yarn_proc.wait()
 
 
-def ensure_app(app_dir, logger=None):
+def ensure_app(app_dir):
     """Ensure that an application directory is available.
+
+    If it does not exist, return a list of messages to prompt the user.
     """
-    logger = _ensure_logger(logger)
     if osp.exists(pjoin(app_dir, 'static', 'index.html')):
         return
 
-    if which('node'):
-        logger.info('Assets not found, building application')
-        build(self.app_dir)
-    else:
-        msg = 'JupyterLab application assets not found in %s'
-        raise RuntimeError(msg % self.app_dir)
+    msgs = ['JupyterLab application assets not found in "%s"' % app_dir,
+            'Please run `jupyter lab build` or use a different app directory']
+    return msgs
 
 
 def watch_packages(logger=None):

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -87,7 +87,8 @@ def load_jupyter_server_extension(nbapp):
         extensions_handler_path, ExtensionManager, ExtensionHandler
     )
     from .commands import (
-        DEV_DIR, HERE, ensure_core, ensure_dev, watch, watch_dev, get_app_dir
+        DEV_DIR, HERE, ensure_app, ensure_core, ensure_dev, watch,
+        watch_dev, get_app_dir
     )
 
     web_app = nbapp.web_app
@@ -157,18 +158,22 @@ def load_jupyter_server_extension(nbapp):
         nbapp.default_url = uri
         nbapp.file_to_run = ''
 
+    # Print messages.
+    logger.info('JupyterLab extension loaded from %s' % HERE)
+    logger.info('JupyterLab application directory is %s' % app_dir)
+
     if core_mode:
         logger.info(CORE_NOTE.strip())
         ensure_core(logger)
 
     elif dev_mode:
-        ensure_dev(logger)
         if not watch_mode:
+            ensure_dev(logger)
             logger.info(DEV_NOTE)
 
-    # Print messages.
-    logger.info('JupyterLab extension loaded from %s' % HERE)
-    logger.info('JupyterLab application directory is %s' % app_dir)
+    # Make sure the app dir exists.
+    else:
+        ensure_app(app_dir, logger=logger)
 
     if watch_mode:
         logger.info('Starting JupyterLab watch mode...')

--- a/jupyterlab/handlers/build_handler.py
+++ b/jupyterlab/handlers/build_handler.py
@@ -10,7 +10,7 @@ from notebook.base.handlers import APIHandler
 from tornado import gen, web
 from tornado.concurrent import run_on_executor
 
-from .commands import build, clean, build_check
+from ..commands import build, clean, build_check
 
 
 class Builder(object):

--- a/jupyterlab/handlers/error_handler.py
+++ b/jupyterlab/handlers/error_handler.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+"""An error handler for JupyterLab."""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from tornado import web
+from jupyterlab_server.server import JupyterHandler
+
+
+TEMPLATE = """
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>JupyterLab Error</title>
+</head>
+<body>
+<h1>JupyterLab Error<h1>
+%s
+</body>
+"""
+
+class ErrorHandler(JupyterHandler):
+
+    def initialize(self, messages):
+        self.messages = messages
+
+    @web.authenticated
+    @web.removeslash
+    def get(self):
+        msgs = ['<h2>%s</h2>' % msg for msg in self.messages]
+        self.write(TEMPLATE % '\n'.join(msgs))

--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 from notebook.base.handlers import APIHandler
 from tornado import gen, web
 
-from .commands import (
+from ..commands import (
     get_app_info, install_extension, uninstall_extension,
     enable_extension, disable_extension, read_package,
     _AppHandler, get_latest_compatible_package_versions

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -6,6 +6,8 @@
 
 import json
 import os
+import os.path as osp
+from os.path import join as pjoin
 import sys
 
 from jupyter_core.application import JupyterApp, base_aliases
@@ -140,9 +142,9 @@ class LabWorkspaceExportApp(JupyterApp):
         raw = (page_url if not self.extra_args
                else ujoin(config.workspaces_url, self.extra_args[0]))
         slug = slugify(raw, base_url)
-        workspace_path = os.path.join(directory, slug + WORKSPACE_EXTENSION)
+        workspace_path = pjoin(directory, slug + WORKSPACE_EXTENSION)
 
-        if os.path.exists(workspace_path):
+        if osp.exists(workspace_path):
             with open(workspace_path) as fid:
                 try:  # to load the workspace file.
                     print(fid.read())
@@ -195,7 +197,7 @@ class LabWorkspaceImportApp(JupyterApp):
                 print('%s is not a valid workspace:\n%s' % (fid.name, e))
                 sys.exit(1)
 
-        if not os.path.exists(directory):
+        if not osp.exists(directory):
             try:
                 os.makedirs(directory)
             except Exception as e:
@@ -203,7 +205,7 @@ class LabWorkspaceImportApp(JupyterApp):
                 sys.exit(1)
 
         slug = slugify(workspace['metadata']['id'], base_url)
-        workspace_path = os.path.join(directory, slug + WORKSPACE_EXTENSION)
+        workspace_path = pjoin(directory, slug + WORKSPACE_EXTENSION)
 
         # Write the workspace data to a file.
         with open(workspace_path, 'w') as fid:
@@ -217,12 +219,12 @@ class LabWorkspaceImportApp(JupyterApp):
         if file_name == '-':
             return sys.stdin
         else:
-            file_path = os.path.abspath(file_name)
+            file_path = osp.abspath(file_name)
 
-            if not os.path.exists(file_path):
+            if not osp.exists(file_path):
                 print('%s does not exist.' % file_name)
                 sys.exit(1)
-            
+
             return open(file_path)
 
     def _validate(self, data, base_url, page_url, workspaces_url):


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #5881 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Clean up of the server extension startup to check for the static assets and show a proper error to the user.   Also cleans up handling of core and dev modes to better detect when to auto-build.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Better documentation around `JUPYTERLAB_DIR` and better handling of an empty application directory with browser and console errors.

![image](https://user-images.githubusercontent.com/2096628/57980984-ba3db500-79f7-11e9-977f-1635aea1f302.png)

![image](https://user-images.githubusercontent.com/2096628/57981019-13a5e400-79f8-11e9-8e32-46dd3b7be888.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
