### PR TITLE
Change keyboard shortcut for 'Close Tab' to 'Alt+W' from 'Accel+W'.

### DIFF
--- a/packages/application-extension/schema/main.json
+++ b/packages/application-extension/schema/main.json
@@ -15,7 +15,7 @@
     },
     {
       "command": "application:close",
-      "keys": ["Accel W"],
+      "keys": ["Alt W"],
       "selector": ".jp-Activity"
     },
     {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6357.

## Code changes
This changes the keyboard shortcut for the 'Close Tab' command to 'Alt+W' from 'Accel+W'. On Windows and MacOS 10.14, 'Accel+W' closes the whole browser tab for several browsers. Per the discussion in #6357 , the 'Alt+W' shortcut looks like it is available and will not conflict with any browser shortcuts.

## User-facing changes
Before:
<img width="373" alt="Screen Shot 2019-06-06 at 2 08 04 PM" src="https://user-images.githubusercontent.com/14915251/59032515-c7b3c580-8866-11e9-8847-ae90df29ca90.png">

After:
<img width="371" alt="Screen Shot 2019-06-06 at 2 18 20 PM" src="https://user-images.githubusercontent.com/14915251/59032526-cda9a680-8866-11e9-848b-dcf57e8c5461.png">

## Backwards-incompatible changes
None