### PR TITLE
We do not need universal wheels now that we do not support python 2.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [metadata]
 license_file = LICENSE
 
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 testpaths=jupyterlab/tests
 norecursedirs=node_modules .git _build


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

See the docs at https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels

## Code changes

Remove the universal wheel configuration.

## User-facing changes



## Backwards-incompatible changes


