### PR TITLE
Allow for renders for nbformat.IError to be created

### DIFF
--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -279,6 +279,7 @@ namespace Private {
         bundle['application/vnd.jupyter.stdout'] = output.text;
       }
     } else if (nbformat.isError(output)) {
+      bundle['application/vnd.jupyter.error'] = output;
       let traceback = output.traceback.join('\n');
       bundle['application/vnd.jupyter.stderr'] =
         traceback || `${output.ename}: ${output.evalue}`;


### PR DESCRIPTION
## References
Fixes #7193
## Code changes

Adds a mime type which gives developers access to the raw nbformat IError data via a new mime type. This is backwards compatible and allows for an error render to be built.