### PR TITLE
Add cd and command args to create terminal command

### DIFF
--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -351,6 +351,23 @@ export function addCommands(
       term.title.icon = TERMINAL_ICON_CLASS;
       term.title.label = '...';
 
+      const folder = args['cd'] as string;
+      const command = args['command'] as string;
+      let execute: string = '';
+      if (command) {
+        execute += `${command}\n`;
+      }
+      if (folder) {
+        execute += `cd ${folder}\n`;
+      }
+
+      if (execute) {
+        session.send({
+          type: 'stdin',
+          content: [execute]
+        });
+      }
+
       let main = new MainAreaWidget({ content: term });
       app.shell.add(main);
       void tracker.add(main);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fix #7604 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Add arguments `cd` and `command` to the `terminal:create-new` command to optionally change the current directory of the terminal and execute a command in it.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
None

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None
