### PR TITLE
Infer filetype from mimetype when possible

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -416,13 +416,16 @@ function addCommands(
     execute: args => {
       const path =
         typeof args['path'] === 'undefined' ? '' : (args['path'] as string);
+      const mimetype = (args['mimetype'] as string) || void 0;
       const factory = (args['factory'] as string) || void 0;
       const kernel = (args['kernel'] as Kernel.IModel) || void 0;
       const options =
         (args['options'] as DocumentRegistry.IOpenOptions) || void 0;
       return docManager.services.contents
         .get(path, { content: false })
-        .then(() => docManager.openOrReveal(path, factory, kernel, options));
+        .then(() =>
+          docManager.openOrReveal(path, factory, kernel, mimetype, options)
+        );
     },
     icon: args => (args['icon'] as string) || '',
     label: args => (args['label'] || args['factory']) as string,

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -765,28 +765,6 @@ function handleContext(
   });
 }
 
-// function handleTitle(title: Title<Widget>, mimetype: string) {
-//   if (
-//     title.dataset.mimetype &&
-//     title.dataset.mimetype !== mimetype
-//   ) {
-//     console.warn(
-//       `mimetype of document title did not match in all contexts.\n` +
-//       `title.label: ${title.label},\n` +
-//       `title.dataset.mimetype: ${title.dataset.mimetype},\n` +
-//       `mimetype: ${mimetype}`
-//     );
-//
-//     return;
-//   }
-//
-//   title.dataset = {
-//     ...title.dataset,
-//     mimetype,
-//     type: 'document-title'
-//   };
-// }
-
 /**
  * A namespace for private module data.
  */

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -416,16 +416,13 @@ function addCommands(
     execute: args => {
       const path =
         typeof args['path'] === 'undefined' ? '' : (args['path'] as string);
-      const mimetype = (args['mimetype'] as string) || void 0;
       const factory = (args['factory'] as string) || void 0;
       const kernel = (args['kernel'] as Kernel.IModel) || void 0;
       const options =
         (args['options'] as DocumentRegistry.IOpenOptions) || void 0;
       return docManager.services.contents
         .get(path, { content: false })
-        .then(() =>
-          docManager.openOrReveal(path, factory, kernel, mimetype, options)
-        );
+        .then(() => docManager.openOrReveal(path, factory, kernel, options));
     },
     icon: args => (args['icon'] as string) || '',
     label: args => (args['label'] || args['factory']) as string,
@@ -640,7 +637,8 @@ function addLabCommands(
       return labShell.currentWidget;
     }
     const pathMatch = node['title'].match(pathRe);
-    return docManager.findWidget(pathMatch[1], null, node.dataset.mimetype);
+    const options = { mimetype: node.dataset.mimetype };
+    return docManager.findWidget(pathMatch[1], null, options);
   };
 
   // Returns `true` if the current widget has a document context.
@@ -766,6 +764,28 @@ function handleContext(
     }
   });
 }
