### PR TITLE
Build system maintenance

### DIFF
--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -46,7 +46,7 @@ try {
 }
 
 // Build the core assets.
-utils.run('jlpm run build:prod', { cwd: staging });
+utils.run('jlpm run build:prod:minimize', { cwd: staging });
 
 // Run integrity
 utils.run('jlpm integrity');

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup_args = dict(
     platforms='Linux, Mac OS X, Windows',
     keywords=['ipython', 'jupyter', 'Web'],
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Intended Audience :: Science/Research',
@@ -131,6 +131,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,11 @@ package_data_spec[NAME] = [
     'themes/**', 'schemas/**', '*.js'
 ]
 
+
+def exclude(filename):
+    """Exclude JavaScript map files"""
+    return filename.endswith('.js.map')
+
 staging = pjoin(HERE, NAME, 'staging')
 npm = ['node', pjoin(staging, 'yarn.js')]
 VERSION = get_version('%s/_version.py' % NAME)
@@ -74,7 +79,7 @@ def check_assets():
 
 
 cmdclass = create_cmdclass('jsdeps', data_files_spec=data_files_spec,
-                           package_data_spec=package_data_spec)
+                           package_data_spec=package_data_spec, exclude=exclude)
 cmdclass['jsdeps'] = combine_commands(
     install_npm(build_cmd='build:prod', path=staging, source_dir=staging,
                 build_dir=pjoin(HERE, NAME, 'static'), npm=npm),

--- a/setupbase.py
+++ b/setupbase.py
@@ -11,6 +11,7 @@ within a Python package.
 """
 from collections import defaultdict
 from os.path import join as pjoin
+from shutil import which
 import io
 import os
 import functools
@@ -394,60 +395,6 @@ def ensure_targets(targets):
                 raise ValueError(('missing files: %s' % missing))
 
     return TargetsCheck
-
-
-# `shutils.which` function copied verbatim from the Python-3.3 source.
-def which(cmd, mode=os.F_OK | os.X_OK, path=None):
-    """Given a command, mode, and a PATH string, return the path which
-    conforms to the given mode on the PATH, or None if there is no such
-    file.
-    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
-    of os.environ.get("PATH"), or can be overridden with a custom search
-    path.
-    """
-
-    # Check that a given file can be accessed with the correct mode.
-    # Additionally check that `file` is not a directory, as on Windows
-    # directories pass the os.access check.
-    def _access_check(fn, mode):
-        return (os.path.exists(fn) and os.access(fn, mode) and
-                not os.path.isdir(fn))
-
-    # Short circuit. If we're given a full path which matches the mode
-    # and it exists, we're done here.
-    if _access_check(cmd, mode):
-        return cmd
-
-    path = (path or os.environ.get("PATH", os.defpath)).split(os.pathsep)
-
-    if sys.platform == "win32":
-        # The current directory takes precedence on Windows.
-        if os.curdir not in path:
-            path.insert(0, os.curdir)
-
-        # PATHEXT is necessary to check on Windows.
-        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
-        # See if the given file matches any of the expected path extensions.
-        # This will allow us to short circuit when given "python.exe".
-        matches = [cmd for ext in pathext if cmd.lower().endswith(ext.lower())]
-        # If it does match, only test that one, otherwise we have to try
-        # others.
-        files = [cmd] if matches else [cmd + ext.lower() for ext in pathext]
-    else:
-        # On other platforms you don't have things like PATHEXT to tell you
-        # what file suffixes are executable, so just pass on cmd as-is.
-        files = [cmd]
-
-    seen = set()
-    for dir in path:
-        dir = os.path.normcase(dir)
-        if dir not in seen:
-            seen.add(dir)
-            for thefile in files:
-                name = os.path.join(dir, thefile)
-                if _access_check(name, mode):
-                    return name
-    return None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## References

Fixes #7041
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

1. Excludes `.js.map` files from the python package
2. Minimizes the core build in the python package by default
3. Updates the pypi metadata to claim python 3.7 support and stable/production development status
4. Imports a function from python 3 instead of copying it, now that we depend on python 3.

The thought is that if a user needs source maps or a non-minimized build, they can do `jupyter lab build --minimize=False`.

Overall, package size shrinks from:

```
15M jupyterlab-1.1.1-py2.py3-none-any.whl
11M jupyterlab-1.1.1.tar.gz
```
to
```
6.1M jupyterlab-1.1.1-py2.py3-none-any.whl
6.3M jupyterlab-1.1.1.tar.gz
```

## User-facing changes

Just deleting the map files gives us a nice size reduction:

* `jupyterlab-1.1.1-py2.py3-none-any.whl` goes from 15M to 8.3M
* `jupyterlab-1.1.1.tar.gz` goes from 11M to 7.4M

The following files are removed from the source package (found by building before/after and diffing the filelist)

```
-jupyterlab-1.1.1/jupyterlab/static/2.f4b81e2bc1963983ecc5.js.map
-jupyterlab-1.1.1/jupyterlab/static/3.80d8e6cc8397ffebf731.js.map
-jupyterlab-1.1.1/jupyterlab/static/4.b9d6e5fd43159ea216bf.js.map
-jupyterlab-1.1.1/jupyterlab/static/5.996e6d254152c9a96d99.js.map
-jupyterlab-1.1.1/jupyterlab/static/6.64052a7445962e5fc5af.js.map
-jupyterlab-1.1.1/jupyterlab/static/7.07aebb4cee80d7092240.js.map
-jupyterlab-1.1.1/jupyterlab/static/main.f723825c0024a62d4234.js.map
-jupyterlab-1.1.1/jupyterlab/static/vendors~main.d162dc3201a296b02800.js.map
```

The minimization also gives us a further size reduction to:

```
6.1M jupyterlab-1.1.1-py2.py3-none-any.whl
6.3M jupyterlab-1.1.1.tar.gz
```

Here are the sizes of js files in the shipped static directory before minimization:
```
869K jupyterlab-1.1.1/jupyterlab/static/2.f4b81e2bc1963983ecc5.js
425K jupyterlab-1.1.1/jupyterlab/static/3.80d8e6cc8397ffebf731.js
750K jupyterlab-1.1.1/jupyterlab/static/4.b9d6e5fd43159ea216bf.js
720K jupyterlab-1.1.1/jupyterlab/static/5.996e6d254152c9a96d99.js
209K jupyterlab-1.1.1/jupyterlab/static/6.64052a7445962e5fc5af.js
4.2K jupyterlab-1.1.1/jupyterlab/static/7.07aebb4cee80d7092240.js
 39K jupyterlab-1.1.1/jupyterlab/static/index.out.js
 57K jupyterlab-1.1.1/jupyterlab/static/main.f723825c0024a62d4234.js
9.4M jupyterlab-1.1.1/jupyterlab/static/vendors~main.d162dc3201a296b02800.js
```
and after minimization:
```
448K jupyterlab-1.1.1/jupyterlab/static/2.91ad8acff312caa83432.js
221K jupyterlab-1.1.1/jupyterlab/static/3.b7259e99b6ade59189d3.js
749K jupyterlab-1.1.1/jupyterlab/static/4.bde7a573928640f9799f.js
720K jupyterlab-1.1.1/jupyterlab/static/5.fe4d31673850621b0b6d.js
 81K jupyterlab-1.1.1/jupyterlab/static/6.7c5016a0309f4c06caa0.js
3.6K jupyterlab-1.1.1/jupyterlab/static/7.bbcd0d685bbf1d91df0e.js
 39K jupyterlab-1.1.1/jupyterlab/static/index.out.js
 24K jupyterlab-1.1.1/jupyterlab/static/main.c4138f27656ea550fd3c.js
4.1M jupyterlab-1.1.1/jupyterlab/static/vendors~main.42e08061e9f18dcec479.js
```

## Backwards-incompatible changes

None
