### PR TITLE
Resolve race condition between default file browser and tree URLs.

### DIFF
--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -40,6 +40,8 @@
     "@jupyterlab/apputils": "^2.0.0-alpha.4",
     "@jupyterlab/coreutils": "^4.0.0-alpha.4",
     "@lumino/algorithm": "^1.2.1",
+    "@lumino/coreutils": "^1.4.0",
+    "@lumino/disposable": "^1.3.2",
     "@lumino/widgets": "^1.9.4",
     "react": "~16.9.0"
   },

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -318,7 +318,6 @@ const tree: JupyterFrontEndPlugin<JupyterFrontEnd.ITreeResolver> = {
     // If a route is handled by the router without the tree command being
     // invoked, resolve to `null` and clean up artifacts.
     const listener = () => {
-      console.log('listener in tree plugin', set.isDisposed);
       if (set.isDisposed) {
         return;
       }

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -282,10 +282,10 @@ const tree: JupyterFrontEndPlugin<JupyterFrontEnd.ITreeResolver> = {
           const treeMatch = args.path.match(treePattern);
           const workspaceMatch = args.path.match(workspacePattern);
           const match = treeMatch || workspaceMatch;
-          const file = match ? decodeURI(match[1]) : undefined;
+          const file = match ? decodeURI(match[1]) : '';
           const workspace = PathExt.basename(resolver.name);
           const query = URLExt.queryStringToObject(args.search ?? '');
-          const browser = query['file-browser-path'];
+          const browser = query['file-browser-path'] || '';
 
           // Remove the file browser path from the query string.
           delete query['file-browser-path'];

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -33,6 +33,10 @@ import {
 
 import { each, iter, toArray } from '@lumino/algorithm';
 
+import { PromiseDelegate } from '@lumino/coreutils';
+
+import { DisposableDelegate, DisposableSet } from '@lumino/disposable';
+
 import { Widget, DockLayout } from '@lumino/widgets';
 
 import * as React from 'react';
@@ -247,63 +251,88 @@ const router: JupyterFrontEndPlugin<IRouter> = {
 };
 
 /**
- * The tree route handler provider.
+ * The default tree route resolver plugin.
  */
-const tree: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/application-extension:tree',
+const tree: JupyterFrontEndPlugin<JupyterFrontEnd.ITreeResolver> = {
+  id: '@jupyterlab/application-extension:tree-resolver',
   autoStart: true,
   requires: [JupyterFrontEnd.IPaths, IRouter, IWindowResolver],
+  provides: JupyterFrontEnd.ITreeResolver,
   activate: (
     app: JupyterFrontEnd,
     paths: JupyterFrontEnd.IPaths,
     router: IRouter,
     resolver: IWindowResolver
-  ) => {
+  ): JupyterFrontEnd.ITreeResolver => {
     const { commands } = app;
     const treePattern = new RegExp(`^${paths.urls.tree}([^?]+)`);
     const workspacePattern = new RegExp(
       `^${paths.urls.workspaces}/[^?/]+/tree/([^?]+)`
     );
+    const set = new DisposableSet();
+    const delegate = new PromiseDelegate<JupyterFrontEnd.ITreeResolver.Paths>();
 
-    commands.addCommand(CommandIDs.tree, {
-      execute: async (args: IRouter.ILocation) => {
-        const treeMatch = args.path.match(treePattern);
-        const workspaceMatch = args.path.match(workspacePattern);
-        const match = treeMatch || workspaceMatch;
-        const path = match ? decodeURI(match[1]) : undefined;
-        const workspace = PathExt.basename(resolver.name);
-        const query = URLExt.queryStringToObject(args.search ?? '');
-        const fileBrowserPath = query['file-browser-path'];
-
-        // Remove the file browser path from the query string.
-        delete query['file-browser-path'];
-
-        // Remove the tree portion of the URL.
-        const url =
-          (workspaceMatch
-            ? URLExt.join(paths.urls.workspaces, workspace)
-            : paths.urls.app) +
-          URLExt.objectToQueryString(query) +
-          args.hash;
-
-        router.navigate(url);
-
-        try {
-          await commands.execute('filebrowser:open-path', { path });
-
-          if (fileBrowserPath) {
-            await commands.execute('filebrowser:open-path', {
-              path: fileBrowserPath
-            });
+    set.add(
+      commands.addCommand(CommandIDs.tree, {
+        execute: async (args: IRouter.ILocation) => {
+          if (set.isDisposed) {
+            return;
           }
-        } catch (error) {
-          console.warn('Tree routing failed.', error);
-        }
-      }
-    });
 
-    router.register({ command: CommandIDs.tree, pattern: treePattern });
-    router.register({ command: CommandIDs.tree, pattern: workspacePattern });
+          const treeMatch = args.path.match(treePattern);
+          const workspaceMatch = args.path.match(workspacePattern);
+          const match = treeMatch || workspaceMatch;
+          const file = match ? decodeURI(match[1]) : undefined;
+          const workspace = PathExt.basename(resolver.name);
+          const query = URLExt.queryStringToObject(args.search ?? '');
+          const browser = query['file-browser-path'];
+
+          // Remove the file browser path from the query string.
+          delete query['file-browser-path'];
+
+          // Remove the tree portion of the URL.
+          const url =
+            (workspaceMatch
+              ? URLExt.join(paths.urls.workspaces, workspace)
+              : paths.urls.app) +
+            URLExt.objectToQueryString(query) +
+            args.hash;
+
+          // Route to the cleaned URL.
+          router.navigate(url);
+
+          // Clean up artifacts immediately upon routing.
+          set.dispose();
+
+          delegate.resolve({ browser, file });
+        }
+      })
+    );
+    set.add(
+      router.register({ command: CommandIDs.tree, pattern: treePattern })
+    );
+    set.add(
+      router.register({ command: CommandIDs.tree, pattern: workspacePattern })
+    );
+
+    // If a route is handled by the router without the tree command being
+    // invoked, resolve to `null` and clean up artifacts.
+    const listener = () => {
+      console.log('listener in tree plugin', set.isDisposed);
+      if (set.isDisposed) {
+        return;
+      }
+      set.dispose();
+      delegate.resolve(null);
+    };
+    router.routed.connect(listener);
+    set.add(
+      new DisposableDelegate(() => {
+        router.routed.disconnect(listener);
+      })
+    );
+
+    return { paths: delegate.promise };
   }
 };
 

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -305,6 +305,39 @@ export namespace JupyterFrontEnd {
       readonly workspaces: string;
     };
   }
+
+  /**
+   * The application tree resolver token.
+   *
+   * #### Notes
+   * Not all Jupyter front-end applications will have a tree resolver
+   * implemented on the client-side. This token should not be required as a
+   * dependency if it is possible to make it an optional dependency.
+   */
+  export const ITreeResolver = new Token<ITreeResolver>(
+    '@jupyterlab/application:ITreeResolver'
+  );
+
+  /**
+   * An interface for a front-end tree route resolver.
+   */
+  export interface ITreeResolver {
+    /**
+     * A promise that resolves to the routed tree paths or null.
+     */
+    readonly paths: Promise<ITreeResolver.Paths>;
+  }
+
+  /**
+   * A namespace for tree resolver types.
+   */
+  export namespace ITreeResolver {
+    /**
+     * The browser and file paths if the tree resolver encountered and handled
+     * a tree URL or `null` if not.
+     */
+    export type Paths = { browser: string; file: string } | null;
+  }
 }
 
 /**

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -334,7 +334,7 @@ export namespace JupyterFrontEnd {
   export namespace ITreeResolver {
     /**
      * The browser and file paths if the tree resolver encountered and handled
-     * a tree URL or `null` if not.
+     * a tree URL or `null` if not. Empty string paths should be ignored.
      */
     export type Paths = { browser: string; file: string } | null;
   }

--- a/packages/coreutils/src/text.ts
+++ b/packages/coreutils/src/text.ts
@@ -102,7 +102,7 @@ export namespace Text {
    * @returns the same string, but with each word capitalized.
    */
   export function titleCase(str: string) {
-    return str
+    return (str || '')
       .toLowerCase()
       .split(' ')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1))

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -230,7 +230,8 @@ async function activateFactory(
       manager: docManager,
       driveName: options.driveName || '',
       refreshInterval: options.refreshInterval,
-      state: options.state === null ? undefined : options.state || state
+      state:
+        options.state === null ? undefined : options.state || state || undefined
     });
     const restore = options.restore;
     const widget = new FileBrowser({ id, model, restore });

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -228,10 +228,7 @@ function activateFactory(
       refreshInterval: options.refreshInterval,
       state: options.state === null ? undefined : options.state || state
     });
