### PR TITLE
Fix minor typo in documentation

### DIFF
--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -512,7 +512,7 @@ export namespace nbformat {
   }
 
   /**
-   * Test whether an output is from a stream.
+   * Test whether an output is an error.
    */
   export function isError(output: IOutput): output is IError {
     return output.output_type === 'error';


### PR DESCRIPTION
Just a drive by commit :car: to fix a typo I came across.

## References

None

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None