### PR TITLE
Focus-with-select when focusing Search box (#7932)

### DIFF
--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -81,7 +81,11 @@ class SearchEntry extends React.Component<ISearchEntryProps> {
    * Focus the input.
    */
   focusInput() {
-    (this.refs.searchInputNode as HTMLInputElement).focus();
+    // Select (and focus) any text already present.
+    // This makes typing in the box starts a new query (the common case),
+    // while arrow keys can be used to move cursor in preparation for
+    // modifying previous query.
+    (this.refs.searchInputNode as HTMLInputElement).select();
   }
 
   componentDidUpdate() {


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Issue #7932

## Code changes

Focus-with-select when focusing Search box

https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement

Old: `focus()`	Focuses on the input element; keystrokes will subsequently go to this element.
New: `select()`	Selects all the text in the input element, and focuses it so the user can subsequently replace all of its content.
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Focus-with-select when focusing Search box.

<!-- For visual changes, include before and after screenshots here. -->

Test env setup on
https://mybinder.org/v2/gh/misterbeebee/jupyterlab/patch-1?urlpath=lab-dev


Before:
<img width="900" alt="before" src="https://user-images.githubusercontent.com/656964/77352241-4524c580-6d15-11ea-9c07-3fdb2dedc026.png">

After:
<img width="743" alt="after" src="https://user-images.githubusercontent.com/656964/77352135-1eff2580-6d15-11ea-9fce-49f417f1c30b.png">

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

N/A