### PR TITLE
Added optional className param to JLIcon constructor

### DIFF
--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -265,6 +265,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
     render,
     unrender,
     rendererClass = LabIcon.ElementRenderer,
+    className = '',
     _loading = false
   }: LabIcon.IOptions & { _loading?: boolean }) {
     if (!(name && svgstr)) {
@@ -299,7 +300,8 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
     }
 
     this.name = name;
-    this._className = Private.nameToClassName(name);
+    this._className =
+      className != undefined ? className : Private.nameToClassName(name);
     this.svgstr = svgstr;
 
     this.react = this._initReact();
@@ -606,6 +608,7 @@ export namespace LabIcon {
    */
   export interface IOptions extends IIcon, Partial<VirtualElement.IRenderer> {
     rendererClass?: typeof Renderer;
+    className?: string;
   }
 
   /**


### PR DESCRIPTION
## References

This follows on @telamonian work with #7700 

## Code changes

Currently `JLIcon`s are initialized with a generated `className` based on the name. This means all `className`s are prepended with `jp-`, but this precludes the idea of extensions creating their own `JLIcon`s with project unique CSS selectors.

## User-facing changes

N/a

## Backwards-incompatible changes

N/A