### PR TITLE
Workaround for Chrome download issue

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -314,14 +314,21 @@ export class FileBrowserModel implements IDisposable {
    */
   download(path: string): Promise<void> {
     return this.manager.services.contents.getDownloadUrl(path).then(url => {
-      let element = document.createElement('a');
-      document.body.appendChild(element);
-      element.setAttribute('href', url);
-      element.setAttribute('target', '_blank');
-      element.setAttribute('download', '');
-      element.click();
-      document.body.removeChild(element);
-      return void 0;
+      // Check the browser is Chrome https://stackoverflow.com/a/9851769
+      const chrome = (window as any).chrome;
+      const isChrome = !!chrome && (!!chrome.webstore || !!chrome.runtime);
+      if (isChrome) {
+        // Workaround https://bugs.chromium.org/p/chromium/issues/detail?id=455987
+        window.open(url);
+      } else {
+        let element = document.createElement('a');
+        document.body.appendChild(element);
+        element.setAttribute('href', url);
+        element.setAttribute('download', '');
+        element.click();
+        document.body.removeChild(element);
+        return void 0;
+      }
     });
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/6658

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

This is a temporary (safe) version of this PR https://github.com/jupyterlab/jupyterlab/pull/6686

If the other PR is vetted, this one should be replaced.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Use `window.open` in Chrome. This downloads many file types in a new tab, and opens others (they can be saved by copy-paste).
