### PR TITLE
Eliminate superfluous installs from extension tutorial

### DIFF
--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -293,13 +293,6 @@ Now return to your editor. Modify the imports at the top of the file to add a fe
       Widget
     } from '@lumino/widgets';
 
-Install this new dependency as well:
-
-.. code:: bash
-
-    jlpm add @lumino/widgets
-
-
 Then modify the ``activate`` function again so that it has the following
 code:
 

--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -255,16 +255,7 @@ will pass an instance of ``ICommandPalette`` as the second parameter of
 in that function. The second ``console.log`` line exists only so that
 you can immediately check that your changes work.
 
-Now you will need to install these dependencies. Run the following commands in the
-repository root folder to install the dependencies and save them to your
-`package.json`:
-
-.. code:: bash
-
-    jlpm add @jupyterlab/apputils
-    jlpm add @jupyterlab/application
-
-Finally, run the following to rebuild your extension.
+Run the following to rebuild your extension.
 
 .. code:: bash
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Do simple documentation updates require dedicated issues?

## Code changes

The tutorial recommends running these two commands to install dependencies. 
```bash
jlpm add @jupyterlab/apputils
jlpm add @jupyterlab/application
```
This appears to be superfluous. Everything runs fine without the execution of these commands. 

After doing the initial conda environment creation (`conda create -n jupyterlab-ext --override-channels --strict-channel-priority -c conda-forge -c anaconda jupyterlab cookiecutter nodejs git`), if I run `jlpm list`, I see the following:

```bash
├─ @jupyterlab/application@2.0.2
│  ├─ @fortawesome/fontawesome-free@^5.12.0
│  ├─ @jupyterlab/apputils@^2.0.2
│  ├─ @jupyterlab/coreutils@^4.0.2
│  ├─ @jupyterlab/docregistry@^2.0.2
│  ├─ @jupyterlab/rendermime-interfaces@^2.0.1
│  ├─ @jupyterlab/rendermime@^2.0.2
│  ├─ @jupyterlab/services@^5.0.2
│  ├─ @jupyterlab/statedb@^2.0.1
│  ├─ @jupyterlab/ui-components@^2.0.2
│  ├─ @lumino/algorithm@^1.2.3
│  ├─ @lumino/application@^1.8.4
│  ├─ @lumino/commands@^1.10.1
│  ├─ @lumino/coreutils@^1.4.2
│  ├─ @lumino/disposable@^1.3.5
│  ├─ @lumino/messaging@^1.3.3
│  ├─ @lumino/polling@^1.0.4
│  ├─ @lumino/properties@^1.1.6
│  ├─ @lumino/signaling@^1.3.5
│  └─ @lumino/widgets@^1.11.1
```

## User-facing changes

None.

## Backwards-incompatible changes

None. 
