### PR TITLE
Restore behavior of the "raises-exception" cell tag

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1020,7 +1020,11 @@ export namespace CodeCell {
     }
 
     let cellId = { cellId: model.id };
-    metadata = { ...metadata, ...cellId };
+    metadata = {
+      ...model.metadata.toJSON(),
+      ...metadata,
+      ...cellId
+    };
     model.executionCount = null;
     cell.outputHidden = false;
     cell.setPrompt('*');


### PR DESCRIPTION
This restores the intended behavior of the `raises-exception` cell tag. Details can be found in #7015.

Close #7015

@vidartf Let me know if there are more changes required.
