### PR TITLE
Add optional metadata to launcher and running items

### DIFF
--- a/packages/launcher/src/index.tsx
+++ b/packages/launcher/src/index.tsx
@@ -339,6 +339,12 @@ export namespace ILauncher {
      * spec.
      */
     kernelIconUrl?: string;
+
+    /**
+     * Additional metadata that could be used by the launcher to
+     * render the item (or choose whether to render the item).
+     */
+    metadata?: ReadonlyJSONObject;
   }
 }
 

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -12,7 +12,7 @@ import {
   ToolbarButtonComponent
 } from '@jupyterlab/apputils';
 
-import { Token } from '@phosphor/coreutils';
+import { Token, ReadonlyJSONObject } from '@phosphor/coreutils';
 
 import { DisposableDelegate, IDisposable } from '@phosphor/disposable';
 
@@ -277,5 +277,8 @@ export namespace IRunningSessions {
     label: () => string;
     // called to determine the `title` attribute for each item, which is revealed on hover
     labelTitle?: () => string;
+    // called to get the metadata for each item, which can be used
+    // in the rendering of the item.
+    metadata?: () => ReadonlyJSONObject;
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Stepping stone toward #3795 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Adds optional metadata for launcher items and running items.  These changes are needed to explore making environments (such as conda) first class citizens in the application.  I will bring this up at the JupyterLab meeting this week.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
