### PR TITLE
Turn off MathJax status messages

### DIFF
--- a/packages/mathjax2/src/index.ts
+++ b/packages/mathjax2/src/index.ts
@@ -96,7 +96,8 @@ export class MathJaxTypesetter implements IRenderMime.ILatexTypesetter {
         styles: { '.MathJax_Display': { margin: 0 } },
         linebreaks: { automatic: true }
       },
-      skipStartupTypeset: true
+      skipStartupTypeset: true,
+      messageStyle: 'none'
     });
     MathJax.Hub.Configured();
     this._initPromise.resolve(void 0);


### PR DESCRIPTION
- This change turns off MathJax load status message visibility which is on by default. Below is the demonstration of the issue (notice the loading message at lower left)

![mathjax](https://user-images.githubusercontent.com/40003442/78622042-f3159100-7838-11ea-921e-60840cb1d569.gif)

