### PR TITLE
Fix publish on Windows

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,9 +67,11 @@ JupyterLab itself, run `jlpm run bumpversion major`.
 
 - Run `jlpm run bumpversion build` to create a new `alpha` version.
 - Push the commits and tags as prompted.
-- Run `jlpm run publish:all` to publish the JS and Python packages.
+- Run `npm run publish:all` to publish the JS and Python packages.
+  Note that the use of `npm` instead of `jlpm` is
+  [significant on Windows](https://github.com/jupyterlab/jupyterlab/issues/6733).
   Execute the suggested commands after doing a quick sanity check.
-  If there is a network error during JS publish, run `jlpm run publish:all --skip-build` to resume publish without requiring another
+  If there is a network error during JS publish, run `npm run publish:all --skip-build` to resume publish without requiring another
   clean and build phase of the JS packages.
 - Run `jlpm run bumpversion release` to switch to an `rc` version.
   (running `jlpm run bumpversion build` will then increment `rc` versions).
@@ -106,7 +108,7 @@ Now do the actual final release:
 
 - [ ] Run `jlpm run bumpversion release` to switch to final release
 - [ ] Push the commit and tags to master
-- [ ] Run `jlpm run publish:all` to publish the packages
+- [ ] Run `npm run publish:all` to publish the packages
 - [ ] Create a branch for the release and push to GitHub
 - [ ] Merge the PRs on the other repos and set the default branch of the
       xckd repo
@@ -117,7 +119,7 @@ the next release:
 
 - [ ] Run `jlpm run bumpversion minor` to bump to alpha for the next alpha release
 - [ ] Put the commit and tags to master
-- [ ] Run `jlpm run publish:all` to publish the packages
+- [ ] Run `npm run publish:all` to publish the packages
 - [ ] Release the other repos as appropriate
 - [ ] Update version for [binder](https://github.com/jupyterlab/jupyterlab/blob/master/RELEASE.md#update-version-for-binder)
 

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -219,7 +219,9 @@ function ensureJupyterlab(): string[] {
     }
 
     // watch all src, build, and test files in the Jupyterlab project
-    let relativePath = `../${path.relative(basePath, pkgPath)}`;
+    let relativePath = utils.ensureUnixPathSep(
+      path.join('..', path.relative(basePath, pkgPath))
+    );
     corePackage.jupyterlab.linkedPackages[data.name] = relativePath;
   });
 

--- a/buildutils/src/prepublish-check.ts
+++ b/buildutils/src/prepublish-check.ts
@@ -8,7 +8,7 @@ import * as glob from 'glob';
 import * as path from 'path';
 import * as utils from './utils';
 
-utils.run('jlpm run clean:slate');
+utils.run('npm run clean:slate');
 utils.run('lerna run prepublishOnly');
 
 utils.getLernaPaths().forEach(pkgPath => {

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -24,7 +24,7 @@ commander
     // Optionally clean and build the python packages.
     if (!options.skipBuild) {
       // Ensure a clean state.
-      utils.run('jlpm run clean:slate');
+      utils.run('npm run clean:slate');
     }
 
     // Publish JS to the appropriate tag.

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -8,6 +8,8 @@ import coreutils = require('@phosphor/coreutils');
 
 type Dict<T> = { [key: string]: T };
 
+const backSlash = /\\/g;
+
 /**
  * Get all of the lerna package paths.
  */
@@ -261,4 +263,14 @@ function requirePackage(parentModule: string, module: string) {
     paths: [parentModulePath]
   });
   return require(requirePath);
+}
+
+/**
+ * Ensure the given path uses '/' as path separator.
+ */
+export function ensureUnixPathSep(source: string) {
+  if (path.sep === '/') {
+    return source;
+  }
+  return source.replace(backSlash, '/');
 }

--- a/clean.py
+++ b/clean.py
@@ -13,11 +13,11 @@ if os.name == 'nt':
             dnames.remove('node_modules')
 
 
+subprocess.check_call('python -m pip uninstall -y jupyterlab'.split(), cwd=here)
+
 git_clean_exclude = [
     '-e',
     '/.vscode',
 ]
 git_clean_command = ['git', 'clean', '-dfx'] + git_clean_exclude
 subprocess.check_call(git_clean_command, cwd=here)
-
-subprocess.call('python -m pip uninstall -y jupyterlab'.split(), cwd=here)


### PR DESCRIPTION
## References

Fixes #6733.

## Code changes

- Uses `npm` instead of `jlpm` in all calls that lead to the `clean:slate` script. See #6733 for details about why.
- ~Adds a dependency in `buildutils` (not seen by users) to ensure paths output to package.json use forward-slashes. This function should probably be used for other paths as well? Left as a future exercise as uncovered.~
-  Ensure paths output to package.json use forward-slashes, using a new util function in buildutils.

## User-facing changes

None.

## Backwards-incompatible changes

None.
