### PR TITLE
Use mouseup vs. mousedown for toolbar buttons

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -440,11 +440,12 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
   // We avoid a click event by calling preventDefault in mousedown, and
   // we bind the button action to `mousedown`.
   const handleMouseDown = (event: React.MouseEvent) => {
-    // Fire action only when left button is pressed.
-    if (event.button === 0) {
-      event.preventDefault();
-      props.onClick();
-    }
+    event.preventDefault();
+  };
+
+  const handleMouseUp = (event: React.MouseEvent) => {
+    event.preventDefault();
+    props.onClick();
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -463,6 +464,7 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
       }
       disabled={props.enabled === false}
       onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
       onKeyDown={handleKeyDown}
       title={props.tooltip || props.iconLabel}
       minimal

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -443,7 +443,7 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
     event.preventDefault();
   };
 
-  const handleMouseUp = (event: React.MouseEvent) => {
+  const handleClick = (event: React.MouseEvent) => {
     event.preventDefault();
     props.onClick();
   };
@@ -464,7 +464,7 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
       }
       disabled={props.enabled === false}
       onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
+      onClick={handleClick}
       onKeyDown={handleKeyDown}
       title={props.tooltip || props.iconLabel}
       minimal

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -425,7 +425,7 @@ describe('@jupyterlab/apputils', () => {
           });
           Widget.attach(button, document.body);
           await framePromise();
-          simulate(button.node.firstChild as HTMLElement, 'mousedown');
+          simulate(button.node.firstChild as HTMLElement, 'click');
           expect(called).to.equal(true);
           button.dispose();
         });


### PR DESCRIPTION
This is a continuation of https://github.com/jupyterlab/jupyterlab/pull/6692 and closes https://github.com/jupyterlab/jupyterlab/issues/6691.

https://github.com/jupyterlab/jupyterlab/pull/6692 fixes the "toolbar button triggering on right-click" but doesn't address "toolbar button triggering on mousedown vs. mouseup". By calling `props.onClick` on mouseup vs. mousedown, we get behavior that is consistent with click while maintaining focus elsewhere in the app (click stole focus and that's why we're currently using mousedown). I have user tested and everything appears to be working as expected. 

cc @AlbertHilb @jasongrout 