### PR TITLE
Align close and refresh buttons in the running tab

### DIFF
--- a/packages/running/style/base.css
+++ b/packages/running/style/base.css
@@ -29,12 +29,7 @@
   flex: 0 0 auto;
   display: flex;
   flex-direction: row;
-  margin: var(--jp-toolbar-header-margin);
   justify-content: flex-end;
-}
-
-.jp-RunningSessions-header .jp-ToolbarButtonComponent {
-  padding: 0px 16px;
 }
 
 .jp-RunningSessions-shutdownAll {
@@ -65,6 +60,7 @@
 .jp-RunningSessions-sectionHeader {
   flex: 0 0 auto;
   align-items: center;
+  justify-content: space-between;
   height: 28px;
   display: flex;
   border-bottom: var(--jp-border-width) solid var(--jp-border-color2);


### PR DESCRIPTION
## References

Just a quick CSS tweak, after using the running tab regularly recently.

## Code changes

CSS adjustments.

## User-facing changes

Icons to shut down terminals and kernels are aligned with the refresh icon.

### Before

![image](https://user-images.githubusercontent.com/591645/69833589-29148a00-1235-11ea-9996-9a8789596558.png)

### After

![image](https://user-images.githubusercontent.com/591645/69833582-1b5f0480-1235-11ea-9689-88d1f545ab53.png)
 

## Backwards-incompatible changes

None.