### PR TITLE
[WIP] Make it easier to find the appropriate widget from context menu actions

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -301,6 +301,20 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   }
 
   /**
+   * The current widget associated with a context menu event.
+   *
+   * #### Notes
+   * If the context event happened on a tab, this will return the widget
+   * associated with the tab. Otherwise it returns the widget associated with
+   * the context event. As a last resort, it will return the current widget.
+   */
+  get contextWidget(): Widget | null {
+    // Check if we have a context menu event
+    this.contex;
+    return null;
+  }
+
+  /**
    * A signal emitted when the main area's layout is modified.
    */
   get layoutModified(): ISignal<this, void> {
@@ -880,7 +894,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   }
 
   /*
-   * Return the TabBar that has the currently active Widget or null.
+   * Return the TabBar that has the current widget or null.
    */
   private _currentTabBar(): TabBar<Widget> | null {
     const current = this._tracker.currentWidget;
@@ -891,6 +905,22 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     const title = current.title;
     const bars = this._dockPanel.tabBars();
     return find(bars, bar => bar.titles.indexOf(title) > -1) || null;
+  }
+
+  /**
+   * Return the tab that contains the node or undefined.
+   */
+  findTab(node: HTMLElement): Widget {
+    const bars = this._dockPanel.tabBars();
+    const bar = find(bars, bar => bar.node.contains(node));
+    if (bar) {
+      const tab = find(bar.contentNode.children, tab =>
+        tab.node.contains(node)
+      );
+      if (tab) {
+        return tab;
+      }
+    }
   }
 
   /**

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -30,7 +30,7 @@ import {
   SavingStatus
 } from '@jupyterlab/docmanager';
 
-import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
 
@@ -574,20 +574,45 @@ function addLabCommands(
 ): void {
   const { commands } = app;
 
-  // Returns the doc widget associated with the most recent contextmenu event.
-  const contextMenuWidget = (): Widget => {
+  /**
+   * Retrieve the intended document widget if there is one.
+   *
+   * If there is currently a context menu event, this retrieves the document
+   * widget associated with the context menu event if possible. If there is not
+   * a context menu event, it returns the shell's current widget if it is a
+   * document widget.
+   */
+  function contextMenuWidget(): IDocumentWidget | undefined {
+    // This hit test tries to recover a path from a click on a tab too. It is
+    // somewhat brittle, in that it actually recovers any node with a title
+    // attribute matching this particular regex.
     const pathRe = /[Pp]ath:\s?(.*)\n?/;
-    const test = (node: HTMLElement) =>
-      node['title'] && !!node['title'].match(pathRe);
-    const node = app.contextMenuHitTest(test);
+    const node = app.contextMenuHitTest(
+      (node: HTMLElement) => node['title'] && !!node['title'].match(pathRe)
+    );
 
-    if (!node) {
-      // Fall back to active doc widget if path cannot be obtained from event.
-      return labShell.currentWidget;
+    if (node) {
+      const pathMatch = node['title'].match(pathRe);
+      let widgets = docManager.findWidgets(pathMatch[1]);
+      // How do we pick out the right widget? The node may correspond to a tab,
+      // not a widget itself, so we cannot test w.node.contains(node). Can we
+      // recover a tab widget from its node? TODO: have an app hit test that, if
+      // the hit is on a tab, returns the associated widget.
+      return widgets[0];
     }
+<<<<<<< HEAD
     const pathMatch = node['title'].match(pathRe);
     return docManager.findWidget(pathMatch[1], null);
   };
+=======
+
+    // Fall back to current widget if it is an IDocumentWidget.
+    const { currentWidget } = labShell;
+    if (currentWidget && docManager.contextForWidget(currentWidget)) {
+      return currentWidget as IDocumentWidget;
+    }
+  }
+>>>>>>> Make cloneWidget take an IDocumentWidget instead of a generic Widget.
 
   // Returns `true` if the current widget has a document context.
   const isEnabled = () => {
@@ -600,12 +625,12 @@ function addLabCommands(
     isEnabled,
     execute: args => {
       const widget = contextMenuWidget();
-      const options = (args['options'] as DocumentRegistry.IOpenOptions) || {
-        mode: 'split-right'
-      };
       if (!widget) {
         return;
       }
+      const options = (args['options'] as DocumentRegistry.IOpenOptions) || {
+        mode: 'split-right'
+      };
       // Clone the widget.
       let child = docManager.cloneWidget(widget);
       if (child) {

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -145,7 +145,7 @@ export class DocumentManager implements IDocumentManager {
   /**
    * Clone a widget.
    *
-   * @param widget - The source widget.
+   * @param widget - The source IDocumentWidget.
    *
    * @returns A new widget or `undefined`.
    *
@@ -153,7 +153,7 @@ export class DocumentManager implements IDocumentManager {
    *  Uses the same widget factory and context as the source, or returns
    *  `undefined` if the source widget is not managed by this manager.
    */
-  cloneWidget(widget: Widget): IDocumentWidget | undefined {
+  cloneWidget(widget: IDocumentWidget): IDocumentWidget | undefined {
     return this._widgetManager.cloneWidget(widget);
   }
 

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -1,14 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import {
-  ArrayExt,
-  each,
-  map,
-  find,
-  filter,
-  toArray
-} from '@phosphor/algorithm';
+import { ArrayExt, each, map, filter, toArray } from '@phosphor/algorithm';
 
 import { DisposableSet, IDisposable } from '@phosphor/disposable';
 
@@ -139,25 +132,25 @@ export class DocumentWidgetManager implements IDisposable {
   }
 
   /**
-   * See if a widget already exists for the given context and widget name.
+   * Find all widgets for a given context and widget name.
    *
    * @param context - The document context object.
    *
-   * @returns The found widget, or `undefined`.
+   * @returns The list of found widgets.
    *
    * #### Notes
    * This can be used to use an existing widget instead of opening
    * a new widget.
    */
-  findWidget(
+  findWidgets(
     context: DocumentRegistry.Context,
     widgetName: string
-  ): IDocumentWidget | undefined {
+  ): IDocumentWidget[] {
     let widgets = Private.widgetsProperty.get(context);
     if (!widgets) {
-      return undefined;
+      return [];
     }
-    return find(widgets, widget => {
+    return widgets.filter(widget => {
       let factory = Private.factoryProperty.get(widget);
       if (!factory) {
         return false;

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -181,7 +181,7 @@ export class DocumentWidgetManager implements IDisposable {
    *  Uses the same widget factory and context as the source, or throws
    *  if the source widget is not managed by this manager.
    */
-  cloneWidget(widget: Widget): IDocumentWidget | undefined {
+  cloneWidget(widget: IDocumentWidget): IDocumentWidget | undefined {
     let context = Private.contextProperty.get(widget);
     if (!context) {
       return undefined;
@@ -190,7 +190,7 @@ export class DocumentWidgetManager implements IDisposable {
     if (!factory) {
       return undefined;
     }
-    let newWidget = factory.clone(widget as IDocumentWidget, context);
+    let newWidget = factory.clone(widget, context);
     this._initializeWidget(newWidget, factory, context);
     return newWidget;
   }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1190,10 +1190,10 @@ export class DirListing extends Widget {
           return;
         }
         let path = item.path;
-        let widget = this._manager.findWidget(path);
-        if (!widget) {
-          widget = this._manager.open(item.path);
-        }
+        let widgets = this._manager.findWidgets(path);
+        let widget = widgets.length
+          ? widgets[0]
+          : this._manager.open(item.path);
         if (otherPaths.length) {
           const firstWidgetPlaced = new PromiseDelegate<void>();
           void firstWidgetPlaced.promise.then(() => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1561,10 +1561,14 @@ function addCommands(
       let path = args.path as string | undefined | null;
       let index = args.index as number | undefined | null;
       if (path && index !== undefined && index !== null) {
-        current = docManager.findWidget(path, FACTORY) as NotebookPanel;
-        if (!current) {
+        const widgets = docManager.findWidgets(
+          path,
+          FACTORY
+        ) as NotebookPanel[];
+        if (!widgets.length) {
           return;
         }
+        current = widgets[0];
       } else {
         current = getCurrent({ ...args, activate: false });
         if (!current) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This comes from work stemming from #6060 to make it easier to get widgets associated with a context menu event.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This is a work-in-progress. I'll update these descriptions as the work progresses.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
