### PR TITLE
Use conda instead of conda-forge for nodejs install

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -33,7 +33,7 @@ If you use ``conda``, you can get it with:
 
 .. code:: bash
 
-    conda install -c conda-forge nodejs
+    conda install nodejs
 
 If you use `Homebrew <https://brew.sh/>`__ on Mac OS X:
 

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -29,11 +29,13 @@ see the :ref:`developer documentation <developer_extensions>`.
 In order to install JupyterLab extensions, you need to have `Node.js
 <https://nodejs.org/>`__ installed.
 
-If you use ``conda``, you can get it with:
+If you use ``conda`` with ``conda-forge`` packages, you can get it with:
 
 .. code:: bash
 
-    conda install nodejs
+    conda install -c conda-forge nodejs
+    
+If you use ``conda`` with default Anaconda packages (i.e., you don't normally use ``conda-forge``), you should install nodejs with ``conda install nodejs`` instead.
 
 If you use `Homebrew <https://brew.sh/>`__ on Mac OS X:
 


### PR DESCRIPTION
The docs currently recommend that conda users use conda-forge to install nodejs. However, [conda and conda-forge are not 100% compatible](https://conda-forge.org/docs/user/tipsandtricks.html). In some cases, installing packages via `conda-forge` [breaks the existing conda installation](https://github.com/conda-forge/conda-forge.github.io/issues/547). 

Anecdotally, I just spent more time than I'd like to admit unbricking my conda environment because I thoughtlessly ran this command, and it unlinked my Python installation. Eventually, I gave up and rebuilt my whole environment on a new cloud instance, and installed `nodejs` via conda:

```
conda install nodejs
```

Is there some reason why we're not just using that command?