### PR TITLE
fixes a double drive prefix that was showing up in filebrowser paths

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -683,6 +683,8 @@ namespace Private {
     const driveName = contents.driveName(root);
     const localPath = contents.localPath(root);
     const resolved = PathExt.resolve(localPath, path);
-    return driveName ? `${driveName}:${resolved}` : resolved;
+    return driveName && !resolved.startsWith(driveName)
+      ? `${driveName}:${resolved}`
+      : resolved;
   }
 }


### PR DESCRIPTION
## References

#6841
#6900

## Code changes

## User-facing changes

Another hangover from #6841, in which the `cd` functionality was changed to use full paths instead of single directory names. Drive names were getting appended to the front of paths multiple times, for example `Github:Github:jupyterlab`. This fixes that by ensuring the second drive name is never added.

Note that #6841 broke `jupyterlab-github` for this and other reasons (it's path handling currently doesn't conform to the new interface, paging @ian-r-rose).

## Backwards-incompatible changes
