### PR TITLE
Document how to add commands to notebook toolbar

### DIFF
--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -72,6 +72,8 @@ After a command has been added to the application command registry
 you can add them to various places in the application user interface,
 where they will be rendered using the metadata you provided.
 
+For example, you can add a button the Notebook toolbar to run the command with the ``CommandToolbarButtonComponent``.
+
 Add a Command to the Command Palette
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This documents the ability to add a command to the notebook toolbar, in response to [this gitter question](https://gitter.im/jupyterlab/jupyterlab?at=5e3989efea9ba00b84af4892) asking how to change whether a notebook button is enabled after it has been created. @afshin and @ian-r-rose's suggestion was to switch to using a `CommandToolbarButtonComponent` and creating a command for that action.