### PR TITLE
Add scrollbar styles to nbconvert-css

### DIFF
--- a/packages/nbconvert-css/raw.css
+++ b/packages/nbconvert-css/raw.css
@@ -3,6 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+@import url('~@jupyterlab/application/style/scrollbar.css');
 @import url('~@jupyterlab/apputils/style/index.css');
 @import url('~@jupyterlab/cells/style/index.css');
 @import url('~@jupyterlab/codemirror/style/index.css');


### PR DESCRIPTION
## Code changes
This adds the scrollbar style to the nbconvert-css package in order to export the scrollbar styling with all the rest.

## User-facing changes
No user-facing changes that would affect JupyterLab users.  Any user of the nbconvert-css stylesheet will be able to style their scrollbars if they set `data-jp-theme-scrollbars="true"`.

## Backwards-incompatible changes
None.
