### PR TITLE
Break up windows js tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
     name: Windows
     strategy:
       matrix:
-        group: [javascript, python, integrity]
+        group: [python, integrity, application, apputils, cells, codeeditor, codemirror, completer, console, coreutils, csvviewer, docmanager, docregistry, filebrowser, fileeditor, imageviewer, inspector, logconsole, mainmenu, nbformat, notebook, observables, outputarea, rendermime, services, settingregistry, statedb, statusbar, terminal, ui-components]
       fail-fast: false
     runs-on: windows-latest
     steps:

--- a/scripts/appveyor.cmd
+++ b/scripts/appveyor.cmd
@@ -20,12 +20,11 @@ IF "%NAME%"=="python" (
     python -m jupyterlab.browser_check
 
 ) ELSE (
-    set NODE_OPTIONS=--max-old-space-size=1028
-    jlpm run build:packages
+    jlpm run build:packages:scope --scope "@jupyterlab/%NAME%"
     if !errorlevel! neq 0 exit /b !errorlevel!
-    jlpm run build:test
+    jlpm run build:test:scope --scope "@jupyterlab/test-%NAME%"
     if !errorlevel! neq 0 exit /b !errorlevel!
-    setx FORCE_COLOR 1 && jlpm coverage --loglevel success
+    setx FORCE_COLOR 1 && jlpm run test:scope --loglevel success --scope "@jupyterlab/test-%NAME%"
 )
 
 if !errorlevel! neq 0 exit /b !errorlevel!


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow up to #8064 to break up Windows js tests.

## Code changes

This breaks up the windows js tests so that we run test suite per run.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
