### PR TITLE
Allow Raises-exception

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -538,8 +538,8 @@ export namespace OutputArea {
     let stopOnError = true;
     if (
       metadata &&
-      metadata.tags &&
-      (metadata.tags as string[]).indexOf('raises-exception') !== -1
+      Array.isArray(metadata.tags) &&
+      metadata.tags.indexOf('raises-exception') !== -1
     ) {
       stopOnError = false;
     }

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -535,9 +535,17 @@ export namespace OutputArea {
     metadata?: JSONObject
   ): Promise<KernelMessage.IExecuteReplyMsg> {
     // Override the default for `stop_on_error`.
+    let stopOnError = true;
+    if (
+      metadata &&
+      metadata.tags &&
+      (metadata.tags as string[]).indexOf('raises-exception') !== -1
+    ) {
+      stopOnError = false;
+    }
     let content: KernelMessage.IExecuteRequest = {
       code,
-      stop_on_error: true
+      stop_on_error: stopOnError
     };
 
     if (!session.kernel) {

--- a/tests/test-outputarea/src/widget.spec.ts
+++ b/tests/test-outputarea/src/widget.spec.ts
@@ -257,6 +257,31 @@ describe('outputarea/widget', () => {
         expect(outputs[2].data).to.deep.equal({ 'text/plain': '4' });
         await ipySession.shutdown();
       });
+
+      it('should raise an error', async () => {
+        const widget1 = new LogOutputArea({ rendermime, model });
+        const reply = await OutputArea.execute('a++1', widget, session);
+        const reply2 = await OutputArea.execute('a=1', widget1, session);
+        expect(reply.content.status).to.equal('hi');
+        expect(reply2.content.status).to.equal('hi');
+        expect(model.length).to.equal(1);
+        widget1.dispose();
+      });
+
+      it('should allow an error given "raises-exception" metadata tag', async () => {
+        const widget1 = new LogOutputArea({ rendermime, model });
+        const metadata = { tags: ['raises-exception'] };
+        const reply = await OutputArea.execute(
+          'a++1',
+          widget,
+          session,
+          metadata
+        );
+        const reply2 = await OutputArea.execute('a=1', widget1, session);
+        expect(reply.content.execution_count).to.equal('hi');
+        expect(reply2.content.execution_count).to.equal('hi');
+        widget1.dispose();
+      });
     });
 
     describe('.ContentFactory', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #2412 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Changes the `stop_on_error` behavior of `OutputArea.execute` to account for `raises-exception` tags.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users are able to use the `raises-exception` tags in the same way they have been available to in nbconvert and notebook.  cf https://github.com/jupyter/notebook/pull/2549 , https://github.com/jupyter/nbconvert/pull/684

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