+
+// function handleTitle(title: Title<Widget>, mimetype: string) {
+//   if (
+//     title.dataset.mimetype &&
+//     title.dataset.mimetype !== mimetype
+//   ) {
+//     console.warn(
+//       `mimetype of document title did not match in all contexts.\n` +
+//       `title.label: ${title.label},\n` +
+//       `title.dataset.mimetype: ${title.dataset.mimetype},\n` +
+//       `mimetype: ${mimetype}`
+//     );
+//
+//     return;
+//   }
+//
+//   title.dataset = {
+//     ...title.dataset,
+//     mimetype,
+//     type: 'document-title'
+//   };
+// }
 
 /**
  * A namespace for private module data.

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -271,19 +271,22 @@ export class DocumentManager implements IDocumentManager {
   findWidget(
     path: string,
     widgetName: string | null = 'default',
-    mimetype?: string
+    options: DocumentRegistry.IFindOptions = {}
   ): IDocumentWidget | undefined {
     let newPath = PathExt.normalize(path);
     let widgetNames = [widgetName];
     if (widgetName === 'default') {
-      let factory = this.registry.defaultWidgetFactory(newPath, mimetype);
+      let factory = this.registry.defaultWidgetFactory(
+        newPath,
+        options.mimetype
+      );
       if (!factory) {
         return undefined;
       }
       widgetNames = [factory.name];
     } else if (widgetName === null) {
       widgetNames = this.registry
-        .preferredWidgetFactories(newPath, mimetype)
+        .preferredWidgetFactories(newPath, options.mimetype)
         .map(f => f.name);
     }
 
@@ -329,7 +332,6 @@ export class DocumentManager implements IDocumentManager {
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
-    mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined {
     return this._createOrOpenDocument(
@@ -337,7 +339,6 @@ export class DocumentManager implements IDocumentManager {
       path,
       widgetName,
       kernel,
-      mimetype,
       options
     );
   }
@@ -362,15 +363,15 @@ export class DocumentManager implements IDocumentManager {
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
-    mimetype?: string,
-    options?: DocumentRegistry.IOpenOptions
+    options: DocumentRegistry.IOpenOptions = {}
   ): IDocumentWidget | undefined {
-    let widget = this.findWidget(path, widgetName, mimetype);
+    const mimetype = options.mimetype;
+    let widget = this.findWidget(path, widgetName, { mimetype });
     if (widget) {
-      this._opener.open(widget, options || {});
+      this._opener.open(widget, options);
       return widget;
     }
-    return this.open(path, widgetName, kernel, mimetype, options || {});
+    return this.open(path, widgetName, kernel, options);
   }
 
   /**
@@ -525,10 +526,13 @@ export class DocumentManager implements IDocumentManager {
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
-    mimetype?: string,
-    options?: DocumentRegistry.IOpenOptions
+    options: DocumentRegistry.IOpenOptions = {}
   ): IDocumentWidget | undefined {
-    let widgetFactory = this._widgetFactoryFor(path, widgetName, mimetype);
+    let widgetFactory = this._widgetFactoryFor(
+      path,
+      widgetName,
+      options.mimetype
+    );
     if (!widgetFactory) {
       return undefined;
     }

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -270,19 +270,20 @@ export class DocumentManager implements IDocumentManager {
    */
   findWidget(
     path: string,
-    widgetName: string | null = 'default'
+    widgetName: string | null = 'default',
+    mimetype?: string
   ): IDocumentWidget | undefined {
     let newPath = PathExt.normalize(path);
     let widgetNames = [widgetName];
     if (widgetName === 'default') {
-      let factory = this.registry.defaultWidgetFactory(newPath);
+      let factory = this.registry.defaultWidgetFactory(newPath, mimetype);
       if (!factory) {
         return undefined;
       }
       widgetNames = [factory.name];
     } else if (widgetName === null) {
       widgetNames = this.registry
-        .preferredWidgetFactories(newPath)
+        .preferredWidgetFactories(newPath, mimetype)
         .map(f => f.name);
     }
 
@@ -364,7 +365,7 @@ export class DocumentManager implements IDocumentManager {
     mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined {
-    let widget = this.findWidget(path, widgetName);
+    let widget = this.findWidget(path, widgetName, mimetype);
     if (widget) {
       this._opener.open(widget, options || {});
       return widget;

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -328,6 +328,7 @@ export class DocumentManager implements IDocumentManager {
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
+    mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined {
     return this._createOrOpenDocument(
@@ -335,6 +336,7 @@ export class DocumentManager implements IDocumentManager {
       path,
       widgetName,
       kernel,
+      mimetype,
       options
     );
   }
@@ -359,6 +361,7 @@ export class DocumentManager implements IDocumentManager {
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
+    mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined {
     let widget = this.findWidget(path, widgetName);
@@ -366,7 +369,7 @@ export class DocumentManager implements IDocumentManager {
       this._opener.open(widget, options || {});
       return widget;
     }
-    return this.open(path, widgetName, kernel, options || {});
+    return this.open(path, widgetName, kernel, mimetype, options || {});
   }
 
   /**
@@ -494,11 +497,12 @@ export class DocumentManager implements IDocumentManager {
    */
   private _widgetFactoryFor(
     path: string,
-    widgetName: string
+    widgetName: string,
+    mimetype?: string
   ): DocumentRegistry.WidgetFactory | undefined {
     let { registry } = this;
     if (widgetName === 'default') {
-      let factory = registry.defaultWidgetFactory(path);
+      let factory = registry.defaultWidgetFactory(path, mimetype);
       if (!factory) {
         return undefined;
       }
@@ -520,9 +524,10 @@ export class DocumentManager implements IDocumentManager {
     path: string,
     widgetName = 'default',
     kernel?: Partial<Kernel.IModel>,
+    mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined {
-    let widgetFactory = this._widgetFactoryFor(path, widgetName);
+    let widgetFactory = this._widgetFactoryFor(path, widgetName, mimetype);
     if (!widgetFactory) {
       return undefined;
     }

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -150,7 +150,8 @@ export interface IDocumentManager extends IDisposable {
    */
   findWidget(
     path: string,
-    widgetName?: string | null
+    widgetName?: string | null,
+    mimetype?: string
   ): IDocumentWidget | undefined;
 
   /**
@@ -179,6 +180,7 @@ export interface IDocumentManager extends IDisposable {
     path: string,
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>,
+    mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined;
 
@@ -202,6 +204,7 @@ export interface IDocumentManager extends IDisposable {
     path: string,
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>,
+    mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined;
 

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -151,7 +151,7 @@ export interface IDocumentManager extends IDisposable {
   findWidget(
     path: string,
     widgetName?: string | null,
-    mimetype?: string
+    options?: DocumentRegistry.IFindOptions
   ): IDocumentWidget | undefined;
 
   /**
@@ -180,7 +180,6 @@ export interface IDocumentManager extends IDisposable {
     path: string,
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>,
-    mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined;
 
@@ -204,7 +203,6 @@ export interface IDocumentManager extends IDisposable {
     path: string,
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>,
-    mimetype?: string,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined;
 

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1032,6 +1032,16 @@ export namespace DocumentRegistry {
   }
 
   /**
+   * The options used to find a widget.
+   */
+  export interface IFindOptions {
+    /**
+     * The mimetype of the file associated with the widget, if known
+     */
+    mimetype?: string;
+  }
+
+  /**
    * The options used to open a widget.
    */
   export interface IOpenOptions {
@@ -1062,6 +1072,11 @@ export namespace DocumentRegistry {
      * This field may be used or ignored depending on shell implementation.
      */
     rank?: number;
+
+    /**
+     * The mimetype of the file associated with the widget, if known
+     */
+    mimetype?: string;
   }
 
   /**

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -548,7 +548,8 @@ function addCommands(
 
             return commands.execute('docmanager:open', {
               factory: factory,
-              path: item.path
+              path: item.path,
+              mimetype: item.mimetype
             });
           })
         )
@@ -790,7 +791,7 @@ function addCommands(
 
     static _getFactories(item: Contents.IModel): Array<string> {
       let factories = registry
-        .preferredWidgetFactories(item.path)
+        .preferredWidgetFactories(item.path, item.mimetype)
         .map(f => f.name);
       const notebookFactory = registry.getWidgetFactory('notebook').name;
       if (

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -549,7 +549,7 @@ function addCommands(
             return commands.execute('docmanager:open', {
               factory: factory,
               path: item.path,
-              mimetype: item.mimetype
+              options: { mimetype: item.mimetype }
             });
           })
         )

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -934,7 +934,9 @@ export class DirListing extends Widget {
         .catch(error => showErrorMessage('Open directory', error));
     } else {
       let path = item.path;
-      this._manager.openOrReveal(path);
+      this._manager.openOrReveal(path, void 0, void 0, {
+        mimetype: item.mimetype
+      });
     }
   }
   /**
@@ -1202,9 +1204,10 @@ export class DirListing extends Widget {
           return;
         }
         let path = item.path;
-        let widget = this._manager.findWidget(path, undefined, item.mimetype);
+        const options = { mimetype: item.mimetype };
+        let widget = this._manager.findWidget(path, undefined, options);
         if (!widget) {
-          widget = this._manager.open(item.path, void 0, void 0, item.mimetype);
+          widget = this._manager.open(item.path, void 0, void 0, options);
         }
         if (otherPaths.length) {
           const firstWidgetPlaced = new PromiseDelegate<void>();
@@ -1213,21 +1216,18 @@ export class DirListing extends Widget {
             otherPaths.forEach(path => {
               const options: DocumentRegistry.IOpenOptions = {
                 ref: prevWidget.id,
-                mode: 'tab-after'
+                mode: 'tab-after',
+                mimetype: item.mimetype
               };
               prevWidget = this._manager.openOrReveal(
                 path,
                 void 0,
                 void 0,
-                void 0,
                 options
               );
-              this._manager.openOrReveal(
-                item.path,
-                void 0,
-                void 0,
-                item.mimetype
-              );
+              this._manager.openOrReveal(item.path, void 0, void 0, {
+                mimetype: item.mimetype
+              });
             });
           });
           firstWidgetPlaced.resolve(void 0);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1202,9 +1202,9 @@ export class DirListing extends Widget {
           return;
         }
         let path = item.path;
-        let widget = this._manager.findWidget(path);
+        let widget = this._manager.findWidget(path, undefined, item.mimetype);
         if (!widget) {
-          widget = this._manager.open(item.path);
+          widget = this._manager.open(item.path, void 0, void 0, item.mimetype);
         }
         if (otherPaths.length) {
           const firstWidgetPlaced = new PromiseDelegate<void>();
@@ -1222,7 +1222,12 @@ export class DirListing extends Widget {
                 void 0,
                 options
               );
-              this._manager.openOrReveal(item.path);
+              this._manager.openOrReveal(
+                item.path,
+                void 0,
+                void 0,
+                item.mimetype
+              );
             });
           });
           firstWidgetPlaced.resolve(void 0);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1219,6 +1219,7 @@ export class DirListing extends Widget {
                 path,
                 void 0,
                 void 0,
+                void 0,
                 options
               );
               this._manager.openOrReveal(item.path);


### PR DESCRIPTION
## References

telamonian/jupyterlab-hdf#1
telamonian/jupyterlab-hdf#2

https://github.com/ian-r-rose/jupyterlab-remote-data/blob/master/jupyterlab-remote-data/src/extension.ts#L20-L25

## Code changes

When opening a file from a listing in the default filebrowser, the `path` of the file is known, but the `mimetype` of the file is not known upfront. Thus, all of the file type inference stuff we have in `docregistry` is designed to only work with file paths.

However, in other situations (and when opening files using non-standard filebrowsers) the `mimetype` might be known, so we should make use of `mimetype` where we can. This PR widens various signatures and passes `mimetype` around where appropriate.

## User-facing changes

This PR will fix the behavior of special file types in both [telamonian/jupyterlab-hdf](https://github.com/telamonian/jupyterlab-hdf) and [ian-r-rose/jupyterlab-remote-data](https://github.com/ian-r-rose/jupyterlab-remote-data), and remove the need for monkey patches.

## Backwards-incompatible changes
