### PR TITLE
Add back autolink support

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -481,7 +481,7 @@ function autolink(content: string): string {
     url => {
       const a = document.createElement('a');
       a.href = url;
-      a.innerHTML = url;
+      a.textContent = url;
       a.rel = 'noopener';
       a.target = '_blank';
       return a.outerHTML;

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -468,6 +468,28 @@ export namespace renderSVG {
 }
 
 /**
+ * Replace URLs with links.
+ *
+ * @param content - The plain text content.
+ *
+ * @returns The content where all URLs have been replaced with corresponding links.
+ */
+function autolink(content: string): string {
+  return content.replace(
+    // Same pattern as in classic notebook with word boundaries (\b).
+    /\b((https?|ftp)(:[^'"<>\s]+))\b/g,
+    url => {
+      const a = document.createElement('a');
+      a.href = url;
+      a.innerHTML = url;
+      a.rel = 'noopener';
+      a.target = '_blank';
+      return a.outerHTML;
+    }
+  );
+}
+
+/**
  * Render text into a host node.
  *
  * @params options - The options for rendering.
@@ -485,7 +507,7 @@ export function renderText(options: renderText.IRenderOptions): Promise<void> {
 
   // Set the sanitized content for the host node.
   const pre = document.createElement('pre');
-  pre.innerHTML = content;
+  pre.innerHTML = autolink(content);
   host.appendChild(pre);
 
   // Return the rendered promise.

--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -25,6 +25,19 @@
   line-height: normal;
 }
 
+.jp-RenderedText pre a:link {
+  text-decoration: none;
+  color: var(--jp-content-link-color);
+}
+.jp-RenderedText pre a:hover {
+  text-decoration: underline;
+  color: var(--jp-content-link-color);
+}
+.jp-RenderedText pre a:visited {
+  text-decoration: none;
+  color: var(--jp-content-link-color);
+}
+
 /* console foregrounds and backgrounds */
 .jp-RenderedText pre .ansi-black-fg {
   color: #3e424d;

--- a/tests/test-rendermime/src/factories.spec.ts
+++ b/tests/test-rendermime/src/factories.spec.ts
@@ -100,6 +100,27 @@ describe('rendermime/factories', () => {
           '<pre>There is no text &lt;script&gt;window.x=1&lt;/script&gt; but <span class="ansi-green-intense-fg ansi-red-bg ansi-bold">text</span>.\nWoo.</pre>'
         );
       });
+
+      it('should autolink URLs', async () => {
+        const f = textRendererFactory;
+        const urls = [
+          'https://example.com#anchor',
+          'http://localhost:9090/app',
+          'http://127.0.0.1/test?query=string'
+        ];
+        await Promise.all(
+          urls.map(async url => {
+            const source = `Here is some text with an URL such as ${url} inside.`;
+            const mimeType = 'text/plain';
+            const model = createModel(mimeType, source);
+            const w = f.createRenderer({ mimeType, ...defaultOptions });
+            await w.renderModel(model);
+            expect(w.node.innerHTML).to.equal(
+              `<pre>Here is some text with an URL such as <a href="${url}" rel="noopener" target="_blank">${url}</a> inside.</pre>`
+            );
+          })
+        );
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

Close #7393.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

I took the [pattern from the classic notebook interface](https://github.com/jupyter/notebook/blob/43df5af2b614088b4b297fae90a70b6505b9bf84/notebook/static/base/js/utils.js#L508) and added word boundaries to it (`\b`). Compared to patterns like the one used by nteract, it has the benefit of matching URLs targeting localhost or an IP address.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Looks like that:

<img width="750" alt="Screenshot 2020-03-23 at 20 25 35" src="https://user-images.githubusercontent.com/6574550/77355282-7bc60480-6d44-11ea-8db5-9fe51b22ad0e.png">

Before, the URLs in the output wouldn't be turned into links.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None that I'm aware of. This can even be seen as necessary for feature parity with the classic notebook interface.
