### PR TITLE
Refine log console message UX

### DIFF
--- a/packages/logconsole-extension/src/status.tsx
+++ b/packages/logconsole-extension/src/status.tsx
@@ -27,14 +27,15 @@ import React from 'react';
 function LogConsoleStatusComponent(
   props: LogConsoleStatusComponent.IProps
 ): React.ReactElement<LogConsoleStatusComponent.IProps> {
+  let title = '';
+  if (props.newMessages > 0) {
+    title = `${props.newMessages} new messages, `;
+  }
+  title += `${props.logEntries} log entries for ${props.source}`;
   return (
-    <GroupItem
-      spacing={0}
-      onClick={props.handleClick}
-      title={`${props.messages} messages in current log`}
-    >
+    <GroupItem spacing={0} onClick={props.handleClick} title={title}>
       <DefaultIconReact name={'list'} top={'2px'} kind={'statusBar'} />
-      <TextItem source={props.messages} />
+      {props.newMessages > 0 && <TextItem source={props.newMessages} />}
     </GroupItem>
   );
 }
@@ -54,9 +55,19 @@ namespace LogConsoleStatusComponent {
     handleClick: () => void;
 
     /**
-     * Number of log messages.
+     * Number of log entries.
      */
-    messages: number;
+    logEntries: number;
+
+    /**
+     * Number of new log messages.
+     */
+    newMessages: number;
+
+    /**
+     * Log source name
+     */
+    source: string;
   }
 }
 
@@ -106,7 +117,9 @@ export class LogConsoleStatus extends VDomRenderer<LogConsoleStatus.Model> {
     return (
       <LogConsoleStatusComponent
         handleClick={this._handleClick}
-        messages={messages}
+        logEntries={messages}
+        newMessages={version - versionDisplayed}
+        source={this.model.source}
       />
     );
   }

--- a/packages/logconsole/src/logger.ts
+++ b/packages/logconsole/src/logger.ts
@@ -132,6 +132,24 @@ export class LoggerOutputAreaModel extends OutputAreaModel
   }
 
   /**
+   * Whether an output should combine with the previous output.
+   *
+   * We combine if the two outputs are in the same second, which is the
+   * resolution for our time display.
+   */
+  protected shouldCombine(options: {
+    value: ILogOutput;
+    lastModel: ILogOutputModel;
+  }): boolean {
+    const { value, lastModel } = options;
+
+    let oldSeconds = Math.trunc(lastModel.timestamp.getTime() / 1000);
+    let newSeconds = Math.trunc(value.timestamp / 1000);
+
+    return oldSeconds === newSeconds;
+  }
+
+  /**
    * Get an item at the specified index.
    */
   get(index: number): ILogOutputModel {

--- a/packages/logconsole/src/widget.ts
+++ b/packages/logconsole/src/widget.ts
@@ -49,15 +49,26 @@ class LogConsoleOutputPrompt extends Widget implements IOutputPrompt {
    * Date & time when output is logged.
    */
   set timestamp(value: Date) {
-    this._timestampNode.innerHTML = value.toLocaleTimeString();
+    this._timestamp = value;
+    this._timestampNode.innerHTML = this._timestamp.toLocaleTimeString();
+    this.update();
   }
 
   /**
    * Log level
    */
   set level(value: FullLogLevel) {
+    this._level = value;
     this.node.dataset.logLevel = value;
-    this.node.title = `${toTitleCase(value)} message`;
+    this.update();
+  }
+
+  update() {
+    if (this._level !== undefined && this._timestamp !== undefined) {
+      this.node.title = `${this._timestamp.toLocaleString()}; ${toTitleCase(
+        this._level
+      )} level`;
+    }
   }
 
   /**
@@ -65,6 +76,8 @@ class LogConsoleOutputPrompt extends Widget implements IOutputPrompt {
    */
   executionCount: nbformat.ExecutionCount;
 
+  private _timestamp: Date;
+  private _level: FullLogLevel;
   private _timestampNode: HTMLDivElement;
 }
 

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -307,7 +307,11 @@ export class OutputAreaModel implements IOutputAreaModel {
     if (
       nbformat.isStream(value) &&
       this._lastStream &&
-      value.name === this._lastName
+      value.name === this._lastName &&
+      this.shouldCombine({
+        value,
+        lastModel: this.list.get(this.length - 1)
+      })
     ) {
       // In order to get a list change event, we add the previous
       // text to the current item and replace the previous item.
@@ -340,6 +344,19 @@ export class OutputAreaModel implements IOutputAreaModel {
 
     // Add the item to our list and return the new length.
     return this.list.push(item);
+  }
+
+  /**
+   * Whether a new value should be consolidated with the previous output.
+   *
+   * This will only be called if the minimal criteria of both being stream
+   * messages of the same type.
+   */
+  protected shouldCombine(options: {
+    value: nbformat.IOutput;
+    lastModel: IOutputModel;
+  }) {
+    return true;
   }
 
   /**


### PR DESCRIPTION
## References

Fixes #7444 and appears to also fix #7443

## Code changes

* Introduces a protected output function to determine when messages should be collapsed, and uses it to collapse messages less aggressively. In particular, we only collapse messages that are in the same timestamp second (so that the timestamp at second resolution is accurate).
* Change the title of the log console prompt nodes to include the full date.
* Change the status bar indicator to indicate number of incoming messages that have not been displayed, rather than total number of (possibly collapsed) log entries. This gives the user more relevant information ("How much new stuff is there" instead of "how much stuff is there total")

## User-facing changes

![logs](https://user-images.githubusercontent.com/192614/67913905-efccf980-fb64-11e9-9d84-a85b1662a6a3.gif)


## Backwards-incompatible changes

I don't think there are any backwards incompatible changes. The one function signature that changes is a private function to the module.
