### PR TITLE
made non-breaking space change

### DIFF
--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -173,7 +173,7 @@ function Item<M>(props: SessionProps<M> & { model: M }) {
         className={`${SHUTDOWN_BUTTON_CLASS} jp-mod-styled`}
         onClick={() => props.shutdown(model)}
       >
-        SHUT DOWN
+        SHUT&nbsp;DOWN
       </button>
     </li>
   );


### PR DESCRIPTION
## References

This PR addresses issue #6477, where the "SHUT DOWN" link wraps when the screen is narrow

## Code changes

Thanks to a tip from @jasongrout, we added `&nbsp;` to make the space non-breaking.

## User-facing changes

![SHUT_DOWN_after](https://user-images.githubusercontent.com/24281433/59034885-072ce280-8864-11e9-9b11-7f266c3393eb.gif)


## Backwards-incompatible changes

None that I can think of.
