### PR TITLE
Fixed refresh issue for html viewer(slides)-7552

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -486,16 +486,25 @@ function addCommands(
           buttons: [Dialog.okButton()]
         });
       }
-      return showDialog({
-        title: `Reload ${type} from Disk`,
-        body: `Are you sure you want to reload
+      if (context.model.dirty) {
+        return showDialog({
+          title: `Reload ${type} from Disk`,
+          body: `Are you sure you want to reload
           the ${type} from the disk?`,
-        buttons: [Dialog.cancelButton(), Dialog.warnButton({ label: 'Reload' })]
-      }).then(result => {
-        if (result.button.accept && !context.isDisposed) {
+          buttons: [
+            Dialog.cancelButton(),
+            Dialog.warnButton({ label: 'Reload' })
+          ]
+        }).then(result => {
+          if (result.button.accept && !context.isDisposed) {
+            return context.revert();
+          }
+        });
+      } else {
+        if (!context.isDisposed) {
           return context.revert();
         }
-      });
+      }
     }
   });
 

--- a/packages/htmlviewer/src/index.tsx
+++ b/packages/htmlviewer/src/index.tsx
@@ -90,8 +90,11 @@ export class HTMLViewer extends DocumentWidget<IFrame>
       'refresh',
       new ToolbarButton({
         iconRenderer: refreshIcon,
-        onClick: () => {
-          this.content.url = this.content.url;
+        onClick: async () => {
+          if (!this.context.model.dirty) {
+            await this.context.revert();
+            this.update();
+          }
         },
         tooltip: 'Rerender HTML Document'
       })


### PR DESCRIPTION
**References**
Fix for [#7552](https://github.com/jupyterlab/jupyterlab/issues/7552)

**Code changes**
As @jasongrout suggested added dirty check and reload from disk instead of just reassigning the content url for iframe in htmlviewer.
Also added dirty check for reload from disk logic so that confirmation dialog will be shown only if the current context model is dirty.

**User-facing changes**
None.