### PR TITLE
Remove obsolete documentation on "keymap" interface

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -86,7 +86,6 @@ A Jupyter front-end application object is given to each plugin in its
 ``activate()`` function. The application object has:
 
 -  commands - used to add and execute commands in the application.
--  keymap - used to add keyboard shortcuts to the application.
 -  shell - a generic Jupyter front-end shell instance.
 
 Jupyter Front-End Shell


### PR DESCRIPTION
#6463 

As I have recently found out, the way to add keyboard shortcuts as described in the [extension developer's guide](https://jupyterlab.readthedocs.io/en/stable/developer/extension_dev.html) is obsolete. 

This patch removes the "keymap" line from the guide:

![image](https://user-images.githubusercontent.com/9889312/58895899-93030b00-86ba-11e9-86da-b34de35ac490.png)

Not sure where to add information on the new way of using  `jupyter.lab.shortcuts` in `schema/plugin.json` though.