### PR TITLE
Minor changes to the launcher card styling

### DIFF
--- a/packages/launcher/style/base.css
+++ b/packages/launcher/style/base.css
@@ -111,7 +111,7 @@
   margin: 8px;
   padding: 0px;
   border: 1px solid var(--jp-border-color2);
-  background: var(--jp-layout-color1);
+  background: var(--jp-layout-color0);
   box-shadow: var(--jp-elevation-z2);
   transition: 0.2s box-shadow;
   border-radius: var(--jp-border-radius);
@@ -124,6 +124,7 @@
 
 .jp-LauncherCard:hover {
   box-shadow: var(--jp-elevation-z6);
+  background: var(--jp-layout-color1);
 }
 
 .jp-LauncherCard:active {


### PR DESCRIPTION
This changes the launcher card background at rest and on hover.

## References

Fixes #6639 with the suggestion therein.

## User-facing changes

Light theme is the same, dark mode at rest:

<img width="166" alt="Screen Shot 2019-06-20 at 2 52 17 PM" src="https://user-images.githubusercontent.com/27600/59883773-079ca180-936b-11e9-899c-aa5542b3bbac.png">

On hover:

<img width="182" alt="Screen Shot 2019-06-20 at 2 52 24 PM" src="https://user-images.githubusercontent.com/27600/59883782-0b302880-936b-11e9-9c16-3a792443a590.png">





