### PR TITLE
Rewrite Kernel Message typings and only clear cell execution prompt if needed

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -43,7 +43,6 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.6.0",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -43,6 +43,7 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
+    "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
     "@phosphor/widgets": "^1.6.0",

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1006,7 +1006,7 @@ export namespace CodeCell {
   /**
    * Execute a cell given a client session.
    */
-  export function execute(
+  export async function execute(
     cell: CodeCell,
     session: IClientSession,
     metadata?: JSONObject
@@ -1016,7 +1016,7 @@ export namespace CodeCell {
     if (!code.trim() || !session.kernel) {
       model.executionCount = null;
       model.outputs.clear();
-      return Promise.resolve(void 0);
+      return;
     }
 
     let cellId = { cellId: model.id };
@@ -1026,17 +1026,21 @@ export namespace CodeCell {
     cell.setPrompt('*');
     model.trusted = true;
 
-    return OutputArea.execute(code, cell.outputArea, session, metadata)
-      .then(msg => {
-        model.executionCount = msg.content.execution_count;
-        return msg;
-      })
-      .catch(e => {
-        if (e.message === 'Canceled') {
-          cell.setPrompt('');
-        }
-        throw e;
-      });
+    try {
+      const msg = await OutputArea.execute(
+        code,
+        cell.outputArea,
+        session,
+        metadata
+      );
+      model.executionCount = msg.content.execution_count;
+      return msg;
+    } catch (e) {
+      if (e.message === 'Canceled') {
+        cell.setPrompt('');
+      }
+      throw e;
+    }
   }
 }
 

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1010,7 +1010,7 @@ export namespace CodeCell {
     cell: CodeCell,
     session: IClientSession,
     metadata?: JSONObject
-  ): Promise<KernelMessage.IExecuteReplyMsg> {
+  ): Promise<KernelMessage.IExecuteReplyMsg | void> {
     let model = cell.model;
     let code = model.value.text;
     if (!code.trim() || !session.kernel) {
@@ -1031,10 +1031,15 @@ export namespace CodeCell {
       KernelMessage.IExecuteReplyMsg
     >;
     try {
-      // We assume cell.outputArea.future is the future for this execution.
-      OutputArea.execute(code, cell.outputArea, session, metadata);
-      let future = cell.outputArea.future;
-      const msg = await future.done;
+      const msgPromise = OutputArea.execute(
+        code,
+        cell.outputArea,
+        session,
+        metadata
+      );
+      // Save this execution's future so we can compare in the catch below.
+      future = cell.outputArea.future;
+      const msg = await msgPromise;
       model.executionCount = msg.content.execution_count;
       return msg;
     } catch (e) {

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -144,11 +144,19 @@ export class OutputArea extends Widget {
   /**
    * The kernel future associated with the output area.
    */
-  get future(): Kernel.IFuture {
+  get future(): Kernel.IFuture<
+    KernelMessage.IExecuteRequestMsg,
+    KernelMessage.IExecuteReplyMsg
+  > | null {
     return this._future;
   }
 
-  set future(value: Kernel.IFuture) {
+  set future(
+    value: Kernel.IFuture<
+      KernelMessage.IExecuteRequestMsg,
+      KernelMessage.IExecuteReplyMsg
+    > | null
+  ) {
     // Bail if the model is disposed.
     if (this.model.isDisposed) {
       throw Error('Model is disposed');
@@ -476,7 +484,10 @@ export class OutputArea extends Widget {
   };
 
   private _minHeightTimeout: number = null;
-  private _future: Kernel.IFuture = null;
+  private _future: Kernel.IFuture<
+    KernelMessage.IExecuteRequestMsg,
+    KernelMessage.IExecuteReplyMsg
+  > | null = null;
   private _displayIdMap = new Map<string, number[]>();
 }
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -556,7 +556,7 @@ export namespace OutputArea {
     }
     let future = session.kernel.requestExecute(content, false, metadata);
     output.future = future;
-    return future.done as Promise<KernelMessage.IExecuteReplyMsg>;
+    return future.done;
   }
 
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -420,7 +420,7 @@ export class OutputArea extends Widget {
     let model = this.model;
     let msgType = msg.header.msg_type;
     let output: nbformat.IOutput;
-    let transient = (msg.content.transient || {}) as JSONObject;
+    let transient = ((msg.content as any).transient || {}) as JSONObject;
     let displayId = transient['display_id'] as string;
     let targets: number[];
 

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -528,7 +528,7 @@ export namespace OutputArea {
   /**
    * Execute code on an output area.
    */
-  export function execute(
+  export async function execute(
     code: string,
     output: OutputArea,
     session: IClientSession,
@@ -541,7 +541,7 @@ export namespace OutputArea {
     };
 
     if (!session.kernel) {
-      return Promise.reject('Session has no kernel.');
+      throw new Error('Session has no kernel.');
     }
     let future = session.kernel.requestExecute(content, false, metadata);
     output.future = future;

--- a/packages/services/src/kernel/comm.ts
+++ b/packages/services/src/kernel/comm.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JSONObject, JSONValue } from '@phosphor/coreutils';
+import { JSONObject } from '@phosphor/coreutils';
 
 import { DisposableDelegate } from '@phosphor/disposable';
 
@@ -100,7 +100,7 @@ export class CommHandler extends DisposableDelegate implements Kernel.IComm {
    * **See also:** [[ICommOpen]]
    */
   open(
-    data?: JSONValue,
+    data?: JSONObject,
     metadata?: JSONObject,
     buffers: (ArrayBuffer | ArrayBufferView)[] = []
   ): Kernel.IFuture {
@@ -136,7 +136,7 @@ export class CommHandler extends DisposableDelegate implements Kernel.IComm {
    * **See also:** [[ICommMsg]]
    */
   send(
-    data: JSONValue,
+    data: JSONObject,
     metadata?: JSONObject,
     buffers: (ArrayBuffer | ArrayBufferView)[] = [],
     disposeOnDone: boolean = true
@@ -175,7 +175,7 @@ export class CommHandler extends DisposableDelegate implements Kernel.IComm {
    * **See also:** [[ICommClose]], [[onClose]]
    */
   close(
-    data?: JSONValue,
+    data?: JSONObject,
     metadata?: JSONObject,
     buffers: (ArrayBuffer | ArrayBufferView)[] = []
   ): Kernel.IFuture {
@@ -183,7 +183,7 @@ export class CommHandler extends DisposableDelegate implements Kernel.IComm {
       throw new Error('Cannot close');
     }
     let options: KernelMessage.IOptions = {
-      msgType: 'comm_msg',
+      msgType: 'comm_close',
       channel: 'shell',
       username: this._kernel.username,
       session: this._kernel.clientId
@@ -199,11 +199,10 @@ export class CommHandler extends DisposableDelegate implements Kernel.IComm {
       buffers
     );
     let future = this._kernel.sendShellMessage(msg, false, true);
-    options.channel = 'iopub';
     let onClose = this._onClose;
     if (onClose) {
       let ioMsg = KernelMessage.createMessage(
-        options,
+        { ...options, msgType: 'comm_close', channel: 'iopub' },
         content,
         metadata,
         buffers

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -126,11 +126,11 @@ export namespace Kernel {
      *
      * If the kernel status is `'dead'`, this will throw an error.
      */
-    sendShellMessage(
-      msg: KernelMessage.IShellMessage,
+    sendShellMessage<T extends KernelMessage.ShellMessageType>(
+      msg: KernelMessage.IShellMessage<T>,
       expectReply?: boolean,
       disposeOnDone?: boolean
-    ): Kernel.IFuture;
+    ): Kernel.IFuture<KernelMessage.IShellMessage<T>>;
 
     /**
      * Reconnect to a disconnected kernel.
@@ -268,7 +268,10 @@ export namespace Kernel {
       content: KernelMessage.IExecuteRequest,
       disposeOnDone?: boolean,
       metadata?: JSONObject
-    ): Kernel.IFuture;
+    ): Kernel.IFuture<
+      KernelMessage.IExecuteRequestMsg,
+      KernelMessage.IExecuteReplyMsg
+    >;
 
     /**
      * Send an `is_complete_request` message.
@@ -739,11 +742,14 @@ export namespace Kernel {
    * When a message is sent to a kernel, a Future is created to handle any
    * responses that may come from the kernel.
    */
-  export interface IFuture extends IDisposable {
+  export interface IFuture<
+    REQUEST extends KernelMessage.IShellMessage = KernelMessage.IShellMessage,
+    REPLY extends KernelMessage.IShellMessage = KernelMessage.IShellMessage
+  > extends IDisposable {
     /**
      * The original outgoing message.
      */
-    readonly msg: KernelMessage.IShellMessage;
+    readonly msg: REQUEST;
 
     /**
      * A promise that resolves when the future is done.
@@ -755,7 +761,7 @@ export namespace Kernel {
      * The `done` promise resolves to the reply message if there is one,
      * otherwise it resolves to `undefined`.
      */
-    readonly done: Promise<KernelMessage.IShellMessage | undefined>;
+    readonly done: Promise<REPLY | undefined>;
 
     /**
      * The reply handler for the kernel future.
@@ -766,7 +772,7 @@ export namespace Kernel {
      * `done` promise also resolves to the reply message after this handler has
      * been called.
      */
-    onReply: (msg: KernelMessage.IShellMessage) => void | PromiseLike<void>;
+    onReply: (msg: REPLY) => void | PromiseLike<void>;
 
     /**
      * The stdin handler for the kernel future.

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -612,8 +612,8 @@ export namespace KernelMessage {
     parent_header: IHeader<'history_request'>;
     content: {
       history:
-        | [string, number, string][]
-        | [string, number, [string, string]][];
+        | [number, number, string][]
+        | [number, number, [string, string]][];
     };
   }
 

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -52,6 +52,9 @@ export namespace KernelMessage {
     return msg as IShellMessage;
   }
 
+  /**
+   * Shell message types.
+   */
   export type ShellMessageType =
     | 'comm_close'
     | 'comm_info_reply'
@@ -75,6 +78,9 @@ export namespace KernelMessage {
     | 'shutdown_reply'
     | 'shutdown_request';
 
+  /**
+   * IOPub message types.
+   */
   export type IOPubMessageType =
     | 'clear_output'
     | 'comm_close'
@@ -88,15 +94,21 @@ export namespace KernelMessage {
     | 'stream'
     | 'update_display_data';
 
+  /**
+   * Stdin message types.
+   */
   export type StdinMessageType = 'input_request' | 'input_reply';
 
+  /**
+   * Jupyter message types.
+   */
   export type MessageType =
     | IOPubMessageType
     | ShellMessageType
     | StdinMessageType;
 
   /**
-   * The valid channel names.
+   * The valid Jupyter channel names in a message to a frontend.
    */
   export type Channel = 'shell' | 'iopub' | 'stdin';
 
@@ -166,7 +178,7 @@ export namespace KernelMessage {
     content: any;
 
     /**
-     * Which channel on which the message is transmitted.
+     * The channel on which the message is transmitted.
      */
     channel: Channel;
 
@@ -486,6 +498,13 @@ export namespace KernelMessage {
     nbconverter_exporter?: string;
   }
 
+  /**
+   * A  `'complete_request'` message.
+   *
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#completion).
+   *
+   * **See also:** [[ICompleteReplyMsg]], [[IKernel.complete]]
+   */
   export interface ICompleteRequestMsg
     extends IShellMessage<'complete_request'> {
     content: ICompleteRequest;
@@ -521,6 +540,13 @@ export namespace KernelMessage {
     };
   }
 
+  /**
+   * An `'inspect_request'` message.
+   *
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#introspection).
+   *
+   * **See also:** [[IInspectReplyMsg]], [[[IKernel.inspect]]]
+   */
   export interface IInspectRequestMsg extends IShellMessage<'inspect_request'> {
     content: IInspectRequest;
   }
@@ -555,6 +581,13 @@ export namespace KernelMessage {
     };
   }
 
+  /**
+   * A `'history_request'` message.
+   *
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#history).
+   *
+   * **See also:** [[IHistoryReplyMsg]], [[[IKernel.history]]]
+   */
   export interface IHistoryRequestMsg extends IShellMessage<'history_request'> {
     content: IHistoryRequest;
   }
@@ -565,7 +598,7 @@ export namespace KernelMessage {
   export type HistAccess = 'range' | 'tail' | 'search';
 
   /**
-   * The content of a `'history_request'` message.
+   * The content of a `'history_request'` range message.
    *
    * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#history).
    *
@@ -580,6 +613,13 @@ export namespace KernelMessage {
     stop: number;
   }
 
+  /**
+   * The content of a `'history_request'` tail message.
+   *
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#history).
+   *
+   * **See also:** [[IHistoryReply]], [[[IKernel.history]]]
+   */
   export interface IHistoryRequestTail {
     output: boolean;
     raw: boolean;
@@ -587,6 +627,13 @@ export namespace KernelMessage {
     n: number;
   }
 
+  /**
+   * The content of a `'history_request'` search message.
+   *
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#history).
+   *
+   * **See also:** [[IHistoryReply]], [[[IKernel.history]]]
+   */
   export interface IHistoryRequestSearch {
     output: boolean;
     raw: boolean;
@@ -596,6 +643,13 @@ export namespace KernelMessage {
     unique: boolean;
   }
 
+  /**
+   * The content of a `'history_request'` message.
+   *
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#history).
+   *
+   * **See also:** [[IHistoryReply]], [[[IKernel.history]]]
+   */
   export type IHistoryRequest =
     | IHistoryRequestRange
     | IHistoryRequestTail
@@ -617,6 +671,13 @@ export namespace KernelMessage {
     };
   }
 
+  /**
+   * An `'is_complete_request'` message.
+   *
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#code-completeness).
+   *
+   * **See also:** [[IIsCompleteReplyMsg]], [[IKernel.isComplete]]
+   */
   export interface IIsCompleteRequestMsg
     extends IShellMessage<'is_complete_request'> {
     content: IIsCompleteRequest;
@@ -857,6 +918,11 @@ export namespace KernelMessage {
     };
   }
 
+  /**
+   * Base options for an `IMessage`.
+   *
+   * **See also:** [[IMessage]]
+   */
   export interface IOptionsBase {
     msgType: MessageType;
     channel: Channel;
@@ -865,16 +931,31 @@ export namespace KernelMessage {
     msgId?: string;
   }
 
+  /**
+   * Options for an iopub `IMessage`.
+   *
+   * **See also:** [[IMessage]]
+   */
   export interface IOptionsIOPub extends IOptionsBase {
     msgType: IOPubMessageType;
     channel: 'iopub';
   }
 
+  /**
+   * Options for a shell `IMessage`.
+   *
+   * **See also:** [[IMessage]]
+   */
   export interface IOptionsShell extends IOptionsBase {
     msgType: ShellMessageType;
     channel: 'shell';
   }
 
+  /**
+   * Options for a stdin `IMessage`.
+   *
+   * **See also:** [[IMessage]]
+   */
   export interface IOptionsStdin extends IOptionsBase {
     msgType: StdinMessageType;
     channel: 'stdin';

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -13,43 +13,118 @@ import { Kernel } from './kernel';
  * A namespace for kernel messages.
  */
 export namespace KernelMessage {
-  /**
-   * Create a well-formed kernel message.
-   */
-  export function createMessage(
-    options: IOptions,
-    content: any = {},
-    metadata: any = {},
-    buffers: (ArrayBuffer | ArrayBufferView)[] = []
-  ): IMessage {
+  export interface IOptions<T extends Message> {
+    session: string;
+    channel: T['channel'];
+    msgType: T['header']['msg_type'];
+    content: T['content'];
+    buffers?: (ArrayBuffer | ArrayBufferView)[];
+    metadata?: JSONObject;
+    msgId?: string;
+    username?: string;
+    parentHeader?: T['parent_header'];
+  }
+  export function createMessage<T extends IClearOutputMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICommCloseMsg<'iopub'>>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICommCloseMsg<'shell'>>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICommInfoReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICommInfoRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICommMsgMsg<'iopub'>>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICommMsgMsg<'shell'>>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICommOpenMsg<'iopub'>>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICommOpenMsg<'shell'>>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICompleteReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends ICompleteRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IDisplayDataMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IErrorMsg>(options: IOptions<T>): T;
+  export function createMessage<T extends IExecuteInputMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IExecuteReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IExecuteRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IExecuteResultMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IHistoryReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IHistoryRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IInfoReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IInfoRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IInputReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IInputRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IInspectReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IInspectRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IIsCompleteReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IIsCompleteRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IStatusMsg>(options: IOptions<T>): T;
+  export function createMessage<T extends IStreamMsg>(options: IOptions<T>): T;
+  export function createMessage<T extends IUpdateDisplayDataMsg>(
+    options: IOptions<T>
+  ): T;
+
+  export function createMessage<T extends Message>(options: IOptions<T>): T {
     return {
+      buffers: options.buffers || [],
+      channel: options.channel,
+      content: options.content,
       header: {
         date: new Date().toISOString(),
-        username: options.username || '',
-        version: '5.2',
-        session: options.session,
         msg_id: options.msgId || UUID.uuid4(),
-        msg_type: options.msgType
+        msg_type: options.msgType,
+        session: options.session,
+        username: options.username || '',
+        version: '5.2'
       },
-      parent_header: {},
-      channel: options.channel,
-      content,
-      metadata,
-      buffers
-    };
-  }
-
-  /**
-   * Create a well-formed kernel shell message.
-   */
-  export function createShellMessage(
-    options: IOptionsShell,
-    content: any = {},
-    metadata: any = {},
-    buffers: (ArrayBuffer | ArrayBufferView)[] = []
-  ): IShellMessage {
-    let msg = createMessage(options, content, metadata, buffers);
-    return msg as IShellMessage;
+      metadata: options.metadata || {},
+      parent_header: options.parentHeader || {}
+    } as T;
   }
 
   /**
@@ -175,7 +250,7 @@ export namespace KernelMessage {
     /**
      * The content of the message.
      */
-    content: any;
+    content: MessageContent;
 
     /**
      * The channel on which the message is transmitted.
@@ -211,6 +286,40 @@ export namespace KernelMessage {
     extends IMessage<T> {
     channel: 'stdin';
   }
+
+  export type Message =
+    | IClearOutputMsg
+    | ICommCloseMsg<'iopub'>
+    | ICommCloseMsg<'shell'>
+    | ICommInfoReplyMsg
+    | ICommInfoRequestMsg
+    | ICommMsgMsg<'iopub'>
+    | ICommMsgMsg<'shell'>
+    | ICommOpenMsg<'iopub'>
+    | ICommOpenMsg<'shell'>
+    | ICompleteReplyMsg
+    | ICompleteRequestMsg
+    | IDisplayDataMsg
+    | IErrorMsg
+    | IExecuteInputMsg
+    | IExecuteReplyMsg
+    | IExecuteRequestMsg
+    | IExecuteResultMsg
+    | IHistoryReplyMsg
+    | IHistoryRequestMsg
+    | IInfoReplyMsg
+    | IInfoRequestMsg
+    | IInputReplyMsg
+    | IInputRequestMsg
+    | IInspectReplyMsg
+    | IInspectRequestMsg
+    | IIsCompleteReplyMsg
+    | IIsCompleteRequestMsg
+    | IStatusMsg
+    | IStreamMsg
+    | IUpdateDisplayDataMsg;
+
+  export type MessageContent<T extends Message = Message> = T['content'];
 
   /**
    * A `'stream'` message on the `'iopub'` channel.
@@ -302,6 +411,7 @@ export namespace KernelMessage {
       execution_count: nbformat.ExecutionCount;
       data: nbformat.IMimeBundle;
       metadata: nbformat.OutputMetadata;
+      transient?: { display_id?: string };
     };
   }
 
@@ -373,8 +483,30 @@ export namespace KernelMessage {
    *
    * See [Comm open](https://jupyter-client.readthedocs.io/en/latest/messaging.html#opening-a-comm).
    */
-  export interface ICommOpenMsg extends IMessage<'comm_open'> {
-    channel: 'shell' | 'iopub';
+  export interface ICommOpenMsg<
+    T extends 'shell' | 'iopub' = 'iopub' | 'shell'
+  > extends IMessage<'comm_open'> {
+    channel: T;
+    content: ICommOpen;
+  }
+
+  /**
+   * A `'comm_open'` message on the `'iopub'` channel.
+   *
+   * See [Comm open](https://jupyter-client.readthedocs.io/en/latest/messaging.html#opening-a-comm).
+   */
+  export interface ICommOpenIOPubMsg extends IIOPubMessage<'comm_open'> {
+    channel: 'iopub';
+    content: ICommOpen;
+  }
+
+  /**
+   * A `'comm_open'` message on the `'shell'` channel.
+   *
+   * See [Comm open](https://jupyter-client.readthedocs.io/en/latest/messaging.html#opening-a-comm).
+   */
+  export interface ICommOpenShellMsg extends IShellMessage<'comm_open'> {
+    channel: 'shell';
     content: ICommOpen;
   }
 
@@ -394,17 +526,23 @@ export namespace KernelMessage {
   /**
    * Test whether a kernel message is a `'comm_open'` message.
    */
-  export function isCommOpenMsg(msg: IMessage): msg is ICommOpenMsg {
+  export function isCommOpenMsg(
+    msg: IMessage
+  ): msg is ICommOpenIOPubMsg | ICommOpenShellMsg {
     return msg.header.msg_type === 'comm_open';
   }
+
+  export type iopubshell = 'iopub' | 'shell';
 
   /**
    * A `'comm_close'` message on the `'iopub'` channel.
    *
    * See [Comm close](https://jupyter-client.readthedocs.io/en/latest/messaging.html#opening-a-comm).
    */
-  export interface ICommCloseMsg extends IMessage<'comm_close'> {
-    channel: 'iopub' | 'shell';
+  export interface ICommCloseMsg<
+    T extends 'iopub' | 'shell' = 'iopub' | 'shell'
+  > extends IMessage<'comm_close'> {
+    channel: T;
     content: ICommClose;
   }
 
@@ -422,7 +560,9 @@ export namespace KernelMessage {
   /**
    * Test whether a kernel message is a `'comm_close'` message.
    */
-  export function isCommCloseMsg(msg: IMessage): msg is ICommCloseMsg {
+  export function isCommCloseMsg(
+    msg: IMessage
+  ): msg is ICommCloseMsg<'iopub' | 'shell'> {
     return msg.header.msg_type === 'comm_close';
   }
 
@@ -431,8 +571,9 @@ export namespace KernelMessage {
    *
    * See [Comm msg](https://jupyter-client.readthedocs.io/en/latest/messaging.html#opening-a-comm).
    */
-  export interface ICommMsgMsg extends IMessage<'comm_msg'> {
-    channel: 'iopub' | 'shell';
+  export interface ICommMsgMsg<T extends 'iopub' | 'shell' = 'iopub' | 'shell'>
+    extends IMessage<'comm_msg'> {
+    channel: T;
     content: ICommMsg;
   }
 
@@ -450,7 +591,9 @@ export namespace KernelMessage {
   /**
    * Test whether a kernel message is a `'comm_msg'` message.
    */
-  export function isCommMsgMsg(msg: IMessage): msg is ICommMsgMsg {
+  export function isCommMsgMsg(
+    msg: IMessage
+  ): msg is ICommMsgMsg<'iopub' | 'shell'> {
     return msg.header.msg_type === 'comm_msg';
   }
 
@@ -462,6 +605,13 @@ export namespace KernelMessage {
   export interface IInfoRequestMsg
     extends IShellMessage<'kernel_info_request'> {
     content: {};
+  }
+
+  /**
+   * Test whether a kernel message is a `'kernel_info_request'` message.
+   */
+  export function isInfoRequestMsg(msg: IMessage): msg is IInfoRequestMsg {
+    return msg.header.msg_type === 'kernel_info_request';
   }
 
   /**
@@ -869,6 +1019,11 @@ export namespace KernelMessage {
     return msg.header.msg_type === 'input_request';
   }
 
+  /**
+   * An `'input_reply'` message on the `'stdin'` channel.
+   *
+   * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#messages-on-the-stdin-router-dealer-sockets).
+   */
   export interface IInputReplyMsg extends IStdinMessage<'input_reply'> {
     parent_header: IHeader<'input_request'>;
     content: IInputReply;
@@ -883,6 +1038,13 @@ export namespace KernelMessage {
    */
   export interface IInputReply {
     value: string;
+  }
+
+  /**
+   * Test whether a kernel message is an `'input_reply'` message.
+   */
+  export function isInputReplyMsg(msg: IMessage): msg is IInputReplyMsg {
+    return msg.header.msg_type === 'input_reply';
   }
 
   export interface ICommInfoRequestMsg
@@ -917,54 +1079,4 @@ export namespace KernelMessage {
       comms: { [commId: string]: { target_name: string } };
     };
   }
-
-  /**
-   * Base options for an `IMessage`.
-   *
-   * **See also:** [[IMessage]]
-   */
-  export interface IOptionsBase {
-    msgType: MessageType;
-    channel: Channel;
-    session: string;
-    username?: string;
-    msgId?: string;
-  }
-
-  /**
-   * Options for an iopub `IMessage`.
-   *
-   * **See also:** [[IMessage]]
-   */
-  export interface IOptionsIOPub extends IOptionsBase {
-    msgType: IOPubMessageType;
-    channel: 'iopub';
-  }
-
-  /**
-   * Options for a shell `IMessage`.
-   *
-   * **See also:** [[IMessage]]
-   */
-  export interface IOptionsShell extends IOptionsBase {
-    msgType: ShellMessageType;
-    channel: 'shell';
-  }
-
-  /**
-   * Options for a stdin `IMessage`.
-   *
-   * **See also:** [[IMessage]]
-   */
-  export interface IOptionsStdin extends IOptionsBase {
-    msgType: StdinMessageType;
-    channel: 'stdin';
-  }
-
-  /**
-   * Options for an `IMessage`.
-   *
-   * **See also:** [[IMessage]]
-   */
-  export type IOptions = IOptionsIOPub | IOptionsShell | IOptionsStdin;
 }

--- a/tests/test-cells/src/widget.spec.ts
+++ b/tests/test-cells/src/widget.spec.ts
@@ -766,15 +766,16 @@ describe('cells/widget', () => {
         const widget = new CodeCell({ model, rendermime, contentFactory });
         widget.initializeState();
         widget.model.value.text = 'foo';
-        const future1 = CodeCell.execute(widget, session);
+        const future1 = CodeCell.execute(widget, session).catch(() => {
+          /* no-op */
+        });
         expect(widget.promptNode.textContent).to.equal('[*]:');
         const future2 = CodeCell.execute(widget, session);
         expect(widget.promptNode.textContent).to.equal('[*]:');
-        try {
-          await future1;
-        } catch (e) {
-          /* no-op */
-        }
+        await framePromise();
+        expect(widget.promptNode.textContent).to.equal('[*]:');
+
+        await future1;
         let msg = await future2;
         expect(widget.promptNode.textContent).to.equal(
           `[${msg.content.execution_count}]:`

--- a/tests/test-cells/src/widget.spec.ts
+++ b/tests/test-cells/src/widget.spec.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { expect } from 'chai';
-
 import { Message, MessageLoop } from '@phosphor/messaging';
 
 import { Widget } from '@phosphor/widgets';
@@ -104,13 +102,13 @@ describe('cells/widget', () => {
     describe('#constructor()', () => {
       it('should create a base cell widget', () => {
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget).to.be.an.instanceof(Cell);
+        expect(widget).toBeInstanceOf(Cell);
       });
 
       it('should accept a custom contentFactory', () => {
         const contentFactory = NBTestUtils.createBaseCellFactory();
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget).to.be.an.instanceof(Cell);
+        expect(widget).toBeInstanceOf(Cell);
       });
 
       it('shoule accept a custom editorConfig', () => {
@@ -123,9 +121,9 @@ describe('cells/widget', () => {
           model,
           contentFactory
         }).initializeState();
-        expect(widget.editor.getOption('insertSpaces')).to.equal(false);
-        expect(widget.editor.getOption('matchBrackets')).to.equal(false);
-        expect(widget.editor.getOption('lineNumbers')).to.equal(
+        expect(widget.editor.getOption('insertSpaces')).toEqual(false);
+        expect(widget.editor.getOption('matchBrackets')).toEqual(false);
+        expect(widget.editor.getOption('lineNumbers')).toEqual(
           CodeEditor.defaultConfig.lineNumbers
         );
       });
@@ -135,40 +133,40 @@ describe('cells/widget', () => {
       it('should be the model used by the widget', () => {
         const model = new CellModel({});
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.model).to.equal(model);
+        expect(widget.model).toEqual(model);
       });
     });
 
     describe('#editorWidget', () => {
       it('should be a code editor widget', () => {
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.editorWidget).to.be.an.instanceof(CodeEditorWrapper);
+        expect(widget.editorWidget).toBeInstanceOf(CodeEditorWrapper);
       });
     });
 
     describe('#editor', () => {
       it('should be a cell editor', () => {
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.editor.uuid).to.be.ok;
+        expect(widget.editor.uuid).toBeTruthy();
       });
     });
 
     describe('#inputArea', () => {
       it('should be the input area for the cell', () => {
         const widget = new Cell({ model }).initializeState();
-        expect(widget.inputArea).to.be.an.instanceof(InputArea);
+        expect(widget.inputArea).toBeInstanceOf(InputArea);
       });
     });
 
     describe('#readOnly', () => {
       it('should be a boolean', () => {
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(typeof widget.readOnly).to.equal('boolean');
+        expect(typeof widget.readOnly).toEqual('boolean');
       });
 
       it('should default to false', () => {
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.readOnly).to.equal(false);
+        expect(widget.readOnly).toEqual(false);
       });
 
       it('should be settable', () => {
@@ -177,7 +175,7 @@ describe('cells/widget', () => {
           contentFactory
         }).initializeState();
         widget.readOnly = true;
-        expect(widget.readOnly).to.equal(true);
+        expect(widget.readOnly).toEqual(true);
       });
 
       it('should ignore being set to the same value', async () => {
@@ -185,7 +183,7 @@ describe('cells/widget', () => {
         widget.readOnly = true;
         widget.readOnly = true;
         await framePromise();
-        expect(widget.methods).to.deep.equal(['onUpdateRequest']);
+        expect(widget.methods).toEqual(['onUpdateRequest']);
       });
 
       it('should reflect model metadata', () => {
@@ -195,16 +193,16 @@ describe('cells/widget', () => {
           model,
           contentFactory
         }).initializeState();
-        expect(widget.readOnly).to.equal(true);
+        expect(widget.readOnly).toEqual(true);
       });
     });
 
     describe('#inputCollapsed', () => {
       it('should be the view state of the input being collapsed', () => {
         const widget = new LogBaseCell().initializeState();
-        expect(widget.inputHidden).to.equal(false);
+        expect(widget.inputHidden).toEqual(false);
         widget.inputHidden = true;
-        expect(widget.inputHidden).to.equal(true);
+        expect(widget.inputHidden).toEqual(true);
       });
     });
 
@@ -212,15 +210,15 @@ describe('cells/widget', () => {
       it('should load the editable state from the model', () => {
         const model = new CellModel({});
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.readOnly).to.equal(false);
+        expect(widget.readOnly).toEqual(false);
 
         model.metadata.set('editable', false);
         widget.loadEditableState();
-        expect(widget.readOnly).to.equal(true);
+        expect(widget.readOnly).toEqual(true);
 
         model.metadata.set('editable', true);
         widget.loadEditableState();
-        expect(widget.readOnly).to.equal(false);
+        expect(widget.readOnly).toEqual(false);
       });
     });
 
@@ -228,16 +226,16 @@ describe('cells/widget', () => {
       it('should save the editable state to the model', () => {
         const model = new CellModel({});
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.readOnly).to.equal(false);
+        expect(widget.readOnly).toEqual(false);
 
         widget.readOnly = true;
         widget.saveEditableState();
-        expect(model.metadata.get('editable')).to.equal(false);
+        expect(model.metadata.get('editable')).toEqual(false);
 
         widget.readOnly = false;
         widget.saveEditableState();
         // Default values are not saved explicitly
-        expect(model.metadata.get('editable')).to.equal(undefined);
+        expect(model.metadata.get('editable')).toEqual(undefined);
       });
     });
 
@@ -245,31 +243,31 @@ describe('cells/widget', () => {
       it('should control automatic syncing of editable state with model', () => {
         const model = new CellModel({});
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.syncEditable).to.equal(false);
-        expect(widget.readOnly).to.equal(false);
+        expect(widget.syncEditable).toEqual(false);
+        expect(widget.readOnly).toEqual(false);
 
         // Not synced if setting widget attribute
         widget.readOnly = true;
-        expect(model.metadata.get('editable')).to.equal(undefined);
+        expect(model.metadata.get('editable')).toEqual(undefined);
 
         // Not synced if setting metadata attribute
         model.metadata.set('editable', true);
-        expect(widget.readOnly).to.equal(true);
+        expect(widget.readOnly).toEqual(true);
 
         widget.syncEditable = true;
 
         // Setting sync does an initial sync from model to view. This also sets
         // the metadata to undefined if it is the default value.
-        expect(model.metadata.get('editable')).to.equal(undefined);
-        expect(widget.readOnly).to.equal(false);
+        expect(model.metadata.get('editable')).toEqual(undefined);
+        expect(widget.readOnly).toEqual(false);
 
         // Synced if setting widget attribute
         widget.readOnly = true;
-        expect(model.metadata.get('editable')).to.equal(false);
+        expect(model.metadata.get('editable')).toEqual(false);
 
         // Synced if setting metadata attribute
         model.metadata.set('editable', true);
-        expect(widget.readOnly).to.equal(false);
+        expect(widget.readOnly).toEqual(false);
       });
     });
 
@@ -277,15 +275,15 @@ describe('cells/widget', () => {
       it('should load the input collapse state from the model', () => {
         const model = new CellModel({});
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.inputHidden).to.equal(false);
+        expect(widget.inputHidden).toEqual(false);
 
         model.metadata.set('jupyter', { source_hidden: true });
         widget.loadCollapseState();
-        expect(widget.inputHidden).to.equal(true);
+        expect(widget.inputHidden).toEqual(true);
 
         model.metadata.set('jupyter', { source_hidden: false });
         widget.loadCollapseState();
-        expect(widget.inputHidden).to.equal(false);
+        expect(widget.inputHidden).toEqual(false);
       });
     });
 
@@ -293,18 +291,18 @@ describe('cells/widget', () => {
       it('should save the collapse state to the model', () => {
         const model = new CellModel({});
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.inputHidden).to.equal(false);
+        expect(widget.inputHidden).toEqual(false);
 
         widget.inputHidden = true;
         widget.saveCollapseState();
-        expect(model.metadata.get('jupyter')).to.deep.equal({
+        expect(model.metadata.get('jupyter')).toEqual({
           source_hidden: true
         });
 
         widget.inputHidden = false;
         widget.saveCollapseState();
         // Default values are not saved explicitly
-        expect(model.metadata.get('jupyter')).to.equal(undefined);
+        expect(model.metadata.get('jupyter')).toEqual(undefined);
       });
     });
 
@@ -312,33 +310,33 @@ describe('cells/widget', () => {
       it('should control automatic syncing of collapse state with model', () => {
         const model = new CellModel({});
         const widget = new Cell({ model, contentFactory }).initializeState();
-        expect(widget.syncCollapse).to.equal(false);
-        expect(widget.inputHidden).to.equal(false);
+        expect(widget.syncCollapse).toEqual(false);
+        expect(widget.inputHidden).toEqual(false);
 
         // Not synced if setting widget attribute
         widget.inputHidden = true;
-        expect(model.metadata.get('jupyter')).to.equal(undefined);
+        expect(model.metadata.get('jupyter')).toEqual(undefined);
 
         // Not synced if setting metadata attribute
         model.metadata.set('jupyter', { source_hidden: false });
-        expect(widget.inputHidden).to.equal(true);
+        expect(widget.inputHidden).toEqual(true);
 
         widget.syncCollapse = true;
 
         // Setting sync does an initial sync from model to view. This also sets
         // the metadata to undefined if it is the default value.
-        expect(model.metadata.get('jupyter')).to.equal(undefined);
-        expect(widget.inputHidden).to.equal(false);
+        expect(model.metadata.get('jupyter')).toEqual(undefined);
+        expect(widget.inputHidden).toEqual(false);
 
         // Synced if setting widget attribute
         widget.inputHidden = true;
-        expect(model.metadata.get('jupyter')).to.deep.equal({
+        expect(model.metadata.get('jupyter')).toEqual({
           source_hidden: true
         });
 
         // Synced if setting metadata attribute
         model.metadata.set('jupyter', {});
-        expect(widget.inputHidden).to.equal(false);
+        expect(widget.inputHidden).toEqual(false);
       });
     });
 
@@ -348,9 +346,9 @@ describe('cells/widget', () => {
         Widget.attach(widget, document.body);
         widget.activate();
         await framePromise();
-        expect(widget.methods).to.contain('onActivateRequest');
+        expect(widget.methods).toContain('onActivateRequest');
         await framePromise();
-        expect(widget.editor.hasFocus()).to.equal(true);
+        expect(widget.editor.hasFocus()).toEqual(true);
         widget.dispose();
       });
     });
@@ -360,19 +358,19 @@ describe('cells/widget', () => {
         const widget = new Cell({ model, contentFactory }).initializeState();
         expect(() => {
           widget.setPrompt(void 0);
-        }).to.not.throw;
+        }).not.toThrow();
         expect(() => {
           widget.setPrompt(null);
-        }).to.not.throw();
+        }).not.toThrow();
         expect(() => {
           widget.setPrompt('');
-        }).to.not.throw();
+        }).not.toThrow();
         expect(() => {
           widget.setPrompt('null');
-        }).to.not.throw();
+        }).not.toThrow();
         expect(() => {
           widget.setPrompt('test');
-        }).to.not.throw();
+        }).not.toThrow();
       });
     });
 
@@ -380,23 +378,23 @@ describe('cells/widget', () => {
       it('should dispose of the resources held by the widget', () => {
         const widget = new Cell({ model, contentFactory }).initializeState();
         widget.dispose();
-        expect(widget.isDisposed).to.equal(true);
+        expect(widget.isDisposed).toEqual(true);
       });
 
       it('should be safe to call multiple times', () => {
         const widget = new Cell({ model, contentFactory }).initializeState();
         widget.dispose();
         widget.dispose();
-        expect(widget.isDisposed).to.equal(true);
+        expect(widget.isDisposed).toEqual(true);
       });
     });
 
     describe('#onAfterAttach()', () => {
       it('should run when widget is attached', () => {
         const widget = new LogBaseCell().initializeState();
-        expect(widget.methods).to.not.contain('onAfterAttach');
+        expect(widget.methods).not.toContain('onAfterAttach');
         Widget.attach(widget, document.body);
-        expect(widget.methods).to.contain('onAfterAttach');
+        expect(widget.methods).toContain('onAfterAttach');
         widget.dispose();
       });
     });
@@ -404,17 +402,15 @@ describe('cells/widget', () => {
     describe('#onUpdateRequest()', () => {
       it('should update the widget', () => {
         const widget = new LogBaseCell().initializeState();
-        expect(widget.methods).to.not.contain('onUpdateRequest');
+        expect(widget.methods).not.toContain('onUpdateRequest');
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(widget.methods).to.contain('onUpdateRequest');
+        expect(widget.methods).toContain('onUpdateRequest');
       });
     });
 
     describe('#.defaultContentFactory', () => {
       it('should be a contentFactory', () => {
-        expect(Cell.defaultContentFactory).to.be.an.instanceof(
-          Cell.ContentFactory
-        );
+        expect(Cell.defaultContentFactory).toBeInstanceOf(Cell.ContentFactory);
       });
     });
 
@@ -422,44 +418,42 @@ describe('cells/widget', () => {
       describe('#constructor', () => {
         it('should create a ContentFactory', () => {
           const factory = new Cell.ContentFactory({ editorFactory });
-          expect(factory).to.be.an.instanceof(Cell.ContentFactory);
+          expect(factory).toBeInstanceOf(Cell.ContentFactory);
         });
       });
 
       describe('#editorFactory', () => {
         it('should be the editor factory used by the content factory', () => {
           const factory = new Cell.ContentFactory({ editorFactory });
-          expect(factory.editorFactory).to.equal(editorFactory);
+          expect(factory.editorFactory).toEqual(editorFactory);
         });
       });
 
       describe('#createCellHeader()', () => {
         it('should create a new cell header', () => {
           const factory = new Cell.ContentFactory();
-          expect(factory.createCellHeader()).to.be.an.instanceof(CellHeader);
+          expect(factory.createCellHeader()).toBeInstanceOf(CellHeader);
         });
       });
 
       describe('#createCellFooter()', () => {
         it('should create a new cell footer', () => {
           const factory = new Cell.ContentFactory();
-          expect(factory.createCellFooter()).to.be.an.instanceof(CellFooter);
+          expect(factory.createCellFooter()).toBeInstanceOf(CellFooter);
         });
       });
 
       describe('#createOutputPrompt()', () => {
         it('should create a new output prompt', () => {
           const factory = new Cell.ContentFactory();
-          expect(factory.createOutputPrompt()).to.be.an.instanceof(
-            OutputPrompt
-          );
+          expect(factory.createOutputPrompt()).toBeInstanceOf(OutputPrompt);
         });
       });
 
       describe('#createInputPrompt()', () => {
         it('should create a new input prompt', () => {
           const factory = new Cell.ContentFactory();
-          expect(factory.createInputPrompt()).to.be.an.instanceof(InputPrompt);
+          expect(factory.createInputPrompt()).toBeInstanceOf(InputPrompt);
         });
       });
     });
@@ -473,14 +467,14 @@ describe('cells/widget', () => {
       it('should create a code cell widget', () => {
         const widget = new CodeCell({ model, rendermime, contentFactory });
         widget.initializeState();
-        expect(widget).to.be.an.instanceof(CodeCell);
+        expect(widget).toBeInstanceOf(CodeCell);
       });
 
       it('should accept a custom contentFactory', () => {
         const contentFactory = NBTestUtils.createCodeCellFactory();
         const widget = new CodeCell({ model, contentFactory, rendermime });
         widget.initializeState();
-        expect(widget).to.be.an.instanceof(CodeCell);
+        expect(widget).toBeInstanceOf(CodeCell);
       });
     });
 
@@ -488,7 +482,7 @@ describe('cells/widget', () => {
       it('should be the output area used by the cell', () => {
         const widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputArea).to.be.an.instanceof(OutputArea);
+        expect(widget.outputArea).toBeInstanceOf(OutputArea);
       });
     });
 
@@ -497,26 +491,26 @@ describe('cells/widget', () => {
         const collapsedModel = new CodeCellModel({});
         let widget = new CodeCell({ model: collapsedModel, rendermime });
         widget.initializeState();
-        expect(widget.outputHidden).to.equal(false);
+        expect(widget.outputHidden).toEqual(false);
 
         collapsedModel.metadata.set('collapsed', true);
         widget = new CodeCell({ model: collapsedModel, rendermime });
         widget.initializeState();
-        expect(widget.outputHidden).to.equal(true);
+        expect(widget.outputHidden).toEqual(true);
 
         collapsedModel.metadata.delete('collapsed');
         collapsedModel.metadata.set('jupyter', { outputs_hidden: true });
         widget = new CodeCell({ model: collapsedModel, rendermime });
         widget.initializeState();
-        expect(widget.outputHidden).to.equal(true);
+        expect(widget.outputHidden).toEqual(true);
       });
 
       it('should be the view state of the output being collapsed', () => {
         const widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputHidden).to.equal(false);
+        expect(widget.outputHidden).toEqual(false);
         widget.outputHidden = true;
-        expect(widget.outputHidden).to.equal(true);
+        expect(widget.outputHidden).toEqual(true);
       });
     });
 
@@ -525,22 +519,22 @@ describe('cells/widget', () => {
         const model = new CodeCellModel({});
         let widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(widget.outputsScrolled).toEqual(false);
 
         model.metadata.set('scrolled', false);
         widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(widget.outputsScrolled).toEqual(false);
 
         model.metadata.set('scrolled', 'auto');
         widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(widget.outputsScrolled).toEqual(false);
 
         model.metadata.set('scrolled', true);
         widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputsScrolled).to.equal(true);
+        expect(widget.outputsScrolled).toEqual(true);
       });
     });
 
@@ -549,15 +543,15 @@ describe('cells/widget', () => {
         const model = new CodeCellModel({});
         let widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(widget.outputsScrolled).toEqual(false);
 
         model.metadata.set('scrolled', true);
         widget.loadScrolledState();
-        expect(widget.outputsScrolled).to.equal(true);
+        expect(widget.outputsScrolled).toEqual(true);
 
         model.metadata.set('scrolled', false);
         widget.loadScrolledState();
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(widget.outputsScrolled).toEqual(false);
       });
     });
 
@@ -566,16 +560,16 @@ describe('cells/widget', () => {
         const model = new CodeCellModel({});
         let widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(widget.outputsScrolled).toEqual(false);
 
         widget.outputsScrolled = true;
         widget.saveScrolledState();
-        expect(model.metadata.get('scrolled')).to.equal(true);
+        expect(model.metadata.get('scrolled')).toEqual(true);
 
         widget.outputsScrolled = false;
         widget.saveScrolledState();
         // Default values are not saved explicitly
-        expect(model.metadata.get('scrolled')).to.equal(undefined);
+        expect(model.metadata.get('scrolled')).toEqual(undefined);
       });
     });
 
@@ -584,31 +578,31 @@ describe('cells/widget', () => {
         const model = new CodeCellModel({});
         let widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.syncScrolled).to.equal(false);
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(widget.syncScrolled).toEqual(false);
+        expect(widget.outputsScrolled).toEqual(false);
 
         // Not synced if setting widget attribute
         widget.outputsScrolled = true;
-        expect(model.metadata.get('scrolled')).to.equal(undefined);
+        expect(model.metadata.get('scrolled')).toEqual(undefined);
 
         // Not synced if setting metadata attribute
         model.metadata.set('scrolled', false);
-        expect(widget.outputsScrolled).to.equal(true);
+        expect(widget.outputsScrolled).toEqual(true);
 
         widget.syncScrolled = true;
 
         // Setting sync does an initial sync from model to view. This also sets
         // the metadata to undefined if it is the default value.
-        expect(model.metadata.get('scrolled')).to.equal(undefined);
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(model.metadata.get('scrolled')).toEqual(undefined);
+        expect(widget.outputsScrolled).toEqual(false);
 
         // Synced if setting widget attribute
         widget.outputsScrolled = true;
-        expect(model.metadata.get('scrolled')).to.equal(true);
+        expect(model.metadata.get('scrolled')).toEqual(true);
 
         // Synced if setting metadata attribute
         model.metadata.set('scrolled', false);
-        expect(widget.outputsScrolled).to.equal(false);
+        expect(widget.outputsScrolled).toEqual(false);
       });
     });
 
@@ -618,15 +612,15 @@ describe('cells/widget', () => {
         let widget = new CodeCell({ model, rendermime });
         widget.initializeState();
         widget.loadCollapseState();
-        expect(widget.outputHidden).to.equal(false);
+        expect(widget.outputHidden).toEqual(false);
 
         model.metadata.set('collapsed', true);
         widget.loadCollapseState();
-        expect(widget.outputHidden).to.equal(true);
+        expect(widget.outputHidden).toEqual(true);
 
         model.metadata.set('collapsed', false);
         widget.loadCollapseState();
-        expect(widget.outputHidden).to.equal(false);
+        expect(widget.outputHidden).toEqual(false);
       });
     });
 
@@ -635,22 +629,22 @@ describe('cells/widget', () => {
         const model = new CodeCellModel({});
         let widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.outputHidden).to.equal(false);
+        expect(widget.outputHidden).toEqual(false);
 
         widget.outputHidden = true;
         widget.saveCollapseState();
-        expect(model.metadata.get('collapsed')).to.equal(true);
+        expect(model.metadata.get('collapsed')).toEqual(true);
 
         // Default values are not saved explicitly
         widget.outputHidden = false;
         widget.saveCollapseState();
-        expect(model.metadata.get('collapsed')).to.equal(undefined);
+        expect(model.metadata.get('collapsed')).toEqual(undefined);
 
         // Default values are explicitly deleted
         model.metadata.set('collapsed', false);
         widget.outputHidden = false;
         widget.saveCollapseState();
-        expect(model.metadata.get('collapsed')).to.equal(undefined);
+        expect(model.metadata.get('collapsed')).toEqual(undefined);
       });
     });
 
@@ -659,36 +653,36 @@ describe('cells/widget', () => {
         const model = new CodeCellModel({});
         let widget = new CodeCell({ model, rendermime });
         widget.initializeState();
-        expect(widget.syncCollapse).to.equal(false);
-        expect(widget.outputHidden).to.equal(false);
+        expect(widget.syncCollapse).toEqual(false);
+        expect(widget.outputHidden).toEqual(false);
 
         // Not synced if setting widget attribute
         widget.outputHidden = true;
-        expect(model.metadata.get('collapsed')).to.equal(undefined);
+        expect(model.metadata.get('collapsed')).toEqual(undefined);
 
         // Not synced if setting metadata attribute
         model.metadata.set('collapsed', false);
-        expect(widget.outputHidden).to.equal(true);
+        expect(widget.outputHidden).toEqual(true);
 
         widget.syncCollapse = true;
 
         // Setting sync does an initial sync from model to view.
-        expect(model.metadata.get('collapsed')).to.equal(undefined);
-        expect(widget.outputHidden).to.equal(false);
+        expect(model.metadata.get('collapsed')).toEqual(undefined);
+        expect(widget.outputHidden).toEqual(false);
 
         // Synced if setting widget attribute
         widget.outputHidden = true;
-        expect(model.metadata.get('collapsed')).to.equal(true);
+        expect(model.metadata.get('collapsed')).toEqual(true);
 
         // Synced if setting metadata attribute
         model.metadata.set('collapsed', false);
-        expect(widget.outputHidden).to.equal(false);
+        expect(widget.outputHidden).toEqual(false);
 
         // Synced if deleting collapsed metadata attribute
         widget.outputHidden = true;
-        expect(model.metadata.get('collapsed')).to.equal(true);
+        expect(model.metadata.get('collapsed')).toEqual(true);
         model.metadata.delete('collapsed');
-        expect(widget.outputHidden).to.equal(false);
+        expect(widget.outputHidden).toEqual(false);
       });
     });
 
@@ -697,7 +691,7 @@ describe('cells/widget', () => {
         const widget = new CodeCell({ model, rendermime, contentFactory });
         widget.initializeState();
         widget.dispose();
-        expect(widget.isDisposed).to.equal(true);
+        expect(widget.isDisposed).toEqual(true);
       });
 
       it('should be safe to call multiple times', () => {
@@ -705,16 +699,16 @@ describe('cells/widget', () => {
         widget.initializeState();
         widget.dispose();
         widget.dispose();
-        expect(widget.isDisposed).to.equal(true);
+        expect(widget.isDisposed).toEqual(true);
       });
     });
 
     describe('#onUpdateRequest()', () => {
       it('should update the widget', () => {
         const widget = new LogCodeCell().initializeState();
-        expect(widget.methods).to.not.contain('onUpdateRequest');
+        expect(widget.methods).not.toContain('onUpdateRequest');
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(widget.methods).to.contain('onUpdateRequest');
+        expect(widget.methods).toContain('onUpdateRequest');
       });
     });
 
@@ -722,9 +716,9 @@ describe('cells/widget', () => {
       it('should fire when model metadata changes', () => {
         const method = 'onMetadataChanged';
         const widget = new LogCodeCell().initializeState();
-        expect(widget.methods).to.not.contain(method);
+        expect(widget.methods).not.toContain(method);
         widget.model.metadata.set('foo', 1);
-        expect(widget.methods).to.contain(method);
+        expect(widget.methods).toContain(method);
       });
     });
 
@@ -759,27 +753,28 @@ describe('cells/widget', () => {
         originalCount = widget.model.executionCount;
         await CodeCell.execute(widget, session);
         const executionCount = widget.model.executionCount;
-        expect(executionCount).to.not.equal(originalCount);
+        expect(executionCount).not.toEqual(originalCount);
       });
 
       it('should set the cell prompt properly while executing', async () => {
         const widget = new CodeCell({ model, rendermime, contentFactory });
         widget.initializeState();
         widget.model.value.text = 'foo';
-        const future1 = CodeCell.execute(widget, session).catch(() => {
-          /* no-op */
-        });
-        expect(widget.promptNode.textContent).to.equal('[*]:');
+        const future1 = CodeCell.execute(widget, session);
+        expect(widget.promptNode.textContent).toEqual('[*]:');
         const future2 = CodeCell.execute(widget, session);
-        expect(widget.promptNode.textContent).to.equal('[*]:');
-        await framePromise();
-        expect(widget.promptNode.textContent).to.equal('[*]:');
-
-        await future1;
+        expect(widget.promptNode.textContent).toEqual('[*]:');
+        await expect(future1).rejects.toThrow('Canceled');
+        expect(widget.promptNode.textContent).toEqual('[*]:');
         let msg = await future2;
-        expect(widget.promptNode.textContent).to.equal(
-          `[${msg.content.execution_count}]:`
-        );
+        expect(msg).not.toBeUndefined;
+
+        // The `if` is a Typescript type guard so that msg.content works below.
+        if (msg) {
+          expect(widget.promptNode.textContent).toEqual(
+            `[${msg.content.execution_count}]:`
+          );
+        }
       });
     });
   });
@@ -792,19 +787,19 @@ describe('cells/widget', () => {
       it('should create a markdown cell widget', () => {
         const widget = new MarkdownCell({ model, rendermime, contentFactory });
         widget.initializeState();
-        expect(widget).to.be.an.instanceof(MarkdownCell);
+        expect(widget).toBeInstanceOf(MarkdownCell);
       });
 
       it('should accept a custom contentFactory', () => {
         const widget = new MarkdownCell({ model, rendermime, contentFactory });
         widget.initializeState();
-        expect(widget).to.be.an.instanceof(MarkdownCell);
+        expect(widget).toBeInstanceOf(MarkdownCell);
       });
 
       it('should set the default mimetype to text/x-ipythongfm', () => {
         const widget = new MarkdownCell({ model, rendermime, contentFactory });
         widget.initializeState();
-        expect(widget.model.mimeType).to.equal('text/x-ipythongfm');
+        expect(widget.model.mimeType).toEqual('text/x-ipythongfm');
       });
     });
 
@@ -813,9 +808,9 @@ describe('cells/widget', () => {
         const widget = new MarkdownCell({ model, rendermime, contentFactory });
         widget.initializeState();
         Widget.attach(widget, document.body);
-        expect(widget.rendered).to.equal(true);
+        expect(widget.rendered).toEqual(true);
         await framePromise();
-        expect(widget.node.classList.contains(RENDERED_CLASS)).to.equal(true);
+        expect(widget.node.classList.contains(RENDERED_CLASS)).toEqual(true);
       });
 
       it('should unrender the widget', async () => {
@@ -824,7 +819,7 @@ describe('cells/widget', () => {
         Widget.attach(widget, document.body);
         widget.rendered = false;
         await framePromise();
-        expect(widget.node.classList.contains(RENDERED_CLASS)).to.equal(false);
+        expect(widget.node.classList.contains(RENDERED_CLASS)).toEqual(false);
         widget.dispose();
       });
     });
@@ -834,7 +829,7 @@ describe('cells/widget', () => {
         const widget = new MarkdownCell({ model, rendermime, contentFactory });
         widget.initializeState();
         widget.dispose();
-        expect(widget.isDisposed).to.equal(true);
+        expect(widget.isDisposed).toEqual(true);
       });
 
       it('should be safe to call multiple times', () => {
@@ -842,7 +837,7 @@ describe('cells/widget', () => {
         widget.initializeState();
         widget.dispose();
         widget.dispose();
-        expect(widget.isDisposed).to.equal(true);
+        expect(widget.isDisposed).toEqual(true);
       });
     });
 
@@ -853,9 +848,9 @@ describe('cells/widget', () => {
           rendermime,
           contentFactory
         }).initializeState();
-        expect(widget.methods).to.not.contain('onUpdateRequest');
+        expect(widget.methods).not.toContain('onUpdateRequest');
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(widget.methods).to.contain('onUpdateRequest');
+        expect(widget.methods).toContain('onUpdateRequest');
       });
     });
   });
@@ -867,7 +862,7 @@ describe('cells/widget', () => {
       it('should create a raw cell widget', () => {
         const model = new RawCellModel({});
         const widget = new RawCell({ model, contentFactory }).initializeState();
-        expect(widget).to.be.an.instanceof(RawCell);
+        expect(widget).toBeInstanceOf(RawCell);
       });
     });
   });
@@ -875,7 +870,7 @@ describe('cells/widget', () => {
   describe('CellHeader', () => {
     describe('#constructor()', () => {
       it('should create a new cell header', () => {
-        expect(new CellHeader()).to.be.an.instanceof(CellHeader);
+        expect(new CellHeader()).toBeInstanceOf(CellHeader);
       });
     });
   });
@@ -883,7 +878,7 @@ describe('cells/widget', () => {
   describe('CellFooter', () => {
     describe('#constructor()', () => {
       it('should create a new cell footer', () => {
-        expect(new CellFooter()).to.be.an.instanceof(CellFooter);
+        expect(new CellFooter()).toBeInstanceOf(CellFooter);
       });
     });
   });

--- a/tests/test-cells/src/widget.spec.ts
+++ b/tests/test-cells/src/widget.spec.ts
@@ -761,6 +761,25 @@ describe('cells/widget', () => {
         const executionCount = widget.model.executionCount;
         expect(executionCount).to.not.equal(originalCount);
       });
+
+      it('should set the cell prompt properly while executing', async () => {
+        const widget = new CodeCell({ model, rendermime, contentFactory });
+        widget.initializeState();
+        widget.model.value.text = 'foo';
+        const future1 = CodeCell.execute(widget, session);
+        expect(widget.promptNode.textContent).to.equal('[*]:');
+        const future2 = CodeCell.execute(widget, session);
+        expect(widget.promptNode.textContent).to.equal('[*]:');
+        try {
+          await future1;
+        } catch (e) {
+          /* no-op */
+        }
+        let msg = await future2;
+        expect(widget.promptNode.textContent).to.equal(
+          `[${msg.content.execution_count}]:`
+        );
+      });
     });
   });
 

--- a/tests/test-console/src/history.spec.ts
+++ b/tests/test-console/src/history.spec.ts
@@ -17,7 +17,14 @@ import { createClientSession, signalToPromise } from '@jupyterlab/testutils';
 
 const mockHistory: KernelMessage.IHistoryReplyMsg = {
   header: null,
-  parent_header: {},
+  parent_header: {
+    date: '',
+    msg_id: '',
+    msg_type: 'history_request',
+    username: '',
+    session: '',
+    version: '5.3'
+  },
   metadata: null,
   buffers: null,
   channel: 'shell',

--- a/tests/test-services/src/kernel/comm.spec.ts
+++ b/tests/test-services/src/kernel/comm.spec.ts
@@ -250,11 +250,11 @@ describe('jupyter.services - Comm', () => {
         await future.done;
         const encoder = new TextEncoder();
         const data = encoder.encode('hello');
-        future = comm.open({ foo: 'bar' }, { fizz: 'buzz' }, [
+        let future2 = comm.open({ foo: 'bar' }, { fizz: 'buzz' }, [
           data,
           data.buffer
         ]);
-        await future.done;
+        await future2.done;
       });
     });
 

--- a/tests/test-services/src/kernel/comm.spec.ts
+++ b/tests/test-services/src/kernel/comm.spec.ts
@@ -220,14 +220,17 @@ describe('jupyter.services - Comm', () => {
           called = true;
         };
         expect(typeof comm.onMsg).to.equal('function');
-        const options: KernelMessage.IOptions = {
+        const msg = KernelMessage.createMessage({
           msgType: 'comm_msg',
           channel: 'iopub',
           username: kernel.username,
-          session: kernel.clientId
-        };
-        const msg = KernelMessage.createMessage(options);
-        comm.onMsg(msg as KernelMessage.ICommMsgMsg);
+          session: kernel.clientId,
+          content: {
+            comm_id: 'abcd',
+            data: {}
+          }
+        });
+        comm.onMsg(msg);
         expect(called).to.equal(true);
       });
 

--- a/tests/test-services/src/kernel/ifuture.spec.ts
+++ b/tests/test-services/src/kernel/ifuture.spec.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 
-import { KernelTester, createMsg } from '../utils';
+import { KernelTester } from '../utils';
 
 describe('Kernel.IFuture', () => {
   let tester: KernelTester;
@@ -43,21 +43,38 @@ describe('Kernel.IFuture', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader) as any;
-        tester.send(msg);
+        const session = 'session';
+        tester.send(
+          KernelMessage.createMessage({
+            parentHeader,
+            session,
+            channel: 'shell',
+            msgType: 'comm_open',
+            content: { comm_id: 'B', data: {}, target_name: 'C' }
+          })
+        );
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader) as any;
-          msgStream.header.msg_type = 'stream';
-          msgStream.content = { name: 'stdout', text: 'foo' };
-          tester.send(msgStream);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'stream',
+              content: { name: 'stdout', text: 'foo' }
+            })
+          );
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader) as any;
-          msgDone.header.msg_type = 'status';
-          (msgDone as KernelMessage.IStatusMsg).content.execution_state =
-            'idle';
-          tester.send(msgDone);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'status',
+              content: { execution_state: 'idle' }
+            })
+          );
         };
 
         future.registerMessageHook(async msg => {
@@ -119,21 +136,38 @@ describe('Kernel.IFuture', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader) as any;
-        tester.send(msg);
+        const session = 'session';
+        tester.send(
+          KernelMessage.createMessage({
+            parentHeader,
+            session,
+            channel: 'shell',
+            msgType: 'comm_open',
+            content: { comm_id: 'B', data: {}, target_name: 'C' }
+          })
+        );
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader) as any;
-          msgStream.header.msg_type = 'stream';
-          msgStream.content = { name: 'stdout', text: 'foo' };
-          tester.send(msgStream);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'stream',
+              content: { name: 'stdout', text: 'foo' }
+            })
+          );
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader) as any;
-          msgDone.header.msg_type = 'status';
-          (msgDone as KernelMessage.IStatusMsg).content.execution_state =
-            'idle';
-          tester.send(msgDone);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'status',
+              content: { execution_state: 'idle' }
+            })
+          );
         };
 
         future.registerMessageHook(msg => {
@@ -174,21 +208,38 @@ describe('Kernel.IFuture', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader) as any;
-        tester.send(msg);
+        const session = 'session';
+        tester.send(
+          KernelMessage.createMessage({
+            parentHeader,
+            session,
+            channel: 'shell',
+            msgType: 'comm_open',
+            content: { comm_id: 'B', data: {}, target_name: 'C' }
+          })
+        );
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader) as any;
-          msgStream.header.msg_type = 'stream';
-          msgStream.content = { name: 'stdout', text: 'foo' };
-          tester.send(msgStream);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'stream',
+              content: { name: 'stdout', text: 'foo' }
+            })
+          );
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader) as any;
-          msgDone.header.msg_type = 'status';
-          (msgDone as KernelMessage.IStatusMsg).content.execution_state =
-            'idle';
-          tester.send(msgDone);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'status',
+              content: { execution_state: 'idle' }
+            })
+          );
         };
 
         future.registerMessageHook(msg => {
@@ -240,21 +291,38 @@ describe('Kernel.IFuture', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader) as any;
-        tester.send(msg);
+        const session = 'session';
+        tester.send(
+          KernelMessage.createMessage({
+            parentHeader,
+            session,
+            channel: 'shell',
+            msgType: 'comm_open',
+            content: { comm_id: 'B', data: {}, target_name: 'C' }
+          })
+        );
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader) as any;
-          msgStream.header.msg_type = 'stream';
-          msgStream.content = { name: 'stdout', text: 'foo' };
-          tester.send(msgStream);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'stream',
+              content: { name: 'stdout', text: 'foo' }
+            })
+          );
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader) as any;
-          msgDone.header.msg_type = 'status';
-          (msgDone as KernelMessage.IStatusMsg).content.execution_state =
-            'idle';
-          tester.send(msgDone);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'status',
+              content: { execution_state: 'idle' }
+            })
+          );
         };
 
         future.registerMessageHook(toDelete);

