### PR TITLE
Use the same TextRenderer for all regions in CSV data grid

### DIFF
--- a/packages/csvviewer-extension/src/index.ts
+++ b/packages/csvviewer-extension/src/index.ts
@@ -271,6 +271,7 @@ namespace Private {
    * The dark theme for the data grid.
    */
   export const DARK_STYLE: DataGrid.Style = {
+    ...DataGrid.defaultStyle,
     voidColor: 'black',
     backgroundColor: '#111111',
     headerBackgroundColor: '#424242',

--- a/packages/csvviewer/src/widget.ts
+++ b/packages/csvviewer/src/widget.ts
@@ -386,14 +386,18 @@ export class CSVViewer extends Widget {
       return;
     }
     const rendererConfig = this._baseRenderer;
+    const renderer = new TextRenderer({
+      textColor: rendererConfig.textColor,
+      horizontalAlignment: rendererConfig.horizontalAlignment,
+      backgroundColor: this._searchService.cellBackgroundColorRendererFunc(
+        rendererConfig
+      )
+    });
     this._grid.cellRenderers.update({
-      body: new TextRenderer({
-        textColor: rendererConfig.textColor,
-        horizontalAlignment: rendererConfig.horizontalAlignment,
-        backgroundColor: this._searchService.cellBackgroundColorRendererFunc(
-          rendererConfig
-        )
-      })
+      body: renderer,
+      'column-header': renderer,
+      'corner-header': renderer,
+      'row-header': renderer
     });
   }
 


### PR DESCRIPTION
## References

Fixes #7984.

## Code changes

Use the same TextRenderer for all regions (`body`, `row-header`, `column-header`, `corner-header`) in the CSV data grid.

It appears that previously the data grid was using a default cell renderer that would be used for the entire grid.

## User-facing changes

### Before


![image](https://user-images.githubusercontent.com/591645/75817889-3ee79d00-5d98-11ea-8a25-44fad8d9841e.png)

### After

![image](https://user-images.githubusercontent.com/591645/75857718-edbac600-5df6-11ea-9694-b2885cdb73e2.png)
 
## Backwards-incompatible changes

None