### PR TITLE
[datastore] fix inverted history replay condition

### DIFF
--- a/packages/datastore/src/client.ts
+++ b/packages/datastore/src/client.ts
@@ -118,7 +118,7 @@ export class CollaborationClient extends WSConnection<
       checkpointId: checkpointId === undefined ? null : checkpointId
     });
     const response = await this._requestMessageReply(msg);
-    if (response.content.transactions.length) {
+    if (!response.content.transactions.length) {
       return false;
     }
     this._handleTransactions(response.content.transactions);


### PR DESCRIPTION
condition for whether history needed replaying was inverted, causing history to be replayed only if it is empty, rather than when there was history to replay.

This fixes most of the issues I was having with testing RTC, which were apparently down to incorrect initial state.

for #6871