### PR TITLE
Better handling of fallback versions for an extension

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1499,11 +1499,25 @@ class _AppHandler(object):
         info = self._extract_package(extension, tempdir, pin=pin)
         data = info['data']
 
+        # Check for compatible version unless:
+        # - A specific version was requested (@ in name,
+        #   but after first char to allow for scope marker).
+        # - Package is locally installed.
+        allow_fallback = '@' not in extension[1:] and not info['is_dir']
+        name = info['name']
+
         # Verify that the package is an extension.
         messages = _validate_extension(data)
         if messages:
             msg = '"%s" is not a valid extension:\n%s'
-            raise ValueError(msg % (extension, '\n'.join(messages)))
+            msg = msg % (extension, '\n'.join(messages))
+            if allow_fallback:
+                try:
+                    version = self._latest_compatible_package_version(name)
+                except URLError:
+                    raise ValueError(msg)
+            else:
+                raise ValueError(msg)
 
         # Verify package compatibility.
         deps = data.get('dependencies', dict())
@@ -1512,12 +1526,7 @@ class _AppHandler(object):
             msg = _format_compatibility_errors(
                 data['name'], data['version'], errors
             )
-            # Check for compatible version unless:
-            # - A specific version was requested (@ in name,
-            #   but after first char to allow for scope marker).
-            # - Package is locally installed.
-            if '@' not in extension[1:] and not info['is_dir']:
-                name = info['name']
+            if allow_fallback:
                 try:
                     version = self._latest_compatible_package_version(name)
                 except URLError:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7969
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Updates the fallback behavior of installing an extension to handle a current version that is not a valid extension.

Manual testing: made the changes in-place in JupyterLab 1.2.6 conda environment and ran `jupyter labextension install @jupyterlab/celltags --no-build`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users can install `@jupyterlab/celltags` with JupyterLab 1.x.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
