### PR TITLE
Add settings to override theme font sizes

### DIFF
--- a/packages/application/style/scrollbar.css
+++ b/packages/application/style/scrollbar.css
@@ -8,12 +8,13 @@
  */
 
 /* use standard opaque scrollbars for most nodes */
-div.jp-LabShell[data-jp-theme-scrollbars='true'] {
+[data-jp-theme-scrollbars='true'] {
   scrollbar-color: rgb(var(--jp-scrollbar-thumb-color))
     var(--jp-scrollbar-background-color);
 }
 
-/* for code nodes, use a transparent style of scrollbar */
+/* for code nodes, use a transparent style of scrollbar. These selectors
+ * will match lower in the tree, and so will override the above */
 [data-jp-theme-scrollbars='true'] .CodeMirror-hscrollbar,
 [data-jp-theme-scrollbars='true'] .CodeMirror-vscrollbar {
   scrollbar-color: rgba(var(--jp-scrollbar-thumb-color), 0.5) transparent;

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -4,6 +4,16 @@
   "description": "Theme manager settings.",
   "type": "object",
   "additionalProperties": false,
+  "definitions": {
+    "themeOverrides": {
+      "type": "object",
+      "properties": {
+        "code-font-size": { "type": "string", "default": "" },
+        "content-font-size1": { "type": "string", "default": "" },
+        "ui-font-size1": { "type": "string", "default": "" }
+      }
+    }
+  },
   "properties": {
     "theme": {
       "type": "string",
@@ -19,16 +29,12 @@
     },
     "overrides": {
       "title": "Theme CSS Overrides",
-      "description": "The list of theme CSS overrides",
-      "$ref": "#/definitions/theme-overrides"
-    }
-  },
-  "definitions": {
-    "theme-overrides": {
-      "type": "object",
-      "properties": {
-        "code-font-size": { "type": "string", "default": "" },
-        "ui-font-size1": { "type": "string", "default": "" }
+      "description": "Override theme CSS variables by setting key-value pairs here",
+      "$ref": "#/definitions/themeOverrides",
+      "default": {
+        "code-font-size": "",
+        "content-font-size1": "",
+        "ui-font-size1": ""
       }
     }
   }

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -2,6 +2,7 @@
   "title": "Theme",
   "jupyter.lab.setting-icon-label": "Theme Manager",
   "description": "Theme manager settings.",
+  "type": "object",
   "additionalProperties": false,
   "properties": {
     "theme": {
@@ -16,24 +17,30 @@
       "description": "Enable/disable styling of the application scrollbars",
       "default": false
     },
-    "code-font-size": {
-      "type": "string",
-      "title": "Code font size",
-      "description": "Set the code font size. Defaults to the `--jp-code-font-size` CSS variable from the theme.`",
-      "default": ""
-    },
-    "content-font-size": {
-      "type": "string",
-      "title": "Content font size",
-      "description": "Set the content font size. Defaults to the `--jp-content-font-size1` CSS variable from the theme.`",
-      "default": ""
-    },
-    "ui-font-size": {
-      "type": "string",
-      "title": "UI font size",
-      "description": "Set the UI font size. Defaults to the `--jp-ui-font-size1` CSS variable from the theme.`",
-      "default": ""
+    "overrides": {
+      "title": "Theme CSS Overrides",
+      "description": "The list of theme CSS overrides",
+      "items": { "$ref": "#/definitions/theme-override" },
+      "type": "array",
+      "default": []
     }
   },
-  "type": "object"
+  "definitions": {
+    "theme-override": {
+      "required": ["key", "value"],
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "title": "Theme CSS variable key",
+          "description": "The name of a theme CSS variable, minus the leading `--jp-`"
+        },
+        "value": {
+          "type": "string",
+          "title": "Theme CSS override value",
+          "description": "An empty string or a valid CSS value, in which case it is assigned to the CSS variable corresponding to `key`"
+        }
+      }
+    }
+  }
 }

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -15,6 +15,24 @@
       "title": "Scrollbar Theming",
       "description": "Enable/disable styling of the application scrollbars",
       "default": false
+    },
+    "code-font-size": {
+      "type": "number",
+      "title": "Code font size",
+      "description": "Set the code font size. Defaults to the `--jp-code-font-size` CSS variable from the theme.`",
+      "default": null
+    },
+    "content-font-size": {
+      "type": "number",
+      "title": "Content font size",
+      "description": "Set the content font size. Defaults to the `--jp-content-font-size1` CSS variable from the theme.`",
+      "default": null
+    },
+    "ui-font-size": {
+      "type": "number",
+      "title": "UI font size",
+      "description": "Set the UI font size. Defaults to the `--jp-ui-font-size1` CSS variable from the theme.`",
+      "default": null
     }
   },
   "type": "object"

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -9,9 +9,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "code-font-size": { "type": "string" },
-        "content-font-size1": { "type": "string" },
-        "ui-font-size1": { "type": "string" }
+        "code-font-size": { "type": ["string", "null"] },
+        "content-font-size1": { "type": ["string", "null"] },
+        "ui-font-size1": { "type": ["string", "null"] }
       }
     }
   },
