### PR TITLE
apply all options to initial jlab instance

### DIFF
--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -25,7 +25,7 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
    * Construct a new JupyterLab object.
    */
   constructor(options: JupyterLab.IOptions = { shell: new LabShell() }) {
-    super({ shell: options.shell || new LabShell() });
+    super({ ...options, shell: options.shell || new LabShell() });
     this.restored = this.shell.restored
       .then(() => undefined)
       .catch(() => undefined);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Issue:
https://github.com/jupyterlab/jupyterlab/issues/6400
<!-- Note any other pull requests that address this issue and how this pull request is different. -->
Relevant past commits:
https://github.com/jupyterlab/jupyterlab/commit/39ccbc9d2829867e4a227bb6baa259a183b9d11f
https://github.com/jupyterlab/jupyterlab/commit/9b2e915b18eec9defcf8522e07489fd32f8e35b2
## Code changes

<!-- Describe the code changes and how they address the issue. -->
When instantiating `JupyterLab`, the full options object is passed up to the superclass. Previously, only the `shell` seemed to be.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
