### PR TITLE
lazy load of vim mode

### DIFF
--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -155,7 +155,7 @@ function activateEditorCommands(
     // Lazy loading of vim mode
     if (keyMap === 'vim') {
       // @ts-ignore
-      import('codemirror/keymap/vim.js');
+      void import('codemirror/keymap/vim.js');
     }
 
     theme = (settings.get('theme').composite as string | null) || theme;

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -154,6 +154,7 @@ function activateEditorCommands(
 
     // Lazy loading of vim mode
     if (keyMap === 'vim') {
+      // @ts-ignore
       import('codemirror/keymap/vim.js');
     }
 

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -151,6 +151,12 @@ function activateEditorCommands(
    */
   function updateSettings(settings: ISettingRegistry.ISettings): void {
     keyMap = (settings.get('keyMap').composite as string | null) || keyMap;
+
+    // Lazy loading of vim mode
+    if (keyMap === 'vim') {
+      import('codemirror/keymap/vim.js');
+    }
+
     theme = (settings.get('theme').composite as string | null) || theme;
     scrollPastEnd = settings.get('scrollPastEnd').composite as boolean | null;
     styleActiveLine =

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -49,7 +49,7 @@ import 'codemirror/addon/selection/mark-selection';
 import 'codemirror/addon/selection/selection-pointer';
 import 'codemirror/keymap/emacs.js';
 import 'codemirror/keymap/sublime.js';
-import 'codemirror/keymap/vim.js';
+// import 'codemirror/keymap/vim.js';  lazy loading of vim mode is available in ../codemirror-extension/index.ts
 
 /**
  * The class name added to CodeMirrorWidget instances.


### PR DESCRIPTION
## References

This PR implements issue #6511, lazy load of vim mode.

Thank you @blink1073 for pointing out where in the code this should be implemented.

**Important:** I had to add a basic vim.d.ts type declaration type file to the node_modules/@types/codemirror/keymap folder as jlpm wouldn't compile otherwise. The compiling issue only happens when the conditional `import('xyz)` command is used. Regular `import 'xyz'` gives this warning but does not cause any compiling issues.

## Code changes

vim.js is now only loaded when vim mode is selected.

## User-facing changes

No visual changes.

## Backwards-incompatible changes

None that I can see.
