### PR TITLE
Only write to filebrowser listing text if the text would change

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1763,7 +1763,7 @@ export namespace DirListing {
 
       node.title = model.name;
       // If an item is being edited currently, its text node is unavailable.
-      if (text) {
+      if (text && text.textContent !== model.name) {
         text.textContent = model.name;
       }
 


### PR DESCRIPTION

CC @afshin

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #5996

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

It seems that Safari loses track of mouse events when we replace the text, which means that clicking/double-clicking on filenames (which calls this update function) never register click/dblclick events, just mousedown events in Safari.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Double-clicking filenames works in Safari.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
