### PR TITLE
fix dropdown option style issue in Windows

### DIFF
--- a/packages/ui-components/style/base.css
+++ b/packages/ui-components/style/base.css
@@ -104,8 +104,9 @@ input::placeholder {
   color: var(--jp-ui-font-color0);
 }
 
-/* Use our own theme for hover styles */
-.jp-HTMLSelect.bp3-html-select.bp3-minimal select:hover {
+/* Use our own theme for hover and option styles */
+.jp-HTMLSelect.bp3-html-select.bp3-minimal select:hover,
+.jp-HTMLSelect.bp3-html-select.bp3-minimal select > option {
   color: var(--jp-ui-font-color0);
   background-color: var(--jp-layout-color2);
 }


### PR DESCRIPTION
This fixes an issue in Windows which can be reproduced by clicking cell type dropdown on notebook toolbar. If you move mouse out of option list then its style resets. This problem makes options not legible in dark theme.

before
![OptionStyleBefore](https://user-images.githubusercontent.com/40003442/68686233-4fe67700-0539-11ea-9e81-729ceec561b3.png)

after
![OptionStyleAfter](https://user-images.githubusercontent.com/40003442/68686255-5674ee80-0539-11ea-8f9c-870f43c72ec1.png)
