### PR TITLE
Fix string quoting

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update PR Labels
     runs-on: ubuntu-latest
     steps:
-      - if: github.repository == "jupyterlab/jupyterlab"
+      - if: github.repository == 'jupyterlab/jupyterlab'
         uses: paulfantom/periodic-labeler@dffbc90404f371f76444a69221c2f7ad079e2319
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix [string quoting](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions) in github action introduced in #8119

> You must use single quotes. Escape literal single-quotes with a single quote.
