### PR TITLE
Reevaluate output renderer on some changes

### DIFF
--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -45,6 +45,7 @@
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/disposable": "^1.2.0",
     "@phosphor/messaging": "^1.2.3",
+    "@phosphor/properties": "^1.1.3",
     "@phosphor/signaling": "^1.2.3",
     "@phosphor/widgets": "^1.8.0"
   },

--- a/tests/test-outputarea/src/widget.spec.ts
+++ b/tests/test-outputarea/src/widget.spec.ts
@@ -174,6 +174,60 @@ describe('outputarea/widget', () => {
         expect(widget.methods).to.contain('onModelChanged');
         expect(widget.widgets.length).to.equal(1);
       });
+
+      it('should rerender when preferred mimetype changes', () => {
+        // Add output with both safe and unsafe types
+        widget.model.clear();
+        widget.model.add({
+          output_type: 'display_data',
+          data: {
+            'image/svg+xml':
+              '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"></svg>',
+            'text/plain': 'hello, world'
+          },
+          metadata: {}
+        });
+        expect(widget.node.innerHTML).to.contain(
+          '<img src="data:image/svg+xml'
+        );
+        widget.model.trusted = !widget.model.trusted;
+        expect(widget.node.innerHTML).to.not.contain(
+          '<img src="data:image/svg+xml'
+        );
+        widget.model.trusted = !widget.model.trusted;
+        expect(widget.node.innerHTML).to.contain(
+          '<img src="data:image/svg+xml'
+        );
+      });
+
+      it('should rerender when isolation changes', () => {
+        // Add output with both safe and unsafe types
+        widget.model.clear();
+        widget.model.add({
+          output_type: 'display_data',
+          data: {
+            'text/plain': 'hello, world'
+          }
+        });
+        expect(widget.node.innerHTML).to.not.contain('<iframe');
+        widget.model.set(0, {
+          output_type: 'display_data',
+          data: {
+            'text/plain': 'hello, world'
+          },
+          metadata: {
+            isolated: true
+          }
+        });
+        expect(widget.node.innerHTML).to.contain('<iframe');
+        widget.model.set(0, {
+          output_type: 'display_data',
+          data: {
+            'text/plain': 'hello, world'
+          }
+        });
+        expect(widget.node.innerHTML).to.not.contain('<iframe');
+      });
     });
 
     describe('.execute()', () => {


### PR DESCRIPTION
## References

Fixes #6762.

Adds a conditional for the optimization from #4320.

## Code changes

Before reusing the output renderer, it checks whether:
- The preferred mimetype has changed. This is tracked with an attached property.
- The `isolated` metadata has changed.

If either of these cases are true, it discards the current renderer and create a new one (as before #4320).

## User-facing changes

Notebook output renderers will now re-render correctly after trusting a notebook.

## Backwards-incompatible changes

None.
