### PR TITLE
Show "Enable" button only for installed extensions

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -196,7 +196,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
               Disable
             </Button>
           )}
-          {!entry.enabled && (
+          {entry.installed && !entry.enabled && (
             <Button
               onClick={() => props.performAction('enable', entry)}
               minimal


### PR DESCRIPTION
## References

At the moment, both "Install" and "Enable" are shown in the extension manager when searching for a new extension to install. However clicking on "Enable" doesn't perform any action if the extension is not already installed.

## User-facing changes

Show the "Enable" button in the extension manager only if the extension is installed.

### Before

![image](https://user-images.githubusercontent.com/591645/68320176-c3aefc80-00bf-11ea-94aa-185c5acb8c7a.png)


### After

![image](https://user-images.githubusercontent.com/591645/68320104-a843f180-00bf-11ea-8961-e8029e79ecf5.png)


## Backwards-incompatible changes

None
