### PR TITLE
Makes index template more extensible

### DIFF
--- a/dev_mode/templates/insert-body.html
+++ b/dev_mode/templates/insert-body.html
@@ -1,0 +1,31 @@
+{% block bodyContent %}
+
+<script type="text/javascript">
+  /* Remove token from URL. */
+  (function () {
+    var location = window.location;
+    var search = location.search;
+
+    // If there is no query string, bail.
+    if (search.length <= 1) {
+      return;
+    }
+
+    // Rebuild the query string without the `token`.
+    var query = '?' + search.slice(1).split('&')
+      .filter(function (param) { return param.split('=')[0] !== 'token'; })
+      .join('&');
+
+    // Rebuild the URL with the new query string.
+    var url = location.origin + location.pathname +
+      (query !== '?' ? query : '') + location.hash;
+
+    if (url === location.href) {
+      return;
+    }
+
+    window.history.replaceState({ }, '', url);
+  })();
+</script>
+
+{% endblock %}

--- a/dev_mode/templates/partial.html
+++ b/dev_mode/templates/partial.html
@@ -1,14 +1,20 @@
-{# Copy so we do not modify the page_config with updates. #}
-{% set page_config_full = page_config.copy() %}
+  {# Copy so we do not modify the page_config with updates. #}
+  {% set page_config_full = page_config.copy() %}
 
-{# Set a dummy variable - we just want the side effect of the update. #}
-{% set _ = page_config_full.update(baseUrl=base_url, wsUrl=ws_url) %}
+  {# Set a dummy variable - we just want the side effect of the update. #}
+  {% set _ = page_config_full.update(baseUrl=base_url, wsUrl=ws_url) %}
 
+  {% block header}
+
+  {% block page-config}
   <script id="jupyter-config-data" type="application/json">
     {{ page_config_full | tojson }}
   </script>
+  {% endblock %}
 
   {% block favicon %}
   <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/base/images/favicon.ico" class="idle favicon">
   <link rel="" type="image/x-icon" href="{{ base_url | escape }}static/base/images/favicon-busy-1.ico" class="busy favicon">
+  {% endblock %}
+
   {% endblock %}

--- a/dev_mode/templates/template.html
+++ b/dev_mode/templates/template.html
@@ -8,33 +8,7 @@
 </head>
 <body>
 
-<script type="text/javascript">
-  /* Remove token from URL. */
-  (function () {
-    var location = window.location;
-    var search = location.search;
-
-    // If there is no query string, bail.
-    if (search.length <= 1) {
-      return;
-    }
-
-    // Rebuild the query string without the `token`.
-    var query = '?' + search.slice(1).split('&')
-      .filter(function (param) { return param.split('=')[0] !== 'token'; })
-      .join('&');
-
-    // Rebuild the URL with the new query string.
-    var url = location.origin + location.pathname +
-      (query !== '?' ? query : '') + location.hash;
-
-    if (url === location.href) {
-      return;
-    }
-
-    window.history.replaceState({ }, '', url);
-  })();
-</script>
+<%= require('html-loader!./insert-body.html') %>
 
 </body>
 </html>


### PR DESCRIPTION
## Code changes

Adds more jinja2 `blocks` to the application index template, so that it is easier to extend it. Currently the mix of Jinja2 and the webpack html plugin makes things hard to extend. This should make it easier to extend the main template.

## User-facing changes

None, the resulting output from Jinja2 should be the same as before unless explicitly extended.


## Backwards-incompatible changes

None, the resulting output from Jinja2 should be the same as before unless explicitly extended.
