### PR TITLE
Consider indentation for the determination of complete statements

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -993,7 +993,7 @@ function addCommands(
           while (firstLine < editor.lineCount && srcIndents[firstLine] === -1) {
             firstLine += 1;
           }
-          // if firstLine/lastLine was pointing to an empty lines, move lastLine as well
+          // if firstLine moves away from an empty line, move lastLine as well
           if (lastLine <= firstLine) {
             lastLine = firstLine + 1;
           }


### PR DESCRIPTION
## References

Remaining issue of #6645 , rebased after #6645 is merged.

When we try to find a complete Python statement, the current add-a-new-line algorithm will take the first complete statement inside `if`, `for`, `while`, `def` etc and stop. 
 
![image](https://user-images.githubusercontent.com/9889312/59786718-7f949a00-928d-11e9-879e-a771b5e0d0e6.png)


## Code changes

When finding a complete statement, it will stop before a line with equal or less indentation. That is to say, when executing from an `if` or `for` block, the entire block will be included. so that
```
if True: <- cursor here
    print(1)

    print(2)

print(3)
```
would yield

![image](https://user-images.githubusercontent.com/9889312/59709443-6bd52f00-91cc-11e9-949a-458e0bbb1fad.png)

## Backwards-incompatible changes

non-Python kernels will be affected, which could submit more than one statements if the first statement has smaller indentation.

![image](https://user-images.githubusercontent.com/9889312/59709624-e0a86900-91cc-11e9-9618-1feccbf4f37b.png)

## Potential solution:

It is possible to limit the indentation-aware behavior only to Python kernels but there is no easy way to tell which kernel should be indentation-aware (for example, SoS is based on Python and would like to be treated this way). I personally do not mind the indentation problem with R because that was a bad coding style anyway.

