### PR TITLE
Delete left over parameter "quiet" to fix error "TypeError:

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1482,7 +1482,7 @@ class _AppHandler(object):
                 # Verify that the version is a valid extension.
                 with TemporaryDirectory() as tempdir:
                     info = self._extract_package(
-                        '%s@%s' % (name, version), tempdir, quiet=True)
+                        '%s@%s' % (name, version), tempdir)
                 if _validate_extension(info['data']):
                     # Invalid, do not consider other versions
                     return


### PR DESCRIPTION
_extract_package()" when trying to install jupyterlab-manager.

## References
Fixing issue #6634

## Code changes
Delete lef over parameter `quiet` from commit https://github.com/jupyterlab/jupyterlab/commit/64ba3c82f9203efc5f9102369acc2e402c700ea0