### PR TITLE
added default text to inspector module

### DIFF
--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -18,6 +18,11 @@ const PANEL_CLASS = 'jp-Inspector';
 const CONTENT_CLASS = 'jp-Inspector-content';
 
 /**
+ * The class name added to default inspector content.
+ */
+const DEFAULT_CONTENT_CLASS = 'jp-Inspector-default-content';
+
+/**
  * A panel which contains a set of inspectors.
  */
 export class InspectorPanel extends Panel
@@ -28,6 +33,7 @@ export class InspectorPanel extends Panel
   constructor() {
     super();
     this.addClass(PANEL_CLASS);
+    (this.layout as PanelLayout).addWidget(this._content);
   }
 
   /**
@@ -92,17 +98,14 @@ export class InspectorPanel extends Panel
     const { content } = args;
 
     // Update the content of the inspector widget.
-    if (content === this._content) {
+    if (!content || content === this._content) {
       return;
     }
-    if (this._content) {
-      this._content.dispose();
-    }
+    this._content.dispose();
+
     this._content = content;
-    if (content) {
-      content.addClass(CONTENT_CLASS);
-      (this.layout as PanelLayout).addWidget(content);
-    }
+    content.addClass(CONTENT_CLASS);
+    (this.layout as PanelLayout).addWidget(content);
   }
 
   /**
@@ -112,6 +115,18 @@ export class InspectorPanel extends Panel
     this.source = null;
   }
 
-  private _content: Widget | null = null;
+  private _content: Widget = Private.defaultContent();
   private _source: IInspector.IInspectable | null = null;
+}
+
+namespace Private {
+  export function defaultContent() {
+    const defaultContent = new Widget();
+    defaultContent.node.innerHTML =
+      '<p>Click on a function to see documentation.</p>';
+    defaultContent.addClass(CONTENT_CLASS);
+    defaultContent.addClass(DEFAULT_CONTENT_CLASS);
+
+    return defaultContent;
+  }
 }

--- a/packages/inspector/style/index.css
+++ b/packages/inspector/style/index.css
@@ -46,3 +46,11 @@
   background-image: var(--jp-icon-inspector);
   transform: scaleX(-1);
 }
+
+.jp-Inspector-default-content {
+  align-items: center;
+  justify-content: center;
+  font-size: xx-large;
+  font-style: italic;
+  color: darkgray;
+}


### PR DESCRIPTION
## References
This pull request addresses one of the issues raised in #2398, where users who open the Inspector see a blank window without any indication as to what it is supposed to show, often leading them to think it is broken.

## Code changes

With the help of @jasongrout  and @ivanov, we modified the inspector.ts file to implement the following logic:

1. Upon instantiation, the Inspector module will render with a default text indicating what the user should do in order to get docstrings to display. 
2. When a user clicks on/types a defined function in any cell, that function's docstring will be displayed in the Inspector window.
3. When the user navigates away from the function or clicks on any other element which is not a defined function and has no docstring, the Inspector window will simply keep the old docstring on the screen until a new docstring from another function is fed in.

## User-facing changes

The Inspector window will now **always** have some content displayed, whereas before, upon instantiation, it was blank. In addition, when a user navigated away from a defined function into an empty cell, the Inspector window would clear.

#### Before
![inspector_before](https://user-images.githubusercontent.com/24281433/58972542-b2329300-87b5-11e9-8976-a47c4b960a24.gif)

#### After
![inspector_after](https://user-images.githubusercontent.com/24281433/58972553-b8287400-87b5-11e9-8155-5a8122e55016.gif)




## Backwards-incompatible changes

None that I can see. 