### PR TITLE
"Download as an archive" entry to the context menu for folders in the filebrowser.

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -70,6 +70,8 @@ namespace CommandIDs {
 
   export const download = 'filebrowser:download';
 
+  export const downloadFolder = 'filebrowser:downloadFolder';
+
   export const duplicate = 'filebrowser:duplicate';
 
   // For main browser only.
@@ -434,6 +436,18 @@ function addCommands(
     },
     iconClass: 'jp-MaterialIcon jp-DownloadIcon',
     label: 'Download'
+  });
+
+  commands.addCommand(CommandIDs.downloadFolder, {
+    execute: () => {
+      const widget = tracker.currentWidget;
+
+      if (widget) {
+        return widget.downloadFolder();
+      }
+    },
+    iconClass: 'jp-MaterialIcon jp-DownloadIcon',
+    label: 'Download as an archive'
   });
 
   commands.addCommand(CommandIDs.duplicate, {
@@ -832,6 +846,8 @@ function addCommands(
   const selectorItem = '.jp-DirListing-item[data-isdir]';
   // matches only non-directory items
   const selectorNotDir = '.jp-DirListing-item[data-isdir="false"]';
+  // matches only non-file items
+  const selectorNotFile = '.jp-DirListing-item[data-isdir="true"]';
 
   // If the user did not click on any file, we still want to show paste and new folder,
   // so target the content rather than an item.
@@ -901,25 +917,30 @@ function addCommands(
     rank: 9
   });
   app.contextMenu.addItem({
+    command: CommandIDs.downloadFolder,
+    selector: selectorNotFile,
+    rank: 10
+  });
+  app.contextMenu.addItem({
     command: CommandIDs.shutdown,
     selector: selectorNotDir,
-    rank: 10
+    rank: 11
   });
 
   app.contextMenu.addItem({
     command: CommandIDs.share,
     selector: selectorItem,
-    rank: 11
+    rank: 12
   });
   app.contextMenu.addItem({
     command: CommandIDs.copyPath,
     selector: selectorItem,
-    rank: 12
+    rank: 13
   });
   app.contextMenu.addItem({
     command: CommandIDs.copyDownloadLink,
     selector: selectorNotDir,
-    rank: 13
+    rank: 14
   });
 }
 

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -213,10 +213,17 @@ export class FileBrowser extends Widget {
   }
 
   /**
-   * Download the currently selected item(s).
+   * Download the currently selected file(s).
    */
   download(): Promise<void> {
     return this._listing.download();
+  }
+
+  /**
+   * Download the currently selected folder(s).
+   */
+  downloadFolder(): Promise<void> {
+    return this._listing.downloadFolder();
   }
 
   /**

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -422,13 +422,24 @@ export class DirListing extends Widget {
   }
 
   /**
-   * Download the currently selected item(s).
+   * Download the currently selected file(s).
    */
   async download(): Promise<void> {
     await Promise.all(
       toArray(this.selectedItems())
         .filter(item => item.type !== 'directory')
         .map(item => this._model.download(item.path))
+    );
+  }
+
+  /**
+   * Download the currently selected folder(s).
+   */
+  async downloadFolder(): Promise<void> {
+    await Promise.all(
+      toArray(this.selectedItems())
+        .filter(item => item.type == 'directory')
+        .map(item => this._model.downloadFolder(item.path))
     );
   }
 

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -333,6 +333,25 @@ export class FileBrowserModel implements IDisposable {
   }
 
   /**
+   * Download a folder.
+   *
+   * @param path - The path of the folder to be downloaded.
+   *
+   * @returns A promise which resolves when the folder has begun
+   *   downloading.
+   */
+  async downloadFolder(path: string): Promise<void> {
+    const url = await this.manager.services.contents.getDownloadFolderUrl(path);
+    let element = document.createElement('a');
+    element.href = url;
+    element.download = '';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+    return void 0;
+  }
+
+  /**
    * Restore the state of the file browser.
    *
    * @param id - The unique ID that is used to construct a state database key.


### PR DESCRIPTION
## References

- Extension to be integrated to Jupyter: https://github.com/hadim/jupyter-archive/issues/2
- Server-side PR in notebook: https://github.com/jupyter/notebook/pull/4945

## Code changes

Add a button 'Download as an archive' to folders in filebrowser and implement the logic to construct the URL.

## User-facing changes

![Screenshot from 2019-10-04 13-38-46](https://user-images.githubusercontent.com/528003/66227976-523cf200-e6ac-11e9-9e94-6f9307de0eca.png)
