### PR TITLE
watch mode: reduces noise in console output by disabling pkg duplicate checker

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -44,6 +44,7 @@
     "commander": "~4.0.1",
     "crypto": "~1.0.1",
     "dependency-graph": "^0.8.1",
+    "duplicate-package-checker-webpack-plugin": "^3.0.0",
     "fs-extra": "^8.1.0",
     "glob": "~7.1.6",
     "inquirer": "^7.0.0",
@@ -57,6 +58,7 @@
     "webpack": "^4.41.2"
   },
   "devDependencies": {
+    "@types/duplicate-package-checker-webpack-plugin": "^2.1.0",
     "@types/fs-extra": "^8.0.1",
     "@types/glob": "^7.1.1",
     "@types/inquirer": "^6.5.0",

--- a/buildutils/src/webpack-plugins.ts
+++ b/buildutils/src/webpack-plugins.ts
@@ -3,9 +3,9 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import * as webpack from 'webpack';
+import DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 import * as fs from 'fs-extra';
-var DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
+import * as webpack from 'webpack';
 
 export namespace WPPlugin {
   /**
@@ -185,5 +185,7 @@ export namespace WPPlugin {
         }
       );
     }
+
+    options: DuplicatePackageCheckerPlugin.Options;
   }
 }

--- a/buildutils/src/webpack-plugins.ts
+++ b/buildutils/src/webpack-plugins.ts
@@ -5,6 +5,7 @@
 
 import * as webpack from 'webpack';
 import * as fs from 'fs-extra';
+var DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 
 export namespace WPPlugin {
   /**
@@ -170,5 +171,19 @@ export namespace WPPlugin {
     }
 
     ignored: (path: string) => boolean;
+  }
+
+  export class NowatchDuplicatePackageCheckerPlugin extends DuplicatePackageCheckerPlugin {
+    apply(compiler: any) {
+      const options = this.options;
+
+      compiler.hooks.run.tap(
+        'NowatchDuplicatePackageCheckerPlugin',
+        (compiler: any) => {
+          const p = new DuplicatePackageCheckerPlugin(options);
+          p.apply(compiler);
+        }
+      );
+    }
   }
 }

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -8,7 +8,6 @@ var fs = require('fs-extra');
 var Handlebars = require('handlebars');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var webpack = require('webpack');
-var DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 var BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin;
 
@@ -122,7 +121,7 @@ function ignored(path) {
 }
 
 const plugins = [
-  new DuplicatePackageCheckerPlugin({
+  new WPPlugin.NowatchDuplicatePackageCheckerPlugin({
     verbose: true,
     exclude(instance) {
       // ignore known duplicates
@@ -137,7 +136,6 @@ const plugins = [
     title: jlab.name || 'JupyterLab'
   }),
   new webpack.HashedModuleIdsPlugin(),
-
   // custom plugin for ignoring files during a `--watch` build
   new WPPlugin.FilterWatchIgnorePlugin(ignored),
   // custom plugin that copies the assets to the static directory
@@ -223,9 +221,6 @@ module.exports = [
     bail: true,
     devtool: 'inline-source-map',
     externals: ['node-fetch', 'ws'],
-    plugins,
-    stats: {
-      chunkModules: true
-    }
+    plugins
   }
 ].concat(extraConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2719,6 +2719,13 @@
   dependencies:
     "@types/domhandler" "*"
 
+"@types/duplicate-package-checker-webpack-plugin@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/duplicate-package-checker-webpack-plugin/-/duplicate-package-checker-webpack-plugin-2.1.0.tgz#02f030a6432274b16529e434d5ea696024f363b2"
+  integrity sha512-lS1AUw32mjdqhObsY2lxzo5qWeFnMZmhAVmh+rHbXdsxIE8cFMIA37NtIDXxkLhFLvF1ua/C5rcMsGumhpGFuA==
+  dependencies:
+    "@types/webpack" "*"
+
 "@types/estree@*":
   version "0.0.41"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.41.tgz#fd90754150b57432b72bf560530500597ff04421"


### PR DESCRIPTION
When running in watch mode (ie `jupyter lab --watch`), I currently find it really difficult to see important messages in the build output, such as Typescript build errors. This PR reduce the noise in the watch build output by making sure that the duplicate package checker only runs for the regular webpack build, and not for the watch build.

I also removed the `stats: {chunkModules: true}` option from the webpack config:

- That option already [defaults to true](https://webpack.js.org/configuration/stats/#statschunkmodules)
- I did some experiments while working on this PR, and as far as I can tell in our current version of webpack, even if you set the option to `false` it doesn't change the build stats output