### PR TITLE
Fix unexpected jump to last search result when using documentsearch

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,6 +1,0 @@
-{
- "cells": [],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 4
-}

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,6 @@
+{
+ "cells": [],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -60,15 +60,10 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
     this._searchTarget = searchTarget;
     const cells = this._searchTarget.content.widgets;
 
-    this._query = query;
     this._filters =
       !filters || Object.entries(filters).length === 0
         ? { output: true }
         : filters;
-    // Listen for cell model change to redo the search in case of
-    // new/pasted/deleted cells
-    const cellList = this._searchTarget.model!.cells;
-    cellList.changed.connect(this._restartQuery.bind(this), this);
 
     // hide the current notebook widget to prevent expensive layout re-calculation operations
     this._searchTarget.hide();
@@ -461,12 +456,6 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
     return match;
   }
 
-  private async _restartQuery() {
-    await this.endQuery();
-    await this.startQuery(this._query, this._searchTarget!, this._filters);
-    this._changed.emit(undefined);
-  }
-
   private _getMatchesFromCells(): ISearchMatch[][] {
     let indexTotal = 0;
     const result: ISearchMatch[][] = [];
@@ -503,7 +492,6 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
   }
 
   private _searchTarget: NotebookPanel | undefined | null;
-  private _query: RegExp;
   private _filters: INotebookFilters;
   private _searchProviders: ICellSearchPair[] = [];
   private _currentProvider: ICellSearchPair | null | undefined;


### PR DESCRIPTION
## References
This is a fix to issue #7476: adding or deleting cells while using _documentsearch_ unexpectedly jumps to the last result of the query.

## Code changes
The jumping behavior was originally an intentional feature, but one that contradicts expected behavior of _documentsearch_. I have removed `_restartQuery()` and modified functions supporting this feature in [notebooksearchprovider.ts](https://github.com/jupyterlab/jupyterlab/blob/37c7a647a1344712c8cf80414db73809f486e766/packages/documentsearch/src/providers/notebooksearchprovider.ts). 

## User-facing changes
This fix allows users to continue working in their current spot after adding or deleting cells while keeping the document search box open. To proceed to the next search result, users can press enter within the search box as expected.

## Backwards-incompatible changes
None
