### PR TITLE
Enable extension manager by default

### DIFF
--- a/packages/extensionmanager-extension/schema/plugin.json
+++ b/packages/extensionmanager-extension/schema/plugin.json
@@ -7,7 +7,7 @@
     "enabled": {
       "title": "Enabled Status",
       "description": "Enables extension manager (requires Node.js/npm).\nWARNING: installing untrusted extensions may be unsafe.",
-      "default": false,
+      "default": true,
       "type": "boolean"
     }
   },


### PR DESCRIPTION
## References

Further to the black and white listings https://github.com/jupyterlab/jupyterlab/issues/7989 and https://github.com/jupyterlab/jupyterlab_server/pull/82 that brings more control on which extension can or can not be installed, it makes sense to enable by default the extension manager once the 2 referenced PRs are merged.

## Code changes

The default value for `enabled` settings of the `extensionmanager-extension` schema is set to `true` instead of `false.

## User-facing changes

The `extension manager` icon will be visible by default in the left bar.

![Screenshot 2020-03-18 at 14 34 19](https://user-images.githubusercontent.com/226720/76966176-d49d3380-6925-11ea-8ddf-12ed3b094deb.png)

## Backwards-incompatible changes

None.
