### PR TITLE
add domutils to staging

### DIFF
--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -168,6 +168,7 @@
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/datagrid": "^0.1.9",
     "@phosphor/disposable": "^1.2.0",
+    "@phosphor/domutils": "^1.1.3",
     "@phosphor/messaging": "^1.2.3",
     "@phosphor/properties": "^1.1.3",
     "@phosphor/signaling": "^1.2.3",


### PR DESCRIPTION
## References

Fixes: #7115 

## Code changes

This adds domutils to staging/package.json so it is captured in core_data as loaded [here](https://github.com/jupyterlab/jupyterlab/blob/e7d5441f745bc96741a168c187cd1b5508489a69/jupyterlab/coreconfig.py#L22).

This allowed me to build jupyterlab-vim for 1.1, please close if this is the incorrect fix.