### PR TITLE
Make handling comm messages optional in a kernel connection.

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1702,7 +1702,10 @@ namespace Private {
       // them in our clone, since the comm message protocol has implicit
       // assumptions that only one connection is handling comm messages.
       // See https://github.com/jupyter/jupyter_client/issues/263
-      const handleComms = !some(runningKernels, k => k.handleComms);
+      const handleComms = !some(
+        runningKernels,
+        k => k.id === model.id && k.handleComms
+      );
       const newKernel = kernel.clone({ handleComms });
       return newKernel;
     }

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -61,7 +61,8 @@ export class DefaultKernel implements Kernel.IKernel {
       options.serverSettings || ServerConnection.makeSettings();
     this._clientId = options.clientId || UUID.uuid4();
     this._username = options.username || '';
-    this.handleComms = options.handleComms || true;
+    this.handleComms =
+      options.handleComms === undefined ? true : options.handleComms;
 
     void this._readyPromise.promise.then(() => {
       this._sendPending();

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -91,6 +91,18 @@ export namespace Kernel {
     readonly ready: Promise<void>;
 
     /**
+     * Whether the kernel connection handles comm messages.
+     *
+     * #### Notes
+     * The comm message protocol currently has implicit assumptions that only
+     * one kernel connection is handling comm messages. This option allows a
+     * kernel connection to opt out of handling comms.
+     *
+     * See https://github.com/jupyter/jupyter_client/issues/263
+     */
+    handleComms: boolean;
+
+    /**
      * Get the kernel spec.
      *
      * @returns A promise that resolves with the kernel spec for this kernel.
@@ -636,6 +648,18 @@ export namespace Kernel {
      * The username of the kernel client.
      */
     username?: string;
+
+    /**
+     * Whether the kernel connection should handle comm messages
+     *
+     * #### Notes
+     * The comm message protocol currently has implicit assumptions that only
+     * one kernel connection is handling comm messages. This option allows a
+     * kernel connection to opt out of handling comms.
+     *
+     * See https://github.com/jupyter/jupyter_client/issues/263
+     */
+    handleComms?: boolean;
 
     /**
      * The unique identifier for the kernel client.

--- a/tests/test-services/src/config/config.spec.ts
+++ b/tests/test-services/src/config/config.spec.ts
@@ -9,12 +9,9 @@ import { JSONObject } from '@phosphor/coreutils';
 
 import { ConfigSection, ConfigWithDefaults } from '@jupyterlab/services';
 
-import {
-  expectFailure,
-  handleRequest,
-  makeSettings,
-  getRequestHandler
-} from '../utils';
+import { expectFailure } from '@jupyterlab/testutils';
+
+import { handleRequest, makeSettings, getRequestHandler } from '../utils';
 
 /**
  * Generate a random config section name.

--- a/tests/test-services/src/contents/index.spec.ts
+++ b/tests/test-services/src/contents/index.spec.ts
@@ -10,12 +10,9 @@ import {
   ServerConnection
 } from '@jupyterlab/services';
 
-import {
-  DEFAULT_FILE,
-  makeSettings,
-  expectFailure,
-  handleRequest
-} from '../utils';
+import { expectFailure } from '@jupyterlab/testutils';
+
+import { DEFAULT_FILE, makeSettings, handleRequest } from '../utils';
 
 const DEFAULT_DIR: Contents.IModel = {
   name: 'bar',

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -11,12 +11,9 @@ import { PromiseDelegate } from '@phosphor/coreutils';
 
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 
-import {
-  expectFailure,
-  KernelTester,
-  handleRequest,
-  testEmission
-} from '../utils';
+import { expectFailure, testEmission } from '@jupyterlab/testutils';
+
+import { KernelTester, handleRequest } from '../utils';
 
 describe('Kernel.IKernel', () => {
   let defaultKernel: Kernel.IKernel;

--- a/tests/test-services/src/kernel/kernel.spec.ts
+++ b/tests/test-services/src/kernel/kernel.spec.ts
@@ -9,13 +9,13 @@ import { toArray } from '@phosphor/algorithm';
 
 import { Kernel } from '@jupyterlab/services';
 
+import { expectFailure, testEmission } from '@jupyterlab/testutils';
+
 import {
-  expectFailure,
   KernelTester,
   makeSettings,
   PYTHON_SPEC,
-  getRequestHandler,
-  testEmission
+  getRequestHandler
 } from '../utils';
 
 const PYTHON3_SPEC = JSON.parse(JSON.stringify(PYTHON_SPEC));

--- a/tests/test-services/src/kernel/kernel.spec.ts
+++ b/tests/test-services/src/kernel/kernel.spec.ts
@@ -164,6 +164,22 @@ describe('kernel', () => {
       expect(kernel.id).to.equal(id);
       kernel.dispose();
     });
+
+    it('should turn off comm handling in the new connection if it was enabled in first kernel', () => {
+      expect(defaultKernel.handleComms).to.be.true;
+      const kernel = Kernel.connectTo(defaultKernel.model);
+      expect(kernel.handleComms).to.be.false;
+      kernel.dispose();
+    });
+
+    it('should turn on comm handling in the new connection if it was disabled in all other connections', async () => {
+      const kernel = await Kernel.startNew({ handleComms: false });
+      expect(kernel.handleComms).to.be.false;
+      const kernel2 = Kernel.connectTo(defaultKernel.model);
+      expect(kernel2.handleComms).to.be.true;
+      kernel.dispose();
+      kernel2.dispose();
+    });
   });
 
   describe('Kernel.shutdown()', () => {

--- a/tests/test-services/src/kernel/kernel.spec.ts
+++ b/tests/test-services/src/kernel/kernel.spec.ts
@@ -165,11 +165,13 @@ describe('kernel', () => {
       kernel.dispose();
     });
 
-    it('should turn off comm handling in the new connection if it was enabled in first kernel', () => {
-      expect(defaultKernel.handleComms).to.be.true;
-      const kernel = Kernel.connectTo(defaultKernel.model);
-      expect(kernel.handleComms).to.be.false;
+    it('should turn off comm handling in the new connection if it was enabled in first kernel', async () => {
+      const kernel = await Kernel.startNew();
+      expect(kernel.handleComms).to.be.true;
+      const kernel2 = Kernel.connectTo(kernel.model);
+      expect(kernel2.handleComms).to.be.false;
       kernel.dispose();
+      kernel2.dispose();
     });
 
     it('should turn on comm handling in the new connection if it was disabled in all other connections', async () => {

--- a/tests/test-services/src/kernel/manager.spec.ts
+++ b/tests/test-services/src/kernel/manager.spec.ts
@@ -9,12 +9,13 @@ import { JSONExt } from '@phosphor/coreutils';
 
 import { KernelManager, Kernel } from '@jupyterlab/services';
 
+import { testEmission } from '@jupyterlab/testutils';
+
 import {
   PYTHON_SPEC,
   KERNELSPECS,
   handleRequest,
-  makeSettings,
-  testEmission
+  makeSettings
 } from '../utils';
 
 class TestManager extends KernelManager {

--- a/tests/test-services/src/session/isession.spec.ts
+++ b/tests/test-services/src/session/isession.spec.ts
@@ -13,13 +13,9 @@ import { Kernel, KernelMessage } from '@jupyterlab/services';
 
 import { Session } from '@jupyterlab/services';
 
-import {
-  expectFailure,
-  handleRequest,
-  SessionTester,
-  init,
-  testEmission
-} from '../utils';
+import { expectFailure, testEmission } from '@jupyterlab/testutils';
+
+import { handleRequest, SessionTester, init } from '../utils';
 
 init();
 

--- a/tests/test-services/src/session/manager.spec.ts
+++ b/tests/test-services/src/session/manager.spec.ts
@@ -16,7 +16,9 @@ import {
   Session
 } from '@jupyterlab/services';
 
-import { KERNELSPECS, handleRequest, testEmission } from '../utils';
+import { testEmission } from '@jupyterlab/testutils';
+
+import { KERNELSPECS, handleRequest } from '../utils';
 
 class TestManager extends SessionManager {
   intercept: Kernel.ISpecModels | null = null;

--- a/tests/test-services/src/session/session.spec.ts
+++ b/tests/test-services/src/session/session.spec.ts
@@ -11,8 +11,9 @@ import { ServerConnection } from '@jupyterlab/services';
 
 import { Session } from '@jupyterlab/services';
 
+import { expectFailure } from '@jupyterlab/testutils';
+
 import {
-  expectFailure,
   makeSettings,
   SessionTester,
   createSessionModel,

--- a/tests/test-services/src/terminal/manager.spec.ts
+++ b/tests/test-services/src/terminal/manager.spec.ts
@@ -10,7 +10,8 @@ import {
   TerminalSession,
   TerminalManager
 } from '@jupyterlab/services';
-import { testEmission } from '../utils';
+
+import { testEmission } from '@jupyterlab/testutils';
 
 describe('terminal', () => {
   let manager: TerminalSession.IManager;

--- a/tests/test-services/src/terminal/terminal.spec.ts
+++ b/tests/test-services/src/terminal/terminal.spec.ts
@@ -9,7 +9,9 @@ import { UUID } from '@phosphor/coreutils';
 
 import { TerminalSession } from '@jupyterlab/services';
 
-import { handleRequest, testEmission } from '../utils';
+import { testEmission } from '@jupyterlab/testutils';
+
+import { handleRequest } from '../utils';
 
 describe('terminal', () => {
   let defaultSession: TerminalSession.ISession;

--- a/tests/test-services/src/utils.spec.ts
+++ b/tests/test-services/src/utils.spec.ts
@@ -7,7 +7,11 @@ import { PromiseDelegate } from '@phosphor/coreutils';
 
 import { Signal } from '@phosphor/signaling';
 
-import { expectFailure, isFulfilled, testEmission } from './utils';
+import {
+  expectFailure,
+  isFulfilled,
+  testEmission
+} from '@jupyterlab/testutils';
 
 describe('test/utils', () => {
   describe('testEmission', () => {

--- a/testutils/src/index.ts
+++ b/testutils/src/index.ts
@@ -153,12 +153,22 @@ export function signalToPromise<T, U>(signal: ISignal<T, U>): Promise<[T, U]> {
 /**
  * Test to see if a promise is fulfilled.
  *
+ * @param delay - optional delay in milliseconds before checking
  * @returns true if the promise is fulfilled (either resolved or rejected), and
  * false if the promise is still pending.
  */
-export async function isFulfilled<T>(p: PromiseLike<T>): Promise<boolean> {
+export async function isFulfilled<T>(
+  p: PromiseLike<T>,
+  delay = 0
+): Promise<boolean> {
   let x = Object.create(null);
-  let result = await Promise.race([p, x]).catch(() => false);
+  let race: any;
+  if (delay > 0) {
+    race = sleep(delay, x);
+  } else {
+    race = x;
+  }
+  let result = await Promise.race([p, race]).catch(() => false);
   return result !== x;
 }
 

--- a/testutils/src/index.ts
+++ b/testutils/src/index.ts
@@ -48,7 +48,7 @@ export { defaultRenderMime } from './rendermime';
  * The reason this function is asynchronous is so that the thing causing the
  * signal emission (such as a websocket message) can be asynchronous.
  */
-export function testEmission<T, U, V>(
+export async function testEmission<T, U, V>(
   signal: ISignal<T, U>,
   options: {
     find?: (a: T, b: U) => boolean;
@@ -72,6 +72,35 @@ export function testEmission<T, U, V>(
     }
   }, object);
   return done.promise;
+}
+
+/**
+ * Expect a failure on a promise with the given message.
+ */
+export async function expectFailure(
+  promise: Promise<any>,
+  message?: string
+): Promise<void> {
+  let called = false;
+  try {
+    await promise;
+    called = true;
+  } catch (err) {
+    if (message && err.message.indexOf(message) === -1) {
+      throw Error(`Error "${message}" not in: "${err.message}"`);
+    }
+  }
+  if (called) {
+    throw Error(`Failure was not triggered, message was: ${message}`);
+  }
+}
+
+/**
+ * Do something in the future ensuring total ordering with respect to promises.
+ */
+export async function doLater(cb: () => void): Promise<void> {
+  await Promise.resolve(void 0);
+  cb();
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References



## Code changes

The comm message protocol currently has implicit assumptions that only
one kernel connection is handling comm messages. This option allows a
kernel connection to opt out of handling comms.

See https://github.com/jupyter/jupyter_client/issues/263

This should fix the error where ipywidgets stops working if you open a notebook and a console to the same kernel, since the console automatically closes all comms since it does not have the comm target registered.


## User-facing changes

The first connection to a kernel will handle comm messages, and subsequent connections will ignore comm connections by default. This is better than the status quo, where often subsequent connections would often *close* comm connections for everyone.

This also prevents many errors in the console from comm messages not being processed in a kernel connection without comm targets. For example, you could see these from the help menu kernel connection, or the console kernel connection.

## Backwards-incompatible changes

None. I think all parameters introduced are optional with sensible defaults, and the test suite utility deletions are from a private package.

The `connectToComm` function does throw a new error if the kernel does not handle comms. But its signature hasn't changed in a backwards-incompatible way.