### PR TITLE
Default screen reader mode on terminals to false

### DIFF
--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -51,6 +51,12 @@
       "$ref": "#/definitions/theme",
       "default": "inherit"
     },
+    "screenReaderMode": {
+      "title": "Screen Reader Mod3",
+      "description": "Whether add accessibility elements for use with screen readers.",
+      "type": "boolean",
+      "default": false
+    },
     "scrollback": {
       "title": "Scrollback Buffer",
       "description": "The amount of scrollback beyond initial viewport",

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -53,7 +53,7 @@
     },
     "screenReaderMode": {
       "title": "Screen Reader Mode",
-      "description": "Whether add accessibility elements for use with screen readers.",
+      "description": "Add accessibility elements for use with screen readers.",
       "type": "boolean",
       "default": false
     },
@@ -65,13 +65,13 @@
     },
     "shutdownOnClose": {
       "title": "Shut down on close",
-      "description": "Whether to shut down or not the session when closing the terminal.",
+      "description": "Shut down the session when closing the terminal.",
       "type": "boolean",
       "default": false
     },
     "pasteWithCtrlV": {
       "title": "Paste with Ctrl+V",
-      "description": "Whether to enable pasting with Ctrl+V.  This can be disabled to use Ctrl+V in the vi editor, for instance.  This setting has no effect on macOS, where Cmd+V is available",
+      "description": "Enable pasting with Ctrl+V.  This can be disabled to use Ctrl+V in the vi editor, for instance.  This setting has no effect on macOS, where Cmd+V is available",
       "type": "boolean",
       "default": true
     }

--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -52,7 +52,7 @@
       "default": "inherit"
     },
     "screenReaderMode": {
-      "title": "Screen Reader Mod3",
+      "title": "Screen Reader Mode",
       "description": "Whether add accessibility elements for use with screen readers.",
       "type": "boolean",
       "default": false

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -97,8 +97,6 @@ export namespace ITerminal {
 
     /**
      * Whether to enable screen reader support.
-     *
-     * Set to false if you run into performance problems from DOM overhead
      */
     screenReaderMode: boolean;
 
@@ -122,7 +120,7 @@ export namespace ITerminal {
     shutdownOnClose: false,
     cursorBlink: true,
     initialCommand: '',
-    screenReaderMode: false, // False by default, can cause scrollbar rendering issues.
+    screenReaderMode: false, // False by default, can cause scrollbar mouse interaction issues.
     pasteWithCtrlV: true
   };
 

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -122,7 +122,7 @@ export namespace ITerminal {
     shutdownOnClose: false,
     cursorBlink: true,
     initialCommand: '',
-    screenReaderMode: true,
+    screenReaderMode: false, // False by default, can cause scrollbar rendering issues.
     pasteWithCtrlV: true
   };
 


### PR DESCRIPTION
It can still be enabled in the settings editor.

## References

Fixes #6674. I wish I had a better understanding of why this was a fix, but I don't.

## Code changes

Default screen reader mode to `false` in the terminal. Add it to the settings schema so it can be user-configured.

## User-facing changes

Scroll bar is working again. Screen-reader users must enable screen-reader mode.

## Backwards-incompatible changes

None