### PR TITLE
Fix codemirror lineWrap max-width

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1438,7 +1438,7 @@ namespace Private {
           value === 'bounded' ? `${config.wordWrapColumn}ch` : null;
         const width =
           value === 'wordWrapColumn' ? `${config.wordWrapColumn}ch` : null;
-        lines.style.setProperty('maxWidth', maxWidth);
+        lines.style.setProperty('max-width', maxWidth);
         lines.style.setProperty('width', width);
         editor.setOption('lineWrapping', lineWrapping);
         break;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->
Issue similar to #7909 and PR #7910 .  style.setProperty to use css property names with hyphen case and not camel case.

## References
#7909
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Code change is to use hypen-case instead of camel case in css property name while using style.setProperty. Replacing `maxWidth` with `max-width`

https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
