### PR TITLE
Better error message for text file with non utf-8 encoding

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -581,7 +581,9 @@ export class Context<T extends DocumentRegistry.IModel>
         const localPath = this._manager.contents.localPath(this._path);
         const name = PathExt.basename(localPath);
         if (err.message === 'Invalid response: 400 bad format') {
-          err = new Error('JupyterLab is unable to open this file type.');
+          err = new Error(
+            'If your file is text, check if it is using utf-8 encoding.'
+          );
         }
         void this._handleError(err, `File Load Error for ${name}`);
         throw err;


### PR DESCRIPTION


## References

Fixes #7141 

## Code changes

Spoke to @jasongrout about this code change. And we felt writing async code for this will be some work. So we decided to go with a appropriate error message

## User-facing changes

User will see `If your file is text, check if it is using utf-8 encoding` error message no

