### PR TITLE
Complete docstring for IExecuteRequestMsg

### DIFF
--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -986,7 +986,7 @@ export namespace KernelMessage {
   }
 
   /**
-   * An `execute_request` message on the `
+   * An `execute_request` message on the `'shell'` channel.
    */
   export interface IExecuteRequestMsg extends IShellMessage<'execute_request'> {
     content: {


### PR DESCRIPTION
## References

The docstring for `IExecuteRequestMsg` was incomplete.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None