### PR TITLE
Fix for extension manager toggling visual issue

### DIFF
--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -72,6 +72,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
           view = view || createView();
           shell.add(view, 'left');
         } else if (!enabled && view && view.isAttached) {
+          app.commands.notifyCommandChanged(CommandIDs.toggle);
           view.close();
         }
       });


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#7429 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Added a line to notify the command registry of when the extension manager became disabled. Thus, the checkmark icon should appropriately disappear when the extension manager is disabled.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
N/A
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
