### PR TITLE
Integrity updates to fix an error from removing vega4

### DIFF
--- a/dev_mode/imports.css
+++ b/dev_mode/imports.css
@@ -35,5 +35,4 @@
 @import url('~@jupyterlab/tooltip-extension/style/index.css');
 @import url('~@jupyterlab/ui-components-extension/style/index.css');
 @import url('~@jupyterlab/vdom-extension/style/index.css');
-@import url('~@jupyterlab/vega4-extension/style/index.css');
 @import url('~@jupyterlab/vega5-extension/style/index.css');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#7650 missed one place that the integrity check script caught.

## Code changes

Remove vega4 reference

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

