### PR TITLE
Unpin tornado (bump to 6.x) 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,17 +20,13 @@ makes sure that we don't have any extra tags or commits in our repo (especially
 since we will push our tags later in the process), and that we are on the master
 branch.
 
-Note that right now, we pin tornado to version 5 because there are some
-incompatibilities with tornado 6. See
-https://github.com/jupyterlab/jupyterlab/issues/6131.
-
 ```bash
 cd release
 conda deactivate
 conda remove --all -y -n jlabrelease
 rm -rf jupyterlab
 
-conda create -c conda-forge -y -n jlabrelease notebook nodejs twine 'tornado<6'
+conda create -c conda-forge -y -n jlabrelease notebook nodejs twine
 conda activate jlabrelease
 git clone git@github.com:jupyterlab/jupyterlab.git
 cd jupyterlab

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup_args = dict(
 
 setup_args['install_requires'] = [
     'notebook>=4.3.1',
-    'tornado<6',
+    'tornado>=6.0.3',
     'jupyterlab_server~=1.0.0rc0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup_args = dict(
 
 setup_args['install_requires'] = [
     'notebook>=4.3.1',
-    'tornado>=6.0.3',
+    'tornado!=6.0.0, !=6.0.1, !=6.0.2',
     'jupyterlab_server~=1.0.0rc0'
 ]
 


### PR DESCRIPTION
:tada: Unpin tornado! 🎉 

## References

Fixes #6131. 

This problem was caused by a bug in tornado that we fixed in tornadoweb/tornado#2670. 


## Code changes

Unpin tornado from `5.x` to `>=6.0.3` in `setup.py`. 
