### PR TITLE
Fix Save As for files without sessions

### DIFF
--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -779,16 +779,11 @@ export class Context<T extends DocumentRegistry.IModel>
    */
   private async _finishSaveAs(newPath: string): Promise<void> {
     this._path = newPath;
-    return this.sessionContext.session
-      ?.setPath(newPath)
-      .then(() => {
-        void this.sessionContext.session?.setName(newPath.split('/').pop()!);
-        return this.save();
-      })
-      .then(() => {
-        this._pathChanged.emit(this._path);
-        return this._maybeCheckpoint(true);
-      });
+    await this.sessionContext.session?.setPath(newPath);
+    await this.sessionContext.session?.setName(newPath.split('/').pop()!);
+    await this.save();
+    this._pathChanged.emit(this._path);
+    await this._maybeCheckpoint(true);
   }
 
   private _manager: ServiceManager.IManager;

--- a/tests/test-docregistry/src/context.spec.ts
+++ b/tests/test-docregistry/src/context.spec.ts
@@ -350,9 +350,15 @@ describe('docregistry/context', () => {
         };
         const promise = func();
         await initialize;
+
+        const oldPath = context.path;
         await context.saveAs();
-        expect(context.path).to.equal(newPath);
         await promise;
+        expect(context.path).to.equal(newPath);
+        // Make sure the both files are there now.
+        const model = await manager.contents.get('', { content: true });
+        expect(model.content.find((x: any) => x.name === oldPath)).to.be.ok;
+        expect(model.content.find((x: any) => x.name === newPath)).to.be.ok;
       });
 
       it('should bring up a conflict dialog', async () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #8216 

## Code changes

The save as code had an early return if the session was null, which meant the save wasn't actually performed. Worse yet, our unit test for save as didn't actually test if the file was actually saved to disk. We correct both of these issues.

## User-facing changes

File Save As works for files without an associated session.

## Backwards-incompatible changes

None