### PR TITLE
Alias phosphor packages to lumino

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -152,6 +152,67 @@ module.exports = [
     entry: {
       main: ['whatwg-fetch', plib.resolve(buildDir, 'index.out.js')]
     },
+    // Map Phosphor files to Lumino files.
+    resolve: {
+      alias: {
+        '@phosphor/algorithm$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/algorithm/lib/index.js'
+        ),
+        '@phosphor/application$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/application/lib/index.js'
+        ),
+        '@phosphor/commands$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/commands/lib/index.js'
+        ),
+        '@phosphor/coreutils$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/coreutils/lib/index.js'
+        ),
+        '@phosphor/disposable$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/disposable/lib/index.js'
+        ),
+        '@phosphor/domutils$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/domutils/lib/index.js'
+        ),
+        '@phosphor/dragdrop$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/dragdrop/lib/index.js'
+        ),
+        '@phosphor/dragdrop/style': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/widgets/style'
+        ),
+        '@phosphor/messaging$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/messaging/lib/index.js'
+        ),
+        '@phosphor/properties$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/properties/lib'
+        ),
+        '@phosphor/signaling': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/signaling/lib/index.js'
+        ),
+        '@phosphor/widgets/style': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/widgets/style'
+        ),
+        '@phosphor/virtualdom$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/virtualdom/lib/index.js'
+        ),
+        '@phosphor/widgets$': plib.resolve(
+          __dirname,
+          'node_modules/@lumino/widgets/lib/index.js'
+        )
+      }
+    },
     output: {
       path: plib.resolve(buildDir),
       publicPath: '{{page_config.fullStaticUrl}}/',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses https://github.com/jupyterlab/jupyterlab/issues/7230#issuecomment-586651219

Extension authors can continue to use `phosphor` packages if desired during this major release cycle. 

Verification: 

- Created an extension that creates a Phosphor widget and logs the instance
- Updated webpack config using the above changes
- Launched JupyerLab
- Console output has `node: <div class="lm-Widget p-Widget">`
- Verified that there were no `@phosphor` modules in `vendor.bundle` or `main.bundle`.

Note:
Extension authors using TypeScript would still have to switch to Lumino if they want to interact with core JupyterLab components such as adding `content` to a `MainAreaWidget`.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Aliases `phosphor` packages to `lumino` packages in webpack.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
