### PR TITLE
Added the Selection of cells till Top and Bottom

### DIFF
--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -169,7 +169,7 @@ export const SetupCommands = (
     execute: () => NotebookActions.extendSelectionAbove(nbWidget.content, false)
   });
   commands.addCommand(cmdIds.extendTop, {
-    label: 'Extend Above',
+    label: 'Extend to Top',
     execute: () => NotebookActions.extendSelectionAbove(nbWidget.content, true)
   });
   commands.addCommand(cmdIds.extendBelow, {
@@ -177,7 +177,7 @@ export const SetupCommands = (
     execute: () => NotebookActions.extendSelectionBelow(nbWidget.content, false)
   });
   commands.addCommand(cmdIds.extendBottom, {
-    label: 'Extend Below',
+    label: 'Extend to Bottom',
     execute: () => NotebookActions.extendSelectionBelow(nbWidget.content, true)
   });
   commands.addCommand(cmdIds.merge, {

--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -166,7 +166,7 @@ export const SetupCommands = (
   });
   commands.addCommand(cmdIds.extendAbove, {
     label: 'Extend Above',
-    execute: () => NotebookActions.extendSelectionAbove(nbWidget.content, false)
+    execute: () => NotebookActions.extendSelectionAbove(nbWidget.content)
   });
   commands.addCommand(cmdIds.extendTop, {
     label: 'Extend to Top',
@@ -174,7 +174,7 @@ export const SetupCommands = (
   });
   commands.addCommand(cmdIds.extendBelow, {
     label: 'Extend Below',
-    execute: () => NotebookActions.extendSelectionBelow(nbWidget.content, false)
+    execute: () => NotebookActions.extendSelectionBelow(nbWidget.content)
   });
   commands.addCommand(cmdIds.extendBottom, {
     label: 'Extend to Bottom',

--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -30,7 +30,9 @@ const cmdIds = {
   selectAbove: 'notebook-cells:select-above',
   selectBelow: 'notebook-cells:select-below',
   extendAbove: 'notebook-cells:extend-above',
+  extendTop: 'notebook-cells:extend-top',
   extendBelow: 'notebook-cells:extend-below',
+  extendBottom: 'notebook-cells:extend-bottom',
   editMode: 'notebook:edit-mode',
   merge: 'notebook-cells:merge',
   split: 'notebook-cells:split',
@@ -164,11 +166,19 @@ export const SetupCommands = (
   });
   commands.addCommand(cmdIds.extendAbove, {
     label: 'Extend Above',
-    execute: () => NotebookActions.extendSelectionAbove(nbWidget.content)
+    execute: () => NotebookActions.extendSelectionAbove(nbWidget.content, false)
+  });
+  commands.addCommand(cmdIds.extendTop, {
+    label: 'Extend Above',
+    execute: () => NotebookActions.extendSelectionAbove(nbWidget.content, true)
   });
   commands.addCommand(cmdIds.extendBelow, {
     label: 'Extend Below',
-    execute: () => NotebookActions.extendSelectionBelow(nbWidget.content)
+    execute: () => NotebookActions.extendSelectionBelow(nbWidget.content, false)
+  });
+  commands.addCommand(cmdIds.extendBottom, {
+    label: 'Extend Below',
+    execute: () => NotebookActions.extendSelectionBelow(nbWidget.content, true)
   });
   commands.addCommand(cmdIds.merge, {
     label: 'Merge Cells',

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -89,7 +89,7 @@
     },
     {
       "command": "notebook:extend-marked-cells-top",
-      "keys": ["Shift PageUp"],
+      "keys": ["Shift Home"],
       "selector": ".jp-Notebook:focus"
     },
     {
@@ -99,7 +99,7 @@
     },
     {
       "command": "notebook:extend-marked-cells-bottom",
-      "keys": ["Shift PageDown"],
+      "keys": ["Shift End"],
       "selector": ".jp-Notebook:focus"
     },
     {

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -88,8 +88,18 @@
       "selector": ".jp-Notebook:focus"
     },
     {
+      "command": "notebook:extend-marked-cells-top",
+      "keys": ["Shift PageUp"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
       "command": "notebook:extend-marked-cells-below",
       "keys": ["Shift ArrowDown"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:extend-marked-cells-bottom",
+      "keys": ["Shift PageDown"],
       "selector": ".jp-Notebook:focus"
     },
     {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1463,7 +1463,7 @@ function addCommands(
       const current = getCurrent(args);
 
       if (current) {
-        return NotebookActions.extendSelectionAbove(current.content, false);
+        return NotebookActions.extendSelectionAbove(current.content);
       }
     },
     isEnabled
@@ -1485,7 +1485,7 @@ function addCommands(
       const current = getCurrent(args);
 
       if (current) {
-        return NotebookActions.extendSelectionBelow(current.content, false);
+        return NotebookActions.extendSelectionBelow(current.content);
       }
     },
     isEnabled

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -157,7 +157,11 @@ namespace CommandIDs {
 
   export const extendAbove = 'notebook:extend-marked-cells-above';
 
+  export const extendTop = 'notebook:extend-marked-cells-top';
+
   export const extendBelow = 'notebook:extend-marked-cells-below';
+
+  export const extendBottom = 'notebook:extend-marked-cells-bottom';
 
   export const selectAll = 'notebook:select-all';
 
@@ -1459,7 +1463,18 @@ function addCommands(
       const current = getCurrent(args);
 
       if (current) {
-        return NotebookActions.extendSelectionAbove(current.content);
+        return NotebookActions.extendSelectionAbove(current.content, false);
+      }
+    },
+    isEnabled
+  });
+  commands.addCommand(CommandIDs.extendTop, {
+    label: 'Extend Selection to Top',
+    execute: args => {
+      const current = getCurrent(args);
+
+      if (current) {
+        return NotebookActions.extendSelectionAbove(current.content, true);
       }
     },
     isEnabled
@@ -1470,7 +1485,18 @@ function addCommands(
       const current = getCurrent(args);
 
       if (current) {
-        return NotebookActions.extendSelectionBelow(current.content);
+        return NotebookActions.extendSelectionBelow(current.content, false);
+      }
+    },
+    isEnabled
+  });
+  commands.addCommand(CommandIDs.extendBottom, {
+    label: 'Extend Selection to Bottom',
+    execute: args => {
+      const current = getCurrent(args);
+
+      if (current) {
+        return NotebookActions.extendSelectionBelow(current.content, true);
       }
     },
     isEnabled
@@ -1908,7 +1934,9 @@ function populatePalette(
     CommandIDs.selectAbove,
     CommandIDs.selectBelow,
     CommandIDs.extendAbove,
+    CommandIDs.extendTop,
     CommandIDs.extendBelow,
+    CommandIDs.extendBottom,
     CommandIDs.moveDown,
     CommandIDs.moveUp,
     CommandIDs.undoCellAction,

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -739,7 +739,7 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
 
     notebook.mode = 'command';
-    //Check if toTop is true, if yes, selection is made till top.
+    // Check if toTop is true, if yes, selection is made till top.
     if (toTop) {
       notebook.extendContiguousSelectionTo(0);
     } else {
@@ -772,7 +772,7 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
 
     notebook.mode = 'command';
-    //Check if toBottom is true, if yes selection is made till bottom.
+    // Check if toBottom is true, if yes selection is made till bottom.
     if (toBottom) {
       notebook.extendContiguousSelectionTo(notebook.widgets.length - 1);
     } else {

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -719,14 +719,14 @@ export namespace NotebookActions {
    * Extend the selection to the cell above.
    *
    * @param notebook - The target notebook widget.
-   *
+   * @param toTop - If true, denotes selection to extend till the top.
    * #### Notes
    * This is a no-op if the first cell is the active cell.
    * The new cell will be activated.
    */
   export function extendSelectionAbove(
     notebook: Notebook,
-    toTop: boolean
+    toTop: boolean = false
   ): void {
     if (!notebook.model || !notebook.activeCell) {
       return;
@@ -752,14 +752,14 @@ export namespace NotebookActions {
    * Extend the selection to the cell below.
    *
    * @param notebook - The target notebook widget.
-   *
+   * @param toBottom - If true, denotes selection to extend till the bottom.
    * #### Notes
    * This is a no-op if the last cell is the active cell.
    * The new cell will be activated.
    */
   export function extendSelectionBelow(
     notebook: Notebook,
-    toBottom: boolean
+    toBottom: boolean = false
   ): void {
     if (!notebook.model || !notebook.activeCell) {
       return;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -724,7 +724,10 @@ export namespace NotebookActions {
    * This is a no-op if the first cell is the active cell.
    * The new cell will be activated.
    */
-  export function extendSelectionAbove(notebook: Notebook): void {
+  export function extendSelectionAbove(
+    notebook: Notebook,
+    toTop: boolean
+  ): void {
     if (!notebook.model || !notebook.activeCell) {
       return;
     }
@@ -736,7 +739,12 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
 
     notebook.mode = 'command';
-    notebook.extendContiguousSelectionTo(notebook.activeCellIndex - 1);
+    //Check if toTop is true, if yes, selection is made till top.
+    if (toTop) {
+      notebook.extendContiguousSelectionTo(0);
+    } else {
+      notebook.extendContiguousSelectionTo(notebook.activeCellIndex - 1);
+    }
     Private.handleState(notebook, state, true);
   }
 
@@ -749,7 +757,10 @@ export namespace NotebookActions {
    * This is a no-op if the last cell is the active cell.
    * The new cell will be activated.
    */
-  export function extendSelectionBelow(notebook: Notebook): void {
+  export function extendSelectionBelow(
+    notebook: Notebook,
+    toBottom: boolean
+  ): void {
     if (!notebook.model || !notebook.activeCell) {
       return;
     }
@@ -761,7 +772,12 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
 
     notebook.mode = 'command';
-    notebook.extendContiguousSelectionTo(notebook.activeCellIndex + 1);
+    //Check if toBottom is true, if yes selection is made till bottom.
+    if (toBottom) {
+      notebook.extendContiguousSelectionTo(notebook.widgets.length - 1);
+    } else {
+      notebook.extendContiguousSelectionTo(notebook.activeCellIndex + 1);
+    }
     Private.handleState(notebook, state, true);
   }
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -719,7 +719,8 @@ export namespace NotebookActions {
    * Extend the selection to the cell above.
    *
    * @param notebook - The target notebook widget.
-   * @param toTop - If true, denotes selection to extend till the top.
+   * @param toTop - If true, denotes selection to extend to the top.
+   *
    * #### Notes
    * This is a no-op if the first cell is the active cell.
    * The new cell will be activated.
@@ -739,7 +740,7 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
 
     notebook.mode = 'command';
-    // Check if toTop is true, if yes, selection is made till top.
+    // Check if toTop is true, if yes, selection is made to the top.
     if (toTop) {
       notebook.extendContiguousSelectionTo(0);
     } else {
@@ -752,7 +753,8 @@ export namespace NotebookActions {
    * Extend the selection to the cell below.
    *
    * @param notebook - The target notebook widget.
-   * @param toBottom - If true, denotes selection to extend till the bottom.
+   * @param toBottom - If true, denotes selection to extend to the bottom.
+   *
    * #### Notes
    * This is a no-op if the last cell is the active cell.
    * The new cell will be activated.
@@ -772,7 +774,7 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
 
     notebook.mode = 'command';
-    // Check if toBottom is true, if yes selection is made till bottom.
+    // Check if toBottom is true, if yes selection is made to the bottom.
     if (toBottom) {
       notebook.extendContiguousSelectionTo(notebook.widgets.length - 1);
     } else {

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -912,26 +912,32 @@ describe('@jupyterlab/notebook', () => {
     describe('#extendSelectionAbove()', () => {
       it('should extend the selection to the cell above', () => {
         widget.activeCellIndex = 1;
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
+        expect(widget.isSelected(widget.widgets[0])).to.equal(true);
+      });
+
+      it('should extend the selection to the topmost cell', () => {
+        widget.activeCellIndex = 1;
+        NotebookActions.extendSelectionAbove(widget, true);
         expect(widget.isSelected(widget.widgets[0])).to.equal(true);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
         expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should change to command mode if there is a selection', () => {
         widget.mode = 'edit';
         widget.activeCellIndex = 1;
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
         expect(widget.mode).to.equal('command');
       });
 
       it('should not wrap around to the bottom', () => {
         widget.mode = 'edit';
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
         expect(widget.activeCellIndex).to.equal(0);
         const last = widget.widgets[widget.widgets.length - 1];
         expect(widget.isSelected(last)).to.equal(false);
@@ -939,44 +945,49 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should deselect the current cell if the cell above is selected', () => {
-        NotebookActions.extendSelectionBelow(widget, false);
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget);
         const cell = widget.activeCell;
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
         expect(widget.isSelected(cell)).to.equal(false);
       });
 
       it('should select only the first cell if we move from the second to first', () => {
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         const cell = widget.activeCell;
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
         expect(widget.isSelected(cell)).to.equal(false);
         expect(widget.activeCellIndex).to.equal(0);
       });
 
       it('should activate the cell', () => {
         widget.activeCellIndex = 1;
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
         expect(widget.activeCellIndex).to.equal(0);
       });
     });
 
     describe('#extendSelectionBelow()', () => {
       it('should extend the selection to the cell below', () => {
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         expect(widget.isSelected(widget.widgets[0])).to.equal(true);
         expect(widget.isSelected(widget.widgets[1])).to.equal(true);
       });
 
+      it('should extend the selection the bottomost cell', () => {
+        NotebookActions.extendSelectionBelow(widget, true);
+        expect(widget.isSelected(widget.widgets[0])).to.equal(true);
+        expect(widget.isSelected(widget.widgets[1])).to.equal(true);
+      });
       it('should be a no-op if there is no model', () => {
         widget.model = null;
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should change to command mode if there is a selection', () => {
         widget.mode = 'edit';
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         expect(widget.mode).to.equal('command');
       });
 
@@ -984,7 +995,7 @@ describe('@jupyterlab/notebook', () => {
         const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
         widget.mode = 'edit';
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         expect(widget.activeCellIndex).to.equal(last);
         expect(widget.isSelected(widget.widgets[0])).to.equal(false);
         expect(widget.mode).to.equal('edit');
@@ -993,25 +1004,25 @@ describe('@jupyterlab/notebook', () => {
       it('should deselect the current cell if the cell below is selected', () => {
         const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
-        NotebookActions.extendSelectionAbove(widget, false);
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget);
         const current = widget.activeCell;
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         expect(widget.isSelected(current)).to.equal(false);
       });
 
       it('should select only the last cell if we move from the second last to last', () => {
         const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
         const current = widget.activeCell;
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         expect(widget.isSelected(current)).to.equal(false);
         expect(widget.activeCellIndex).to.equal(last);
       });
 
       it('should activate the cell', () => {
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         expect(widget.activeCellIndex).to.equal(1);
       });
     });
@@ -1019,7 +1030,7 @@ describe('@jupyterlab/notebook', () => {
     describe('#moveUp()', () => {
       it('should move the selected cells up', () => {
         widget.activeCellIndex = 2;
-        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget);
         NotebookActions.moveUp(widget);
         expect(widget.isSelected(widget.widgets[0])).to.equal(true);
         expect(widget.isSelected(widget.widgets[1])).to.equal(true);
@@ -1051,7 +1062,7 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#moveDown()', () => {
       it('should move the selected cells down', () => {
-        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget);
         NotebookActions.moveDown(widget);
         expect(widget.isSelected(widget.widgets[0])).to.equal(false);
         expect(widget.isSelected(widget.widgets[1])).to.equal(true);

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -919,7 +919,9 @@ describe('@jupyterlab/notebook', () => {
       it('should extend the selection to the topmost cell', () => {
         widget.activeCellIndex = 1;
         NotebookActions.extendSelectionAbove(widget, true);
-        expect(widget.isSelected(widget.widgets[0])).to.equal(true);
+        for (let i = widget.activeCellIndex; i >= 0; i--) {
+          expect(widget.isSelected(widget.widgets[i])).to.equal(true);
+        }
       });
 
       it('should be a no-op if there is no model', () => {
@@ -976,8 +978,9 @@ describe('@jupyterlab/notebook', () => {
 
       it('should extend the selection the bottomost cell', () => {
         NotebookActions.extendSelectionBelow(widget, true);
-        expect(widget.isSelected(widget.widgets[0])).to.equal(true);
-        expect(widget.isSelected(widget.widgets[1])).to.equal(true);
+        for (let i = widget.activeCellIndex; i < widget.widgets.length; i++) {
+          expect(widget.isSelected(widget.widgets[i])).to.equal(true);
+        }
       });
       it('should be a no-op if there is no model', () => {
         widget.model = null;

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -912,26 +912,26 @@ describe('@jupyterlab/notebook', () => {
     describe('#extendSelectionAbove()', () => {
       it('should extend the selection to the cell above', () => {
         widget.activeCellIndex = 1;
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         expect(widget.isSelected(widget.widgets[0])).to.equal(true);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should change to command mode if there is a selection', () => {
         widget.mode = 'edit';
         widget.activeCellIndex = 1;
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         expect(widget.mode).to.equal('command');
       });
 
       it('should not wrap around to the bottom', () => {
         widget.mode = 'edit';
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         expect(widget.activeCellIndex).to.equal(0);
         const last = widget.widgets[widget.widgets.length - 1];
         expect(widget.isSelected(last)).to.equal(false);
@@ -939,44 +939,44 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should deselect the current cell if the cell above is selected', () => {
-        NotebookActions.extendSelectionBelow(widget);
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
+        NotebookActions.extendSelectionBelow(widget, false);
         const cell = widget.activeCell;
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         expect(widget.isSelected(cell)).to.equal(false);
       });
 
       it('should select only the first cell if we move from the second to first', () => {
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         const cell = widget.activeCell;
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         expect(widget.isSelected(cell)).to.equal(false);
         expect(widget.activeCellIndex).to.equal(0);
       });
 
       it('should activate the cell', () => {
         widget.activeCellIndex = 1;
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         expect(widget.activeCellIndex).to.equal(0);
       });
     });
 
     describe('#extendSelectionBelow()', () => {
       it('should extend the selection to the cell below', () => {
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         expect(widget.isSelected(widget.widgets[0])).to.equal(true);
         expect(widget.isSelected(widget.widgets[1])).to.equal(true);
       });
 
       it('should be a no-op if there is no model', () => {
         widget.model = null;
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         expect(widget.activeCellIndex).to.equal(-1);
       });
 
       it('should change to command mode if there is a selection', () => {
         widget.mode = 'edit';
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         expect(widget.mode).to.equal('command');
       });
 
@@ -984,7 +984,7 @@ describe('@jupyterlab/notebook', () => {
         const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
         widget.mode = 'edit';
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         expect(widget.activeCellIndex).to.equal(last);
         expect(widget.isSelected(widget.widgets[0])).to.equal(false);
         expect(widget.mode).to.equal('edit');
@@ -993,25 +993,25 @@ describe('@jupyterlab/notebook', () => {
       it('should deselect the current cell if the cell below is selected', () => {
         const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
-        NotebookActions.extendSelectionAbove(widget);
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
+        NotebookActions.extendSelectionAbove(widget, false);
         const current = widget.activeCell;
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         expect(widget.isSelected(current)).to.equal(false);
       });
 
       it('should select only the last cell if we move from the second last to last', () => {
         const last = widget.widgets.length - 1;
         widget.activeCellIndex = last;
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         const current = widget.activeCell;
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         expect(widget.isSelected(current)).to.equal(false);
         expect(widget.activeCellIndex).to.equal(last);
       });
 
       it('should activate the cell', () => {
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         expect(widget.activeCellIndex).to.equal(1);
       });
     });
@@ -1019,7 +1019,7 @@ describe('@jupyterlab/notebook', () => {
     describe('#moveUp()', () => {
       it('should move the selected cells up', () => {
         widget.activeCellIndex = 2;
-        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.extendSelectionAbove(widget, false);
         NotebookActions.moveUp(widget);
         expect(widget.isSelected(widget.widgets[0])).to.equal(true);
         expect(widget.isSelected(widget.widgets[1])).to.equal(true);
@@ -1051,7 +1051,7 @@ describe('@jupyterlab/notebook', () => {
 
     describe('#moveDown()', () => {
       it('should move the selected cells down', () => {
-        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.extendSelectionBelow(widget, false);
         NotebookActions.moveDown(widget);
         expect(widget.isSelected(widget.widgets[0])).to.equal(false);
         expect(widget.isSelected(widget.widgets[1])).to.equal(true);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
This Pull Request solves the issue: #6783

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The following files were changed:
1. jupyterlab/packages/notebook-extension/src/index.ts
in which two new command definitions i.e extendBottom and extendTop have been added.
2. jupyterlab/packages/notebook-extension/schema/tracker.json
in which two new shortcut keys are defined i.e Shift+PageUp and Shift+PageDown to select to top and bottom respectively.
3. jupyterlab/packages/notebook/src/actions.tsx
in which the function definitions extendSelectionAbove and extendSelectionBelow have been added an extra parameter to identify selections till top or only one cell above and vice versa, respectively.
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
