### PR TITLE
Icons for Completion Items UI

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -929,7 +929,7 @@ export namespace Completer {
     ): HTMLLIElement {
       // Add the icon or type monogram
       if (icon) {
-        let iconNode = icon.element({
+        const iconNode = icon.element({
           className: 'jp-Completer-type jp-Completer-icon'
         });
         li.appendChild(iconNode);

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -868,7 +868,8 @@ export namespace Completer {
         this._createMatchNode(item.label),
         !!item.type,
         item.type,
-        orderedTypes
+        orderedTypes,
+        item.icon
       );
     }
 
@@ -921,24 +922,33 @@ export namespace Completer {
       matchNode: HTMLElement,
       typesExist: boolean,
       type: any,
-      orderedTypes: string[]
+      orderedTypes: string[],
+      icon?: string
     ): HTMLLIElement {
-      // If there are types provided add those.
-      if (typesExist) {
+      // Add the icon or type monogram
+      if (icon) {
+        let iconNode = document.createElement('img');
+        iconNode.className = 'jp-Completer-type';
+        iconNode.src = icon;
+        li.appendChild(iconNode);
+      } else if (typesExist) {
         const typeNode = document.createElement('span');
         typeNode.textContent = (type[0] || '').toLowerCase();
         const colorIndex = (orderedTypes.indexOf(type) % N_COLORS) + 1;
         typeNode.className = 'jp-Completer-type';
         typeNode.setAttribute(`data-color-index`, colorIndex.toString());
+        li.appendChild(typeNode);
+      }
+
+      li.appendChild(matchNode);
+
+      // If there is a type, add the type extension and title
+      if (typesExist) {
         li.title = type;
         const typeExtendedNode = document.createElement('code');
         typeExtendedNode.className = 'jp-Completer-typeExtended';
         typeExtendedNode.textContent = type.toLocaleLowerCase();
-        li.appendChild(typeNode);
-        li.appendChild(matchNode);
         li.appendChild(typeExtendedNode);
-      } else {
-        li.appendChild(matchNode);
       }
       return li;
     }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -928,14 +928,14 @@ export namespace Completer {
       // Add the icon or type monogram
       if (icon) {
         let iconNode = document.createElement('img');
-        iconNode.className = 'jp-Completer-icon';
+        iconNode.className = 'jp-Completer-type jp-Completer-icon';
         iconNode.src = icon;
         li.appendChild(iconNode);
       } else if (typesExist) {
         const typeNode = document.createElement('span');
         typeNode.textContent = (type[0] || '').toLowerCase();
         const colorIndex = (orderedTypes.indexOf(type) % N_COLORS) + 1;
-        typeNode.className = 'jp-Completer-type';
+        typeNode.className = 'jp-Completer-type jp-Completer-monogram';
         typeNode.setAttribute(`data-color-index`, colorIndex.toString());
         li.appendChild(typeNode);
       }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -5,6 +5,8 @@ import { HoverBox, defaultSanitizer } from '@jupyterlab/apputils';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
+import { LabIcon } from '@jupyterlab/ui-components';
+
 import { IIterator, IterableOrArrayLike, toArray } from '@lumino/algorithm';
 
 import { JSONObject, JSONExt } from '@lumino/coreutils';
@@ -923,13 +925,13 @@ export namespace Completer {
       typesExist: boolean,
       type: any,
       orderedTypes: string[],
-      icon?: string
+      icon?: LabIcon
     ): HTMLLIElement {
       // Add the icon or type monogram
       if (icon) {
-        let iconNode = document.createElement('img');
-        iconNode.className = 'jp-Completer-type jp-Completer-icon';
-        iconNode.src = icon;
+        let iconNode = icon.element({
+          className: 'jp-Completer-type jp-Completer-icon'
+        });
         li.appendChild(iconNode);
       } else if (typesExist) {
         const typeNode = document.createElement('span');

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -940,6 +940,14 @@ export namespace Completer {
         typeNode.className = 'jp-Completer-type jp-Completer-monogram';
         typeNode.setAttribute(`data-color-index`, colorIndex.toString());
         li.appendChild(typeNode);
+      } else {
+        // Create empty span to ensure consistent list styling.
+        // Otherwise, in a list of two items,
+        // if one item has an icon, but the other has type,
+        // the icon grows out of its bounds.
+        const dummyNode = document.createElement('span');
+        dummyNode.className = 'jp-Completer-monogram';
+        li.appendChild(dummyNode);
       }
 
       li.appendChild(matchNode);
@@ -951,6 +959,13 @@ export namespace Completer {
         typeExtendedNode.className = 'jp-Completer-typeExtended';
         typeExtendedNode.textContent = type.toLocaleLowerCase();
         li.appendChild(typeExtendedNode);
+      } else {
+        // If no type is present on the right,
+        // the highlighting of the completion item
+        // doesn't cover the entire row.
+        const dummyTypeExtendedNode = document.createElement('span');
+        dummyTypeExtendedNode.className = 'jp-Completer-typeExtended';
+        li.appendChild(dummyTypeExtendedNode);
       }
       return li;
     }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -928,7 +928,7 @@ export namespace Completer {
       // Add the icon or type monogram
       if (icon) {
         let iconNode = document.createElement('img');
-        iconNode.className = 'jp-Completer-type';
+        iconNode.className = 'jp-Completer-icon';
         iconNode.src = icon;
         li.appendChild(iconNode);
       } else if (typesExist) {

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -5,7 +5,7 @@
 |----------------------------------------------------------------------------*/
 
 :root {
-  --jp-private-completer-item-height: 22px;
+  --jp-private-completer-item-height: 24px;
   /* Shift the baseline of the type character to align with the match text */
   --jp-private-completer-type-offset: 2px;
 }
@@ -66,6 +66,16 @@
   font-family: var(--jp-code-font-family);
   font-size: var(--jp-code-font-size);
   line-height: var(--jp-private-completer-item-height);
+  vertical-align: middle;
+}
+
+.jp-Completer-item .jp-Completer-icon {
+  display: table-cell;
+  box-sizing: border-box;
+  height: var(--jp-private-completer-item-height);
+  background: transparent;
+  width: var(--jp-private-completer-item-height);
+  vertical-align: middle;
 }
 
 .jp-Completer-deprecated .jp-Completer-match {
@@ -102,6 +112,7 @@
   font-size: var(--jp-code-font-size);
   line-height: var(--jp-private-completer-item-height);
   padding-right: 8px;
+  vertical-align: middle;
 }
 
 .jp-Completer-item:hover {

--- a/packages/completer/style/base.css
+++ b/packages/completer/style/base.css
@@ -69,15 +69,6 @@
   vertical-align: middle;
 }
 
-.jp-Completer-item .jp-Completer-icon {
-  display: table-cell;
-  box-sizing: border-box;
-  height: var(--jp-private-completer-item-height);
-  background: transparent;
-  width: var(--jp-private-completer-item-height);
-  vertical-align: middle;
-}
-
 .jp-Completer-deprecated .jp-Completer-match {
   text-decoration: line-through;
   color: var(--jp-content-font-color2);
@@ -87,8 +78,19 @@
   display: table-cell;
   box-sizing: border-box;
   height: var(--jp-private-completer-item-height);
-  text-align: center;
   background: transparent;
+  width: var(--jp-private-completer-item-height);
+}
+
+.jp-Completer-item .jp-Completer-icon {
+  vertical-align: middle;
+  /* Normal element size from LabIconStyle.ISheetOptions */
+  height: 16px;
+  width: 16px;
+}
+
+.jp-Completer-item .jp-Completer-monogram {
+  text-align: center;
   color: white;
   width: var(--jp-private-completer-item-height);
   min-width: var(--jp-private-completer-item-height);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
A component of #7983 

This PR depends on #8080, and so will include some commits from that PR until it is merged.

The relevant changes actually proposed by this PR are [here](https://github.com/jupyterlab/jupyterlab/pull/8140/files/747850432102a5e2a86272a29a179c82597020a2..afc899b55d1034e23786f5a6e16177eb04be0e01)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
#### Widget:
- In `createCompletionItemNode`, if the completion item includes an icon (in the form of a base64-encoded svg data-uri), an `<img>` with the encoded svg will be added to the list item instead of the usual `<span>`
#### CSS:
- New class `jp-Completer-monogram` includes all the styling that is exclusively relevant to the monogram version of a completion
- New class `jp-Completer-icon` includes all the styling that is exclusively relevant to the icon version of a completion

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

#### Before:
Light:
![Screen Shot 2020-03-30 at 7 23 49 PM](https://user-images.githubusercontent.com/12799462/77980427-1c27a600-72bc-11ea-9022-d0a9f0f726c0.png)
Dark:
![Screen Shot 2020-03-30 at 7 24 10 PM](https://user-images.githubusercontent.com/12799462/77980430-1df16980-72bc-11ea-91ca-71e5eeeb9ca2.png)

#### After:
All function completions given an icon.
Light:
![Screen Shot 2020-03-30 at 7 16 30 PM](https://user-images.githubusercontent.com/12799462/77980003-0960a180-72bb-11ea-9932-1f436682afae.png)
Dark:
![Screen Shot 2020-03-30 at 7 16 16 PM](https://user-images.githubusercontent.com/12799462/77980008-0b2a6500-72bb-11ea-99b3-4a55c9f88191.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A