### PR TITLE
Partial JSON types to enable strict null checks

### DIFF
--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -5,7 +5,13 @@
 
 import { WidgetTracker } from '@jupyterlab/apputils';
 
-import { IDataConnector, IRestorer } from '@jupyterlab/coreutils';
+import {
+  IDataConnector,
+  IRestorer,
+  PartialJSONObject,
+  ReadonlyPartialJSONValue,
+  ReadonlyPartialJSONObject
+} from '@jupyterlab/coreutils';
 
 import { CommandRegistry } from '@phosphor/commands';
 
@@ -383,7 +389,7 @@ export class LayoutRestorer implements ILayoutRestorer {
     this._widgets.delete(name);
   }
 
-  private _connector: IDataConnector<ReadonlyJSONValue>;
+  private _connector: IDataConnector<ReadonlyPartialJSONValue>;
   private _first: Promise<any>;
   private _firstDone = false;
   private _promisesDone = false;
@@ -434,7 +440,7 @@ namespace Private {
    * It is meant to be a data structure can translate into a `LabShell.ILayout`
    * data structure for consumption by the application shell.
    */
-  export interface ILayout extends JSONObject {
+  export interface ILayout extends PartialJSONObject {
     /**
      * The main area of the user interface.
      */
@@ -454,7 +460,7 @@ namespace Private {
   /**
    * The restorable description of the main application area.
    */
-  export interface IMainArea extends JSONObject {
+  export interface IMainArea extends PartialJSONObject {
     /**
      * The current widget that has application focus.
      */
@@ -474,7 +480,7 @@ namespace Private {
   /**
    * The restorable description of a sidebar in the user interface.
    */
-  export interface ISideArea extends JSONObject {
+  export interface ISideArea extends PartialJSONObject {
     /**
      * A flag denoting whether the sidebar has been collapsed.
      */
@@ -664,7 +670,7 @@ namespace Private {
    * For fault tolerance, types are manually checked in deserialization.
    */
   export function deserializeMain(
-    area: JSONObject,
+    area: ReadonlyPartialJSONObject,
     names: Map<string, Widget>
   ): ILabShell.IMainArea | null {
     if (!area) {

--- a/packages/application/src/tokens.ts
+++ b/packages/application/src/tokens.ts
@@ -5,11 +5,13 @@ import { CommandRegistry } from '@phosphor/commands';
 
 import { ServerConnection, ServiceManager } from '@jupyterlab/services';
 
-import { ReadonlyJSONObject, Token } from '@phosphor/coreutils';
+import { Token } from '@phosphor/coreutils';
 
 import { IDisposable } from '@phosphor/disposable';
 
 import { ISignal } from '@phosphor/signaling';
+
+import { ReadonlyPartialJSONObject } from '@jupyterlab/coreutils';
 
 /**
  * A token for which a plugin can provide to respond to connection failures
@@ -109,7 +111,7 @@ export namespace IRouter {
   /**
    * The parsed location currently being routed.
    */
-  export interface ILocation extends ReadonlyJSONObject {
+  export interface ILocation extends ReadonlyPartialJSONObject {
     /**
      * The location hash.
      */

--- a/packages/coreutils/src/index.ts
+++ b/packages/coreutils/src/index.ts
@@ -4,6 +4,7 @@
 export * from './activitymonitor';
 export * from './dataconnector';
 export * from './interfaces';
+export * from './partialjson';
 export * from './markdowncodeblocks';
 export * from './nbformat';
 export * from './pageconfig';

--- a/packages/coreutils/src/interfaces.ts
+++ b/packages/coreutils/src/interfaces.ts
@@ -337,7 +337,7 @@ export interface IRateLimiter<T = any, U = any> extends IDisposable {
   /**
    * Invoke the rate limited function.
    */
-  invoke(): Promise<T>;
+  invoke(): Promise<T | undefined>;
 
   /**
    * Stop the function if it is mid-flight.

--- a/packages/coreutils/src/interfaces.ts
+++ b/packages/coreutils/src/interfaces.ts
@@ -3,11 +3,14 @@
 
 import { CommandRegistry } from '@phosphor/commands';
 
-import { ReadonlyJSONObject, ReadonlyJSONValue } from '@phosphor/coreutils';
-
 import { IDisposable, IObservableDisposable } from '@phosphor/disposable';
 
 import { ISignal } from '@phosphor/signaling';
+
+import {
+  ReadonlyPartialJSONObject,
+  ReadonlyPartialJSONValue
+} from './partialjson';
 
 /**
  * A generic interface for change emitter payloads.
@@ -392,7 +395,7 @@ export namespace IRestorer {
     /**
      * A function that returns the args needed to restore an instance.
      */
-    args?: (obj: T) => ReadonlyJSONObject;
+    args?: (obj: T) => ReadonlyPartialJSONObject;
 
     /**
      * A function that returns a unique persistent name for this instance.
@@ -444,7 +447,7 @@ export namespace IRestorable {
     /**
      * The data connector to fetch restore data.
      */
-    connector: IDataConnector<ReadonlyJSONValue>;
+    connector: IDataConnector<ReadonlyPartialJSONValue>;
 
     /**
      * The command registry which holds the restore command.

--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -5,9 +5,7 @@
 // https://nbformat.readthedocs.io/en/latest/format_description.html
 // https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
 
-import { JSONExt } from '@phosphor/coreutils';
-
-import { PartialJSONObject } from './partialjson';
+import { PartialJSONObject, PartialJSONExt } from './partialjson';
 
 /**
  * A namespace for nbformat interfaces.
@@ -137,7 +135,7 @@ export namespace nbformat {
     }
 
     // It is a JSON type, make sure it is a valid JSON object.
-    return JSONExt.isObject(value);
+    return PartialJSONExt.isObject(value);
   }
 
   /**

--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -5,7 +5,9 @@
 // https://nbformat.readthedocs.io/en/latest/format_description.html
 // https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
 
-import { JSONObject, JSONExt } from '@phosphor/coreutils';
+import { JSONExt } from '@phosphor/coreutils';
+
+import { PartialJSONObject } from './partialjson';
 
 /**
  * A namespace for nbformat interfaces.
@@ -24,7 +26,7 @@ export namespace nbformat {
   /**
    * The kernelspec metadata.
    */
-  export interface IKernelspecMetadata extends JSONObject {
+  export interface IKernelspecMetadata extends PartialJSONObject {
     name: string;
     display_name: string;
   }
@@ -32,9 +34,9 @@ export namespace nbformat {
   /**
    * The language info metatda
    */
-  export interface ILanguageInfoMetadata extends JSONObject {
+  export interface ILanguageInfoMetadata extends PartialJSONObject {
     name: string;
-    codemirror_mode?: string | JSONObject;
+    codemirror_mode?: string | PartialJSONObject;
     file_extension?: string;
     mimetype?: string;
     pygments_lexer?: string;
@@ -43,7 +45,7 @@ export namespace nbformat {
   /**
    * The default metadata for the notebook.
    */
-  export interface INotebookMetadata extends JSONObject {
+  export interface INotebookMetadata extends PartialJSONObject {
     kernelspec?: IKernelspecMetadata;
     language_info?: ILanguageInfoMetadata;
     orig_nbformat: number;
@@ -52,7 +54,7 @@ export namespace nbformat {
   /**
    * The notebook content.
    */
-  export interface INotebookContent extends JSONObject {
+  export interface INotebookContent extends PartialJSONObject {
     metadata: INotebookMetadata;
     nbformat_minor: number;
     nbformat: number;
@@ -67,8 +69,8 @@ export namespace nbformat {
   /**
    * A mime-type keyed dictionary of data.
    */
-  export interface IMimeBundle extends JSONObject {
-    [key: string]: MultilineString | JSONObject;
+  export interface IMimeBundle extends PartialJSONObject {
+    [key: string]: MultilineString | PartialJSONObject;
   }
 
   /**
@@ -86,7 +88,7 @@ export namespace nbformat {
   /**
    * Cell output metadata.
    */
-  export type OutputMetadata = JSONObject;
+  export type OutputMetadata = PartialJSONObject;
 
   /**
    * Validate a mime type/value pair.
@@ -99,7 +101,7 @@ export namespace nbformat {
    */
   export function validateMimeValue(
     type: string,
-    value: MultilineString | JSONObject
+    value: MultilineString | PartialJSONObject
   ): boolean {
     // Check if "application/json" or "application/foo+json"
     const jsonTest = /^application\/(.*?)+\+json$/;
@@ -146,7 +148,7 @@ export namespace nbformat {
   /**
    * The Jupyter metadata namespace.
    */
-  export interface IBaseCellJupyterMetadata extends JSONObject {
+  export interface IBaseCellJupyterMetadata extends PartialJSONObject {
     /**
      * Whether the source is hidden.
      */
@@ -156,7 +158,7 @@ export namespace nbformat {
   /**
    * Cell-level metadata.
    */
-  export interface IBaseCellMetadata extends JSONObject {
+  export interface IBaseCellMetadata extends PartialJSONObject {
     /**
      * Whether the cell is trusted.
      *
@@ -187,7 +189,7 @@ export namespace nbformat {
   /**
    * The base cell interface.
    */
-  export interface IBaseCell extends JSONObject {
+  export interface IBaseCell extends PartialJSONObject {
     /**
      * String identifying the type of cell.
      */
@@ -356,7 +358,7 @@ export namespace nbformat {
   /**
    * The base output type.
    */
-  export interface IBaseOutput extends JSONObject {
+  export interface IBaseOutput extends PartialJSONObject {
     /**
      * Type of cell output.
      */

--- a/packages/coreutils/src/partialjson.ts
+++ b/packages/coreutils/src/partialjson.ts
@@ -1,0 +1,317 @@
+/*-----------------------------------------------------------------------------
+This code is based on code from PhosphorJS under the following license:
+
+Copyright (c) 2014-2017, PhosphorJS Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------*/
+
+import { JSONPrimitive } from '@phosphor/coreutils';
+
+/**
+ * A type alias for a JSON value.
+ */
+export type PartialJSONValue =
+  | JSONPrimitive
+  | PartialJSONObject
+  | PartialJSONArray;
+
+/**
+ * A type definition for a JSON object.
+ */
+// tslint:disable-next-line:interface-name
+export interface PartialJSONObject {
+  [key: string]: PartialJSONValue | undefined;
+}
+
+/**
+ * A type definition for a JSON array.
+ */
+// tslint:disable-next-line:interface-name
+export interface PartialJSONArray extends Array<PartialJSONValue> {}
+
+/**
+ * A type definition for a readonly JSON object.
+ */
+// tslint:disable-next-line:interface-name
+export interface ReadonlyPartialJSONObject {
+  readonly [key: string]: ReadonlyPartialJSONValue | undefined;
+}
+
+/**
+ * A type definition for a readonly JSON array.
+ */
+// tslint:disable-next-line:interface-name
+export interface ReadonlyPartialJSONArray
+  extends ReadonlyArray<ReadonlyPartialJSONValue> {}
+
+/**
+ * A type alias for a readonly JSON value.
+ */
+export type ReadonlyPartialJSONValue =
+  | JSONPrimitive
+  | ReadonlyPartialJSONObject
+  | ReadonlyPartialJSONArray;
+
+/**
+ * The namespace for JSON-specific functions.
+ */
+export namespace PartialJSONExt {
+  /**
+   * A shared frozen empty JSONObject
+   */
+  export const emptyObject = Object.freeze({}) as ReadonlyPartialJSONObject;
+
+  /**
+   * A shared frozen empty JSONArray
+   */
+  export const emptyArray = Object.freeze([]) as ReadonlyPartialJSONArray;
+
+  /**
+   * Test whether a JSON value is a primitive.
+   *
+   * @param value - The JSON value of interest.
+   *
+   * @returns `true` if the value is a primitive,`false` otherwise.
+   */
+  export function isPrimitive(
+    value: ReadonlyPartialJSONValue
+  ): value is JSONPrimitive {
+    return (
+      value === null ||
+      typeof value === 'boolean' ||
+      typeof value === 'number' ||
+      typeof value === 'string'
+    );
+  }
+
+  /**
+   * Test whether a JSON value is an array.
+   *
+   * @param value - The JSON value of interest.
+   *
+   * @returns `true` if the value is a an array, `false` otherwise.
+   */
+  export function isArray(value: PartialJSONValue): value is PartialJSONArray;
+  export function isArray(
+    value: ReadonlyPartialJSONValue
+  ): value is ReadonlyPartialJSONArray;
+  export function isArray(value: ReadonlyPartialJSONValue): boolean {
+    return Array.isArray(value);
+  }
+
+  /**
+   * Test whether a JSON value is an object.
+   *
+   * @param value - The JSON value of interest.
+   *
+   * @returns `true` if the value is a an object, `false` otherwise.
+   */
+  export function isObject(value: PartialJSONValue): value is PartialJSONObject;
+  export function isObject(
+    value: ReadonlyPartialJSONValue
+  ): value is ReadonlyPartialJSONObject;
+  export function isObject(value: ReadonlyPartialJSONValue): boolean {
+    return !isPrimitive(value) && !isArray(value);
+  }
+
+  /**
+   * Compare two JSON values for deep equality.
+   *
+   * @param first - The first JSON value of interest.
+   *
+   * @param second - The second JSON value of interest.
+   *
+   * @returns `true` if the values are equivalent, `false` otherwise.
+   */
+  export function deepEqual(
+    first: ReadonlyPartialJSONValue,
+    second: ReadonlyPartialJSONValue
+  ): boolean {
+    // Check referential and primitive equality first.
+    if (first === second) {
+      return true;
+    }
+
+    // If one is a primitive, the `===` check ruled out the other.
+    if (isPrimitive(first) || isPrimitive(second)) {
+      return false;
+    }
+
+    // Test whether they are arrays.
+    let a1 = isArray(first);
+    let a2 = isArray(second);
+
+    // Bail if the types are different.
+    if (a1 !== a2) {
+      return false;
+    }
+
+    // If they are both arrays, compare them.
+    if (a1 && a2) {
+      return deepArrayEqual(
+        first as ReadonlyPartialJSONArray,
+        second as ReadonlyPartialJSONArray
+      );
+    }
+
+    // At this point, they must both be objects.
+    return deepObjectEqual(
+      first as ReadonlyPartialJSONObject,
+      second as ReadonlyPartialJSONObject
+    );
+  }
+
+  /**
+   * Create a deep copy of a JSON value.
+   *
+   * @param value - The JSON value to copy.
+   *
+   * @returns A deep copy of the given JSON value.
+   */
+  export function deepCopy<T extends ReadonlyPartialJSONValue>(value: T): T {
+    // Do nothing for primitive values.
+    if (isPrimitive(value)) {
+      return value;
+    }
+
+    // Deep copy an array.
+    if (isArray(value)) {
+      return deepArrayCopy(value);
+    }
+
+    // Deep copy an object.
+    return deepObjectCopy(value);
+  }
+
+  /**
+   * Compare two JSON arrays for deep equality.
+   */
+  function deepArrayEqual(
+    first: ReadonlyPartialJSONArray,
+    second: ReadonlyPartialJSONArray
+  ): boolean {
+    // Check referential equality first.
+    if (first === second) {
+      return true;
+    }
+
+    // Test the arrays for equal length.
+    if (first.length !== second.length) {
+      return false;
+    }
+
+    // Compare the values for equality.
+    for (let i = 0, n = first.length; i < n; ++i) {
+      if (!deepEqual(first[i], second[i])) {
+        return false;
+      }
+    }
+
+    // At this point, the arrays are equal.
+    return true;
+  }
+
+  /**
+   * Compare two JSON objects for deep equality.
+   */
+  function deepObjectEqual(
+    first: ReadonlyPartialJSONObject,
+    second: ReadonlyPartialJSONObject
+  ): boolean {
+    // Check referential equality first.
+    if (first === second) {
+      return true;
+    }
+
+    // Check for the first object's keys in the second object.
+    for (let key in first) {
+      if (first[key] !== undefined && !(key in second)) {
+        return false;
+      }
+    }
+
+    // Check for the second object's keys in the first object.
+    for (let key in second) {
+      if (second[key] !== undefined && !(key in first)) {
+        return false;
+      }
+    }
+
+    // Compare the values for equality.
+    for (let key in first) {
+      // Get the values.
+      let firstValue = first[key];
+      let secondValue = second[key];
+
+      // If both are undefined, ignore the key.
+      if (firstValue === undefined && secondValue === undefined) {
+        continue;
+      }
+
+      // If only one value is undefined, the objects are not equal.
+      if (firstValue === undefined || secondValue === undefined) {
+        return false;
+      }
+
+      // Compare the values.
+      if (!deepEqual(firstValue, secondValue)) {
+        return false;
+      }
+    }
+
+    // At this point, the objects are equal.
+    return true;
+  }
+
+  /**
+   * Create a deep copy of a JSON array.
+   */
+  function deepArrayCopy(value: any): any {
+    let result = new Array<any>(value.length);
+    for (let i = 0, n = value.length; i < n; ++i) {
+      result[i] = deepCopy(value[i]);
+    }
+    return result;
+  }
+
+  /**
+   * Create a deep copy of a JSON object.
+   */
+  function deepObjectCopy(value: any): any {
+    let result: any = {};
+    for (let key in value) {
+      // Ignore undefined values.
+      let subvalue = value[key];
+      if (subvalue === undefined) {
+        continue;
+      }
+      result[key] = deepCopy(subvalue);
+    }
+    return result;
+  }
+}

--- a/packages/coreutils/src/restorablepool.ts
+++ b/packages/coreutils/src/restorablepool.ts
@@ -56,9 +56,12 @@ export class RestorablePool<
   get current(): T | null {
     return this._current;
   }
-  set current(obj: T) {
+  set current(obj: T | null) {
     if (this._current === obj) {
       return;
+    }
+    if (obj === null) {
+      throw new TypeError('Cannot set current object to null');
     }
     if (this._objects.has(obj)) {
       this._current = obj;
@@ -138,7 +141,7 @@ export class RestorablePool<
 
       if (objName) {
         const name = `${this.namespace}:${objName}`;
-        const data = this._restore.args(obj);
+        const data = this._restore.args && this._restore.args(obj);
 
         Private.nameProperty.set(obj, name);
         await connector.save(name, { data });
@@ -298,7 +301,7 @@ export class RestorablePool<
     Private.nameProperty.set(obj, newName);
 
     if (newName) {
-      const data = this._restore.args(obj);
+      const data = this._restore.args && this._restore.args(obj);
       await connector.save(newName, { data });
     }
 

--- a/packages/coreutils/src/tokens.ts
+++ b/packages/coreutils/src/tokens.ts
@@ -71,7 +71,7 @@ export interface ISettingRegistry {
   get(
     plugin: string,
     key: string
-  ): Promise<{ composite: JSONValue; user: JSONValue }>;
+  ): Promise<{ composite: JSONValue | undefined; user: JSONValue | undefined }>;
 
   /**
    * Load a plugin's settings into the setting registry.
@@ -379,7 +379,12 @@ export namespace ISettingRegistry {
      *
      * @returns The setting value.
      */
-    get(key: string): { composite: ReadonlyJSONValue; user: ReadonlyJSONValue };
+    get(
+      key: string
+    ): {
+      composite: ReadonlyJSONValue | undefined;
+      user: ReadonlyJSONValue | undefined;
+    };
 
     /**
      * Remove a single setting.

--- a/packages/coreutils/src/tokens.ts
+++ b/packages/coreutils/src/tokens.ts
@@ -13,6 +13,8 @@ import { IDisposable } from '@phosphor/disposable';
 
 import { ISignal } from '@phosphor/signaling';
 
+import { PartialJSONObject } from './partialjson';
+
 import { ISchemaValidator } from './settingregistry';
 
 import { IDataConnector } from './interfaces';
@@ -171,7 +173,7 @@ export namespace ISettingRegistry {
   /**
    * The settings for a specific plugin.
    */
-  export interface IPlugin extends JSONObject {
+  export interface IPlugin extends PartialJSONObject {
     /**
      * The name of the plugin.
      */
@@ -217,7 +219,7 @@ export namespace ISettingRegistry {
   /**
    * A minimal subset of the formal JSON Schema that describes a property.
    */
-  export interface IProperty extends JSONObject {
+  export interface IProperty extends PartialJSONObject {
     /**
      * The default value, if any.
      */
@@ -423,7 +425,7 @@ export namespace ISettingRegistry {
   /**
    * An interface describing a JupyterLab keyboard shortcut.
    */
-  export interface IShortcut extends JSONObject {
+  export interface IShortcut extends PartialJSONObject {
     /**
      * The optional arguments passed into the shortcut's command.
      */

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -28,7 +28,9 @@ export namespace URLExt {
   /**
    * Normalize a url.
    */
-  export function normalize(url: string | undefined): string {
+  export function normalize(url: string): string;
+  export function normalize(url: undefined): undefined;
+  export function normalize(url: string | undefined): string | undefined {
     return url && parse(url).toString();
   }
 
@@ -51,8 +53,8 @@ export namespace URLExt {
     // Parse the top element into a header collection.
     const header = top.match(/(\w+)(:)(\/\/)?/);
     const protocol = header && header[1];
-    const colon = protocol && header[2];
-    const slashes = colon && header[3];
+    const colon = protocol && header![2];
+    const slashes = colon && header![3];
 
     // Construct the URL prefix.
     const prefix = shorthand
@@ -149,7 +151,10 @@ export namespace URLExt {
   export function isLocal(url: string): boolean {
     const { protocol } = parse(url);
 
-    return url.toLowerCase().indexOf(protocol) !== 0 && url.indexOf('/') !== 0;
+    return (
+      !protocol ||
+      (url.toLowerCase().indexOf(protocol) !== 0 && url.indexOf('/') !== 0)
+    );
   }
 
   /**

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JSONObject } from '@phosphor/coreutils';
+import { PartialJSONObject } from './partialjson';
 
 import urlparse from 'url-parse';
 
@@ -28,7 +28,7 @@ export namespace URLExt {
   /**
    * Normalize a url.
    */
-  export function normalize(url: string): string {
+  export function normalize(url: string | undefined): string {
     return url && parse(url).toString();
   }
 
@@ -97,7 +97,7 @@ export namespace URLExt {
    * #### Notes
    * Modified version of [stackoverflow](http://stackoverflow.com/a/30707423).
    */
-  export function objectToQueryString(value: JSONObject): string {
+  export function objectToQueryString(value: PartialJSONObject): string {
     const keys = Object.keys(value).filter(key => key.length > 0);
 
     if (!keys.length) {

--- a/packages/coreutils/tsconfig.json
+++ b/packages/coreutils/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "module": "commonjs",
+    "strictNullChecks": true,
     "types": ["node"]
   },
   "files": ["src/plugin-schema.json"],

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { URLExt, PathExt } from '@jupyterlab/coreutils';
+import { PartialJSONObject, PathExt, URLExt } from '@jupyterlab/coreutils';
 
 import { ModelDB } from '@jupyterlab/observables';
-
-import { JSONObject } from '@phosphor/coreutils';
 
 import { each } from '@phosphor/algorithm';
 
@@ -898,7 +896,8 @@ export class ContentsManager implements Contents.IManager {
     const driveName = this.driveName(path);
     const localPath = this.localPath(path);
     if (driveName) {
-      return [this._additionalDrives.get(driveName), localPath];
+      // A valid driveName assures its presence in `_additionalDrives`
+      return [this._additionalDrives.get(driveName)!, localPath];
     } else {
       return [this._defaultDrive, localPath];
     }
@@ -1016,7 +1015,7 @@ export class Drive implements Contents.IDrive {
         delete options['format'];
       }
       let content = options.content ? '1' : '0';
-      let params: JSONObject = { ...options, content };
+      let params: PartialJSONObject = { ...options, content };
       url += URLExt.objectToQueryString(params);
     }
 

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -739,7 +739,7 @@ export class DefaultKernel implements Kernel.IKernel {
     }
 
     if (this._comms.has(commId)) {
-      return this._comms.get(commId);
+      return this._comms.get(commId)!;
     }
     let comm = new CommHandler(targetName, commId, this, () => {
       this._unregisterComm(commId);
@@ -1236,17 +1236,15 @@ export class DefaultKernel implements Kernel.IKernel {
     this._kernelSession = msg.header.session;
 
     // Handle the message asynchronously, in the order received.
-    this._msgChain = this._msgChain
-      .then(() => {
-        // Return so that any promises from handling a message are fulfilled
-        // before proceeding to the next message.
-        return this._handleMessage(msg);
-      })
-      .catch(error => {
-        // Log any errors in handling the message, thus resetting the _msgChain
-        // promise so we can process more messages.
-        console.error(error);
-      });
+    this._msgChain = this._msgChain!.then(() => {
+      // Return so that any promises from handling a message are fulfilled
+      // before proceeding to the next message.
+      return this._handleMessage(msg);
+    }).catch(error => {
+      // Log any errors in handling the message, thus resetting the _msgChain
+      // promise so we can process more messages.
+      console.error(error);
+    });
 
     // Emit the message receive signal
     this._anyMessage.emit({ msg, direction: 'recv' });
@@ -1359,7 +1357,7 @@ export class DefaultKernel implements Kernel.IKernel {
   };
 
   private _id = '';
-  private _name = '';
+  private _name: string | undefined = '';
   private _status: Kernel.Status = 'unknown';
   private _kernelSession = '';
   private _clientId = '';
@@ -1862,7 +1860,7 @@ namespace Private {
   export async function handleShellMessage(
     kernel: Kernel.IKernel,
     msg: KernelMessage.IShellMessage
-  ): Promise<KernelMessage.IShellMessage> {
+  ): Promise<KernelMessage.IShellMessage | undefined> {
     let future = kernel.sendShellMessage(msg, true);
     return future.done;
   }

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -165,7 +165,7 @@ export abstract class KernelFutureHandler<
     this._stdin = Private.noOp;
     this._iopub = Private.noOp;
     this._reply = Private.noOp;
-    this._hooks = null;
+    this._hooks = null!;
     if (!this._testFlag(Private.KernelFutureFlag.IsDone)) {
       // Reject the `done` promise, but catch its error here in case no one else
       // is waiting for the promise to resolve. This prevents the error from

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { PartialJSONObject } from '@jupyterlab/coreutils';
+
 import { IIterator } from '@phosphor/algorithm';
 
 import { JSONObject, JSONValue } from '@phosphor/coreutils';
@@ -1031,7 +1033,7 @@ export namespace Kernel {
    * #### Notes
    * See [Kernel specs](https://jupyter-client.readthedocs.io/en/latest/kernels.html#kernelspecs).
    */
-  export interface ISpecModel extends JSONObject {
+  export interface ISpecModel extends PartialJSONObject {
     /**
      * The name of the kernel spec.
      */
@@ -1055,7 +1057,7 @@ export namespace Kernel {
     /**
      * A dictionary of environment variables to set for the kernel.
      */
-    readonly env?: JSONObject;
+    readonly env?: PartialJSONObject;
 
     /**
      * A mapping of resource file name to download path.
@@ -1069,7 +1071,7 @@ export namespace Kernel {
    * #### Notes
    * See the [Jupyter Notebook API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml#!/kernelspecs).
    */
-  export interface ISpecModels extends JSONObject {
+  export interface ISpecModels extends PartialJSONObject {
     /**
      * The name of the default kernel spec.
      */

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Poll } from '@jupyterlab/coreutils';
+import { Poll, PartialJSONExt } from '@jupyterlab/coreutils';
 
 import { ArrayExt, IIterator, iter } from '@phosphor/algorithm';
-
-import { JSONExt } from '@phosphor/coreutils';
 
 import { ISignal, Signal } from '@phosphor/signaling';
 
@@ -294,7 +292,7 @@ export class KernelManager implements Kernel.IManager {
     if (this._isDisposed) {
       return;
     }
-    if (!JSONExt.deepEqual(models, this._models)) {
+    if (!PartialJSONExt.deepEqual(models, this._models)) {
       const ids = models.map(({ id }) => id);
       const kernels = this._kernels;
       kernels.forEach(kernel => {
@@ -316,7 +314,7 @@ export class KernelManager implements Kernel.IManager {
     if (this._isDisposed) {
       return;
     }
-    if (!JSONExt.deepEqual(specs, this._specs)) {
+    if (!PartialJSONExt.deepEqual(specs, this._specs)) {
       this._specs = specs;
       this._specsChanged.emit(specs);
     }

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Poll } from '@jupyterlab/coreutils';
+import { Poll, PartialJSONExt } from '@jupyterlab/coreutils';
 
 import { ArrayExt, IIterator, iter } from '@phosphor/algorithm';
-
-import { JSONExt } from '@phosphor/coreutils';
 
 import { ISignal, Signal } from '@phosphor/signaling';
 
@@ -303,7 +301,7 @@ export class SessionManager implements Session.IManager {
     if (this.isDisposed) {
       return;
     }
-    if (!JSONExt.deepEqual(models, this._models)) {
+    if (!PartialJSONExt.deepEqual(models, this._models)) {
       const ids = models.map(model => model.id);
       const sessions = this._sessions;
       sessions.forEach(session => {
@@ -325,7 +323,7 @@ export class SessionManager implements Session.IManager {
     if (this.isDisposed) {
       return;
     }
-    if (!JSONExt.deepEqual(specs, this._specs)) {
+    if (!PartialJSONExt.deepEqual(specs, this._specs)) {
       this._specs = specs;
       this._specsChanged.emit(specs);
     }

--- a/packages/services/tsconfig.json
+++ b/packages/services/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "module": "commonjs",
+    "strictNullChecks": true,
     "types": ["node"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
Proof of concept for having partial JSON types, allowing strict null checks to be enabled.

## References

Proof of concept, alternative resolution for https://github.com/phosphorjs/phosphor/pull/303. I.e. if this concept is acceptable for inclusion in phosphor it should be upstreamed.

## Code changes

Adds types `PartialJSONObject` etc that allow undefined values / missing keys on the JSON objects.

Also enables `strictNullChecks` on coreutils and services. There is currently one compile error, which was an error revealed by the strict checks (i.e. not introduced by this PR).

## User-facing changes

None, this is purely about type safety, but it might fix some bugs.

## Backwards-incompatible changes

Consumers would possibly have to change some imports to be compatible with APIs, but this should be considered a "bug fix", as it is simply clarifying the currently in-use types.
