### PR TITLE
ensures that 'shift tab' => dedent shortcut works correctly in the file editor

### DIFF
--- a/packages/tooltip-extension/schema/files.json
+++ b/packages/tooltip-extension/schema/files.json
@@ -5,7 +5,7 @@
     {
       "command": "tooltip:launch-file",
       "keys": ["Shift Tab"],
-      "selector": ".jp-FileEditor"
+      "selector": ".jp-FileEditor .jp-CodeMirrorEditor:not(.jp-mod-has-primary-selection):not(.jp-mod-in-leading-whitespace)"
     }
   ],
   "properties": {},


### PR DESCRIPTION
## References

fixes  #6127
cf #5060

Fixes `'shift tab'` behavior in the file editor, makes it the same as in console and notebook.

With the fix, `'shift tab'` will behave the following way in these contexts:
- cursor in leading whitespace on a line
    - dedent line
- text is selected
    - dedent all lines on which text is selected
- cursor is within text on a line
    - run the `"tooltip:launch-file"` command (tries to open a tooltip with a docstring)

## Code changes

Made the `'shift tab'` shortcut for the `"tooltip:launch-file"` command appropriately selective (same behavior as for "tooltip:launch-console" and "tooltip:launch-notebook")

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
