### PR TITLE
Add theme cookiecutter to the docs and release check-list

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -97,6 +97,7 @@ JupyterLab itself, run `jlpm run bumpversion major`.
   - [ ] https://github.com/jupyterlab/extension-cookiecutter-ts
   - [ ] https://github.com/jupyterlab/mimerender-cookiecutter
   - [ ] https://github.com/jupyterlab/mimerender-cookiecutter-ts
+  - [ ] https://github.com/jupyterlab/theme-cookiecutter
   - [ ] https://github.com/jupyterlab/jupyter-renderers
   - [ ] https://github.com/jupyterhub/jupyterlab-hub
 - [ ] Add a tag to [ts cookiecutter](https://github.com/jupyterlab/extension-cookiecutter-ts) with the new JupyterLab version

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -43,7 +43,7 @@ A plugin adds a core functionality to the application:
    interface, by exporting a plugin object or array of plugin objects as
    the default export.
 
-   We provide two cookie cutters to create JuptyerLab plugin extensions in
+   We provide two cookie cutters to create JupyterLab plugin extensions in
    `CommonJS <https://github.com/jupyterlab/extension-cookiecutter-js>`__ and
    `TypeScript <https://github.com/jupyterlab/extension-cookiecutter-ts>`__.
 
@@ -299,6 +299,9 @@ location of your choice, and start making desired changes.
 
 The theme extension is installed in the same way as a regular extension (see
 `extension authoring <#extension-authoring>`__).
+
+It is also possible to create a new theme using the
+`TypeScript theme cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`__.
 
 Standard (General-Purpose) Extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## References

There is a new cookiecutter that was recently introduced by @telamonian to create a theme more easily: https://github.com/jupyterlab/theme-cookiecutter

There is also some discussion in https://github.com/jupyterlab/jupyterlab/issues/5893 about this cookiecutter and the `create:theme` command.

## Code changes

None.

The removal / deprecation of the `create:theme` command is not implemented (left as a good first issue)

## User-facing changes

N/A

## Backwards-incompatible changes

N/A

cc @deeplook who was interested in this