### PR TITLE
Update buildutils dep updater to support lerna

### DIFF
--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -15,7 +15,10 @@ export function getLernaPaths(basePath = '.'): string[] {
   basePath = path.resolve(basePath);
   let baseConfig = require(path.join(basePath, 'package.json'));
   let paths: string[] = [];
-  let packages = baseConfig.workspaces.packages || baseConfig.workspaces;
+  let packages =
+    baseConfig.workspaces.packages ||
+    baseConfig.workspaces ||
+    baseConfig.packages;
   for (let config of packages) {
     paths = paths.concat(glob.sync(path.join(basePath, config)));
   }


### PR DESCRIPTION
## Code changes

Allows buildutils/update-dependency to work on lerna repositories.

## User-facing changes
None

## Backwards-incompatible changes
None
