### PR TITLE
Use correctly typed searchtarget in NotebookSearchProvider

### DIFF
--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -110,7 +110,9 @@ export class NotebookSearchProvider implements ISearchProvider {
       });
     }
 
-    this._currentMatch = await this._stepNext(searchTarget.content.activeCell);
+    this._currentMatch = await this._stepNext(
+      this._searchTarget.content.activeCell
+    );
 
     return allMatches;
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes broken build introduced by combination of #6699 and #6716
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Fixes the build.  Switches to using `this._searchTarget` which has been typed as `NotebookPanel` and will have a `content` property.  Before, it was trying to access a `content` property on what it thought was just a `Widget`.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
