### PR TITLE
Only display node structure in JSONTree for arrays and empty objects

### DIFF
--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -71,6 +71,7 @@ export class Component extends React.Component<IProps, IState> {
           }}
           invertTheme={false}
           keyPath={[root]}
+          getItemString={() => null}
           labelRenderer={([label, type]) => {
             // let className = 'cm-variable';
             // if (type === 'root') {

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -71,13 +71,16 @@ export class Component extends React.Component<IProps, IState> {
           }}
           invertTheme={false}
           keyPath={[root]}
-          getItemString={(type, data, itemType) =>
-            ((Array.isArray(data) && data) || Object.keys(data)).length ===
-            0 ? (
-              // When there is no data, we display the collection type ("{}" or "[]").
+          getItemString={(type, data, itemType, itemString) =>
+            Array.isArray(data) ? (
+              // Always display array type and the number of items i.e. "[] 2 items".
+              <span>
+                {itemType} {itemString}
+              </span>
+            ) : Object.keys(data).length === 0 ? (
+              // Only display object type when it's empty i.e. "{}".
               <span>{itemType}</span>
-            ) : // Otherwise, the data speaks for itself.
-            null
+            ) : null
           }
           labelRenderer={([label, type]) => {
             // let className = 'cm-variable';

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -71,7 +71,14 @@ export class Component extends React.Component<IProps, IState> {
           }}
           invertTheme={false}
           keyPath={[root]}
-          getItemString={() => null}
+          getItemString={(type, data, itemType) =>
+            ((Array.isArray(data) && data) || Object.keys(data)).length ===
+            0 ? (
+              // When there is no data, we display the collection type ("{}" or "[]").
+              <span>{itemType}</span>
+            ) : // Otherwise, the data speaks for itself.
+            null
+          }
           labelRenderer={([label, type]) => {
             // let className = 'cm-variable';
             // if (type === 'root') {


### PR DESCRIPTION
I feel like the item strings draw the attention away from the actual content of the tree.

## Code changes

Pass an additional `getItemString` prop to `<JSONTree />`.

## User-facing changes

### In a notebook

#### Before

![Screenshot_2019-09-18 JupyterLab(2)](https://user-images.githubusercontent.com/6574550/65163531-5d044f80-da3b-11e9-95e7-6b4e9cb20eac.png)

#### After

![Screenshot_2019-09-18 JupyterLab(1)](https://user-images.githubusercontent.com/6574550/65163570-70afb600-da3b-11e9-9b53-a34505d9f4de.png)

### Exploring a JSON file

#### Before

![Screenshot_2019-09-18 JupyterLab(3)](https://user-images.githubusercontent.com/6574550/65163626-891fd080-da3b-11e9-9679-5cc7d445b0d2.png)

#### After

![Screenshot_2019-09-18 JupyterLab](https://user-images.githubusercontent.com/6574550/65163637-8f15b180-da3b-11e9-92ad-5ea6bd171cca.png)

---

If you feel this is too much, we could do like Google Chrome DevTools console which only shows this information for arrays (not for objects):

![Screenshot 2019-09-18 at 17 43 58](https://user-images.githubusercontent.com/6574550/65163813-f0d61b80-da3b-11e9-9dab-c5a03393e7eb.png)

## Backwards-incompatible changes

None.