--- a/tests/test-services/src/kernel/ifuture.spec.ts
+++ b/tests/test-services/src/kernel/ifuture.spec.ts
@@ -43,17 +43,17 @@ describe('Kernel.IFuture', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader);
+        const msg = createMsg('shell', parentHeader) as any;
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader) as any;
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader) as any;
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -119,17 +119,17 @@ describe('Kernel.IFuture', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader);
+        const msg = createMsg('shell', parentHeader) as any;
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader) as any;
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader) as any;
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -174,17 +174,17 @@ describe('Kernel.IFuture', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader);
+        const msg = createMsg('shell', parentHeader) as any;
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader) as any;
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader) as any;
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';
@@ -240,17 +240,17 @@ describe('Kernel.IFuture', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader);
+        const msg = createMsg('shell', parentHeader) as any;
         tester.send(msg);
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader);
+          const msgStream = createMsg('iopub', parentHeader) as any;
           msgStream.header.msg_type = 'stream';
           msgStream.content = { name: 'stdout', text: 'foo' };
           tester.send(msgStream);
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader);
+          const msgDone = createMsg('iopub', parentHeader) as any;
           msgDone.header.msg_type = 'status';
           (msgDone as KernelMessage.IStatusMsg).content.execution_state =
             'idle';

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -7,7 +7,7 @@ import { PageConfig } from '@jupyterlab/coreutils';
 
 import { UUID } from '@phosphor/coreutils';
 
