### PR TITLE
Commands options

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import pytest
+
+def pytest_addoption(parser):
+    """
+    Adds flags for py.test.
+
+    This is called by the pytest API
+    """
+    group = parser.getgroup("general")
+    group.addoption('--quick', action='store_true',
+                    help="Skip slow tests")
+    group.addoption('--slow', action='store_true',
+                    help="Run only slow tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--quick"):
+        skip_slow = pytest.mark.skip(reason="skipping slow test")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
+    elif config.getoption("--slow"):
+        skip_quick = pytest.mark.skip(reason="skipping non-slow test")
+        for item in items:
+            if "slow" not in item.keywords:
+                item.add_marker(skip_quick)

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -518,8 +518,11 @@ class _AppHandler(object):
     def __init__(self, options):
         """Create a new _AppHandler object
         """
-        self.sys_dir = get_app_dir()
         self.app_dir = options.get('app_dir', None) or get_app_dir()
+        use_sys_dir = options.get('use_sys_dir', None) 
+        self.sys_dir = (
+            get_app_dir() if options.get('use_sys_dir', None) is not False
+            else self.app_dir)
         self.logger = _ensure_logger(options.get('logger'))
         core_config = options.get('core_config', None)
         self.core_data = (

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -290,10 +290,19 @@ def watch_dev(logger=None):
 
 
 class AppOptions(HasTraits):
+    def __init__(self, core_config=None, **kwargs):
+        if core_config is not None:
+            kwargs['core_config'] = core_config
+        super(AppOptions, self).__init__(**kwargs)
+
     app_dir = Unicode()
+
     use_sys_dir = Bool(True)
+
     logger = Instance(logging.Logger, allow_none=True)
+
     core_config = Instance(CoreConfig)
+
     kill_event = Instance(Event, args=())
 
     # These defaults need to be dynamic to pick up

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -560,7 +560,7 @@ class _AppHandler(object):
         """
         self.app_dir = options.app_dir
         self.sys_dir = get_app_dir() if options.use_sys_dir else self.app_dir
-        self.logger = _ensure_logger(options.logger)
+        self.logger = options.logger
         self.core_data = options.core_config._data
         self.info = self._get_app_info()
         self.kill_event = options.kill_event

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -159,7 +159,7 @@ def load_jupyter_server_extension(nbapp):
     logger.info('JupyterLab application directory is %s' % app_dir)
 
     build_url = ujoin(base_url, build_path)
-    builder = Builder(None, core_mode, app_options=build_handler_options)
+    builder = Builder(None, core_mode, None, app_options=build_handler_options)
     build_handler = (build_url, BuildHandler, {'builder': builder})
     handlers = [build_handler]
 

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -38,7 +38,7 @@ def load_config(nbapp):
     )
 
     app_dir = getattr(nbapp, 'app_dir', get_app_dir())
-    info = get_app_info(app_dir)
+    info = get_app_info(options=dict(app_dir=app_dir))
     static_url = info['staticUrl']
     user_settings_dir = getattr(
         nbapp, 'user_settings_dir', get_user_settings_dir()
@@ -188,7 +188,7 @@ def load_jupyter_server_extension(nbapp):
         if dev_mode:
             watch_dev(logger)
         else:
-            watch(app_dir, logger)
+            watch(options=dict(app_dir=app_dir, logger=logger))
             page_config['buildAvailable'] = False
 
         config.cache_files = False

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -159,7 +159,7 @@ def load_jupyter_server_extension(nbapp):
     logger.info('JupyterLab application directory is %s' % app_dir)
 
     build_url = ujoin(base_url, build_path)
-    builder = Builder(logger, core_mode, app_dir)
+    builder = Builder(None, core_mode, app_options=build_handler_options)
     build_handler = (build_url, BuildHandler, {'builder': builder})
     handlers = [build_handler]
 
@@ -198,7 +198,7 @@ def load_jupyter_server_extension(nbapp):
 
     if not core_mode and not errored:
         ext_url = ujoin(base_url, extensions_handler_path)
-        ext_manager = ExtensionManager(None, None, app_options=build_handler_options)
+        ext_manager = ExtensionManager(app_options=build_handler_options)
         ext_handler = (ext_url, ExtensionHandler, {'manager': ext_manager})
         handlers.append(ext_handler)
 

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -34,11 +34,12 @@ def load_config(nbapp):
         get_app_info,
         get_workspaces_dir,
         get_user_settings_dir,
-        pjoin
+        pjoin,
+        AppOptions,
     )
 
     app_dir = getattr(nbapp, 'app_dir', get_app_dir())
-    info = get_app_info(options=dict(app_dir=app_dir))
+    info = get_app_info(app_options=AppOptions(app_dir=app_dir))
     static_url = info['staticUrl']
     user_settings_dir = getattr(
         nbapp, 'user_settings_dir', get_user_settings_dir()
@@ -89,7 +90,7 @@ def load_jupyter_server_extension(nbapp):
     from .handlers.error_handler import ErrorHandler
     from .commands import (
         DEV_DIR, HERE, ensure_app, ensure_core, ensure_dev, watch,
-        watch_dev, get_app_dir
+        watch_dev, get_app_dir, AppOptions
     )
 
     web_app = nbapp.web_app
@@ -98,6 +99,8 @@ def load_jupyter_server_extension(nbapp):
 
     # Handle the app_dir
     app_dir = getattr(nbapp, 'app_dir', get_app_dir())
+
+    build_handler_options = AppOptions(logger=logger, app_dir=app_dir)
 
     # Check for core mode.
     core_mode = False
@@ -188,14 +191,14 @@ def load_jupyter_server_extension(nbapp):
         if dev_mode:
             watch_dev(logger)
         else:
-            watch(options=dict(app_dir=app_dir, logger=logger))
+            watch(app_options=build_handler_options)
             page_config['buildAvailable'] = False
 
         config.cache_files = False
 
     if not core_mode and not errored:
         ext_url = ujoin(base_url, extensions_handler_path)
-        ext_manager = ExtensionManager(logger, app_dir)
+        ext_manager = ExtensionManager(None, None, app_options=build_handler_options)
         ext_handler = (ext_url, ExtensionHandler, {'manager': ext_manager})
         handlers.append(ext_handler)
 

--- a/jupyterlab/handlers/build_handler.py
+++ b/jupyterlab/handlers/build_handler.py
@@ -88,22 +88,22 @@ class Builder(object):
 
     @run_on_executor
     def _run_build_check(self, app_dir, logger, core_config):
-        return build_check(
-            app_dir=app_dir, logger=logger, core_config=core_config)
+        return build_check(options=dict(
+            app_dir=app_dir, logger=logger, core_config=core_config))
 
     @run_on_executor
     def _run_build(self, app_dir, logger, kill_event, core_config):
-        kwargs = dict(
+        options = dict(
             app_dir=app_dir, logger=logger, kill_event=kill_event,
-            core_config=core_config, command='build')
+            core_config=core_config)
         try:
-            return build(**kwargs)
+            return build(command='build', options=options)
         except Exception as e:
             if self._kill_event.is_set():
                 return
             self.log.warn('Build failed, running a clean and rebuild')
-            clean(app_dir)
-            return build(**kwargs)
+            clean(options=options)
+            return build(command='build', options=options)
 
 
 class BuildHandler(APIHandler):

--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -137,13 +137,13 @@ class ExtensionManager(object):
     def uninstall(self, extension):
         """Handle an uninstall request"""
         did_uninstall = uninstall_extension(
-            extension, app_options=AppOptions(self.app_options))
+            extension, app_options=self.app_options)
         raise gen.Return(dict(status='ok' if did_uninstall else 'error',))
 
     @gen.coroutine
     def enable(self, extension):
         """Handle an enable request"""
-        enable_extension(extension, app_options=AppOptions(self.app_options))
+        enable_extension(extension, app_options=self.app_options)
         raise gen.Return(dict(status='ok',))
 
     @gen.coroutine

--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -15,7 +15,8 @@ from tornado import gen, web
 from ..commands import (
     get_app_info, install_extension, uninstall_extension,
     enable_extension, disable_extension, read_package,
-    _AppHandler, get_latest_compatible_package_versions
+    _AppHandler, get_latest_compatible_package_versions,
+    AppOptions, _ensure_options
 )
 
 
@@ -37,9 +38,9 @@ def _make_extension_entry(name, description, url, enabled, core, latest_version,
     return ret
 
 
-def _ensure_compat_errors(info, options):
+def _ensure_compat_errors(info, app_options):
     """Ensure that the app info has compat_errors field"""
-    handler = _AppHandler(options)
+    handler = _AppHandler(app_options)
     info['compat_errors'] = handler._get_extension_compat()
 
 
@@ -49,9 +50,9 @@ _message_map = {
     'update': re.compile(r'(?P<name>.*) changed from (?P<oldver>.*) to (?P<newver>.*)'),
 }
 
-def _build_check_info(options):
+def _build_check_info(app_options):
     """Get info about packages scheduled for (un)install/update"""
-    handler = _AppHandler(options)
+    handler = _AppHandler(app_options)
     messages = handler.build_check(fast=True)
     # Decode the messages into a dict:
     status = {'install': [], 'uninstall': [], 'update': []}
@@ -66,10 +67,13 @@ def _build_check_info(options):
 class ExtensionManager(object):
     executor = ThreadPoolExecutor(max_workers=1)
 
-    def __init__(self, log, app_dir, core_config=None):
-        self.log = log
-        self.app_dir = app_dir
-        self.core_config = core_config
+    # TODO 2.0: Clean up signature to (self, app_options=None)
+    def __init__(self, log=None, app_dir=None, core_config=None, app_options=None):
+        app_options = _ensure_options(app_options, logger=log, app_dir=app_dir, core_config=core_config)
+        self.log = app_options.logger
+        self.app_dir = app_options.app_dir
+        self.core_config = app_options.core_config
+        self.app_options = app_options
         self._outdated = None
         # To start fetching data on outdated extensions immediately, uncomment:
         # IOLoop.current().spawn_callback(self._get_outdated)
@@ -77,10 +81,10 @@ class ExtensionManager(object):
     @gen.coroutine
     def list_extensions(self):
         """Handle a request for all installed extensions"""
-        options = dict(app_dir=self.app_dir, logger=self.log)
-        info = get_app_info(options=options)
-        build_check_info = _build_check_info(options)
-        _ensure_compat_errors(info, options)
+        app_options = self.app_options
+        info = get_app_info(app_options=app_options)
+        build_check_info = _build_check_info(app_options)
+        _ensure_compat_errors(info, app_options)
         extensions = []
         # TODO: Ensure loops can run in parallel
         for name, data in info['extensions'].items():
@@ -124,10 +128,7 @@ class ExtensionManager(object):
     def install(self, extension):
         """Handle an install/update request"""
         try:
-            install_extension(
-                extension, options=dict(
-                    app_dir=self.app_dir, logger=self.log,
-                    core_config=self.core_config))
+            install_extension(extension, app_options=self.app_options)
         except ValueError as e:
             raise gen.Return(dict(status='error', message=str(e)))
         raise gen.Return(dict(status='ok',))
@@ -136,27 +137,19 @@ class ExtensionManager(object):
     def uninstall(self, extension):
         """Handle an uninstall request"""
         did_uninstall = uninstall_extension(
-            extension, options=dict(
-                app_dir=self.app_dir, logger=self.log,
-                core_config=self.core_config))
+            extension, app_options=AppOptions(self.app_options))
         raise gen.Return(dict(status='ok' if did_uninstall else 'error',))
 
     @gen.coroutine
     def enable(self, extension):
         """Handle an enable request"""
-        enable_extension(
-            extension, options=dict(
-                app_dir=self.app_dir, logger=self.log,
-                core_config=self.core_config))
+        enable_extension(extension, app_options=AppOptions(self.app_options))
         raise gen.Return(dict(status='ok',))
 
     @gen.coroutine
     def disable(self, extension):
         """Handle a disable request"""
-        disable_extension(
-            extension, options=dict(
-                app_dir=self.app_dir, logger=self.log,
-                core_config=self.core_config))
+        disable_extension(extension, app_options=self.app_options)
         raise gen.Return(dict(status='ok',))
 
     @gen.coroutine
@@ -194,17 +187,12 @@ class ExtensionManager(object):
     @gen.coroutine
     def _load_outdated(self):
         """Get the latest compatible version"""
-        options = dict(
-            app_dir=self.app_dir,
-            logger=self.log,
-            core_config=self.core_config
-        )
-        info = get_app_info(options=options)
+        info = get_app_info(app_options=self.app_options)
         names = tuple(info['extensions'].keys())
         data = yield self.executor.submit(
             get_latest_compatible_package_versions,
             names,
-            options=options
+            app_options=self.app_options
         )
         raise gen.Return(data)
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -118,7 +118,9 @@ class LabCleanApp(JupyterApp):
     app_dir = Unicode('', config=True, help='The app directory to clean')
 
     def start(self):
-        clean(app_options=AppOptions(app_dir=self.app_dir, logger=self.log))
+        clean(app_options=AppOptions(
+            app_dir=self.app_dir, logger=self.log,
+            core_config=self.core_config))
 
 
 class LabPathApp(JupyterApp):

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -118,7 +118,7 @@ class LabCleanApp(JupyterApp):
     app_dir = Unicode('', config=True, help='The app directory to clean')
 
     def start(self):
-        clean(options=dict(self.app_dir, logger=self.log))
+        clean(options=dict(app_dir=self.app_dir, logger=self.log))
 
 
 class LabPathApp(JupyterApp):

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -21,7 +21,7 @@ from .debuglog import DebugLogFileMixin
 from .extension import load_config, load_jupyter_server_extension
 from .commands import (
     build, clean, get_app_dir, get_app_version, get_user_settings_dir,
-    get_workspaces_dir
+    get_workspaces_dir, AppOptions,
 )
 from .coreconfig import CoreConfig
 
@@ -85,17 +85,17 @@ class LabBuildApp(JupyterApp, DebugLogFileMixin):
         command = ':'.join(parts)
 
         app_dir = self.app_dir or get_app_dir()
-        options = dict(
+        app_options = AppOptions(
             app_dir=app_dir, logger=self.log, core_config=self.core_config
         )
         self.log.info('JupyterLab %s', version)
         with self.debug_logging():
             if self.pre_clean:
                 self.log.info('Cleaning %s' % app_dir)
-                clean(options=options)
+                clean(app_options=app_options)
             self.log.info('Building in %s', app_dir)
             build(name=self.name, version=self.version,
-                  command=command, options=options)
+                  command=command, app_options=app_options)
 
 
 clean_aliases = dict(base_aliases)
@@ -118,7 +118,7 @@ class LabCleanApp(JupyterApp):
     app_dir = Unicode('', config=True, help='The app directory to clean')
 
     def start(self):
-        clean(options=dict(app_dir=self.app_dir, logger=self.log))
+        clean(app_options=AppOptions(app_dir=self.app_dir, logger=self.log))
 
 
 class LabPathApp(JupyterApp):

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -85,15 +85,17 @@ class LabBuildApp(JupyterApp, DebugLogFileMixin):
         command = ':'.join(parts)
 
         app_dir = self.app_dir or get_app_dir()
+        options = dict(
+            app_dir=app_dir, logger=self.log, core_config=self.core_config
+        )
         self.log.info('JupyterLab %s', version)
         with self.debug_logging():
             if self.pre_clean:
                 self.log.info('Cleaning %s' % app_dir)
-                clean(self.app_dir)
+                clean(options=options)
             self.log.info('Building in %s', app_dir)
-            build(app_dir=app_dir, name=self.name, version=self.version,
-                  command=command, logger=self.log,
-                  core_config=self.core_config)
+            build(name=self.name, version=self.version,
+                  command=command, options=options)
 
 
 clean_aliases = dict(base_aliases)
@@ -116,7 +118,7 @@ class LabCleanApp(JupyterApp):
     app_dir = Unicode('', config=True, help='The app directory to clean')
 
     def start(self):
-        clean(self.app_dir, logger=self.log)
+        clean(options=dict(self.app_dir, logger=self.log))
 
 
 class LabPathApp(JupyterApp):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -17,7 +17,7 @@ from .commands import (
     install_extension, uninstall_extension, list_extensions,
     enable_extension, disable_extension, check_extension,
     link_package, unlink_package, build, get_app_version, HERE,
-    update_extension,
+    update_extension, AppOptions,
 )
 from .coreconfig import CoreConfig
 from .debuglog import DebugLogFileMixin
@@ -99,10 +99,10 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
                 if self.minimize:
                     parts.append('minimize')
                 command = ':'.join(parts)
-                options = dict(app_dir=self.app_dir, logger=self.log,
+                app_options = AppOptions(app_dir=self.app_dir, logger=self.log,
                       core_config=self.core_config)
                 build(clean_staging=self.should_clean,
-                      command=command, options=options)
+                      command=command, app_options=app_options)
 
     def run_task(self):
         pass
@@ -140,7 +140,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
                 arg,
                 # Pass in pinned alias if we have it
                 pin=pinned_versions[i] if i < len(pinned_versions) else None,
-                options=dict(
+                app_options=AppOptions(
                     app_dir=self.app_dir,
                     logger=self.log,
                     core_config=self.core_config,
@@ -161,12 +161,12 @@ class UpdateLabExtensionApp(BaseExtensionApp):
         if not self.all and not self.extra_args:
             self.log.warn('Specify an extension to update, or use --all to update all extensions')
             return False
-        options = dict(app_dir=self.app_dir, logger=self.log,
+        app_options = AppOptions(app_dir=self.app_dir, logger=self.log,
             core_config=self.core_config)
         if self.all:
-            return update_extension(all_=True, options=options)
+            return update_extension(all_=True, app_options=app_options)
         return any([
-            update_extension(name=arg, options=options)
+            update_extension(name=arg, app_options=app_options)
             for arg in self.extra_args
         ])
 
@@ -187,7 +187,7 @@ class LinkLabExtensionApp(BaseExtensionApp):
         return any([
             link_package(
                 arg,
-                options=dict(
+                app_options=AppOptions(
                     self.app_dir, logger=self.log,
                     core_config=self.core_config))
             for arg in self.extra_args
@@ -202,7 +202,7 @@ class UnlinkLabExtensionApp(BaseExtensionApp):
         return any([
             unlink_package(
                 arg,
-                options=dict(
+                app_options=AppOptions(
                     self.app_dir, logger=self.log,
                     core_config=self.core_config))
             for arg in self.extra_args
@@ -221,7 +221,7 @@ class UninstallLabExtensionApp(BaseExtensionApp):
         return any([
             uninstall_extension(
                 arg, all_=self.all,
-                options=dict(
+                app_options=AppOptions(
                     app_dir=self.app_dir, logger=self.log,
                     core_config=self.core_config))
             for arg in self.extra_args
@@ -232,7 +232,7 @@ class ListLabExtensionsApp(BaseExtensionApp):
     description = "List the installed labextensions"
 
     def run_task(self):
-        list_extensions(options=dict(
+        list_extensions(app_options=AppOptions(
             self.app_dir, logger=self.log, core_config=self.core_config))
 
 
@@ -240,18 +240,18 @@ class EnableLabExtensionsApp(BaseExtensionApp):
     description = "Enable labextension(s) by name"
 
     def run_task(self):
-        options = dict(
+        app_options = AppOptions(
             app_dir=self.app_dir, logger=self.log, core_config=self.core_config)
-        [enable_extension(arg, options=options) for arg in self.extra_args]
+        [enable_extension(arg, app_options=app_options) for arg in self.extra_args]
 
 
 class DisableLabExtensionsApp(BaseExtensionApp):
     description = "Disable labextension(s) by name"
 
     def run_task(self):
-        options = dict(
+        app_options = AppOptions(
             app_dir=self.app_dir, logger=self.log, core_config=self.core_config)
-        [disable_extension(arg, options=options) for arg in self.extra_args]
+        [disable_extension(arg, app_options=app_options) for arg in self.extra_args]
 
 
 class CheckLabExtensionsApp(BaseExtensionApp):
@@ -262,13 +262,13 @@ class CheckLabExtensionsApp(BaseExtensionApp):
         help="Whether it should check only if the extensions is installed")
 
     def run_task(self):
-        options = dict(
+        app_options = AppOptions(
             app_dir=self.app_dir, logger=self.log, core_config=self.core_config)
         all_enabled = all(
             check_extension(
                 arg,
                 installed=self.should_check_installed_only,
-                options=options)
+                app_options=app_options)
             for arg in self.extra_args)
         if not all_enabled:
             self.exit(1)

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -185,7 +185,8 @@ class LinkLabExtensionApp(BaseExtensionApp):
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
         options = AppOptions(
-            self.app_dir, logger=self.log, core_config=self.core_config)
+            app_dir=self.app_dir, logger=self.log,
+            core_config=self.core_config)
         return any([
             link_package(
                 arg,
@@ -200,7 +201,8 @@ class UnlinkLabExtensionApp(BaseExtensionApp):
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
         options = AppOptions(
-            self.app_dir, logger=self.log, core_config=self.core_config)
+            app_dir=self.app_dir, logger=self.log,
+            core_config=self.core_config)
         return any([
             unlink_package(
                 arg,
@@ -234,7 +236,7 @@ class ListLabExtensionsApp(BaseExtensionApp):
 
     def run_task(self):
         list_extensions(app_options=AppOptions(
-            self.app_dir, logger=self.log, core_config=self.core_config))
+            app_dir=self.app_dir, logger=self.log, core_config=self.core_config))
 
 
 class EnableLabExtensionsApp(BaseExtensionApp):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -184,12 +184,12 @@ class LinkLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
+        options = AppOptions(
+            self.app_dir, logger=self.log, core_config=self.core_config)
         return any([
             link_package(
                 arg,
-                app_options=AppOptions(
-                    self.app_dir, logger=self.log,
-                    core_config=self.core_config))
+                app_options=options)
             for arg in self.extra_args
         ])
 
@@ -199,12 +199,12 @@ class UnlinkLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
+        options = AppOptions(
+            self.app_dir, logger=self.log, core_config=self.core_config)
         return any([
             unlink_package(
                 arg,
-                app_options=AppOptions(
-                    self.app_dir, logger=self.log,
-                    core_config=self.core_config))
+                app_options=options)
             for arg in self.extra_args
         ])
 
@@ -218,12 +218,13 @@ class UninstallLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
+        options = AppOptions(
+            app_dir=self.app_dir, logger=self.log,
+            core_config=self.core_config)
         return any([
             uninstall_extension(
                 arg, all_=self.all,
-                app_options=AppOptions(
-                    app_dir=self.app_dir, logger=self.log,
-                    core_config=self.core_config))
+                app_options=options)
             for arg in self.extra_args
         ])
 

--- a/jupyterlab/tests/test_build_api.py
+++ b/jupyterlab/tests/test_build_api.py
@@ -45,6 +45,7 @@ class BuildAPITest(LabTestBase):
 
         self.build_api = BuildAPITester(self.request)
 
+    @pytest.mark.timeout(timeout=30)
     def test_get_status(self):
         """Make sure there are no kernels running at the start"""
         resp = self.build_api.getStatus().json()

--- a/jupyterlab/tests/test_build_api.py
+++ b/jupyterlab/tests/test_build_api.py
@@ -2,6 +2,8 @@
 from tempfile import TemporaryDirectory
 import threading
 
+import pytest
+
 from jupyterlab.labapp import LabApp
 from jupyterlab_server.tests.utils import APITester, LabTestBase
 from notebook.tests.launchnotebook import assert_http_error
@@ -21,6 +23,7 @@ class BuildAPITester(APITester):
         return self._req('DELETE', '')
 
 
+@pytest.mark.slow
 class BuildAPITest(LabTestBase):
     """Test the build web service API"""
     Application = LabApp

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -138,17 +138,17 @@ class TestExtension(TestCase):
         assert install_extension(self.mock_extension) is True
         path = pjoin(self.app_dir, 'extensions', '*.tgz')
         assert glob.glob(path)
-        extensions = get_app_info(self.app_dir)['extensions']
+        extensions = get_app_info()['extensions']
         name = self.pkg_names['extension']
         assert name in extensions
         assert check_extension(name)
 
     def test_install_twice(self):
         assert install_extension(self.mock_extension) is True
-        path = pjoin(commands.get_app_dir(), 'extensions', '*.tgz')
+        path = pjoin(self.app_dir, 'extensions', '*.tgz')
         assert install_extension(self.mock_extension) is True
         assert glob.glob(path)
-        extensions = get_app_info(self.app_dir)['extensions']
+        extensions = get_app_info()['extensions']
         name = self.pkg_names['extension']
         assert name in extensions
         assert check_extension(name)
@@ -156,11 +156,11 @@ class TestExtension(TestCase):
     def test_install_mime_renderer(self):
         install_extension(self.mock_mimeextension)
         name = self.pkg_names['mimeextension']
-        assert name in get_app_info(self.app_dir)['extensions']
+        assert name in get_app_info()['extensions']
         assert check_extension(name)
 
         assert uninstall_extension(name) is True
-        assert name not in get_app_info(self.app_dir)['extensions']
+        assert name not in get_app_info()['extensions']
         assert not check_extension(name)
 
     def test_install_incompatible(self):
@@ -175,7 +175,7 @@ class TestExtension(TestCase):
             install_extension(path)
         with open(pjoin(path, 'package.json')) as fid:
             data = json.load(fid)
-        extensions = get_app_info(self.app_dir)['extensions']
+        extensions = get_app_info()['extensions']
         name = data['name']
         assert name not in extensions
         assert not check_extension(name)
@@ -200,7 +200,7 @@ class TestExtension(TestCase):
         assert uninstall_extension(self.pkg_names['extension']) is True
         path = pjoin(self.app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
-        extensions = get_app_info(self.app_dir)['extensions']
+        extensions = get_app_info()['extensions']
         assert name not in extensions
         assert not check_extension(name)
 
@@ -212,7 +212,7 @@ class TestExtension(TestCase):
         assert check_extension(ext_name) is True
         assert check_extension(mime_ext_name) is True
         assert uninstall_extension(all_=True) is True
-        extensions = get_app_info(self.app_dir)['extensions']
+        extensions = get_app_info()['extensions']
         assert ext_name not in extensions
         assert mime_ext_name not in extensions
 
@@ -221,7 +221,7 @@ class TestExtension(TestCase):
     def test_uninstall_core_extension(self):
         assert uninstall_extension('@jupyterlab/console-extension') is True
         app_dir = self.app_dir
-        build(app_dir)
+        build()
         with open(pjoin(app_dir, 'staging', 'package.json')) as fid:
             data = json.load(fid)
         extensions = data['jupyterlab']['extensions']
@@ -229,7 +229,7 @@ class TestExtension(TestCase):
         assert not check_extension('@jupyterlab/console-extension')
 
         assert install_extension('@jupyterlab/console-extension') is True
-        build(app_dir)
+        build()
         with open(pjoin(app_dir, 'staging', 'package.json')) as fid:
             data = json.load(fid)
         extensions = data['jupyterlab']['extensions']
@@ -245,7 +245,7 @@ class TestExtension(TestCase):
         assert install_extension(self.pinned_packages[0], pin=NAMES[0])
         assert install_extension(self.pinned_packages[1], pin=NAMES[1])
 
-        extensions = get_app_info(self.app_dir)['extensions']
+        extensions = get_app_info()['extensions']
         assert NAMES[0] in extensions
         assert NAMES[1] in extensions
         assert check_extension(NAMES[0])
@@ -255,7 +255,7 @@ class TestExtension(TestCase):
         assert uninstall_extension(NAMES[0])
         assert uninstall_extension(NAMES[1])
 
-        extensions = get_app_info(self.app_dir)['extensions']
+        extensions = get_app_info()['extensions']
         assert NAMES[0] not in extensions
         assert NAMES[1] not in extensions
         assert not check_extension(NAMES[0])
@@ -292,28 +292,26 @@ class TestExtension(TestCase):
         path = self.mock_extension
         name = self.pkg_names['extension']
         link_package(path)
-        app_dir = self.app_dir
-        linked = get_app_info(app_dir)['linked_packages']
+        linked = get_app_info()['linked_packages']
         assert name not in linked
-        assert name in get_app_info(app_dir)['extensions']
+        assert name in get_app_info()['extensions']
         assert check_extension(name)
         assert unlink_package(path) is True
-        linked = get_app_info(app_dir)['linked_packages']
+        linked = get_app_info()['linked_packages']
         assert name not in linked
-        assert name not in get_app_info(app_dir)['extensions']
+        assert name not in get_app_info()['extensions']
         assert not check_extension(name)
 
     def test_link_package(self):
         path = self.mock_package
         name = self.pkg_names['package']
         assert link_package(path) is True
-        app_dir = self.app_dir
-        linked = get_app_info(app_dir)['linked_packages']
+        linked = get_app_info()['linked_packages']
         assert name in linked
-        assert name not in get_app_info(app_dir)['extensions']
+        assert name not in get_app_info()['extensions']
         assert check_extension(name)
         assert unlink_package(path)
-        linked = get_app_info(app_dir)['linked_packages']
+        linked = get_app_info()['linked_packages']
         assert name not in linked
         assert not check_extension(name)
 
@@ -321,7 +319,7 @@ class TestExtension(TestCase):
         target = self.mock_package
         assert link_package(target) is True
         assert unlink_package(target) is True
-        linked = get_app_info(self.app_dir)['linked_packages']
+        linked = get_app_info()['linked_packages']
         name = self.pkg_names['package']
         assert name not in linked
         assert not check_extension(name)
@@ -332,49 +330,52 @@ class TestExtension(TestCase):
 
     def test_app_dir(self):
         app_dir = self.tempdir()
+        options = dict(app_dir=app_dir)
 
-        assert install_extension(self.mock_extension, app_dir) is True
+        assert install_extension(self.mock_extension, options=options) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert glob.glob(path)
-        extensions = get_app_info(app_dir)['extensions']
+        extensions = get_app_info(options=options)['extensions']
         ext_name = self.pkg_names['extension']
         assert ext_name in extensions
-        assert check_extension(ext_name, app_dir)
+        assert check_extension(ext_name, options=options)
 
-        assert uninstall_extension(self.pkg_names['extension'], app_dir) is True
+        assert uninstall_extension(self.pkg_names['extension'], options=options) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
-        extensions = get_app_info(app_dir)['extensions']
+        extensions = get_app_info(options=options)['extensions']
         assert ext_name not in extensions
-        assert not check_extension(ext_name, app_dir)
+        assert not check_extension(ext_name, options=options)
 
-        assert link_package(self.mock_package, app_dir) is True
-        linked = get_app_info(app_dir)['linked_packages']
+        assert link_package(self.mock_package, options=options) is True
+        linked = get_app_info(options=options)['linked_packages']
         pkg_name = self.pkg_names['package']
         assert pkg_name in linked
-        assert check_extension(pkg_name, app_dir)
+        assert check_extension(pkg_name, options=options)
 
-        assert unlink_package(self.mock_package, app_dir) is True
-        linked = get_app_info(app_dir)['linked_packages']
+        assert unlink_package(self.mock_package, options=options) is True
+        linked = get_app_info(options=options)['linked_packages']
         assert pkg_name not in linked
-        assert not check_extension(pkg_name, app_dir)
+        assert not check_extension(pkg_name, options=options)
 
     def test_app_dir_use_sys_prefix(self):
         app_dir = self.tempdir()
+        options = dict(app_dir=app_dir)
         if os.path.exists(self.app_dir):
             os.removedirs(self.app_dir)
 
         assert install_extension(self.mock_extension) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
-        extensions = get_app_info(app_dir)['extensions']
+        extensions = get_app_info(options=options)['extensions']
         ext_name = self.pkg_names['extension']
         assert ext_name in extensions
-        assert check_extension(ext_name, app_dir)
+        assert check_extension(ext_name, options=options)
 
     def test_app_dir_shadowing(self):
         app_dir = self.tempdir()
         sys_dir = self.app_dir
+        app_options = dict(app_dir=app_dir)
         if os.path.exists(sys_dir):
             os.removedirs(sys_dir)
 
@@ -383,30 +384,30 @@ class TestExtension(TestCase):
         assert glob.glob(sys_path)
         app_path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(app_path)
-        extensions = get_app_info(app_dir)['extensions']
+        extensions = get_app_info(options=app_options)['extensions']
         ext_name = self.pkg_names['extension']
         assert ext_name in extensions
-        assert check_extension(ext_name, app_dir)
+        assert check_extension(ext_name, options=app_options)
 
-        assert install_extension(self.mock_extension, app_dir) is True
+        assert install_extension(self.mock_extension, options=app_options) is True
         assert glob.glob(app_path)
-        extensions = get_app_info(app_dir)['extensions']
+        extensions = get_app_info(options=app_options)['extensions']
         assert ext_name in extensions
-        assert check_extension(ext_name, app_dir)
+        assert check_extension(ext_name, options=app_options)
 
-        assert uninstall_extension(self.pkg_names['extension'], app_dir) is True
+        assert uninstall_extension(self.pkg_names['extension'], options=app_options) is True
         assert not glob.glob(app_path)
         assert glob.glob(sys_path)
-        extensions = get_app_info(app_dir)['extensions']
+        extensions = get_app_info(options=app_options)['extensions']
         assert ext_name in extensions
-        assert check_extension(ext_name, app_dir)
+        assert check_extension(ext_name, options=app_options)
 
-        assert uninstall_extension(self.pkg_names['extension'], app_dir) is True
+        assert uninstall_extension(self.pkg_names['extension'], options=app_options) is True
         assert not glob.glob(app_path)
         assert not glob.glob(sys_path)
-        extensions = get_app_info(app_dir)['extensions']
+        extensions = get_app_info(options=app_options)['extensions']
         assert ext_name not in extensions
-        assert not check_extension(ext_name, app_dir)
+        assert not check_extension(ext_name, options=app_options)
 
     @pytest.mark.slow
     def test_build(self):
@@ -449,6 +450,13 @@ class TestExtension(TestCase):
         core_config.clear_packages()
         logger = logging.getLogger('jupyterlab_test_logger')
         logger.setLevel('DEBUG')
+        app_dir = self.tempdir()
+        options = dict(
+            app_dir=app_dir,
+            core_config=core_config,
+            logger=logger,
+        )
+
         extensions = (
             '@jupyterlab/application-extension',
             '@jupyterlab/apputils-extension',
@@ -466,16 +474,16 @@ class TestExtension(TestCase):
             semver = default_config.singletons[name]
             core_config.add(name, semver)
 
-        assert install_extension(self.mock_extension) is True
-        build(core_config=core_config, logger=logger)
+        assert install_extension(self.mock_extension, options=options) is True
+        build(options=options)
 
         # check static directory.
-        entry = pjoin(self.app_dir, 'static', 'index.out.js')
+        entry = pjoin(app_dir, 'static', 'index.out.js')
         with open(entry) as fid:
             data = fid.read()
         assert self.pkg_names['extension'] in data
 
-        pkg = pjoin(self.app_dir, 'static', 'package.json')
+        pkg = pjoin(app_dir, 'static', 'package.json')
         with open(pkg) as fid:
             data = json.load(fid)
         assert list(data['jupyterlab']['extensions'].keys()) == [
@@ -497,37 +505,37 @@ class TestExtension(TestCase):
         load_jupyter_server_extension(app)
 
     def test_disable_extension(self):
-        app_dir = self.tempdir()
-        assert install_extension(self.mock_extension, app_dir) is True
-        assert disable_extension(self.pkg_names['extension'], app_dir) is True
-        info = get_app_info(app_dir)
+        options = dict(app_dir=self.tempdir())
+        assert install_extension(self.mock_extension, options=options) is True
+        assert disable_extension(self.pkg_names['extension'], options=options) is True
+        info = get_app_info(options=options)
         name = self.pkg_names['extension']
         assert name in info['disabled']
-        assert not check_extension(name, app_dir)
-        assert check_extension(name, app_dir, True)
-        assert disable_extension('@jupyterlab/notebook-extension', app_dir) is True
-        info = get_app_info(app_dir)
+        assert not check_extension(name, options=options)
+        assert check_extension(name, installed=True, options=options)
+        assert disable_extension('@jupyterlab/notebook-extension', options=options) is True
+        info = get_app_info(options=options)
         assert '@jupyterlab/notebook-extension' in info['disabled']
-        assert not check_extension('@jupyterlab/notebook-extension', app_dir)
-        assert check_extension('@jupyterlab/notebook-extension', app_dir, True)
+        assert not check_extension('@jupyterlab/notebook-extension', options=options)
+        assert check_extension('@jupyterlab/notebook-extension', installed=True, options=options)
         assert name in info['disabled']
-        assert not check_extension(name, app_dir)
-        assert check_extension(name, app_dir, True)
+        assert not check_extension(name, options=options)
+        assert check_extension(name, installed=True, options=options)
 
     def test_enable_extension(self):
-        app_dir = self.tempdir()
-        assert install_extension(self.mock_extension, app_dir) is True
-        assert disable_extension(self.pkg_names['extension'], app_dir) is True
-        assert enable_extension(self.pkg_names['extension'], app_dir) is True
-        info = get_app_info(app_dir)
+        options = dict(app_dir=self.tempdir())
+        assert install_extension(self.mock_extension, options=options) is True
+        assert disable_extension(self.pkg_names['extension'], options=options) is True
+        assert enable_extension(self.pkg_names['extension'], options=options) is True
+        info = get_app_info(options=options)
         name = self.pkg_names['extension']
         assert name not in info['disabled']
-        assert check_extension(name, app_dir)
-        assert disable_extension('@jupyterlab/notebook-extension', app_dir) is True
+        assert check_extension(name, options=options)
+        assert disable_extension('@jupyterlab/notebook-extension', options=options) is True
         assert name not in info['disabled']
-        assert check_extension(name, app_dir)
+        assert check_extension(name, options=options)
         assert '@jupyterlab/notebook-extension' not in info['disabled']
-        assert not check_extension('@jupyterlab/notebook-extension', app_dir)
+        assert not check_extension('@jupyterlab/notebook-extension', options=options)
 
     @pytest.mark.slow
     def test_build_check(self):

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -217,6 +217,7 @@ class TestExtension(TestCase):
         assert mime_ext_name not in extensions
 
 
+    @pytest.mark.slow
     def test_uninstall_core_extension(self):
         assert uninstall_extension('@jupyterlab/console-extension') is True
         app_dir = self.app_dir
@@ -407,6 +408,7 @@ class TestExtension(TestCase):
         assert ext_name not in extensions
         assert not check_extension(ext_name, app_dir)
 
+    @pytest.mark.slow
     def test_build(self):
         assert install_extension(self.mock_extension) is True
         build()
@@ -422,6 +424,7 @@ class TestExtension(TestCase):
             data = fid.read()
         assert self.pkg_names['extension'] in data
 
+    @pytest.mark.slow
     def test_build_custom(self):
         assert install_extension(self.mock_extension) is True
         build(name='foo', version='1.0', static_url='bar')
@@ -439,6 +442,7 @@ class TestExtension(TestCase):
         assert data['jupyterlab']['version'] == '1.0'
         assert data['jupyterlab']['staticUrl'] == 'bar'
 
+    @pytest.mark.slow
     def test_build_custom_minimal_core_config(self):
         default_config = CoreConfig()
         core_config = CoreConfig()
@@ -525,6 +529,7 @@ class TestExtension(TestCase):
         assert '@jupyterlab/notebook-extension' not in info['disabled']
         assert not check_extension('@jupyterlab/notebook-extension', app_dir)
 
+    @pytest.mark.slow
     def test_build_check(self):
         # Do the initial build.
         assert build_check()

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -372,6 +372,20 @@ class TestExtension(TestCase):
         assert ext_name in extensions
         assert check_extension(ext_name, options=options)
 
+    def test_app_dir_disable_sys_prefix(self):
+        app_dir = self.tempdir()
+        options = dict(app_dir=app_dir, use_sys_dir=False)
+        if os.path.exists(self.app_dir):
+            os.removedirs(self.app_dir)
+
+        assert install_extension(self.mock_extension) is True
+        path = pjoin(app_dir, 'extensions', '*.tgz')
+        assert not glob.glob(path)
+        extensions = get_app_info(options=options)['extensions']
+        ext_name = self.pkg_names['extension']
+        assert ext_name not in extensions
+        assert not check_extension(ext_name, options=options)
+
     def test_app_dir_shadowing(self):
         app_dir = self.tempdir()
         sys_dir = self.app_dir
@@ -455,6 +469,7 @@ class TestExtension(TestCase):
             app_dir=app_dir,
             core_config=core_config,
             logger=logger,
+            use_sys_dir=False,
         )
 
         extensions = (
@@ -489,7 +504,6 @@ class TestExtension(TestCase):
         assert list(data['jupyterlab']['extensions'].keys()) == [
             '@jupyterlab/application-extension',
             '@jupyterlab/apputils-extension',
-            self.pkg_names['extension'],
         ]
         assert data['jupyterlab']['mimeExtensions'] == {}
         for pkg in data['jupyterlab']['singletonPackages']:

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -28,7 +28,8 @@ from jupyterlab.commands import (
     install_extension, uninstall_extension, list_extensions,
     build, link_package, unlink_package, build_check,
     disable_extension, enable_extension, get_app_info,
-    check_extension, _test_overlap, update_extension
+    check_extension, _test_overlap, update_extension,
+    AppOptions
 )
 from jupyterlab.coreconfig import CoreConfig, _get_default_core_data
 
@@ -330,66 +331,66 @@ class TestExtension(TestCase):
 
     def test_app_dir(self):
         app_dir = self.tempdir()
-        options = dict(app_dir=app_dir)
+        options = AppOptions(app_dir=app_dir)
 
-        assert install_extension(self.mock_extension, options=options) is True
+        assert install_extension(self.mock_extension, app_options=options) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert glob.glob(path)
-        extensions = get_app_info(options=options)['extensions']
+        extensions = get_app_info(app_options=options)['extensions']
         ext_name = self.pkg_names['extension']
         assert ext_name in extensions
-        assert check_extension(ext_name, options=options)
+        assert check_extension(ext_name, app_options=options)
 
-        assert uninstall_extension(self.pkg_names['extension'], options=options) is True
+        assert uninstall_extension(self.pkg_names['extension'], app_options=options) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
-        extensions = get_app_info(options=options)['extensions']
+        extensions = get_app_info(app_options=options)['extensions']
         assert ext_name not in extensions
-        assert not check_extension(ext_name, options=options)
+        assert not check_extension(ext_name, app_options=options)
 
-        assert link_package(self.mock_package, options=options) is True
-        linked = get_app_info(options=options)['linked_packages']
+        assert link_package(self.mock_package, app_options=options) is True
+        linked = get_app_info(app_options=options)['linked_packages']
         pkg_name = self.pkg_names['package']
         assert pkg_name in linked
-        assert check_extension(pkg_name, options=options)
+        assert check_extension(pkg_name, app_options=options)
 
-        assert unlink_package(self.mock_package, options=options) is True
-        linked = get_app_info(options=options)['linked_packages']
+        assert unlink_package(self.mock_package, app_options=options) is True
+        linked = get_app_info(app_options=options)['linked_packages']
         assert pkg_name not in linked
-        assert not check_extension(pkg_name, options=options)
+        assert not check_extension(pkg_name, app_options=options)
 
     def test_app_dir_use_sys_prefix(self):
         app_dir = self.tempdir()
-        options = dict(app_dir=app_dir)
+        options = AppOptions(app_dir=app_dir)
         if os.path.exists(self.app_dir):
             os.removedirs(self.app_dir)
 
         assert install_extension(self.mock_extension) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
-        extensions = get_app_info(options=options)['extensions']
+        extensions = get_app_info(app_options=options)['extensions']
         ext_name = self.pkg_names['extension']
         assert ext_name in extensions
-        assert check_extension(ext_name, options=options)
+        assert check_extension(ext_name, app_options=options)
 
     def test_app_dir_disable_sys_prefix(self):
         app_dir = self.tempdir()
-        options = dict(app_dir=app_dir, use_sys_dir=False)
+        options = AppOptions(app_dir=app_dir, use_sys_dir=False)
         if os.path.exists(self.app_dir):
             os.removedirs(self.app_dir)
 
         assert install_extension(self.mock_extension) is True
         path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(path)
-        extensions = get_app_info(options=options)['extensions']
+        extensions = get_app_info(app_options=options)['extensions']
         ext_name = self.pkg_names['extension']
         assert ext_name not in extensions
-        assert not check_extension(ext_name, options=options)
+        assert not check_extension(ext_name, app_options=options)
 
     def test_app_dir_shadowing(self):
         app_dir = self.tempdir()
         sys_dir = self.app_dir
-        app_options = dict(app_dir=app_dir)
+        app_options = AppOptions(app_dir=app_dir)
         if os.path.exists(sys_dir):
             os.removedirs(sys_dir)
 
@@ -398,30 +399,30 @@ class TestExtension(TestCase):
         assert glob.glob(sys_path)
         app_path = pjoin(app_dir, 'extensions', '*.tgz')
         assert not glob.glob(app_path)
-        extensions = get_app_info(options=app_options)['extensions']
+        extensions = get_app_info(app_options=app_options)['extensions']
         ext_name = self.pkg_names['extension']
         assert ext_name in extensions
-        assert check_extension(ext_name, options=app_options)
+        assert check_extension(ext_name, app_options=app_options)
 
-        assert install_extension(self.mock_extension, options=app_options) is True
+        assert install_extension(self.mock_extension, app_options=app_options) is True
         assert glob.glob(app_path)
-        extensions = get_app_info(options=app_options)['extensions']
+        extensions = get_app_info(app_options=app_options)['extensions']
         assert ext_name in extensions
-        assert check_extension(ext_name, options=app_options)
+        assert check_extension(ext_name, app_options=app_options)
 
-        assert uninstall_extension(self.pkg_names['extension'], options=app_options) is True
+        assert uninstall_extension(self.pkg_names['extension'], app_options=app_options) is True
         assert not glob.glob(app_path)
         assert glob.glob(sys_path)
-        extensions = get_app_info(options=app_options)['extensions']
+        extensions = get_app_info(app_options=app_options)['extensions']
         assert ext_name in extensions
-        assert check_extension(ext_name, options=app_options)
+        assert check_extension(ext_name, app_options=app_options)
 
-        assert uninstall_extension(self.pkg_names['extension'], options=app_options) is True
+        assert uninstall_extension(self.pkg_names['extension'], app_options=app_options) is True
         assert not glob.glob(app_path)
         assert not glob.glob(sys_path)
-        extensions = get_app_info(options=app_options)['extensions']
+        extensions = get_app_info(app_options=app_options)['extensions']
         assert ext_name not in extensions
-        assert not check_extension(ext_name, options=app_options)
+        assert not check_extension(ext_name, app_options=app_options)
 
     @pytest.mark.slow
     def test_build(self):
@@ -465,7 +466,7 @@ class TestExtension(TestCase):
         logger = logging.getLogger('jupyterlab_test_logger')
         logger.setLevel('DEBUG')
         app_dir = self.tempdir()
-        options = dict(
+        options = AppOptions(
             app_dir=app_dir,
             core_config=core_config,
             logger=logger,
@@ -489,8 +490,8 @@ class TestExtension(TestCase):
             semver = default_config.singletons[name]
             core_config.add(name, semver)
 
-        assert install_extension(self.mock_extension, options=options) is True
-        build(options=options)
+        assert install_extension(self.mock_extension, app_options=options) is True
+        build(app_options=options)
 
         # check static directory.
         entry = pjoin(app_dir, 'static', 'index.out.js')
@@ -504,6 +505,7 @@ class TestExtension(TestCase):
         assert list(data['jupyterlab']['extensions'].keys()) == [
             '@jupyterlab/application-extension',
             '@jupyterlab/apputils-extension',
+            '@jupyterlab/mock-extension',
         ]
         assert data['jupyterlab']['mimeExtensions'] == {}
         for pkg in data['jupyterlab']['singletonPackages']:
@@ -519,37 +521,37 @@ class TestExtension(TestCase):
         load_jupyter_server_extension(app)
 
     def test_disable_extension(self):
-        options = dict(app_dir=self.tempdir())
-        assert install_extension(self.mock_extension, options=options) is True
-        assert disable_extension(self.pkg_names['extension'], options=options) is True
-        info = get_app_info(options=options)
+        options = AppOptions(app_dir=self.tempdir())
+        assert install_extension(self.mock_extension, app_options=options) is True
+        assert disable_extension(self.pkg_names['extension'], app_options=options) is True
+        info = get_app_info(app_options=options)
         name = self.pkg_names['extension']
         assert name in info['disabled']
-        assert not check_extension(name, options=options)
-        assert check_extension(name, installed=True, options=options)
-        assert disable_extension('@jupyterlab/notebook-extension', options=options) is True
-        info = get_app_info(options=options)
+        assert not check_extension(name, app_options=options)
+        assert check_extension(name, installed=True, app_options=options)
+        assert disable_extension('@jupyterlab/notebook-extension', app_options=options) is True
+        info = get_app_info(app_options=options)
         assert '@jupyterlab/notebook-extension' in info['disabled']
-        assert not check_extension('@jupyterlab/notebook-extension', options=options)
-        assert check_extension('@jupyterlab/notebook-extension', installed=True, options=options)
+        assert not check_extension('@jupyterlab/notebook-extension', app_options=options)
+        assert check_extension('@jupyterlab/notebook-extension', installed=True, app_options=options)
         assert name in info['disabled']
-        assert not check_extension(name, options=options)
-        assert check_extension(name, installed=True, options=options)
+        assert not check_extension(name, app_options=options)
+        assert check_extension(name, installed=True, app_options=options)
 
     def test_enable_extension(self):
-        options = dict(app_dir=self.tempdir())
-        assert install_extension(self.mock_extension, options=options) is True
-        assert disable_extension(self.pkg_names['extension'], options=options) is True
-        assert enable_extension(self.pkg_names['extension'], options=options) is True
-        info = get_app_info(options=options)
+        options = AppOptions(app_dir=self.tempdir())
+        assert install_extension(self.mock_extension, app_options=options) is True
+        assert disable_extension(self.pkg_names['extension'], app_options=options) is True
+        assert enable_extension(self.pkg_names['extension'], app_options=options) is True
+        info = get_app_info(app_options=options)
         name = self.pkg_names['extension']
         assert name not in info['disabled']
-        assert check_extension(name, options=options)
-        assert disable_extension('@jupyterlab/notebook-extension', options=options) is True
+        assert check_extension(name, app_options=options)
+        assert disable_extension('@jupyterlab/notebook-extension', app_options=options) is True
         assert name not in info['disabled']
-        assert check_extension(name, options=options)
+        assert check_extension(name, app_options=options)
         assert '@jupyterlab/notebook-extension' not in info['disabled']
-        assert not check_extension('@jupyterlab/notebook-extension', options=options)
+        assert not check_extension('@jupyterlab/notebook-extension', app_options=options)
 
     @pytest.mark.slow
     def test_build_check(self):

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -121,25 +121,25 @@ if [[ $GROUP == usage ]]; then
     jlpm run test:examples
 
     # Test the cli apps.
-    jupyter lab clean
-    jupyter lab build
-    jupyter lab path
+    jupyter lab clean --debug
+    jupyter lab build --debug
+    jupyter lab path --debug
     pushd jupyterlab/tests/mock_packages
-    jupyter labextension link extension --no-build
-    jupyter labextension unlink extension --no-build
-    jupyter labextension link extension --no-build
-    jupyter labextension unlink  @jupyterlab/mock-extension --no-build
-    jupyter labextension install extension  --no-build
-    jupyter labextension list
-    jupyter labextension disable @jupyterlab/mock-extension
-    jupyter labextension enable @jupyterlab/mock-extension
-    jupyter labextension disable @jupyterlab/notebook-extension
-    jupyter labextension uninstall @jupyterlab/mock-extension --no-build
-    jupyter labextension uninstall @jupyterlab/notebook-extension --no-build
+    jupyter labextension link extension --no-build --debug
+    jupyter labextension unlink extension --no-build --debug
+    jupyter labextension link extension --no-build --debug
+    jupyter labextension unlink  @jupyterlab/mock-extension --no-build --debug
+    jupyter labextension install extension  --no-build --debug
+    jupyter labextension list --debug
+    jupyter labextension disable @jupyterlab/mock-extension --debug
+    jupyter labextension enable @jupyterlab/mock-extension --debug
+    jupyter labextension disable @jupyterlab/notebook-extension --debug
+    jupyter labextension uninstall @jupyterlab/mock-extension --no-build --debug
+    jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
     popd
-    jupyter lab workspaces export > workspace.json
-    jupyter lab workspaces import --name newspace workspace.json
-    jupyter lab workspaces export newspace > newspace.json
+    jupyter lab workspaces export > workspace.json --debug
+    jupyter lab workspaces import --name newspace workspace.json --debug
+    jupyter lab workspaces export newspace > newspace.json --debug
     rm workspace.json newspace.json
 
     # Make sure we can call help on all the cli apps.
@@ -206,9 +206,9 @@ if [[ $GROUP == usage ]]; then
     python -m jupyterlab.browser_check --core-mode
 
     # Make sure we can run the built app.
-    jupyter labextension install ./jupyterlab/tests/mock_packages/extension
+    jupyter labextension install ./jupyterlab/tests/mock_packages/extension --debug
     python -m jupyterlab.browser_check
-    jupyter labextension list
+    jupyter labextension list --debug
 
     # Make sure the deprecated `selenium_check` command still works
     python -m jupyterlab.selenium_check


### PR DESCRIPTION
## References

Fixes #6989 (the last bit).

## Code changes

Three distinct changes:
1. **Some test utilities** (`pytest --quick` and `pytest --slow`)
2. **Refactor commands.py to use `options`:**

   This makes it easier to add new kwargs to `_AppHandler` later on without having to update all API functions (still minor change, but makes it clear that argument order is not significant, and less developer work, and also ensures the APIs are more consistent).

   Con: Lack of argument name checking. Possible solution: Use a namedtuple (with `defaults`) to specify all supported options (Python >= 3.7, or 3.x with small polyfill).

   Also: `options` is possibly a too generic name. Maybe `apphandler_options` or `app_options`?

3. **Add _AppHandler option `use_sys_dir`:**

   This allows API users to specify that the `sys_dir` argument should not be used (or rather, set to the same as the `app_dir`).

## User-facing changes

This is a change for python library users, as it deprecates an old API, and allows for new behavior (pt 3).

## Backwards-incompatible changes

None, but gives a deprecation warning for the old APIs.
