### PR TITLE
Adding file size to File browser hover

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1833,12 +1833,27 @@ export namespace DirListing {
         // clean up the svg icon annotation, if any
         delete icon.dataset.icon;
       }
+
+      let hoverText = 'Name: ' + model.name;
       // add file size to pop up if its available
       if (model.size !== null && model.size !== undefined) {
-        node.title = model.name + ' - ' + Private.formatFileSize(model.size, 1);
-      } else {
-        node.title = model.name;
+        hoverText += '\nSize: ' + Private.formatFileSize(model.size, 1, 1024);
       }
+      if (model.path) {
+        hoverText += '\nPath: ' + model.path.substr(0, 50);
+        if (model.path.length > 50) {
+          hoverText += '...';
+        }
+      }
+      if (model.created) {
+        hoverText += '\nCreated: ' + Time.formatHuman(new Date(model.created));
+      }
+      if (model.last_modified) {
+        hoverText +=
+          '\nModified: ' + Time.formatHuman(new Date(model.last_modified));
+      }
+
+      node.title = hoverText;
 
       // If an item is being edited currently, its text node is unavailable.
       if (text && text.textContent !== model.name) {
@@ -2032,12 +2047,15 @@ namespace Private {
   /**
    * Format bytes to human readable string.
    */
-  export function formatFileSize(bytes: number, decimalPoint: number): string {
+  export function formatFileSize(
+    bytes: number,
+    decimalPoint: number,
+    k: number
+  ): string {
     // https://www.codexworld.com/how-to/convert-file-size-bytes-kb-mb-gb-javascript/
     if (bytes === 0) {
       return '0 Bytes';
     }
-    const k = 1000;
     const dm = decimalPoint || 2;
     const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1840,17 +1840,23 @@ export namespace DirListing {
         hoverText += '\nSize: ' + Private.formatFileSize(model.size, 1, 1024);
       }
       if (model.path) {
-        hoverText += '\nPath: ' + model.path.substr(0, 50);
-        if (model.path.length > 50) {
-          hoverText += '...';
+        let dirname = PathExt.dirname(model.path);
+        if (dirname) {
+          hoverText += '\nPath: ' + dirname.substr(0, 50);
+          if (dirname.length > 50) {
+            hoverText += '...';
+          }
         }
       }
       if (model.created) {
-        hoverText += '\nCreated: ' + Time.formatHuman(new Date(model.created));
+        hoverText +=
+          '\nCreated: ' +
+          Time.format(new Date(model.created), 'YYYY-MM-DD HH:mm:ss');
       }
       if (model.last_modified) {
         hoverText +=
-          '\nModified: ' + Time.formatHuman(new Date(model.last_modified));
+          '\nModified: ' +
+          Time.format(new Date(model.last_modified), 'YYYY-MM-DD HH:mm:ss');
       }
 
       node.title = hoverText;

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1833,8 +1833,13 @@ export namespace DirListing {
         // clean up the svg icon annotation, if any
         delete icon.dataset.icon;
       }
+      // add file size to pop up if its available
+      if (model.size !== null && model.size !== undefined) {
+        node.title = model.name + ' - ' + Private.formatFileSize(model.size, 1);
+      } else {
+        node.title = model.name;
+      }
 
-      node.title = model.name;
       // If an item is being edited currently, its text node is unavailable.
       if (text && text.textContent !== model.name) {
         text.textContent = model.name;
@@ -2022,5 +2027,24 @@ namespace Private {
     return ArrayExt.findFirstIndex(nodes, node =>
       ElementExt.hitTest(node, x, y)
     );
+  }
+
+  /**
+   * Format bytes to human readable string.
+   */
+  export function formatFileSize(bytes: number, decimalPoint: number): string {
+    // https://www.codexworld.com/how-to/convert-file-size-bytes-kb-mb-gb-javascript/
+    if (bytes === 0) {
+      return '0 Bytes';
+    }
+    const k = 1000;
+    const dm = decimalPoint || 2;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    if (i >= 0 && i < sizes.length) {
+      return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+    } else {
+      return String(bytes);
+    }
   }
 }

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -96,6 +96,11 @@ export namespace Contents {
      * Only relevant for type: 'file'
      */
     readonly format: FileFormat;
+
+    /**
+     * The size of then file in bytes.
+     */
+    readonly size?: number;
   }
 
   /**


### PR DESCRIPTION
## References

Fixes #7352

## Code changes

added size field to the Contents.IModel
added more file context to title in updateItemNode (filebrowser/src/listing.ts)

## User-facing changes

Hover in file vrowser will now show.

Name:
Size: If available the human readable file size with a single decimal.
Path: only the directory limited to 50
Created: YYYY-MM-DD HH:mm:ss
Modified: YYYY-MM-DD HH:mm:ss

## Backwards-incompatible changes

added new field which is optional so no backwards compatibility issues.
