### PR TITLE
Changes to setting editor should trigger application dirty state

### DIFF
--- a/packages/settingeditor-extension/package.json
+++ b/packages/settingeditor-extension/package.json
@@ -43,7 +43,8 @@
     "@jupyterlab/settingeditor": "^2.0.0-beta.2",
     "@jupyterlab/settingregistry": "^2.0.0-beta.2",
     "@jupyterlab/statedb": "^2.0.0-beta.2",
-    "@jupyterlab/ui-components": "^2.0.0-beta.2"
+    "@jupyterlab/ui-components": "^2.0.0-beta.2",
+    "@lumino/disposable": "^1.3.4"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",


### PR DESCRIPTION
## References

Fixes #7757

## Code changes
In `settingEditor` extension, when the status of the commands (revert, save) change, I check if the editor has unsaved changes (using the property editor.canSaveRaw). If this is set to `true`, `LabStatus.setDIrty` is invoked. If set to `false`, the dirty status is cleared.

## User-facing changes

Closing / reloading lab when there are unsaved changes in the settings editor would warn of unsaved changes and ask if the user should .