### PR TITLE
Enables private npm registry passing a npm-registry config flag

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -252,14 +252,14 @@ def install_extension(extension, app_dir=None, logger=None, npm_registry=None):
     return handler.install_extension(extension)
 
 
-def uninstall_extension(name=None, app_dir=None, logger=None, all_=False):
+def uninstall_extension(name=None, app_dir=None, logger=None, all_=False, npm_registry=None):
     """Uninstall an extension by name or path.
 
     Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     logger = _ensure_logger(logger)
     _node_check(logger)
-    handler = _AppHandler(app_dir, logger)
+    handler = _AppHandler(app_dir, logger, npm_registry=npm_registry)
     if all_ is True:
         return handler.uninstall_all_extensions()
     return handler.uninstall_extension(name)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

This PR try to fix #4149 issue.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
On the labextension command we add a npm-registry flag and propagate it downstream to commands._AppHandler to install extensions not present on 'https://registry.npmjs.org'.
