### PR TITLE
Give kernel connection options to a session connection

### DIFF
--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -192,16 +192,24 @@ function activate(
     if (!sessionModel.kernel || kernelInfoCache.has(sessionModel.kernel.name)) {
       return;
     }
-    const session = serviceManager.sessions.connectTo({ model: sessionModel });
-    // Note: .ready implies session.kernel.info is non-null
-    void session.kernel!.info.then(kernelInfo => {
+    const session = serviceManager.sessions.connectTo({
+      model: sessionModel,
+      kernelConnectionOptions: { handleComms: false }
+    });
+
+    const kernel = session.kernel;
+    if (!kernel) {
+      return;
+    }
+    void kernel.info.then(kernelInfo => {
+      const name = session.kernel!.name;
+
       // Check the cache second time so that, if two callbacks get scheduled,
       // they don't try to add the same commands.
-      if (kernelInfoCache.has(sessionModel.kernel!.name)) {
+      if (kernelInfoCache.has(name)) {
         return;
       }
       // Set the Kernel Info cache.
-      const name = session.kernel!.name;
       kernelInfoCache.set(name, kernelInfo);
 
       // Utility function to check if the current widget

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -197,11 +197,7 @@ function activate(
       kernelConnectionOptions: { handleComms: false }
     });
 
-    const kernel = session.kernel;
-    if (!kernel) {
-      return;
-    }
-    void kernel.info.then(kernelInfo => {
+    void session.kernel?.info.then(kernelInfo => {
       const name = session.kernel!.name;
 
       // Check the cache second time so that, if two callbacks get scheduled,

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -33,6 +33,7 @@ export class SessionConnection implements Session.ISessionConnection {
     this._username = options.username ?? '';
     this._clientId = options.clientId ?? UUID.uuid4();
     this._connectToKernel = options.connectToKernel;
+    this._kernelConnectionOptions = options.kernelConnectionOptions ?? {};
     this.serverSettings =
       options.serverSettings ?? ServerConnection.makeSettings();
     this.setupKernel(options.model.kernel);
@@ -305,6 +306,7 @@ export class SessionConnection implements Session.ISessionConnection {
       return;
     }
     const kc = this._connectToKernel({
+      ...this._kernelConnectionOptions,
       model,
       username: this._username,
       clientId: this._clientId,
@@ -421,4 +423,8 @@ export class SessionConnection implements Session.ISessionConnection {
   private _connectToKernel: (
     options: Kernel.IKernelConnection.IOptions
   ) => Kernel.IKernelConnection;
+  private _kernelConnectionOptions: Omit<
+    Kernel.IKernelConnection.IOptions,
+    'model' | 'username' | 'clientId' | 'serverSettings'
+  >;
 }

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -187,6 +187,13 @@ export namespace ISessionConnection {
     model: IModel;
 
     /**
+     * Connects to an existing kernel
+     */
+    connectToKernel(
+      options: Kernel.IKernelConnection.IOptions
+    ): Kernel.IKernelConnection;
+
+    /**
      * The server settings.
      */
     serverSettings?: ServerConnection.ISettings;
@@ -202,11 +209,12 @@ export namespace ISessionConnection {
     clientId?: string;
 
     /**
-     * Connects to an existing kernel
+     * Kernel connection options
      */
-    connectToKernel(
-      options: Kernel.IKernelConnection.IOptions
-    ): Kernel.IKernelConnection;
+    kernelConnectionOptions?: Omit<
+      Kernel.IKernelConnection.IOptions,
+      'model' | 'username' | 'clientId' | 'serverSettings'
+    >;
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This may help with https://github.com/jupyter-widgets/ipywidgets/issues/2748

## Code changes

Adds optional kernel connection options to a session connection, so (for now) you can say you want kernel connections that do not handle comms.

## User-facing changes

None

## Backwards-incompatible changes

This is backwards compatible because it introduces an optional argument.
