### PR TITLE
Fix directory browsing

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -532,7 +532,7 @@ function addCommands(
         toArray(
           map(widget.selectedItems(), item => {
             if (item.type === 'directory') {
-              return widget.model.cd(item.path);
+              return widget.model.cd(`/${item.path}`);
             }
 
             return commands.execute('docmanager:open', {

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -922,7 +922,7 @@ export class DirListing extends Widget {
     this._onItemOpened.emit(item);
     if (item.type === 'directory') {
       this._model
-        .cd(item.path)
+        .cd(`/${item.path}`)
         .catch(error => showErrorMessage('Open directory', error));
     } else {
       let path = item.path;


### PR DESCRIPTION




<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #6898
Fixes an error with #6841

## Code changes

filebrowser model cd handles relative paths, and item.path never starts with a root /, so add one.

## User-facing changes

This lets the filebrowser browser more than one directory level deep.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
