### PR TITLE
Add release helper scripts and update release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,26 +15,9 @@ setup instructions and for why twine is the recommended method.
 
 ## Getting a clean environment
 
-### Clean environment with Conda
+### Using Docker
 
-For convenience, here are commands for getting a completely clean repo. This
-makes sure that we don't have any extra tags or commits in our repo (especially
-since we will push our tags later in the process), and that we are on the master
-branch.
-
-```bash
-cd release
-conda deactivate
-conda remove --all -y -n jlabrelease
-rm -rf jupyterlab
-
-conda create -c conda-forge -y -n jlabrelease notebook nodejs twine
-conda activate jlabrelease
-```
-
-### Clean environment with Docker
-
-Instead of following the conda instructions above, you can use Docker to create a new container with a fresh clone of JupyterLab.
+If desired, you can use Docker to create a new container with a fresh clone of JupyterLab.
 
 First, build a Docker base image. This container is customized with your git commit information. The build is cached so rebuilding it is fast and easy.
 
@@ -53,21 +36,14 @@ docker run -it --name jlabrelease -w /usr/src/app jlabreleaseimage bash
 
 Now you should be at a shell prompt as root inside the docker container (the prompt should be something like `root@20dcc0cdc0b4:/usr/src/app`).
 
-## Set up JupyterLab
+### Clean environment
 
-Now clone the repo and build it
+For convenience, here is a script for getting a completely clean repo. This
+makes sure that we don't have any extra tags or commits in our repo (especially
+since we will push our tags later in the process), and that we are on the correct branch. The script creates a conda env, pulls down a git checkout with the
+appropriate branch, and installs JupyterLab with `pip install -e .`.
 
-```bash
-git clone https://github.com/jupyterlab/jupyterlab.git
-cd jupyterlab
-```
-
-Check out the branch you are doing the release from, if different from master.
-Then build and install jupyterlab:
-
-```bash
-pip install -ve .
-```
+`source scripts/release_prep.sh <branch_name>`
 
 ## Bump version
 
@@ -122,9 +98,8 @@ If there is a network error during JS publish, run `npm run publish:all --skip-b
 
 Note that the use of `npm` instead of `jlpm` is [significant on Windows](https://github.com/jupyterlab/jupyterlab/issues/6733).
 
-This is a good time to sanity-check the built packages. In another terminal, create a
-new environment, pip install the wheel from the `dist/` directory, and run both
-`jupyter lab` and `jupyter lab build`.
+At this point, run the `source scripts/release_test.sh` to test the wheel in
+a fresh conda environment with and without extensions installed.
 
 ## Finish
 

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -826,8 +826,8 @@ class _AppHandler(object):
             return self.install_extension(path)
 
         # Warn that it is a linked package.
-        self.logger.warning('Installing %s as a linked package:', path)
-        [self.logger.warning(m) for m in messages]
+        self.logger.warning('Installing %s as a linked package because it does not have extension metadata:', path)
+        [self.logger.warning('   %s' % m) for m in messages]
 
         # Add to metadata.
         config = self._read_build_config()
@@ -1611,7 +1611,7 @@ class _AppHandler(object):
 
             store = tuple(sorted(versions.items(), key=sort_key, reverse=True))
             latest_deps = store[0][1].get('dependencies', {})
-            core_deps = core_data['dependencies']
+            core_deps = core_data['resolutions']
             singletons = core_data['jupyterlab']['singletonPackages']
 
             for (key, value) in latest_deps.items():

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -1,0 +1,22 @@
+# Prep a fresh conda environment in a temporary folder for a release
+if [[ $# -ne 1 ]]; then
+    echo "Specify branch"
+    exit 1
+fi
+branch=$1
+env=jlabrelease_$branch
+
+WORK_DIR=`mktemp -d`
+cd $WORK_DIR
+conda deactivate
+conda remove --all -y -n jlabrelease_$branch
+
+conda create -c conda-forge -y -n $env notebook nodejs twine
+conda activate $env
+
+git clone https://github.com/jupyterlab/jupyterlab.git
+cd jupyterlab
+
+git checkout $branch
+
+pip install -ve .

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -1,0 +1,32 @@
+# Test a release wheel in a fresh conda environment with and without installed
+# extensions
+set -e
+env=${CONDA_DEFAULT_ENV}_test
+
+conda deactivate
+conda remove --all -y -n $env
+
+conda create -c conda-forge -y -n $env notebook nodejs twine
+conda activate $env
+
+pip install dist/*.whl
+
+WORK_DIR=`mktemp -d`
+cp examples/notebooks/*.ipynb $WORK_DIR
+cd $WORK_DIR
+
+python -m jupyterlab.browser_check
+
+jupyter labextension install @jupyterlab/fasta-extension --no-build
+jupyter labextension install @jupyterlab/geojson-extension --no-build
+jupyter labextension install @jupyterlab/plotly-extension --no-build
+jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
+jupyter labextension install bqplot --no-build
+jupyter labextension install jupyter-leaflet --no-build
+jupyter lab clean
+jupyter lab build
+
+conda install -c conda-forge -y ipywidgets
+python -m jupyterlab.browser_check
+
+jupyter lab


### PR DESCRIPTION
Cleans up our release process, to include automated testing against the same extensions used in our demo repo.