### PR TITLE
Add shortcut for file browser to its tooltip

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -44,7 +44,7 @@ import { IStatusBar } from '@jupyterlab/statusbar';
 
 import { addIcon, folderIcon } from '@jupyterlab/ui-components';
 
-import { IIterator, map, reduce, toArray } from '@lumino/algorithm';
+import { IIterator, map, reduce, toArray, find } from '@lumino/algorithm';
 
 import { CommandRegistry } from '@lumino/commands';
 
@@ -294,7 +294,23 @@ function activateBrowser(
   );
 
   browser.title.iconRenderer = folderIcon;
-  browser.title.caption = 'File Browser';
+  // Show the current file browser shortcut in its title.
+  const updatePaletteTitle = () => {
+    const binding = find(
+      app.commands.keyBindings,
+      b => b.command === CommandIDs.toggleBrowser
+    );
+    if (binding) {
+      const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
+      browser.title.caption = `File Browser (${ks})`;
+    } else {
+      browser.title.caption = 'File Browser';
+    }
+  };
+  updatePaletteTitle();
+  app.commands.keyBindingChanged.connect(() => {
+    updatePaletteTitle();
+  });
   labShell.add(browser, 'left', { rank: 100 });
 
   // If the layout is a fresh session without saved data, open file browser.

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -295,7 +295,7 @@ function activateBrowser(
 
   browser.title.iconRenderer = folderIcon;
   // Show the current file browser shortcut in its title.
-  const updatePaletteTitle = () => {
+  const updateBrowserTitle = () => {
     const binding = find(
       app.commands.keyBindings,
       b => b.command === CommandIDs.toggleBrowser
@@ -307,9 +307,9 @@ function activateBrowser(
       browser.title.caption = 'File Browser';
     }
   };
-  updatePaletteTitle();
+  updateBrowserTitle();
   app.commands.keyBindingChanged.connect(() => {
-    updatePaletteTitle();
+    updateBrowserTitle();
   });
   labShell.add(browser, 'left', { rank: 100 });
 


### PR DESCRIPTION

## References

Addresses #7547. 

## Code changes

The activateBrowser function in filebrowser-extension now checks for a binding associated with toggle-main and includes it in browser.title.caption if found.

## User-facing changes

Tooltip for file browser now includes the shortcut to toggle it.

## Backwards-incompatible changes
