### PR TITLE
Adding Max Klein as a maintainer to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ JupyterLab's current maintainers are listed in alphabetical order, with affiliat
 - Steven Silvester, AWS (co-creator, release management, packaging,
   prolific contributions throughout the code base).
 - Vidar T. Fauske, JPMorgan Chase (general development, extensions).
-- Max Klein (UI Package, build system, general development, extensions).
+- Max Klein, JPMorgan Chase (UI Package, build system, general development, extensions).
 
 Maintainer emeritus:
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ JupyterLab's current maintainers are listed in alphabetical order, with affiliat
 
 - Afshin Darian, Two Sigma (co-creator, application/high-level architecture,
   prolific contributions throughout the code base).
-- Jessica Forde, Project Jupyter (demo, documentation)
 - Tim George, Cal Poly (UI/UX design, strategy, management, user needs analysis)
 - Brian Granger, AWS (co-creator, strategy, vision, management, UI/UX design,
   architecture).
@@ -136,12 +135,14 @@ JupyterLab's current maintainers are listed in alphabetical order, with affiliat
 - Steven Silvester, AWS (co-creator, release management, packaging,
   prolific contributions throughout the code base).
 - Vidar T. Fauske, JPMorgan Chase (general development, extensions).
+- Max Klein (UI Package, build system, general development, extensions).
 
 Maintainer emeritus:
 
 - Chris Colbert, Project Jupyter (co-creator, application/low-level architecture,
   technical leadership, vision, PhosphorJS)
 - Cameron Oelsen, Cal Poly (UI/UX design).
+- Jessica Forde, Project Jupyter (demo, documentation)
 
 This list is provided to give the reader context on who we are and how our team functions.
 To be listed, please submit a pull request with your information.


### PR DESCRIPTION


## References

I just thought it was time to add Max to the README.md

## Code changes

NONE

## User-facing changes

NONE

## Backwards-incompatible changes

NONE
