### PR TITLE
Match react version in ui-components peerDependencies

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -60,7 +60,7 @@
     "typescript": "~3.7.3"
   },
   "peerDependencies": {
-    "react": "~16.8.4"
+    "react": "~16.9.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Update the version of React in the `ui-components` `peerDependencies` to match the recently updated `16.9.0`.

## Code changes

Change to `ui-components/package.json`.

## User-facing changes

None

## Backwards-incompatible changes

None