### PR TITLE
fixed silent error in `usage` CI test by fixing `jlpm remove:package`

### DIFF
--- a/buildutils/src/remove-package.ts
+++ b/buildutils/src/remove-package.ts
@@ -37,5 +37,5 @@ if (!fs.existsSync(packagePath)) {
 // Remove the package from the local tree.
 fs.removeSync(path.dirname(packagePath));
 
-// Update the core jupyterlab build dependencies.
-utils.run('npm run integrity');
+// Remove any dependencies on the package (will also run `jlpm integrity`)
+utils.run(`jlpm remove:dependency ${target}`);

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -180,7 +180,7 @@ if [[ $GROUP == usage ]]; then
     jlpm run build:packages
     jlpm run build:dev
     python -m jupyterlab.browser_check --dev-mode
-    rm -rf packages/foo
+    jlpm run remove:package foo
     jlpm run integrity
 
     ## Test app directory support being a symlink


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/pull/6870#issuecomment-514466936

## Code changes

Runs `jlpm remove:dependency` as a part of `jlpm remove:package`. Otherwise, the next run of `jlpm integrity` fails.

## User-facing changes

## Backwards-incompatible changes
