### PR TITLE
Fix dialog button UX

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -127,7 +127,7 @@ const main: JupyterFrontEndPlugin<void> = {
             body: 'Build successfully completed, reload page?',
             buttons: [
               Dialog.cancelButton(),
-              Dialog.warnButton({ label: 'RELOAD' })
+              Dialog.warnButton({ label: 'Reload' })
             ]
           });
         })
@@ -164,7 +164,7 @@ const main: JupyterFrontEndPlugin<void> = {
         void showDialog({
           title: 'Build Recommended',
           body,
-          buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'BUILD' })]
+          buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Build' })]
         }).then(result => (result.button.accept ? build() : undefined));
       });
     }

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -14,28 +14,11 @@ export const ConnectionLost: IConnectionLost = async function(
   manager: ServiceManager.IManager,
   err: ServerConnection.NetworkError
 ): Promise<void> {
-  if (Private.showingError) {
-    return;
-  }
-  Private.showingError = true;
-
   const title = 'Server Connection Error';
   const networkMsg =
     'A connection to the Jupyter server could not be established.\n' +
     'JupyterLab will continue trying to reconnect.\n' +
     'Check your network connection or Jupyter server configuration.\n';
 
-  return showErrorMessage(title, { message: networkMsg }).then(() => {
-    Private.showingError = false;
-  });
+  return showErrorMessage(title, { message: networkMsg });
 };
-
-/**
- * A namespace for module private functionality.
- */
-namespace Private {
-  /**
-   * Whether the connection lost error is currently being shown.
-   */
-  export let showingError = false;
-}

