### PR TITLE
Increase the search debounce from 100ms to 500ms

### DIFF
--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -417,7 +417,7 @@ class SearchOverlay extends React.Component<
 
   private _debouncedStartSearch = new Debouncer(() => {
     this._executeSearch(true, this.state.searchText);
-  }, 100);
+  }, 500);
 }
 
 export function createSearchOverlay(


### PR DESCRIPTION


## References

Solves #7007

## User-facing changes

The search will not start up until 500ms after the last character was typed, which was previously 100ms. This follows the discussion in #7007 and is motivated by the slowness of search (and interface slowness) when lots of characters are matched. This value could be decreased to more balanced 250ms in the future once we have a way to speed up rendering of CodeMirror editors.