### PR TITLE
Change companion dialog title to "Kernel and Server Companions"

### DIFF
--- a/packages/extensionmanager/src/companions.tsx
+++ b/packages/extensionmanager/src/companions.tsx
@@ -151,8 +151,18 @@ export function presentCompanions(
       </p>
     </div>
   );
+  const hasKernelCompanions = kernelCompanions.length > 0;
+  const hasServerCompanion = !!serverCompanion;
+  let title = '';
+  if (hasKernelCompanions && hasServerCompanion) {
+    title = 'Kernel and Server Companions';
+  } else if (hasKernelCompanions) {
+    title = 'Kernel Companions';
+  } else {
+    title = 'Server Companion';
+  }
   return showDialog({
-    title: 'Kernel and Server Companions',
+    title,
     body,
     buttons: [
       Dialog.cancelButton(),

--- a/packages/extensionmanager/src/companions.tsx
+++ b/packages/extensionmanager/src/companions.tsx
@@ -152,13 +152,13 @@ export function presentCompanions(
     </div>
   );
   return showDialog({
-    title: 'Kernel companions',
+    title: 'Kernel and Server Companions',
     body,
     buttons: [
       Dialog.cancelButton(),
       Dialog.okButton({
         label: 'OK',
-        caption: 'Install the Jupyterlab extension.'
+        caption: 'Install the JupyterLab extension.'
       })
     ]
   }).then(result => {


### PR DESCRIPTION
## References

Follow-up on https://github.com/jupyterlab/jupyterlab/pull/4682

The metadata accepts entries for both `kernel` and `server` extensions, so this can also be reflected in the title of the dialog.

Technically the title could be even more specific depending on whether it's a kernel package or a package for a server extension, or both. But that's probably overkill. 

## User-facing changes

Change the title for the companion extension dialog to "Kernel and Server Companions"

## Backwards-incompatible changes

None.

### Before

![image](https://user-images.githubusercontent.com/591645/60293777-380ead80-9920-11e9-9463-8210ec50b1a0.png)


### After

![image](https://user-images.githubusercontent.com/591645/60293683-0695e200-9920-11e9-8c67-84ac630bab92.png)

