### PR TITLE
Revert "Pressing Backspace in an empty cell deletes the cell"

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -385,11 +385,6 @@ export namespace CodeEditor {
     readonly edgeRequested: ISignal<IEditor, EdgeLocation>;
 
     /**
-     * A signal emitted when hitting backspace in an empty editor.
-     */
-    readonly emptyBackspace: ISignal<IEditor, void>;
-
-    /**
      * The default selection style for the editor.
      */
     selectionStyle: CodeEditor.ISelectionStyle;

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -80,11 +80,6 @@ const UP_ARROW = 38;
 const DOWN_ARROW = 40;
 
 /**
- * The key code for the backspace key.
- */
-const BACKSPACE = 8;
-
-/**
  * The time that a collaborator name hover persists.
  */
 const HOVER_TIMEOUT = 1000;
@@ -180,11 +175,6 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * A signal emitted when either the top or bottom edge is requested.
    */
   readonly edgeRequested = new Signal<this, CodeEditor.EdgeLocation>(this);
-
-  /**
-   * A signal emitted when backspace is pressed in an empty cell.
-   */
-  readonly emptyBackspace = new Signal<this, void>(this);
 
   /**
    * The DOM node that hosts the editor.
@@ -657,10 +647,6 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       if (!event.shiftKey) {
         this.edgeRequested.emit('bottom');
       }
-      return false;
-    }
-    if (event.keyCode === BACKSPACE && this._model.value.text === '') {
-      this.emptyBackspace.emit();
       return false;
     }
     return false;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -1458,7 +1458,6 @@ export class Notebook extends StaticNotebook {
       });
     }
     cell.editor.edgeRequested.connect(this._onEdgeRequest, this);
-    cell.editor.emptyBackspace.connect(this._onEmptyBackspace, this);
     // If the insertion happened above, increment the active cell
     // index, otherwise it stays the same.
     this.activeCellIndex =
@@ -1535,22 +1534,6 @@ export class Notebook extends StaticNotebook {
       }
     }
     this.mode = 'edit';
-  }
-
-  /**
-   * Handle empty backspace signals from cells (delete the cell).
-   */
-
-  private _onEmptyBackspace(editor: CodeEditor.IEditor) {
-    let activeCellIndex = this.activeCellIndex;
-    const model = this.model!;
-    const cells = model.cells;
-    const child = cells.get(activeCellIndex);
-    const deletable = child.metadata.get('deletable') !== false;
-
-    if (deletable) {
-      cells.remove(activeCellIndex);
-    }
   }
 
   /**

--- a/tests/test-codemirror/src/editor.spec.ts
+++ b/tests/test-codemirror/src/editor.spec.ts
@@ -16,8 +16,6 @@ const UP_ARROW = 38;
 
 const DOWN_ARROW = 40;
 
-const BACKSPACE = 8;
-
 const ENTER = 13;
 
 class LogFileEditor extends CodeMirrorEditor {
@@ -77,37 +75,6 @@ describe('CodeMirrorEditor', () => {
       expect(edge).to.be.null;
       editor.editor.triggerOnKeyDown(event);
       expect(edge).to.equal('bottom');
-    });
-  });
-
-  describe('#backspaceEmpty', () => {
-    it('should emit a signal when backspace in empty cell', () => {
-      const event = generate('keydown', { keyCode: BACKSPACE });
-      let called = false;
-      const listener = (sender: any, args: any) => {
-        expect(sender).to.be.equal(editor);
-        expect(args).to.be.undefined;
-        called = true;
-      };
-      editor.emptyBackspace.connect(listener);
-      expect(called).to.be.false;
-      editor.editor.triggerOnKeyDown(event);
-      expect(called).to.be.true;
-    });
-
-    it('should not emit a signal when backspace in non-empty cell', () => {
-      editor.model.value.text = 'foo\nbar\nbaz';
-      const event = generate('keydown', { keyCode: BACKSPACE });
-      let called = false;
-      const listener = (sender: any, args: any) => {
-        expect(sender).to.be.equal(editor);
-        expect(args).to.be.undefined;
-        called = true;
-      };
-      editor.emptyBackspace.connect(listener);
-      expect(called).to.be.false;
-      editor.editor.triggerOnKeyDown(event);
-      expect(called).to.be.false;
     });
   });
 

--- a/tests/test-notebook/src/widget.spec.ts
+++ b/tests/test-notebook/src/widget.spec.ts
@@ -1475,20 +1475,6 @@ describe('@jupyter/notebook', () => {
           expect(widget.activeCellIndex).to.equal(1);
         });
       });
-
-      context('`emptyBackspace` signal', () => {
-        it('should delete cell', () => {
-          const widget = createActiveWidget();
-          widget.model!.fromJSON(NBTestUtils.DEFAULT_CONTENT);
-          widget.activeCellIndex = 1;
-          const cell = widget.model!.cells.get(1);
-          const child = widget.widgets[widget.activeCellIndex];
-          (child.editor.emptyBackspace as any).emit();
-          expect(widget.activeCellIndex).to.equal(0);
-          expect(cell.isDisposed).to.equal(false);
-          expect(child.isDisposed).to.equal(true);
-        });
-      });
     });
 
     describe('#onCellMoved()', () => {


### PR DESCRIPTION
Reverts jupyterlab/jupyterlab#7834


Further discussion suggests we need some more time to discuss this because some people feel like it will be surprising to have this destructive behavior bound to backspace: https://github.com/jupyterlab/jupyterlab/issues/7713.

