### PR TITLE
Add note on json version in installations section

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -205,7 +205,7 @@ on connectivity problems to HTTPS servers, you can disable using SSL for ``npm``
 Problems with Extensions and Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Jupyterlab changes its internal state with `PUT` requests with JSON5 compatible payload. `JSON5 <https://json5.org/>`__ is not necessarily compatible on all existing systems. If by enabling extensions or changing settings on Jupyterlab's UI causes 400 return codes, it is likely that the `PUT` request's body was parsed unsuccessfully by a routing layer that does not accept JSON5 payload.
+Jupyterlab saves settings via `PUT` requests to the server with a JSON5-compatible payload, even though it claims the PUT request is valid JSON. `JSON5 <https://json5.org/>`__ is a superset of JSON that allows comments, etc. There may be deployment problems, manifest as 400 error return codes when saving settings, if these `PUT` requests are rejected by a routing layer that tries to validate the payload as JSON instead of JSON5.
 
 Common symptoms of this during debugging are:
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -209,6 +209,6 @@ Jupyterlab saves settings via `PUT` requests to the server with a JSON5-compatib
 
 Common symptoms of this during debugging are:
 
-- The settings are selected but nothing changes, or when extension manager is 
+- The settings are selected but nothing changes, or when extension manager is enabled but the manager tab is not added.
 - JupyterLab's logs don't have the 400 return codes when `PUT` requests are issued.
 - If your JupyterLab logs are on Elastic Search, you'll see `Unexpected token / in JSON at position`. This comes from the JSON5 comments not being valid JSON.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -210,5 +210,5 @@ Jupyterlab saves settings via `PUT` requests to the server with a JSON5-compatib
 Common symptoms of this during debugging are:
 
 - The settings are selected but nothing changes, or when extension manager is 
-- Jupyterlab's logs don't have the 400 return codes when `PUT` requests are issued.
+- JupyterLab's logs don't have the 400 return codes when `PUT` requests are issued.
 - If your Jupyterlab logs are on elastic search, you'll see `Unexpected token / in JSON at position`, signalling that the comments are invalid JSON.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -201,3 +201,14 @@ on connectivity problems to HTTPS servers, you can disable using SSL for ``npm``
 
     # Configure npm to not use SSL
     npm set strict-ssl False
+
+Problems with Extensions and Settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Jupyterlab changes its internal state with `PUT` requests with JSON5 compatible payload. `JSON5 <https://json5.org/>`__ is not necessarily compatible on all existing systems. If by enabling extensions or changing settings on Jupyterlab's UI causes 400 return codes, it is likely that the `PUT` request's body was parsed unsuccessfully by a routing layer that does not accept JSON5 payload.
+
+Common symptoms of this during debugging are:
+
+- The settings are selected but nothing changes, or when extension manager is 
+- Jupyterlab's logs don't have the 400 return codes when `PUT` requests are issued.
+- If your Jupyterlab logs are on elastic search, you'll see `Unexpected token / in JSON at position`, signalling that the comments are invalid JSON.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -211,4 +211,4 @@ Common symptoms of this during debugging are:
 
 - The settings are selected but nothing changes, or when extension manager is 
 - JupyterLab's logs don't have the 400 return codes when `PUT` requests are issued.
-- If your Jupyterlab logs are on elastic search, you'll see `Unexpected token / in JSON at position`, signalling that the comments are invalid JSON.
+- If your JupyterLab logs are on Elastic Search, you'll see `Unexpected token / in JSON at position`. This comes from the JSON5 comments not being valid JSON.


### PR DESCRIPTION
#  References

This PR is a documentation on the issue in #7162. A small TL;DR for the issue diagnosis is below:

The payload for extensions is actually only JSON5 and above compatible. This also affects settings. For example, the following is only JSON5 compatible:

```
{
    // Extension Manager
    // @jupyterlab/extensionmanager-extension:plugin
    // Extension manager settings.
    // *********************************************
    // Enabled Status
    // Enables extension manager (requires Node.js/npm).
    // WARNING: installing untrusted extensions may be unsafe.
    "enabled": true
}
```

users a lot of existing authentication layers and rerouting in internal infrastructure uses parsers that are JSON4 and below. Things like //'s give a parse error and the request does not go through.
I think it's a good idea to note that one dependency in a system that uses Jupyterlab is JSON5+, as the error was super hard to debug and figure out. I've added an addendum in the documentation for debugging.

## Code changes

N/A

## User-facing changes

N/A

## Backwards-incompatible changes

N/A