### PR TITLE
Add command to open find with replace

### DIFF
--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -8,11 +8,6 @@
       "selector": ".jp-mod-searchable"
     },
     {
-      "command": "documentsearch:startWithReplace",
-      "keys": ["Accel H"],
-      "selector": ".jp-mod-searchable"
-    },
-    {
       "command": "documentsearch:highlightNext",
       "keys": ["Accel G"],
       "selector": ".jp-mod-searchable"

--- a/packages/documentsearch-extension/schema/plugin.json
+++ b/packages/documentsearch-extension/schema/plugin.json
@@ -8,6 +8,11 @@
       "selector": ".jp-mod-searchable"
     },
     {
+      "command": "documentsearch:startWithReplace",
+      "keys": ["Accel H"],
+      "selector": ".jp-mod-searchable"
+    },
+    {
       "command": "documentsearch:highlightNext",
       "keys": ["Accel G"],
       "selector": ".jp-mod-searchable"

--- a/packages/documentsearch-extension/src/index.ts
+++ b/packages/documentsearch-extension/src/index.ts
@@ -93,14 +93,14 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
     const nextCommand: string = 'documentsearch:highlightNext';
     const prevCommand: string = 'documentsearch:highlightPrevious';
 
-    const startCommandEnabled = () => {
+    const currentWidgetHasSearchProvider = () => {
       const currentWidget = app.shell.currentWidget;
       if (!currentWidget) {
         return false;
       }
       return registry.getProviderForWidget(currentWidget) !== undefined;
     };
-    const executeStartCommand = () => {
+    const getCurrentWidgetSearchInstance = () => {
       const currentWidget = app.shell.currentWidget;
       if (!currentWidget) {
         return;
@@ -129,9 +129,9 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
 
     app.commands.addCommand(startCommand, {
       label: 'Find…',
-      isEnabled: startCommandEnabled,
+      isEnabled: currentWidgetHasSearchProvider,
       execute: () => {
-        const searchInstance = executeStartCommand();
+        const searchInstance = getCurrentWidgetSearchInstance();
         if (searchInstance) {
           searchInstance.focusInput();
         }
@@ -140,9 +140,9 @@ const extension: JupyterFrontEndPlugin<ISearchProviderRegistry> = {
 
     app.commands.addCommand(startReplaceCommand, {
       label: 'Find and Replace…',
-      isEnabled: startCommandEnabled,
+      isEnabled: currentWidgetHasSearchProvider,
       execute: () => {
-        const searchInstance = executeStartCommand();
+        const searchInstance = getCurrentWidgetSearchInstance();
         if (searchInstance) {
           searchInstance.showReplace();
           searchInstance.focusInput();

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -82,7 +82,6 @@ export class SearchInstance implements IDisposable {
    */
   showReplace(): void {
     this._displayState.replaceEntryShown = true;
-    this._updateDisplay();
   }
   /**
    * Updates the match index and total display in the search widget.

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -78,10 +78,11 @@ export class SearchInstance implements IDisposable {
   }
 
   /**
-   * If there is a replace box, show it
+   * If there is a replace box, show it.
    */
   showReplace(): void {
     this._displayState.replaceEntryShown = true;
+    this._updateDisplay();
   }
   /**
    * Updates the match index and total display in the search widget.

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -78,6 +78,12 @@ export class SearchInstance implements IDisposable {
   }
 
   /**
+   * If there is a replace box, show it
+   */
+  showReplace(): void {
+    this._displayState.replaceEntryShown = true;
+  }
+  /**
    * Updates the match index and total display in the search widget.
    */
   updateIndices(): void {


### PR DESCRIPTION
Adds a `Accel H` command by default which opens the find box with replace expanded. This mirrors how most editors and Microsoft products work.

## Code changes
Refactored the find command to add a find + replace option.

## User-facing changes

New default hotkey added.
