### PR TITLE
Do not wait for a console session to be ready before showing the console

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -245,8 +245,9 @@ async function activateConsole(
     )).composite as string;
     panel.console.node.dataset.jpInteractionMode = interactionMode;
 
-    // Add the console panel to the tracker and wait for it to be ready.
-    await Promise.all([tracker.add(panel), panel.session.ready]);
+    // Add the console panel to the tracker. We want the panel to show up before
+    // any kernel selection dialog, so we do not await panel.session.ready;
+    await tracker.add(panel);
     panel.session.propertyChanged.connect(() => tracker.save(panel));
 
     shell.add(panel, 'main', {


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6457

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Before, the application spinner was delayed by a kernel selection dialog. This causes the console to show even if a kernel selection dialog is still up.

Now we don't wait for a kernel to be ready, but show the console almost immediately.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

The application spinner can go away even if a console kernel selection dialog is open.


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
