### PR TITLE
Restore default file browser manually.

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -1087,7 +1087,7 @@ namespace Private {
       router.routed.disconnect(listener);
 
       const paths = await tree?.paths;
-      if (paths) {
+      if (paths?.file || paths?.browser) {
         // Restore the model without populating it.
         await browser.model.restore(browser.id, false);
         if (paths.file) {

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -313,8 +313,11 @@ export namespace FileBrowser {
 
     /**
      * Whether a file browser automatically restores state when instantiated.
-     *
      * The default is `true`.
+     *
+     * #### Notes
+     * The file browser model will need to be restored before for the file
+     * browser to start saving its state.
      */
     restore?: boolean;
   }

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -101,6 +101,8 @@ export class FileBrowserModel implements IDisposable {
     };
     window.addEventListener('beforeunload', this._unloadEventListener);
     this._poll = new Poll({
+      auto: options.auto ?? true,
+      name: '@jupyterlab/filebrowser:Model',
       factory: () => this.cd('.'),
       frequency: {
         interval: refreshInterval,
@@ -656,6 +658,19 @@ export namespace FileBrowserModel {
    */
   export interface IOptions {
     /**
+     * Whether a file browser automatically loads its initial path.
+     * The default is `true`.
+     */
+    auto?: boolean;
+
+    /**
+     * An optional `Contents.IDrive` name for the model.
+     * If given, the model will prepend `driveName:` to
+     * all paths used in file operations.
+     */
+    driveName?: string;
+
+    /**
      * An icon registry instance.
      */
     iconRegistry: IIconRegistry;
@@ -664,13 +679,6 @@ export namespace FileBrowserModel {
      * A document manager instance.
      */
     manager: IDocumentManager;
-
-    /**
-     * An optional `Contents.IDrive` name for the model.
-     * If given, the model will prepend `driveName:` to
-     * all paths used in file operations.
-     */
-    driveName?: string;
 
     /**
      * The time interval for browser refreshing, in ms.

--- a/packages/filebrowser/src/tokens.ts
+++ b/packages/filebrowser/src/tokens.ts
@@ -72,6 +72,14 @@ export namespace IFileBrowserFactory {
    */
   export interface IOptions {
     /**
+     * Whether a file browser automatically loads its initial path.
+     *
+     * #### Notes
+     * The default is `true`.
+     */
+    auto?: boolean;
+
+    /**
      * An optional `Contents.IDrive` name for the model.
      * If given, the model will prepend `driveName:` to
      * all paths used in file operations.
@@ -84,10 +92,12 @@ export namespace IFileBrowserFactory {
     refreshInterval?: number;
 
     /**
-     * Whether to restore the file browser state after instantiation.
+     * Whether a file browser automatically restores state when instantiated.
+     * The default is `true`.
      *
      * #### Notes
-     * The default value is `true`.
+     * The file browser model will need to be restored before for the file
+     * browser to start saving its state.
      */
     restore?: boolean;
 


### PR DESCRIPTION
# References
Fixes #4009

## Code changes
Uses the `auto` parameter of the file browser model `Poll` to prevent it from loading the default file browser before it has been restored.

## User-facing changes
N/A, but page loading is faster for `/tree` URLs.

## Backwards-incompatible changes
N/A

cc: @timkpaine, finally 😌 
