### PR TITLE
Session context changes

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -313,6 +313,13 @@ export class SessionContext implements ISessionContext {
   get path(): string {
     return this._path;
   }
+  set path(value: string) {
+    this._path = value;
+
+    if (this._session) {
+      void this._session.setPath(value);
+    }
+  }
 
   /**
    * The session type.
@@ -324,6 +331,13 @@ export class SessionContext implements ISessionContext {
   get type(): string {
     return this._type;
   }
+  set type(value: string) {
+    this._type = value;
+
+    if (this._session) {
+      void this._session.setType(value);
+    }
+  }
 
   /**
    * The session name.
@@ -334,6 +348,13 @@ export class SessionContext implements ISessionContext {
    */
   get name(): string {
     return this._name;
+  }
+  set name(value: string) {
+    this._name = value;
+
+    if (this._session) {
+      void this._session.setName(value);
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References


## Code changes

Right now, if a session context does not have an active session connection, you cannot change, for example, the path or other information. This might happen with, for example, a markdown file that is moved or renamed. This PR starts allowing these sorts of updates.

- [ ] Actually use this set when moving a file.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
