### PR TITLE
WIP: Fix/slow search

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1120,6 +1120,7 @@ export class MarkdownCell extends Cell {
       return;
     }
     this._rendered = value;
+    this._dirty = false;
     this._handleRendered();
     // Refreshing an editor can be really expensive, so we don't call it from
     // _handleRendered, since _handledRendered is also called on every update
@@ -1129,18 +1130,24 @@ export class MarkdownCell extends Cell {
     }
   }
 
-  set editor_activated_for_search(value: boolean) {
-    value = !value;
+  /**
+   * Whether the cell is rendered in "dirty" state (without proper re-paint).
+   *
+   * A variant of `rendered` property which does not refresh the editor,
+   * used during search operations due to increased performance.
+   */
+  get renderedDirty(): boolean {
+    return this._rendered && this._dirty;
+  }
+  set renderedDirty(value: boolean) {
     if (value === this._rendered) {
       return;
     }
     this._rendered = value;
-    if (!this._rendered) {
-      this.showEditor();
-    } else {
-      void this._updateRenderedInput();
-      this.renderInput(this._renderer);
-    }
+    this._handleRendered();
+    // do not refresh the editor as it invokes full re-paint,
+    // just mark as dirty
+    this._dirty = !this._rendered;
   }
 
   /**
@@ -1217,6 +1224,7 @@ export class MarkdownCell extends Cell {
   private _renderer: IRenderMime.IRenderer = null;
   private _rendermime: IRenderMimeRegistry;
   private _rendered = true;
+  private _dirty = false;
   private _prevText = '';
   private _ready = new PromiseDelegate<void>();
 }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1129,6 +1129,20 @@ export class MarkdownCell extends Cell {
     }
   }
 
+  set editor_activated_for_search(value: boolean) {
+    value = !value;
+    if (value === this._rendered) {
+      return;
+    }
+    this._rendered = value;
+    if (!this._rendered) {
+      this.showEditor();
+    } else {
+      void this._updateRenderedInput();
+      this.renderInput(this._renderer);
+    }
+  }
+
   /**
    * Render an input instead of the text editor.
    */

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -142,7 +142,9 @@ export class CodeMirrorSearchProvider
     this._matchState = {};
     this._currentMatch = null;
 
-    if (removeOverlay) this._cm.removeOverlay(this._overlay);
+    if (removeOverlay) {
+      this._cm.removeOverlay(this._overlay);
+    }
     const from = this._cm.getCursor('from');
     const to = this._cm.getCursor('to');
     // Setting a reverse selection to allow search-as-you-type to maintain the
@@ -369,7 +371,7 @@ export class CodeMirrorSearchProvider
     return {
       /**
        * Token function is called when a line needs to be processed -
-       * when the overlay is intially created, it's called on all lines;
+       * when the overlay is initially created, it's called on all lines;
        * when a line is modified and needs to be re-evaluated, it's called
        * on just that line.
        *

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -106,7 +106,8 @@ export class CodeMirrorSearchProvider
     query: RegExp,
     refreshOverlay: boolean = true
   ): Promise<ISearchMatch[]> {
-    await this.endQuery();
+    // no point in removing overlay in the middle of the search
+    await this.endQuery(false);
 
     this._query = query;
 
@@ -137,10 +138,11 @@ export class CodeMirrorSearchProvider
    * @returns A promise that resolves when the search provider is ready to
    * begin a new search.
    */
-  async endQuery(): Promise<void> {
+  async endQuery(removeOverlay = true): Promise<void> {
     this._matchState = {};
     this._currentMatch = null;
-    this._cm.removeOverlay(this._overlay);
+
+    if (removeOverlay) this._cm.removeOverlay(this._overlay);
     const from = this._cm.getCursor('from');
     const to = this._cm.getCursor('to');
     // Setting a reverse selection to allow search-as-you-type to maintain the

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -95,16 +95,25 @@ export class CodeMirrorSearchProvider
     searchTarget: CodeMirrorEditor
   ): Promise<ISearchMatch[]> {
     this._cm = searchTarget;
-    return this._startQuery(query);
+    return this._startQuery(query, false);
   }
 
-  private async _startQuery(query: RegExp): Promise<ISearchMatch[]> {
+  refreshOverlay() {
+    this._refreshOverlay();
+  }
+
+  private async _startQuery(
+    query: RegExp,
+    refreshOverlay: boolean = true
+  ): Promise<ISearchMatch[]> {
     await this.endQuery();
 
     this._query = query;
 
     CodeMirror.on(this._cm.doc, 'change', this._onDocChanged.bind(this));
-    this._refreshOverlay();
+    if (refreshOverlay) {
+      this._refreshOverlay();
+    }
     this._setInitialMatches(query);
 
     const matches = this._parseMatchesFromState();

--- a/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
+++ b/packages/documentsearch/src/providers/codemirrorsearchprovider.ts
@@ -262,7 +262,7 @@ export class CodeMirrorSearchProvider
   }
 
   /**
-   * The same list of matches provided by the startQuery promise resoluton
+   * The same list of matches provided by the startQuery promise resolution
    */
   get matches(): ISearchMatch[] {
     return this._parseMatchesFromState();

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -32,7 +32,7 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
   }
 
   /**
-   * Initialize the search using the provided options.  Should update the UI
+   * Initialize the search using the provided options. Should update the UI
    * to highlight all matches and "select" whatever the first match should be.
    *
    * @param query A RegExp to be use to perform the search
@@ -133,7 +133,7 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
 
   /**
    * Gradually refresh cells in the background so that the user will not
-   * experience frozen interface, 5 cells at a time
+   * experience frozen interface, 5 cells at a time.
    */
   private _refreshCellsEditorsInBackground(cells: Cell[], n: number = 5) {
     let i = 0;
@@ -150,7 +150,7 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
   }
 
   /**
-   * Refresh the editor in the cell for the current match
+   * Refresh the editor in the cell for the current match.
    */
   private _refreshCurrentCellEditor() {
     const notebook = this._searchTarget.content;

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -70,7 +70,7 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
       // or if there are no matches
       let cellShouldReRender = false;
       if (cell instanceof MarkdownCell && cell.rendered) {
-        cell.rendered = false;
+        cell.editor_activated_for_search = true;
         cellShouldReRender = true;
       }
 
@@ -88,8 +88,11 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
           // un-render markdown cells with matches
           this._unRenderedMarkdownCells.push(cell);
         } else if (cellShouldReRender) {
-          cell.rendered = true;
+          cell.editor_activated_for_search = false;
         }
+      }
+      if (matchesFromCell.length !== 0) {
+        cmSearchProvider.refreshOverlay();
       }
 
       // update the match indices to reflect the whole document index values

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -138,15 +138,15 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
   private _refreshCellsEditorsInBackground(cells: Cell[], n: number = 5) {
     let i = 0;
 
-    let refreshNextCell = () => {
+    let refreshNextNCells = () => {
       for (let stop = i + n; i < stop && i < cells.length; i++) {
         cells[i].editor.refresh();
       }
       if (i < cells.length) {
-        window.setTimeout(refreshNextCell, 0);
+        window.setTimeout(refreshNextNCells, 0);
       }
     };
-    window.setTimeout(refreshNextCell, 0);
+    window.setTimeout(refreshNextNCells, 0);
   }
 
   /**

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -138,7 +138,7 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
     this._unRenderedMarkdownCells.forEach((cell: MarkdownCell) => {
       // Guard against the case where markdown cells have been deleted
       if (!cell.isDisposed) {
-        cell.rendered = true;
+        cell.editor_activated_for_search = false;
       }
     });
     this._unRenderedMarkdownCells = [];
@@ -162,7 +162,7 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
 
     this._cmSearchProviders = [];
     this._unRenderedMarkdownCells.forEach((cell: MarkdownCell) => {
-      cell.rendered = true;
+      cell.editor_activated_for_search = false;
     });
     this._unRenderedMarkdownCells = [];
 

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -53,6 +53,9 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
     const cellList = this._searchTarget.model.cells;
     cellList.changed.connect(this._restartQuery.bind(this), this);
 
+    // hide the current notebook widget to prevent expensive layout re-calculation operations
+    this._searchTarget.hide();
+
     let indexTotal = 0;
     const allMatches: ISearchMatch[] = [];
     // For each cell, create a search provider and collect the matches
@@ -70,7 +73,7 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
       // or if there are no matches
       let cellShouldReRender = false;
       if (cell instanceof MarkdownCell && cell.rendered) {
-        cell.editor_activated_for_search = true;
+        cell.renderedDirty = false;
         cellShouldReRender = true;
       }
 
@@ -88,11 +91,13 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
           // un-render markdown cells with matches
           this._unRenderedMarkdownCells.push(cell);
         } else if (cellShouldReRender) {
-          cell.editor_activated_for_search = false;
+          // was rendered previously, no need to refresh
+          cell.renderedDirty = true;
         }
       }
       if (matchesFromCell.length !== 0) {
         cmSearchProvider.refreshOverlay();
+        this._cellsWithMatches.push(cell);
       }
 
       // update the match indices to reflect the whole document index values
@@ -112,11 +117,44 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
       });
     }
 
+    // show the widget again, recalculation of layout will matter again
+    // and so that the next step will scroll correctly to the first match
+    this._searchTarget.show();
+
     this._currentMatch = await this._stepNext(
       this._searchTarget.content.activeCell
     );
+    this._refreshCurrentCellEditor();
+
+    this._refreshCellsEditorsInBackground(this._cellsWithMatches);
 
     return allMatches;
+  }
+
+  /**
+   * Gradually refresh cells in the background so that the user will not
+   * experience frozen interface, 5 cells at a time
+   */
+  private _refreshCellsEditorsInBackground(cells: Cell[], n: number = 5) {
+    let i = 0;
+
+    let refreshNextCell = () => {
+      for (let stop = i + n; i < stop && i < cells.length; i++) {
+        cells[i].editor.refresh();
+      }
+      if (i < cells.length) {
+        window.setTimeout(refreshNextCell, 0);
+      }
+    };
+    window.setTimeout(refreshNextCell, 0);
+  }
+
+  /**
+   * Refresh the editor in the cell for the current match
+   */
+  private _refreshCurrentCellEditor() {
+    const notebook = this._searchTarget.content;
+    notebook.activeCell.editor.refresh();
   }
 
   /**
@@ -127,6 +165,8 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
    * begin a new search.
    */
   async endQuery(): Promise<void> {
+    this._searchTarget.hide();
+
     const queriesEnded: Promise<void>[] = [];
     this._cmSearchProviders.forEach(({ provider }) => {
       queriesEnded.push(provider.endQuery());
@@ -138,11 +178,21 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
     this._unRenderedMarkdownCells.forEach((cell: MarkdownCell) => {
       // Guard against the case where markdown cells have been deleted
       if (!cell.isDisposed) {
-        cell.editor_activated_for_search = false;
+        cell.renderedDirty = true;
       }
     });
     this._unRenderedMarkdownCells = [];
     await Promise.all(queriesEnded);
+    this._searchTarget.show();
+
+    this._refreshCurrentCellEditor();
+    // re-render all non-markdown cells with matches (which were rendered, thus do not need refreshing)
+    this._refreshCellsEditorsInBackground(
+      this._cellsWithMatches.filter(
+        (cell: Cell) => !(cell instanceof MarkdownCell)
+      )
+    );
+    this._cellsWithMatches = [];
   }
 
   /**
@@ -151,6 +201,7 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
    * @returns A promise that resolves when all state has been cleaned up.
    */
   async endSearch(): Promise<void> {
+    this._searchTarget.hide();
     Signal.disconnectBetween(this._searchTarget.model.cells, this);
 
     const index = this._searchTarget.content.activeCellIndex;
@@ -162,15 +213,25 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
 
     this._cmSearchProviders = [];
     this._unRenderedMarkdownCells.forEach((cell: MarkdownCell) => {
-      cell.editor_activated_for_search = false;
+      cell.renderedDirty = true;
     });
     this._unRenderedMarkdownCells = [];
 
     this._searchTarget.content.activeCellIndex = index;
     this._searchTarget.content.mode = 'edit';
-    this._searchTarget = null;
     this._currentMatch = null;
     await Promise.all(searchEnded);
+    this._searchTarget.show();
+    this._refreshCurrentCellEditor();
+    this._searchTarget = null;
+
+    // re-render all non-markdown cells with matches (which were rendered, thus do not need refreshing)
+    this._refreshCellsEditorsInBackground(
+      this._cellsWithMatches.filter(
+        (cell: Cell) => !(cell instanceof MarkdownCell)
+      )
+    );
+    this._cellsWithMatches = [];
   }
 
   /**
@@ -370,5 +431,6 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
   private _cmSearchProviders: ICellSearchPair[] = [];
   private _currentMatch: ISearchMatch;
   private _unRenderedMarkdownCells: MarkdownCell[] = [];
+  private _cellsWithMatches: Cell[] = [];
   private _changed = new Signal<this, void>(this);
 }


### PR DESCRIPTION
## References

Fixes #6756

## Code changes

The major culprit of the slowness is re-rendering of the CodeMirror cells. This PR addresses this issue by:
- eliminating use of `rendered` property setter at search time setter which has a side-effects of refreshing the editor (instead introducing `renderedDirty` which does not refresh editor)
- removing unnecessary refreshing operations for search overlay in-between of search operations (by introducing `removeOverlay` argument to `endQuery`)
- disabling all layout recalculations during the actual search and then re-rendering cells gradually in a non-blocking manner, which eliminates interface freezes (implemented by hiding the Notebook widget for the search time and then refreshing editors of cells in background)

## User-facing changes

Positive:
- the JupyterLab interface no longer freezes for 10+ seconds when searching in a large notebook
- the code cell with the first result is now always available and rendered immediately

Negative (can be addressed later or maybe as a part of this PR):
- the re-rendering is sometimes noticeable:
   - in the first search after opening the notebook, when the markdown cells have empty editors
  -  in cells around the active cell when the active cell is close to the end of the notebook

## Backwards-incompatible changes

None.

## Performance testing and characteristics

### Before:
In large noteboks the UI has been freezing for tens of seconds (here showing response time 14s):
![Screenshot from 2019-07-14 00-21-40](https://user-images.githubusercontent.com/5832902/61177455-a1074e00-a5cd-11e9-92a5-9a0f27c8b9c5.png)

Which was caused by consecutive layout recalculations (cell-by-cell), repainting the entire notebook:
![Screenshot from 2019-07-13 23-54-14](https://user-images.githubusercontent.com/5832902/61177420-1b839e00-a5cd-11e9-9bb9-56b99bef9aaf.png)

Each individuall cell (Code or Markdown) was limitted by the known bottlnecks of CodeMirror: 
![Screenshot from 2019-07-13 20-43-23](https://user-images.githubusercontent.com/5832902/61177417-0575dd80-a5cd-11e9-9a1b-a7095f1b8f47.png)

### After:

The actual search is performed quickly (here in 1.5s), while the repainting of cells is spread in time allowing for full responsiveness of the user interface:
![Screenshot from 2019-07-14 00-23-12](https://user-images.githubusercontent.com/5832902/61177459-b7150e80-a5cd-11e9-9c79-46585f838672.png)

The first task repaints entire notebook once; second tasks repaints the first cells with matches (activated by `_stepNext`) and consecutive tasks are running in the background, refreshing editors for all cells with matches:
![Screenshot from 2019-07-13 23-56-42](https://user-images.githubusercontent.com/5832902/61177419-145c9000-a5cd-11e9-84c4-e14a53dd018f.png)
