### PR TITLE
fix issue with autogenerated workspaces breaking sharable links

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -260,7 +260,7 @@ const resolver: JupyterFrontEndPlugin<IWindowResolver> = {
         const pool =
           'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
         const random = pool[Math.floor(Math.random() * pool.length)];
-        const path = URLExt.join(base, workspaces, `auto-${random}`) + rest;
+        const path = URLExt.join(base, workspaces, `auto-${random}`, rest);
 
         // Clone the originally requested workspace after redirecting.
         query['clone'] = workspace;


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/6772

## Code changes

As is, there is no `/` between auto-generated workspace names and `rest` (i.e. the rest of the stuff in the path). This PR makes a change so the entire path is concatenated together using the `URLExt.join` function instead of the `+` operator

## User-facing changes

After merging this PR, users should be able to open sharable links regardless of whether a workspace is autogenerated.

## Backwards-incompatible changes
