### PR TITLE
Fix Log Console log level dropdown state

### DIFF
--- a/packages/logconsole-extension/src/index.tsx
+++ b/packages/logconsole-extension/src/index.tsx
@@ -340,6 +340,7 @@ export class LogLevelSwitcher extends ReactWidget {
    */
   handleChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
     this._logConsole.logger.level = event.target.value as LogLevel;
+    this.update();
   };
 
   /**


### PR DESCRIPTION
changing log level in Log Console updates the state internally but the dropdown itself still shows the old level as selected. now an update is requested after level change to make sure dropdown is also re-rendered.