### PR TITLE
Change kernel.connectComm to kernel.createComm and add a new hasComm method

### DIFF
--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -231,11 +231,10 @@ Kernel.getSpecs()
     });
   })
   .then(kernel => {
-    let comm = kernel.connectToComm('test').then(comm => {
-      comm.open('initial state');
-      comm.send('test');
-      comm.close('bye');
-    });
+    let comm = kernel.createComm('test');
+    comm.open('initial state');
+    comm.send('test');
+    comm.close('bye');
   });
 
 // Create a comm from the client side.

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -724,28 +724,35 @@ export class DefaultKernel implements Kernel.IKernel {
   }
 
   /**
-   * Connect to a comm, or create a new one.
+   * Create a new comm.
    *
    * #### Notes
-   * If a client-side comm already exists with the given commId, it is returned.
-   * An error is thrown if the kernel does not handle comms.
+   * If a client-side comm already exists with the given commId, an error is thrown.
+   * If the kernel does not handle comms, an error is thrown.
    */
-  connectToComm(
+  createComm(
     targetName: string,
     commId: string = UUID.uuid4()
   ): Kernel.IComm {
     if (!this.handleComms) {
       throw new Error('Comms are disabled on this kernel connection');
     }
-
     if (this._comms.has(commId)) {
-      return this._comms.get(commId);
+      throw new Error('Comm is already created');
     }
+
     let comm = new CommHandler(targetName, commId, this, () => {
       this._unregisterComm(commId);
     });
     this._comms.set(commId, comm);
     return comm;
+  }
+
+  /**
+   * Check if a comm exists.
+   */
+  hasComm(commId: string): boolean {
+    return this._comms.has(commId);
   }
 
   /**

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -359,7 +359,7 @@ export namespace Kernel {
     sendInputReply(content: KernelMessage.IInputReplyMsg['content']): void;
 
     /**
-     * Connect to a comm, or create a new one.
+     * Create a new comm.
      *
      * @param targetName - The name of the comm target.
      *
@@ -367,7 +367,12 @@ export namespace Kernel {
      *
      * @returns A comm instance.
      */
-    connectToComm(targetName: string, commId?: string): Kernel.IComm;
+    createComm(targetName: string, commId?: string): Kernel.IComm;
+
+    /**
+     * Check if a comm exists.
+     */
+    hasComm(commId: string): boolean;
 
     /**
      * Register a comm target handler.

--- a/packages/vdom/src/index.tsx
+++ b/packages/vdom/src/index.tsx
@@ -107,7 +107,7 @@ export class RenderedVDOM extends Widget implements IRenderMime.IRenderer {
     if (this._session) {
       this._timer = window.setTimeout(() => {
         if (!this._comms[targetName]) {
-          this._comms[targetName] = this._session.kernel.connectToComm(
+          this._comms[targetName] = this._session.kernel.createComm(
             targetName
           );
           this._comms[targetName].open();

--- a/tests/test-services/src/kernel/comm.spec.ts
+++ b/tests/test-services/src/kernel/comm.spec.ts
@@ -66,23 +66,22 @@ describe('jupyter.services - Comm', () => {
   });
 
   describe('Kernel', () => {
-    describe('#connectToComm()', () => {
+    describe('#createComm()', () => {
       it('should create an instance of IComm', () => {
-        const comm = kernel.connectToComm('test');
+        const comm = kernel.createComm('test');
         expect(comm.targetName).to.equal('test');
         expect(typeof comm.commId).to.equal('string');
       });
 
       it('should use the given id', () => {
-        const comm = kernel.connectToComm('test', '1234');
+        const comm = kernel.createComm('test', '1234');
         expect(comm.targetName).to.equal('test');
         expect(comm.commId).to.equal('1234');
       });
 
-      it('should reuse an existing comm', () => {
-        const comm = kernel.connectToComm('test', '1234');
-        const comm2 = kernel.connectToComm('test', '1234');
-        expect(comm).to.equal(comm2);
+      it('should throw an error if there is an existing comm', () => {
+        kernel.createComm('test', '1234');
+        expect(() => kernel.createComm('test', '1234')).to.throw();
       });
 
       it('should throw an error when the kernel does not handle comms', async () => {
@@ -91,7 +90,17 @@ describe('jupyter.services - Comm', () => {
           handleComms: false
         });
         expect(kernel2.handleComms).to.be.false;
-        expect(() => kernel2.connectToComm('test', '1234')).to.throw();
+        expect(() => kernel2.createComm('test', '1234')).to.throw();
+      });
+    });
+
+    describe('#hasComm()', () => {
+      it('should test if there is a registered comm', () => {
+        expect(kernel.hasComm('test comm')).to.false;
+        const comm = kernel.createComm('test', 'test comm');
+        expect(kernel.hasComm('test comm')).to.true;
+        comm.dispose();
+        expect(kernel.hasComm('test comm')).to.false;
       });
     });
 
@@ -194,14 +203,14 @@ describe('jupyter.services - Comm', () => {
 
     describe('#isDisposed', () => {
       it('should be true after we dispose of the comm', () => {
-        const comm = kernel.connectToComm('test');
+        const comm = kernel.createComm('test');
         expect(comm.isDisposed).to.equal(false);
         comm.dispose();
         expect(comm.isDisposed).to.equal(true);
       });
 
       it('should be safe to call multiple times', () => {
-        const comm = kernel.connectToComm('test');
+        const comm = kernel.createComm('test');
         expect(comm.isDisposed).to.equal(false);
         expect(comm.isDisposed).to.equal(false);
         comm.dispose();
@@ -212,7 +221,7 @@ describe('jupyter.services - Comm', () => {
 
     describe('#dispose()', () => {
       it('should dispose of the resources held by the comm', () => {
-        const comm = kernel.connectToComm('foo');
+        const comm = kernel.createComm('foo');
         comm.dispose();
         expect(comm.isDisposed).to.equal(true);
       });
@@ -223,7 +232,7 @@ describe('jupyter.services - Comm', () => {
     let comm: Kernel.IComm;
 
     beforeEach(() => {
-      comm = kernel.connectToComm('test');
+      comm = kernel.createComm('test');
     });
 
     describe('#id', () => {

--- a/tests/test-services/src/kernel/ikernel.spec.ts
+++ b/tests/test-services/src/kernel/ikernel.spec.ts
@@ -658,7 +658,7 @@ describe('Kernel.IKernel', () => {
 
     it('should dispose of existing comm and future objects', async () => {
       const kernel = defaultKernel;
-      const comm = kernel.connectToComm('test');
+      const comm = kernel.createComm('test');
       const future = kernel.requestExecute({ code: 'foo' });
       await kernel.restart();
       await kernel.ready;


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Previously, if you tried to create a comm that already existed, you could get the comm someone else had created, which means you would overwrite their message handlers, etc. This was a bad design decision.

This changes the API so that you can only create comms with ids that do not exist. You can also query to see if a given id is used.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

Changed the connectToComm method to createComm, and made it throw an error if you tried to create a comm with an id that was already used.
