### PR TITLE
Simplify user experience when selecting 'no kernel' for notebook

### DIFF
--- a/packages/apputils/src/clientsession.tsx
+++ b/packages/apputils/src/clientsession.tsx
@@ -606,7 +606,10 @@ export class ClientSession implements IClientSession {
     }
     const buttons = cancelable
       ? [Dialog.cancelButton(), Dialog.okButton({ label: 'Select' })]
-      : [Dialog.okButton({ label: 'Select' })];
+      : [
+          Dialog.cancelButton({ label: 'No Kernel' }),
+          Dialog.okButton({ label: 'Select' })
+        ];
 
     let dialog = (this._dialog = new Dialog({
       title: 'Select Kernel',


### PR DESCRIPTION

## References

This change addresses the user experience described in #7646

## Code changes

Simplify the user experience to select `no kernel` when opening a notebook that does not have a matching kernel available on the current environment. 

## User-facing changes

Original UI:
![jupyterlab-select-notebook-kernel-no-kernel](https://user-images.githubusercontent.com/382917/71101144-11149400-216b-11ea-9618-d3ef63fe0a72.gif)

Updated UI:
![jupyterlab-select-notebook-kernel-updated](https://user-images.githubusercontent.com/382917/71101172-1a9dfc00-216b-11ea-80ee-09ee452d0920.gif)


