### PR TITLE
CodeMirror font size setting issue (#7909)

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1479,7 +1479,7 @@ namespace Private {
         el.style.fontFamily = value;
         break;
       case 'fontSize':
-        el.style.setProperty('fontSize', value ? value + 'px' : null);
+        el.style.setProperty('font-size', value ? value + 'px' : null);
         break;
       case 'lineHeight':
         el.style.lineHeight = value ? value.toString() : null;


### PR DESCRIPTION
Use the right property name, `font-size`, in the style declaration.

Fixes #7909. 

Regards