### PR TITLE
Fix #7456

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1762,8 +1762,12 @@ def _yarn_config(logger):
     -------
     {"yarn config": dict, "npm config": dict} if unsuccessfull the subdictionary are empty
     """
-    node = which('node')
     configuration = {"yarn config": {}, "npm config": {}}
+    try:
+        node = which('node')
+    except ValueError:  # Node not found == user with no need for building jupyterlab
+        return configuration
+
     try:
         output_binary = subprocess.check_output([node, YARN_PATH, 'config', 'list', '--json'], stderr=subprocess.PIPE, cwd=HERE)
         output = output_binary.decode('utf-8')

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1766,6 +1766,7 @@ def _yarn_config(logger):
     try:
         node = which('node')
     except ValueError:  # Node not found == user with no need for building jupyterlab
+        logger.debug("NodeJS was not found. Yarn user configuration is ignored.")
         return configuration
 
     try:

--- a/jupyterlab/tests/test_registry.py
+++ b/jupyterlab/tests/test_registry.py
@@ -19,6 +19,21 @@ from .test_jupyterlab import AppHandlerTest
 
 class TestAppHandlerRegistry(AppHandlerTest):
 
+    def test_node_not_available(self):
+        # patch should be applied on `jupyterlab.commands` and not on `jupyterlab_server.process`
+        # See https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+        with patch("jupyterlab.commands.which") as which:
+            which.side_effect = ValueError("Command not found")
+
+            logger = logging.getLogger('jupyterlab')
+            config = commands._yarn_config(logger)
+
+            which.assert_called_once_with('node')
+            self.assertDictEqual(config, 
+                {"yarn config": {}, 
+                "npm config": {}}
+            )
+
     def test_yarn_config(self):
         with patch("subprocess.check_output") as check_output:
             yarn_registry = "https://private.yarn/manager"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This fixes #7456 

Would it be easy to set a case in the CI to simulate the installation and execution of JupyterLab with no NodeJS available ?

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
