### PR TITLE
avoid clobbering palette icon stylesheet

### DIFF
--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -29,7 +29,6 @@ export class Palette implements ICommandPalette {
    */
   constructor(palette: CommandPalette) {
     this._palette = palette;
-    this._palette.title.icon = paletteIcon;
     this._palette.title.label = '';
     this._palette.title.caption = 'Command Palette';
   }


### PR DESCRIPTION
cf #7931, which got merged 5 minutes before I pushed a final commit with a final icon fix:

avoid clobbering palette icon stylesheet by only setting Palette.title.icon once


## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
