### PR TITLE
Strict null checks for coreutils

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -39,7 +39,7 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@yarnpkg/lockfile": "^1.1.0",
     "child_process": "~1.0.2",
     "commander": "~2.20.0",

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -171,7 +171,7 @@
     "@lumino/algorithm": "^1.2.0",
     "@lumino/application": "^1.7.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/domutils": "^1.1.3",
     "@lumino/dragdrop": "^1.3.0",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -46,7 +46,7 @@
     "@lumino/algorithm": "^1.2.0",
     "@lumino/application": "^1.7.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/polling": "^1.0.1",

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -14,6 +14,9 @@ import {
   JSONObject,
   PromiseDelegate,
   ReadonlyJSONValue,
+  PartialJSONObject,
+  ReadonlyPartialJSONValue,
+  ReadonlyPartialJSONObject,
   Token
 } from '@lumino/coreutils';
 
@@ -383,7 +386,7 @@ export class LayoutRestorer implements ILayoutRestorer {
     this._widgets.delete(name);
   }
 
-  private _connector: IDataConnector<ReadonlyJSONValue>;
+  private _connector: IDataConnector<ReadonlyPartialJSONValue>;
   private _first: Promise<any>;
   private _firstDone = false;
   private _promisesDone = false;
@@ -434,7 +437,7 @@ namespace Private {
    * It is meant to be a data structure can translate into a `LabShell.ILayout`
    * data structure for consumption by the application shell.
    */
-  export interface ILayout extends JSONObject {
+  export interface ILayout extends PartialJSONObject {
     /**
      * The main area of the user interface.
      */
@@ -454,7 +457,7 @@ namespace Private {
   /**
    * The restorable description of the main application area.
    */
-  export interface IMainArea extends JSONObject {
+  export interface IMainArea extends PartialJSONObject {
     /**
      * The current widget that has application focus.
      */
@@ -474,7 +477,7 @@ namespace Private {
   /**
    * The restorable description of a sidebar in the user interface.
    */
-  export interface ISideArea extends JSONObject {
+  export interface ISideArea extends PartialJSONObject {
     /**
      * A flag denoting whether the sidebar has been collapsed.
      */
@@ -664,7 +667,7 @@ namespace Private {
    * For fault tolerance, types are manually checked in deserialization.
    */
   export function deserializeMain(
-    area: JSONObject,
+    area: ReadonlyPartialJSONObject,
     names: Map<string, Widget>
   ): ILabShell.IMainArea | null {
     if (!area) {

--- a/packages/application/src/tokens.ts
+++ b/packages/application/src/tokens.ts
@@ -5,7 +5,7 @@ import { CommandRegistry } from '@lumino/commands';
 
 import { ServerConnection, ServiceManager } from '@jupyterlab/services';
 
-import { ReadonlyJSONObject, Token } from '@lumino/coreutils';
+import { ReadonlyPartialJSONObject, Token } from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
 
@@ -109,7 +109,7 @@ export namespace IRouter {
   /**
    * The parsed location currently being routed.
    */
-  export interface ILocation extends ReadonlyJSONObject {
+  export interface ILocation extends ReadonlyPartialJSONObject {
     /**
      * The location hash.
      */

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -44,7 +44,7 @@
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/polling": "^1.0.1",
     "@lumino/widgets": "^1.9.0",

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/domutils": "^1.1.3",
     "@lumino/messaging": "^1.3.0",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/dragdrop": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/signaling": "^1.3.0",

--- a/packages/codeeditor/package.json
+++ b/packages/codeeditor/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/observables": "^3.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/dragdrop": "^1.3.0",
     "@lumino/messaging": "^1.3.0",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/polling": "^1.0.1",
     "@lumino/signaling": "^1.3.0",

--- a/packages/completer/package.json
+++ b/packages/completer/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/domutils": "^1.1.3",
     "@lumino/messaging": "^1.3.0",

--- a/packages/console-extension/package.json
+++ b/packages/console-extension/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/mainmenu": "^2.0.0-alpha.4",
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/properties": "^1.1.3",
     "@lumino/widgets": "^1.9.0"

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -43,7 +43,7 @@
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/dragdrop": "^1.3.0",
     "@lumino/messaging": "^1.3.0",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/properties": "^1.1.3",
     "@lumino/signaling": "^1.3.0",

--- a/packages/coreutils/src/interfaces.ts
+++ b/packages/coreutils/src/interfaces.ts
@@ -3,7 +3,10 @@
 
 import { CommandRegistry } from '@lumino/commands';
 
-import { ReadonlyJSONObject, ReadonlyJSONValue } from '@lumino/coreutils';
+import {
+  ReadonlyPartialJSONObject,
+  ReadonlyPartialJSONValue
+} from '@lumino/coreutils';
 
 import { IDisposable, IObservableDisposable } from '@lumino/disposable';
 
@@ -227,7 +230,7 @@ export namespace IRestorer {
     /**
      * A function that returns the args needed to restore an instance.
      */
-    args?: (obj: T) => ReadonlyJSONObject;
+    args?: (obj: T) => ReadonlyPartialJSONObject;
 
     /**
      * A function that returns a unique persistent name for this instance.
@@ -279,7 +282,7 @@ export namespace IRestorable {
     /**
      * The data connector to fetch restore data.
      */
-    connector: IDataConnector<ReadonlyJSONValue>;
+    connector: IDataConnector<ReadonlyPartialJSONValue>;
 
     /**
      * The command registry which holds the restore command.

--- a/packages/coreutils/src/nbformat.ts
+++ b/packages/coreutils/src/nbformat.ts
@@ -5,7 +5,7 @@
 // https://nbformat.readthedocs.io/en/latest/format_description.html
 // https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
 
-import { JSONObject, JSONExt } from '@lumino/coreutils';
+import { PartialJSONObject, JSONExt } from '@lumino/coreutils';
 
 /**
  * A namespace for nbformat interfaces.
@@ -24,7 +24,7 @@ export namespace nbformat {
   /**
    * The kernelspec metadata.
    */
-  export interface IKernelspecMetadata extends JSONObject {
+  export interface IKernelspecMetadata extends PartialJSONObject {
     name: string;
     display_name: string;
   }
@@ -32,9 +32,9 @@ export namespace nbformat {
   /**
    * The language info metatda
    */
-  export interface ILanguageInfoMetadata extends JSONObject {
+  export interface ILanguageInfoMetadata extends PartialJSONObject {
     name: string;
-    codemirror_mode?: string | JSONObject;
+    codemirror_mode?: string | PartialJSONObject;
     file_extension?: string;
     mimetype?: string;
     pygments_lexer?: string;
@@ -43,7 +43,7 @@ export namespace nbformat {
   /**
    * The default metadata for the notebook.
    */
-  export interface INotebookMetadata extends JSONObject {
+  export interface INotebookMetadata extends PartialJSONObject {
     kernelspec?: IKernelspecMetadata;
     language_info?: ILanguageInfoMetadata;
     orig_nbformat: number;
@@ -52,7 +52,7 @@ export namespace nbformat {
   /**
    * The notebook content.
    */
-  export interface INotebookContent extends JSONObject {
+  export interface INotebookContent extends PartialJSONObject {
     metadata: INotebookMetadata;
     nbformat_minor: number;
     nbformat: number;
@@ -67,8 +67,8 @@ export namespace nbformat {
   /**
    * A mime-type keyed dictionary of data.
    */
-  export interface IMimeBundle extends JSONObject {
-    [key: string]: MultilineString | JSONObject;
+  export interface IMimeBundle extends PartialJSONObject {
+    [key: string]: MultilineString | PartialJSONObject;
   }
 
   /**
@@ -86,7 +86,7 @@ export namespace nbformat {
   /**
    * Cell output metadata.
    */
-  export type OutputMetadata = JSONObject;
+  export type OutputMetadata = PartialJSONObject;
 
   /**
    * Validate a mime type/value pair.
@@ -99,7 +99,7 @@ export namespace nbformat {
    */
   export function validateMimeValue(
     type: string,
-    value: MultilineString | JSONObject
+    value: MultilineString | PartialJSONObject
   ): boolean {
     // Check if "application/json" or "application/foo+json"
     const jsonTest = /^application\/(.*?)+\+json$/;
@@ -146,7 +146,7 @@ export namespace nbformat {
   /**
    * The Jupyter metadata namespace.
    */
-  export interface IBaseCellJupyterMetadata extends JSONObject {
+  export interface IBaseCellJupyterMetadata extends PartialJSONObject {
     /**
      * Whether the source is hidden.
      */
@@ -156,7 +156,7 @@ export namespace nbformat {
   /**
    * Cell-level metadata.
    */
-  export interface IBaseCellMetadata extends JSONObject {
+  export interface IBaseCellMetadata extends PartialJSONObject {
     /**
      * Whether the cell is trusted.
      *
@@ -187,7 +187,7 @@ export namespace nbformat {
   /**
    * The base cell interface.
    */
-  export interface IBaseCell extends JSONObject {
+  export interface IBaseCell extends PartialJSONObject {
     /**
      * String identifying the type of cell.
      */
@@ -356,7 +356,7 @@ export namespace nbformat {
   /**
    * The base output type.
    */
-  export interface IBaseOutput extends JSONObject {
+  export interface IBaseOutput extends PartialJSONObject {
     /**
      * Type of cell output.
      */

--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -62,25 +62,6 @@ export namespace PathExt {
   }
 
   /**
-   * Get the last portion of a path, without its extension (if any).
-   *
-   * @param path - The file path.
-   *
-   * @returns the last part of the path, sans extension.
-   */
-  export function stem(path: string): string {
-    // TODO: This will always fail?
-    // TODO: Exclamation marks are only here to allow it to compile
-    return path
-      .split('\\')
-      .pop()!
-      .split('/')
-      .pop()!
-      .split('.')
-      .shift()!;
-  }
-
-  /**
    * Normalize a string path, reducing '..' and '.' parts.
    * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used.
    * When an empty path is given, returns the root path.

--- a/packages/coreutils/src/path.ts
+++ b/packages/coreutils/src/path.ts
@@ -69,13 +69,15 @@ export namespace PathExt {
    * @returns the last part of the path, sans extension.
    */
   export function stem(path: string): string {
+    // TODO: This will always fail?
+    // TODO: Exclamation marks are only here to allow it to compile
     return path
       .split('\\')
-      .pop()
+      .pop()!
       .split('/')
-      .pop()
+      .pop()!
       .split('.')
-      .shift();
+      .shift()!;
   }
 
   /**

--- a/packages/coreutils/src/restorablepool.ts
+++ b/packages/coreutils/src/restorablepool.ts
@@ -56,11 +56,11 @@ export class RestorablePool<
   get current(): T | null {
     return this._current;
   }
-  set current(obj: T) {
+  set current(obj: T | null) {
     if (this._current === obj) {
       return;
     }
-    if (this._objects.has(obj)) {
+    if (obj !== null && this._objects.has(obj)) {
       this._current = obj;
       this._currentChanged.emit(this._current);
     }

--- a/packages/coreutils/src/restorablepool.ts
+++ b/packages/coreutils/src/restorablepool.ts
@@ -138,7 +138,7 @@ export class RestorablePool<
 
       if (objName) {
         const name = `${this.namespace}:${objName}`;
-        const data = this._restore.args(obj);
+        const data = this._restore.args?.(obj);
 
         Private.nameProperty.set(obj, name);
         await connector.save(name, { data });
@@ -298,7 +298,7 @@ export class RestorablePool<
     Private.nameProperty.set(obj, newName);
 
     if (newName) {
-      const data = this._restore.args(obj);
+      const data = this._restore.args?.(obj);
       await connector.save(newName, { data });
     }
 

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -357,6 +357,16 @@ export class SettingRegistry implements ISettingRegistry {
     const plugins = this.plugins;
     const registry = this;
 
+    if (fetched === undefined) {
+      throw [
+        {
+          dataPath: '',
+          keyword: 'id',
+          message: `Could not fetch settings for ${plugin}.`,
+          schemaPath: ''
+        } as ISchemaValidator.IError
+      ];
+    }
     await this._load(await this._transform('fetch', fetched));
     this._pluginChanged.emit(plugin);
 
@@ -553,6 +563,16 @@ export class SettingRegistry implements ISettingRegistry {
 
     // Fetch and reload the data to guarantee server and client are in sync.
     const fetched = await this.connector.fetch(plugin);
+    if (fetched === undefined) {
+      throw [
+        {
+          dataPath: '',
+          keyword: 'id',
+          message: `Could not fetch settings for ${plugin}.`,
+          schemaPath: ''
+        } as ISchemaValidator.IError
+      ];
+    }
     await this._load(await this._transform('fetch', fetched));
     this._pluginChanged.emit(plugin);
   }

--- a/packages/coreutils/src/settingregistry.ts
+++ b/packages/coreutils/src/settingregistry.ts
@@ -147,7 +147,7 @@ export class DefaultSchemaValidator implements ISchemaValidator {
     // Parse the raw commented JSON into a user map.
     let user: JSONObject;
     try {
-      user = json.parse(plugin.raw, null) as JSONObject;
+      user = json.parse(plugin.raw) as JSONObject;
     } catch (error) {
       if (error instanceof SyntaxError) {
         return [
@@ -296,7 +296,10 @@ export class SettingRegistry implements ISettingRegistry {
   async get(
     plugin: string,
     key: string
-  ): Promise<{ composite: JSONValue; user: JSONValue }> {
+  ): Promise<{
+    composite: JSONValue | undefined;
+    user: JSONValue | undefined;
+  }> {
     // Wait for data preload before allowing normal operation.
     await this._ready;
 
@@ -379,7 +382,7 @@ export class SettingRegistry implements ISettingRegistry {
       return;
     }
 
-    const raw = json.parse(plugins[plugin].raw, null);
+    const raw = json.parse(plugins[plugin].raw);
 
     // Delete both the value and any associated comment.
     delete raw[key];
@@ -412,7 +415,7 @@ export class SettingRegistry implements ISettingRegistry {
     }
 
     // Parse the raw JSON string removing all comments and return an object.
-    const raw = json.parse(plugins[plugin].raw, null);
+    const raw = json.parse(plugins[plugin].raw);
 
     plugins[plugin].raw = Private.annotatedPlugin(plugins[plugin], {
       ...raw,
@@ -750,7 +753,12 @@ export class Settings implements ISettingRegistry.ISettings {
    * This method returns synchronously because it uses a cached copy of the
    * plugin settings that is synchronized with the registry.
    */
-  get(key: string): { composite: ReadonlyJSONValue; user: ReadonlyJSONValue } {
+  get(
+    key: string
+  ): {
+    composite: ReadonlyJSONValue | undefined;
+    user: ReadonlyJSONValue | undefined;
+  } {
     const { composite, user } = this;
 
     return {
@@ -980,7 +988,9 @@ namespace Private {
     plugin: string
   ): string {
     const { description, properties, title } = schema;
-    const keys = Object.keys(properties).sort((a, b) => a.localeCompare(b));
+    const keys = properties
+      ? Object.keys(properties).sort((a, b) => a.localeCompare(b))
+      : [];
     const length = Math.max((description || nondescript).length, plugin.length);
 
     return [
@@ -1096,7 +1106,7 @@ namespace Private {
     root?: string
   ): JSONValue | undefined {
     // If the property is at the root level, traverse its schema.
-    schema = (root ? schema.properties[root] : schema) || {};
+    schema = (root ? schema.properties?.[root] : schema) || {};
 
     // If the property has no default or is a primitive, return.
     if (!('default' in schema) || schema.type !== 'object') {
@@ -1107,8 +1117,9 @@ namespace Private {
     const result = JSONExt.deepCopy(schema.default);
 
     // Iterate through and populate each child property.
-    for (let property in schema.properties || {}) {
-      result[property] = reifyDefault(schema.properties[property]);
+    const props = schema.properties || {};
+    for (let property in props) {
+      result[property] = reifyDefault(props[property]);
     }
 
     return result;

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ReadonlyJSONObject, ReadonlyJSONValue } from '@lumino/coreutils';
+import { ReadonlyJSONValue } from '@lumino/coreutils';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
@@ -19,30 +19,34 @@ export class StateDB<T extends ReadonlyJSONValue = ReadonlyJSONValue>
    *
    * @param options - The instantiation options for a state database.
    */
-  constructor(options: StateDB.IOptions = {}) {
+  constructor(options: StateDB.IOptions<T> = {}) {
     const { connector, transform } = options;
 
     this._connector = connector || new StateDB.Connector();
-    this._ready = (transform || Promise.resolve(null)).then(transformation => {
-      if (!transformation) {
-        return;
-      }
-
-      const { contents, type } = transformation;
-
-      switch (type) {
-        case 'cancel':
+    if (!transform) {
+      this._ready = Promise.resolve(undefined);
+    } else {
+      this._ready = transform.then(transformation => {
+        if (!transformation) {
           return;
-        case 'clear':
-          return this._clear();
-        case 'merge':
-          return this._merge(contents || {});
-        case 'overwrite':
-          return this._overwrite(contents || {});
-        default:
-          return;
-      }
-    });
+        }
+
+        const { contents, type } = transformation;
+
+        switch (type) {
+          case 'cancel':
+            return;
+          case 'clear':
+            return this._clear();
+          case 'merge':
+            return this._merge(contents || {});
+          case 'overwrite':
+            return this._overwrite(contents || {});
+          default:
+            return;
+        }
+      });
+    }
   }
 
   /**
@@ -78,7 +82,7 @@ export class StateDB<T extends ReadonlyJSONValue = ReadonlyJSONValue>
    * retrieving the data. Non-existence of an `id` will succeed with the `value`
    * `undefined`.
    */
-  async fetch(id: string): Promise<T> {
+  async fetch(id: string): Promise<T | undefined> {
     await this._ready;
     return this._fetch(id);
   }
@@ -188,7 +192,7 @@ export class StateDB<T extends ReadonlyJSONValue = ReadonlyJSONValue>
   /**
    * Merge data into the state database.
    */
-  private async _merge(contents: { [id: string]: T }): Promise<void> {
+  private async _merge(contents: StateDB.Content<T>): Promise<void> {
     await Promise.all(
       Object.keys(contents).map(key => this._save(key, contents[key]))
     );
@@ -197,7 +201,7 @@ export class StateDB<T extends ReadonlyJSONValue = ReadonlyJSONValue>
   /**
    * Overwrite the entire database with new contents.
    */
-  private async _overwrite(contents: { [id: string]: T }): Promise<void> {
+  private async _overwrite(contents: StateDB.Content<T>): Promise<void> {
     await this._clear();
     await this._merge(contents);
   }
@@ -246,7 +250,7 @@ export namespace StateDB {
   /**
    * A data transformation that can be applied to a state database.
    */
-  export type DataTransform = {
+  export type DataTransform<T extends ReadonlyJSONValue = ReadonlyJSONValue> = {
     /*
      * The change operation being applied.
      */
@@ -255,13 +259,18 @@ export namespace StateDB {
     /**
      * The contents of the change operation.
      */
-    contents: ReadonlyJSONObject | null;
+    contents: Content<T> | null;
   };
+
+  /**
+   * Database content map
+   */
+  export type Content<T> = { [id: string]: T };
 
   /**
    * The instantiation options for a state database.
    */
-  export interface IOptions {
+  export interface IOptions<T extends ReadonlyJSONValue = ReadonlyJSONValue> {
     /**
      * Optional string key/value connector. Defaults to in-memory connector.
      */
@@ -272,7 +281,7 @@ export namespace StateDB {
      * applied to the database contents before the database begins resolving
      * client requests.
      */
-    transform?: Promise<DataTransform>;
+    transform?: Promise<DataTransform<T>>;
   }
 
   /**
@@ -298,7 +307,7 @@ export namespace StateDB {
           }
           return acc;
         },
-        { ids: [], values: [] }
+        { ids: [] as string[], values: [] as string[] }
       );
     }
 

--- a/packages/coreutils/src/statedb.ts
+++ b/packages/coreutils/src/statedb.ts
@@ -27,10 +27,6 @@ export class StateDB<T extends ReadonlyJSONValue = ReadonlyJSONValue>
       this._ready = Promise.resolve(undefined);
     } else {
       this._ready = transform.then(transformation => {
-        if (!transformation) {
-          return;
-        }
-
         const { contents, type } = transformation;
 
         switch (type) {

--- a/packages/coreutils/src/tokens.ts
+++ b/packages/coreutils/src/tokens.ts
@@ -6,6 +6,7 @@ import {
   JSONValue,
   ReadonlyJSONObject,
   ReadonlyJSONValue,
+  PartialJSONObject,
   Token
 } from '@lumino/coreutils';
 
@@ -171,7 +172,7 @@ export namespace ISettingRegistry {
   /**
    * The settings for a specific plugin.
    */
-  export interface IPlugin extends JSONObject {
+  export interface IPlugin extends PartialJSONObject {
     /**
      * The name of the plugin.
      */
@@ -217,7 +218,7 @@ export namespace ISettingRegistry {
   /**
    * A minimal subset of the formal JSON Schema that describes a property.
    */
-  export interface IProperty extends JSONObject {
+  export interface IProperty extends PartialJSONObject {
     /**
      * The default value, if any.
      */
@@ -423,7 +424,7 @@ export namespace ISettingRegistry {
   /**
    * An interface describing a JupyterLab keyboard shortcut.
    */
-  export interface IShortcut extends JSONObject {
+  export interface IShortcut extends PartialJSONObject {
     /**
      * The optional arguments passed into the shortcut's command.
      */

--- a/packages/coreutils/src/tokens.ts
+++ b/packages/coreutils/src/tokens.ts
@@ -70,7 +70,7 @@ export interface ISettingRegistry {
   get(
     plugin: string,
     key: string
-  ): Promise<{ composite: JSONValue; user: JSONValue }>;
+  ): Promise<{ composite: JSONValue | undefined; user: JSONValue | undefined }>;
 
   /**
    * Load a plugin's settings into the setting registry.
@@ -378,7 +378,12 @@ export namespace ISettingRegistry {
      *
      * @returns The setting value.
      */
-    get(key: string): { composite: ReadonlyJSONValue; user: ReadonlyJSONValue };
+    get(
+      key: string
+    ): {
+      composite: ReadonlyJSONValue | undefined;
+      user: ReadonlyJSONValue | undefined;
+    };
 
     /**
      * Remove a single setting.

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -28,7 +28,9 @@ export namespace URLExt {
   /**
    * Normalize a url.
    */
-  export function normalize(url: string): string {
+  export function normalize(url: string): string;
+  export function normalize(url: undefined): undefined;
+  export function normalize(url: string | undefined): string | undefined {
     return url && parse(url).toString();
   }
 

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { JSONObject } from '@lumino/coreutils';
+import { PartialJSONObject } from '@lumino/coreutils';
 
 import urlparse from 'url-parse';
 
@@ -97,7 +97,7 @@ export namespace URLExt {
    * #### Notes
    * Modified version of [stackoverflow](http://stackoverflow.com/a/30707423).
    */
-  export function objectToQueryString(value: JSONObject): string {
+  export function objectToQueryString(value: PartialJSONObject): string {
     const keys = Object.keys(value).filter(key => key.length > 0);
 
     if (!keys.length) {

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -51,8 +51,8 @@ export namespace URLExt {
     // Parse the top element into a header collection.
     const header = top.match(/(\w+)(:)(\/\/)?/);
     const protocol = header && header[1];
-    const colon = protocol && header[2];
-    const slashes = colon && header[3];
+    const colon = protocol && header![2];
+    const slashes = colon && header![3];
 
     // Construct the URL prefix.
     const prefix = shorthand
@@ -146,7 +146,10 @@ export namespace URLExt {
   export function isLocal(url: string): boolean {
     const { protocol } = parse(url);
 
-    return url.toLowerCase().indexOf(protocol) !== 0 && url.indexOf('/') !== 0;
+    return (
+      (!protocol || url.toLowerCase().indexOf(protocol) !== 0) &&
+      url.indexOf('/') !== 0
+    );
   }
 
   /**

--- a/packages/coreutils/tsconfig.json
+++ b/packages/coreutils/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "module": "commonjs",
+    "strictNullChecks": true,
     "types": ["node"]
   },
   "files": ["src/plugin-schema.json"],

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/docregistry": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/datagrid": "^0.3.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -45,7 +45,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/widgets": "^1.9.0"
   },

--- a/packages/docmanager/package.json
+++ b/packages/docmanager/package.json
@@ -41,7 +41,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/properties": "^1.1.3",

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -44,7 +44,7 @@
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/signaling": "^1.3.0",

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -38,7 +38,7 @@
     "@jupyterlab/codemirror": "^2.0.0-alpha.4",
     "@jupyterlab/fileeditor": "^2.0.0-alpha.4",
     "@jupyterlab/notebook": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/polling": "^1.0.1",
     "@lumino/signaling": "^1.3.0",

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -43,7 +43,7 @@
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/domutils": "^1.1.3",
     "@lumino/dragdrop": "^1.3.0",

--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -48,7 +48,7 @@
     "@jupyterlab/mainmenu": "^2.0.0-alpha.4",
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/widgets": "^1.9.0"
   },
   "devDependencies": {

--- a/packages/fileeditor/package.json
+++ b/packages/fileeditor/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/codeeditor": "^2.0.0-alpha.4",
     "@jupyterlab/docregistry": "^2.0.0-alpha.4",
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "react": "~16.8.4"

--- a/packages/htmlviewer/package.json
+++ b/packages/htmlviewer/package.json
@@ -35,7 +35,7 @@
     "@jupyterlab/apputils": "^2.0.0-alpha.4",
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/docregistry": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/signaling": "^1.3.0",
     "react": "~16.8.4"
   },

--- a/packages/imageviewer/package.json
+++ b/packages/imageviewer/package.json
@@ -38,7 +38,7 @@
     "@jupyterlab/apputils": "^2.0.0-alpha.4",
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/docregistry": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0"
   },

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/polling": "^1.0.1",
     "@lumino/signaling": "^1.3.0",

--- a/packages/json-extension/package.json
+++ b/packages/json-extension/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/apputils": "^2.0.0-alpha.4",
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "react": "~16.8.4",

--- a/packages/launcher-extension/package.json
+++ b/packages/launcher-extension/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/apputils": "^2.0.0-alpha.4",
     "@jupyterlab/launcher": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/widgets": "^1.9.0"
   },
   "devDependencies": {

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/properties": "^1.1.3",
     "@lumino/widgets": "^1.9.0",

--- a/packages/logconsole-extension/package.json
+++ b/packages/logconsole-extension/package.json
@@ -43,7 +43,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/signaling": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "react": "~16.8.4"

--- a/packages/logconsole/package.json
+++ b/packages/logconsole/package.json
@@ -36,7 +36,7 @@
     "@jupyterlab/outputarea": "^2.0.0-alpha.4",
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/signaling": "^1.3.0",

--- a/packages/mainmenu/package.json
+++ b/packages/mainmenu/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/widgets": "^1.9.0"
   },

--- a/packages/markdownviewer/package.json
+++ b/packages/markdownviewer/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/docregistry": "^2.0.0-alpha.4",
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0"
   },

--- a/packages/mathjax2/package.json
+++ b/packages/mathjax2/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1"
+    "@lumino/coreutils": "^1.4.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/packages/notebook-extension/package.json
+++ b/packages/notebook-extension/package.json
@@ -51,7 +51,7 @@
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0"

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/statusbar": "^2.0.0-alpha.4",
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/domutils": "^1.1.3",
     "@lumino/dragdrop": "^1.3.0",
     "@lumino/messaging": "^1.3.0",

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/signaling": "^1.3.0"

--- a/packages/outputarea/package.json
+++ b/packages/outputarea/package.json
@@ -42,7 +42,7 @@
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/properties": "^1.1.3",

--- a/packages/pdf-extension/package.json
+++ b/packages/pdf-extension/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/widgets": "^1.9.0"
   },

--- a/packages/rendermime-interfaces/package.json
+++ b/packages/rendermime-interfaces/package.json
@@ -31,7 +31,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/widgets": "^1.9.0"
   },
   "devDependencies": {

--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -42,7 +42,7 @@
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/signaling": "^1.3.0",
     "@lumino/widgets": "^1.9.0",

--- a/packages/running/package.json
+++ b/packages/running/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jupyterlab/apputils": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/signaling": "^1.3.0",
     "react": "~16.8.4"

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -44,7 +44,7 @@
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/observables": "^3.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/polling": "^1.0.1",
     "@lumino/signaling": "^1.3.0",

--- a/packages/settingeditor/package.json
+++ b/packages/settingeditor/package.json
@@ -42,7 +42,7 @@
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/signaling": "^1.3.0",
     "@lumino/widgets": "^1.9.0",

--- a/packages/shortcuts-extension/package.json
+++ b/packages/shortcuts-extension/package.json
@@ -35,7 +35,7 @@
     "@jupyterlab/application": "^2.0.0-alpha.4",
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -37,7 +37,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/polling": "^1.0.1",

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/domutils": "^1.1.3",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",

--- a/packages/tooltip-extension/package.json
+++ b/packages/tooltip-extension/package.json
@@ -46,7 +46,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/tooltip": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/widgets": "^1.9.0"
   },
   "devDependencies": {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/codeeditor": "^2.0.0-alpha.4",
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0"
   },

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -37,7 +37,7 @@
     "@blueprintjs/core": "^3.9.0",
     "@blueprintjs/select": "^3.3.0",
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/virtualdom": "^1.2.0",
     "@lumino/widgets": "^1.9.0",

--- a/packages/vdom/package.json
+++ b/packages/vdom/package.json
@@ -38,7 +38,7 @@
     "@jupyterlab/docregistry": "^2.0.0-alpha.4",
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "@nteract/transform-vdom": "^4.0.1",

--- a/packages/vega4-extension/package.json
+++ b/packages/vega4-extension/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/widgets": "^1.9.0"
   },
   "devDependencies": {

--- a/packages/vega5-extension/package.json
+++ b/packages/vega5-extension/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@jupyterlab/rendermime-interfaces": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/widgets": "^1.9.0"
   },
   "devDependencies": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -29,7 +29,7 @@
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/domutils": "^1.1.3",
     "@lumino/messaging": "^1.3.0",

--- a/tests/test-application/package.json
+++ b/tests/test-application/package.json
@@ -18,7 +18,7 @@
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0",

--- a/tests/test-apputils/package.json
+++ b/tests/test-apputils/package.json
@@ -17,7 +17,7 @@
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
     "@lumino/commands": "^1.7.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/virtualdom": "^1.2.0",
     "@lumino/widgets": "^1.9.0",

--- a/tests/test-cells/package.json
+++ b/tests/test-cells/package.json
@@ -19,7 +19,7 @@
     "@jupyterlab/outputarea": "^2.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0",

--- a/tests/test-completer/package.json
+++ b/tests/test-completer/package.json
@@ -18,7 +18,7 @@
     "@jupyterlab/completer": "^2.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0",

--- a/tests/test-console/package.json
+++ b/tests/test-console/package.json
@@ -23,7 +23,7 @@
     "@jupyterlab/console": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/signaling": "^1.3.0",
     "@lumino/widgets": "^1.9.0",

--- a/tests/test-coreutils/package.json
+++ b/tests/test-coreutils/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/signaling": "^1.3.0",
     "chai": "^4.2.0",

--- a/tests/test-coreutils/src/path.spec.ts
+++ b/tests/test-coreutils/src/path.spec.ts
@@ -79,17 +79,6 @@ describe('@jupyterlab/coreutils', () => {
       });
     });
 
-    describe('.stem()', () => {
-      it('almost always fails', () => {
-        // This works
-        let path = PathExt.stem('var\\foo/src.ext');
-        expect(path).to.equal('src');
-        // This fails
-        path = PathExt.stem('var/src');
-        expect(path).to.equal('src');
-      });
-    });
-
     describe('.normalizeExtension()', () => {
       it('should normalize a file extension to be of type `.foo`', () => {
         expect(PathExt.normalizeExtension('foo')).to.equal('.foo');

--- a/tests/test-coreutils/src/path.spec.ts
+++ b/tests/test-coreutils/src/path.spec.ts
@@ -79,6 +79,17 @@ describe('@jupyterlab/coreutils', () => {
       });
     });
 
+    describe('.stem()', () => {
+      it('almost always fails', () => {
+        // This works
+        let path = PathExt.stem('var\\foo/src.ext');
+        expect(path).to.equal('src');
+        // This fails
+        path = PathExt.stem('var/src');
+        expect(path).to.equal('src');
+      });
+    });
+
     describe('.normalizeExtension()', () => {
       it('should normalize a file extension to be of type `.foo`', () => {
         expect(PathExt.normalizeExtension('foo')).to.equal('.foo');

--- a/tests/test-csvviewer/package.json
+++ b/tests/test-csvviewer/package.json
@@ -20,7 +20,7 @@
     "@jupyterlab/docregistry": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/datagrid": "^0.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0",

--- a/tests/test-docmanager/package.json
+++ b/tests/test-docmanager/package.json
@@ -20,7 +20,7 @@
     "@jupyterlab/docregistry": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0"

--- a/tests/test-docregistry/package.json
+++ b/tests/test-docregistry/package.json
@@ -17,7 +17,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/disposable": "^1.3.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",

--- a/tests/test-filebrowser/package.json
+++ b/tests/test-filebrowser/package.json
@@ -24,7 +24,7 @@
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0",

--- a/tests/test-fileeditor/package.json
+++ b/tests/test-fileeditor/package.json
@@ -17,7 +17,7 @@
     "@jupyterlab/fileeditor": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0",

--- a/tests/test-imageviewer/package.json
+++ b/tests/test-imageviewer/package.json
@@ -16,7 +16,7 @@
     "@jupyterlab/imageviewer": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0",

--- a/tests/test-notebook/package.json
+++ b/tests/test-notebook/package.json
@@ -27,7 +27,7 @@
     "@jupyterlab/observables": "^3.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/messaging": "^1.3.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0",

--- a/tests/test-observables/package.json
+++ b/tests/test-observables/package.json
@@ -15,7 +15,7 @@
     "@jupyterlab/observables": "^3.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",

--- a/tests/test-rendermime/package.json
+++ b/tests/test-rendermime/package.json
@@ -23,7 +23,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/widgets": "^1.9.0",
     "chai": "^4.2.0"
   },

--- a/tests/test-services/package.json
+++ b/tests/test-services/package.json
@@ -16,7 +16,7 @@
     "@jupyterlab/services": "^5.0.0-alpha.4",
     "@jupyterlab/testutils": "^2.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.0",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/signaling": "^1.3.0",
     "chai": "^4.2.0",
     "jest": "^24.7.1",

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/notebook": "^2.0.0-alpha.4",
     "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "@jupyterlab/services": "^5.0.0-alpha.4",
-    "@lumino/coreutils": "^1.3.1",
+    "@lumino/coreutils": "^1.4.0",
     "@lumino/signaling": "^1.3.0",
     "fs-extra": "^8.0.1",
     "identity-obj-proxy": "^3.0.0",

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "composite": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8317,15 +8317,20 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8317,20 +8317,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
   integrity sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=
-
-inherits@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"


### PR DESCRIPTION
## References

Partially supersedes #7002.

## Code changes

Some updated typings to be more clear about where null/undefined is expected/allowed, some bug fixes.

## User-facing changes

None.

## Backwards-incompatible changes

Strictly, these could all be categorized as bug fixes, but due to the number of minor tweaks, it might be better to do this as part of a major version release.

@afshin If this causes a major version release, it might be the timing for moving the settings registry etc, out of coreutils.

## TODO before merging

- [ ] Some bugs were left in place as I want input on how to resolve. These should be fixed before merging.
- [x] Individual questions below should all be resolved.
- [ ] ~Each type in the public facing API in the package should be re-evaluated if it should also accept null/undefined... or we can leave it as is, and issue bug fixes if we need to expand the accepted values to include undefined/null.~ (this should be done at the end of all strict null PRs)