### PR TITLE
accept query parameter to optionally change file browser location

### DIFF
--- a/docs/source/user/urls.rst
+++ b/docs/source/user/urls.rst
@@ -24,6 +24,16 @@ the nomenclature of the classic notebook; these URLs are ``/tree`` URLs:
 Entering this URL will open the notebook in JupyterLab in
 :ref:`single-document mode <tabs>`.
 
+By default, the file browser will navigate to the directory containing the requested
+file. This behavior can be changed with the optional ``file-browser-path`` query parameter:
+
+.. code-block:: none
+
+  http(s)://<server:port>/<lab-location>/lab/tree/path/to/notebook.ipynb?file-browser-path=/
+
+Entering the above URL will show the workspace root directory instead of the ``/path/to/``
+directory in the file browser.
+
 
 .. _url-workspaces-ui:
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -276,8 +276,8 @@ const tree: JupyterFrontEndPlugin<void> = {
         router.navigate(url);
 
         const query = URLExt.queryStringToObject(args.search);
-        if (query.filebrowserPath) {
-          path = query.filebrowserPath;
+        if (query['file-browser-path']) {
+          path = query['file-browser-path'];
         }
 
         try {

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -262,7 +262,7 @@ const tree: JupyterFrontEndPlugin<void> = {
         const treeMatch = args.path.match(treePattern);
         const workspaceMatch = args.path.match(workspacePattern);
         const match = treeMatch || workspaceMatch;
-        const path = decodeURI(match[1]);
+        let path = decodeURI(match[1]);
         // const { page, workspaces } = info.urls;
         const workspace = PathExt.basename(resolver.name);
         const url =
@@ -274,6 +274,11 @@ const tree: JupyterFrontEndPlugin<void> = {
 
         // Remove the tree portion of the URL leaving the rest intact.
         router.navigate(url);
+
+        const query = URLExt.queryStringToObject(args.search);
+        if (query.filebrowserPath) {
+          path = query.filebrowserPath;
+        }
 
         try {
           await commands.execute('filebrowser:open-path', { path });


### PR DESCRIPTION
## References

#6874

## Code changes

It is now possible to pass a query parameter called `filebrowserPath` to the tree route handler. If this parameter is set, the filebrowser is navigated to this path.

## User-facing changes

By default, the behavior does not change for the user. Only if the `filebrowserPath` parameter is passed, the location of the filebrowser differs from the location of the opened notebook.

For example, the URL `/lab/tree/test/example.ipynb?filebrowserPath=/` shows the notebook `test/example.ipynb` while still showing the workspace root directory in the filebrowser (instead of the `test` directory).