### PR TITLE
Increment the template package prerelease build numbers

### DIFF
--- a/buildutils/template/package.json
+++ b/buildutils/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/template",
-  "version": "1.2.0-alpha.0",
+  "version": "1.2.0-alpha.2",
   "description": "JupyterLab - Package Template",
   "homepage": "https://github.com/jupyterlab/jupyterlab",
   "bugs": {

--- a/buildutils/test-template/package.json
+++ b/buildutils/test-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/template-for-tests",
-  "version": "1.2.0-alpha.0",
+  "version": "1.2.0-alpha.2",
   "private": true,
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
The 1.2.0-alpha.1 template packages were already released in master. We increment them here to alpha.2, and we’ll need to do a major version bump in master.
