### PR TITLE
Close output views on notebook closed

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1668,8 +1668,9 @@ function addCommands(
       const updateCloned = () => {
         void clonedOutputs.save(widget);
       };
+
       current.context.pathChanged.connect(updateCloned);
-      current.content.model.cells.changed.connect(updateCloned);
+      current.context.model.cells.changed.connect(updateCloned);
 
       // Add the cloned output to the output widget tracker.
       void clonedOutputs.add(widget);
@@ -1677,7 +1678,7 @@ function addCommands(
       // Remove the output view if the parent notebook is closed.
       current.content.disposed.connect(() => {
         current.context.pathChanged.disconnect(updateCloned);
-        current.content.model.cells.changed.disconnect(updateCloned);
+        current.context.model.cells.changed.disconnect(updateCloned);
         widget.dispose();
       });
     },


### PR DESCRIPTION
## References

Fixes #7301.

## Code changes

Since `content.model` is disposed, its reference to the model would be set to `null` before accessing it and disconnect the signals handlers.

## User-facing changes

### Before

![close-output-views-issue](https://user-images.githubusercontent.com/591645/70862922-c57fa180-1f42-11ea-8256-66b6938f9336.gif)

### After

![close-output-views-fix](https://user-images.githubusercontent.com/591645/70862924-cadcec00-1f42-11ea-8b4e-d6d7ea125755.gif)

## Backwards-incompatible changes

None
