### PR TITLE
Require ipython>=7.0.0 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,7 @@ setup_args = dict(
 
 setup_args['install_requires'] = [
     'notebook>=4.3.1',
+    'ipython>=7.0.0',
     'tornado<6',
     'jupyterlab_server~=1.0.0rc0'
 ]


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/pull/6515#pullrequestreview-247872834

`ipython.core.inputtransformer2` was introduced to [ipython 7.0.0]( 
https://ipython.readthedocs.io/en/latest/api/generated/IPython.core.inputtransformer2.html) for better understanding of the "completeness" of statements, as required by #6515. With an earlier version of ipython #6515 would work in a rather strange way in that multi-line statements could sometimes be correctly identified, but sometimes not with the addition of spaces and newlines.

## Code changes

Require ipython 7.0.0 in setup.py.

## Backwards-incompatible changes

jupyterlab is very conservative in its dependencies and still supports `notebook >= 4.3.1` which was released in Dec 2016. `notebook` depends on `ipykernel` ([not versioned](https://github.com/jupyter/notebook/blob/master/setup.py#L111)), which [requires `ipython>=5.0.0`](https://github.com/ipython/ipykernel/blob/master/setup.py#L91), so requiring `ipython 7.0.0` will not cause chain reactions (`notebook 4.3.1` will continue to work).

@jasongrout Your thought?