### PR TITLE
Point to Jupyter docs landing page

### DIFF
--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -65,8 +65,8 @@ const RESOURCES = [
     url: 'https://jupyterlab.readthedocs.io/en/stable/'
   },
   {
-    text: 'Notebook Reference',
-    url: 'https://jupyter-notebook.readthedocs.io/en/latest/'
+    text: 'Jupyter Documentation',
+    url: 'https://jupyter.org/documentation'
   },
   {
     text: 'Markdown Reference',
@@ -242,7 +242,7 @@ function activate(
             body,
             buttons: [
               Dialog.createButton({
-                label: 'DISMISS',
+                label: 'Dismiss',
                 className: 'jp-About-button jp-mod-reject jp-mod-styled'
               })
             ]
@@ -335,7 +335,7 @@ function activate(
         body,
         buttons: [
           Dialog.createButton({
-            label: 'DISMISS',
+            label: 'Dismiss',
             className: 'jp-About-button jp-mod-reject jp-mod-styled'
           })
         ]

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -65,7 +65,10 @@ const RESOURCES = [
     url: 'https://jupyterlab.readthedocs.io/en/stable/'
   },
   {
-    text: 'Jupyter Documentation',
+    text: 'JupyterLab FAQ',
+    url: 'https://jupyterlab.readthedocs.io/en/stable/getting_started/faq.html'
+  },
+  {
     url: 'https://jupyter.org/documentation'
   },
   {


### PR DESCRIPTION
This removes the link to the Jupyter Notebook docs, and replaces it with a link to the main Jupyter Documentation landing page.

## References

Fixes #6610 

## Screenshot

<img width="913" alt="Screen Shot 2019-06-18 at 2 14 06 PM" src="https://user-images.githubusercontent.com/27600/59720307-5a435580-91d3-11e9-8fd2-3104af160a9e.png">
