### PR TITLE
Docs: link to jupyterlab on jupyterhub page

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -89,11 +89,7 @@ the version of the ``notebook`` package that you have installed:
 Usage with JupyterHub
 ~~~~~~~~~~~~~~~~~~~~~
 
-Install JupyterLab and JupyterHub.
-
-In ``jupyterhub_config.py``, configure the ``Spawner`` to tell the single-user notebook servers to default to JupyterLab:
-
-``c.Spawner.default_url = '/lab'``
+Read the details on our :ref:`JupyterLab on JupyterHub documentation page <jupyterhub>`.
 
 
 Supported browsers

--- a/docs/source/user/jupyterhub.rst
+++ b/docs/source/user/jupyterhub.rst
@@ -1,4 +1,4 @@
-.. _jupyterlab:
+.. _jupyterhub:
 
 JupyterLab on JupyterHub
 ------------------------


### PR DESCRIPTION
This is a simple PR to link the install documentation to the jupyterlab on jupyterhub page.

(The content was duplicated, and current content on install page was even incomplete)