### PR TITLE
Do not build source maps for releases.

### DIFF
--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -46,7 +46,7 @@ try {
 }
 
 // Build the core assets.
-utils.run('jlpm run build:prod:minimize', { cwd: staging });
+utils.run('jlpm run build:prod:release', { cwd: staging });
 
 // Run integrity
 utils.run('jlpm integrity');

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -8,6 +8,7 @@
     "build:dev:minimize": "jlpm run build:dev",
     "build:prod": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --config webpack.prod.config.js",
     "build:prod:minimize": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --config webpack.prod.minimize.config.js",
+    "build:prod:release": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --config webpack.prod.release.config.js",
     "build:prod:stats": "cross-env NODE_OPTIONS=--max_old_space_size=4096 webpack --profile --config webpack.prod.minimize.config.js --json > stats.json",
     "build:stats": "webpack --profile --json > stats.json",
     "clean": "rimraf build",

--- a/dev_mode/webpack.prod.release.config.js
+++ b/dev_mode/webpack.prod.release.config.js
@@ -1,0 +1,9 @@
+var merge = require('webpack-merge');
+var config = require('./webpack.prod.minimize.config');
+
+config[0] = merge(config[0], {
+  // Turn off source maps
+  devtool: false
+});
+
+module.exports = config;


### PR DESCRIPTION
If we build them, the browser tries to fetch them and gets a 404 since we do not package them.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to #7136 

CC @vidartf who had some thoughts about source map files being shipped. I think it is fine not to ship source map files and ask people who need them to do `jupyter lab build` which will build them and put them in place.

## Code changes

In #7136, we eliminate source map files from our pypi and conda-forge packages. However, we still build the source maps, so the browser still attempts to get them, and gets a 404 for the source map.

This goes all the way and stops building source maps for releases.

In theory we could remove some of the packaging code in #7136, but it is also provides a good fail-safe against include map files, so might as well leave it in?

## User-facing changes

The user will not see a 404 for source map files in `--core-mode` like in 1.2.0a0.

## Backwards-incompatible changes

None
