### PR TITLE
Fix bumpversion script to properly switch to alpha for a minor release

### DIFF
--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -73,11 +73,14 @@ commander
     } else if (spec === 'release' && prev.indexOf('rc') !== -1) {
       lernaVersion = 'patch';
     }
+    if (lernaVersion === 'preminor') {
+      lernaVersion += ' --preid=a';
+    }
+
     let cmd = `lerna version -m \"New version\" --force-publish=* --no-push ${lernaVersion}`;
     if (opts.force) {
       cmd += ' --yes';
     }
-
     let oldVersion = utils.run(
       'git rev-parse HEAD',
       {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Integrity build is currently broken in master.   This fixes our bumpversion script to properly switch to alpha during a minor bump.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Fix in buildutils bumpversion script.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
