### PR TITLE
Fix lazy-loading of vim mode so it doesn't race.

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -87,6 +87,7 @@
   },
   "devDependencies": {
     "@jupyterlab/buildutils": "^1.0.1",
+    "cross-env": "^5.2.0",
     "css-loader": "~2.1.1",
     "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "file-loader": "~3.0.1",

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -77,7 +77,6 @@
     "@phosphor/widgets": "^1.8.0",
     "ajv": "^6.5.5",
     "codemirror": "~5.47.0",
-    "cross-env": "^5.2.0",
     "es6-promise": "~4.2.6",
     "json5": "^2.1.0",
     "moment": "^2.24.0",

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -149,13 +149,15 @@ function activateEditorCommands(
   /**
    * Update the setting values.
    */
-  function updateSettings(settings: ISettingRegistry.ISettings): void {
+  async function updateSettings(
+    settings: ISettingRegistry.ISettings
+  ): Promise<void> {
     keyMap = (settings.get('keyMap').composite as string | null) || keyMap;
 
     // Lazy loading of vim mode
     if (keyMap === 'vim') {
       // @ts-ignore
-      void import('codemirror/keymap/vim.js');
+      await import('codemirror/keymap/vim.js');
     }
 
     theme = (settings.get('theme').composite as string | null) || theme;
@@ -191,11 +193,11 @@ function activateEditorCommands(
 
   // Fetch the initial state of the settings.
   Promise.all([settingRegistry.load(id), restored])
-    .then(([settings]) => {
-      updateSettings(settings);
+    .then(async ([settings]) => {
+      await updateSettings(settings);
       updateTracker();
-      settings.changed.connect(() => {
-        updateSettings(settings);
+      settings.changed.connect(async () => {
+        await updateSettings(settings);
         updateTracker();
       });
     })
@@ -252,7 +254,6 @@ function activateEditorCommands(
       const key = 'theme';
       const value = (theme = (args['theme'] as string) || theme);
 
-      updateTracker();
       return settingRegistry.set(id, key, value).catch((reason: Error) => {
         console.error(`Failed to set ${id}:${key} - ${reason.message}`);
       });
@@ -269,7 +270,6 @@ function activateEditorCommands(
       const key = 'keyMap';
       const value = (keyMap = (args['keyMap'] as string) || keyMap);
 
-      updateTracker();
       return settingRegistry.set(id, key, value).catch((reason: Error) => {
         console.error(`Failed to set ${id}:${key} - ${reason.message}`);
       });

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
     client: {
       captureConsole: true,
       mocha: {
-        timeout: 10000, // 10 seconds - upped from 2 seconds
+        timeout: 30000, // 30 seconds - upped from 2 seconds
         retries: 3 // Allow for slow server on CI.
       }
     },

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -65,7 +65,7 @@ describe('@jupyterlab/notebook', () => {
 
     after(() => {
       return Promise.all([session.shutdown(), ipySession.shutdown()]);
-    }).timeout(30000); // Allow for slower CI
+    });
 
     describe('#executed', () => {
       it('should emit when Markdown and code cells are run', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,6 +3839,14 @@ create-react-context@<=0.2.2:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -6593,7 +6601,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3839,14 +3839,6 @@ create-react-context@<=0.2.2:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-cross-env@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
-  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
-  dependencies:
-    cross-spawn "^6.0.5"
-    is-windows "^1.0.0"
-
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -6601,7 +6593,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
I think this is a big enough bug that it should be in the next patch release.

## References
Fixes #6744, #6516 

## Code changes
Makes lazy-vim-loading properly async

## User-facing changes
Vim mode works again.

## Backwards-incompatible changes

None