### PR TITLE
Adjust settings toolbar alignment

### DIFF
--- a/packages/settingeditor/style/base.css
+++ b/packages/settingeditor/style/base.css
@@ -130,7 +130,8 @@
 }
 
 #setting-editor .jp-SettingsRawEditor .jp-Toolbar-item {
-  margin-top: 2px;
+  margin-top: 1px;
+  align-items: center;
 }
 
 .jp-ToolbarButtonComponent-label


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6622
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Adjusts the alignment of toolbar items in the settings editor.

before:
<img width="343" alt="Screen Shot 2019-06-19 at 4 14 26 PM" src="https://user-images.githubusercontent.com/192614/59807564-571c9800-92ad-11e9-9471-59789af4e64a.png">


after:
<img width="357" alt="Screen Shot 2019-06-19 at 4 11 26 PM" src="https://user-images.githubusercontent.com/192614/59807539-3a806000-92ad-11e9-9ef7-09dcf0ed19a6.png">

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
