### PR TITLE
Update the version of jupyterlab manually

### DIFF
--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -80,6 +80,7 @@ Note: if you have an older version of JupyterLab previously installed, you may n
 the version of JupyterLab manually.
 
 .. code:: bash
+
     conda install -c conda-forge jupyterlab=1
 
 Create a repository

--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -77,7 +77,7 @@ before you can work with the tools you installed in the
 ``jupyterlab-ext`` environment.
 
 Note: if you have an older version of JupyterLab previously installed, you may need to update
-the version of jupyterlab manually.
+the version of JupyterLab manually.
 
 .. code:: bash
     conda install -c conda-forge jupyterlab=1

--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -76,7 +76,7 @@ Note: You'll need to run the command above in each new terminal you open
 before you can work with the tools you installed in the
 ``jupyterlab-ext`` environment.
 
-Note: if you have an older version of jupyterlab previously installed, you may need to update
+Note: if you have an older version of JupyterLab previously installed, you may need to update
 the version of jupyterlab manually.
 
 .. code:: bash

--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -76,6 +76,12 @@ Note: You'll need to run the command above in each new terminal you open
 before you can work with the tools you installed in the
 ``jupyterlab-ext`` environment.
 
+Note: if you have an older version of jupyterlab previously installed, you may need to update
+the version of jupyterlab manually.
+
+.. code:: bash
+    conda install -c conda-forge jupyterlab=1.0.2
+
 Create a repository
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -80,7 +80,7 @@ Note: if you have an older version of jupyterlab previously installed, you may n
 the version of jupyterlab manually.
 
 .. code:: bash
-    conda install -c conda-forge jupyterlab=1.0.2
+    conda install -c conda-forge jupyterlab=1
 
 Create a repository
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I tried a variety of methods of updating jupyterlab, and this finally worked.

You may need to adjust the text appropriately.

An error occurred when trying to build the `jupyterlab_apod` extension and needed jupyterlab version updated.