### PR TITLE
Fix property inspector and widget tracker load behavior

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -822,13 +822,21 @@ const propertyInspector: JupyterFrontEndPlugin<IPropertyInspectorProvider> = {
   id: '@jupyterlab/application-extension:property-inspector',
   autoStart: true,
   requires: [ILabShell],
+  optional: [ILayoutRestorer],
   provides: IPropertyInspectorProvider,
-  activate: (app: JupyterFrontEnd, labshell: ILabShell) => {
+  activate: (
+    app: JupyterFrontEnd,
+    labshell: ILabShell,
+    restorer: ILayoutRestorer | null
+  ) => {
     const widget = new SideBarPropertyInspectorProvider(labshell);
     widget.title.icon = buildIcon;
     widget.title.caption = 'Property Inspector';
     widget.id = 'jp-property-inspector';
     labshell.add(widget, 'left');
+    if (restorer) {
+      restorer.add(widget, 'jp-property-inspector');
+    }
     return widget;
   }
 };

--- a/packages/apputils/src/widgettracker.ts
+++ b/packages/apputils/src/widgettracker.ts
@@ -142,6 +142,7 @@ export class WidgetTracker<T extends Widget = Widget>
         pool.current = focus.currentWidget;
         return;
       }
+
       this.onCurrentChanged(widget);
       this._currentChanged.emit(widget);
     }, this);
@@ -216,11 +217,16 @@ export class WidgetTracker<T extends Widget = Widget>
    * the tracker can be checked with the `has()` method. The promise this method
    * returns resolves after the widget has been added and saved to an underlying
    * restoration connector, if one is available.
+   *
+   * The newly added widget becomes the current widget unless the focus tracker
+   * already had a focused widget.
    */
   async add(widget: T): Promise<void> {
     this._focusTracker.add(widget);
     await this._pool.add(widget);
-    this._pool.current = widget;
+    if (!this._focusTracker.activeWidget) {
+      this._pool.current = widget;
+    }
   }
 
   /**

--- a/packages/property-inspector/src/index.ts
+++ b/packages/property-inspector/src/index.ts
@@ -164,6 +164,7 @@ export class SideBarPropertyInspectorProvider extends PropertyInspectorProvider 
     }
     layout.widget = this._placeholder;
     labshell.currentChanged.connect(this._onShellCurrentChanged, this);
+    this._onShellCurrentChanged();
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#8113 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Adds layout restoration for the property inspector and fixes the case where a widget is added to a widget tracker when another widget already has focus.  The edge case that this does not address is when an old widget is focused and new widget gets activated but never gets focused.  In that case I think it is still fair to call the last focused widget the current one, as the focus tracker does.

The changes to the widget tracker need to be backported to 1.2.x.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Fixes a user-facing bug where the wrong widget's properties are being inspected.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
