### PR TITLE
Auto-disable statusbar leaf components

### DIFF
--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -71,13 +71,18 @@ const commands: JupyterFrontEndPlugin<void> = {
 export const editorSyntaxStatus: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/codemirror-extension:editor-syntax-status',
   autoStart: true,
-  requires: [IStatusBar, IEditorTracker, ILabShell],
+  requires: [IEditorTracker, ILabShell],
+  optional: [IStatusBar],
   activate: (
     app: JupyterFrontEnd,
-    statusBar: IStatusBar,
     tracker: IEditorTracker,
-    labShell: ILabShell
+    labShell: ILabShell,
+    statusBar: IStatusBar | null
   ) => {
+    if (!statusBar) {
+      // Automatically disable if statusbar missing
+      return;
+    }
     let item = new EditorSyntaxStatus({ commands: app.commands });
     labShell.currentChanged.connect(() => {
       const current = labShell.currentWidget;

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -167,13 +167,18 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
 export const savingStatusPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/docmanager-extension:saving-status',
   autoStart: true,
-  requires: [IStatusBar, IDocumentManager, ILabShell],
+  requires: [IDocumentManager, ILabShell],
+  optional: [IStatusBar],
   activate: (
     _: JupyterFrontEnd,
-    statusBar: IStatusBar,
     docManager: IDocumentManager,
-    labShell: ILabShell
+    labShell: ILabShell,
+    statusBar: IStatusBar | null
   ) => {
+    if (!statusBar) {
+      // Automatically disable if statusbar missing
+      return;
+    }
     const saving = new SavingStatus({ docManager });
 
     // Keep the currently active widget synchronized.
@@ -197,13 +202,18 @@ export const savingStatusPlugin: JupyterFrontEndPlugin<void> = {
 export const pathStatusPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/docmanager-extension:path-status',
   autoStart: true,
-  requires: [IStatusBar, IDocumentManager, ILabShell],
+  requires: [IDocumentManager, ILabShell],
+  optional: [IStatusBar],
   activate: (
     _: JupyterFrontEnd,
-    statusBar: IStatusBar,
     docManager: IDocumentManager,
-    labShell: ILabShell
+    labShell: ILabShell,
+    statusBar: IStatusBar | null
   ) => {
+    if (!statusBar) {
+      // Automatically disable if statusbar missing
+      return;
+    }
     const path = new PathStatus({ docManager });
 
     // Keep the file path widget up-to-date with the application active widget.

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -155,12 +155,17 @@ const shareFile: JupyterFrontEndPlugin<void> = {
 export const fileUploadStatus: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/filebrowser-extension:file-upload-status',
   autoStart: true,
-  requires: [IStatusBar, IFileBrowserFactory],
+  requires: [IFileBrowserFactory],
+  optional: [IStatusBar],
   activate: (
     app: JupyterFrontEnd,
-    statusBar: IStatusBar,
-    browser: IFileBrowserFactory
+    browser: IFileBrowserFactory,
+    statusBar: IStatusBar | null
   ) => {
+    if (!statusBar) {
+      // Automatically disable if statusbar missing
+      return;
+    }
     const item = new FileUploadStatus({
       tracker: browser.tracker
     });

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -114,13 +114,18 @@ const plugin: JupyterFrontEndPlugin<IEditorTracker> = {
 export const tabSpaceStatus: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/fileeditor-extension:tab-space-status',
   autoStart: true,
-  requires: [IStatusBar, IEditorTracker, ISettingRegistry],
+  requires: [IEditorTracker, ISettingRegistry],
+  optional: [IStatusBar],
   activate: (
     app: JupyterFrontEnd,
-    statusBar: IStatusBar,
     editorTracker: IEditorTracker,
-    settingRegistry: ISettingRegistry
+    settingRegistry: ISettingRegistry,
+    statusBar: IStatusBar | null
   ) => {
+    if (!statusBar) {
+      // Automatically disable if statusbar missing
+      return;
+    }
     // Create a menu for switching tabs vs spaces.
     const menu = new Menu({ commands: app.commands });
     const command = 'fileeditor:change-tabs';

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -306,12 +306,17 @@ const tools: JupyterFrontEndPlugin<INotebookTools> = {
 export const commandEditItem: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/notebook-extension:mode-status',
   autoStart: true,
-  requires: [IStatusBar, INotebookTracker],
+  requires: [INotebookTracker],
+  optional: [IStatusBar],
   activate: (
     app: JupyterFrontEnd,
-    statusBar: IStatusBar,
-    tracker: INotebookTracker
+    tracker: INotebookTracker,
+    statusBar: IStatusBar | null
   ) => {
+    if (!statusBar) {
+      // Automatically disable if statusbar missing
+      return;
+    }
     const { shell } = app;
     const item = new CommandEditStatus();
 
@@ -340,11 +345,16 @@ export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/notebook-extension:trust-status',
   autoStart: true,
   requires: [IStatusBar, INotebookTracker, ILabShell],
+  optional: [IStatusBar],
   activate: (
     app: JupyterFrontEnd,
-    statusBar: IStatusBar,
-    tracker: INotebookTracker
+    tracker: INotebookTracker,
+    statusBar: IStatusBar | null
   ) => {
+    if (!statusBar) {
+      // Automatically disable if statusbar missing
+      return;
+    }
     const { shell } = app;
     const item = new NotebookTrustStatus();
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -344,7 +344,7 @@ export const commandEditItem: JupyterFrontEndPlugin<void> = {
 export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/notebook-extension:trust-status',
   autoStart: true,
-  requires: [INotebookTracker, ILabShell],
+  requires: [INotebookTracker],
   optional: [IStatusBar],
   activate: (
     app: JupyterFrontEnd,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -344,7 +344,7 @@ export const commandEditItem: JupyterFrontEndPlugin<void> = {
 export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/notebook-extension:trust-status',
   autoStart: true,
-  requires: [IStatusBar, INotebookTracker, ILabShell],
+  requires: [INotebookTracker, ILabShell],
   optional: [IStatusBar],
   activate: (
     app: JupyterFrontEnd,


### PR DESCRIPTION
## References

Fixes #6981 

## Code changes

This change ensures that if the statusbar plugin is missing, all the plugins that supply components to it will silently do nothing.

All of the plugins were ensured to leaf nodes, i.e. they do not `provide` an interface of their own.

## User-facing changes

No errors in the JS console if the statusbar plugin is uninstalled/disabled.

## Backwards-incompatible changes

Component providers will now not throw an error if the statusbar extension is missing (I do think this should not be considered part of the API though).