### PR TITLE
Clean up integrity script

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -335,11 +335,16 @@ export async function ensureIntegrity(): Promise<boolean> {
 
   // Validate each package.
   for (let name in locals) {
+    // application-top is handled elsewhere
+    if (name === '@jupyterlab/application-top') {
+      continue;
+    }
     let unused = UNUSED[name] || [];
     // Allow jest-junit to be unused in the test suite.
     if (name.indexOf('@jupyterlab/test-') === 0) {
       unused.push('jest-junit');
     }
+
     let options: IEnsurePackageOptions = {
       pkgPath: pkgPaths[name],
       data: pkgData[name],
@@ -381,17 +386,13 @@ export async function ensureIntegrity(): Promise<boolean> {
   // Handle the JupyterLab application top package.
   pkgMessages = ensureJupyterlab();
   if (pkgMessages.length > 0) {
-    let pkgName = '@jupyterlab/application-top';
-    if (!messages[pkgName]) {
-      messages[pkgName] = [];
-    }
-    messages[pkgName] = messages[pkgName].concat(pkgMessages);
+    messages['@application/top'] = pkgMessages;
   }
 
   // Handle any messages.
   if (Object.keys(messages).length > 0) {
     console.log(JSON.stringify(messages, null, 2));
-    if ('--force' in process.argv) {
+    if (process.argv.indexOf('--force') !== -1) {
       console.log(
         '\n\nPlease run `jlpm run integrity` locally and commit the changes'
       );

--- a/packages/celltags-extension/package.json
+++ b/packages/celltags-extension/package.json
@@ -40,10 +40,10 @@
   "dependencies": {
     "@jupyterlab/application": "^2.0.0-alpha.4",
     "@jupyterlab/celltags": "^2.0.0-alpha.4",
-    "@jupyterlab/notebook": "^2.0.0-alpha.4",
-    "@types/node": "^12.12.17"
+    "@jupyterlab/notebook": "^2.0.0-alpha.4"
   },
   "devDependencies": {
+    "@types/node": "^12.12.17",
     "rimraf": "~3.0.0",
     "typescript": "~3.7.3"
   },

--- a/packages/celltags/package.json
+++ b/packages/celltags/package.json
@@ -43,10 +43,10 @@
     "@jupyterlab/cells": "^2.0.0-alpha.4",
     "@jupyterlab/notebook": "^2.0.0-alpha.4",
     "@jupyterlab/ui-components": "^2.0.0-alpha.4",
-    "@lumino/widgets": "^1.9.4",
-    "@types/node": "^12.12.17"
+    "@lumino/widgets": "^1.9.4"
   },
   "devDependencies": {
+    "@types/node": "^12.12.17",
     "rimraf": "~3.0.0",
     "typescript": "~3.7.3"
   }

--- a/packages/filebrowser-extension/package.json
+++ b/packages/filebrowser-extension/package.json
@@ -49,7 +49,6 @@
     "@lumino/algorithm": "^1.2.1",
     "@lumino/commands": "^1.8.0",
     "@lumino/messaging": "^1.3.1",
-    "@lumino/polling": "^1.0.1",
     "@lumino/widgets": "^1.9.4"
   },
   "devDependencies": {

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -42,12 +42,6 @@
     "@jupyterlab/rendermime": "^2.0.0-alpha.4"
   },
   "devDependencies": {
-    "@jupyterlab/apputils": "^2.0.0-alpha.4",
-    "@jupyterlab/cells": "^2.0.0-alpha.4",
-    "@jupyterlab/codemirror": "^2.0.0-alpha.4",
-    "@jupyterlab/notebook": "^2.0.0-alpha.4",
-    "@jupyterlab/outputarea": "^2.0.0-alpha.4",
-    "@jupyterlab/rendermime": "^2.0.0-alpha.4",
     "css-loader": "~3.2.0",
     "file-loader": "~5.0.2",
     "mini-css-extract-plugin": "~0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6208,11 +6208,6 @@ detect-indent@^6.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
   integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
 
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
-
 detect-newline@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -8483,7 +8478,7 @@ husky@^3.1.0:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -11247,15 +11242,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -11392,22 +11378,6 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.42:
   version "1.1.43"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.43.tgz#2c6ca237f88ce11d49631f11190bb01f8d0549f2"
@@ -11518,7 +11488,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
   integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
@@ -11549,7 +11519,7 @@ npm-run-path@^3.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -12766,7 +12736,7 @@ raw-loader@~4.0.0:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -14670,7 +14640,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
Our integrity script was not previously enforcing on CI (the `--force` option had no effect).  This fixes that issue and updates the integrity script.  

- fix a few imports that should be removed
- the `application-top` was being changed twice (once with `~` and once with `^` dependencies on local packages
- nbconvert-css had some dependencies that were also listed as devDependencies, which I believe caused the integrity changes we saw during publishing.