### PR TITLE
fixes #6557

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1514,7 +1514,7 @@ export class Notebook extends StaticNotebook {
         let lastLine = editor.lineCount - 1;
         editor.setCursorPosition({ line: lastLine, column: 0 });
       }
-    } else {
+    } else if (location === 'bottom') {
       this.activeCellIndex++;
       // Move the cursor to the first character.
       if (this.activeCellIndex > prev) {


### PR DESCRIPTION
## References
#6557

## Code changes

Three possible edge signals can get sent (see [`packages/codemirror/src/editor.ts:621`](https://github.com/jupyterlab/jupyterlab/blob/master/packages/codemirror/src/editor.ts#L621)), `top | topLine | bottom`. This adds code to properly distinguish between `topLine` and `bottom` when determining how to move the cursor at the edge of a cell.

## User-facing changes

Pushing up on the top line of a cell will now work correctly.

## Backwards-incompatible changes

None