### PR TITLE
Fix Widget Tracker in 1.2.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
     name: Windows
     strategy:
       matrix:
-        group: [python, integrity, application, apputils, cells, codeeditor, codemirror, completer, console, coreutils, csvviewer, docmanager, docregistry, filebrowser, fileeditor, imageviewer, inspector, logconsole, mainmenu, nbformat, notebook, observables, outputarea, rendermime, services, settingregistry, statedb, statusbar, terminal, ui-components]
+        group: [javascript, python, integrity]
       fail-fast: false
     runs-on: windows-latest
     steps:

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -48,6 +48,9 @@ class LogErrorHandler(logging.Handler):
         # known startup error message
         if 'paste' in record.msg:
             return
+        # handle known shutdown message
+        if 'Stream is closed' in record.msg:
+            return
         return super().filter(record)
 
     def emit(self, record):

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -280,7 +280,7 @@ class TestExtension(AppHandlerTest):
                 stdout=subprocess.PIPE,
                 universal_newlines=True,
                 check=True,
-                cwd=base_dir
+                cwd=str(base_dir)
             ).stdout.strip()
             for name in self.pinned_packages
         ]
@@ -505,11 +505,15 @@ class TestExtension(AppHandlerTest):
         pkg = pjoin(app_dir, 'static', 'package.json')
         with open(pkg) as fid:
             data = json.load(fid)
-        assert list(data['jupyterlab']['extensions'].keys()) == [
+
+        for key in [
             '@jupyterlab/application-extension',
             '@jupyterlab/apputils-extension',
             '@jupyterlab/mock-extension',
-        ]
+        ]:
+            assert key in data['jupyterlab']['extensions']
+        assert len(data['jupyterlab']['extensions']) == 3
+
         assert data['jupyterlab']['mimeExtensions'] == {}
         for pkg in data['jupyterlab']['singletonPackages']:
             if pkg.startswith('@jupyterlab/'):

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -505,15 +505,11 @@ class TestExtension(AppHandlerTest):
         pkg = pjoin(app_dir, 'static', 'package.json')
         with open(pkg) as fid:
             data = json.load(fid)
-
-        for key in [
+        assert sorted(data['jupyterlab']['extensions'].keys()) == [
             '@jupyterlab/application-extension',
             '@jupyterlab/apputils-extension',
             '@jupyterlab/mock-extension',
-        ]:
-            assert key in data['jupyterlab']['extensions']
-        assert len(data['jupyterlab']['extensions']) == 3
-
+        ]
         assert data['jupyterlab']['mimeExtensions'] == {}
         for pkg in data['jupyterlab']['singletonPackages']:
             if pkg.startswith('@jupyterlab/'):

--- a/packages/apputils/src/widgettracker.ts
+++ b/packages/apputils/src/widgettracker.ts
@@ -142,6 +142,7 @@ export class WidgetTracker<T extends Widget = Widget>
         pool.current = focus.currentWidget;
         return;
       }
+
       this.onCurrentChanged(widget);
       this._currentChanged.emit(widget);
     }, this);
@@ -216,11 +217,16 @@ export class WidgetTracker<T extends Widget = Widget>
    * the tracker can be checked with the `has()` method. The promise this method
    * returns resolves after the widget has been added and saved to an underlying
    * restoration connector, if one is available.
+   *
+   * The newly added widget becomes the current widget unless the focus tracker
+   * already had a focused widget.
    */
   async add(widget: T): Promise<void> {
     this._focusTracker.add(widget);
     await this._pool.add(widget);
-    this._pool.current = widget;
+    if (!this._focusTracker.activeWidget) {
+      this._pool.current = widget;
+    }
   }
 
   /**

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -26,20 +26,25 @@ fi
 
 
 if [[ $GROUP == docs ]]; then
+    # Run the link check - allow for a link to fail once (--lf means only run last failed)
+    py.test --check-links -k .md . || py.test --check-links -k .md --lf .
 
     # Build the docs
     jlpm build:packages
     jlpm docs
 
-    # Verify tutorial docs build
+    # Verify sphinx docs build
     pushd docs
     pip install sphinx sphinx-copybutton sphinx_rtd_theme recommonmark
-    make linkcheck
     make html
+
+    # Remove internal sphinx files and use pytest-check-links on the generated html
+    rm build/html/genindex.html
+    rm build/html/search.html
+    py.test --check-links -k .html build/html || py.test --check-links -k .html --lf build/html
+
     popd
 
-    # Run the link check - allow for a link to fail once
-    py.test --check-links -k .md . || py.test --check-links -k .md --lf .
 fi
 
 

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -214,7 +214,7 @@ if [[ $GROUP == usage ]]; then
     python -m jupyterlab.selenium_check
 
     # Make sure we can non-dev install.
-    virtualenv -p $(which python3) test_install
+    venv -p $(which python3) test_install
     ./test_install/bin/pip install -q ".[test]"  # this populates <sys_prefix>/share/jupyter/lab
     ./test_install/bin/python -m jupyterlab.browser_check
     # Make sure we can run the build

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -214,7 +214,8 @@ if [[ $GROUP == usage ]]; then
     python -m jupyterlab.selenium_check
 
     # Make sure we can non-dev install.
-    venv -p $(which python3) test_install
+    pip install virtualenv
+    virtualenv -p $(which python3) test_install
     ./test_install/bin/pip install -q ".[test]"  # this populates <sys_prefix>/share/jupyter/lab
     ./test_install/bin/python -m jupyterlab.browser_check
     # Make sure we can run the build

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -27,9 +27,6 @@ fi
 
 if [[ $GROUP == docs ]]; then
 
-    # Run the link check - allow for a link to fail once
-    py.test --check-links -k .md . || py.test --check-links -k .md --lf .
-
     # Build the docs
     jlpm build:packages
     jlpm docs
@@ -40,6 +37,9 @@ if [[ $GROUP == docs ]]; then
     make linkcheck
     make html
     popd
+
+    # Run the link check - allow for a link to fail once
+    py.test --check-links -k .md . || py.test --check-links -k .md --lf .
 fi
 
 

--- a/tests/test-apputils/src/widgettracker.spec.ts
+++ b/tests/test-apputils/src/widgettracker.spec.ts
@@ -79,7 +79,7 @@ describe('@jupyterlab/apputils', () => {
         const widget2 = createWidget();
         Widget.attach(widget, document.body);
         focus(widget);
-        tracker.add(widget);
+        await tracker.add(widget);
         let called = false;
         tracker.currentChanged.connect(() => {
           called = true;
@@ -96,7 +96,7 @@ describe('@jupyterlab/apputils', () => {
         Widget.attach(widget, document.body);
         Widget.attach(widget2, document.body);
         focus(widget);
-        tracker.add(widget);
+        await tracker.add(widget);
         await tracker.add(widget2);
         let promise = signalToPromise(tracker.currentChanged);
         focus(widget2);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Backport of #8114 to `1.2.x`, but just the commit that fixed the widget tracker since there was no property inspector panel.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Cleans up handling of widgets added to the tracker to defer to focus state.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Better tracking of the current widget.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
