### PR TITLE
Minor fixes to theme border colors.

### DIFF
--- a/packages/launcher/style/base.css
+++ b/packages/launcher/style/base.css
@@ -110,7 +110,7 @@
   height: var(--jp-private-launcher-card-size);
   margin: 8px;
   padding: 0px;
-  border: 1px solid var(--jp-border-color1);
+  border: 1px solid var(--jp-border-color2);
   background: var(--jp-layout-color1);
   box-shadow: var(--jp-elevation-z2);
   transition: 0.2s box-shadow;

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -90,7 +90,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   --jp-border-width: 1px;
   --jp-border-color0: var(--md-grey-700);
-  --jp-border-color1: var(--md-grey-800);
+  --jp-border-color1: var(--md-grey-700);
   --jp-border-color2: var(--md-grey-800);
   --jp-border-color3: var(--md-grey-900);
   --jp-border-radius: 2px;


### PR DESCRIPTION
Fixes #6527 with two changes:

* Makes the border colors in light/dark themes consistent.
* Makes launcher card border more subtle.

Light theme:

<img width="1256" alt="Screen Shot 2019-06-17 at 4 40 56 PM" src="https://user-images.githubusercontent.com/27600/59643837-38889680-911f-11e9-93f5-8835fe388d76.png">

Dark theme:

<img width="1255" alt="Screen Shot 2019-06-17 at 4 40 42 PM" src="https://user-images.githubusercontent.com/27600/59643844-40483b00-911f-11e9-9ce8-84d19a482323.png">
