### PR TITLE
Make session dialogs configurable

### DIFF
--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -2,6 +2,7 @@
  * Set up keyboard shortcuts & commands for notebook
  */
 import { CommandRegistry } from '@lumino/commands';
+import { sessionContextDialogs } from '@jupyterlab/apputils';
 import { CompletionHandler } from '@jupyterlab/completer';
 import { NotebookPanel, NotebookActions } from '@jupyterlab/notebook';
 import {
@@ -126,12 +127,13 @@ export const SetupCommands = (
   });
   commands.addCommand(cmdIds.restart, {
     label: 'Restart Kernel',
-    execute: async () =>
-      nbWidget.context.sessionContext.session?.kernel?.restart()
+    execute: () =>
+      sessionContextDialogs.restart(nbWidget.context.sessionContext)
   });
   commands.addCommand(cmdIds.switchKernel, {
     label: 'Switch Kernel',
-    execute: async () => nbWidget.context.sessionContext.selectKernel()
+    execute: () =>
+      sessionContextDialogs.selectKernel(nbWidget.context.sessionContext)
   });
   commands.addCommand(cmdIds.runAndAdvance, {
     label: 'Run and Advance',

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -112,7 +112,7 @@ function createApp(manager: ServiceManager.IManager): void {
   const model = new CompleterModel();
   const completer = new Completer({ editor, model });
   const connector = new KernelConnector({
-    session: nbWidget.sessionContext.session
+    session: nbWidget.context.sessionContext.session
   });
   const handler = new CompletionHandler({ completer, connector });
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -11,6 +11,7 @@ checked before the browser.close() call).
 import argparse
 import glob
 import os.path as osp
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -42,9 +43,14 @@ def main():
 
     count = 0
     for path in sorted(paths):
-        if 'node' in path:
-            continue
-        if osp.exists(osp.join(path, 'main.py')):
+        if osp.basename(path) == 'node':
+            with tempfile.TemporaryDirectory() as cwd:
+                shutil.copytree(path, cwd)
+                header(path)
+                runner = osp.join(cwd, 'main.py')
+                subprocess.check_call([sys.executable, runner], cwd=cwd)
+                count += 1
+        elif osp.exists(osp.join(path, 'main.py')):
             with tempfile.TemporaryDirectory() as cwd:
                 header(path)
                 runner = osp.join(here, 'example_check.py')

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -42,6 +42,8 @@ def main():
 
     count = 0
     for path in sorted(paths):
+        if 'node' in path:
+            continue
         if osp.exists(osp.join(path, 'main.py')):
             with tempfile.TemporaryDirectory() as cwd:
                 header(path)

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -42,13 +42,7 @@ def main():
 
     count = 0
     for path in sorted(paths):
-        if osp.basename(path) == 'node':
-            with tempfile.TemporaryDirectory() as cwd:
-                header(path)
-                runner = osp.join(path, 'main.py')
-                subprocess.check_call([sys.executable, runner], cwd=cwd)
-                count += 1
-        elif osp.exists(osp.join(path, 'main.py')):
+        if osp.exists(osp.join(path, 'main.py')):
             with tempfile.TemporaryDirectory() as cwd:
                 header(path)
                 runner = osp.join(here, 'example_check.py')

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -19,11 +19,10 @@ here = osp.abspath(osp.dirname(__file__))
 
 def header(path):
     test_name = osp.basename(path)
-    test_dir = osp.dirname(path)
     print('\n'.join((
         '\n',
         '*' * 40,
-        'Starting %s test in %s' % (test_name, test_dir),
+        'Starting %s test in %s' % (test_name, path),
         '*' * 40
     )), flush=True)
 
@@ -47,7 +46,7 @@ def main():
             with tempfile.TemporaryDirectory() as cwd:
                 header(path)
                 runner = osp.join(path, 'main.py')
-                subprocess.check_call([sys.executable, runner])
+                subprocess.check_call([sys.executable, runner], cwd=cwd)
                 count += 1
         elif osp.exists(osp.join(path, 'main.py')):
             with tempfile.TemporaryDirectory() as cwd:

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -17,12 +17,13 @@ import tempfile
 
 here = osp.abspath(osp.dirname(__file__))
 
-def header(path, cwd = ''):
+def header(path):
     test_name = osp.basename(path)
+    test_dir = osp.dirname(path)
     print('\n'.join((
         '\n',
         '*' * 40,
-        'Starting %s test in %s' % (test_name, cwd),
+        'Starting %s test in %s' % (test_name, test_dir),
         '*' * 40
     )), flush=True)
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -11,7 +11,6 @@ checked before the browser.close() call).
 import argparse
 import glob
 import os.path as osp
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -45,9 +44,8 @@ def main():
     for path in sorted(paths):
         if osp.basename(path) == 'node':
             with tempfile.TemporaryDirectory() as cwd:
-                shutil.copytree(path, cwd)
                 header(path)
-                runner = osp.join(cwd, 'main.py')
+                runner = osp.join(path, 'main.py')
                 subprocess.check_call([sys.executable, runner], cwd=cwd)
                 count += 1
         elif osp.exists(osp.join(path, 'main.py')):

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -13,10 +13,12 @@ import {
 import {
   Dialog,
   ICommandPalette,
+  ISessionContextDialogs,
   ISplashScreen,
   IWindowResolver,
   WindowResolver,
-  Printing
+  Printing,
+  sessionContextDialogs
 } from '@jupyterlab/apputils';
 
 import { URLExt } from '@jupyterlab/coreutils';
@@ -442,6 +444,18 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
 };
 
 /**
+ * The default session context dialogs extension.
+ */
+const sessionDialogs: JupyterFrontEndPlugin<ISessionContextDialogs> = {
+  id: '@jupyterlab/apputils-extension:sessionDialogs',
+  provides: ISessionContextDialogs,
+  autoStart: true,
+  activate: () => {
+    return sessionContextDialogs;
+  }
+};
+
+/**
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
@@ -452,6 +466,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   settingsPlugin,
   state,
   splash,
+  sessionDialogs,
   themesPlugin,
   themesPaletteMenuPlugin
 ];

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -698,7 +698,7 @@ export class SessionContext implements ISessionContext {
       this._session.dispose();
     }
     this._session = session;
-    this._prevKernelName = session.kernel?.name || '';
+    this._prevKernelName = session.kernel?.name ?? '';
 
     session.disposed.connect(this._onSessionDisposed, this);
     session.propertyChanged.connect(this._onPropertyChanged, this);

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -48,6 +48,8 @@ export interface ISessionContext extends IObservableDisposable {
   /**
    * Initialize the session context.
    *
+   * @returns A promise that resolves with whether to ask the user to select a kernel.
+   *
    * #### Notes
    * This includes starting up an initial kernel if needed.
    */
@@ -556,9 +558,9 @@ export class SessionContext implements ISessionContext {
   }
 
   /**
-   * Initialize the session.
+   * Initialize the session context
    *
-   * @returns Whether we need to ask the user to select a kernel.
+   * @returns A promise that resolves with whether to ask the user to select a kernel.
    *
    * #### Notes
    * If a server session exists on the current path, we will connect to it.

--- a/packages/apputils/src/tokens.ts
+++ b/packages/apputils/src/tokens.ts
@@ -9,6 +9,22 @@ import { IDisposable } from '@lumino/disposable';
 
 import { ISignal } from '@lumino/signaling';
 
+import { ISessionContext } from './sessioncontext';
+
+/**
+ * An interface for the session context dialogs.
+ */
+export interface ISessionContextDialogs extends ISessionContext.IDialogs {}
+
+/* tslint:disable */
+/**
+ * The session context dialogs token.
+ */
+export const ISessionContextDialogs = new Token<ISessionContext.IDialogs>(
+  '@jupyterlab/apputils:ISessionContextDialogs'
+);
+/* tslint:enable */
+
 /* tslint:disable */
 /**
  * The theme manager token.

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -390,7 +390,7 @@ export namespace Toolbar {
     return new ToolbarButton({
       iconClassName: 'jp-RefreshIcon',
       onClick: () => {
-        void (dialogs || sessionContextDialogs).restart(sessionContext);
+        void (dialogs ?? sessionContextDialogs).restart(sessionContext);
       },
       tooltip: 'Restart the kernel'
     });
@@ -421,7 +421,7 @@ export namespace Toolbar {
     const el = ReactWidget.create(
       <Private.KernelNameComponent
         sessionContext={sessionContext}
-        dialogs={dialogs || sessionContextDialogs}
+        dialogs={dialogs ?? sessionContextDialogs}
       />
     );
     el.addClass('jp-KernelName');

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -152,7 +152,7 @@ async function activateConsole(
   const manager = app.serviceManager;
   const { commands, shell } = app;
   const category = 'Console';
-  sessionDialogs = sessionDialogs || sessionContextDialogs;
+  sessionDialogs = sessionDialogs ?? sessionContextDialogs;
 
   // Create a widget tracker for all console panels.
   const tracker = new WidgetTracker<MainAreaWidget<ConsolePanel>>({

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -451,7 +451,7 @@ async function activateConsole(
       if (!current) {
         return;
       }
-      return sessionDialogs.restart(current.console.sessionContext);
+      return sessionDialogs!.restart(current.console.sessionContext);
     },
     isEnabled
   });
@@ -508,7 +508,7 @@ async function activateConsole(
       if (!current) {
         return;
       }
-      return sessionDialogs.selectKernel(current.console.sessionContext);
+      return sessionDialogs!.selectKernel(current.console.sessionContext);
     },
     isEnabled
   });
@@ -565,9 +565,9 @@ async function activateConsole(
     },
     noun: 'Console',
     restartKernel: current =>
-      sessionDialogs.restart(current.content.console.sessionContext),
+      sessionDialogs!.restart(current.content.console.sessionContext),
     restartKernelAndClear: current => {
-      return sessionDialogs
+      return sessionDialogs!
         .restart(current.content.console.sessionContext)
         .then(restarted => {
           if (restarted) {
@@ -577,7 +577,7 @@ async function activateConsole(
         });
     },
     changeKernel: current =>
-      sessionDialogs.selectKernel(current.content.console.sessionContext),
+      sessionDialogs!.selectKernel(current.content.console.sessionContext),
     shutdownKernel: current => current.content.console.sessionContext.shutdown()
   } as IKernelMenu.IKernelUser<MainAreaWidget<ConsolePanel>>);
 

--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ISessionContext, SessionContext } from '@jupyterlab/apputils';
+import {
+  ISessionContext,
+  SessionContext,
+  sessionContextDialogs
+} from '@jupyterlab/apputils';
 
 import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 
@@ -83,7 +87,10 @@ export class ConsolePanel extends Panel {
     });
     this.addWidget(this.console);
 
-    void sessionContext.initialize().then(() => {
+    void sessionContext.initialize().then(async value => {
+      if (value) {
+        await sessionContextDialogs.selectKernel(sessionContext);
+      }
       this._connected = new Date();
       this._updateTitle();
     });

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -12,7 +12,8 @@ import {
   showDialog,
   showErrorMessage,
   Dialog,
-  ICommandPalette
+  ICommandPalette,
+  ISessionContextDialogs
 } from '@jupyterlab/apputils';
 
 import { IChangedArgs, Time } from '@jupyterlab/coreutils';
@@ -85,14 +86,21 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
   id: pluginId,
   provides: IDocumentManager,
   requires: [ISettingRegistry],
-  optional: [ILabStatus, ICommandPalette, ILabShell, IMainMenu],
+  optional: [
+    ILabStatus,
+    ICommandPalette,
+    ILabShell,
+    IMainMenu,
+    ISessionContextDialogs
+  ],
   activate: (
     app: JupyterFrontEnd,
     settingRegistry: ISettingRegistry,
     status: ILabStatus | null,
     palette: ICommandPalette | null,
     labShell: ILabShell | null,
-    mainMenu: IMainMenu | null
+    mainMenu: IMainMenu | null,
+    sessionDialogs: ISessionContextDialogs | null
   ): IDocumentManager => {
     const { shell } = app;
     const manager = app.serviceManager;
@@ -128,7 +136,8 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
       manager,
       opener,
       when,
-      setBusy: (status && (() => status.setBusy())) ?? undefined
+      setBusy: (status && (() => status.setBusy())) ?? undefined,
+      sessionDialogs
     });
 
     // Register the file operations commands.

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -137,7 +137,7 @@ const docManagerPlugin: JupyterFrontEndPlugin<IDocumentManager> = {
       opener,
       when,
       setBusy: (status && (() => status.setBusy())) ?? undefined,
-      sessionDialogs
+      sessionDialogs: sessionDialogs || undefined
     });
 
     // Register the file operations commands.

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ISessionContext } from '@jupyterlab/apputils';
+import { ISessionContext, sessionContextDialogs } from '@jupyterlab/apputils';
 
 import { PathExt } from '@jupyterlab/coreutils';
 
@@ -48,6 +48,7 @@ export class DocumentManager implements IDocumentManager {
   constructor(options: DocumentManager.IOptions) {
     this.registry = options.registry;
     this.services = options.manager;
+    this._dialogs = options.sessionDialogs || sessionContextDialogs;
 
     this._opener = options.opener;
     this._when = options.when || options.manager.ready;
@@ -473,7 +474,8 @@ export class DocumentManager implements IDocumentManager {
       path,
       kernelPreference,
       modelDBFactory,
-      setBusy: this._setBusy
+      setBusy: this._setBusy,
+      sessionDialogs: this._dialogs
     });
     let handler = new SaveHandler({
       context,
@@ -598,6 +600,7 @@ export class DocumentManager implements IDocumentManager {
   private _autosaveInterval = 120;
   private _when: Promise<void>;
   private _setBusy: (() => IDisposable) | undefined;
+  private _dialogs: ISessionContext.IDialogs;
 }
 
 /**
@@ -632,6 +635,11 @@ export namespace DocumentManager {
      * A function called when a kernel is busy.
      */
     setBusy?: () => IDisposable;
+
+    /**
+     * The provider for session dialogs.
+     */
+    sessionDialogs?: ISessionContext.IDialogs;
   }
 
   /**

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -704,7 +704,7 @@ export namespace Commands {
     commands: CommandRegistry,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     consoleTracker: IConsoleTracker,
-    sessionDialogs?: ISessionContextDialogs
+    sessionDialogs: ISessionContextDialogs | null
   ) {
     // Add the editing commands to the settings menu.
     addEditingCommandsToSettingsMenu(menu, commands);

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -3,7 +3,12 @@
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
 
-import { ICommandPalette, WidgetTracker } from '@jupyterlab/apputils';
+import {
+  ICommandPalette,
+  WidgetTracker,
+  ISessionContextDialogs,
+  sessionContextDialogs
+} from '@jupyterlab/apputils';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
@@ -698,7 +703,8 @@ export namespace Commands {
     menu: IMainMenu,
     commands: CommandRegistry,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
-    consoleTracker: IConsoleTracker
+    consoleTracker: IConsoleTracker,
+    sessionDialogs?: ISessionContextDialogs
   ) {
     // Add the editing commands to the settings menu.
     addEditingCommandsToSettingsMenu(menu, commands);
@@ -719,7 +725,13 @@ export namespace Commands {
     addConsoleCreatorToFileMenu(menu, commands, tracker);
 
     // Add a code runner to the run menu.
-    addCodeRunnersToRunMenu(menu, commands, tracker, consoleTracker);
+    addCodeRunnersToRunMenu(
+      menu,
+      commands,
+      tracker,
+      consoleTracker,
+      sessionDialogs
+    );
   }
 
   /**
@@ -857,7 +869,8 @@ export namespace Commands {
     menu: IMainMenu,
     commands: CommandRegistry,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
-    consoleTracker: IConsoleTracker
+    consoleTracker: IConsoleTracker,
+    sessionDialogs: ISessionContextDialogs | null
   ) {
     menu.runMenu.codeRunners.add({
       tracker,
@@ -875,12 +888,14 @@ export namespace Commands {
             widget.content.sessionContext.session?.path === current.context.path
         );
         if (widget) {
-          return widget.content.sessionContext.restart().then(restarted => {
-            if (restarted) {
-              void commands.execute(CommandIDs.runAllCode);
-            }
-            return restarted;
-          });
+          return (sessionDialogs || sessionContextDialogs)
+            .restart(widget.content.sessionContext)
+            .then(restarted => {
+              if (restarted) {
+                void commands.execute(CommandIDs.runAllCode);
+              }
+              return restarted;
+            });
         }
       }
     } as IRunMenu.ICodeRunner<IDocumentWidget<FileEditor>>);

--- a/packages/fileeditor-extension/src/index.ts
+++ b/packages/fileeditor-extension/src/index.ts
@@ -7,7 +7,11 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
-import { ICommandPalette, WidgetTracker } from '@jupyterlab/apputils';
+import {
+  ICommandPalette,
+  WidgetTracker,
+  ISessionContextDialogs
+} from '@jupyterlab/apputils';
 
 import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 
@@ -52,7 +56,13 @@ const plugin: JupyterFrontEndPlugin<IEditorTracker> = {
     IFileBrowserFactory,
     ISettingRegistry
   ],
-  optional: [ICommandPalette, ILauncher, IMainMenu, ILayoutRestorer],
+  optional: [
+    ICommandPalette,
+    ILauncher,
+    IMainMenu,
+    ILayoutRestorer,
+    ISessionContextDialogs
+  ],
   provides: IEditorTracker,
   autoStart: true
 };
@@ -148,7 +158,8 @@ function activate(
   palette: ICommandPalette | null,
   launcher: ILauncher | null,
   menu: IMainMenu | null,
-  restorer: ILayoutRestorer | null
+  restorer: ILayoutRestorer | null,
+  sessionDialogs: ISessionContextDialogs | null
 ): IEditorTracker {
   const id = plugin.id;
   const namespace = 'editor';
@@ -229,7 +240,13 @@ function activate(
   }
 
   if (menu) {
-    Commands.addMenuItems(menu, commands, tracker, consoleTracker);
+    Commands.addMenuItems(
+      menu,
+      commands,
+      tracker,
+      consoleTracker,
+      sessionDialogs
+    );
   }
 
   Commands.addContextMenuItems(app);

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -507,7 +507,7 @@ function activateNotebookHandler(
   restorer: ILayoutRestorer | null,
   mainMenu: IMainMenu | null,
   settingRegistry: ISettingRegistry | null,
-  sessionDialogs: ISessionContextDialogs
+  sessionDialogs: ISessionContextDialogs | null
 ): INotebookTracker {
   const services = app.serviceManager;
 
@@ -1147,7 +1147,7 @@ function addCommands(
       const current = getCurrent(args);
 
       if (current) {
-        return sessionDialogs.restart(current.sessionContext);
+        return sessionDialogs!.restart(current.sessionContext);
       }
     },
     isEnabled
@@ -1233,7 +1233,7 @@ function addCommands(
       if (current) {
         const { content, sessionContext } = current;
 
-        return sessionDialogs.restart(sessionContext).then(() => {
+        return sessionDialogs!.restart(sessionContext).then(() => {
           NotebookActions.clearAllOutputs(content);
         });
       }
@@ -1248,7 +1248,7 @@ function addCommands(
       if (current) {
         const { context, content, sessionContext } = current;
 
-        return sessionDialogs.restart(sessionContext).then(restarted => {
+        return sessionDialogs!.restart(sessionContext).then(restarted => {
           if (restarted) {
             void NotebookActions.runAll(content, context.sessionContext);
           }
@@ -1611,7 +1611,7 @@ function addCommands(
       const current = getCurrent(args);
 
       if (current) {
-        return sessionDialogs.selectKernel(current.context.sessionContext);
+        return sessionDialogs!.selectKernel(current.context.sessionContext);
       }
     },
     isEnabled
@@ -2092,9 +2092,9 @@ function populateMenus(
       return Promise.resolve(void 0);
     },
     noun: 'All Outputs',
-    restartKernel: current => sessionDialogs.restart(current.sessionContext),
+    restartKernel: current => sessionDialogs!.restart(current.sessionContext),
     restartKernelAndClear: current => {
-      return sessionDialogs.restart(current.sessionContext).then(restarted => {
+      return sessionDialogs!.restart(current.sessionContext).then(restarted => {
         if (restarted) {
           NotebookActions.clearAllOutputs(current.content);
         }
@@ -2102,7 +2102,7 @@ function populateMenus(
       });
     },
     changeKernel: current =>
-      sessionDialogs.selectKernel(current.sessionContext),
+      sessionDialogs!.selectKernel(current.sessionContext),
     shutdownKernel: current => current.sessionContext.shutdown()
   } as IKernelMenu.IKernelUser<NotebookPanel>);
 
@@ -2169,7 +2169,7 @@ function populateMenus(
     },
     restartAndRunAll: current => {
       const { context, content } = current;
-      return sessionDialogs.restart(context.sessionContext).then(restarted => {
+      return sessionDialogs!.restart(context.sessionContext).then(restarted => {
         if (restarted) {
           void NotebookActions.runAll(content, context.sessionContext);
         }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -872,7 +872,7 @@ function addCommands(
 ): void {
   const { commands, shell } = app;
 
-  sessionDialogs = sessionDialogs || sessionContextDialogs;
+  sessionDialogs = sessionDialogs ?? sessionContextDialogs;
 
   // Get the current widget and activate unless the args specify otherwise.
   function getCurrent(args: ReadonlyPartialJSONObject): NotebookPanel | null {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -11,9 +11,11 @@ import {
 import {
   Dialog,
   ICommandPalette,
+  ISessionContextDialogs,
   MainAreaWidget,
   showDialog,
-  WidgetTracker
+  WidgetTracker,
+  sessionContextDialogs
 } from '@jupyterlab/apputils';
 
 import { CodeCell } from '@jupyterlab/cells';
@@ -277,7 +279,8 @@ const trackerPlugin: JupyterFrontEndPlugin<INotebookTracker> = {
     ILauncher,
     ILayoutRestorer,
     IMainMenu,
-    ISettingRegistry
+    ISettingRegistry,
+    ISessionContextDialogs
   ],
   activate: activateNotebookHandler,
   autoStart: true
@@ -503,7 +506,8 @@ function activateNotebookHandler(
   launcher: ILauncher | null,
   restorer: ILayoutRestorer | null,
   mainMenu: IMainMenu | null,
-  settingRegistry: ISettingRegistry | null
+  settingRegistry: ISettingRegistry | null,
+  sessionDialogs: ISessionContextDialogs
 ): INotebookTracker {
   const services = app.serviceManager;
 
@@ -551,7 +555,14 @@ function activateNotebookHandler(
   registry.addModelFactory(new NotebookModelFactory({}));
   registry.addWidgetFactory(factory);
 
-  addCommands(app, docManager, services, tracker, clonedOutputs);
+  addCommands(
+    app,
+    docManager,
+    services,
+    tracker,
+    clonedOutputs,
+    sessionDialogs
+  );
   if (palette) {
     populatePalette(palette, services);
   }
@@ -637,7 +648,7 @@ function activateNotebookHandler(
 
   // Add main menu notebook menu.
   if (mainMenu) {
-    populateMenus(app, mainMenu, tracker, services, palette);
+    populateMenus(app, mainMenu, tracker, services, palette, sessionDialogs);
   }
 
   // Utility function to create a new notebook.
@@ -856,9 +867,12 @@ function addCommands(
   docManager: IDocumentManager,
   services: ServiceManager,
   tracker: NotebookTracker,
-  clonedOutputs: WidgetTracker<MainAreaWidget>
+  clonedOutputs: WidgetTracker<MainAreaWidget>,
+  sessionDialogs: ISessionContextDialogs | null
 ): void {
   const { commands, shell } = app;
+
+  sessionDialogs = sessionDialogs || sessionContextDialogs;
 
   // Get the current widget and activate unless the args specify otherwise.
   function getCurrent(args: ReadonlyPartialJSONObject): NotebookPanel | null {
@@ -1133,7 +1147,7 @@ function addCommands(
       const current = getCurrent(args);
 
       if (current) {
-        return current.sessionContext.restart();
+        return sessionDialogs.restart(current.sessionContext);
       }
     },
     isEnabled
@@ -1219,7 +1233,7 @@ function addCommands(
       if (current) {
         const { content, sessionContext } = current;
 
-        return sessionContext.restart().then(() => {
+        return sessionDialogs.restart(sessionContext).then(() => {
           NotebookActions.clearAllOutputs(content);
         });
       }
@@ -1234,7 +1248,7 @@ function addCommands(
       if (current) {
         const { context, content, sessionContext } = current;
 
-        return sessionContext.restart().then(restarted => {
+        return sessionDialogs.restart(sessionContext).then(restarted => {
           if (restarted) {
             void NotebookActions.runAll(content, context.sessionContext);
           }
@@ -1597,7 +1611,7 @@ function addCommands(
       const current = getCurrent(args);
 
       if (current) {
-        return current.context.sessionContext.selectKernel();
+        return sessionDialogs.selectKernel(current.context.sessionContext);
       }
     },
     isEnabled
@@ -1975,9 +1989,12 @@ function populateMenus(
   mainMenu: IMainMenu,
   tracker: INotebookTracker,
   services: ServiceManager,
-  palette: ICommandPalette | null
+  palette: ICommandPalette | null,
+  sessionDialogs: ISessionContextDialogs | null
 ): void {
   let { commands } = app;
+
+  sessionDialogs = sessionDialogs || sessionContextDialogs;
 
   // Add undo/redo hooks to the edit menu.
   mainMenu.editMenu.undoers.add({
@@ -2075,16 +2092,17 @@ function populateMenus(
       return Promise.resolve(void 0);
     },
     noun: 'All Outputs',
-    restartKernel: current => current.sessionContext.restart(),
+    restartKernel: current => sessionDialogs.restart(current.sessionContext),
     restartKernelAndClear: current => {
-      return current.sessionContext.restart().then(restarted => {
+      return sessionDialogs.restart(current.sessionContext).then(restarted => {
         if (restarted) {
           NotebookActions.clearAllOutputs(current.content);
         }
         return restarted;
       });
     },
-    changeKernel: current => current.sessionContext.selectKernel(),
+    changeKernel: current =>
+      sessionDialogs.selectKernel(current.sessionContext),
     shutdownKernel: current => current.sessionContext.shutdown()
   } as IKernelMenu.IKernelUser<NotebookPanel>);
 
@@ -2151,7 +2169,7 @@ function populateMenus(
     },
     restartAndRunAll: current => {
       const { context, content } = current;
-      return context.sessionContext.restart().then(restarted => {
+      return sessionDialogs.restart(context.sessionContext).then(restarted => {
         if (restarted) {
           void NotebookActions.runAll(content, context.sessionContext);
         }

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -17,7 +17,8 @@ import {
   UseSignal,
   addToolbarButtonClass,
   ReactWidget,
-  ToolbarButton
+  ToolbarButton,
+  ISessionContextDialogs
 } from '@jupyterlab/apputils';
 
 import * as nbformat from '@jupyterlab/nbformat';
@@ -197,7 +198,8 @@ export namespace ToolbarItems {
    * Get the default toolbar items for panel
    */
   export function getDefaultItems(
-    panel: NotebookPanel
+    panel: NotebookPanel,
+    sessionDialogs?: ISessionContextDialogs
   ): DocumentRegistry.IToolbarItem[] {
     return [
       { name: 'save', widget: createSaveButton(panel) },
@@ -212,13 +214,19 @@ export namespace ToolbarItems {
       },
       {
         name: 'restart',
-        widget: Toolbar.createRestartButton(panel.sessionContext)
+        widget: Toolbar.createRestartButton(
+          panel.sessionContext,
+          sessionDialogs
+        )
       },
       { name: 'cellType', widget: createCellTypeItem(panel) },
       { name: 'spacer', widget: Toolbar.createSpacerItem() },
       {
         name: 'kernelName',
-        widget: Toolbar.createKernelNameItem(panel.sessionContext)
+        widget: Toolbar.createKernelNameItem(
+          panel.sessionContext,
+          sessionDialogs
+        )
       },
       {
         name: 'kernelStatus',

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -15,6 +15,11 @@ import { NotebookPanel } from './panel';
 
 import { StaticNotebook } from './widget';
 
+import {
+  ISessionContextDialogs,
+  sessionContextDialogs
+} from '@jupyterlab/apputils';
+
 /**
  * A widget factory for notebook panels.
  */
@@ -37,6 +42,7 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
       options.editorConfig || StaticNotebook.defaultEditorConfig;
     this._notebookConfig =
       options.notebookConfig || StaticNotebook.defaultNotebookConfig;
+    this._sessionDialogs = options.sessionDialogs || sessionContextDialogs;
   }
 
   /*
@@ -106,11 +112,12 @@ export class NotebookWidgetFactory extends ABCWidgetFactory<
   protected defaultToolbarFactory(
     widget: NotebookPanel
   ): DocumentRegistry.IToolbarItem[] {
-    return ToolbarItems.getDefaultItems(widget);
+    return ToolbarItems.getDefaultItems(widget, this._sessionDialogs);
   }
 
   private _editorConfig: StaticNotebook.IEditorConfig;
   private _notebookConfig: StaticNotebook.INotebookConfig;
+  private _sessionDialogs: ISessionContextDialogs;
 }
 
 /**
@@ -146,5 +153,10 @@ export namespace NotebookWidgetFactory {
      * The notebook configuration.
      */
     notebookConfig?: StaticNotebook.INotebookConfig;
+
+    /**
+     * The session context dialogs.
+     */
+    sessionDialogs?: ISessionContextDialogs;
   }
 }

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -7,7 +7,12 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
-import { ISessionContext, ICommandPalette } from '@jupyterlab/apputils';
+import {
+  ISessionContext,
+  ICommandPalette,
+  ISessionContextDialogs,
+  sessionContextDialogs
+} from '@jupyterlab/apputils';
 
 import { Cell, CodeCell } from '@jupyterlab/cells';
 
