### PR TITLE
fix typo (repeated letter)

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -526,7 +526,7 @@ JupyterLab Workspaces Directory
 JupyterLab sessions always reside in a workspace. Workspaces contain the state
 of JupyterLab: the files that are currently open, the layout of the application
 areas and tabs, etc. When the page is refreshed, the workspace is restored.
-By default, the location is ``~/.jupyter/lab/workspacess/``, where ``~`` is the user's home directory. This folder is not in the JupyterLab application directory,
+By default, the location is ``~/.jupyter/lab/workspaces/``, where ``~`` is the user's home directory. This folder is not in the JupyterLab application directory,
 because these files are typically shared across Python environments.
 The location can be modified using the ``JUPYTERLAB_WORKSPACES_DIR`` environment variable. These files can be imported and exported to create default "profiles",
 using the :ref:`workspace command line tool <url-workspaces-cli>`.


### PR DESCRIPTION
line 529: change "workspacess" to "workspaces"

## References
This is just some basic documentation maintenance, so I didn't create an issue for it. This seemed reasonable based on the contribution guidelines because it is such a small change that only affects the docs rather than Jupyter itself.
 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Deleted a (single) extra letter 's' from the default path given in the documentation (line 529).

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Fixes a typo in the documentation

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
Pretty sure this is fully backwards compatible.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
