### PR TITLE
Make kernel message typings more correct

### DIFF
--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -41,7 +41,7 @@ export abstract class JupyterFrontEnd<
     super(options);
 
     // The default restored promise if one does not exist in the options.
-    const restored = new Promise(resolve => {
+    const restored = new Promise<void>(resolve => {
       requestAnimationFrame(() => {
         resolve();
       });

--- a/packages/completer/src/kernelconnector.ts
+++ b/packages/completer/src/kernelconnector.ts
@@ -41,7 +41,7 @@ export class KernelConnector extends DataConnector<
       return Promise.reject(new Error('No kernel for completion request.'));
     }
 
-    const contents: KernelMessage.ICompleteRequest = {
+    const contents: KernelMessage.ICompleteRequestMsg['content'] = {
       code: request.text,
       cursor_pos: request.offset
     };

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -224,10 +224,12 @@ export class ConsoleHistory implements IConsoleHistory {
     this._history.length = 0;
     let last = '';
     let current = '';
-    for (let i = 0; i < value.content.history.length; i++) {
-      current = (value.content.history[i] as string[])[2];
-      if (current !== last) {
-        this._history.push((last = current));
+    if (value.content.status === 'ok') {
+      for (let i = 0; i < value.content.history.length; i++) {
+        current = (value.content.history[i] as string[])[2];
+        if (current !== last) {
+          this._history.push((last = current));
+        }
       }
     }
     // Reset the history navigation cursor back to the bottom.
@@ -360,7 +362,7 @@ export namespace ConsoleHistory {
  * A namespace for private data.
  */
 namespace Private {
-  export const initialRequest: KernelMessage.IHistoryRequest = {
+  export const initialRequest: KernelMessage.IHistoryRequestMsg['content'] = {
     output: false,
     raw: true,
     hist_access_type: 'tail',

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -646,7 +646,7 @@ export class CodeConsole extends Widget {
         return;
       }
       if (value && value.content.status === 'ok') {
-        let content = value.content as KernelMessage.IExecuteOkReply;
+        let content = value.content;
         // Use deprecated payloads for backwards compatibility.
         if (content.payload && content.payload.length) {
           let setNextInput = content.payload.filter(i => {
@@ -682,7 +682,11 @@ export class CodeConsole extends Widget {
   /**
    * Update the console based on the kernel info.
    */
-  private _handleInfo(info: KernelMessage.IInfoReply): void {
+  private _handleInfo(info: KernelMessage.IInfoReplyMsg['content']): void {
+    if (info.status !== 'ok') {
+      this._banner.model.value.text = 'Error in getting kernel banner';
+      return;
+    }
     this._banner.model.value.text = info.banner;
     let lang = info.language_info as nbformat.ILanguageInfoMetadata;
     this._mimetype = this._mimeTypeService.getMimeTypeByLanguage(lang);

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -164,7 +164,10 @@ function activate(
   helpMenu.addGroup(resourcesGroup, 10);
 
   // Generate a cache of the kernel help links.
-  const kernelInfoCache = new Map<string, KernelMessage.IInfoReply>();
+  const kernelInfoCache = new Map<
+    string,
+    KernelMessage.IInfoReplyMsg['content']
+  >();
   serviceManager.sessions.runningChanged.connect((m, sessions) => {
     // If a new session has been added, it is at the back
     // of the session list. If one has changed or stopped,

--- a/packages/inspector/src/kernelconnector.ts
+++ b/packages/inspector/src/kernelconnector.ts
@@ -41,7 +41,7 @@ export class KernelConnector extends DataConnector<
       return Promise.reject(new Error('Inspection fetch requires a kernel.'));
     }
 
-    const contents: KernelMessage.IInspectRequest = {
+    const contents: KernelMessage.IInspectRequestMsg['content'] = {
       code: request.text,
       cursor_pos: request.offset,
       detail_level: 0

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1488,7 +1488,7 @@ namespace Private {
               }
 
               if (reply.content.status === 'ok') {
-                const content = reply.content as KernelMessage.IExecuteOkReply;
+                const content = reply.content;
 
                 if (content.payload && content.payload.length) {
                   handlePayload(content, notebook, cell);
@@ -1532,7 +1532,7 @@ namespace Private {
    * See [Payloads (DEPRECATED)](https://jupyter-client.readthedocs.io/en/latest/messaging.html#payloads-deprecated).
    */
   function handlePayload(
-    content: KernelMessage.IExecuteOkReply,
+    content: KernelMessage.IExecuteReply,
     notebook: Notebook,
     cell: Cell
   ) {

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -468,7 +468,10 @@ export class OutputArea extends Widget {
     // is overridden from 'execute_reply' to 'display_data' in order to
     // render output.
     let model = this.model;
-    let content = msg.content as KernelMessage.IExecuteOkReply;
+    let content = msg.content;
+    if (content.status !== 'ok') {
+      return;
+    }
     let payload = content && content.payload;
     if (!payload || !payload.length) {
       return;
@@ -557,7 +560,7 @@ export namespace OutputArea {
     ) {
       stopOnError = false;
     }
-    let content: KernelMessage.IExecuteRequest = {
+    let content: KernelMessage.IExecuteRequestMsg['content'] = {
       code,
       stop_on_error: stopOnError
     };
@@ -712,6 +715,7 @@ export class Stdin extends Widget implements IStdin {
       if ((event as KeyboardEvent).keyCode === 13) {
         // Enter
         this._future.sendInputReply({
+          status: 'ok',
           value: input.value
         });
         if (input.type === 'password') {

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -415,6 +415,9 @@ export class DefaultKernel implements Kernel.IKernel {
     if (this.isDisposed) {
       throw new Error('Disposed kernel');
     }
+    if (reply.content.status !== 'ok') {
+      throw new Error('Kernel info reply errored');
+    }
     this._info = reply.content;
     return reply;
   }
@@ -429,7 +432,7 @@ export class DefaultKernel implements Kernel.IKernel {
    * received and validated.
    */
   requestComplete(
-    content: KernelMessage.ICompleteRequest
+    content: KernelMessage.ICompleteRequestMsg['content']
   ): Promise<KernelMessage.ICompleteReplyMsg> {
     let msg = KernelMessage.createMessage({
       msgType: 'complete_request',
@@ -453,7 +456,7 @@ export class DefaultKernel implements Kernel.IKernel {
    * received and validated.
    */
   requestInspect(
-    content: KernelMessage.IInspectRequest
+    content: KernelMessage.IInspectRequestMsg['content']
   ): Promise<KernelMessage.IInspectReplyMsg> {
     let msg = KernelMessage.createMessage({
       msgType: 'inspect_request',
@@ -477,7 +480,7 @@ export class DefaultKernel implements Kernel.IKernel {
    * received and validated.
    */
   requestHistory(
-    content: KernelMessage.IHistoryRequest
+    content: KernelMessage.IHistoryRequestMsg['content']
   ): Promise<KernelMessage.IHistoryReplyMsg> {
     let msg = KernelMessage.createMessage({
       msgType: 'history_request',
@@ -507,7 +510,7 @@ export class DefaultKernel implements Kernel.IKernel {
    * **See also:** [[IExecuteReply]]
    */
   requestExecute(
-    content: KernelMessage.IExecuteRequest,
+    content: KernelMessage.IExecuteRequestMsg['content'],
     disposeOnDone: boolean = true,
     metadata?: JSONObject
   ): Kernel.IFuture<
@@ -544,7 +547,7 @@ export class DefaultKernel implements Kernel.IKernel {
    * received and validated.
    */
   requestIsComplete(
-    content: KernelMessage.IIsCompleteRequest
+    content: KernelMessage.IIsCompleteRequestMsg['content']
   ): Promise<KernelMessage.IIsCompleteReplyMsg> {
     let msg = KernelMessage.createMessage({
       msgType: 'is_complete_request',
@@ -566,7 +569,7 @@ export class DefaultKernel implements Kernel.IKernel {
    * received and validated.
    */
   requestCommInfo(
-    content: KernelMessage.ICommInfoRequest
+    content: KernelMessage.ICommInfoRequestMsg['content']
   ): Promise<KernelMessage.ICommInfoReplyMsg> {
     let msg = KernelMessage.createMessage({
       msgType: 'comm_info_request',
@@ -586,7 +589,7 @@ export class DefaultKernel implements Kernel.IKernel {
    * #### Notes
    * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#messages-on-the-stdin-router-dealer-sockets).
    */
-  sendInputReply(content: KernelMessage.IInputReply): void {
+  sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void {
     if (this.status === 'dead') {
       throw new Error('Kernel is dead');
     }

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -154,7 +154,7 @@ export class KernelFutureHandler<
   /**
    * Send an `input_reply` message.
    */
-  sendInputReply(content: KernelMessage.IInputReply): void {
+  sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void {
     this._kernel.sendInputReply(content);
   }
 

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -206,7 +206,7 @@ export namespace Kernel {
      * received and validated.
      */
     requestComplete(
-      content: KernelMessage.ICompleteRequest
+      content: KernelMessage.ICompleteRequestMsg['content']
     ): Promise<KernelMessage.ICompleteReplyMsg>;
 
     /**
@@ -223,7 +223,7 @@ export namespace Kernel {
      * received and validated.
      */
     requestInspect(
-      content: KernelMessage.IInspectRequest
+      content: KernelMessage.IInspectRequestMsg['content']
     ): Promise<KernelMessage.IInspectReplyMsg>;
 
     /**
@@ -240,7 +240,7 @@ export namespace Kernel {
      * received and validated.
      */
     requestHistory(
-      content: KernelMessage.IHistoryRequest
+      content: KernelMessage.IHistoryRequestMsg['content']
     ): Promise<KernelMessage.IHistoryReplyMsg>;
 
     /**
@@ -265,7 +265,7 @@ export namespace Kernel {
      * **See also:** [[IExecuteReply]]
      */
     requestExecute(
-      content: KernelMessage.IExecuteRequest,
+      content: KernelMessage.IExecuteRequestMsg['content'],
       disposeOnDone?: boolean,
       metadata?: JSONObject
     ): Kernel.IFuture<
@@ -287,7 +287,7 @@ export namespace Kernel {
      * received and validated.
      */
     requestIsComplete(
-      content: KernelMessage.IIsCompleteRequest
+      content: KernelMessage.IIsCompleteRequestMsg['content']
     ): Promise<KernelMessage.IIsCompleteReplyMsg>;
 
     /**
@@ -304,7 +304,7 @@ export namespace Kernel {
      * received and validated.
      */
     requestCommInfo(
-      content: KernelMessage.ICommInfoRequest
+      content: KernelMessage.ICommInfoRequestMsg['content']
     ): Promise<KernelMessage.ICommInfoReplyMsg>;
 
     /**
@@ -315,7 +315,7 @@ export namespace Kernel {
      * #### Notes
      * See [Messaging in Jupyter](https://jupyter-client.readthedocs.io/en/latest/messaging.html#messages-on-the-stdin-router-dealer-sockets).
      */
-    sendInputReply(content: KernelMessage.IInputReply): void;
+    sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void;
 
     /**
      * Connect to a comm, or create a new one.
@@ -830,7 +830,7 @@ export namespace Kernel {
     /**
      * Send an `input_reply` message.
      */
-    sendInputReply(content: KernelMessage.IInputReply): void;
+    sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void;
   }
 
   /**

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -301,7 +301,7 @@ namespace Private {
       return Promise.reject(void 0);
     }
 
-    let contents: KernelMessage.IInspectRequest = {
+    let contents: KernelMessage.IInspectRequestMsg['content'] = {
       code,
       cursor_pos: offset,
       detail_level: detail || 0

--- a/tests/test-console/src/history.spec.ts
+++ b/tests/test-console/src/history.spec.ts
@@ -29,6 +29,7 @@ const mockHistory: KernelMessage.IHistoryReplyMsg = {
   buffers: null,
   channel: 'shell',
   content: {
+    status: 'ok',
     history: [[0, 0, 'foo'], [0, 0, 'bar'], [0, 0, 'baz'], [0, 0, 'qux']]
   }
 };
@@ -116,6 +117,9 @@ describe('console/history', () => {
         const history = new TestHistory({ session });
         history.onHistory(mockHistory);
         const result = await history.back('');
+        if (mockHistory.content.status !== 'ok') {
+          throw new Error('Test history reply is not an "ok" reply');
+        }
         const index = mockHistory.content.history.length - 1;
         const last = (mockHistory.content.history[index] as any)[2];
         expect(result).to.equal(last);
@@ -134,6 +138,9 @@ describe('console/history', () => {
         history.onHistory(mockHistory);
         await Promise.all([history.back(''), history.back('')]);
         const result = await history.forward('');
+        if (mockHistory.content.status !== 'ok') {
+          throw new Error('Test history reply is not an "ok" reply');
+        }
         const index = mockHistory.content.history.length - 1;
         const last = (mockHistory.content.history[index] as any)[2];
         expect(result).to.equal(last);

--- a/tests/test-services/src/kernel/comm.spec.ts
+++ b/tests/test-services/src/kernel/comm.spec.ts
@@ -124,6 +124,10 @@ describe('jupyter.services - Comm', () => {
         // Ask the kernel for the list of current comms.
         const msg = await kernel.requestCommInfo({});
 
+        if (msg.content.status !== 'ok') {
+          throw new Error('Message error');
+        }
+
         // Test to make sure the comm we just created is listed.
         const comms = msg.content.comms;
         expect(comms[comm.commId].target_name).to.equal('test');
@@ -136,6 +140,9 @@ describe('jupyter.services - Comm', () => {
       it('should allow an optional target', async () => {
         await kernel.requestExecute({ code: SEND }, true).done;
         const msg = await kernel.requestCommInfo({ target: 'test' });
+        if (msg.content.status !== 'ok') {
+          throw new Error('Message error');
+        }
         const comms = msg.content.comms;
         for (const id in comms) {
           expect(comms[id].target_name).to.equal('test');

--- a/tests/test-services/src/kernel/ifuture.spec.ts
+++ b/tests/test-services/src/kernel/ifuture.spec.ts
@@ -27,7 +27,7 @@ describe('Kernel.IFuture', () => {
 
   describe('Message hooks', () => {
     it('should have the most recently registered hook run first', async () => {
-      const options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequestMsg['content'] = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -120,7 +120,7 @@ describe('Kernel.IFuture', () => {
     });
 
     it('should abort processing if a hook returns false, but the done logic should still work', async () => {
-      const options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequestMsg['content'] = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -193,7 +193,7 @@ describe('Kernel.IFuture', () => {
     });
 
     it('should process additions on the next run', async () => {
-      const options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequestMsg['content'] = {
         code: 'test',
         silent: false,
         store_history: true,
@@ -263,7 +263,7 @@ describe('Kernel.IFuture', () => {
     });
 
     it('should deactivate message hooks immediately on removal', async () => {
-      const options: KernelMessage.IExecuteRequest = {
+      const options: KernelMessage.IExecuteRequestMsg['content'] = {
         code: 'test',
         silent: false,
         store_history: true,

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -791,7 +791,7 @@ describe('Kernel.IKernel', () => {
 
   describe('#requestIsComplete()', () => {
     it('should resolve the promise', async () => {
-      const options: KernelMessage.IIsCompleteRequest = {
+      const options: KernelMessage.IIsCompleteRequestMsg['content'] = {
         code: 'hello'
       };
       await defaultKernel.requestIsComplete(options);

--- a/tests/test-services/src/kernel/messages.spec.ts
+++ b/tests/test-services/src/kernel/messages.spec.ts
@@ -161,6 +161,7 @@ describe('kernel/messages', () => {
         channel: 'stdin',
         session: 'baz',
         content: {
+          status: 'ok',
           value: ''
         }
       });

--- a/tests/test-services/src/utils.ts
+++ b/tests/test-services/src/utils.ts
@@ -58,7 +58,7 @@ export function makeSettings(
   return ServerConnection.makeSettings(settings);
 }
 
-const EXAMPLE_KERNEL_INFO: KernelMessage.IInfoReply = {
+const EXAMPLE_KERNEL_INFO: KernelMessage.IInfoReplyMsg['content'] = {
   protocol_version: '1',
   implementation: 'a',
   implementation_version: '1',

--- a/tests/test-services/src/utils.ts
+++ b/tests/test-services/src/utils.ts
@@ -59,6 +59,7 @@ export function makeSettings(
 }
 
 const EXAMPLE_KERNEL_INFO: KernelMessage.IInfoReplyMsg['content'] = {
+  status: 'ok',
   protocol_version: '1',
   implementation: 'a',
   implementation_version: '1',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This continues work done in #6412.

https://github.com/jupyter/jupyter_client/issues/442 and https://github.com/jupyter/jupyter_client/issues/443 stemmed from the investigations into the spec for this PR.

## Code changes

The idea here was to simplify the typings, and more fully conform to the spec about error reply messages.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

Kernel message typings are changed in a backwards-incompatible way, since we are eliminating some publicly available interface names. Some typings, for example, are now accessible via the message `content` type fields (e.g., `ICompleteRequestMsg['content']`)