### PR TITLE
Make selected command palette darker on hover

### DIFF
--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -133,6 +133,10 @@
   background: var(--jp-layout-color3);
 }
 
+.p-CommandPalette-item.p-mod-active:hover:not(.p-mod-disabled) {
+  background: var(--jp-layout-color4);
+}
+
 .p-CommandPalette-item:hover:not(.p-mod-active):not(.p-mod-disabled) {
   background: var(--jp-layout-color2);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This fixes #279. In it @Carreau said:

> I think that this might be because for selected item, the appearance is not different on :hover, and that having an extra-highlight or underline on hover will partly help my brain adjust and click only once.

Other next steps would be to:

* Flash the command after it is activated so that the user knows they have activated it (https://github.com/jupyterlab/jupyterlab/issues/1095)
* Debounce the click so that a double click doesn't trigger the command twice.

## Code changes

None.

## User-facing changes

Not hover selected (same as before):
<img width="316" alt="Screen Shot 2019-05-24 at 3 55 10 PM" src="https://user-images.githubusercontent.com/1186124/58353519-af8e8000-7e3c-11e9-8686-e4a7bf6728e7.png">

hover and selected (darker than before):
<img width="332" alt="Screen Shot 2019-05-24 at 3 55 19 PM" src="https://user-images.githubusercontent.com/1186124/58353542-bb7a4200-7e3c-11e9-8796-c5565224c4ff.png">


## Backwards-incompatible changes

None