### PR TITLE
Focus on the file browser after renaming

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1354,6 +1354,7 @@ export class DirListing extends Widget {
     this._selectItem(index, false);
 
     return Private.doRename(nameNode, this._editNode).then(newName => {
+      this.node.focus();
       if (!newName || newName === original) {
         this._inRename = false;
         return original;


### PR DESCRIPTION
## References

This should fix the flow for "Entering a folder by pressing the Enter key after creating and renaming it".

Part of the general issue on UX: https://github.com/jupyterlab/jupyterlab/issues/6593

Mentioned in the following comment: https://github.com/jupyterlab/jupyterlab/issues/6593#issuecomment-503224712

## Code changes

Explicit focus on the `DirListing` DOM `node` after renaming an item. 

## User-facing changes

Users can use the keyboard to navigate the file browser tree after renaming an item.

## Backwards-incompatible changes

N/A

## Demo

The folder is open using the Enter key.

![file-browser-edit-focus](https://user-images.githubusercontent.com/591645/59710374-2125d800-9209-11e9-86dd-0a2fd0e1031e.gif)

cc @tgeorgeux 