### PR TITLE
Make sure label is linked to a control when checking for element type

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -329,11 +329,11 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   protected handleClick(event: Event) {
     // Clicking a label focuses the corresponding control
     // that is linked with `for` attribute, so let it be.
-    if (
-      event.target instanceof HTMLLabelElement &&
-      this.node.querySelector(`#${event.target.getAttribute('for')}`)
-    ) {
-      return;
+    if (event.target instanceof HTMLLabelElement) {
+      const forId = event.target.getAttribute('for');
+      if (forId && this.node.querySelector(`#${forId}`)) {
+        return;
+      }
     }
 
     // If this click already focused a control, let it be.

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -327,8 +327,12 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
    * Handle a DOM click event.
    */
   protected handleClick(event: Event) {
-    // Clicking a label focuses the corresponding control, so let it be.
-    if (event.target instanceof HTMLLabelElement) {
+    // Clicking a label focuses the corresponding control
+    // that is linked with `for` attribute, so let it be.
+    if (
+      event.target instanceof HTMLLabelElement &&
+      this.node.querySelector(`#${event.target.getAttribute('for')}`)
+    ) {
       return;
     }
 


### PR DESCRIPTION
This is an enhancement to https://github.com/jupyterlab/jupyterlab/pull/7406/commits/a669392e4c5355c36413f5549164878ca2830940 making sure the label is actually linked to another control.