### PR TITLE
Add Copy Shareable Link to common extension points.

### DIFF
--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -407,3 +407,14 @@ browser supports overriding the behavior of this item.
        label: 'Copy Shareable Link'
      });
    }
+
+Note that before enabling this plugin in the usual way, you must *disable* the
+default plugin provided by the built-in file browser.
+
+.. code:: bash
+
+   jupyter labextension disable @jupyterlab/filebrowser-extension:share-file
+
+There are plans to, in a future release of JupyterLab, provide a way for
+extensions to describe which extension points they override, so that
+procedurally disabiling the default will no longer be necessary.

--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -356,3 +356,54 @@ Widget tracker tokens are provided for many activities in JupyterLab, including
 notebooks, consoles, text files, mime documents, and terminals.
 If you are adding your own activities to JupyterLab, you might consider providing
 a ``WidgetTracker`` token of your own, so that other extensions can make use of it.
+
+.. _copy_shareable_link:
+
+Copy Shareable Link
+~~~~~~~~~~~~~~~~~~~
+
+The file browser provides a context menu item "Copy Shareable Link". The
+desired behavior will vary by deployment and the users it serves. The file
+browser supports overriding the behavior of this item.
+
+.. code:: typescript
+
+   import {
+     IFileBrowserFactory
+   } from '@jupyterlab/filebrowser';
+
+   import {
+     JupyterFrontEnd, JupyterFrontEndPlugin
+   } from '@jupyterlab/application';
+
+
+   const shareFile: JupyterFrontEndPlugin<void> = {
+     activate: activateShareFile,
+     id: commandID,
+     requires: [IFileBrowserFactory],
+     autoStart: true
+   };
+
+   function activateShareFile(
+     app: JupyterFrontEnd,
+     factory: IFileBrowserFactory
+   ): void {
+     const { commands } = app;
+     const { tracker } = factory;
+
+     commands.addCommand('filebrowser:share-main', {
+       execute: () => {
+         const widget = tracker.currentWidget;
+         if (!widget) {
+           return;
+         }
+         const path = encodeURI(widget.selectedItems().next().path);
+         // Do something with path.
+       },
+       isVisible: () =>
+         tracker.currentWidget &&
+         toArray(tracker.currentWidget.selectedItems()).length === 1,
+       iconClass: 'jp-MaterialIcon jp-LinkIcon',
+       label: 'Copy Shareable Link'
+     });
+   }

--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -414,7 +414,3 @@ default plugin provided by the built-in file browser.
 .. code:: bash
 
    jupyter labextension disable @jupyterlab/filebrowser-extension:share-file
-
-There are plans to, in a future release of JupyterLab, provide a way for
-extensions to describe which extension points they override, so that
-procedurally disabiling the default will no longer be necessary.


### PR DESCRIPTION
This PR only touches documentation. It adds a subsection to the
developer documentation on common extension points to address "Copy
Shareable Link". @afshin mentioned that I am the second (known) user to
look for this extension point so it might be worth documenting.

Is this too much detail? Feel free to suggest heavy edits.