### PR TITLE
Resolve #7889 avoid 3 fetch calls to load a notebook

### DIFF
--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -48,6 +48,7 @@
     "@lumino/algorithm": "^1.2.3",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.4",
+    "@lumino/polling": "^1.0.3",
     "@lumino/widgets": "^1.10.2"
   },
   "devDependencies": {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -44,7 +44,7 @@ import { IDisposable } from '@lumino/disposable';
 
 import { Widget } from '@lumino/widgets';
 
-import { Debouncer } from '@lumino/polling';
+import { Throttler } from '@lumino/polling';
 
 /**
  * The command IDs used by the document manager plugin.
@@ -246,11 +246,11 @@ ${fileTypes}`;
 
     // callback to registry change that ensures not to invoke reload method when there is already a promise that is pending
     let reloadSettingsRegistry = () => {
-      let reloadDebounce = new Debouncer(() =>
+      let reloadThrottle = new Throttler(() =>
         settingRegistry.reload(pluginId)
       );
 
-      return reloadDebounce.invoke.bind(reloadDebounce);
+      return reloadThrottle.invoke.bind(reloadThrottle);
     };
 
     // If the document registry gains or loses a factory or file type,

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -44,6 +44,8 @@ import { IDisposable } from '@lumino/disposable';
 
 import { Widget } from '@lumino/widgets';
 
+import { Debouncer } from '@lumino/polling';
+
 /**
  * The command IDs used by the document manager plugin.
  */
@@ -244,15 +246,11 @@ ${fileTypes}`;
 
     // callback to registry change that ensures not to invoke reload method when there is already a promise that is pending
     let reloadSettingsRegistry = () => {
-      let promisePending = false;
+      let reloadDebounce = new Debouncer(() =>
+        settingRegistry.reload(pluginId)
+      );
 
-      return async () => {
-        if (!promisePending) {
-          promisePending = true;
-          await settingRegistry.reload(pluginId);
-          promisePending = false;
-        }
-      };
+      return reloadDebounce.invoke.bind(reloadDebounce);
     };
 
     // If the document registry gains or loses a factory or file type,


### PR DESCRIPTION
1. Resolve #7889 to avoid 3 fetch calls to load a notebook.
2. Refactored my old PR https://github.com/jupyterlab/jupyterlab/pull/7879 to use debouncer instead of boolean flags
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#7889
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
1. listCheckpoints() gets invoked thrice when a notebook is loaded resulting in 3 checkpoint calls. The code change is to have an object- checkpointPromiseQueue that holds the promises with locaPath as key.  If there is already a promise to be resolved, the pending promise object is returned back instead of creating one. And the promise reference to be cleared off from the checkpointPromiseQueue, when the promise if resolved/rejected via finally block. And as a result only 1 fetch call to checkpoint is triggered.

2. Refactor of older PR https://github.com/jupyterlab/jupyterlab/pull/7879, to make use of Debouncer in this use case as it solves the purpose of executing the callback only once even though invoked multiple times and making the code more cleaner.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
No
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->


