### PR TITLE
Logging tweaks for labextension update

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1475,14 +1475,17 @@ class _AppHandler(object):
         for version, data in sorted(versions.items(),
                                     key=sort_key,
                                     reverse=True):
-            # skip deprecated versions
-            if 'deprecated' in data:
-                continue
-
             deps = data.get('dependencies', {})
             errors = _validate_compatibility(name, deps, core_data)
             if not errors:
                 # Found a compatible version
+                # skip deprecated versions
+                if 'deprecated' in data:
+                    self.logger.debug(
+                        'Disregarding compatible version of package as it is deprecated: %s@%s'
+                        % (name, version)
+                    )
+                    continue
                 # Verify that the version is a valid extension.
                 with TemporaryDirectory() as tempdir:
                     info = self._extract_package(

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -780,6 +780,7 @@ class _AppHandler(object):
         except URLError:
             return False
         if latest is None:
+            self.logger.warn('No compatible version found for %s!' % (name,))
             return False
         if latest == self.info['extensions'][name]['version']:
             self.logger.info('Extension %r already up to date' % name)


### PR DESCRIPTION
## References

Follow up to #6711.

## Code changes

- Logs a warning if no compatible version could be found when updating an extension (warnings goes to stderr by default, so the user will see it).
- Logs to debug if a deprecated, compatible version was found when updating an extension. This way, if the user cannot find a compatible version, the `--debug` flag will give the extra details to troubleshoot an issue,

## User-facing changes

When updating a package with no compatible versions:

```
jupyter labextension update @jupyter-widgets/jupyterlab-manager
No compatible version found for @jupyter-widgets/jupyterlab-manager
```

When adding the `--debug` flag:

```
jupyter labextension update @jupyter-widgets/jupyterlab-manager --debug
<debug output of paths snipped>
Node v11.9.0

Fetching URL: https://registry.npmjs.org/@jupyter-widgets%2Fjupyterlab-manager
Disregarding compatible version of package as it is deprecated: @jupyter-widgets/jupyterlab-manager@0.39.1
Disregarding compatible version of package as it is deprecated: @jupyter-widgets/jupyterlab-manager@0.39.0
Disregarding compatible version of package as it is deprecated: @jupyter-widgets/jupyterlab-manager@0.39.0-alpha.0
No compatible version found for @jupyter-widgets/jupyterlab-manager
```

## Backwards-incompatible changes

None.