### PR TITLE
Add null fileformat

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -572,7 +572,7 @@ export class Context<T extends DocumentRegistry.IModel>
     const opts: Contents.IFetchOptions = {
       format: this._factory.fileFormat,
       type: this._factory.contentType,
-      content: this._factory.fileFormat !== 'null'
+      content: this._factory.fileFormat !== null
     };
     const path = this._path;
     const model = this._model;

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -572,7 +572,7 @@ export class Context<T extends DocumentRegistry.IModel>
     const opts: Contents.IFetchOptions = {
       format: this._factory.fileFormat,
       type: this._factory.contentType,
-      content: true
+      content: this._factory.fileFormat !== 'null'
     };
     const path = this._path;
     const model = this._model;

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -126,7 +126,7 @@ export namespace Contents {
   /**
    * A contents file format.
    */
-  export type FileFormat = 'json' | 'text' | 'base64';
+  export type FileFormat = 'json' | 'text' | 'base64' | 'null';
 
   /**
    * The options used to fetch a file.

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -126,7 +126,7 @@ export namespace Contents {
   /**
    * A contents file format.
    */
-  export type FileFormat = 'json' | 'text' | 'base64' | 'null';
+  export type FileFormat = 'json' | 'text' | 'base64' | null;
 
   /**
    * The options used to fetch a file.

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -112,7 +112,7 @@ export namespace Contents {
   }
 
   /**
-   * Validates an IModel, thowing an error if it does not pass.
+   * Validates an IModel, throwing an error if it does not pass.
    */
   export function validateContentsModel(contents: IModel): void {
     validate.validateContentsModel(contents);


### PR DESCRIPTION
## References

fixes  #5885

## Code changes

This adds a `null` `FileType`, and ensures that when getting such files their contents is not fetched. Previously, when getting a file there was no way to do anything other than get the entire contents eagerly.

This potentially solves a big issue for file types that want to fetch contents lazily. I'll start this PR out as WIP and test it against the hdf5 filetype in [jupyterlab/jupyterlab-hdf5](https://github.com/jupyterlab/jupyterlab-hdf5). I did inspect the contents stack (on both the frontend and the `notebook` backend) through which the `Contents.IFetchOptions` gets passed, and it does indeed appear that the minimal changes in this PR are sufficient to ensure that only metadata gets fetched when `FileType` is `null`

## User-facing changes

None

## Backwards-incompatible changes

None