### PR TITLE
Fix browser check in 1.x

### DIFF
--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -56,7 +56,7 @@ def run_browser(url):
     target = osp.join(get_app_dir(), 'example_test')
     if not osp.exists(osp.join(target, 'node_modules')):
         os.makedirs(target)
-        subprocess.call(["jlpm"], cwd=target)
+        subprocess.call(["jlpm", "init", "-y"], cwd=target)
         subprocess.call(["jlpm", "add", "puppeteer"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-example-test.js'), osp.join(target, 'chrome-example-test.js'))
     return subprocess.check_call(["node", "chrome-example-test.js", url], cwd=target)

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -128,7 +128,7 @@ def run_browser(url):
     target = osp.join(get_app_dir(), 'browser_test')
     if not osp.exists(osp.join(target, 'node_modules')):
         os.makedirs(target)
-        subprocess.call(["jlpm"], cwd=target)
+        subprocess.call(["jlpm", "init", "-y"], cwd=target)
         subprocess.call(["jlpm", "add", "puppeteer"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))
     return subprocess.check_call(["node", "chrome-test.js", url], cwd=target)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Manual backport of #7813 to the 1.x branch.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Fixes creation of the puppeteer to be self-contained and not subject to location on disk (see #7813).

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Extension authors will be able to use `browser_check` for their 1.x extensions in CI.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
