### PR TITLE
Stop using base_url in workspace name.

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -607,7 +607,7 @@ namespace Private {
     workspace = ''
   ): string {
     return workspace
-      ? URLExt.join(urls.base, urls.workspaces, workspace)
-      : URLExt.join(urls.base, urls.page);
+      ? URLExt.join(urls.workspaces, workspace)
+      : URLExt.join(urls.page);
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'notebook>=4.3.1',
     'tornado<6',
-    'jupyterlab_server>=0.3.3,<0.4.0'
+    'jupyterlab_server>=0.3.4,<0.4.0'
 ]
 
 setup_args['extras_require'] = {


### PR DESCRIPTION
## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/5977
Requires https://github.com/jupyterlab/jupyterlab_server/pull/68

## Code changes
Workspace names no longer include `base_url`.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
