### PR TITLE
Control

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -144,7 +144,7 @@ export class OutputArea extends Widget {
   /**
    * The kernel future associated with the output area.
    */
-  get future(): Kernel.IFuture<
+  get future(): Kernel.IShellFuture<
     KernelMessage.IExecuteRequestMsg,
     KernelMessage.IExecuteReplyMsg
   > | null {
@@ -152,7 +152,7 @@ export class OutputArea extends Widget {
   }
 
   set future(
-    value: Kernel.IFuture<
+    value: Kernel.IShellFuture<
       KernelMessage.IExecuteRequestMsg,
       KernelMessage.IExecuteReplyMsg
     > | null
@@ -284,7 +284,7 @@ export class OutputArea extends Widget {
    */
   protected onInputRequest(
     msg: KernelMessage.IInputRequestMsg,
-    future: Kernel.IFuture
+    future: Kernel.IShellFuture
   ): void {
     // Add an output widget to the end.
     let factory = this.contentFactory;
@@ -493,7 +493,7 @@ export class OutputArea extends Widget {
   };
 
   private _minHeightTimeout: number = null;
-  private _future: Kernel.IFuture<
+  private _future: Kernel.IShellFuture<
     KernelMessage.IExecuteRequestMsg,
     KernelMessage.IExecuteReplyMsg
   > | null = null;
@@ -506,7 +506,7 @@ export class SimplifiedOutputArea extends OutputArea {
    */
   protected onInputRequest(
     msg: KernelMessage.IInputRequestMsg,
-    future: Kernel.IFuture
+    future: Kernel.IShellFuture
   ): void {
     return;
   }
@@ -755,7 +755,7 @@ export class Stdin extends Widget implements IStdin {
     this._input.removeEventListener('keydown', this);
   }
 
-  private _future: Kernel.IFuture = null;
+  private _future: Kernel.IShellFuture = null;
   private _input: HTMLInputElement = null;
   private _value: string;
   private _promise = new PromiseDelegate<void>();
@@ -779,7 +779,7 @@ export namespace Stdin {
     /**
      * The kernel future associated with the request.
      */
-    future: Kernel.IFuture;
+    future: Kernel.IShellFuture;
   }
 }
 

--- a/packages/services/src/kernel/comm.ts
+++ b/packages/services/src/kernel/comm.ts
@@ -103,7 +103,7 @@ export class CommHandler extends DisposableDelegate implements Kernel.IComm {
     data?: JSONObject,
     metadata?: JSONObject,
     buffers: (ArrayBuffer | ArrayBufferView)[] = []
-  ): Kernel.IFuture {
+  ): Kernel.IShellFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
       throw new Error('Cannot open');
     }
@@ -136,7 +136,7 @@ export class CommHandler extends DisposableDelegate implements Kernel.IComm {
     metadata?: JSONObject,
     buffers: (ArrayBuffer | ArrayBufferView)[] = [],
     disposeOnDone: boolean = true
-  ): Kernel.IFuture {
+  ): Kernel.IShellFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
       throw new Error('Cannot send');
     }
@@ -170,7 +170,7 @@ export class CommHandler extends DisposableDelegate implements Kernel.IComm {
     data?: JSONObject,
     metadata?: JSONObject,
     buffers: (ArrayBuffer | ArrayBufferView)[] = []
-  ): Kernel.IFuture {
+  ): Kernel.IShellFuture {
     if (this.isDisposed || this._kernel.isDisposed) {
       throw new Error('Cannot close');
     }

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -596,30 +596,6 @@ export class DefaultKernel implements Kernel.IKernel {
     >;
   }
 
-  requestDebug(
-    content: KernelMessage.IDebugRequest,
-    disposeOnDone: boolean = true
-  ): Kernel.IControlFuture<
-    KernelMessage.IDebugRequestMsg,
-    KernelMessage.IDebugReplyMsg
-  > {
-    let msg = KernelMessage.createMessage({
-      msgType: 'debug_request',
-      channel: 'control',
-      username: this._username,
-      session: this._clientId,
-      content
-    });
-    return this.sendControlMessage(
-      msg,
-      true,
-      disposeOnDone
-    ) as Kernel.IControlFuture<
-      KernelMessage.IDebugRequestMsg,
-      KernelMessage.IDebugReplyMsg
-    >;
-  }
-
   /**
    * Send an `is_complete_request` message.
    *

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -308,7 +308,9 @@ export class DefaultKernel implements Kernel.IKernel {
   }
 
   private _sendKernelShellControl<
-    KFH extends new (...params: any[]) => KernelFutureHandler,
+    REQUEST extends KernelMessage.IShellControlMessage,
+    REPLY extends KernelMessage.IShellControlMessage,
+    KFH extends new (...params: any[]) => KernelFutureHandler<REQUEST, REPLY>,
     T extends KernelMessage.IMessage
   >(
     ctor: KFH,
@@ -958,7 +960,13 @@ export class DefaultKernel implements Kernel.IKernel {
     });
     this._msgChain = Promise.resolve();
     this._kernelSession = '';
-    this._futures = new Map<string, KernelFutureHandler>();
+    this._futures = new Map<
+      string,
+      KernelFutureHandler<
+        KernelMessage.IShellControlMessage,
+        KernelMessage.IShellControlMessage
+      >
+    >();
     this._comms = new Map<string, Kernel.IComm>();
     this._displayIdToParentIds.clear();
     this._msgIdToDisplayIds.clear();
@@ -1291,7 +1299,13 @@ export class DefaultKernel implements Kernel.IKernel {
   private _isReady = false;
   private _readyPromise = new PromiseDelegate<void>();
   private _initialized = false;
-  private _futures = new Map<string, KernelFutureHandler>();
+  private _futures = new Map<
+    string,
+    KernelFutureHandler<
+      KernelMessage.IShellControlMessage,
+      KernelMessage.IShellControlMessage
+    >
+  >();
   private _comms = new Map<string, Kernel.IComm>();
   private _targetRegistry: {
     [key: string]: (

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -189,6 +189,9 @@ export abstract class KernelFutureHandler<
     super.dispose();
   }
 
+  /**
+   * Handle an incoming kernel message.
+   */
   async handleMsg(msg: KernelMessage.IMessage): Promise<void> {
     switch (msg.channel) {
       case 'control':

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -202,21 +202,21 @@ export abstract class KernelFutureHandler<
             KernelMessage.MessageType
           >).msg_id === this.msg.header.msg_id
         ) {
-          await this.handleReply(msg as REPLY);
+          await this._handleReply(msg as REPLY);
         }
         break;
       case 'stdin':
-        await this.handleStdin(msg as KernelMessage.IStdinMessage);
+        await this._handleStdin(msg as KernelMessage.IStdinMessage);
         break;
       case 'iopub':
-        await this.handleIOPub(msg as KernelMessage.IIOPubMessage);
+        await this._handleIOPub(msg as KernelMessage.IIOPubMessage);
         break;
       default:
         break;
     }
   }
 
-  protected async handleReply(msg: REPLY): Promise<void> {
+  private async _handleReply(msg: REPLY): Promise<void> {
     let reply = this._reply;
     if (reply) {
       // tslint:disable-next-line:await-promise
@@ -229,7 +229,7 @@ export abstract class KernelFutureHandler<
     }
   }
 
-  protected async handleStdin(msg: KernelMessage.IStdinMessage): Promise<void> {
+  private async _handleStdin(msg: KernelMessage.IStdinMessage): Promise<void> {
     let stdin = this._stdin;
     if (stdin) {
       // tslint:disable-next-line:await-promise
@@ -237,7 +237,7 @@ export abstract class KernelFutureHandler<
     }
   }
 
-  protected async handleIOPub(msg: KernelMessage.IIOPubMessage): Promise<void> {
+  private async _handleIOPub(msg: KernelMessage.IIOPubMessage): Promise<void> {
     let process = await this._hooks.process(msg);
     let iopub = this._iopub;
     if (process && iopub) {
@@ -295,7 +295,7 @@ export abstract class KernelFutureHandler<
   private _replyMsg: REPLY;
   private _hooks = new Private.HookList<KernelMessage.IIOPubMessage>();
   private _disposeOnDone = true;
-  protected _kernel: Kernel.IKernel;
+  private _kernel: Kernel.IKernel;
 }
 
 export class KernelControlFutureHandler<

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -58,6 +58,17 @@ export abstract class KernelFutureHandler<
   }
 
   /**
+   * Get the stdin handler.
+   * @deprecated - This method exists to satisfy the `IFuture` interface and
+   * will be removed in a future version.
+   */
+  get onStdin(): (
+    msg: KernelMessage.IStdinMessage
+  ) => void | PromiseLike<void> {
+    return undefined;
+  }
+
+  /**
    * Get the reply handler.
    */
   get onReply(): (msg: REPLY) => void | PromiseLike<void> {

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -278,14 +278,6 @@ export namespace Kernel {
       KernelMessage.IExecuteReplyMsg
     >;
 
-    requestDebug(
-      content: KernelMessage.IDebugRequest,
-      disposeOnDone?: boolean
-    ): Kernel.IControlFuture<
-      KernelMessage.IDebugRequestMsg,
-      KernelMessage.IDebugReplyMsg
-    >;
-
     /**
      * Send an `is_complete_request` message.
      *

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -756,8 +756,12 @@ export namespace Kernel {
    * responses that may come from the kernel.
    */
   export interface IFuture<
-    REQUEST extends KernelMessage.IShellMessage | KernelMessage.IControlMessage,
-    REPLY extends KernelMessage.IShellMessage | KernelMessage.IControlMessage
+    REQUEST extends
+      | KernelMessage.IShellMessage
+      | KernelMessage.IControlMessage = KernelMessage.IShellMessage,
+    REPLY extends
+      | KernelMessage.IShellMessage
+      | KernelMessage.IControlMessage = KernelMessage.IShellMessage
   > extends IDisposable {
     /**
      * The original outgoing message.

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -748,24 +748,9 @@ export namespace Kernel {
    * responses that may come from the kernel.
    */
   export interface IFuture<
-    REQUEST extends
-      | KernelMessage.IShellMessage
-      | KernelMessage.IControlMessage = KernelMessage.IShellMessage,
-    REPLY extends
-      | KernelMessage.IShellMessage
-      | KernelMessage.IControlMessage = KernelMessage.IShellMessage
+    REQUEST extends KernelMessage.IShellMessage | KernelMessage.IControlMessage,
+    REPLY extends KernelMessage.IShellMessage | KernelMessage.IControlMessage
   > extends IDisposable {
-    /**
-     * The stdin handler for the kernel future.
-     * @deprecated - This handler properly belongs in `IShellFuture` and will be
-     * removed in a future version of `@jupyterlab/services`.
-     *
-     * #### Notes
-     * If the handler returns a promise, all kernel message processing pauses
-     * until the promise is resolved.
-     */
-    onStdin: (msg: KernelMessage.IStdinMessage) => void | PromiseLike<void>;
-
     /**
      * The original outgoing message.
      */
@@ -804,6 +789,15 @@ export namespace Kernel {
     onIOPub: (msg: KernelMessage.IIOPubMessage) => void | PromiseLike<void>;
 
     /**
+     * The stdin handler for the kernel future.
+     *
+     * #### Notes
+     * If the handler returns a promise, all kernel message processing pauses
+     * until the promise is resolved.
+     */
+    onStdin: (msg: KernelMessage.IStdinMessage) => void | PromiseLike<void>;
+
+    /**
      * Register hook for IOPub messages.
      *
      * @param hook - The callback invoked for an IOPub message.
@@ -837,26 +831,17 @@ export namespace Kernel {
     removeMessageHook(
       hook: (msg: KernelMessage.IIOPubMessage) => boolean | PromiseLike<boolean>
     ): void;
-  }
-
-  export interface IShellFuture<
-    REQUEST extends KernelMessage.IShellMessage = KernelMessage.IShellMessage,
-    REPLY extends KernelMessage.IShellMessage = KernelMessage.IShellMessage
-  > extends IFuture<REQUEST, REPLY> {
-    /**
-     * The stdin handler for the kernel future.
-     *
-     * #### Notes
-     * If the handler returns a promise, all kernel message processing pauses
-     * until the promise is resolved.
-     */
-    onStdin: (msg: KernelMessage.IStdinMessage) => void | PromiseLike<void>;
 
     /**
      * Send an `input_reply` message.
      */
     sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void;
   }
+
+  export interface IShellFuture<
+    REQUEST extends KernelMessage.IShellMessage = KernelMessage.IShellMessage,
+    REPLY extends KernelMessage.IShellMessage = KernelMessage.IShellMessage
+  > extends IFuture<REQUEST, REPLY> {}
 
   export interface IControlFuture<
     REQUEST extends KernelMessage.IControlMessage = KernelMessage.IControlMessage,

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -764,6 +764,17 @@ export namespace Kernel {
       | KernelMessage.IControlMessage = KernelMessage.IShellMessage
   > extends IDisposable {
     /**
+     * The stdin handler for the kernel future.
+     * @deprecated - This handler properly belongs in `IShellFuture` and will be
+     * removed in a future version of `@jupyterlab/services`.
+     *
+     * #### Notes
+     * If the handler returns a promise, all kernel message processing pauses
+     * until the promise is resolved.
+     */
+    onStdin: (msg: KernelMessage.IStdinMessage) => void | PromiseLike<void>;
+
+    /**
      * The original outgoing message.
      */
     readonly msg: REQUEST;

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -748,8 +748,8 @@ export namespace Kernel {
    * responses that may come from the kernel.
    */
   export interface IFuture<
-    REQUEST extends KernelMessage.IShellMessage | KernelMessage.IControlMessage,
-    REPLY extends KernelMessage.IShellMessage | KernelMessage.IControlMessage
+    REQUEST extends KernelMessage.IShellControlMessage,
+    REPLY extends KernelMessage.IShellControlMessage
   > extends IDisposable {
     /**
      * The original outgoing message.

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -163,9 +163,7 @@ export namespace KernelMessage {
   /**
    * Control message types.
    */
-  export type ControlMessageType = 
-    | 'debug_request'
-    | 'debug_reply';
+  export type ControlMessageType = 'debug_request' | 'debug_reply';
 
   /**
    * IOPub message types.
@@ -289,11 +287,13 @@ export namespace KernelMessage {
   /**
    * A kernel message on the `'control'` channel.
    */
-  export interface IControlMessage<T extends ControlMessageType = ControlMessageType>
-    extends IMessage<T> {
+  export interface IControlMessage<
+    T extends ControlMessageType = ControlMessageType
+  > extends IMessage<T> {
     channel: 'control';
   }
 
+  export type IShellControlMessage = IShellMessage | IControlMessage;
   /**
    * A kernel message on the `'iopub'` channel.
    */
@@ -985,16 +985,14 @@ export namespace KernelMessage {
   /**
    * Debug message types.
    */
-  export type DebugMessageType =
-    | 'request'
-    | 'response'
-    | 'event';
+  export type DebugMessageType = 'request' | 'response' | 'event';
 
   /**
    * Base interface for debug protocol message.
    */
-  export interface IDebugProtocolMsg<T extends DebugMessageType = DebugMessageType>
-  {
+  export interface IDebugProtocolMsg<
+    T extends DebugMessageType = DebugMessageType
+  > {
     seq: number;
     type: T;
   }

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -156,7 +156,7 @@ export namespace KernelMessage {
   /**
    * Control message types.
    */
-  export type ControlMessageType = 'never';
+  export type ControlMessageType = never;
 
   /**
    * IOPub message types.

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -108,13 +108,6 @@ export namespace KernelMessage {
   export function createMessage<T extends IUpdateDisplayDataMsg>(
     options: IOptions<T>
   ): T;
-  export function createMessage<T extends IDebugRequestMsg>(
-    options: IOptions<T>
-  ): T;
-
-  export function createMessage<T extends IDebugReplyMsg>(
-    options: IOptions<T>
-  ): T;
 
   export function createMessage<T extends Message>(options: IOptions<T>): T {
     return {
@@ -163,7 +156,7 @@ export namespace KernelMessage {
   /**
    * Control message types.
    */
-  export type ControlMessageType = 'debug_request' | 'debug_reply';
+  export type ControlMessageType = 'never';
 
   /**
    * IOPub message types.
@@ -293,7 +286,14 @@ export namespace KernelMessage {
     channel: 'control';
   }
 
+  /**
+   * A message type for shell or control messages.
+   *
+   * #### Notes
+   * This convenience is so we can use it as a generic type constraint.
+   */
   export type IShellControlMessage = IShellMessage | IControlMessage;
+
   /**
    * A kernel message on the `'iopub'` channel.
    */
@@ -340,9 +340,7 @@ export namespace KernelMessage {
     | IIsCompleteRequestMsg
     | IStatusMsg
     | IStreamMsg
-    | IUpdateDisplayDataMsg
-    | IDebugRequestMsg
-    | IDebugReplyMsg;
+    | IUpdateDisplayDataMsg;
 
   //////////////////////////////////////////////////
   // IOPub Messages
@@ -980,55 +978,6 @@ export namespace KernelMessage {
    */
   export function isExecuteReplyMsg(msg: IMessage): msg is IExecuteReplyMsg {
     return msg.header.msg_type === 'execute_reply';
-  }
-
-  /**
-   * Debug message types.
-   */
-  export type DebugMessageType = 'request' | 'response' | 'event';
-
-  /**
-   * Base interface for debug protocol message.
-   */
-  export interface IDebugProtocolMsg<
-    T extends DebugMessageType = DebugMessageType
-  > {
-    seq: number;
-    type: T;
-  }
-
-  /**
-   * The content of a `'debug_request'` message.
-   */
-  export interface IDebugRequest extends IDebugProtocolMsg<'request'> {
-    command: string;
-    arguments?: any;
-  }
-
-  /**
-   * A `'debug_request'` message on the `'control'` channel.
-   */
-  export interface IDebugRequestMsg extends IControlMessage<'debug_request'> {
-    content: IDebugRequest;
-  }
-
-  /**
-   * The content of a `'debug_reply'` message.
-   */
-  export interface IDebugResponse extends IDebugProtocolMsg<'response'> {
-    request_seq: number;
-    success: boolean;
-    command: string;
-    message?: string;
-    body?: any;
-  }
-
-  /**
-   * A `'debug_reply'` message on the `'control'` channel.
-   */
-  export interface IDebugReplyMsg extends IControlMessage<'debug_reply'> {
-    parent_header: IHeader<'debug_request'>;
-    content: IDebugResponse;
   }
 
   /**

--- a/tests/test-services/src/kernel/ifuture.spec.ts
+++ b/tests/test-services/src/kernel/ifuture.spec.ts
@@ -7,7 +7,7 @@ import { Kernel, KernelMessage } from '@jupyterlab/services';
 
 import { KernelTester } from '../utils';
 
-describe('Kernel.IFuture', () => {
+describe('Kernel.IShellFuture', () => {
   let tester: KernelTester;
 
   afterEach(() => {
@@ -37,7 +37,7 @@ describe('Kernel.IFuture', () => {
       };
       const calls: string[] = [];
       tester = new KernelTester();
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
       let kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
@@ -130,7 +130,7 @@ describe('Kernel.IFuture', () => {
       };
       const calls: string[] = [];
       tester = new KernelTester();
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
       let kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
@@ -203,7 +203,7 @@ describe('Kernel.IFuture', () => {
       };
       const calls: string[] = [];
       tester = new KernelTester();
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
 
       tester.onMessage(message => {
         // send a reply
@@ -273,7 +273,7 @@ describe('Kernel.IFuture', () => {
       };
       const calls: string[] = [];
       tester = new KernelTester();
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
 
       const toDelete = (msg: KernelMessage.IIOPubMessage) => {
         calls.push('delete');

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -888,7 +888,7 @@ describe('Kernel.IKernel', () => {
         session: defaultKernel.clientId
       };
 
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
       const tester = new KernelTester();
 
       tester.onMessage(msg => {
@@ -1009,7 +1009,7 @@ describe('Kernel.IKernel', () => {
         stop_on_error: false
       };
       const calls: string[] = [];
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
 
       let kernel: Kernel.IKernel;
 
@@ -1097,7 +1097,7 @@ describe('Kernel.IKernel', () => {
       const calls: string[] = [];
 
       const tester = new KernelTester();
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
       let kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
@@ -1173,7 +1173,7 @@ describe('Kernel.IKernel', () => {
       };
       const calls: string[] = [];
       const tester = new KernelTester();
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
       let kernel: Kernel.IKernel;
 
       tester.onMessage(message => {
@@ -1246,7 +1246,7 @@ describe('Kernel.IKernel', () => {
       };
       const calls: string[] = [];
       const tester = new KernelTester();
-      let future: Kernel.IFuture;
+      let future: Kernel.IShellFuture;
       let kernel: Kernel.IKernel;
 
       tester.onMessage(message => {

--- a/tests/test-services/tsconfig.json
+++ b/tests/test-services/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "build",
     "rootDir": "src"
   },
-  "include": ["src/*"],
+  "include": ["src/**/*"],
   "references": [
     {
       "path": "../../packages/coreutils"


### PR DESCRIPTION
## References

This PR partially implements changes described in https://github.com/jupyter/jupyter_client/issues/446.
For now it allows to send `debug_request` messages on the Control channel.

## Code changes

- Adds interface for messages sent on the Control channel, as well as new message types for debugging.
- New methods have been added in the default kernel implementation (`sendControlMEssage` and `requestDebug`)
- `IFuture` and `KernelFutureHandler` have been refactored: `IFuture` is now the common interface of `IShellFuture` and `IControlFuture`, and `KernelFutureHandler` is an abstract base class of the new `KernelShellFutureHandler` and `KernelControlFutureHandler`. `IFuture` should only be used by methods that can operate on or return bothe types of messages, otherwise the more specialized `IShellFuture` or `IControlFuture` should be preferred.

## User-facing changes

None

## Backwards-incompatible changes

- ~`onStdin` and `sendInputReply` have been moved from `kernel.IFuture` to `kernel.IShellFuture` because they don't make sense for `IControlFuture`. However they could be moved back if this backward incompatible change is problematic.~
- `sendShellMessage` return type is now `IShellFuture` instead of `IFuture`. This can also be reverted if required. **Edit:** This works fine because `IShellFuture` extends `IFuture` so it is not backward-incompatible.