### PR TITLE
Clean up file watching

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -66,30 +66,6 @@ let sourceMapRes = Object.values(watched).reduce((res, name) => {
 }, []);
 
 /**
- * Sync a local path to a linked package path if they are files and differ.
- */
-function maybeSync(localPath, name, rest) {
-  const stats = fs.statSync(localPath);
-  if (!stats.isFile(localPath)) {
-    return;
-  }
-  const source = fs.realpathSync(plib.join(jlab.linkedPackages[name], rest));
-  if (source === fs.realpathSync(localPath)) {
-    return;
-  }
-  fs.watchFile(source, { interval: 500 }, function(curr) {
-    if (!curr || curr.nlink === 0) {
-      return;
-    }
-    try {
-      fs.copySync(source, localPath);
-    } catch (err) {
-      console.error(err);
-    }
-  });
-}
-
-/**
  * A filter function set up to exclude all files that are not
  * in a package contained by the Jupyterlab repo. Used to ignore
  * files during a `--watch` build.
@@ -112,7 +88,6 @@ function ignored(path) {
     const rest = path.slice(rootPath.length);
     if (rest.indexOf('node_modules') === -1) {
       ignore = false;
-      maybeSync(path, name, rest);
     }
     return true;
   });
@@ -274,7 +249,8 @@ module.exports = [
       ]
     },
     watchOptions: {
-      poll: 333
+      poll: 500,
+      aggregateTimeout: 1000
     },
     node: {
       fs: 'empty'


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->
## Description
In watch mode, we were both watching the same files twice, and watching too often.
This resulted in a cascade of webpack changes when you made a change in source.

## Code changes
Remove duplicate file watchers and clean up watch config to account for many files being written during the same compilation.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Better dev experience for watch mode for extension authors and maintainers.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
