### PR TITLE
Typo in UseSignal documentation

### DIFF
--- a/packages/apputils/src/vdom.ts
+++ b/packages/apputils/src/vdom.ts
@@ -220,6 +220,7 @@ export interface IUseSignalState<SENDER, ARGS> {
  *    />
  *  )
  * }
+ * ```
  */
 export class UseSignal<SENDER, ARGS> extends React.Component<
   IUseSignalProps<SENDER, ARGS>,


### PR DESCRIPTION
There was no closing tag for code block which lead to the broken rendering on https://jupyterlab.github.io/jupyterlab/apputils/classes/usesignal.html

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
