### PR TITLE
Properly escape template variables

### DIFF
--- a/dev_mode/templates/error.html
+++ b/dev_mode/templates/error.html
@@ -8,7 +8,7 @@ Distributed under the terms of the Modified BSD License.
 <head>
   <meta charset="utf-8">
 
-  <title>{% block title %}{{page_title}}{% endblock %}</title>
+  <title>{% block title %}{{page_title | escape}}{% endblock %}</title>
 
   {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
 
@@ -30,7 +30,7 @@ div#header, div#site {
     {% block h1_error %}
     <h2>JupyterLab assets not detected, please rebuild</h2>
     <script>
-    console.error('Missing assets in "{{static_dir}}"');
+    console.error('Missing assets in "{{static_dir | escape}}"');
     </script>
     {% endblock h1_error %}
 </header>

--- a/dev_mode/templates/partial.html
+++ b/dev_mode/templates/partial.html
@@ -9,6 +9,6 @@
   </script>
 
   {% block favicon %}
-  <link rel="icon" type="image/x-icon" href="{{ base_url | urlencode }}static/base/images/favicon.ico" class="idle favicon">
-  <link rel="" type="image/x-icon" href="{{ base_url | urlencode }}static/base/images/favicon-busy-1.ico" class="busy favicon">
+  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/base/images/favicon.ico" class="idle favicon">
+  <link rel="" type="image/x-icon" href="{{ base_url | escape }}static/base/images/favicon-busy-1.ico" class="busy favicon">
   {% endblock %}

--- a/dev_mode/templates/partial.html
+++ b/dev_mode/templates/partial.html
@@ -1,12 +1,14 @@
-  <script id="jupyter-config-data" type="application/json">{
-    {% for key, value in page_config.items() -%}
-    "{{ key }}": "{{ value }}",
-    {% endfor -%}
-    "baseUrl": "{{ base_url }}",
-    "wsUrl": "{{ ws_url }}"
-  }</script>
+{# Copy so we do not modify the page_config with updates. #}
+{% set page_config_full = page_config.copy() %}
+
+{# Set a dummy variable - we just want the side effect of the update. #}
+{% set _ = page_config_full.update(baseUrl=base_url, wsUrl=ws_url) %}
+
+  <script id="jupyter-config-data" type="application/json">
+    {{ page_config_full | tojson }}
+  </script>
 
   {% block favicon %}
-  <link rel="icon" type="image/x-icon" href="{{ base_url }}static/base/images/favicon.ico" class="idle favicon">
-  <link rel="" type="image/x-icon" href="{{ base_url }}static/base/images/favicon-busy-1.ico" class="busy favicon">
+  <link rel="icon" type="image/x-icon" href="{{ base_url | urlencode }}static/base/images/favicon.ico" class="idle favicon">
+  <link rel="" type="image/x-icon" href="{{ base_url | urlencode }}static/base/images/favicon-busy-1.ico" class="busy favicon">
   {% endblock %}

--- a/examples/app/templates/error.html
+++ b/examples/app/templates/error.html
@@ -8,7 +8,7 @@ Distributed under the terms of the Modified BSD License.
 <head>
   <meta charset="utf-8">
 
-  <title>{% block title %}{{page_title}}{% endblock %}</title>
+  <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
   {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
 
@@ -28,13 +28,13 @@ div#header, div#site {
 
 <div class="error">
     {% block h1_error %}
-    <h1>{{status_code}} : {{status_message}}</h1>
+    <h1>{{status_code | e}} : {{status_message | e}}</h1>
     {% endblock h1_error %}
     {% block error_detail %}
     {% if message %}
     <p>The error was:</p>
     <div class="traceback-wrapper">
-    <pre class="traceback">{{message}}</pre>
+    <pre class="traceback">{{message | e}}</pre>
     </div>
     {% endif %}
     {% endblock %}
@@ -48,7 +48,7 @@ window.onload = function () {
   var tb = document.getElementsByClassName('traceback')[0];
   tb.scrollTop = tb.scrollHeight;
   {% if message %}
-  console.error("{{message}}")
+  console.error("{{message | e}}")
   {% endif %}
 };
 </script>

--- a/examples/app/templates/index.html
+++ b/examples/app/templates/index.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>{{page_config['appName']}}</title>
+  <title>{{page_config['appName'] | e}}</title>
 </head>
 <body>
-  <script id='jupyter-config-data' type="application/json">{
-  {% for key, value in page_config.items() -%}
-  "{{ key }}": "{{ value }}",
-  {% endfor -%}
-  "baseUrl": "{{base_url}}",
-  "wsUrl": "{{ws_url}}"
- }</script>
-  <script src="{{page_config['fullStaticUrl']}}/bundle.js" main="index"></script>
+    {# Copy so we do not modify the page_config with updates. #}
+    {% set page_config_full = page_config.copy() %}
+    
+    {# Set a dummy variable - we just want the side effect of the update. #}
+    {% set _ = page_config_full.update(baseUrl=base_url, wsUrl=ws_url) %}
+    
+      <script id="jupyter-config-data" type="application/json">
+        {{ page_config_full | tojson }}
+      </script>
+  <script src="{{page_config['fullStaticUrl'] | e}}/bundle.js" main="index"></script>
 
   <script type="text/javascript">
     /* Remove token from URL. */

--- a/examples/cell/index.html
+++ b/examples/cell/index.html
@@ -5,11 +5,12 @@
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>
   </head>
   <body>
-    <script id='jupyter-config-data' type="application/json">{
-        "baseUrl": "{{base_url}}",
-        "token": "{{token}}"
-    }</script>
-    <script src="{{base_url}}example/bundle.js"></script>
+      {% set page_config_full = {'baseUrl': base_url, 'token': token} %}
+      
+        <script id="jupyter-config-data" type="application/json">
+          {{ page_config_full | tojson }}
+        </script>
+    <script src="{{base_url | e}}example/bundle.js"></script>
 
     <script type="text/javascript">
       /* Remove token from URL. */

--- a/examples/console/index.html
+++ b/examples/console/index.html
@@ -5,11 +5,13 @@
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>
   </head>
   <body>
-    <script id='jupyter-config-data' type="application/json">{
-        "baseUrl": "{{base_url}}",
-        "token": "{{token}}"
-    }</script>
-    <script src="{{base_url}}example/bundle.js"></script>
+    {% set page_config_full = {'baseUrl': base_url, 'token': token} %}
+    
+    <script id="jupyter-config-data" type="application/json">
+      {{ page_config_full | tojson }}
+    </script>
+  
+    <script src="{{base_url | e}}example/bundle.js"></script>
 
     <script type="text/javascript">
       /* Remove token from URL. */

--- a/examples/filebrowser/index.html
+++ b/examples/filebrowser/index.html
@@ -4,11 +4,13 @@
     <title>FileBrowser Demo</title>
   </head>
   <body>
-    <script id='jupyter-config-data' type="application/json">{
-        "baseUrl": "{{base_url}}",
-        "token": "{{token}}"
-    }</script>
-    <script src="{{base_url}}example/bundle.js"></script>
+    {% set page_config_full = {'baseUrl': base_url, 'token': token} %}
+    
+    <script id="jupyter-config-data" type="application/json">
+      {{ page_config_full | tojson }}
+    </script>
+  
+    <script src="{{base_url | e}}example/bundle.js"></script>
 
     <script type="text/javascript">
       /* Remove token from URL. */

--- a/examples/notebook/index.html
+++ b/examples/notebook/index.html
@@ -7,7 +7,7 @@
     <script id='jupyter-config-data' type="application/json">
       {{ config_data|tojson }}
     </script>
-    <script src="{{config_data['frontendUrl']}}bundle.js"></script>
+    <script src="{{config_data['frontendUrl'] | e}}bundle.js"></script>
 
     <script type="text/javascript">
       /* Remove token from URL. */

--- a/examples/terminal/index.html
+++ b/examples/terminal/index.html
@@ -4,12 +4,13 @@
     <title>Terminal Demo</title>
   </head>
   <body>
-    <script id='jupyter-config-data' type="application/json">{
-      "baseUrl": "{{base_url}}",
-      "terminalsAvailable": "{{terminals_available}}",
-      "token": "{{token}}"
-    }</script>
-    <script src="{{base_url}}example/bundle.js"></script>
+    {% set page_config_full = {'baseUrl': base_url, 'token': token, 'terminalsAvailable': terminals_available} %}
+    
+    <script id="jupyter-config-data" type="application/json">
+      {{ page_config_full | tojson }}
+    </script>
+  
+    <script src="{{base_url | e}}example/bundle.js"></script>
 
     <script type="text/javascript">
       /* Remove token from URL. */

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -141,13 +141,9 @@ def load_jupyter_server_extension(nbapp):
     page_config['devMode'] = dev_mode
     page_config['token'] = nbapp.token
 
-    # Export the version info tuple to a JSON array. This gets printed
-    # inside double quote marks, so we render it to a JSON string of the
-    # JSON data (so that we can call JSON.parse on the frontend on it).
-    # We also have to wrap it in `Markup` so that it isn't escaped
-    # by Jinja. Otherwise, if the version has string parts these will be
-    # escaped and then will have to be unescaped on the frontend.
-    page_config['notebookVersion'] = Markup(dumps(dumps(version_info))[1:-1])
+    # Client-side code assumes notebookVersion is a JSON-encoded string
+    # TODO: fix this when we can make such a change
+    page_config['notebookVersion'] = dumps(version_info)
 
     if nbapp.file_to_run and type(nbapp).__name__ == "LabApp":
         relpath = os.path.relpath(nbapp.file_to_run, nbapp.notebook_dir)

--- a/packages/services/examples/browser-require/index.html
+++ b/packages/services/examples/browser-require/index.html
@@ -10,7 +10,12 @@
     </style>
   </head>
   <body>
-    <script id='jupyter-config-data' type="application/json">{ "baseUrl": "{{base_url}}" }</script>
+    {% set page_config_full = {'baseUrl': base_url} %}
+  
+    <script id="jupyter-config-data" type="application/json">
+      {{ page_config_full | tojson }}
+    </script>
+  
     <h1>Run code!</h1>
     <p>
       Type code in the text area and click run to execute it.
@@ -33,6 +38,6 @@
         }
     });
     </script>
-    <script src="{{base_url}}example/index.js"></script>
+    <script src="{{base_url | e}}example/index.js"></script>
   </body>
 </html>

--- a/packages/services/examples/browser/index.html
+++ b/packages/services/examples/browser/index.html
@@ -5,8 +5,13 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
   </head>
   <body>
-    <script id='jupyter-config-data' type="application/json">{ "baseUrl": "{{base_url}}" }</script>
-    <script src="{{base_url}}example/bundle.js"></script>
+    {% set page_config_full = {'baseUrl': base_url} %}
+
+    <script id="jupyter-config-data" type="application/json">
+      {{ page_config_full | tojson }}
+    </script>
+  
+    <script src="{{base_url | e}}example/bundle.js"></script>
     <pre id='output'></pre>
   </body>
 </html>

--- a/packages/services/examples/typescript-browser-with-output/index.html
+++ b/packages/services/examples/typescript-browser-with-output/index.html
@@ -5,8 +5,13 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
   </head>
   <body>
-    <script id='jupyter-config-data' type="application/json">{ "baseUrl": "{{base_url}}" }</script>
-    <script src="{{base_url}}example/bundle.js"></script>
+    {% set page_config_full = {'baseUrl': base_url} %}
+
+    <script id="jupyter-config-data" type="application/json">
+      {{ page_config_full | tojson }}
+    </script>
+
+    <script src="{{base_url | e}}example/bundle.js"></script>
     <span id='outputarea'></span>
   </body>
 </html>


### PR DESCRIPTION
## References

See https://github.com/jupyterlab/jupyterlab_server/pull/73 for another attempt at this in the server. This may conflict with that change (i.e., there may be double escaping with both that change and this change).

Fixes #7024.

## Code changes

Add proper Jinja escapes to template variables. In particular, this escapes the JSON strings and urls added to the template.

Note that similar escaping should be added to the jupyterlab_server as well. However, since JupyterLab overrides the index.html template from jupyterlab_server, this PR is the one that affects JupyterLab itself.

## User-facing changes

None

## Backwards-incompatible changes

Should be none
