### PR TITLE
fix bug #6072

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -373,7 +373,11 @@ export class Context<T extends DocumentRegistry.IModel>
       // When folder name changed, `oldPath` is `foo`, `newPath` is `bar` and `this._path` is `foo/test`,
       // we should update `foo/test` to `bar/test` as well
       if (oldPath !== this._path) {
-        newPath = this._path.replace(new RegExp(`^${oldPath}`), newPath);
+        if (this._path.indexOf('/') !== -1) {
+          newPath = this._path.replace(new RegExp(`^${oldPath}`), newPath);
+        } else {
+          newPath = this._path;
+        }
         oldPath = this._path;
         // Update client file model from folder change
         changeModel = {


### PR DESCRIPTION
## References

#6072

## Code changes

find _path not with "/", don't need change

## User-facing changes

Consider an open file in JupyterLab called `"FOLDERNAME-suffix", and a directory called "FOLDERNAME", both in the same parent directory. Rrenaming the directory to "NEWFOLDERNAME" will lead to the open file tab being renamed to "NEWFOLDERNAME-suffix".

Now, it don't change "FOLDERNAME-suffix"

## Backwards-incompatible changes

None.