### PR TITLE
Fixed wrapSelect to support multiple selects

### DIFF
--- a/packages/apputils/src/styling.ts
+++ b/packages/apputils/src/styling.ts
@@ -73,8 +73,8 @@ export namespace Styling {
       caretDownEmptyIcon.element({
         tag: 'span',
         kind: 'select',
-        right: '15px',
-        top: '23px',
+        right: '8px',
+        top: '5px',
         width: '18px'
       })
     );

--- a/packages/apputils/style/styling.css
+++ b/packages/apputils/style/styling.css
@@ -42,6 +42,7 @@ input.jp-mod-styled:focus {
 
 .jp-select-wrapper {
   display: flex;
+  position: relative;
   flex-direction: column;
   padding: 1px;
   background-color: var(--jp-layout-color1);


### PR DESCRIPTION
## References

Bug initially added in #7700 

## Code changes

With the new LabIcon updates the wrapSelect changes set the caretdown icon
relative to the module body instead of the select. The inital values made
this work for the one use case in lab, but breaks all uses in extensions.

This pr makes the icon location relative to the select-wrapper div to fix this.

## User-facing changes

Minor visual changes that bring to location of the down caret in a drop down back to where it was in 1.X

## Backwards-incompatible changes

N/A