### PR TITLE
Make patch releases increment the version all the way to final release

### DIFF
--- a/buildutils/src/patch-release.ts
+++ b/buildutils/src/patch-release.ts
@@ -54,7 +54,8 @@ commander
 
     // Patch the python version
     utils.run('bumpversion patch'); // switches to alpha
-    utils.run('bumpversion release --allow-dirty'); // switches to rc
+    utils.run('bumpversion release --allow-dirty'); // switches to beta
+    utils.run('bumpversion release --allow-dirty'); // switches to rc.
     utils.run('bumpversion release --allow-dirty'); // switches to final.
 
     // Run post-bump actions.


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

We recently introduced beta versions, but I think forgot to account for them in doing patch releases.

This should make the `jlpm patch:release` command work again. For 2.0.1, it just incremented the python version to 2.0.1rc0 instead of 2.0.1 (final).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
