### PR TITLE
Release cleanup

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -72,6 +72,7 @@ JupyterLab itself, run `jlpm run bumpversion major`.
 - Run `jlpm run bumpversion build` to create a new `alpha` version.
 - Push the commits and tags as prompted.
 - Run `jlpm run publish:all` to publish the JS and Python packages.
+  Execute the suggested commands after doing a quick sanity check.
 
 - Run `jlpm run bumpversion release` to switch to an `rc` version.
   (running `jlpm run bumpversion build` will then increment `rc` versions).

--- a/buildutils/src/bump-js-major.ts
+++ b/buildutils/src/bump-js-major.ts
@@ -5,24 +5,77 @@
 
 import commander from 'commander';
 import semver from 'semver';
+import path from 'path';
 import * as utils from './utils';
+
+/**
+ * Get the packages that depend on a given package, recursively.
+ */
+export function getDeps(
+  pkgName: string,
+  lut: { [key: string]: { [key: string]: string } }
+): Set<string> {
+  const deps: Set<string> = new Set();
+  for (let name in lut) {
+    if ('@jupyterlab/' + pkgName in lut[name]) {
+      const otherName = name.replace('@jupyterlab/', '');
+      deps.add(otherName);
+      const otherDeps = getDeps(otherName, lut);
+      otherDeps.forEach(dep => {
+        deps.add(dep);
+      });
+    }
+  }
+  return deps;
+}
 
 // Specify the program signature.
 commander
   .description('Bump the major version of JS package(s)')
   .arguments('<package> [others...]')
   .option('--force', 'Force the upgrade')
+  .option('--dry-run', 'Show what would be executed')
   .action((pkg: string, others: Array<string>, options: any) => {
     others.push(pkg);
-    const toBump: string[] = [];
-    others.forEach(pkg => {
+    const toBump: Set<string> = new Set();
+    const ignoreBump: Set<string> = new Set();
+    const maybeBump = (pkg: string) => {
+      if (pkg in toBump || pkg in ignoreBump) {
+        return;
+      }
       const version = utils.getJSVersion(pkg);
       if (semver.minor(version) === 0 && semver.prerelease(version)) {
         console.warn(`${pkg} has already been bumped`);
+        ignoreBump.add(pkg);
       } else {
-        toBump.push(pkg);
+        toBump.add(pkg);
       }
+    };
+    others.forEach(pkg => {
+      maybeBump(pkg);
     });
+
+    // Create a lut of dependencies
+    const lut: { [key: string]: { [key: string]: string } } = {};
+    utils.getCorePaths().forEach(corePath => {
+      const pkgDataPath = path.join(corePath, 'package.json');
+      const data = utils.readJSONFile(pkgDataPath);
+      lut[data.name] = data.dependencies || {};
+    });
+
+    // Look for dependencies of bumped packages
+    Array.from(toBump).forEach(val => {
+      const deps = getDeps(val, lut);
+      deps.forEach(dep => {
+        maybeBump(dep);
+      });
+    });
+
+    if (!toBump.size) {
+      console.warn('No packages found to bump!');
+      return;
+    }
+
     const pyVersion = utils.getPythonVersion();
     let preId = '';
     if (pyVersion.includes('a')) {
@@ -34,10 +87,16 @@ commander
         'Cannot bump JS packages until we switch to prerelease mode'
       );
     }
-    const pkgs = toBump.join(',');
+    const pkgs = Array.from(toBump).join(',');
     let cmd = `lerna version premajor --preid=${preId} --force-publish=${pkgs} --no-push`;
     if (options.force) {
       cmd += ' --yes';
+    }
+
+    if (options.dryRun) {
+      console.log('Would run:');
+      console.log(cmd);
+      return;
     }
     utils.run(cmd);
   });

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -45,6 +45,18 @@ commander
       return;
     }
 
