### PR TITLE
Update html viewer repo link

### DIFF
--- a/packages/htmlviewer-extension/package.json
+++ b/packages/htmlviewer-extension/package.json
@@ -4,8 +4,7 @@
   "description": "JupyterLab extension to render HTML files",
   "keywords": [
     "jupyter",
-    "jupyterlab",
-    "jupyterlab-extension"
+    "jupyterlab"
   ],
   "homepage": "https://github.com/jupyterlab/jupyterlab",
   "bugs": {


### PR DESCRIPTION
While looking at npm, I found this package had an incorrect repo link (old repo, 404'd).