### PR TITLE
add command and context menu item for opening markdown editor

### DIFF
--- a/packages/markdownviewer-extension/package.json
+++ b/packages/markdownviewer-extension/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@jupyterlab/application": "^2.0.2",
     "@jupyterlab/apputils": "^2.0.2",
+    "@jupyterlab/coreutils": "^4.0.2",
     "@jupyterlab/markdownviewer": "^2.0.2",
     "@jupyterlab/rendermime": "^2.0.2",
     "@jupyterlab/settingregistry": "^2.0.1"

--- a/packages/markdownviewer-extension/src/index.ts
+++ b/packages/markdownviewer-extension/src/index.ts
@@ -23,11 +23,14 @@ import {
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
+import { PathExt } from '@jupyterlab/coreutils';
+
 /**
  * The command IDs used by the markdownviewer plugin.
  */
 namespace CommandIDs {
   export const markdownPreview = 'markdownviewer:open';
+  export const markdownEditor = 'markdownviewer:edit';
 }
 
 /**
@@ -140,6 +143,35 @@ function activate(
         options: args['options']
       });
     }
+  });
+
+  commands.addCommand(CommandIDs.markdownEditor, {
+    execute: () => {
+      let widget = tracker.currentWidget;
+      if (!widget) {
+        return;
+      }
+      let path = widget.context.path;
+      return commands.execute('docmanager:open', {
+        path,
+        factory: 'Editor',
+        options: {
+          mode: 'split-right'
+        }
+      });
+    },
+    isVisible: () => {
+      let widget = tracker.currentWidget;
+      return (
+        (widget && PathExt.extname(widget.context.path) === '.md') || false
+      );
+    },
+    label: 'Show Markdown Editor'
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.markdownEditor,
+    selector: '.jp-RenderedMarkdown'
   });
 
   return tracker;

--- a/packages/markdownviewer-extension/tsconfig.json
+++ b/packages/markdownviewer-extension/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../apputils"
     },
     {
+      "path": "../coreutils"
+    },
+    {
       "path": "../markdownviewer"
     },
     {


### PR DESCRIPTION
## References

Addresses #7738. 

## Code changes

Adds a command to show markdown editor when previewing a markdown file. Adds this to the context menu for previewed markdown files.

## User-facing changes

Option to open a markdown file in the editor now appears in the context menu for previewed md files. Previously, there was an option to open the preview from the editor, but not vice versa.

## Backwards-incompatible changes

None
