### PR TITLE
Add types to ContextConnector

### DIFF
--- a/packages/completer/src/contextconnector.ts
+++ b/packages/completer/src/contextconnector.ts
@@ -76,15 +76,22 @@ namespace Private {
 
     // Only choose the ones that have a non-empty type
     // field, which are likely to be of interest.
-    const completionList = tokenList.filter(t => t.type).map(t => t.value);
-    // Remove duplicate completsions from the list
-    const matches = Array.from(new Set<string>(completionList));
+    let completionList = tokenList.filter(t => t.type);
+
+    // Extract value and remove duplicate completions
+    let completionValuesSet = new Set<string>(completionList.map(t => t.value));
+    const matches = Array.from(completionValuesSet);
+
+    // Create value-type mappings
+    const types = completionList.map(t => ({ text: t.value, type: t.type }));
 
     return {
       start: token.offset,
       end: token.offset + token.value.length,
       matches,
-      metadata: {}
+      metadata: {
+        _jupyter_types_experimental: types
+      }
     };
   }
 


### PR DESCRIPTION

## References

Fix #7040.

## Code changes

The implementation of `ContextConnector` passes `_jupyter_types_experimental` metadata with completion response, using token types. No changes to `ContextConnector`/`KernelConnector` merging strategy mean that the token types are only used when kernel is not available - when kernel is available, kernel types are used instead (and matches are merged, as it was before).

## User-facing changes

### R examples

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2019-08-17 15-31-54](https://user-images.githubusercontent.com/5832902/63213429-35505d80-c104-11e9-8eee-5621a85c0686.png)  | ![Screenshot from 2019-08-17 15-26-31](https://user-images.githubusercontent.com/5832902/63213432-35505d80-c104-11e9-8dc2-6c2c0dcf526c.png) |
|  ![Screenshot from 2019-08-17 15-31-44](https://user-images.githubusercontent.com/5832902/63213430-35505d80-c104-11e9-8759-1156bfafb1ac.png)  | ![Screenshot from 2019-08-17 15-28-01](https://user-images.githubusercontent.com/5832902/63213431-35505d80-c104-11e9-97eb-e7cdc34e288f.png)  |

Type indicators are shown, however are not as accurate as those from kernel would be (I think that library is more of a builtin or function than a variable).

### Python examples

| Before  | After |
| ------------- | ------------- |
| ![Screenshot from 2019-08-17 15-35-54](https://user-images.githubusercontent.com/5832902/63213498-fc64b880-c104-11e9-863a-0ff931144514.png) | ![Screenshot from 2019-08-17 15-37-25](https://user-images.githubusercontent.com/5832902/63213497-fc64b880-c104-11e9-8bd8-98b8de001085.png) |
| ![Screenshot from 2019-08-17 15-35-23](https://user-images.githubusercontent.com/5832902/63213499-fc64b880-c104-11e9-8d1a-6b23d5285c94.png) | ![Screenshot from 2019-08-17 15-37-39](https://user-images.githubusercontent.com/5832902/63213496-fc64b880-c104-11e9-8bc3-7b066d98e379.png) |
| ![Screenshot from 2019-08-17 15-46-33](https://user-images.githubusercontent.com/5832902/63213607-40a48880-c106-11e9-91ef-05e7d0bb39e3.png) | ![Screenshot from 2019-08-17 15-45-35](https://user-images.githubusercontent.com/5832902/63213608-40a48880-c106-11e9-9e1a-f541120e588c.png) |

Positive:
- the keywords (which are conceptually different) are distinct and easily noticeable.
- properties are no longer easily mistaken as global functions

Negative:
- `self` has the not very appealing "variable-2" type; we could create a rule to overwrite it with a substitute map - what do you think?
- functions have "variable" type - which has some merit to it (every function in Python can be assigned to a variable), but makes it less useful than I originally though it would be.

## Backwards-incompatible changes

None.