### PR TITLE
URL resolver should use the session context path

### DIFF
--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -321,11 +321,7 @@ export namespace RenderMimeRegistry {
      */
     resolveUrl(url: string): Promise<string> {
       if (this.isLocal(url)) {
-        const sc = Private.sessionConnection(this._session);
-        if (!sc) {
-          throw new Error('Cannot resolve local url with no session');
-        }
-        const cwd = encodeURI(PathExt.dirname(sc.path));
+        const cwd = encodeURI(PathExt.dirname(this._session.path));
         url = PathExt.resolve(cwd, url);
       }
       return Promise.resolve(url);

--- a/tests/test-rendermime/src/registry.spec.ts
+++ b/tests/test-rendermime/src/registry.spec.ts
@@ -13,6 +13,8 @@ import { PageConfig } from '@jupyterlab/coreutils';
 
 import { Widget } from '@lumino/widgets';
 
+import { SessionContext } from '@jupyterlab/apputils';
+
 import { MathJaxTypesetter } from '@jupyterlab/mathjax2';
 
 import {
@@ -310,6 +312,7 @@ describe('rendermime/registry', () => {
     });
 
     describe('.UrlResolver', () => {
+      let manager: ServiceManager;
       let resolver: RenderMimeRegistry.UrlResolver;
       let contents: Contents.IManager;
       let session: Session.ISessionConnection;
@@ -317,7 +320,7 @@ describe('rendermime/registry', () => {
       const urlParent = encodeURI(pathParent);
 
       before(async () => {
-        const manager = new ServiceManager({ standby: 'never' });
+        manager = new ServiceManager({ standby: 'never' });
         const drive = new Drive({ name: 'extra' });
         const path = pathParent + '/pr%25 ' + UUID.uuid4();
         contents = manager.contents;
@@ -346,6 +349,20 @@ describe('rendermime/registry', () => {
 
       context('#resolveUrl()', () => {
         it('should resolve a relative url', async () => {
+          const path = await resolver.resolveUrl('./foo');
+          expect(path).to.equal(urlParent + '/foo');
+        });
+
+        it('should resolve a relative url with no active session', async () => {
+          const resolver = new RenderMimeRegistry.UrlResolver({
+            session: new SessionContext({
+              sessionManager: manager.sessions,
+              specsManager: manager.kernelspecs,
+              path: pathParent + '/pr%25 ' + UUID.uuid4(),
+              kernelPreference: { canStart: false, shouldStart: false }
+            }),
+            contents: manager.contents
+          });
           const path = await resolver.resolveUrl('./foo');
           expect(path).to.equal(urlParent + '/foo');
         });


### PR DESCRIPTION



<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7962
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

URL resolver should use the session context path so it works even when there is no active session connection.

This still has issues with files being renamed, which will be fixed in a follow-up PR.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
