### PR TITLE
Add auto generated header to files in staging

### DIFF
--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -23,6 +23,9 @@ let staging = './jupyterlab/staging';
 utils.writePackageData(path.join(staging, 'package.json'), data);
 
 // Update our staging files.
+const notice =
+  '// This file is auto-generated from the corresponding file in dev_mode\n';
+
 [
   'index.js',
   'webpack.config.js',
@@ -31,10 +34,14 @@ utils.writePackageData(path.join(staging, 'package.json'), data);
   'webpack.prod.release.config.js',
   'templates'
 ].forEach(name => {
-  fs.copySync(
-    path.join('.', 'dev_mode', name),
-    path.join('.', 'jupyterlab', 'staging', name)
-  );
+  const dest = path.join('.', 'jupyterlab', 'staging', name);
+  fs.copySync(path.join('.', 'dev_mode', name), dest);
+
+  if (path.extname(name) === 'js') {
+    const oldContent = fs.readFileSync(dest);
+    const newContent = notice + oldContent;
+    fs.writeFileSync(dest, newContent);
+  }
 });
 
 // Create a new yarn.lock file to ensure it is correct.

--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -24,7 +24,7 @@ utils.writePackageData(path.join(staging, 'package.json'), data);
 
 // Update our staging files.
 const notice =
-  '// This file is auto-generated from the corresponding file in dev_mode\n';
+  '// This file is auto-generated from the corresponding file in /dev_mode\n';
 
 [
   'index.js',
@@ -37,7 +37,7 @@ const notice =
   const dest = path.join('.', 'jupyterlab', 'staging', name);
   fs.copySync(path.join('.', 'dev_mode', name), dest);
 
-  if (path.extname(name) === 'js') {
+  if (path.extname(name) === '.js') {
     const oldContent = fs.readFileSync(dest);
     const newContent = notice + oldContent;
     fs.writeFileSync(dest, newContent);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6506.

Adds the following header to the auto-generated JS files in `jupyterlab/staging/`:

```javascript
// This file is auto-generated from the corresponding file in /dev_mode
```

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Changes one file in buildutils that is only used in JupyterLab.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
