### PR TITLE
Fix jupyterlab/services README

### DIFF
--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -121,9 +121,8 @@ import { KernelMessage, Kernel } from '@jupyterlab/services';
 
 // Get a list of available kernels and connect to one.
 Kernel.listRunning().then(kernelModels => {
-    const kernel = Kernel.connectTo(kernelModels[0]);
-    console.log(kernel.name);
-  });
+  const kernel = Kernel.connectTo(kernelModels[0]);
+  console.log(kernel.name);
 });
 
 // Get info about the available kernels and start a new one.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## Changes

This only make a small change on the jupyterlab/services README. There is an extra `});`.