### PR TITLE
Update browser check to use asyncio and suppress Stream is Closed errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -123,6 +123,7 @@ git push origin --tags <BRANCH>
 ```
 
 These lines:
+
 - upload to pypi with twine
 - double-check what branch you are on, then push changes to the correct upstream branch with the `--tags` option.
 

--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -15,12 +15,11 @@ from os import path as osp
 import os
 import shutil
 import sys
-import subprocess
 
 from tornado.ioloop import IOLoop
 from traitlets import Bool, Unicode
 from jupyterlab.labapp import get_app_dir
-from jupyterlab.browser_check import run_test
+from jupyterlab.browser_check import run_test, run_async_process
 
 here = osp.abspath(osp.dirname(__file__))
 
@@ -50,16 +49,16 @@ def main():
     App.launch_instance()
 
 
-def run_browser(url):
+async def run_browser(url):
     """Run the browser test and return an exit code.
     """
     target = osp.join(get_app_dir(), 'example_test')
     if not osp.exists(osp.join(target, 'node_modules')):
         os.makedirs(target)
-        subprocess.call(["jlpm", "init", "-y"], cwd=target)
-        subprocess.call(["jlpm", "add", "puppeteer"], cwd=target)
+        await run_async_process(["jlpm", "init", "-y"], cwd=target)
+        await run_async_process(["jlpm", "add", "puppeteer"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-example-test.js'), osp.join(target, 'chrome-example-test.js'))
-    return subprocess.check_call(["node", "chrome-example-test.js", url], cwd=target)
+    await run_async_process(["node", "chrome-example-test.js", url], cwd=target)
 
 
 if __name__ == '__main__':

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -5,6 +5,7 @@ This module is meant to run JupyterLab in a headless browser, making sure
 the application launches and starts up without errors.
 """
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import inspect
 import logging
 from os import path as osp
@@ -86,10 +87,13 @@ async def run_test_async(app, func):
     if inspect.isawaitable(func):
         test = func(url)
     else:
-        test = asyncio.ensure_future(func(url))
+        loop = asyncio.get_event_loop()
+        executur = ThreadPoolExecutor()
+        task = loop.run_in_executor(executor, func, url)
+        test = asyncio.wait([task])
 
     try:
-        await test
+       await test
     except Exception as e:
         app.log.critical("Caught exception during the test:")
         app.log.error(str(e))

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -93,11 +93,12 @@ async def run_test_async(app, func):
         url = app.display_url
 
     # Allow a synchronous function to be passed in.
+    import pdb; pdb.set_trace()
     if inspect.isawaitable(func):
         test = func(url)
     else:
         loop = asyncio.get_event_loop()
-        executur = ThreadPoolExecutor()
+        executor = ThreadPoolExecutor()
         task = loop.run_in_executor(executor, func, url)
         test = asyncio.wait([task])
 

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -61,7 +61,13 @@ class LogErrorHandler(logging.Handler):
 
 
 def run_test(app, func):
-    """Synchronous entry point to run a test function"""
+    """Synchronous entry point to run a test function.
+
+    func is a function that accepts an app url as a parameter and returns a result.
+
+    func can be synchronous or asynchronous.  If it is synchronous, it will be run
+    in a thread, so asynchronous is preferred.
+    """
     IOLoop.current().spawn_callback(run_test_async, app, func)
 
 
@@ -69,6 +75,9 @@ async def run_test_async(app, func):
     """Run a test against the application.
 
     func is a function that accepts an app url as a parameter and returns a result.
+
+    func can be synchronous or asynchronous.  If it is synchronous, it will be run
+    in a thread, so asynchronous is preferred.
     """
     handler = LogErrorHandler()
     app.log.addHandler(handler)

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -4,15 +4,16 @@
 This module is meant to run JupyterLab in a headless browser, making sure
 the application launches and starts up without errors.
 """
-from concurrent.futures import ThreadPoolExecutor
+import asyncio
+import inspect
 import logging
 from os import path as osp
 import os
 import shutil
 import sys
-import subprocess
 
 from tornado.ioloop import IOLoop
+from tornado.iostream import StreamClosedError
 from notebook.notebookapp import flags, aliases
 from notebook.utils import urljoin, pathname2url
 from traitlets import Bool
@@ -45,11 +46,11 @@ class LogErrorHandler(logging.Handler):
         self.errored = False
 
     def filter(self, record):
-        # known startup error message
-        if 'paste' in record.msg:
-            return
-        # handle known shutdown message
-        if 'Stream is closed' in record.msg:
+        # Handle known StreamClosedError from Tornado
+        # These occur when we forcibly close Websockets or
+        # browser connections during the test.
+        # https://github.com/tornadoweb/tornado/issues/2834
+        if hasattr(record, 'exc_info') and isinstance(record.exc_info[1], StreamClosedError):
             return
         return super().filter(record)
 
@@ -59,41 +60,20 @@ class LogErrorHandler(logging.Handler):
 
 
 def run_test(app, func):
+    """Synchronous entry point to run a test function"""
+    IOLoop.current().spawn_callback(run_test_async, app, func)
+
+
+async def run_test_async(app, func):
     """Run a test against the application.
 
     func is a function that accepts an app url as a parameter and returns a result.
     """
     handler = LogErrorHandler()
+    app.log.addHandler(handler)
 
     env_patch = TestEnv()
     env_patch.start()
-
-    def finished(future):
-        try:
-            result = future.result()
-        except Exception as e:
-            app.log.error(str(e))
-        app.log.info('Stopping server...')
-        app.stop()
-        if handler.errored:
-            app.log.critical('Exiting with 1 due to errors')
-            result = 1
-        elif result != 0:
-            app.log.critical('Exiting with %s due to errors' % result)
-        else:
-            app.log.info('Exiting normally')
-            result = 0
-
-        try:
-            app.http_server.stop()
-            app.io_loop.stop()
-            env_patch.stop()
-            os._exit(result)
-        except Exception as e:
-            self.log.error(str(e))
-            if 'Stream is closed' in str(e):
-                os._exit(result)
-            os._exit(1)
 
     # The entry URL for browser tests is different in notebook >= 6.0,
     # since that uses a local HTML file to point the user at the app.
@@ -102,22 +82,58 @@ def run_test(app, func):
     else:
         url = app.display_url
 
-    app.log.addHandler(handler)
-    pool = ThreadPoolExecutor()
-    future = pool.submit(func, url)
-    IOLoop.current().add_future(future, finished)
+    # Allow a synchronous function to be passed in.
+    if inspect.isawaitable(func):
+        test = func(url)
+    else:
+        test = asyncio.ensure_future(func(url))
+
+    try:
+        await test
+    except Exception as e:
+        app.log.critical("Caught exception during the test:")
+        app.log.error(str(e))
+
+    app.log.info("Test Complete")
+
+    result = 0
+    if handler.errored:
+        result = 1
+        app.log.critical('Exiting with 1 due to errors')
+    else:
+        app.log.info('Exiting normally')
+
+    app.log.info('Stopping server...')
+    try:
+        app.http_server.stop()
+        app.io_loop.stop()
+        env_patch.stop()
+    except Exception as e:
+        self.log.error(str(e))
+        result = 1
+    finally:
+        sys.exit(result)
 
 
-def run_browser(url):
+async def run_async_process(cmd, **kwargs):
+    """Run an asynchronous command"""
+    proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            **kwargs)
+
+    return await proc.communicate()
+
+
+async def run_browser(url):
     """Run the browser test and return an exit code.
     """
     target = osp.join(get_app_dir(), 'browser_test')
     if not osp.exists(osp.join(target, 'node_modules')):
         os.makedirs(target)
-        subprocess.call(["jlpm", "init", "-y"], cwd=target)
-        subprocess.call(["jlpm", "add", "puppeteer"], cwd=target)
+        await run_async_process(["jlpm", "init", "-y"], cwd=target)
+        await run_async_process(["jlpm", "add", "puppeteer"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))
-    return subprocess.check_call(["node", "chrome-test.js", url], cwd=target)
+    await run_async_process(["node", "chrome-test.js", url], cwd=target)
 
 
 class BrowserApp(LabApp):
@@ -129,14 +145,15 @@ class BrowserApp(LabApp):
     ip = '127.0.0.1'
     flags = test_flags
     aliases = test_aliases
-    test_browser = True
+    test_browser = Bool(True)
 
     def start(self):
         web_app = self.web_app
         web_app.settings.setdefault('page_config_data', dict())
         web_app.settings['page_config_data']['browserTest'] = True
         web_app.settings['page_config_data']['buildAvailable'] = False
-        run_test(self, run_browser if self.test_browser else lambda url: 0)
+        func = run_browser if self.test_browser else lambda url: 0
+        run_test(self, func)
         super().start()
 
 

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -93,7 +93,6 @@ async def run_test_async(app, func):
         url = app.display_url
 
     # Allow a synchronous function to be passed in.
-    import pdb; pdb.set_trace()
     if inspect.isawaitable(func):
         test = func(url)
     else:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->


## References
Fixes intermittent errors seen in CI, see https://github.com/tornadoweb/tornado/issues/2834.   The takeway is that these errors are intended behavior and occur because we are forcibly closing websocket and browser connections before the server has a chance to respond, but they do not affect our unit under test.


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Converts our browser and example checks to use asyncio instead of threads, and suppresses the `Stream is Closed` error raised during `app.stop()`.  Preserves the existing ability to test against a synchronous function, falling back on a `ThreadPoolExecutor`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Extension authors using `browser_check` will see less intermittent failures.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
