### PR TITLE
Make deduplication commands fail on duplicates

### DIFF
--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -58,7 +58,7 @@ const notice =
 // Create a new yarn.lock file to ensure it is correct.
 utils.run('jlpm', { cwd: staging });
 try {
-  utils.run('jlpm yarn-deduplicate -s fewer', { cwd: staging });
+  utils.run('jlpm yarn-deduplicate -s fewer --fail', { cwd: staging });
 } catch {
   // re-run install if we deduped packages!
   utils.run('jlpm', { cwd: staging });

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -174,7 +174,7 @@ def dedupe_yarn(path, logger=None):
         pins above, for example, known-bad versions
     """
     had_dupes = ProgressProcess(
-        ['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer'],
+        ['node', YARN_PATH, 'yarn-deduplicate', '-s', 'fewer', '--fail'],
         cwd=path, logger=logger
     ).wait() != 0
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "create:package": "node buildutils/lib/create-package.js",
     "create:test": "node buildutils/lib/create-test-package.js",
     "create:theme": "node buildutils/lib/create-theme.js",
-    "deduplicate": "jlpm yarn-deduplicate -s fewer",
+    "deduplicate": "jlpm yarn-deduplicate -s fewer --fail",
     "docs": "lerna run docs",
     "eslint": "eslint --fix .",
     "eslint:check": "eslint .",


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes the issue brought up on gitter at https://gitter.im/jupyter-widgets/Lobby?at=5e5e81c8b873303e2778b0a9

I think this should be backported to 1.2.x and released in a new 1.2.7.

## Code changes

Many places in the code, we assume that the deduplication returns an error code if there were duplicates, but yarn-deduplicate only returns an error code on duplicates if the --fail option was given. Here we give that option everywhere we deduplicate.

This came up when installing a custom widget which supports both JLab 1 and JLab 2, which needs the deduplication strategy to work. An initial installation will not work since yarn was not run after the deduplication. With this change, yarn is run after the deduplication when there were packages deduplicated, and the extension installs correctly.

## User-facing changes

`jlpm run deduplicate` now exits with an error code when there were duplicates, like we assumed elsewhere in the package.json.

## Backwards-incompatible changes

