### PR TITLE
UI components missing from example app

### DIFF
--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -37,7 +37,10 @@
     "@jupyterlab/theme-dark-extension": "^2.0.0-alpha.4",
     "@jupyterlab/theme-light-extension": "^2.0.0-alpha.4",
     "@jupyterlab/tooltip-extension": "^2.0.0-alpha.4",
-    "es6-promise": "~4.2.6"
+    "@jupyterlab/ui-components-extension": "^2.0.0-alpha.4",
+    "es6-promise": "~4.2.6",
+    "react": "~16.8.4",
+    "react-dom": "~16.8.4"
   },
   "devDependencies": {
     "css-loader": "~2.1.1",


### PR DESCRIPTION
When building example app from scratch received the following:

```
ModuleNotFoundError: Module not found: Error: Can't resolve '@jupyterlab/ui-components-extension'
```

Hopefully this should fix that.

I also needed to add the following:

```
    "react": "~16.8.4",
    "react-dom": "^16.12.0"
```

But not sure whether I should submit those.

Cheers :)
Simon