### PR TITLE
Populate singleton resolutions from all core packages, not just core extensions.

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -152,7 +152,7 @@ function ensureJupyterlab(): string[] {
   corePackage.dependencies = {};
   corePackage.resolutions = {};
 
-  let singletonPackages = corePackage.jupyterlab.singletonPackages;
+  let singletonPackages: string[] = corePackage.jupyterlab.singletonPackages;
   const coreData = new Map<string, any>();
 
   utils.getCorePaths().forEach(pkgPath => {
@@ -166,11 +166,39 @@ function ensureJupyterlab(): string[] {
     coreData.set(data.name, data);
   });
 
+  // Populate the yarn resolutions. First we make sure direct packages have
+  // resolutions.
   coreData.forEach((data, name) => {
-    // Insist on this version in the yarn resolution.
-    const version = `~${data.version}`;
-    corePackage.resolutions[name] = version;
+    // Insist on a restricted version in the yarn resolution.
+    corePackage.resolutions[name] = `~${data.version}`;
   });
+
+  // Then fill in any missing packages that should be singletons from the direct
+  // package dependencies.
+  coreData.forEach(data => {
+    if (data.dependencies) {
+      Object.entries(data.dependencies).forEach(([dep, version]) => {
+        if (
+          singletonPackages.includes(dep) &&
+          !(dep in corePackage.resolutions)
+        ) {
+          corePackage.resolutions[dep] = version;
+        }
+      });
+    }
+  });
+
+  // At this point, each singleton should have a resolution. Check this.
+  let unresolvedSingletons = singletonPackages.filter(
+    pkg => !(pkg in corePackage.resolutions)
+  );
+  if (unresolvedSingletons.length > 0) {
+    throw new Error(
+      `Singleton packages must have a resolved version number; these do not: ${unresolvedSingletons.join(
+        ', '
+      )}`
+    );
+  }
 
   coreData.forEach((data, name) => {
     // Determine if the package wishes to be included in the top-level
@@ -185,19 +213,7 @@ function ensureJupyterlab(): string[] {
     }
 
     // Make sure it is included as a dependency.
-    const version = `~${data.version}`;
-    corePackage.dependencies[data.name] = version;
-
-    // Add its dependencies to the resolutions if they are in the singleton
-    // packages packages. This lets yarn force the singleton status.
-    let deps = data.dependencies || {};
-    for (let dep in deps) {
-      if (singletonPackages.indexOf(dep) !== -1) {
-        if (!(dep in corePackage.resolutions)) {
-          corePackage.resolutions[dep] = deps[dep];
-        }
-      }
-    }
+    corePackage.dependencies[data.name] = `~${data.version}`;
 
     // Handle extensions.
     ['extension', 'mimeExtension'].forEach(item => {

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -168,9 +168,12 @@
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/datagrid": "^0.1.9",
     "@phosphor/disposable": "^1.2.0",
+    "@phosphor/domutils": "^1.1.3",
+    "@phosphor/dragdrop": "^1.3.3",
     "@phosphor/messaging": "^1.2.3",
     "@phosphor/properties": "^1.1.3",
     "@phosphor/signaling": "^1.2.3",
+    "@phosphor/virtualdom": "^1.1.3",
     "@phosphor/widgets": "^1.8.0",
     "react": "~16.8.4",
     "react-dom": "~16.8.4"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #7115
Fixes #7121
Fixes #7116

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Our integrity script was just pulling in singleton resolutions from core extensions, but some singletons like `@phosphor/dragdrop` were only dependencies of core packages that weren't an extension. This caused issues with installing extensions that depended on these three phosphor packages, since our script would check to see if they had compatible versions, but the resolution was not listed for these three packages.

This pulls in resolutions for any dependency of the core packages, and then checks to make sure all singleton packages actually do have a resolution.

## User-facing changes

None

## Backwards-incompatible changes

None
