### PR TITLE
Added hyphen to jupyter lab installation doc

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -26,7 +26,7 @@ If you use ``pip``, you can install it with:
 
 If installing using ``pip install --user``, you must add the user-level
 ``bin`` directory to your ``PATH`` environment variable in order to launch
-``jupyter lab``.
+``jupyter-lab``.
 
 pipenv
 ~~~~~~


### PR DESCRIPTION
I've just installed jupyter lab. 
I've noticed that running jupyter lab was not working. This is because the correct command is jupyter-lab.
So I propose to update the docs.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->
![image](https://user-images.githubusercontent.com/39261852/75158182-dfddb480-5715-11ea-8542-35c71e4dae74.png)




