### PR TITLE
Use `which` to find the right command to run to rebuild jlab

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -55,7 +55,8 @@
     "semver": "^6.1.0",
     "sort-package-json": "~1.22.1",
     "typescript": "~3.5.1",
-    "webpack": "^4.32.2"
+    "webpack": "^4.32.2",
+    "which": "^1.3.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^7.0.0",
@@ -65,6 +66,7 @@
     "@types/node": "^12.0.2",
     "@types/prettier": "^1.16.4",
     "@types/webpack": "^4.4.32",
+    "@types/which": "^1.3.2",
     "rimraf": "~2.6.2"
   }
 }

--- a/buildutils/src/ensure-max-old-space.ts
+++ b/buildutils/src/ensure-max-old-space.ts
@@ -17,6 +17,7 @@
  * node ensure-max-old-space.js real-cli.js arg1 arg2
  */
 import { execFileSync } from 'child_process';
+import * as which from 'which';
 
 const MAX_OLD_SPACE = '--max_old_space_size=4096';
 
@@ -26,6 +27,6 @@ if (!process.env.NODE_OPTIONS) {
   process.env.NODE_OPTIONS += ` ${MAX_OLD_SPACE}`;
 }
 
-const program = process.argv[2];
+const program = which.sync(process.argv[2]);
 const args = process.argv.slice(3);
 execFileSync(program, args, { env: process.env, stdio: 'inherit' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,6 +2141,11 @@
     "@types/uglify-js" "*"
     source-map "^0.6.0"
 
+"@types/which@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.3.2.tgz#9c246fc0c93ded311c8512df2891fb41f6227fdf"
+  integrity sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==
+
 "@types/ws@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #7425. Fixes a problem with #7201.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

On Windows, our build script wasn’t properly appending the .cmd to find the actual executable command (i.e., it was trying to execute webpack instead of webpack.cmd). Using ‘which’ finds the correct command for us to use.

To test, I copied the compiled ensure-max-old-space.js script to a windows 1.2.1 install, and then successfully ran `jupyter lab build` (where there was an error before).


## User-facing changes

`jupyter lab build` and installing extensions works on Windows

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
