### PR TITLE
Activate new current tab

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -112,9 +112,10 @@ const main: JupyterFrontEndPlugin<void> = {
       app.commands.notifyCommandChanged();
     });
 
-    // when current tab changes, make sure it is activated
+    // when current tab changes, activate the new current tab
+    // if there isn't an active tab
     app.shell.currentChanged.connect((sender, args) => {
-      if (args.newValue) {
+      if (!app.shell.activeWidget && args.newValue) {
         app.shell.activateById(args.newValue.id);
       }
     });

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -112,6 +112,13 @@ const main: JupyterFrontEndPlugin<void> = {
       app.commands.notifyCommandChanged();
     });
 
+    // when current tab changes, make sure it is activated
+    app.shell.currentChanged.connect((sender, args) => {
+      if (args.newValue) {
+        app.shell.activateById(args.newValue.id);
+      }
+    });
+
     // If the connection to the server is lost, handle it with the
     // connection lost handler.
     connectionLost = connectionLost || ConnectionLost;

--- a/packages/tabmanager-extension/src/index.ts
+++ b/packages/tabmanager-extension/src/index.ts
@@ -64,13 +64,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
         labShell.layoutModified.connect(() => {
           populate();
         });
-
-        // when current tab changes, make sure it is activated
-        labShell.currentChanged.connect((sender, args) => {
-          if (args.newValue) {
-            shell.activateById(args.newValue.id);
-          }
-        });
       }
 
       // Populate the tab manager.

--- a/packages/tabmanager-extension/src/index.ts
+++ b/packages/tabmanager-extension/src/index.ts
@@ -64,6 +64,13 @@ const plugin: JupyterFrontEndPlugin<void> = {
         labShell.layoutModified.connect(() => {
           populate();
         });
+
+        // when current tab changes, make sure it is activated
+        labShell.currentChanged.connect((sender, args) => {
+          if (args.newValue) {
+            shell.activateById(args.newValue.id);
+          }
+        });
       }
 
       // Populate the tab manager.


### PR DESCRIPTION
fixes #6648 

This fixes the issue when current tab and active widget mismatch after closing a tab using keyboard shortcut [Alt W]. It is done by explicitly activating new current tab.