### PR TITLE
Pass in safari10 option to terser plugin.

### DIFF
--- a/dev_mode/webpack.prod.config.js
+++ b/dev_mode/webpack.prod.config.js
@@ -17,7 +17,8 @@ config[0] = merge(config[0], {
           output: {
             beautify: false,
             comments: false
-          }
+          },
+          safari10: true
         },
         cache: process.platform !== 'win32'
       })

--- a/jupyterlab/staging/webpack.prod.config.js
+++ b/jupyterlab/staging/webpack.prod.config.js
@@ -17,7 +17,8 @@ config[0] = merge(config[0], {
           output: {
             beautify: false,
             comments: false
-          }
+          },
+          safari10: true
         },
         cache: process.platform !== 'win32'
       })


### PR DESCRIPTION
Fixes #6748 

## References
* https://github.com/terser-js/terser/issues/117
* https://bugs.webkit.org/show_bug.cgi?id=189914

## Backwards-incompatible changes
N/A

## To test
1. Run `jupyter lab build --dev=False` in the `master` branch and try to run `jupyter lab` in Safari.
1. Switch to this branch and do the same as above.