### PR TITLE
Fix tree URLs to work when there is a workspace in the URL.

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -254,7 +254,7 @@ const tree: JupyterFrontEndPlugin<void> = {
     const { commands } = app;
     const treePattern = new RegExp(`^${paths.urls.tree}([^?]+)`);
     const workspacePattern = new RegExp(
-      `^${paths.urls.workspaces}[^?\/]+/tree/([^?]+)`
+      `^${paths.urls.workspaces}/[^?/]+/tree/([^?]+)`
     );
 
     commands.addCommand(CommandIDs.tree, {


### PR DESCRIPTION
This is a bug fix of a regression that prevented `/tree/` URLs from working when there was a workspace in the URL.

## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/7156

## Code changes
Fixes a regular expression.

## User-facing changes
`/tree/` URLs with workspaces work now.

## Backwards-incompatible changes
N/A
