### PR TITLE
Document the need to enable jupyterlab extension for JupyterHub

### DIFF
--- a/docs/source/user/jupyterhub.rst
+++ b/docs/source/user/jupyterhub.rst
@@ -25,6 +25,8 @@ In this configuration, users can still access the classic Notebook at ``/tree``,
 by either typing that URL into the browser, or by using the "Launch Classic
 Notebook" item in JupyterLab's Help menu.
 
+For this to work, you will need to enable the jupyterlab server 
+extension with ``jupyter serverextension enable jupyterlab``.
 
 Example Configuration
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
As discussed in https://github.com/jupyterhub/jupyterhub/pull/2980, this PR documents the need to enable jupyterlab extension for JupyterHub.