### PR TITLE
Add functions for dealing with phosphor iterators and converting to/from js iterators

### DIFF
--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -32,6 +32,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
+    "@phosphor/algorithm": "^1.2.0",
     "@phosphor/commands": "^1.7.0",
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/disposable": "^1.3.0",

--- a/packages/coreutils/src/index.ts
+++ b/packages/coreutils/src/index.ts
@@ -4,6 +4,7 @@
 export * from './activitymonitor';
 export * from './dataconnector';
 export * from './interfaces';
+export * from './iter';
 export * from './markdowncodeblocks';
 export * from './nbformat';
 export * from './pageconfig';

--- a/packages/coreutils/src/iter.ts
+++ b/packages/coreutils/src/iter.ts
@@ -1,0 +1,189 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  IIterable,
+  IIterator,
+  ArrayIterator,
+  FilterIterator,
+  MapIterator,
+  each
+} from '@phosphor/algorithm';
+
+/**
+ * A type alias for a Phosphor iterable, array-like, JS iterable, or JS iterator object.
+ */
+export type IterableOrArrayLike<T> =
+  | IIterable<T>
+  | ArrayLike<T>
+  | Iterator<T>
+  | Iterable<T>;
+
+/**
+ * Create an iterator for an iterable object.
+ *
+ * @param object - The Phosphor iterable, array-like, or JS iterable or iterator object of interest.
+ *
+ * @returns A new Phosphor iterator for the given object.
+ *
+ * #### Notes
+ * This function allows iteration algorithms to operate on user-defined
+ * iterable types and builtin array-like objects in a uniform fashion.
+ */
+export function iter<T>(object: IterableOrArrayLike<T>): ConvenientIterator<T> {
+  let it: IIterator<T>;
+  if (typeof (object as any).iter === 'function') {
+    it = (object as IIterable<T>).iter();
+  } else if (typeof (object as any).length === 'number') {
+    it = new ArrayIterator<T>(object as ArrayLike<T>);
+  } else if (
+    typeof (object as any)[Symbol.iterator] === 'function' ||
+    typeof (object as any).next === 'function'
+  ) {
+    it = new JSToPhosphorIterator(object as Iterable<T> | Iterator<T>);
+  }
+  return new ConvenientIterator(it);
+}
+
+/**
+ * A Phosphor iterator and iterable that is also a JS iterable.
+ */
+export type FullIterable<T> = IIterator<T> & Iterable<T>;
+
+/**
+ * A convenience iterator that defines some very common iteration functions.
+ */
+class ConvenientIterator<T> implements FullIterable<T> {
+  constructor(it: IIterator<T>) {
+    this._it = it;
+  }
+
+  next(): T | undefined {
+    return this._it.next();
+  }
+
+  clone(): IIterator<T> {
+    return new ConvenientIterator(this._it.clone());
+  }
+
+  iter(): IIterator<T> {
+    return this;
+  }
+
+  /**
+   * Wrap this iterator in a JavaScript iteratable/iterator.
+   */
+  jsIter(): IterableIterator<T> {
+    return new PhosphorToJSIterator(this);
+  }
+
+  [Symbol.iterator](): Iterator<T> {
+    return this.jsIter();
+  }
+
+  filter(fn: (value: T, index: number) => boolean): ConvenientIterator<T> {
+    return new ConvenientIterator(new FilterIterator<T>(this, fn));
+  }
+
+  map<U>(fn: (value: T, index: number) => U): ConvenientIterator<U> {
+    return new ConvenientIterator(new MapIterator<T, U>(this, fn));
+  }
+
+  each(fn: (value: T, index: number) => boolean | void): void {
+    each(this, fn);
+  }
+
+  private _it: IIterator<T>;
+}
+
+/**
+ * Wraps a JavaScript iterator in a Phosphor iterator
+ *
+ * @param object - The iterable or array-like object of interest.
+ *
+ * @returns A new iterator for the given object.
+ *
+ * #### Notes
+ * This function allows iteration algorithms to operate on user-defined
+ * iterable types and builtin array-like objects in a uniform fashion.
+ */
+export class JSToPhosphorIterator<T> implements IIterator<T> {
+  /**
+   * Construct a new Phosphor iterator from a JavaScript iterator.
+   *
+   * @param it - The iterator-like function of interest.
+   */
+  constructor(it: Iterator<T> | Iterable<T>) {
+    if (typeof (it as any)[Symbol.iterator] === 'function') {
+      it = (it as Iterable<T>)[Symbol.iterator]();
+    }
+    this._it = it as Iterator<T>;
+  }
+
+  /**
+   * Get an iterator over the object's values.
+   *
+   * @returns An iterator which yields the object's values.
+   */
+  iter(): IIterator<T> {
+    return this;
+  }
+
+  /**
+   * Create an independent clone of the iterator.
+   *
+   * @returns A new independent clone of the iterator.
+   */
+  clone(): IIterator<T> {
+    throw new Error('A `JSIterator` cannot be cloned.');
+  }
+
+  /**
+   * Get the next value from the iterator.
+   *
+   * @returns The next value from the iterator, or `undefined`.
+   */
+  next(): T | undefined {
+    const { done, value } = this._it.next();
+    if (done) {
+      return undefined;
+    }
+    if (value === undefined) {
+      throw new Error(
+        "'undefined' is a Phosphor iterator value, which is not allowed"
+      );
+    }
+    return value;
+  }
+
+  private _it: Iterator<T>;
+}
+
+/**
+ * Converts a Phosphor iterator into a JS iterator.
+ */
+export function iterjs<T>(it: IterableOrArrayLike<T>): IterableIterator<T> {
+  return new PhosphorToJSIterator(it);
+}
+
+/**
+ * Converts a Phosphor iterator into a JS iterator.
+ */
+export class PhosphorToJSIterator<T> implements IterableIterator<T> {
+  constructor(it: IterableOrArrayLike<T>) {
+    this._it = iter(it);
+  }
+
+  [Symbol.iterator]: () => this;
+
+  next(): IteratorResult<T, any> {
+    const value = this._it.next();
+    if (value === undefined) {
+      return { done: true, value };
+    } else {
+      return { value };
+    }
+  }
+
+  private _it: IIterator<T>;
+}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

## Code changes

This introduces some convenience iterator functions for dealing with phosphor iterators, and converting js and phosphor iterators.

I haven't tested these, and I haven't documented them very well. I'm putting them up here for thoughts on if we want to pursue this more. On the one hand, there are a lot of very convenient transformation functions for phosphor iterators. On the other hand, new contributors are not generally familiar with phosphor iterators, and we have talked about moving more and more to plain js iterators. Perhaps this code is just enough to be able to help us bridge the gap better.

If we do want more of this, I'll probably implement the rest of the array-like functions on the convenient iterator (such as find, findIndex, etc.), so we can treat phosphor iterators much like arrays.

So what do you think? Move forward? Bad idea? Eventually this might end up in Phosphor itself, once phosphor upgrades its ts target from es5 to at least es2015.

Of note, we could also move more towards other js libraries implementing native iteration convenience functions, but these all seem at first glance like large dependencies (though some are written so they can be tree-shaken):

* https://github.com/iter-tools/iter-tools
* https://github.com/nvie/itertools.js
* https://github.com/blakeembrey/iterative