-import { JSONObject, PromiseDelegate } from '@phosphor/coreutils';
+import { PromiseDelegate } from '@phosphor/coreutils';
 
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 
@@ -551,7 +551,6 @@ describe('Kernel.IKernel', () => {
       });
       const future = kernel.sendShellMessage(msg, true);
 
-      let newMsg: KernelMessage.IMessage;
       tester.onMessage(msg => {
         // trigger onDone
         tester.send(
@@ -566,7 +565,6 @@ describe('Kernel.IKernel', () => {
         );
 
         future.onIOPub = () => {
-          newMsg.parent_header = msg.header;
           tester.send(
             KernelMessage.createMessage({
               msgType: 'comm_open',
@@ -870,7 +868,6 @@ describe('Kernel.IKernel', () => {
 
   describe('#requestExecute()', () => {
     it('should send and handle incoming messages', async () => {
-      let newMsg: KernelMessage.IMessage;
       const content: KernelMessage.IExecuteRequest = {
         code: 'test',
         silent: false,

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -472,8 +472,9 @@ describe('Kernel.IKernel', () => {
         session: kernel.clientId,
         msgId
       };
+
       const msg = KernelMessage.createShellMessage(options);
-      await kernel.sendShellMessage(msg, true).done;
+      kernel.sendShellMessage(msg, true);
       await done.promise;
     });
 
@@ -506,7 +507,7 @@ describe('Kernel.IKernel', () => {
         data,
         data.buffer
       ]);
-      await kernel.sendShellMessage(msg, true).done;
+      kernel.sendShellMessage(msg, true);
       await done.promise;
     });
 

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -116,7 +116,7 @@ describe('Kernel.IKernel', () => {
         find: (k, msg) => msg.header.msg_id === msgId
       });
       const msg = KernelMessage.createShellMessage({
-        msgType: 'foo',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         session: tester.serverSessionId,
         msgId
@@ -143,7 +143,7 @@ describe('Kernel.IKernel', () => {
 
       // Send a shell message.
       const msg = KernelMessage.createShellMessage({
-        msgType: 'foo',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         session: tester.serverSessionId,
         msgId
@@ -172,7 +172,7 @@ describe('Kernel.IKernel', () => {
 
       // Send a shell message with the wrong client (parent) session.
       const msg1 = KernelMessage.createShellMessage({
-        msgType: 'foo',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         session: tester.serverSessionId,
         msgId: 'message from wrong session'
@@ -182,7 +182,7 @@ describe('Kernel.IKernel', () => {
 
       // Send a shell message with the right client (parent) session.
       const msg2 = KernelMessage.createShellMessage({
-        msgType: 'foo',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         session: tester.serverSessionId,
         msgId: msgId
@@ -217,7 +217,7 @@ describe('Kernel.IKernel', () => {
       });
 
       const msg = KernelMessage.createShellMessage({
-        msgType: 'foo',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         session: tester.serverSessionId,
         msgId
@@ -455,7 +455,7 @@ describe('Kernel.IKernel', () => {
       });
 
       const options: KernelMessage.IOptions = {
-        msgType: 'custom',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId,
@@ -487,7 +487,7 @@ describe('Kernel.IKernel', () => {
       });
 
       const options: KernelMessage.IOptions = {
-        msgType: 'custom',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId,
@@ -517,7 +517,7 @@ describe('Kernel.IKernel', () => {
       await dead;
 
       const options: KernelMessage.IOptions = {
-        msgType: 'custom',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId
@@ -538,7 +538,7 @@ describe('Kernel.IKernel', () => {
       const kernel = await tester.start();
 
       const options: KernelMessage.IOptions = {
-        msgType: 'custom',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId
@@ -846,7 +846,7 @@ describe('Kernel.IKernel', () => {
       };
 
       const options: KernelMessage.IOptions = {
-        msgType: 'custom',
+        msgType: 'kernel_info_request',
         channel: 'shell',
         username: defaultKernel.username,
         session: defaultKernel.clientId

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -457,7 +457,6 @@ describe('Kernel.IKernel', () => {
 
       tester.onMessage(msg => {
         try {
-          console.log('*************IN MESSAGE***************');
           expect(msg.header.msg_id).to.equal(msgId);
         } catch (e) {
           done.reject(e);
@@ -467,14 +466,14 @@ describe('Kernel.IKernel', () => {
       });
 
       const options: KernelMessage.IOptions = {
-        msgType: 'kernel_info_request',
+        msgType: 'comm_info_request',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId,
         msgId
       };
       const msg = KernelMessage.createShellMessage(options);
-      kernel.sendShellMessage(msg, true);
+      await kernel.sendShellMessage(msg, true).done;
       await done.promise;
     });
 
@@ -495,7 +494,7 @@ describe('Kernel.IKernel', () => {
       });
 
       const options: KernelMessage.IOptions = {
-        msgType: 'kernel_info_request',
+        msgType: 'comm_info_request',
         channel: 'shell',
         username: kernel.username,
         session: kernel.clientId,
@@ -507,7 +506,7 @@ describe('Kernel.IKernel', () => {
         data,
         data.buffer
       ]);
-      kernel.sendShellMessage(msg, true);
+      await kernel.sendShellMessage(msg, true).done;
       await done.promise;
     });
 

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -463,7 +463,7 @@ describe('Kernel.IKernel', () => {
           done.reject(e);
           throw e;
         }
-        done.resolve(null);
+        done.resolve();
       });
 
       const options: KernelMessage.IOptions = {
@@ -491,7 +491,7 @@ describe('Kernel.IKernel', () => {
           done.reject(e);
           throw e;
         }
-        done.resolve(null);
+        done.resolve();
       });
 
       const options: KernelMessage.IOptions = {
@@ -512,7 +512,6 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should fail if the kernel is dead', async () => {
-
       // Create a promise that resolves when the kernel's status changes to dead
       const dead = testEmission(kernel.statusChanged, {
         find: () => kernel.status === 'dead'

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -15,7 +15,6 @@ import {
   expectFailure,
   KernelTester,
   handleRequest,
-  createMsg,
   testEmission
 } from '../utils';
 
@@ -1014,21 +1013,38 @@ describe('Kernel.IKernel', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader) as any;
-        tester.send(msg);
+        const session = 'session';
+        tester.send(
+          KernelMessage.createMessage({
+            parentHeader,
+            session,
+            channel: 'shell',
+            msgType: 'comm_open',
+            content: { comm_id: 'B', data: {}, target_name: 'C' }
+          })
+        );
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader) as any;
-          msgStream.header.msg_type = 'stream';
-          msgStream.content = { name: 'stdout', text: 'foo' };
-          tester.send(msgStream);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'stream',
+              content: { name: 'stdout', text: 'foo' }
+            })
+          );
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader) as any;
-          msgDone.header.msg_type = 'status';
-          (msgDone as KernelMessage.IStatusMsg).content.execution_state =
-            'idle';
-          tester.send(msgDone);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'status',
+              content: { execution_state: 'idle' }
+            })
+          );
         };
 
         kernel.registerMessageHook(parentHeader.msg_id, async msg => {
@@ -1083,21 +1099,38 @@ describe('Kernel.IKernel', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader) as any;
-        tester.send(msg);
+        const session = 'session';
+        tester.send(
+          KernelMessage.createMessage({
+            parentHeader,
+            session,
+            channel: 'shell',
+            msgType: 'comm_open',
+            content: { comm_id: 'B', data: {}, target_name: 'C' }
+          })
+        );
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader) as any;
-          msgStream.header.msg_type = 'stream';
-          msgStream.content = { name: 'stdout', text: 'foo' };
-          tester.send(msgStream);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'stream',
+              content: { name: 'stdout', text: 'foo' }
+            })
+          );
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader) as any;
-          msgDone.header.msg_type = 'status';
-          (msgDone as KernelMessage.IStatusMsg).content.execution_state =
-            'idle';
-          tester.send(msgDone);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'status',
+              content: { execution_state: 'idle' }
+            })
+          );
         };
 
         kernel.registerMessageHook(parentHeader.msg_id, msg => {
@@ -1142,21 +1175,38 @@ describe('Kernel.IKernel', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader) as any;
-        tester.send(msg);
+        const session = 'session';
+        tester.send(
+          KernelMessage.createMessage({
+            parentHeader,
+            session,
+            channel: 'shell',
+            msgType: 'comm_open',
+            content: { comm_id: 'B', data: {}, target_name: 'C' }
+          })
+        );
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader) as any;
-          msgStream.header.msg_type = 'stream';
-          msgStream.content = { name: 'stdout', text: 'foo' };
-          tester.send(msgStream);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'stream',
+              content: { name: 'stdout', text: 'foo' }
+            })
+          );
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader) as any;
-          msgDone.header.msg_type = 'status';
-          (msgDone as KernelMessage.IStatusMsg).content.execution_state =
-            'idle';
-          tester.send(msgDone);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'status',
+              content: { execution_state: 'idle' }
+            })
+          );
         };
 
         kernel.registerMessageHook(parentHeader.msg_id, msg => {
@@ -1198,21 +1248,38 @@ describe('Kernel.IKernel', () => {
       tester.onMessage(message => {
         // send a reply
         const parentHeader = message.header;
-        const msg = createMsg('shell', parentHeader) as any;
-        tester.send(msg);
+        const session = 'session';
+        tester.send(
+          KernelMessage.createMessage({
+            parentHeader,
+            session,
+            channel: 'shell',
+            msgType: 'comm_open',
+            content: { comm_id: 'B', data: {}, target_name: 'C' }
+          })
+        );
 
         future.onReply = () => {
           // trigger onIOPub with a 'stream' message
-          const msgStream = createMsg('iopub', parentHeader) as any;
-          msgStream.header.msg_type = 'stream';
-          msgStream.content = { name: 'stdout', text: 'foo' };
-          tester.send(msgStream);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'stream',
+              content: { name: 'stdout', text: 'foo' }
+            })
+          );
           // trigger onDone
-          const msgDone = createMsg('iopub', parentHeader) as any;
-          msgDone.header.msg_type = 'status';
-          (msgDone as KernelMessage.IStatusMsg).content.execution_state =
-            'idle';
-          tester.send(msgDone);
+          tester.send(
+            KernelMessage.createMessage({
+              parentHeader,
+              session,
+              channel: 'iopub',
+              msgType: 'status',
+              content: { execution_state: 'idle' }
+            })
+          );
         };
 
         const toDelete = (msg: KernelMessage.IIOPubMessage) => {

--- a/tests/test-services/src/kernel/messages.spec.ts
+++ b/tests/test-services/src/kernel/messages.spec.ts
@@ -15,7 +15,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isStreamMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'status',
         channel: 'iopub',
         session: 'baz'
       });
@@ -32,7 +32,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isDisplayDataMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'status',
         channel: 'iopub',
         session: 'baz'
       });
@@ -49,7 +49,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isExecuteInputMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'status',
         channel: 'iopub',
         session: 'baz'
       });
@@ -66,7 +66,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isExecuteResultMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'status',
         channel: 'iopub',
         session: 'baz'
       });
@@ -83,7 +83,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isStatusMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'execute_input',
         channel: 'iopub',
         session: 'baz'
       });
@@ -100,7 +100,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isClearOutputMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'status',
         channel: 'iopub',
         session: 'baz'
       });
@@ -117,7 +117,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isCommOpenMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'status',
         channel: 'iopub',
         session: 'baz'
       });
@@ -134,7 +134,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isErrorMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'status',
         channel: 'iopub',
         session: 'baz'
       });
@@ -151,11 +151,11 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isInputRequestMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'foo',
+        msgType: 'status',
         channel: 'stdin',
         session: 'baz'
       });
-      expect(KernelMessage.isStatusMsg(msg)).to.equal(false);
+      expect(KernelMessage.isInputRequestMsg(msg)).to.equal(false);
     });
   });
 });

