### PR TITLE
Factory overrides

### DIFF
--- a/packages/application-extension/tdoptions.json
+++ b/packages/application-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/application-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/application/tdoptions.json
+++ b/packages/application/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/application",
   "baseUrl": ".",
   "paths": {

--- a/packages/apputils-extension/tdoptions.json
+++ b/packages/apputils-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/apputils-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/apputils/tdoptions.json
+++ b/packages/apputils/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/apputils",
   "baseUrl": ".",
   "paths": {

--- a/packages/attachments/tdoptions.json
+++ b/packages/attachments/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/attachments",
   "baseUrl": ".",
   "paths": {

--- a/packages/cells/tdoptions.json
+++ b/packages/cells/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/cells",
   "baseUrl": ".",
   "paths": {

--- a/packages/codeeditor/tdoptions.json
+++ b/packages/codeeditor/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/codeeditor",
   "baseUrl": ".",
   "paths": {

--- a/packages/codemirror-extension/tdoptions.json
+++ b/packages/codemirror-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/codemirror-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/codemirror/tdoptions.json
+++ b/packages/codemirror/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/codemirror",
   "baseUrl": ".",
   "paths": {

--- a/packages/completer-extension/tdoptions.json
+++ b/packages/completer-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/completer-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/completer/tdoptions.json
+++ b/packages/completer/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/completer",
   "baseUrl": ".",
   "paths": {

--- a/packages/console-extension/tdoptions.json
+++ b/packages/console-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/console-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/console/tdoptions.json
+++ b/packages/console/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/console",
   "baseUrl": ".",
   "paths": {

--- a/packages/coreutils/tdoptions.json
+++ b/packages/coreutils/tdoptions.json
@@ -1,15 +1,10 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "commonjs",
   "esModuleInterop": true,
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/coreutils",
   "baseUrl": ".",
   "paths": {

--- a/packages/csvviewer-extension/tdoptions.json
+++ b/packages/csvviewer-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/csvviewer-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/csvviewer/tdoptions.json
+++ b/packages/csvviewer/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/csvviewer",
   "baseUrl": ".",
   "paths": {

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -45,6 +45,7 @@
     "@jupyterlab/services": "^4.1.0-alpha.2",
     "@jupyterlab/statusbar": "^1.1.0-alpha.2",
     "@phosphor/algorithm": "^1.1.3",
+    "@phosphor/coreutils": "^1.3.1",
     "@phosphor/disposable": "^1.2.0",
     "@phosphor/widgets": "^1.8.0"
   },

--- a/packages/docmanager-extension/schema/plugin.json
+++ b/packages/docmanager-extension/schema/plugin.json
@@ -27,6 +27,16 @@
       "title": "Autosave Interval",
       "description": "Length of save interval in seconds",
       "default": 120
+    },
+    "defaultViewers": {
+      "type": "object",
+      "title": "Default Viewers",
+      "default": {},
+      "description": "Overrides for the default viewers for file types",
+      "properties": {},
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,

--- a/packages/docmanager-extension/schema/plugin.json
+++ b/packages/docmanager-extension/schema/plugin.json
@@ -3,6 +3,7 @@
   "description": "Document Manager settings.",
   "jupyter.lab.setting-icon-class": "jp-FileIcon",
   "jupyter.lab.setting-icon-label": "Document Manager",
+  "jupyter.lab.transform": true,
   "jupyter.lab.shortcuts": [
     {
       "command": "docmanager:save",

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -149,18 +149,25 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
       docManager.autosaveInterval = autosaveInterval || 120;
 
       // Handle default widget factory overrides.
-      const factoryOverrides = settings.get('defaultViewers').composite as {
+      const defaultViewers = settings.get('defaultViewers').composite as {
         [ft: string]: string;
       };
-      Object.keys(factoryOverrides).forEach(ft => {
+      const overrides: { [ft: string]: string } = {};
+      // Filter the defaultViewers and file types for existing ones.
+      Object.keys(defaultViewers).forEach(ft => {
         if (!registry.getFileType(ft)) {
           console.warn(`File Type ${ft} not found`);
           return;
         }
-        if (!registry.getWidgetFactory(factoryOverrides[ft])) {
-          console.warn(`Document viewer ${factoryOverrides[ft]} not found`);
+        if (!registry.getWidgetFactory(defaultViewers[ft])) {
+          console.warn(`Document viewer ${defaultViewers[ft]} not found`);
         }
-        registry.setDefaultWidgetFactory(ft, factoryOverrides[ft]);
+        overrides[ft] = defaultViewers[ft];
+      });
+      // Set the default factory overrides. If not provided, this has the
+      // effect of unsetting any previous overrides.
+      each(registry.fileTypes(), ft => {
+        registry.setDefaultWidgetFactory(ft.name, overrides[ft.name]);
       });
     };
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -167,7 +167,15 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
       // Set the default factory overrides. If not provided, this has the
       // effect of unsetting any previous overrides.
       each(registry.fileTypes(), ft => {
-        registry.setDefaultWidgetFactory(ft.name, overrides[ft.name]);
+        try {
+          registry.setDefaultWidgetFactory(ft.name, overrides[ft.name]);
+        } catch {
+          console.warn(
+            `Failed to set default viewer ${overrides[ft.name]} for file type ${
+              ft.name
+            }`
+          );
+        }
       });
     };
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -136,15 +136,32 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
 
     // Keep up to date with the settings registry.
     const onSettingsUpdated = (settings: ISettingRegistry.ISettings) => {
+      // Handle whether to autosave
       const autosave = settings.get('autosave').composite as boolean | null;
       docManager.autosave =
         autosave === true || autosave === false ? autosave : true;
       app.commands.notifyCommandChanged(CommandIDs.toggleAutosave);
 
+      // Handle autosave interval
       const autosaveInterval = settings.get('autosaveInterval').composite as
         | number
         | null;
       docManager.autosaveInterval = autosaveInterval || 120;
+
+      // Handle default widget factory overrides.
+      const factoryOverrides = settings.get('defaultViewers').composite as {
+        [ft: string]: string;
+      };
+      Object.keys(factoryOverrides).forEach(ft => {
+        if (!registry.getFileType(ft)) {
+          console.warn(`File Type ${ft} not found`);
+          return;
+        }
+        if (!registry.getWidgetFactory(factoryOverrides[ft])) {
+          console.warn(`Document viewer ${factoryOverrides[ft]} not found`);
+        }
+        registry.setDefaultWidgetFactory(ft, factoryOverrides[ft]);
+      });
     };
 
     // Fetch the initial state of the settings.

--- a/packages/docmanager-extension/tdoptions.json
+++ b/packages/docmanager-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/docmanager-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/docmanager/tdoptions.json
+++ b/packages/docmanager/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/docmanager",
   "baseUrl": ".",
   "paths": {

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -449,9 +449,10 @@ export class DocumentRegistry implements IDisposable {
       throw Error(`Cannot find widget factory ${factory}`);
     }
     factory = factory.toLowerCase();
+    const factories = this._widgetFactoriesForFileType[fileType];
     if (
-      !this._widgetFactoriesForFileType[fileType] ||
-      !this._widgetFactoriesForFileType[fileType].includes(factory)
+      factory !== this._defaultWidgetFactory &&
+      !(factories && factories.includes(factory))
     ) {
       throw Error(`Factory ${factory} cannot view file type ${fileType}`);
     }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -104,15 +104,19 @@ export class DocumentRegistry implements IDisposable {
    * @returns A disposable which will unregister the factory.
    *
    * #### Notes
-   * If a factory with the given `'displayName'` is already registered,
+   * If a factory with the given `'name'` is already registered,
    * a warning will be logged, and this will be a no-op.
    * If `'*'` is given as a default extension, the factory will be registered
    * as the global default.
    * If an extension or global default is already registered, this factory
    * will override the existing default.
+   * The factory cannot be named an empty string or the string `'default'`.
    */
   addWidgetFactory(factory: DocumentRegistry.WidgetFactory): IDisposable {
     let name = factory.name.toLowerCase();
+    if (!name || name === 'default') {
+      throw Error('Invalid factory name');
+    }
     if (this._widgetFactories[name]) {
       console.warn(`Duplicate registered factory ${name}`);
       return new DisposableDelegate(Private.noOp);

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -310,6 +310,9 @@ export class DocumentRegistry implements IDisposable {
 
     // Start with the file type default factories.
     fts.forEach(ft => {
+      if (ft.name in this._defaultWidgetFactoryOverrides) {
+        factories.add(this._defaultWidgetFactoryOverrides[ft.name]);
+      }
       if (ft.name in this._defaultWidgetFactories) {
         factories.add(this._defaultWidgetFactories[ft.name]);
       }
@@ -408,7 +411,7 @@ export class DocumentRegistry implements IDisposable {
   }
 
   /**
-   * Set the default widget factory for a file type.
+   * Set overrides for the default widget factory for a file type.
    *
    * Normally, a widget factory informs the document registry which file types
    * it should be the default for using the `defaultFor` option in the
@@ -420,17 +423,18 @@ export class DocumentRegistry implements IDisposable {
    * @param factory: The name of the factory.
    *
    * #### Notes
-   * If `factory` is undefined, then no factory will be default for the file
-   * type.
+   * If `factory` is undefined, then any override will be unset, and the
+   * default factory will revert to the original value.
    */
   setDefaultWidgetFactory(fileType: string, factory: string | undefined): void {
+    fileType = fileType.toLowerCase();
     if (!this.getFileType(fileType)) {
       console.warn(`Cannot find file type ${fileType}`);
       return;
     }
     if (!factory) {
-      if (this._defaultWidgetFactories[fileType]) {
-        delete this._defaultWidgetFactories[fileType];
+      if (this._defaultWidgetFactoryOverrides[fileType]) {
+        delete this._defaultWidgetFactoryOverrides[fileType];
       }
       return;
     }
@@ -438,7 +442,7 @@ export class DocumentRegistry implements IDisposable {
       console.warn(`Cannot find widget factory ${factory}`);
       return;
     }
-    this._defaultWidgetFactories[fileType] = factory;
+    this._defaultWidgetFactoryOverrides[fileType] = factory.toLowerCase();
   }
 
   /**
@@ -638,6 +642,9 @@ export class DocumentRegistry implements IDisposable {
     [key: string]: DocumentRegistry.WidgetFactory;
   } = Object.create(null);
   private _defaultWidgetFactory = '';
+  private _defaultWidgetFactoryOverrides: {
+    [key: string]: string;
+  } = Object.create(null);
   private _defaultWidgetFactories: { [key: string]: string } = Object.create(
     null
   );

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -171,6 +171,11 @@ export class DocumentRegistry implements IDisposable {
           delete this._widgetFactoriesForFileType[ext];
         }
       }
+      for (let ext of Object.keys(this._defaultWidgetFactoryOverrides)) {
+        if (this._defaultWidgetFactoryOverrides[ext] === name) {
+          delete this._defaultWidgetFactoryOverrides[ext];
+        }
+      }
       this._changed.emit({
         type: 'widgetFactory',
         name,

--- a/packages/docregistry/tdoptions.json
+++ b/packages/docregistry/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/docregistry",
   "baseUrl": ".",
   "paths": {

--- a/packages/extensionmanager-extension/tdoptions.json
+++ b/packages/extensionmanager-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/extensionmanager-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/extensionmanager/tdoptions.json
+++ b/packages/extensionmanager/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/extensionmanager",
   "baseUrl": ".",
   "paths": {

--- a/packages/filebrowser-extension/tdoptions.json
+++ b/packages/filebrowser-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/filebrowser-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/filebrowser/tdoptions.json
+++ b/packages/filebrowser/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/filebrowser",
   "baseUrl": ".",
   "paths": {

--- a/packages/fileeditor-extension/tdoptions.json
+++ b/packages/fileeditor-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/fileeditor-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/fileeditor/tdoptions.json
+++ b/packages/fileeditor/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/fileeditor",
   "baseUrl": ".",
   "paths": {

--- a/packages/help-extension/tdoptions.json
+++ b/packages/help-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/help-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/htmlviewer-extension/tdoptions.json
+++ b/packages/htmlviewer-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/htmlviewer-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/htmlviewer/tdoptions.json
+++ b/packages/htmlviewer/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/htmlviewer",
   "baseUrl": ".",
   "paths": {

--- a/packages/imageviewer-extension/tdoptions.json
+++ b/packages/imageviewer-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/imageviewer-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/imageviewer/tdoptions.json
+++ b/packages/imageviewer/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/imageviewer",
   "baseUrl": ".",
   "paths": {

--- a/packages/inspector-extension/tdoptions.json
+++ b/packages/inspector-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/inspector-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/inspector/tdoptions.json
+++ b/packages/inspector/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/inspector",
   "baseUrl": ".",
   "paths": {

--- a/packages/javascript-extension/tdoptions.json
+++ b/packages/javascript-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/javascript-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/json-extension/tdoptions.json
+++ b/packages/json-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/json-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/launcher-extension/tdoptions.json
+++ b/packages/launcher-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/launcher-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/launcher/tdoptions.json
+++ b/packages/launcher/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/launcher",
   "baseUrl": ".",
   "paths": {

--- a/packages/mainmenu-extension/tdoptions.json
+++ b/packages/mainmenu-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/mainmenu-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/mainmenu/tdoptions.json
+++ b/packages/mainmenu/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/mainmenu",
   "baseUrl": ".",
   "paths": {

--- a/packages/markdownviewer-extension/tdoptions.json
+++ b/packages/markdownviewer-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/markdownviewer-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/markdownviewer/tdoptions.json
+++ b/packages/markdownviewer/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/markdownviewer",
   "baseUrl": ".",
   "paths": {

--- a/packages/mathjax2-extension/tdoptions.json
+++ b/packages/mathjax2-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/mathjax2-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/mathjax2/tdoptions.json
+++ b/packages/mathjax2/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/mathjax2",
   "baseUrl": ".",
   "paths": {

--- a/packages/notebook-extension/tdoptions.json
+++ b/packages/notebook-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/notebook-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/notebook/tdoptions.json
+++ b/packages/notebook/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/notebook",
   "baseUrl": ".",
   "paths": {

--- a/packages/observables/tdoptions.json
+++ b/packages/observables/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/observables",
   "baseUrl": ".",
   "paths": {

--- a/packages/outputarea/tdoptions.json
+++ b/packages/outputarea/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/outputarea",
   "baseUrl": ".",
   "paths": {

--- a/packages/pdf-extension/tdoptions.json
+++ b/packages/pdf-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/pdf-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/rendermime-extension/tdoptions.json
+++ b/packages/rendermime-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/rendermime-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/rendermime-interfaces/tdoptions.json
+++ b/packages/rendermime-interfaces/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/rendermime-interfaces",
   "baseUrl": ".",
   "paths": {

--- a/packages/rendermime/tdoptions.json
+++ b/packages/rendermime/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/rendermime",
   "baseUrl": ".",
   "paths": {

--- a/packages/running-extension/tdoptions.json
+++ b/packages/running-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/running-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/running/tdoptions.json
+++ b/packages/running/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/running",
   "baseUrl": ".",
   "paths": {

--- a/packages/services/tdoptions.json
+++ b/packages/services/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/services",
   "baseUrl": ".",
   "paths": {

--- a/packages/settingeditor-extension/tdoptions.json
+++ b/packages/settingeditor-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/settingeditor-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/settingeditor/tdoptions.json
+++ b/packages/settingeditor/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/settingeditor",
   "baseUrl": ".",
   "paths": {

--- a/packages/shortcuts-extension/tdoptions.json
+++ b/packages/shortcuts-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/shortcuts-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/statusbar-extension/tdoptions.json
+++ b/packages/statusbar-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/statusbar-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/statusbar/tdoptions.json
+++ b/packages/statusbar/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/statusbar",
   "baseUrl": ".",
   "paths": {

--- a/packages/tabmanager-extension/tdoptions.json
+++ b/packages/tabmanager-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/tabmanager-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/terminal-extension/tdoptions.json
+++ b/packages/terminal-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/terminal-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/terminal/tdoptions.json
+++ b/packages/terminal/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/terminal",
   "baseUrl": ".",
   "paths": {

--- a/packages/theme-dark-extension/tdoptions.json
+++ b/packages/theme-dark-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/theme-dark-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/theme-light-extension/tdoptions.json
+++ b/packages/theme-light-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/theme-light-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/tooltip-extension/tdoptions.json
+++ b/packages/tooltip-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/tooltip-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/tooltip/tdoptions.json
+++ b/packages/tooltip/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/tooltip",
   "baseUrl": ".",
   "paths": {

--- a/packages/ui-components/tdoptions.json
+++ b/packages/ui-components/tdoptions.json
@@ -3,10 +3,7 @@
   "mode": "file",
   "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.dom.d.ts",
-    "lib.es2017.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/ui-components",
   "baseUrl": ".",
   "paths": {

--- a/packages/ui-components/tdoptions.json
+++ b/packages/ui-components/tdoptions.json
@@ -1,14 +1,11 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
   "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
     "lib.dom.d.ts",
-    "lib.dom.iterable.d.ts"
+    "lib.es2017.d.ts"
   ],
   "out": "../../docs/api/ui-components",
   "baseUrl": ".",

--- a/packages/vdom-extension/tdoptions.json
+++ b/packages/vdom-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/vdom-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/vdom/tdoptions.json
+++ b/packages/vdom/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/vdom",
   "baseUrl": ".",
   "paths": {

--- a/packages/vega4-extension/tdoptions.json
+++ b/packages/vega4-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/vega4-extension",
   "baseUrl": ".",
   "paths": {

--- a/packages/vega5-extension/tdoptions.json
+++ b/packages/vega5-extension/tdoptions.json
@@ -1,14 +1,9 @@
 {
   "excludeNotExported": true,
   "mode": "file",
-  "target": "es5",
+  "target": "es2017",
   "module": "es5",
-  "lib": [
-    "lib.es2015.d.ts",
-    "lib.es2015.collection.d.ts",
-    "lib.es2015.promise.d.ts",
-    "lib.dom.d.ts"
-  ],
+  "lib": ["lib.dom.d.ts", "lib.es2017.d.ts"],
   "out": "../../docs/api/vega5-extension",
   "baseUrl": ".",
   "paths": {

--- a/tests/test-docregistry/src/registry.spec.ts
+++ b/tests/test-docregistry/src/registry.spec.ts
@@ -138,6 +138,27 @@ describe('docregistry/registry', () => {
         disposable.dispose();
         expect(registry.getWidgetFactory('test')).to.be.undefined;
       });
+
+      it('should throw for an invalid factory name', () => {
+        expect(() => {
+          registry.addWidgetFactory(
+            new WidgetFactory({
+              name: 'default',
+              fileTypes: [],
+              defaultFor: []
+            })
+          );
+        }).to.throw(/Invalid/);
+        expect(() => {
+          registry.addWidgetFactory(
+            new WidgetFactory({
+              name: '',
+              fileTypes: [],
+              defaultFor: []
+            })
+          );
+        }).to.throw(/Invalid/);
+      });
     });
 
     describe('#addModelFactory()', () => {

--- a/tests/test-docregistry/src/registry.spec.ts
+++ b/tests/test-docregistry/src/registry.spec.ts
@@ -353,6 +353,58 @@ describe('docregistry/registry', () => {
       });
     });
 
+    describe('#setDefaultWidgetFactory()', () => {
+      it('should override the default widget factory for a file type', () => {
+        const factory = createFactory();
+        registry.addWidgetFactory(factory);
+        const mdFactory = new WidgetFactory({
+          name: 'markdown',
+          fileTypes: ['markdown', 'foobar'],
+          defaultFor: []
+        });
+        registry.addWidgetFactory(mdFactory);
+        registry.setDefaultWidgetFactory('foobar', 'markdown');
+        expect(registry.defaultWidgetFactory('a.foo.bar')).to.equal(mdFactory);
+      });
+
+      it('should revert to the default widget factory when unset', () => {
+        const factory = createFactory();
+        registry.addWidgetFactory(factory);
+        const mdFactory = new WidgetFactory({
+          name: 'markdown',
+          fileTypes: ['markdown', 'foobar'],
+          defaultFor: []
+        });
+        registry.addWidgetFactory(mdFactory);
+        registry.setDefaultWidgetFactory('foobar', 'markdown');
+        registry.setDefaultWidgetFactory('foobar', undefined);
+        expect(registry.defaultWidgetFactory('a.foo.bar')).to.equal(factory);
+      });
+
+      it('should throw if the factory or file type do not exist', () => {
+        const factory = createFactory();
+        registry.addWidgetFactory(factory);
+        expect(() => {
+          registry.setDefaultWidgetFactory('foobar', 'fake');
+        }).to.throw(/Cannot find/);
+        expect(() => {
+          registry.setDefaultWidgetFactory('fake', undefined);
+        }).to.throw(/Cannot find/);
+      });
+
+      it('should throw if the factory cannot render a file type', () => {
+        const mdFactory = new WidgetFactory({
+          name: 'markdown',
+          fileTypes: ['markdown'],
+          defaultFor: []
+        });
+        registry.addWidgetFactory(mdFactory);
+        expect(() => {
+          registry.setDefaultWidgetFactory('foobar', 'markdown');
+        }).to.throw(/cannot view/);
+      });
+    });
+
     describe('#defaultRenderedWidgetFactory()', () => {
       it('should get the default rendered widget factory for a given extension', () => {
         const factory = createFactory();

--- a/tests/test-docregistry/src/registry.spec.ts
+++ b/tests/test-docregistry/src/registry.spec.ts
@@ -376,8 +376,6 @@ describe('docregistry/registry', () => {
 
     describe('#setDefaultWidgetFactory()', () => {
       it('should override the default widget factory for a file type', () => {
-        const factory = createFactory();
-        registry.addWidgetFactory(factory);
         const mdFactory = new WidgetFactory({
           name: 'markdown',
           fileTypes: ['markdown', 'foobar'],
@@ -423,6 +421,20 @@ describe('docregistry/registry', () => {
         expect(() => {
           registry.setDefaultWidgetFactory('foobar', 'markdown');
         }).to.throw(/cannot view/);
+      });
+
+      it('should revert to the default widget factory if the override is removed', () => {
+        const factory = createFactory();
+        registry.addWidgetFactory(factory);
+        const mdFactory = new WidgetFactory({
+          name: 'markdown',
+          fileTypes: ['markdown', 'foobar'],
+          defaultFor: []
+        });
+        const disposable = registry.addWidgetFactory(mdFactory);
+        registry.setDefaultWidgetFactory('foobar', 'markdown');
+        disposable.dispose();
+        expect(registry.defaultWidgetFactory('a.foo.bar')).to.equal(factory);
       });
     });
 


### PR DESCRIPTION
This adds a way for the end-user to override the default viewer for a given file type. I waffled for a while about whether this should be implemented on the file browser, the document manager, or the document registry. I went with the latter, since that handles all the logic for deciding which factories to use normally.

I am also thinking about adding a menu item to the "Settings" or "View" menu which exposes this for the markdown viewer specifically. Any thoughts about that?
![image](https://user-images.githubusercontent.com/5728311/61161911-fd2d7d80-a4ba-11e9-8457-60e31f52d977.png)

This is a separate question from whether to make the markdown viewer default (which I would personally be in favor of), but should make it less pressing.

## References
alleviates #6442, fixes #4048

## Code changes

New function on the document registry to set an override for a given file type.
New user-settings in the `docmanager-extension` to expose this functionality.

## User-facing changes

Users can set their own default renderer for a file type.
## Backwards-incompatible changes

None, as far as I can tell.