### PR TITLE
Update the notebook tools on tracker.currentChanged

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -507,11 +507,11 @@ function activateNotebookTools(
       labShell.currentChanged.connect((sender, args) => {
         updateTools();
       });
-    } else {
-      tracker.currentChanged.connect((sender, args) => {
-        updateTools();
-      });
     }
+    // A notebook widget could be closed without a change to labShell.currentWidget
+    tracker.currentChanged.connect((sender, args) => {
+      updateTools();
+    });
   });
 
   return notebookTools;


### PR DESCRIPTION
## References

Fixes #7643.

## Code changes

Update the notebook tools on `tracker.currentChanged`.

## User-facing changes

The notebooks tools should now be removed from the left area when a notebook that doesn't have the focus is closed:

![notebook-tools-currentwidget](https://user-images.githubusercontent.com/591645/71164089-a6d51f80-224e-11ea-8b30-bac7ca445230.gif)

## Backwards-incompatible changes

None.
