### PR TITLE
Changed Spining to clockwise for jupyter lab build

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -88,7 +88,7 @@ class ProgressProcess(Process):
         proc = self.proc
         kill_event = self._kill_event
         import itertools
-        spinner = itertools.cycle(['-', '/', '|', '\\'])
+        spinner = itertools.cycle(['-', '\\', '|', '/'])
         while proc.poll() is None:
             sys.stdout.write(next(spinner))   # write the next character
             sys.stdout.flush()                # flush stdout buffer (actual character display)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
This request address this issue: #7169
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
As mentioned in the issue, the line at jupyterlab/jupyterlab/commands.py
is changed from 
` spinner = itertools.cycle(['-', '/', '|', '\\'])` 
to
` spinner = itertools.cycle(['-', '\\', '|', '/'])` 
This helps in displaying a clockwise animation during the issue of jupyter lab build command.
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
