### PR TITLE
Integrity updates for the cell-tags extension.

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -95,6 +95,7 @@
     "@jupyterlab/attachments": "~2.0.0-alpha.4",
     "@jupyterlab/cells": "~2.0.0-alpha.4",
     "@jupyterlab/celltags": "~0.1.0",
+    "@jupyterlab/celltags-extension": "~0.1.0",
     "@jupyterlab/codeeditor": "~2.0.0-alpha.4",
     "@jupyterlab/codemirror": "~2.0.0-alpha.4",
     "@jupyterlab/codemirror-extension": "~2.0.0-alpha.4",

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -38,9 +38,9 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/application": "^2.0.0-alpha.3",
+    "@jupyterlab/application": "^2.0.0-alpha.4",
     "@jupyterlab/celltags": "^0.1.0",
-    "@jupyterlab/notebook": "^2.0.0-alpha.3",
+    "@jupyterlab/notebook": "^2.0.0-alpha.4",
     "@types/node": "^12.0.2"
   },
   "devDependencies": {

--- a/packages/celltags/package.json
+++ b/packages/celltags/package.json
@@ -39,10 +39,10 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
-    "@jupyterlab/application": "^2.0.0-alpha.3",
-    "@jupyterlab/cells": "^2.0.0-alpha.3",
-    "@jupyterlab/notebook": "^2.0.0-alpha.3",
-    "@jupyterlab/ui-components": "^2.0.0-alpha.3",
+    "@jupyterlab/application": "^2.0.0-alpha.4",
+    "@jupyterlab/cells": "^2.0.0-alpha.4",
+    "@jupyterlab/notebook": "^2.0.0-alpha.4",
+    "@jupyterlab/ui-components": "^2.0.0-alpha.4",
     "@lumino/widgets": "^1.9.0",
     "@types/node": "^12.0.2"
   },


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#7407 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

It seems that there are some integrity updates dealing with pulling celltags into core.


## User-facing changes
None

## Backwards-incompatible changes
None