### PR TITLE
Restyle the launcher, enable keyboard navigation

### DIFF
--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -185,6 +185,9 @@ export class Launcher extends VDomRenderer<LauncherModel> {
       }
     }
 
+    // The tabindex of cards in each category are separated by 100.
+    let tabIndexStep = 100;
+
     // Now create the sections for each category
     orderedCategories.forEach(cat => {
       const item = categories[cat][0] as ILauncher.IItemOptions;
@@ -203,20 +206,25 @@ export class Launcher extends VDomRenderer<LauncherModel> {
             </div>
             <div className="jp-Launcher-cardContainer">
               {toArray(
-                map(categories[cat], (item: ILauncher.IItemOptions) => {
-                  return Card(
-                    kernel,
-                    item,
-                    this,
-                    this._commands,
-                    this._callback
-                  );
-                })
+                map(
+                  categories[cat],
+                  (item: ILauncher.IItemOptions, tabindex: number) => {
+                    return Card(
+                      kernel,
+                      item,
+                      tabIndexStep + tabindex + 1,
+                      this,
+                      this._commands,
+                      this._callback
+                    );
+                  }
+                )
               )}
             </div>
           </div>
         );
         sections.push(section);
+        tabIndexStep += 100;
       }
     });
 
@@ -338,6 +346,7 @@ export namespace ILauncher {
 function Card(
   kernel: boolean,
   item: ILauncher.IItemOptions,
+  tabindex: number,
   launcher: Launcher,
   commands: CommandRegistry,
   launcherCallback: (widget: Widget) => void
@@ -375,12 +384,22 @@ function Card(
       });
   };
 
+  // With tabindex working, you can now pick a kernel by tabbing around and
+  // pressing Enter.
+  let onkeypress = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      onclick();
+    }
+  };
+
   // Return the VDOM element.
   return (
     <div
       className="jp-LauncherCard"
       title={title}
       onClick={onclick}
+      onKeyPress={onkeypress}
+      tabIndex={tabindex}
       data-category={item.category || 'Other'}
       key={Private.keyProperty.get(item)}
     >

--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -185,9 +185,6 @@ export class Launcher extends VDomRenderer<LauncherModel> {
       }
     }
 
-    // The tabindex of cards in each category are separated by 100.
-    let tabIndexStep = 100;
-
     // Now create the sections for each category
     orderedCategories.forEach(cat => {
       const item = categories[cat][0] as ILauncher.IItemOptions;
@@ -206,25 +203,20 @@ export class Launcher extends VDomRenderer<LauncherModel> {
             </div>
             <div className="jp-Launcher-cardContainer">
               {toArray(
-                map(
-                  categories[cat],
-                  (item: ILauncher.IItemOptions, tabindex: number) => {
-                    return Card(
-                      kernel,
-                      item,
-                      tabIndexStep + tabindex + 1,
-                      this,
-                      this._commands,
-                      this._callback
-                    );
-                  }
-                )
+                map(categories[cat], (item: ILauncher.IItemOptions) => {
+                  return Card(
+                    kernel,
+                    item,
+                    this,
+                    this._commands,
+                    this._callback
+                  );
+                })
               )}
             </div>
           </div>
         );
         sections.push(section);
-        tabIndexStep += 100;
       }
     });
 
@@ -346,7 +338,6 @@ export namespace ILauncher {
 function Card(
   kernel: boolean,
   item: ILauncher.IItemOptions,
-  tabindex: number,
   launcher: Launcher,
   commands: CommandRegistry,
   launcherCallback: (widget: Widget) => void
@@ -399,7 +390,7 @@ function Card(
       title={title}
       onClick={onclick}
       onKeyPress={onkeypress}
-      tabIndex={tabindex}
+      tabIndex={100}
       data-category={item.category || 'Other'}
       key={Private.keyProperty.get(item)}
     >

--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -347,7 +347,7 @@ function Card(
   const args = { ...item.args, cwd: launcher.cwd };
   const caption = commands.caption(command, args);
   const label = commands.label(command, args);
-  const title = caption || label;
+  const title = kernel ? label : caption || label;
 
   // Build the onclick handler.
   let onclick = () => {
@@ -400,7 +400,7 @@ function Card(
         )}
       </div>
       <div className="jp-LauncherCard-label" title={title}>
-        {label}
+        <p>{label}</p>
       </div>
     </div>
   );

--- a/packages/launcher/style/base.css
+++ b/packages/launcher/style/base.css
@@ -117,8 +117,17 @@
   border-radius: var(--jp-border-radius);
 }
 
+.jp-LauncherCard:focus:not(:active) {
+  border: 1px solid var(--jp-brand-color1);
+  box-shadow: var(--jp-elevation-z6);
+}
+
 .jp-LauncherCard:hover {
   box-shadow: var(--jp-elevation-z6);
+}
+
+.jp-LauncherCard:active {
+  box-shadow: var(--jp-elevation-z4);
 }
 
 .jp-LauncherCard-icon {

--- a/packages/launcher/style/base.css
+++ b/packages/launcher/style/base.css
@@ -9,8 +9,8 @@
   --jp-private-launcher-top-padding: 16px;
   --jp-private-launcher-side-padding: 32px;
   --jp-private-launcher-card-size: 100px;
-  --jp-private-launcher-card-label-height: 25px;
-  --jp-private-launcher-card-icon-height: 75px;
+  --jp-private-launcher-card-label-height: 32px;
+  --jp-private-launcher-card-icon-height: 68px;
   --jp-private-launcher-large-icon-size: 52px;
   --jp-private-launcher-small-icon-size: 32px;
 }
@@ -150,15 +150,19 @@
 .jp-LauncherCard-label {
   width: 100%;
   height: var(--jp-private-launcher-card-label-height);
-  line-height: var(--jp-private-launcher-card-label-height);
-  font-size: var(--jp-ui-font-size1);
-  padding: 0 8px;
-  color: var(--jp-ui-font-color1);
+  padding: 0 4px 4px 4px;
   box-sizing: border-box;
   overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+}
+
+.jp-LauncherCard-label p {
+  height: 28px;
+  word-break: break-word;
   text-align: center;
+  color: var(--jp-ui-font-color1);
+  line-height: 14px;
+  font-size: 12px;
+  overflow: hidden;
 }
 
 /* Icons, kernel icons */


### PR DESCRIPTION
## References

Partial fix for #3795 intended for 1.0. A more ambitious improvement is being done in #5953.

See #6529 for full details. This PR supersedes that one.

## Code changes

* Each launcher card now has a valid `tabindex` and pressing enter when a card is focused will call `onclick` to open the activity. This enables keyboard interaction with the launcher.
* The title of the card is now the kernel name if it is a notebook or console.

## User-facing changes

* Name of kernel now wraps to 2 lines to make longer kernel names visible.
* Additional styling for active and focus states of cards.

![Screen Shot 2019-06-10 at 3 07 06 PM](https://user-images.githubusercontent.com/27600/59230452-5b9cce80-8b92-11e9-8783-18da688b87d4.png)

More examples:

![Screen Shot 2019-06-10 at 3 09 36 PM](https://user-images.githubusercontent.com/27600/59230457-5e97bf00-8b92-11e9-92e4-395cc5e6edcc.png)


## Backwards-incompatible changes

None.
