### PR TITLE
Clean up kernel startup error messages

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -744,16 +744,30 @@ export class SessionContext implements ISessionContext {
   private async _handleSessionError(
     err: ServerConnection.ResponseError
   ): Promise<void> {
-    let text = await err.response.text();
-    let message = err.message;
+    let traceback = '';
+    let message = '';
     try {
-      message = JSON.parse(text)['traceback'];
+      const json = await err.response.json();
+      traceback = json['traceback'];
+      message = json['message'];
     } catch (err) {
       // no-op
     }
-    let dialog = (this._dialog = new Dialog({
+    const body = (
+      <div>
+        <pre>{err.message}</pre>
+        {message && <pre>{message}</pre>}
+        {traceback && (
+          <details className="jp-mod-wide">
+            <pre>{traceback}</pre>
+          </details>
+        )}
+      </div>
+    );
+
+    const dialog = (this._dialog = new Dialog({
       title: 'Error Starting Kernel',
-      body: <pre>{message}</pre>,
+      body,
       buttons: [Dialog.okButton()]
     }));
     await dialog.launch();

--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -30,7 +30,7 @@
   padding-bottom: 12px;
   min-width: 300px;
   min-height: 150px;
-  max-width: 500px;
+  max-width: 1000px;
   max-height: 500px;
   box-sizing: border-box;
   box-shadow: var(--jp-elevation-z20);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Related to #7403.  We currently only supply a traceback if given when a kernel starts, but there is more information potentially available.  For instance, non-500 errors do not have a traceback.  We now display both the reason and message if available, and also a collapsed traceback if available.
I simulated errors by raising `ValueError("Triggered an Error")` and `tornado.web.HTTPError(409, "Extra message from server", reason="Some Made up Reason")` in [`start_kernel`](https://github.com/jupyter/notebook/blob/d04cbb6a98b1c73b6cfb9fc8af969ca0c95c13d2/notebook/services/kernels/kernelmanager.py#L158). 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Internal changes in session context.  I bumped the max width of a dialog to 1000px because you can't read a traceback at 500px.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
### Before

500 Error:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/2096628/78537145-a12b2780-77b4-11ea-8c02-dc1e8663b0b9.png">

409 Error:
<img width="291" alt="image" src="https://user-images.githubusercontent.com/2096628/78537168-a9836280-77b4-11ea-8cfa-dae9147503d0.png">

### After

500 Error:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/2096628/78537215-bb650580-77b4-11ea-8d6e-e7b55eb6b885.png">

<img width="934" alt="image" src="https://user-images.githubusercontent.com/2096628/78537223-be5ff600-77b4-11ea-8bf8-72ed0d0d40fc.png">

409 Error:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/2096628/78537273-d6377a00-77b4-11ea-960a-1301c0a461dc.png">


## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
