### PR TITLE
Update phosphor packages to restore tab drop zone

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -73,7 +73,7 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "ajv": "^6.5.5",
     "codemirror": "~5.47.0",
     "es6-promise": "~4.2.6",

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -16,7 +16,7 @@
     "@jupyterlab/services": "^4.0.0-alpha.8",
     "@jupyterlab/theme-light-extension": "^1.0.0-alpha.9",
     "@phosphor/commands": "^1.6.1",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "es6-promise": "~4.2.6"
   },
   "devDependencies": {

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -14,7 +14,7 @@
     "@jupyterlab/services": "^4.0.0-alpha.8",
     "@jupyterlab/theme-light-extension": "^1.0.0-alpha.9",
     "@phosphor/commands": "^1.6.1",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "es6-promise": "~4.2.6"
   },
   "devDependencies": {

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -18,7 +18,7 @@
     "@jupyterlab/theme-light-extension": "^1.0.0-alpha.9",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/commands": "^1.6.1",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "es6-promise": "~4.2.6"
   },
   "devDependencies": {

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -19,7 +19,7 @@
     "@jupyterlab/services": "^4.0.0-alpha.8",
     "@jupyterlab/theme-light-extension": "^1.0.0-alpha.9",
     "@phosphor/commands": "^1.6.1",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "es6-promise": "~4.2.6"
   },
   "devDependencies": {

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -11,7 +11,7 @@
     "@jupyterlab/services": "^4.0.0-alpha.8",
     "@jupyterlab/terminal": "^1.0.0-alpha.8",
     "@jupyterlab/theme-light-extension": "^1.0.0-alpha.9",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "es6-promise": "~4.2.6"
   },
   "devDependencies": {

--- a/jupyterlab/tests/mock_packages/mimeextension/package.json
+++ b/jupyterlab/tests/mock_packages/mimeextension/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "private": true,
   "dependencies": {
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "jupyterlab": {
     "mimeExtension": true

--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -35,7 +35,7 @@
     "@jupyterlab/apputils": "^1.0.0-alpha.8",
     "@jupyterlab/coreutils": "^3.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -46,7 +46,7 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "font-awesome": "~4.7.0"
   },
   "devDependencies": {

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -41,7 +41,7 @@
     "@phosphor/commands": "^1.6.1",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "es6-promise": "~4.2.6"
   },
   "devDependencies": {

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -43,7 +43,7 @@
     "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "@types/react": "~16.8.18",
     "react": "~16.8.4",
     "react-dom": "~16.8.4",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -45,7 +45,7 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -38,7 +38,7 @@
     "@phosphor/dragdrop": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/fileeditor": "^1.0.0-alpha.8",
     "@jupyterlab/mainmenu": "^1.0.0-alpha.8",
     "@jupyterlab/statusbar": "^1.0.0-alpha.8",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "codemirror": "~5.47.0"
   },
   "devDependencies": {

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -41,7 +41,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "codemirror": "~5.47.0",
     "react": "~16.8.4"
   },

--- a/packages/completer-extension/package.json
+++ b/packages/completer-extension/package.json
@@ -38,7 +38,7 @@
     "@jupyterlab/notebook": "^1.0.0-alpha.9",
     "@jupyterlab/services": "^4.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -41,7 +41,7 @@
     "@phosphor/domutils": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -44,7 +44,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/properties": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -44,7 +44,7 @@
     "@phosphor/dragdrop": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -40,7 +40,7 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -41,7 +41,7 @@
     "@jupyterlab/statusbar": "^1.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/disposable": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -41,7 +41,7 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -44,7 +44,7 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/documentsearch-extension/package.json
+++ b/packages/documentsearch-extension/package.json
@@ -33,7 +33,7 @@
     "@jupyterlab/apputils": "^1.0.0-alpha.8",
     "@jupyterlab/documentsearch": "^1.0.0-alpha.9",
     "@jupyterlab/mainmenu": "^1.0.0-alpha.8",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -38,7 +38,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "codemirror": "~5.47.0",
     "react": "~16.8.4"
   },

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -42,7 +42,7 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/commands": "^1.6.1",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -44,7 +44,7 @@
     "@phosphor/dragdrop": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -43,7 +43,7 @@
     "@jupyterlab/mainmenu": "^1.0.0-alpha.8",
     "@jupyterlab/statusbar": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/statusbar": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/help-extension/package.json
+++ b/packages/help-extension/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/coreutils": "^3.0.0-alpha.8",
     "@jupyterlab/mainmenu": "^1.0.0-alpha.8",
     "@jupyterlab/services": "^4.0.0-alpha.8",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -36,7 +36,7 @@
     "@jupyterlab/docregistry": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -39,7 +39,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -35,7 +35,7 @@
     "@jupyterlab/ui-components": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4",
     "react-dom": "~16.8.4",
     "react-highlighter": "^0.4.0",

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/launcher": "^1.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -37,7 +37,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/properties": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/services": "^4.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/disposable": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -36,7 +36,7 @@
     "@phosphor/commands": "^1.6.1",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/rendermime": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -49,7 +49,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -49,7 +49,7 @@
     "@phosphor/properties": "^1.1.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4"
   },
   "devDependencies": {

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -42,7 +42,7 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -34,7 +34,7 @@
     "@jupyterlab/rendermime-interfaces": "^1.3.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -41,7 +41,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "lodash.escape": "^4.0.1",
     "marked": "0.6.2"
   },

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -40,7 +40,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4",
     "react-dom": "~16.8.4"
   },

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -42,7 +42,7 @@
     "@jupyterlab/mainmenu": "^1.0.0-alpha.8",
     "@jupyterlab/notebook": "^1.0.0-alpha.9",
     "@jupyterlab/statusbar": "^1.0.0-alpha.8",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "@types/react": "~16.8.18",

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -38,7 +38,7 @@
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4",
     "typestyle": "^2.0.1"
   },

