### PR TITLE
Add explicit doc encouraging people to re-use lab components

### DIFF
--- a/docs/source/developer/components.rst
+++ b/docs/source/developer/components.rst
@@ -1,0 +1,12 @@
+Using JupyterLab components
+---------------------------
+
+JupyterLab is built with many re-usable components that are
+independently `published on npm <https://www.npmjs.com/search?q=%40jupyterlab>`_.
+JupyterLab itself assembles these components together to provide a full,
+IDE-like experience. However, developers are encouraged to use these to bring
+to life their own visions of what a computational environment should look
+like.
+
+The JupyterLab repository has `many examples <https://github.com/jupyterlab/jupyterlab/tree/master/examples>`_
+to get you started.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,7 @@ JupyterLab is the next-generation web-based user interface for Project Jupyter. 
    developer/extension_dev
    developer/extension_points
    developer/contributing
+   developer/components
    developer/documents
    developer/notebook
    developer/patterns


### PR DESCRIPTION
Based on chat with @jasongrout, to make it clear that
the JupyterLab team is pleased when this happens.
