### PR TITLE
Fix handling of kernel cwd

### DIFF
--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -97,7 +97,7 @@ class ExtensionManager(object):
                         status = 'warning'
             extensions.append(_make_extension_entry(
                 name=name,
-                description=pkg_info['description'],
+                description=pkg_info.get('description', ''),
                 url=data['url'],
                 enabled=(name not in info['disabled']),
                 core=False,
@@ -112,7 +112,7 @@ class ExtensionManager(object):
             if data is not None:
                 extensions.append(_make_extension_entry(
                     name=name,
-                    description=data['description'],
+                    description=data.get('description', ''),
                     url=data.get('homepage', ''),
                     installed=False,
                     enabled=False,

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -740,12 +740,18 @@ export class SessionContext implements ISessionContext {
     if (!this._pendingSessionRequest) {
       this._initStarted.resolve(void 0);
     }
-    const requestId = (this._pendingSessionRequest = UUID.uuid4());
+
+    // Use a UUID for the path to overcome a race condition on the server
+    // where it will re-use a session for a given path but only after
+    // the kernel finishes starting.
+    // We later switch to the real path below.
+    // Use the correct directory so the kernel will be started in that directory.
+    const dirName = PathExt.dirname(this._path);
+    const requestId = (this._pendingSessionRequest = PathExt.join(
+      dirName,
+      UUID.uuid4()
+    ));
     try {
-      // Use a UUID for the path to overcome a race condition on the server
-      // where it will re-use a session for a given path but only after
-      // the kernel finishes starting.
-      // We later switch to the real path below.
       this._statusChanged.emit('starting');
       const session = await this.sessionManager.startNew({
         path: requestId,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses #8209 in master.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Uses the correct cwd for the temporary path so the kernel is started in the right directory.  Also fixes a `500 GET /lab/api/extensions` seen when an installed extension did not have `description` metadata.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Kernels are started in the correct directory.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