--- a/packages/tabmanager-extension/package.json
+++ b/packages/tabmanager-extension/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@jupyterlab/application": "^1.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/terminal-extension/package.json
+++ b/packages/terminal-extension/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/launcher": "^1.0.0-alpha.8",
     "@jupyterlab/mainmenu": "^1.0.0-alpha.8",
     "@jupyterlab/terminal": "^1.0.0-alpha.8",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "@types/webpack-env": "^1.13.9",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -36,7 +36,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/domutils": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "xterm": "~3.13.2"
   },
   "devDependencies": {

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -42,7 +42,7 @@
     "@jupyterlab/tooltip": "^1.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/services": "^4.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/vdom/package.json
+++ b/packages/vdom/package.json
@@ -37,7 +37,7 @@
     "@nteract/transform-vdom": "^4.0.1",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "react": "~16.8.4",
     "react-dom": "~16.8.4"
   },

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^1.3.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "vega": "^5.3.5",
     "vega-embed": "^4.0.0",
     "vega-lite": "^3.2.1"

--- a/tests/package.json
+++ b/tests/package.json
@@ -35,7 +35,7 @@
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "expect.js": "~0.3.1",
     "json-to-html": "~0.1.2",

--- a/tests/test-application/package.json
+++ b/tests/test-application/package.json
@@ -19,7 +19,7 @@
     "@phosphor/commands": "^1.6.1",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-apputils/package.json
+++ b/tests/test-apputils/package.json
@@ -20,7 +20,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/virtualdom": "^1.1.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-cells/package.json
+++ b/tests/test-cells/package.json
@@ -21,7 +21,7 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-codeeditor/package.json
+++ b/tests/test-codeeditor/package.json
@@ -17,7 +17,7 @@
     "@jupyterlab/observables": "^2.2.0-alpha.8",
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-completer/package.json
+++ b/tests/test-completer/package.json
@@ -20,7 +20,7 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-console/package.json
+++ b/tests/test-console/package.json
@@ -26,7 +26,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0"
   },
   "devDependencies": {

--- a/tests/test-csvviewer/package.json
+++ b/tests/test-csvviewer/package.json
@@ -22,7 +22,7 @@
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/datagrid": "^0.1.6",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "csv-spectrum": "~1.0.0",
     "simulate-event": "~1.4.0"

--- a/tests/test-docmanager/package.json
+++ b/tests/test-docmanager/package.json
@@ -22,7 +22,7 @@
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0"
   },
   "devDependencies": {

--- a/tests/test-docregistry/package.json
+++ b/tests/test-docregistry/package.json
@@ -20,7 +20,7 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.2",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-filebrowser/package.json
+++ b/tests/test-filebrowser/package.json
@@ -25,7 +25,7 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "simulate-event": "~1.4.0"
   },

