### PR TITLE
Add sass-loader in the build

### DIFF
--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -75,6 +75,8 @@
     "sort-package-json": "~1.22.1",
     "source-map-loader": "~0.2.1",
     "style-loader": "~0.23.1",
+    "sass-loader": "~8.0.0",
+    "sass": "~1.23.3",
     "svg-url-loader": "~2.3.2",
     "svgo": "~1.2.1",
     "svgo-loader": "~2.2.0",

--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -161,6 +161,10 @@ module.exports = [
     module: {
       rules: [
         { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+        {
+          test: /\.s[ac]ss$/i,
+          use: ['style-loader', 'css-loader', 'sass-loader']
+        },
         { test: /\.md$/, use: 'raw-loader' },
         { test: /\.txt$/, use: 'raw-loader' },
         {


### PR DESCRIPTION

## References

JupyterLab build fails with extensions having SCSS to be loaded https://github.com/jupyterlab/jupyterlab/issues/7502

## Code changes

jupyterlab/staging/package.json is upgraded with a sass-loader devDependency.
jupyterlab/staging/webpack.config.js configured with `{ test: /\.s[ac]ss$/i, use: ['style-loader', 'css-loader', 'sass-loader'] },`

## User-facing changes

NA

## Backwards-incompatible changes

None.