+    // If this is a major release during the alpha cycle, bump
+    // just the Python version.
+    if (prev.indexOf('a') !== -1 && spec === 'major') {
+      // Bump the version.
+      utils.run(`bumpversion ${spec}`);
+
+      // Run the post-bump script.
+      utils.postbump();
+
+      return;
+    }
+
     // Determine the version spec to use for lerna.
     let lernaVersion = 'preminor';
     if (spec === 'build') {
@@ -81,11 +93,6 @@ commander
     if (oldVersion === newVersion) {
       // lerna didn't version anything, so we assume the user aborted
       throw new Error('Lerna aborted');
-    }
-
-    // Our work is done if this is a major or minor bump.
-    if (spec in ['major', 'minor']) {
-      return;
     }
 
     // Bump the version.

--- a/buildutils/src/prepublish-check.ts
+++ b/buildutils/src/prepublish-check.ts
@@ -1,0 +1,41 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+import * as fs from 'fs-extra';
+import * as glob from 'glob';
+import * as path from 'path';
+import * as utils from './utils';
+
+utils.run('jlpm run clean:slate');
+utils.run('lerna run prepublishOnly');
+
+utils.getLernaPaths().forEach(pkgPath => {
+  const pkgData = utils.readJSONFile(path.join(pkgPath, 'package.json'));
+  const name = pkgData.name;
+
+  // Skip private packages.
+  if (!pkgData.public) {
+    return;
+  }
+  console.log(`Checking ${name}...`);
+
+  // Make sure each glob resolves to at least one file.
+  pkgData.files.forEach((fGlob: string) => {
+    const result = glob.sync(fGlob);
+    if (result.length === 0) {
+      throw new Error(`${name} has missing file(s) "${fGlob}"`);
+    }
+  });
+
+  // Make sure there is a main and that it exists.
+  const main = pkgData.main;
+  if (!main) {
+    throw new Error(`No "main" entry for ${name}`);
+  }
+  const mainPath = path.join(pkgPath, main);
+  if (!fs.existsSync(mainPath)) {
+    throw new Error(`"main" entry "${main}" not found for ${name}`);
+  }
+});

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -29,14 +29,23 @@ async function main() {
     });
   });
 
-  // Update core mode.
+  // Update core mode.  This cannot be done until the JS packages are
+  // released.
   utils.run('node buildutils/lib/update-core-mode.js');
 
   // Make the Python release.
   utils.run('python setup.py sdist');
