### PR TITLE
fixes #7264: use default `app_dir` when `app_dir == ''`

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -302,6 +302,11 @@ class AppOptions(HasTraits):
             kwargs['core_config'] = core_config
         if logger is not None:
             kwargs['logger'] = logger
+
+        # use the default if app_dir is empty
+        if 'app_dir' in kwargs and not kwargs['app_dir']:
+            kwargs.pop('app_dir')
+
         super(AppOptions, self).__init__(**kwargs)
 
     app_dir = Unicode(help='The application directory')


### PR DESCRIPTION
## References

fixes #7264

## Code changes

Ensures that the default value of `app_dir` is used when `app_dir == ''`

## User-facing changes

Extensions will install correctly, instead of lab assets building in an extension dir

## Backwards-incompatible changes
