### PR TITLE
Manually refresh on codemirror undo/redo.

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -321,6 +321,9 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    */
   undo(): void {
     this.doc.undo();
+    // On some platforms undoing can cause rendering issues,
+    // so we manually trigger a refresh here.
+    this.refresh();
   }
 
   /**
@@ -328,6 +331,9 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    */
   redo(): void {
     this.doc.redo();
+    // On some platforms redoing can cause rendering issues,
+    // so we manually trigger a refresh here.
+    this.refresh();
   }
 
   /**


### PR DESCRIPTION
Fixes some issues with codemirror rendering upon undo/redo with completions. `refresh()` is potentially an expensive call, but I couldn't figure out another way to fix this. I'm not sure of the underlying cause, which is likely deep in the CodeMirror renderer. Fixes #5872 .

I also see some issues around cursor placement with completions. Specifically, invoking the completer resets the text editor content, and that can cause the editor to lose cursor position. But that is orthogonal to this problem.

## References

#5872 

## Code changes

Manual call to `Editor.refresh()` on redo/undo.

## User-facing changes

Fix of some intermittent rendering issues upon undo/redo.

## Backwards-incompatible changes

None