### PR TITLE
Post 2.0 improvements to LabIcon: work with all svg loaders, improve performance, fix issue with menus from extensions

### DIFF
--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -7,7 +7,7 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { ServiceManager } from '@jupyterlab/services';
 
-import { MenuSvg } from '@jupyterlab/ui-components';
+import { ContextMenuSvg } from '@jupyterlab/ui-components';
 
 import { IIterator } from '@lumino/algorithm';
 
@@ -40,11 +40,13 @@ export abstract class JupyterFrontEnd<
    * Construct a new JupyterFrontEnd object.
    */
   constructor(options: JupyterFrontEnd.IOptions<T>) {
-    // render context menu with inline svg icon tweaks
-    options.contextMenuRenderer =
-      options.contextMenuRenderer || MenuSvg.defaultRenderer;
-
     super(options);
+
+    // render context menu/submenus with inline svg icon tweaks
+    this.contextMenu = new ContextMenuSvg({
+      commands: this.commands,
+      renderer: options.contextMenuRenderer
+    });
 
     // The default restored promise if one does not exist in the options.
     const restored = new Promise<void>(resolve => {
@@ -180,6 +182,8 @@ export abstract class JupyterFrontEnd<
       event.stopPropagation();
     }
   }
+
+  readonly contextMenu: ContextMenuSvg;
 
   private _contextMenuEvent: MouseEvent;
 }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -50,6 +50,18 @@ import {
 
 import { TextModelFactory } from './default';
 
+// monkey patch omni-loader support for svgs in LabIcon
+//
+// const oldResolveSvg = LabIcon.resolveSvg;
+// function resolveSvgShim({ name, svgstr }: LabIcon.IIcon): HTMLElement | null {
+//   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+//   const [, base64, raw] = svgstr.split(/data:.*?(;base64)?,/);
+
+//   // convert from base64 if needed, decode any uri escaped chars
+//   return oldResolveSvg({name, svgstr: decodeURIComponent(base64 ? atob(raw) : raw) });
+// }
+// LabIcon.resolveSvg = resolveSvgShim;
+
 /**
  * The document registry.
  */

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -50,18 +50,6 @@ import {
 
 import { TextModelFactory } from './default';
 
-// monkey patch omni-loader support for svgs in LabIcon
-//
-// const oldResolveSvg = LabIcon.resolveSvg;
-// function resolveSvgShim({ name, svgstr }: LabIcon.IIcon): HTMLElement | null {
-//   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
-//   const [, base64, raw] = svgstr.split(/data:.*?(;base64)?,/);
-
-//   // convert from base64 if needed, decode any uri escaped chars
-//   return oldResolveSvg({name, svgstr: decodeURIComponent(base64 ? atob(raw) : raw) });
-// }
-// LabIcon.resolveSvg = resolveSvgShim;
-
 /**
  * The document registry.
  */

--- a/packages/mainmenu/src/labmenu.ts
+++ b/packages/mainmenu/src/labmenu.ts
@@ -3,8 +3,6 @@
 
 import { IWidgetTracker } from '@jupyterlab/apputils';
 
-import { MenuSvg } from '@jupyterlab/ui-components';
-
 import { ArrayExt } from '@lumino/algorithm';
 
 import { DisposableDelegate, IDisposable } from '@lumino/disposable';
@@ -63,8 +61,7 @@ export class JupyterLabMenu implements IJupyterLabMenu {
    *   groups that are added to the menu.
    */
   constructor(options: Menu.IOptions, includeSeparators: boolean = true) {
-    // render menu with inline svg icon tweaks
-    this.menu = new MenuSvg(options);
+    this.menu = new Menu(options);
     this._includeSeparators = includeSeparators;
   }
 

--- a/packages/mainmenu/src/mainmenu.ts
+++ b/packages/mainmenu/src/mainmenu.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { MenuSvg } from '@jupyterlab/ui-components';
+
 import { ArrayExt } from '@lumino/algorithm';
 
 import { CommandRegistry } from '@lumino/commands';
@@ -97,6 +99,9 @@ export class MainMenu extends MenuBar implements IMainMenu {
    * Add a new menu to the main menu bar.
    */
   addMenu(menu: Menu, options: IMainMenu.IAddOptions = {}): void {
+    // override default renderer with svg-supporting renderer
+    MenuSvg.overrideDefaultRenderer(menu);
+
     if (ArrayExt.firstIndexOf(this.menus, menu) > -1) {
       return;
     }

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -814,14 +814,18 @@ namespace Private {
    * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
    */
   export function svgstrShim(svgstr: string, strict: boolean = true): string {
-    // decode any uri escaping then match to raw svg string
-    const [, base64, raw] = decodeURIComponent(svgstr).match(
-      strict
-        ? // match based on data url schema
-          /^(?:data:.*?(;base64)?,)?(.*)/
-        : // match based on open of svg tag
-          /^.*?(?:(base64).*)?,?(<svg.*)/
-    )!;
+    // decode any uri escaping, condense leading/lagging whitespace,
+    // then match to raw svg string
+    const [, base64, raw] = decodeURIComponent(svgstr)
+      .replace(/>\s*\n\s*</g, '><')
+      .replace(/\s*\n\s*/g, ' ')
+      .match(
+        strict
+          ? // match based on data url schema
+            /^(?:data:.*?(;base64)?,)?(.*)/
+          : // match based on open of svg tag
+            /(?:(base64).*)?(<svg.*)/
+      )!;
 
     // decode from base64, if needed
     return base64 ? atob(raw) : raw;

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -370,7 +370,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
     });
   }
 
-  get svgElement(): HTMLElement | null {
+  protected get svgElement(): HTMLElement | null {
     if (this._svgElement === undefined) {
       this._svgElement = this._initSvg({ uuid: this._uuid });
     }
@@ -378,7 +378,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
     return this._svgElement;
   }
 
-  get svgInnerHTML(): string | null {
+  protected get svgInnerHTML(): string | null {
     if (this._svgInnerHTML === undefined) {
       if (this.svgElement === null) {
         // the svg element resolved to null, mark this null too
@@ -391,7 +391,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
     return this._svgInnerHTML;
   }
 
-  get svgReactAttrs(): any | null {
+  protected get svgReactAttrs(): any | null {
     if (this._svgReactAttrs === undefined) {
       if (this.svgElement === null) {
         // the svg element resolved to null, mark this null too

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -805,25 +805,22 @@ namespace Private {
   }
 
   /**
-   * a shim for svgstrs loaded using any loader other than raw-loader,
-   * which in general may look like:
-   *   data:[<mediatype>][;base64],<svg>...
+   * A shim for svgstrs loaded using any loader other than raw-loader,
+   * which in general may look like the raw contents of an .svg file:
+   *   <svg...</svg>
+   * or like a data URL:
+   *   data:[<mediatype>][;base64],<svg...</svg>
    *
-   * see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+   * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
    */
   export function shimSvgstr(svgstr: string): string {
-    // may be uri encoded, decode
-    svgstr = decodeURIComponent(svgstr);
+    // decode any uri escaping then match to data url schema
+    const [, base64, raw] = decodeURIComponent(svgstr).match(
+      /^(?:data:.*?(;base64)?,)?(.*)/
+    )!;
 
-    if (svgstr.startsWith('data:')) {
-      // split any prefix from the raw svg data
-      const [, base64, raw] = svgstr.split(/^data:.*?(;base64)?,/);
-
-      // convert from base64 if needed
-      return base64 ? atob(raw) : raw;
-    } else {
-      return svgstr;
-    }
+    // decode from base64, if needed
+    return base64 ? atob(raw) : raw;
   }
 
   /**

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -427,9 +427,8 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
     document
       .querySelectorAll(`[data-icon-id="${uuidOld}"]`)
       .forEach(oldSvgElement => {
-        const svgElement = this._initSvg({ uuid });
-        if (svgElement) {
-          oldSvgElement.replaceWith(svgElement);
+        if (this.svgElement) {
+          oldSvgElement.replaceWith(this.svgElement.cloneNode(true));
         }
       });
 

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -169,7 +169,7 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
    */
   static resolveSvg({ name, svgstr }: LabIcon.IIcon): HTMLElement | null {
     const svgDoc = new DOMParser().parseFromString(
-      Private.shimSvgstr(svgstr),
+      Private.svgstrShim(svgstr),
       'image/svg+xml'
     );
 
@@ -813,10 +813,14 @@ namespace Private {
    *
    * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
    */
-  export function shimSvgstr(svgstr: string): string {
-    // decode any uri escaping then match to data url schema
+  export function svgstrShim(svgstr: string, strict: boolean = true): string {
+    // decode any uri escaping then match to raw svg string
     const [, base64, raw] = decodeURIComponent(svgstr).match(
-      /^(?:data:.*?(;base64)?,)?(.*)/
+      strict
+        ? // match based on data url schema
+          /^(?:data:.*?(;base64)?,)?(.*)/
+        : // match based on open of svg tag
+          /^.*?(?:(base64).*)?,?(<svg.*)/
     )!;
 
     // decode from base64, if needed

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -851,10 +851,13 @@ namespace Private {
   }
 
   /**
-   * A shim for svgstrs loaded using any loader other than raw-loader,
-   * which in general may look like the raw contents of an .svg file:
+   * A shim for svgstrs loaded using any loader other than raw-loader.
+   * This function assumes that svgstr will look like one of:
+   *
+   * - the raw contents of an .svg file:
    *   <svg...</svg>
-   * or like a data URL:
+   *
+   * - a data URL:
    *   data:[<mediatype>][;base64],<svg...</svg>
    *
    * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs

--- a/packages/ui-components/src/icon/widgets/menusvg.ts
+++ b/packages/ui-components/src/icon/widgets/menusvg.ts
@@ -41,27 +41,8 @@ export class MenuSvg extends Menu {
    * The index will be clamped to the bounds of the items.
    */
   insertItem(index: number, options: Menu.IItemOptions): Menu.IItem {
-    if (options.submenu?.renderer === Menu.defaultRenderer) {
-      // create a "view" of the submenu with a different default renderer
-      const submenu = Object.create(options.submenu, {
-        renderer: {
-          configurable: true,
-          enumerable: true,
-          value: MenuSvg.defaultRenderer
-        }
-      });
-
-      // Widget.title is an AttachedProperty, and needs special handling
-      submenu.title.label = options.submenu.title.label;
-      submenu.title.mnemonic = options.submenu.title.mnemonic;
-      submenu.title.icon = options.submenu.title.icon;
-      submenu.title.iconClass = options.submenu.title.iconClass;
-      submenu.title.iconLabel = options.submenu.title.iconLabel;
-      submenu.title.caption = options.submenu.title.caption;
-      submenu.title.className = options.submenu.title.className;
-      submenu.title.dataset = options.submenu.title.dataset;
-
-      options.submenu = submenu;
+    if (options.submenu) {
+      MenuSvg.overrideDefaultRenderer(options.submenu);
     }
 
     return super.insertItem(index, options);
@@ -69,6 +50,20 @@ export class MenuSvg extends Menu {
 }
 
 export namespace MenuSvg {
+  export function overrideDefaultRenderer(menu: Menu): void {
+    // override renderer, if needed
+    if (menu.renderer === Menu.defaultRenderer) {
+      (menu as any).renderer = defaultRenderer;
+    }
+
+    // recurse through submenus
+    for (const item of (menu as any)._items as Menu.IItem[]) {
+      if (item.submenu) {
+        overrideDefaultRenderer(item.submenu);
+      }
+    }
+  }
+
   /**
    * a modified implementation of the Menu Renderer
    */

--- a/packages/ui-components/src/icon/widgets/menusvg.ts
+++ b/packages/ui-components/src/icon/widgets/menusvg.ts
@@ -77,6 +77,9 @@ export namespace MenuSvg {
       (menu as any).renderer = MenuSvg.defaultRenderer;
     }
 
+    // ensure correct renderer on any submenus that get added in the future
+    menu.insertItem = MenuSvg.prototype.insertItem;
+
     // recurse through submenus
     for (const item of (menu as any)._items as Menu.IItem[]) {
       if (item.submenu) {

--- a/packages/ui-components/src/icon/widgets/menusvg.ts
+++ b/packages/ui-components/src/icon/widgets/menusvg.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { h, VirtualElement } from '@lumino/virtualdom';
-import { Menu } from '@lumino/widgets';
+import { Menu, ContextMenu } from '@lumino/widgets';
 
 import { caretRightIcon, checkIcon } from '../iconimports';
 import { LabIconStyle } from '../../style';
@@ -11,6 +11,26 @@ import { classes } from '../../utils';
 const submenuIcon = caretRightIcon.bindprops({
   stylesheet: 'menuItem'
 });
+
+/**
+ * An object which implements a universal context menu.
+ * Tweaked to use inline svg icons
+ */
+export class ContextMenuSvg extends ContextMenu {
+  /**
+   * Construct a new context menu.
+   *
+   * @param options - The options for initializing the menu.
+   */
+  constructor(options: ContextMenu.IOptions) {
+    super(options);
+
+    // override the vanilla .menu
+    this.menu = new MenuSvg(options);
+  }
+
+  readonly menu: MenuSvg;
+}
 
 /**
  * a widget which displays items as a canonical menu.
@@ -53,7 +73,8 @@ export namespace MenuSvg {
   export function overrideDefaultRenderer(menu: Menu): void {
     // override renderer, if needed
     if (menu.renderer === Menu.defaultRenderer) {
-      (menu as any).renderer = defaultRenderer;
+      // cast away readonly on menu.renderer
+      (menu as any).renderer = MenuSvg.defaultRenderer;
     }
 
     // recurse through submenus

--- a/packages/ui-components/src/style/icon.ts
+++ b/packages/ui-components/src/style/icon.ts
@@ -141,7 +141,7 @@ export namespace LabIconStyle {
     stylesheet?: ISheetResolvable | ISheetResolvable[];
 
     /**
-     * @depreacted use stylesheet instead
+     * @deprecated use stylesheet instead
      */
     kind?: IBuiltin;
 

--- a/packages/ui-components/src/utils.ts
+++ b/packages/ui-components/src/utils.ts
@@ -66,12 +66,17 @@ export function classesDedupe(
  *
  * @param elem - A DOM element
  *
+ * @param ignore - An optional list of attribute names to ignore
+ *
  * @returns An object with key:value pairs that are the React-friendly
  * translation of elem's attributes
  */
-export function getReactAttrs(elem: Element) {
+export function getReactAttrs(
+  elem: Element,
+  { ignore = [] }: { ignore?: string[] } = {}
+) {
   return elem.getAttributeNames().reduce((d, name) => {
-    if (name === 'style') {
+    if (name === 'style' || ignore.includes(name)) {
       void 0;
     } else if (name.startsWith('data')) {
       d[name] = elem.getAttribute(name);


### PR DESCRIPTION
## References

jupyter/nbdime#512

Some improvements to LabIcon.

@vidartf With these changes you should be able to use LabIcon/`@jupyterlab/ui-components` in just about any project regardless of how svg loading is configured.

## Code changes

- LabIcon should now work with all commonly-used svg loaders/loading schemes
  - previously, LabIcon expected svgs to be loaded using a raw loader (such as Webpack's `raw-loader`) that directly loaded the raw data from an .svg file as a string
  - accomplished by shimming the input svgstr

- 15-20x speedup of icon creation (on the javascript side)
  - accomplished by caching the intermediates produced while parsing LabIcon.svgstr into actual svg nodes
  - results in an overall 2x speedup of icon creation + render
  - profiling of creating/rendering ~1500 filebrowser items
    - old code:

      ![image](https://user-images.githubusercontent.com/2263641/77872555-45412b80-7215-11ea-8afa-d0415c3e580a.png)


    - new code (compare `cloneNode` to `resolveSvg` above):

      ![image](https://user-images.githubusercontent.com/2263641/77872508-1c209b00-7215-11ea-88e6-56303396e101.png)


- Fix icons in menus added to main menubar by extensions, and ensure that correct renderer is used for all submenus
  - done via fixes to the implementation of MenuSvg

## User-facing changes

- improved performance related to icons (especially when opening dirs with 1000+ files in the filebrowser)

- icons should now work correctly in menus added to main menubar and in all submenus (including context submenus)

## Backwards-incompatible changes

None