### PR TITLE
DevOps fixes

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,13 +2,14 @@ name: Pull Request Labeler
 # This workflow is supposed to run every 5 minutes
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/120 * * * *'
 jobs:
   triage:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-      - uses: paulfantom/periodic-labeler@dffbc90404f371f76444a69221c2f7ad079e2319
+      - if: github.repository == "jupyterlab/jupyterlab"
+        uses: paulfantom/periodic-labeler@dffbc90404f371f76444a69221c2f7ad079e2319
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,7 @@ name: Pull Request Labeler
 # This workflow is supposed to run every 5 minutes
 on:
   schedule:
-    - cron: '*/120 * * * *'
+    - cron: '*/20 * * * *'
 jobs:
   triage:
     name: Update PR Labels

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
     name: Windows
     strategy:
       matrix:
-        group: [python, integrity, application, apputils, cells, codeeditor, codemirror, completer, console, coreutils, csvviewer, docmanager, docregistry, filebrowser, fileeditor, imageviewer, inspector, logconsole, mainmenu, nbformat, notebook, observables, outputarea, rendermime, services, settingregistry, statedb, statusbar, terminal, ui-components]
+        group: [javascript, python, integrity]
       fail-fast: false
     runs-on: windows-latest
     steps:

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -84,15 +84,15 @@ def run_test(app, func):
             app.log.info('Exiting normally')
             result = 0
 
-        app.http_server.stop()
-        app.io_loop.stop()
-        env_patch.stop()
         try:
+            app.http_server.stop()
+            app.io_loop.stop()
+            env_patch.stop()
             os._exit(result)
         except Exception as e:
             self.log.error(str(e))
             if 'Stream is closed' in str(e):
-                os._exit(0)
+                os._exit(result)
             os._exit(1)
 
     # The entry URL for browser tests is different in notebook >= 6.0,

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -91,6 +91,8 @@ def run_test(app, func):
             os._exit(result)
         except Exception as e:
             self.log.error(str(e))
+            if 'Stream is closed' in str(e):
+                os._exit(0)
             os._exit(1)
 
     # The entry URL for browser tests is different in notebook >= 6.0,

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -48,6 +48,9 @@ class LogErrorHandler(logging.Handler):
         # known startup error message
         if 'paste' in record.msg:
             return
+        # handle known shutdown message
+        if 'Stream is closed' in record.msg:
+            return
         return super().filter(record)
 
     def emit(self, record):

--- a/scripts/appveyor.cmd
+++ b/scripts/appveyor.cmd
@@ -20,11 +20,12 @@ IF "%NAME%"=="python" (
     python -m jupyterlab.browser_check
 
 ) ELSE (
-    jlpm run build:packages:scope --scope "@jupyterlab/%NAME%"
+    set NODE_OPTIONS=--max-old-space-size=1028
+    jlpm run build:packages
     if !errorlevel! neq 0 exit /b !errorlevel!
-    jlpm run build:test:scope --scope "@jupyterlab/test-%NAME%"
+    jlpm run build:test
     if !errorlevel! neq 0 exit /b !errorlevel!
-    setx FORCE_COLOR 1 && jlpm run test:scope --loglevel success --scope "@jupyterlab/test-%NAME%"
+    setx FORCE_COLOR 1 && jlpm coverage --loglevel success
 )
 
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -45,7 +45,7 @@ fi
 
 
 if [[ $GROUP == docs ]]; then
-    # Run the link check - allow for a link to fail once
+    # Run the link check - allow for a link to fail once (--lf means only run last failed)
     py.test --check-links -k .md . || py.test --check-links -k .md --lf .
 
     # Build the docs
@@ -56,6 +56,12 @@ if [[ $GROUP == docs ]]; then
     pushd docs
     pip install sphinx sphinx-copybutton sphinx_rtd_theme recommonmark jsx-lexer
     make html
+
+    # Remove internal sphinx files and use pytest-check-links on the generated html
+    rm build/html/genindex.html
+    rm build/html/search.html
+    py.test --check-links -k .html build/html || py.test --check-links -k .html --lf build/html
+
     popd
 fi
 

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -60,7 +60,8 @@ if [[ $GROUP == docs ]]; then
     # Remove internal sphinx files and use pytest-check-links on the generated html
     rm build/html/genindex.html
     rm build/html/search.html
-    py.test --check-links -k .html build/html || py.test --check-links -k .html --lf build/html
+    # FIXME: re-enable pending https://github.com/minrk/pytest-check-links/pull/7
+    #py.test --check-links -k .html build/html || py.test --check-links -k .html --lf build/html
 
     popd
 fi

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -53,7 +53,6 @@ if [[ $GROUP == docs ]]; then
     pushd docs
     pip install sphinx sphinx-copybutton sphinx_rtd_theme recommonmark jsx-lexer
     make html
-    make linkcheck
     popd
 
     # Run the link check - allow for a link to fail once

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -45,6 +45,9 @@ fi
 
 
 if [[ $GROUP == docs ]]; then
+    # Run the link check - allow for a link to fail once
+    py.test --check-links -k .md . || py.test --check-links -k .md --lf .
+
     # Build the docs
     jlpm build:packages
     jlpm docs
@@ -54,10 +57,6 @@ if [[ $GROUP == docs ]]; then
     pip install sphinx sphinx-copybutton sphinx_rtd_theme recommonmark jsx-lexer
     make html
     popd
-
-    # Run the link check - allow for a link to fail once
-    py.test --check-links -k .md . || py.test --check-links -k .md --lf .
-
 fi
 
 


### PR DESCRIPTION
The labeller is currently running on forks, which can lead to contributors getting emails when the build fails periodically.   Also, 10 minutes seems to aggressive, pushing it up to 20.

Reverts changes from e4a1aa8a04cdf7d4bea640362bb4ae7f18a173c1 to reduce the number of jobs.  Ref #8117 

Use pytest-check-links for the html tests.  Once we have a new release of that library, we will be able to handle the 429 errors.

Handle stream processing error due to requests to the notebook server as it is shutting down, addressing the usage test failures. 