### PR TITLE
Add kernelspec metadata

### DIFF
--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -1061,6 +1061,11 @@ export namespace Kernel {
      * A mapping of resource file name to download path.
      */
     readonly resources: { [key: string]: string };
+
+    /**
+     * A dictionary of additional attributes about this kernel; used by clients to aid in kernel selection.
+     */
+    readonly metadata?: JSONObject;
   }
 
   /**

--- a/packages/services/src/kernel/validate.ts
+++ b/packages/services/src/kernel/validate.ts
@@ -120,12 +120,19 @@ export function validateSpecModel(data: any): Kernel.ISpecModel {
   validateProperty(spec, 'language', 'string');
   validateProperty(spec, 'display_name', 'string');
   validateProperty(spec, 'argv', 'array');
+
+  let metadata: any = null;
+  if (spec.hasOwnProperty('metadata')) {
+    validateProperty(spec, 'metadata', 'object');
+    metadata = spec.metadata;
+  }
   return {
     name: data.name,
     resources: data.resources,
     language: spec.language,
     display_name: spec.display_name,
-    argv: spec.argv
+    argv: spec.argv,
+    metadata
   };
 }
 

--- a/packages/services/src/kernel/validate.ts
+++ b/packages/services/src/kernel/validate.ts
@@ -126,13 +126,20 @@ export function validateSpecModel(data: any): Kernel.ISpecModel {
     validateProperty(spec, 'metadata', 'object');
     metadata = spec.metadata;
   }
+
+  let env: any = null;
+  if (spec.hasOwnProperty('env')) {
+    validateProperty(spec, 'env', 'object');
+    env = spec.env;
+  }
   return {
     name: data.name,
     resources: data.resources,
     language: spec.language,
     display_name: spec.display_name,
     argv: spec.argv,
-    metadata
+    metadata,
+    env
   };
 }
 

--- a/tests/test-services/src/kernel/kernel.spec.ts
+++ b/tests/test-services/src/kernel/kernel.spec.ts
@@ -316,5 +316,23 @@ describe('kernel', () => {
         'value'
       );
     });
+
+    it('should handle env values', async () => {
+      const PYTHON_SPEC_W_ENV = JSON.parse(JSON.stringify(PYTHON_SPEC));
+      PYTHON_SPEC_W_ENV.spec.env = {
+        SOME_ENV: 'some_value',
+        LANG: 'en_US.UTF-8'
+      };
+      const serverSettings = getRequestHandler(200, {
+        default: 'python',
+        kernelspecs: { python: PYTHON_SPEC_W_ENV }
+      });
+      const specs = await Kernel.getSpecs(serverSettings);
+
+      expect(specs.kernelspecs['python']).to.have.property('env');
+      const env = specs.kernelspecs['python'].env;
+      expect(env).to.have.property('SOME_ENV', 'some_value');
+      expect(env).to.have.property('LANG', 'en_US.UTF-8');
+    });
   });
 });

--- a/tests/test-services/src/kernel/kernel.spec.ts
+++ b/tests/test-services/src/kernel/kernel.spec.ts
@@ -298,5 +298,23 @@ describe('kernel', () => {
       const promise = Kernel.getSpecs(serverSettings);
       await expectFailure(promise, 'Invalid response: 201 Created');
     });
+
+    it('should handle metadata', async () => {
+      const PYTHON_SPEC_W_MD = JSON.parse(JSON.stringify(PYTHON_SPEC));
+      PYTHON_SPEC_W_MD.spec.metadata = { some_application: { key: 'value' } };
+      const serverSettings = getRequestHandler(200, {
+        default: 'python',
+        kernelspecs: { python: PYTHON_SPEC_W_MD }
+      });
+      const specs = await Kernel.getSpecs(serverSettings);
+
+      expect(specs.kernelspecs['python']).to.have.property('metadata');
+      const metadata = specs.kernelspecs['python'].metadata;
+      expect(metadata).to.have.property('some_application');
+      expect((metadata as any).some_application).to.have.property(
+        'key',
+        'value'
+      );
+    });
   });
 });


### PR DESCRIPTION
## References

This closes #7228 based on the proposed actions.

## Code changes

Added `metadata` field to `ISpecModel` and validation code. Added `env` field to validation code.

## User-facing changes

This enables extension developers to coordinate easily with a back-end application that store information in the kernelspec metadata.

## Backwards-incompatible changes

None

@dleen @blink1073 
