### PR TITLE
Allow Custom Gutters

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1410,9 +1410,8 @@ namespace Private {
       'CodeMirror-linenumbers': 'lineNumbers',
       'CodeMirror-foldgutter': 'codeFolding'
     };
-    // do not remove custom gutters
 
-    console.log(config, config.gutters);
+    // do not remove custom gutters
     const customGutters = (config.gutters || []).filter(
       gutter => !classToSwitch[gutter]
     );

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1402,6 +1402,9 @@ namespace Private {
   /**
    * Get the list of active gutters
    *
+   * This logic is somewhat naunced and is required in order to handle the
+   * way in which setOption over-rides previous options
+   *
    * @param config Editor configuration
    */
   function getActiveGutters(config: CodeMirrorEditor.IConfig): string[] {
@@ -1410,14 +1413,20 @@ namespace Private {
       'CodeMirror-linenumbers': 'lineNumbers',
       'CodeMirror-foldgutter': 'codeFolding'
     };
+    const configGutters = config.gutters || [];
+    const predefinedGuttersToAdd = Object.keys(classToSwitch).filter(gutter => {
+      return !configGutters.includes(gutter) && config[classToSwitch[gutter]];
+    });
 
-    // do not remove custom gutters
-    const customGutters = (config.gutters || []).filter(
-      gutter => !classToSwitch[gutter]
-    );
-    return Object.keys(classToSwitch)
-      .filter(gutter => config[classToSwitch[gutter]])
-      .concat(customGutters);
+    return configGutters
+      .filter(gutter => {
+        // if the gutter is custom, then keep it
+        const customGutters = !classToSwitch[gutter];
+        // keep or remove gutters already specified
+        const configSpecified = config[classToSwitch[gutter]];
+        return customGutters || configSpecified;
+      })
+      .concat(predefinedGuttersToAdd);
   }
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1410,9 +1410,15 @@ namespace Private {
       'CodeMirror-linenumbers': 'lineNumbers',
       'CodeMirror-foldgutter': 'codeFolding'
     };
-    return Object.keys(classToSwitch).filter(
-      gutter => config[classToSwitch[gutter]]
+    // do not remove custom gutters
+
+    const customGutters = config.gutters.filter(
+      gutter => !classToSwitch[gutter]
     );
+
+    return Object.keys(classToSwitch)
+      .filter(gutter => config[classToSwitch[gutter]])
+      .concat(customGutters);
   }
 
   /**
@@ -1425,6 +1431,7 @@ namespace Private {
     config: CodeMirrorEditor.IConfig
   ): void {
     let el = editor.getWrapperElement();
+    console.log('losing my mind');
     switch (option) {
       case 'lineWrap':
         const lineWrapping = value === 'off' ? false : true;

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1412,10 +1412,10 @@ namespace Private {
     };
     // do not remove custom gutters
 
-    const customGutters = config.gutters.filter(
+    console.log(config, config.gutters);
+    const customGutters = (config.gutters || []).filter(
       gutter => !classToSwitch[gutter]
     );
-
     return Object.keys(classToSwitch)
       .filter(gutter => config[classToSwitch[gutter]])
       .concat(customGutters);
@@ -1431,7 +1431,7 @@ namespace Private {
     config: CodeMirrorEditor.IConfig
   ): void {
     let el = editor.getWrapperElement();
-    console.log('losing my mind');
+    console.log('losing my mind', option);
     switch (option) {
       case 'lineWrap':
         const lineWrapping = value === 'off' ? false : true;

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1430,7 +1430,6 @@ namespace Private {
     config: CodeMirrorEditor.IConfig
   ): void {
     let el = editor.getWrapperElement();
-    console.log('losing my mind', option);
     switch (option) {
       case 'lineWrap':
         const lineWrapping = value === 'off' ? false : true;


### PR DESCRIPTION

CodeMirror supports creating custom gutters, this PR add that same functionality for jupyterlab by expanding which gutters are allowed to be present.
 
This change facilitates the construction of a future linting extension ( #1278). Currently custom gutters can be added in a some what hacky way (through modification of the _config object), however any changes made there are blown away on any subsequent alteration to the gutters (such as toggle lineNumbers or codeFolding), which necessitates this change. As discussed in the above issue, an alternative version of this same idea could see there being a lot of work done to give programatic access to code-mirrors own notion of a linter, but it seems to me that this approach is a little more flexible, and facilitates interactions from the gutter beyond just lint.


## References
#1278

## Code changes
Extension consumer will be able to add custom gutters. This is a non-breaking change! I think!

## User-facing changes
No end-user facing changes!

## Backwards-incompatible changes
None!