### PR TITLE
Update docs on storing extension data

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -490,11 +490,8 @@ Storing Extension Data
 ^^^^^^^^^^^^^^^^^^^^^^
 
 In addition to the file system that is accessed by using the
-``@jupyterlab/services`` package, JupyterLab offers two ways for
-extensions to store data: a client-side state database that is built on
-top of ``localStorage`` and a plugin settings system that provides for
-default setting values and user overrides.
-
+``@jupyterlab/services`` package, JupyterLab exposes a plugin settings
+system that can be used to provide default setting values and user overrides.
 
 Extension Settings
 ``````````````````

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -45,10 +45,6 @@ fi
 
 
 if [[ $GROUP == docs ]]; then
-
-    # Run the link check - allow for a link to fail once
-    py.test --check-links -k .md . || py.test --check-links -k .md --lf .
-
     # Build the docs
     jlpm build:packages
     jlpm docs
@@ -56,9 +52,13 @@ if [[ $GROUP == docs ]]; then
     # Verify tutorial docs build
     pushd docs
     pip install sphinx sphinx-copybutton sphinx_rtd_theme recommonmark jsx-lexer
-    make linkcheck
     make html
+    make linkcheck
     popd
+
+    # Run the link check - allow for a link to fail once
+    py.test --check-links -k .md . || py.test --check-links -k .md --lf .
+
 fi
 
 


### PR DESCRIPTION
## References

It looks like support for storing user data with `localStorage` (using the state db) was dropped in https://github.com/jupyterlab/jupyterlab/pull/6345.

## Code changes

None. This is a documentation change to remove the mention to `localStorage`.

## User-facing changes

None

## Backwards-incompatible changes

None