### PR TITLE
fixed sphinx warning for deprecated source_parsers config field

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,6 @@
 # sys.path.insert(0, os.path.abspath('.'))
 
 # For conversion from markdown to html
-import recommonmark.parser
 from recommonmark.transform import AutoStructify
 
 
@@ -35,23 +34,23 @@ from recommonmark.transform import AutoStructify
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.intersphinx',
+extensions = [
+    'recommonmark',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
-    'sphinx_copybutton']
+    'sphinx_copybutton'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-#
-# source_suffix = ['.rst', '.md']
-
-source_parsers = {
-    '.md': 'recommonmark.parser.CommonMarkParser',
+# The file extensions of source files.
+# Sphinx considers the files with this suffix as sources.
+# The value can be a dictionary mapping file extensions to file types.
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown'
 }
-
-source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = 'index'


### PR DESCRIPTION
## References

## Code changes

Minor fix for a Sphinx warning that comes up during the docs CI test.

While trying to figure why a docs CI test failed (it was github flood protection during the link check), I noticed this warning:

```
/opt/hostedtoolcache/Python/3.6.8/x64/lib/python3.6/site-packages/sphinx/util/compat.py:33: RemovedInSphinx30Warning: The config variable "source_parsers" is deprecated. Please update your extension for the parser and remove the setting.
  RemovedInSphinx30Warning)
/opt/hostedtoolcache/Python/3.6.8/x64/lib/python3.6/site-packages/sphinx/util/compat.py:37: RemovedInSphinx30Warning: app.add_source_parser() does not support suffix argument. Use app.add_source_suffix() instead.
  app.add_source_parser(suffix, parser)
```

I fixed the issue following the markdown setup instructions at https://www.sphinx-doc.org/en/master/usage/markdown.html

## User-facing changes

None

## Backwards-incompatible changes

None
