### PR TITLE
When timing metadata changes, ensure metadata.changed fires

### DIFF
--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -515,9 +515,6 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   }
   set executionCount(newValue: nbformat.ExecutionCount) {
     let oldValue = this.executionCount;
-    if (!newValue) {
-      this.metadata.delete('execution');
-    }
     if (newValue === oldValue) {
       return;
     }

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -101,6 +101,11 @@ export interface ICodeCellModel extends ICellModel {
    * The cell outputs.
    */
   readonly outputs: IOutputAreaModel;
+
+  /**
+   * Clear execution, outputs, and related metadata
+   */
+  clearExecution(): void;
 }
 
 /**
@@ -519,6 +524,12 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
       return;
     }
     this.modelDB.setValue('executionCount', newValue || null);
+  }
+
+  clearExecution() {
+    this.outputs.clear();
+    this.executionCount = null;
+    this.metadata.delete('execution');
   }
 
   /**

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -515,6 +515,9 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
   }
   set executionCount(newValue: nbformat.ExecutionCount) {
     let oldValue = this.executionCount;
+    if (!newValue) {
+      this.metadata.delete('execution');
+    }
     if (newValue === oldValue) {
       return;
     }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1083,7 +1083,10 @@ export namespace CodeCell {
           if (!value) {
             return;
           }
-          const timingInfo: any = model.metadata.get('execution') || {};
+          const timingInfo: any = Object.assign(
+            {},
+            model.metadata.get('execution')
+          );
           timingInfo[`iopub.${label}`] = value;
           model.metadata.set('execution', timingInfo);
           return true;
@@ -1096,7 +1099,10 @@ export namespace CodeCell {
       model.executionCount = msg.content.execution_count;
       const started = msg.metadata.started as string;
       if (recordTiming && started) {
-        const timingInfo = (model.metadata.get('execution') as any) || {};
+        const timingInfo = Object.assign(
+          {},
+          model.metadata.get('execution') as any
+        );
         if (started) {
           timingInfo['shell.execute_reply.started'] = started;
         }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1037,8 +1037,7 @@ export namespace CodeCell {
     let model = cell.model;
     let code = model.value.text;
     if (!code.trim() || !session.kernel) {
-      model.executionCount = null;
-      model.outputs.clear();
+      model.clearExecution();
       return;
     }
     let cellId = { cellId: model.id };
@@ -1048,7 +1047,7 @@ export namespace CodeCell {
       ...cellId
     };
     const { recordTiming } = metadata;
-    model.executionCount = null;
+    model.clearExecution();
     cell.outputHidden = false;
     cell.setPrompt('*');
     model.trusted = true;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1056,6 +1056,7 @@ export namespace NotebookActions {
         cell.outputs.clear();
         (child as CodeCell).outputHidden = false;
         cell.executionCount = null;
+        cell.metadata.delete('execution');
       }
     });
     Private.handleState(notebook, state);

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1053,10 +1053,8 @@ export namespace NotebookActions {
       const child = notebook.widgets[index];
 
       if (notebook.isSelectedOrActive(child) && cell.type === 'code') {
-        cell.outputs.clear();
+        cell.clearExecution();
         (child as CodeCell).outputHidden = false;
-        cell.executionCount = null;
-        cell.metadata.delete('execution');
       }
     });
     Private.handleState(notebook, state);
@@ -1081,8 +1079,7 @@ export namespace NotebookActions {
       const child = notebook.widgets[index];
 
       if (cell.type === 'code') {
-        cell.outputs.clear();
-        cell.executionCount = null;
+        cell.clearExecution();
         (child as CodeCell).outputHidden = false;
       }
     });
@@ -1606,7 +1603,7 @@ namespace Private {
               return ran;
             });
         }
-        (cell.model as ICodeCellModel).executionCount = null;
+        (cell.model as ICodeCellModel).clearExecution();
         break;
       default:
         break;


### PR DESCRIPTION
This bug was caused by updating the object in place instead of copying before each change. With the former, metadata.changed does not signal.