### PR TITLE
Change CommonJS to JavaScript in extension dev doc

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -39,7 +39,7 @@ A plugin adds a core functionality to the application:
    the default export.
 
    We provide two cookiecutters to create JupyterLab plugin extensions in
-   `CommonJS <https://github.com/jupyterlab/extension-cookiecutter-js>`__ and
+   `JavaScript <https://github.com/jupyterlab/extension-cookiecutter-js>`__ and
    `TypeScript <https://github.com/jupyterlab/extension-cookiecutter-ts>`__.
 
 The default plugins in the JupyterLab application include:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This follows up on a [similar change done in ipywidgets recently](https://github.com/jupyter-widgets/ipywidgets/pull/2675), where it was decided to use the term `JavaScript` instead of `CommonJS` to point to the JS cookiecutter.

The idea is to use the same terminology here too.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None
