### PR TITLE
Fixed Multicursor backspacing

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1361,7 +1361,7 @@ namespace Private {
    */
   export function delSpaceToPrevTabStop(cm: CodeMirror.Editor): void {
     let doc = cm.getDoc();
-    var tabSize = doc.getOption('indentUnit');
+    var tabSize = cm.getOption('indentUnit');
     var ranges = doc.listSelections(); // handle multicursor
     for (var i = ranges.length - 1; i >= 0; i--) {
       // iterate reverse so any deletions don't overlap
@@ -1377,11 +1377,11 @@ namespace Private {
         if (line.match(/^\ +$/) !== null) {
           // delete tabs
           var prevTabStop = (Math.ceil(head.ch / tabSize) - 1) * tabSize;
-          var from = CodeMirror.Position(head.line, prevTabStop);
+          var from = CodeMirror.Pos(head.line, prevTabStop);
           doc.replaceRange('', from, head);
         } else {
           // delete non-tabs
-          var from = CodeMirror.Position(head.line, head.ch - 1);
+          var from = CodeMirror.Pos(head.line, head.ch - 1);
           doc.replaceRange('', from, head);
         }
       }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1361,34 +1361,34 @@ namespace Private {
    */
   export function delSpaceToPrevTabStop(cm: CodeMirror.Editor): void {
     let doc = cm.getDoc();
-    var tabSize = cm.getOption('indentUnit');
-    var ranges = doc.listSelections(); // handle multicursor
-    for (var i = ranges.length - 1; i >= 0; i--) {
+    let tabSize = cm.getOption('indentUnit');
+    let ranges = doc.listSelections(); // handle multicursor
+    for (let i = ranges.length - 1; i >= 0; i--) {
       // iterate reverse so any deletions don't overlap
-      var head = ranges[i].head;
-      var anchor = ranges[i].anchor;
-      var isSelection = !posEq(head, anchor);
+      let head = ranges[i].head;
+      let anchor = ranges[i].anchor;
+      let isSelection = !posEq(head, anchor);
       if (isSelection) {
         doc.replaceRange('', anchor, head);
       } else {
-        var line = doc.getLine(head.line).substring(0, head.ch);
+        let line = doc.getLine(head.line).substring(0, head.ch);
         if (line.match(/^\ +$/) !== null) {
           // delete tabs
-          var prevTabStop = (Math.ceil(head.ch / tabSize) - 1) * tabSize;
-          var from = CodeMirror.Pos(head.line, prevTabStop);
+          let prevTabStop = (Math.ceil(head.ch / tabSize) - 1) * tabSize;
+          let from = CodeMirror.Pos(head.line, prevTabStop);
           doc.replaceRange('', from, head);
         } else {
           // delete non-tabs
-          if (head.ch == 0) {
-            if (head.line != 0) {
-              var from = CodeMirror.Pos(
+          if (head.ch === 0) {
+            if (head.line !== 0) {
+              let from = CodeMirror.Pos(
                 head.line - 1,
                 doc.getLine(head.line - 1).length
               );
               doc.replaceRange('', from, head);
             }
           } else {
-            var from = CodeMirror.Pos(head.line, head.ch - 1);
+            let from = CodeMirror.Pos(head.line, head.ch - 1);
             doc.replaceRange('', from, head);
           }
         }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1379,8 +1379,18 @@ namespace Private {
           doc.replaceRange('', from, head);
         } else {
           // delete non-tabs
-          var from = CodeMirror.Pos(head.line, head.ch - 1);
-          doc.replaceRange('', from, head);
+          if (head.ch == 0) {
+            if (head.line != 0) {
+              var from = CodeMirror.Pos(
+                head.line - 1,
+                doc.getLine(head.line - 1).length
+              );
+              doc.replaceRange('', from, head);
+            }
+          } else {
+            var from = CodeMirror.Pos(head.line, head.ch - 1);
+            doc.replaceRange('', from, head);
+          }
         }
       }
     }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1367,12 +1367,10 @@ namespace Private {
       // iterate reverse so any deletions don't overlap
       var head = ranges[i].head;
       var anchor = ranges[i].anchor;
-      var sel = !posEq(head, anchor);
-      if (sel) {
-        // range is selection
+      var isSelection = !posEq(head, anchor);
+      if (isSelection) {
         doc.replaceRange('', anchor, head);
       } else {
-        // range is cursor
         var line = doc.getLine(head.line).substring(0, head.ch);
         if (line.match(/^\ +$/) !== null) {
           // delete tabs


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

fixes #7205

Other references:
https://github.com/jupyter/notebook/pull/4880
https://github.com/jupyter/notebook/issues/4796
## Code changes

Iterates through selections, and handle backspacing appropriately. There are three cases: 
 1. Selection
    - Delete everything in selection
 2. Leading spaces
    - Delete to previous indentation
 3. Other
    - Delete previous character

3\. Can be broken down into the cases of the beginning of the line too, but they behave as you would expect

This solution is similar but not exactly the same as for the same problem in jupyter notebook https://github.com/jupyter/notebook/pull/4880

## User-facing changes

Basically, backspacing when using multicursor works as expected now whereas before it didn't handle tabs correctly.

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
