### PR TITLE
followup #7147: adds SettingConnector.save, reenables saving of user settings

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -9,7 +9,6 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-
 import {
   Dialog,
   ICommandPalette,
@@ -18,28 +17,20 @@ import {
   WindowResolver,
   Printing
 } from '@jupyterlab/apputils';
-
 import {
   Debouncer,
-  ISettingRegistry,
   IStateDB,
-  PageConfig,
-  SettingRegistry,
   StateDB,
   Throttler,
   URLExt
 } from '@jupyterlab/coreutils';
-
 import { defaultIconRegistry } from '@jupyterlab/ui-components';
 
 import { PromiseDelegate } from '@lumino/coreutils';
-
 import { DisposableDelegate } from '@lumino/disposable';
 
 import { Palette } from './palette';
-
-import { SettingConnector } from './settingconnector';
-
+import { settingsPlugin } from './settingsplugin';
 import { themesPlugin, themesPaletteMenuPlugin } from './themeplugins';
 
 /**
@@ -84,51 +75,6 @@ const paletteRestorer: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/apputils-extension:palette-restorer',
   requires: [ILayoutRestorer],
   autoStart: true
-};
-
-/**
- * The default setting registry provider.
- */
-const settings: JupyterFrontEndPlugin<ISettingRegistry> = {
-  id: '@jupyterlab/apputils-extension:settings',
-  activate: async (app: JupyterFrontEnd): Promise<ISettingRegistry> => {
-    const { isDisabled } = PageConfig.Extension;
-    const connector = new SettingConnector(app.serviceManager.settings);
-
-    const registry = new SettingRegistry({
-      connector,
-      plugins: (await connector.list('active')).values
-    });
-
-    // If there are plugins that have schemas that are not in the setting
-    // registry after the application has restored, try to load them manually
-    // because otherwise, its settings will never become available in the
-    // setting registry.
-    void app.restored.then(async () => {
-      const plugins = await connector.list('all');
-      plugins.ids.forEach(async (id, index) => {
-        if (isDisabled(id) || id in registry.plugins) {
-          return;
-        }
-
-        try {
-          await registry.load(id);
-        } catch (error) {
-          console.warn(`Settings failed to load for (${id})`, error);
-          if (plugins.values[index].schema['jupyter.lab.transform']) {
-            console.warn(
-              `This may happen if {autoStart: false} in (${id}) ` +
-                `or if it is one of the deferredExtensions in page config.`
-            );
-          }
-        }
-      });
-    });
-
-    return registry;
-  },
-  autoStart: true,
-  provides: ISettingRegistry
 };
 
 /**
@@ -497,13 +443,13 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
 const plugins: JupyterFrontEndPlugin<any>[] = [
   palette,
   paletteRestorer,
+  print,
   resolver,
-  settings,
+  settingsPlugin,
   state,
   splash,
   themesPlugin,
-  themesPaletteMenuPlugin,
-  print
+  themesPaletteMenuPlugin
 ];
 export default plugins;
 

--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -40,5 +40,9 @@ export class SettingConnector extends DataConnector<
     };
   }
 
+  async save(id: string, raw: string): Promise<void> {
+    await this._connector.save(id, raw);
+  }
+
   private _connector: IDataConnector<ISettingRegistry.IPlugin, string>;
 }

--- a/packages/apputils-extension/src/settingsplugin.ts
+++ b/packages/apputils-extension/src/settingsplugin.ts
@@ -1,0 +1,61 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import {
+  ISettingRegistry,
+  PageConfig,
+  SettingRegistry
+} from '@jupyterlab/coreutils';
+
+import { SettingConnector } from './settingconnector';
+
+/**
+ * The default setting registry provider.
+ */
+export const settingsPlugin: JupyterFrontEndPlugin<ISettingRegistry> = {
+  id: '@jupyterlab/apputils-extension:settings',
+  activate: async (app: JupyterFrontEnd): Promise<ISettingRegistry> => {
+    const { isDisabled } = PageConfig.Extension;
+    const connector = new SettingConnector(app.serviceManager.settings);
+
+    const registry = new SettingRegistry({
+      connector,
+      plugins: (await connector.list('active')).values
+    });
+
+    // If there are plugins that have schemas that are not in the setting
+    // registry after the application has restored, try to load them manually
+    // because otherwise, its settings will never become available in the
+    // setting registry.
+    void app.restored.then(async () => {
+      const plugins = await connector.list('all');
+      plugins.ids.forEach(async (id, index) => {
+        if (isDisabled(id) || id in registry.plugins) {
+          return;
+        }
+
+        try {
+          await registry.load(id);
+        } catch (error) {
+          console.warn(`Settings failed to load for (${id})`, error);
+          if (plugins.values[index].schema['jupyter.lab.transform']) {
+            console.warn(
+              `This may happen if {autoStart: false} in (${id}) ` +
+                `or if it is one of the deferredExtensions in page config.`
+            );
+          }
+        }
+      });
+    });
+
+    return registry;
+  },
+  autoStart: true,
+  provides: ISettingRegistry
+};


### PR DESCRIPTION
## References

followup #7147

In the latest master, you cannot change/save any of the user settings. This PR fixes that.

## Code changes

Digging through the merged PRs, it looks like in #7147 a `save` method was left out of the `SettingConnector` that now wraps the preexisting `SettingManager`. I added `SettingConnector.save`, which just forwards `SettingManager.save`.

I also did a little bit of related code cleanup in `apputils-extension`, and moved the settings plugin out into its own src file (mostly for the sake of making it easier for me to grasp what had broken)

## User-facing changes

Unbreaks settings

## Backwards-incompatible changes

None