### PR TITLE
Add smart copy/paste in terminal and update docs

### DIFF
--- a/docs/source/user/terminal.rst
+++ b/docs/source/user/terminal.rst
@@ -47,20 +47,19 @@ re-open it using the Running tab in the left sidebar:
 Copy/Paste
 ~~~~~~~~~~~~
 
-For both Windows and Mac users, press ``shift`` + ``right-click`` to get to the right-click menu from inside Jupyterlab terminal. Or by using shortcut keys as follows:
+For all platforms, JupyterLab will interpret ``Ctrl+C`` as a copy if there is text selected.
+In addition, ``Ctrl+V`` will be interpreted as a paste command unless the ``pasteWithCtrlV``
+setting is disabled.  One may want to disable ``pasteWithCtrlV`` if the shortcut is needed
+for something else such as the vi editor.
 
-* **For Mac users:**
+To use the native browser Copy/Paste menu, hold ``Shift`` and right click to bring up the
+context menu.
 
-	**Copy** : ``Cmd`` + ``c`` 
+For MacOS users, ``Cmd+C`` and ``Cmd+V`` work as usual.
 
-	**Paste**: ``Cmd`` + ``v``
+For Windows users using ``PowerShell``, ``Ctrl+Insert`` and ``Shift+Insert`` work as usual.
 
-
-* **For Windows users (Power shell):**
-
-	**Copy** : ``Ctrl`` + ``Insert``
-
-	**Paste** : ``Shift`` + ``Insert``
-
-
-
+For anyone using a *nix shell, the default ``Ctrl+Shift+C`` conflicts with the default
+shortcut for toggling the command palette (``apputils:activate-command-palette``).
+If desired, that shortcut can be changed by editing the keyboard shortcuts in setttings.
+Using ``Ctrl+Shift+V`` for paste works as usual.

--- a/docs/source/user/terminal.rst
+++ b/docs/source/user/terminal.rst
@@ -59,7 +59,7 @@ In addition, ``Ctrl+V`` will be interpreted as a paste command unless the ``past
 setting is disabled.  One may want to disable ``pasteWithCtrlV`` if the shortcut is needed
 for something else such as the vi editor.
 
-For anyone using a *nix shell, the default ``Ctrl+Shift+C`` conflicts with the default
+For anyone using a \*nix shell, the default ``Ctrl+Shift+C`` conflicts with the default
 shortcut for toggling the command palette (``apputils:activate-command-palette``).
 If desired, that shortcut can be changed by editing the keyboard shortcuts in setttings.
 Using ``Ctrl+Shift+V`` for paste works as usual.

--- a/docs/source/user/terminal.rst
+++ b/docs/source/user/terminal.rst
@@ -47,17 +47,17 @@ re-open it using the Running tab in the left sidebar:
 Copy/Paste
 ~~~~~~~~~~~~
 
-For all platforms, JupyterLab will interpret ``Ctrl+C`` as a copy if there is text selected.
+For macOS users,  ``Cmd+C`` and ``Cmd+V`` work as usual.
+
+For Windows users using ``PowerShell``, ``Ctrl+Insert`` and ``Shift+Insert`` work as usual.
+
+To use the native browser Copy/Paste menu, hold ``Shift`` and right click to bring up the
+context menu (note: this may not work in all browsers).
+
+For non-macOS users, JupyterLab will interpret ``Ctrl+C`` as a copy if there is text selected.
 In addition, ``Ctrl+V`` will be interpreted as a paste command unless the ``pasteWithCtrlV``
 setting is disabled.  One may want to disable ``pasteWithCtrlV`` if the shortcut is needed
 for something else such as the vi editor.
-
-To use the native browser Copy/Paste menu, hold ``Shift`` and right click to bring up the
-context menu.
-
-For MacOS users, ``Cmd+C`` and ``Cmd+V`` work as usual.
-
-For Windows users using ``PowerShell``, ``Ctrl+Insert`` and ``Shift+Insert`` work as usual.
 
 For anyone using a *nix shell, the default ``Ctrl+Shift+C`` conflicts with the default
 shortcut for toggling the command palette (``apputils:activate-command-palette``).

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -65,7 +65,7 @@
     },
     "pasteWithCtrlV": {
       "title": "Paste with Ctrl+V",
-      "description": "Whether to enable pasting with Ctrl+V.  This can be disabled to use Ctrl+V in the vi editor, for instance",
+      "description": "Whether to enable pasting with Ctrl+V.  This can be disabled to use Ctrl+V in the vi editor, for instance.  This setting has no effect on macOS, where Cmd+V is available",
       "type": "boolean",
       "default": true
     }

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -21,6 +21,9 @@
     },
     "scrollback": {
       "type": "number"
+    },
+    "pasteWithCtrlV": {
+      "type": "boolean"
     }
   },
   "properties": {
@@ -59,6 +62,12 @@
       "description": "Whether to shut down or not the session when closing the terminal.",
       "type": "boolean",
       "default": false
+    },
+    "pasteWithCtrlV": {
+      "title": "Paste with Ctrl+V",
+      "description": "Whether to enable pasting with Ctrl+V.  This can be disabled to use Ctrl+V in the vi editor, for instance",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -34,6 +34,7 @@
     "@jupyterlab/apputils": "^1.0.0-alpha.6",
     "@jupyterlab/services": "^4.0.0-alpha.6",
     "@phosphor/coreutils": "^1.3.0",
+    "@phosphor/domutils": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
     "xterm": "~3.10.1"

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -96,11 +96,16 @@ export namespace ITerminal {
     initialCommand: string;
 
     /**
-     * Wether to enable screen reader support.
+     * Whether to enable screen reader support.
      *
      * Set to false if you run into performance problems from DOM overhead
      */
     screenReaderMode: boolean;
+
+    /**
+     * Whether to enable using Ctrl+V to paste.
+     */
+    pasteWithCtrlV: boolean;
   }
 
   /**
@@ -115,7 +120,8 @@ export namespace ITerminal {
     shutdownOnClose: false,
     cursorBlink: true,
     initialCommand: '',
-    screenReaderMode: true
+    screenReaderMode: true,
+    pasteWithCtrlV: true
   };
 
   /**

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -104,6 +104,8 @@ export namespace ITerminal {
 
     /**
      * Whether to enable using Ctrl+V to paste.
+     *
+     * This setting has no effect on macOS, where Cmd+V is available.
      */
     pasteWithCtrlV: boolean;
   }

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -3,7 +3,7 @@
 
 import { TerminalSession } from '@jupyterlab/services';
 
