### PR TITLE
Don't require status to exist in kernel info reply

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -472,10 +472,13 @@ export class DefaultKernel implements Kernel.IKernel {
     if (this.isDisposed) {
       throw new Error('Disposed kernel');
     }
-    if (reply.content.status !== 'ok') {
+    // Relax the requirement that a kernel info reply has a status attribute,
+    // since this part of the spec is not yet widely conformed-to.
+    if (reply.content.status && reply.content.status !== 'ok') {
       throw new Error('Kernel info reply errored');
     }
-    this._info = reply.content;
+    // Type assertion is necessary until we can rely on the status message.
+    this._info = reply.content as KernelMessage.IInfoReply;
     return reply;
   }
 


### PR DESCRIPTION
#  References
Temporary fix for #6826 

## Code changes

Relaxes the requirement that status exists in a kernel info reply.

## User-facing changes

Fixes syntax highlighting/language info for some kernels.

## Backwards-incompatible changes
None