### PR TITLE
Fix status bar item styling

### DIFF
--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -43,6 +43,7 @@
     "@lumino/polling": "^1.0.4",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1",
+    "csstype": "~2.6.9",
     "react": "~16.9.0",
     "typestyle": "^2.0.4"
   },

--- a/packages/statusbar/src/style/statusbar.ts
+++ b/packages/statusbar/src/style/statusbar.ts
@@ -50,7 +50,10 @@ export const item = style(
     maxHeight: vars.height,
     marginLeft: vars.itemMargin,
     marginRight: vars.itemMargin,
-    height: vars.height
+    height: vars.height,
+    whiteSpace: vars.whiteSpace,
+    textOverflow: vars.textOverflow,
+    color: vars.textColor
   },
   itemPadding
 );

--- a/packages/statusbar/src/style/variables.ts
+++ b/packages/statusbar/src/style/variables.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
+import { WhiteSpaceProperty } from 'csstype';
 
 export default {
   hoverColor: 'var(--jp-layout-color3)',
@@ -13,5 +14,7 @@ export default {
   itemMargin: '2px',
   itemPadding: '6px',
   statusBarPadding: '10px',
-  interItemHalfSpacing: '2px' // this amount accounts for half the spacing between items
+  interItemHalfSpacing: '2px', // this amount accounts for half the spacing between items
+  whiteSpace: 'nowrap' as WhiteSpaceProperty,
+  textOverflow: 'ellipsis'
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5720,6 +5720,11 @@ csstype@^2.2.0, csstype@^2.4.0, csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
   integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
 
+csstype@~2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
+  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+
 csv-spectrum@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/csv-spectrum/-/csv-spectrum-1.0.0.tgz#591ac9ff48ad4f3eb4338457bc9801b349e3d628"


### PR DESCRIPTION
## References

This fixes issue: #7963 

## Code changes

The change affects the style that is applied to all `TextItem`s registered through `registerStatusItem`.

## User-facing changes

Before:
<img width="515" alt="Screen Shot 2020-03-02 at 2 18 19 PM" src="https://user-images.githubusercontent.com/2256598/75723984-4290fc00-5c92-11ea-8897-a07f3c6949e0.png">

After:
<img width="514" alt="Screen Shot 2020-03-02 at 2 17 45 PM" src="https://user-images.githubusercontent.com/2256598/75723986-43299280-5c92-11ea-8b21-b196ae403d2d.png">
