### PR TITLE
Fix file browser model autostart, simplify poll start logic.

### DIFF
--- a/buildutils/README.md
+++ b/buildutils/README.md
@@ -3,4 +3,4 @@
 A JupyterLab package which provides utility functions that are used to compile
 and build JupyterLab.
 
-This package is only intended for use within a Node.js environments.
+This package is only intended for use within Node.js environments.

--- a/buildutils/README.md
+++ b/buildutils/README.md
@@ -1,0 +1,6 @@
+# @jupyterlab/buildutils
+
+A JupyterLab package which provides utility functions that are used to compile
+and build JupyterLab.
+
+This package is only intended for use within a Node.js environments.

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -352,7 +352,7 @@ The following configurations may be present in this file:
 2. ``disabledExtensions`` controls which extensions should not load at all.
 3. ``deferredExtensions`` controls which extensions should not load until
    they are required by something, irrespective of whether they set
-   ``autostart`` to ``true``.
+   ``autoStart`` to ``true``.
 
 The value for the ``disabledExtensions`` and ``deferredExtensions`` fields
 are an array of strings. The following sequence of checks are performed

--- a/packages/coreutils/README.md
+++ b/packages/coreutils/README.md
@@ -1,4 +1,7 @@
 # @jupyterlab/coreutils
 
-A JupyterLab package which provides utility functions that are widely used across many
-of the `@jupyterlab` packages. This includes (among other things) functions for manipulating paths, urls, and the notebook format.
+A JupyterLab package which provides utility functions that are widely used
+across many of the `@jupyterlab` packages. This includes (among other things)
+functions for manipulating paths, urls, and the notebook format.
+
+This package is intended for use within both Node.js and browser environments.

--- a/packages/coreutils/src/activitymonitor.ts
+++ b/packages/coreutils/src/activitymonitor.ts
@@ -73,7 +73,7 @@ export class ActivityMonitor<Sender, Args> implements IDisposable {
     }, this._timeout);
   }
 
-  private _timer = -1;
+  private _timer: any = -1;
   private _timeout = -1;
   private _sender: Sender;
   private _args: Args;

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -10,18 +10,18 @@ import { ISignal, Signal } from '@phosphor/signaling';
 /**
  * A function to defer an action immediately.
  */
-const schedule = (() => {
-  let ok = typeof requestAnimationFrame === 'function';
-  return ok ? requestAnimationFrame : setImmediate;
-})();
+const defer =
+  typeof requestAnimationFrame === 'function'
+    ? requestAnimationFrame
+    : setImmediate;
 
 /**
- * A function to unschedule a deferred action.
+ * A function to cancel a deferred action.
  */
