### PR TITLE
increase timeout in isession.spec.ts from 20s => 60s

### DIFF
--- a/tests/test-services/src/session/isession.spec.ts
+++ b/tests/test-services/src/session/isession.spec.ts
@@ -31,6 +31,7 @@ describe('session', () => {
   let defaultSession: Session.ISession;
 
   beforeAll(async () => {
+    jest.setTimeout(60000);
     defaultSession = await startNew();
     await defaultSession.kernel.ready;
   });


### PR DESCRIPTION
Followup: #6853 #7270 #7271

This is yet another attempt to make our CI more robust. I've seen the `isession.spec.ts` tests from `@jupyterlab/test-services` fail randomly from timeouts at least a dozen times in varous PRs. This increases the timeout to 60s, from the 20s timeout that's set by default in `testutils/src/jest-script.ts`.

CC @blink1073 