### PR TITLE
Improve autolink

### DIFF
--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -475,18 +475,25 @@ export namespace renderSVG {
  * @returns The content where all URLs have been replaced with corresponding links.
  */
 function autolink(content: string): string {
-  return content.replace(
-    // Same pattern as in classic notebook with word boundaries (\b).
-    /\b((https?|ftp)(:[^'"<>\s]+))\b/g,
-    url => {
-      const a = document.createElement('a');
-      a.href = url;
-      a.textContent = url;
-      a.rel = 'noopener';
-      a.target = '_blank';
-      return a.outerHTML;
-    }
+  // Taken from Visual Studio Code:
+  // https://github.com/microsoft/vscode/blob/9f709d170b06e991502153f281ec3c012add2e42/src/vs/workbench/contrib/debug/browser/linkDetector.ts#L17-L18
+  const controlCodes = '\\u0000-\\u0020\\u007f-\\u009f';
+  const webLinkRegex = new RegExp(
+    '(?:[a-zA-Z][a-zA-Z0-9+.-]{2,}:\\/\\/|data:|www\\.)[^\\s' +
+      controlCodes +
+      '"]{2,}[^\\s' +
+      controlCodes +
+      '"\')}\\],:;.!?]',
+    'ug'
   );
+  return content.replace(webLinkRegex, url => {
+    const a = document.createElement('a');
+    a.href = url;
+    a.textContent = url;
+    a.rel = 'noopener';
+    a.target = '_blank';
+    return a.outerHTML;
+  });
 }
 
 /**

--- a/tests/test-rendermime/src/factories.spec.ts
+++ b/tests/test-rendermime/src/factories.spec.ts
@@ -104,8 +104,11 @@ describe('rendermime/factories', () => {
       it('should autolink URLs', async () => {
         const f = textRendererFactory;
         const urls = [
+          'https://example.com',
+          'https://example.com/',
           'https://example.com#anchor',
           'http://localhost:9090/app',
+          'http://localhost:9090/app/',
           'http://127.0.0.1/test?query=string'
         ];
         await Promise.all(


### PR DESCRIPTION
## References

This improves #8075 by using the [more robust link detection regex used by Visual Studio Code](https://github.com/microsoft/vscode/blob/9f709d170b06e991502153f281ec3c012add2e42/src/vs/workbench/contrib/debug/browser/linkDetector.ts#L17-L18).

## Code changes

Just the regex and more test cases.

## User-facing changes

URLs ending with a `/` match till the end:

<img width="233" alt="Screenshot 2020-04-21 at 12 16 06" src="https://user-images.githubusercontent.com/6574550/79854638-0e9ca200-83ca-11ea-975f-8a51d339c3d5.png">

where before the `/` would be left outside the link:

<img width="232" alt="Screenshot 2020-04-21 at 12 15 37" src="https://user-images.githubusercontent.com/6574550/79854652-13f9ec80-83ca-11ea-87be-001da62d25d5.png">

## Backwards-incompatible changes

None.