--- a/tests/test-services/src/kernel/messages.spec.ts
+++ b/tests/test-services/src/kernel/messages.spec.ts
@@ -151,7 +151,7 @@ describe('kernel/messages', () => {
       });
       expect(KernelMessage.isInputRequestMsg(msg)).to.equal(true);
       msg = KernelMessage.createMessage({
-        msgType: 'status',
+        msgType: 'input_reply',
         channel: 'stdin',
         session: 'baz'
       });

--- a/tests/test-services/src/kernel/messages.spec.ts
+++ b/tests/test-services/src/kernel/messages.spec.ts
@@ -6,54 +6,60 @@ import { expect } from 'chai';
 import { KernelMessage } from '@jupyterlab/services';
 
 describe('kernel/messages', () => {
+  const iopubStatusMsg = KernelMessage.createMessage({
+    msgType: 'status',
+    channel: 'iopub',
+    session: 'baz',
+    content: {
+      execution_state: 'idle'
+    }
+  });
+
   describe('KernelMessage.isStreamMsg()', () => {
     it('should check for a stream message type', () => {
-      let msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage<KernelMessage.IStreamMsg>({
         msgType: 'stream',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: {
+          name: 'stdout',
+          text: 'hello world'
+        }
       });
       expect(KernelMessage.isStreamMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
-        msgType: 'status',
-        channel: 'iopub',
-        session: 'baz'
-      });
-      expect(KernelMessage.isStreamMsg(msg)).to.equal(false);
+      expect(KernelMessage.isStreamMsg(iopubStatusMsg)).to.equal(false);
     });
   });
 
   describe('KernelMessage.isDisplayDataMsg()', () => {
     it('should check for a display data message type', () => {
-      let msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage<KernelMessage.IDisplayDataMsg>({
         msgType: 'display_data',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: {
+          data: {},
+          metadata: {}
+        }
       });
       expect(KernelMessage.isDisplayDataMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
-        msgType: 'status',
-        channel: 'iopub',
-        session: 'baz'
-      });
-      expect(KernelMessage.isDisplayDataMsg(msg)).to.equal(false);
+      expect(KernelMessage.isDisplayDataMsg(iopubStatusMsg)).to.equal(false);
     });
   });
 
   describe('KernelMessage.isExecuteInputMsg()', () => {
     it('should check for a execute input message type', () => {
-      let msg = KernelMessage.createMessage({
+      let msg = KernelMessage.createMessage<KernelMessage.IExecuteInputMsg>({
         msgType: 'execute_input',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: {
+          code: '',
+          execution_count: 1
+        }
       });
       expect(KernelMessage.isExecuteInputMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
-        msgType: 'status',
-        channel: 'iopub',
-        session: 'baz'
-      });
-      expect(KernelMessage.isExecuteInputMsg(msg)).to.equal(false);
+      expect(KernelMessage.isExecuteInputMsg(iopubStatusMsg)).to.equal(false);
     });
   });
 
@@ -62,15 +68,11 @@ describe('kernel/messages', () => {
       let msg = KernelMessage.createMessage({
         msgType: 'execute_result',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: { data: {}, execution_count: 1, metadata: {} }
       });
       expect(KernelMessage.isExecuteResultMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
-        msgType: 'status',
-        channel: 'iopub',
-        session: 'baz'
-      });
-      expect(KernelMessage.isExecuteResultMsg(msg)).to.equal(false);
+      expect(KernelMessage.isExecuteResultMsg(iopubStatusMsg)).to.equal(false);
     });
   });
 
