### PR TITLE
Add support for rank to the top area

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -175,13 +175,13 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     this.addClass(APPLICATION_SHELL_CLASS);
     this.id = 'main';
 
-    let bottomPanel = (this._bottomPanel = new BoxPanel());
+    let headerPanel = (this._headerPanel = new Panel());
     let topHandler = (this._topHandler = new Private.PanelHandler());
+    let bottomPanel = (this._bottomPanel = new BoxPanel());
     let hboxPanel = new BoxPanel();
     let dockPanel = (this._dockPanel = new DockPanelSvg({
       kind: 'dockPanelBar'
     }));
-    let headerPanel = (this._headerPanel = new Panel());
     MessageLoop.installMessageHook(dockPanel, this._dockChildHook);
 
     let hsplitPanel = new SplitPanel();
@@ -191,12 +191,12 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     ));
     let rootLayout = new BoxLayout();
 
-    bottomPanel.id = 'jp-bottom-panel';
+    headerPanel.id = 'jp-header-panel';
     topHandler.panel.id = 'jp-top-panel';
+    bottomPanel.id = 'jp-bottom-panel';
     hboxPanel.id = 'jp-main-content-panel';
     dockPanel.id = 'jp-main-dock-panel';
     hsplitPanel.id = 'jp-main-split-panel';
-    headerPanel.id = 'jp-header-panel';
 
     leftHandler.sideBar.addClass(SIDEBAR_CLASS);
     leftHandler.sideBar.addClass('jp-mod-left');
@@ -206,13 +206,13 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     rightHandler.sideBar.addClass('jp-mod-right');
     rightHandler.stackedPanel.id = 'jp-right-stack';
 
-    bottomPanel.direction = 'bottom-to-top';
     hboxPanel.spacing = 0;
     dockPanel.spacing = 5;
     hsplitPanel.spacing = 1;
 
     hboxPanel.direction = 'left-to-right';
     hsplitPanel.orientation = 'horizontal';
+    bottomPanel.direction = 'bottom-to-top';
 
     SplitPanel.setStretch(leftHandler.stackedPanel, 0);
     SplitPanel.setStretch(dockPanel, 1);

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -176,7 +176,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     this.id = 'main';
 
     let bottomPanel = (this._bottomPanel = new BoxPanel());
