### PR TITLE
Change JSON5 payload to JSON payload

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -56,6 +56,7 @@
     "@lumino/disposable": "^1.3.5",
     "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
+    "json5": "^2.1.1",
     "node-fetch": "^2.6.0",
     "ws": "^7.2.0"
   },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -56,7 +56,6 @@
     "@lumino/disposable": "^1.3.5",
     "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
-    "json5": "^2.1.1",
     "node-fetch": "^2.6.0",
     "ws": "^7.2.0"
   },

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import * as json5 from 'json5';
+
 import { URLExt } from '@jupyterlab/coreutils';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
@@ -106,7 +108,8 @@ export class SettingManager extends DataConnector<
     const { makeRequest, ResponseError } = ServerConnection;
     const base = baseUrl + appUrl;
     const url = Private.url(base, id);
-    const init = { body: raw, method: 'PUT' };
+    // NOTE: The body is JSON5, so it must be converted to valid JSON beforehand.
+    const init = { body: JSON.stringify(json5.parse(raw)), method: 'PUT' };
     const response = await makeRequest(url, init, serverSettings);
 
     if (response.status !== 204) {

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -106,8 +106,7 @@ export class SettingManager extends DataConnector<
     const { makeRequest, ResponseError } = ServerConnection;
     const base = baseUrl + appUrl;
     const url = Private.url(base, id);
-    // NOTE: The body is JSON5, so it must be converted to valid JSON beforehand by wrapping it as a string
-    // in the form {'raw': '...'} where '...' is the JSON5 payload string.
+    // NOTE: 'raw' is JSON5 (not valid JSON), so we encode it as a string in a valid JSON body
     const init = { body: JSON.stringify({ raw }), method: 'PUT' };
     const response = await makeRequest(url, init, serverSettings);
 

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import * as json5 from 'json5';
-
 import { URLExt } from '@jupyterlab/coreutils';
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
@@ -109,7 +107,7 @@ export class SettingManager extends DataConnector<
     const base = baseUrl + appUrl;
     const url = Private.url(base, id);
     // NOTE: The body is JSON5, so it must be converted to valid JSON beforehand.
-    const init = { body: JSON.stringify(json5.parse(raw)), method: 'PUT' };
+    const init = { body: JSON.stringify({ raw }), method: 'PUT' };
     const response = await makeRequest(url, init, serverSettings);
 
     if (response.status !== 204) {

--- a/packages/services/src/setting/index.ts
+++ b/packages/services/src/setting/index.ts
@@ -106,7 +106,8 @@ export class SettingManager extends DataConnector<
     const { makeRequest, ResponseError } = ServerConnection;
     const base = baseUrl + appUrl;
     const url = Private.url(base, id);
-    // NOTE: The body is JSON5, so it must be converted to valid JSON beforehand.
+    // NOTE: The body is JSON5, so it must be converted to valid JSON beforehand by wrapping it as a string
+    // in the form {'raw': '...'} where '...' is the JSON5 payload string.
     const init = { body: JSON.stringify({ raw }), method: 'PUT' };
     const response = await makeRequest(url, init, serverSettings);
 

--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -3,7 +3,7 @@
 
 import Ajv from 'ajv';
 
-import * as json from 'json5';
+import * as json5 from 'json5';
 
 import { CommandRegistry } from '@lumino/commands';
 
@@ -152,7 +152,7 @@ export class DefaultSchemaValidator implements ISchemaValidator {
     // Parse the raw commented JSON into a user map.
     let user: JSONObject;
     try {
-      user = json.parse(plugin.raw) as JSONObject;
+      user = json5.parse(plugin.raw) as JSONObject;
     } catch (error) {
       if (error instanceof SyntaxError) {
         return [
@@ -400,7 +400,7 @@ export class SettingRegistry implements ISettingRegistry {
       return;
     }
 
-    const raw = json.parse(plugins[plugin].raw);
+    const raw = json5.parse(plugins[plugin].raw);
 
     // Delete both the value and any associated comment.
     delete raw[key];
@@ -433,7 +433,7 @@ export class SettingRegistry implements ISettingRegistry {
     }
 
     // Parse the raw JSON string removing all comments and return an object.
-    const raw = json.parse(plugins[plugin].raw);
+    const raw = json5.parse(plugins[plugin].raw);
 
     plugins[plugin].raw = Private.annotatedPlugin(plugins[plugin], {
       ...raw,

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'ipython',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
-    'jupyterlab_server>=2.0.0a4',
+    'jupyterlab_server>=2.0.0b0',
     'jupyter_server>=1.0.0rc5',
     'nbclassic>=0.2.0rc3',
     'jinja2>=2.10'


### PR DESCRIPTION
## References

This is a fix to #7162 

## Code changes

We first make it clear that json5 is being loaded as raw text from the settings by wrapping it in the form `{'raw':'...'}`. The payload difference is the following pre and post-patch:

Before (JSON5, unparse-able by many default json parsers)
```
{
    // Theme
    // @jupyterlab/apputils-extension:themes
    // Theme manager settings.
    // *************************************

    // Selected Theme
    // Application-level visual styling theme
    "theme": "JupyterLab Dark"
}
```

After (wrapped)
```
{"raw":"{\n    // Theme\n    // @jupyterlab/apputils-extension:themes\n    // Theme manager settings.\n    // *************************************\n\n    // Selected Theme\n    // Application-level visual styling theme\n    \"theme\": \"JupyterLab Dark\"\n}"}
```

## User-facing changes

N/A

## Backwards-incompatible changes

N/A. Any JSON5 compatible payload should be convertible to JSON after parsing then stringifying.