### PR TITLE
Fix project name typo

### DIFF
--- a/design/real_time_collab.md
+++ b/design/real_time_collab.md
@@ -1,7 +1,7 @@
 # Read Time Collaboration Design
 
 This purpose of this document is to describe the design of the real-time collaboration (RTC)
-features we are building for JuptyerLab. The focus here is primarily on the user experience
+features we are building for JupyterLab. The focus here is primarily on the user experience
 and usage cases, rather than on the implementation details.
 
 ## Personas
@@ -49,7 +49,7 @@ software engieering practices (version control with Git/GitHub, Travis, Slack, e
 control everything and run an extensive test suite on each commit. The collaboration is exploring the possibility of using JupyterHub to provide a unified user-experience for their users to access data
 and their analysis software.
 
-The collaboration would run JupyterLab with JuptyerHub, and build custom JupyterLab extensions that
+The collaboration would run JupyterLab with JupyterHub, and build custom JupyterLab extensions that
 have custom front-end UIs that talk to their various backend services. They want to provide RTC
 capabilities for all of their services to enable the users and scientists to work with notebooks,
 text files and their custom backend services in a collaborative manner. Most of their RTC session will

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -470,7 +470,7 @@ staging and static
 ''''''''''''''''''
 
 The ``static`` directory contains the assets that will be loaded by the
-JuptyerLab application. The ``staging`` directory is used to create the
+JupyterLab application. The ``staging`` directory is used to create the
 build and then populate the ``static`` directory.
 
 Running ``jupyter lab`` will attempt to run the ``static`` assets in the


### PR DESCRIPTION
## References

None, just fixing a small typo.

## Code changes

Fixed the docs with the typo.

## User-facing changes

Just text in the docs.

## Backwards-incompatible changes

N/A
