### PR TITLE
Fix usage of bind in application busy status.

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -233,7 +233,7 @@ async function activateConsole(
       contentFactory,
       mimeTypeService: editorServices.mimeTypeService,
       rendermime,
-      setBusy: status ? status.setBusy.bind(status) : undefined,
+      setBusy: status && (() => status.setBusy()),
       ...(options as Partial<ConsolePanel.IOptions>)
     });
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -123,7 +123,7 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
       manager,
       opener,
       when,
-      setBusy: status.setBusy.bind(app)
+      setBusy: status && (() => status.setBusy())
     });
 
     // Register the file operations commands.


### PR DESCRIPTION
## References

Fixes #6668 

## Code changes

`bind` is bad. Particularly when it binds to the wrong thing and `this` no longer references what we thing it references. Also, it loses type-safety.

## User-facing changes

The favicon now changes as expected when the kernel is busy.

## Backwards-incompatible changes

None