### PR TITLE
Emit session changed signal from session context

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -728,13 +728,19 @@ export class SessionContext implements ISessionContext {
       this._onPropertyChanged(session, 'type');
     }
 
-    // Any existing kernel connection was disposed above when the session was
+    // Any existing session/kernel connection was disposed above when the session was
     // disposed, so the oldValue should be null.
     this._kernelChanged.emit({
       oldValue: null,
       newValue: session.kernel,
       name: 'kernel'
     });
+    this._sessionChanged.emit({
+      oldValue: null,
+      newValue: session,
+      name: 'session'
+    });
+
     return session.kernel;
   }
 

--- a/packages/completer/src/kernelconnector.ts
+++ b/packages/completer/src/kernelconnector.ts
@@ -36,7 +36,7 @@ export class KernelConnector extends DataConnector<
     const kernel = this._session?.kernel;
 
     if (!kernel) {
-      return Promise.reject(new Error('No kernel for completion request.'));
+      throw new Error('No kernel for completion request.');
     }
 
     const contents: KernelMessage.ICompleteRequestMsg['content'] = {

--- a/tests/test-apputils/src/sessioncontext.spec.ts
+++ b/tests/test-apputils/src/sessioncontext.spec.ts
@@ -100,6 +100,22 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
+    describe('#sessionChanged', () => {
+      it('should be emitted when the session changes', async () => {
+        let called = false;
+        sessionContext.sessionChanged.connect(
+          (sender, { oldValue, newValue }) => {
+            expect(sender).to.equal(sessionContext);
+            expect(oldValue).to.be.null;
+            expect(newValue).to.equal(sessionContext.session);
+            called = true;
+          }
+        );
+        await sessionContext.initialize();
+        expect(called).to.be.true;
+      });
+    });
+
     describe('#statusChanged', () => {
       it('should be emitted when the status changes', async () => {
         let called = false;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #8180 

## Code changes

Somehow we forgot to emit a sessionChanged signal from a session context when the session changes.  

## User-facing changes

## Backwards-incompatible changes

None
