### PR TITLE
Support transient editor configs

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -147,11 +147,15 @@ export namespace Commands {
 
   /**
    * Update the settings of a widget.
+   * Skip global settings for transient editor specific configs.
    */
   export function updateWidget(widget: FileEditor): void {
+    const transientConfigs = ['lineNumbers', 'lineWrap', 'matchBrackets'];
     const editor = widget.editor;
     Object.keys(config).forEach((key: keyof CodeEditor.IConfig) => {
-      editor.setOption(key, config[key]);
+      if (!transientConfigs.includes(key)) {
+        editor.setOption(key, config[key]);
+      }
     });
   }
 


### PR DESCRIPTION
## References 

Fixes #7295 as (re)discovered in #7350

## Code changes

Currently when global file editor settings are changed the transient editor-specific settings are reset to their default global values.

Now the transient editor-specific configs are skipped when any global settings updates are applied to each editor's configs.

## User-facing changes

Now when users change setting such as tab size or font size the settings for line numbers, match brackets and line wrap wont reset to their default

## Backwards-incompatible changes

N/A