### PR TITLE
CSS: Remove 'overflow: visible' property from '.p-DockPanel-tabBar' class.

### DIFF
--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -20,7 +20,6 @@
 
 .p-DockPanel-tabBar {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
-  overflow: visible;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #3986.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Per the discussion in #3986, this removes the `overflow: visible` property from the `.p-DockPanel-tabBar` class. This is to fix overflow tabs on one panel strip being visible beyond the boundary of another panel strip. I'm not sure if it has any other side effects but it looks alright on my end so far.

## User-facing changes
Before:
<img width="760" alt="Screen Shot 2019-06-06 at 4 08 36 PM" src="https://user-images.githubusercontent.com/14915251/59040386-ddc98200-8876-11e9-986b-3b49b54dbfb2.png">

After:
<img width="1031" alt="Screen Shot 2019-06-06 at 4 18 07 PM" src="https://user-images.githubusercontent.com/14915251/59040390-e0c47280-8876-11e9-802c-6c5a399df0ba.png">

## Backwards-incompatible changes
None
