### PR TITLE
attempting to make `test-notebook` more robust wrt CI

### DIFF
--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -36,11 +36,12 @@ describe('@jupyterlab/notebook', () => {
     let session: ClientSession;
     let ipySession: ClientSession;
 
-    before(async () => {
-      session = await createClientSession();
-      ipySession = await createClientSession({
-        kernelPreference: { name: 'ipython' }
-      });
+    before(async function() {
+      this.timeout(60000);
+      [session, ipySession] = await Promise.all([
+        createClientSession(),
+        createClientSession({ kernelPreference: { name: 'ipython' } })
+      ]);
       await Promise.all([ipySession.initialize(), session.initialize()]);
       await Promise.all([ipySession.kernel.ready, session.kernel.ready]);
     });
@@ -63,8 +64,8 @@ describe('@jupyterlab/notebook', () => {
       NBTestUtils.clipboard.clear();
     });
 
-    after(() => {
-      return Promise.all([session.shutdown(), ipySession.shutdown()]);
+    after(async () => {
+      await Promise.all([session.shutdown(), ipySession.shutdown()]);
     });
 
     describe('#executed', () => {

--- a/tests/test-notebook/src/actions.spec.ts
+++ b/tests/test-notebook/src/actions.spec.ts
@@ -37,6 +37,7 @@ describe('@jupyterlab/notebook', () => {
     let ipySession: ClientSession;
 
     before(async function() {
+      // tslint:disable-next-line:no-invalid-this
       this.timeout(60000);
       [session, ipySession] = await Promise.all([
         createClientSession(),

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -229,7 +229,8 @@ describe('@jupyterlab/notebook', () => {
       let context: Context<INotebookModel>;
       let panel: NotebookPanel;
 
-      beforeEach(async () => {
+      beforeEach(async function() {
+        this.timeout(60000);
         context = await initNotebookContext({ startKernel: true });
         panel = NBTestUtils.createNotebookPanel(context);
         context.model.fromJSON(NBTestUtils.DEFAULT_CONTENT);

--- a/tests/test-notebook/src/default-toolbar.spec.ts
+++ b/tests/test-notebook/src/default-toolbar.spec.ts
@@ -230,6 +230,7 @@ describe('@jupyterlab/notebook', () => {
       let panel: NotebookPanel;
 
       beforeEach(async function() {
+        // tslint:disable-next-line:no-invalid-this
         this.timeout(60000);
         context = await initNotebookContext({ startKernel: true });
         panel = NBTestUtils.createNotebookPanel(context);


### PR DESCRIPTION
## References

The Windows JS CI test suite is once again experiencing a high rate of failures, and once again it seems to have something to do with starting up/shutting down kernels and probably also #6727.

## Code changes

In an attempt to make `test-notebook` more robust, I've restructured some slow async code and increased some timeouts.

## User-facing changes

None

## Backwards-incompatible changes

None
