### PR TITLE
Handle small tabs overflowing and preserve the border bridging for the active tab

### DIFF
--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -19,6 +19,8 @@
 |----------------------------------------------------------------------------*/
 
 .p-DockPanel-tabBar {
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  overflow: visible;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
 }
@@ -44,7 +46,7 @@
   min-height: calc(
     var(--jp-private-horizontal-tab-height) + var(--jp-border-width)
   );
-  min-width: 36px;
+  min-width: 0px;
   margin-left: calc(-1 * var(--jp-border-width));
   line-height: var(--jp-private-horizontal-tab-height);
   padding: 0px 8px;
@@ -52,7 +54,6 @@
   border: var(--jp-border-width) solid var(--jp-border-color1);
   border-bottom: none;
   position: relative;
-  overflow: visible;
 }
 
 .p-DockPanel-tabBar .p-TabBar-tab:hover:not(.p-mod-current) {


### PR DESCRIPTION
## References

Fixes #6532
Reverts #6526
Reverts #6492
Unfixes #3986


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

#3986 is now an issue again, but setting the tab min width to 0px (instead of 36px) and setting the tab overflow to hidden makes it less likely to appear in practice (i.e., the tabs need to be much denser now to overflow into the splitter). Setting the tab overflow to hidden also makes the close icon for tabs not overlap the next tab, which was very confusing.

I think this is the best compromise at this point.

I also experimented unsuccessfully with setting the z-index of the splitter handle in an attempt to get it to be on top of overflowing tabs.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

Before, showing the tab bar getting correctly clipped, but no bottom border and the close icons overlapping the adjacent tab.
<img width="643" alt="Screen Shot 2019-06-12 at 6 25 32 AM" src="https://user-images.githubusercontent.com/192614/59355341-a4ac6a00-8cdb-11e9-96b7-63efaaf4dad3.png">

After, showing the tab bar not getting correctly clipped, but having a bottom border and the close icons getting clipped, as well as showing the tabs sizing down to be much smaller (so the old tab bar clipping issue is harder to trigger)
<img width="636" alt="Screen Shot 2019-06-12 at 6 23 17 AM" src="https://user-images.githubusercontent.com/192614/59355451-d58c9f00-8cdb-11e9-860f-0c3e7fe3de8d.png">

## Backwards-incompatible changes

None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
