### PR TITLE
Fix #6767 - requestExecute should use the metadata argument

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -586,7 +586,8 @@ export class DefaultKernel implements Kernel.IKernel {
       channel: 'shell',
       username: this._username,
       session: this._clientId,
-      content: { ...defaults, ...content }
+      content: { ...defaults, ...content },
+      metadata
     });
     return this.sendShellMessage(
       msg,


### PR DESCRIPTION
This change has the fix to pass the metadata during message creation.
