### PR TITLE
Add download command to file menu

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -67,6 +67,8 @@ namespace CommandIDs {
 
   export const saveAs = 'docmanager:save-as';
 
+  export const download = 'docmanager:download';
+
   export const toggleAutosave = 'docmanager:toggle-autosave';
 
   export const showInFileBrowser = 'docmanager:show-in-file-browser';
@@ -576,6 +578,18 @@ function addCommands(
     }
   });
 
+  commands.addCommand(CommandIDs.download, {
+    label: 'Download',
+    caption: 'Download the file to your computer',
+    isEnabled,
+    execute: () => {
+      if (isEnabled()) {
+        let context = docManager.contextForWidget(shell.currentWidget);
+        return context.download();
+      }
+    }
+  });
+
   commands.addCommand(CommandIDs.toggleAutosave, {
     label: 'Autosave Documents',
     isToggled: () => docManager.autosave,
@@ -605,6 +619,7 @@ function addCommands(
       CommandIDs.restoreCheckpoint,
       CommandIDs.save,
       CommandIDs.saveAs,
+      CommandIDs.download,
       CommandIDs.toggleAutosave
     ].forEach(command => {
       palette.addItem({ command, category });
@@ -613,6 +628,7 @@ function addCommands(
 
   if (mainMenu) {
     mainMenu.settingsMenu.addGroup([{ command: CommandIDs.toggleAutosave }], 5);
+    mainMenu.fileMenu.addGroup([{ command: CommandIDs.download }], 6);
   }
 }
 

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -271,6 +271,28 @@ export class Context<T extends DocumentRegistry.IModel>
   }
 
   /**
+   * Download a file.
+   *
+   * @param path - The path of the file to be downloaded.
+   *
+   * @returns A promise which resolves when the file has begun
+   *   downloading.
+   */
+  async download(): Promise<void> {
+    console.log({ path: this._path });
+    console.log(this._manager);
+    const url = await this._manager.contents.getDownloadUrl(this._path);
+    console.log({ url });
+    let element = document.createElement('a');
+    element.href = url;
+    element.download = '';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+    return void 0;
+  }
+
+  /**
    * Revert the document contents to disk contents.
    */
   revert(): Promise<void> {

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -279,10 +279,7 @@ export class Context<T extends DocumentRegistry.IModel>
    *   downloading.
    */
   async download(): Promise<void> {
-    console.log({ path: this._path });
-    console.log(this._manager);
     const url = await this._manager.contents.getDownloadUrl(this._path);
-    console.log({ url });
     let element = document.createElement('a');
     element.href = url;
     element.download = '';

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -883,6 +883,11 @@ export namespace DocumentRegistry {
     saveAs(): Promise<void>;
 
     /**
+     * Save the document to a different path chosen by the user.
+     */
+    download(): Promise<void>;
+
+    /**
      * Revert the document contents to disk contents.
      */
     revert(): Promise<void>;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
For implementing issue #6868. 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Added a command to the file context manager to download the file to your computer. Also added a menu item to the file menu.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

A new menu item in the file menu which reads "Download"

<!-- For visual changes, include before and after screenshots here. -->

<img width="1792" alt="Screen Shot 2019-11-06 at 11 05 28 AM" src="https://user-images.githubusercontent.com/8334252/68316159-f7b9fb80-0086-11ea-87a2-0b2377589325.png">

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None