@@ -33,9 +33,9 @@
       "description": "Override theme CSS variables by setting key-value pairs here",
       "$ref": "#/definitions/themeOverrides",
       "default": {
-        "code-font-size": "",
-        "content-font-size1": "",
-        "ui-font-size1": ""
+        "code-font-size": null,
+        "content-font-size1": null,
+        "ui-font-size1": null
       }
     }
   }

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -8,9 +8,9 @@
     "themeOverrides": {
       "type": "object",
       "properties": {
-        "code-font-size": { "type": "string", "default": "" },
-        "content-font-size1": { "type": "string", "default": "" },
-        "ui-font-size1": { "type": "string", "default": "" }
+        "code-font-size": { "type": "string" },
+        "content-font-size1": { "type": "string" },
+        "ui-font-size1": { "type": "string" }
       }
     }
   },

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -10,12 +10,18 @@
       "additionalProperties": false,
       "description": "The description field of each item is the CSS property that will be used to validate an override's value",
       "properties": {
-        "code-font-size": { "type": ["string", "null"], "description": "size" },
+        "code-font-size": {
+          "type": ["string", "null"],
+          "description": "font-size"
+        },
         "content-font-size1": {
           "type": ["string", "null"],
-          "description": "size"
+          "description": "font-size"
         },
-        "ui-font-size1": { "type": ["string", "null"], "description": "size" }
+        "ui-font-size1": {
+          "type": ["string", "null"],
+          "description": "font-size"
+        }
       }
     }
   },

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -8,6 +8,7 @@
     "cssOverrides": {
       "type": "object",
       "additionalProperties": false,
+      "description": "The description field of each item is the CSS property that will be used to validate an override's value",
       "properties": {
         "code-font-size": { "type": ["string", "null"], "description": "size" },
         "content-font-size1": {

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -17,22 +17,22 @@
       "default": false
     },
     "code-font-size": {
-      "type": "number",
+      "type": "string",
       "title": "Code font size",
       "description": "Set the code font size. Defaults to the `--jp-code-font-size` CSS variable from the theme.`",
-      "default": null
+      "default": ""
     },
     "content-font-size": {
-      "type": "number",
+      "type": "string",
       "title": "Content font size",
       "description": "Set the content font size. Defaults to the `--jp-content-font-size1` CSS variable from the theme.`",
-      "default": null
+      "default": ""
     },
     "ui-font-size": {
-      "type": "number",
+      "type": "string",
       "title": "UI font size",
       "description": "Set the UI font size. Defaults to the `--jp-ui-font-size1` CSS variable from the theme.`",
-      "default": null
+      "default": ""
     }
   },
   "type": "object"

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -20,26 +20,15 @@
     "overrides": {
       "title": "Theme CSS Overrides",
       "description": "The list of theme CSS overrides",
-      "items": { "$ref": "#/definitions/theme-override" },
-      "type": "array",
-      "default": []
+      "$ref": "#/definitions/theme-overrides"
     }
   },
   "definitions": {
-    "theme-override": {
-      "required": ["key", "value"],
+    "theme-overrides": {
       "type": "object",
       "properties": {
-        "key": {
-          "type": "string",
-          "title": "Theme CSS variable key",
-          "description": "The name of a theme CSS variable, minus the leading `--jp-`"
-        },
-        "value": {
-          "type": "string",
-          "title": "Theme CSS override value",
-          "description": "An empty string or a valid CSS value, in which case it is assigned to the CSS variable corresponding to `key`"
-        }
+        "code-font-size": { "type": "string", "default": "" },
+        "ui-font-size1": { "type": "string", "default": "" }
       }
     }
   }

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -4,17 +4,6 @@
   "description": "Theme manager settings.",
   "type": "object",
   "additionalProperties": false,
-  "definitions": {
-    "cssOverrides": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "code-font-size": { "type": ["string", "null"] },
-        "content-font-size1": { "type": ["string", "null"] },
-        "ui-font-size1": { "type": ["string", "null"] }
-      }
-    }
-  },
   "properties": {
     "theme": {
       "type": "string",
@@ -29,9 +18,18 @@
       "default": false
     },
     "overrides": {
+      "type": "object",
+      "additionalProperties": false,
       "title": "Theme CSS Overrides",
-      "description": "Override theme CSS variables by setting key-value pairs here",
-      "$ref": "#/definitions/cssOverrides",
+      "description": "Override theme CSS variables by setting key-value pairs here. The description field of each item is the CSS property that will be used to validate an override's value.",
+      "properties": {
+        "code-font-size": { "type": ["string", "null"], "description": "size" },
+        "content-font-size1": {
+          "type": ["string", "null"],
+          "description": "size"
+        },
+        "ui-font-size1": { "type": ["string", "null"], "description": "size" }
+      },
       "default": {
         "code-font-size": null,
         "content-font-size1": null,

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -4,6 +4,20 @@
   "description": "Theme manager settings.",
   "type": "object",
   "additionalProperties": false,
+  "definitions": {
+    "cssOverrides": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "code-font-size": { "type": ["string", "null"], "description": "size" },
+        "content-font-size1": {
+          "type": ["string", "null"],
+          "description": "size"
+        },
+        "ui-font-size1": { "type": ["string", "null"], "description": "size" }
+      }
+    }
+  },
   "properties": {
     "theme": {
       "type": "string",
@@ -18,18 +32,9 @@
       "default": false
     },
     "overrides": {
-      "type": "object",
-      "additionalProperties": false,
       "title": "Theme CSS Overrides",
-      "description": "Override theme CSS variables by setting key-value pairs here. The description field of each item is the CSS property that will be used to validate an override's value.",
-      "properties": {
-        "code-font-size": { "type": ["string", "null"], "description": "size" },
-        "content-font-size1": {
-          "type": ["string", "null"],
-          "description": "size"
-        },
-        "ui-font-size1": { "type": ["string", "null"], "description": "size" }
-      },
+      "description": "Override theme CSS variables by setting key-value pairs here",
+      "$ref": "#/definitions/cssOverrides",
       "default": {
         "code-font-size": null,
         "content-font-size1": null,

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -7,6 +7,7 @@
   "definitions": {
     "themeOverrides": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "code-font-size": { "type": "string" },
         "content-font-size1": { "type": "string" },

--- a/packages/apputils-extension/schema/themes.json
+++ b/packages/apputils-extension/schema/themes.json
@@ -5,7 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "definitions": {
-    "themeOverrides": {
+    "cssOverrides": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -31,7 +31,7 @@
     "overrides": {
       "title": "Theme CSS Overrides",
       "description": "Override theme CSS variables by setting key-value pairs here",
-      "$ref": "#/definitions/themeOverrides",
+      "$ref": "#/definitions/cssOverrides",
       "default": {
         "code-font-size": null,
         "content-font-size1": null,

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -14,9 +14,7 @@ import {
   Dialog,
   ICommandPalette,
   ISplashScreen,
-  IThemeManager,
   IWindowResolver,
-  ThemeManager,
   WindowResolver,
   Printing
 } from '@jupyterlab/apputils';
@@ -32,17 +30,15 @@ import {
   URLExt
 } from '@jupyterlab/coreutils';
 
-import { IMainMenu } from '@jupyterlab/mainmenu';
-
 import { defaultIconRegistry } from '@jupyterlab/ui-components';
 
 import { PromiseDelegate } from '@phosphor/coreutils';
 
 import { DisposableDelegate } from '@phosphor/disposable';
 
-import { Menu } from '@phosphor/widgets';
-
 import { Palette } from './palette';
+
+import { themesPlugin, themesPaletteMenuPlugin } from './themeplugins';
 
 /**
  * The interval in milliseconds before recover options appear during splash.
@@ -53,14 +49,6 @@ const SPLASH_RECOVER_TIMEOUT = 12000;
  * The command IDs used by the apputils plugin.
  */
 namespace CommandIDs {
-  export const changeTheme = 'apputils:change-theme';
-
-  export const themeScrollbars = 'apputils:theme-scrollbars';
-
-  export const incrFontSize = 'apputils:incr-font-size';
-
-  export const decrFontSize = 'apputils:decr-font-size';
-
   export const loadState = 'apputils:load-statedb';
 
   export const print = 'apputils:print';
@@ -109,226 +97,6 @@ const settings: JupyterFrontEndPlugin<ISettingRegistry> = {
   },
   autoStart: true,
   provides: ISettingRegistry
-};
-
-/**
- * The default theme manager provider.
- */
-const themes: JupyterFrontEndPlugin<IThemeManager> = {
-  id: '@jupyterlab/apputils-extension:themes',
-  requires: [ISettingRegistry, JupyterFrontEnd.IPaths],
-  optional: [ISplashScreen],
-  activate: (
-    app: JupyterFrontEnd,
-    settings: ISettingRegistry,
-    paths: JupyterFrontEnd.IPaths,
-    splash: ISplashScreen | null
-  ): IThemeManager => {
-    const host = app.shell;
-    const commands = app.commands;
-    const url = URLExt.join(paths.urls.base, paths.urls.themes);
-    const key = themes.id;
-    const manager = new ThemeManager({ key, host, settings, splash, url });
-
-    // Keep a synchronously set reference to the current theme,
-    // since the asynchronous setting of the theme in `changeTheme`
-    // can lead to an incorrect toggle on the currently used theme.
-    let currentTheme: string;
-
-    manager.themeChanged.connect((sender, args) => {
-      // Set data attributes on the application shell for the current theme.
-      currentTheme = args.newValue;
-      document.body.dataset.jpThemeLight = String(
-        manager.isLight(currentTheme)
-      );
-      document.body.dataset.jpThemeName = currentTheme;
-      if (
-        document.body.dataset.jpThemeScrollbars !==
-        String(manager.themeScrollbars(currentTheme))
-      ) {
-        document.body.dataset.jpThemeScrollbars = String(
-          manager.themeScrollbars(currentTheme)
-        );
-      }
-
-      // Set any CSS overrides
-      manager.loadCSSOverrides();
-
-      commands.notifyCommandChanged(CommandIDs.changeTheme);
-    });
-
-    commands.addCommand(CommandIDs.changeTheme, {
-      label: args => {
-        const theme = args['theme'] as string;
-        return args['isPalette'] ? `Use ${theme} Theme` : theme;
-      },
-      isToggled: args => args['theme'] === currentTheme,
-      execute: args => {
-        const theme = args['theme'] as string;
-        if (theme === manager.theme) {
-          return;
-        }
-        return manager.setTheme(theme);
-      }
-    });
-
-    commands.addCommand(CommandIDs.themeScrollbars, {
-      label: 'Theme Scrollbars',
-      isToggled: () => manager.themeScrollbars(currentTheme),
-      execute: () => manager.toggleThemeScrollbars()
-    });
-
-    commands.addCommand(CommandIDs.incrFontSize, {
-      label: args => `Increase ${args['label']} Font Size`,
-      execute: args => manager.incrFontSize(args['key'] as string)
-    });
-
-    commands.addCommand(CommandIDs.decrFontSize, {
-      label: args => `Decrease ${args['label']} Font Size`,
-      execute: args => manager.decrFontSize(args['key'] as string)
-    });
-
-    return manager;
-  },
-  autoStart: true,
-  provides: IThemeManager
-};
-
-/**
- * The default theme manager's UI command palette and main menu functionality.
- *
- * #### Notes
- * This plugin loads separately from the theme manager plugin in order to
- * prevent blocking of the theme manager while it waits for the command palette
- * and main menu to become available.
- */
-const themesPaletteMenu: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/apputils-extension:themes-palette-menu',
-  requires: [IThemeManager],
-  optional: [ICommandPalette, IMainMenu],
-  activate: (
-    app: JupyterFrontEnd,
-    manager: IThemeManager,
-    palette: ICommandPalette | null,
-    mainMenu: IMainMenu | null
-  ): void => {
-    const commands = app.commands;
-
-    // If we have a main menu, add the theme manager to the settings menu.
-    if (mainMenu) {
-      const themeMenu = new Menu({ commands });
-      themeMenu.title.label = 'JupyterLab Theme';
-      void app.restored.then(() => {
-        const isPalette = false;
-
-        // choose a theme
-        manager.themes.forEach(theme => {
-          themeMenu.addItem({
-            command: CommandIDs.changeTheme,
-            args: { isPalette, theme }
-          });
-        });
-        themeMenu.addItem({ type: 'separator' });
-
-        // toggle scrollbar theming
-        themeMenu.addItem({ command: CommandIDs.themeScrollbars });
-        themeMenu.addItem({ type: 'separator' });
-
-        // increase/decrease code font size
-        themeMenu.addItem({
-          command: CommandIDs.incrFontSize,
-          args: { label: 'Code', key: 'code-font-size' }
-        });
-        themeMenu.addItem({
-          command: CommandIDs.decrFontSize,
-          args: { label: 'Code', key: 'code-font-size' }
-        });
-        themeMenu.addItem({ type: 'separator' });
-
-        // increase/decrease content font size
-        themeMenu.addItem({
-          command: CommandIDs.incrFontSize,
-          args: { label: 'Content', key: 'content-font-size1' }
-        });
-        themeMenu.addItem({
-          command: CommandIDs.decrFontSize,
-          args: { label: 'Content', key: 'content-font-size1' }
-        });
-        themeMenu.addItem({ type: 'separator' });
-
-        // increase/decrease ui font size
-        themeMenu.addItem({
-          command: CommandIDs.incrFontSize,
-          args: { label: 'UI', key: 'ui-font-size1' }
-        });
-        themeMenu.addItem({
-          command: CommandIDs.decrFontSize,
-          args: { label: 'UI', key: 'ui-font-size1' }
-        });
-      });
-      mainMenu.settingsMenu.addGroup(
-        [
-          {
-            type: 'submenu' as Menu.ItemType,
-            submenu: themeMenu
-          }
-        ],
-        0
-      );
-    }
-
-    // If we have a command palette, add theme switching options to it.
-    if (palette) {
-      void app.restored.then(() => {
-        const category = 'Theme';
-        const command = CommandIDs.changeTheme;
-        const isPalette = true;
-
-        // choose a theme
-        manager.themes.forEach(theme => {
-          palette.addItem({ command, args: { isPalette, theme }, category });
-        });
-
-        // toggle scrollbar theming
-        palette.addItem({ command: CommandIDs.themeScrollbars, category });
-
-        // increase/decrease code font size
-        palette.addItem({
-          command: CommandIDs.incrFontSize,
-          args: { label: 'Code', key: 'code-font-size' },
-          category
-        });
-        palette.addItem({
-          command: CommandIDs.decrFontSize,
-          args: { label: 'Code', key: 'code-font-size' },
-          category
-        });
-        // increase/decrease content font size
-        palette.addItem({
-          command: CommandIDs.incrFontSize,
-          args: { label: 'Content', key: 'content-font-size1' },
-          category
-        });
-        palette.addItem({
-          command: CommandIDs.decrFontSize,
-          args: { label: 'Content', key: 'content-font-size1' },
-          category
-        });
-        // increase/decrease ui font size
-        palette.addItem({
-          command: CommandIDs.incrFontSize,
-          args: { label: 'UI', key: 'ui-font-size1' },
-          category
-        });
-        palette.addItem({
-          command: CommandIDs.decrFontSize,
-          args: { label: 'UI', key: 'ui-font-size1' },
-          category
-        });
-      });
-    }
-  },
-  autoStart: true
 };
 
 /**
@@ -698,8 +466,8 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   settings,
   state,
   splash,
-  themes,
-  themesPaletteMenu,
+  themesPlugin,
+  themesPaletteMenuPlugin,
   print
 ];
 export default plugins;

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -152,7 +152,7 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
       }
 
       // Set any CSS overrides
-      manager.loadCssOverrides();
+      manager.loadCSSOverrides();
 
       commands.notifyCommandChanged(CommandIDs.changeTheme);
     });

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -230,7 +230,7 @@ const themesPaletteMenu: JupyterFrontEndPlugin<void> = {
         });
         themeMenu.addItem({ type: 'separator' });
 
-        // theme scrollbars
+        // toggle scrollbar theming
         themeMenu.addItem({ command: CommandIDs.themeScrollbars });
         themeMenu.addItem({ type: 'separator' });
 
@@ -280,12 +280,50 @@ const themesPaletteMenu: JupyterFrontEndPlugin<void> = {
     // If we have a command palette, add theme switching options to it.
     if (palette) {
       void app.restored.then(() => {
-        const category = 'Settings';
+        const category = 'Theme';
         const command = CommandIDs.changeTheme;
         const isPalette = true;
 
+        // choose a theme
         manager.themes.forEach(theme => {
           palette.addItem({ command, args: { isPalette, theme }, category });
+        });
+
+        // toggle scrollbar theming
+        palette.addItem({ command: CommandIDs.themeScrollbars, category });
+
+        // increase/decrease code font size
+        palette.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'Code', key: 'code-font-size' },
+          category
+        });
+        palette.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'Code', key: 'code-font-size' },
+          category
+        });
+        // increase/decrease content font size
+        palette.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'Content', key: 'content-font-size1' },
+          category
+        });
+        palette.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'Content', key: 'content-font-size1' },
+          category
+        });
+        // increase/decrease ui font size
+        palette.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'UI', key: 'ui-font-size1' },
+          category
+        });
+        palette.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'UI', key: 'ui-font-size1' },
+          category
         });
       });
     }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -146,7 +146,7 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
       }
 
       // Set any CSS overrides
-      manager.setOverrides();
+      manager.setCssOverrides();
 
       commands.notifyCommandChanged(CommandIDs.changeTheme);
     });

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -146,6 +146,10 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
       }
 
       // Set any CSS overrides
+      for (let key in ThemeManager.fontVars) {
+        // Set the font size overrides
+        manager.setFontSize(key, ThemeManager.fontVars[key]);
+      }
 
       commands.notifyCommandChanged(CommandIDs.changeTheme);
     });

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -55,6 +55,12 @@ const SPLASH_RECOVER_TIMEOUT = 12000;
 namespace CommandIDs {
   export const changeTheme = 'apputils:change-theme';
 
+  export const themeScrollbars = 'apputils:theme-scrollbars';
+
+  export const incrFontSize = 'apputils:incr-font-size';
+
+  export const decrFontSize = 'apputils:decr-font-size';
+
   export const loadState = 'apputils:load-statedb';
 
   export const print = 'apputils:print';
@@ -146,7 +152,7 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
       }
 
       // Set any CSS overrides
-      manager.setCssOverrides();
+      manager.loadCssOverrides();
 
       commands.notifyCommandChanged(CommandIDs.changeTheme);
     });
@@ -164,6 +170,22 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
         }
         return manager.setTheme(theme);
       }
+    });
+
+    commands.addCommand(CommandIDs.themeScrollbars, {
+      label: 'Theme Scrollbars',
+      isToggled: () => manager.themeScrollbars(currentTheme),
+      execute: () => manager.toggleThemeScrollbars()
+    });
+
+    commands.addCommand(CommandIDs.incrFontSize, {
+      label: args => `Increase ${args['label']} Font Size`,
+      execute: args => manager.incrFontSize(args['key'] as string)
+    });
+
+    commands.addCommand(CommandIDs.decrFontSize, {
+      label: args => `Decrease ${args['label']} Font Size`,
+      execute: args => manager.decrFontSize(args['key'] as string)
     });
 
     return manager;
@@ -197,11 +219,51 @@ const themesPaletteMenu: JupyterFrontEndPlugin<void> = {
       const themeMenu = new Menu({ commands });
       themeMenu.title.label = 'JupyterLab Theme';
       void app.restored.then(() => {
-        const command = CommandIDs.changeTheme;
         const isPalette = false;
 
+        // choose a theme
         manager.themes.forEach(theme => {
-          themeMenu.addItem({ command, args: { isPalette, theme } });
+          themeMenu.addItem({
+            command: CommandIDs.changeTheme,
+            args: { isPalette, theme }
+          });
+        });
+        themeMenu.addItem({ type: 'separator' });
+
+        // theme scrollbars
+        themeMenu.addItem({ command: CommandIDs.themeScrollbars });
+        themeMenu.addItem({ type: 'separator' });
+
+        // increase/decrease code font size
+        themeMenu.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'Code', key: 'code-font-size' }
+        });
+        themeMenu.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'Code', key: 'code-font-size' }
+        });
+        themeMenu.addItem({ type: 'separator' });
+
+        // increase/decrease content font size
+        themeMenu.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'Content', key: 'content-font-size1' }
+        });
+        themeMenu.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'Content', key: 'content-font-size1' }
+        });
+        themeMenu.addItem({ type: 'separator' });
+
+        // increase/decrease ui font size
+        themeMenu.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'UI', key: 'ui-font-size1' }
+        });
+        themeMenu.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'UI', key: 'ui-font-size1' }
         });
       });
       mainMenu.settingsMenu.addGroup(

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -129,8 +129,8 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
     // can lead to an incorrect toggle on the currently used theme.
     let currentTheme: string;
 
-    // Set data attributes on the application shell for the current theme.
     manager.themeChanged.connect((sender, args) => {
+      // Set data attributes on the application shell for the current theme.
       currentTheme = args.newValue;
       document.body.dataset.jpThemeLight = String(
         manager.isLight(currentTheme)
@@ -144,6 +144,9 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
           manager.themeScrollbars(currentTheme)
         );
       }
+
+      // Set any CSS overrides
+
       commands.notifyCommandChanged(CommandIDs.changeTheme);
     });
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -146,10 +146,7 @@ const themes: JupyterFrontEndPlugin<IThemeManager> = {
       }
 
       // Set any CSS overrides
-      for (let key in ThemeManager.fontVars) {
-        // Set the font size overrides
-        manager.setFontSize(key, ThemeManager.fontVars[key]);
-      }
+      manager.setOverrides();
 
       commands.notifyCommandChanged(CommandIDs.changeTheme);
     });

--- a/packages/apputils-extension/src/themeplugins.ts
+++ b/packages/apputils-extension/src/themeplugins.ts
@@ -1,0 +1,252 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+import {
+  ICommandPalette,
+  ISplashScreen,
+  IThemeManager,
+  ThemeManager
+} from '@jupyterlab/apputils';
+
+import { ISettingRegistry, URLExt } from '@jupyterlab/coreutils';
+
+import { IMainMenu } from '@jupyterlab/mainmenu';
+
+import { Menu } from '@phosphor/widgets';
+
+namespace CommandIDs {
+  export const changeTheme = 'apputils:change-theme';
+
+  export const themeScrollbars = 'apputils:theme-scrollbars';
+
+  export const incrFontSize = 'apputils:incr-font-size';
+
+  export const decrFontSize = 'apputils:decr-font-size';
+}
+
+/**
+ * The default theme manager provider.
+ */
+export const themesPlugin: JupyterFrontEndPlugin<IThemeManager> = {
+  id: '@jupyterlab/apputils-extension:themes',
+  requires: [ISettingRegistry, JupyterFrontEnd.IPaths],
+  optional: [ISplashScreen],
+  activate: (
+    app: JupyterFrontEnd,
+    settings: ISettingRegistry,
+    paths: JupyterFrontEnd.IPaths,
+    splash: ISplashScreen | null
+  ): IThemeManager => {
+    const host = app.shell;
+    const commands = app.commands;
+    const url = URLExt.join(paths.urls.base, paths.urls.themes);
+    const key = themesPlugin.id;
+    const manager = new ThemeManager({ key, host, settings, splash, url });
+
+    // Keep a synchronously set reference to the current theme,
+    // since the asynchronous setting of the theme in `changeTheme`
+    // can lead to an incorrect toggle on the currently used theme.
+    let currentTheme: string;
+
+    manager.themeChanged.connect((sender, args) => {
+      // Set data attributes on the application shell for the current theme.
+      currentTheme = args.newValue;
+      document.body.dataset.jpThemeLight = String(
+        manager.isLight(currentTheme)
+      );
+      document.body.dataset.jpThemeName = currentTheme;
+      if (
+        document.body.dataset.jpThemeScrollbars !==
+        String(manager.themeScrollbars(currentTheme))
+      ) {
+        document.body.dataset.jpThemeScrollbars = String(
+          manager.themeScrollbars(currentTheme)
+        );
+      }
+
+      // Set any CSS overrides
+      manager.loadCSSOverrides();
+
+      commands.notifyCommandChanged(CommandIDs.changeTheme);
+    });
+
+    commands.addCommand(CommandIDs.changeTheme, {
+      label: args => {
+        const theme = args['theme'] as string;
+        return args['isPalette'] ? `Use ${theme} Theme` : theme;
+      },
+      isToggled: args => args['theme'] === currentTheme,
+      execute: args => {
+        const theme = args['theme'] as string;
+        if (theme === manager.theme) {
+          return;
+        }
+        return manager.setTheme(theme);
+      }
+    });
+
+    commands.addCommand(CommandIDs.themeScrollbars, {
+      label: 'Theme Scrollbars',
+      isToggled: () => manager.isToggledThemeScrollbars(),
+      execute: () => manager.toggleThemeScrollbars()
+    });
+
+    commands.addCommand(CommandIDs.incrFontSize, {
+      label: args => `Increase ${args['label']} Font Size`,
+      execute: args => manager.incrFontSize(args['key'] as string)
+    });
+
+    commands.addCommand(CommandIDs.decrFontSize, {
+      label: args => `Decrease ${args['label']} Font Size`,
+      execute: args => manager.decrFontSize(args['key'] as string)
+    });
+
+    return manager;
+  },
+  autoStart: true,
+  provides: IThemeManager
+};
+
+/**
+ * The default theme manager's UI command palette and main menu functionality.
+ *
+ * #### Notes
+ * This plugin loads separately from the theme manager plugin in order to
+ * prevent blocking of the theme manager while it waits for the command palette
+ * and main menu to become available.
+ */
+export const themesPaletteMenuPlugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/apputils-extension:themes-palette-menu',
+  requires: [IThemeManager],
+  optional: [ICommandPalette, IMainMenu],
+  activate: (
+    app: JupyterFrontEnd,
+    manager: IThemeManager,
+    palette: ICommandPalette | null,
+    mainMenu: IMainMenu | null
+  ): void => {
+    const commands = app.commands;
+
+    // If we have a main menu, add the theme manager to the settings menu.
+    if (mainMenu) {
+      const themeMenu = new Menu({ commands });
+      themeMenu.title.label = 'JupyterLab Theme';
+      void app.restored.then(() => {
+        const isPalette = false;
+
+        // choose a theme
+        manager.themes.forEach(theme => {
+          themeMenu.addItem({
+            command: CommandIDs.changeTheme,
+            args: { isPalette, theme }
+          });
+        });
+        themeMenu.addItem({ type: 'separator' });
+
+        // toggle scrollbar theming
+        themeMenu.addItem({ command: CommandIDs.themeScrollbars });
+        themeMenu.addItem({ type: 'separator' });
+
+        // increase/decrease code font size
+        themeMenu.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'Code', key: 'code-font-size' }
+        });
+        themeMenu.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'Code', key: 'code-font-size' }
+        });
+        themeMenu.addItem({ type: 'separator' });
+
+        // increase/decrease content font size
+        themeMenu.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'Content', key: 'content-font-size1' }
+        });
+        themeMenu.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'Content', key: 'content-font-size1' }
+        });
+        themeMenu.addItem({ type: 'separator' });
+
+        // increase/decrease ui font size
+        themeMenu.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'UI', key: 'ui-font-size1' }
+        });
+        themeMenu.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'UI', key: 'ui-font-size1' }
+        });
+      });
+      mainMenu.settingsMenu.addGroup(
+        [
+          {
+            type: 'submenu' as Menu.ItemType,
+            submenu: themeMenu
+          }
+        ],
+        0
+      );
+    }
+
+    // If we have a command palette, add theme switching options to it.
+    if (palette) {
+      void app.restored.then(() => {
+        const category = 'Theme';
+        const command = CommandIDs.changeTheme;
+        const isPalette = true;
+
+        // choose a theme
+        manager.themes.forEach(theme => {
+          palette.addItem({ command, args: { isPalette, theme }, category });
+        });
+
+        // toggle scrollbar theming
+        palette.addItem({ command: CommandIDs.themeScrollbars, category });
+
+        // increase/decrease code font size
+        palette.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'Code', key: 'code-font-size' },
+          category
+        });
+        palette.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'Code', key: 'code-font-size' },
+          category
+        });
+        // increase/decrease content font size
+        palette.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'Content', key: 'content-font-size1' },
+          category
+        });
+        palette.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'Content', key: 'content-font-size1' },
+          category
+        });
+        // increase/decrease ui font size
+        palette.addItem({
+          command: CommandIDs.incrFontSize,
+          args: { label: 'UI', key: 'ui-font-size1' },
+          category
+        });
+        palette.addItem({
+          command: CommandIDs.decrFontSize,
+          args: { label: 'UI', key: 'ui-font-size1' },
+          category
+        });
+      });
+    }
+  },
+  autoStart: true
+};

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -396,12 +396,6 @@ export namespace ThemeManager {
      */
     url: string;
   }
