### PR TITLE
Added env prop to kernel options

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1668,7 +1668,7 @@ namespace Private {
     let url = URLExt.join(settings.baseUrl, KERNEL_SERVICE_URL);
     let init = {
       method: 'POST',
-      body: JSON.stringify({ name: options.name })
+      body: JSON.stringify({ name: options.name, env: options.env })
     };
     let response = await ServerConnection.makeRequest(url, init, settings);
     if (response.status !== 201) {

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -640,6 +640,13 @@ export namespace Kernel {
     name?: string;
 
     /**
+     * Environment variables passed to the kernelspec (used in Enterprise Gateway)
+     */
+    env?: {
+      [key: string]: string;
+    };
+
+    /**
      * The server settings for the kernel.
      */
     serverSettings?: ServerConnection.ISettings;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fix for #7498

## Code changes

Added property `env` to kernel options. `env` is added tothe request body.

## User-facing changes

No user-facing changes

## Backwards-incompatible changes

Fully backwards-compatible
