### PR TITLE
[datastore] collaboration id may include slash

### DIFF
--- a/jupyterlab/datastore/handler.py
+++ b/jupyterlab/datastore/handler.py
@@ -286,5 +286,5 @@ class CollaborationHandler(WSBaseHandler):
 
 # The path for lab build.
 # TODO: Is this a reasonable path?
-collaboration_path = r"/lab/api/datastore/(?P<collaboration_id>(?:(?:[^/]+)+|/?))"
+collaboration_path = r"/lab/api/datastore/(?P<collaboration_id>.+)(?:[^/])/?"
 datastore_rest_path = r"/lab/api/datastore/?"


### PR DESCRIPTION
since it is now the document path


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

contributing to wip pr for RTC #6871

## Code changes

Fixes collaboration-path url pattern to allow `/` in the collaboration id. This is needed because the collaboration id is currently set as the document path, which can be in a subdirectory.

## User-facing changes

Files in subdirectories can now be opened, instead of opening and closing immediately due to an error opening the collaboration websocket, caused by the fact that the collaboration URL was not being handled by the CollaborationHandler, due to the mismatch in the pattern.