### PR TITLE
Allow spaces in names of files attached to markdown cells

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1326,7 +1326,17 @@ export abstract class AttachmentsCell extends Cell {
       const mimeType = matches[1];
       const encodedData = matches[3];
       const bundle: nbformat.IMimeBundle = { [mimeType]: encodedData };
-      const URI = encodeURI(blob.name)
+
+      // Find an unused URI
+      let URI = encodeURI(blob.name)
+      let URI_array = URI.split(/(\.)(?=[^\.]+$)/);
+      URI_array.splice(1, 0, '');
+      let i = 1;
+      while (this.model.attachments.has(URI)){
+        URI_array[1] = `_${i}`;
+        URI = URI_array.join('');
+        i = i+1;
+      }
       this.model.attachments.set(URI, bundle);
       this.updateCellSourceWithAttachment(blob.name, URI);
     };

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1344,7 +1344,7 @@ export abstract class AttachmentsCell extends Cell {
    * Generates a unique URI for a file 
    * while preserving the file extension.
    */
-  private _generateURI(name: string): string {
+  private _generateURI(name = ''): string {
     const lastIndex = name.lastIndexOf('.');
     return lastIndex !== -1 ? UUID.uuid4().concat(name.substring(lastIndex)) : UUID.uuid4();
   }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1448,7 +1448,7 @@ export class MarkdownCell extends AttachmentsCell {
    * Modify the cell source to include a reference to the attachment.
    */
   protected updateCellSourceWithAttachment(attachmentName: string, URI?: string) {
-    const textToBeAppended = `![${attachmentName}](attachment:${URI})`;
+    const textToBeAppended = `![${attachmentName}](attachment:${URI ?? attachmentName})`;
     this.model.value.insert(this.model.value.text.length, textToBeAppended);
   }
 

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1447,7 +1447,7 @@ export class MarkdownCell extends AttachmentsCell {
   /**
    * Modify the cell source to include a reference to the attachment.
    */
-  protected updateCellSourceWithAttachment(attachmentName: string, URI: string) {
+  protected updateCellSourceWithAttachment(attachmentName: string, URI?: string) {
     const textToBeAppended = `![${attachmentName}](attachment:${URI})`;
     this.model.value.insert(this.model.value.text.length, textToBeAppended);
   }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1461,7 +1461,7 @@ export class MarkdownCell extends AttachmentsCell {
    * Modify the cell source to include a reference to the attachment.
    */
   protected updateCellSourceWithAttachment(attachmentName: string, URI?: string) {
-    const textToBeAppended = `![${attachmentName}](attachment:${URI ?? attachmentName})`;
+    const textToBeAppended = `![${attachmentName}](attachment:${URI ?? encodeURI(attachmentName)})`;
     this.model.value.insert(this.model.value.text.length, textToBeAppended);
   }
 

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1329,7 +1329,7 @@ export abstract class AttachmentsCell extends Cell {
       const bundle: nbformat.IMimeBundle = { [mimeType]: encodedData };
       const URI = this._generateURI(blob.name);
 
-      if (mimeType.includes('image')){
+      if (mimeType.startsWith('image/')){
         this.model.attachments.set(URI, bundle);
         this.updateCellSourceWithAttachment(name, URI);
       }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1331,7 +1331,7 @@ export abstract class AttachmentsCell extends Cell {
 
       if (mimeType.startsWith('image/')){
         this.model.attachments.set(URI, bundle);
-        this.updateCellSourceWithAttachment(name, URI);
+        this.updateCellSourceWithAttachment(blob.name, URI);
       }
     };
     reader.onerror = evt => {

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1461,7 +1461,7 @@ export class MarkdownCell extends AttachmentsCell {
    * Modify the cell source to include a reference to the attachment.
    */
   protected updateCellSourceWithAttachment(attachmentName: string, URI?: string) {
-    const textToBeAppended = `![${attachmentName}](attachment:${URI ?? encodeURI(attachmentName)})`;
+    const textToBeAppended = `![${attachmentName}](attachment:${URI ?? attachmentName})`;
     this.model.value.insert(this.model.value.text.length, textToBeAppended);
   }
 

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1170,7 +1170,7 @@ export abstract class AttachmentsCell extends Cell {
    */
   protected abstract updateCellSourceWithAttachment(
     attachmentName: string,
-    URI: string
+    URI?: string
   ): void;
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1283,7 +1283,7 @@ export abstract class AttachmentsCell extends Cell {
         }
       } else {
         // Pure mimetype, no useful name to infer
-        const URI = UUID.uuid4();
+        const URI = this._generateURI();
         this.model.attachments.set(URI, {
           [mimeType]: event.mimeData.getData(mimeType)
         });

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1169,7 +1169,8 @@ export abstract class AttachmentsCell extends Cell {
    * Modify the cell source to include a reference to the attachment.
    */
   protected abstract updateCellSourceWithAttachment(
-    attachmentName: string
+    attachmentName: string,
+    URI: string
   ): void;
 
   /**
@@ -1325,8 +1326,9 @@ export abstract class AttachmentsCell extends Cell {
       const mimeType = matches[1];
       const encodedData = matches[3];
       const bundle: nbformat.IMimeBundle = { [mimeType]: encodedData };
-      this.model.attachments.set(blob.name, bundle);
-      this.updateCellSourceWithAttachment(blob.name);
+      const URI = encodeURI(blob.name)
+      this.model.attachments.set(URI, bundle);
+      this.updateCellSourceWithAttachment(blob.name, URI);
     };
     reader.onerror = evt => {
       console.error(`Failed to attach ${blob.name}` + evt);
@@ -1445,8 +1447,8 @@ export class MarkdownCell extends AttachmentsCell {
   /**
    * Modify the cell source to include a reference to the attachment.
    */
-  protected updateCellSourceWithAttachment(attachmentName: string) {
-    const textToBeAppended = `![${attachmentName}](attachment:${attachmentName})`;
+  protected updateCellSourceWithAttachment(attachmentName: string, URI: string) {
+    const textToBeAppended = `![${attachmentName}](attachment:${URI})`;
     this.model.value.insert(this.model.value.text.length, textToBeAppended);
   }
 

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1273,9 +1273,9 @@ export abstract class AttachmentsCell extends Cell {
           CONTENTS_MIME_RICH
         ) as DirListing.IContentsThunk;
         if (model.type === 'file') {
-          this.updateCellSourceWithAttachment(model.name);
+          this.updateCellSourceWithAttachment(model.name, encodeURI(model.name));
           void withContent().then(fullModel => {
-            this.model.attachments.set(fullModel.name, {
+            this.model.attachments.set(encodeURI(fullModel.name), {
               [fullModel.mimetype]: fullModel.content
             });
           });
@@ -1283,10 +1283,10 @@ export abstract class AttachmentsCell extends Cell {
       } else {
         // Pure mimetype, no useful name to infer
         const name = UUID.uuid4();
-        this.model.attachments.set(name, {
+        this.model.attachments.set(encodeURI(name), {
           [mimeType]: event.mimeData.getData(mimeType)
         });
-        this.updateCellSourceWithAttachment(name);
+        this.updateCellSourceWithAttachment(name, encodeURI(name));
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
partially fixes: https://github.com/jupyterlab/jupyterlab/issues/8067:
This will fix the dragging and dropping behavior, but as noted https://github.com/jupyterlab/jupyterlab/issues/8062#issuecomment-604692801 the other issue raised there of typing in the name will remain as that is not supported by markdown.
partially addresses: https://github.com/jupyterlab/jupyterlab/issues/8062: 
the spaces in names also came up there.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

call `encodeURI` when setting the attachment to a markdown cell. This allows the attachment to be found when the markdown is being rendered. I was able to confirm that this fixes the issues for `nativeDrop` and `paste` events. However, I don't know how to trigger the `lm-drop` events so I wasn't able to directly verify that this fixes the issue for those events. If these are meant to be triggered by dragging a file from the jupyterlab filebrowser then I was unable to do that and have a new issue to report.
## User-facing changes
An image with spaces in the name that is drag and dropped or copied into a markdown cell will now render:
![wokring_spaces](https://user-images.githubusercontent.com/10111092/77718345-1890d800-6fb9-11ea-97ca-5bee3bda630c.gif)



<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
