### PR TITLE
Switch Auto-Labeler to Periodic Labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,13 +1,18 @@
 name: 'Pull Request Labeler'
 
-# This workflow is triggered whenever a PR is opened, changed, or reopened.
-on: [pull_request]
 
+name: Pull Request Labeler
+# This workflow is supposed to run every 5 minutes
+on:
+  schedule:
+    - cron: '*/5 * * * *'
 jobs:
   triage:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v2
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: paulfantom/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-      - uses: paulfantom/periodic-labeler@master
+      - uses: paulfantom/periodic-labeler@8c477b324178bda91aeede9a35ece2b8d8813478
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## References

See #7729 for discussion. This also relates to the auto-labeling introduced in #7730.

## Code changes

Switch automatic labelling action from `actions/labeler` to `paulfantom/periodic-labeler` to work around the issue of the labeler failing on PRs from forked repositories. Currently the workflow is set to run every 5 minutes.

## User-facing changes

None

## Backwards-incompatible changes

None
