### PR TITLE
Hide the Last Modified column on a narrow filebrowser.

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -786,6 +786,12 @@ export class DirListing extends Widget {
     this._prevPath = this._model.path;
   }
 
+  onResize(msg: Widget.ResizeMessage) {
+    const { width } =
+      msg.width === -1 ? this.node.getBoundingClientRect() : msg;
+    this.toggleClass('jp-DirListing-narrow', width < 250);
+  }
+
   /**
    * Handle the `'click'` event for the widget.
    */

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -120,7 +120,8 @@
   text-align: right;
 }
 
-.jp-DirListing-narrow .jp-id-modified, .jp-DirListing-narrow .jp-DirListing-itemModified {
+.jp-DirListing-narrow .jp-id-modified,
+.jp-DirListing-narrow .jp-DirListing-itemModified {
   display: none;
 }
 

--- a/packages/filebrowser/style/index.css
+++ b/packages/filebrowser/style/index.css
@@ -120,6 +120,10 @@
   text-align: right;
 }
 
+.jp-DirListing-narrow .jp-id-modified, .jp-DirListing-narrow .jp-DirListing-itemModified {
+  display: none;
+}
+
 .jp-DirListing-headerItem.jp-mod-selected {
   font-weight: 600;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #6093
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds an onResize handler to the directory listing that toggles a class when the width is narrow. Additionally, the last modified column css hides itself when the directory listing is narrow.

## User-facing changes

When the user narrows the filebrowser, the last modified column disappears.

### Before

Minimal width:
<img width="255" alt="Screen Shot 2019-05-24 at 11 27 16 AM" src="https://user-images.githubusercontent.com/192614/58349000-a825a180-7e51-11e9-9774-94ef1a297bc5.png">


### After

Just over 250px:
<img width="346" alt="Screen Shot 2019-05-24 at 11 10 33 AM" src="https://user-images.githubusercontent.com/192614/58348216-8b886a00-7e4f-11e9-83b9-d629ad560aa2.png">

Just under 250px wide:

<img width="591" alt="Screen Shot 2019-05-24 at 11 10 24 AM" src="https://user-images.githubusercontent.com/192614/58348227-94793b80-7e4f-11e9-8e17-daec92cfe78b.png">

Minimum width filebrowser:
<img width="336" alt="Screen Shot 2019-05-24 at 11 10 43 AM" src="https://user-images.githubusercontent.com/192614/58348238-9d6a0d00-7e4f-11e9-9296-477f1a882ae5.png">



## Backwards-incompatible changes

None.