### PR TITLE
Be more careful about sessioncontext kernelChanged and sessionChanged signal emissions

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -766,8 +766,10 @@ export class SessionContext implements ISessionContext {
     if (this._session) {
       this._session.dispose();
     }
+    const oldValue = this._session;
     this._session = null;
-    this._terminated.emit(undefined);
+    const newValue = this._session;
+    this._sessionChanged.emit({ name: 'session', oldValue, newValue });
   }
 
   /**
@@ -873,7 +875,6 @@ export class SessionContext implements ISessionContext {
   private _initializing = false;
   private _initPromise = new PromiseDelegate<boolean>();
   private _isReady = false;
-  private _terminated = new Signal<this, void>(this);
   private _kernelChanged = new Signal<
     this,
     Session.ISessionConnection.IKernelChangedArgs

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -512,6 +512,8 @@ export class SessionContext implements ISessionContext {
       return;
     }
     this._isDisposed = true;
+    this._disposed.emit();
+
     if (this._session) {
       if (this.kernelPreference.shutdownOnDispose) {
         // Fire and forget the session shutdown request
@@ -531,7 +533,6 @@ export class SessionContext implements ISessionContext {
       this._busyDisposable.dispose();
       this._busyDisposable = null;
     }
-    this._disposed.emit();
     Signal.clearData(this);
   }
 
@@ -765,11 +766,11 @@ export class SessionContext implements ISessionContext {
   private _onSessionDisposed(): void {
     if (this._session) {
       this._session.dispose();
+      const oldValue = this._session;
+      this._session = null;
+      const newValue = this._session;
+      this._sessionChanged.emit({ name: 'session', oldValue, newValue });
     }
-    const oldValue = this._session;
-    this._session = null;
-    const newValue = this._session;
-    this._sessionChanged.emit({ name: 'session', oldValue, newValue });
   }
 
   /**

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -162,17 +162,19 @@ async function activateConsole(
   // Handle state restoration.
   void restorer.restore(tracker, {
     command: CommandIDs.create,
-    args: widget => ({
-      path: widget.content.console.sessionContext.session?.path,
-      name: widget.content.console.sessionContext.session?.name,
-      kernelPreference: {
-        name: widget.content.console.sessionContext.kernelPreference.name,
-        language:
-          widget.content.console.sessionContext.kernelPreference.language
-      }
-    }),
-    name: widget =>
-      widget.content.console.sessionContext.session?.path ?? UUID.uuid4(),
+    args: widget => {
+      const {
+        path,
+        name,
+        kernelPreference
+      } = widget.content.console.sessionContext;
+      return {
+        path,
+        name,
+        kernelPreference: { ...kernelPreference }
+      };
+    },
+    name: widget => widget.content.console.sessionContext.path ?? UUID.uuid4(),
     when: manager.ready
   });
 

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -206,8 +206,15 @@ export class SessionConnection implements Session.ISessionConnection {
     }
     this._isDisposed = true;
     this._disposed.emit();
-    this._kernel?.dispose();
-    this._kernel = null;
+
+    if (this._kernel) {
+      this._kernel.dispose();
+      let oldValue = this._kernel;
+      this._kernel = null;
+      let newValue = this._kernel;
+      this._kernelChanged.emit({ name: 'kernel', oldValue, newValue });
+    }
+
     Signal.clearData(this);
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #7690 and #7693 

## Code changes

Emit the session and kernel changed signals when needed, like when the connection is disposed. Also use sessioncontext path/name for console tracker restoration.

## User-facing changes

Fixes #7690, showing the kernel status correctly.

## Backwards-incompatible changes

No APIs were changed.