### PR TITLE
documentation update: better overview about contributing

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -1,5 +1,14 @@
+Contributing to JupyterLab
+--------------------------
+
+This page provides general information about contributing to the project.
+
+.. contents:: Table of contents
+    :local:
+    :depth: 1
+
 Writing Documentation
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 This section provides information about writing documentation for JupyterLab.
 See  our  `Contributor
@@ -7,7 +16,7 @@ Guide <https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`_ f
 details on installation and testing.
 
 Writing Style
-~~~~~~~~~~~~~
+'''''''''''''
 
 -  The documentation should be written in the second person, referring
    to the reader as "you" and not using the first person plural "we."

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,11 +52,11 @@ JupyterLab is the next-generation web-based user interface for Project Jupyter. 
    developer/repo
    developer/extension_dev
    developer/extension_points
+   developer/contributing
    developer/documents
    developer/notebook
    developer/patterns
    developer/css
-   developer/documentation
    developer/virtualdom
    developer/examples
    developer/ui_helpers


### PR DESCRIPTION
Changes:
1. "Writing Documentation" is now "Contributing to JupyterLab"
2. There is table of contents in the page
3. "Writing Documentation" is a sub-point of "Contributing to JupyterLab"

Main issue: https://github.com/jupyterlab/jupyterlab/issues/7345#issuecomment-542733926
General documentation issue: https://github.com/jupyterlab/jupyterlab/issues/7273#issuecomment-541322516

**Screenshots**:

![image](https://user-images.githubusercontent.com/7236157/66947392-18c49900-f053-11e9-8636-76fdc16bf407.png)

![image](https://user-images.githubusercontent.com/7236157/66947409-211cd400-f053-11e9-9349-85de84d5810c.png)
