### PR TITLE
clarify that cookiecutter is a Python tool

### DIFF
--- a/docs/source/developer/css.rst
+++ b/docs/source/developer/css.rst
@@ -15,7 +15,7 @@ CSS checklist
    subdirectory and imported into the plugin's ``index.css``.
 -  The JupyterLab default CSS variables in the ``theme-light-extension``
    and ``theme-dark-extension`` packages are used to style packages
-   where ever possible. Individual packages should not npm-depend on
+   wherever possible. Individual packages should not npm-depend on
    these packages though, to enable the theme to be swapped out.
 -  Additional public/private CSS variables are defined by plugins
    sparingly and in accordance with the conventions described below.

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -52,7 +52,7 @@ Next create a conda environment that includes:
 
 1. the latest release of JupyterLab
 2. `cookiecutter <https://github.com/audreyr/cookiecutter>`__, the tool
-   you'll use to bootstrap your extension project structure
+   you'll use to bootstrap your extension project structure (this is a Python tool, do not try to install with `npm`)
 3. `NodeJS <https://nodejs.org>`__, the JavaScript runtime you'll use to
    compile the web assets (e.g., TypeScript, CSS) for your extension
 4. `git <https://git-scm.com>`__, a version control system you'll use to

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -52,7 +52,7 @@ Next create a conda environment that includes:
 
 1. the latest release of JupyterLab
 2. `cookiecutter <https://github.com/audreyr/cookiecutter>`__, the tool
-   you'll use to bootstrap your extension project structure (this is a Python tool, do not try to install with `npm`)
+   you'll use to bootstrap your extension project structure; this is a Python tool, install with e.g. `pip install cookiecutter`
 3. `NodeJS <https://nodejs.org>`__, the JavaScript runtime you'll use to
    compile the web assets (e.g., TypeScript, CSS) for your extension
 4. `git <https://git-scm.com>`__, a version control system you'll use to


### PR DESCRIPTION
a simple clarification in the docs, that hopefully has no impact at all

I was following the tutorial and somehow managed to understand that `cookiecutter` was to be installed by `npm`...

I am pouring in the mix another typo that I came across earlier today