### PR TITLE
Continuation of Allow shortcuts to be empty and to have win/mac/linux-specific keys

### DIFF
--- a/jupyterlab/staging/yarn.lock
+++ b/jupyterlab/staging/yarn.lock
@@ -3574,7 +3574,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5323,11 +5323,6 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
 safe-regex@^1.1.0:
   version "1.1.0"

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -883,10 +883,6 @@ export namespace SettingRegistry {
       const keys = shortcut.keys.join(RECORD_SEPARATOR);
       const { selector } = shortcut;
 
-      if (!keys) {
-        console.warn('Shortcut skipped because `keys` are [""].', shortcut);
-        return false;
-      }
       if (!(keys in memo)) {
         memo[keys] = {};
       }
@@ -906,7 +902,7 @@ export namespace SettingRegistry {
       const { disabled } = shortcut;
       const keys = shortcut.keys.join(RECORD_SEPARATOR);
 
-      if (disabled || !keys) {
+      if (disabled) {
         return false;
       }
       if (!(keys in memo)) {

--- a/packages/shortcuts-extension/schema/shortcuts.json
+++ b/packages/shortcuts-extension/schema/shortcuts.json
@@ -22,7 +22,18 @@
         "command": { "type": "string" },
         "keys": {
           "items": { "type": "string" },
-          "minItems": 1,
+          "type": "array"
+        },
+        "winKeys": {
+          "items": { "type": "string" },
+          "type": "array"
+        },
+        "macKeys": {
+          "items": { "type": "string" },
+          "type": "array"
+        },
+        "linuxKeys": {
+          "items": { "type": "string" },
           "type": "array"
         },
         "selector": { "type": "string" }

--- a/packages/shortcuts-extension/schema/shortcuts.json
+++ b/packages/shortcuts-extension/schema/shortcuts.json
@@ -8,7 +8,6 @@
   "additionalProperties": false,
   "properties": {
     "shortcuts": {
-      "title": "Keyboard Shortcuts",
       "description": "The list of keyboard shortcuts.",
       "items": { "$ref": "#/definitions/shortcut" },
       "type": "array",

--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -162,10 +162,7 @@ const shortcuts: JupyterFrontEndPlugin<void> = {
         })
         .reduce((acc, val) => acc.concat(val), [])
         .sort((a, b) => a.command.localeCompare(b.command));
-      schema.properties.shortcuts.title =
-        'List of Commands (followed by shortcuts)';
-
-      const disableShortcutInstructions = `Note: To disable a system default shortcut,
+      schema.properties.shortcuts.description = `To disable a system default shortcut,
 copy it to User Preferences and add the
 "disabled" key, for example:
 {
@@ -175,12 +172,12 @@ copy it to User Preferences and add the
     ],
     "selector": "body",
     "disabled": true
-}`;
-      schema.properties.shortcuts.description = `${commands}
+}
 
-${disableShortcutInstructions}
+List of commands followed by keyboard shortcuts:
+${commands}
 
-List of Keyboard Shortcuts`;
+List of keyboard shortcuts`;
     }
 
     registry.pluginChanged.connect(async (sender, plugin) => {


### PR DESCRIPTION
## References
Continues #7335 

## Code changes

This PR removes jupyterlab checks for empty shortcuts allowing phosphor to handle platform specific keyboard shortcuts.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users can define platform specific shortcuts as follows:
```
{
    "shortcuts": [
        {
            "command": "filebrowser:create-main-launcher",
            "keys": ["Accel Shift L"],
            "selector": "body",
            "disabled": true
        },
        {
            "command": "filebrowser:create-main-launcher",
            "keys": [],
            "linuxKeys": ["Accel Y"],
            "winKeys": ["Accel Shift ;"],
            "selector": "body"
        },
    ]
}
```
Note that the "keys" list is still required, but can be empty now.  As referenced in #7335, this allows phosphor to use "linuxKeys", "winKeys", or "macKeys" depending on the platform.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