-    const widget = new FileBrowser({
-      id,
-      model
-    });
+    const widget = new FileBrowser({ id, model });
 
     // Add a launcher toolbar item.
     let launcher = new ToolbarButton({
@@ -263,8 +260,8 @@ function activateBrowser(
   labShell: ILabShell,
   restorer: ILayoutRestorer,
   settingRegistry: ISettingRegistry,
-  commandPalette: ICommandPalette,
-  mainMenu: IMainMenu
+  commandPalette: ICommandPalette | null,
+  mainMenu: IMainMenu | null
 ): void {
   const browser = factory.defaultBrowser;
   const { commands } = app;

--- a/packages/filebrowser-extension/style/index.css
+++ b/packages/filebrowser-extension/style/index.css
@@ -4,3 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 @import url('~@jupyterlab/filebrowser/style/index.css');
+
+#filebrowser.jp-mod-restoring .jp-DirListing-content {
+  display: none;
+}

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -64,19 +64,17 @@ export class FileBrowser extends Widget {
     this._manager = model.manager;
     this._crumbs = new BreadCrumbs({ model });
     this.toolbar = new Toolbar<Widget>();
-
     this._directoryPending = false;
-    let newFolder = new ToolbarButton({
+
+    const newFolder = new ToolbarButton({
       iconClassName: 'jp-NewFolderIcon',
       onClick: () => {
         this.createNewDirectory();
       },
       tooltip: 'New Folder'
     });
-
-    let uploader = new Uploader({ model });
-
-    let refresher = new ToolbarButton({
+    const uploader = new Uploader({ model });
+    const refresher = new ToolbarButton({
       iconClassName: 'jp-RefreshIcon',
       onClick: () => {
         void model.refresh();
@@ -94,13 +92,16 @@ export class FileBrowser extends Widget {
     this.toolbar.addClass(TOOLBAR_CLASS);
     this._listing.addClass(LISTING_CLASS);
 
-    let layout = new PanelLayout();
+    const layout = new PanelLayout();
+
     layout.addWidget(this.toolbar);
     layout.addWidget(this._crumbs);
     layout.addWidget(this._listing);
-
     this.layout = layout;
-    void model.restore(this.id);
+
+    if (options.restore !== false) {
+      void model.restore(this.id);
+    }
   }
 
   /**
@@ -309,5 +310,12 @@ export namespace FileBrowser {
      * The default is a shared instance of `DirListing.Renderer`.
      */
     renderer?: DirListing.IRenderer;
+
+    /**
+     * Whether a file browser automatically restores state when instantiated.
+     *
+     * The default is `true`.
+     */
+    restore?: boolean;
   }
 }

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -99,7 +99,9 @@ export class FileBrowser extends Widget {
     layout.addWidget(this._listing);
     this.layout = layout;
 
-    void model.restore(this.id, options.restore !== false);
+    if (options.restore !== false) {
+      void model.restore(this.id);
+    }
   }
 
   /**

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -99,9 +99,7 @@ export class FileBrowser extends Widget {
     layout.addWidget(this._listing);
     this.layout = layout;
 
-    if (options.restore !== false) {
-      void model.restore(this.id);
-    }
+    void model.restore(this.id, options.restore !== false);
   }
 
   /**

--- a/packages/filebrowser/src/tokens.ts
+++ b/packages/filebrowser/src/tokens.ts
@@ -79,6 +79,19 @@ export namespace IFileBrowserFactory {
     driveName?: string;
 
     /**
+     * The time interval for browser refreshing, in ms.
+     */
+    refreshInterval?: number;
+
+    /**
+     * Whether to restore the file browser state after instantiation.
+     *
+     * #### Notes
+     * The default value is `true`.
+     */
+    restore?: boolean;
+
+    /**
      * The state database to use for saving file browser state and restoring it.
      *
      * #### Notes
@@ -86,10 +99,5 @@ export namespace IFileBrowserFactory {
      * database will be automatically passed in and used for state restoration.
      */
     state?: IStateDB | null;
-
-    /**
-     * The time interval for browser refreshing, in ms.
-     */
-    refreshInterval?: number;
   }
 }


### PR DESCRIPTION
## References
Fixes #4009

## Code changes
- [x] Fix unrelated issue in `titleCase` function where it fails if `null` or `undefined` is passed in at runtime.
- [x] Fix race condition between default file browser and tree handler. (#4009)
- [x] The default file browser hides its listing until it is restored.

## User-facing changes
The default file browser hides its listing until it is restored.

![file-browser](https://user-images.githubusercontent.com/159529/71366044-bd55e080-2598-11ea-9e81-3482a3bb05e0.gif)

## Backwards-incompatible changes
N/A
