### PR TITLE
Better handling of slow kernel startup

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -491,7 +491,7 @@ export class SessionContext implements ISessionContext {
     }
 
     if (!kernel && this._pendingKernelName) {
-      return 'starting';
+      return 'initializing';
     }
 
     if (

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -752,7 +752,10 @@ namespace Private {
      */
     private _isBusy(status: ISessionContext.KernelDisplayStatus): boolean {
       return (
-        status === 'busy' || status === 'starting' || status === 'restarting'
+        status === 'busy' ||
+        status === 'starting' ||
+        status === 'restarting' ||
+        status === 'initializing'
       );
     }
   }

--- a/packages/statusbar/src/defaults/kernelStatus.tsx
+++ b/packages/statusbar/src/defaults/kernelStatus.tsx
@@ -19,12 +19,14 @@ import { JSONExt, JSONArray } from '@lumino/coreutils';
 function KernelStatusComponent(
   props: KernelStatusComponent.IProps
 ): React.ReactElement<KernelStatusComponent.IProps> {
+  let statusText = '';
+  if (props.status) {
+    statusText = ` | ${Text.titleCase(props.status)}`;
+  }
   return (
     <TextItem
       onClick={props.handleClick}
-      source={`${props.kernelName} | ${Text.titleCase(
-        props.status ?? 'undefined'
-      )}`}
+      source={`${props.kernelName}${statusText}`}
       title={`Change kernel for ${props.activityName}`}
     />
   );
@@ -147,7 +149,7 @@ export namespace KernelStatus {
       const oldState = this._getAllState();
       this._sessionContext = sessionContext;
       this._kernelStatus = sessionContext?.kernelDisplayStatus;
-      this._kernelName = sessionContext?.kernelDisplayName ?? 'No Kernel!';
+      this._kernelName = sessionContext?.kernelDisplayName ?? 'No Kernel';
       sessionContext?.statusChanged.connect(this._onKernelStatusChanged, this);
       sessionContext?.connectionStatusChanged.connect(
         this._onKernelStatusChanged,
@@ -173,17 +175,11 @@ export namespace KernelStatus {
       change: Session.ISessionConnection.IKernelChangedArgs
     ) => {
       const oldState = this._getAllState();
-      const { newValue } = change;
-      if (newValue !== null) {
-        // sync setting of status and display name
-        this._kernelStatus = this._sessionContext?.kernelDisplayStatus;
-        this._kernelName = _sessionContext.kernelDisplayName;
-        this._triggerChange(oldState, this._getAllState());
-      } else {
-        this._kernelStatus = '';
-        this._kernelName = 'No Kernel!';
-        this._triggerChange(oldState, this._getAllState());
-      }
+
+      // sync setting of status and display name
+      this._kernelStatus = this._sessionContext?.kernelDisplayStatus;
+      this._kernelName = _sessionContext.kernelDisplayName;
+      this._triggerChange(oldState, this._getAllState());
     };
 
     private _getAllState(): Private.State {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#7403 #6007 

See discussion in https://github.com/jupyter/jupyter_server/issues/197 about the issues around slow starting kernels/terminals and a longer term solution.

While a slow kernel is starting, show it as being in "initializing" status with a filled circle and the name of the pending kernel.  The user is now allowed to change the kernel while the previous session is starting.  When a session is started, it shuts down an existing session so there is only one running session on the server. 

We have to destroy an in-flight session connection rather than wait for it to finish.  We properly shut down sessions that have been superseded.   The classic notebook handles session restarts by [destoying/creating](https://github.com/jupyter/notebook/blob/master/notebook/static/services/sessions/session.js#L222), but does so synchronously.  The user has to wait for the slow session to start before it switches.  Classic notebook does not handle a change kernel request while the initial kernel is being created.

We use a unique id for the path when creating the session, and then change the path of the created session to the desired path.  This is to avoid the race condition of when a session with a given path saves its state in the server database.

Note, I simulated slow kernels by adding a `gen.sleep()` in [`start_kernel`](https://github.com/jupyter/notebook/blob/d04cbb6a98b1c73b6cfb9fc8af969ca0c95c13d2/notebook/services/kernels/kernelmanager.py#L158). 

I plan to backport this to 1.2.x since it involves no API changes and is a bug fix.

Slow start:
<img width="255" alt="image" src="https://user-images.githubusercontent.com/2096628/78593921-07439900-780d-11ea-8385-b57fed53a15e.png">

<img width="314" alt="image" src="https://user-images.githubusercontent.com/2096628/78593930-0a3e8980-780d-11ea-81f8-3a619ca88f75.png">

Switching during a slow start:
<img width="235" alt="image" src="https://user-images.githubusercontent.com/2096628/78593945-11659780-780d-11ea-9c28-5696cbe922ae.png">

Selecting no kernel during a slow start:
<img width="229" alt="image" src="https://user-images.githubusercontent.com/2096628/78593962-1aeeff80-780d-11ea-8eaa-d9460c175520.png">

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Add internal logic to session context to handle slow kernel behavior.   Show filled icon for initializing status and in the toolbar.  Update status bar handlers to always use display name and display status from the session context.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Better indication of the status of slow starting kernels.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