@@ -79,15 +81,22 @@ describe('kernel/messages', () => {
       let msg = KernelMessage.createMessage({
         msgType: 'status',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: {
+          execution_state: 'idle'
+        }
       });
       expect(KernelMessage.isStatusMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
+      let msg2 = KernelMessage.createMessage<KernelMessage.IExecuteInputMsg>({
         msgType: 'execute_input',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: {
+          code: '',
+          execution_count: 1
+        }
       });
-      expect(KernelMessage.isStatusMsg(msg)).to.equal(false);
+      expect(KernelMessage.isStatusMsg(msg2)).to.equal(false);
     });
   });
 
@@ -96,15 +105,11 @@ describe('kernel/messages', () => {
       let msg = KernelMessage.createMessage({
         msgType: 'clear_output',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: { wait: true }
       });
       expect(KernelMessage.isClearOutputMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
-        msgType: 'status',
-        channel: 'iopub',
-        session: 'baz'
-      });
-      expect(KernelMessage.isClearOutputMsg(msg)).to.equal(false);
+      expect(KernelMessage.isClearOutputMsg(iopubStatusMsg)).to.equal(false);
     });
   });
 
@@ -113,15 +118,15 @@ describe('kernel/messages', () => {
       let msg = KernelMessage.createMessage({
         msgType: 'comm_open',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: {
+          comm_id: 'id',
+          data: {},
+          target_name: 'target'
+        }
       });
       expect(KernelMessage.isCommOpenMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
-        msgType: 'status',
-        channel: 'iopub',
-        session: 'baz'
-      });
-      expect(KernelMessage.isCommOpenMsg(msg)).to.equal(false);
+      expect(KernelMessage.isCommOpenMsg(iopubStatusMsg)).to.equal(false);
     });
   });
 
