### PR TITLE
reenables #5722: the `jlpm analyze`/webpack-visualizer command

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "scripts": {
     "add:sibling": "node buildutils/lib/add-sibling.js",
     "analyze": "jlpm run analyze:dev",
-    "analyze:dev": "cd dev_mode && jlpm run build --analyze && opn static/stats.html",
-    "analyze:prod": "cd dev_mode && jlpm run build:prod --analyze && opn static/stats.html",
+    "analyze:dev": "cd dev_mode && jlpm run build --analyze && open-cli static/stats.html",
+    "analyze:prod": "cd dev_mode && jlpm run build:prod --analyze && open-cli static/stats.html",
     "build": "jlpm run build:dev",
     "build:core": "cd jupyterlab/staging && jlpm && (jlpm deduplicate || jlpm) && jlpm run build",
     "build:dev": "jlpm run integrity && jlpm run build:vega && jlpm run build:packages && cd dev_mode && jlpm run build",
@@ -101,6 +101,7 @@
     "husky": "^2.3.0",
     "lerna": "^3.13.2",
     "lint-staged": "^8.1.5",
+    "open-cli": "^5.0.0",
     "prettier": "^1.17.0",
     "tslint": "^5.15.0",
     "tslint-config-prettier": "^1.18.0",


### PR DESCRIPTION
## References

The `jlpm analyze` command implemented in #5722 by @gnestor is currently broken. It relies on the deprecated `opn-cli` package and the `opn` command it provides. However, at some point the dependency on `opn-cli` was removed from `package.json`, which broke the command.

## Code changes

Added a dependency on `open-cli` (the new version of `opn-cli`) to `package.json`, and changed the broken `opn` commands to `open-cli`.

## User-facing changes

`jlpm analyze` will now run as expected, and produce a pretty graph of the dependencies/open it in a browser.

## Backwards-incompatible changes

None