### PR TITLE
added "dirlike" filetypes that get opened in a specific browser

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -417,12 +417,12 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
    */
   activateById(id: string): void {
     if (this._leftHandler.has(id)) {
-      this._leftHandler.activate(id);
+      this._leftHandler.activateById(id);
       return;
     }
 
     if (this._rightHandler.has(id)) {
-      this._rightHandler.activate(id);
+      this._rightHandler.activateById(id);
       return;
     }
 
@@ -1075,7 +1075,7 @@ namespace Private {
       const previous =
         this._lastCurrent || (this._items.length > 0 && this._items[0].widget);
       if (previous) {
-        this.activate(previous.id);
+        this.activateById(previous.id);
       }
     }
 
@@ -1084,7 +1084,7 @@ namespace Private {
      *
      * @param id - The widget's unique ID.
      */
-    activate(id: string): void {
+    activateById(id: string): void {
       let widget = this._findWidgetByID(id);
       if (widget) {
         this._sideBar.currentTitle = widget.title;
@@ -1140,7 +1140,7 @@ namespace Private {
      */
     rehydrate(data: ILabShell.ISideArea): void {
       if (data.currentWidget) {
-        this.activate(data.currentWidget.id);
+        this.activateById(data.currentWidget.id);
       } else if (data.collapsed) {
         this.collapse();
       }

--- a/packages/apputils/src/index.ts
+++ b/packages/apputils/src/index.ts
@@ -14,6 +14,7 @@ export * from './inputdialog';
 export * from './mainareawidget';
 export * from './printing';
 export * from './sanitizer';
+export * from './sidebarwidget';
 export * from './spinner';
 export * from './splash';
 export * from './styling';

--- a/packages/apputils/src/sidebarwidget.ts
+++ b/packages/apputils/src/sidebarwidget.ts
@@ -1,0 +1,19 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+import { Widget } from '@phosphor/widgets';
+
+export class SideBarWidget extends Widget {
+  activateInSidebar(): void {
+    let parent: Widget = this.parent;
+
+    while (parent) {
+      if ('activateById' in parent) {
+        (parent as any).activateById(this.id);
+      }
+      parent = parent.parent;
+    }
+  }
+}

--- a/packages/apputils/src/sidebarwidget.ts
+++ b/packages/apputils/src/sidebarwidget.ts
@@ -5,11 +5,20 @@
 
 import { Widget } from '@phosphor/widgets';
 
+/**
+ * A widget suitable for use in the application sidebars.
+ */
 export class SideBarWidget extends Widget {
+  /**
+   * Activates the widget and selects the tab associated with the widget
+   * in its containing sidebar. Crawls up a widget's ancestors until a
+   * SideBarHandler or LabShell is found.
+   */
   activateInSidebar(): void {
     let parent: Widget = this.parent;
 
     while (parent) {
+      // avoid direct dependency on LabShell from @jupyterlab/application
       if ('activateById' in parent) {
         (parent as any).activateById(this.id);
       }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1174,7 +1174,7 @@ export namespace DocumentRegistry {
     /**
      * The content type of the new file.
      */
-    readonly contentType: Contents.ContentType;
+    readonly contentType: Contents.ContentType | 'dirlike';
 
     /**
      * The format of the new file.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Contents, Kernel } from '@jupyterlab/services';
-
 import {
   ArrayExt,
   ArrayIterator,
@@ -21,7 +19,7 @@ import { ISignal, Signal } from '@phosphor/signaling';
 
 import { DockLayout, Widget } from '@phosphor/widgets';
 
-import { IClientSession, Toolbar } from '@jupyterlab/apputils';
+import { IClientSession, SideBarWidget, Toolbar } from '@jupyterlab/apputils';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
@@ -33,6 +31,8 @@ import {
 import { IModelDB } from '@jupyterlab/observables';
 
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
+
+import { Contents, Kernel } from '@jupyterlab/services';
 
 import { TextModelFactory } from './default';
 
@@ -1167,9 +1167,9 @@ export namespace DocumentRegistry {
     readonly iconLabel?: string;
 
     /**
-     * The name of the drive associated with this file type, if any
+     * The browser widget associated with this file type
      */
-    readonly driveName?: string;
+    readonly browser?: SideBarWidget;
 
     /**
      * The content type of the new file.

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1167,7 +1167,8 @@ export namespace DocumentRegistry {
     readonly iconLabel?: string;
 
     /**
-     * The browser widget associated with this file type
+     * If content type is 'dirlike', this is the browser associated with this
+     * file type.
      */
     readonly browser?: SideBarWidget;
 

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1167,6 +1167,11 @@ export namespace DocumentRegistry {
     readonly iconLabel?: string;
 
     /**
+     * The name of the drive associated with this file type, if any
+     */
+    readonly driveName?: string;
+
+    /**
      * The content type of the new file.
      */
     readonly contentType: Contents.ContentType;

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1168,7 +1168,7 @@ export namespace DocumentRegistry {
 
     /**
      * If content type is 'dirlike', this is the browser associated with this
-     * file type.
+     * file type.  If undefined, the default browser is assumed.
      */
     readonly browser?: SideBarWidget;
 

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -544,7 +544,7 @@ function addCommands(
             // check for nonstandard content type
             const ft = widget.model.manager.registry.getFileTypeForModel(item);
             if (ft && ft.contentType === 'dirlike') {
-              const model = ft.browser.model as FileBrowserModel;
+              const model = (ft.browser as any).model as FileBrowserModel;
               const localPath = this._manager.services.contents.localPath(
                 item.path
               );

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -15,7 +15,8 @@ import {
   WidgetTracker,
   ICommandPalette,
   InputDialog,
-  showErrorMessage
+  showErrorMessage,
+  SideBarWidget
 } from '@jupyterlab/apputils';
 
 import {
@@ -544,12 +545,15 @@ function addCommands(
             // check for nonstandard content type
             const ft = widget.model.manager.registry.getFileTypeForModel(item);
             if (ft && ft.contentType === 'dirlike') {
-              const model = (ft.browser as any).model as FileBrowserModel;
-              const localPath = model.manager.services.contents.localPath(
+              // cast to FileBrowser-like
+              const browserlike = (ft.browser || widget) as SideBarWidget & {
+                model: FileBrowserModel;
+              };
+              const localPath = browserlike.model.manager.services.contents.localPath(
                 item.path
               );
-              ft.browser.activateInSidebar();
-              return model.cd(`/${localPath}`);
+              browserlike.activateInSidebar();
+              return browserlike.model.cd(`/${localPath}`);
             }
 
             if (item.type === 'directory') {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -541,6 +541,17 @@ function addCommands(
       return Promise.all(
         toArray(
           map(widget.selectedItems(), item => {
+            // check for nonstandard content type
+            const ft = widget.model.manager.registry.getFileTypeForModel(item);
+            if (ft && ft.contentType === 'dirlike') {
+              // if needed, fix the drive prefix of the path
+              const path =
+                ft.driveName && !item.path.startsWith(ft.driveName)
+                  ? `${ft.driveName}:${item.path}`
+                  : item.path;
+              return commands.execute(CommandIDs.goToPath, { path });
+            }
+
             if (item.type === 'directory') {
               const localPath = contents.localPath(item.path);
               return widget.model.cd(`/${localPath}`);

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -544,12 +544,19 @@ function addCommands(
             // check for nonstandard content type
             const ft = widget.model.manager.registry.getFileTypeForModel(item);
             if (ft && ft.contentType === 'dirlike') {
-              // if needed, fix the drive prefix of the path
-              const path =
-                ft.driveName && !item.path.startsWith(ft.driveName)
-                  ? `${ft.driveName}:${item.path}`
-                  : item.path;
-              return commands.execute(CommandIDs.goToPath, { path });
+              const model = ft.browser.model as FileBrowserModel;
+              const localPath = this._manager.services.contents.localPath(
+                item.path
+              );
+              ft.browser.activateInSidebar();
+              model.cd(`/${localPath}`);
+
+              // // if needed, fix the drive prefix of the path
+              // const path =
+              //   ft.driveName && !item.path.startsWith(ft.driveName)
+              //     ? `${ft.driveName}:${item.path}`
+              //     : item.path;
+              // return commands.execute(CommandIDs.goToPath, { path });
             }
 
             if (item.type === 'directory') {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -545,11 +545,11 @@ function addCommands(
             const ft = widget.model.manager.registry.getFileTypeForModel(item);
             if (ft && ft.contentType === 'dirlike') {
               const model = (ft.browser as any).model as FileBrowserModel;
-              const localPath = this._manager.services.contents.localPath(
+              const localPath = model.manager.services.contents.localPath(
                 item.path
               );
               ft.browser.activateInSidebar();
-              model.cd(`/${localPath}`);
+              return model.cd(`/${localPath}`);
 
               // // if needed, fix the drive prefix of the path
               // const path =

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -550,13 +550,6 @@ function addCommands(
               );
               ft.browser.activateInSidebar();
               return model.cd(`/${localPath}`);
-
-              // // if needed, fix the drive prefix of the path
-              // const path =
-              //   ft.driveName && !item.path.startsWith(ft.driveName)
-              //     ? `${ft.driveName}:${item.path}`
-              //     : item.path;
-              // return commands.execute(CommandIDs.goToPath, { path });
             }
 
             if (item.type === 'directory') {

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { showErrorMessage, Toolbar, ToolbarButton } from '@jupyterlab/apputils';
+import {
+  SideBarWidget,
+  showErrorMessage,
+  Toolbar,
+  ToolbarButton
+} from '@jupyterlab/apputils';
 
 import { IDocumentManager } from '@jupyterlab/docmanager';
 
@@ -46,7 +51,7 @@ const LISTING_CLASS = 'jp-FileBrowser-listing';
  * and presents itself as a flat list of files and directories with
  * breadcrumbs.
  */
-export class FileBrowser extends Widget {
+export class FileBrowser extends SideBarWidget {
   /**
    * Construct a new file browser.
    *

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -5,7 +5,8 @@ import {
   Dialog,
   DOMUtils,
   showDialog,
-  showErrorMessage
+  showErrorMessage,
+  SideBarWidget
 } from '@jupyterlab/apputils';
 
 import { PathExt, Time } from '@jupyterlab/coreutils';
@@ -185,7 +186,7 @@ const FACTORY_MIME = 'application/vnd.phosphor.widget-factory';
 /**
  * A widget which hosts a file list area.
  */
-export class DirListing extends Widget {
+export class DirListing extends SideBarWidget {
   /**
    * Construct a new file browser directory listing widget.
    *
@@ -936,10 +937,15 @@ export class DirListing extends Widget {
     // check for nonstandard content type
     const ft = this._model.manager.registry.getFileTypeForModel(item);
     if (ft && ft.contentType === 'dirlike') {
-      const model = (ft.browser as any).model as FileBrowserModel;
-      const localPath = model.manager.services.contents.localPath(item.path);
-      ft.browser.activateInSidebar();
-      model
+      // cast to FileBrowser-like
+      const browserlike = (ft.browser || this) as SideBarWidget & {
+        model: FileBrowserModel;
+      };
+      const localPath = browserlike.model.manager.services.contents.localPath(
+        item.path
+      );
+      browserlike.activateInSidebar();
+      browserlike.model
         .cd(`/${localPath}`)
         .catch(error => showErrorMessage('Open directory', error));
     } else if (item.type === 'directory') {

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -932,6 +932,23 @@ export class DirListing extends Widget {
    */
   private _handleOpen(item: Contents.IModel): void {
     this._onItemOpened.emit(item);
+
+    // check for nonstandard content type
+    const ft = this._model.manager.registry.getFileTypeForModel(item);
+    if (ft && ft.contentType === 'dirlike') {
+      const model = ft.browser.model as FileBrowserModel;
+      const localPath = this._manager.services.contents.localPath(item.path);
+      ft.browser.activateInSidebar();
+      model.cd(`/${localPath}`);
+
+      // if needed, fix the drive prefix of the path
+      // const path =
+      //   ft.driveName && !item.path.startsWith(ft.driveName)
+      //     ? `${ft.driveName}:${item.path}`
+      //     : item.path;
+      // return commands.execute(CommandIDs.goToPath, { path });
+    }
+
     if (item.type === 'directory') {
       const localPath = this._manager.services.contents.localPath(item.path);
       this._model
@@ -942,6 +959,7 @@ export class DirListing extends Widget {
       this._manager.openOrReveal(path);
     }
   }
+
   /**
    * Handle the `'keydown'` event for the widget.
    */

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -936,7 +936,7 @@ export class DirListing extends Widget {
     // check for nonstandard content type
     const ft = this._model.manager.registry.getFileTypeForModel(item);
     if (ft && ft.contentType === 'dirlike') {
-      const model = ft.browser.model as FileBrowserModel;
+      const model = (ft.browser as any).model as FileBrowserModel;
       const localPath = this._manager.services.contents.localPath(item.path);
       ft.browser.activateInSidebar();
       model.cd(`/${localPath}`);

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -937,19 +937,12 @@ export class DirListing extends Widget {
     const ft = this._model.manager.registry.getFileTypeForModel(item);
     if (ft && ft.contentType === 'dirlike') {
       const model = (ft.browser as any).model as FileBrowserModel;
-      const localPath = this._manager.services.contents.localPath(item.path);
+      const localPath = model.manager.services.contents.localPath(item.path);
       ft.browser.activateInSidebar();
-      model.cd(`/${localPath}`);
-
-      // if needed, fix the drive prefix of the path
-      // const path =
-      //   ft.driveName && !item.path.startsWith(ft.driveName)
-      //     ? `${ft.driveName}:${item.path}`
-      //     : item.path;
-      // return commands.execute(CommandIDs.goToPath, { path });
-    }
-
-    if (item.type === 'directory') {
+      model
+        .cd(`/${localPath}`)
+        .catch(error => showErrorMessage('Open directory', error));
+    } else if (item.type === 'directory') {
       const localPath = this._manager.services.contents.localPath(item.path);
       this._model
         .cd(`/${localPath}`)

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -108,7 +108,7 @@ export namespace Contents {
   /**
    * A contents file type.
    */
-  export type ContentType = 'notebook' | 'file' | 'directory' | 'dirlike';
+  export type ContentType = 'notebook' | 'file' | 'directory';
 
   /**
    * A contents file format.

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -108,7 +108,7 @@ export namespace Contents {
   /**
    * A contents file type.
    */
-  export type ContentType = 'notebook' | 'file' | 'directory';
+  export type ContentType = 'notebook' | 'file' | 'directory' | 'dirlike';
 
   /**
    * A contents file format.


### PR DESCRIPTION
## References

telamonian/jupyterlab-hdf#3

## Code changes

Added `'dirlike'` to `ContentType`, made some small supporting changes.

## User-facing changes

The `contentType` of a filetype can now be set to `'dirlike'`. Instead of spawning a new document widget when opened, opening a `'dirlike'` file will instead first activate a specific browser, then navigate to the `path` of the `'dirlike'` file.

Thus, `'dirlike'` files provide an "entry point" for specialized browser widgets and any custom file handling they may implement. Opening a `'dirlike'` file in the default filebrowser will automatically switch to the appropriate browser.

The `browser` for a `'dirlike'` filetype is specified via the new `driveName` property, which has to match `browser.model.driveName`. 

Check out [this `.hdf5` filetype](https://github.com/telamonian/jupyterlab-hdf/blob/6fa625944e89154c53e311c88f4c7d157ba5cc3f/src/index.ts#L128) for an example of `'dirlike'` in action.

## Backwards-incompatible changes
