### PR TITLE
Fix missing text in #6652 which caused a sort error in js.

### DIFF
--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -69,6 +69,7 @@ const RESOURCES = [
     url: 'https://jupyterlab.readthedocs.io/en/stable/getting_started/faq.html'
   },
   {
+    text: 'Jupyter Reference',
     url: 'https://jupyter.org/documentation'
   },
   {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes an error introduced by #6652, where missing text caused a js error when sorting help entries.