### PR TITLE
Added download attribute to Download context menu option

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -318,6 +318,7 @@ export class FileBrowserModel implements IDisposable {
       document.body.appendChild(element);
       element.setAttribute('href', url);
       element.setAttribute('target', '_blank');
+      element.setAttribute('download', '');
       element.click();
       document.body.removeChild(element);
       return void 0;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
When downloading html-files via the context-menu option, the file just opens in a new browser-tab instead of getting downloaded. To prevent this, we tell the browser explicitly, that we want to download that file.
Added HTML5-download-tag to Download.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
