### PR TITLE
Allow main app plugin to work without palette

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -572,9 +572,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       shell.activateNextTab();
     }
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.activateNextTab, category });
-  }
 
   commands.addCommand(CommandIDs.activatePreviousTab, {
     label: 'Activate Previous Tab',
@@ -582,9 +579,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       shell.activatePreviousTab();
     }
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.activatePreviousTab, category });
-  }
 
   commands.addCommand(CommandIDs.activateNextTabBar, {
     label: 'Activate Next Tab Bar',
@@ -592,9 +586,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       shell.activateNextTabBar();
     }
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.activateNextTabBar, category });
-  }
 
   commands.addCommand(CommandIDs.activatePreviousTabBar, {
     label: 'Activate Previous Tab Bar',
@@ -602,9 +593,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       shell.activatePreviousTabBar();
     }
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.activatePreviousTabBar, category });
-  }
 
   // A CSS selector targeting tabs in the main area. This is a very
   // specific selector since we really only want tabs that are
@@ -622,9 +610,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       }
     }
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.close, category });
-  }
   contextMenu.addItem({
     command: CommandIDs.close,
     selector: tabSelector,
@@ -637,9 +622,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       shell.closeAll();
     }
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.closeAll, category });
-  }
 
   commands.addCommand(CommandIDs.closeOtherTabs, {
     label: () => `Close All Other Tabs`,
@@ -660,9 +642,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       closeWidgets(otherWidgets);
     }
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.closeOtherTabs, category });
-  }
   contextMenu.addItem({
     command: CommandIDs.closeOtherTabs,
     selector: tabSelector,
@@ -681,9 +660,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       closeWidgets(widgetsRightOf(widget));
     }
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.closeRightTabs, category });
-  }
   contextMenu.addItem({
     command: CommandIDs.closeRightTabs,
     selector: tabSelector,
@@ -705,9 +681,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
     isToggled: () => !shell.leftCollapsed,
     isVisible: () => !shell.isEmpty('left')
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.toggleLeftArea, category });
-  }
 
   app.commands.addCommand(CommandIDs.toggleRightArea, {
     label: () => 'Show Right Sidebar',
@@ -724,9 +697,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
     isToggled: () => !shell.rightCollapsed,
     isVisible: () => !shell.isEmpty('right')
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.toggleRightArea, category });
-  }
 
   app.commands.addCommand(CommandIDs.togglePresentationMode, {
     label: () => 'Presentation Mode',
@@ -736,9 +706,6 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
     isToggled: () => shell.presentationMode,
     isVisible: () => true
   });
-  if (palette) {
-    palette.addItem({ command: CommandIDs.togglePresentationMode, category });
-  }
 
   app.commands.addCommand(CommandIDs.setMode, {
     isVisible: args => {
@@ -766,7 +733,19 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       return app.commands.execute(CommandIDs.setMode, args);
     }
   });
+
   if (palette) {
+    palette.addItem({ command: CommandIDs.activateNextTab, category });
+    palette.addItem({ command: CommandIDs.activatePreviousTab, category });
+    palette.addItem({ command: CommandIDs.activateNextTabBar, category });
+    palette.addItem({ command: CommandIDs.activatePreviousTabBar, category });
+    palette.addItem({ command: CommandIDs.close, category });
+    palette.addItem({ command: CommandIDs.closeAll, category });
+    palette.addItem({ command: CommandIDs.closeOtherTabs, category });
+    palette.addItem({ command: CommandIDs.closeRightTabs, category });
+    palette.addItem({ command: CommandIDs.toggleLeftArea, category });
+    palette.addItem({ command: CommandIDs.toggleRightArea, category });
+    palette.addItem({ command: CommandIDs.togglePresentationMode, category });
     palette.addItem({ command: CommandIDs.toggleMode, category });
   }
 }

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -90,14 +90,14 @@ namespace CommandIDs {
  */
 const main: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/application-extension:main',
-  requires: [ICommandPalette, IRouter, IWindowResolver],
-  optional: [IConnectionLost],
+  requires: [IRouter, IWindowResolver],
+  optional: [ICommandPalette, IConnectionLost],
   activate: (
     app: JupyterFrontEnd,
-    palette: ICommandPalette,
     router: IRouter,
     resolver: IWindowResolver,
-    connectionLost: IConnectionLost | undefined
+    palette: ICommandPalette | null,
+    connectionLost: IConnectionLost | null
   ) => {
     if (!(app instanceof JupyterLab)) {
       throw new Error(`${main.id} must be activated in JupyterLab.`);
@@ -486,7 +486,7 @@ const sidebar: JupyterFrontEndPlugin<void> = {
 /**
  * Add the main application commands.
  */
-function addCommands(app: JupyterLab, palette: ICommandPalette): void {
+function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
   const { commands, contextMenu, shell } = app;
   const category = 'Main Area';
 
@@ -572,7 +572,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
       shell.activateNextTab();
     }
   });
-  palette.addItem({ command: CommandIDs.activateNextTab, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.activateNextTab, category });
+  }
 
   commands.addCommand(CommandIDs.activatePreviousTab, {
     label: 'Activate Previous Tab',
@@ -580,7 +582,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
       shell.activatePreviousTab();
     }
   });
