### PR TITLE
[datastore] fix return for merged streams

### DIFF
--- a/packages/outputarea/src/data.ts
+++ b/packages/outputarea/src/data.ts
@@ -251,8 +251,8 @@ export namespace OutputAreaData {
           );
           value.text = lastValue.text;
           OutputModel.fromJSON(outputData, value, trusted);
+          return;
         }
-        return;
       }
 
       if (nbformat.isStream(value)) {


### PR DESCRIPTION
return was at the wrong scope (`if list.length` instead of `if list.length && isStream...`), preventing display of outputs after the first.


for #6871