### PR TITLE
Pause lockbot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,7 @@
 # Configuration for Lock Threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 30
+daysUntilLock: 10000
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable


### PR DESCRIPTION
## References

#6943 

## User-facing changes

This pauses the lockbot sweep through issues so we can reevaluate if we really want a message on each and every issue we are locking.

Keep in mind that this is also messaging all people collaborating on the issue that it is locked. There are huge numbers of notifications going out.