-    let topPanel = (this._topPanel = new Panel());
+    let topHandler = (this._topHandler = new Private.PanelHandler());
     let hboxPanel = new BoxPanel();
     let dockPanel = (this._dockPanel = new DockPanelSvg({
       kind: 'dockPanelBar'
@@ -192,7 +192,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     let rootLayout = new BoxLayout();
 
     bottomPanel.id = 'jp-bottom-panel';
-    topPanel.id = 'jp-top-panel';
+    topHandler.panel.id = 'jp-top-panel';
     hboxPanel.id = 'jp-main-content-panel';
     dockPanel.id = 'jp-main-dock-panel';
     hsplitPanel.id = 'jp-main-split-panel';
@@ -238,12 +238,12 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     hsplitPanel.setRelativeSizes([1, 2.5, 1]);
 
     BoxLayout.setStretch(headerPanel, 0);
-    BoxLayout.setStretch(topPanel, 0);
+    BoxLayout.setStretch(topHandler.panel, 0);
     BoxLayout.setStretch(hboxPanel, 1);
     BoxLayout.setStretch(bottomPanel, 0);
 
     rootLayout.addWidget(headerPanel);
-    rootLayout.addWidget(topPanel);
+    rootLayout.addWidget(topHandler.panel);
     rootLayout.addWidget(hboxPanel);
     rootLayout.addWidget(bottomPanel);
 
@@ -597,7 +597,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       case 'header':
         return this._headerPanel.widgets.length === 0;
       case 'top':
-        return this._topPanel.widgets.length === 0;
+        return this._topHandler.panel.widgets.length === 0;
       case 'bottom':
         return this._bottomPanel.widgets.length === 0;
       case 'right':
@@ -681,7 +681,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       case 'header':
         return this._headerPanel.children();
       case 'top':
-        return this._topPanel.children();
+        return this._topHandler.panel.children();
       case 'bottom':
         return this._bottomPanel.children();
       default:
@@ -803,9 +803,13 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       console.error('Widgets added to app shell must have unique id property.');
       return;
     }
-    // Temporary: widgets are added to the panel in order of insertion.
-    this._topPanel.addWidget(widget);
+    options = options || {};
+    const rank = 'rank' in options ? options.rank : DEFAULT_RANK;
+    this._topHandler.addWidget(widget, rank);
     this._onLayoutModified();
+    if (this._topHandler.panel.isHidden) {
+      this._topHandler.panel.show();
+    }
   }
 
   /**
@@ -974,7 +978,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   private _rightHandler: Private.SideBarHandler;
   private _tracker = new FocusTracker<Widget>();
   private _headerPanel: Panel;
-  private _topPanel: Panel;
+  private _topHandler: Private.PanelHandler;
   private _bottomPanel: Panel;
   private _mainOptionsCache = new Map<Widget, DocumentRegistry.IOpenOptions>();
   private _sideOptionsCache = new Map<Widget, DocumentRegistry.IOpenOptions>();
@@ -1022,6 +1026,34 @@ namespace Private {
     area.children.forEach(child => {
       normalizeAreaConfig(parent, child);
     });
+  }
+
+  /**
+   * A class which manages a panel and sort its widgets by rank.
+   */
+  export class PanelHandler {
+    /**
+     * Get the panel managed by the handler.
+     */
+    get panel() {
+      return this._panel;
+    }
+
+    /**
+     * Add a widget to the panel.
+     *
+     * If the widget is already added, it will be moved.
+     */
+    addWidget(widget: Widget, rank: number): void {
+      widget.parent = null;
+      const item = { widget, rank };
+      const index = ArrayExt.upperBound(this._items, item, Private.itemCmp);
+      ArrayExt.insert(this._items, index, item);
+      this._panel.insertWidget(index, widget);
+    }
+
+    private _items = new Array<Private.IRankItem>();
+    private _panel = new Panel();
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1029,7 +1029,7 @@ namespace Private {
   }
 
   /**
-   * A class which manages a panel and sort its widgets by rank.
+   * A class which manages a panel and sorts its widgets by rank.
    */
   export class PanelHandler {
     /**

--- a/tests/test-application/package.json
+++ b/tests/test-application/package.json
@@ -16,6 +16,7 @@
     "@jupyterlab/apputils": "^2.0.0-alpha.0",
     "@jupyterlab/coreutils": "^4.0.0-alpha.0",
     "@jupyterlab/testutils": "^2.0.0-alpha.0",
+    "@phosphor/algorithm": "^1.2.0",
     "@phosphor/commands": "^1.7.0",
     "@phosphor/coreutils": "^1.3.1",
     "@phosphor/messaging": "^1.3.0",

--- a/tests/test-application/src/shell.spec.ts
+++ b/tests/test-application/src/shell.spec.ts
@@ -5,6 +5,8 @@ import { expect } from 'chai';
 
 import { framePromise } from '@jupyterlab/testutils';
 
+import { toArray } from '@phosphor/algorithm';
+
 import { Message } from '@phosphor/messaging';
 
 import { Widget } from '@phosphor/widgets';
@@ -165,6 +167,16 @@ describe('LabShell', () => {
       widget.id = 'foo';
       shell.add(widget, 'top', { rank: 10 });
       expect(shell.isEmpty('top')).to.equal(false);
+    });
+
+    it('should add widgets according to their ranks', () => {
+      const foo = new Widget();
+      const bar = new Widget();
+      foo.id = 'foo';
+      bar.id = 'bar';
+      shell.add(foo, 'top', { rank: 20 });
+      shell.add(bar, 'top', { rank: 10 });
+      expect(toArray(shell.widgets('top'))).to.deep.equal([bar, foo]);
     });
   });
 


### PR DESCRIPTION
## References

Partially related to https://github.com/jupyterlab/jupyterlab/issues/6096.

https://github.com/jupyterlab/jupyterlab/issues/6096 is more general and also considers the `main` area.

This change is only for the `top` area.

## Code changes

Add a `PanelHandler` wrapper to store the widget ranks for the top area.
It should be possible to use the same wrapper for the `header` and `bottom` areas too, and potentially merge it with the existing `SideBarHandler` (also sorting its widgets).

Ideally all areas should support ranks by default. However [as pointed out](https://github.com/jupyterlab/jupyterlab/issues/6096#issuecomment-476324100) by @Madhu94 in #6096 this might become tricky for the `main` area (is there a notion of rank / order for this area?)

## Developer-facing changes

Third-party extensions ([example](https://github.com/jtpio/jupyterlab-topbar)) can now use the `rank` parameter when adding widgets to the top area:

```typescript
// place a custom widget in front of the Jupyter logo
app.shell(widget, 'top', { rank: -1 });
```

## User-facing changes

None

## Backwards-incompatible changes

None