### PR TITLE
Remove focus on esc in console

### DIFF
--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -613,6 +613,11 @@ export class CodeConsole extends Widget {
     if (event.keyCode === 13 && !editor.hasFocus()) {
       event.preventDefault();
       editor.focus();
+    } else if (event.keyCode === 27 && editor.hasFocus()) {
+      // Set to command mode
+      event.preventDefault();
+      event.stopPropagation();
+      this.node.focus();
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

- #3484 ('Esc' in the input of the console should switch to command mode)

## Code changes

Remove focus from the console input on 'Esc' (27).

## User-facing changes

The 'Esc' in the input cell of the console removes focus and switches to command mode.

## Backwards-incompatible changes

None.