### PR TITLE
Make dependencies of VDOM extension optional 

### DIFF
--- a/packages/vdom-extension/src/index.ts
+++ b/packages/vdom-extension/src/index.ts
@@ -90,7 +90,7 @@ const plugin: JupyterFrontEndPlugin<IVDOMTracker> = {
       dataType: 'json',
       rendermime,
       name: FACTORY_NAME,
-      primaryFileType: app.docRegistry.getFileType('vdom'),
+      primaryFileType: app.docRegistry.getFileType('vdom')!,
       fileTypes: ['vdom', 'json'],
       defaultFor: ['vdom']
     });


### PR DESCRIPTION
## Code changes

Makes the dependencies of the VDOM extension optional. Also ran with strictNullChecks locally to clean up null/undefined use.

## User-facing changes

The extension can now be used in lab deployments without some of the core components.

## Backwards-incompatible changes

None.