### PR TITLE
fix duplicate inspect message when typing

### DIFF
--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -72,8 +72,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
       // the active cell
       this.onEditorChange();
       let signals: ISignal<any, any>[] = [
-        editor.model.selections.changed,
-        editor.model.value.changed
+        editor.model.selections.changed
       ];
       this._monitors = signals.map(s => {
         let m = new ActivityMonitor({ signal: s, timeout: 250 });

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -3,7 +3,7 @@
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
-import { IDataConnector, Text, ActivityMonitor } from '@jupyterlab/coreutils';
+import { IDataConnector, Text, Debouncer } from '@jupyterlab/coreutils';
 
 import { MimeModel, IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
@@ -25,6 +25,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
   constructor(options: InspectionHandler.IOptions) {
     this._connector = options.connector;
     this._rendermime = options.rendermime;
+    this._debouncer = new Debouncer(() => this.onEditorChange, 250);
   }
 
   /**
@@ -58,12 +59,9 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
     if (newValue === this._editor) {
       return;
     }
+    // Remove all of our listeners.
+    Signal.disconnectReceiver(this);
 
-    if (this._editor && !this._editor.isDisposed) {
-      this._monitors.forEach(monitor => {
-        monitor.activityStopped.disconnect(this.onEditorChange, this);
-      });
-    }
     let editor = (this._editor = newValue);
     if (editor) {
       // Clear the inspector in preparation for a new editor.
@@ -71,14 +69,8 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
       // Call onEditorChange to cover the case where the user changes
       // the active cell
       this.onEditorChange();
-      let signals: ISignal<any, any>[] = [
-        editor.model.selections.changed
-      ];
-      this._monitors = signals.map(s => {
-        let m = new ActivityMonitor({ signal: s, timeout: 250 });
-        m.activityStopped.connect(this.onEditorChange, this);
-        return m;
-      });
+      editor.model.selections.changed.connect(this._onChange, this);
+      editor.model.value.changed.connect(this._onChange, this);
     }
   }
 
@@ -171,6 +163,13 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
       });
   }
 
+  /**
+   * Handle changes to the editor state, debouncing.
+   */
+  private _onChange(): void {
+    this._debouncer.invoke();
+  }
+
   private _cleared = new Signal<InspectionHandler, void>(this);
   private _connector: IDataConnector<
     InspectionHandler.IReply,
@@ -184,7 +183,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
   private _pending = 0;
   private _rendermime: IRenderMimeRegistry;
   private _standby = true;
-  private _monitors: ActivityMonitor<any, any>[];
+  private _debouncer: Debouncer;
 }
 
 /**

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -25,7 +25,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
   constructor(options: InspectionHandler.IOptions) {
     this._connector = options.connector;
     this._rendermime = options.rendermime;
-    this._debouncer = new Debouncer(() => this.onEditorChange, 250);
+    this._debouncer = new Debouncer(this.onEditorChange.bind(this), 250);
   }
 
   /**


### PR DESCRIPTION
## References
The pull request https://github.com/jupyterlab/jupyterlab/pull/5906 triggers the cursor movement to send inspect message, which is pretty helpful. But I found that when you are typing, the same inspect message is sent twice.
Because in https://github.com/jupyterlab/jupyterlab/blob/594076f2e79a91758caa91ed3a69c216ecece422/packages/inspector/src/handler.ts#L74-L82 both `editor.model.selections.changed` and `editor.model.value.changed` could trigger a inspect message.
And when a user enters a new character to the cell, both signals are sent, which means two identical inspect messages are sent.

## Screenshot of websocket
When I enter a letter
![When I enter a letter](https://user-images.githubusercontent.com/10969537/58111500-d9079b80-7bf1-11e9-88eb-0674ca6e6858.png)

When I move the cursor
![When I move the cursor](https://user-images.githubusercontent.com/10969537/58111567-ff2d3b80-7bf1-11e9-99b2-f1489238cfbc.png)



## Code changes

removed  `editor.model.value.changed`, since it introduces a duplicate inspect message when typing.

