### PR TITLE
Support yarn configs with plain workspaces lists.

### DIFF
--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -15,7 +15,8 @@ export function getLernaPaths(basePath = '.'): string[] {
   basePath = path.resolve(basePath);
   let baseConfig = require(path.join(basePath, 'package.json'));
   let paths: string[] = [];
-  for (let config of baseConfig.workspaces.packages) {
+  let packages = baseConfig.workspaces.packages || baseConfig.workspaces;
+  for (let config of packages) {
     paths = paths.concat(glob.sync(path.join(basePath, config)));
   }
   return paths.filter(pkgPath => {


### PR DESCRIPTION
This is so that other projects can use buildutils even if they don’t use the nohoists format for their yarn workspace config.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This was updated in #6591. 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Other projects sometimes would like to use buildutils (for example, I use the update-dependency script to update things in ipywidgets), so understanding both versions of the yarn workspaces format is very useful.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
