### PR TITLE
refactoring various tests to be faster/less likely to time out

### DIFF
--- a/tests/test-console/src/foreign.spec.ts
+++ b/tests/test-console/src/foreign.spec.ts
@@ -111,8 +111,12 @@ describe('@jupyterlab/console', () => {
       [local, foreign, session] = await Promise.all([
         Session.startNew({ path }),
         Session.startNew({ path }),
-        createClientSession({ path: local.path })
+        createClientSession({ path })
       ]);
+
+      // check path prop
+      expect(local.path).to.equal(path);
+
       await (session as ClientSession).initialize();
       await session.kernel.ready;
     });
@@ -127,9 +131,11 @@ describe('@jupyterlab/console', () => {
     });
 
     after(async () => {
+      // local, foreign, and session share state, so only one shutdown
+      await session.shutdown();
+
       local.dispose();
       foreign.dispose();
-      await session.shutdown();
       session.dispose();
     });
 

--- a/tests/test-console/src/foreign.spec.ts
+++ b/tests/test-console/src/foreign.spec.ts
@@ -103,11 +103,16 @@ describe('@jupyterlab/console', () => {
     let handler: TestHandler;
     let session: IClientSession;
 
-    before(async () => {
+    before(async function() {
+      // tslint:disable-next-line:no-invalid-this
+      this.timeout(60000);
+
       const path = UUID.uuid4();
-      const sessions = [Session.startNew({ path }), Session.startNew({ path })];
-      [local, foreign] = await Promise.all(sessions);
-      session = await createClientSession({ path: local.path });
+      [local, foreign, session] = await Promise.all([
+        Session.startNew({ path }),
+        Session.startNew({ path }),
+        createClientSession({ path: local.path })
+      ]);
       await (session as ClientSession).initialize();
       await session.kernel.ready;
     });


### PR DESCRIPTION
## References

Yet another PR like #7270, for yet another intermittent failure in the `Windows JS` CI, this time in `test-console`. I'll leave this PR open for a bit, since I've also recently seen an uptick in intermittent failures in `test-services` (and who knows where else). 

Anyone have guesses as to what set off this round of test weirdness?

## Code changes

Cleaned up tests to run faster, and also added longer timeouts where appropriate.

## User-facing changes

None

## Backwards-incompatible changes

None