### PR TITLE
Remove "experimental" from enable extension command label

### DIFF
--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -87,7 +87,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       });
 
     commands.addCommand(CommandIDs.toggle, {
-      label: 'Enable Extension Manager (experimental)',
+      label: 'Enable Extension Manager',
       execute: () => {
         if (registry) {
           void registry.set(plugin.id, 'enabled', !enabled);


### PR DESCRIPTION
## References

This PR implements https://github.com/jupyterlab/jupyterlab/issues/8144

It remove "Experimental" text from `enable extension manager menu item`.