### PR TITLE
Start new notebooks in edit mode

### DIFF
--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -285,6 +285,10 @@ export class NotebookModel extends DocumentModel implements INotebookModel {
    */
   initialize(): void {
     super.initialize();
+    if (!this.cells.length) {
+      let factory = this.contentFactory;
+      this.cells.push(factory.createCodeCell({}));
+    }
     this.cells.clearUndo();
   }
 

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -282,6 +282,10 @@ export class NotebookModel extends DocumentModel implements INotebookModel {
 
   /**
    * Initialize the model with its current state.
+   *
+   * # Notes
+   * Adds an empty code cell if the model is empty
+   * and clears undo state.
    */
   initialize(): void {
     super.initialize();

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -63,19 +63,19 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
       this
     );
     this.context.saveState.connect(this._onSave, this);
-
     void this.revealed.then(() => {
       if (this.isDisposed) {
         // this widget has already been disposed, bail
         return;
       }
 
-      // Set the document edit mode on initial open if it looks like a new document.
-      if (this.content.widgets.length === 1) {
-        let cellModel = this.content.widgets[0].model;
-        if (cellModel.type === 'code' && cellModel.value.text === '') {
+      // If the notebook model is empty (new file), set it to edit mode.
+      if (this.content.model.cells.length === 0) {
+        // Wait for an animation frame so the spinner is hidden and the
+        // widget can be focused.
+        requestAnimationFrame(() => {
           this.content.mode = 'edit';
-        }
+        });
       }
     });
   }

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -69,13 +69,12 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
         return;
       }
 
-      // If the notebook model is empty (new file), set it to edit mode.
-      if (this.content.model.cells.length === 0) {
-        // Wait for an animation frame so the spinner is hidden and the
-        // widget can be focused.
-        requestAnimationFrame(() => {
+      // Set the document edit mode on initial open if it looks like a new document.
+      if (this.content.widgets.length === 1) {
+        let cellModel = this.content.widgets[0].model;
+        if (cellModel.type === 'code' && cellModel.value.text === '') {
           this.content.mode = 'edit';
-        });
+        }
       }
     });
   }

--- a/tests/test-notebook/src/model.spec.ts
+++ b/tests/test-notebook/src/model.spec.ts
@@ -345,6 +345,26 @@ describe('@jupyterlab/notebook', () => {
       });
     });
 
+    describe('#initialize()', () => {
+      it('should add one code cell if the model is empty', () => {
+        const model = new NotebookModel();
+        expect(model.cells.length).to.equal(0);
+        model.initialize();
+        expect(model.cells.length).to.equal(1);
+        expect(model.cells.get(0).type).to.equal('code');
+      });
+
+      it('should clear undo state', () => {
+        const model = new NotebookModel();
+        const cell = model.contentFactory.createCodeCell({});
+        cell.value.text = 'foo';
+        model.cells.push(cell);
+        expect(model.cells.canUndo).to.equal(true);
+        model.initialize();
+        expect(model.cells.canUndo).to.equal(false);
+      });
+    });
+
     describe('.ContentFactory', () => {
       let factory = new NotebookModel.ContentFactory({});
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #6731 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Updates `NotebookModel.initialize()` to add an empty code cell if the model is empty.
This allows the logic for detecting an "empty" notebook to work on notebook opening.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
New notebooks now start in edit mode.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
