### PR TITLE
Add sideEffects fields to package.json files

### DIFF
--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -201,6 +201,17 @@ export async function ensurePackage(
     }
   }
 
+  // Ensure that sideEffects are declared, and that any styles are covered
+  if (styles.length > 0) {
+    if (data.sideEffects === undefined) {
+      messages.push(
+        `Side effects not declared in ${pkgPath}, and styles are present.`
+      );
+    } else if (data.sideEffects === false) {
+      messages.push(`Style files not included in sideEffects in ${pkgPath}`);
+    }
+  }
+
   // Ensure dependencies and dev dependencies.
   data.dependencies = deps;
   data.devDependencies = devDeps;

--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -17,6 +17,9 @@
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -19,6 +19,9 @@
     "lib/*.js.map",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -20,6 +20,9 @@
     "style/images/*.svg",
     "schema/*.json"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": true,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "lib/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -17,6 +17,7 @@
     "lib/*.js.map",
     "lib/*.js"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -17,6 +17,7 @@
     "lib/*.js.map",
     "lib/*.js"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/index.css"
   ],
+  "sideEffects": [
+    "style/index.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -17,6 +17,9 @@
     "schema/*.json",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -16,6 +16,9 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/extensionmanager-extension/package.json
+++ b/packages/extensionmanager-extension/package.json
@@ -19,6 +19,9 @@
     "schema/*.json",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/faq-extension/package.json
+++ b/packages/faq-extension/package.json
@@ -19,6 +19,9 @@
     "style/*.css",
     "faq.md"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -19,6 +19,9 @@
     "schema/*.json",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -21,6 +21,9 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -16,6 +16,9 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/imageviewer-extension/package.json
+++ b/packages/imageviewer-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/inspector-extension/package.json
+++ b/packages/inspector-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/javascript-extension/package.json
+++ b/packages/javascript-extension/package.json
@@ -17,6 +17,9 @@
     "lib/*.js",
     "style/*"
   ],
+  "sideEffects": [
+    "style/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -17,6 +17,9 @@
     "lib/*.js",
     "style/*"
   ],
+  "sideEffects": [
+    "style/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -19,6 +19,9 @@
     "schema/*.json",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -17,6 +17,7 @@
     "lib/*.js.map",
     "lib/*.js"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/mathjax2-extension/package.json
+++ b/packages/mathjax2-extension/package.json
@@ -16,6 +16,9 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -16,6 +16,9 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -17,6 +17,7 @@
     "lib/*.js.map",
     "lib/*.js"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -16,6 +16,9 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/rendermime-extension/package.json
+++ b/packages/rendermime-extension/package.json
@@ -16,6 +16,9 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -17,6 +17,7 @@
     "lib/*.js.map",
     "lib/*.js"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -17,6 +17,7 @@
     "lib/*.js.map",
     "lib/*.js"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -27,6 +27,7 @@
     "dist/*.js",
     "dist/**/*.js"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "browser": {
     "node-fetch": false,

--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -19,6 +19,9 @@
     "schema/*.json",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -19,6 +19,9 @@
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
     "schema/*.json"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -16,6 +16,7 @@
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": true,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/tabmanager-extension/package.json
+++ b/packages/tabmanager-extension/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/theme-dark-extension/package.json
+++ b/packages/theme-dark-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": true,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/theme-light-extension/package.json
+++ b/packages/theme-light-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
   ],
+  "sideEffects": true,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -18,6 +18,7 @@
     "lib/*.js",
     "schema/*.json"
   ],
+  "sideEffects": false,
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/*.css"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -18,6 +18,9 @@
     "lib/*.js",
     "style/*.css"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/vdom-extension/package.json
+++ b/packages/vdom-extension/package.json
@@ -17,6 +17,9 @@
     "lib/*.js",
     "style/*"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/vdom/package.json
+++ b/packages/vdom/package.json
@@ -17,6 +17,9 @@
     "lib/*.js",
     "style/*"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -17,6 +17,9 @@
     "lib/*.js",
     "style/*.*"
   ],
+  "sideEffects": [
+    "style/**/*"
+  ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {


### PR DESCRIPTION
## References

Partially resolves #6392.

## Code changes

Adds the field "sideEffects" to all package.json files in packages/. This should help consumers (including ourselves) to tree-shake a built bundle.

Noteworthy entries:
- Themes have `"sideEffects": true` as we need to ensure that the CSS is available when dynamically loading with `IThemeManager.loadCSS()`.
- The `codemirror` package was also marked as having side effects due to it loading modes, and doing some import time config steps. A more granular setting is likely possible, but it is probably not worth the overhead, so I just set `"sideEffects": true`.
- The `statusbar` package uses typestyle throughout its code, which will put `<style>` elements into the DOM (if the global `document` is defined). For this reason, it is also marked as having side effects.

## User-facing changes

Down the line, this should help contribute to smaller bundles (quicker load times).

## Backwards-incompatible changes

None.