### PR TITLE
Stop endless Firefox redirect.

### DIFF
--- a/dev_mode/templates/template.html
+++ b/dev_mode/templates/template.html
@@ -28,6 +28,10 @@
     var url = location.origin + location.pathname +
       (query !== '?' ? query : '') + location.hash;
 
+    if (url === location.href) {
+      return;
+    }
+
     window.history.replaceState({ }, '', url);
   })();
 </script>

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -270,10 +270,9 @@ const tree: JupyterFrontEndPlugin<void> = {
           args.search +
           args.hash;
         const immediate = true;
-        const silent = true;
 
-        // Silently remove the tree portion of the URL leaving the rest intact.
-        router.navigate(url, { silent });
+        // Remove the tree portion of the URL leaving the rest intact.
+        router.navigate(url);
 
         try {
           await commands.execute('filebrowser:navigate', { path });
@@ -311,9 +310,8 @@ const notfound: JupyterFrontEndPlugin<void> = {
       The path: ${bad} was not found. JupyterLab redirected to: ${base}
     `;
 
-    // Change the URL back to the base application URL without adding the
-    // URL change to the browser history.
-    router.navigate('', { silent: true });
+    // Change the URL back to the base application URL.
+    router.navigate('');
 
     void showErrorMessage('Path Not Found', { message });
   },

--- a/packages/application/src/router.ts
+++ b/packages/application/src/router.ts
@@ -73,7 +73,7 @@ export class Router implements IRouter {
   navigate(path: string, options: IRouter.INavOptions = {}): void {
     const { base } = this;
     const { history } = window;
-    const { hard, silent } = options;
+    const { hard } = options;
     const old = document.location.href;
     const url =
       path && path.indexOf(base) === 0 ? path : URLExt.join(base, path);
@@ -82,11 +82,7 @@ export class Router implements IRouter {
       return hard ? this.reload() : undefined;
     }
 
-    if (silent) {
-      history.replaceState({}, '', url);
-    } else {
-      history.pushState({}, '', url);
-    }
+    history.pushState({}, '', url);
 
     if (hard) {
       return this.reload();

--- a/packages/application/src/tokens.ts
+++ b/packages/application/src/tokens.ts
@@ -144,11 +144,6 @@ export namespace IRouter {
      * history API change.
      */
     hard?: boolean;
-
-    /**
-     * Whether the navigation should be added to the browser's history.
-     */
-    silent?: boolean;
   }
 
   /**

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -265,9 +265,8 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
         // Clone the originally requested workspace after redirecting.
         query['clone'] = workspace;
 
-        // Change the URL and trigger a hard reload to re-route.
         const url = path + URLExt.objectToQueryString(query) + (hash || '');
-        router.navigate(url, { hard: true, silent: true });
+        router.navigate(url, { hard: true });
       });
     }
   }
@@ -492,7 +491,7 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
 
           // After the state has been cloned, navigate to the URL.
           void cloned.then(() => {
-            router.navigate(url, { silent: true });
+            router.navigate(url);
           });
 
           return cloned;
@@ -541,19 +540,17 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
         // Maintain the query string parameters but remove `reset`.
         delete query['reset'];
 
-        const silent = true;
-        const hard = true;
         const url = path + URLExt.objectToQueryString(query) + hash;
         const cleared = db.clear().then(() => router.stop);
 
         // After the state has been reset, navigate to the URL.
         if (clone) {
           void cleared.then(() => {
-            router.navigate(url, { silent, hard });
+            router.navigate(url, { hard: true });
           });
         } else {
           void cleared.then(() => {
-            router.navigate(url, { silent });
+            router.navigate(url);
             loading.dispose();
           });
         }


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/6408

The root cause of this bug is that Firefox incorrectly reports the value of `window.location.href` after our 302 redirect from the server is followed by a `window.replaceState` call (to remove the `token` from the URL and then to change the URL to a free workspace). Since Firefox reports the URL as `/lab` even after it has changed to `/lab/workspaces/foo`, JupyterLab gets caught in an endless redirect loop.

This bug manifested after the last alpha release, which switched to automatically resolving a workspace instead of asking the user to supply one.

The Firefox bug is documented here: https://bugzilla.mozilla.org/show_bug.cgi?id=1422334 (h/t @vidartf)

## Code changes

Removes `silent` flag from `Router#navigate()` options.

## User-facing changes

* Fixes redirect loop in Firefox.
* JupyterLab windows now add to browser history when they redirect. This is unfortunate, but currently unavoidable. A future version of JupyterLab and Firefox may allow us to go back to the original `replaceState` behavior.

## Backwards-incompatible changes

Removes `IRouter.INavOptions.silent`
