### PR TITLE
Handle cell execution cancellation because cell is disposed.

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1108,8 +1108,9 @@ export namespace CodeCell {
       }
       return msg;
     } catch (e) {
-      // If this is still the current execution, clear the prompt.
-      if (e.message === 'Canceled' && cell.outputArea.future === future) {
+      // If we started executing, and the cell is still indicating this
+      // execution, clear the prompt.
+      if (future && !cell.isDisposed && cell.outputArea.future === future) {
         cell.setPrompt('');
       }
       throw e;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1555,11 +1555,10 @@ namespace Private {
               }
             })
             .catch(reason => {
-              if (reason.message !== 'Canceled') {
-                throw reason;
+              if (cell.isDisposed || reason.message.startsWith('Canceled')) {
+                return false;
               }
-
-              return false;
+              throw reason;
             })
             .then(ran => {
               if (ran) {


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #7554

## Code changes

More careful error handling when objects have already been disposed.

## User-facing changes

None

## Backwards-incompatible changes

None.
