### PR TITLE
fixed the css to fix filter box cut off issue when only one row in json

### DIFF
--- a/packages/json-extension/style/base.css
+++ b/packages/json-extension/style/base.css
@@ -23,6 +23,7 @@
 .jp-RenderedJSON .container {
   position: relative;
   width: 100%;
+  min-height: 30px;
 }
 
 .jp-RenderedJSON .filter {


### PR DESCRIPTION

## References
#7542 

## Code changes
Added min height for filter box container since filter box is an absolutely positioned item. 


## User-facing changes
Previous:
<img width="732" alt="filter-cut" src="https://user-images.githubusercontent.com/4777119/73260914-ffee8680-41f0-11ea-9f49-20d9485acf45.PNG">

Fixed:
<img width="723" alt="filter-fixed" src="https://user-images.githubusercontent.com/4777119/73260933-0846c180-41f1-11ea-8e3d-bef3d5d6b217.PNG">


## Backwards-incompatible changes

