### PR TITLE
Disable chunksSort in HtmlWebpackPlugin

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -122,6 +122,7 @@ const plugins = [
     }
   }),
   new HtmlWebpackPlugin({
+    chunksSortMode: 'none',
     template: path.join('templates', 'template.html'),
     title: jlab.name || 'JupyterLab'
   }),

--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -122,6 +122,7 @@ const plugins = [
     }
   }),
   new HtmlWebpackPlugin({
+    chunksSortMode: 'none',
     template: path.join('templates', 'template.html'),
     title: jlab.name || 'JupyterLab'
   }),


### PR DESCRIPTION
Due to a bug in HtmlWebpackPlugin 3.x (https://github.com/jantimon/html-webpack-plugin/issues/870), disabling
chunksSortMode is required for some extensions to be bundled
correctly. This is fixed in HtmlWebpackPlugin 4.x and can be
removed when we upgrade, but at the time of this writing, 4.x is
still in alpha.
