### PR TITLE
Remove lockbot message, re-engage lockbot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -14,6 +14,8 @@ exemptLabels: []
 lockLabel: status:resolved-locked
 
 # Comment to post before locking. Set to `false` to disable
+lockComment: false
+
 # lockComment: >
 #   This thread has been automatically locked since there has not been
 #   any recent activity after it was closed. Please open a [new issue](https://github.com/jupyterlab/jupyterlab/issues/new/choose)

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,7 +1,7 @@
 # Configuration for Lock Threads - https://github.com/dessant/lock-threads
 
 # Number of days of inactivity before a closed issue or pull request is locked
-daysUntilLock: 10000
+daysUntilLock: 30
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
@@ -11,13 +11,13 @@ skipCreatedBefore: false
 exemptLabels: []
 
 # Label to add before locking, such as `outdated`. Set to `false` to disable
-lockLabel: false
+lockLabel: status:resolved-locked
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a [new issue](https://github.com/jupyterlab/jupyterlab/issues/new/choose)
-  for related discussion.
+# lockComment: >
+#   This thread has been automatically locked since there has not been
+#   any recent activity after it was closed. Please open a [new issue](https://github.com/jupyterlab/jupyterlab/issues/new/choose)
+#   for related discussion.
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#6953 #6943 

## Code changes

This removes the lockbot message so we don't get inundated with the backlog of closed issues being locked. It also adds a status:resolved-locked label which has description "Closed issues are locked after 30 days inactivity. Please open a new issue for related discussion." to help users understand what the lock means.
