### PR TITLE
Use stricter CSS selector for main area tab context menu so the commands don't show up elsewhere.

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -534,6 +534,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   });
   palette.addItem({ command: CommandIDs.activatePreviousTab, category });
 
+  // A CSS selector targeting tabs in the main area.
+  const tabSelector = '.p-DockPanel .p-TabBar-tab';
+
   commands.addCommand(CommandIDs.close, {
     label: () => 'Close Tab',
     isEnabled: () =>
@@ -547,7 +550,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   palette.addItem({ command: CommandIDs.close, category });
   contextMenu.addItem({
     command: CommandIDs.close,
-    selector: '.p-TabBar-tab',
+    selector: tabSelector,
     rank: 4
   });
 
@@ -581,7 +584,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   palette.addItem({ command: CommandIDs.closeOtherTabs, category });
   contextMenu.addItem({
     command: CommandIDs.closeOtherTabs,
-    selector: '.p-TabBar-tab',
+    selector: tabSelector,
     rank: 4
   });
 
@@ -600,7 +603,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   palette.addItem({ command: CommandIDs.closeRightTabs, category });
   contextMenu.addItem({
     command: CommandIDs.closeRightTabs,
-    selector: '.p-TabBar-tab',
+    selector: tabSelector,
     rank: 5
   });
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -538,7 +538,7 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   // specific selector since we really only want tabs that are
   // in the main area, as opposed to those in sidebars, ipywidgets, etc.
   const tabSelector =
-    '#jp-main-dock-panel > .p-TabBar > .p-TabBar-content > .p-TabBar-tab';
+    '#jp-main-dock-panel .p-DockPanel-tabBar.jp-Activity .p-TabBar-tab';
 
   commands.addCommand(CommandIDs.close, {
     label: () => 'Close Tab',

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -534,8 +534,11 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
   });
   palette.addItem({ command: CommandIDs.activatePreviousTab, category });
 
-  // A CSS selector targeting tabs in the main area.
-  const tabSelector = '.p-DockPanel .p-TabBar-tab';
+  // A CSS selector targeting tabs in the main area. This is a very
+  // specific selector since we really only want tabs that are
+  // in the main area, as opposed to those in sidebars, ipywidgets, etc.
+  const tabSelector =
+    '#jp-main-dock-panel > .p-TabBar > .p-TabBar-content > .p-TabBar-tab';
 
   commands.addCommand(CommandIDs.close, {
     label: () => 'Close Tab',


### PR DESCRIPTION

## References
Fixes #6619. This was an unintended consequence of #6052.

## Code changes

Uses a more specific CSS selector for application tab-oriented commands to only apply to the DockPanel.

## User-facing changes

More correct context menu items.

## Backwards-incompatible changes

None.