### PR TITLE
Add types to the Activity Monitors

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1481,7 +1481,7 @@ export class MarkdownCell extends AttachmentsCell {
     });
   }
 
-  private _monitor: ActivityMonitor<any, any> = null;
+  private _monitor: ActivityMonitor<ICellModel, void> = null;
   private _renderer: IRenderMime.IRenderer = null;
   private _rendermime: IRenderMimeRegistry;
   private _rendered = true;

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -366,7 +366,10 @@ export class CSVViewer extends Widget {
   private _context: DocumentRegistry.Context;
   private _grid: DataGrid;
   private _searchService: GridSearchService;
-  private _monitor: ActivityMonitor<any, any> | null = null;
+  private _monitor: ActivityMonitor<
+    DocumentRegistry.IModel,
+    void
+  > | null = null;
   private _delimiter = ',';
   private _revealed = new PromiseDelegate<void>();
 }

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -199,7 +199,7 @@ export class MimeContent extends Widget {
 
   private _context: DocumentRegistry.IContext<DocumentRegistry.IModel>;
   private _fragment = '';
-  private _monitor: ActivityMonitor<any, any> | null;
+  private _monitor: ActivityMonitor<DocumentRegistry.IModel, void> | null;
   private _ready = new PromiseDelegate<void>();
   private _dataType: 'string' | 'json';
   private _isRendering = false;

--- a/packages/htmlviewer/src/index.tsx
+++ b/packages/htmlviewer/src/index.tsx
@@ -203,7 +203,10 @@ export class HTMLViewer extends DocumentWidget<IFrame>
 
   private _renderPending = false;
   private _parser = new DOMParser();
-  private _monitor: ActivityMonitor<any, any> | null = null;
+  private _monitor: ActivityMonitor<
+    DocumentRegistry.IModel,
+    void
+  > | null = null;
   private _objectUrl: string = '';
   private _trustedChanged = new Signal<this, boolean>(this);
 }

--- a/packages/markdownviewer/src/widget.ts
+++ b/packages/markdownviewer/src/widget.ts
@@ -204,7 +204,7 @@ export class MarkdownViewer extends Widget {
 
   private _config = { ...MarkdownViewer.defaultConfig };
   private _fragment = '';
-  private _monitor: ActivityMonitor<any, any> | null;
+  private _monitor: ActivityMonitor<DocumentRegistry.IModel, void> | null;
   private _ready = new PromiseDelegate<void>();
   private _isRendering = false;
   private _renderRequested = false;


### PR DESCRIPTION
## Code changes

It looks like most of the Activity Monitors were typed with `ActivityMonitor<any, any>`.

This change adds types based on the signals they are monitoring.

## User-facing changes

None.

## Backwards-incompatible changes

None