### PR TITLE
Expose global app instance with command-line option

### DIFF
--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -101,8 +101,11 @@ function main() {
   register.forEach(function(item) { lab.registerPluginModule(item); });
   lab.start({ ignorePlugins: ignorePlugins });
 
-  // Expose global lab instance when in dev mode.
-  if ((PageConfig.getOption('devMode') || '').toLowerCase() === 'true') {
+  // Expose global lab instance when in dev mode or when toggled explicitly.
+  var exposeGlobal = (PageConfig.getOption('exposeGlobal') || '').toLowerCase() === 'true';
+  var devMode = (PageConfig.getOption('devMode') || '').toLowerCase() === 'true';
+
+  if (exposeGlobal || devMode) {
     window.lab = lab;
   }
 

--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -101,12 +101,12 @@ function main() {
   register.forEach(function(item) { lab.registerPluginModule(item); });
   lab.start({ ignorePlugins: ignorePlugins });
 
-  // Expose global lab instance when in dev mode or when toggled explicitly.
-  var exposeGlobal = (PageConfig.getOption('exposeGlobal') || '').toLowerCase() === 'true';
+  // Expose global app instance when in dev mode or when toggled explicitly.
+  var exposeAppInBrowser = (PageConfig.getOption('exposeAppInBrowser') || '').toLowerCase() === 'true';
   var devMode = (PageConfig.getOption('devMode') || '').toLowerCase() === 'true';
 
-  if (exposeGlobal || devMode) {
-    window.lab = lab;
+  if (exposeAppInBrowser || devMode) {
+    window.jupyterlab = lab;
   }
 
   // Handle a browser test.

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -147,7 +147,7 @@ def load_jupyter_server_extension(nbapp):
 
     # Client-side code assumes notebookVersion is a JSON-encoded string
     page_config['notebookVersion'] = dumps(version_info)
-    page_config['exposeAppInBrowser'] = nbapp.expose_app_in_browser
+    page_config['exposeAppInBrowser'] = getattr(nbapp, 'expose_app_in_browser', False)
 
     if nbapp.file_to_run and type(nbapp).__name__ == "LabApp":
         relpath = os.path.relpath(nbapp.file_to_run, nbapp.notebook_dir)

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -147,6 +147,7 @@ def load_jupyter_server_extension(nbapp):
 
     # Client-side code assumes notebookVersion is a JSON-encoded string
     page_config['notebookVersion'] = dumps(version_info)
+    page_config['exposeGlobal'] = nbapp.expose_global
 
     if nbapp.file_to_run and type(nbapp).__name__ == "LabApp":
         relpath = os.path.relpath(nbapp.file_to_run, nbapp.notebook_dir)

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -147,7 +147,7 @@ def load_jupyter_server_extension(nbapp):
 
     # Client-side code assumes notebookVersion is a JSON-encoded string
     page_config['notebookVersion'] = dumps(version_info)
-    page_config['exposeGlobal'] = nbapp.expose_global
+    page_config['exposeAppInBrowser'] = nbapp.expose_app_in_browser
 
     if nbapp.file_to_run and type(nbapp).__name__ == "LabApp":
         relpath = os.path.relpath(nbapp.file_to_run, nbapp.notebook_dir)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -396,9 +396,9 @@ lab_flags['watch'] = (
     {'LabApp': {'watch': True}},
     "Start the app in watch mode."
 )
-lab_flags['expose-global'] = (
-    {'LabApp': {'expose_global': True}},
-    "Expose the global app instance to browser via window.lab"
+lab_flags['expose-app-in-browser'] = (
+    {'LabApp': {'expose_app_in_browser': True}},
+    "Expose the global app instance to browser via window.jupyterlab"
 )
 
 
@@ -480,8 +480,8 @@ class LabApp(NotebookApp):
     watch = Bool(False, config=True,
         help="Whether to serve the app in watch mode")
 
-    expose_global = Bool(False, config=True,
-        help="Whether to expose the global app instance to browser via window.lab")
+    expose_app_in_browser = Bool(False, config=True,
+        help="Whether to expose the global app instance to browser via window.jupyterlab")
 
     def init_webapp(self, *args, **kwargs):
         super().init_webapp(*args, **kwargs)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -396,6 +396,10 @@ lab_flags['watch'] = (
     {'LabApp': {'watch': True}},
     "Start the app in watch mode."
 )
+lab_flags['expose-global'] = (
+    {'LabApp': {'expose_global': True}},
+    "Expose the global app instance to browser via window.lab"
+)
 
 
 class LabApp(NotebookApp):
@@ -475,6 +479,9 @@ class LabApp(NotebookApp):
 
     watch = Bool(False, config=True,
         help="Whether to serve the app in watch mode")
+
+    expose_global = Bool(False, config=True,
+        help="Whether to expose the global app instance to browser via window.lab")
 
     def init_webapp(self, *args, **kwargs):
         super().init_webapp(*args, **kwargs)

--- a/jupyterlab/staging/index.js
+++ b/jupyterlab/staging/index.js
@@ -102,12 +102,12 @@ function main() {
   register.forEach(function(item) { lab.registerPluginModule(item); });
   lab.start({ ignorePlugins: ignorePlugins });
 
-  // Expose global lab instance when in dev mode or when toggled explicitly.
-  var exposeGlobal = (PageConfig.getOption('exposeGlobal') || '').toLowerCase() === 'true';
+  // Expose global app instance when in dev mode or when toggled explicitly.
+  var exposeAppInBrowser = (PageConfig.getOption('exposeAppInBrowser') || '').toLowerCase() === 'true';
   var devMode = (PageConfig.getOption('devMode') || '').toLowerCase() === 'true';
 
-  if (exposeGlobal || devMode) {
-    window.lab = lab;
+  if (exposeAppInBrowser || devMode) {
+    window.jupyterlab = lab;
   }
 
   // Handle a browser test.

--- a/jupyterlab/staging/index.js
+++ b/jupyterlab/staging/index.js
@@ -102,12 +102,9 @@ function main() {
   register.forEach(function(item) { lab.registerPluginModule(item); });
   lab.start({ ignorePlugins: ignorePlugins });
 
-  // Expose global app instance when in dev mode or when toggled explicitly.
-  var exposeAppInBrowser = (PageConfig.getOption('exposeAppInBrowser') || '').toLowerCase() === 'true';
-  var devMode = (PageConfig.getOption('devMode') || '').toLowerCase() === 'true';
-
-  if (exposeAppInBrowser || devMode) {
-    window.jupyterlab = lab;
+  // Expose global lab instance when in dev mode.
+  if ((PageConfig.getOption('devMode') || '').toLowerCase() === 'true') {
+    window.lab = lab;
   }
 
   // Handle a browser test.

--- a/jupyterlab/staging/index.js
+++ b/jupyterlab/staging/index.js
@@ -102,8 +102,11 @@ function main() {
   register.forEach(function(item) { lab.registerPluginModule(item); });
   lab.start({ ignorePlugins: ignorePlugins });
 
-  // Expose global lab instance when in dev mode.
-  if ((PageConfig.getOption('devMode') || '').toLowerCase() === 'true') {
+  // Expose global lab instance when in dev mode or when toggled explicitly.
+  var exposeGlobal = (PageConfig.getOption('exposeGlobal') || '').toLowerCase() === 'true';
+  var devMode = (PageConfig.getOption('devMode') || '').toLowerCase() === 'true';
+
+  if (exposeGlobal || devMode) {
     window.lab = lab;
   }
 


### PR DESCRIPTION
- Introduces a new command-line option `--expose-global`, default is false
- Explicitly exposes global lab app object to browser via window.lab
- Mainly needed for testing/debugging prod build