### PR TITLE
Add save action when exiting unsaved notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ MANIFEST
 *.map
 *.swp
 .DS_Store
+.log/
 \#*#
 .#*
 

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -359,11 +359,11 @@ export class DocumentWidgetManager implements IDisposable {
     const fileName = widget.title.label;
     const saveLabel = context.contentsModel?.writable ? 'Save' : 'Save as';
     return showDialog({
-      title: 'Confirm close',
-      body: `File "${fileName}" has unsaved changes, save before closing?`,
+      title: 'Save your work',
+      body: `Save changes in "${fileName}" before closing?`,
       buttons: [
         Dialog.cancelButton(),
-        Dialog.warnButton({ label: 'Discard changes' }),
+        Dialog.warnButton({ label: 'Discard' }),
         Dialog.okButton({ label: saveLabel })
       ]
     }).then(result => {

--- a/packages/docmanager/src/widgetmanager.ts
+++ b/packages/docmanager/src/widgetmanager.ts
@@ -301,7 +301,11 @@ export class DocumentWidgetManager implements IDisposable {
         if (!context) {
           return true;
         }
-        await context.save();
+        if (context.contentsModel?.writable) {
+          await context.save();
+        } else {
+          await context.saveAs();
+        }
       }
       if (widget.isDisposed) {
         return true;
@@ -353,13 +357,14 @@ export class DocumentWidgetManager implements IDisposable {
       return Promise.resolve([true, true]);
     }
     const fileName = widget.title.label;
+    const saveLabel = context.contentsModel?.writable ? 'Save' : 'Save as';
     return showDialog({
       title: 'Confirm close',
       body: `File "${fileName}" has unsaved changes, save before closing?`,
       buttons: [
         Dialog.cancelButton(),
         Dialog.warnButton({ label: 'Discard changes' }),
-        Dialog.okButton({ label: 'Save' })
+        Dialog.okButton({ label: saveLabel })
       ]
     }).then(result => {
       return [result.button.accept, result.button.displayType === 'warn'];

--- a/packages/docmanager/test/widgetmanager.spec.ts
+++ b/packages/docmanager/test/widgetmanager.spec.ts
@@ -22,7 +22,7 @@ import { IMessageHandler, Message, MessageLoop } from '@lumino/messaging';
 
 import { Widget } from '@lumino/widgets';
 
-import { acceptDialog, dismissDialog } from '@jupyterlab/testutils';
+import { dangerDialog, dismissDialog } from '@jupyterlab/testutils';
 
 import * as Mock from '@jupyterlab/testutils/lib/mock';
 
@@ -280,7 +280,7 @@ describe('@jupyterlab/docmanager', () => {
         const widget = manager.createWidget(widgetFactory, context);
         const closed = manager.onClose(widget);
 
-        await Promise.all([acceptDialog(), closed]);
+        await Promise.all([dangerDialog(), closed]);
 
         expect(widget.isDisposed).toBe(true);
       });
@@ -315,7 +315,7 @@ describe('@jupyterlab/docmanager', () => {
         const readonly = manager.createWidget(readOnlyFactory, context);
         const closed = manager.onClose(writable);
 
-        await acceptDialog();
+        await dangerDialog();
         await closed;
 
         expect(writable.isDisposed).toBe(true);

--- a/testutils/src/common.ts
+++ b/testutils/src/common.ts
@@ -333,6 +333,23 @@ export async function acceptDialog(
 }
 
 /**
+ * Click on the warning button in a dialog after it is attached
+ *
+ */
+export async function dangerDialog(
+  host: HTMLElement = document.body,
+  timeout: number = 250
+): Promise<void> {
+  await waitForDialog(host, timeout);
+
+  const node = host.getElementsByClassName('jp-mod-warn')[0];
+
+  if (node) {
+    simulate(node as HTMLElement, 'click', { button: 1 });
+  }
+}
+
+/**
  * Dismiss a dialog after it is attached.
  *
  * #### Notes

--- a/testutils/src/common.ts
+++ b/testutils/src/common.ts
@@ -334,7 +334,6 @@ export async function acceptDialog(
 
 /**
  * Click on the warning button in a dialog after it is attached
- *
  */
 export async function dangerDialog(
   host: HTMLElement = document.body,

--- a/testutils/src/index.ts
+++ b/testutils/src/index.ts
@@ -22,6 +22,7 @@ export {
   initNotebookContext,
   waitForDialog,
   acceptDialog,
+  dangerDialog,
   dismissDialog
 } from './common';
 


### PR DESCRIPTION
## References
#8094 Improvement to Save dialog

## Code changes
- Change some promises to async/await.
- Write new function called `dangerDialog` in testutils to click on a warning button in a dialog
- Replace the acceptDialog -> dangerDialog in widgetmanager.spec.ts accordingly

## User-facing changes
The exit dialog now looks like this
![exit dialog with 3 button](https://user-images.githubusercontent.com/13181907/79775573-74bdf200-8302-11ea-9079-596e2b98a737.png)


## Backwards-incompatible changes
Nothing that I am aware of 