### PR TITLE
Clean up UX of property inspector

### DIFF
--- a/packages/property-inspector/src/index.ts
+++ b/packages/property-inspector/src/index.ts
@@ -154,8 +154,12 @@ export class SideBarPropertyInspectorProvider extends PropertyInspectorProvider 
     if (placeholder) {
       this._placeholder = placeholder;
     } else {
-      this._placeholder = new Widget();
-      this._placeholder.node.textContent = 'No properties to inspect.';
+      const node = document.createElement('div');
+      const content = document.createElement('div');
+      content.textContent = 'No properties to inspect.';
+      content.className = 'jp-PropertyInspector-placeholderContent';
+      node.appendChild(content);
+      this._placeholder = new Widget({ node });
       this._placeholder.addClass('jp-PropertyInspector-placeholder');
     }
     layout.widget = this._placeholder;

--- a/packages/property-inspector/style/base.css
+++ b/packages/property-inspector/style/base.css
@@ -6,12 +6,20 @@
 
 .jp-PropertyInspector {
   display: flex;
-  align-items: center;
-  justify-content: center;
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
 }
 
+.jp-PropertyInspector-content {
+  flex-grow: 1;
+}
+
 .jp-PropertyInspector-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.jp-PropertyInspector-placeholderContent {
   padding: 8px;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7686 
<img width="388" alt="image" src="https://user-images.githubusercontent.com/2096628/71679911-51206d00-2d4e-11ea-9c58-0d591b6b85fb.png">


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Cleans up the CSS for property inspector children.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Notebook tools are now rendered properly.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