--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -18,28 +18,44 @@ button {
 
 button.jp-mod-styled.jp-mod-accept {
   background: var(--md-blue-500);
-  border: 1px solid var(--md-blue-500);
+  border: 0;
   color: white;
 }
 
-button.jp-mod-styled:hover {
-  opacity: 0.85;
+button.jp-mod-styled.jp-mod-accept:hover {
+  background: var(--md-blue-600);
 }
 
-button.jp-mod-styled:active {
-  opacity: 1;
+button.jp-mod-styled.jp-mod-accept:active {
+  background: var(--md-blue-700);
 }
 
 button.jp-mod-styled.jp-mod-reject {
   background: var(--md-grey-500);
-  border: 1px solid var(--md-grey-500);
+  border: 0;
   color: white;
+}
+
+button.jp-mod-styled.jp-mod-reject:hover {
+  background: var(--md-grey-600);
+}
+
+button.jp-mod-styled.jp-mod-reject:active {
+  background: var(--md-grey-700);
 }
 
 button.jp-mod-styled.jp-mod-warn {
   background: var(--jp-error-color1);
-  border: 1px solid var(--jp-error-color1);
+  border: 0;
   color: white;
+}
+
+button.jp-mod-styled.jp-mod-warn:hover {
+  background: var(--md-red-600);
+}
+
+button.jp-mod-styled.jp-mod-warn:active {
+  background: var(--md-red-700);
 }
 
 .jp-Button-flat {

--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -17,9 +17,17 @@ button {
 }
 
 button.jp-mod-styled.jp-mod-accept {
-  background: var(--jp-brand-color1);
+  background: var(--md-blue-500);
+  border: 1px solid var(--md-blue-500);
   color: white;
-  border: 1px solid var(--jp-brand-color1);
+}
+
+button.jp-mod-styled:hover {
+  opacity: 0.85;
+}
+
+button.jp-mod-styled:active {
+  opacity: 1;
 }
 
 button.jp-mod-styled.jp-mod-reject {
@@ -30,8 +38,8 @@ button.jp-mod-styled.jp-mod-reject {
 
 button.jp-mod-styled.jp-mod-warn {
   background: var(--jp-error-color1);
-  color: white;
   border: 1px solid var(--jp-error-color1);
+  color: white;
 }
 
 .jp-Button-flat {

--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -601,8 +601,8 @@ export class ClientSession implements IClientSession {
       return Promise.resolve();
     }
     const buttons = cancelable
-      ? [Dialog.cancelButton(), Dialog.okButton({ label: 'SELECT' })]
-      : [Dialog.okButton({ label: 'SELECT' })];
+      ? [Dialog.cancelButton(), Dialog.okButton({ label: 'Select' })]
+      : [Dialog.okButton({ label: 'Select' })];
 
     let dialog = (this._dialog = new Dialog({
       title: 'Select Kernel',
@@ -881,7 +881,7 @@ export namespace ClientSession {
   export async function restartKernel(
     kernel: Kernel.IKernelConnection
   ): Promise<boolean> {
-    let restartBtn = Dialog.warnButton({ label: 'RESTART ' });
+    let restartBtn = Dialog.warnButton({ label: 'Restart' });
     const result = await showDialog({
       title: 'Restart Kernel?',
       body:

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -54,7 +54,6 @@ export function showErrorMessage(
   let key = title + '----' + body;
   let promise = Private.errorMessagePromiseCache.get(key);
   if (promise) {
-    console.log(key);
     return promise;
   } else {
     let dialogPromise = showDialog({

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -43,7 +43,7 @@ export function showErrorMessage(
   title: string,
   error: any,
   buttons: ReadonlyArray<Dialog.IButton> = [
-    Dialog.okButton({ label: 'DISMISS' })
+    Dialog.okButton({ label: 'Dismiss' })
   ]
 ): Promise<void> {
   console.warn('Showing error:', error);
@@ -522,7 +522,7 @@ export namespace Dialog {
    */
   export function createButton(value: Partial<IButton>): Readonly<IButton> {
     value.accept = value.accept !== false;
-    let defaultLabel = value.accept ? 'OK' : 'CANCEL';
+    let defaultLabel = value.accept ? 'OK' : 'Cancel';
     return {
       label: value.label || defaultLabel,
       iconClass: value.iconClass || '',

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -49,6 +49,11 @@
 button.jp-Dialog-button:focus {
   outline: 1px solid var(--jp-brand-color1);
   outline-offset: 4px;
+  -moz-outline-radius: 0px;
+}
+
+button.jp-Dialog-button:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .jp-Dialog-header {

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -42,6 +42,15 @@
   color: var(--jp-ui-font-color1);
 }
 
+.jp-Dialog-button {
+  overflow: visible;
+}
+
+button.jp-Dialog-button:focus {
+  outline: 1px solid var(--jp-brand-color1);
+  outline-offset: 4px;
+}
+
 .jp-Dialog-header {
   flex: 0 0 auto;
   padding-bottom: 12px;

--- a/packages/apputils/style/styling.css
+++ b/packages/apputils/style/styling.css
@@ -9,7 +9,6 @@ button.jp-mod-styled {
   color: var(--jp-ui-font-color0);
   border: none;
   box-sizing: border-box;
-  text-transform: uppercase;
   text-align: center;
   line-height: 32px;
   height: 32px;

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -48,7 +48,7 @@ export function renameDialog(
     title: 'Rename File',
     body: new RenameHandler(oldPath),
     focusNodeSelector: 'input',
-    buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'RENAME' })]
+    buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Rename' })]
   }).then(result => {
     if (!result.value) {
       return;
@@ -98,7 +98,7 @@ export function shouldOverwrite(path: string): Promise<boolean> {
   let options = {
     title: 'Overwrite file?',
     body: `"${path}" already exists, overwrite?`,
-    buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'OVERWRITE' })]
+    buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Overwrite' })]
   };
   return showDialog(options).then(result => {
     return Promise.resolve(result.button.accept);
@@ -178,10 +178,10 @@ export function getOpenPath(contentsManager: any): Promise<string | undefined> {
   return showDialog({
     title: 'Open File',
     body: new OpenDirectWidget(),
-    buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'OPEN' })],
+    buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Open' })],
     focusNodeSelector: 'input'
   }).then((result: any) => {
-    if (result.button.label === 'OPEN') {
+    if (result.button.label === 'Open') {
       return result.value;
     }
     return;

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -19,7 +19,8 @@ import {
   showDialog,
   ClientSession,
   Dialog,
-  IClientSession
+  IClientSession,
+  showErrorMessage
 } from '@jupyterlab/apputils';
 
 import { PathExt } from '@jupyterlab/coreutils';
@@ -630,9 +631,8 @@ export class Context<T extends DocumentRegistry.IModel>
     err: Error | ServerConnection.ResponseError,
     title: string
   ): Promise<void> {
-    let buttons = [Dialog.okButton()];
-
     // Check for a more specific error message.
+    let error = { message: '' };
     if (err instanceof ServerConnection.ResponseError) {
       const text = await err.response.text();
       let body = '';
@@ -641,14 +641,12 @@ export class Context<T extends DocumentRegistry.IModel>
       } catch (e) {
         body = text;
       }
-      body = body || err.message;
-      await showDialog({ title, body, buttons });
-      return;
+      error.message = body || err.message;
     } else {
-      let body = err.message;
-      await showDialog({ title, body, buttons });
-      return;
+      error.message = err.message;
     }
+    await showErrorMessage(title, error);
+    return;
   }
 
   /**

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -699,8 +699,8 @@ export class Context<T extends DocumentRegistry.IModel>
       `was opened or saved. ` +
       `Do you want to overwrite the file on disk with the version ` +
       ` open here, or load the version on disk (revert)?`;
-    let revertBtn = Dialog.okButton({ label: 'REVERT' });
-    let overwriteBtn = Dialog.warnButton({ label: 'OVERWRITE' });
+    let revertBtn = Dialog.okButton({ label: 'Revert' });
+    let overwriteBtn = Dialog.warnButton({ label: 'Overwrite' });
     return showDialog({
       title: 'File Changed',
       body,
@@ -709,10 +709,10 @@ export class Context<T extends DocumentRegistry.IModel>
       if (this.isDisposed) {
         return Promise.reject(new Error('Disposed'));
       }
-      if (result.button.label === 'OVERWRITE') {
+      if (result.button.label === 'Overwrite') {
         return this._manager.contents.save(this._path, options);
       }
-      if (result.button.label === 'REVERT') {
+      if (result.button.label === 'Revert') {
         return this.revert().then(() => {
           return model;
         });
@@ -726,7 +726,7 @@ export class Context<T extends DocumentRegistry.IModel>
    */
   private _maybeOverWrite(path: string): Promise<void> {
     let body = `"${path}" already exists. Do you want to replace it?`;
-    let overwriteBtn = Dialog.warnButton({ label: 'OVERWRITE' });
+    let overwriteBtn = Dialog.warnButton({ label: 'Overwrite' });
     return showDialog({
       title: 'File Overwrite?',
       body,
@@ -735,7 +735,7 @@ export class Context<T extends DocumentRegistry.IModel>
       if (this.isDisposed) {
         return Promise.reject(new Error('Disposed'));
       }
-      if (result.button.label === 'OVERWRITE') {
+      if (result.button.label === 'Overwrite') {
         return this._manager.contents.delete(path).then(() => {
           return this._finishSaveAs(path);
         });
@@ -835,13 +835,13 @@ namespace Private {
    * Get a new file path from the user.
    */
   export function getSavePath(path: string): Promise<string | undefined> {
-    let saveBtn = Dialog.okButton({ label: 'SAVE' });
+    let saveBtn = Dialog.okButton({ label: 'Save' });
     return showDialog({
       title: 'Save File As..',
       body: new SaveWidget(path),
       buttons: [Dialog.cancelButton(), saveBtn]
     }).then(result => {
-      if (result.button.label === 'SAVE') {
+      if (result.button.label === 'Save') {
         return result.value;
       }
       return;

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -128,8 +128,8 @@ namespace Private {
         'and some may introduce security risks. ' +
         'Do you want to continue?',
       buttons: [
-        Dialog.cancelButton({ label: 'DISABLE' }),
-        Dialog.warnButton({ label: 'ENABLE' })
+        Dialog.cancelButton({ label: 'Disable' }),
+        Dialog.warnButton({ label: 'Enable' })
       ]
     }).then(result => {
       if (result.button.accept) {

--- a/packages/extensionmanager/src/build-helper.tsx
+++ b/packages/extensionmanager/src/build-helper.tsx
@@ -22,7 +22,7 @@ export function doBuild(builder: Builder.IManager): Promise<void> {
           body: 'Build successfully completed, reload page?',
           buttons: [
             Dialog.cancelButton(),
-            Dialog.warnButton({ label: 'RELOAD' })
+            Dialog.warnButton({ label: 'Reload' })
           ]
         });
       })

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -245,23 +245,18 @@ export class FileBrowser extends Widget {
    */
   private _onConnectionFailure(sender: FileBrowserModel, args: Error): void {
     if (
-      !this._showingError &&
       args instanceof ServerConnection.ResponseError &&
       args.response.status === 404
     ) {
       const title = 'Directory not found';
       args.message = `Directory not found: "${this.model.path}"`;
-      this._showingError = true;
-      void showErrorMessage(title, args).then(() => {
-        this._showingError = false;
-      });
+      void showErrorMessage(title, args);
     }
   }
 
   private _crumbs: BreadCrumbs;
   private _listing: DirListing;
   private _manager: IDocumentManager;
-  private _showingError = false;
   private _directoryPending: boolean;
 }
 

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -381,7 +381,7 @@ export class DirListing extends Widget {
       return showDialog({
         title: 'Delete',
         body: message,
-        buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'DELETE' })]
+        buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Delete' })]
       }).then(result => {
         if (!this.isDisposed && result.button.accept) {
           return this._delete(names);

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -415,7 +415,7 @@ export class FileBrowserModel implements IDisposable {
       body: `The file size is ${Math.round(
         file.size / (1024 * 1024)
       )} MB. Do you still want to upload it?`,
-      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'UPLOAD' })]
+      buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Upload' })]
     });
     return button.accept;
   }

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -528,7 +528,7 @@ export function createKernelMenu(app: JupyterFrontEnd, menu: KernelMenu): void {
         body: 'Shut down all kernels?',
         buttons: [
           Dialog.cancelButton(),
-          Dialog.warnButton({ label: 'SHUT DOWN ALL' })
+          Dialog.warnButton({ label: 'Shut Down All' })
         ]
       }).then(result => {
         if (result.button.accept) {

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -219,7 +219,7 @@ function Section<M>(props: SessionProps<M>) {
       title: `Shut Down All ${props.name} Sessions?`,
       buttons: [
         Dialog.cancelButton(),
-        Dialog.warnButton({ label: 'SHUT DOWN ALL' })
+        Dialog.warnButton({ label: 'Shut Down All' })
       ]
     }).then(result => {
       if (result.button.accept) {

--- a/packages/ui-components/style/base.css
+++ b/packages/ui-components/style/base.css
@@ -53,7 +53,6 @@ a:hover {
   border-radius: var(--jp-border-radius);
   padding: 0px 12px;
   font-size: var(--jp-ui-font-size1);
-  text-transform: uppercase;
 }
 /* Use our own theme for hover styles */
 button.jp-Button.bp3-button.bp3-minimal:hover {

--- a/tests/test-apputils/src/dialog.spec.tsx
+++ b/tests/test-apputils/src/dialog.spec.tsx
@@ -163,7 +163,7 @@ describe('@jupyterlab/apputils', () => {
 
         const result = await prompt;
 
-        expect(result.button.label).toBe('CANCEL');
+        expect(result.button.label).toBe('Cancel');
         expect(result.button.accept).toBe(false);
       });
     });

--- a/tests/test-docmanager/src/savehandler.spec.ts
+++ b/tests/test-docmanager/src/savehandler.spec.ts
@@ -168,7 +168,7 @@ describe('docregistry/savehandler', () => {
           const buttons = dialog.getElementsByTagName('button');
 
           for (let i = 0; i < buttons.length; i++) {
-            if (buttons[i].textContent === 'REVERT') {
+            if (buttons[i].textContent === 'Revert') {
               buttons[i].click();
               return;
             }


### PR DESCRIPTION
## References

Fixes #6230 


## Code changes

None.

## User-facing changes

* On dialog buttons only, use a 1px solid outline of our brand color 1, with an exterior offset of 4px as the focus indicator. This required making the widget have `overflow: visible` which isn't possible for all our buttons (in particular in toolsbars) as they have compact layout and this outline would be cut off.
* Slight opacity changes to indicate hover and active.
* Caps case for all buttons.
 
![Screen Shot 2019-06-09 at 12 58 19 PM](https://user-images.githubusercontent.com/27600/59163501-e3ada600-8ab6-11e9-850d-e6020c9e6d7d.png)

![Screen Shot 2019-06-09 at 12 58 28 PM](https://user-images.githubusercontent.com/27600/59163502-e6a89680-8ab6-11e9-81a4-55ccf0eaf38d.png)

![Screen Shot 2019-06-09 at 12 58 40 PM](https://user-images.githubusercontent.com/27600/59163503-ea3c1d80-8ab6-11e9-8a6b-c4f4acd51e8b.png)

![Screen Shot 2019-06-09 at 12 58 49 PM](https://user-images.githubusercontent.com/27600/59163504-edcfa480-8ab6-11e9-81cf-64762cdb06e8.png)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None.