### PR TITLE
PrepublishOnly integrity check

### DIFF
--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -216,6 +216,12 @@ export async function ensurePackage(
   // when a package is actually being published.
   delete data.gitHead;
 
+  // Ensure there is a minimal prepublishOnly script
+  if (!data.private && !data.scripts.prepublishOnly) {
+    messages.push(`prepublishOnly script missing in ${pkgPath}`);
+    data.scripts.prepublishOnly = 'npm run build';
+  }
+
   if (utils.writePackageData(path.join(pkgPath, 'package.json'), data)) {
     messages.push('Updated package.json');
   }

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -27,6 +27,7 @@
     "build": "tsc -b",
     "clean": "rimraf lib",
     "docs": "typedoc --options tdoptions.json --theme ../../typedoc-theme src",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -26,6 +26,7 @@
     "build": "tsc -b",
     "clean": "rimraf lib",
     "docs": "typedoc --options tdoptions.json --theme ../../typedoc-theme src",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -26,7 +26,6 @@
   "scripts": {
     "build": "tsc -b && webpack && rimraf style/index.js",
     "clean": "rimraf lib/ & rimraf style/",
-    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -27,6 +27,7 @@
     "build": "tsc -b && webpack && rimraf style/index.js",
     "clean": "rimraf lib/ & rimraf style/",
     "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -27,6 +27,7 @@
     "build": "tsc -b",
     "clean": "rimraf lib",
     "docs": "typedoc --options tdoptions.json --theme ../../typedoc-theme src",
+    "prepublishOnly": "npm run build",
     "watch": "tsc -b --watch"
   },
   "dependencies": {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

(Hopefully) fixes the release 1.0.0a4 and #6436.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Some packages did not have a prepublishOnly step, so presumably they weren't built properly before publishing. `@jupyterlab/mainmenu` was one such package, and it seems to have serious problems in the 1.0a4 release.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None

## Backwards-incompatible changes

None