### PR TITLE
Remove unused IRouter dependency from the hub extension

### DIFF
--- a/packages/hub-extension/src/index.ts
+++ b/packages/hub-extension/src/index.ts
@@ -8,7 +8,6 @@ import { Dialog, ICommandPalette, showDialog } from '@jupyterlab/apputils';
 import {
   ConnectionLost,
   IConnectionLost,
-  IRouter,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
@@ -35,7 +34,6 @@ export namespace CommandIDs {
  */
 function activateHubExtension(
   app: JupyterFrontEnd,
-  router: IRouter,
   paths: JupyterFrontEnd.IPaths,
   palette: ICommandPalette,
   mainMenu: IMainMenu
@@ -103,7 +101,7 @@ function activateHubExtension(
 const hubExtension: JupyterFrontEndPlugin<void> = {
   activate: activateHubExtension,
   id: 'jupyter.extensions.hub-extension',
-  requires: [IRouter, JupyterFrontEnd.IPaths, ICommandPalette, IMainMenu],
+  requires: [JupyterFrontEnd.IPaths, ICommandPalette, IMainMenu],
   autoStart: true
 };
 


### PR DESCRIPTION
## Code changes

Removed the dependency on `IRouter` for the hub extension as it doesn't appear to be used.

## User-facing changes

None

## Backwards-incompatible changes

None
