### PR TITLE
Run eslint/tslint on staged files and ignore removed files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,29 +2,30 @@ const escape = require('shell-quote').quote;
 const fs = require('fs');
 const isWin = process.platform === 'win32';
 
+const escapeFileNames = filenames =>
+  filenames
+    .filter(filename => fs.existsSync(filename))
+    .map(filename => `"${isWin ? filename : escape([filename])}"`)
+    .join(' ');
+
 module.exports = {
   '**/*{.css,.json,.md}': filenames => {
-    const escapedFileNames = filenames
-      .filter(filename => fs.existsSync(filename))
-      .map(filename => `"${isWin ? filename : escape([filename])}"`)
-      .join(' ');
+    const escapedFileNames = escapeFileNames(filenames);
     return [
       `prettier --write ${escapedFileNames}`,
       `git add ${escapedFileNames}`
     ];
   },
   '**/*{.ts,.tsx}': filenames => {
-    const escapedFileNames = filenames
-      .filter(filename => fs.existsSync(filename))
-      .map(filename => `"${isWin ? filename : escape([filename])}"`)
-      .join(' ');
-    return [`tslint --fix ${escapedFileNames}`, `git add ${escapedFileNames}`];
+    const escapedFileNames = escapeFileNames(filenames);
+    return [
+      `prettier --write ${escapedFileNames}`,
+      `tslint --fix ${escapedFileNames}`,
+      `git add ${escapedFileNames}`
+    ];
   },
-  '**/*{.ts,.tsx,.js,.jsx}': filenames => {
-    const escapedFileNames = filenames
-      .filter(filename => fs.existsSync(filename))
-      .map(filename => `"${isWin ? filename : escape([filename])}"`)
-      .join(' ');
+  '**/*{.js,.jsx}': filenames => {
+    const escapedFileNames = escapeFileNames(filenames);
     return [
       `prettier --write ${escapedFileNames}`,
       `eslint --fix ${escapedFileNames}`,

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,13 +1,33 @@
 const escape = require('shell-quote').quote;
+const fs = require('fs');
 const isWin = process.platform === 'win32';
 
 module.exports = {
-  '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}': filenames => {
+  '**/*{.css,.json,.md}': filenames => {
     const escapedFileNames = filenames
+      .filter(filename => fs.existsSync(filename))
       .map(filename => `"${isWin ? filename : escape([filename])}"`)
       .join(' ');
     return [
       `prettier --write ${escapedFileNames}`,
+      `git add ${escapedFileNames}`
+    ];
+  },
+  '**/*{.ts,.tsx}': filenames => {
+    const escapedFileNames = filenames
+      .filter(filename => fs.existsSync(filename))
+      .map(filename => `"${isWin ? filename : escape([filename])}"`)
+      .join(' ');
+    return [`tslint --fix ${escapedFileNames}`, `git add ${escapedFileNames}`];
+  },
+  '**/*{.ts,.tsx,.js,.jsx}': filenames => {
+    const escapedFileNames = filenames
+      .filter(filename => fs.existsSync(filename))
+      .map(filename => `"${isWin ? filename : escape([filename])}"`)
+      .join(' ');
+    return [
+      `prettier --write ${escapedFileNames}`,
+      `eslint --fix ${escapedFileNames}`,
       `git add ${escapedFileNames}`
     ];
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Partial fix for #7939.
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Improved lint-staged file.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Better experience for contributors, who don't have to run the linter manually after the fact.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
