### PR TITLE
Fixes lint-on-commit hook

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
-"\"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"": [
+"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}": [
   "prettier --write",
   "git add"
 ]


### PR DESCRIPTION
Currently, lint-on-commit is broken; no files ever get linted, and then the integrity CI check complains. It turns out that the glob pattern given in the `.lintstagedrc` doesn't match any files. It looks like @vidartf made the relevant change in 0bdce26 as part of #7657. The commit msg from 0bdce26 suggests that the changes were made with the goal of Windows compatibility.

This PR has the fix needed to get the lint hook working for me (OS X 10.14). Could someone with Windows please also test this PR?