### PR TITLE
Add new file and new markdown file to file browser context menu

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -87,6 +87,10 @@ namespace CommandIDs {
 
   export const createNewDirectory = 'filebrowser:create-new-directory';
 
+  export const createNewFile = 'filebrowser:create-new-file';
+
+  export const createNewMarkdownFile = 'filebrowser:create-new-markdown-file';
+
   export const rename = 'filebrowser:rename';
 
   // For main browser only.
@@ -640,6 +644,36 @@ function addCommands(
     label: 'New Folder'
   });
 
+  commands.addCommand(CommandIDs.createNewFile, {
+    execute: () => {
+      const {
+        model: { path }
+      } = browser;
+      commands.execute('docmanager:new-untitled', {
+        path,
+        type: 'file',
+        ext: 'txt'
+      });
+    },
+    iconClass: 'jp-MaterialIcon jp-TextEditorIcon',
+    label: 'New File'
+  });
+
+  commands.addCommand(CommandIDs.createNewMarkdownFile, {
+    execute: () => {
+      const {
+        model: { path }
+      } = browser;
+      commands.execute('docmanager:new-untitled', {
+        path,
+        type: 'file',
+        ext: 'md'
+      });
+    },
+    iconClass: 'jp-MaterialIcon jp-MarkdownIcon',
+    label: 'New Markdown File'
+  });
+
   commands.addCommand(CommandIDs.rename, {
     execute: args => {
       const widget = tracker.currentWidget;
@@ -842,9 +876,21 @@ function addCommands(
   });
 
   app.contextMenu.addItem({
-    command: CommandIDs.paste,
+    command: CommandIDs.createNewFile,
     selector: selectorContent,
     rank: 2
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.createNewMarkdownFile,
+    selector: selectorContent,
+    rank: 3
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.paste,
+    selector: selectorContent,
+    rank: 4
   });
 
   app.contextMenu.addItem({


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Resolves #4280

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Added 'New File' and 'New Markdown File' commands to the file browser context menu .

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<img width="1792" alt="Screen Shot 2019-11-06 at 12 39 27 PM" src="https://user-images.githubusercontent.com/1537852/68323018-87b17280-0092-11ea-86d1-7798ffbe62a7.png">

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
