### PR TITLE
Allow shortcuts to be empty and to have win/mac/linux-specific keys.

### DIFF
--- a/packages/shortcuts-extension/schema/shortcuts.json
+++ b/packages/shortcuts-extension/schema/shortcuts.json
@@ -22,7 +22,18 @@
         "command": { "type": "string" },
         "keys": {
           "items": { "type": "string" },
-          "minItems": 1,
+          "type": "array"
+        },
+        "winKeys": {
+          "items": { "type": "string" },
+          "type": "array"
+        },
+        "macKeys": {
+          "items": { "type": "string" },
+          "type": "array"
+        },
+        "linuxKeys": {
+          "items": { "type": "string" },
           "type": "array"
         },
         "selector": { "type": "string" }


### PR DESCRIPTION
## References

See https://github.com/phosphorjs/phosphor/issues/438 for some discussion.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Phosphor allows shortcuts to be empty, and it’s the only way to have platform-specific shortcuts (define keys to be [], and the platform keys to be something specific). We didn't allow this, but we should.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
