### PR TITLE
Add missing "Merge Selected Cells" item to context menu

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -782,26 +782,31 @@ function activateNotebookHandler(
     rank: 7
   });
   app.contextMenu.addItem({
-    type: 'separator',
+    command: CommandIDs.merge,
     selector: '.jp-Notebook .jp-Cell',
     rank: 8
+  });
+  app.contextMenu.addItem({
+    type: 'separator',
+    selector: '.jp-Notebook .jp-Cell',
+    rank: 9
   });
 
   // CodeCell context menu groups
   app.contextMenu.addItem({
     command: CommandIDs.createOutputView,
     selector: '.jp-Notebook .jp-CodeCell',
-    rank: 9
+    rank: 10
   });
   app.contextMenu.addItem({
     type: 'separator',
     selector: '.jp-Notebook .jp-CodeCell',
-    rank: 10
+    rank: 11
   });
   app.contextMenu.addItem({
     command: CommandIDs.clearOutputs,
     selector: '.jp-Notebook .jp-CodeCell',
-    rank: 11
+    rank: 12
   });
 
   // Notebook context menu groups


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #6318 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Adds missing "Merge Selected Cells" option to context menu in `packages/notebook-extension`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
Before:
<img width="391" alt="Before" src="https://user-images.githubusercontent.com/15837247/57987293-bbb2c000-7a7f-11e9-911f-26eb577629a8.png">

After:
<img width="391" alt="After" src="https://user-images.githubusercontent.com/15837247/57987297-c8cfaf00-7a7f-11e9-8fd3-e767cd98185a.png">

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None