### PR TITLE
fix intermittent CI failure in `@jupyterlab/test-notebook` by explicitly handling kernels and other external resources

### DIFF
--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -60,6 +60,11 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
     );
 
     void this.revealed.then(() => {
+      if (this.isDisposed) {
+        // this widget has already been disposed, bail
+        return;
+      }
+
       // Set the document edit mode on initial open if it looks like a new document.
       if (this.content.widgets.length === 1) {
         let cellModel = this.content.widgets[0].model;

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -21,7 +21,7 @@ import {
   waitForDialog,
   acceptDialog,
   dismissDialog,
-  createNotebookContext,
+  initNotebookContext,
   NBTestUtils
 } from '@jupyterlab/testutils';
 
@@ -189,7 +189,7 @@ describe('docregistry/context', () => {
       });
 
       it('should initialize the model when the file is saved for the first time', async () => {
-        const context = await createNotebookContext();
+        const context = await initNotebookContext();
         context.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
         expect(context.model.cells.canUndo).to.equal(true);
         await context.initialize(true);
@@ -198,7 +198,7 @@ describe('docregistry/context', () => {
       });
 
       it('should initialize the model when the file is reverted for the first time', async () => {
-        const context = await createNotebookContext();
+        const context = await initNotebookContext();
         await manager.contents.save(context.path, {
           type: 'notebook',
           format: 'json',

--- a/tests/test-notebook/package.json
+++ b/tests/test-notebook/package.json
@@ -12,8 +12,8 @@
     "test:debug": "python run-test.py  --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000 karma.conf.js",
     "test:debug:chrome-headless": "python run-test.py  --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000 karma.conf.js",
     "test:firefox": "python run-test.py --browsers=Firefox karma.conf.js",
-    "test:watch": "python run-test.py  --browsers=Chrome --singleRun=false --debug=true --watch --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000 karma.conf.js",
     "test:ie": "python run-test.py  --browsers=IE karma.conf.js",
+    "test:watch": "python run-test.py  --browsers=Chrome --singleRun=false --debug=true --watch --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000 karma.conf.js",
     "watch": "tsc -b --watch",
     "watch:src": "tsc -p src --watch"
   },

--- a/tests/test-notebook/package.json
+++ b/tests/test-notebook/package.json
@@ -9,8 +9,10 @@
     "test": "jlpm run test:firefox",
     "test:chrome": "python run-test.py --browsers=Chrome karma.conf.js",
     "test:chrome-headless": "python run-test.py --browsers=ChromeHeadless karma.conf.js",
-    "test:debug": "python run-test.py  --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 karma.conf.js",
+    "test:debug": "python run-test.py  --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000 karma.conf.js",
+    "test:debug:chrome-headless": "python run-test.py  --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000 karma.conf.js",
     "test:firefox": "python run-test.py --browsers=Firefox karma.conf.js",
+    "test:watch": "python run-test.py  --browsers=Chrome --singleRun=false --debug=true --watch --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000 karma.conf.js",
     "test:ie": "python run-test.py  --browsers=IE karma.conf.js",
     "watch": "tsc -b --watch",
     "watch:src": "tsc -p src --watch"

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -40,6 +40,8 @@ describe('@jupyterlab/notebook', () => {
       await context.initialize(true);
       panel = NBTestUtils.createNotebookPanel(context);
       context.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
+      await context.session.initialize();
+      await context.session.kernel.ready;
     });
 
     afterEach(async () => {

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -21,7 +21,7 @@ import {
 } from '@jupyterlab/notebook';
 
 import {
-  createNotebookContext,
+  initNotebookContext,
   signalToPromise,
   sleep,
   NBTestUtils,
@@ -32,225 +32,250 @@ const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
 
 describe('@jupyterlab/notebook', () => {
   describe('ToolbarItems', () => {
-    let context: Context<INotebookModel>;
-    let panel: NotebookPanel;
+    describe('noKernel', () => {
+      let context: Context<INotebookModel>;
+      let panel: NotebookPanel;
 
-    beforeEach(async () => {
-      context = await createNotebookContext();
-      await context.initialize(true);
-      panel = NBTestUtils.createNotebookPanel(context);
-      context.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-      await context.session.initialize();
-      await context.session.kernel.ready;
-    });
-
-    afterEach(async () => {
-      await context.session.shutdown();
-      context.dispose();
-      panel.dispose();
-    });
-
-    describe('#createSaveButton()', () => {
-      it('should save when clicked', async () => {
-        const button = ToolbarItems.createSaveButton(panel);
-        Widget.attach(button, document.body);
-        let promise = signalToPromise(context.fileChanged);
-        await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
-        await promise;
-        button.dispose();
+      beforeEach(async () => {
+        context = await initNotebookContext();
+        panel = NBTestUtils.createNotebookPanel(context);
+        context.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
       });
 
-      it("should have the `'jp-SaveIcon'` class", async () => {
-        const button = ToolbarItems.createSaveButton(panel);
-        Widget.attach(button, document.body);
-        await framePromise();
-        expect(button.node.querySelector('.jp-SaveIcon')).to.exist;
-      });
-    });
-
-    describe('#createInsertButton()', () => {
-      it('should insert below when clicked', async () => {
-        const button = ToolbarItems.createInsertButton(panel);
-        Widget.attach(button, document.body);
-        await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
-        expect(panel.content.activeCellIndex).to.equal(1);
-        expect(panel.content.activeCell).to.be.an.instanceof(CodeCell);
-        button.dispose();
+      afterEach(() => {
+        panel.dispose();
+        context.dispose();
       });
 
-      it("should have the `'jp-AddIcon'` class", async () => {
-        const button = ToolbarItems.createInsertButton(panel);
-        Widget.attach(button, document.body);
-        await framePromise();
-        expect(button.node.querySelector('.jp-AddIcon')).to.exist;
-      });
-    });
-
-    describe('#createCutButton()', () => {
-      it('should cut when clicked', async () => {
-        const button = ToolbarItems.createCutButton(panel);
-        const count = panel.content.widgets.length;
-        Widget.attach(button, document.body);
-        await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
-        expect(panel.content.widgets.length).to.equal(count - 1);
-        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
-        button.dispose();
-      });
-
-      it("should have the `'jp-CutIcon'` class", async () => {
-        const button = ToolbarItems.createCutButton(panel);
-        Widget.attach(button, document.body);
-        await framePromise();
-        expect(button.node.querySelector('.jp-CutIcon')).to.exist;
-      });
-    });
-
-    describe('#createCopyButton()', () => {
-      it('should copy when clicked', async () => {
-        const button = ToolbarItems.createCopyButton(panel);
-        const count = panel.content.widgets.length;
-        Widget.attach(button, document.body);
-        await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
-        expect(panel.content.widgets.length).to.equal(count);
-        expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(true);
-        button.dispose();
-      });
-
-      it("should have the `'jp-CopyIcon'` class", async () => {
-        const button = ToolbarItems.createCopyButton(panel);
-        Widget.attach(button, document.body);
-        await framePromise();
-        expect(button.node.querySelector('.jp-CopyIcon')).to.exist;
-      });
-    });
-
-    describe('#createPasteButton()', () => {
-      it('should paste when clicked', async () => {
-        const button = ToolbarItems.createPasteButton(panel);
-        const count = panel.content.widgets.length;
-        Widget.attach(button, document.body);
-        await framePromise();
-        NotebookActions.copy(panel.content);
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
-        await sleep();
-        expect(panel.content.widgets.length).to.equal(count + 1);
-        button.dispose();
-      });
-
-      it("should have the `'jp-PasteIcon'` class", async () => {
-        const button = ToolbarItems.createPasteButton(panel);
-        Widget.attach(button, document.body);
-        await framePromise();
-        expect(button.node.querySelector('.jp-PasteIcon')).to.exist;
-      });
-    });
-
-    describe('#createRunButton()', () => {
-      it('should run and advance when clicked', async () => {
-        const button = ToolbarItems.createRunButton(panel);
-        const widget = panel.content;
-
-        // Clear and select the first two cells.
-        const codeCell = widget.widgets[0] as CodeCell;
-        codeCell.model.outputs.clear();
-        widget.select(codeCell);
-        const mdCell = widget.widgets[1] as MarkdownCell;
-        mdCell.rendered = false;
-        widget.select(mdCell);
-
-        Widget.attach(button, document.body);
-        await context.ready;
-        await context.session.ready;
-        await context.session.kernel.ready;
-        const p = new PromiseDelegate();
-        context.session.statusChanged.connect((sender, status) => {
-          // Find the right status idle message
-          if (status === 'idle' && codeCell.model.outputs.length > 0) {
-            expect(mdCell.rendered).to.equal(true);
-            expect(widget.activeCellIndex).to.equal(2);
-            button.dispose();
-            p.resolve(0);
-          }
+      describe('#createSaveButton()', () => {
+        it('should save when clicked', async () => {
+          const button = ToolbarItems.createSaveButton(panel);
+          Widget.attach(button, document.body);
+          let promise = signalToPromise(context.fileChanged);
+          await framePromise();
+          simulate(button.node.firstChild as HTMLElement, 'mousedown');
+          await promise;
+          button.dispose();
         });
-        await framePromise();
-        simulate(button.node.firstChild as HTMLElement, 'mousedown');
-        await p.promise;
-      }).timeout(30000); // Allow for slower CI
 
-      it("should have the `'jp-RunIcon'` class", async () => {
-        const button = ToolbarItems.createRunButton(panel);
-        Widget.attach(button, document.body);
-        await framePromise();
-        expect(button.node.querySelector('.jp-RunIcon')).to.exist;
+        it("should have the `'jp-SaveIcon'` class", async () => {
+          const button = ToolbarItems.createSaveButton(panel);
+          Widget.attach(button, document.body);
+          await framePromise();
+          expect(button.node.querySelector('.jp-SaveIcon')).to.exist;
+        });
+      });
+
+      describe('#createInsertButton()', () => {
+        it('should insert below when clicked', async () => {
+          const button = ToolbarItems.createInsertButton(panel);
+          Widget.attach(button, document.body);
+          await framePromise();
+          simulate(button.node.firstChild as HTMLElement, 'mousedown');
+          expect(panel.content.activeCellIndex).to.equal(1);
+          expect(panel.content.activeCell).to.be.an.instanceof(CodeCell);
+          button.dispose();
+        });
+
+        it("should have the `'jp-AddIcon'` class", async () => {
+          const button = ToolbarItems.createInsertButton(panel);
+          Widget.attach(button, document.body);
+          await framePromise();
+          expect(button.node.querySelector('.jp-AddIcon')).to.exist;
+          button.dispose();
+        });
+      });
+
+      describe('#createCutButton()', () => {
+        it('should cut when clicked', async () => {
+          const button = ToolbarItems.createCutButton(panel);
+          const count = panel.content.widgets.length;
+          Widget.attach(button, document.body);
+          await framePromise();
+          simulate(button.node.firstChild as HTMLElement, 'mousedown');
+          expect(panel.content.widgets.length).to.equal(count - 1);
+          expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(
+            true
+          );
+          button.dispose();
+        });
+
+        it("should have the `'jp-CutIcon'` class", async () => {
+          const button = ToolbarItems.createCutButton(panel);
+          Widget.attach(button, document.body);
+          await framePromise();
+          expect(button.node.querySelector('.jp-CutIcon')).to.exist;
+          button.dispose();
+        });
+      });
+
+      describe('#createCopyButton()', () => {
+        it('should copy when clicked', async () => {
+          const button = ToolbarItems.createCopyButton(panel);
+          const count = panel.content.widgets.length;
+          Widget.attach(button, document.body);
+          await framePromise();
+          simulate(button.node.firstChild as HTMLElement, 'mousedown');
+          expect(panel.content.widgets.length).to.equal(count);
+          expect(NBTestUtils.clipboard.hasData(JUPYTER_CELL_MIME)).to.equal(
+            true
+          );
+          button.dispose();
+        });
+
+        it("should have the `'jp-CopyIcon'` class", async () => {
+          const button = ToolbarItems.createCopyButton(panel);
+          Widget.attach(button, document.body);
+          await framePromise();
+          expect(button.node.querySelector('.jp-CopyIcon')).to.exist;
+          button.dispose();
+        });
+      });
+
+      describe('#createPasteButton()', () => {
+        it('should paste when clicked', async () => {
+          const button = ToolbarItems.createPasteButton(panel);
+          const count = panel.content.widgets.length;
+          Widget.attach(button, document.body);
+          await framePromise();
+          NotebookActions.copy(panel.content);
+          simulate(button.node.firstChild as HTMLElement, 'mousedown');
+          await sleep();
+          expect(panel.content.widgets.length).to.equal(count + 1);
+          button.dispose();
+        });
+
+        it("should have the `'jp-PasteIcon'` class", async () => {
+          const button = ToolbarItems.createPasteButton(panel);
+          Widget.attach(button, document.body);
+          await framePromise();
+          expect(button.node.querySelector('.jp-PasteIcon')).to.exist;
+          button.dispose();
+        });
+      });
+
+      describe('#createCellTypeItem()', () => {
+        it('should track the cell type of the current cell', async () => {
+          const item = ToolbarItems.createCellTypeItem(panel);
+          Widget.attach(item, document.body);
+          await framePromise();
+          const node = item.node.getElementsByTagName(
+            'select'
+          )[0] as HTMLSelectElement;
+          expect(node.value).to.equal('code');
+          panel.content.activeCellIndex++;
+          await framePromise();
+          expect(node.value).to.equal('markdown');
+          item.dispose();
+        });
+
+        it("should display `'-'` if multiple cell types are selected", async () => {
+          const item = ToolbarItems.createCellTypeItem(panel);
+          Widget.attach(item, document.body);
+          await framePromise();
+          const node = item.node.getElementsByTagName(
+            'select'
+          )[0] as HTMLSelectElement;
+          expect(node.value).to.equal('code');
+          panel.content.select(panel.content.widgets[1]);
+          await framePromise();
+          expect(node.value).to.equal('-');
+          item.dispose();
+        });
+
+        it('should display the active cell type if multiple cells of the same type are selected', async () => {
+          const item = ToolbarItems.createCellTypeItem(panel);
+          Widget.attach(item, document.body);
+          await framePromise();
+          const node = item.node.getElementsByTagName(
+            'select'
+          )[0] as HTMLSelectElement;
+          expect(node.value).to.equal('code');
+          const cell = panel.model.contentFactory.createCodeCell({});
+          panel.model.cells.insert(1, cell);
+          panel.content.select(panel.content.widgets[1]);
+          await framePromise();
+          expect(node.value).to.equal('code');
+          item.dispose();
+        });
+      });
+
+      describe('#getDefaultItems()', () => {
+        it('should return the default items of the panel toolbar', () => {
+          const names = ToolbarItems.getDefaultItems(panel).map(item => {
+            const name = item.name;
+            item.widget.dispose();
+            return name;
+          });
+          expect(names).to.deep.equal([
+            'save',
+            'insert',
+            'cut',
+            'copy',
+            'paste',
+            'run',
+            'interrupt',
+            'restart',
+            'cellType',
+            'spacer',
+            'kernelName',
+            'kernelStatus'
+          ]);
+        });
       });
     });
 
-    describe('#createCellTypeItem()', () => {
-      it('should track the cell type of the current cell', async () => {
-        const item = ToolbarItems.createCellTypeItem(panel);
-        Widget.attach(item, document.body);
-        await framePromise();
-        const node = item.node.getElementsByTagName(
-          'select'
-        )[0] as HTMLSelectElement;
-        expect(node.value).to.equal('code');
-        panel.content.activeCellIndex++;
-        await framePromise();
-        expect(node.value).to.equal('markdown');
+    describe('kernelRequired', () => {
+      let context: Context<INotebookModel>;
+      let panel: NotebookPanel;
+
+      beforeEach(async () => {
+        context = await initNotebookContext({ startKernel: true });
+        panel = NBTestUtils.createNotebookPanel(context);
+        context.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);
       });
 
-      it("should display `'-'` if multiple cell types are selected", async () => {
-        const item = ToolbarItems.createCellTypeItem(panel);
-        Widget.attach(item, document.body);
-        await framePromise();
-        const node = item.node.getElementsByTagName(
-          'select'
-        )[0] as HTMLSelectElement;
-        expect(node.value).to.equal('code');
-        panel.content.select(panel.content.widgets[1]);
-        await framePromise();
-        expect(node.value).to.equal('-');
+      afterEach(async () => {
+        await context.session.shutdown();
+        panel.dispose();
+        context.dispose();
       });
 
-      it('should display the active cell type if multiple cells of the same type are selected', async () => {
-        const item = ToolbarItems.createCellTypeItem(panel);
-        Widget.attach(item, document.body);
-        await framePromise();
-        const node = item.node.getElementsByTagName(
-          'select'
-        )[0] as HTMLSelectElement;
-        expect(node.value).to.equal('code');
-        const cell = panel.model.contentFactory.createCodeCell({});
-        panel.model.cells.insert(1, cell);
-        panel.content.select(panel.content.widgets[1]);
-        await framePromise();
-        expect(node.value).to.equal('code');
-      });
-    });
+      describe('#createRunButton()', () => {
+        it('should run and advance when clicked', async () => {
+          const button = ToolbarItems.createRunButton(panel);
+          const widget = panel.content;
 
-    describe('#getDefaultItems()', () => {
-      it('should return the default items of the panel toolbar', () => {
-        const names = ToolbarItems.getDefaultItems(panel).map(
-          item => item.name
-        );
-        expect(names).to.deep.equal([
-          'save',
-          'insert',
-          'cut',
-          'copy',
-          'paste',
-          'run',
-          'interrupt',
-          'restart',
-          'cellType',
-          'spacer',
-          'kernelName',
-          'kernelStatus'
-        ]);
+          // Clear and select the first two cells.
+          const codeCell = widget.widgets[0] as CodeCell;
+          codeCell.model.outputs.clear();
+          widget.select(codeCell);
+          const mdCell = widget.widgets[1] as MarkdownCell;
+          mdCell.rendered = false;
+          widget.select(mdCell);
+
+          Widget.attach(button, document.body);
+          const p = new PromiseDelegate();
+          context.session.statusChanged.connect((sender, status) => {
+            // Find the right status idle message
+            if (status === 'idle' && codeCell.model.outputs.length > 0) {
+              expect(mdCell.rendered).to.equal(true);
+              expect(widget.activeCellIndex).to.equal(2);
+              button.dispose();
+              p.resolve(0);
+            }
+          });
+          await framePromise();
+          simulate(button.node.firstChild as HTMLElement, 'mousedown');
+          await p.promise;
+        }).timeout(30000); // Allow for slower CI
+
+        it("should have the `'jp-RunIcon'` class", async () => {
+          const button = ToolbarItems.createRunButton(panel);
+          Widget.attach(button, document.body);
+          await framePromise();
+          expect(button.node.querySelector('.jp-RunIcon')).to.exist;
+        });
       });
     });
   });

--- a/tests/test-notebook/src/notebooktools.spec.ts
+++ b/tests/test-notebook/src/notebooktools.spec.ts
@@ -26,7 +26,7 @@ import {
 } from '@jupyterlab/notebook';
 
 import {
-  createNotebookContext,
+  initNotebookContext,
   // sleep,
   NBTestUtils
 } from '@jupyterlab/testutils';
@@ -112,12 +112,10 @@ describe('@jupyterlab/notebook', () => {
     let panel1: NotebookPanel;
 
     beforeEach(async () => {
-      context0 = await createNotebookContext();
-      await context0.initialize(true);
+      context0 = await initNotebookContext();
       panel0 = NBTestUtils.createNotebookPanel(context0);
       NBTestUtils.populateNotebook(panel0.content);
-      context1 = await createNotebookContext();
-      await context1.initialize(true);
+      context1 = await initNotebookContext();
       panel1 = NBTestUtils.createNotebookPanel(context1);
       NBTestUtils.populateNotebook(panel1.content);
       tracker = new NotebookTracker({ namespace: 'notebook' });
@@ -130,29 +128,16 @@ describe('@jupyterlab/notebook', () => {
       tabpanel.addWidget(notebookTools);
       tabpanel.node.style.height = '800px';
       Widget.attach(tabpanel, document.body);
-      // // Give the posted messages a chance to be handled.
-      // await sleep();
-
-      await Promise.all([
-        await context0.session.initialize(),
-        await context1.session.initialize()
-      ]);
-      await Promise.all([
-        context0.session.kernel.ready,
-        context1.session.kernel.ready
-      ]);
     });
 
-    afterEach(async () => {
-      panel0.dispose();
-      panel1.dispose();
+    afterEach(() => {
       tabpanel.dispose();
       notebookTools.dispose();
+      panel1.dispose();
+      panel0.dispose();
 
-      await context0.session.shutdown();
-      context0.dispose();
-      await context1.session.shutdown();
       context1.dispose();
+      context0.dispose();
     });
 
     describe('NotebookTools', () => {

--- a/tests/test-notebook/src/notebooktools.spec.ts
+++ b/tests/test-notebook/src/notebooktools.spec.ts
@@ -27,7 +27,7 @@ import {
 
 import {
   createNotebookContext,
-  sleep,
+  // sleep,
   NBTestUtils
 } from '@jupyterlab/testutils';
 
@@ -130,8 +130,17 @@ describe('@jupyterlab/notebook', () => {
       tabpanel.addWidget(notebookTools);
       tabpanel.node.style.height = '800px';
       Widget.attach(tabpanel, document.body);
-      // Give the posted messages a chance to be handled.
-      await sleep();
+      // // Give the posted messages a chance to be handled.
+      // await sleep();
+
+      await Promise.all([
+        await context0.session.initialize(),
+        await context1.session.initialize()
+      ]);
+      await Promise.all([
+        context0.session.kernel.ready,
+        context1.session.kernel.ready
+      ]);
     });
 
     afterEach(async () => {

--- a/tests/test-notebook/src/notebooktools.spec.ts
+++ b/tests/test-notebook/src/notebooktools.spec.ts
@@ -25,11 +25,7 @@ import {
   NotebookTracker
 } from '@jupyterlab/notebook';
 
-import {
-  initNotebookContext,
-  // sleep,
-  NBTestUtils
-} from '@jupyterlab/testutils';
+import { initNotebookContext, sleep, NBTestUtils } from '@jupyterlab/testutils';
 
 class LogTool extends NotebookTools.Tool {
   methods: string[] = [];
@@ -128,6 +124,8 @@ describe('@jupyterlab/notebook', () => {
       tabpanel.addWidget(notebookTools);
       tabpanel.node.style.height = '800px';
       Widget.attach(tabpanel, document.body);
+      // Give the posted messages a chance to be handled.
+      await sleep();
     });
 
     afterEach(() => {

--- a/tests/test-notebook/src/notebooktools.spec.ts
+++ b/tests/test-notebook/src/notebooktools.spec.ts
@@ -13,13 +13,16 @@ import { simulate } from 'simulate-event';
 
 import { CodeMirrorEditorFactory } from '@jupyterlab/codemirror';
 
+import { Context } from '@jupyterlab/docregistry';
+
 import { ObservableJSON } from '@jupyterlab/observables';
 
 import {
-  NotebookTools,
+  INotebookModel,
+  NotebookActions,
   NotebookPanel,
-  NotebookTracker,
-  NotebookActions
+  NotebookTools,
+  NotebookTracker
 } from '@jupyterlab/notebook';
 
 import {
@@ -103,15 +106,17 @@ describe('@jupyterlab/notebook', () => {
     let notebookTools: NotebookTools;
     let tabpanel: TabPanel;
     let tracker: NotebookTracker;
+    let context0: Context<INotebookModel>;
+    let context1: Context<INotebookModel>;
     let panel0: NotebookPanel;
     let panel1: NotebookPanel;
 
     beforeEach(async () => {
-      const context0 = await createNotebookContext();
+      context0 = await createNotebookContext();
       await context0.initialize(true);
       panel0 = NBTestUtils.createNotebookPanel(context0);
       NBTestUtils.populateNotebook(panel0.content);
-      const context1 = await createNotebookContext();
+      context1 = await createNotebookContext();
       await context1.initialize(true);
       panel1 = NBTestUtils.createNotebookPanel(context1);
       NBTestUtils.populateNotebook(panel1.content);
@@ -129,9 +134,16 @@ describe('@jupyterlab/notebook', () => {
       await sleep();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+      panel0.dispose();
+      panel1.dispose();
       tabpanel.dispose();
       notebookTools.dispose();
+
+      await context0.session.shutdown();
+      context0.dispose();
+      await context1.session.shutdown();
+      context1.dispose();
     });
 
     describe('NotebookTools', () => {

--- a/tests/test-notebook/src/panel.spec.ts
+++ b/tests/test-notebook/src/panel.spec.ts
@@ -9,7 +9,7 @@ import { INotebookModel, NotebookPanel, Notebook } from '@jupyterlab/notebook';
 
 import { Toolbar } from '@jupyterlab/apputils';
 
-import { createNotebookContext, NBTestUtils } from '@jupyterlab/testutils';
+import { initNotebookContext, NBTestUtils } from '@jupyterlab/testutils';
 
 /**
  * Default data.
@@ -21,14 +21,10 @@ describe('@jupyterlab/notebook', () => {
     let context: Context<INotebookModel>;
 
     beforeEach(async () => {
-      context = await createNotebookContext();
-      await context.initialize(true);
-      await context.session.initialize();
-      await context.session.kernel.ready;
+      context = await initNotebookContext();
     });
 
-    afterEach(async () => {
-      await context.session.shutdown();
+    afterEach(() => {
       context.dispose();
     });
 

--- a/tests/test-notebook/src/panel.spec.ts
+++ b/tests/test-notebook/src/panel.spec.ts
@@ -22,6 +22,9 @@ describe('@jupyterlab/notebook', () => {
 
     beforeEach(async () => {
       context = await createNotebookContext();
+      await context.initialize(true);
+      await context.session.initialize();
+      await context.session.kernel.ready;
     });
 
     afterEach(async () => {

--- a/tests/test-notebook/src/tracker.spec.ts
+++ b/tests/test-notebook/src/tracker.spec.ts
@@ -32,6 +32,9 @@ describe('@jupyterlab/notebook', () => {
 
     beforeEach(async () => {
       context = await createNotebookContext();
+      await context.initialize(true);
+      await context.session.initialize();
+      await context.session.kernel.ready;
     });
 
     afterEach(async () => {

--- a/tests/test-notebook/src/tracker.spec.ts
+++ b/tests/test-notebook/src/tracker.spec.ts
@@ -13,7 +13,7 @@ import {
   NotebookTracker
 } from '@jupyterlab/notebook';
 
-import { createNotebookContext, NBTestUtils } from '@jupyterlab/testutils';
+import { initNotebookContext, NBTestUtils } from '@jupyterlab/testutils';
 
 const namespace = 'notebook-tracker-test';
 
@@ -31,14 +31,10 @@ describe('@jupyterlab/notebook', () => {
     let context: Context<INotebookModel>;
 
     beforeEach(async () => {
-      context = await createNotebookContext();
-      await context.initialize(true);
-      await context.session.initialize();
-      await context.session.kernel.ready;
+      context = await initNotebookContext();
     });
 
-    afterEach(async () => {
-      await context.session.shutdown();
+    afterEach(() => {
       context.dispose();
     });
 

--- a/tests/test-notebook/src/widgetfactory.spec.ts
+++ b/tests/test-notebook/src/widgetfactory.spec.ts
@@ -40,6 +40,9 @@ describe('@jupyterlab/notebook', () => {
 
     beforeEach(async () => {
       context = await createNotebookContext();
+      await context.initialize(true);
+      await context.session.initialize();
+      await context.session.kernel.ready;
     });
 
     afterEach(async () => {

--- a/tests/test-notebook/src/widgetfactory.spec.ts
+++ b/tests/test-notebook/src/widgetfactory.spec.ts
@@ -5,17 +5,17 @@ import { expect } from 'chai';
 
 import { toArray } from '@phosphor/algorithm';
 
-import { INotebookModel } from '@jupyterlab/notebook';
-
-import { NotebookPanel } from '@jupyterlab/notebook';
-
-import { NotebookWidgetFactory } from '@jupyterlab/notebook';
+import { ToolbarButton } from '@jupyterlab/apputils';
 
 import { DocumentRegistry, Context } from '@jupyterlab/docregistry';
 
-import { createNotebookContext, NBTestUtils } from '@jupyterlab/testutils';
+import {
+  INotebookModel,
+  NotebookPanel,
+  NotebookWidgetFactory
+} from '@jupyterlab/notebook';
 
-import { ToolbarButton } from '@jupyterlab/apputils';
+import { createNotebookContext, NBTestUtils } from '@jupyterlab/testutils';
 
 const contentFactory = NBTestUtils.createNotebookPanelFactory();
 const rendermime = NBTestUtils.defaultRenderMime();

--- a/tests/test-notebook/src/widgetfactory.spec.ts
+++ b/tests/test-notebook/src/widgetfactory.spec.ts
@@ -15,7 +15,7 @@ import {
   NotebookWidgetFactory
 } from '@jupyterlab/notebook';
 
-import { createNotebookContext, NBTestUtils } from '@jupyterlab/testutils';
+import { initNotebookContext, NBTestUtils } from '@jupyterlab/testutils';
 
 const contentFactory = NBTestUtils.createNotebookPanelFactory();
 const rendermime = NBTestUtils.defaultRenderMime();
@@ -39,14 +39,10 @@ describe('@jupyterlab/notebook', () => {
     let context: Context<INotebookModel>;
 
     beforeEach(async () => {
-      context = await createNotebookContext();
-      await context.initialize(true);
-      await context.session.initialize();
-      await context.session.kernel.ready;
+      context = await initNotebookContext();
     });
 
-    afterEach(async () => {
-      await context.session.shutdown();
+    afterEach(() => {
       context.dispose();
     });
 

--- a/tests/webpack.config.js
+++ b/tests/webpack.config.js
@@ -1,8 +1,9 @@
 // Use sourcemaps if in watch or debug mode;
-var devtool = 'eval';
-if (process.argv.indexOf('--watch') !== -1) {
-  devtool = 'cheap-module-eval-sourcemap';
-}
+const devtool =
+  process.argv.indexOf('--watch') !== -1 ||
+  process.argv.indexOf('--debug') !== -1
+    ? 'source-map-inline'
+    : 'eval';
 
 module.exports = {
   resolve: {

--- a/testutils/src/index.ts
+++ b/testutils/src/index.ts
@@ -209,7 +209,11 @@ export async function createNotebookContext(
     manager,
     factory,
     path,
-    kernelPreference: { name: manager.specs.default }
+    kernelPreference: {
+      shouldStart: true,
+      canStart: true,
+      name: manager.specs.default
+    }
   });
 }
 

--- a/testutils/src/index.ts
+++ b/testutils/src/index.ts
@@ -217,7 +217,6 @@ export async function initNotebookContext(
     kernelPreference: {
       shouldStart: startKernel,
       canStart: startKernel,
-      // autoStartDefault: true,
       shutdownOnClose: true,
       name: manager.specs.default
     }


### PR DESCRIPTION
## References

None

## Code changes

Fixes the setups and teardowns in `test-notebook` so that the only resources initialized are those needed by each individual test, and so that the next test awaits the proper cleanup of those resources.

- Many of the tests were creating their own document `Context` object. Each `Context` owns a kernel and a file handle. Many of the tests did not need the kernel, and subsequent tests were not waiting for the cleanup of kernel/file.

## User-facing changes

None

## Backwards-incompatible changes

None
