### PR TITLE
Debounce search queries in the extension-manager extension.

### DIFF
--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -39,6 +39,7 @@
     "@jupyterlab/services": "^5.0.0-beta.2",
     "@jupyterlab/ui-components": "^2.0.0-beta.2",
     "@lumino/messaging": "^1.3.3",
+    "@lumino/polling": "^1.0.3",
     "react": "~16.9.0",
     "react-paginate": "^6.3.2",
     "semver": "^6.3.0"

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -9,6 +9,8 @@ import {
   ServiceManager
 } from '@jupyterlab/services';
 
+import { Debouncer } from '@lumino/polling';
+
 import * as semver from 'semver';
 
 import { doBuild } from './build-helper';
@@ -148,6 +150,7 @@ export class ListModel extends VDomModel {
     this._searchResult = [];
     this.serviceManager = serviceManager;
     this.serverConnectionSettings = ServerConnection.makeSettings();
+    this._debouncedUpdate = new Debouncer(this.update.bind(this), 1000);
   }
 
   /**
@@ -174,7 +177,7 @@ export class ListModel extends VDomModel {
   }
   set query(value: string | null) {
     this._query = value;
-    void this.update();
+    void this._debouncedUpdate.invoke();
   }
 
   /**
@@ -704,6 +707,7 @@ export class ListModel extends VDomModel {
   private _installed: IEntry[];
   private _searchResult: IEntry[];
   private _pendingActions: Promise<any>[] = [];
+  private _debouncedUpdate: Debouncer<void, void>;
 }
 
 /**


### PR DESCRIPTION
Fixes #7484

## Code changes
Uses the debounce utils in `@lumino/polling` to debounce search queries to npm in the extension manager

## User-facing changes
None

## Backwards-incompatible changes
None