### PR TITLE
Document how to use React

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -25,7 +25,7 @@ See :ref:`xkcd_extension_tutorial` to learn how to make a simple JupyterLab exte
 
 A JupyterLab application is comprised of:
 
--  A core Application object
+-  A core Applicaztion object
 -  Plugins
 
 Plugins
@@ -515,6 +515,11 @@ This would look something like the following in a ``Widget`` subclass:
 
 .. |dependencies| image:: dependency-graph.svg
 
+
+Using React
+^^^^^^^^^^^
+We also provide support for using :ref:`react` in your JupyterLab
+extensions, as well as in the core codebase.
 
 
 .. _ext-author-companion-packages:

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -25,7 +25,7 @@ See :ref:`xkcd_extension_tutorial` to learn how to make a simple JupyterLab exte
 
 A JupyterLab application is comprised of:
 
--  A core Applicaztion object
+-  A core Application object
 -  Plugins
 
 Plugins

--- a/docs/source/developer/virtualdom.create.tsx
+++ b/docs/source/developer/virtualdom.create.tsx
@@ -3,4 +3,8 @@ import * as React from 'react';
 import { Widget } from '@phosphor/widgets';
 import { ReactWidget } from '@jupyterlab/apputils';
 
-const myWidget: Widget = ReactWidget.create(<div>My Widget</div>);
+function MyComponent() {
+  return <div>My Widget</div>;
+}
+
+const myWidget: Widget = ReactWidget.create(<MyComponent />);

--- a/docs/source/developer/virtualdom.create.tsx
+++ b/docs/source/developer/virtualdom.create.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+import { Widget } from '@phosphor/widgets';
+import { ReactWidget } from '@jupyterlab/apputils';
+
+const myWidget: Widget = ReactWidget.create(<div>My Widget</div>);

--- a/docs/source/developer/virtualdom.reactwidget.tsx
+++ b/docs/source/developer/virtualdom.reactwidget.tsx
@@ -3,9 +3,12 @@ import * as React from 'react';
 import { Widget } from '@phosphor/widgets';
 import { ReactWidget } from '@jupyterlab/apputils';
 
+function MyComponent() {
+  return <div>My Widget</div>;
+}
 class MyWidget extends ReactWidget {
   render() {
-    return <div>My Widget</div>;
+    return <MyComponent />;
   }
 }
 const myWidget: Widget = new MyWidget();

--- a/docs/source/developer/virtualdom.reactwidget.tsx
+++ b/docs/source/developer/virtualdom.reactwidget.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+import { Widget } from '@phosphor/widgets';
+import { ReactWidget } from '@jupyterlab/apputils';
+
+class MyWidget extends ReactWidget {
+  render() {
+    return <div>My Widget</div>;
+  }
+}
+const myWidget: Widget = new MyWidget();

--- a/docs/source/developer/virtualdom.rst
+++ b/docs/source/developer/virtualdom.rst
@@ -43,9 +43,9 @@ override the ``render`` method to return a React element:
     import { ReactWidget } from '@jupyterlab/apputils';
 
     class MyWidget extends ReactWidget {
-        render() {
-            return <div>My Widget</div>
-        }
+      render() {
+        return <div>My Widget</div>;
+      }
     }
     const myWidget: Widget = new MyWidget();
 

--- a/docs/source/developer/virtualdom.rst
+++ b/docs/source/developer/virtualdom.rst
@@ -15,16 +15,8 @@ which have some additional features over native DOM elements, including:
 We support wrapping React components to turn them into Phosphor
 widgets using the ``ReactWidget`` class from ``@jupyterlab/apputils``:
 
-.. code:: typescript
+.. literalinclude:: virtualdom.create.jsx
 
-    import * as React from 'react';
-
-    import { Widget } from '@phosphor/widgets';
-    import { ReactWidget } from '@jupyterlab/apputils';
-
-    const myWidget: Widget = ReactWidget.create(
-        <div>My Widget</div>
-    );
 
 Here we use the ``create`` static method to transform a React element
 into a Phosphor widget. Whenever the widget is mounted, the React
@@ -35,19 +27,7 @@ or add other methods to it, you can subbclass ``ReactWidget`` and
 override the ``render`` method to return a React element:
 
 
-.. code:: typescript
-
-    import * as React from 'react';
-
-    import { Widget } from '@phosphor/widgets';
-    import { ReactWidget } from '@jupyterlab/apputils';
-
-    class MyWidget extends ReactWidget {
-      render() {
-        return <div>My Widget</div>;
-      }
-    }
-    const myWidget: Widget = new MyWidget();
+.. literalinclude:: virtualdom.reactwidget.jsx
 
 
 We use Phosphor `Signals <https://phosphorjs.github.io/phosphor/api/signaling/interfaces/isignal.html>`__ to represent

--- a/docs/source/developer/virtualdom.rst
+++ b/docs/source/developer/virtualdom.rst
@@ -1,25 +1,64 @@
-Virtual DOM and React
----------------------
+.. _react:
 
-JupyterLab is based on `PhosphorJS <https://phosphorjs.github.io/>`__,
-which provides a flexible ``Widget`` class that handles the following:
+React
+-----
+
+
+Many JupyterLab APIs require `Phosphor <https://phosphorjs.github.io/>`__
+`Widgets <https://phosphorjs.github.io/phosphor/api/widgets/classes/widget.html>`__
+which have some additional features over native DOM elements, including:
 
 -  Resize events that propagate down the Widget hierarchy.
 -  Lifecycle events (``onBeforeDetach``, ``onAfterAttach``, etc.).
 -  Both CSS-based and absolutely positioned layouts.
 
