### PR TITLE
switch from moment.js to date-fns

### DIFF
--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -38,6 +38,7 @@
     "@phosphor/properties": "^1.1.3",
     "@phosphor/signaling": "^1.2.3",
     "ajv": "^6.5.5",
+    "date-fns": "~2.0.1",
     "json5": "^2.1.0",
     "minimist": "~1.2.0",
     "moment": "^2.24.0",

--- a/packages/coreutils/src/time.ts
+++ b/packages/coreutils/src/time.ts
@@ -1,12 +1,24 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import moment from 'moment';
+import { parseISO, formatDistanceToNow, format as formatDate } from 'date-fns';
 
 /**
  * The namespace for date functions.
  */
 export namespace Time {
+  /**
+   * Convert a timestring to a date object
+   *
+   * @param value - The date timestring or date object. This function is used internally in the Time namespace
+   *
+   * @returns A date object
+   */
+  function convertToDateObject(value: string | Date): Date {
+    typeof value === 'string' ? (value = parseISO(value)) : (value = value);
+    return value;
+  }
+
   /**
    * Convert a timestring to a human readable string (e.g. 'two minutes ago').
    *
@@ -15,9 +27,13 @@ export namespace Time {
    * @returns A formatted date.
    */
   export function formatHuman(value: string | Date): string {
-    let time = moment(value).fromNow();
-    time = time === 'a few seconds ago' ? 'seconds ago' : time;
-    return time;
+    // We must convert any strings to Date objects as that is the type expected by formatDate
+    value = convertToDateObject(value);
+
+    return formatDistanceToNow(value, {
+      includeSeconds: false,
+      addSuffix: true
+    });
   }
 
   /**
@@ -31,8 +47,11 @@ export namespace Time {
    */
   export function format(
     value: string | Date,
-    format = 'YYYY-MM-DD HH:mm'
+    formatString = 'yyyy-MM-dd HH:mm'
   ): string {
-    return moment(value).format(format);
+    // We must convert any strings to Date objects as that is the type expected by formatDate
+    value = convertToDateObject(value);
+
+    return formatDate(value, formatString);
   }
 }

--- a/packages/coreutils/src/time.ts
+++ b/packages/coreutils/src/time.ts
@@ -31,7 +31,7 @@ export namespace Time {
     value = convertToDateObject(value);
 
     return formatDistanceToNow(value, {
-      includeSeconds: false,
+      includeSeconds: true,
       addSuffix: true
     });
   }

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1799,7 +1799,10 @@ export namespace DirListing {
       let modTitle = '';
       if (model.last_modified) {
         modText = Time.formatHuman(new Date(model.last_modified));
-        modTitle = Time.format(new Date(model.last_modified), 'lll');
+        modTitle = Time.format(
+          new Date(model.last_modified),
+          'MMM dd, yyyy hh:mm a'
+        );
       }
       modified.textContent = modText;
       modified.title = modTitle;

--- a/tests/test-coreutils/src/time.spec.js
+++ b/tests/test-coreutils/src/time.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+exports.__esModule = true;
+var chai_1 = require('chai');
+var coreutils_1 = require('@jupyterlab/coreutils');
+describe('@jupyterlab/coreutils', function() {
+  describe('Time', function() {
+    describe('.formatHuman()', function() {
+      it('should convert a time to a human readable string', function() {
+        var date = new Date();
+        date.setSeconds(date.getSeconds() - 10);
+        var value = coreutils_1.Time.formatHuman(date);
+        chai_1.expect(value).to.equal('seconds ago');
+        date.setMinutes(date.getMinutes() - 3);
+        chai_1
+          .expect(coreutils_1.Time.formatHuman(date.toISOString()))
+          .to.equal('3 minutes ago');
+      });
+    });
+    describe('.format()', function() {
+      it('should convert a timestring to a date format', function() {
+        chai_1.expect(coreutils_1.Time.format(new Date()).length).to.equal(16);
+        var date = new Date();
+        var value = coreutils_1.Time.format(date.toISOString(), 'MM-DD');
+        chai_1.expect(value.length).to.equal(5);
+      });
+    });
+  });
+});

--- a/tests/test-coreutils/src/time.spec.ts
+++ b/tests/test-coreutils/src/time.spec.ts
@@ -12,7 +12,7 @@ describe('@jupyterlab/coreutils', () => {
         const date = new Date();
         date.setSeconds(date.getSeconds() - 10);
         const value = Time.formatHuman(date);
-        expect(value).to.equal('seconds ago');
+        expect(value).to.equal('less than a minute ago');
         date.setMinutes(date.getMinutes() - 3);
         expect(Time.formatHuman(date.toISOString())).to.equal('3 minutes ago');
       });
@@ -22,7 +22,7 @@ describe('@jupyterlab/coreutils', () => {
       it('should convert a timestring to a date format', () => {
         expect(Time.format(new Date()).length).to.equal(16);
         const date = new Date();
-        const value = Time.format(date.toISOString(), 'MM-DD');
+        const value = Time.format(date.toISOString(), 'MM-dd');
         expect(value.length).to.equal(5);
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4328,6 +4328,11 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
+date-fns@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.1.tgz#c5f30e31d3294918e6b6a82753a4e719120e203d"
+  integrity sha512-C14oTzTZy8DH1Eq8N78owrCWvf3+cnJw88BTK/N3DYWVxDJuJzPaNdplzYxDYuuXXGvqBcO4Vy5SOrwAooXSWw==
+
 date-format@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.0.0.tgz#7cf7b172f1ec564f0003b39ea302c5498fb98c8f"


### PR DESCRIPTION
## References
This PR implements #6510. Switching from moment.js to date-fns for our time functions in the Time module.

## Code changes

Most of the changes are in the time.ts file, where I am using two functions, `formatDistanceToNow()` and `formatDate()` (alias for `format`), to generate and return human readable time frames. I also added a helper function, `convertToDateObject()`, which takes string dates and converts them to a valid TS Date object. Date-fns won't allow string dates as inputs.

There is an additional change applied to the listing.ts file in the filebrowser module. It was previously calling `formatDate()` with `lll` passed as an argument for the date format , which is not a compatible input to the format functions in date-fns. I therefore changed the argument from `lll` to `MMM dd, yyyy hh:mm a`. I retrieved the formatting details from the the momentjs.com website.

## User-facing changes

None.

## Backwards-incompatible changes

Accepted time formats by date-fns are different from moment.js and therefore any calls using moment.js time formats won't work.
