### PR TITLE
Fix Compatibility Check for Prereleases

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1982,7 +1982,7 @@ def _compare_ranges(spec1, spec2):
     y1 = r2.set[0][0].semver
     y2 = r2.set[0][-1].semver
 
-    # Drop prereleases in comparisons (to allow extension authors)
+    # Drop prereleases in comparisons to allow extension authors
     # to not have to update their versions for each
     # Jupyterlab prerelease version.
     if x1.prerelease:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1186,7 +1186,7 @@ class _AppHandler(object):
             json.dump(data, fid, indent=4)
 
         # copy known-good yarn.lock if missing
-        lock_path = pjoin(staging, 'yarn.lock')        
+        lock_path = pjoin(staging, 'yarn.lock')
         lock_template = pjoin(HERE, 'staging', 'yarn.lock')
         if self.registry != YARN_DEFAULT_REGISTRY:  # Replace on the fly the yarn repository see #3658
             with open(lock_template, encoding='utf-8') as f:
@@ -1774,7 +1774,7 @@ def _node_check(logger):
 
 def _yarn_config(logger):
     """Get the yarn configuration.
-    
+
     Returns
     -------
     {"yarn config": dict, "npm config": dict} if unsuccessfull the subdictionary are empty
@@ -1981,6 +1981,15 @@ def _compare_ranges(spec1, spec2):
     x2 = r1.set[0][-1].semver
     y1 = r2.set[0][0].semver
     y2 = r2.set[0][-1].semver
+
+    # Drop prereleases in comparisons (to allow extension authors)
+    # to not have to update their versions for each
+    # Jupyterlab prerelease version.
+    if x1.prerelease:
+        x1 = x1.inc('patch')
+
+    if x2.prelease:
+        x2 = x2.inc('patch')
 
     o1 = r1.set[0][0].operator
     o2 = r2.set[0][0].operator

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1988,7 +1988,7 @@ def _compare_ranges(spec1, spec2):
     if x1.prerelease:
         x1 = x1.inc('patch')
 
-    if x2.prelease:
+    if x2.prerelease:
         x2 = x2.inc('patch')
 
     o1 = r1.set[0][0].operator

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1726,7 +1726,10 @@ class _AppHandler(object):
 
             for (key, value) in latest_deps.items():
                 if key in singletons:
-                    c = _compare_ranges(core_deps[key], value)
+                    # Drop prereleases in comparisons to allow extension authors
+                    # to not have to update their versions for each
+                    # Jupyterlab prerelease version.
+                    c = _compare_ranges(core_deps[key], value, drop_prerelease1=True)
                     lab_newer_than_latest = lab_newer_than_latest or c < 0
                     latest_newer_than_lab = latest_newer_than_lab or c > 0
 
@@ -1942,26 +1945,30 @@ def _validate_compatibility(extension, deps, core_data):
 
     for (key, value) in deps.items():
         if key in singletons:
-            overlap = _test_overlap(core_deps[key], value)
+            # Drop prereleases in comparisons to allow extension authors
+            # to not have to update their versions for each
+            # Jupyterlab prerelease version.
+            overlap = _test_overlap(core_deps[key], value, drop_prerelease1=True)
             if overlap is False:
                 errors.append((key, core_deps[key], value))
 
     return errors
 
 
-def _test_overlap(spec1, spec2):
+def _test_overlap(spec1, spec2, drop_prerelease1=False, drop_prerelease2=False):
     """Test whether two version specs overlap.
 
     Returns `None` if we cannot determine compatibility,
     otherwise whether there is an overlap
     """
-    cmp = _compare_ranges(spec1, spec2)
+    cmp = _compare_ranges(spec1, spec2, drop_prerelease1=drop_prerelease1,
+        drop_prerelease2=drop_prerelease2)
     if cmp is None:
         return
     return cmp == 0
 
 
-def _compare_ranges(spec1, spec2):
+def _compare_ranges(spec1, spec2, drop_prerelease1=False, drop_prerelease2=False):
     """Test whether two version specs overlap.
 
     Returns `None` if we cannot determine compatibility,
@@ -1982,11 +1989,11 @@ def _compare_ranges(spec1, spec2):
     y1 = r2.set[0][0].semver
     y2 = r2.set[0][-1].semver
 
-    # Drop prereleases in comparisons to allow extension authors
-    # to not have to update their versions for each
-    # Jupyterlab prerelease version.
-    if x1.prerelease:
+    if x1.prerelease and drop_prerelease1:
         x1 = x1.inc('patch')
+
+    if y1.prerelease and drop_prerelease2:
+        y1 = y1.inc('patch')
 
     o1 = r1.set[0][0].operator
     o2 = r2.set[0][0].operator
@@ -2113,7 +2120,10 @@ def _compat_error_age(errors):
     any_newer = False
 
     for _, jlab, ext in errors:
-        c = _compare_ranges(ext, jlab)
+        # Drop prereleases in comparisons to allow extension authors
+        # to not have to update their versions for each
+        # Jupyterlab prerelease version.
+        c = _compare_ranges(ext, jlab, drop_prerelease1=True)
         any_newer = any_newer or c < 0
         any_older = any_older or c > 0
     if any_older and not any_newer:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1988,9 +1988,6 @@ def _compare_ranges(spec1, spec2):
     if x1.prerelease:
         x1 = x1.inc('patch')
 
-    if x2.prerelease:
-        x2 = x2.inc('patch')
-
     o1 = r1.set[0][0].operator
     o2 = r2.set[0][0].operator
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7241

The previous behavior is as follows:

- `^1.x` is seen overlapping with `~2.0.0-x.y` because `2.0.0-x.y` is less than `2.0.0` in our logic
- `^1.x` is not seen as overlapping with `~2.0.0` (verified locally)

This changes the logic to always strip our prelease info when doing the version compatibility check.

With these changes, the latest `@jupyter-widgets/jupyterlab-manager` cannot be installed into the alpha release:

```
Conflicting Dependencies:
JupyterLab                        Extension              Package
>=2.0.0-alpha.0 <2.1.0            >=1.2.0 <2.0.0         @jupyterlab/application
>=4.0.0-alpha.0 <4.1.0            >=3.2.0 <4.0.0         @jupyterlab/coreutils
>=2.0.0-alpha.0 <2.1.0            >=1.2.0 <2.0.0         @jupyterlab/notebook
>=2.0.0-alpha.0 <2.1.0            >=1.2.0 <2.0.0         @jupyterlab/rendermime
>=2.0.0-alpha.0 <2.1.0            >=1.5.0 <2.0.0         @jupyterlab/rendermime-interfaces
>=5.0.0-alpha.0 <5.1.0            >=4.2.0 <5.0.0         @jupyterlab/services
```

However, an extension that declares a dependency on any prerelease version or final version of JupyterLab can be installed (tested with a local extension depending on `"@jupyterlab/application": "^2.0.0-rc.0"` and `"@jupyterlab/application": "^2.0.0"`).

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Compare against final releases in the version compatibility check.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users can no longer install incompatible extensions during the prerelease cycle.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
Incompatible extensions can no longer be installed.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
