### PR TITLE
Add commands to move to next/prev tab bar in shell

### DIFF
--- a/packages/application-extension/schema/main.json
+++ b/packages/application-extension/schema/main.json
@@ -14,6 +14,16 @@
       "selector": "body"
     },
     {
+      "command": "application:activate-next-tab-bar",
+      "keys": ["Ctrl Shift ."],
+      "selector": "body"
+    },
+    {
+      "command": "application:activate-previous-tab-bar",
+      "keys": ["Ctrl Shift ,"],
+      "selector": "body"
+    },
+    {
       "command": "application:close",
       "keys": ["Alt W"],
       "selector": ".jp-Activity"

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -46,6 +46,11 @@ namespace CommandIDs {
   export const activatePreviousTab: string =
     'application:activate-previous-tab';
 
+  export const activateNextTabBar: string = 'application:activate-next-tab-bar';
+
+  export const activatePreviousTabBar: string =
+    'application:activate-previous-tab-bar';
+
   export const close = 'application:close';
 
   export const closeOtherTabs = 'application:close-other-tabs';
@@ -550,6 +555,22 @@ function addCommands(app: JupyterLab, palette: ICommandPalette): void {
     }
   });
   palette.addItem({ command: CommandIDs.activatePreviousTab, category });
+
+  commands.addCommand(CommandIDs.activateNextTabBar, {
+    label: 'Activate Next Tab Bar',
+    execute: () => {
+      shell.activateNextTabBar();
+    }
+  });
+  palette.addItem({ command: CommandIDs.activateNextTabBar, category });
+
+  commands.addCommand(CommandIDs.activatePreviousTabBar, {
+    label: 'Activate Previous Tab Bar',
+    execute: () => {
+      shell.activatePreviousTabBar();
+    }
+  });
+  palette.addItem({ command: CommandIDs.activatePreviousTabBar, category });
 
   // A CSS selector targeting tabs in the main area. This is a very
   // specific selector since we really only want tabs that are

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -499,6 +499,30 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     }
   }
 
+  /*
+   * Activate the next TabBar.
+   */
+  activateNextTabBar(): void {
+    let nextBar = this._adjacentBar('next');
+    if (nextBar) {
+      if (nextBar.currentTitle) {
+        nextBar.currentTitle.owner.activate();
+      }
+    }
+  }
+
+  /*
+   * Activate the next TabBar.
+   */
+  activatePreviousTabBar(): void {
+    let nextBar = this._adjacentBar('previous');
+    if (nextBar) {
+      if (nextBar.currentTitle) {
+        nextBar.currentTitle.owner.activate();
+      }
+    }
+  }
+
   add(
     widget: Widget,
     area: ILabShell.Area = 'main',

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -723,6 +723,8 @@ export function createTabsMenu(
     [
       { command: 'application:activate-next-tab' },
       { command: 'application:activate-previous-tab' },
+      { command: 'application:activate-next-tab-bar' },
+      { command: 'application:activate-previous-tab-bar' },
       { command: CommandIDs.activatePreviouslyUsedTab }
     ],
     0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixing #7434, so that users can toggle between Tab Bars 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

added `activateNextTabBar` and `activatePreviousTabBar` to `LabShell`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

Users can now move though different panels using `Ctrl Shift .` to go the the next tab bar and `Ctrl Shift ,` to go to the previous. There are also commands in the menu and command palette. 

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None
