### PR TITLE
Add home tooltip showing server root if available for user information.

### DIFF
--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -13,7 +13,7 @@ import { Widget } from '@phosphor/widgets';
 
 import { DOMUtils, showErrorMessage } from '@jupyterlab/apputils';
 
-import { PathExt } from '@jupyterlab/coreutils';
+import { PathExt, PageConfig } from '@jupyterlab/coreutils';
 
 import { renameFile } from '@jupyterlab/docmanager';
 
@@ -355,6 +355,7 @@ namespace Private {
     home.className =
       MATERIAL_CLASS + ' ' + BREADCRUMB_HOME + ' ' + BREADCRUMB_ITEM_CLASS;
     home.title = 'Home';
+    home.title = PageConfig.getOption('serverRoot') || 'Home';
     let ellipsis = document.createElement('span');
     ellipsis.className =
       MATERIAL_CLASS + ' ' + BREADCRUMB_ELLIPSES + ' ' + BREADCRUMB_ITEM_CLASS;

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -354,7 +354,6 @@ namespace Private {
     let home = document.createElement('span');
     home.className =
       MATERIAL_CLASS + ' ' + BREADCRUMB_HOME + ' ' + BREADCRUMB_ITEM_CLASS;
-    home.title = 'Home';
     home.title = PageConfig.getOption('serverRoot') || 'Home';
     let ellipsis = document.createElement('span');
     ellipsis.className =


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Addresses https://github.com/jupyterlab/jupyterlab/issues/6539#issuecomment-501063504 (i.e., https://github.com/jupyterlab/jupyterlab/issues/6207#issuecomment-484674867 )

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Hovering over the home icon shows the server root, if available in page config.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
