### PR TITLE
added troubleshooting message on build failure

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -45,21 +45,22 @@ buildFailureMsg = """Build failed.
 Troubleshooting: If the build failed due to an out-of-memory error, you
 may be able to fix it by disabling the `dev_build` and/or `minimize` options.
 
-If you are building via the `build jupyter lab` command, you can disable
+If you are building via the `jupyter lab build` command, you can disable
 these options like so:
 
-build jupyter lab --dev-mode=False --minimize=False
+jupyter lab build --dev-mode=False --minimize=False
 
 You can also disable these options for all JupyterLab builds by adding these
-lines to your Jupyter config file (`jupyter_notebook_config.py`):
+lines to a Jupyter config file named `jupyter_config.py`:
 
 c.LabBuildApp.minimize = False
 c.LabBuildApp.dev_build = False
 
-If you haven't done so previously, you can generate a Jupyter config file by
-running:
+If you don't already have a `jupyter_config.py` file, you can create one by
+adding a blank file of that name to any of the Jupyter config directories.
+The config directories can be listed by running:
 
-jupyter lab --generate-config
+jupyter --paths
 
 Explanation:
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -41,6 +41,40 @@ app_version = get_app_version()
 if version != app_version:
     version = '%s (dev), %s (app)' % (__version__, app_version)
 
+buildFailureMsg = """Build failed.
+Troubleshooting: If the build failure due to an out-of-memory error, you
+may be able to fix it by disabling the `dev_build` and/or `minimize` options.
+
+If you are building via the `build jupyter lab` command, you can disable
+these options like so:
+
+build jupyter lab --dev-mode=False --minimize=False
+
+You can also disable these options for all JupyterLab builds by adding these
+lines to your Jupyter config file:
+
+c.LabBuildApp.minimize = False
+c.LabBuildApp.dev_build = False
+
+If you haven't done so previously, you can generate a Jupyter config file by
+running:
+
+jupyter lab --generate-config
+
+Explanation:
+
+- `dev-build`: This option controls whether a `dev` or a more streamlined
+`production` build is used. This option will default to `False` (ie the
+`production` build) for most users. However, if you have any labextensions
+installed from local files, this option will instead default to `True`.
+Explicitly setting `dev-build` to `False` will ensure that the `production`
+build is used in all circumstances.
+
+- `minimize`: This options controls whether your JS bundle is minified
+during the Webpack build, which helps to improve JupyterLab's overall
+performance. However, the minifier Webpack plugin is very memory
+intensive, so turning it off may help in low-memory environments.
+"""
 
 class LabBuildApp(JupyterApp, DebugLogFileMixin):
     version = version
@@ -94,8 +128,12 @@ class LabBuildApp(JupyterApp, DebugLogFileMixin):
                 self.log.info('Cleaning %s' % app_dir)
                 clean(app_options=app_options)
             self.log.info('Building in %s', app_dir)
-            build(name=self.name, version=self.version,
+            try:
+                build(name=self.name, version=self.version,
                   command=command, app_options=app_options)
+            except Exception as e:
+                print(buildFailureMsg)
+                raise e
 
 
 clean_aliases = dict(base_aliases)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -71,18 +71,11 @@ installed from local files, this option will instead default to `True`.
 Explicitly setting `dev-build` to `False` will ensure that the `production`
 build is used in all circumstances.
 
-<<<<<<< HEAD
-- `minimize`: This options controls whether your JS bundle is minified
-during the Webpack build, which helps to improve JupyterLab's overall
-performance. However, the minifier Webpack plugin is very memory
-intensive, so turning it off may help in low-memory environments.
-=======
 - `minimize`: This option controls whether your JS bundle is minified
 during the Webpack build, which helps to improve JupyterLab's overall
 performance. However, the minifier plugin used by Webpack is very memory
 intensive, so turning it off may help the build finish successfully in
 low-memory environments.
->>>>>>> 4335b0558... fixes to `buildFailureMsg`
 """
 
 class LabBuildApp(JupyterApp, DebugLogFileMixin):

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -42,7 +42,7 @@ if version != app_version:
     version = '%s (dev), %s (app)' % (__version__, app_version)
 
 buildFailureMsg = """Build failed.
-Troubleshooting: If the build failure due to an out-of-memory error, you
+Troubleshooting: If the build failed due to an out-of-memory error, you
 may be able to fix it by disabling the `dev_build` and/or `minimize` options.
 
 If you are building via the `build jupyter lab` command, you can disable
@@ -51,7 +51,7 @@ these options like so:
 build jupyter lab --dev-mode=False --minimize=False
 
 You can also disable these options for all JupyterLab builds by adding these
-lines to your Jupyter config file:
+lines to your Jupyter config file (`jupyter_notebook_config.py`):
 
 c.LabBuildApp.minimize = False
 c.LabBuildApp.dev_build = False
@@ -70,10 +70,18 @@ installed from local files, this option will instead default to `True`.
 Explicitly setting `dev-build` to `False` will ensure that the `production`
 build is used in all circumstances.
 
+<<<<<<< HEAD
 - `minimize`: This options controls whether your JS bundle is minified
 during the Webpack build, which helps to improve JupyterLab's overall
 performance. However, the minifier Webpack plugin is very memory
 intensive, so turning it off may help in low-memory environments.
+=======
+- `minimize`: This option controls whether your JS bundle is minified
+during the Webpack build, which helps to improve JupyterLab's overall
+performance. However, the minifier plugin used by Webpack is very memory
+intensive, so turning it off may help the build finish successfully in
+low-memory environments.
+>>>>>>> 4335b0558... fixes to `buildFailureMsg`
 """
 
 class LabBuildApp(JupyterApp, DebugLogFileMixin):


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/pull/6907#issuecomment-521945425

## Code changes

Wraps the `build` function in `LabBuildApp` in a `try...except` that will print a helpful troubleshooting message if the build fails.

## User-facing changes

Users get a troubleshooting message if their build fails.

## Backwards-incompatible changes

None