### PR TITLE
Fixes #6729: Do not attempt to select directories in goToPath

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -452,18 +452,19 @@ function addCommands(
     execute: async args => {
       const path = (args.path as string) || '';
       try {
-        await Private.navigateToPath(path, factory);
+        const item = await Private.navigateToPath(path, factory);
+        if (item.type !== 'directory') {
+          const browserForPath = Private.getBrowserForPath(path, factory);
+          browserForPath.clearSelectedItems();
+          const parts = path.split('/');
+          const name = parts[parts.length - 1];
+          if (name) {
+            await browserForPath.selectItemByName(name);
+          }
+        }
       } catch (reason) {
         console.warn(`${CommandIDs.goToPath} failed to go to: ${path}`, reason);
       }
-      const browserForPath = Private.getBrowserForPath(path, factory);
-      browserForPath.clearSelectedItems();
-      const parts = path.split('/');
-      const name = parts[parts.length - 1];
-      if (name) {
-        await browserForPath.selectItemByName(name);
-      }
-
       return commands.execute(CommandIDs.showBrowser, { path });
     }
   });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

https://github.com/jupyterlab/jupyterlab/issues/6729

Sorry about this one, it was my fault!

I personally find the `navigateToPath` and `getBrowserForPath` callings a bit weird now, but I tried to fix this issue with minimal changes for now. Might want to look at simplifying these flows later.