### PR TITLE
Expose install_kernel for tests

### DIFF
--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -136,7 +136,7 @@ class ProcessTestApp(ProcessApp):
         pass
 
     def start(self):
-        self._install_kernels()
+        self._install_default_kernels()
         self.kernel_manager.default_kernel_name = 'echo'
         self.lab_config.schemas_dir = self.schemas_dir
         self.lab_config.user_settings_dir = self.user_settings_dir
@@ -159,7 +159,7 @@ class ProcessTestApp(ProcessApp):
         with open(pjoin(kernel_dir, 'kernel.json'), 'w') as f:
             f.write(json.dumps(kernel_spec))
 
-    def _install_kernels(self):
+    def _install_default_kernels(self):
         # Install echo and ipython kernels - should be done after env patch
         self.install_kernel(
             kernel_name="echo",

--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -77,27 +77,6 @@ def _create_workspaces_dir():
     return root_dir
 
 
-def _install_kernels():
-    # Install echo and ipython kernels - should be done after env patch
-    kernel_json = {
-        'argv': [
-            sys.executable,
-            '-m', 'jupyterlab.tests.echo_kernel',
-            '-f', '{connection_file}'
-        ],
-        'display_name': "Echo Kernel",
-        'language': 'echo'
-    }
-    paths = jupyter_core.paths
-    kernel_dir = pjoin(paths.jupyter_data_dir(), 'kernels', 'echo')
-    os.makedirs(kernel_dir)
-    with open(pjoin(kernel_dir, 'kernel.json'), 'w') as f:
-        f.write(json.dumps(kernel_json))
-
-    ipykernel_dir = pjoin(paths.jupyter_data_dir(), 'kernels', 'ipython')
-    write_kernel_spec(ipykernel_dir)
-
-
 class TestEnv(object):
     """Set Jupyter path variables to a temporary directory
 
@@ -157,12 +136,47 @@ class ProcessTestApp(ProcessApp):
         pass
 
     def start(self):
-        _install_kernels()
+        self._install_kernels()
         self.kernel_manager.default_kernel_name = 'echo'
         self.lab_config.schemas_dir = self.schemas_dir
         self.lab_config.user_settings_dir = self.user_settings_dir
         self.lab_config.workspaces_dir = self.workspaces_dir
         ProcessApp.start(self)
+
+    def install_kernel(self, kernel_name, kernel_spec):
+        """Install a kernel spec to the data directory.
+
+        Parameters
+        ----------
+        kernel_name: str
+            Name of the kernel.
+        kernel_spec: dict
+            The kernel spec for the kernel
+        """
+        paths = jupyter_core.paths
+        kernel_dir = pjoin(paths.jupyter_data_dir(), 'kernels', kernel_name)
+        os.makedirs(kernel_dir)
+        with open(pjoin(kernel_dir, 'kernel.json'), 'w') as f:
+            f.write(json.dumps(kernel_spec))
+
+    def _install_kernels(self):
+        # Install echo and ipython kernels - should be done after env patch
+        self.install_kernel(
+            kernel_name="echo",
+            kernel_spec={
+                'argv': [
+                    sys.executable,
+                    '-m', 'jupyterlab.tests.echo_kernel',
+                    '-f', '{connection_file}'
+                ],
+                'display_name': "Echo Kernel",
+                'language': 'echo'
+            }
+        )
+
+        paths = jupyter_core.paths
+        ipykernel_dir = pjoin(paths.jupyter_data_dir(), 'kernels', 'ipython')
+        write_kernel_spec(ipykernel_dir)
 
     def _process_finished(self, future):
         self.http_server.stop()


### PR DESCRIPTION
## References

Following up on https://github.com/jupyterlab/jupyterlab/pull/6776 and https://github.com/jupyterlab/jupyterlab/issues/6770 to make the test framework reusable outside of JupyterLab.

## Code changes

`ProcessTestApp` now exposes the `install_kernel(kernel_name, kernel_spec)` method.

## Developer-facing changes

This change exposes the `install_kernel` method to be able to install extra kernel specs other than the default ones.

This is useful for applications and third-party extensions reusing the `JestApp` from `jupyterlab.tests.test_app` to run tests that require a specific kernel.

### Example

```python
jest_app = JestApp.instance()
jest_app.jest_dir = HERE
jest_app.install_kernel(
    kernel_name="xpython",
    kernel_spec={
        'argv': [
            'xpython',
            '-f', '{connection_file}'
        ],
        'display_name': "xpython",
        'language': 'python'
    }
)
jest_app.initialize()
jest_app.start()
```

## User-facing changes

None

## Backwards-incompatible changes

None
