### PR TITLE
Add missing import to commands.py

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -29,7 +29,7 @@ from notebook.nbextensions import GREEN_ENABLED, GREEN_OK, RED_DISABLED, RED_X
 
 from .semver import Range, gte, lt, lte, gt, make_semver
 from .jlpmapp import YARN_PATH, HERE
-from .coreconfig import _get_default_core_data
+from .coreconfig import _get_default_core_data, CoreConfig
 
 
 # The regex for expecting the webpack output.


### PR DESCRIPTION
## References

Fixes #7353 on 1.1.x branch.

This is fixed on master via https://github.com/jupyterlab/jupyterlab/pull/7079, which should not be backported in its entirety.

## Code changes

Adds missing import that was only hit when the node check failed.

## User-facing changes

Cleaner error if node version is unsupported.

## Backwards-incompatible changes

None.
