### PR TITLE
Release cleanup

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,13 +3,14 @@ current_version = 2, 0, 0, 'alpha', 4
 commit = False
 tag = False
 parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)
-serialize = 
+serialize =
 	{major}, {minor}, {patch}, '{release}', {build}
 
 [bumpversion:part:release]
 optional_value = final
-values = 
+values =
 	alpha
+	beta
 	candidate
 	final
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,15 +54,14 @@ version, and we keep the JS versions and tags in sync with the release cycle.
 Here is an example of how version numbers progress through a release process.
 Choose and run an appropriate command to bump version numbers for this release.
 
-| Command                            | Python Version Change | NPM Version change                 |
-| ---------------------------------- | --------------------- | ---------------------------------- |
-| `jlpm bumpversion minor`           | x.y.z-> x.(y+1).0.a0  | All a.b.c -> a.(b+1).0-alpha.0     |
-| `jlpm bumpversion build`           | x.y.z.a0-> x.y.z.a1   | All a.b.c-alpha.0 -> a.b.c-alpha.1 |
-| `jlpm bumpversion release`         | x.y.z.a1-> x.y.z.rc0  | All a.b.c-alpha.1 -> a.b.c-rc.0    |
-| `jlpm bumpversion release`         | x.y.z.rc0-> x.y.z     | All a.b.c-rc0 -> a.b.c             |
-| `jlpm patch:release [...packages]` | x.y.z -> x.y.(z+1)    | Selected a.b.c -> a.b.(c+1)        |
-
-Note: if you are making a patch release, and want to update whatever JS packages changed, just do `jlpm patch:release js` (in fact, _any_ argument, not just `js`, forces all JS packages to be examined).
+| Command                    | Python Version Change | NPM Version change                 |
+| -------------------------- | --------------------- | ---------------------------------- |
+| `jlpm bumpversion minor`   | x.y.z-> x.(y+1).0.a0  | All a.b.c -> a.(b+1).0-alpha.0     |
+| `jlpm bumpversion build`   | x.y.z.a0-> x.y.z.a1   | All a.b.c-alpha.0 -> a.b.c-alpha.1 |
+| `jlpm bumpversion release` | x.y.z.a1-> x.y.z.b0   | All a.b.c-alpha.1 -> a.b.c-beta.0  |
+| `jlpm bumpversion release` | x.y.z.a1-> x.y.z.rc0  | All a.b.c-alpha.1 -> a.b.c-rc.0    |
+| `jlpm bumpversion release` | x.y.z.rc0-> x.y.z     | All a.b.c-rc0 -> a.b.c             |
+| `jlpm patch:release`       | x.y.z -> x.y.(z+1)    | Changed a.b.c -> a.b.(c+1)         |
 
 ### JS major release(s)
 
@@ -78,15 +77,9 @@ Results:
 - Python package is not affected.
 - JS dependencies are also bumped a major version.
 - Packages that have already had a major bump in this prerelease cycle are not affected.
-- All affected packages changed to match the current release type of the Python package (`alpha` or `rc`).
+- All affected packages changed to match the current release type of the Python package (`alpha`, `beta`, or `rc`).
 
 ## Publishing Packages
-
-Currently we end up with some uncommitted changes at this step. We'll need to commit them before running the publish.
-
-```bash
-git commit -am "bump version"
-```
 
 Now publish the JS packages and build the python packages
 
@@ -109,11 +102,9 @@ IntSlider()
 
 ## Finish
 
-Follow instructions printed at the end of the publish step above, including:
+Follow instructions printed at the end of the publish step above:
 
-- committing changes
-- tagging the release
-- and uploading to pypi with twine
+- upload to pypi with twine
 - double-check what branch you are on, then push changes to the correct upstream branch with the `--tags` option.
 
 ## Post release candidate checklist

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,12 +56,18 @@ Choose and run an appropriate command to bump version numbers for this release.
 
 | Command                    | Python Version Change | NPM Version change                 |
 | -------------------------- | --------------------- | ---------------------------------- |
-| `jlpm bumpversion minor`   | x.y.z-> x.(y+1).0.a0  | All a.b.c -> a.(b+1).0-alpha.0     |
+| `jlpm bumpversion minor`   | x.y.z-> x.(y+1).0.a0  | All a.b.c -> a.(b+10).0-alpha.0    |
 | `jlpm bumpversion build`   | x.y.z.a0-> x.y.z.a1   | All a.b.c-alpha.0 -> a.b.c-alpha.1 |
 | `jlpm bumpversion release` | x.y.z.a1-> x.y.z.b0   | All a.b.c-alpha.1 -> a.b.c-beta.0  |
 | `jlpm bumpversion release` | x.y.z.a1-> x.y.z.rc0  | All a.b.c-alpha.1 -> a.b.c-rc.0    |
 | `jlpm bumpversion release` | x.y.z.rc0-> x.y.z     | All a.b.c-rc0 -> a.b.c             |
 | `jlpm patch:release`       | x.y.z -> x.y.(z+1)    | Changed a.b.c -> a.b.(c+1)         |
