### PR TITLE
replaced rotted link in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you believe you’ve found a security vulnerability in JupyterLab or any
 Jupyter project, please report it to
 [security@ipython.org](mailto:security@ipython.org). If you prefer to encrypt your
 security reports, you can use [this PGP public
-key](https://jupyter-notebook.readthedocs.io/en/stable/_downloads/ipython_security.asc).
+key](https://raw.githubusercontent.com/jupyter/notebook/master/docs/source/ipython_security.asc).
 
 ## General Guidelines for Contributing
 


### PR DESCRIPTION
this was fouling up the docs CI

## References

None

## Code changes

The link to the IPython PGP key rotted (the link in the latest version of the `notebook` docs added a commit hash). I replaced it with a link to the raw file in Github.

## User-facing changes

## Backwards-incompatible changes