@@ -130,15 +135,15 @@ describe('kernel/messages', () => {
       let msg = KernelMessage.createMessage({
         msgType: 'error',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: {
+          ename: '',
+          evalue: '',
+          traceback: []
+        }
       });
       expect(KernelMessage.isErrorMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
-        msgType: 'status',
-        channel: 'iopub',
-        session: 'baz'
-      });
-      expect(KernelMessage.isErrorMsg(msg)).to.equal(false);
+      expect(KernelMessage.isErrorMsg(iopubStatusMsg)).to.equal(false);
     });
   });
 
@@ -147,15 +152,19 @@ describe('kernel/messages', () => {
       let msg = KernelMessage.createMessage({
         msgType: 'input_request',
         channel: 'stdin',
-        session: 'baz'
+        session: 'baz',
+        content: { prompt: '', password: false }
       });
       expect(KernelMessage.isInputRequestMsg(msg)).to.equal(true);
-      msg = KernelMessage.createMessage({
+      let msg2 = KernelMessage.createMessage<KernelMessage.IInputReplyMsg>({
         msgType: 'input_reply',
         channel: 'stdin',
-        session: 'baz'
+        session: 'baz',
+        content: {
+          value: ''
+        }
       });
-      expect(KernelMessage.isInputRequestMsg(msg)).to.equal(false);
+      expect(KernelMessage.isInputRequestMsg(msg2)).to.equal(false);
     });
   });
 });

