### PR TITLE
Add the `notebook:run` command to the notebook example

### DIFF
--- a/examples/notebook/src/commands.ts
+++ b/examples/notebook/src/commands.ts
@@ -27,6 +27,7 @@ const cmdIds = {
   restart: 'notebook:restart-kernel',
   switchKernel: 'notebook:switch-kernel',
   runAndAdvance: 'notebook-cells:run-and-advance',
+  run: 'notebook:run-cell',
   deleteCell: 'notebook-cells:delete',
   selectAbove: 'notebook-cells:select-above',
   selectBelow: 'notebook-cells:select-below',
@@ -144,6 +145,15 @@ export const SetupCommands = (
       );
     }
   });
+  commands.addCommand(cmdIds.run, {
+    label: 'Run',
+    execute: () => {
+      return NotebookActions.run(
+        nbWidget.content,
+        nbWidget.context.sessionContext
+      );
+    }
+  });
   commands.addCommand(cmdIds.editMode, {
     label: 'Edit Mode',
     execute: () => {
@@ -212,6 +222,7 @@ export const SetupCommands = (
   category = 'Notebook Cell Operations';
   [
     cmdIds.runAndAdvance,
+    cmdIds.run,
     cmdIds.split,
     cmdIds.merge,
     cmdIds.selectAbove,
@@ -232,6 +243,11 @@ export const SetupCommands = (
       selector: `.jp-mod-completer-active`,
       keys: ['Enter'],
       command: cmdIds.selectNotebook
+    },
+    {
+      selector: '.jp-Notebook',
+      keys: ['Ctrl Enter'],
+      command: cmdIds.run
     },
     {
       selector: '.jp-Notebook',


### PR DESCRIPTION
After trying out the [notebook example](https://github.com/jupyterlab/jupyterlab/tree/master/examples/notebook), it feels more natural to have the possibility to execute a cell without advancing to the next one, by hitting <kbd>Ctrl-Enter</kbd> like in stock JupyterLab.

## Code changes

Add the `notebook-run` command to the notebook example with its <kbd>Ctrl-Enter</kbd> keybinding.

## User-facing changes

None

## Backwards-incompatible changes

None