### PR TITLE
Fixes search next/previous buttons wrapping in Firefox.

### DIFF
--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -149,7 +149,7 @@
   background-repeat: no-repeat;
   background-position: center;
   vertical-align: middle;
-  margin: 1px 7px 2px;
+  margin: 1px 5px 2px;
 }
 
 .jp-DocumentSearch-up-down-button {

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -135,6 +135,7 @@
   display: inline-block;
   padding-right: 2px;
   margin-left: auto;
+  white-space: nowrap;
 }
 
 .jp-DocumentSearch-spacer {


### PR DESCRIPTION
For me, a 7px margin was just enough to cause the buttons to wrap and display on top of each other. I put it to 5px just to be safe, even though 6px also worked for me.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Addresses the most glaring issue on #8101, the next/previous buttons wrapping so that they are on top of each other in Firefox.

## Code changes

Trim the margin for find overlay buttons slightly. 6px worked for me, but I put it to 5px to be safer.

## User-facing changes

Before:
<img width="420" alt="Screen Shot 2020-03-27 at 7 11 16 AM" src="https://user-images.githubusercontent.com/192614/78194058-e821c180-7430-11ea-9ac7-8b76b20ed8ac.png">


After:

<img width="423" alt="Screen Shot 2020-04-01 at 3 52 53 PM" src="https://user-images.githubusercontent.com/192614/78194049-e1934a00-7430-11ea-8443-0c17f4a5ec61.png">


## Backwards-incompatible changes

None
