### PR TITLE
define base shareUrl

### DIFF
--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -209,6 +209,7 @@ def load_jupyter_server_extension(nbapp):
         page_config['hubPrefix'] = nbapp.hub_prefix
         page_config['hubHost'] = nbapp.hub_host
         page_config['hubUser'] = nbapp.user
+        page_config['shareUrl'] = ujoin(nbapp.hub_prefix, 'user-redirect')
         # Assume the server_name property indicates running JupyterHub 1.0.
         if hasattr(nbapp, 'server_name'):
             page_config['hubServerName'] = nbapp.server_name

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -118,6 +118,22 @@ export namespace PageConfig {
   }
 
   /**
+   * Get the base url for sharing links (usually baseUrl)
+   */
+  export function getShareUrl(): string {
+    return URLExt.normalize(getOption('shareUrl') || getBaseUrl());
+  }
+
+  /**
+   * Get the tree url for shareable links.
+   * Usually the same as treeUrl,
+   * but overrideable e.g. when sharing with JupyterHub.
+   */
+  export function getTreeShareUrl(): string {
+    return URLExt.normalize(URLExt.join(getShareUrl(), getOption('treeUrl')));
+  }
+
+  /**
    * Get the base websocket url for a Jupyter application, or an empty string.
    */
   export function getWsUrl(baseUrl?: string): string {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -388,7 +388,7 @@ function activateShareFile(
         return;
       }
       const path = encodeURI(model.path);
-      Clipboard.copyToSystem(URLExt.join(PageConfig.getTreeUrl(), path));
+      Clipboard.copyToSystem(URLExt.join(PageConfig.getTreeShareUrl(), path));
     },
     isVisible: () =>
       !!tracker.currentWidget &&


### PR DESCRIPTION
allows simplest override of "get shareable link" extension when sharing setup is the same, just on a different base URL.

And set this when run under JupyterHub, so folks get proper shareable links to /hub/user-redirect by default.


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

related to #5388 which made the share extension overrideable. I initially set out to do exactly that, but since the only change for JupyterHub is that of the base URL, I thought making the base share URL itself part of page config would cover the default Hub case, at least.

jupyterhub cross-ref: https://github.com/jupyterhub/jupyterhub/issues/2017

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

No changes for most users. JupyterHub users using 'get shareable link' will get
actually shareable links to `/hub/user-redirect/lab/tree/...` instead of links to
their own server, which are often not accessible to other users.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->