### PR TITLE
Add "go-up" navigation support in filebrowser, fix other shortcuts behaviour

### DIFF
--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -13,6 +13,11 @@
       "command": "filebrowser:toggle-main",
       "keys": ["Accel Shift F"],
       "selector": "body"
+    },
+    {
+      "command": "filebrowser:go-up",
+      "keys": ["Backspace"],
+      "selector": ".jp-FileBrowser-listing"
     }
   ],
   "properties": {

--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -17,7 +17,7 @@
     {
       "command": "filebrowser:go-up",
       "keys": ["Backspace"],
-      "selector": ".jp-FileBrowser-listing"
+      "selector": ".jp-DirListing-content .jp-DirListing-itemText"
     }
   ],
   "properties": {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -800,6 +800,7 @@ function addCommands(
     execute: async () => {
       const browserForPath = Private.getBrowserForPath('', factory);
       const { model } = browserForPath;
+
       await model.restored;
       if (model.path === model.rootPath) {
         return;
@@ -812,6 +813,16 @@ function addCommands(
           reason
         );
       }
+    },
+    isEnabled: args => {
+      const browserForPath = Private.getBrowserForPath('', factory);
+      // @ts-ignore
+      const { _listing } = browserForPath;
+
+      if (_listing._inRename) {
+        return false;
+      }
+      return true;
     }
   });
 

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -799,6 +799,9 @@ function addCommands(
     label: 'go up',
     execute: async () => {
       const browserForPath = Private.getBrowserForPath('', factory);
+      if (!browserForPath) {
+        return;
+      }
       const { model } = browserForPath;
 
       await model.restored;
@@ -813,16 +816,6 @@ function addCommands(
           reason
         );
       }
-    },
-    isEnabled: args => {
-      const browserForPath = Private.getBrowserForPath('', factory);
-      // @ts-ignore
-      const { _listing } = browserForPath;
-
-      if (_listing._inRename) {
-        return false;
-      }
-      return true;
     }
   });
 
@@ -1114,8 +1107,10 @@ function addCommands(
     });
   }
 