-  palette.addItem({ command: CommandIDs.activatePreviousTab, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.activatePreviousTab, category });
+  }
 
   commands.addCommand(CommandIDs.activateNextTabBar, {
     label: 'Activate Next Tab Bar',
@@ -614,7 +618,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
       }
     }
   });
-  palette.addItem({ command: CommandIDs.close, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.close, category });
+  }
   contextMenu.addItem({
     command: CommandIDs.close,
     selector: tabSelector,
@@ -627,7 +633,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
       shell.closeAll();
     }
   });
-  palette.addItem({ command: CommandIDs.closeAll, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.closeAll, category });
+  }
 
   commands.addCommand(CommandIDs.closeOtherTabs, {
     label: () => `Close All Other Tabs`,
@@ -648,7 +656,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
       closeWidgets(otherWidgets);
     }
   });
-  palette.addItem({ command: CommandIDs.closeOtherTabs, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.closeOtherTabs, category });
+  }
   contextMenu.addItem({
     command: CommandIDs.closeOtherTabs,
     selector: tabSelector,
@@ -667,7 +677,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
       closeWidgets(widgetsRightOf(widget));
     }
   });
-  palette.addItem({ command: CommandIDs.closeRightTabs, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.closeRightTabs, category });
+  }
   contextMenu.addItem({
     command: CommandIDs.closeRightTabs,
     selector: tabSelector,
@@ -689,7 +701,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     isToggled: () => !shell.leftCollapsed,
     isVisible: () => !shell.isEmpty('left')
   });
-  palette.addItem({ command: CommandIDs.toggleLeftArea, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.toggleLeftArea, category });
+  }
 
   app.commands.addCommand(CommandIDs.toggleRightArea, {
     label: () => 'Show Right Sidebar',
@@ -706,7 +720,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     isToggled: () => !shell.rightCollapsed,
     isVisible: () => !shell.isEmpty('right')
   });
-  palette.addItem({ command: CommandIDs.toggleRightArea, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.toggleRightArea, category });
+  }
 
   app.commands.addCommand(CommandIDs.togglePresentationMode, {
     label: () => 'Presentation Mode',
@@ -716,7 +732,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     isToggled: () => shell.presentationMode,
     isVisible: () => true
   });
-  palette.addItem({ command: CommandIDs.togglePresentationMode, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.togglePresentationMode, category });
+  }
 
   app.commands.addCommand(CommandIDs.setMode, {
     isVisible: args => {
@@ -744,7 +762,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
       return app.commands.execute(CommandIDs.setMode, args);
     }
   });