-
-  export const fontVars: { [key: string]: string } = {
-    'code-font-size': '--jp-code-font-size',
-    'content-font-size': '--jp-content-font-size1',
-    'ui-font-size': '--jp-ui-font-size1'
-  };
 }
 
 /**

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -139,10 +139,7 @@ export class ThemeManager implements IThemeManager {
    * setting if it exists
    */
   getFontSize(settingsKey: string, cssKey: string): string {
-    return (
-      (this._settings.composite[settingsKey] as string) ||
-      getComputedStyle(document.documentElement).getPropertyValue(cssKey)
-    );
+    return (this._settings.composite[settingsKey] as string) || `initial`;
   }
 
   /**

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -134,6 +134,39 @@ export class ThemeManager implements IThemeManager {
     return this._themes[name].isLight;
   }
 
+  get codeFontSize(): number {
+    return (
+      (this._settings.composite['code-font-size'] as number) ||
+      parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          '---jp-code-font-size'
+        )
+      )
+    );
+  }
+
+  get contentFontSize(): number {
+    return (
+      (this._settings.composite['content-font-size'] as number) ||
+      parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          '--jp-content-font-size1'
+        )
+      )
+    );
+  }
+
+  get uiFontSize(): number {
+    return (
+      (this._settings.composite['ui-font-size'] as number) ||
+      parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          '--jp-ui-font-size1'
+        )
+      )
+    );
+  }
+
   /**
    * Test whether a given theme styles scrollbars,
    * and if the user has scrollbar styling enabled.

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -227,12 +227,10 @@ export class ThemeManager implements IThemeManager {
     );
 
     // determine the increment
-    const incr = parts[1] === 'em' ? 0.1 : 1;
+    const incr = (add ? 1 : -1) * (parts[1] === 'em' ? 0.1 : 1);
 
     // increment the font size and set it as an override
-    this._overrides[key] = `${Number(parts[0]) + (add ? incr : -incr)}${
-      parts[1]
-    }`;
+    this._overrides[key] = `${Number(parts[0]) + incr}${parts[1]}`;
     return this._settings.set('overrides', this._overrides);
   }
 

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -5,8 +5,6 @@ import { IChangedArgs, ISettingRegistry, URLExt } from '@jupyterlab/coreutils';
 
 import { each } from '@phosphor/algorithm';
 
-import { ReadonlyJSONArray } from '@phosphor/coreutils';
-
 import { DisposableDelegate, IDisposable } from '@phosphor/disposable';
 
 import { Widget } from '@phosphor/widgets';
@@ -30,7 +28,7 @@ const REQUEST_INTERVAL = 75;
 const REQUEST_THRESHOLD = 20;
 
 type Dict<T> = { [key: string]: T };
-type Pair<T> = { key: string; value: T };
+// type Pair<T> = { key: string; value: T };
 
 /**
  * A class that provides theme management.
@@ -139,31 +137,31 @@ export class ThemeManager implements IThemeManager {
     return this._themes[name].isLight;
   }
 
-  setOverride(key: string) {
+  setCssOverride(key: string) {
+    const overrides = (this._settings.user['overrides'] as Dict<string>) || {};
+
     document.documentElement.style.setProperty(
       `--jp-${key}`,
-      this._overrides[key] || 'initial'
+      overrides[key] || 'initial'
     );
   }
 
-  setOverrides() {
-    let newOverrides: Dict<string> = {};
-    (this._settings.composite['overrides'] as ReadonlyJSONArray).forEach(
-      (x: Pair<string>) => {
-        newOverrides[x.key] = x.value;
-      }
-    );
+  setCssOverrides() {
+    const newOverrides =
+      (this._settings.user['overrides'] as Dict<string>) || {};
+
     Object.keys(this._overrides).forEach(key => {
       if (!(key in newOverrides)) {
         // unset the override
-        this.setOverride(key);
+        this.setCssOverride(key);
       }
     });
-    this._overrides = newOverrides;
-
-    Object.keys(this._overrides).forEach(key => {
-      this.setOverride(key);
+    Object.keys(newOverrides).forEach(key => {
+      // set the override
+      this.setCssOverride(key);
     });
+
+    this._overrides = newOverrides;
   }
 
   /**

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -110,10 +110,11 @@ export class ThemeManager implements IThemeManager {
   loadCssOverride(key: string): void {
     const overrides = (this._settings.user['overrides'] as Dict<string>) || {};
 
-    document.documentElement.style.setProperty(
-      `--jp-${key}`,
-      overrides[key] || 'initial'
-    );
+    if (overrides[key]) {
+      document.documentElement.style.setProperty(`--jp-${key}`, overrides[key]);
+    } else {
+      document.documentElement.style.removeProperty(`--jp-${key}`);
+    }
   }
 
   /**

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -217,8 +217,8 @@ export class ThemeManager implements IThemeManager {
   /**
    * Toggle the `theme-scrollbbars` setting.
    */
