### PR TITLE
followup #7767: small bugfix to lookup in UNSTABLE_getReact

### DIFF
--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -216,7 +216,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
   }: { name: string; fallback?: LabIcon } & LabIcon.IReactProps) {
     for (let className of name.split(/\s+/)) {
       if (LabIcon._instancesByNameAndClassName.has(className)) {
-        const icon = LabIcon._instances.get(className)!;
+        const icon = LabIcon._instancesByNameAndClassName.get(className)!;
         return <icon.react {...props} />;
       }
     }


### PR DESCRIPTION
## References

followup to #7767

Small fix to icon lookup routine in `LabIcon.UNSTABLE_getReact`

## Code changes

changed ref to `._instances` => `._instancesByNameAndClassName`

## User-facing changes

N/A

## Backwards-incompatible changes

N/A