### PR TITLE
Fix UI problems when some of the package versions mismatch

### DIFF
--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -283,6 +283,7 @@ export class ThemeManager implements IThemeManager {
     const definitions = this._settings.schema.definitions as any;
 
     // workaround for 1.0.x versions of Jlab pulling in 1.1.x versions of apputils
+    // TODO: delete workaround in v2.0.0
     if (definitions && definitions.cssOverrides) {
       const oSchema = definitions.cssOverrides.properties;
       // the description field of each item in the overrides schema stores a

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -280,14 +280,17 @@ export class ThemeManager implements IThemeManager {
    * Initialize the key -> property dict for the overrides
    */
   private _initOverrideProps(): void {
-    const oSchema = (this._settings.schema.definitions as any).cssOverrides
-      .properties;
+    const definitions = this._settings.schema.definitions as any;
 
-    // the description field of each item in the overrides schema stores a
-    // CSS property that will be used to validate that override's values
-    Object.keys(oSchema).forEach(key => {
-      this._overrideProps[key] = oSchema[key].description;
-    });
+    // workaround for 1.0.x versions of Jlab pulling in 1.1.x versions of apputils
+    if (definitions && definitions.cssOverrides) {
+      const oSchema = definitions.cssOverrides.properties;
+      // the description field of each item in the overrides schema stores a
+      // CSS property that will be used to validate that override's values
+      Object.keys(oSchema).forEach(key => {
+        this._overrideProps[key] = oSchema[key].description;
+      });
+    }
   }
 
   /**

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1184,7 +1184,7 @@ export namespace DocumentRegistry {
     name: 'default',
     extensions: [],
     mimeTypes: [],
-    iconClass: 'jp-FileIcon',
+    iconClass: 'jp-MaterialIcon jp-FileIcon',
     iconLabel: '',
     contentType: 'file',
     fileFormat: 'text'
@@ -1235,7 +1235,7 @@ export namespace DocumentRegistry {
     extensions: ['.ipynb'],
     contentType: 'notebook',
     fileFormat: 'json',
-    iconClass: 'jp-NotebookIcon'
+    iconClass: 'jp-MaterialIcon jp-NotebookIcon'
   };
 
   /**
@@ -1247,7 +1247,7 @@ export namespace DocumentRegistry {
     extensions: [],
     mimeTypes: ['text/directory'],
     contentType: 'directory',
-    iconClass: 'jp-FolderIcon'
+    iconClass: 'jp-MaterialIcon jp-FolderIcon'
   };
 
   /**
@@ -1262,56 +1262,56 @@ export namespace DocumentRegistry {
       displayName: 'Markdown File',
       extensions: ['.md'],
       mimeTypes: ['text/markdown'],
-      iconClass: 'jp-MarkdownIcon'
+      iconClass: 'jp-MaterialIcon jp-MarkdownIcon'
     },
     {
       name: 'python',
       displayName: 'Python File',
       extensions: ['.py'],
       mimeTypes: ['text/x-python'],
-      iconClass: 'jp-PythonIcon'
+      iconClass: 'jp-MaterialIcon jp-PythonIcon'
     },
     {
       name: 'json',
       displayName: 'JSON File',
       extensions: ['.json'],
       mimeTypes: ['application/json'],
-      iconClass: 'jp-JsonIcon'
+      iconClass: 'jp-MaterialIcon jp-JSONIcon'
     },
     {
       name: 'csv',
       displayName: 'CSV File',
       extensions: ['.csv'],
       mimeTypes: ['text/csv'],
-      iconClass: 'jp-SpreadsheetIcon'
+      iconClass: 'jp-MaterialIcon jp-SpreadsheetIcon'
     },
     {
       name: 'tsv',
       displayName: 'TSV File',
       extensions: ['.tsv'],
       mimeTypes: ['text/csv'],
-      iconClass: 'jp-SpreadsheetIcon'
+      iconClass: 'jp-MaterialIcon jp-SpreadsheetIcon'
     },
     {
       name: 'r',
       displayName: 'R File',
       mimeTypes: ['text/x-rsrc'],
       extensions: ['.r'],
-      iconClass: 'jp-RKernelIcon'
+      iconClass: 'jp-MaterialIcon jp-RKernelIcon'
     },
     {
       name: 'yaml',
       displayName: 'YAML File',
       mimeTypes: ['text/x-yaml', 'text/yaml'],
       extensions: ['.yaml', '.yml'],
-      iconClass: 'jp-YamlIcon'
+      iconClass: 'jp-MaterialIcon jp-YAMLIcon'
     },
     {
       name: 'svg',
       displayName: 'Image',
       mimeTypes: ['image/svg+xml'],
       extensions: ['.svg'],
-      iconClass: 'jp-ImageIcon',
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
       fileFormat: 'base64'
     },
     {
@@ -1319,7 +1319,7 @@ export namespace DocumentRegistry {
       displayName: 'Image',
       mimeTypes: ['image/tiff'],
       extensions: ['.tif', '.tiff'],
-      iconClass: 'jp-ImageIcon',
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
       fileFormat: 'base64'
     },
     {
@@ -1327,7 +1327,7 @@ export namespace DocumentRegistry {
       displayName: 'Image',
       mimeTypes: ['image/jpeg'],
       extensions: ['.jpg', '.jpeg'],
-      iconClass: 'jp-ImageIcon',
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
       fileFormat: 'base64'
     },
     {
@@ -1335,7 +1335,7 @@ export namespace DocumentRegistry {
       displayName: 'Image',
       mimeTypes: ['image/gif'],
       extensions: ['.gif'],
-      iconClass: 'jp-ImageIcon',
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
       fileFormat: 'base64'
     },
     {
@@ -1343,7 +1343,7 @@ export namespace DocumentRegistry {
       displayName: 'Image',
       mimeTypes: ['image/png'],
       extensions: ['.png'],
-      iconClass: 'jp-ImageIcon',
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
       fileFormat: 'base64'
     },
     {
@@ -1351,7 +1351,7 @@ export namespace DocumentRegistry {
       displayName: 'Image',
       mimeTypes: ['image/bmp'],
       extensions: ['.bmp'],
-      iconClass: 'jp-ImageIcon',
+      iconClass: 'jp-MaterialIcon jp-ImageIcon',
       fileFormat: 'base64'
     }
   ];

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1276,7 +1276,7 @@ export namespace DocumentRegistry {
       displayName: 'JSON File',
       extensions: ['.json'],
       mimeTypes: ['application/json'],
-      iconClass: 'jp-MaterialIcon jp-JSONIcon'
+      iconClass: 'jp-MaterialIcon jp-JsonIcon'
     },
     {
       name: 'csv',
@@ -1304,7 +1304,7 @@ export namespace DocumentRegistry {
       displayName: 'YAML File',
       mimeTypes: ['text/x-yaml', 'text/yaml'],
       extensions: ['.yaml', '.yml'],
-      iconClass: 'jp-MaterialIcon jp-YAMLIcon'
+      iconClass: 'jp-MaterialIcon jp-YamlIcon'
     },
     {
       name: 'svg',

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -745,14 +745,11 @@ export class DirListing extends Widget {
       content.appendChild(node);
     }
 
-    // Remove extra classes/data from the nodes.
+    // Remove extra classes from the nodes.
     nodes.forEach(item => {
       item.classList.remove(SELECTED_CLASS);
       item.classList.remove(RUNNING_CLASS);
       item.classList.remove(CUT_CLASS);
-      if (item.children[0]) {
-        delete (item.children[0] as HTMLElement).dataset.icon;
-      }
     });
 
     // Add extra classes to item nodes based on widget state.
@@ -1815,7 +1812,7 @@ export namespace DirListing {
         if (
           !this._iconRegistry.icon({
             name: fileType.iconClass,
-            className: '',
+            className: ITEM_ICON_CLASS,
             title: fileType.iconLabel,
             container: icon,
             center: true,
@@ -1825,11 +1822,15 @@ export namespace DirListing {
           // add icon as CSS background image. Can't be styled using CSS
           icon.className = `${ITEM_ICON_CLASS} ${fileType.iconClass || ''}`;
           icon.textContent = fileType.iconLabel || '';
+          // clean up the svg icon annotation, if any
+          delete icon.dataset.icon;
         }
       } else {
         // use default icon as CSS background image
-        icon.textContent = '';
         icon.className = ITEM_ICON_CLASS;
+        icon.textContent = '';
+        // clean up the svg icon annotation, if any
+        delete icon.dataset.icon;
       }
 
       node.title = model.name;

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1815,7 +1815,7 @@ export namespace DirListing {
         if (
           !this._iconRegistry.icon({
             name: fileType.iconClass,
-            className: ITEM_ICON_CLASS,
+            className: '',
             title: fileType.iconLabel,
             container: icon,
             center: true,

--- a/packages/ui-components/src/icon/iconregistry.tsx
+++ b/packages/ui-components/src/icon/iconregistry.tsx
@@ -55,14 +55,18 @@ export class IconRegistry implements IIconRegistry {
 
     // we may have been handed a className in place of name
     let resolvedName = this.resolveName(name);
-    if (
-      !resolvedName ||
-      (container &&
-        container.dataset.icon &&
-        container.dataset.icon === resolvedName)
-    ) {
+    if (!resolvedName) {
       // bail if failing silently or icon node is already set
       return null;
+    }
+    if (
+      container &&
+      container.dataset.icon &&
+      container.dataset.icon === resolvedName &&
+      container.children[0]
+    ) {
+      // return the existing icon node
+      return container.children[0] as HTMLElement;
     }
 
     // ensure that svg html is valid
@@ -128,6 +132,7 @@ export class IconRegistry implements IIconRegistry {
     return (
       <Tag
         className={classes(className, propsStyle ? iconStyle(propsStyle) : '')}
+        data-icon={resolvedName}
         dangerouslySetInnerHTML={{
           __html: svgElement.outerHTML
         }}

--- a/packages/ui-components/src/icon/iconregistry.tsx
+++ b/packages/ui-components/src/icon/iconregistry.tsx
@@ -169,6 +169,7 @@ export class IconRegistry implements IIconRegistry {
     let svgHtml = this.svg(name);
 
     // workaround for 1.0.x versions of Jlab pulling in 1.1.x versions of ui-components
+    // TODO: delete workaround in v2.0.0
     const bprefix = 'data:image/svg+xml;base64,';
     if (svgHtml.startsWith(bprefix)) {
       // slice off the prefix and covert base64 to string

--- a/packages/ui-components/src/icon/iconregistry.tsx
+++ b/packages/ui-components/src/icon/iconregistry.tsx
@@ -181,13 +181,15 @@ export class IconRegistry implements IIconRegistry {
       .documentElement;
 
     if (svgElement.getElementsByTagName('parsererror').length > 0) {
+      const errmsg = `SVG HTML was malformed for icon name: ${name}`;
       // parse failed, svgElement will be an error box
       if (this._debug) {
         // fail noisily, render the error box
-        console.error(`SVG HTML was malformed for icon name: ${name}`);
+        console.error(errmsg);
         return svgElement;
       } else {
-        // silently fail by returning null
+        // bad svg is always a real error, fail silently but warn
+        console.warn(errmsg);
         return null;
       }
     } else {

--- a/packages/ui-components/src/icon/tabbarsvg.ts
+++ b/packages/ui-components/src/icon/tabbarsvg.ts
@@ -42,6 +42,7 @@ export class TabBarSvg<T> extends TabBar<T> {
         defaultIconRegistry.icon({
           name: title.iconClass,
           className: '',
+          title: title.iconLabel,
           container: iconNode,
           center: true,
           kind: this._kind


### PR DESCRIPTION
## References

fixes #7181
and a whole bunch of other recent issues

## Code changes

The latest version of eg `ui-components` relies on recent changes made across the codebase. There's currently an issue where a `1.0.x` installation of Jlab (up to `1.0.7`) will pull in the newest version of a package under certain conditions (eg install an extension and then rebuild). This in turn was causing various problems with the appearance of Jlab. This PR fixes three such appearance bugs, listed in order of descending severity:

- The latest version of `ui-components` relies on changes made to the `.svg` loader configuration in `webpack.config.js`. This PR adds a shim that allows the new icon stuff in `ui-components` to work properly with `.svg` files loaded the old way.
- The latest version of `apputils` relies on changes made to the schema in `themes.json` in the latest version of `apputils-extension`. The PR adds an explicit check for those changes, and graceful handling if they aren't there.
- The PR improves the appearance of filebrowser listing icons in the case where the new icon handling machinery fails (for whatever reason) and the listing falls back to the old icon handling behavior.

## User-facing changes

No more appearance glitches for `v1.0.0-1.0.7`

## Backwards-incompatible changes
