### PR TITLE
No extra text when pasting image to markdown cell + insert at cursor location

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1483,7 +1483,7 @@ export class MarkdownCell extends AttachmentsCell {
   ) {
     const textToBeAppended = `![${attachmentName}](attachment:${URI ??
       attachmentName})`;
-    this.model.value.insert(this.model.value.text.length, textToBeAppended);
+    this.editor.replaceSelection?.(textToBeAppended);
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -1224,7 +1224,19 @@ export abstract class AttachmentsCell extends Cell {
    */
   private _evtPaste(event: ClipboardEvent): void {
     if (event.clipboardData) {
-      this._attachFiles(event.clipboardData.items);
+      const items = event.clipboardData.items;
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].type === 'text/plain') {
+          // Skip if this text is the path to a file
+          if (i < items.length - 1 && items[i + 1].kind === 'file') {
+            continue;
+          }
+          items[i].getAsString(text => {
+            this.editor.replaceSelection?.(text);
+          });
+        }
+        this._attachFiles(event.clipboardData.items);
+      }
     }
     event.preventDefault();
   }
@@ -1384,6 +1396,9 @@ export class MarkdownCell extends AttachmentsCell {
         model: this.model.attachments
       })
     });
+
+    // Stop codemirror handling paste
+    this.editor.setOption('handlePaste', false);
 
     // Throttle the rendering rate of the widget.
     this._monitor = new ActivityMonitor({

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -637,6 +637,11 @@ export namespace CodeEditor {
     autoClosingBrackets: boolean;
 
     /**
+     * Whether the editor should handle paste events.
+     */
+    handlePaste: boolean;
+
+    /**
      * The column where to break text line.
      */
     wordWrapColumn: number;
@@ -667,6 +672,7 @@ export namespace CodeEditor {
     insertSpaces: true,
     matchBrackets: true,
     autoClosingBrackets: true,
+    handlePaste: true,
     rulers: [],
     codeFolding: false
   };

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -163,6 +163,14 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       this._lastChange = change;
     });
 
+    // Turn off paste handling in codemirror since sometimes we want to
+    // replace it with our own.
+    editor.on('paste', (instance: CodeMirror.Editor, event: any) => {
+      if (!this._config['handlePaste']) {
+        event.codemirrorIgnore = true;
+      }
+    });
+
     // Manually refresh on paste to make sure editor is properly sized.
     editor.getWrapperElement().addEventListener('paste', () => {
       if (this.hasFocus()) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes: https://github.com/jupyterlab/jupyterlab/issues/8062
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

1. Added a option to codeeditor that allows the widget using it to prevent codemirror from handling paste events.
2. Markdown cells now handle pasting on their own using `editor.replaceSelection` 
3. All file attachments to markdown cells now use `replaceSelection` to place the attachment
<!-- Describe the code changes and how they address the issue. -->

Explanations:
1. Is necessary avoid the file path erroneously being pasted in when pasting an image.
2. replaceSelection gives the expected copy paste behavior now that we've turned off codemirror pasting.
3. This makes attachments be placed at the cursor location rather than always at the end of the cell. This is visible in GIFs below
## User-facing changes
Two changes:
1. No extra texting when pasting an image to markdown cell
2. images are attached at the cursor location they are dragged to or pasted into.

**before:**  
![old_pasting](https://user-images.githubusercontent.com/10111092/78955971-e39f7d80-7aae-11ea-976d-93c25971ef91.gif)

**this PR:**
![new_pasting](https://user-images.githubusercontent.com/10111092/78955983-eb5f2200-7aae-11ea-8b5c-24bc63476ab5.gif)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
I don't think so? Is it of consequence that `replaceSelection` is an optional part of the codemirror interface?
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