-  palette.addItem({ command: CommandIDs.toggleMode, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.toggleMode, category });
+  }
 }
 
 /**

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -592,7 +592,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       shell.activateNextTabBar();
     }
   });
-  palette.addItem({ command: CommandIDs.activateNextTabBar, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.activateNextTabBar, category });
+  }
 
   commands.addCommand(CommandIDs.activatePreviousTabBar, {
     label: 'Activate Previous Tab Bar',
@@ -600,7 +602,9 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
       shell.activatePreviousTabBar();
     }
   });
-  palette.addItem({ command: CommandIDs.activatePreviousTabBar, category });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.activatePreviousTabBar, category });
+  }
 
   // A CSS selector targeting tabs in the main area. This is a very
   // specific selector since we really only want tabs that are

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -104,7 +104,13 @@ const tracker: JupyterFrontEndPlugin<IConsoleTracker> = {
     IRenderMimeRegistry,
     ISettingRegistry
   ],
-  optional: [IMainMenu, ICommandPalette, ILauncher, ILabStatus, ISessionContextDialogs],
+  optional: [
+    IMainMenu,
+    ICommandPalette,
+    ILauncher,
+    ILabStatus,
+    ISessionContextDialogs
+  ],
   activate: activateConsole,
   autoStart: true
 };
@@ -650,7 +656,7 @@ async function activateConsole(
     // Add kernel information to the application help menu.
     mainMenu.helpMenu.kernelUsers.add({
       tracker,
-    getKernel: current => current.sessionContext.session?.kernel
+      getKernel: current => current.sessionContext.session?.kernel
     } as IHelpMenu.IKernelUser<ConsolePanel>);
   }
 

--- a/packages/hub-extension/src/index.ts
+++ b/packages/hub-extension/src/index.ts
@@ -36,7 +36,7 @@ function activateHubExtension(
   app: JupyterFrontEnd,
   paths: JupyterFrontEnd.IPaths,
   palette: ICommandPalette | null,
-  mainMenu: IMainMenu | null,
+  mainMenu: IMainMenu | null
 ): void {
   const hubHost = paths.urls.hubHost || '';
   const hubPrefix = paths.urls.hubPrefix || '';

--- a/packages/hub-extension/src/index.ts
+++ b/packages/hub-extension/src/index.ts
@@ -35,8 +35,8 @@ export namespace CommandIDs {
 function activateHubExtension(
   app: JupyterFrontEnd,
   paths: JupyterFrontEnd.IPaths,
-  palette: ICommandPalette,
-  mainMenu: IMainMenu
+  palette: ICommandPalette | null,
+  mainMenu: IMainMenu | null,
 ): void {
   const hubHost = paths.urls.hubHost || '';
   const hubPrefix = paths.urls.hubPrefix || '';
@@ -85,14 +85,18 @@ function activateHubExtension(
     }
   });
 
-  // Add commands and menu itmes.
-  mainMenu.fileMenu.addGroup(
-    [{ command: CommandIDs.controlPanel }, { command: CommandIDs.logout }],
-    100
-  );
-  const category = 'Hub';
-  palette.addItem({ category, command: CommandIDs.controlPanel });
-  palette.addItem({ category, command: CommandIDs.logout });
+  // Add palette and menu itmes.
+  if (mainMenu) {
+    mainMenu.fileMenu.addGroup(
+      [{ command: CommandIDs.controlPanel }, { command: CommandIDs.logout }],
+      100
+    );
+  }
+  if (palette) {
+    const category = 'Hub';
+    palette.addItem({ category, command: CommandIDs.controlPanel });
+    palette.addItem({ category, command: CommandIDs.logout });
+  }
 }
 
 /**
@@ -101,7 +105,8 @@ function activateHubExtension(
 const hubExtension: JupyterFrontEndPlugin<void> = {
   activate: activateHubExtension,
   id: 'jupyter.extensions.hub-extension',
-  requires: [JupyterFrontEnd.IPaths, ICommandPalette, IMainMenu],
+  requires: [JupyterFrontEnd.IPaths],
+  optional: [ICommandPalette, IMainMenu],
   autoStart: true
 };
 

--- a/packages/launcher-extension/src/index.ts
+++ b/packages/launcher-extension/src/index.ts
@@ -27,7 +27,8 @@ namespace CommandIDs {
 const plugin: JupyterFrontEndPlugin<ILauncher> = {
   activate,
   id: '@jupyterlab/launcher-extension:plugin',
-  requires: [ICommandPalette, ILabShell],
+  requires: [ILabShell],
+  optional: [ICommandPalette],
   provides: ILauncher,
   autoStart: true
 };
@@ -42,8 +43,8 @@ export default plugin;
  */
 function activate(
   app: JupyterFrontEnd,
-  palette: ICommandPalette,
-  labShell: ILabShell
+  labShell: ILabShell,
+  palette: ICommandPalette | null
 ): ILauncher {
   const { commands } = app;
   const model = new LauncherModel();
@@ -79,7 +80,9 @@ function activate(
     }
   });
 