+
+Note: For a minor release, we bump the JS packages by 10 versions so that
+we are not competing amongst the minor releases for version numbers.
+We are essentially sub-dividing semver to allow us to bump minor versions
+of the JS packages as many times as we need to for minor releases of the
+top level JupyterLab application.
 
 ### JS major release(s)
 

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -81,7 +81,17 @@ commander
       },
       true
     );
-    utils.run(cmd);
+    // For a preminor release, we bump 10 minor versions so that we do
+    // not conflict with versions during minor releases of the top
+    // level package.
+    if (lernaVersion === 'preminor') {
+      for (let i = 0; i < 10; i++) {
+        utils.run(cmd);
+      }
+    } else {
+      utils.run(cmd);
+    }
+
     let newVersion = utils.run(
       'git rev-parse HEAD',
       {

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -23,6 +23,7 @@ commander
     }
     if (
       prev.indexOf('a') === -1 &&
+      prev.indexOf('b') === -1 &&
       prev.indexOf('rc') === -1 &&
       spec === 'release'
     ) {
@@ -30,6 +31,7 @@ commander
     }
     if (
       prev.indexOf('a') === -1 &&
+      prev.indexOf('b') === -1 &&
       prev.indexOf('rc') === -1 &&
       spec === 'build'
     ) {
@@ -61,8 +63,11 @@ commander
     let lernaVersion = 'preminor';
     if (spec === 'build') {
       lernaVersion = 'prerelease';
-      // a -> rc
+      // a -> b
     } else if (spec === 'release' && prev.indexOf('a') !== -1) {
+      lernaVersion = 'prerelease --preid=beta';
+      // b -> rc
+    } else if (spec === 'release' && prev.indexOf('b') !== -1) {
       lernaVersion = 'prerelease --preid=rc';
       // rc -> final
     } else if (spec === 'release' && prev.indexOf('rc') !== -1) {

--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -8,48 +8,48 @@ import * as utils from './utils';
 
 // Specify the program signature.
 commander
-  .description('Create a patch release with optional patch JS releases')
-  .arguments('[pkgs...]')
+  .description('Create a patch release')
   .option('--force', 'Force the upgrade')
-  .action((pkgNames: Array<string>, options: any) => {
+  .action((options: any) => {
     // Make sure we can patch release.
     const pyVersion = utils.getPythonVersion();
-    if (pyVersion.includes('a') || pyVersion.includes('rc')) {
+    if (
+      pyVersion.includes('a') ||
+      pyVersion.includes('b') ||
+      pyVersion.includes('rc')
+    ) {
       throw new Error('Can only make a patch release from a final version');
     }
 
     // Run pre-bump actions.
     utils.prebump();
 
-    // Version the desired packages
-    const pkgs = pkgNames.join(',');
-    if (pkgs) {
-      let cmd = `lerna version patch -m \"New version\" --force-publish=${pkgs} --no-push`;
-      if (options.force) {
-        cmd += ' --yes';
-      }
-      let oldVersion = utils.run(
-        'git rev-parse HEAD',
-        {
-          stdio: 'pipe',
-          encoding: 'utf8'
-        },
-        true
-      );
-      utils.run(cmd);
-      let newVersion = utils.run(
-        'git rev-parse HEAD',
-        {
-          stdio: 'pipe',
-          encoding: 'utf8'
-        },
-        true
-      );
-      if (oldVersion === newVersion) {
-        console.log('aborting');
-        // lerna didn't version anything, so we assume the user aborted
-        throw new Error('Lerna aborted');
-      }
+    // Version the changed
+    let cmd = `lerna version patch -m \"New version\" --no-push`;
+    if (options.force) {
+      cmd += ' --yes';
+    }
+    let oldVersion = utils.run(
+      'git rev-parse HEAD',
+      {
+        stdio: 'pipe',
+        encoding: 'utf8'
+      },
+      true
+    );
+    utils.run(cmd);
+    let newVersion = utils.run(
+      'git rev-parse HEAD',
+      {
+        stdio: 'pipe',
+        encoding: 'utf8'
+      },
+      true
+    );
+    if (oldVersion === newVersion) {
+      console.log('aborting');
+      // lerna didn't version anything, so we assume the user aborted
+      throw new Error('Lerna aborted');
     }
 
     // Patch the python version

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -22,11 +22,17 @@ commander
     if (utils.checkStatus('npm whoami') !== 0) {
       console.error('Please run `npm login`');
     }
+    const distDir = './dist';
 
     // Optionally clean and build the python packages.
     if (!options.skipBuild) {
       // Ensure a clean state.
       utils.run('npm run clean:slate');
+    } else {
+      // Still clean the dist directory.
+      if (fs.existsSync(distDir)) {
+        fs.removeSync(distDir);
+      }
     }
 
     // Publish JS to the appropriate tag.
@@ -57,11 +63,11 @@ commander
     utils.run('python -m pip install -U twine');
     utils.run('twine check dist/*');
 
-    const files = fs.readdirSync('./dist/');
+    const files = fs.readdirSync(distDir);
     const hashes = new Map<string, string>();
     files.forEach(file => {
       const shasum = crypto.createHash('sha256');
-      const hash = shasum.update(fs.readFileSync('./dist/' + file));
+      const hash = shasum.update(fs.readFileSync(path.join(distDir, file)));
       hashes.set(file, hash.digest('hex'));
     });
 
@@ -69,15 +75,17 @@ commander
       .map(entry => `${entry[0]}: ${entry[1]}`)
       .join('" -m "');
 
+    // Make the commit and the tag.
+    utils.run(
+      `git commit -am "Publish ${curr}" -m "SHA256 hashes:" -m "${hashString}"`
+    );
+    utils.run(`git tag v${curr}`);
+
     // Prompt the user to finalize.
     console.log('*'.repeat(40));
     console.log('*'.repeat(40));
     console.log('Ready to publish!');
     console.log('Run these command when ready:');
-    console.log(
-      `git commit -am "Publish ${curr}" -m "SHA256 hashes:" -m "${hashString}"`
-    );
-    console.log(`git tag v${curr}`);
     console.log('twine upload dist/*');
     console.log('git push origin <BRANCH> --tags');
   });

--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -20,6 +20,16 @@ data['jupyterlab']['staticDir'] = '../static';
 data['jupyterlab']['linkedPackages'] = {};
 
 let staging = './jupyterlab/staging';
+
+// Ensure a clean staging directory.
+const keep = ['yarn.js', '.yarnrc'];
+fs.readdirSync(staging).forEach(name => {
+  if (keep.indexOf(name) === -1) {
+    fs.removeSync(path.join(staging, name));
+  }
+});
+fs.ensureDirSync(staging);
+
 utils.writePackageData(path.join(staging, 'package.json'), data);
 
 // Update our staging files.
@@ -45,7 +55,6 @@ const notice =
 });
 
 // Create a new yarn.lock file to ensure it is correct.
-fs.removeSync(path.join(staging, 'yarn.lock'));
 utils.run('jlpm', { cwd: staging });
 try {
   utils.run('jlpm yarn-deduplicate -s fewer', { cwd: staging });

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -224,6 +224,9 @@ export function postbump() {
   let data = readJSONFile(filePath);
   data.jupyterlab.version = curr;
   writeJSONFile(filePath, data);
+
+  // Commit changes.
+  run('git commit -am "bump version"');
 }
 
 /**

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -94,8 +94,6 @@ if [[ $GROUP == integrity ]]; then
     # make sure we can patch release
     jlpm bumpversion release --force  # switch to final
     jlpm patch:release --force
-    jlpm patch:release console --force
-    jlpm patch:release filebrowser notebook --force
 
     # make sure we can bump major JS releases
     jlpm bumpversion minor --force

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -84,25 +84,17 @@ if [[ $GROUP == integrity ]]; then
     git checkout -b commit_${BUILD_SOURCEVERSION}
     git clean -df
     jlpm bumpversion minor --force
-    git commit -a -m "minor"
     jlpm bumpversion major --force
-    git commit -a -m "major"
     jlpm bumpversion release --force # switch to rc
-    git commit -a -m "release"
     jlpm bumpversion build --force
-    git commit -a -m "build"
     VERSION=$(python setup.py --version)
     if [[ $VERSION != *rc1 ]]; then exit 1; fi
 
     # make sure we can patch release
     jlpm bumpversion release --force  # switch to final
-    git commit -a -m "release"
     jlpm patch:release --force
-    git commit -a -m "patched"
     jlpm patch:release console --force
-    git commit -a -m "patched single"
     jlpm patch:release filebrowser notebook --force
-    git commit -a -m "patched multiple"
 
     # make sure we can bump major JS releases
     jlpm bumpversion minor --force

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -85,6 +85,7 @@ if [[ $GROUP == integrity ]]; then
     git clean -df
     jlpm bumpversion minor --force
     jlpm bumpversion major --force
+    jlpm bumpversion release --force # switch to beta
     jlpm bumpversion release --force # switch to rc
     jlpm bumpversion build --force
     VERSION=$(python setup.py --version)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7474.  Fixes #7238

- Add a new `beta` release type in anticipation of a beta next Friday
- Add 10 minor versions to JS packages when updating so that we have room between our minor releases of the top level application
- Cleaned up the release flow to auto-commit and auto-tag.  It is up to the publisher to then push the commits/tags
- Cleaned up the `patch:release` script to use the change detection logic in lerna instead of the unused argument.
- Always clean the `./dist` directory before publishing

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Internal changes to the release process
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