-  utils.run('python setup.py bdist_wheel --universal');
-  utils.run('python -m pip install twine');
-  utils.run('twine upload dist/*');
+  utils.run('python setup.py bdist_wheel');
+  utils.run('python -m pip install -U twine');
+  utils.run('twine check dist/*');
+
+  // Prompt the user to finalize.
+  console.log('*'.repeat(40));
+  console.log('Ready to publish!');
+  console.log('Run these command when ready:');
+  console.log(`git tag v${curr}`);
+  console.log(`git commit -am "Publish ${curr}"`);
+  console.log('twine upload dist/*');
 }
 
 void main();

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -107,7 +107,7 @@ export function checkStatus(cmd: string) {
  */
 export function getPythonVersion() {
   const cmd = 'python setup.py --version';
-  return run(cmd, { stdio: 'pipe' });
+  return run(cmd, { stdio: 'pipe' }, true);
 }
 
 /**
@@ -155,10 +155,6 @@ export function postbump() {
   let data = readJSONFile(filePath);
   data.jupyterlab.version = curr;
   writeJSONFile(filePath, data);
-
-  // Create a git tag and commit.
-  run(`git tag v${curr}`);
-  run(`git commit -am "Publish ${curr}"`);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lint": "jlpm && jlpm run prettier && jlpm run eslint && jlpm run tslint",
     "lint:check": "jlpm run prettier:check && jlpm run eslint:check && jlpm run tslint:check",
     "patch:release": "node buildutils/lib/patch-release.js",
+    "prepublish:check": "node buildutils/lib/prepublish-check.js",
     "prettier": "prettier --write '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
     "prettier:check": "prettier --list-different '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
     "publish:all": "node buildutils/lib/publish.js",

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -13,10 +13,6 @@ sudo rm -rf $(which yarn)
 # create jupyter base dir (needed for config retrieval)
 mkdir ~/.jupyter
 
-# do not download chrome when installing puppeteer
-# (to avoid 502 errors)
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-
 # Install and enable the server extension
 pip install -q --upgrade pip
 pip --version

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -15,7 +15,7 @@ mkdir ~/.jupyter
 
 # do not download chrome when installing puppeteer
 # (to avoid 502 errors)
-npm config set puppeteer_skip_chromium_download true
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # Install and enable the server extension
 pip install -q --upgrade pip

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -13,6 +13,10 @@ sudo rm -rf $(which yarn)
 # create jupyter base dir (needed for config retrieval)
 mkdir ~/.jupyter
 
+# do not download chrome when installing puppeteer
+# (to avoid 502 errors)
+npm config set puppeteer_skip_chromium_download true
+
 # Install and enable the server extension
 pip install -q --upgrade pip
 pip --version

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -62,36 +62,12 @@ if [[ $GROUP == integrity ]]; then
     jlpm config set prefix ~/.yarn
     ~/.yarn/bin/postcss packages/**/style/*.css --dir /tmp
 
-    # Make sure we can successfully load the dev app.
-    python -m jupyterlab.browser_check --dev-mode
-
-    # Make sure core mode works
-    jlpm run build:core
-    python -m jupyterlab.browser_check --core-mode
-
-    # Make sure we can run the built app.
-    jupyter labextension install ./jupyterlab/tests/mock_packages/extension
-    python -m jupyterlab.browser_check
-    jupyter labextension list
-
-    # Make sure the deprecated `selenium_check` command still works
-    python -m jupyterlab.selenium_check
-
-    # Make sure we can non-dev install.
-    virtualenv -p $(which python3) test_install
-    ./test_install/bin/pip install -q ".[test]"  # this populates <sys_prefix>/share/jupyter/lab
-    ./test_install/bin/python -m jupyterlab.browser_check
-    # Make sure we can run the build
-    ./test_install/bin/jupyter lab build
-
-    # Make sure we can start and kill the lab server
-    ./test_install/bin/jupyter lab --no-browser &
-    TASK_PID=$!
-    # Make sure the task is running
-    ps -p $TASK_PID || exit 1
-    sleep 5
-    kill $TASK_PID
-    wait $TASK_PID
+    # run twine check on the python build assets.
+    # this must be done before altering any versions below.
+    python -m pip install -U twine wheel
+    python setup.py sdist
+    python setup.py bdist_wheel
+    twine check dist/*
 
     # Make sure we can bump the version
     # This must be done at the end so as not to interfere
@@ -102,23 +78,33 @@ if [[ $GROUP == integrity ]]; then
     git checkout -b commit_${BUILD_SOURCEVERSION}
     git clean -df
     jlpm bumpversion minor --force
+    git commit -a -m "minor"
     jlpm bumpversion major --force
+    git commit -a -m "major"
     jlpm bumpversion release --force # switch to rc
+    git commit -a -m "release"
     jlpm bumpversion build --force
+    git commit -a -m "build"
     VERSION=$(python setup.py --version)
     if [[ $VERSION != *rc1 ]]; then exit 1; fi
 
     # make sure we can patch release
     jlpm bumpversion release --force  # switch to final
+    git commit -a -m "release"
     jlpm patch:release --force
+    git commit -a -m "patched"
     jlpm patch:release console --force
+    git commit -a -m "patched single"
     jlpm patch:release filebrowser notebook --force
+    git commit -a -m "patched multiple"
 
     # make sure we can bump major JS releases
     jlpm bumpversion minor --force
     jlpm bump:js:major console --force
     jlpm bump:js:major console notebook --force
 
+    # Make sure that a prepublish would include the proper files.
+    jlpm run prepublish:check
 fi
 
 
@@ -197,4 +183,40 @@ if [[ $GROUP == usage ]]; then
     env JUPYTERLAB_DIR=./link_app_dir jupyter lab path | grep link_app_dir
     popd
 
+    # Build the examples.
+    jlpm run build:examples
+
+    # Test the examples
+    jlpm run test:examples
+
+    # Make sure we can successfully load the dev app.
+    python -m jupyterlab.browser_check --dev-mode
+
+    # Make sure core mode works
+    jlpm run build:core
+    python -m jupyterlab.browser_check --core-mode
+
+    # Make sure we can run the built app.
+    jupyter labextension install ./jupyterlab/tests/mock_packages/extension
+    python -m jupyterlab.browser_check
+    jupyter labextension list
+
+    # Make sure the deprecated `selenium_check` command still works
+    python -m jupyterlab.selenium_check
+
+    # Make sure we can non-dev install.
+    virtualenv -p $(which python3) test_install
+    ./test_install/bin/pip install -q ".[test]"  # this populates <sys_prefix>/share/jupyter/lab
+    ./test_install/bin/python -m jupyterlab.browser_check
+    # Make sure we can run the build
+    ./test_install/bin/jupyter lab build
+
+    # Make sure we can start and kill the lab server
+    ./test_install/bin/jupyter lab --no-browser &
+    TASK_PID=$!
+    # Make sure the task is running
+    ps -p $TASK_PID || exit 1
+    sleep 5
+    kill $TASK_PID
+    wait $TASK_PID
 fi

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -8,10 +8,6 @@ set -o pipefail
 
 python -c "from jupyterlab.commands import build_check; build_check()"
 
-# do not download chrome when installing puppeteer
-# (to avoid 502 errors)
-export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-
 
 if [[ $GROUP == python ]]; then
     # Run the python tests

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -8,6 +8,10 @@ set -o pipefail
 
 python -c "from jupyterlab.commands import build_check; build_check()"
 
+# do not download chrome when installing puppeteer
+# (to avoid 502 errors)
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
 
 if [[ $GROUP == python ]]; then
     # Run the python tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [metadata]
 license_file = LICENSE
 
+[bdist_wheel]
+universal=1
+
 [tool:pytest]
 testpaths=jupyterlab/tests
 norecursedirs=node_modules .git _build

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,9 @@ from setuptools.command.develop import develop
 
 NAME = 'jupyterlab'
 DESCRIPTION = 'The JupyterLab notebook server extension.'
-LONG_DESCRIPTION = """
-An extensible, comprehensive Jupyter web application.
-Development happens on https://github.com/jupyter/jupyterlab, with chat on
-https://gitter.im/jupyterlab/jupyterlab.
-"""
+
+with open(pjoin(HERE, 'README.md')) as fid:
+    LONG_DESCRIPTION = fid.read()
 
 ensure_python(['>=3.5'])
 
@@ -108,6 +106,7 @@ setup_args = dict(
     name=NAME,
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     version=VERSION,
     packages=find_packages(),
     cmdclass=cmdclass,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6435, Fixes #6431
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Cleans up the release process.
- Moves the rest of the file changes into the version process
- Adds more CI checks for versioning and integrity, including making sure expected files are present
- Moves the final tag and PyPI release to a manual process after a sanity check
- Uses the new metadata for Markdown Readmes on PyPI: https://packaging.python.org/guides/making-a-pypi-friendly-readme/

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None, these are maintainer-facing.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
```
$ node buildutils/lib/bump-js-major.js cells --dry-run
Would run:
lerna version premajor --preid=alpha --force-publish=cells,console,completer-extension,metapackage,console-extension,fileeditor-extension,inspector-extension,statusbar-extension,tooltip-extension,documentsearch,csvviewer-extension,documentsearch-extension,nbconvert-css,notebook,notebook-extension,vdom-extension --no-push
Done in 1.11s.
```

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

