### PR TITLE
Fix removal of dependencies in package template

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1231,10 +1231,11 @@ class _AppHandler(object):
         for item in self.info['uninstalled_core']:
             if item in jlab['extensions']:
                 data['jupyterlab']['extensions'].pop(item)
-            else:
+            elif item in jlab['mimeExtensions']:
                 data['jupyterlab']['mimeExtensions'].pop(item)
             # Remove from dependencies as well.
-            data['dependencies'].pop(item)
+            if item in data['dependencies']:
+                data['dependencies'].pop(item)
 
         return data
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7562 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Only removes packages from the extension and dependency metadata in the built application if they exist.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users are able to uninstall extensions (including core extensions), and still use the extension manager.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
