### PR TITLE
Update import in tutorial

### DIFF
--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -209,22 +209,27 @@ you in JupyterLab. For your first addition, you're going to add a
 tab panel when invoked.
 
 Fire up your favorite text editor and open the ``src/index.ts`` file in
-your extension project. Add the following import at the top of the file
-to get a reference to the command palette interface.
+your extension project. Change the import at the top of the file to get 
+a reference to the command palette interface and the Jupyter front end.
 
 .. code:: typescript
-
+    
+    import {
+      JupyterFrontEnd, JupyterFrontEndPlugin
+    } from '@jupyterlab/application';
+    
     import {
       ICommandPalette
     } from '@jupyterlab/apputils';
 
-You will also need to install this dependency. Run the following command in the
+You will also need to install these dependencies. Run the following commands in the
 repository root folder install the dependency and save it to your
 `package.json`:
 
 .. code:: bash
 
     jlpm add @jupyterlab/apputils
+    jlpm add @jupyterlab/application
 
 Locate the ``extension`` object of type ``JupyterFrontEndPlugin``. Change the
 definition so that it reads like so:


### PR DESCRIPTION
Initially when you make the cookiecutter there is the following import at the top of the file:

```
import {
  JupyterLab, JupyterLabPlugin
} from '@jupyterlab/application';
```

which needs to be changed to 

```
import {
      JupyterFrontEnd, JupyterFrontEndPlugin
    } from '@jupyterlab/application';
```

in order to make the extension work at this point in the tutorial.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