--- a/tests/test-services/src/kernel/validate.spec.ts
+++ b/tests/test-services/src/kernel/validate.spec.ts
@@ -98,8 +98,8 @@ describe('kernel/validate', () => {
         msgType: 'error',
         channel: 'iopub',
         session: 'baz',
-        content: { ename: '', evalue: '', traceback: [] }
-      });
+        content: {} as any
+      } as any);
       expect(() => validateMessage(msg)).to.throw();
     });
 

--- a/tests/test-services/src/kernel/validate.spec.ts
+++ b/tests/test-services/src/kernel/validate.spec.ts
@@ -89,7 +89,7 @@ describe('kernel/validate', () => {
           msgType: 'foo',
           channel: 'iopub',
           session: 'baz'
-        },
+        } as any,
         {}
       );
       validateMessage(msg);

--- a/tests/test-services/src/kernel/validate.spec.ts
+++ b/tests/test-services/src/kernel/validate.spec.ts
@@ -19,14 +19,12 @@ import { PYTHON_SPEC } from '../utils';
 describe('kernel/validate', () => {
   describe('validateMessage', () => {
     it('should pass a valid message', () => {
-      const msg = KernelMessage.createMessage(
-        {
-          msgType: 'comm_msg',
-          channel: 'iopub',
-          session: 'foo'
-        },
-        { comm_id: 'foo', data: {} }
-      );
+      const msg = KernelMessage.createMessage({
+        msgType: 'comm_msg',
+        channel: 'iopub',
+        session: 'foo',
+        content: { comm_id: 'foo', data: {} }
+      });
       validateMessage(msg);
     });
 
@@ -34,7 +32,8 @@ describe('kernel/validate', () => {
       const msg = KernelMessage.createMessage({
         msgType: 'comm_msg',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: { comm_id: 'foo', data: {} }
       });
       delete msg.channel;
       expect(() => validateMessage(msg)).to.throw();
@@ -44,7 +43,8 @@ describe('kernel/validate', () => {
       const msg = KernelMessage.createMessage({
         msgType: 'comm_msg',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: { comm_id: 'foo', data: {} }
       });
       (msg as any).header.username = 1;
       expect(() => validateMessage(msg)).to.throw();
@@ -54,7 +54,8 @@ describe('kernel/validate', () => {
       const msg = KernelMessage.createMessage({
         msgType: 'comm_msg',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: { comm_id: 'foo', data: {} }
       });
       msg.parent_header = msg.header;
       (msg as any).parent_header.username = 1;
@@ -65,69 +66,60 @@ describe('kernel/validate', () => {
       const msg = KernelMessage.createMessage({
         msgType: 'comm_msg',
         channel: 'iopub',
-        session: 'baz'
+        session: 'baz',
+        content: { comm_id: 'foo', data: {} }
       });
       (msg as any).channel = 1;
       expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should validate an iopub message', () => {
-      const msg = KernelMessage.createMessage(
-        {
-          msgType: 'comm_close',
-          channel: 'iopub',
-          session: 'baz'
-        },
-        { comm_id: 'foo' }
-      );
+      const msg = KernelMessage.createMessage({
+        msgType: 'comm_close',
+        channel: 'iopub',
+        session: 'baz',
+        content: { comm_id: 'foo', data: {} }
+      });
       validateMessage(msg);
     });
 
     it('should ignore on an unknown iopub message type', () => {
-      const msg = KernelMessage.createMessage(
-        {
-          msgType: 'foo',
-          channel: 'iopub',
-          session: 'baz'
-        } as any,
-        {}
-      );
+      const msg = KernelMessage.createMessage({
+        msgType: 'foo',
+        channel: 'iopub',
+        session: 'baz',
+        content: {}
+      } as any);
       validateMessage(msg);
     });
 
     it('should throw on missing iopub message content', () => {
-      const msg = KernelMessage.createMessage(
-        {
-          msgType: 'error',
-          channel: 'iopub',
-          session: 'baz'
-        },
-        {}
-      );
+      const msg = KernelMessage.createMessage<KernelMessage.IErrorMsg>({
+        msgType: 'error',
+        channel: 'iopub',
+        session: 'baz',
+        content: { ename: '', evalue: '', traceback: [] }
+      });
       expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should throw on invalid iopub message content', () => {
-      const msg = KernelMessage.createMessage(
-        {
-          msgType: 'clear_output',
-          channel: 'iopub',
-          session: 'baz'
-        },
-        { wait: 1 }
-      );
+      const msg = KernelMessage.createMessage<KernelMessage.IClearOutputMsg>({
+        msgType: 'clear_output',
+        channel: 'iopub',
+        session: 'baz',
+        content: { wait: 1 as any }
+      });
       expect(() => validateMessage(msg)).to.throw();
     });
 
     it('should handle no buffers field', () => {
-      const msg = KernelMessage.createMessage(
-        {
-          msgType: 'comm_msg',
-          channel: 'iopub',
-          session: 'foo'
-        },
-        { comm_id: 'foo', data: {} }
-      );
+      const msg = KernelMessage.createMessage({
+        msgType: 'comm_msg',
+        channel: 'iopub',
+        session: 'foo',
+        content: { comm_id: 'foo', data: {} }
+      });
       delete msg['buffers'];
       validateMessage(msg);
     });

--- a/tests/test-services/src/session/isession.spec.ts
+++ b/tests/test-services/src/session/isession.spec.ts
@@ -121,11 +121,12 @@ describe('session', () => {
         const emission = testEmission(session.unhandledMessage, {
           find: (k, msg) => msg.header.msg_id === msgId
         });
-        const msg = KernelMessage.createShellMessage({
+        const msg = KernelMessage.createMessage({
           msgType: 'kernel_info_request',
           channel: 'shell',
           session: tester.serverSessionId,
-          msgId
+          msgId,
+          content: {}
         });
         msg.parent_header = { session: session.kernel.clientId };
         tester.send(msg);

--- a/tests/test-services/src/session/isession.spec.ts
+++ b/tests/test-services/src/session/isession.spec.ts
@@ -122,7 +122,7 @@ describe('session', () => {
           find: (k, msg) => msg.header.msg_id === msgId
         });
         const msg = KernelMessage.createShellMessage({
-          msgType: 'foo',
+          msgType: 'kernel_info_request',
           channel: 'shell',
           session: tester.serverSessionId,
           msgId

--- a/tests/test-services/src/utils.ts
+++ b/tests/test-services/src/utils.ts
@@ -130,7 +130,7 @@ export const KERNELSPECS: JSONObject = {
  */
 export function createMsg(
   channel: KernelMessage.Channel,
-  parentHeader: JSONObject
+  parentHeader: KernelMessage.IHeader | {}
 ): KernelMessage.IMessage {
   return {
     channel: channel,

--- a/tests/test-services/src/utils.ts
+++ b/tests/test-services/src/utils.ts
@@ -332,20 +332,24 @@ export class KernelTester extends SocketTester {
    * Send the status from the server to the client.
    */
   sendStatus(msgId: string, status: Kernel.Status) {
-    return this.sendMessage(
-      { msgId, msgType: 'status', channel: 'iopub' },
-      { execution_state: status }
-    );
+    return this.sendMessage({
+      msgId,
+      msgType: 'status',
+      channel: 'iopub',
+      content: { execution_state: status }
+    });
   }
 
   /**
    * Send an iopub stream message.
    */
   sendStream(msgId: string, content: KernelMessage.IStreamMsg['content']) {
-    return this.sendMessage(
-      { msgId, msgType: 'stream', channel: 'iopub' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'stream',
+      channel: 'iopub',
       content
-    );
+    });
   }
 
   /**
@@ -355,10 +359,12 @@ export class KernelTester extends SocketTester {
     msgId: string,
     content: KernelMessage.IDisplayDataMsg['content']
   ) {
-    return this.sendMessage(
-      { msgId, msgType: 'display_data', channel: 'iopub' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'display_data',
+      channel: 'iopub',
       content
-    );
+    });
   }
 
   /**
@@ -368,19 +374,23 @@ export class KernelTester extends SocketTester {
     msgId: string,
     content: KernelMessage.IUpdateDisplayDataMsg['content']
   ) {
-    return this.sendMessage(
-      { msgId, msgType: 'update_display_data', channel: 'iopub' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'update_display_data',
+      channel: 'iopub',
       content
-    );
+    });
   }
   /**
    * Send an iopub comm open message.
    */
   sendCommOpen(msgId: string, content: KernelMessage.ICommOpenMsg['content']) {
-    return this.sendMessage(
-      { msgId, msgType: 'comm_open', channel: 'iopub' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'comm_open',
+      channel: 'iopub',
       content
-    );
+    });
   }
 
   /**
@@ -390,74 +400,84 @@ export class KernelTester extends SocketTester {
     msgId: string,
     content: KernelMessage.ICommCloseMsg['content']
   ) {
-    return this.sendMessage(
-      { msgId, msgType: 'comm_close', channel: 'iopub' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'comm_close',
+      channel: 'iopub',
       content
-    );
+    });
   }
 
   /**
    * Send an iopub comm message.
    */
   sendCommMsg(msgId: string, content: KernelMessage.ICommMsgMsg['content']) {
-    return this.sendMessage(
-      { msgId, msgType: 'comm_msg', channel: 'iopub' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'comm_msg',
+      channel: 'iopub',
       content
-    );
+    });
   }
 
   sendExecuteResult(
     msgId: string,
     content: KernelMessage.IExecuteResultMsg['content']
   ) {
-    return this.sendMessage(
-      { msgId, msgType: 'execute_result', channel: 'iopub' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'execute_result',
+      channel: 'iopub',
       content
-    );
+    });
   }
 
   sendExecuteReply(
     msgId: string,
     content: KernelMessage.IExecuteReplyMsg['content']
   ) {
-    return this.sendMessage(
-      { msgId, msgType: 'execute_reply', channel: 'shell' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'execute_reply',
+      channel: 'shell',
       content
-    );
+    });
   }
 
   sendKernelInfoReply(
     msgId: string,
     content: KernelMessage.IInfoReplyMsg['content']
   ) {
-    return this.sendMessage(
-      { msgId, msgType: 'kernel_info_reply', channel: 'shell' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'kernel_info_reply',
+      channel: 'shell',
       content
-    );
+    });
   }
 
   sendInputRequest(
     msgId: string,
     content: KernelMessage.IInputRequestMsg['content']
   ) {
-    return this.sendMessage(
-      { msgId, msgType: 'input_request', channel: 'stdin' },
+    return this.sendMessage({
+      msgId,
+      msgType: 'input_request',
+      channel: 'stdin',
       content
-    );
+    });
   }
 
   /**
    * Send a kernel message with sensible defaults.
    */
-  sendMessage(
-    options: MakeOptional<KernelMessage.IOptions, 'session'>,
-    content: any
+  sendMessage<T extends KernelMessage.Message>(
+    options: MakeOptional<KernelMessage.IOptions<T>, 'session'>
   ) {
-    options.session = this.serverSessionId;
-    const msg = KernelMessage.createMessage(
-      options as KernelMessage.IOptions,
-      content
-    );
+    const msg = KernelMessage.createMessage<any>({
+      session: this.serverSessionId,
+      ...options
+    });
     msg.parent_header = this.parentHeader;
     this.send(msg);
     return msg.header.msg_id;
@@ -466,7 +486,7 @@ export class KernelTester extends SocketTester {
   /**
    * Send a kernel message from the server to the client.
    */
-  send(msg: KernelMessage.IMessage): void {
+  send(msg: KernelMessage.Message): void {
     this.sendRaw(serialize(msg));
   }
 
@@ -614,14 +634,14 @@ export class SessionTester extends SocketTester {
   /**
    * Send the status from the server to the client.
    */
-  sendStatus(status: string, parentHeader?: KernelMessage.IHeader) {
-    const options: KernelMessage.IOptions = {
+  sendStatus(status: Kernel.Status, parentHeader?: KernelMessage.IHeader) {
+    const msg = KernelMessage.createMessage({
       msgType: 'status',
       channel: 'iopub',
-      session: this.serverSessionId
-    };
-    const msg = KernelMessage.createMessage(options, {
-      execution_state: status
+      session: this.serverSessionId,
+      content: {
+        execution_state: status
+      }
     });
     if (parentHeader) {
       msg.parent_header = parentHeader;
@@ -653,19 +673,19 @@ export class SessionTester extends SocketTester {
         msg = new Uint8Array(msg).buffer;
       }
       const data = deserialize(msg);
-      if (data.header.msg_type === 'kernel_info_request') {
+      if (KernelMessage.isInfoRequestMsg(data)) {
         // First send status busy message.
         this.sendStatus('busy', data.header);
 
         // Then send the kernel_info_reply message.
-        const options: KernelMessage.IOptions = {
+        const reply = KernelMessage.createMessage({
           msgType: 'kernel_info_reply',
           channel: 'shell',
-          session: this.serverSessionId
-        };
-        const msg = KernelMessage.createMessage(options, EXAMPLE_KERNEL_INFO);
-        msg.parent_header = data.header;
-        this.send(msg);
+          session: this.serverSessionId,
+          content: EXAMPLE_KERNEL_INFO
+        });
+        reply.parent_header = data.header;
+        this.send(reply);
 
         // Then send status idle message.
         this.sendStatus('idle', data.header);

--- a/tests/test-services/src/utils.ts
+++ b/tests/test-services/src/utils.ts
@@ -126,23 +126,6 @@ export const KERNELSPECS: JSONObject = {
 };
 
 /**
- * Create a message from an existing message.
- */
-export function createMsg(
-  channel: KernelMessage.Channel,
-  parentHeader: KernelMessage.IHeader | {}
-): KernelMessage.IMessage {
-  return {
-    channel: channel,
-    parent_header: JSON.parse(JSON.stringify(parentHeader)),
-    content: {},
-    header: JSON.parse(JSON.stringify(parentHeader)),
-    metadata: {},
-    buffers: []
-  };
-}
-
-/**
  * Get a single handler for a request.
  */
 export function getRequestHandler(

--- a/tests/test-services/src/utils.ts
+++ b/tests/test-services/src/utils.ts
@@ -418,7 +418,7 @@ export class KernelTester extends SocketTester {
 
   sendExecuteReply(
     msgId: string,
-    content: KernelMessage.IExecuteReply['content']
+    content: KernelMessage.IExecuteReplyMsg['content']
   ) {
     return this.sendMessage(
       { msgId, msgType: 'execute_reply', channel: 'shell' },


### PR DESCRIPTION
## References

Fixes #5779 

## Code changes

Two major code changes:

1. Only clear a cell execution prompt if the *current* execution future for that cell is canceled. This makes sure that if we execute the cell again (setting the prompt to '*'), disposing the last future doesn't reset the cell's prompt.
2. Make the kernel message typing much more precise

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Execute this:

```python
i=0
```

If you execute the following several times rapidly, before it has a chance to complete:

```python
from time import sleep
i+=1
sleep(5)
print(i)
```
it used to clear the cell prompt on the second execution. Now it correctly leaves the cell prompt as `*`.

## Backwards-incompatible changes

The kernel message typing is much more precise and robust now, but unfortunately probably is not strictly backwards compatible (we were too loose in our typing before). In particular, a number of message attributes no longer extend JSONObject, so they don't allow extra attributes, etc.

CC @cquah 
