### PR TITLE
Eliminate scrolling on search with no match

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -527,7 +527,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     options?: { bias?: number; origin?: string; scroll?: boolean }
   ): void {
     const cursor = this._toCodeMirrorPosition(position);
-    this.doc.setCursor(cursor.line, cursor.ch, options);
+    this.doc.setCursor(cursor, undefined, options);
     // If the editor does not have focus, this cursor change
     // will get screened out in _onCursorsChanged(). Make an
     // exception for this method.

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -522,9 +522,12 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * #### Notes
    * This will remove any secondary cursors.
    */
-  setCursorPosition(position: CodeEditor.IPosition): void {
+  setCursorPosition(
+    position: CodeEditor.IPosition,
+    options?: { bias?: number; origin?: string; scroll?: boolean }
+  ): void {
     const cursor = this._toCodeMirrorPosition(position);
-    this.doc.setCursor(cursor);
+    this.doc.setCursor(cursor.line, cursor.ch, options);
     // If the editor does not have focus, this cursor change
     // will get screened out in _onCursorsChanged(). Make an
     // exception for this method.

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -473,7 +473,6 @@ export class CodeMirrorSearchProvider implements ISearchProvider {
       };
 
       this._cm.setSelection(selRange);
-
       this._cm.scrollIntoView(
         {
           from: fromPos,

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -441,7 +441,7 @@ export class CodeMirrorSearchProvider implements ISearchProvider {
       if (!cursor.find(reverse)) {
         // if we don't want to loop, no more matches found, reset the cursor and exit
         if (this.isSubProvider) {
-          this._cm.setCursorPosition(position);
+          this._cm.setCursorPosition(position, { scroll: false });
           this._currentMatch = null;
           return null;
         }
@@ -474,7 +474,6 @@ export class CodeMirrorSearchProvider implements ISearchProvider {
 
       this._cm.setSelection(selRange);
 
-      console.log('scrolling from to: ', fromPos, toPos);
       this._cm.scrollIntoView(
         {
           from: fromPos,

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -473,6 +473,8 @@ export class CodeMirrorSearchProvider implements ISearchProvider {
       };
 
       this._cm.setSelection(selRange);
+
+      console.log('scrolling from to: ', fromPos, toPos);
       this._cm.scrollIntoView(
         {
           from: fromPos,

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -160,7 +160,6 @@ export class NotebookSearchProvider implements ISearchProvider {
     });
     this._unRenderedMarkdownCells = [];
 
-    console.log('setting active cell index to: ', index);
     this._searchTarget.content.activeCellIndex = index;
     this._searchTarget.content.mode = 'edit';
     this._searchTarget = null;
@@ -281,7 +280,6 @@ export class NotebookSearchProvider implements ISearchProvider {
     steps = 0
   ): Promise<ISearchMatch | undefined> {
     const notebook = this._searchTarget.content;
-    // const activeCell: Cell = notebook.activeCell;
     const cellIndex = notebook.widgets.indexOf(activeCell);
     const numCells = notebook.widgets.length;
     const { provider } = this._cmSearchProviders[cellIndex];
@@ -302,8 +300,7 @@ export class NotebookSearchProvider implements ISearchProvider {
       }
       const nextIndex =
         ((reverse ? cellIndex - 1 : cellIndex + 1) + numCells) % numCells;
-      console.log('nextindex: ', nextIndex);
-      const editor = notebook.activeCell.editor as CodeMirrorEditor;
+      const editor = notebook.widgets[nextIndex].editor as CodeMirrorEditor;
       // move the cursor of the next cell to the start/end of the cell so it can
       // search the whole thing
       const newPosCM = reverse
@@ -313,10 +310,11 @@ export class NotebookSearchProvider implements ISearchProvider {
         line: newPosCM.line,
         column: newPosCM.ch
       };
-      editor.setCursorPosition(newPos);
+      editor.setCursorPosition(newPos, { scroll: false });
       return this._stepNext(notebook.widgets[nextIndex], reverse, steps + 1);
     }
 
+    notebook.activeCellIndex = cellIndex;
     return match;
   }
 

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -302,7 +302,7 @@ export class NotebookSearchProvider implements ISearchProvider {
         ((reverse ? cellIndex - 1 : cellIndex + 1) + numCells) % numCells;
       const editor = notebook.widgets[nextIndex].editor as CodeMirrorEditor;
       // move the cursor of the next cell to the start/end of the cell so it can
-      // search the whole thing
+      // search the whole thing (but don't scroll because we haven't found anything yet)
       const newPosCM = reverse
         ? CodeMirror.Pos(editor.lastLine())
         : CodeMirror.Pos(editor.firstLine(), 0);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This addresses part of #6650.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
This changes the notebooksearchprovider to avoid setting the active cell for each cell it searches, only setting the active cell if it finds a match.  It also adds the optional options argument to the `setCursorPosition` function on the `CodeMirrorEditor` interface, in alignment with the [documentation](https://codemirror.net/doc/manual.html#setCursor).  Without the options object, CodeMirror was defaulting to scrolling any time the cursor was set.  When searching the cells, the cursor must be set to the start or end of the cell (`highlightNext` vs `highlightPrevious`) in order for the `SearchCursor` to search the whole cell.  Now we can turn off the scrolling behavior when looping through the cells to search.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
This eliminates the scrolling that would occur when searching for something for which there was no match.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
This adds the options object as a parameter to the `setCursorPosition` on `CodeMirrorEditor`.  This is an optional argument, so it shouldn't be backwards incompatible.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
