### PR TITLE
Add Automatic Labelling of PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,281 @@
+Design System CSS:
+  - '**/*.css'
+  - '*.css'
+
+tag:CSS:
+  - '**/*.css'
+  - '*.css'
+
+'tag:Design and UX':
+  - design/**/*
+  - design/*
+
+tag:Documentation:
+  - docs/**/*
+  - docs/*
+
+tag:Examples:
+  - examples/**/*
+  - examples/*
+
+tag:Testing:
+  - tests/**/*
+  - tests/*
+
+######################
+#   Package Labels   #
+######################
+
+pkg:application:
+  - packages/application/**/*
+  - packages/application/*
+  - packages/application-extension/**/*
+  - packages/application-extension/*
+
+pkg:apputils:
+  - packages/apputils/**/*
+  - packages/apputils/*
+  - packages/apputils-extension/**/*
+  - packages/apputils-extension/*
+
+pkg:attachments:
+  - packages/attachments/**/*
+  - packages/attachments/*
+
+pkg:cells:
+  - packages/cells/**/*
+  - packages/cells/*
+
+# Missing `celltags`
+
+pkg:codeeditor:
+  - packages/codeeditor/**/*
+  - packages/codeeditor/*
+
+pkg:codemirror:
+  - packages/codemirror/**/*
+  - packages/codemirror/*
+  - packages/codemirror-extension/**/*
+  - packages/codemirror-extension/*
+
+pkg:completer:
+  - packages/completer/**/*
+  - packages/completer/*
+  - packages/completer-extension/**/*
+  - packages/completer-extension/*
+
+pkg:console:
+  - packages/console/**/*
+  - packages/console/*
+  - packages/console-extension/**/*
+  - packages/console-extension/*
+
+pkg:coreutils:
+  - packages/coreutils/**/*
+  - packages/coreutils/*
+
+pkg:csvviewer:
+  - packages/csvviewer/**/*
+  - packages/csvviewer/*
+  - packages/csvviewer-extension/**/*
+  - packages/csvviewer-extension/*
+
+# `dataregistry` is not a package any longer
+
+pkg:docmanager:
+  - packages/docmanager/**/*
+  - packages/docmanager/*
+  - packages/docmanager-extension/**/*
+  - packages/docmanager-extension/*
+
+pkg:docregistry:
+  - packages/docregistry/**/*
+  - packages/docregistry/*
+
+pkg:documentsearch:
+  - packages/documentsearch/**/*
+  - packages/documentsearch/*
+  - packages/documentsearch-extension/**/*
+  - packages/documentsearch-extension/*
+
+pkg:extensionmanager:
+  - packages/extensionmanager/**/*
+  - packages/extensionmanager/*
+  - packages/extensionmanager-extension/**/*
+  - packages/extensionmanager-extension/*
+
+# `faq` is not a package any longer
+
+pkg:filebrowser:
+  - packages/filebrowser/**/*
+  - packages/filebrowser/*
+  - packages/filebrowser-extension/**/*
+  - packages/filebrowser-extension/*
+
+pkg:fileeditor:
+  - packages/fileeditor/**/*
+  - packages/fileeditor/*
+  - packages/fileeditor-extension/**/*
+  - packages/fileeditor-extension/*
+
+pkg:help:
+  - packages/help-extension/**/*
+  - packages/help-extension/*
+
+pkg:htmlviewer:
+  - packages/htmlviewer/**/*
+  - packages/htmlviewer/*
+  - packages/htmlviewer-extension/**/*
+  - packages/htmlviewer-extension/*
+
+pkg:hub:
+  - packages/hub-extension/**/*
+  - packages/hub-extension/*
+
+# `iframe` is not a package any longer
+
+pkg:imageviewer:
+  - packages/imageviewer/**/*
+  - packages/imageviewer/*
+  - packages/imageviewer-extension/**/*
+  - packages/imageviewer-extension/*
+
+pkg:inspector:
+  - packages/inspector/**/*
+  - packages/inspector/*
+  - packages/inspector-extension/**/*
+  - packages/inspector-extension/*
+
+pkg:javascript:
+  - packages/javascript-extension/**/*
+  - packages/javascript-extension/*
+
+pkg:json:
+  - packages/json-extension/**/*
+  - packages/json-extension/*
+
+pkg:launcher:
+  - packages/launcher/**/*
+  - packages/launcher/*
+  - packages/launcher-extension/**/*
+  - packages/launcher-extension/*
+
+pkg:logconsole:
+  - packages/logconsole/**/*
+  - packages/logconsole/*
+  - packages/logconsole-extension/**/*
+  - packages/logconsole-extension/*
+
+pkg:mainmenu:
+  - packages/mainmenu/**/*
+  - packages/mainmenu/*
+  - packages/mainmenu-extension/**/*
+  - packages/mainmenu-extension/*
+
+pkg:markdownviewer:
+  - packages/markdownviewer/**/*
+  - packages/markdownviewer/*
+  - packages/markdownviewer-extension/**/*
+  - packages/markdownviewer-extension/*
+
+pkg:mathjax2:
+  - packages/mathjax2/**/*
+  - packages/mathjax2/*
+  - packages/mathjax2-extension/**/*
+  - packages/mathjax2-extension/*
+
+pkg:notebook:
+  - packages/notebook/**/*
+  - packages/notebook/*
+  - packages/notebook-extension/**/*
+  - packages/notebook-extension/*
+
+pkg:observables:
+  - packages/observables/**/*
+  - packages/observables/*
+
+pkg:outputarea:
+  - packages/outputarea/**/*
+  - packages/outputarea/*
+
+pkg:pdf:
+  - packages/pdf-extension/**/*
+  - packages/pdf-extension/*
+
+# Missing `property-inspector`
+
+pkg:rendermime:
+  - packages/rendermime/**/*
+  - packages/rendermime/*
+  - packages/rendermime-interfaces/**/*
+  - packages/rendermime-interfaces/*
+  - packages/rendermime-extension/**/*
+  - packages/rendermime-extension/*
+
+pkg:running:
+  - packages/running/**/*
+  - packages/running/*
+  - packages/running-extension/**/*
+  - packages/running-extension/*
+
+pkg:services:
+  - packages/services/**/*
+  - packages/services/*
+
+pkg:settingeditor:
+  - packages/settingeditor/**/*
+  - packages/settingeditor/*
+  - packages/settingeditor/**/*
+  - packages/settingeditor/*
+
+# Missing `settingsregistry`
+
+pkg:shortcuts:
+  - packages/shortcuts-extension/**/*
+  - packages/shortcuts-extension/*
+
+# Missing `statedb`
+
+pkg:statusbar:
+  - packages/statusbar/**/*
+  - packages/statusbar/*
+  - packages/statusbar-extension/**/*
+  - packages/statusbar-extension/*
+
+pkg:tabmanager:
+  - packages/tabmanager-extension/**/*
+  - packages/tabmanager-extension/*
+
+pkg:terminal:
+  - packages/terminal/**/*
+  - packages/terminal/*
+  - packages/terminal-extension/**/*
+  - packages/terminal-extension/*
+
+pkg:themes:
+  - packages/theme-dark-extension/**/*
+  - packages/theme-dark-extension/*
+  - packages/theme-light-extension/**/*
+  - packages/theme-light-extension/*
+
+pkg:tooltip:
+  - packages/tooltip/**/*
+  - packages/tooltip/*
+  - packages/tooltip-extension/**/*
+  - packages/tooltip-extension/*
+
+pkg:ui-components:
+  - packages/ui-components/**/*
+  - packages/ui-components/*
+  - packages/ui-components-extension/**/*
+  - packages/ui-components-extension/*
+
+pkg:vdom:
+  - packages/vdom/**/*
+  - packages/vdom/*
+  - packages/vdom-extension/**/*
+  - packages/vdom-extension/*
+
+pkg:vega:
+  - packages/vega5-extension/**/*
+  - packages/vega5-extension/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -46,7 +46,11 @@ pkg:cells:
   - packages/cells/**/*
   - packages/cells/*
 
-# Missing `celltags`
+pkg:celltags:
+  - packages/celltags/**/*
+  - packages/celltags/*
+  - packages/celltags-extension/**/*
+  - packages/celltags-extension/*
 
 pkg:codeeditor:
   - packages/codeeditor/**/*
