### PR TITLE
Fix for center-aligned images with IPython.display.Image

### DIFF
--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -412,8 +412,8 @@
 /* Restrict to direct children as other images could be nested in other content. */
 .jp-RenderedHTMLCommon > img {
   display: block;
-  margin-left: auto;
-  margin-right: auto;
+  margin-left: 0;
+  margin-right: 0;
   margin-bottom: 1em;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

#7752 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Changed the margins from auto to 0 for image rendering in rendermime.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Changes the alignment of images from IPython.display.Image when embed=False

<!-- For visual changes, include before and after screenshots here. -->

Before:
![Before](https://user-images.githubusercontent.com/55801982/72670588-b938a980-3a04-11ea-9963-a698d12fbe27.png)

After:
![After](https://user-images.githubusercontent.com/55801982/72670538-e5075f80-3a03-11ea-95fc-9cc4b6785c70.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
