### PR TITLE
Change header area to a box panel

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -175,7 +175,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     this.addClass(APPLICATION_SHELL_CLASS);
     this.id = 'main';
 
-    let headerPanel = (this._headerPanel = new Panel());
+    let headerPanel = (this._headerPanel = new BoxPanel());
     let topHandler = (this._topHandler = new Private.PanelHandler());
     let bottomPanel = (this._bottomPanel = new BoxPanel());
     let hboxPanel = new BoxPanel();
@@ -206,6 +206,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     dockPanel.spacing = 5;
     hsplitPanel.spacing = 1;
 
+    headerPanel.direction = 'top-to-bottom';
     hboxPanel.direction = 'left-to-right';
     hsplitPanel.orientation = 'horizontal';
     bottomPanel.direction = 'bottom-to-top';


### PR DESCRIPTION


## References

Fixes #7279

## Code changes

This makes the header area similar to the bottom area, and means header children can set their min-height and the header area will adjust to accommodate it.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

This *might* be considered a backwards-incompatible change, in that it changes the behavior of the header area. If you previously set the min-height of the header area, that could be overridden now with the min-height of a header child element. On the other hand, if we consider this more of a bugfix, then perhaps we do not consider it backwards incompatible.