### PR TITLE
Remove the settings editor bug icon and always display the error inspector

### DIFF
--- a/packages/settingeditor-extension/schema/plugin.json
+++ b/packages/settingeditor-extension/schema/plugin.json
@@ -3,11 +3,6 @@
   "description": "Setting editor settings.",
   "jupyter.lab.shortcuts": [
     {
-      "command": "settingeditor:debug",
-      "keys": ["Accel I"],
-      "selector": ".jp-SettingEditor"
-    },
-    {
       "command": "settingeditor:open",
       "keys": ["Accel ,"],
       "selector": "body"

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -30,8 +30,6 @@ import {
  * The command IDs used by the setting editor.
  */
 namespace CommandIDs {
-  export const debug = 'settingeditor:debug';
-
   export const open = 'settingeditor:open';
 
   export const revert = 'settingeditor:revert';
@@ -85,15 +83,6 @@ function activate(
     name: widget => namespace
   });
 
-  commands.addCommand(CommandIDs.debug, {
-    execute: () => {
-      tracker.currentWidget.content.toggleDebug();
-    },
-    iconClass: 'jp-MaterialIcon jp-BugIcon',
-    label: 'Debug User Settings In Inspector',
-    isToggled: () => tracker.currentWidget.content.isDebugVisible
-  });
-
   commands.addCommand(CommandIDs.open, {
     execute: () => {
       if (tracker.currentWidget) {
@@ -107,7 +96,6 @@ function activate(
       editor = new SettingEditor({
         commands: {
           registry: commands,
-          debug: CommandIDs.debug,
           revert: CommandIDs.revert,
           save: CommandIDs.save
         },

--- a/packages/settingeditor/src/plugineditor.ts
+++ b/packages/settingeditor/src/plugineditor.ts
@@ -202,11 +202,6 @@ export namespace PluginEditor {
       registry: CommandRegistry;
 
       /**
-       * The debug command ID.
-       */
-      debug: string;
-
-      /**
        * The revert command ID.
        */
       revert: string;

--- a/packages/settingeditor/src/raweditor.ts
+++ b/packages/settingeditor/src/raweditor.ts
@@ -122,13 +122,6 @@ export class RawEditor extends SplitPanel {
   }
 
   /**
-   * Whether the debug panel is visible.
-   */
-  get isDebugVisible(): boolean {
-    return this._inspector.isVisible;
-  }
-
-  /**
    * Tests whether the settings have been modified and need saving.
    */
   get isDirty(): boolean {
@@ -235,20 +228,6 @@ export class RawEditor extends SplitPanel {
   }
 
   /**
-   * Toggle the debug functionality.
-   */
-  toggleDebug(): void {
-    const inspector = this._inspector;
-
-    if (inspector.isHidden) {
-      inspector.show();
-    } else {
-      inspector.hide();
-    }
-    this._updateToolbar();
-  }
-
-  /**
    * Handle `after-attach` messages.
    */
   protected onAfterAttach(msg: Message): void {
@@ -313,11 +292,7 @@ export class RawEditor extends SplitPanel {
 
     this._canRevert = revert;
     this._canSave = save;
-    this._commandsChanged.emit([
-      commands.debug,
-      commands.revert,
-      commands.save
-    ]);
+    this._commandsChanged.emit([commands.revert, commands.save]);
   }
 
   private _canRevert = false;
@@ -344,11 +319,6 @@ export namespace RawEditor {
      * The command registry.
      */
     registry: CommandRegistry;
-
-    /**
-     * The debug command ID.
-     */
-    debug: string;
 
     /**
      * The revert command ID.
@@ -420,14 +390,14 @@ namespace Private {
     commands: RawEditor.ICommandBundle,
     toolbar: Toolbar<Widget>
   ): void {
-    const { debug, registry, revert, save } = commands;
+    const { registry, revert, save } = commands;
 
     toolbar.addItem('spacer', Toolbar.createSpacerItem());
 
     // Note the button order. The rationale here is that no matter what state
     // the toolbar is in, the relative location of the revert button in the
     // toolbar remains the same.
-    [revert, debug, save].forEach(name => {
+    [revert, save].forEach(name => {
       const item = new CommandToolbarButton({ commands: registry, id: name });
       toolbar.addItem(name, item);
     });

--- a/packages/settingeditor/src/settingeditor.tsx
+++ b/packages/settingeditor/src/settingeditor.tsx
@@ -131,13 +131,6 @@ export class SettingEditor extends Widget {
   }
 
   /**
-   * Whether the debug panel is visible.
-   */
-  get isDebugVisible(): boolean {
-    return this._editor.raw.isDebugVisible;
-  }
-
-  /**
    * The currently loaded settings.
    */
   get settings(): ISettingRegistry.ISettings {
@@ -178,13 +171,6 @@ export class SettingEditor extends Widget {
    */
   save(): Promise<void> {
     return this._editor.raw.save();
-  }
-
-  /**
-   * Toggle the debug functionality.
-   */
-  toggleDebug(): void {
-    this._editor.raw.toggleDebug();
   }
 
   /**
@@ -365,11 +351,6 @@ export namespace SettingEditor {
        * The command registry.
        */
       registry: CommandRegistry;
-
-      /**
-       * The debug command ID.
-       */
-      debug: string;
 
       /**
        * The revert command ID.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #6623 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Removes the bug icon in the settings editor and always displays the error messages.
<img width="404" alt="Screen Shot 2019-06-19 at 3 56 08 PM" src="https://user-images.githubusercontent.com/192614/59806873-c644bd00-92aa-11e9-912f-12f6515904c8.png">


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

Removes some commands and accessors dealing with hiding/showing the debug messages.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
