### PR TITLE
Update checkout tag to v2.0 in extension tutorial

### DIFF
--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -102,7 +102,7 @@ This will create a new folder for your extension in your current directory.
 
 .. code:: bash
 
-    cookiecutter https://github.com/jupyterlab/extension-cookiecutter-ts --checkout v2.0beta
+    cookiecutter https://github.com/jupyterlab/extension-cookiecutter-ts --checkout v2.0
 
 When prompted, enter values like the following for all of the cookiecutter
 prompts (``apod`` stands for Astronomy Picture of the Day, the NASA service we


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Relevant [Issue](https://github.com/jupyterlab/jupyterlab/issues/7990).

## Code changes
A minor update to the checkout tag in the `cookiecutter` invocation in the extension tutorial -- from `v2.0beta` to `v2.0`.

This resolves the issue version incompatibility described in the issue linked above.

## User-facing changes

Not relevant.

## Backwards-incompatible changes

None.