-const unschedule = (() => {
-  let ok = typeof cancelAnimationFrame === 'function';
-  return ok ? cancelAnimationFrame : clearImmediate;
-})();
+const cancel =
+  typeof cancelAnimationFrame === 'function'
+    ? cancelAnimationFrame
+    : clearImmediate;
 
 /**
  * A readonly poll that calls an asynchronous function with each tick.
@@ -198,9 +198,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
     this.name = options.name || Private.DEFAULT_NAME;
 
     if ('auto' in options ? options.auto : true) {
-      schedule(() => {
-        void this.start();
-      });
+      defer(() => void this.start());
     }
   }
 
@@ -368,7 +366,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
 
     // Clear the schedule if possible.
     if (last.interval === Poll.IMMEDIATE) {
-      unschedule(this._timeout);
+      cancel(this._timeout);
     } else {
       clearTimeout(this._timeout);
     }
@@ -388,7 +386,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
     };
     this._timeout =
       state.interval === Poll.IMMEDIATE
-        ? schedule(execute)
+        ? defer(execute)
         : state.interval === Poll.NEVER
         ? -1
         : setTimeout(execute, state.interval);

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -301,7 +301,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
    */
   refresh(): Promise<void> {
     return this.schedule({
-      cancel: last => last.phase === 'refreshed',
+      cancel: ({ phase }) => phase === 'refreshed',
       interval: Poll.IMMEDIATE,
       phase: 'refreshed'
     });
@@ -397,7 +397,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
    */
   stop(): Promise<void> {
     return this.schedule({
-      cancel: last => last.phase === 'stopped',
+      cancel: ({ phase }) => phase === 'stopped',
       interval: Poll.NEVER,
       phase: 'stopped'
     });

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -112,9 +112,7 @@ export namespace IPoll {
     | 'resolved'
     | 'standby'
     | 'started'
-    | 'stopped'
-    | 'when-rejected'
-    | 'when-resolved';
+    | 'stopped';
 
   /**
    * Definition of poll state at any given time.
@@ -183,23 +181,9 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
     };
     this.name = options.name || Private.DEFAULT_NAME;
 
-    // Schedule poll ticks after `when` promise is settled.
-    (options.when || Promise.resolve())
-      .then(_ => {
-        if (this.isDisposed) {
-          return;
-        }
-
-        void this.schedule({ phase: 'when-resolved' });
-      })
-      .catch(reason => {
-        if (this.isDisposed) {
-          return;
-        }
-
-        console.warn(`Poll (${this.name}) started despite rejection.`, reason);
-        void this.schedule({ phase: 'when-rejected' });
-      });
+    if ('auto' in options ? options.auto : true) {
+      void this.start();
+    }
   }
 
   /**
@@ -345,13 +329,6 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
       return;
     }
 
-    // The `when` promise in the constructor options acts as a gate.
-    if (this.state.phase === 'constructed') {
-      if (next.phase !== 'when-rejected' && next.phase !== 'when-resolved') {
-        await this.tick;
-      }
-    }
-
     // Check if the phase transition should be canceled.
     if (next.cancel && next.cancel(this.state)) {
       return;
@@ -406,7 +383,8 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
    */
   start(): Promise<void> {
     return this.schedule({
-      cancel: last => last.phase !== 'standby' && last.phase !== 'stopped',
+      cancel: ({ phase }) =>
+        phase !== 'constructed' && phase !== 'standby' && phase !== 'stopped',
       interval: Poll.IMMEDIATE,
       phase: 'started'
     });
@@ -513,6 +491,11 @@ export namespace Poll {
    */
   export interface IOptions<T, U, V extends string> {
     /**
+     * Whether to begin polling automatically; defaults to `true`.
+     */
+    auto?: boolean;
+
+    /**
      * A factory function that is passed a poll tick and returns a poll promise.
      */
     factory: Factory<T, U, V>;
@@ -539,11 +522,6 @@ export namespace Poll {
      * tick execution, but may be called by clients as well.
      */
     standby?: Standby | (() => boolean | Standby);
-
-    /**
-     * If set, a promise which must resolve (or reject) before polling begins.
-     */
-    when?: Promise<any>;
   }
   /**
    * An interval value that indicates the poll should tick immediately.

--- a/packages/coreutils/src/poll.ts
+++ b/packages/coreutils/src/poll.ts
@@ -18,7 +18,7 @@ const defer =
 /**
  * A function to cancel a deferred action.
  */
-const cancel =
+const cancel: (timeout: any) => void =
   typeof cancelAnimationFrame === 'function'
     ? cancelAnimationFrame
     : clearImmediate;

--- a/packages/coreutils/src/ratelimiter.ts
+++ b/packages/coreutils/src/ratelimiter.ts
@@ -25,6 +25,7 @@ export abstract class RateLimiter<T, U> implements IRateLimiter<T, U> {
   constructor(fn: () => T | Promise<T>, limit = 500) {
     this.limit = limit;
     this.poll = new Poll({
+      auto: false,
       factory: async () => await fn(),
       frequency: { backoff: false, interval: Poll.NEVER, max: Poll.NEVER },
       standby: 'never'

--- a/packages/coreutils/tsconfig.json
+++ b/packages/coreutils/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "module": "commonjs"
+    "module": "commonjs",
+    "types": ["node"]
   },
   "files": ["src/plugin-schema.json"],
   "include": ["src/*"]

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -39,6 +39,7 @@ export class KernelManager implements Kernel.IManager {
 
     // Start model and specs polling with exponential backoff.
     this._pollModels = new Poll({
+      auto: false,
       factory: () => this.requestRunning(),
       frequency: {
         interval: 10 * 1000,
@@ -46,10 +47,10 @@ export class KernelManager implements Kernel.IManager {
         max: 300 * 1000
       },
       name: `@jupyterlab/services:KernelManager#models`,
-      standby: options.standby || 'when-hidden',
-      when: this.ready
+      standby: options.standby || 'when-hidden'
     });
     this._pollSpecs = new Poll({
+      auto: false,
       factory: () => this.requestSpecs(),
       frequency: {
         interval: 61 * 1000,
@@ -57,8 +58,11 @@ export class KernelManager implements Kernel.IManager {
         max: 300 * 1000
       },
       name: `@jupyterlab/services:KernelManager#specs`,
-      standby: options.standby || 'when-hidden',
-      when: this.ready
+      standby: options.standby || 'when-hidden'
+    });
+    void this.ready.then(() => {
+      void this._pollModels.start();
+      void this._pollSpecs.start();
     });
   }
 

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -41,6 +41,7 @@ export class SessionManager implements Session.IManager {
 
     // Start model and specs polling with exponential backoff.
     this._pollModels = new Poll({
+      auto: false,
       factory: () => this.requestRunning(),
       frequency: {
         interval: 10 * 1000,
@@ -48,10 +49,10 @@ export class SessionManager implements Session.IManager {
         max: 300 * 1000
       },
       name: `@jupyterlab/services:SessionManager#models`,
-      standby: options.standby || 'when-hidden',
-      when: this.ready
+      standby: options.standby || 'when-hidden'
     });
     this._pollSpecs = new Poll({
+      auto: false,
       factory: () => this.requestSpecs(),
       frequency: {
         interval: 61 * 1000,
@@ -59,8 +60,11 @@ export class SessionManager implements Session.IManager {
         max: 300 * 1000
       },
       name: `@jupyterlab/services:SessionManager#specs`,
-      standby: options.standby || 'when-hidden',
-      when: this.ready
+      standby: options.standby || 'when-hidden'
+    });
+    void this.ready.then(() => {
+      void this._pollModels.start();
+      void this._pollSpecs.start();
     });
   }
 

--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -44,6 +44,7 @@ export class TerminalManager implements TerminalSession.IManager {
 
     // Start polling with exponential backoff.
     this._pollModels = new Poll({
+      auto: false,
       factory: () => this.requestRunning(),
       frequency: {
         interval: 10 * 1000,
@@ -51,8 +52,10 @@ export class TerminalManager implements TerminalSession.IManager {
         max: 300 * 1000
       },
       name: `@jupyterlab/services:TerminalManager#models`,
-      standby: options.standby || 'when-hidden',
-      when: this.ready
+      standby: options.standby || 'when-hidden'
+    });
+    void this.ready.then(() => {
+      void this._pollModels.start();
     });
   }
 


### PR DESCRIPTION
## References

PR https://github.com/jupyterlab/jupyterlab/pull/6394

PR https://github.com/jupyterlab/jupyterlab/pull/6399

## Code changes

Removes the `when` field from poll instantiation options and the consequent `when` logic in favor of an `auto` boolean field that defaults to `true` and starts most polls automatically. If necessary, `auto` can be set to `false` to allow a client to manually `Poll#start()`. This should simplify both the `Poll` class and its usage.

## User-facing changes

File browser works again when the page loads.

## Backwards-incompatible changes

`Poll` instantiation `IOptions` no longer accepts `when`.
