### PR TITLE
[BackPort] Better handling of slow kernel startup

### DIFF
--- a/examples/cell/src/index.ts
+++ b/examples/cell/src/index.ts
@@ -62,6 +62,9 @@ function main(): void {
 
   // Handle the mimeType for the current kernel.
   session.kernelChanged.connect(() => {
+    if (!session.kernel) {
+      return;
+    }
     void session.kernel.ready.then(() => {
       const lang = session.kernel.info.language_info;
       const mimeType = mimeService.getMimeTypeByLanguage(lang);

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -406,7 +406,7 @@ export namespace Toolbar {
    *
    * #### Notes
    * It will display the `'display_name`' of the current kernel,
-   * or `'No Kernel!'` if there is no kernel.
+   * or `'No Kernel'` if there is no kernel.
    * It can handle a change in context or kernel.
    */
   export function createKernelNameItem(session: IClientSession): Widget {

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -750,6 +750,7 @@ namespace Private {
         return response.json();
       })
       .then(data => {
+        console.log('got session data', data.id);
         const model = validate.validateModel(data);
         return updateFromServer(model, settings.baseUrl);
       });

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -750,7 +750,6 @@ namespace Private {
         return response.json();
       })
       .then(data => {
-        console.log('got session data', data.id);
         const model = validate.validateModel(data);
         return updateFromServer(model, settings.baseUrl);
       });

--- a/packages/statusbar/src/defaults/kernelStatus.tsx
+++ b/packages/statusbar/src/defaults/kernelStatus.tsx
@@ -19,10 +19,14 @@ import { JSONExt } from '@phosphor/coreutils';
 function KernelStatusComponent(
   props: KernelStatusComponent.IProps
 ): React.ReactElement<KernelStatusComponent.IProps> {
+  let statusText = '';
+  if (props.status) {
+    statusText = ` | ${Text.titleCase(props.status)}`;
+  }
   return (
     <TextItem
       onClick={props.handleClick}
-      source={`${props.kernelName} | ${Text.titleCase(props.status)}`}
+      source={`${props.kernelName}${statusText}`}
       title={`Change kernel for ${props.activityName}`}
     />
   );
@@ -179,24 +183,10 @@ export namespace KernelStatus {
       change: Session.IKernelChangedArgs
     ) => {
       const oldState = this._getAllState();
-      const { newValue } = change;
-      if (newValue !== null) {
-        newValue
-          .getSpec()
-          .then(spec => {
-            // sync setting of status and display name
-            this._kernelStatus = newValue.status;
-            this._kernelName = spec.display_name;
-            this._triggerChange(oldState, this._getAllState());
-          })
-          .catch(err => {
-            throw err;
-          });
-      } else {
-        this._kernelStatus = 'unknown';
-        this._kernelName = 'unknown';
-        this._triggerChange(oldState, this._getAllState());
-      }
+      // sync setting of status and display name
+      this._kernelStatus = this._session.status;
+      this._kernelName = this._session.kernelDisplayName;
+      this._triggerChange(oldState, this._getAllState());
     };
 
     private _getAllState(): [string, string, string] {

--- a/tests/test-apputils/src/toolbar.spec.ts
+++ b/tests/test-apputils/src/toolbar.spec.ts
@@ -314,13 +314,14 @@ describe('@jupyterlab/apputils', () => {
           ).to.equal(session.kernelDisplayName);
         });
 
-        it("should display `'No Kernel!'` if there is no kernel", async () => {
+        it("should display `'No Kernel'` if there is no kernel", async () => {
+          session.kernelPreference = { canStart: false };
           const item = Toolbar.createKernelNameItem(session);
           Widget.attach(item, document.body);
           await framePromise();
           expect(
             (item.node.firstChild.lastChild as HTMLElement).textContent
-          ).to.equal('No Kernel!');
+          ).to.equal('No Kernel');
         });
       });
 
@@ -364,6 +365,11 @@ describe('@jupyterlab/apputils', () => {
           await session.kernel.ready;
           await session.shutdown();
           session = await createClientSession();
+          session.kernelPreference = {
+            shouldStart: true,
+            canStart: true,
+            autoStartDefault: true
+          };
           const item = Toolbar.createKernelStatusItem(session);
           expect(item.node.title).to.equal('Kernel Starting');
           expect(item.hasClass('jp-FilledCircleIcon')).to.equal(true);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Manual backport of #8174 to the 1.2.x branch.  A cherry-pick was not possible because the classes differ too much.  The behavior is the same as #8174, except we say "Starting" instead of "Initializing" because there is no "Initializing" status.

<img width="266" alt="image" src="https://user-images.githubusercontent.com/2096628/78728088-0b9aaf80-78fc-11ea-956b-5e3b7b61ec10.png">


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Clean up handling of session state in client session and adjust consumers to use the display name and status.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Better handling of slow starting kernels.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
