### PR TITLE
Update user messages when installing extensions with companions

### DIFF
--- a/packages/extensionmanager/src/companions.tsx
+++ b/packages/extensionmanager/src/companions.tsx
@@ -141,7 +141,7 @@ export function presentCompanions(
     entries.push(
       <p key="server-companion">
         This package has indicated that it needs a corresponding server
-        extension. Please contact your Adminstrator to update the server with
+        extension. Please contact your Administrator to update the server with
         one of the following commands:
         {getInstallCommands(serverCompanion).map(command => {
           return (

--- a/packages/extensionmanager/src/companions.tsx
+++ b/packages/extensionmanager/src/companions.tsx
@@ -178,7 +178,7 @@ export function presentCompanions(
       }
       entries.push(<ul key={'kernel-companion-end'}>{kernelEntries}</ul>);
       entries.push(
-        <p key="server-companion">
+        <p key={`kernel-companion-${index}`}>
           This package has indicated that it needs a corresponding server
           extension. Please contact your Adminstrator to update the server with
           one of the following commands:

--- a/packages/extensionmanager/src/companions.tsx
+++ b/packages/extensionmanager/src/companions.tsx
@@ -179,8 +179,8 @@ export function presentCompanions(
       entries.push(<ul key={'kernel-companion-end'}>{kernelEntries}</ul>);
       entries.push(
         <p key={`kernel-companion-${index}`}>
-          This package has indicated that it needs a corresponding server
-          extension. Please contact your Adminstrator to update the server with
+          This package has indicated that it needs a corresponding kernel
+          package. Please contact your Administrator to update the server with
           one of the following commands:
           {getInstallCommands(entry.kernelInfo).map(command => {
             return (

--- a/packages/extensionmanager/src/companions.tsx
+++ b/packages/extensionmanager/src/companions.tsx
@@ -98,11 +98,7 @@ export interface IJupyterLabPackageData {
 
 function getInstallCommands(info: IInstallInfo) {
   let commands = Array<string>();
-  if (
-    info.overrides &&
-    info.overrides!['pip'] &&
-    info.overrides!['pip']!.name
-  ) {
+  if (info.overrides?.pip?.name) {
     commands.push(`pip install ${info.overrides!['pip']!.name}`);
   } else {
     const pip = info.managers.find(s => s === 'pip');
@@ -110,11 +106,7 @@ function getInstallCommands(info: IInstallInfo) {
       commands.push(`pip install ${info.base.name}`);
     }
   }
-  if (
-    info.overrides &&
-    info.overrides!['conda'] &&
-    info.overrides!['conda']!.name
-  ) {
+  if (info.overrides?.conda?.name) {
     commands.push(
       `conda install -c conda-forge ${info.overrides!['conda']!.name}`
     );

--- a/packages/extensionmanager/src/companions.tsx
+++ b/packages/extensionmanager/src/companions.tsx
@@ -99,7 +99,7 @@ export interface IJupyterLabPackageData {
 function getInstallCommands(info: IInstallInfo) {
   let commands = Array<string>();
   if (info.overrides?.pip?.name) {
-    commands.push(`pip install ${info.overrides!['pip']!.name}`);
+    commands.push(`pip install ${info.overrides.pip.name}`);
   } else {
     const pip = info.managers.find(s => s === 'pip');
     if (pip) {
@@ -107,9 +107,7 @@ function getInstallCommands(info: IInstallInfo) {
     }
   }
   if (info.overrides?.conda?.name) {
-    commands.push(
-      `conda install -c conda-forge ${info.overrides!['conda']!.name}`
-    );
+    commands.push(`conda install -c conda-forge ${info.overrides.conda.name}`);
   } else {
     const conda = info.managers.find(s => s === 'conda');
     if (conda) {

--- a/packages/extensionmanager/src/companions.tsx
+++ b/packages/extensionmanager/src/companions.tsx
@@ -96,6 +96,37 @@ export interface IJupyterLabPackageData {
   };
 }
 
+function getInstallCommands(info: IInstallInfo) {
+  let commands = Array<string>();
+  if (
+    info.overrides &&
+    info.overrides!['pip'] &&
+    info.overrides!['pip']!.name
+  ) {
+    commands.push(`pip install ${info.overrides!['pip']!.name}`);
+  } else {
+    const pip = info.managers.find(s => s === 'pip');
+    if (pip) {
+      commands.push(`pip install ${info.base.name}`);
+    }
+  }
+  if (
+    info.overrides &&
+    info.overrides!['conda'] &&
+    info.overrides!['conda']!.name
+  ) {
+    commands.push(
+      `conda install -c conda-forge ${info.overrides!['conda']!.name}`
+    );
+  } else {
+    const conda = info.managers.find(s => s === 'conda');
+    if (conda) {
+      commands.push(`conda install -c conda-forge ${info.base.name}`);
+    }
+  }
+  return commands;
+}
+
 /**
  * Prompt the user what do about companion packages, if present.
  *
@@ -110,8 +141,15 @@ export function presentCompanions(
     entries.push(
       <p key="server-companion">
         This package has indicated that it needs a corresponding server
-        extension:
-        <code> {serverCompanion.base.name!}</code>
+        extension. Please contact your Adminstrator to update the server with
+        one of the following commands:
+        {getInstallCommands(serverCompanion).map(command => {
+          return (
+            <p>
+              <code>{command}</code>
+            </p>
+          );
+        })}
       </p>
     );
   }
@@ -139,6 +177,20 @@ export function presentCompanions(
         );
       }
       entries.push(<ul key={'kernel-companion-end'}>{kernelEntries}</ul>);
+      entries.push(
+        <p key="server-companion">
+          This package has indicated that it needs a corresponding server
+          extension. Please contact your Adminstrator to update the server with
+          one of the following commands:
+          {getInstallCommands(entry.kernelInfo).map(command => {
+            return (
+              <p>
+                <code>{command}</code>
+              </p>
+            );
+          })}
+        </p>
+      );
     }
   }
   let body = (


### PR DESCRIPTION
## References

The goal of this PR is to give better message to the user when he wants to install an extension that has [companion packages](https://jupyterlab.readthedocs.io/en/stable/developer/extension_dev.html#companion-packages) defined.

## Code changes

The changes create the commands to run and take into account the presence or absence of `pip` and `conda` managers, and also take into account the `overrides` property. This was not the case before.

## User-facing changes

Before

<img width="518" alt="before" src="https://user-images.githubusercontent.com/226720/77439035-dadc5580-6de6-11ea-9883-492abc47a79f.png">

After

<img width="522" alt="after" src="https://user-images.githubusercontent.com/226720/77439054-df087300-6de6-11ea-95a6-0405141a96e7.png">

## Backwards-incompatible changes

None