### PR TITLE
Trim css values loaded from theme #6757

### DIFF
--- a/packages/terminal/src/widget.ts
+++ b/packages/terminal/src/widget.ts
@@ -370,21 +370,21 @@ namespace Private {
    * The current theme.
    */
   export const inheritTheme = (): ITerminal.IThemeObject => ({
-    foreground: getComputedStyle(document.body).getPropertyValue(
-      '--jp-ui-font-color0'
-    ),
-    background: getComputedStyle(document.body).getPropertyValue(
-      '--jp-layout-color0'
-    ),
-    cursor: getComputedStyle(document.body).getPropertyValue(
-      '--jp-ui-font-color1'
-    ),
-    cursorAccent: getComputedStyle(document.body).getPropertyValue(
-      '--jp-ui-inverse-font-color0'
-    ),
-    selection: getComputedStyle(document.body).getPropertyValue(
-      '--jp-ui-font-color3'
-    )
+    foreground: getComputedStyle(document.body)
+      .getPropertyValue('--jp-ui-font-color0')
+      .trim(),
+    background: getComputedStyle(document.body)
+      .getPropertyValue('--jp-layout-color0')
+      .trim(),
+    cursor: getComputedStyle(document.body)
+      .getPropertyValue('--jp-ui-font-color1')
+      .trim(),
+    cursorAccent: getComputedStyle(document.body)
+      .getPropertyValue('--jp-ui-inverse-font-color0')
+      .trim(),
+    selection: getComputedStyle(document.body)
+      .getPropertyValue('--jp-ui-font-color3')
+      .trim()
   });
 
   export function getXTermTheme(

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -65,7 +65,7 @@ describe('@jupyterlab/notebook', () => {
 
     after(() => {
       return Promise.all([session.shutdown(), ipySession.shutdown()]);
-    });
+    }).timeout(30000); // Allow for slower CI
 
     describe('#executed', () => {
       it('should emit when Markdown and code cells are run', async () => {


### PR DESCRIPTION
## References

#6757 

## Code changes

Trim colors loaded from theme, so that `" white"` would be passed to `terminal.js` as `"white"`.

## User-facing changes

Light theme now works with safari under mac.

![image](https://user-images.githubusercontent.com/9889312/60836528-7a8b8200-a18b-11e9-95fa-27e6a24d3fcd.png)

## Backwards-incompatible changes

None.