### PR TITLE
Fix for settings editor not hiding error messages once fixed by user

### DIFF
--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -36,11 +36,11 @@ export class InspectorPanel extends Panel
     if (options.initialContent instanceof Widget) {
       this._content = options.initialContent;
     } else if (typeof options.initialContent === 'string') {
-      this._content = InspectorPanel.generateContentWidget(
+      this._content = InspectorPanel._generateContentWidget(
         `<p>${options.initialContent}</p>`
       );
     } else {
-      this._content = InspectorPanel.generateContentWidget(
+      this._content = InspectorPanel._generateContentWidget(
         '<p>Click on a function to see documentation.</p>'
       );
     }
@@ -131,7 +131,7 @@ export class InspectorPanel extends Panel
   /**
    * Generate content widget from string
    */
-  private static generateContentWidget(message: string): Widget {
+  private static _generateContentWidget(message: string): Widget {
     const widget = new Widget();
     widget.node.innerHTML = message;
     widget.addClass(CONTENT_CLASS);

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -30,8 +30,21 @@ export class InspectorPanel extends Panel
   /**
    * Construct an inspector.
    */
-  constructor() {
+  constructor(options: InspectorPanel.IOptions = {}) {
     super();
+
+    if (options.initialContent instanceof Widget) {
+      this._content = options.initialContent;
+    } else if (typeof options.initialContent === 'string') {
+      this._content = InspectorPanel.generateContentWidget(
+        `<p>${options.initialContent}</p>`
+      );
+    } else {
+      this._content = InspectorPanel.generateContentWidget(
+        '<p>Click on a function to see documentation.</p>'
+      );
+    }
+
     this.addClass(PANEL_CLASS);
     (this.layout as PanelLayout).addWidget(this._content);
   }
@@ -115,18 +128,24 @@ export class InspectorPanel extends Panel
     this.source = null;
   }
 
-  private _content: Widget = Private.defaultContent();
+  /**
+   * Generate content widget from string
+   */
+  private static generateContentWidget(message: string): Widget {
+    const widget = new Widget();
+    widget.node.innerHTML = message;
+    widget.addClass(CONTENT_CLASS);
+    widget.addClass(DEFAULT_CONTENT_CLASS);
+
+    return widget;
+  }
+
+  private _content: Widget = null;
   private _source: IInspector.IInspectable | null = null;
 }
 
-namespace Private {
-  export function defaultContent() {
-    const defaultContent = new Widget();
-    defaultContent.node.innerHTML =
-      '<p>Click on a function to see documentation.</p>';
-    defaultContent.addClass(CONTENT_CLASS);
-    defaultContent.addClass(DEFAULT_CONTENT_CLASS);
-
-    return defaultContent;
+export namespace InspectorPanel {
+  export interface IOptions {
+    initialContent?: Widget | string | undefined;
   }
 }

--- a/packages/settingeditor/src/inspector.ts
+++ b/packages/settingeditor/src/inspector.ts
@@ -25,7 +25,9 @@ export function createInspector(
   rendermime?: IRenderMimeRegistry
 ): InspectorPanel {
   const connector = new InspectorConnector(editor);
-  const inspector = new InspectorPanel();
+  const inspector = new InspectorPanel({
+    initialContent: 'Any errors will be listed here'
+  });
   const handler = new InspectionHandler({
     connector,
     rendermime:
@@ -76,7 +78,10 @@ class InspectorConnector extends DataConnector<
         const errors = this._validate(request.text);
 
         if (!errors) {
-          return resolve(null);
+          return resolve({
+            data: { 'text/markdown': 'No errors found' },
+            metadata: {}
+          });
         }
 
         resolve({ data: Private.render(errors), metadata: {} });


### PR DESCRIPTION
- adds ability to customize initial content shown in Inspector Panel component
- fixes error messages not disappearing when issues in JSON input are cleared by user

fixes #6601 
