### PR TITLE
Add by Jupyter label on extensions developed by Jupyter Org

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -10,6 +10,7 @@ import {
   caretRightIcon,
   Collapse,
   InputGroup,
+  jupyterIcon,
   listingsInfoIcon,
   refreshIcon
 } from '@jupyterlab/ui-components';
@@ -19,6 +20,7 @@ import * as React from 'react';
 import ReactPaginate from 'react-paginate';
 
 import { ListModel, IEntry, Action } from './model';
+import { isJupyterOrg } from './npm';
 
 // TODO: Replace pagination with lazy loading of lower search results
 
@@ -168,6 +170,10 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
     flagClasses.push(`jp-extensionmanager-entry-${entry.status}`);
   }
   let title = entry.name;
+  const entryIsJupyterOrg = isJupyterOrg(entry.name);
+  if (entryIsJupyterOrg) {
+    title = `${entry.name} (Developed by Project Jupyter)`;
+  }
   const githubUser = getExtensionGitHubUser(entry);
   if (
     listMode === 'black' &&
@@ -237,6 +243,14 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 }
               />
             )}
+          {entryIsJupyterOrg && (
+            <jupyterIcon.react
+              className="jp-extensionmanager-is-jupyter-org"
+              top="1px"
+              height="auto"
+              width="1em"
+            />
+          )}
         </div>
         <div className="jp-extensionmanager-entry-content">
           <div className="jp-extensionmanager-entry-description">

--- a/packages/extensionmanager/style/base.css
+++ b/packages/extensionmanager/style/base.css
@@ -17,6 +17,17 @@
 }
 
 /*
+  Jupyter Org
+*/
+
+.jp-extensionmanager-is-jupyter-org {
+  position: absolute;
+  right: 8px;
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
+}
+
+/*
   List view layout and styling
 */
 


### PR DESCRIPTION
Addresses discussions in https://github.com/jupyterlab/jupyterlab/issues/8161

<img width="347" alt="Screenshot 2020-04-04 at 10 12 42" src="https://user-images.githubusercontent.com/226720/78422149-6e225000-765d-11ea-8707-6fc2c599773e.png">

Extensions developed by Jupyter have now a small text at the top right.