--- a/tests/test-fileeditor/package.json
+++ b/tests/test-fileeditor/package.json
@@ -19,7 +19,7 @@
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-imageviewer/package.json
+++ b/tests/test-imageviewer/package.json
@@ -18,7 +18,7 @@
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-inspector/package.json
+++ b/tests/test-inspector/package.json
@@ -15,7 +15,7 @@
     "@jupyterlab/inspector": "^1.0.0-alpha.8",
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-mainmenu/package.json
+++ b/tests/test-mainmenu/package.json
@@ -17,7 +17,7 @@
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/commands": "^1.6.1",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-notebook/package.json
+++ b/tests/test-notebook/package.json
@@ -27,7 +27,7 @@
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "simulate-event": "~1.4.0"
   },

--- a/tests/test-outputarea/package.json
+++ b/tests/test-outputarea/package.json
@@ -18,7 +18,7 @@
     "@jupyterlab/services": "^4.0.0-alpha.8",
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-rendermime/package.json
+++ b/tests/test-rendermime/package.json
@@ -24,7 +24,7 @@
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/algorithm": "^1.1.2",
     "@phosphor/coreutils": "^1.3.0",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0"
   },
   "devDependencies": {

--- a/tests/test-statusbar/package.json
+++ b/tests/test-statusbar/package.json
@@ -15,7 +15,7 @@
     "@jupyterlab/statusbar": "^1.0.0-alpha.8",
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/signaling": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "ts-jest": "^24.0.2"

--- a/tests/test-terminal/package.json
+++ b/tests/test-terminal/package.json
@@ -20,7 +20,7 @@
     "@jupyterlab/terminal": "^1.0.0-alpha.8",
     "@jupyterlab/testutils": "^1.0.0-alpha.8",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0",
+    "@phosphor/widgets": "^1.7.0",
     "chai": "^4.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,126 +1554,126 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@phosphor/algorithm@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/algorithm/-/algorithm-1.1.2.tgz#fd1de9104c9a7f34e92864586ddf2e7f2e7779e8"
-  integrity sha1-/R3pEEyafzTpKGRYbd8ufy53eeg=
+"@phosphor/algorithm@^1.1.2", "@phosphor/algorithm@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/algorithm/-/algorithm-1.1.3.tgz#fb0e974f4e81aadc06f948770b3060c4ec8a1e27"
+  integrity sha512-+dkdYTBglR+qGnLVQdCvYojNZMGxf+xSl1Jeksha3pm7niQktSFz2aR5gEPu/nI5LM8T8slTpqE4Pjvq8P+IVA==
 
 "@phosphor/application@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@phosphor/application/-/application-1.6.0.tgz#e1f1bf300680f982881d222a77b24ba8589d3fa2"
-  integrity sha512-SeW2YFjtpmCYbZPpB4aTehyIsI/iGoSrV60Y4/OAp1CwDRT8eu1Rv276F67aermXQFjLK6c58JGucbhNq/BepQ==
-  dependencies:
-    "@phosphor/commands" "^1.5.0"
-    "@phosphor/coreutils" "^1.3.0"
-    "@phosphor/widgets" "^1.6.0"
-
-"@phosphor/collections@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/collections/-/collections-1.1.2.tgz#c4c0b8b91129905fb36a9f243f2dbbde462dab8d"
-  integrity sha1-xMC4uREpkF+zap8kPy273kYtq40=
-  dependencies:
-    "@phosphor/algorithm" "^1.1.2"
-
-"@phosphor/commands@^1.5.0", "@phosphor/commands@^1.6.1":
   version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@phosphor/commands/-/commands-1.6.1.tgz#6f60c2a3b759316cd1363b426df3b4036bb2c7fd"
-  integrity sha512-iRgn7QX64e0VwZ91KFo964a/LVpw9XtiYIYtpymEyKY757NXvx6ZZMt1CqKfntoDcSZJeVte4eV8jJWhZoVlDA==
+  resolved "https://registry.yarnpkg.com/@phosphor/application/-/application-1.6.1.tgz#2eb64a9f46deb3cad9e32e055e37ef3970e6517e"
+  integrity sha512-zyrY8o8Zht4vpyA7fTWHRcj+vzVuJLvAMX2UOVHMgKtaqkRRtuCEvo/cXm/JJM5DjK3x5xv8RnLaKJl6J421qA==
   dependencies:
-    "@phosphor/algorithm" "^1.1.2"
-    "@phosphor/coreutils" "^1.3.0"
-    "@phosphor/disposable" "^1.1.2"
-    "@phosphor/domutils" "^1.1.2"
-    "@phosphor/keyboard" "^1.1.2"
-    "@phosphor/signaling" "^1.2.2"
+    "@phosphor/commands" "^1.6.2"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/widgets" "^1.7.0"
 
-"@phosphor/coreutils@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@phosphor/coreutils/-/coreutils-1.3.0.tgz#63292d381c012c5ab0d0196e83ced829b7e04a42"
-  integrity sha1-YyktOBwBLFqw0Blug87YKbfgSkI=
+"@phosphor/collections@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/collections/-/collections-1.1.3.tgz#c938ee4138d97377bba1f0970102071ca3ac1420"
+  integrity sha512-J2U1xd2e5LtqoOJt4kynrjDNeHhVpJjuY2/zA0InS5kyOuWmvy79pt/KJ22n0LBNcU/fjkImqtQmbrC2Z4q2xQ==
+  dependencies:
+    "@phosphor/algorithm" "^1.1.3"
+
+"@phosphor/commands@^1.6.1", "@phosphor/commands@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@phosphor/commands/-/commands-1.6.2.tgz#f276952d76dcb6f938e5eba746b0d9080d7489ba"
+  integrity sha512-vQFO7ff0ZGfhPft2xJXj30EnYExZgs2l7rbgTBn9PfySNFY6Y1PGMdmEnpcYAT6BPqWrNXMPqZpRWqG3xqNN7w==
+  dependencies:
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.1.3"
+    "@phosphor/domutils" "^1.1.3"
+    "@phosphor/keyboard" "^1.1.3"
+    "@phosphor/signaling" "^1.2.3"
+
+"@phosphor/coreutils@^1.3.0", "@phosphor/coreutils@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@phosphor/coreutils/-/coreutils-1.3.1.tgz#441e34f42340f7faa742a88b2a181947a88d7226"
+  integrity sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA==
 
 "@phosphor/datagrid@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@phosphor/datagrid/-/datagrid-0.1.6.tgz#c5f6d423c2899b22c137b60f07c9054bbce59004"
-  integrity sha512-JDeM5Y9+S1pvB4u75eYtOeCr6Ra2vLNh4UGNg3aYwtqK8OYNNVBiPhPKK8Fw3zR+vjS3GDy8DYX6A5jRY1uW2g==
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@phosphor/datagrid/-/datagrid-0.1.7.tgz#255dd65ba8cd9e9c92d93f18b28e3d2bd3bbb8ae"
+  integrity sha512-VY+G3Umwj0xLrvyrUBU0RpYS8uPihYSO0wicfpvOazmgskDrU0LdVgS+UldQnWeVJ6GrcEwXwnMlTkyPszk+vg==
   dependencies:
-    "@phosphor/algorithm" "^1.1.2"
-    "@phosphor/coreutils" "^1.3.0"
-    "@phosphor/disposable" "^1.1.2"
-    "@phosphor/domutils" "^1.1.2"
-    "@phosphor/dragdrop" "^1.3.0"
-    "@phosphor/messaging" "^1.2.2"
-    "@phosphor/signaling" "^1.2.2"
-    "@phosphor/widgets" "^1.6.0"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.1.3"
+    "@phosphor/domutils" "^1.1.3"
+    "@phosphor/dragdrop" "^1.3.1"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/signaling" "^1.2.3"
+    "@phosphor/widgets" "^1.7.0"
 
-"@phosphor/disposable@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/disposable/-/disposable-1.1.2.tgz#a192dd6a2e6c69d5d09d39ecf334dab93778060e"
-  integrity sha1-oZLdai5sadXQnTns8zTauTd4Bg4=
+"@phosphor/disposable@^1.1.2", "@phosphor/disposable@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/disposable/-/disposable-1.1.3.tgz#912765c02e2f04b8d56efb26ecd7270207a40f41"
+  integrity sha512-yH5/HZzOyp37y+G/6X1hem3EfQCsUMtiStacG9W5F7mRsO4UuIXGxY3/XyJHAzy9UFrInOJD7alurQc/4wYhbQ==
   dependencies:
-    "@phosphor/algorithm" "^1.1.2"
+    "@phosphor/algorithm" "^1.1.3"
 
-"@phosphor/domutils@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/domutils/-/domutils-1.1.2.tgz#e2efeb052f398c42b93b89e9bab26af15cc00514"
-  integrity sha1-4u/rBS85jEK5O4npurJq8VzABRQ=
+"@phosphor/domutils@^1.1.2", "@phosphor/domutils@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/domutils/-/domutils-1.1.3.tgz#5aeeaefb4bbfcc7c0942e5287a29d3c7f2b1a2bc"
+  integrity sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA==
 
-"@phosphor/dragdrop@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@phosphor/dragdrop/-/dragdrop-1.3.0.tgz#7ce6ad39d6ca216d62a56f78104d02a77ae67307"
-  integrity sha1-fOatOdbKIW1ipW94EE0Cp3rmcwc=
+"@phosphor/dragdrop@^1.3.0", "@phosphor/dragdrop@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@phosphor/dragdrop/-/dragdrop-1.3.1.tgz#a16a274f9418916a34ea7edf9ba53bd0d0890b78"
+  integrity sha512-SkxyV43QiBlDU9I9Y8ou+U2Ty8BwwRbEsiet+ZTaDBp5TKDmSOfsZ/dsfUpKBDfGe4Lj95h8z9Dn8pjJsnoEuQ==
   dependencies:
-    "@phosphor/coreutils" "^1.3.0"
-    "@phosphor/disposable" "^1.1.2"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.1.3"
 
-"@phosphor/keyboard@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/keyboard/-/keyboard-1.1.2.tgz#3e32234451764240a98e148034d5a8797422dd1f"
-  integrity sha1-PjIjRFF2QkCpjhSANNWoeXQi3R8=
+"@phosphor/keyboard@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/keyboard/-/keyboard-1.1.3.tgz#e5fd13af0479034ef0b5fffcf43ef2d4a266b5b6"
+  integrity sha512-dzxC/PyHiD6mXaESRy6PZTd9JeK+diwG1pyngkyUf127IXOEzubTIbu52VSdpGBklszu33ws05BAGDa4oBE4mQ==
 
-"@phosphor/messaging@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/messaging/-/messaging-1.2.2.tgz#7d896ddd3797b94a347708ded13da5783db75c14"
-  integrity sha1-fYlt3TeXuUo0dwje0T2leD23XBQ=
+"@phosphor/messaging@^1.2.2", "@phosphor/messaging@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/messaging/-/messaging-1.2.3.tgz#860423261df8ac6c30344cc036b10b0e83d3c0db"
+  integrity sha512-89Ps4uSRNOEQoepB/0SDoyPpNUWd6VZnmbMetmeXZJHsuJ1GLxtnq3WBdl7UCVNsw3W9NC610pWaDCy/BafRlg==
   dependencies:
-    "@phosphor/algorithm" "^1.1.2"
-    "@phosphor/collections" "^1.1.2"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/collections" "^1.1.3"
 
-"@phosphor/properties@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/properties/-/properties-1.1.2.tgz#78cc77eff452839da02255de48e814946cc09a28"
-  integrity sha1-eMx37/RSg52gIlXeSOgUlGzAmig=
+"@phosphor/properties@^1.1.2", "@phosphor/properties@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/properties/-/properties-1.1.3.tgz#63e4355be5e22a411c566fd1860207038f171598"
+  integrity sha512-GiglqzU77s6+tFVt6zPq9uuyu/PLQPFcqZt914ZhJ4cN/7yNI/SLyMzpYZ56IRMXvzK9TUgbRna6URE3XAwFUg==
 
-"@phosphor/signaling@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/signaling/-/signaling-1.2.2.tgz#3fcf97ca88e38bfb357fe8fe6bf7513347a514a9"
-  integrity sha1-P8+Xyojji/s1f+j+a/dRM0elFKk=
+"@phosphor/signaling@^1.2.2", "@phosphor/signaling@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/signaling/-/signaling-1.2.3.tgz#2fde0ee810b0fab5f3fc765f81ed08ae671e76f1"
+  integrity sha512-DMwS0m9OgfY5ljpTsklRQPUQpTyg4obz85FyImRDacUVxUVbas95djIDEbU4s1TMzdHBBO+gfki3V4giXUvXzw==
   dependencies:
-    "@phosphor/algorithm" "^1.1.2"
+    "@phosphor/algorithm" "^1.1.3"
 
-"@phosphor/virtualdom@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@phosphor/virtualdom/-/virtualdom-1.1.2.tgz#ce55c86eef31e5d0e26b1dc96ea32bd684458f41"
-  integrity sha1-zlXIbu8x5dDiax3JbqMr1oRFj0E=
+"@phosphor/virtualdom@^1.1.2", "@phosphor/virtualdom@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@phosphor/virtualdom/-/virtualdom-1.1.3.tgz#33ddebc710ad5bd136fd5f61d7adb4fa14e781e0"
+  integrity sha512-V8PHhhnZCRa5esrC4q5VthqlLtxTo9ZV1mZ6b4YEloapca1S1nggZSQhrSlltXQjtYNUaWJZUZ/BlFD8wFtIEQ==
   dependencies:
-    "@phosphor/algorithm" "^1.1.2"
+    "@phosphor/algorithm" "^1.1.3"
 
-"@phosphor/widgets@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@phosphor/widgets/-/widgets-1.6.0.tgz#ebba8008b6b13247d03e73e5f3872c90d2c9c78f"
-  integrity sha512-HqVckVF8rJ15ss0Zf/q0AJ69ZKNFOO26qtNKAdGZ9SmmkSMf73X6pB0R3Fj5+Y4Sjl8ezIIKG6mXj+DxOofnwA==
+"@phosphor/widgets@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@phosphor/widgets/-/widgets-1.7.0.tgz#1985372ac9e6b2a80b550d5652461c9145721be0"
+  integrity sha512-LavrlJHnki2x5PyBbfEdY4UJSARTu4anVZ9l2YOKGVUGE3mwl1pVJqJAghYC/M+OhSXcvHzFgxwaZxBQZ1gHbQ==
   dependencies:
-    "@phosphor/algorithm" "^1.1.2"
-    "@phosphor/commands" "^1.5.0"
-    "@phosphor/coreutils" "^1.3.0"
-    "@phosphor/disposable" "^1.1.2"
-    "@phosphor/domutils" "^1.1.2"
-    "@phosphor/dragdrop" "^1.3.0"
-    "@phosphor/keyboard" "^1.1.2"
-    "@phosphor/messaging" "^1.2.2"
-    "@phosphor/properties" "^1.1.2"
-    "@phosphor/signaling" "^1.2.2"
-    "@phosphor/virtualdom" "^1.1.2"
+    "@phosphor/algorithm" "^1.1.3"
+    "@phosphor/commands" "^1.6.2"
+    "@phosphor/coreutils" "^1.3.1"
+    "@phosphor/disposable" "^1.1.3"
+    "@phosphor/domutils" "^1.1.3"
+    "@phosphor/dragdrop" "^1.3.1"
+    "@phosphor/keyboard" "^1.1.3"
+    "@phosphor/messaging" "^1.2.3"
+    "@phosphor/properties" "^1.1.3"
+    "@phosphor/signaling" "^1.2.3"
+    "@phosphor/virtualdom" "^1.1.3"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
This pulls in the tab drop zone change in @phosphor/widgets 1.7.0.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #5406 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Updates phosphor packages.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

See the updated tab drop behavior at https://github.com/phosphorjs/phosphor/pull/365 (screenshots are there).

## Backwards-incompatible changes

None