-  palette.addItem({ command: CommandIDs.create, category: 'Launcher' });
+  if (palette) {
+    palette.addItem({ command: CommandIDs.create, category: 'Launcher' });
+  }
 
   return model;
 }

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -116,13 +116,13 @@ export namespace CommandIDs {
  */
 const plugin: JupyterFrontEndPlugin<IMainMenu> = {
   id: '@jupyterlab/mainmenu-extension:plugin',
-  requires: [ICommandPalette, IRouter],
-  optional: [ILabShell],
+  requires: [IRouter],
+  optional: [ICommandPalette, ILabShell],
   provides: IMainMenu,
   activate: (
     app: JupyterFrontEnd,
-    palette: ICommandPalette,
     router: IRouter,
+    palette: ICommandPalette | null,
     labShell: ILabShell | null
   ): IMainMenu => {
     const { commands } = app;
@@ -203,27 +203,29 @@ const plugin: JupyterFrontEndPlugin<IMainMenu> = {
       }
     });
 
-    // Add some of the commands defined here to the command palette.
-    if (menu.fileMenu.quitEntry) {
+    if (palette) {
+      // Add some of the commands defined here to the command palette.
+      if (menu.fileMenu.quitEntry) {
+        palette.addItem({
+          command: CommandIDs.shutdown,
+          category: 'Main Area'
+        });
+        palette.addItem({
+          command: CommandIDs.logout,
+          category: 'Main Area'
+        });
+      }
+
       palette.addItem({
-        command: CommandIDs.shutdown,
-        category: 'Main Area'
+        command: CommandIDs.shutdownAllKernels,
+        category: 'Kernel Operations'
       });
+
       palette.addItem({
-        command: CommandIDs.logout,
+        command: CommandIDs.activatePreviouslyUsedTab,
         category: 'Main Area'
       });
     }
-
-    palette.addItem({
-      command: CommandIDs.shutdownAllKernels,
-      category: 'Kernel Operations'
-    });
-
-    palette.addItem({
-      command: CommandIDs.activatePreviouslyUsedTab,
-      category: 'Main Area'
-    });
 
     app.shell.add(logo, 'top');
     app.shell.add(menu, 'top');

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -46,10 +46,10 @@ const plugin: JupyterFrontEndPlugin<ISettingEditorTracker> = {
     ISettingRegistry,
     IEditorServices,
     IStateDB,
-    IRenderMimeRegistry,
-    ICommandPalette,
+    IRenderMimeRegistry
     ILabStatus
   ],
+  optional: [ICommandPalette],
   autoStart: true,
   provides: ISettingEditorTracker,
   activate
@@ -65,8 +65,8 @@ function activate(
   editorServices: IEditorServices,
   state: IStateDB,
   rendermime: IRenderMimeRegistry,
-  palette: ICommandPalette,
   status: ILabStatus
+  palette: ICommandPalette | null
 ): ISettingEditorTracker {
   const { commands, shell } = app;
   const namespace = 'setting-editor';
@@ -141,7 +141,9 @@ function activate(
     },
     label: 'Advanced Settings Editor'
   });
-  palette.addItem({ category: 'Settings', command: CommandIDs.open });
+  if (palette) {
+    palette.addItem({ category: 'Settings', command: CommandIDs.open });
+  }
 
   commands.addCommand(CommandIDs.revert, {
     execute: () => {

--- a/packages/settingeditor-extension/src/index.ts
+++ b/packages/settingeditor-extension/src/index.ts
@@ -46,7 +46,7 @@ const plugin: JupyterFrontEndPlugin<ISettingEditorTracker> = {
     ISettingRegistry,
     IEditorServices,
     IStateDB,
-    IRenderMimeRegistry
+    IRenderMimeRegistry,
     ILabStatus
   ],
   optional: [ICommandPalette],
@@ -65,7 +65,7 @@ function activate(
   editorServices: IEditorServices,
   state: IStateDB,
   rendermime: IRenderMimeRegistry,
-  status: ILabStatus
+  status: ILabStatus,
   palette: ICommandPalette | null
 ): ISettingEditorTracker {
   const { commands, shell } = app;


### PR DESCRIPTION
## Code changes

Changes the dependency of various plugins on the Command palette from `required` to `optional`.

## User-facing changes

Users can now disable the command palette without causing other core plugins to fail to activate.

## Backwards-incompatible changes

Some of the plugins' `activate` function changes signature. This should *probably* be considered backwards incompatible, but *could* be considered non-breaking as well if we insist on the signature being dynamically defined by the required/optional keys.
