### PR TITLE
[Docs] Add table of contents in 'Common Extension Points'

### DIFF
--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -13,6 +13,9 @@ and more detailed descriptions of their public APIs may be found in the
 `JupyterLab <http://jupyterlab.github.io/jupyterlab/index.html>`__ and
 `Phosphor <http://phosphorjs.github.io/docs.html>`__ API documentation.
 
+.. contents:: Table of contents
+    :local:
+    :depth: 1
 
 Commands
 ~~~~~~~~


### PR DESCRIPTION

## References

**Issue**: https://github.com/jupyterlab/jupyterlab/issues/7339

## Code changes

Added a simple level-1 table of contents in the common extension points

## User-facing changes

Users are now having a better overview of the page, which might get longer as we add other use casers.

## Backwards-incompatible changes

It's just documentation :) should be fine 
