### PR TITLE
removed svg styling from old icon behavior fallback

### DIFF
--- a/packages/ui-components/src/icon/iconregistry.tsx
+++ b/packages/ui-components/src/icon/iconregistry.tsx
@@ -67,11 +67,7 @@ export class IconRegistry implements IIconRegistry {
       if (fallback) {
         if (container) {
           container.textContent = title || '';
-          container.className = classes(
-            name,
-            className,
-            propsStyle ? iconStyleFlat(propsStyle) : ''
-          );
+          container.className = classes(name, className);
           return container;
         } else {
           // the non-container fallback isn't implemented
@@ -146,17 +142,7 @@ export class IconRegistry implements IIconRegistry {
     if (!resolvedName) {
       // TODO: remove fallback in jlab 2.0
       if (fallback) {
-        return (
-          <Tag
-            className={classes(
-              name,
-              className,
-              propsStyle ? iconStyleFlat(propsStyle) : ''
-            )}
-          >
-            {title || ''}
-          </Tag>
-        );
+        return <Tag className={classes(name, className)}>{title || ''}</Tag>;
       }
 
       // bail if failing silently

--- a/packages/ui-components/src/style/icon.ts
+++ b/packages/ui-components/src/style/icon.ts
@@ -220,6 +220,12 @@ const containerCSSTabManager: NestedCSSProperties = {
   position: 'relative'
 };
 
+const containerCSSToolbarButton: NestedCSSProperties = {
+  display: 'inline-block',
+  margin: 'auto',
+  verticalAlign: 'middle'
+};
+
 const containerCSSKind: { [k in IconKindType]: NestedCSSProperties } = {
   breadCrumb: {},
   dockPanelBar: containerCSSDockPanelBar,
@@ -231,7 +237,7 @@ const containerCSSKind: { [k in IconKindType]: NestedCSSProperties } = {
   splash: containerCSSSplash,
   statusBar: {},
   tabManager: containerCSSTabManager,
-  toolbarButton: {},
+  toolbarButton: containerCSSToolbarButton,
   unset: {}
 };
 


### PR DESCRIPTION
## References

fixes #7265

## Code changes

Removes SVG-specific styling from icons when icon handling falls back to the old "icons as CSS background images" behavior.

Also fixed SVG styling for toolbar icon labels.

## User-facing changes

Toolbar icon labels now display correctly.

## Backwards-incompatible changes

None