@@ -124,12 +129,14 @@ export const kernelStatus: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/statusbar-extension:kernel-status',
   autoStart: true,
   requires: [IStatusBar, INotebookTracker, IConsoleTracker, ILabShell],
+  optional: [ISessionContextDialogs],
   activate: (
     app: JupyterFrontEnd,
     statusBar: IStatusBar,
     notebookTracker: INotebookTracker,
     consoleTracker: IConsoleTracker,
-    labShell: ILabShell
+    labShell: ILabShell,
+    sessionDialogs: ISessionContextDialogs | null
   ) => {
     // When the status item is clicked, launch the kernel
     // selection dialog for the current session.
@@ -138,7 +145,9 @@ export const kernelStatus: JupyterFrontEndPlugin<void> = {
       if (!currentSession) {
         return;
       }
-      await currentSession.selectKernel();
+      await (sessionDialogs || sessionContextDialogs).selectKernel(
+        currentSession
+      );
     };
 
     // Create the status item.

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -180,12 +180,6 @@ if [[ $GROUP == usage ]]; then
     env JUPYTERLAB_DIR=./link_app_dir jupyter lab path | grep link_app_dir
     popd
 
-    # Build the examples.
-    jlpm run build:examples
-
-    # Test the examples
-    jlpm run test:examples
-
     # Make sure we can successfully load the dev app.
     python -m jupyterlab.browser_check --dev-mode
 

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -184,6 +184,7 @@ if [[ $GROUP == usage ]]; then
     jlpm run build:examples
 
     # Test the examples
+    python packages/services/examples/node/main.py
     jlpm run test:examples
 
     # Make sure we can successfully load the dev app.

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -184,7 +184,6 @@ if [[ $GROUP == usage ]]; then
     jlpm run build:examples
 
     # Test the examples
-    python packages/services/examples/node/main.py
     jlpm run test:examples
 
     # Make sure we can successfully load the dev app.

--- a/tests/test-apputils/src/sessioncontext.spec.ts
+++ b/tests/test-apputils/src/sessioncontext.spec.ts
@@ -453,28 +453,28 @@ describe('@jupyterlab/apputils', () => {
           await sessionContext.initialize();
           const session = sessionContext?.session;
 
-          const { id, name } = session.kernel;
+          const { id, name } = session!.kernel!;
           const accept = acceptDialog();
 
           await sessionContextDialogs.selectKernel(sessionContext);
           await accept;
 
-          expect(session.kernel?.id).to.not.equal(id);
-          expect(session.kernel?.name).to.equal(name);
+          expect(session!.kernel!.id).to.not.equal(id);
+          expect(session!.kernel!.name).to.equal(name);
         });
 
         it('should keep the existing kernel if dismissed', async () => {
           await sessionContext.initialize();
           const session = sessionContext!.session;
 
-          const { id, name } = session.kernel;
+          const { id, name } = session!.kernel!;
           const dismiss = dismissDialog();
 
           await sessionContextDialogs.selectKernel(sessionContext);
           await dismiss;
 
-          expect(session.kernel?.id).to.equal(id);
-          expect(session.kernel?.name).to.equal(name);
+          expect(session!.kernel!.id).to.equal(id);
+          expect(session!.kernel!.name).to.equal(name);
         });
       });
 

