### PR TITLE
Make extension management quiet

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -99,11 +99,8 @@ class ProgressProcess(Process):
                 cache.append(out)
             except subprocess.TimeoutExpired:
                 continue
-        if proc.returncode:
-            self.logger.error('\n'.join(cache))
-        else:
-            self.logger.debug('\n'.join(cache))
-            sys.stdout.flush()
+        self.logger.debug('\n'.join(cache))
+        sys.stdout.flush()
         return self.terminate()
 
 
@@ -558,7 +555,7 @@ class _AppHandler(object):
         ret = self._run(['node', YARN_PATH, 'install', '--non-interactive'], cwd=staging)
         if ret != 0:
             msg = 'npm dependencies failed to install'
-            self.logger.error(msg)
+            self.logger.debug(msg)
             raise RuntimeError(msg)
 
         dedupe_yarn(staging, self.logger)
@@ -567,7 +564,7 @@ class _AppHandler(object):
         ret = self._run(['node', YARN_PATH, 'run', command], cwd=staging)
         if ret != 0:
             msg = 'JupyterLab failed to build'
-            self.logger.error(msg)
+            self.logger.debug(msg)
             raise RuntimeError(msg)
 
     def watch(self):

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1404,8 +1404,8 @@ class _AppHandler(object):
                     raise ValueError(msg)
 
                 if version and name:
-                    self.logger.warning('Incompatible extension:\n%s', msg)
-                    self.logger.warning('Found compatible version: %s', version)
+                    self.logger.debug('Incompatible extension:\n%s', name)
+                    self.logger.debug('Found compatible version: %s', version)
                     with TemporaryDirectory() as tempdir2:
                         return self._install_extension(
                             '%s@%s' % (name, version), tempdir2)

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -52,12 +52,10 @@ class ProgressProcess(Process):
             The logger instance.
         cwd: string, optional
             The cwd of the process.
-        env: dict, optional
-            The environment for the process.
         kill_event: :class:`~threading.Event`, optional
             An event used to kill the process operation.
-        quiet: bool, optional
-            Whether to suppress output.
+        env: dict, optional
+            The environment for the process.
         """
         if not isinstance(cmd, (list, tuple)):
             raise ValueError('Command must be given as a list')

--- a/jupyterlab/debuglog.py
+++ b/jupyterlab/debuglog.py
@@ -16,13 +16,15 @@ import traceback
 from traitlets import HasTraits, Unicode, default
 
 class DebugLogFileMixin(HasTraits):
-    debug_log_path = Unicode('', config=True, help='TODO')
+    debug_log_path = Unicode('', config=True, help='Path to use for the debug log file')
 
     @contextlib.contextmanager
     def debug_logging(self):
         log_path = self.debug_log_path
+        if os.path.isdir(log_path):
+            log_path = os.path.join(log_path, 'jupyterlab-debug.log')
         if not log_path:
-            handle, log_path = tempfile.mkstemp(prefix='jupyterlab-log-', suffix='.log')
+            handle, log_path = tempfile.mkstemp(prefix='jupyterlab-debug-', suffix='.log')
             os.close(handle)
         log = self.log
 

--- a/jupyterlab/debuglog.py
+++ b/jupyterlab/debuglog.py
@@ -13,9 +13,10 @@ import sys
 import tempfile
 import traceback
 
-from traitlets import HasTraits, Unicode, default
+from traitlets import Unicode, default
+from traitlets.config import Configurable
 
-class DebugLogFileMixin(HasTraits):
+class DebugLogFileMixin(Configurable):
     debug_log_path = Unicode('', config=True, help='Path to use for the debug log file')
 
     @contextlib.contextmanager

--- a/jupyterlab/debuglog.py
+++ b/jupyterlab/debuglog.py
@@ -1,0 +1,66 @@
+# coding: utf-8
+"""A mixin for adding a debug log file.
+
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import contextlib
+import logging
+import os
+import sys
+import tempfile
+import traceback
+
+from traitlets import HasTraits, Unicode, default
+
+class DebugLogFileMixin(HasTraits):
+    debug_log_path = Unicode('', config=True, help='TODO')
+
+    @contextlib.contextmanager
+    def debug_logging(self):
+        log_path = self.debug_log_path
+        if not log_path:
+            handle, log_path = tempfile.mkstemp(prefix='jupyterlab-log-', suffix='.log')
+            os.close(handle)
+        log = self.log
+
+        # Transfer current log level to the handlers:
+        for h in log.handlers:
+            h.setLevel(self.log_level)
+        log.setLevel('DEBUG')
+
+        # Create our debug-level file handler:
+        _debug_handler = logging.FileHandler(
+            log_path, 'w', 'utf8', delay=True)
+        _log_formatter = self._log_formatter_cls(fmt=self.log_format, datefmt=self.log_datefmt)
+        _debug_handler.setFormatter(_log_formatter)
+        _debug_handler.setLevel('DEBUG')
+
+        log.addHandler(_debug_handler)
+
+        try:
+            yield
+        except Exception as ex:
+            _, _, exc_traceback = sys.exc_info()
+            msg = traceback.format_exception(ex.__class__, ex, exc_traceback)
+            for line in msg:
+                self.log.debug(line)
+            if isinstance(ex, SystemExit):
+                print('An error occured. See the log file for details: ', log_path)
+                raise
+            print('An error occured.')
+            print(msg[-1].strip())
+            print('See the log file for details: ', log_path)
+            self.exit(1)
+        else:
+            log.removeHandler(_debug_handler)
+            _debug_handler.flush()
+            _debug_handler.close()
+            try:
+                os.remove(log_path)
+            except FileNotFoundError:
+                pass
+        log.removeHandler(_debug_handler)
+

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -17,6 +17,7 @@ from notebook.utils import url_path_join as ujoin
 from traitlets import Bool, Unicode
 
 from ._version import __version__
