### PR TITLE
Add a default filetype icon; deprecate LabIcon.resolveX fallback arg

### DIFF
--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -288,7 +288,9 @@ export class DocumentRegistry implements IDisposable {
   addFileType(fileType: Partial<DocumentRegistry.IFileType>): IDisposable {
     let value: DocumentRegistry.IFileType = {
       ...DocumentRegistry.fileTypeDefaults,
-      ...fileType
+      ...fileType,
+      // fall back to fileIcon if needed
+      ...(!(fileType.icon || fileType.iconClass) && { icon: fileIcon })
     };
     this._fileTypes.push(value);
 

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -24,7 +24,6 @@ import {
   caretDownIcon,
   caretUpIcon,
   classes,
-  fileIcon,
   LabIcon
 } from '@jupyterlab/ui-components';
 
@@ -1828,20 +1827,20 @@ export namespace DirListing {
     updateItemNode(
       node: HTMLElement,
       model: Contents.IModel,
-      fileType?: DocumentRegistry.IFileType
+      fileType: DocumentRegistry.IFileType = DocumentRegistry.defaultTextFileType
     ): void {
+      const { icon, iconClass } = fileType;
+
       const iconContainer = DOMUtils.findElement(node, ITEM_ICON_CLASS);
       const text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
       const modified = DOMUtils.findElement(node, ITEM_MODIFIED_CLASS);
 
       // render the file item's icon
       LabIcon.resolveElement({
-        icon: fileType?.icon,
-        iconClass: classes(fileType?.iconClass, 'jp-Icon'),
-        fallback: fileIcon,
+        icon,
+        iconClass: classes(iconClass, 'jp-Icon'),
         container: iconContainer,
         className: ITEM_ICON_CLASS,
-
         stylesheet: 'listing'
       });
 

--- a/packages/settingeditor/src/pluginlist.tsx
+++ b/packages/settingeditor/src/pluginlist.tsx
@@ -277,9 +277,8 @@ namespace Private {
           title={itemTitle}
         >
           <LabIcon.resolveReact
-            icon={icon}
-            iconClass={iconClass && classes(iconClass, 'jp-Icon')}
-            fallback={settingsIcon}
+            icon={icon || (iconClass ? undefined : settingsIcon)}
+            iconClass={classes(iconClass, 'jp-Icon')}
             title={iconTitle}
             tag="span"
             stylesheet="settingsEditor"

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -92,7 +92,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
    * @param iconClass - optional, if the icon arg is not set, the iconClass arg
    * should be a CSS class associated with an existing CSS background-image
    *
-   * @depreacted fallback - don't use, optional, a LabIcon instance that will
+   * @deprecated fallback - don't use, optional, a LabIcon instance that will
    * be used if neither icon nor iconClass are defined
    *
    * @param props - any additional args are passed though to the element method
@@ -134,7 +134,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
    * @param iconClass - optional, if the icon arg is not set, the iconClass arg
    * should be a CSS class associated with an existing CSS background-image
    *
-   * @depreacted fallback - don't use, optional, a LabIcon instance that will
+   * @deprecated fallback - don't use, optional, a LabIcon instance that will
    * be used if neither icon nor iconClass are defined
    *
    * @param props - any additional args are passed though to the React component

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -92,8 +92,8 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
    * @param iconClass - optional, if the icon arg is not set, the iconClass arg
    * should be a CSS class associated with an existing CSS background-image
    *
-   * @param fallback - optional, a LabIcon instance that will be used if
-   * neither icon nor iconClass are defined
+   * @depreacted fallback - don't use, optional, a LabIcon instance that will
+   * be used if neither icon nor iconClass are defined
    *
    * @param props - any additional args are passed though to the element method
    * of the resolved icon on render
@@ -134,8 +134,8 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
    * @param iconClass - optional, if the icon arg is not set, the iconClass arg
    * should be a CSS class associated with an existing CSS background-image
    *
-   * @param fallback - optional, a LabIcon instance that will be used if
-   * neither icon nor iconClass are defined
+   * @depreacted fallback - don't use, optional, a LabIcon instance that will
+   * be used if neither icon nor iconClass are defined
    *
    * @param props - any additional args are passed though to the React component
    * of the resolved icon on render


### PR DESCRIPTION
## References

fixes #7968

Adds a default filetype icon for use when none is specified. It gets added if needed when a filetype is added to the DocumentRegistry. Also deprecates the `fallback` arg for the `LabIcon.resolveElement/.resolveReact` methods. `fallback` wasn't working as expected, and had some undesired interaction with the `iconClass` arg

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
