### PR TITLE
Throttle fetch requests in the setting registry's data connector

### DIFF
--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -50,7 +50,7 @@
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
     "@lumino/messaging": "^1.3.3",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/properties": "^1.1.6",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1"

--- a/packages/apputils-extension/package.json
+++ b/packages/apputils-extension/package.json
@@ -48,7 +48,7 @@
     "@lumino/commands": "^1.10.1",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/widgets": "^1.11.1",
     "es6-promise": "~4.2.8"
   },

--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -31,12 +31,7 @@ export class SettingConnector extends DataConnector<
   fetch(id: string): Promise<ISettingRegistry.IPlugin | undefined> {
     const throttlers = this._throttlers;
     if (!(id in throttlers)) {
-      throttlers[id] = new Throttler(async () => {
-        const fetched = await this._connector.fetch(id);
-        throttlers[id].dispose();
-        delete throttlers[id];
-        return fetched;
-      }, 100);
+      throttlers[id] = new Throttler(() => this._connector.fetch(id), 100);
     }
     return throttlers[id].invoke();
   }

--- a/packages/apputils-extension/src/settingconnector.ts
+++ b/packages/apputils-extension/src/settingconnector.ts
@@ -1,8 +1,10 @@
 import { PageConfig } from '@jupyterlab/coreutils';
 
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
 import { DataConnector, IDataConnector } from '@jupyterlab/statedb';
 
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { Throttler } from '@lumino/polling';
 
 /**
  * A data connector for fetching settings.
@@ -19,8 +21,24 @@ export class SettingConnector extends DataConnector<
     this._connector = connector;
   }
 
+  /**
+   * Fetch settings for a plugin.
+   * @param id - The plugin ID
+   *
+   * #### Notes
+   * The REST API requests are throttled at one request per plugin per 100ms.
+   */
   fetch(id: string): Promise<ISettingRegistry.IPlugin | undefined> {
-    return this._connector.fetch(id);
+    const throttlers = this._throttlers;
+    if (!(id in throttlers)) {
+      throttlers[id] = new Throttler(async () => {
+        const fetched = await this._connector.fetch(id);
+        throttlers[id].dispose();
+        delete throttlers[id];
+        return fetched;
+      }, 100);
+    }
+    return throttlers[id].invoke();
   }
 
   async list(
@@ -44,4 +62,5 @@ export class SettingConnector extends DataConnector<
   }
 
   private _connector: IDataConnector<ISettingRegistry.IPlugin, string>;
+  private _throttlers: { [key: string]: Throttler } = Object.create(null);
 }

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -43,7 +43,7 @@
     "@lumino/commands": "^1.10.1",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1",
     "codemirror": "~5.49.2",

--- a/packages/csvviewer-extension/package.json
+++ b/packages/csvviewer-extension/package.json
@@ -41,7 +41,7 @@
     "@jupyterlab/docregistry": "^2.0.2",
     "@jupyterlab/documentsearch": "^2.0.2",
     "@jupyterlab/mainmenu": "^2.0.2",
-    "@lumino/datagrid": "^0.5.3",
+    "@lumino/datagrid": "^0.6.0",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1"
   },

--- a/packages/csvviewer/package.json
+++ b/packages/csvviewer/package.json
@@ -40,7 +40,7 @@
     "@jupyterlab/docregistry": "^2.0.2",
     "@lumino/algorithm": "^1.2.3",
     "@lumino/coreutils": "^1.4.2",
-    "@lumino/datagrid": "^0.5.3",
+    "@lumino/datagrid": "^0.6.0",
     "@lumino/disposable": "^1.3.5",
     "@lumino/messaging": "^1.3.3",
     "@lumino/signaling": "^1.3.5",

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -48,7 +48,6 @@
     "@lumino/algorithm": "^1.2.3",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