-  // matches the filebrowser itself
-  const selectorBrowser = '.jp-FileBrowser-listing';
+  // matches the text in the filebrowser; relies on an implementation detail
+  // being the text of the listing element being substituted with input
+  // area to deactivate shortcuts when the file name is being edited.
+  const selectorBrowser = '.jp-DirListing-content .jp-DirListing-itemText'
   // matches anywhere on filebrowser
   const selectorContent = '.jp-DirListing-content';
   // matches all filebrowser items

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -98,6 +98,8 @@ namespace CommandIDs {
 
   export const goToPath = 'filebrowser:go-to-path';
 
+  export const goUp = 'filebrowser:go-up';
+
   export const openPath = 'filebrowser:open-path';
 
   export const open = 'filebrowser:open';
@@ -789,6 +791,26 @@ function addCommands(
       }
       if (showBrowser) {
         return commands.execute(CommandIDs.showBrowser, { path });
+      }
+    }
+  });
+
+  commands.addCommand(CommandIDs.goUp, {
+    label: 'go up',
+    execute: async () => {
+      const browserForPath = Private.getBrowserForPath('', factory);
+      const { model } = browserForPath;
+      await model.restored;
+      if (model.path === model.rootPath) {
+        return;
+      }
+      try {
+        await model.cd('..');
+      } catch (reason) {
+        console.warn(
+          `${CommandIDs.goUp} failed to go to parent directory of ${model.path}`,
+          reason
+        );
       }
     }
   });

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -1110,7 +1110,7 @@ function addCommands(
   // matches the text in the filebrowser; relies on an implementation detail
   // being the text of the listing element being substituted with input
   // area to deactivate shortcuts when the file name is being edited.
-  const selectorBrowser = '.jp-DirListing-content .jp-DirListing-itemText'
+  const selectorBrowser = '.jp-DirListing-content .jp-DirListing-itemText';
   // matches anywhere on filebrowser
   const selectorContent = '.jp-DirListing-content';
   // matches all filebrowser items

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -138,9 +138,6 @@ export class FileBrowser extends Widget {
     this.layout.addWidget(this.crumbs);
     this.layout.addWidget(this.listing);
 
-    // We need to make the FileBrowser focusable so that it receives keyboard events
-    this.node.tabIndex = 0;
-
     if (options.restore !== false) {
       void model.restore(this.id);
     }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -814,6 +814,12 @@ export class DirListing extends Widget {
       );
       if (this.selection[item.path]) {
         node.classList.add(SELECTED_CLASS);
+
+        // focus on text to make shortcuts works
+        const text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
+        if (text) {
+          text.focus();
+        }
         if (this._isCut && this._model.path === this._prevPath) {
           node.classList.add(CUT_CLASS);
         }
@@ -1064,6 +1070,9 @@ export class DirListing extends Widget {
     // Not all browsers support .key, but it discharges us from reconstructing
     // characters from key codes.
     if (!this._inRename && event.key !== undefined && event.key.length === 1) {
+      if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+        return;
+      }
       this._searchPrefix += event.key;
 
       clearTimeout(this._searchPrefixTimer);
@@ -1948,6 +1957,12 @@ export namespace DirListing {
       node.appendChild(icon);
       node.appendChild(text);
       node.appendChild(modified);
+
+      // Make the text note focusable so that it receives keyboard events;
+      // text node was specifically chosen to receive shortcuts because
+      // text element gets substituted with input area during file name edits
+      // which conveniently deactivate irrelevant shortcuts.
+      text.tabIndex = 0;
 
       if (hiddenColumns?.has?.('last_modified')) {
         modified.classList.add(MODIFIED_COLUMN_HIDDEN);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1056,17 +1056,6 @@ export class DirListing extends Widget {
         event.stopPropagation();
         event.preventDefault();
         break;
-      case 8: // Backspace
-        if (this._model.path === this._model.rootPath) {
-          return;
-        }
-        this._model
-          .cd('..')
-          .catch(error => showErrorMessage('Open directory', error));
-
-        event.preventDefault();
-        event.stopPropagation();
-        break;
       default:
         break;
     }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1056,6 +1056,17 @@ export class DirListing extends Widget {
         event.stopPropagation();
         event.preventDefault();
         break;
+      case 8: // Backspace
+        if (this._model.path === this._model.rootPath) {
+          return;
+        }
+        this._model
+          .cd('..')
+          .catch(error => showErrorMessage('Open directory', error));
+
+        event.preventDefault();
+        event.stopPropagation();
+        break;
       default:
         break;
     }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -76,7 +76,6 @@ export class FileBrowserModel implements IDisposable {
     this.translator = options.translator || nullTranslator;
     this._trans = this.translator.load('jupyterlab');
     this._driveName = options.driveName || '';
-    const rootPath = this._driveName ? this._driveName + ':' : '';
     this._model = {
       path: this.rootPath,
       name: PathExt.basename(this.rootPath),

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -78,8 +78,8 @@ export class FileBrowserModel implements IDisposable {
     this._driveName = options.driveName || '';
     const rootPath = this._driveName ? this._driveName + ':' : '';
     this._model = {
-      path: rootPath,
-      name: PathExt.basename(rootPath),
+      path: this.rootPath,
+      name: PathExt.basename(this.rootPath),
       type: 'directory',
       content: undefined,
       writable: false,
@@ -155,6 +155,13 @@ export class FileBrowserModel implements IDisposable {
    */
   get path(): string {
     return this._model ? this._model.path : '';
+  }
+
+  /**
+   * Get the root path
+   */
+  get rootPath(): string {
+    return this._driveName ? this._driveName + ':' : '';
   }
 
   /**

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -195,6 +195,14 @@ describe('filebrowser/model', () => {
       });
     });
 
+    describe('#rootPath', () => {
+      it('should be and remain the root path of the model', async () => {
+        expect(model.rootPath).to.equal('');
+        await model.cd('src/');
+        expect(model.rootPath).to.equal('');
+      });
+    });
+
     describe('#items()', () => {
       it('should get an iterator of items in the current path', () => {
         const items = model.items();

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -197,9 +197,9 @@ describe('filebrowser/model', () => {
 
     describe('#rootPath', () => {
       it('should be and remain the root path of the model', async () => {
-        expect(model.rootPath).to.equal('');
+        expect(model.rootPath).toBe('');
         await model.cd('src/');
-        expect(model.rootPath).to.equal('');
+        expect(model.rootPath).toBe('');
       });
     });
 


### PR DESCRIPTION
## References

The option to navigate to the parent directory in the file browser with <kb>backspace</kbd> was suggested in #6808.
Fixes #6808, fixes #10249.

## Code changes

Added `rootPath` property to file browser model to allow for a quick check whether the requested action would not escape from the root directory. Relies on the already implemented normalization (private normalizePath in filebrowser/model.ts) which does relative path resolution.

## User-facing changes

Pressing <kbd>Backspace</kbd> when focued on the filebrowser's listing enters the parent directory.

## Backwards-incompatible changes

None.