### PR TITLE
Fix overwriting of target attribute of anchors rendered by IPython.display

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -597,10 +597,12 @@ namespace Private {
         resolver && resolver.isLocal
           ? resolver.isLocal(path)
           : URLExt.isLocal(path);
-      if (isLocal) {
-        el.target = '_self';
-      } else {
-        el.target = '_blank';
+      // set target attribute if not already present
+      if (!el.target) {
+        el.target = isLocal ? '_self' : '_blank';
+      }
+      // set rel as 'noopener' for non-local anchors
+      if (!isLocal) {
         el.rel = 'noopener';
       }
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

Bug fix for issue where user provided value for target attribute of anchor tags rendered by IPython.display were overwritten by '_blank' or '_self'.

## References

Fixes #6827 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
The bugfix will overwrite the `target` attribute only if it was not set.
Setting of the `rel` attribute to `noopener` moved to separate if block.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
Users rendering anchor elements using IPython.display will be able to set custom values for "target" attribute.
## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
