### PR TITLE
fixes #7141 : display proper error message for non utf-8 files

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -579,11 +579,12 @@ export class Context<T extends DocumentRegistry.IModel>
           return this._populate();
         }
       })
-      .catch(err => {
+      .catch(async err => {
         const localPath = this._manager.contents.localPath(this._path);
         const name = PathExt.basename(localPath);
+        const response = await err.response.json();
         if (err.message === 'Invalid response: 400 bad format') {
-          err = new Error('JupyterLab is unable to open this file type.');
+          err = new Error(response.message);
         }
         void this._handleError(err, `File Load Error for ${name}`);
         throw err;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #7141 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Opening non UTF-8 encoded files would throw an exception in the `_revert` method.
Changed the catch block to `async`.
Await for promise `err.response.json()` in the catch block (as suggested by @jasongrout [here](https://github.com/jupyterlab/jupyterlab/issues/7141#issuecomment-527307506)).
Display the `message` returned by the server in the error dialog box instead of the generic `JupyterLab is unable to open this file type`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

Previously, if user would try to open a non UTF-8 encoded file, he would see this error dialog.
![image](https://user-images.githubusercontent.com/3937361/65795443-e6c4c300-e187-11e9-9746-658358e9d04c.png)


Now, the user will see a more specific error message in the dialog.
![image](https://user-images.githubusercontent.com/3937361/65795335-a9f8cc00-e187-11e9-801f-033f6078429e.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None to my understanding. Please correct me if wrong.