### PR TITLE
Fix binder launch

### DIFF
--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -19,7 +19,7 @@ c.ServerProxy.servers = {
             # Redirect all logs to a log file
             f'{lab_command} >jupyterlab-dev.log 2>&1'
         ],
-        'timeout': 10,
+        'timeout': 20,
         'absolute_url': True
     }
 }

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -6,6 +6,7 @@ lab_command = ' '.join([
     '--no-browser',
     '--port={port}',
     '--NotebookApp.token=""',
+    '--NotebookApp.use_redirect_file=False',
     '--NotebookApp.base_url={base_url}lab-dev',
     # Disable dns rebinding protection here, since our 'Host' header
     # is not going to be localhost when coming from hub.mybinder.org
@@ -19,12 +20,13 @@ c.ServerProxy.servers = {
             # Redirect all logs to a log file
             f'{lab_command} >jupyterlab-dev.log 2>&1'
         ],
-        'timeout': 30,
+        'timeout': 20,
         'absolute_url': True
     }
 }
 
 c.NotebookApp.default_url = '/lab-dev'
+c.NotebookApp.use_redirect_file=False
 
 import logging
 c.NotebookApp.log_level = logging.DEBUG

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -5,6 +5,7 @@ lab_command = ' '.join([
     '--debug',
     '--no-browser',
     '--port={port}',
+    '--NotebookApp.ip=127.0.0.1',
     '--NotebookApp.token=""',
     '--NotebookApp.use_redirect_file=False',
     '--NotebookApp.base_url={base_url}lab-dev',

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -20,7 +20,7 @@ c.ServerProxy.servers = {
             # Redirect all logs to a log file
             f'{lab_command} >jupyterlab-dev.log 2>&1'
         ],
-        'timeout': 10,
+        'timeout': 20,
         'absolute_url': True
     }
 }

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -19,7 +19,7 @@ c.ServerProxy.servers = {
             # Redirect all logs to a log file
             f'{lab_command} >jupyterlab-dev.log 2>&1'
         ],
-        'timeout': 20,
+        'timeout': 30,
         'absolute_url': True
     }
 }

--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -7,7 +7,6 @@ lab_command = ' '.join([
     '--port={port}',
     '--NotebookApp.ip=127.0.0.1',
     '--NotebookApp.token=""',
-    '--NotebookApp.use_redirect_file=False',
     '--NotebookApp.base_url={base_url}lab-dev',
     # Disable dns rebinding protection here, since our 'Host' header
     # is not going to be localhost when coming from hub.mybinder.org
@@ -21,13 +20,12 @@ c.ServerProxy.servers = {
             # Redirect all logs to a log file
             f'{lab_command} >jupyterlab-dev.log 2>&1'
         ],
-        'timeout': 20,
+        'timeout': 10,
         'absolute_url': True
     }
 }
 
 c.NotebookApp.default_url = '/lab-dev'
-c.NotebookApp.use_redirect_file=False
 
 import logging
 c.NotebookApp.log_level = logging.DEBUG

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 pip install -e .
-pip install -U notebook
 
 jlpm
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 pip install -e .
+pip install -U notebook
 
 jlpm
 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,1 +1,1 @@
-jupyter-server-proxy==1.0beta9
+jupyter-server-proxy


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7761 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Increase time limit for server proxy on binder.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Allows PRs to be debugged again using the binder link.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
