### PR TITLE
Add ability to restart kernel and run to current cell

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -91,6 +91,8 @@ export namespace CommandIDs {
 
   export const restartAndRunAll = 'runmenu:restart-and-run-all';
 
+  export const restartAndRunToSelected = 'runmenu:restart-and-run-to-selected';
+
   export const runAbove = 'runmenu:run-above';
 
   export const runBelow = 'runmenu:run-below';
@@ -538,7 +540,8 @@ export function createKernelMenu(app: JupyterFrontEnd, menu: KernelMenu): void {
   const restartGroup = [
     CommandIDs.restartKernel,
     CommandIDs.restartKernelAndClear,
-    CommandIDs.restartAndRunAll
+    CommandIDs.restartAndRunAll,
+    CommandIDs.restartAndRunToSelected
   ].map(command => {
     return { command };
   });
@@ -686,6 +689,21 @@ export function createRunMenu(app: JupyterFrontEnd, menu: RunMenu): void {
       'restartAndRunAll'
     ),
     execute: Private.delegateExecute(app, menu.codeRunners, 'restartAndRunAll')
+  });
+  commands.addCommand(CommandIDs.restartAndRunToSelected, {
+    label: () => {
+      return `Restart Kernel and Run up to Selected Cell …`;
+    },
+    isEnabled: Private.delegateEnabled(
+      app,
+      menu.codeRunners,
+      'restartAndRunToSelected'
+    ),
+    execute: Private.delegateExecute(
+      app,
+      menu.codeRunners,
+      'restartAndRunToSelected'
+    )
   });
 
   const runAllGroup = [CommandIDs.runAll, CommandIDs.restartAndRunAll].map(

--- a/packages/mainmenu/src/run.ts
+++ b/packages/mainmenu/src/run.ts
@@ -79,5 +79,11 @@ export namespace IRunMenu {
      * returns a promise of whether the action was performed.
      */
     restartAndRunAll?: (widget: T) => Promise<boolean>;
+    /**
+     * A function to restart and run all the code hosted by the widget
+     * up to the currently selected cell, which returns a promise of whether
+     * the action was performed.
+     */
+    restartAndRunToSelected?: (widget: T) => Promise<boolean>;
   }
 }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2113,6 +2113,21 @@ function populateMenus(
         }
         return restarted;
       });
+    },
+    restartAndRunToSelected: current => {
+      const { context, content } = current;
+      return context.session.restart().then(restarted => {
+        if (restarted) {
+          void NotebookActions.runAllAbove(content, context.session).then(
+            executed => {
+              if (executed) {
+                void NotebookActions.run(content, context.session);
+              }
+            }
+          );
+        }
+        return restarted;
+      });
     }
   } as IRunMenu.ICodeRunner<NotebookPanel>);
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #6746

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
A new entry is added to the "kernel" menu that reads "Restart Kkernel and Run up to Selected Cell".
Upon clicking, the kernel will be restarted, and all the cells above the current selection (and the current selection itself) will be run.

<!-- For visual changes, include before and after screenshots here. -->
Before:
![Screenshot_2019-07-13 JupyterLab(1)](https://user-images.githubusercontent.com/15913822/61174607-9b2f4f80-a570-11e9-993d-89debc2f2caa.png)

After:
![Screenshot_2019-07-13 JupyterLab](https://user-images.githubusercontent.com/15913822/61174606-98345f00-a570-11e9-9422-f4f553ef9e00.png)



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
