### PR TITLE
Update Periodic Labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,13 +2,13 @@ name: Pull Request Labeler
 # This workflow is supposed to run every 5 minutes
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/10 * * * *'
 jobs:
   triage:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-      - uses: paulfantom/periodic-labeler@8c477b324178bda91aeede9a35ece2b8d8813478
+      - uses: paulfantom/periodic-labeler@dffbc90404f371f76444a69221c2f7ad079e2319
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## References

Discussion at #7729.

## Code changes

Update periodic labeler so that it labels every PR and only runs every 10 minutes.

### Motiviation
Previously, the labeler only ran on 30 PRs max, and ran every 10 minutes. The bug was
fixed, so its now likely that it will label every PR.

5 minutes seemed too short of a period to observe changes to the PR queue, so the period was extended to 10 minutes

## User-facing changes

None

## Backwards-incompatible changes

None
