### PR TITLE
remove removing ws

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -30,7 +30,7 @@
   "main": "lib/index.js",
   "browser": {
     "node-fetch": false,
-    "ws": false
+    "ws": "./lib/shim/ws.js"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -21,7 +21,7 @@ if (typeof window === 'undefined') {
   FETCH = global.fetch ?? fetchMod;
   REQUEST = global.Request ?? fetchMod.Request;
   HEADERS = global.Headers ?? fetchMod.Headers;
-  WEBSOCKET = require('ws').ws;
+  WEBSOCKET = require('ws');
   /* tslint:enable */
 } else {
   FETCH = fetch;

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -21,7 +21,7 @@ if (typeof window === 'undefined') {
   FETCH = global.fetch ?? fetchMod;
   REQUEST = global.Request ?? fetchMod.Request;
   HEADERS = global.Headers ?? fetchMod.Headers;
-  WEBSOCKET = global.WebSocket ?? require('ws');
+  WEBSOCKET = require('ws').ws;
   /* tslint:enable */
 } else {
   FETCH = fetch;

--- a/packages/services/src/shim/ws.ts
+++ b/packages/services/src/shim/ws.ts
@@ -1,1 +1,1 @@
-export const ws = WebSocket;
+export default WebSocket;

--- a/packages/services/src/shim/ws.ts
+++ b/packages/services/src/shim/ws.ts
@@ -1,0 +1,1 @@
+export const ws = WebSocket;


### PR DESCRIPTION
This hopefully fixes issue https://github.com/jupyterlab/jupyterlab/issues/6934 which is really puzzling to developers as `ws` stays undefined without this shim. Many thirdparty libraries just import ws and are done, so not just undefining ws is important (I am listing some workarounds and examples in the issue).

It would be great if we could get this into 2.0 ... 