### PR TITLE
Redirect old tutorial to new tutorial

### DIFF
--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 The extension tutorial has moved!
 ----------------------------------
 

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -1,6 +1,4 @@
-  .. _xkcd_extension_tutorial:
-
-We've moved!
-------------
+The extension tutorial has moved!
+----------------------------------
 
 With the release of JupyterLab 1.0, we've also created a brand-new extension tutorial! This old tutorial is now out-of-date and has been retired, but `you can find the new tutorial here <https://jupyterlab.readthedocs.io/en/stable/developer/extension_tutorial.html>`__.

--- a/docs/source/developer/xkcd_extension_tutorial.rst
+++ b/docs/source/developer/xkcd_extension_tutorial.rst
@@ -1,0 +1,6 @@
+  .. _xkcd_extension_tutorial:
+
+We've moved!
+------------
+
+With the release of JupyterLab 1.0, we've also created a brand-new extension tutorial! This old tutorial is now out-of-date and has been retired, but `you can find the new tutorial here <https://jupyterlab.readthedocs.io/en/stable/developer/extension_tutorial.html>`__.


### PR DESCRIPTION
(continuing from conversation on https://github.com/jupyterlab/jupyterlab/pull/6800) 
Ooh wow I didn't realize the new extension tutorial was up already!

This is really stupid of me, but would it be possible to redirect the [old tutorial page](https://jupyterlab.readthedocs.io/en/latest/developer/xkcd_extension_tutorial.html) to the new tutorial page? I'm not sure if this PR is the best way to do that, feel free to can it if it isn't.

[Whenever I googled "XKCD JupyterLab extension tutorial" and hit this "sorry this page does not exist yet"](https://jupyterlab.readthedocs.io/en/latest/developer/xkcd_extension_tutorial.html), I always incorrectly assumed that that meant that there was not yet any new tutorial for JupyterLab 1.0 (and which is also what I incorrectly told several people too). 

It's unclear to me if anyone else has this problem, although at least for the record, the now defunct XKCD tutorial page is still (for now) the number one Google search result (for me) for "jupyterlab extension tutorial" (i.e. even when omitting the XKCD), so I think something like this would be helpful for avoiding miscommunications. Still it feels like there should be a better way to do such a redirect than adding a stub .rst file to the source cluttering up space.