-In situations where these features are needed, we recommend using
-Phosphor's ``Widget`` class directly.
+We support wrapping React components to turn them into Phosphor
+widgets using the ``ReactWidget`` class from ``@jupyterlab/apputils``:
 
-The idea of virtual DOM rendering, which became popular in the
-`React <https://reactjs.org/>`__ community, is a very elegant and
-efficient way of rendering and updating DOM content in response to
-model/state changes.
+.. code:: typescript
 
-Phosphor's ``Widget`` class integrates well with ReactJS and we are now
-using React in JupyterLab to render leaf content when the above
-capabilities are not needed.
+    import * as React from 'react';
 
-An example of using React with Phosphor can be found in the
-`launcher <https://github.com/jupyterlab/jupyterlab/blob/master/packages/launcher/src/index.tsx>`__
-of JupyterLab.
+    import { Widget } from '@phosphor/widgets';
+    import { ReactWidget } from '@jupyterlab/apputils';
+
+    const myWidget: Widget = ReactWidget.create(
+        <div>My Widget</div>
+    );
+
+Here we use the ``create`` static method to transform a React element
+into a Phosphor widget. Whenever the widget is mounted, the React
+element will be rendered on the page.
+
+If you need to handle other life cycle events on the Phosphor widget
+or add other methods to it, you can subbclass ``ReactWidget`` and
+override the ``render`` method to return a React element:
+
+
+.. code:: typescript
+
+    import * as React from 'react';
+
+    import { Widget } from '@phosphor/widgets';
+    import { ReactWidget } from '@jupyterlab/apputils';
+
+    class MyWidget extends ReactWidget {
+        render() {
+            return <div>My Widget</div>
+        }
+    }
+    const myWidget: Widget = new MyWidget();
+
+
+We use Phosphor `Signals <https://phosphorjs.github.io/phosphor/api/signaling/interfaces/isignal.html>`__ to represent
+data that changes over time in JupyterLab.
+To have your React element change in response to a signal event, use the ``UseSignal`` component,
+which implements the `"render props" <https://reactjs.org/docs/render-props.html>`__.
+
+The `running component <https://github.com/jupyterlab/jupyterlab/blob/79e03992b2964063a917184072be3c8819cefa19/packages/running/src/index.tsx>`__
+and the `search overlay <https://github.com/jupyterlab/jupyterlab/blob/2834c11945232c3901282a870224ba80a009cf8f/packages/documentsearch/src/searchoverlay.tsx#L439-L458>`__
+use both of these features and serve as a good reference for best practices.
+
+We follow the `React documentation <https://reactjs.org/docs/thinking-in-react.html>`__ and
+`"React & Redux in TypeScript - Static Typing Guide" <https://github.com/piotrwitek/react-redux-typescript-guide#readme>`__
+for best practices on using React in TypeScript.

--- a/docs/source/developer/virtualdom.rst
+++ b/docs/source/developer/virtualdom.rst
@@ -55,8 +55,8 @@ data that changes over time in JupyterLab.
 To have your React element change in response to a signal event, use the ``UseSignal`` component,
 which implements the `"render props" <https://reactjs.org/docs/render-props.html>`__.
 
-The `running component <https://github.com/jupyterlab/jupyterlab/blob/79e03992b2964063a917184072be3c8819cefa19/packages/running/src/index.tsx>`__
-and the `search overlay <https://github.com/jupyterlab/jupyterlab/blob/2834c11945232c3901282a870224ba80a009cf8f/packages/documentsearch/src/searchoverlay.tsx#L439-L458>`__
+The `running component <https://github.com/jupyterlab/jupyterlab/blob/master/packages/running/src/index.tsx>`__
+and the ``createSearchOverlay`` function in the `search overlay <https://github.com/jupyterlab/jupyterlab/blob/master/packages/documentsearch/src/searchoverlay.tsx>`__
 use both of these features and serve as a good reference for best practices.
 
 We follow the `React documentation <https://reactjs.org/docs/thinking-in-react.html>`__ and

--- a/docs/source/developer/virtualdom.rst
+++ b/docs/source/developer/virtualdom.rst
@@ -15,7 +15,8 @@ which have some additional features over native DOM elements, including:
 We support wrapping React components to turn them into Phosphor
 widgets using the ``ReactWidget`` class from ``@jupyterlab/apputils``:
 
-.. literalinclude:: virtualdom.create.jsx
+.. literalinclude:: virtualdom.create.tsx
+   :force:
 
 
 Here we use the ``create`` static method to transform a React element
@@ -27,7 +28,8 @@ or add other methods to it, you can subbclass ``ReactWidget`` and
 override the ``render`` method to return a React element:
 
 
-.. literalinclude:: virtualdom.reactwidget.jsx
+.. literalinclude:: virtualdom.reactwidget.tsx
+   :force:
 
 
 We use Phosphor `Signals <https://phosphorjs.github.io/phosphor/api/signaling/interfaces/isignal.html>`__ to represent


### PR DESCRIPTION
I had a go at writing up how we are using React inside JupyterLab.

Happy for any suggestions here.

## References
Closes https://github.com/jupyterlab/jupyterlab/issues/5215 and https://github.com/jupyterlab/jupyterlab/issues/5875
## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Rewrites `virtualdom` doc to explain how to use React in JupyterLab.

## Backwards-incompatible changes

None.