-  toggleThemeScrollbars(): void {
-    this._settings.set(
+  toggleThemeScrollbars(): Promise<void> {
+    return this._settings.set(
       'theme-scrollbars',
       !this._settings.composite['theme-scrollbars']
     );

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -102,22 +102,6 @@ export class ThemeManager implements IThemeManager {
   }
 
   /**
-   * Load a CSS override from settings. If no corresponding override
-   * is found, this function unloads the override instead.
-   *
-   * @param key - A Jupyterlab CSS variable, without the leading '--jp-'.
-   */
-  loadCssOverride(key: string): void {
-    const overrides = (this._settings.user['overrides'] as Dict<string>) || {};
-
-    if (overrides[key]) {
-      document.documentElement.style.setProperty(`--jp-${key}`, overrides[key]);
-    } else {
-      document.documentElement.style.removeProperty(`--jp-${key}`);
-    }
-  }
-
-  /**
    * Loads all current CSS overrides from settings. If an override has been
    * removed, this function unloads it instead.
    */
@@ -125,17 +109,21 @@ export class ThemeManager implements IThemeManager {
     const newOverrides =
       (this._settings.user['overrides'] as Dict<string>) || {};
 
-    Object.keys(this._overrides).forEach(key => {
-      if (!(key in newOverrides)) {
-        // unset the override
-        this.loadCssOverride(key);
+    // iterate over the union of current and new CSS override keys
+    Object.keys({ ...this._overrides, ...newOverrides }).forEach(key => {
+      if (newOverrides[key]) {
+        // if the key is present in newOverrides, the override will be set
+        document.documentElement.style.setProperty(
+          `--jp-${key}`,
+          newOverrides[key]
+        );
+      } else {
+        // otherwise, the override will be removed
+        document.documentElement.style.removeProperty(`--jp-${key}`);
       }
     });
-    Object.keys(newOverrides).forEach(key => {
-      // set the override
-      this.loadCssOverride(key);
-    });
 
+    // replace the current overrides with the new ones
     this._overrides = newOverrides;
   }
 

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -134,36 +134,24 @@ export class ThemeManager implements IThemeManager {
     return this._themes[name].isLight;
   }
 
-  get codeFontSize(): number {
+  /**
+   * Get a font size from the current theme, or the override
+   * setting if it exists
+   */
+  getFontSize(settingsKey: string, cssKey: string): string {
     return (
-      (this._settings.composite['code-font-size'] as number) ||
-      parseFloat(
-        getComputedStyle(document.documentElement).getPropertyValue(
-          '---jp-code-font-size'
-        )
-      )
+      (this._settings.composite[settingsKey] as string) ||
+      getComputedStyle(document.documentElement).getPropertyValue(cssKey)
     );
   }
 
-  get contentFontSize(): number {
-    return (
-      (this._settings.composite['content-font-size'] as number) ||
-      parseFloat(
-        getComputedStyle(document.documentElement).getPropertyValue(
-          '--jp-content-font-size1'
-        )
-      )
-    );
-  }
-
-  get uiFontSize(): number {
-    return (
-      (this._settings.composite['ui-font-size'] as number) ||
-      parseFloat(
-        getComputedStyle(document.documentElement).getPropertyValue(
-          '--jp-ui-font-size1'
-        )
-      )
+  /**
+   * Set a font size based on the return from getFontSize
+   */
+  setFontSize(settingsKey: string, cssKey: string): void {
+    document.documentElement.style.setProperty(
+      cssKey,
+      this.getFontSize(settingsKey, cssKey)
     );
   }
 
@@ -350,6 +338,12 @@ export namespace ThemeManager {
      */
     url: string;
   }
+
+  export const fontVars: { [key: string]: string } = {
+    'code-font-size': '--jp-code-font-size',
+    'content-font-size': '--jp-content-font-size1',
+    'ui-font-size': '--jp-ui-font-size1'
+  };
 }
 
 /**

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -121,19 +121,13 @@ export class ThemeManager implements IThemeManager {
 
     // iterate over the union of current and new CSS override keys
     Object.keys({ ...this._overrides, ...newOverrides }).forEach(key => {
-      if (newOverrides[key]) {
-        // if key is present in newOverrides, validate then set the override
-        if (ThemeManager.validateCSS(key, newOverrides[key])) {
-          document.documentElement.style.setProperty(
-            `--jp-${key}`,
-            newOverrides[key]
-          );
-        } else {
-          // if validation failed, the override will be removed
-          document.documentElement.style.removeProperty(`--jp-${key}`);
-        }
+      const val = newOverrides[key];
+
+      if (val && ThemeManager.validateCSS(key, val)) {
+        // validation succeeded, set the override
+        document.documentElement.style.setProperty(`--jp-${key}`, val);
       } else {
-        // if key is not present, the override will be removed
+        // if key is not present or validation failed, the override will be removed
         document.documentElement.style.removeProperty(`--jp-${key}`);
       }
     });

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -273,7 +273,11 @@ export class ThemeManager implements IThemeManager {
    * Initialize the key -> property dict for the overrides
    */
   private _initOverrideProps(): void {
-    const oSchema: any = this._settings.schema.properties.overrides.properties;
+    const oSchema = (this._settings.schema.definitions as any).cssOverrides
+      .properties;
+
+    // the description field of each item in the overrides schema stores a
+    // CSS property that will be used to validate that override's values
     Object.keys(oSchema).forEach(key => {
       this._overrideProps[key] = oSchema[key].description;
     });

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -246,6 +246,13 @@ export class ThemeManager implements IThemeManager {
   }
 
   /**
+   * Test if the user has scrollbar styling enabled.
+   */
+  isToggledThemeScrollbars(): boolean {
+    return !!this._settings.composite['theme-scrollbars'];
+  }
+
+  /**
    * Toggle the `theme-scrollbbars` setting.
    */
   toggleThemeScrollbars(): Promise<void> {

--- a/packages/statusbar/src/defaults/kernelStatus.tsx
+++ b/packages/statusbar/src/defaults/kernelStatus.tsx
@@ -181,12 +181,17 @@ export namespace KernelStatus {
       const oldState = this._getAllState();
       const { newValue } = change;
       if (newValue !== null) {
-        newValue.getSpec().then(spec => {
-          // sync setting of status and display name
-          this._kernelStatus = newValue.status;
-          this._kernelName = spec.display_name;
-          this._triggerChange(oldState, this._getAllState());
-        });
+        newValue
+          .getSpec()
+          .then(spec => {
+            // sync setting of status and display name
+            this._kernelStatus = newValue.status;
+            this._kernelName = spec.display_name;
+            this._triggerChange(oldState, this._getAllState());
+          })
+          .catch(err => {
+            throw err;
+          });
       } else {
         this._kernelStatus = 'unknown';
         this._kernelName = 'unknown';


### PR DESCRIPTION
## References

#6908
telamonian/theme-darcula#4

Since I released a theme a while ago, I have heard a number of very strong opinions about what the correct size is for various fonts. Since there's clearly no one best solution, I think it's about time we added some general font size settings.

## Code changes

Various minor changes to `ThemeManager` and related code.

## User-facing changes

There are now settings for changing the font sizes, and corresponding items in the `settings` menu and the `theme` palette category. These settings override the font sizes present in the themes. For good measure, I also added items for toggling the scrollbar theming.

Moved theme-related palette items from `Settings` category to new `Theme` category.

## Backwards-incompatible changes

None