### PR TITLE
Update max CSV size for Firefox 68

### DIFF
--- a/docs/source/user/file_formats.rst
+++ b/docs/source/user/file_formats.rst
@@ -144,7 +144,7 @@ Below is a table that shows the sizes of the largest test files we successfully 
 +---------+----------+
 | Browser | Max Size |
 +=========+==========+
-| Firefox |  250MB   |
+| Firefox |  855MB   |
 +---------+----------+
 | Chrome  |  730MB   |
 +---------+----------+

--- a/docs/source/user/file_formats.rst
+++ b/docs/source/user/file_formats.rst
@@ -144,7 +144,7 @@ Below is a table that shows the sizes of the largest test files we successfully 
 +---------+----------+
 | Browser | Max Size |
 +=========+==========+
-| Firefox |  855MB   |
+| Firefox |  1.04GB  |
 +---------+----------+
 | Chrome  |  730MB   |
 +---------+----------+


### PR DESCRIPTION
Issue #6238 documentation update.
Tested on 855MB CSV file, 11.7M rows, loaded in ~35s
Firefox 68.0.1, Mac OS X Mojave

I tried a 1.09GB csv of California, but it didn't load.