### PR TITLE
Update Binder README

### DIFF
--- a/binder/README.md
+++ b/binder/README.md
@@ -7,9 +7,10 @@ https://mybinder.org/v2/gh/jupyterlab/jupyterlab/master?urlpath=lab-dev
 To check out a different version, just replace "master" with the desired
 branch/tag name or commit hash.
 
+If there is an error with the launched application, you can append
+`edit/jupyterlab-dev.log` to the URL (after `lab-dev/`) to see the server logs.
+
 Please note that this setup is developer focused.
 For a more user-focused Binder use this URL:
 
 https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/master?urlpath=lab/tree/demo/Lorenz.ipynb
-
-If there is an error with the launched application, you can browse to the ` `/edit/jupyterlab-dev.log` url to see the server logs.


### PR DESCRIPTION
See https://github.com/jupyterlab/jupyterlab/pull/7766#discussion_r365133574.

I'm not quite sure if I should recommend appending `edit/jupyterlab-dev.log` *after* `lab-dev/` or *instead of* `lab-dev/` (discarding everything that may have been there before).

Both seem to work, I don't know whether there can ever be a difference.

What should I recommend?
What is easiest to understand?

Or should the sentence be changed completely?

The problem is that I can't really refer to the part of the URL before `/lab-dev`, because it will have some random components.