### PR TITLE
Add a script to push docs to gh-pages

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -146,6 +146,7 @@ Now do the actual final release:
 - [ ] Push the commit and tags to master
 - [ ] Run `npm run publish:all` to publish the packages
 - [ ] Create a branch for the release and push to GitHub
+- [ ] Update the API [docs](#updating-api-docs)
 - [ ] Merge the PRs on the other repos and set the default branch of the
       xckd repo
 - [ ] Publish to [conda-forge](https://github.com/jupyterlab/jupyterlab/blob/master/RELEASE.md#publishing-to-conda-forge).
@@ -251,6 +252,10 @@ shasum -a 256 dist/*.tar.gz
 - Fork https://github.com/conda-forge/jupyterlab-feedstock
 - Create a PR with the version bump
 - Update `recipe/meta.yaml` with the new version and md5 and reset the build number to 0.
+
+## Updating API Docs
+
+Run `source scripts/docs_push.sh` to update the `gh-pages` branch that backs http://jupyterlab.github.io/jupyterlab/.
 
 ## Making a patch release
 

--- a/scripts/docs_push.sh
+++ b/scripts/docs_push.sh
@@ -1,0 +1,14 @@
+
+#!/bin/bash
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+jlpm
+jlpm build:packages
+jlpm docs
+cd docs/api
+git init
+touch .nojekyll  # disable jekyll
+git add .
+git commit -m "Deploy to GitHub Pages"
+git push --force "https://github.com/jupyterlab/jupyterlab" master:gh-pages


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This was a missing step in our release process.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Adds instructions and a script to update API docs.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users see current API docs.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
