### PR TITLE
Update state database list method to query based on namespace match.

### DIFF
--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -316,8 +316,8 @@ export namespace FileBrowser {
      * The default is `true`.
      *
      * #### Notes
-     * The file browser model will need to be restored before for the file
-     * browser to start saving its state.
+     * The file browser model will need to be restored manually for the file
+     * browser to be able to save its state.
      */
     restore?: boolean;
   }

--- a/packages/statedb/src/restorablepool.ts
+++ b/packages/statedb/src/restorablepool.ts
@@ -107,8 +107,8 @@ export class RestorablePool<
    * @param obj - The object object being added.
    *
    * #### Notes
-   * The object passed into the tracker is added synchronously; its existence in
-   * the tracker can be checked with the `has()` method. The promise this method
+   * The object passed into the pool is added synchronously; its existence in
+   * the pool can be checked with the `has()` method. The promise this method
    * returns resolves after the object has been added and saved to an underlying
    * restoration connector, if one is available.
    */

--- a/packages/statedb/src/statedb.ts
+++ b/packages/statedb/src/statedb.ts
@@ -177,7 +177,7 @@ export class StateDB<
   /**
    * Fetch a list from the database.
    */
-  private async _list(query?: string): Promise<{ ids: string[]; values: T[] }> {
+  private async _list(query = ''): Promise<{ ids: string[]; values: T[] }> {
     const { ids, values } = await this._connector.list(query);
 
     return {
@@ -304,7 +304,7 @@ export namespace StateDB {
     async list(query = ''): Promise<{ ids: string[]; values: string[] }> {
       return Object.keys(this._storage).reduce(
         (acc, val) => {
-          if (val && val.indexOf(query) === 0) {
+          if (query === '' ? true : query === val.split(':')[0]) {
             acc.ids.push(val);
             acc.values.push(this._storage[val]);
           }

--- a/packages/statedb/src/statedb.ts
+++ b/packages/statedb/src/statedb.ts
@@ -177,8 +177,8 @@ export class StateDB<
   /**
    * Fetch a list from the database.
    */
-  private async _list(query = ''): Promise<{ ids: string[]; values: T[] }> {
-    const { ids, values } = await this._connector.list(query);
+  private async _list(namespace = ''): Promise<{ ids: string[]; values: T[] }> {
+    const { ids, values } = await this._connector.list(namespace);
 
     return {
       ids,
@@ -300,11 +300,14 @@ export namespace StateDB {
 
     /**
      * Retrieve the list of items available from the data connector.
+     *
+     * @param namespace - If not empty, only keys whose first token before `:`
+     * exactly match `namespace` will be returned, e.g. `foo` in `foo:bar`.
      */
-    async list(query = ''): Promise<{ ids: string[]; values: string[] }> {
+    async list(namespace = ''): Promise<{ ids: string[]; values: string[] }> {
       return Object.keys(this._storage).reduce(
         (acc, val) => {
-          if (query === '' ? true : query === val.split(':')[0]) {
+          if (namespace === '' ? true : namespace === val.split(':')[0]) {
             acc.ids.push(val);
             acc.values.push(this._storage[val]);
           }

--- a/tests/test-statedb/src/statedb.spec.ts
+++ b/tests/test-statedb/src/statedb.spec.ts
@@ -120,7 +120,10 @@ describe('StateDB', () => {
         'foo:qux',
         'abc:def',
         'abc:ghi',
-        'abc:jkl'
+        'abc:jkl',
+        'foo-two:bar',
+        'foo-two:baz',
+        'foo-two:qux'
       ];
 
       await Promise.all(keys.map(key => db.save(key, { value: key })));


### PR DESCRIPTION
# References
Fixes #7257.

## Code changes
Instead of checking that the key starts with the sub-string `query`, the state database connector checks for explicit namespace string match.

## User-facing changes
N/A

## Backwards-incompatible changes
The previous behavior could generate false positives. This fixes that bug, but since the behavior is different, it's possible a client relied on the old behavior. I hope that is unlikely, though.