### PR TITLE
Show kernel name for slow-starting kernel

### DIFF
--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -342,6 +342,9 @@ export class ClientSession implements IClientSession {
   get kernelDisplayName(): string {
     let kernel = this.kernel;
     if (!kernel) {
+      if (this._pendingKernel) {
+        return this._pendingKernel;
+      }
       return 'No Kernel!';
     }
     let specs = this.manager.specs;
@@ -586,6 +589,7 @@ export class ClientSession implements IClientSession {
     }
     let session = this._session;
     if (session && session.status !== 'dead') {
+      this._pendingKernel = options.name || '';
       return session.changeKernel(options).catch(err => {
         void this._handleSessionError(err);
         return Promise.reject(err);
@@ -644,6 +648,7 @@ export class ClientSession implements IClientSession {
     if (this.isDisposed) {
       return Promise.reject('Session is disposed.');
     }
+    this._pendingKernel = model ? model.name : '';
     return this.manager
       .startNew({
         path: this._path,
@@ -772,6 +777,7 @@ export class ClientSession implements IClientSession {
     args: Session.IKernelChangedArgs
   ): void {
     this._kernelChanged.emit(args);
+    this._pendingKernel = '';
   }
 
   /**
@@ -836,6 +842,7 @@ export class ClientSession implements IClientSession {
   private _dialog: Dialog<any> | null = null;
   private _setBusy: () => IDisposable | undefined;
   private _busyDisposable: IDisposable | null = null;
+  private _pendingKernel = '';
 }
 
 /**

--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -343,7 +343,7 @@ export class ClientSession implements IClientSession {
     let kernel = this.kernel;
     if (!kernel) {
       if (this._pendingKernel) {
-        return this._pendingKernel;
+        return `Starting... ${this._pendingKernel}`;
       }
       return 'No Kernel!';
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Partially addresses #6007 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Adds a private variable to the client session to track a pending kernel name and displays that name if the kernel is not yet connected.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
The user sees the name of the kernel during startup instead of "No Kernel!".
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
