### PR TITLE
For windows defaults conda channels are needed

### DIFF
--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -63,7 +63,7 @@ new environment named ``jupyterlab-ext``.
 
 .. code:: bash
 
-    conda create -n jupyterlab-ext -c conda-forge --override-channels jupyterlab cookiecutter nodejs git
+    conda create -n jupyterlab-ext -c conda-forge -c defaults --override-channels jupyterlab cookiecutter nodejs git
 
 Now activate the new environment so that all further commands you run
 work out of that environment.

--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -63,7 +63,7 @@ new environment named ``jupyterlab-ext``.
 
 .. code:: bash
 
-    conda create -n jupyterlab-ext -c conda-forge -c defaults --override-channels jupyterlab cookiecutter nodejs git
+    conda create -n jupyterlab-ext --override-channels --strict-channel-priority -c conda-forge -c anaconda jupyterlab cookiecutter nodejs git
 
 Now activate the new environment so that all further commands you run
 work out of that environment.


### PR DESCRIPTION
## References

Fixes #6972 

## Code changes

None

## User-facing changes

Add defaults conda channel as second channel in apod tutorial to successfully create the environment on Windows.

## Backwards-incompatible changes

None
