### PR TITLE
fixes #6439: underhang in highlighting of multiline selections

### DIFF
--- a/packages/codemirror/style/base.css
+++ b/packages/codemirror/style/base.css
@@ -7,14 +7,14 @@
   line-height: var(--jp-code-line-height);
   font-size: var(--jp-code-font-size);
   font-family: var(--jp-code-font-family);
+  border: 0;
+  border-radius: 0;
   height: auto;
   /* Changed to auto to autogrow */
 }
 
 .CodeMirror pre {
-  padding: 0;
-  border: 0;
-  border-radius: 0;
+  padding: 0 var(--jp-code-padding);
 }
 
 .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-dialog {
@@ -26,11 +26,6 @@
 /* May not cause it not because we changed it! */
 .CodeMirror-lines {
   padding: var(--jp-code-padding) 0;
-}
-
-/* Set horizontal padding on line nodes for correct margins */
-pre.CodeMirror-line {
-  padding: 0 var(--jp-code-padding);
 }
 
 .CodeMirror-linenumber {

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -181,7 +181,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   --jp-code-font-size: 13px;
   --jp-code-line-height: 1.3077; /* 17px for 13px base */
-  --jp-code-padding: 5px; /* 5px for 13px base */
+  --jp-code-padding: 5px; /* 5px for 13px base, codemirror highlighting needs integer px value */
   --jp-code-font-family-default: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
   --jp-code-font-family: var(--jp-code-font-family-default);
 

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -181,7 +181,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   --jp-code-font-size: 13px;
   --jp-code-line-height: 1.3077; /* 17px for 13px base */
-  --jp-code-padding: 0.385em; /* 5px for 13px base */
+  --jp-code-padding: 5px; /* 5px for 13px base */
   --jp-code-font-family-default: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
   --jp-code-font-family: var(--jp-code-font-family-default);
 

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -179,7 +179,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   --jp-code-font-size: 13px;
   --jp-code-line-height: 1.3077; /* 17px for 13px base */
-  --jp-code-padding: 0.385em; /* 5px for 13px base */
+  --jp-code-padding: 5px; /* 5px for 13px base */
   --jp-code-font-family-default: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
   --jp-code-font-family: var(--jp-code-font-family-default);
 

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -179,7 +179,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   --jp-code-font-size: 13px;
   --jp-code-line-height: 1.3077; /* 17px for 13px base */
-  --jp-code-padding: 5px; /* 5px for 13px base */
+  --jp-code-padding: 5px; /* 5px for 13px base, codemirror highlighting needs integer px value */
   --jp-code-font-family-default: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
   --jp-code-font-family: var(--jp-code-font-family-default);
 


### PR DESCRIPTION
## References

#6439

## Code changes

Changed the Codemirror CSS to more closely match what Codemirror itself uses in its examples, changed code padding to use a fixed `px` value instead of a scaling `em` value. The fractional `em` values were apparently messing with Codemirror's highlighting

## User-facing changes

Fixes the highlighting underhang in multiline selections in codemirror cells.

## Backwards-incompatible changes

None