### PR TITLE
Delete f-string in codebase to preserve python 3.5 support.

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -554,7 +554,7 @@ class _AppHandler(object):
                         'prod')
         command = ':'.join(parts)
 
-        self.logger.info(f'Building jupyterlab assets ({command})')
+        self.logger.info('Building jupyterlab assets (%s)'%command)
 
         # Set up the build directory.
         app_dir = self.app_dir


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References


Fixes #7124
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
We currently support python 3.5+, but f-strings come in 3.6.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
