### PR TITLE
Upgrade to jupyterlab_server 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'notebook>=4.3.1',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
-    'jupyterlab_server@ git+https://github.com/datalayer-contrib/jupyterlab-server@bw-list',
+    'jupyterlab_server>=1.1.0',
     'jinja2>=2.10'
 ]
 


### PR DESCRIPTION
To support the Listings feature https://github.com/jupyterlab/jupyterlab/issues/7933 we need to upgrade to `jupyterlab_server 1.1.0.`

This PR updates `setup.py` for this.

@saulshanabrook 