### PR TITLE
restores silent failure behavior when a fileType has no iconClass

### DIFF
--- a/packages/ui-components/src/icon/iconregistry.tsx
+++ b/packages/ui-components/src/icon/iconregistry.tsx
@@ -125,12 +125,16 @@ export class IconRegistry implements IIconRegistry {
 
   resolveName(name: string): string {
     if (!(name in this._svg)) {
-      // assume name is really a className, split the className into parts and check each part
-      for (let className of name.split(/\s+/)) {
-        if (className in this._classNameToName) {
-          return this._classNameToName[className];
+      // skip resolution if name is not defined
+      if (name) {
+        // assume name is really a className, split the className into parts and check each part
+        for (let className of name.split(/\s+/)) {
+          if (className in this._classNameToName) {
+            return this._classNameToName[className];
+          }
         }
       }
+
       if (this._debug) {
         // couldn't resolve name, mark as bad and warn
         console.error(`Invalid icon name: ${name}`);


### PR DESCRIPTION
## References

The first fix for the new icon handling stuff from the recently merged #6034

## Code changes

bugfix to `IconRegistry`

## User-facing changes

Previously, if a `FileType` was missing an `iconClass` field, Jlab would fail silently when opening a new document of that type (and show no icon on the document's tab). This restores that behavior.

## Backwards-incompatible changes
