### PR TITLE
Added debug messages

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -600,7 +600,14 @@ export class DefaultKernel implements Kernel.IKernel {
   }
 
   /**
-   * Send an `debug_request` message.
+   * Send an experimental `debug_request` message.
+   *
+   * @hidden
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this function is *NOT* considered
+   * part of the public API, and may change without notice.
    */
   requestDebug(
     content: KernelMessage.IDebugRequestMsg['content'],

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -600,6 +600,33 @@ export class DefaultKernel implements Kernel.IKernel {
   }
 
   /**
+   * Send an `debug_request` message.
+   */
+  requestDebug(
+    content: KernelMessage.IDebugRequestMsg['content'],
+    disposeOnDone: boolean = true
+  ): Kernel.IControlFuture<
+    KernelMessage.IDebugRequestMsg,
+    KernelMessage.IDebugReplyMsg
+  > {
+    let msg = KernelMessage.createMessage({
+      msgType: 'debug_request',
+      channel: 'control',
+      username: this._username,
+      session: this._clientId,
+      content
+    });
+    return this.sendControlMessage(
+      msg,
+      true,
+      disposeOnDone
+    ) as Kernel.IControlFuture<
+      KernelMessage.IDebugRequestMsg,
+      KernelMessage.IDebugReplyMsg
+    >;
+  }
+
+  /**
    * Send an `is_complete_request` message.
    *
    * #### Notes

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -279,13 +279,20 @@ export namespace Kernel {
     >;
 
     /**
-     * Send an `execute_request` message.
+     * Send an experimental `debug_request` message.
+     *
+     * @hidden
      *
      * @param content - The content of the request.
      *
      * @param disposeOnDone - Whether to dispose of the future when done.
      *
      * @returns A kernel future.
+     *
+     * #### Notes
+     * Debug messages are experimental messages that are not in the official
+     * kernel message specification. As such, this function is *NOT* considered
+     * part of the public API, and may change without notice.
      */
     requestDebug(
       content: KernelMessage.IDebugRequestMsg['content'],

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -279,6 +279,23 @@ export namespace Kernel {
     >;
 
     /**
+     * Send an `execute_request` message.
+     *
+     * @param content - The content of the request.
+     *
+     * @param disposeOnDone - Whether to dispose of the future when done.
+     *
+     * @returns A kernel future.
+     */
+    requestDebug(
+      content: KernelMessage.IDebugRequestMsg['content'],
+      disposeOnDone?: boolean
+    ): Kernel.IControlFuture<
+      KernelMessage.IDebugRequestMsg,
+      KernelMessage.IDebugReplyMsg
+    >;
+
+    /**
      * Send an `is_complete_request` message.
      *
      * @param content - The content of the request.

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -108,6 +108,15 @@ export namespace KernelMessage {
   export function createMessage<T extends IUpdateDisplayDataMsg>(
     options: IOptions<T>
   ): T;
+  export function createMessage<T extends IDebugRequestMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IDebugReplyMsg>(
+    options: IOptions<T>
+  ): T;
+  export function createMessage<T extends IDebugEventMsg>(
+    options: IOptions<T>
+  ): T;
 
   export function createMessage<T extends Message>(options: IOptions<T>): T {
     return {
@@ -156,7 +165,7 @@ export namespace KernelMessage {
   /**
    * Control message types.
    */
-  export type ControlMessageType = never;
+  export type ControlMessageType = 'debug_request' | 'debug_reply';
 
   /**
    * IOPub message types.
@@ -172,7 +181,8 @@ export namespace KernelMessage {
     | 'execute_result'
     | 'status'
     | 'stream'
-    | 'update_display_data';
+    | 'update_display_data'
+    | 'debug_event';
 
   /**
    * Stdin message types.
@@ -340,7 +350,10 @@ export namespace KernelMessage {
     | IIsCompleteRequestMsg
     | IStatusMsg
     | IStreamMsg
-    | IUpdateDisplayDataMsg;
+    | IUpdateDisplayDataMsg
+    | IDebugRequestMsg
+    | IDebugReplyMsg
+    | IDebugEventMsg;
 
   //////////////////////////////////////////////////
   // IOPub Messages
@@ -501,6 +514,22 @@ export namespace KernelMessage {
    */
   export function isClearOutputMsg(msg: IMessage): msg is IClearOutputMsg {
     return msg.header.msg_type === 'clear_output';
+  }
+
+  /**
+   * A `'debug_event'` message on the `'iopub'` channel
+   */
+  export interface IDebugEventMsg extends IIOPubMessage<'debug_event'> {
+    content: {
+      seq: number;
+      type: 'event';
+      event: string;
+      body?: any;
+    };
+  }
+
+  export function isDebugEventMsg(msg: IMessage): msg is IDebugEventMsg {
+    return msg.header.msg_type === 'debug_event';
   }
 
   //////////////////////////////////////////////////
@@ -1020,6 +1049,51 @@ export namespace KernelMessage {
   export interface ICommInfoReplyMsg extends IShellMessage<'comm_info_reply'> {
     parent_header: IHeader<'comm_info_request'>;
     content: ReplyContent<ICommInfoReply>;
+  }
+
+  /////////////////////////////////////////////////
+  // Control Messages
+  /////////////////////////////////////////////////
+
+  /**
+   * A `'debug_request'` messsage on the `'control'` channel.
+   */
+  export interface IDebugRequestMsg extends IControlMessage<'debug_request'> {
+    content: {
+      seq: number;
+      type: 'request';
+      command: string;
+      arguments?: any;
+    };
+  }
+
+  /**
+   * Test whether a kernel message is an `'debug_request'` message.
+   */
+  export function isDebugRequestMsg(msg: IMessage): msg is IDebugRequestMsg {
+    return msg.header.msg_type === 'debug_request';
+  }
+
+  /**
+   * A `'debug_reply'` messsage on the `'control'` channel.
+   */
+  export interface IDebugReplyMsg extends IControlMessage<'debug_reply'> {
+    content: {
+      seq: number;
+      type: 'response';
+      request_seq: number;
+      success: boolean;
+      command: string;
+      message?: string;
+      body?: any;
+    };
+  }
+
+  /**
+   * Test whether a kernel message is an `'debug_reply'` message.
+   */
+  export function isDebugReplyMsg(msg: IMessage): msg is IDebugReplyMsg {
+    return msg.header.msg_type === 'debug_reply';
   }
 
   //////////////////////////////////////////////////

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -1179,7 +1179,6 @@ export namespace KernelMessage {
    * Debug messages are experimental messages that are not in the official
    * kernel message specification. As such, this is *NOT* considered
    * part of the public API, and may change without notice.
-
    */
   export function isDebugReplyMsg(msg: IMessage): msg is IDebugReplyMsg {
     return msg.header.msg_type === 'debug_reply';

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -108,12 +108,36 @@ export namespace KernelMessage {
   export function createMessage<T extends IUpdateDisplayDataMsg>(
     options: IOptions<T>
   ): T;
+
+  /**
+   * @hidden
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this function is *NOT* considered
+   * part of the public API, and may change without notice.
+   */
   export function createMessage<T extends IDebugRequestMsg>(
     options: IOptions<T>
   ): T;
+
+  /**
+   * @hidden
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this function is *NOT* considered
+   * part of the public API, and may change without notice.
+   */
   export function createMessage<T extends IDebugReplyMsg>(
     options: IOptions<T>
   ): T;
+
+  /**
+   * @hidden
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this function is *NOT* considered
+   * part of the public API, and may change without notice.
+   */
   export function createMessage<T extends IDebugEventMsg>(
     options: IOptions<T>
   ): T;
@@ -164,11 +188,21 @@ export namespace KernelMessage {
 
   /**
    * Control message types.
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, debug message types are *NOT*
+   * considered part of the public API, and may change without notice.
    */
   export type ControlMessageType = 'debug_request' | 'debug_reply';
 
   /**
    * IOPub message types.
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, debug message types are *NOT*
+   * considered part of the public API, and may change without notice.
    */
   export type IOPubMessageType =
     | 'clear_output'
@@ -320,6 +354,14 @@ export namespace KernelMessage {
     channel: 'stdin';
   }
 
+  /**
+   * Message types.
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, debug message types are *NOT*
+   * considered part of the public API, and may change without notice.
+   */
   export type Message =
     | IClearOutputMsg
     | ICommCloseMsg<'iopub'>
@@ -517,7 +559,14 @@ export namespace KernelMessage {
   }
 
   /**
-   * A `'debug_event'` message on the `'iopub'` channel
+   * An experimental `'debug_event'` message on the `'iopub'` channel
+   *
+   * @hidden
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this is *NOT* considered
+   * part of the public API, and may change without notice.
    */
   export interface IDebugEventMsg extends IIOPubMessage<'debug_event'> {
     content: {
@@ -527,6 +576,17 @@ export namespace KernelMessage {
       body?: any;
     };
   }
+
+  /**
+   * Test whether a kernel message is an experimental `'debug_event'` message.
+   *
+   * @hidden
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this is *NOT* considered
+   * part of the public API, and may change without notice.
+   */
 
   export function isDebugEventMsg(msg: IMessage): msg is IDebugEventMsg {
     return msg.header.msg_type === 'debug_event';
@@ -1056,7 +1116,14 @@ export namespace KernelMessage {
   /////////////////////////////////////////////////
 
   /**
-   * A `'debug_request'` messsage on the `'control'` channel.
+   * An experimental `'debug_request'` messsage on the `'control'` channel.
+   *
+   * @hidden
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this function is *NOT* considered
+   * part of the public API, and may change without notice.
    */
   export interface IDebugRequestMsg extends IControlMessage<'debug_request'> {
     content: {
@@ -1068,14 +1135,28 @@ export namespace KernelMessage {
   }
 
   /**
-   * Test whether a kernel message is an `'debug_request'` message.
+   * Test whether a kernel message is an experimental `'debug_request'` message.
+   *
+   * @hidden
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this is *NOT* considered
+   * part of the public API, and may change without notice.
    */
   export function isDebugRequestMsg(msg: IMessage): msg is IDebugRequestMsg {
     return msg.header.msg_type === 'debug_request';
   }
 
   /**
-   * A `'debug_reply'` messsage on the `'control'` channel.
+   * An experimental `'debug_reply'` messsage on the `'control'` channel.
+   *
+   * @hidden
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this is *NOT* considered
+   * part of the public API, and may change without notice.
    */
   export interface IDebugReplyMsg extends IControlMessage<'debug_reply'> {
     content: {
@@ -1090,7 +1171,15 @@ export namespace KernelMessage {
   }
 
   /**
-   * Test whether a kernel message is an `'debug_reply'` message.
+   * Test whether a kernel message is an experimental `'debug_reply'` message.
+   *
+   * @hidden
+   *
+   * #### Notes
+   * Debug messages are experimental messages that are not in the official
+   * kernel message specification. As such, this is *NOT* considered
+   * part of the public API, and may change without notice.
+
    */
   export function isDebugReplyMsg(msg: IMessage): msg is IDebugReplyMsg {
     return msg.header.msg_type === 'debug_reply';


### PR DESCRIPTION
## References

This PR partially implements changes described in jupyter/jupyter_client#446.
It completes https://github.com/jupyterlab/jupyterlab/pull/6544 and allows to send debug_request messages on the Control channel.

This PR should not be merged until the Jupyter Kernel Protocol has been updated as described in jupyter/jupyter_client#446.

## Code changes

- Adds interface for messages sent on the Control channel, as well as new message types for debugging.
- A new method has been added in the default kernel implementation (`requestDebug`)

## User-facing changes

None

## Backwards-incompatible changes

None
