### PR TITLE
Align celltags UI in the notebook tools

### DIFF
--- a/packages/celltags/style/base.css
+++ b/packages/celltags/style/base.css
@@ -2,7 +2,6 @@
   height: 32px;
   width: fit-content;
   border-radius: 35px;
-  margin-left: 5px;
   margin-right: 5px;
   margin-bottom: 10px;
   padding: 12px;

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -204,6 +204,10 @@
   overflow: auto;
 }
 
+.jp-NotebookTools-tool {
+  padding: 0px 12px 0 12px;
+}
+
 .jp-ActiveCellTool {
   padding: 12px;
   background-color: var(--jp-layout-color1);
@@ -232,10 +236,6 @@
 
 .jp-RankedPanel > :not(:first-child) {
   margin-top: 12px;
-}
-
-.jp-KeySelector {
-  padding: 0px 12px 0 12px;
 }
 
 .jp-KeySelector select.jp-mod-styled {


### PR DESCRIPTION
CSS tweak to align the cell tags UI with the other items in the notebook tools.

## Code changes

CSS only.

## User-facing changes

### Before

![image](https://user-images.githubusercontent.com/591645/72445111-7e8b0300-37b1-11ea-991d-e62263be29da.png)

![image](https://user-images.githubusercontent.com/591645/72445147-8d71b580-37b1-11ea-8fe9-258204d767ed.png)

### After

![image](https://user-images.githubusercontent.com/591645/72445455-05d87680-37b2-11ea-937c-55a1e6985bff.png)

![image](https://user-images.githubusercontent.com/591645/72445435-fbb67800-37b1-11ea-8011-15db4318befa.png)

## Backwards-incompatible changes

None