--- a/tests/test-apputils/src/sessioncontext.spec.ts
+++ b/tests/test-apputils/src/sessioncontext.spec.ts
@@ -451,7 +451,7 @@ describe('@jupyterlab/apputils', () => {
       describe('#selectKernel()', () => {
         it('should select a kernel for the session', async () => {
           await sessionContext.initialize();
-          const session = sessionContext.session;
+          const session = sessionContext?.session;
 
           const { id, name } = session.kernel;
           const accept = acceptDialog();
@@ -459,13 +459,13 @@ describe('@jupyterlab/apputils', () => {
           await sessionContextDialogs.selectKernel(sessionContext);
           await accept;
 
-          expect(session.kernel.id).to.not.equal(id);
-          expect(session.kernel.name).to.equal(name);
+          expect(session.kernel?.id).to.not.equal(id);
+          expect(session.kernel?.name).to.equal(name);
         });
 
         it('should keep the existing kernel if dismissed', async () => {
           await sessionContext.initialize();
-          const session = sessionContext.session;
+          const session = sessionContext!.session;
 
           const { id, name } = session.kernel;
           const dismiss = dismissDialog();
@@ -473,8 +473,8 @@ describe('@jupyterlab/apputils', () => {
           await sessionContextDialogs.selectKernel(sessionContext);
           await dismiss;
 
-          expect(session.kernel.id).to.equal(id);
-          expect(session.kernel.name).to.equal(name);
+          expect(session.kernel?.id).to.equal(id);
+          expect(session.kernel?.name).to.equal(name);
         });
       });
 
@@ -484,7 +484,7 @@ describe('@jupyterlab/apputils', () => {
             find: (_, args) => args === 'restarting'
           });
           await sessionContext.initialize();
-          await sessionContext.session?.kernel?.info;
+          await sessionContext!.session?.kernel?.info;
           const restart = sessionContextDialogs.restart(sessionContext);
 
           await acceptDialog();
@@ -512,7 +512,7 @@ describe('@jupyterlab/apputils', () => {
           await sessionContext.initialize();
           await sessionContext.shutdown();
           await sessionContextDialogs.restart(sessionContext);
-          expect(sessionContext.session?.kernel).to.be.ok;
+          expect(sessionContext?.session?.kernel).to.be.ok;
         });
       });
     });

--- a/tests/test-apputils/src/sessioncontext.spec.ts
+++ b/tests/test-apputils/src/sessioncontext.spec.ts
@@ -9,7 +9,12 @@ import {
   KernelSpecManager
 } from '@jupyterlab/services';
 
-import { SessionContext, Dialog, ISessionContext } from '@jupyterlab/apputils';
+import {
+  SessionContext,
+  Dialog,
+  ISessionContext,
+  sessionContextDialogs
+} from '@jupyterlab/apputils';
 
 import { UUID } from '@lumino/coreutils';
 
@@ -236,28 +241,24 @@ describe('@jupyterlab/apputils', () => {
         other.dispose();
       });
 
-      it('should present a dialog if there is no distinct kernel to start', async () => {
+      it('should yield true if there is no distinct kernel to start', async () => {
         // Remove the kernel preference before initializing.
         sessionContext.kernelPreference = {};
-
-        const accept = acceptDialog();
-
-        await sessionContext.initialize();
-        await accept;
-        expect(sessionContext.session?.kernel?.name).to.equal(
-          specsManager.specs!.default
-        );
+        const result = await sessionContext.initialize();
+        expect(result).to.equal(true);
       });
 
       it('should be a no-op if the shouldStart kernelPreference is false', async () => {
         sessionContext.kernelPreference = { shouldStart: false };
-        await sessionContext.initialize();
+        const result = await sessionContext.initialize();
+        expect(result).to.equal(false);
         expect(sessionContext.session?.kernel).to.not.be.ok;
       });
 
       it('should be a no-op if the canStart kernelPreference is false', async () => {
         sessionContext.kernelPreference = { canStart: false };
-        await sessionContext.initialize();
+        const result = await sessionContext.initialize();
+        expect(result).to.equal(false);
         expect(sessionContext.session?.kernel).to.not.be.ok;
       });
     });
@@ -363,34 +364,6 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('#selectKernel()', () => {
-      it('should select a kernel for the session', async () => {
-        await sessionContext.initialize();
-
-        const { id, name } = sessionContext.session?.kernel!;
-        const accept = acceptDialog();
-
-        await sessionContext.selectKernel();
-        await accept;
-
-        expect(sessionContext.session?.kernel?.id).to.not.equal(id);
-        expect(sessionContext.session?.kernel?.name).to.equal(name);
-      });
-
-      it('should keep the existing kernel if dismissed', async () => {
-        await sessionContext.initialize();
-
-        const { id, name } = sessionContext.session?.kernel!;
-        const dismiss = dismissDialog();
-
-        await sessionContext.selectKernel();
-        await dismiss;
-
-        expect(sessionContext.session?.kernel?.id).to.equal(id);
-        expect(sessionContext.session?.kernel?.name).to.equal(name);
-      });
-    });
-
     describe('#shutdown', () => {
       it('should kill the kernel and shut down the session', async () => {
         await sessionContext.initialize();
@@ -398,87 +371,6 @@ describe('@jupyterlab/apputils', () => {
         await sessionContext.shutdown();
         expect(sessionContext.session?.kernel).to.not.be.ok;
       });
-    });
-
-    describe('#restart()', () => {
-      it('should restart if the user accepts the dialog', async () => {
-        const emission = testEmission(sessionContext.statusChanged, {
-          find: (_, args) => args === 'restarting'
-        });
-        await sessionContext.initialize();
-        await sessionContext.session?.kernel?.info;
-        const restart = sessionContext.restart();
-
-        await acceptDialog();
-        expect(await restart).to.equal(true);
-        await emission;
-      });
-
-      it('should not restart if the user rejects the dialog', async () => {
-        let called = false;
-
-        await sessionContext.initialize();
-        sessionContext.statusChanged.connect((sender, args) => {
-          if (args === 'restarting') {
-            called = true;
-          }
-        });
-
-        const restart = sessionContext.restart();
-
-        await dismissDialog();
-        expect(await restart).to.equal(false);
-        expect(called).to.equal(false);
-      });
-
-      it('should start the same kernel as the previously started kernel', async () => {
-        await sessionContext.initialize();
-        await sessionContext.shutdown();
-        await sessionContext.restart();
-        expect(sessionContext.session?.kernel).to.be.ok;
-      });
-    });
-
-    describe('#restartKernel()', () => {
-      it('should restart if the user accepts the dialog', async () => {
-        let called = false;
-
-        sessionContext.statusChanged.connect((sender, args) => {
-          if (args === 'restarting') {
-            called = true;
-          }
-        });
-        await sessionContext.initialize();
-        await sessionContext.session!.kernel!.info;
-
-        const restart = SessionContext.restartKernel(
-          sessionContext.session?.kernel!
-        );
-
-        await acceptDialog();
-        expect(await restart).to.equal(true);
-        expect(called).to.equal(true);
-      }, 30000); // Allow for slower CI
-
-      it('should not restart if the user rejects the dialog', async () => {
-        let called = false;
-
-        sessionContext.statusChanged.connect((sender, args) => {
-          if (args === 'restarting') {
-            called = true;
-          }
-        });
-        await sessionContext.initialize();
-        await sessionContext.session!.kernel!.info;
-
-        const restart = SessionContext.restartKernel(
-          sessionContext.session?.kernel!
-        );
-
-        await dismissDialog();
-        expect(await restart).to.equal(false);
-        expect(called).to.equal(false);
-      }, 30000); // Allow for slower CI
     });
 
     describe('.getDefaultKernel()', () => {
@@ -555,43 +447,73 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('.populateKernelSelect()', () => {
-      beforeEach(() => {
-        sessionContext.dispose();
+    describe('.sessionContextDialogs', () => {
+      describe('#selectKernel()', () => {
+        it('should select a kernel for the session', async () => {
+          await sessionContext.initialize();
+          const session = sessionContext.session;
+
+          const { id, name } = session.kernel;
+          const accept = acceptDialog();
+
+          await sessionContextDialogs.selectKernel(sessionContext);
+          await accept;
+
+          expect(session.kernel.id).to.not.equal(id);
+          expect(session.kernel.name).to.equal(name);
+        });
+
+        it('should keep the existing kernel if dismissed', async () => {
+          await sessionContext.initialize();
+          const session = sessionContext.session;
+
+          const { id, name } = session.kernel;
+          const dismiss = dismissDialog();
+
+          await sessionContextDialogs.selectKernel(sessionContext);
+          await dismiss;
+
+          expect(session.kernel.id).to.equal(id);
+          expect(session.kernel.name).to.equal(name);
+        });
       });
 
-      it('should populate the select div', () => {
-        const div = document.createElement('select');
+      describe('#restart()', () => {
+        it('should restart if the user accepts the dialog', async () => {
+          const emission = testEmission(sessionContext.statusChanged, {
+            find: (_, args) => args === 'restarting'
+          });
+          await sessionContext.initialize();
+          await sessionContext.session?.kernel?.info;
+          const restart = sessionContextDialogs.restart(sessionContext);
 
-        SessionContext.populateKernelSelect(div, {
-          specs: specsManager.specs,
-          preference: {}
+          await acceptDialog();
+          expect(await restart).to.equal(true);
+          await emission;
         });
-        expect(div.firstChild).to.be.ok;
-        expect(div.value).to.not.equal('null');
-      });
 
-      it('should select the null option', () => {
-        const div = document.createElement('select');
+        it('should not restart if the user rejects the dialog', async () => {
+          let called = false;
 
-        SessionContext.populateKernelSelect(div, {
-          specs: specsManager.specs,
-          preference: { shouldStart: false }
+          await sessionContext.initialize();
+          sessionContext.statusChanged.connect((sender, args) => {
+            if (args === 'restarting') {
+              called = true;
+            }
+          });
+
+          const restart = sessionContextDialogs.restart(sessionContext);
+          await dismissDialog();
+          expect(await restart).to.equal(false);
+          expect(called).to.equal(false);
         });
-        expect(div.firstChild).to.be.ok;
-        expect(div.value).to.equal('null');
-      });
 
-      it('should disable the node', () => {
-        const div = document.createElement('select');
-
-        SessionContext.populateKernelSelect(div, {
-          specs: specsManager.specs,
-          preference: { canStart: false }
+        it('should start the same kernel as the previously started kernel', async () => {
+          await sessionContext.initialize();
+          await sessionContext.shutdown();
+          await sessionContextDialogs.restart(sessionContext);
+          expect(sessionContext.session?.kernel).to.be.ok;
         });
-        expect(div.firstChild).to.be.ok;
-        expect(div.value).to.equal('null');
-        expect(div.disabled).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7616. 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Refactors `ISessionContext` to no longer contain any UI.
- Adds an `ISessionContextDialogs` interface and token
- Adds a default implementation of the `restart` and `selectKernel` dialogs.
- In all places where the two dialogs were called, allow for optional override of the dialogs, defaulting to the base implementation.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
- `ISessionContext` no longer has `restart()` or `selectKernel()` methods.  
- Those wishing to perform UI on an `ISessionContext` should allow the dialogs to be overridden and ultimately depend on the `ISessionContextDialogs` token.  
- Users of the concrete class are now responsible for calling the `selectKernel()` dialog if `initialize()` resolves to `true`. 

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
