### PR TITLE
Add documentation to the Keyboard Shortcuts component in the Advanced Settings Editor to explain how to disable system default shortcuts.

### DIFF
--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -164,7 +164,21 @@ const shortcuts: JupyterFrontEndPlugin<void> = {
         .sort((a, b) => a.command.localeCompare(b.command));
       schema.properties.shortcuts.title =
         'List of Commands (followed by shortcuts)';
+
+      const disableShortcutInstructions = `Note: To disable a system default shortcut,
+copy it to User Preferences and add the
+"disabled" key, for example:
+{
+    "command": "application:activate-next-tab",
+    "keys": [
+        "Ctrl Shift ]"
+    ],
+    "selector": "body",
+    "disabled": true
+}`;
       schema.properties.shortcuts.description = `${commands}
+
+${disableShortcutInstructions}
 
 List of Keyboard Shortcuts`;
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6249.

## Code changes
This adds the following documentation block to the Keyboard Shortcuts component in the Advanced Settings Editor, before the list of keyboard shortcuts, to explain how default keyboard shortcuts can be disabled:
```
Note: To disable a system default shortcut,
copy it to User Preferences and add the
"disabled" key, for example:
{
    "command": "application:activate-next-tab",
    "keys": [
        "Ctrl Shift ]"
    ],
    "selector": "body",
    "disabled": true
}
```

## User-facing changes
Before:
<img width="795" alt="Screen Shot 2019-06-06 at 2 30 11 PM" src="https://user-images.githubusercontent.com/14915251/59035063-bd94c580-886c-11e9-90c2-6b229f986b44.png">

After:
<img width="803" alt="Screen Shot 2019-06-06 at 2 58 29 PM" src="https://user-images.githubusercontent.com/14915251/59035080-c2f21000-886c-11e9-9354-6fa15047d03d.png">

## Backwards-incompatible changes
None