### PR TITLE
Fix ensure-buildutils.js: rebuilds correctly on changes, runs pre integrity

### DIFF
--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -374,7 +374,7 @@ export async function ensureUiComponents(
   const iconModelDeclarations = _iconModelDeclarations.join(',\n');
 
   // generate the actual contents of the iconImports file
-  const iconImportsPath = path.join(iconSrcDir, 'iconImports.ts');
+  const iconImportsPath = path.join(iconSrcDir, 'iconimports.ts');
   const iconImportsContents = utils.fromTemplate(
     HEADER_TEMPLATE + ICON_IMPORTS_TEMPLATE,
     { funcName, iconImportStatements, iconModelDeclarations }

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -397,8 +397,7 @@ export async function ensureIntegrity(): Promise<boolean> {
       );
       process.exit(1);
     }
-    // skip redundant rebuild of buildutils with --ignore-scripts
-    utils.run('jlpm install --ignore-scripts');
+    utils.run('jlpm install');
     console.log('\n\nMade integrity changes!');
     console.log('Please commit the changes by running:');
     console.log('git commit -a -m "Package integrity updates"');

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -397,7 +397,8 @@ export async function ensureIntegrity(): Promise<boolean> {
       );
       process.exit(1);
     }
-    utils.run('jlpm install');
+    // skip redundant rebuild of buildutils with --ignore-scripts
+    utils.run('jlpm install --ignore-scripts');
     console.log('\n\nMade integrity changes!');
     console.log('Please commit the changes by running:');
     console.log('git commit -a -m "Package integrity updates"');

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint:check": "eslint .",
     "get:dependency": "node buildutils/lib/get-dependency.js",
     "postinstall": "node scripts/ensure-buildutils.js",
-    "integrity": "node buildutils/lib/ensure-repo.js",
+    "integrity": "node scripts/ensure-buildutils.js && node buildutils/lib/ensure-repo.js",
     "lighthouse": "lighthouse http://localhost:8888/ --chrome-flags='--headless' --emulated-form-factor=none --throttling-method=provided --only-categories performance",
     "lighthouse:compare": "node testutils/lib/compare-lighthouse.js",
     "lighthouse:throttling:start": "comcast --latency=40 --target-bw=30000 --packet-loss=0.2%",

--- a/scripts/ensure-buildutils.js
+++ b/scripts/ensure-buildutils.js
@@ -49,10 +49,17 @@ if (fs.existsSync(path.join(basePath, 'lib'))) {
 }
 
 if (!current) {
-  // This must be "npm" because it is run during `pip install -e .` before
-  // jlpm is installed.
-  childProcess.execSync('npm run build', {
-    stdio: [0, 1, 2],
-    cwd: path.resolve('./buildutils')
-  });
+  try {
+    childProcess.execSync('jlpm run build', {
+      stdio: [0, 1, 2],
+      cwd: path.resolve('./buildutils')
+    });
+  } catch (e) {
+    // fallback to `npm` during `pip install -e .` before jlpm is installed.
+    // Using `npm` can cause `jlpm check --integrity` to fail
+    childProcess.execSync('npm run build', {
+      stdio: [0, 1, 2],
+      cwd: path.resolve('./buildutils')
+    });
+  }
 }

--- a/scripts/ensure-buildutils.js
+++ b/scripts/ensure-buildutils.js
@@ -2,6 +2,8 @@
 | Copyright (c) Jupyter Development Team.
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
+// uncomment to time script
+// var start = new Date();
 
 var fs = require('fs-extra');
 var glob = require('glob');
@@ -49,17 +51,14 @@ if (fs.existsSync(path.join(basePath, 'lib'))) {
 }
 
 if (!current) {
-  try {
-    childProcess.execSync('jlpm run build', {
-      stdio: [0, 1, 2],
-      cwd: path.resolve('./buildutils')
-    });
-  } catch (e) {
-    // fallback to `npm` during `pip install -e .` before jlpm is installed.
-    // Using `npm` can cause `jlpm check --integrity` to fail
-    childProcess.execSync('npm run build', {
-      stdio: [0, 1, 2],
-      cwd: path.resolve('./buildutils')
-    });
-  }
+  // This must be "npm" because it is run during `pip install -e .` before
+  // jlpm is installed.
+  childProcess.execSync('npm run build', {
+    stdio: [0, 1, 2],
+    cwd: path.resolve('./buildutils')
+  });
 }
+
+// uncomment to time script
+// var end = new Date() - start;
+// console.info('Execution time: %dms', end);

--- a/scripts/ensure-buildutils.js
+++ b/scripts/ensure-buildutils.js
@@ -8,22 +8,32 @@ var glob = require('glob');
 var path = require('path');
 var childProcess = require('child_process');
 
+var basePath = path.join(path.resolve('.'), 'buildutils');
+
 // Make sure that buildutils is built and current
 var current = true;
-if (fs.existsSync(path.join('buildutils', 'lib'))) {
-  var srcFiles = glob.sync(path.join('buildutils', 'src', '*'));
-  var libFiles = glob.sync(path.join('buildutils', 'lib', '*'));
+if (fs.existsSync(path.join(basePath, 'lib'))) {
+  var srcFiles = glob.sync(path.join(basePath, 'src', '*'));
+  var libFiles = glob.sync(path.join(basePath, 'lib', '*'));
   srcFiles.forEach(function(srcPath) {
-    // Bail early if already not current
+    // bail early if already not current
     if (!current) {
       return;
     }
-    var name = path.basename(srcPath);
-    var ext = path.extname(name);
-    if (ext !== 'js') {
+
+    if (srcPath.endsWith('.d.ts')) {
+      // bail if this is a src declarations file
       return;
     }
-    var libPath = path.join('buildutils', 'lib', name.replace('.ts', '.js'));
+
+    var name = path.basename(srcPath);
+    var ext = path.extname(name);
+    if (ext !== '.ts') {
+      current = false;
+      return;
+    }
+
+    var libPath = path.join(basePath, 'lib', name.replace('.ts', '.js'));
     if (libFiles.indexOf(libPath) === -1) {
       current = false;
       return;


### PR DESCRIPTION
## References

Currently, `ensure-buildutils.js` will build `buildutils` the first time it's run, but won't ever trigger a rebuild when you run the script again, due to pathing problems and other minor issues in how it detects changes. This PR fixes these issues, and also ensures that, if needed, `buildutils` will get rebuilt before `integrity` runs.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
