### PR TITLE
Implement Larger Badges for Extension Installer UI

### DIFF
--- a/packages/extensionmanager/style/base.css
+++ b/packages/extensionmanager/style/base.css
@@ -179,15 +179,6 @@
   flex-direction: row;
 }
 
-.jp-extensionmanager-entry-jupyter-org {
-  display: none;
-}
-
-.jp-extensionmanager-entry.jp-extensionmanager-entry-mod-jupyterlab-org
-  .jp-extensionmanager-entry-jupyter-org {
-  display: inline;
-}
-
 .jp-extensionmanager-entry.jp-extensionmanager-entry-should-be-uninstalled {
   background-color: var(--jp-error-color3);
 }


### PR DESCRIPTION
## References

This PR implements the features described in https://github.com/jupyterlab/jupyterlab/issues/8043

## Code changes

`packages/extensionmanager/src/widget.tsx` is updated to define a badge url (from github) if available for each extension.

The badge is fetched from the NPM entry details as described in https://github.com/jupyterlab/jupyterlab/issues/8043

## User-facing changes

A badge is shown for each extension. 

<img width="508" alt="badges" src="https://user-images.githubusercontent.com/226720/77449638-79ba7f00-6df2-11ea-9d90-67b7f1d1c177.png">


## Backwards-incompatible changes

None.