### PR TITLE
Fix browser check

### DIFF
--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -16,7 +16,6 @@ import os
 import shutil
 import sys
 import subprocess
-from tempfile import TemporaryDirectory
 
 from tornado.ioloop import IOLoop
 from traitlets import Bool, Unicode
@@ -57,14 +56,8 @@ def run_browser(url):
     target = osp.join(get_app_dir(), 'example_test')
     if not osp.exists(osp.join(target, 'node_modules')):
         os.makedirs(target)
-        # Install puppeteer in a temporary directory.
-        # This is to avoid an issue seen in CI where running yarn
-        # In the application directory resulted in the whole Python
-        # install getting removed
-        with TemporaryDirectory() as tdname:
-          subprocess.call(["jlpm"], cwd=tdname)
-          subprocess.call(["jlpm", "add", "puppeteer"], cwd=tdname)
-          shutil.copytree(osp.join(tdname, 'node_modules'), osp.join(target, 'node_modules'))
+        subprocess.call(["jlpm", "init", "-y"], cwd=target)
+        subprocess.call(["jlpm", "add", "puppeteer"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-example-test.js'), osp.join(target, 'chrome-example-test.js'))
     return subprocess.check_call(["node", "chrome-example-test.js", url], cwd=target)
 

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -111,6 +111,7 @@ def run_browser(url):
         os.makedirs(target)
         subprocess.call(["jlpm", "init", "-y"], cwd=target)
         subprocess.call(["jlpm", "add", "puppeteer"], cwd=target)
+    shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))
     return subprocess.check_call(["node", "chrome-test.js", url], cwd=target)
 
 

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -11,7 +11,6 @@ import os
 import shutil
 import sys
 import subprocess
-from tempfile import TemporaryDirectory
 
 from tornado.ioloop import IOLoop
 from notebook.notebookapp import flags, aliases
@@ -110,15 +109,8 @@ def run_browser(url):
     target = osp.join(get_app_dir(), 'browser_test')
     if not osp.exists(osp.join(target, 'node_modules')):
         os.makedirs(target)
-        # Install puppeteer in a temporary directory.
-        # This is to avoid an issue seen in CI where running yarn
-        # In the application directory resulted in the whole Python
-        # install getting removed
-        with TemporaryDirectory() as tdname:
-          subprocess.call(["jlpm"], cwd=tdname)
-          subprocess.call(["jlpm", "add", "puppeteer"], cwd=tdname)
-          shutil.copytree(osp.join(tdname, 'node_modules'), osp.join(target, 'node_modules'))
-    shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))
+        subprocess.call(["jlpm", "init", "-y"], cwd=target)
+        subprocess.call(["jlpm", "add", "puppeteer"], cwd=target)
     return subprocess.check_call(["node", "chrome-test.js", url], cwd=target)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Better fix for CI failures that was merged in #7805.  

When we were running `jlpm` on CI, it was walking up the tree to find the nearest `package.json`, which just so happened to have an `install` script that tries to re-install the Python used by the container.

cf https://github.com/actions/virtual-environments/issues/307#issuecomment-577408618

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Makes our puppeteer installs more self-contained so we are shielded from changes in the environment.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Prevent CI failures in master and for extension authors in the future.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
