### PR TITLE
Added hash to the csv delimiter types

### DIFF
--- a/packages/csvviewer/src/toolbar.ts
+++ b/packages/csvviewer/src/toolbar.ts
@@ -14,12 +14,12 @@ import { Styling } from '@jupyterlab/apputils';
 /**
  * The supported parsing delimiters.
  */
-const DELIMITERS = [',', ';', '\t', '|'];
+const DELIMITERS = [',', ';', '\t', '|', '#'];
 
 /**
  * The labels for each delimiter as they appear in the dropdown menu.
  */
-const LABELS = [',', ';', 'tab', 'pipe'];
+const LABELS = [',', ';', 'tab', 'pipe', 'hash'];
 
 /**
  * The class name added to a csv toolbar widget.


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/6324

## Code changes

Updated toolbar.js to add '#' as a possible combination.

## User-facing changes

Users can select hash as a possible delimiter.

![image](https://user-images.githubusercontent.com/1458980/66832776-df106700-ef5a-11e9-8eb1-e19b9c1d3ed3.png)

## Backwards-incompatible changes

None.
