### PR TITLE
Resolve #7874 - stop too many fetch calls to docmanager-extension on …

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -242,16 +242,16 @@ ${fileTypes}`;
       }
     });
 
-    //callback to registry change that ensures not to invoke reload method when there is already a promise that is pending
+    // callback to registry change that ensures not to invoke reload method when there is already a promise that is pending
     let reloadSettingsRegistry = () => {
       let promisePending = false;
 
       return async () => {
-          if(!promisePending) {
-            promisePending = true;
-            await settingRegistry.reload(pluginId);
-            promisePending = false;
-          }
+        if (!promisePending) {
+          promisePending = true;
+          await settingRegistry.reload(pluginId);
+          promisePending = false;
+        }
       };
     };
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -241,9 +241,23 @@ ${fileTypes}`;
         return { ...plugin, schema };
       }
     });
+
+    //callback to registry change that ensures not to invoke reload method when there is already a promise that is pending
+    let reloadSettingsRegistry = () => {
+      let promisePending = false;
+
+      return async () => {
+          if(!promisePending) {
+            promisePending = true;
+            await settingRegistry.reload(pluginId);
+            promisePending = false;
+          }
+      };
+    };
+
     // If the document registry gains or loses a factory or file type,
     // regenerate the settings description with the available options.
-    registry.changed.connect(() => settingRegistry.reload(pluginId));
+    registry.changed.connect(reloadSettingsRegistry());
 
     return docManager;
   }


### PR DESCRIPTION
Fix for #7874, to stop too many fetch calls to docmanager-extension. This happens as there is a change event that gets emit from a forEach loop. All requests info are the same and the response received is the same which make the calls to be redundant. So the fix is to restrict the number of calls to 1.



<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#7874
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Code change is to register a callback that does not trigger a reload (fetch call) when an existing promise is already pending. The promise is tracked by maintaining a promisePending boolean flag. This ensures that even when multiple change events are emitted from a loop, it'll avoid creating multiple promises which ends up in redundant requests.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or 
user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
No

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
Before Fix Network Log
<img width="1367" alt="Before Fix" src="https://user-images.githubusercontent.com/4917563/74409239-5f3ccf80-4e5c-11ea-9326-6d3b6f0d2b1a.png">

After Fix Network Log
<img width="1150" alt="Aftex Fix" src="https://user-images.githubusercontent.com/4917563/74409427-afb42d00-4e5c-11ea-891f-dfd2acdc92a2.png">
