### PR TITLE
Show the completer in the notebook example

### DIFF
--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -7,6 +7,7 @@ __webpack_public_path__ = URLExt.join(PageConfig.getBaseUrl(), 'example/');
 
 import '@jupyterlab/application/style/index.css';
 import '@jupyterlab/codemirror/style/index.css';
+import '@jupyterlab/completer/style/index.css';
 import '@jupyterlab/notebook/style/index.css';
 import '@jupyterlab/theme-light-extension/style/index.css';
 import '../index.css';
@@ -111,10 +112,17 @@ function createApp(manager: ServiceManager.IManager): void {
     nbWidget.content.activeCell && nbWidget.content.activeCell.editor;
   const model = new CompleterModel();
   const completer = new Completer({ editor, model });
+  const sessionContext = nbWidget.context.sessionContext;
   const connector = new KernelConnector({
-    session: nbWidget.context.sessionContext.session
+    session: sessionContext.session
   });
   const handler = new CompletionHandler({ completer, connector });
+
+  void sessionContext.ready.then(() => {
+    handler.connector = new KernelConnector({
+      session: sessionContext.session
+    });
+  });
 
   // Set the handler's editor.
   handler.editor = editor;


### PR DESCRIPTION
It appears that the completer was not being shown in the notebook example.

## Code changes

Wait for the session context to be ready before creating a new `KernelConnector`, so its `SessionConnection` exists.

## User-facing changes

Running the notebook example:

#### Before

![examples-notebook-no-completer](https://user-images.githubusercontent.com/591645/77260547-fe898980-6c88-11ea-8476-a80787fb9c96.gif)

#### After

![examples-notebook-completer](https://user-images.githubusercontent.com/591645/77260552-034e3d80-6c89-11ea-88be-38ff3f44dd91.gif)

## Backwards-incompatible changes

None