### PR TITLE
Document why you can't programmatically update UI from JS output

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -233,6 +233,9 @@ that points to the parent directory's ``karma`` config, and a test runner,
 ``run-test.py`` that starts a Jupyter server.
 
 
+
+.. _rendermime:
+
 Mime Renderer Extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -21,6 +21,16 @@ Development
 -  `How can you
    contribute? <https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`__
 -  :ref:`How can you extend or customize JupyterLab? <user_extensions>`
+-  In the classic Notebook, `I could use custom Javascript outputed by a cell to programatically
+   control the Notebook <https://stackoverflow.com/a/32769976/907060>`__. Can I do the same thing in JupyterLab?
+
+   We intentially do not support this workflow. Instead, we reccomend you display a new mimetype and define a
+   custom renderer for that in a JupyterLab extension. This makes sure the output is not tied directly to JupyterLab
+   so that another frontend could still render it. Also, if the JupyterLab API changes then
+   this change can be supported in your extension and the existing notebooks will still work without changing their
+   outputs. If you have comments or suggestions on changes here, we have `an issue <https://github.com/jupyterlab/jupyterlab/issues/4623>`__
+   to discuss this decision.
+
 
 Tips and Tricks
 ---------------

--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -24,12 +24,13 @@ Development
 -  In the classic Notebook, `I could use custom Javascript outputed by a cell to programatically
    control the Notebook <https://stackoverflow.com/a/32769976/907060>`__. Can I do the same thing in JupyterLab?
 
-   We intentially do not support this workflow. Instead, we reccomend you display a new mimetype and define a
-   custom renderer for that in a JupyterLab extension. This makes sure the output is not tied directly to JupyterLab
-   so that another frontend could still render it. Also, if the JupyterLab API changes then
-   this change can be supported in your extension and the existing notebooks will still work without changing their
-   outputs. If you have comments or suggestions on changes here, we have `an issue <https://github.com/jupyterlab/jupyterlab/issues/4623>`__
-   to discuss this decision.
+   JupyterLab was built to support a wide variety of extensibility, including dynamic behavior based on notebook
+   outputs.To access this extensability, you should write a custom JuptyerLab extension. If you would
+   like trigger some behavior in response to the user executing some code in a notebook, you can output a custom
+   mimetype (:ref:`rendermime`). We currently don't allow access to the JupyterLab
+   API from the Javsacript renderer, because this would tie the kernel and the notebook output to JupyterLab
+   and make it hard for other frontends to support it. 
+   If you have comments or suggestions on changes here, please comment on `this issue <https://github.com/jupyterlab/jupyterlab/issues/4623>`__.
 
 
 Tips and Tricks

--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -25,7 +25,7 @@ Development
    control the Notebook <https://stackoverflow.com/a/32769976/907060>`__. Can I do the same thing in JupyterLab?
 
    JupyterLab was built to support a wide variety of extensibility, including dynamic behavior based on notebook
-   outputs. To access this extensability, you should write a custom JuptyerLab extension. If you would
+   outputs. To access this extensibility, you should write a custom JupyterLab extension. If you would
    like trigger some behavior in response to the user executing some code in a notebook, you can output a custom
    mimetype (:ref:`rendermime`). We currently don't allow access to the JupyterLab
    API from the Javsacript renderer, because this would tie the kernel and the notebook output to JupyterLab

--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -25,7 +25,7 @@ Development
    control the Notebook <https://stackoverflow.com/a/32769976/907060>`__. Can I do the same thing in JupyterLab?
 
    JupyterLab was built to support a wide variety of extensibility, including dynamic behavior based on notebook
-   outputs.To access this extensability, you should write a custom JuptyerLab extension. If you would
+   outputs. To access this extensability, you should write a custom JuptyerLab extension. If you would
    like trigger some behavior in response to the user executing some code in a notebook, you can output a custom
    mimetype (:ref:`rendermime`). We currently don't allow access to the JupyterLab
    API from the Javsacript renderer, because this would tie the kernel and the notebook output to JupyterLab


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Addresses https://github.com/jupyterlab/jupyterlab/issues/4623

## Code changes

None
## User-facing changes

Adds section to FAQ to document why you can't run JS from a notebook output that changes the UI.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
