### PR TITLE
Fix migration note about kernel.info

### DIFF
--- a/docs/source/developer/extension_migration.rst
+++ b/docs/source/developer/extension_migration.rst
@@ -162,12 +162,12 @@ For example, consider how the ``@jupyterlab/debugger`` extension's
 
 .. note::
 
-  One notable change: ``await client.kernel.ready`` is no longer necessary.
-  Using the new API (and
-  `optional chaining in TypeScript 3.7+ <https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining>`__), you can simply:
-  ``await sessionContext.session?.kernel?.info`` to check when a kernel is
-  ready and retrieve its details. --
-  `jupyterlab/debugger#337 <https://github.com/jupyterlab/debugger/pull/337>`__
+  ``await kernel.ready`` is no longer necessary before the kernel connection
+  ``kernel`` can be used. Kernel messages will be buffered as needed while a
+  kernel connection is coming online, so you should be able to use a kernel
+  connection immediately. If you want to retrieve the kernel info (or if for
+  some other reason you want to wait until at least one message has returned
+  from a new kernel connection), you can do ``await kernel.info``.
 
 Using the new icon system and ``LabIcon``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## References


## Code changes

None

## User-facing changes

Corrected a note in the extension migration guide about `kernel.info`.

## Backwards-incompatible changes

None
