### PR TITLE
Remove pre release from 1.0 changelog title

### DIFF
--- a/docs/source/getting_started/changelog.rst
+++ b/docs/source/getting_started/changelog.rst
@@ -3,8 +3,8 @@
 JupyterLab Changelog
 ====================
 
-v1.0.0 (pre release)
---------------------
+v1.0.0
+------
 
 
 See the `JupyterLab


### PR DESCRIPTION
Updates the 1.0 changelog title to remote the pre release moniker