### PR TITLE
added task to release to github 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,8 @@
+trigger:
+  branches:
+    include:
+    - '*'  
+    - refs/tags/*
 jobs:
   - job: 'Linux'
     pool:
@@ -94,3 +99,18 @@ jobs:
           testResultsFiles: '$(testResultsFiles)'
           testRunTitle: 'Windows - $(name)'
           mergeTestResults: true
+  - job: GitHub_Release
+    displayName: Release to GitHub
+    dependsOn: 
+    - Windows
+    - Linux
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v1.'))  
+    steps:
+    - task: GitHubRelease@0
+      displayName: 'GitHub release (create)'
+      inputs:
+        gitHubConnection: 'github-zenithworks'
+        title: JupyterLab Release version $(Build.SourceBranchName) 
+        releaseNotesSource: input
+        releaseNotes: |         
+          [Installation](https://github.com/zenithworks/jupyterlab/blob/master/README.md#installation)   |   [Getting Started](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html)   |   [Changelog](https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html)     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ jobs:
       displayName: 'GitHub release (create)'
       inputs:
         gitHubConnection: 'github-zenithworks'
-        title: JupyterLab Release version $(Build.SourceBranchName) 
+        title: JupyterLab Python version $(Build.SourceBranchName) 
         releaseNotesSource: input
         releaseNotes: |         
           [Installation](https://github.com/jupyterlab/jupyterlab/blob/master/README.md#installation)   |   [Getting Started](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html)   |   [Changelog](https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html)     

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
   branches:
     include:
     - '*'  
-    - refs/tags/*
+    - refs/tags/v1.*
 jobs:
   - job: 'Linux'
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,4 +113,4 @@ jobs:
         title: JupyterLab Release version $(Build.SourceBranchName) 
         releaseNotesSource: input
         releaseNotes: |         
-          [Installation](https://github.com/zenithworks/jupyterlab/blob/master/README.md#installation)   |   [Getting Started](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html)   |   [Changelog](https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html)     
+          [Installation](https://github.com/jupyterlab/jupyterlab/blob/master/README.md#installation)   |   [Getting Started](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html)   |   [Changelog](https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html)     


### PR DESCRIPTION
Raising a pr based on discussion in #6483 :
There are 2 additions in the azure pipelines CI yaml:
1. Adding github release task: This task will automatically publish to github release when a build is run for a tag with version matching patter 'v1.*'.  The release notes will be computed automatically. 
2. I have added triggers to run the pipelines for all pushes including tags.
 Here is a sample pipeline where i tried this out: [Sample Pipeline](https://raiyanalam17.visualstudio.com/AutomateReleases/_build/results?buildId=640)
Here are the release notes that it generated: [Release notes](https://github.com/zenithworks/jupyterlab/releases/tag/v1.0.98)

![image](https://user-images.githubusercontent.com/7879476/59260100-9ec17500-8c58-11e9-8731-0147f929cc2f.png)


PS: For the pipeline to run correctly, it  needs a service connection to be created in azure pipelines portal and the service connection needs to be passed to `gitHubConnection` parameter.