### PR TITLE
Updates to a MainAreaWidget should propagate to the content

### DIFF
--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Message } from '@phosphor/messaging';
+import { Message, MessageLoop } from '@phosphor/messaging';
 
 import { BoxLayout, Widget } from '@phosphor/widgets';
 
@@ -152,6 +152,13 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
    */
   protected onCloseRequest(msg: Message): void {
     this.dispose();
+  }
+
+  /**
+   * Handle `'update-request'` messages by forwarding them to the content.
+   */
+  protected onUpdateRequest(msg: Message): void {
+    MessageLoop.sendMessage(this._content, msg);
   }
 
   /**

--- a/tests/test-apputils/src/mainareawidget.spec.ts
+++ b/tests/test-apputils/src/mainareawidget.spec.ts
@@ -49,6 +49,22 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
+    describe('#onUpdateRequest()', () => {
+      it('should propagate to the content', () => {
+        let updated: boolean;
+        const content = new (class extends Widget {
+          onUpdateRequest() {
+            updated = true;
+          }
+        })();
+        const widget = new MainAreaWidget({ content });
+        Widget.attach(widget, document.body);
+        updated = false;
+        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+        expect(updated).to.equal(true);
+      });
+    });
+
     describe('title', () => {
       it('should proxy from content to main', () => {
         const content = new Widget();


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #6571
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Propagates MainAreaWidget update messages to the content as a convenience.

We already mirror title attributes, etc., to try to make the MainAreaWidget a transparent wrapper around the content in some ways. An update message is a common message, so mirroring that to the content makes sense.
<!-- Describe the code changes and how they address the issue. -->
