### PR TITLE
fix auto import of `fs@~0.0.1-security` by integrity

### DIFF
--- a/testutils/package.json
+++ b/testutils/package.json
@@ -42,6 +42,7 @@
     "@jupyterlab/services": "^4.0.1",
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/signaling": "^1.2.3",
+    "fs-extra": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",
     "json-to-html": "~0.1.2",
     "node-fetch": "^2.6.0",

--- a/testutils/src/compare-lighthouse.ts
+++ b/testutils/src/compare-lighthouse.ts
@@ -3,7 +3,7 @@
  *
  * Outputs in Markdown for easy posting in Github.
  */
-import { readFileSync } from 'fs';
+import { readFileSync } from 'fs-extra';
 
 const firstFilePath = process.argv[2];
 const secondFilePath = process.argv[3];


### PR DESCRIPTION
## References
## Code changes

`jlpm integrity` keeps trying to import a non-existant placeholder package `fs@~0.0.1-security`. This fixes that

## User-facing changes
## Backwards-incompatible changes
