### PR TITLE
Use selected icons in tab manager when appropriate

### DIFF
--- a/packages/tabmanager-extension/style/base.css
+++ b/packages/tabmanager-extension/style/base.css
@@ -58,6 +58,46 @@
   background: var(--jp-brand-color1);
 }
 
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-NotebookIcon {
+  background-image: var(--jp-icon-book-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-OpenFolderIcon {
+  background-image: var(--jp-icon-directory-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-FileIcon {
+  background-image: var(--jp-icon-file-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-YamlIcon {
+  background-image: var(--jp-icon-yaml-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-MarkdownIcon {
+  background-image: var(--jp-icon-markdown-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-ImageIcon {
+  background-image: var(--jp-icon-image-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-SpreadsheetIcon {
+  background-image: var(--jp-icon-spreadsheet-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-JSONIcon {
+  background-image: var(--jp-icon-json-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-PythonIcon {
+  background-image: var(--jp-icon-python-selected);
+}
+
+#tab-manager .p-TabBar-tab.jp-mod-active .p-TabBar-tabIcon.jp-RKernelIcon {
+  background-image: var(--jp-icon-r-selected);
+}
+
 #tab-manager .p-TabBar-tabIcon,
 #tab-manager .p-TabBar-tabLabel,
 #tab-manager .p-TabBar-tabCloseIcon {


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6621
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Copies the code from the filebrowser listing. It feels like there should be a cleaner way than to duplicate the css code from the file listing for each possible icon.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Uses the appropriate selected icons in tab manager.

Before: see #6621 

After:
<img width="247" alt="Screen Shot 2019-06-19 at 4 29 52 PM" src="https://user-images.githubusercontent.com/192614/59808130-c98e7780-92af-11e9-8355-b11d6b83af01.png">

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
