### PR TITLE
first pass at adding scroll to cell method

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-namespace': 'off',
+    '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/ban-ts-comment': ['warn', { 'ts-ignore': true }],
     '@typescript-eslint/ban-types': 'warn',

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -19,6 +19,8 @@ import { PanelLayout, Widget } from '@lumino/widgets';
 
 import { h, VirtualDOM } from '@lumino/virtualdom';
 
+import { ElementExt } from '@phosphor/domutils';
+
 import {
   ICellModel,
   Cell,
@@ -1218,6 +1220,21 @@ export class Notebook extends StaticNotebook {
     if (Math.abs(delta) > (ar.height * threshold) / 100) {
       node.scrollTop += delta;
     }
+  }
+
+  /**
+   * Scroll so that the given cell is in view. Selects and activates cell.
+   *
+   * @param cell - A cell in the notebook widget.
+   *
+   */
+  scrollToCell(cell: Cell): void {
+    // use Phosphor to scroll
+    ElementExt.scrollIntoViewIfNeeded(this.node, cell.node);
+    // change selection and active cell:
+    this.deselectAll();
+    this.select(cell);
+    cell.activate();
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -19,7 +19,7 @@ import { PanelLayout, Widget } from '@lumino/widgets';
 
 import { h, VirtualDOM } from '@lumino/virtualdom';
 
-import { ElementExt } from '@phosphor/domutils';
+import { ElementExt } from '@lumino/domutils';
 
 import {
   ICellModel,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/4229

## Code changes

this adds a new 'scrollToCell' to Notebook, which uses Phosphor's domutil to scroll the given cell into view (also deselects / selects / activates the given cell - should the function name be more explicit to indicate these other operations? Or should scrollToCell just do the Phosphor scrolling action?)

## User-facing changes

No visual/user interaction changes (yet? should this operation be exposed through a command [combining with other cell selection operations?] or menu item?)

## Backwards-incompatible changes

nothing backwards incompatible that I know of!
