### PR TITLE
Fix scrolling down running sessions

### DIFF
--- a/packages/running/style/index.css
+++ b/packages/running/style/index.css
@@ -59,6 +59,7 @@
   display: flex;
   flex: 0 1 auto;
   flex-direction: column;
+  overflow: auto;
 }
 
 .jp-RunningSessions-sectionHeader {


### PR DESCRIPTION
## References

This fixes #6371

## Code changes

Added `overflow:auto` to the `jp-RunningSessions-section` class as suggested by @jasongrout 

## User-facing changes

Before
![image](https://user-images.githubusercontent.com/1191767/57922833-3be7f280-78d3-11e9-8dd1-46040c50cab6.png)

After

![image](https://user-images.githubusercontent.com/1191767/58151777-3f95c380-7c9d-11e9-9a77-daefb1de2238.png)


## Backwards-incompatible changes

None