### PR TITLE
Handle ToolbarButtonComponent without an icon

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -495,16 +495,18 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
       title={props.tooltip || props.iconLabel}
       minimal
     >
-      <LabIcon.resolveReact
-        icon={props.icon}
-        iconClass={
-          // add some extra classes for proper support of icons-as-css-backgorund
-          classes(props.iconClass, 'jp-Icon')
-        }
-        className="jp-ToolbarButtonComponent-icon"
-        tag="span"
-        stylesheet="toolbarButton"
-      />
+      {(props.icon || props.iconClass) && (
+        <LabIcon.resolveReact
+          icon={props.icon}
+          iconClass={
+            // add some extra classes for proper support of icons-as-css-backgorund
+            classes(props.iconClass, 'jp-Icon')
+          }
+          className="jp-ToolbarButtonComponent-icon"
+          tag="span"
+          stylesheet="toolbarButton"
+        />
+      )}
       {props.label && (
         <span className="jp-ToolbarButtonComponent-label">{props.label}</span>
       )}


### PR DESCRIPTION
## References

Fixes #7960

## Code changes

Similar to the label, the icon node is not added to the DOM if it is not specified.

## User-facing changes

Visible when hovering on the kernel selection component (or with extra buttons around the kernel selection button in the toolbar).

### Before

![image](https://user-images.githubusercontent.com/591645/75688639-21370c80-5ca0-11ea-9168-9c1ee7845865.png)

### After

![image](https://user-images.githubusercontent.com/591645/75689046-d5d12e00-5ca0-11ea-98f4-c51c9b54c4ff.png)

## Backwards-incompatible changes

None.