### PR TITLE
Skip custom click behavior on links when the download attribute is set

### DIFF
--- a/packages/rendermime-extension/src/index.ts
+++ b/packages/rendermime-extension/src/index.ts
@@ -80,6 +80,11 @@ function activate(
       ? null
       : {
           handleLink: (node: HTMLElement, path: string, id?: string) => {
+            // If node has the download attribute explicitly set, use the
+            // default browser downloading behavior.
+            if (node.tagName === 'A' && node.hasAttribute('download')) {
+              return;
+            }
             app.commandLinker.connectNode(node, CommandIDs.handleLink, {
               path,
               id

--- a/packages/rendermime-interfaces/src/index.ts
+++ b/packages/rendermime-interfaces/src/index.ts
@@ -320,7 +320,7 @@ export namespace IRenderMime {
     /**
      * Add the link handler to the node.
      *
-     * @param node: the node for which to handle the link.
+     * @param node: the anchor node for which to handle the link.
      *
      * @param path: the path to open when the link is clicked.
      *


### PR DESCRIPTION



<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #5443

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes



## User-facing changes

The presumption here is that if an anchor node has a download attribute explicitly set, the user really does want to download the file rather than opening the file in JLab.

## Backwards-incompatible changes

None - perhaps this should be backported to 1.2?

An incompatible change we probably should do in the future is tighten up the linkHandler signature to insist that the node is an anchor node.
