### PR TITLE
Allow for a global track timing setting

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1089,6 +1089,8 @@ export namespace CodeCell {
           return true;
         };
         cell.outputArea.future.registerMessageHook(recordTimingHook);
+      } else {
+        model.metadata.delete('execution');
       }
       // Save this execution's future so we can compare in the catch below.
       future = cell.outputArea.future;

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -352,6 +352,12 @@
       "description": "Whether to be able to scroll so the last cell is at the top of the panel",
       "type": "boolean",
       "default": true
+    },
+    "recordTiming": {
+      "title": "Recording timing",
+      "description": "Should timing data be recorded in cell metadata",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -631,7 +631,8 @@ function activateNotebookHandler(
     factory.editorConfig = { code, markdown, raw };
     factory.notebookConfig = {
       scrollPastEnd: settings.get('scrollPastEnd').composite as boolean,
-      defaultCell: settings.get('defaultCell').composite as nbformat.CellType
+      defaultCell: settings.get('defaultCell').composite as nbformat.CellType,
+      recordTiming: settings.get('recordTiming').composite as boolean
     };
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;
@@ -1561,7 +1562,7 @@ function addCommands(
     isEnabled
   });
   commands.addCommand(CommandIDs.toggleRecordTiming, {
-    label: 'Toggle Recording Cell Timing',
+    label: 'Toggle Recording Cell Timing for this Notebook',
     execute: args => {
       const current = getCurrent(args);
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -177,8 +177,6 @@ namespace CommandIDs {
 
   export const toggleAllLines = 'notebook:toggle-all-cell-line-numbers';
 
-  export const toggleRecordTiming = 'notebook:toggle-record-timing';
-
   export const undoCellAction = 'notebook:undo-cell-action';
 
   export const redoCellAction = 'notebook:redo-cell-action';
@@ -1561,17 +1559,6 @@ function addCommands(
     },
     isEnabled
   });
-  commands.addCommand(CommandIDs.toggleRecordTiming, {
-    label: 'Toggle Recording Cell Timing for this Notebook',
-    execute: args => {
-      const current = getCurrent(args);
-
-      if (current) {
-        return NotebookActions.toggleRecordTiming(current.content);
-      }
-    },
-    isEnabled
-  });
   commands.addCommand(CommandIDs.commandMode, {
     label: 'Enter Command Mode',
     execute: args => {
@@ -1923,7 +1910,6 @@ function populatePalette(
     CommandIDs.deselectAll,
     CommandIDs.clearAllOutputs,
     CommandIDs.toggleAllLines,
-    CommandIDs.toggleRecordTiming,
     CommandIDs.editMode,
     CommandIDs.commandMode,
     CommandIDs.changeKernel,

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1562,9 +1562,15 @@ namespace Private {
         break;
       case 'code':
         if (session) {
+          let recordTiming = false;
+          if (notebook.model.metadata.get('record_timing') === true) {
+            recordTiming = true;
+          } else if (notebook.model.metadata.get('record_timing') !== false) {
+            recordTiming = notebook.notebookConfig.recordTiming;
+          }
           return CodeCell.execute(cell as CodeCell, session, {
             deletedCells: notebook.model.deletedCells,
-            recordTiming: notebook.model.metadata.get('record_timing') || false
+            recordTiming
           })
             .then(reply => {
               notebook.model.deletedCells.splice(

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1022,19 +1022,6 @@ export namespace NotebookActions {
   }
 
   /**
-   * Toggle whether to record cell timing execution.
-   *
-   * @param notebook - The target notebook widget.
-   */
-  export function toggleRecordTiming(notebook: Notebook): void {
-    if (!notebook.model) {
-      return;
-    }
-    const currentValue = notebook.model.metadata.get('record_timing') || false;
-    notebook.model.metadata.set('record_timing', !currentValue);
-  }
-
-  /**
    * Clear the code outputs of the selected cells.
    *
    * @param notebook - The target notebook widget.
@@ -1562,15 +1549,9 @@ namespace Private {
         break;
       case 'code':
         if (session) {
-          let recordTiming = false;
-          if (notebook.model.metadata.get('record_timing') === true) {
-            recordTiming = true;
-          } else if (notebook.model.metadata.get('record_timing') !== false) {
-            recordTiming = notebook.notebookConfig.recordTiming;
-          }
           return CodeCell.execute(cell as CodeCell, session, {
             deletedCells: notebook.model.deletedCells,
-            recordTiming
+            recordTiming: notebook.notebookConfig.recordTiming
           })
             .then(reply => {
               notebook.model.deletedCells.splice(

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -759,13 +759,19 @@ export namespace StaticNotebook {
      * The default type for new notebook cells.
      */
     defaultCell: nbformat.CellType;
+
+    /**
+     * Should timing be recorded in metadata
+     */
+    recordTiming: boolean;
   }
   /**
    * Default configuration options for notebooks.
    */
   export const defaultNotebookConfig: INotebookConfig = {
     scrollPastEnd: true,
-    defaultCell: 'code'
+    defaultCell: 'code',
+    recordTiming: false
   };
 
   /**


### PR DESCRIPTION
## Code changes

This allows for a global default of whether or not to record timing metadata into the notebook file or not.

## User-facing changes

A notebook setting was added to allow user to opt into this change.

## Backwards-incompatible changes
None.