+from .debuglog import DebugLogFileMixin
 from .extension import load_config, load_jupyter_server_extension
 from .commands import (
     build, clean, get_app_dir, get_app_version, get_user_settings_dir,
@@ -38,7 +39,7 @@ if version != app_version:
     version = '%s (dev), %s (app)' % (__version__, app_version)
 
 
-class LabBuildApp(JupyterApp):
+class LabBuildApp(JupyterApp, DebugLogFileMixin):
     version = version
     description = """
     Build the JupyterLab application
@@ -69,12 +70,13 @@ class LabBuildApp(JupyterApp):
         command = 'build:prod' if not self.dev_build else 'build'
         app_dir = self.app_dir or get_app_dir()
         self.log.info('JupyterLab %s', version)
-        if self.pre_clean:
-            self.log.info('Cleaning %s' % app_dir)
-            clean(self.app_dir)
-        self.log.info('Building in %s', app_dir)
-        build(app_dir=app_dir, name=self.name, version=self.version,
-              command=command, logger=self.log)
+        with self.debug_logging():
+            if self.pre_clean:
+                self.log.info('Cleaning %s' % app_dir)
+                clean(self.app_dir)
+            self.log.info('Building in %s', app_dir)
+            build(app_dir=app_dir, name=self.name, version=self.version,
+                command=command, logger=self.log)
 
 
 clean_aliases = dict(base_aliases)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -30,6 +30,7 @@ build_aliases['app-dir'] = 'LabBuildApp.app_dir'
 build_aliases['name'] = 'LabBuildApp.name'
 build_aliases['version'] = 'LabBuildApp.version'
 build_aliases['dev-build'] = 'LabBuildApp.dev_build'
+build_aliases['debug-log-path'] = 'DebugLogFileMixin.debug_log_path'
 
 build_flags = dict(flags)
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -137,7 +137,7 @@ class LabWorkspaceExportApp(JupyterApp):
 
         if len(self.extra_args) > 1:
             print('Too many arguments were provided for workspace export.')
-            sys.exit(1)
+            self.exit(1)
 
         raw = (page_url if not self.extra_args
                else ujoin(config.workspaces_url, self.extra_args[0]))
@@ -187,7 +187,7 @@ class LabWorkspaceImportApp(JupyterApp):
 
         if len(self.extra_args) != 1:
             print('One argument is required for workspace import.')
-            sys.exit(1)
+            self.exit(1)
 
         workspace = dict()
         with self._smart_open() as fid:
@@ -195,14 +195,14 @@ class LabWorkspaceImportApp(JupyterApp):
                 workspace = self._validate(fid, base_url, page_url, workspaces_url)
             except Exception as e:
                 print('%s is not a valid workspace:\n%s' % (fid.name, e))
-                sys.exit(1)
+                self.exit(1)
 
         if not osp.exists(directory):
             try:
                 os.makedirs(directory)
             except Exception as e:
                 print('Workspaces directory could not be created:\n%s' % e)
-                sys.exit(1)
+                self.exit(1)
 
         slug = slugify(workspace['metadata']['id'], base_url)
         workspace_path = pjoin(directory, slug + WORKSPACE_EXTENSION)
@@ -223,7 +223,7 @@ class LabWorkspaceImportApp(JupyterApp):
 
             if not osp.exists(file_path):
                 print('%s does not exist.' % file_name)
-                sys.exit(1)
+                self.exit(1)
 
             return open(file_path)
 
@@ -275,7 +275,7 @@ class LabWorkspaceApp(JupyterApp):
     def start(self):
         super().start()
         print('Either `export` or `import` must be specified.')
-        sys.exit(1)
+        self.exit(1)
 
 
 lab_aliases = dict(aliases)

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -19,6 +19,7 @@ from .commands import (
     link_package, unlink_package, build, get_app_version, HERE,
     update_extension,
 )
+from .debuglog import DebugLogFileMixin
 
 
 flags = dict(base_flags)
@@ -52,11 +53,12 @@ uninstall_flags['all'] = (
 aliases = dict(base_aliases)
 aliases['app-dir'] = 'BaseExtensionApp.app_dir'
 aliases['dev-build'] = 'BaseExtensionApp.dev_build'
+aliases['debug-log-path'] = 'DebugLogFileMixin.debug_log_path'
 
 VERSION = get_app_version()
 
 
-class BaseExtensionApp(JupyterApp):
+class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
     version = VERSION
     flags = flags
     aliases = aliases
@@ -76,20 +78,12 @@ class BaseExtensionApp(JupyterApp):
     def start(self):
         if self.app_dir and self.app_dir.startswith(HERE):
             raise ValueError('Cannot run lab extension commands in core app')
-        try:
+        with self.debug_logging():
             ans = self.run_task()
             if ans and self.should_build:
                 command = 'build:prod' if not self.dev_build else 'build'
                 build(app_dir=self.app_dir, clean_staging=self.should_clean,
                       logger=self.log, command=command)
-        except Exception as ex:
-            _, _, exc_traceback = sys.exc_info()
-            msg = traceback.format_exception(ex.__class__, ex, exc_traceback)
-            for line in msg:
-                self.log.debug(line)
-            self.log.error('\nErrored, use --debug for full output:')
-            self.log.error(msg[-1].strip())
-            sys.exit(1)
 
     def run_task(self):
         pass

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -212,7 +212,7 @@ class CheckLabExtensionsApp(BaseExtensionApp):
                 logger=self.log)
             for arg in self.extra_args)
         if not all_enabled:
-            exit(1)
+            self.exit(1)
 
 
 _examples = """
@@ -248,7 +248,7 @@ class LabExtensionApp(JupyterApp):
         # The above should have called a subcommand and raised NoStart; if we
         # get here, it didn't, so we should self.log.info a message.
         subcmds = ", ".join(sorted(self.subcommands))
-        sys.exit("Please supply at least one subcommand: %s" % subcmds)
+        self.exit("Please supply at least one subcommand: %s" % subcmds)
 
 
 main = LabExtensionApp.launch_instance


### PR DESCRIPTION
## References

Fixes #5986.
Fixes #6499.

## Code changes

Main points:
- install/uninstall/build commands will now only show a spinner by default
- any failing subprocesses will log its output to error
- use `--debug` to track which commands are being executed, and see their output after command completion
- adds a file-backed log handler for certain entry points (build and ext install/uninstall). Deleted upon successful completion.

## User-facing changes

`jupyter labextension install/uninstall` and `jupyter lab build` will all be mostly quiet by default, but have spinner while processing:

![image](https://user-images.githubusercontent.com/510760/59462245-3969b180-8e1b-11e9-8d1b-cdbd58b8766d.png)

## Backwards-incompatible changes

None (only internal functions change signature).
