### PR TITLE
Make sure we can install the celltags extension on 1.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,3 +89,9 @@ jobs:
           testResultsFiles: '$(testResultsFiles)'
           testRunTitle: 'Windows - $(name)'
           mergeTestResults: true
+
+trigger:
+  branches:
+    include:
+    - master
+    - 1.x

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1169,7 +1169,7 @@ class _AppHandler(object):
             json.dump(data, fid, indent=4)
 
         # copy known-good yarn.lock if missing
-        lock_path = pjoin(staging, 'yarn.lock')        
+        lock_path = pjoin(staging, 'yarn.lock')
         lock_template = pjoin(HERE, 'staging', 'yarn.lock')
         if self.registry != YARN_DEFAULT_REGISTRY:  # Replace on the fly the yarn repository see #3658
             with open(lock_template, encoding='utf-8') as f:
@@ -1509,7 +1509,7 @@ class _AppHandler(object):
 
         # Verify that the package is an extension.
         messages = _validate_extension(data)
-        if messages:
+        if messages and data['name'] != '@jupyterlab/celltags':
             msg = '"%s" is not a valid extension:\n%s'
             raise ValueError(msg % (extension, '\n'.join(messages)))
 
@@ -1763,7 +1763,7 @@ def _node_check(logger):
 
 def _yarn_config(logger):
     """Get the yarn configuration.
-    
+
     Returns
     -------
     {"yarn config": dict, "npm config": dict} if unsuccessfull the subdictionary are empty

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -228,4 +228,7 @@ if [[ $GROUP == usage ]]; then
     sleep 5
     kill $TASK_PID
     wait $TASK_PID
+
+    # Make sure we can install the old celltags extension
+    jupyter labextension install --no-build @jupyterlab/celltags
 fi


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7969
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Allows celltags to be installed in 1.2.  The package used to be an extension but is now a core JupyterLab library, so we special-case its install.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users can now install celltags in JupyterLab 1.2 without using a pinned version.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
