### PR TITLE
Hotfix for update of extensions in manager #6778

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1548,7 +1548,7 @@ class _AppHandler(object):
                 # Verify that the version is a valid extension.
                 if not _validate_extension(data):
                     # Valid
-                    versions[key] = data['version']
+                    versions[data['name']] = data['version']
         return versions
 
     def _format_no_compatible_package_version(self, name):


### PR DESCRIPTION
## References

Fixes #6778

## Code changes

Works around the key of outdated items being composed of the extension number and version, by stripping the version number for the purpose determining the latest version of an extension.

## User-facing changes

The update button is now correctly shown when an update is available:

Before (having this extension installed in version 0.3.0 and version 0.5.2 available in npm):
![Screenshot from 2019-07-07 13-36-33](https://user-images.githubusercontent.com/5832902/60769586-7bf47600-a0c9-11e9-9c9f-63fc754460ed.png)

After:
![Screenshot from 2019-07-07 15-04-08](https://user-images.githubusercontent.com/5832902/60769591-86af0b00-a0c9-11e9-925d-fac087f6d090.png)


## Backwards-incompatible changes

None.