### PR TITLE
Notebook clones should point to the same underlying config attributes

### DIFF
--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -197,7 +197,7 @@ export class DocumentWidgetManager implements IDisposable {
     if (!factory) {
       return undefined;
     }
-    let newWidget = factory.clone(widget as IDocumentWidget, context);
+    let newWidget = factory.createNew(context, widget as IDocumentWidget);
     this._initializeWidget(newWidget, factory, context);
     return newWidget;
   }

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -385,9 +385,9 @@ export abstract class ABCWidgetFactory<
    * #### Notes
    * It should emit the [widgetCreated] signal with the new widget.
    */
-  createNew(context: DocumentRegistry.IContext<U>): T {
+  createNew(context: DocumentRegistry.IContext<U>, source?: T): T {
     // Create the new widget
-    const widget = this.createNewWidget(context);
+    const widget = this.createNewWidget(context, source);
 
     // Add toolbar items
     let items: DocumentRegistry.IToolbarItem[];
@@ -407,21 +407,12 @@ export abstract class ABCWidgetFactory<
   }
 
   /**
-   * Clone a widget given a context
-   *
-   * ### Notes
-   * This implementation defaults to creating a new widget.
-   * Subclasses can override this if they wish to handle
-   * cloning a widget differently.
-   */
-  clone(widget: T, context: DocumentRegistry.IContext<U>): T {
-    return this.createNew(context);
-  }
-
-  /**
    * Create a widget for a context.
    */
-  protected abstract createNewWidget(context: DocumentRegistry.IContext<U>): T;
+  protected abstract createNewWidget(
+    context: DocumentRegistry.IContext<U>,
+    source?: T
+  ): T;
 
   /**
    * Default factory for toolbar items to be added after the widget is created.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -990,15 +990,12 @@ export namespace DocumentRegistry {
     /**
      * Create a new widget given a context.
      *
+     * @param source - A widget to clone
+     *
      * #### Notes
      * It should emit the [widgetCreated] signal with the new widget.
      */
-    createNew(context: IContext<U>): T;
-
-    /**
-     * Clone an existing widget given a context
-     */
-    clone(widget: T, context: IContext<U>): T;
+    createNew(context: IContext<U>, source?: T): T;
   }
 
   /**

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -202,7 +202,7 @@ const notebooks: JupyterFrontEndPlugin<void> = {
     // Create a handler for each notebook that is created.
     notebooks.widgetAdded.connect((sender, parent) => {
       const session = parent.session;
-      const rendermime = parent.rendermime;
+      const rendermime = parent.content.rendermime;
       const connector = new KernelConnector({ session });
       const handler = new InspectionHandler({ connector, rendermime });
 

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -18,8 +18,6 @@ import {
 
 import { DocumentWidget } from '@jupyterlab/docregistry';
 
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-
 import { INotebookModel } from './model';
 
 import { Notebook, StaticNotebook } from './widget';
@@ -84,26 +82,6 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
    */
   get session(): IClientSession {
     return this.context.session;
-  }
-
-  /**
-   * The content factory for the notebook.
-   *
-   * TODO: deprecate this in favor of the .content attribute
-   *
-   */
-  get contentFactory(): Notebook.IContentFactory {
-    return this.content.contentFactory;
-  }
-
-  /**
-   * The rendermime instance for the notebook.
-   *
-   * TODO: deprecate this in favor of the .content attribute
-   *
-   */
-  get rendermime(): IRenderMimeRegistry {
-    return this.content.rendermime;
   }
 
   /**

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -86,7 +86,7 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
   ): NotebookPanel {
     let nbOptions = {
       rendermime: source
-        ? source.rendermime
+        ? source.content.rendermime
         : this.rendermime.clone({ resolver: context.urlResolver }),
       contentFactory: this.contentFactory,
       mimeTypeService: this.mimeTypeService,

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -97,6 +97,22 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
     return new NotebookPanel({ context, content });
   }
 
+  protected clone(
+    widget: NotebookPanel,
+    context: DocumentRegistry.IContext<INotebookModel>
+  ): NotebookPanel {
+    let nbOptions = {
+      rendermime: widget.rendermime,
+      contentFactory: widget.content.contentFactory,
+      mimeTypeService: this.mimeTypeService,
+      editorConfig: widget.content.editorConfig,
+      notebookConfig: widget.content.notebookConfig
+    };
+    let content = this.contentFactory.createNotebook(nbOptions);
+
+    return new NotebookPanel({ context, content });
+  }
+
   /**
    * Default factory for toolbar items to be added after the widget is created.
    */

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -81,32 +81,19 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
    * The factory will start the appropriate kernel.
    */
   protected createNewWidget(
-    context: DocumentRegistry.IContext<INotebookModel>
+    context: DocumentRegistry.IContext<INotebookModel>,
+    source?: NotebookPanel
   ): NotebookPanel {
-    let rendermime = this.rendermime.clone({ resolver: context.urlResolver });
-
     let nbOptions = {
-      rendermime,
+      rendermime: source
+        ? source.rendermime
+        : this.rendermime.clone({ resolver: context.urlResolver }),
       contentFactory: this.contentFactory,
       mimeTypeService: this.mimeTypeService,
-      editorConfig: this._editorConfig,
-      notebookConfig: this._notebookConfig
-    };
-    let content = this.contentFactory.createNotebook(nbOptions);
-
-    return new NotebookPanel({ context, content });
-  }
-
-  protected clone(
-    widget: NotebookPanel,
-    context: DocumentRegistry.IContext<INotebookModel>
-  ): NotebookPanel {
-    let nbOptions = {
-      rendermime: widget.rendermime,
-      contentFactory: widget.content.contentFactory,
-      mimeTypeService: this.mimeTypeService,
-      editorConfig: widget.content.editorConfig,
-      notebookConfig: widget.content.notebookConfig
+      editorConfig: source ? source.content.editorConfig : this._editorConfig,
+      notebookConfig: source
+        ? source.content.notebookConfig
+        : this._notebookConfig
     };
     let content = this.contentFactory.createNotebook(nbOptions);
 

--- a/packages/tooltip-extension/src/index.ts
+++ b/packages/tooltip-extension/src/index.ts
@@ -143,7 +143,7 @@ const notebooks: JupyterFrontEndPlugin<void> = {
         const anchor = parent.content;
         const editor = anchor.activeCell.editor;
         const kernel = parent.session.kernel;
-        const rendermime = parent.rendermime;
+        const rendermime = anchor.rendermime;
 
         // If all components necessary for rendering exist, create a tooltip.
         if (!!editor && !!kernel && !!rendermime) {

--- a/packages/vdom-extension/src/index.ts
+++ b/packages/vdom-extension/src/index.ts
@@ -59,7 +59,10 @@ const plugin: JupyterFrontEndPlugin<IVDOMTracker> = {
 
     notebooks.widgetAdded.connect((sender, panel) => {
       // Get the notebook's context and rendermime;
-      const { context, rendermime } = panel;
+      const {
+        context,
+        content: { rendermime }
+      } = panel;
 
       // Add the renderer factory to the notebook's rendermime registry;
       rendermime.addFactory(

--- a/tests/test-docmanager/src/manager.spec.ts
+++ b/tests/test-docmanager/src/manager.spec.ts
@@ -47,16 +47,13 @@ class CloneTestWidget extends DocumentWidget {
  */
 class WidgetFactoryWithSharedState extends ABCWidgetFactory<CloneTestWidget> {
   protected createNewWidget(
-    context: DocumentRegistry.Context
+    context: DocumentRegistry.Context,
+    source: CloneTestWidget
   ): CloneTestWidget {
-    return new CloneTestWidget({ context, content: new Widget(), count: 0 });
-  }
-
-  clone(widget: CloneTestWidget, context: DocumentRegistry.Context) {
     return new CloneTestWidget({
       context,
       content: new Widget(),
-      count: widget.counter + 1
+      count: source ? source.counter + 1 : 0
     });
   }
 }
@@ -356,7 +353,7 @@ describe('@jupyterlab/docmanager', () => {
         expect(manager.cloneWidget(widget)).to.be.undefined;
       });
 
-      it('should allow widget factories to override clone', () => {
+      it('should allow widget factories to have custom clone behavior', () => {
         widget = manager.createNew('foo', 'CloneTestWidget');
         const clonedWidget: CloneTestWidget = manager.cloneWidget(
           widget

--- a/tests/test-docregistry/src/default.spec.ts
+++ b/tests/test-docregistry/src/default.spec.ts
@@ -233,14 +233,15 @@ describe('docregistry/default', () => {
         const widget = factory.createNew(context);
         expect(widget).to.be.an.instanceof(Widget);
       });
-    });
 
-    describe('#clone()', () => {
-      it('should call createNew in default implementation', () => {
+      it('should take an optional source widget for cloning', () => {
         const factory = createFactory();
         const context = createFileContext();
         const widget = factory.createNew(context);
-        const clonedWidget: IDocumentWidget = factory.clone(widget, context);
+        const clonedWidget: IDocumentWidget = factory.createNew(
+          context,
+          widget
+        );
         expect(clonedWidget).to.not.equal(widget);
         expect(clonedWidget.hasClass('WidgetFactory')).to.be.true;
         expect(clonedWidget.context).to.equal(widget.context);

--- a/tests/test-notebook/src/widgetfactory.spec.ts
+++ b/tests/test-notebook/src/widgetfactory.spec.ts
@@ -136,5 +136,29 @@ describe('@jupyterlab/notebook', () => {
         expect(toArray(panel2.toolbar.children()).length).to.equal(2);
       });
     });
+
+    describe('#clone()', () => {
+      it('should create a new `NotebookPanel` widget', () => {
+        const factory = createFactory();
+        const panel = factory.createNew(context);
+        const clone = factory.clone(panel, panel.context);
+        expect(clone).to.be.an.instanceof(NotebookPanel);
+      });
+
+      it('should point to the same attributes where possible', () => {
+        const factory = createFactory();
+        const panel = factory.createNew(context);
+        const clone = factory.clone(panel, panel.context);
+        expect(clone).to.be.an.instanceof(NotebookPanel);
+        expect(clone.rendermime).to.equal(panel.rendermime);
+        expect(clone.content.editorConfig).to.equal(panel.content.editorConfig);
+        expect(clone.content.contentFactory).to.equal(
+          panel.content.contentFactory
+        );
+        expect(clone.content.notebookConfig).to.equal(
+          panel.content.notebookConfig
+        );
+      });
+    });
   });
 });

--- a/tests/test-notebook/src/widgetfactory.spec.ts
+++ b/tests/test-notebook/src/widgetfactory.spec.ts
@@ -102,7 +102,7 @@ describe('@jupyterlab/notebook', () => {
       it('should create a clone of the rendermime', () => {
         const factory = createFactory();
         const panel = factory.createNew(context);
-        expect(panel.rendermime).to.not.equal(rendermime);
+        expect(panel.content.rendermime).to.not.equal(rendermime);
       });
 
       it('should pass the editor config to the notebook', () => {
@@ -141,7 +141,7 @@ describe('@jupyterlab/notebook', () => {
         const panel = factory.createNew(context);
         const clone = factory.createNew(panel.context, panel);
         expect(clone).to.be.an.instanceof(NotebookPanel);
-        expect(clone.rendermime).to.equal(panel.rendermime);
+        expect(clone.content.rendermime).to.equal(panel.content.rendermime);
         expect(clone.content.editorConfig).to.equal(panel.content.editorConfig);
         expect(clone.content.notebookConfig).to.equal(
           panel.content.notebookConfig

--- a/tests/test-notebook/src/widgetfactory.spec.ts
+++ b/tests/test-notebook/src/widgetfactory.spec.ts
@@ -135,26 +135,14 @@ describe('@jupyterlab/notebook', () => {
         expect(toArray(panel.toolbar.children()).length).to.equal(2);
         expect(toArray(panel2.toolbar.children()).length).to.equal(2);
       });
-    });
 
-    describe('#clone()', () => {
-      it('should create a new `NotebookPanel` widget', () => {
+      it('should clone from the optional source widget', () => {
         const factory = createFactory();
         const panel = factory.createNew(context);
-        const clone = factory.clone(panel, panel.context);
-        expect(clone).to.be.an.instanceof(NotebookPanel);
-      });
-
-      it('should point to the same attributes where possible', () => {
-        const factory = createFactory();
-        const panel = factory.createNew(context);
-        const clone = factory.clone(panel, panel.context);
+        const clone = factory.createNew(panel.context, panel);
         expect(clone).to.be.an.instanceof(NotebookPanel);
         expect(clone.rendermime).to.equal(panel.rendermime);
         expect(clone.content.editorConfig).to.equal(panel.content.editorConfig);
-        expect(clone.content.contentFactory).to.equal(
-          panel.content.contentFactory
-        );
         expect(clone.content.notebookConfig).to.equal(
           panel.content.notebookConfig
         );


### PR DESCRIPTION
This means the create new view for widget will actually be a live updated mirror of the original widget.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #6603

#6044 and #6060 added the clone method. The original motivation was to enable cloned notebook widgets to share the same rendermime (which came up when implementing jupyter widget support).


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Cloned notebooks now share the same rendermime and config objects.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

The clone method on document widget factories is now deleted. Instead, clones are created by giving an optional source widget to the widget creation function.