### PR TITLE
Add package data to setup call.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ setup_args['extras_require'] = {
 }
 
 
+setup_args['package_data'] = package_data_spec
 setup_args['include_package_data'] = True
 setup_args['python_requires'] = '>=3.5'
 


### PR DESCRIPTION
## Code changes

Adds `package_data` key to the arguments passed into the `setup(..)` call in `setup.py`.

We should probably back-port this to the 1.2.x branch if possible.

## User-facing changes

N/A

## Backwards-incompatible changes

N/A