### PR TITLE
Search installed extensions

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -1009,13 +1009,13 @@ risks or contain malicious code that runs on your machine.`)}
   }
 
   /**
-   * Handle the DOM events for the command palette.
+   * Handle the DOM events for the extension manager search bar.
    *
-   * @param event - The DOM event sent to the command palette.
+   * @param event - The DOM event sent to the extension manager search bar.
    *
    * #### Notes
    * This method implements the DOM `EventListener` interface and is
-   * called in response to events on the command palette's DOM node.
+   * called in response to events on the search bar's DOM node.
    * It should not be called directly by user code.
    */
   handleEvent(event: Event): void {

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -867,7 +867,13 @@ risks or contain malicious code that runs on your machine.`)}
             key="installed-items"
             listMode={model.listMode}
             viewType={'installed'}
-            entries={model.installed}
+            entries={
+              model.searchResult.length > 0
+                ? model.installed.filter(
+                    entry => model.searchResult.indexOf(entry) > -1
+                  )
+                : model.installed
+            }
             numPages={1}
             translator={this.translator}
             onPage={value => {


### PR DESCRIPTION
## References

Is feels more natural to be able to use the same search bar to search for installed extensions. Especially when a lot of third-party extensions are installed.

This makes it easier to disable an installed extension for instance.

## Code changes

Use the `searchResult` array to also search for installed extensions.

## User-facing changes

### Before

![no-search-installed-extensions](https://user-images.githubusercontent.com/591645/67633294-802de480-f8ae-11e9-8c8f-5fd7212e0b7e.gif)

### After

![search-installed-extensions](https://user-images.githubusercontent.com/591645/67633296-8328d500-f8ae-11e9-8b41-388556ce95e0.gif)

### Note

If there is no search result (for example no internet connection), all the installed extensions will be shown.

## Backwards-incompatible changes

None
