### PR TITLE
Add a button to the notebook toolbar to show the kernel info

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -260,7 +260,7 @@ export namespace ISessionContext {
    */
   export interface IDialogs {
     /**
-     * Select a kernel for the session.
+     * Select a kernel for the session context.
      */
     selectKernel(session: ISessionContext): Promise<void>;
 
@@ -276,6 +276,11 @@ export namespace ISessionContext {
      * this is a no-op, and resolves with `false`.
      */
     restart(session: ISessionContext): Promise<boolean>;
+
+    /**
+     * Show the kernel info for the session context.
+     */
+    kernelInfo(session: ISessionContext): Promise<void>;
   }
 }
 
@@ -1056,6 +1061,27 @@ export const sessionContextDialogs: ISessionContext.IDialogs = {
       return true;
     }
     return false;
+  },
+
+  /**
+   * Show the kernel info for the session context.
+   */
+  async kernelInfo(sessionContext: ISessionContext): Promise<void> {
+    const info = await sessionContext.session?.kernel?.info;
+    if (!info) {
+      return;
+    }
+    const body = <pre>{info.banner}</pre>;
+
+    void showDialog({
+      body,
+      buttons: [
+        Dialog.createButton({
+          label: 'Dismiss',
+          className: 'jp-mod-accept jp-mod-styled'
+        })
+      ]
+    });
   }
 };
 

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -439,19 +439,18 @@ export namespace Toolbar {
   }
 
   /**
-   * Create a kernel info button.
+   * Create a kernel info item.
    */
-  export function createKernelInfoButton(
+  export function createKernelInfoItem(
     sessionContext: ISessionContext,
     dialogs?: ISessionContext.IDialogs
   ): Widget {
-    return new ToolbarButton({
-      icon: infoIcon,
-      onClick: () => {
-        return (dialogs ?? sessionContextDialogs).kernelInfo(sessionContext);
-      },
-      tooltip: 'Show Kernel Info'
-    });
+    return ReactWidget.create(
+      <Private.KernelInfoComponent
+        sessionContext={sessionContext}
+        dialogs={dialogs ?? sessionContextDialogs}
+      />
+    );
   }
 }
 
@@ -771,5 +770,32 @@ namespace Private {
         status === 'busy' || status === 'starting' || status === 'restarting'
       );
     }
+  }
+
+  /**
+   * React component for a kernel info button.
+   */
+  export function KernelInfoComponent(props: {
+    sessionContext: ISessionContext;
+    dialogs: ISessionContext.IDialogs;
+  }) {
+    const onClick = () => {
+      void props.dialogs.kernelInfo(props.sessionContext);
+    };
+    return (
+      <UseSignal
+        signal={props.sessionContext.kernelChanged}
+        initialSender={props.sessionContext}
+      >
+        {sessionContext => (
+          <ToolbarButtonComponent
+            enabled={!!sessionContext?.session?.kernel}
+            icon={infoIcon}
+            onClick={onClick}
+            tooltip={'Show Kernel Info'}
+          />
+        )}
+      </UseSignal>
+    );
   }
 }

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { Text } from '@jupyterlab/coreutils';
-import { IInfoReply } from '@jupyterlab/services/src/kernel/messages';
 import {
   Button,
   circleEmptyIcon,
@@ -22,7 +21,6 @@ import { AttachedProperty } from '@lumino/properties';
 import { PanelLayout, Widget } from '@lumino/widgets';
 import * as React from 'react';
 
-import { showDialog, Dialog } from './dialog';
 import { ISessionContext, sessionContextDialogs } from './sessioncontext';
 import { UseSignal, ReactWidget } from './vdom';
 
@@ -444,15 +442,13 @@ export namespace Toolbar {
    * Create a kernel info button.
    */
   export function createKernelInfoButton(
-    sessionContext: ISessionContext
+    sessionContext: ISessionContext,
+    dialogs?: ISessionContext.IDialogs
   ): Widget {
     return new ToolbarButton({
       icon: infoIcon,
-      onClick: async () => {
-        const info = await sessionContext.session?.kernel?.info;
-        if (info) {
-          void Private.createKernelInfoDialog(info);
-        }
+      onClick: () => {
+        return (dialogs ?? sessionContextDialogs).kernelInfo(sessionContext);
       },
       tooltip: 'Show Kernel Info'
     });
@@ -775,23 +771,5 @@ namespace Private {
         status === 'busy' || status === 'starting' || status === 'restarting'
       );
     }
-  }
-
-  /**
-   * Show the kernel info in a dialog.
-   * @param info The kernel info
-   */
-  export function createKernelInfoDialog(info: IInfoReply) {
-    const body = <pre>{info.banner}</pre>;
-
-    return showDialog({
-      body,
-      buttons: [
-        Dialog.createButton({
-          label: 'Dismiss',
-          className: 'jp-mod-accept jp-mod-styled'
-        })
-      ]
-    });
   }
 }

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -206,7 +206,7 @@ export namespace ToolbarItems {
       },
       {
         name: 'info',
-        widget: Toolbar.createKernelInfoButton(panel.sessionContext)
+        widget: Toolbar.createKernelInfoItem(panel.sessionContext)
       }
     ];
   }

