### PR TITLE
Include the document search CSS in the notebook example

### DIFF
--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -8,6 +8,7 @@ __webpack_public_path__ = URLExt.join(PageConfig.getBaseUrl(), 'example/');
 import '@jupyterlab/application/style/index.css';
 import '@jupyterlab/codemirror/style/index.css';
 import '@jupyterlab/completer/style/index.css';
+import '@jupyterlab/documentsearch/style/index.css';
 import '@jupyterlab/notebook/style/index.css';
 import '@jupyterlab/theme-light-extension/style/index.css';
 import '../index.css';


### PR DESCRIPTION
Include the document search CSS in the notebook example.

## User-facing changes

In the notebook example:

### Before

![image](https://user-images.githubusercontent.com/591645/77553894-adaaa880-6eb5-11ea-9b71-082b7882b6eb.png)

### After

![image](https://user-images.githubusercontent.com/591645/77554038-d894fc80-6eb5-11ea-9c48-739b5ad4fced.png)

## Backwards-incompatible changes

None