### PR TITLE
Resolve #7889 to avoid redundant checkpoint calls on loading notebook

### DIFF
--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -28,6 +28,14 @@ const SERVICE_DRIVE_URL = 'api/contents';
 const FILES_URL = 'files';
 
 /**
+ * The object to reference listCheckpoints promises
+ * used as a flag to check and return the existing promise if it's pending
+ */
+let checkpointPromiseStore: {
+  [key: string]: Promise<Contents.ICheckpointModel[]>;
+} = {};
+
+/**
  * A namespace for contents interfaces.
  */
 export namespace Contents {
@@ -1309,22 +1317,32 @@ export class Drive implements Contents.IDrive {
    */
   listCheckpoints(localPath: string): Promise<Contents.ICheckpointModel[]> {
     let url = this._getUrl(localPath, 'checkpoints');
-    return ServerConnection.makeRequest(url, {}, this.serverSettings)
-      .then(response => {
-        if (response.status !== 200) {
-          throw new ServerConnection.ResponseError(response);
-        }
-        return response.json();
-      })
-      .then(data => {
-        if (!Array.isArray(data)) {
-          throw new Error('Invalid Checkpoint list');
-        }
-        for (let i = 0; i < data.length; i++) {
-          validate.validateCheckpointModel(data[i]);
-        }
-        return data;
-      });
+    if (!checkpointPromiseStore[localPath]) {
+      checkpointPromiseStore[localPath] = ServerConnection.makeRequest(
+        url,
+        {},
+        this.serverSettings
+      )
+        .then(response => {
+          if (response.status !== 200) {
+            throw new ServerConnection.ResponseError(response);
+          }
+          return response.json();
+        })
+        .then(data => {
+          if (!Array.isArray(data)) {
+            throw new Error('Invalid Checkpoint list');
+          }
+          for (let i = 0; i < data.length; i++) {
+            validate.validateCheckpointModel(data[i]);
+          }
+          return data;
+        })
+        .finally(() => {
+          delete checkpointPromiseStore[localPath];
+        });
+    }
+    return checkpointPromiseStore[localPath];
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->
Resolve #7889 to avoid 3 fetch calls to load a notebook.
## References
#7889
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
listCheckpoints() gets invoked thrice when a notebook is loaded resulting in 3 checkpoint calls. The code change is to have an object- checkpointPromiseQueue that holds the promises with locaPath as key. If there is already a promise to be resolved, the pending promise object is returned back instead of creating one. And the promise reference to be cleared off from the checkpointPromiseQueue, when the promise if resolved/rejected via finally block. And as a result only 1 fetch call to checkpoint is triggered.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
NO
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

Before Fix
<img width="1675" alt="Screenshot 2020-02-17 at 4 58 35 PM" src="https://user-images.githubusercontent.com/4917563/75273692-5ae2c000-5827-11ea-85c4-1acbcb1b64ec.png">

After Fix
<img width="1335" alt="Screenshot 2020-02-25 at 11 22 45 PM" src="https://user-images.githubusercontent.com/4917563/75273633-3d155b00-5827-11ea-952c-37ffc7beee0e.png">