--- a/packages/notebook/src/default-toolbar.tsx
+++ b/packages/notebook/src/default-toolbar.tsx
@@ -203,6 +203,10 @@ export namespace ToolbarItems {
       {
         name: 'kernelStatus',
         widget: Toolbar.createKernelStatusItem(panel.sessionContext)
+      },
+      {
+        name: 'info',
+        widget: Toolbar.createKernelInfoButton(panel.sessionContext)
       }
     ];
   }

--- a/packages/ui-components/src/icon/iconimports.ts
+++ b/packages/ui-components/src/icon/iconimports.ts
@@ -37,6 +37,7 @@ import filterListSvgstr from '../../style/icons/toolbar/filter-list.svg';
 import folderSvgstr from '../../style/icons/filetype/folder.svg';
 import html5Svgstr from '../../style/icons/filetype/html5.svg';
 import imageSvgstr from '../../style/icons/filetype/image.svg';
+import infoSvgstr from '../../style/icons/toolbar/info.svg';
 import inspectorSvgstr from '../../style/icons/filetype/inspector.svg';
 import jsonSvgstr from '../../style/icons/filetype/json.svg';
 import jupyterFaviconSvgstr from '../../style/icons/jupyter/jupyter-favicon.svg';
@@ -104,6 +105,7 @@ export const filterListIcon = new LabIcon({ name: 'ui-components:filter-list', s
 export const folderIcon = new LabIcon({ name: 'ui-components:folder', svgstr: folderSvgstr });
 export const html5Icon = new LabIcon({ name: 'ui-components:html5', svgstr: html5Svgstr });
 export const imageIcon = new LabIcon({ name: 'ui-components:image', svgstr: imageSvgstr });
+export const infoIcon = new LabIcon({ name: 'ui-components:info', svgstr: infoSvgstr });
 export const inspectorIcon = new LabIcon({ name: 'ui-components:inspector', svgstr: inspectorSvgstr });
 export const jsonIcon = new LabIcon({ name: 'ui-components:json', svgstr: jsonSvgstr });
 export const jupyterFaviconIcon = new LabIcon({ name: 'ui-components:jupyter-favicon', svgstr: jupyterFaviconSvgstr });

--- a/packages/ui-components/style/deprecated.css
+++ b/packages/ui-components/style/deprecated.css
@@ -41,6 +41,7 @@
   --jp-icon-folder: url('icons/filetype/folder.svg');
   --jp-icon-html5: url('icons/filetype/html5.svg');
   --jp-icon-image: url('icons/filetype/image.svg');
+  --jp-icon-info: url('icons/toolbar/info.svg');
   --jp-icon-inspector: url('icons/filetype/inspector.svg');
   --jp-icon-json: url('icons/filetype/json.svg');
   --jp-icon-jupyter-favicon: url('icons/jupyter/jupyter-favicon.svg');
@@ -167,6 +168,9 @@
 }
 .jp-ImageIcon {
   background-image: var(--jp-icon-image);
+}
+.jp-InfoIcon {
+  background-image: var(--jp-icon-info);
 }
 .jp-InspectorIcon {
   background-image: var(--jp-icon-inspector);

--- a/packages/ui-components/style/icons/toolbar/info.svg
+++ b/packages/ui-components/style/icons/toolbar/info.svg
@@ -1,0 +1,8 @@
+<svg width="16" version="1.1" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+ <g class="jp-icon3" transform="matrix(.27648 0 0 .27648 6.5116 2.3208)" fill="#616161">
+  <circle cx="9" cy="9" r="8"/>
+ </g>
+ <g class="jp-icon3" transform="matrix(.78644 0 0 .78644 1.922 1.922)" fill="#616161">
+  <rect x="6.1875" y="7.8373" width="5.625" height="9.3041" stroke-width="1.3182"/>
+ </g>
+</svg>


### PR DESCRIPTION
## References

Fixes #7948.

## Code changes

This adds a new info button to the default notebook toolbar, to open a new dialog and show the kernel info.

## User-facing changes

![kernel-info-dialog](https://user-images.githubusercontent.com/591645/76612498-bc3faa00-651c-11ea-94bb-63bfe739b466.gif)

![image](https://user-images.githubusercontent.com/591645/76627785-ebb1df00-653b-11ea-9233-a4b4c95f512e.png)

## Backwards-incompatible changes

None