### PR TITLE
Close Dialog by clicking ouside of it

### DIFF
--- a/packages/apputils/src/dialog.ts
+++ b/packages/apputils/src/dialog.ts
@@ -271,6 +271,7 @@ export class Dialog<T> extends Widget {
     if (!content.contains(event.target as HTMLElement)) {
       event.stopPropagation();
       event.preventDefault();
+      this.reject();
       return;
     }
     for (let buttonNode of this._buttonNodes) {


### PR DESCRIPTION
## References

Fixes #3784

## Code changes

Closes a model/dialog by clicking the greyed out area outside of it.
This functionality is the same as if the user clicked the esc key.

This also addresses an undiscovered bug: Currently if a user clicks outside a dialog all the keyboard related events (escape, enter, tab) stop working until the user interacts with the dialog again (eg. changing a form value). This is "fixed" since clicking outside now closes the dialog.

## User-facing changes

UX change: clicking outside a dialog closes it rather than doing nothing.

## Backwards-incompatible changes

N/A