### PR TITLE
Fix icon overlay when extension manager small

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -212,7 +212,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
           <div style={{ width: `${badgeSize}px`, height: `${badgeSize}px` }} />
         )}
       </div>
-      <div style={{ flexDirection: 'column' }}>
+      <div className="jp-extensionmanager-entry-description">
         <div className="jp-extensionmanager-entry-title">
           <div className="jp-extensionmanager-entry-name">
             <a href={entry.url} target="_blank" rel="noopener">

--- a/packages/extensionmanager/style/base.css
+++ b/packages/extensionmanager/style/base.css
@@ -21,8 +21,6 @@
 */
 
 .jp-extensionmanager-is-jupyter-org {
-  position: absolute;
-  right: 8px;
   font-size: var(--jp-ui-font-size0);
   color: var(--jp-ui-font-color2);
 }
@@ -185,9 +183,15 @@
   border-bottom: solid var(--jp-border-width) var(--jp-border-color2);
 }
 
+.jp-extensionmanager-entry-description {
+  min-width: 0;
+  flex-grow: 1;
+}
+
 .jp-extensionmanager-entry-title {
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
 }
 
 .jp-extensionmanager-entry.jp-extensionmanager-entry-should-be-uninstalled {
@@ -213,6 +217,7 @@
   font-weight: 600;
   padding: 0 8px 0 0;
   margin-bottom: 4px;
+  overflow-wrap: anywhere;
 }
 
 .jp-extensionmanager-entry-name a:link {


### PR DESCRIPTION


## References
Update https://github.com/jupyterlab/jupyterlab/pull/8168 to deal with when the jupyter icon overlaps the text.

## Code changes

Moved once local style to a class

Updated some styles.


## User-facing changes


<img width="449" alt="Screen Shot 2020-04-06 at 3 31 38 PM" src="https://user-images.githubusercontent.com/1186124/78597941-5fce6280-781c-11ea-8070-44e1786a27d7.png">

## Backwards-incompatible changes

None
