### PR TITLE
Bump to “alpha” instead of “a” for consistency with other prerelease bumps

### DIFF
--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -74,7 +74,7 @@ commander
       lernaVersion = 'patch';
     }
     if (lernaVersion === 'preminor') {
-      lernaVersion += ' --preid=a';
+      lernaVersion += ' --preid=alpha';
     }
 
     let cmd = `lerna version -m \"New version\" --force-publish=* --no-push ${lernaVersion}`;


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

CC @saulshanabrook @blink1073 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Currently the bump version creates npm alpha versions as ["2.1.0-a.0"](https://www.npmjs.com/package/@jupyterlab/application/v/2.1.0-a.0), but to be consistent, this should be "2.1.0-alpha.0". This PR effects this change.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
