### PR TITLE
Rename 'Close Other Tabs' command item to 'Close All Other Tabs'.

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -564,7 +564,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   palette.addItem({ command: CommandIDs.closeAll, category });
 
   commands.addCommand(CommandIDs.closeOtherTabs, {
-    label: () => `Close Other Tabs`,
+    label: () => `Close All Other Tabs`,
     isEnabled: () => {
       // Ensure there are at least two widgets.
       const iterator = shell.widgets('main');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses Issue #6482 

## Code changes
This renames the 'Close Other Tabs' command item to 'Close All Other Tabs', to make it clear that all tabs across all open panels will be closed, not only in the current panel.

## User-facing changes
Before:
<img width="452" alt="Screen Shot 2019-06-06 at 1 57 08 PM" src="https://user-images.githubusercontent.com/14915251/59031174-3ee75a80-8863-11e9-81eb-ef5178c86bd2.png">

After:
<img width="522" alt="Screen Shot 2019-06-06 at 2 02 41 PM" src="https://user-images.githubusercontent.com/14915251/59031388-d3ea5380-8863-11e9-8e64-ed93af3a752f.png">

## Backwards-incompatible changes
None
