### PR TITLE
Fix lint-staged for both win and mac

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,0 @@
-"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}": [
-  "prettier --write",
-  "git add"
-]

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,14 @@
+const escape = require('shell-quote').quote;
+const isWin = process.platform === 'win32';
+
+module.exports = {
+  '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}': filenames => {
+    const escapedFileNames = filenames
+      .map(filename => `"${isWin ? filename : escape([filename])}"`)
+      .join(' ');
+    return [
+      `prettier --write ${escapedFileNames}`,
+      `git add ${escapedFileNames}`
+    ];
+  }
+};

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "lerna": "^3.19.0",
     "lint-staged": "^9.5.0",
     "prettier": "^1.19.1",
+    "shell-quote": "^1.7.2",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13734,7 +13734,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2:
+shell-quote@1.7.2, shell-quote@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==


### PR DESCRIPTION
## References

0bdce26
#7708
https://github.com/okonet/lint-staged/issues/676#issuecomment-553598068
https://github.com/zeit/next.js/blob/canary/lint-staged.config.js

## Code changes

Changed the lint-staged config from a json file to a js script. This is to fix an ongoing back and forth in which said config is broken w.r.t. to exactly one of mac and windows.

@vidartf I've tested this PR on mac. Can you please test this out for me on Windows?

## User-facing changes

NA

## Backwards-incompatible changes

NA