### PR TITLE
Use path string instead of session context in url resolver

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -414,7 +414,6 @@ export class Context<T extends DocumentRegistry.IModel>
       } else {
         this.sessionContext.path = newPath;
       }
-      void this.sessionContext.session?.setPath(newPath);
       const updateModel = {
         ...this._contentsModel,
         ...changeModel

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -79,9 +79,12 @@ export class Context<T extends DocumentRegistry.IModel>
     this.sessionContext.propertyChanged.connect(this._onSessionChanged, this);
     manager.contents.fileChanged.connect(this._onFileChanged, this);
 
-    this.urlResolver = new RenderMimeRegistry.UrlResolver({
-      session: this.sessionContext,
+    const urlResolver = (this.urlResolver = new RenderMimeRegistry.UrlResolver({
+      path: this._path,
       contents: manager.contents
+    }));
+    this.pathChanged.connect((sender, newPath) => {
+      urlResolver.path = newPath;
     });
   }
 
@@ -406,6 +409,11 @@ export class Context<T extends DocumentRegistry.IModel>
         };
       }
       this._path = newPath;
+      if (this.sessionContext.session) {
+        void this.sessionContext.session.setPath(newPath);
+      } else {
+        this.sessionContext.path = newPath;
+      }
       void this.sessionContext.session?.setPath(newPath);
       const updateModel = {
         ...this._contentsModel,

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -409,11 +409,7 @@ export class Context<T extends DocumentRegistry.IModel>
         };
       }
       this._path = newPath;
-      if (this.sessionContext.session) {
-        void this.sessionContext.session.setPath(newPath);
-      } else {
-        this.sessionContext.path = newPath;
-      }
+      void this.sessionContext.session?.setPath(newPath);
       const updateModel = {
         ...this._contentsModel,
         ...changeModel

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -305,15 +305,33 @@ export namespace RenderMimeRegistry {
   }
 
   /**
-   * A default resolver that uses a session and a contents manager.
+   * A default resolver that uses a given reference path and a contents manager.
    */
   export class UrlResolver implements IRenderMime.IResolver {
     /**
-     * Create a new url resolver for a console.
+     * Create a new url resolver.
      */
     constructor(options: IUrlResolverOptions) {
-      this._session = options.session;
+      if (options.path) {
+        this._path = options.path;
+      } else if (options.session) {
+        this._session = options.session;
+      } else {
+        throw new Error(
+          "Either 'path' or 'session' must be given as a constructor option"
+        );
+      }
       this._contents = options.contents;
+    }
+
+    /**
+     * The path of the object, from which local urls can be derived.
+     */
+    get path(): string {
+      return this._path ?? this._session.path;
+    }
+    set path(value: string) {
+      this._path = value;
     }
 
     /**
@@ -321,7 +339,7 @@ export namespace RenderMimeRegistry {
      */
     resolveUrl(url: string): Promise<string> {
       if (this.isLocal(url)) {
-        const cwd = encodeURI(PathExt.dirname(this._session.path));
+        const cwd = encodeURI(PathExt.dirname(this.path));
         url = PathExt.resolve(cwd, url);
       }
       return Promise.resolve(url);
@@ -356,6 +374,7 @@ export namespace RenderMimeRegistry {
       return URLExt.isLocal(url) || !!this._contents.driveName(path);
     }
 
+    private _path: string;
     private _session: ISessionContext | Session.ISessionConnection;
     private _contents: Contents.IManager;
   }
@@ -365,12 +384,25 @@ export namespace RenderMimeRegistry {
    */
   export interface IUrlResolverOptions {
     /**
-     * The session used by the resolver.
+     * The path providing context for local urls.
      *
      * #### Notes
-     * For convenience, this can be a session context as well.
+     * Either session or path must be given, and path takes precedence.
      */
-    session: ISessionContext | Session.ISessionConnection;
+    path?: string;
+
+    /**
+     * The session used by the resolver.
+     *
+     * @deprecated use the `path` option instead and update it as needed.
+     *
+     * #### Notes
+     * For convenience, this can be a session context as well. Either session
+     * or path must be given, and path takes precedence.
+     *
+     * TODO: remove this option and make `path` required.
+     */
+    session?: ISessionContext | Session.ISessionConnection;
 
     /**
      * The contents manager used by the resolver.

--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -337,12 +337,12 @@ export namespace RenderMimeRegistry {
     /**
      * Resolve a relative url to an absolute url path.
      */
-    resolveUrl(url: string): Promise<string> {
+    async resolveUrl(url: string): Promise<string> {
       if (this.isLocal(url)) {
         const cwd = encodeURI(PathExt.dirname(this.path));
         url = PathExt.resolve(cwd, url);
       }
-      return Promise.resolve(url);
+      return url;
     }
 
     /**
@@ -351,12 +351,12 @@ export namespace RenderMimeRegistry {
      * #### Notes
      * This URL may include a query parameter.
      */
-    getDownloadUrl(url: string): Promise<string> {
+    async getDownloadUrl(url: string): Promise<string> {
       if (this.isLocal(url)) {
         // decode url->path before passing to contents api
         return this._contents.getDownloadUrl(decodeURI(url));
       }
-      return Promise.resolve(url);
+      return url;
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is a broader fix than #7997 to problems with the url resolver.

## Code changes

The URL resolver right now depends on a session context, but really all it needs is the path. I think it actually doesn't really make sense to depend on the session context, since really it is about the document path, not a server session.

Also, there is no way right now to update the path in a session context when it has no active session connection. This should be possible, since you might want to rename lots of different files that have no active kernel session.

- [ ] Add tests

## User-facing changes

Right now, if you create a local link in a markdown file, then move the file to a different directory (or even if you just rename the file, I think), the url resolver (which relies on the session path) has the old session path and resolves relative URLs incorrectly. These changes should fix this behavior.

This does not automatically rerender already-rendered outputs. To do that, perhaps we can add a signal on the urlresolver signaling that something changed, and the rendermime registry can use that to signal that outputs may need to be rerendered, and then a notebook (for example) can rerender all outputs. That would take care of rerendering things automatically when a file was moved. Or a notebook and other things could just rerender everything by default on file move. Either way, I think these additional changes could be in another ticket.


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
