### PR TITLE
fix bug #6072 

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -370,16 +370,6 @@ export class Context<T extends DocumentRegistry.IModel>
 
     if (newPath && this._path.indexOf(oldPath) === 0) {
       let changeModel = change.newValue;
-
-      console.log('_path dirname', PathExt.dirname(this._path));
-      console.log('_path basename', PathExt.basename(this._path));
-
-      console.log('oldPath dirname', PathExt.dirname(oldPath));
-      console.log('oldPath basename', PathExt.basename(oldPath));
-
-      console.log('newPath', newPath);
-      console.log('oldPath', oldPath);
-      console.log('_path', this._path);
       // When folder name changed, `oldPath` is `foo`, `newPath` is `bar` and `this._path` is `foo/test`,
       // we should update `foo/test` to `bar/test` as well
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -370,11 +370,23 @@ export class Context<T extends DocumentRegistry.IModel>
 
     if (newPath && this._path.indexOf(oldPath) === 0) {
       let changeModel = change.newValue;
+
+      console.log('_path dirname', PathExt.dirname(this._path));
+      console.log('_path basename', PathExt.basename(this._path));
+
+      console.log('oldPath dirname', PathExt.dirname(oldPath));
+      console.log('oldPath basename', PathExt.basename(oldPath));
+
+      console.log('newPath', newPath);
+      console.log('oldPath', oldPath);
+      console.log('_path', this._path);
       // When folder name changed, `oldPath` is `foo`, `newPath` is `bar` and `this._path` is `foo/test`,
       // we should update `foo/test` to `bar/test` as well
+
       if (oldPath !== this._path) {
-        newPath = this._path.replace(new RegExp(`^${oldPath}`), newPath);
+        newPath = this._path.replace(new RegExp(`^${oldPath}/`), newPath + '/');
         oldPath = this._path;
+
         // Update client file model from folder change
         changeModel = {
           last_modified: change.newValue.created,


### PR DESCRIPTION
## References

#6072 

## Code changes

replace _path with "/"

After reread this code, In my opinion, we don't need to check the dirname,
because as code comment describe,
 // When folder name changed, `oldPath` is `foo`, `newPath` is `bar` and `this._path` is `foo/test`,
 // we should update `foo/test` to `bar/test` as well
There will change the folder name, so when can add '/' to run replace instead of replace origin name.

@ian-r-rose 

## User-facing changes

Consider an open file in JupyterLab called `"FOLDERNAME-suffix", and a directory called "FOLDERNAME", both in the same parent directory. Rrenaming the directory to "NEWFOLDERNAME" will lead to the open file tab being renamed to "NEWFOLDERNAME-suffix".

Now, it don't change "FOLDERNAME-suffix"

## Backwards-incompatible changes

None
