### PR TITLE
Fix cell execution when recording timing

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1076,11 +1076,11 @@ export namespace CodeCell {
               label = 'execute_input';
               break;
             default:
-              return false;
+              return true;
           }
           const value = msg.header.date;
           if (!value) {
-            return false;
+            return true;
           }
           const timingInfo: any = Object.assign(
             {},


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #8056

## Code changes

The recordTiming future message hook should always return true.

Returning false prevents the message from being processed by the future or by any other hook, which messes everything up.


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
