### PR TITLE
Change the filebrowser home icon to a folder

### DIFF
--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -30,6 +30,11 @@ const MATERIAL_CLASS = 'jp-MaterialIcon';
 const BREADCRUMB_CLASS = 'jp-BreadCrumbs';
 
 /**
+ * The class name added to add the folder icon for the breadcrumbs
+ */
+const BREADCRUMB_HOME = 'jp-FolderIcon';
+
+/**
  * The class named associated to the ellipses icon
  */
 const BREADCRUMB_ELLIPSES = 'jp-EllipsesIcon';
@@ -318,27 +323,28 @@ namespace Private {
     while (firstChild && firstChild.nextSibling) {
       node.removeChild(firstChild.nextSibling);
     }
+    node.appendChild(separators[0]);
 
     let parts = path.split('/');
     if (parts.length > 2) {
-      node.appendChild(separators[0]);
       node.appendChild(breadcrumbs[Crumb.Ellipsis]);
       let grandParent = parts.slice(0, parts.length - 2).join('/');
       breadcrumbs[Crumb.Ellipsis].title = grandParent;
+      node.appendChild(separators[1]);
     }
 
     if (path) {
       if (parts.length >= 2) {
-        node.appendChild(separators[1]);
         breadcrumbs[Crumb.Parent].textContent = parts[parts.length - 2];
         node.appendChild(breadcrumbs[Crumb.Parent]);
         let parent = parts.slice(0, parts.length - 1).join('/');
         breadcrumbs[Crumb.Parent].title = parent;
+        node.appendChild(separators[2]);
       }
-      node.appendChild(separators[2]);
       breadcrumbs[Crumb.Current].textContent = parts[parts.length - 1];
       node.appendChild(breadcrumbs[Crumb.Current]);
       breadcrumbs[Crumb.Current].title = path;
+      node.appendChild(separators[3]);
     }
   }
 
@@ -347,8 +353,7 @@ namespace Private {
    */
   export function createCrumbs(): ReadonlyArray<HTMLElement> {
     let home = document.createElement('span');
-    home.textContent = 'Root';
-    home.className = BREADCRUMB_ITEM_CLASS;
+    home.className = `${MATERIAL_CLASS} ${BREADCRUMB_HOME} ${BREADCRUMB_ITEM_CLASS}`;
     home.title = PageConfig.getOption('serverRoot') || 'Jupyter Server Root';
     let ellipsis = document.createElement('span');
     ellipsis.className =
@@ -365,9 +370,9 @@ namespace Private {
    */
   export function createCrumbSeparators(): ReadonlyArray<HTMLElement> {
     let items: HTMLElement[] = [];
-    for (let i = 0; i < 3; i++) {
-      let item = document.createElement('i');
-      item.className = 'fa fa-angle-right';
+    for (let i = 0; i < 4; i++) {
+      let item = document.createElement('span');
+      item.textContent = '/';
       items.push(item);
     }
     return items;

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -370,7 +370,12 @@ namespace Private {
    */
   export function createCrumbSeparators(): ReadonlyArray<HTMLElement> {
     let items: HTMLElement[] = [];
-    for (let i = 0; i < 4; i++) {
+    // The maximum number of directories that will be shown in the crumbs
+    const MAX_DIRECTORIES = 2;
+
+    // Make separators for after each directory, one at the beginning, and one
+    // after a possible ellipsis.
+    for (let i = 0; i < MAX_DIRECTORIES + 2; i++) {
       let item = document.createElement('span');
       item.textContent = '/';
       items.push(item);

--- a/packages/filebrowser/src/crumbs.ts
+++ b/packages/filebrowser/src/crumbs.ts
@@ -30,11 +30,6 @@ const MATERIAL_CLASS = 'jp-MaterialIcon';
 const BREADCRUMB_CLASS = 'jp-BreadCrumbs';
 
 /**
- * The class name added to add the home icon for the breadcrumbs
- */
-const BREADCRUMB_HOME = 'jp-HomeIcon';
-
-/**
  * The class named associated to the ellipses icon
  */
 const BREADCRUMB_ELLIPSES = 'jp-EllipsesIcon';
@@ -352,9 +347,9 @@ namespace Private {
    */
   export function createCrumbs(): ReadonlyArray<HTMLElement> {
     let home = document.createElement('span');
-    home.className =
-      MATERIAL_CLASS + ' ' + BREADCRUMB_HOME + ' ' + BREADCRUMB_ITEM_CLASS;
-    home.title = PageConfig.getOption('serverRoot') || 'Home';
+    home.textContent = 'Root';
+    home.className = BREADCRUMB_ITEM_CLASS;
+    home.title = PageConfig.getOption('serverRoot') || 'Jupyter Server Root';
     let ellipsis = document.createElement('span');
     ellipsis.className =
       MATERIAL_CLASS + ' ' + BREADCRUMB_ELLIPSES + ' ' + BREADCRUMB_ITEM_CLASS;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

See https://github.com/jupyterlab/jupyterlab/issues/6539

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Changes the home icon in the filebrowser to be a folder icon and use slash as separators. Some thoughts around this are in https://github.com/jupyterlab/jupyterlab/issues/6539

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
<img width="386" alt="Screen Shot 2019-06-12 at 1 25 51 PM" src="https://user-images.githubusercontent.com/192614/59383919-d93d1780-8d15-11e9-8d8d-e226a77e7a7f.png">
<img width="395" alt="Screen Shot 2019-06-12 at 1 26 01 PM" src="https://user-images.githubusercontent.com/192614/59383924-dd693500-8d15-11e9-8d2e-367e97fbf4eb.png">
<img width="401" alt="Screen Shot 2019-06-12 at 1 26 08 PM" src="https://user-images.githubusercontent.com/192614/59383928-dfcb8f00-8d15-11e9-84a4-4f3b453e7c90.png">
<img width="390" alt="Screen Shot 2019-06-12 at 1 28 23 PM" src="https://user-images.githubusercontent.com/192614/59383984-fc67c700-8d15-11e9-8a5c-4611124ab9e2.png">


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
