### PR TITLE
fixes logconsole icon by fixing the icon name

### DIFF
--- a/packages/logconsole-extension/schema/plugin.json
+++ b/packages/logconsole-extension/schema/plugin.json
@@ -1,5 +1,5 @@
 {
-  "jupyter.lab.setting-icon-class": "jp-SettingsIcon",
+  "jupyter.lab.setting-icon-class": "jp-ListIcon",
   "jupyter.lab.setting-icon-label": "Log Console",
   "title": "Log Console",
   "description": "Log Console settings.",

--- a/packages/logconsole-extension/src/index.tsx
+++ b/packages/logconsole-extension/src/index.tsx
@@ -143,7 +143,7 @@ function activateLogConsole(
     logConsoleWidget.addClass('jp-LogConsole');
     logConsoleWidget.title.closable = true;
     logConsoleWidget.title.label = 'Log Console';
-    logConsoleWidget.title.iconClass = 'jp-LogConsoleIcon';
+    logConsoleWidget.title.iconClass = 'jp-ListIcon';
 
     const addCheckpointButton = new CommandToolbarButton({
       commands: app.commands,

--- a/packages/logconsole-extension/style/base.css
+++ b/packages/logconsole-extension/style/base.css
@@ -3,10 +3,6 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-LogConsoleIcon {
-  background-image: var(--jp-icon-list);
-}
-
 @keyframes flash {
   0% {
     background-color: var(--jp-brand-color1);


### PR DESCRIPTION
## References

fixes #7397

## Code changes

Changes the name of the logconsole icon to match that of the source `.svg` file.

## User-facing changes

Logconsole icon now has correct appearance in tabs and settings editor.

## Backwards-incompatible changes

Removes CSS for `.jp-LogConsoleIcon` selector (though identical `.jp-ListIcon` selector is still in place).