### PR TITLE
Modified Markdown cells' overflow to "auto"

### DIFF
--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -106,5 +106,5 @@
 }
 
 .jp-MarkdownOutput.jp-RenderedHTMLCommon {
-  overflow: visible;
+  overflow: auto;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
[Issue 6441](https://github.com/jupyterlab/jupyterlab/issues/6441): No horizontal scrolling in rendered markdown cells.

## Code changes
Changed the overflow property of Markdown cells from "visible" to "auto"

## User-facing changes
Previously, when the rendering a long and continuous string of non white-space characters in a Markdown cell:
![image](https://user-images.githubusercontent.com/2268615/58696617-82a51480-83ca-11e9-8683-354129efbad8.png)

After the change, now there is a horizontal scroll bar:
![image](https://user-images.githubusercontent.com/2268615/58696567-67d2a000-83ca-11e9-8ce4-ff904e24a239.png)

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