@@ -80,8 +84,6 @@ pkg:csvviewer:
   - packages/csvviewer-extension/**/*
   - packages/csvviewer-extension/*
 
-# `dataregistry` is not a package any longer
-
 pkg:docmanager:
   - packages/docmanager/**/*
   - packages/docmanager/*
@@ -103,8 +105,6 @@ pkg:extensionmanager:
   - packages/extensionmanager/*
   - packages/extensionmanager-extension/**/*
   - packages/extensionmanager-extension/*
-
-# `faq` is not a package any longer
 
 pkg:filebrowser:
   - packages/filebrowser/**/*
@@ -131,8 +131,6 @@ pkg:htmlviewer:
 pkg:hub:
   - packages/hub-extension/**/*
   - packages/hub-extension/*
-
-# `iframe` is not a package any longer
 
 pkg:imageviewer:
   - packages/imageviewer/**/*
@@ -202,7 +200,9 @@ pkg:pdf:
   - packages/pdf-extension/**/*
   - packages/pdf-extension/*
 
-# Missing `property-inspector`
+pkg:property-inspector:
+  - packages/property-inspector/**/*
+  - packages/property-inspector/*
 
 pkg:rendermime:
   - packages/rendermime/**/*
@@ -228,13 +228,17 @@ pkg:settingeditor:
   - packages/settingeditor/**/*
   - packages/settingeditor/*
 
-# Missing `settingsregistry`
+pkg:settingregistry:
+  - packages/settingregistry/**/*
+  - packages/settingregistry/*
 
 pkg:shortcuts:
   - packages/shortcuts-extension/**/*
   - packages/shortcuts-extension/*
 
-# Missing `statedb`
+pkg:statedb:
+  - packages/statedb/**/*
+  - packages/statedb/*
 
 pkg:statusbar:
   - packages/statusbar/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: 'Pull Request Labeler'
+
+# This workflow is triggered whenever a PR is opened, changed, or reopened.
+on: [pull_request]
+
+jobs:
+  triage:
+    name: Update PR Labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## References

See #7729 for discussion.

## Code changes

Add a github workflow that automatically labels PRs and changes in PRs
when they change specific files. The mapping from affected files to labels
is in the `.github/labeler.yml` file.

## User-facing changes

None

## Backwards-incompatible changes

None