-import { IS_MAC } from '@phosphor/domutils';
+import { Platform } from '@phosphor/domutils';
 
 import { Message, MessageLoop } from '@phosphor/messaging';
 
@@ -256,7 +256,7 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
 
     // Do not add any Ctrl+C/Ctrl+V handling on macOS,
     // where Cmd+C/Cmd+V works as intended.
-    if (IS_MAC) {
+    if (Platform.IS_MAC) {
       return;
     }
 

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -3,6 +3,8 @@
 
 import { TerminalSession } from '@jupyterlab/services';
 
+import { IS_MAC } from '@phosphor/domutils';
+
 import { Message, MessageLoop } from '@phosphor/messaging';
 
 import { Widget } from '@phosphor/widgets';
@@ -251,6 +253,12 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
     term.on('title', (title: string) => {
       this.title.label = title;
     });
+
+    // Do not add any Ctrl+C/Ctrl+V handling on macOS,
+    // where Cmd+C/Cmd+V works as intended.
+    if (IS_MAC) {
+      return;
+    }
 
     term.attachCustomKeyEventHandler(event => {
       if (

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -261,21 +261,13 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
     }
 
     term.attachCustomKeyEventHandler(event => {
-      if (
-        (event.ctrlKey || event.metaKey) &&
-        event.key === 'c' &&
-        term.hasSelection()
-      ) {
+      if (event.ctrlKey && event.key === 'c' && term.hasSelection()) {
         // Return so that the usual OS copy happens
         // instead of interrupt signal.
         return false;
       }
 
-      if (
-        (event.ctrlKey || event.metaKey) &&
-        event.key === 'v' &&
-        this._options.pasteWithCtrlV
-      ) {
+      if (event.ctrlKey && event.key === 'v' && this._options.pasteWithCtrlV) {
         // Return so that the usual paste happens.
         return false;
       }

--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -237,7 +237,8 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
    * Initialize the terminal object.
    */
   private _initializeTerm(): void {
-    this._term.on('data', (data: string) => {
+    const term = this._term;
+    term.on('data', (data: string) => {
       if (this.isDisposed) {
         return;
       }
@@ -247,8 +248,31 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
       });
     });
 
-    this._term.on('title', (title: string) => {
+    term.on('title', (title: string) => {
       this.title.label = title;
+    });
+
+    term.attachCustomKeyEventHandler(event => {
+      if (
+        (event.ctrlKey || event.metaKey) &&
+        event.key === 'c' &&
+        term.hasSelection()
+      ) {
+        // Return so that the usual OS copy happens
+        // instead of interrupt signal.
+        return false;
+      }
+
+      if (
+        (event.ctrlKey || event.metaKey) &&
+        event.key === 'v' &&
+        this._options.pasteWithCtrlV
+      ) {
+        // Return so that the usual paste happens.
+        return false;
+      }
+
+      return true;
     });
   }
 
@@ -303,7 +327,7 @@ export class Terminal extends Widget implements ITerminal.ITerminal {
     }
   }
 
-  private _term: Xterm;
+  private readonly _term: Xterm;
   private _needsResize = true;
   private _termOpened = false;
   private _offsetWidth = -1;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #1146.
Fixes #6385.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Adds Ctrl+C/Ctrl+V event handler to `xterm` for clients not on macOS, and a setting for whether to enable pasting with Ctrl+V.  Pressing `Ctrl+C` with no selection when using a *nix shell will send SIGINT as usual.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users can use Ctrl+C on non-macOS platforms to copy selected text.  By default, Ctrl+V will paste unless `pasteWithCtrlV` is disabled.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
![image](https://user-images.githubusercontent.com/2096628/58248809-c476f080-7d22-11e9-8ebc-8030c68fba1f.png)

kudos to @williamstein for the idea and the sample code!

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