-    "@lumino/polling": "^1.1.1",
     "@lumino/widgets": "^1.11.1"
   },
   "devDependencies": {

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -48,6 +48,7 @@
     "@lumino/algorithm": "^1.2.3",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
+    "@lumino/polling": "^1.0.4",
     "@lumino/widgets": "^1.11.1"
   },
   "devDependencies": {

--- a/packages/docmanager-extension/package.json
+++ b/packages/docmanager-extension/package.json
@@ -48,7 +48,7 @@
     "@lumino/algorithm": "^1.2.3",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/widgets": "^1.11.1"
   },
   "devDependencies": {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -44,8 +44,6 @@ import { IDisposable } from '@lumino/disposable';
 
 import { Widget } from '@lumino/widgets';
 
-import { Throttler } from '@lumino/polling';
-
 /**
  * The command IDs used by the document manager plugin.
  */
@@ -244,18 +242,9 @@ ${fileTypes}`;
       }
     });
 
-    // callback to registry change that ensures not to invoke reload method when there is already a promise that is pending
-    let reloadSettingsRegistry = () => {
-      let reloadThrottle = new Throttler(() =>
-        settingRegistry.reload(pluginId)
-      );
-
-      return reloadThrottle.invoke.bind(reloadThrottle);
-    };
-
     // If the document registry gains or loses a factory or file type,
     // regenerate the settings description with the available options.
-    registry.changed.connect(reloadSettingsRegistry());
+    registry.changed.connect(() => settingRegistry.reload(pluginId));
 
     return docManager;
   }

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -44,6 +44,8 @@ import { IDisposable } from '@lumino/disposable';
 
 import { Widget } from '@lumino/widgets';
 
+import { Throttler } from '@lumino/polling';
+
 /**
  * The command IDs used by the document manager plugin.
  */
@@ -244,15 +246,11 @@ ${fileTypes}`;
 
     // callback to registry change that ensures not to invoke reload method when there is already a promise that is pending
     let reloadSettingsRegistry = () => {
-      let promisePending = false;
+      let reloadThrottle = new Throttler(() =>
+        settingRegistry.reload(pluginId)
+      );
 
-      return async () => {
-        if (!promisePending) {
-          promisePending = true;
-          await settingRegistry.reload(pluginId);
-          promisePending = false;
-        }
-      };
+      return reloadThrottle.invoke.bind(reloadThrottle);
     };
 
     // If the document registry gains or loses a factory or file type,

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -42,7 +42,7 @@
     "@lumino/algorithm": "^1.2.3",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1",
     "codemirror": "~5.49.2",

--- a/packages/extensionmanager/package.json
+++ b/packages/extensionmanager/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/services": "^5.0.2",
     "@jupyterlab/ui-components": "^2.0.2",
     "@lumino/messaging": "^1.3.3",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "react": "~16.9.0",
     "react-paginate": "^6.3.2",
     "semver": "^6.3.0"

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -49,7 +49,7 @@
     "@lumino/domutils": "^1.1.7",
     "@lumino/dragdrop": "^1.5.1",
     "@lumino/messaging": "^1.3.3",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1",
     "react": "~16.9.0"

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -43,7 +43,7 @@
     "@jupyterlab/statedb": "^2.0.1",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1"
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -49,7 +49,7 @@
     "@lumino/algorithm": "^1.2.3",
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
     "node-fetch": "^2.6.0",
     "ws": "^7.2.0"

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -40,7 +40,7 @@
     "@lumino/coreutils": "^1.4.2",
     "@lumino/disposable": "^1.3.5",
     "@lumino/messaging": "^1.3.3",
-    "@lumino/polling": "^1.0.4",
+    "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1",
     "csstype": "~2.6.9",

--- a/tests/test-csvviewer/package.json
+++ b/tests/test-csvviewer/package.json
@@ -22,7 +22,7 @@
     "@jupyterlab/services": "^5.0.2",
     "@jupyterlab/testutils": "^2.0.2",
     "@lumino/coreutils": "^1.4.2",
-    "@lumino/datagrid": "^0.5.3",
+    "@lumino/datagrid": "^0.6.0",
     "@lumino/widgets": "^1.11.1",
     "chai": "^4.2.0",
     "csv-spectrum": "~1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,10 +2000,10 @@
   resolved "https://registry.yarnpkg.com/@lumino/coreutils/-/coreutils-1.4.2.tgz#44cd3d55bb692e876c792f1ecc0df3daa1de63e9"
   integrity sha512-SmQ4YDANe25rZd0bLoW7LVAHmgySjkrJmyNPnPW0GrpBt2u4/6D+EQJ8PCCMNWuJvrljBCdlmgOFsT38qYhfcw==
 
-"@lumino/datagrid@^0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@lumino/datagrid/-/datagrid-0.5.3.tgz#62ac692a199e033d811cc2229fa979b01c058889"
-  integrity sha512-5W86WnbZKrX/P+WkXMPRkToM0yISjmKu2ewJ2CtyKw+OsGsBcgshM147k4wxDskAtIv/+wsgdth7sIdzx6OW+A==
+"@lumino/datagrid@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@lumino/datagrid/-/datagrid-0.6.0.tgz#8272fe4cf8bb27f3ec9cc8fee279329c35695d19"
+  integrity sha512-TkpCm4AbCAVwGg3pC5618YnjfHSyzhWxRaM1FQ7RKWS+mZoKhMWVbN0I2o2OLpdaBjvf7sV9JUp08rsouHRqOQ==
   dependencies:
     "@lumino/algorithm" "^1.2.3"
     "@lumino/coreutils" "^1.4.2"
@@ -2049,10 +2049,10 @@
     "@lumino/algorithm" "^1.2.3"
     "@lumino/collections" "^1.2.3"
 
-"@lumino/polling@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@lumino/polling/-/polling-1.0.4.tgz#85f956933fa63c47edf808c141cdb9a7a1a49f4c"
-  integrity sha512-9OYIDTohToj6SLrxOr+FbeyPvirBU/r53FgmPxulcDgUVnVk4tqTSLIJAUu3mjJd9hnmZZqpSn9ppyjQAo3qSg==
+"@lumino/polling@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@lumino/polling/-/polling-1.1.1.tgz#15dcb848dca26573d416f00493e343bc43d79d01"
+  integrity sha512-4ofwz9zOkh3GtTTPKfX9KmsZD66g8M0BG/lLji86GRCQvQDGJaI35c0qD62jMzacfsVxbCBfp89/sbXGDoRIZA==
   dependencies:
     "@lumino/coreutils" "^1.4.2"
     "@lumino/disposable" "^1.3.5"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->
Refactor PR #7879 to use throttler

## References
#7879 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Refactor of older PR #7879, to make use of Throttler in this use case as it solves the purpose of executing the callback only once even though invoked multiple times and making the code more cleaner.

Code change depends on jupyterlab/lumino#54 @afshin 
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
NO
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
