### PR TITLE
fixes #6850 #6851: always use kernel display_name in statusbar

### DIFF
--- a/packages/statusbar/src/defaults/kernelStatus.tsx
+++ b/packages/statusbar/src/defaults/kernelStatus.tsx
@@ -185,13 +185,13 @@ export namespace KernelStatus {
           // sync setting of status and display name
           this._kernelStatus = newValue.status;
           this._kernelName = spec.display_name;
+          this._triggerChange(oldState, this._getAllState());
         });
       } else {
         this._kernelStatus = 'unknown';
         this._kernelName = 'unknown';
+        this._triggerChange(oldState, this._getAllState());
       }
-
-      this._triggerChange(oldState, this._getAllState());
     };
 
     private _getAllState(): [string, string, string] {

--- a/packages/statusbar/src/defaults/kernelStatus.tsx
+++ b/packages/statusbar/src/defaults/kernelStatus.tsx
@@ -22,9 +22,7 @@ function KernelStatusComponent(
   return (
     <TextItem
       onClick={props.handleClick}
-      source={`${Text.titleCase(props.kernelName)} | ${Text.titleCase(
-        props.status
-      )}`}
+      source={`${props.kernelName} | ${Text.titleCase(props.status)}`}
       title={`Change kernel for ${props.activityName}`}
     />
   );
@@ -153,7 +151,7 @@ export namespace KernelStatus {
         this._kernelName = 'unknown';
       } else {
         this._kernelStatus = this._session.status;
-        this._kernelName = this._session.kernelDisplayName.toLowerCase();
+        this._kernelName = this._session.kernelDisplayName;
 
         this._session.statusChanged.connect(this._onKernelStatusChanged);
         this._session.kernelChanged.connect(this._onKernelChanged);
@@ -183,8 +181,11 @@ export namespace KernelStatus {
       const oldState = this._getAllState();
       const { newValue } = change;
       if (newValue !== null) {
-        this._kernelStatus = newValue.status;
-        this._kernelName = newValue.model.name.toLowerCase();
+        newValue.getSpec().then(spec => {
+          // sync setting of status and display name
+          this._kernelStatus = newValue.status;
+          this._kernelName = spec.display_name;
+        });
       } else {
         this._kernelStatus = 'unknown';
         this._kernelName = 'unknown';


### PR DESCRIPTION
Also removes capitalization change of kernel display_name.

## References

#6850 
#6851

## Code changes

Gets kernel specs as a promise, sets kernel `display_name` as part of the resolution.

## User-facing changes

The kernel name in the statusbar will always match the kernel name in the launcher (and elsewhere), and the capitalization will be the same.

## Backwards-incompatible changes

None
