### PR TITLE
Update marked to 0.7.0

### DIFF
--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -47,7 +47,7 @@
     "@phosphor/signaling": "^1.3.0",
     "@phosphor/widgets": "^1.9.0",
     "lodash.escape": "^4.0.1",
-    "marked": "0.6.2"
+    "marked": "^0.7.0"
   },
   "devDependencies": {
     "@types/lodash.escape": "^4.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8296,15 +8296,15 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
-  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
-
 marked@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
   integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
+
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 marky@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #6479

## Code changes

Upgrade marked.js to 0.7.0

## User-facing changes

Some markdown bugs and security issues are fixed.

## Backwards-incompatible changes

Based on https://github.com/jupyterlab/jupyterlab/issues/6479#issuecomment-517771006 and looking again at the [marked.js 0.7.0 release notes](https://github.com/markedjs/marked/releases/tag/v0.7.0), I think this is backwards compatible for our purposes. We're not using the options that make their release not backwards compatible, IIRC.