### PR TITLE
Remove unused ILabShell dependency from the notebook tools

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  ILabShell,
   ILayoutRestorer,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -308,7 +307,7 @@ const tools: JupyterFrontEndPlugin<INotebookTools> = {
   id: '@jupyterlab/notebook-extension:tools',
   autoStart: true,
   requires: [INotebookTracker, IEditorServices, IStateDB],
-  optional: [ILabShell, IPropertyInspectorProvider]
+  optional: [IPropertyInspectorProvider]
 };
 
 /**
@@ -410,7 +409,6 @@ function activateNotebookTools(
   tracker: INotebookTracker,
   editorServices: IEditorServices,
   state: IStateDB,
-  labShell: ILabShell | null,
   inspectorProvider: IPropertyInspectorProvider | null
 ): INotebookTools {
   const id = 'notebook-tools';


### PR DESCRIPTION
## Code changes

Remove unused ILabShell dependency from the notebook tools plugin.

## User-facing changes

None

## Backwards-incompatible changes

None