### PR TITLE
Update MathJax CDN in the cell and console examples

### DIFF
--- a/examples/cell/index.html
+++ b/examples/cell/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <title>Cell Demo</title>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>
   </head>
   <body>
     {% set page_config_full = {'baseUrl': base_url, 'token': token} %}
-      
+
     <script id="jupyter-config-data" type="application/json">
       {{ page_config_full | tojson }}
     </script>

--- a/examples/console/index.html
+++ b/examples/console/index.html
@@ -2,15 +2,15 @@
 <html lang="en">
   <head>
     <title>Console Demo</title>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>
   </head>
   <body>
     {% set page_config_full = {'baseUrl': base_url, 'token': token} %}
-    
+
     <script id="jupyter-config-data" type="application/json">
       {{ page_config_full | tojson }}
     </script>
-  
+
     <script src="{{base_url | e}}example/bundle.js"></script>
 
     <script type="text/javascript">


### PR DESCRIPTION
## Code changes

This fixes the following warning when running the `cell` and `console` examples:

```
WARNING: cdn.mathjax.org has been retired. Check https://www.mathjax.org/cdn-shutting-down/ for migration tips.
```

This change updates the url for the CDN, following the recommendation from https://www.mathjax.org/cdn-shutting-down/.

## User-facing changes

None

## Backwards-incompatible changes

None
