### PR TITLE
Fix handling of code editor refresh

### DIFF
--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -141,7 +141,7 @@ export class CodeEditorWrapper extends Widget {
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
-    if (this._updateOnShow) {
+    if (this._updateOnShow || !this._hasRefreshed) {
       this.update();
     }
   }
@@ -161,7 +161,10 @@ export class CodeEditorWrapper extends Widget {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    this.editor.refresh();
+    if (this.isVisible) {
+      this._hasRefreshed = true;
+      this.editor.refresh();
+    }
   }
 
   /**
@@ -275,6 +278,7 @@ export class CodeEditorWrapper extends Widget {
   }
 
   private _updateOnShow: boolean;
+  private _hasRefreshed = false;
 }
 
 /**

--- a/packages/codeeditor/src/widget.ts
+++ b/packages/codeeditor/src/widget.ts
@@ -121,6 +121,9 @@ export class CodeEditorWrapper extends Widget {
     node.addEventListener('p-dragleave', this);
     node.addEventListener('p-dragover', this);
     node.addEventListener('p-drop', this);
+    // We have to refresh at least once after attaching,
+    // while visible.
+    this._hasRefreshedSinceAttach = false;
     if (this.isVisible) {
       this.update();
     }
@@ -141,7 +144,7 @@ export class CodeEditorWrapper extends Widget {
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
-    if (this._updateOnShow || !this._hasRefreshed) {
+    if (this._updateOnShow || !this._hasRefreshedSinceAttach) {
       this.update();
     }
   }
@@ -162,7 +165,7 @@ export class CodeEditorWrapper extends Widget {
    */
   protected onUpdateRequest(msg: Message): void {
     if (this.isVisible) {
-      this._hasRefreshed = true;
+      this._hasRefreshedSinceAttach = true;
       this.editor.refresh();
     }
   }
@@ -278,7 +281,7 @@ export class CodeEditorWrapper extends Widget {
   }
 
   private _updateOnShow: boolean;
-  private _hasRefreshed = false;
+  private _hasRefreshedSinceAttach = false;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7671 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Handles the case where a code editor is not visible when it tries to update.  This can happen when the widget is attached and visible, and then is no longer visible when `onUpdateRequest` is later called.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None in core JupyterLab, affects extension authors using code editors and things that depend on them (like notebooks).

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
