### PR TITLE
Append an empty line for test of completeness of statements

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -992,7 +992,8 @@ function addCommands(
         while (true) {
           code = srcLines.slice(firstLine, lastLine).join('\n');
           let reply = await current.context.session.kernel.requestIsComplete({
-            code: code
+            // ipython needs an empty line at the end to correctly identify completeness of indented code
+            code: code + '\n\n'
           });
           if (reply.content.status === 'complete') {
             if (curLine < lastLine) {


### PR DESCRIPTION
## References

This PR is the uncontroversial part of #6606 that fixes two issues:

1. https://github.com/jupyterlab/jupyterlab/pull/6602  ipython prior to 7.0.0 fails to detect completeness of statements such as `a = [1, \n 2]`, adding a new line fixes it so that we do not have to depend on ipython 7.0.0.

![image](https://user-images.githubusercontent.com/9889312/59695065-38d07280-91af-11e9-92b1-e5c4dbb219de.png)

2. https://github.com/jupyterlab/jupyterlab/pull/6602#issuecomment-503158707 ipython needs a new line to detect completeness of indented code block.

## Code changes

Append an empty line before sending code to kernel to test for completeness, which is needed for ipython and should not affect any other kernel.

## User-facing changes

![image](https://user-images.githubusercontent.com/9889312/59786664-5ffd7180-928d-11e9-8fd8-fb27e4603ba1.png)

## Backwards-incompatible changes

This does not affect other kernels.

## Remaining problems:

JLab cannot identify the entire indented code block so only the first statement inside an `if`, `for` , `def`, or `class` would be executed. #6606 aims to fix it but has some side effects.

![image](https://user-images.githubusercontent.com/9889312/59786718-7f949a00-928d-11e9-879e-a771b5e0d0e6.png)

@jasongrout I think this one should be safe to merge before 1.0.