### PR TITLE
Don't append content in rendered output upon rerendering.

### DIFF
--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -63,9 +63,20 @@ export abstract class RenderedCommon extends Widget
    * @param model - The mime model to render.
    *
    * @returns A promise which resolves when rendering is complete.
+   *
+   * #### Notes
+   * If the DOM node for this widget already has content, it is emptied
+   * before rendering. Subclasses that do not want this behavior
+   * (if, for instance, they are using DOM diffing), should override
+   * this method.
    */
   async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
     // TODO compare model against old model for early bail?
+
+    // Empty any existing content in the node from previous renders
+    while (this.node.firstChild) {
+      this.node.removeChild(this.node.firstChild);
+    }
 
     // Toggle the trusted class on the widget.
     this.toggleClass('jp-mod-trusted', model.trusted);

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -68,7 +68,7 @@ export abstract class RenderedCommon extends Widget
    * If the DOM node for this widget already has content, it is emptied
    * before rendering. Subclasses that do not want this behavior
    * (if, for instance, they are using DOM diffing), should override
-   * this method.
+   * this method and not call `super.renderModel()`.
    */
   async renderModel(model: IRenderMime.IMimeModel): Promise<void> {
     // TODO compare model against old model for early bail?

--- a/tests/test-rendermime/src/factories.spec.ts
+++ b/tests/test-rendermime/src/factories.spec.ts
@@ -66,6 +66,16 @@ describe('rendermime/factories', () => {
         expect(w.node.innerHTML).to.equal('<pre>x = 2 ** a</pre>');
       });
 
+      it('should be re-renderable', async () => {
+        const f = textRendererFactory;
+        const mimeType = 'text/plain';
+        const model = createModel(mimeType, 'x = 2 ** a');
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal('<pre>x = 2 ** a</pre>');
+      });
+
       it('should output the correct HTML with ansi colors', async () => {
         const f = textRendererFactory;
         const source = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
@@ -113,6 +123,17 @@ describe('rendermime/factories', () => {
         const mimeType = 'text/latex';
         const model = createModel(mimeType, source);
         const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.textContent).to.equal(source);
+      });
+
+      it('should be re-renderable', async () => {
+        const source = 'sumlimits_{i=0}^{infty} \frac{1}{n^2}';
+        const f = latexRendererFactory;
+        const mimeType = 'text/latex';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
         await w.renderModel(model);
         expect(w.node.textContent).to.equal(source);
       });
@@ -174,6 +195,17 @@ describe('rendermime/factories', () => {
         expect(w.node.innerHTML).to.equal(source);
       });
 
+      it('it should be re-renderable', async () => {
+        const f = markdownRendererFactory;
+        const source = '<p>hello</p>';
+        const mimeType = 'text/markdown';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal(source);
+      });
+
       it('should add header anchors', async () => {
         const source = require('../../../examples/filebrowser/sample.md')
           .default as string;
@@ -225,6 +257,17 @@ describe('rendermime/factories', () => {
         const mimeType = 'text/html';
         const model = createModel(mimeType, source);
         const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
+        expect(w.node.innerHTML).to.equal('<h1>This is great</h1>');
+      });
+
+      it('should be re-renderable', async () => {
+        const f = htmlRendererFactory;
+        const source = '<h1>This is great</h1>';
+        const mimeType = 'text/html';
+        const model = createModel(mimeType, source);
+        const w = f.createRenderer({ mimeType, ...defaultOptions });
+        await w.renderModel(model);
         await w.renderModel(model);
         expect(w.node.innerHTML).to.equal('<h1>This is great</h1>');
       });


### PR DESCRIPTION
## References

Fixes #6497, fixes #6505.

I would consider this a bug in the rendermime library that was uncovered by some of the less-aggressive updating of outputs in #6304.

## Code changes

Empties any existing DOM node content in our existing renderers before re-rendering.

## User-facing changes

Fixes re-displaying of already displayed data.

## Backwards-incompatible changes

Possible backwards-incompatible behavior of re-rendering for subclasses of `RenderedCommon` if they were updating existing DOM nodes.