### PR TITLE
Update Contribution Guide to require node v12+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ You can launch a binder with the latest JupyterLab master to test something (thi
 
 ### Installing Node.js and jlpm
 
-Building JupyterLab from its GitHub source code requires Node.js.
+Building JupyterLab from its GitHub source code requires Node.js. The development version requires Node.js version 12+.
 
 If you use `conda`, you can get it with:
 
@@ -84,6 +84,12 @@ brew install node
 ```
 
 You can also use the installer from the [Node.js](https://nodejs.org) website.
+
+To check which version of Node.js is installed:
+
+```bash
+node -v
+```
 
 ## Installing JupyterLab
 


### PR DESCRIPTION
Installing the development branch runs into an issue if node version is
older than 12. This updates the CONTRIBUTING.md guide to ensure that 
developers update the version.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
