### PR TITLE
Client session should dispose the session it owns when it is disposed.

### DIFF
--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -373,6 +373,7 @@ export class ClientSession implements IClientSession {
           console.error(`Kernel not shut down ${reason}`);
         });
       }
+      this._session.dispose();
       this._session = null;
     }
     if (this._dialog) {

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -335,11 +335,11 @@ export class SessionManager implements Session.IManager {
    * Handle a session terminating.
    */
   private _onTerminated(id: string): void {
-    let index = ArrayExt.findFirstIndex(this._models, value => value.id === id);
-    if (index !== -1) {
-      this._models.splice(index, 1);
-      this._runningChanged.emit(this._models.slice());
-    }
+    // A session termination emission could mean the server session is deleted,
+    // or that the session JS object is disposed and the session still exists on
+    // the server, so we refresh from the server to make sure we reflect the
+    // server state.
+    void this.refreshRunning();
   }
 
   /**

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -339,7 +339,14 @@ export class SessionManager implements Session.IManager {
     // or that the session JS object is disposed and the session still exists on
     // the server, so we refresh from the server to make sure we reflect the
     // server state.
-    void this.refreshRunning();
+    this.refreshRunning().catch(e => {
+      // Ignore poll rejection that arises if we are disposed
+      // during this call.
+      if (this.isDisposed) {
+        return;
+      }
+      throw e;
+    });
   }
 
   /**

--- a/tests/test-services/src/session/manager.spec.ts
+++ b/tests/test-services/src/session/manager.spec.ts
@@ -144,6 +144,7 @@ describe('session/manager', () => {
           called = true;
         });
         await s.shutdown();
+        await manager.refreshRunning();
         expect(called).to.equal(true);
       });
 


### PR DESCRIPTION
## References

Fixes #7144

Follow-up from #6929 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

In #6929, we made it so that only one kernel connection is able to handle comms. When you open a notebook, it creates a context which creates a client session which creates a session which creates a kernel connection which handles comms. When you close a notebook, it sees that there are no other widgets using that context, so it disposes the context, which disposes the client session, which does *not* dispose the session. Hence the js kernel connection object stays around. When you open the notebook again, it again creates a context which creates a client session which creates a session which creates a kernel connection. However this new kernel connection, in deciding whether it should be able to handle comms, looks for any other kernel connection that is already handling comms, and finds the old kernel connection still around, so the new kernel connection does *not* handle comms. This then completely breaks widgets.

This PR makes it so that the client session disposes the session (which then disposes the original kernel in our situation above). That means that when the new kernel connection is created, it sees that there is no other connection handling comms, so it says it can handle comms.

A ramification is that this causes an issue with the session manager list of sessions, which should reflect which sessions are active on the server. When a session is disposed, it emits a terminated signal, which in turn causes the session model to be deleted from the session manager’s list, indicating that the session does not exist on the server when it in fact does. We have conflated deleting the js object with the server-side session terminating. The net result of this is that the session in the list of running sessions and the green session indicator on a filename both disappear until the next server session poll, at which point they are restored to accurately reflect what sessions are active on the server.

To solve this ramification issue, we do not automatically delete the session model, but instead refresh our session list from the server, to make sure our session model list accurately reflects what is on the server.


## User-facing changes

Fixes #7144


## Backwards-incompatible changes

(Hopefully) none.