### PR TITLE
Increase timeout for binder launch

### DIFF
--- a/binder/jupyter_notebook_config.py
+++ b/binder/jupyter_notebook_config.py
@@ -20,7 +20,7 @@ c.ServerProxy.servers = {
             # Redirect all logs to a log file
             f'{lab_command} >jupyterlab-dev.log 2>&1'
         ],
-        'timeout': 20,
+        'timeout': 60,
         'absolute_url': True
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
When launching a binder for a JupyterLab PR, it occasionally times out loading the `lab-dev` URL.  The current workaround is to refresh the page.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Increases timeout for application launch on binder.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
