### PR TITLE
Cleanup showErrorMessage

### DIFF
--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -60,12 +60,16 @@ export function showErrorMessage(
       title: title,
       body: body,
       buttons: buttons
-    }).then(() => {
-      Private.errorMessagePromiseCache.delete(key);
-    }, (error) => {  // TODO: Use .finally() above when supported
-      Private.errorMessagePromiseCache.delete(key);
-      throw(error);
-    });
+    }).then(
+      () => {
+        Private.errorMessagePromiseCache.delete(key);
+      },
+      error => {
+        // TODO: Use .finally() above when supported
+        Private.errorMessagePromiseCache.delete(key);
+        throw error;
+      }
+    );
     Private.errorMessagePromiseCache.set(key, dialogPromise);
     return dialogPromise;
   }

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -39,7 +39,7 @@ export function showDialog<T>(
  * @param error - the error to show in the dialog body (either a string
  *   or an object with a string `message` property).
  */
-export async function showErrorMessage(
+export function showErrorMessage(
   title: string,
   error: any,
   buttons: ReadonlyArray<Dialog.IButton> = [
@@ -60,13 +60,11 @@ export async function showErrorMessage(
       title: title,
       body: body,
       buttons: buttons
+    }).finally(() => {
+      Private.errorMessagePromiseCache.delete(key);
     });
     Private.errorMessagePromiseCache.set(key, dialogPromise);
-    try {
-      await dialogPromise;
-    } finally {
-      Private.errorMessagePromiseCache.delete(key);
-    }
+    return dialogPromise;
   }
 }
 

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -62,7 +62,7 @@ export function showErrorMessage(
       buttons: buttons
     }).then(() => {
       Private.errorMessagePromiseCache.delete(key);
-    }).catch((error) => {  // TODO: Use .finally() above when supported
+    }, (error) => {  // TODO: Use .finally() above when supported
       Private.errorMessagePromiseCache.delete(key);
       throw(error);
     });

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -60,8 +60,11 @@ export function showErrorMessage(
       title: title,
       body: body,
       buttons: buttons
-    }).finally(() => {
+    }).then(() => {
       Private.errorMessagePromiseCache.delete(key);
+    }).catch((error) => {  // TODO: Use .finally() above when supported
+      Private.errorMessagePromiseCache.delete(key);
+      throw(error);
     });
     Private.errorMessagePromiseCache.set(key, dialogPromise);
     return dialogPromise;

--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -39,7 +39,7 @@ export function showDialog<T>(
  * @param error - the error to show in the dialog body (either a string
  *   or an object with a string `message` property).
  */
-export function showErrorMessage(
+export async function showErrorMessage(
   title: string,
   error: any,
   buttons: ReadonlyArray<Dialog.IButton> = [
@@ -60,11 +60,13 @@ export function showErrorMessage(
       title: title,
       body: body,
       buttons: buttons
-    }).then(() => {
-      Private.errorMessagePromiseCache.delete(key);
     });
     Private.errorMessagePromiseCache.set(key, dialogPromise);
-    return dialogPromise;
+    try {
+      await dialogPromise;
+    } finally {
+      Private.errorMessagePromiseCache.delete(key);
+    }
   }
 }
 


### PR DESCRIPTION
## Code changes

Just making sure that the error dialog cache is cleaned up even if the dialog rejects. ~Solves this by making the function async and using a `try`/`finally` block.~ Solves this by using `Promise.prototype.finally`. [Is this OK?](https://caniuse.com/#feat=promise-finally)

## User-facing changes

None

## Backwards-incompatible changes

None
