### PR TITLE
Enable typescript sourcemaps for debugging locally installed labextensions

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -60,6 +60,12 @@ Object.keys(jlab.linkedPackages).forEach(function(name) {
   watched[name] = plib.dirname(localPkgPath);
 });
 
+// Set up source-map-loader to look in watched lib dirs
+let sourceMapRes = Object.values(watched).reduce((res, name) => {
+  res.push(new RegExp(name + '/lib'));
+  return res;
+}, []);
+
 /**
  * Sync a local path to a linked package path if they are files and differ.
  */
@@ -165,10 +171,9 @@ module.exports = [
         { test: /\.txt$/, use: 'raw-loader' },
         {
           test: /\.js$/,
+          include: sourceMapRes,
           use: ['source-map-loader'],
-          enforce: 'pre',
-          // eslint-disable-next-line no-undef
-          exclude: /node_modules/
+          enforce: 'pre'
         },
         { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
         { test: /\.js.map$/, use: 'file-loader' },

--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -60,6 +60,12 @@ Object.keys(jlab.linkedPackages).forEach(function(name) {
   watched[name] = plib.dirname(localPkgPath);
 });
 
+// Set up source-map-loader to look in watched lib dirs
+let sourceMapRes = Object.values(watched).reduce((res, name) => {
+  res.push(new RegExp(name + '/lib'));
+  return res;
+}, []);
+
 /**
  * Sync a local path to a linked package path if they are files and differ.
  */
@@ -165,10 +171,9 @@ module.exports = [
         { test: /\.txt$/, use: 'raw-loader' },
         {
           test: /\.js$/,
+          include: sourceMapRes,
           use: ['source-map-loader'],
-          enforce: 'pre',
-          // eslint-disable-next-line no-undef
-          exclude: /node_modules/
+          enforce: 'pre'
         },
         { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
         { test: /\.js.map$/, use: 'file-loader' },


### PR DESCRIPTION
Our `webpack` config for the release build is currently broken w.r.t. source maps in labextensions. Effectively, what happens right now is that even if an extension ships it's own typescript source maps in perfect working order, when `jupyter lab build` is run those `.js.map` files will be thrown out in favor of (javascript, not typescript) source maps produced by the source map tool in `webpack`.

This is a minimal fix that just covers the case of a locally installed extension. There are other use cases that we should maybe support (normally installed extensions, core packages in a release build), but we should definitely support typescript source maps for labextensions under active development (ie locally installed extensions). 

## References

This issue has been fixed and was rebroken at least once before. I think the complexity of having two source map tools (one in `tsc` and one in `webpack`) in the build chain, each with their own arcane set of options, probably has something to do with it.

refs:
#2922 (original fix)
#3093 (rebreak)
jupyterlab/jupyterlab-git#447 (example of PR to correctly configure ts source maps in an extension)

## Code changes

Made needed tweaks to `jupyterlab/staging/webpack.config.js` and copied them over to `dev_mode/webpack.config.js`

## User-facing changes

Extension devs will get typescript source maps to use when debugging local extensions in eg DevTools, given the correct config . Easiest config is to make sure the following is in `tsconfig.json`:

```
{
  "compilerOptions": {
    "inlineSources": true,
    "sourceMap": true,
    ...
  },
  ...
}
```

## Backwards-incompatible changes

None