### PR TITLE
Rename "Inspector" to "Interactive Help"

### DIFF
--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -50,8 +50,8 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
   ): IInspector => {
     const { commands, shell } = app;
     const command = CommandIDs.open;
-    const label = 'Open Inspector';
-    const title = 'Inspector';
+    const label = 'Open Interactive Help';
+    const title = 'Interactive Help';
     const namespace = 'inspector';
     const tracker = new InstanceTracker<MainAreaWidget<InspectorPanel>>({
       namespace


### PR DESCRIPTION
## References

This PR addresses issue #6488, where the "Inspector" name is causing confusion for people running it for the first time. This PR changes the "Inspector" and "Open Inspector" titles and labels to "Interactive Help" and "Open Interactive Help".

Fixes #6488

## Code changes

Simple change to the `index.ts` code of the Inspector module.

## User-facing changes

![Interactive_Help_after](https://user-images.githubusercontent.com/24281433/59041022-bae79f80-886f-11e9-8175-96ad829c18c3.gif)

## Backwards-incompatible changes

None that I can think of.