### PR TITLE
fixed alignment issue for select box arrow icon inside dialog

### DIFF
--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -98,8 +98,6 @@ button.jp-Dialog-button:focus::-moz-focus-inner {
 }
 
 .jp-Dialog-body > label {
-  padding-top: 4px;
-  padding-bottom: 8px;
   line-height: 1.4;
   color: var(--jp-ui-font-color0);
 }


### PR DESCRIPTION
**References**
Fixes [#7778](https://github.com/jupyterlab/jupyterlab/issues/7778)

**Code changes**
Adds styling to the jp-dialog label.

**User-facing changes**
Fixes appearance of arrow in kernel selection dialog select box.
**Before**
![arrorissue](https://user-images.githubusercontent.com/4777119/72868836-374cc700-3d09-11ea-8fbd-89212cfb5517.png)

**After**
<img width="634" alt="arrowfixed" src="https://user-images.githubusercontent.com/4777119/72868853-4764a680-3d09-11ea-91b3-8210e1f491e5.PNG">
