### PR TITLE
Fix baseURL in vega extensions #7047

### DIFF
--- a/packages/vega4-extension/src/index.ts
+++ b/packages/vega4-extension/src/index.ts
@@ -92,7 +92,10 @@ export class RenderedVega extends Widget implements IRenderMime.IRenderer {
       this._result.view.finalize();
     }
 
+    const path = await this._resolver.resolveUrl('');
+    const baseURL = await this._resolver.getDownloadUrl(path);
     const loader = vega.vega.loader({
+      baseURL,
       http: { credentials: 'same-origin' }
     });
 

--- a/packages/vega5-extension/src/index.ts
+++ b/packages/vega5-extension/src/index.ts
@@ -92,7 +92,10 @@ export class RenderedVega extends Widget implements IRenderMime.IRenderer {
       this._result.view.finalize();
     }
 
+    const path = await this._resolver.resolveUrl('');
+    const baseURL = await this._resolver.getDownloadUrl(path);
     const loader = vega.vega.loader({
+      baseURL,
       http: { credentials: 'same-origin' }
     });
     const sanitize = async (uri: string, options: any) => {


### PR DESCRIPTION
This ensures that the path of the current notebook is included in the
URL for data files in the vega extensions.

This adds the baseURL back into the vega loaders which allows notebooks
running in subdirectories to properly load files. With the addition of
the sanitizing of urls in #7022 there are no longer the issues seen in
 #7017 where the _xsrf token was placed in the middle of the URL.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #7047

See also #7017 and #7022 / #7031

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The vega loader includes the baseURL once again so it knows about the current directory of the current notebook.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This changes the behaviour back to what existed in version 1.0.2

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
