### PR TITLE
Add Tutorials and Cookiecutters sections to the extension dev docs

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -41,6 +41,14 @@ We provide several cookiecutters to create JupyterLab plugin extensions:
 - `mimerender-cookiecutter-ts <https://github.com/jupyterlab/mimerender-cookiecutter-ts>`_: Create a MIME Renderer JupyterLab extension in TypeScript
 - `theme-cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`_: Create a new theme for JupyterLab
 
+API Documentation
+~~~~~~~~~~~~~~~~~
+
+If you are looking for lower level details on the JupyterLab and Lumino API:
+
+- `JupyterLab API Documentation <https://jupyterlab.github.io/jupyterlab/>`_
+- `Lumino API Documentation <https://jupyterlab.github.io/lumino/>`_
+
 Plugins
 ~~~~~~~
 

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -46,9 +46,9 @@ A plugin adds a core functionality to the application:
    interface, by exporting a plugin object or array of plugin objects as
    the default export.
 
-   We provide two cookiecutters to create JupyterLab plugin extensions in
-   `JavaScript <https://github.com/jupyterlab/extension-cookiecutter-js>`__ and
-   `TypeScript <https://github.com/jupyterlab/extension-cookiecutter-ts>`__.
+We provide two cookiecutters to create JupyterLab plugin extensions in
+`JavaScript <https://github.com/jupyterlab/extension-cookiecutter-js>`__ and
+`TypeScript <https://github.com/jupyterlab/extension-cookiecutter-ts>`__.
 
 The default plugins in the JupyterLab application include:
 

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -26,10 +26,10 @@ Tutorials
 
 We provide a set of guides to get started writing third-party extensions for JupyterLab:
 
-- :ref:`extension_tutorial`: an in-depth tutorial to learn how to make a simple JupyterLab extension.
-- The `JupyterLab Extension Examples Repository <https://github.com/jupyterlab/extension-examples>`_: a short tutorial series
+- :ref:`extension_tutorial`: An in-depth tutorial to learn how to make a simple JupyterLab extension.
+- The `JupyterLab Extension Examples Repository <https://github.com/jupyterlab/extension-examples>`_: A short tutorial series
   to learn how to develop extensions for JupyterLab, by example.
-- :ref:`developer-extension-points`: a list of the most common JupyterLab extension points.
+- :ref:`developer-extension-points`: A list of the most common JupyterLab extension points.
 
 Cookiecutters
 ~~~~~~~~~~~~~

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -31,6 +31,16 @@ We provide a set of guides to get started writing third-party extensions for Jup
   to learn how to develop extensions for JupyterLab, by example.
 - :ref:`developer-extension-points`: a list of the most common JupyterLab extension points.
 
+Cookiecutters
+~~~~~~~~~~~~~
+
+We provide several cookiecutters to create JupyterLab plugin extensions:
+
+- `extension-cookiecutter-ts <https://github.com/jupyterlab/extension-cookiecutter-ts>`_: Create a JupyterLab extension in TypeScript
+- `extension-cookiecutter-js <https://github.com/jupyterlab/extension-cookiecutter-js>`_: Create a JupyterLab extension in JavaScript
+- `mimerender-cookiecutter-ts <https://github.com/jupyterlab/mimerender-cookiecutter-ts>`_: Create a MIME Renderer JupyterLab extension in TypeScript
+- `theme-cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`_: Create a new theme for JupyterLab
+
 Plugins
 ~~~~~~~
 
@@ -45,10 +55,6 @@ A plugin adds a core functionality to the application:
    `JupyterLab.IPluginModule <https://jupyterlab.github.io/jupyterlab/application/interfaces/jupyterlab.ipluginmodule.html>`__
    interface, by exporting a plugin object or array of plugin objects as
    the default export.
-
-We provide two cookiecutters to create JupyterLab plugin extensions in
-`JavaScript <https://github.com/jupyterlab/extension-cookiecutter-js>`__ and
-`TypeScript <https://github.com/jupyterlab/extension-cookiecutter-ts>`__.
 
 The default plugins in the JupyterLab application include:
 

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -16,12 +16,20 @@ JupyterLab can be extended in four ways via:
    extend the functionality of document widgets added to the
    application, and we cover them in :ref:`documents`.
 
-See :ref:`extension_tutorial` to learn how to make a simple JupyterLab extension.
-
 A JupyterLab application is comprised of:
 
 -  A core Application object
 -  Plugins
+
+Tutorials
+~~~~~~~~~
+
+We provide a set of guides to get started writing third-party extensions for JupyterLab:
+
+- :ref:`extension_tutorial`: an in-depth tutorial to learn how to make a simple JupyterLab extension.
+- The `JupyterLab Extension Examples Repository <https://github.com/jupyterlab/extension-examples>`_: a short tutorial series
+  to learn how to develop extensions for JupyterLab, by example.
+- :ref:`developer-extension-points`: a list of the most common JupyterLab extension points.
 
 Plugins
 ~~~~~~~
@@ -727,7 +735,7 @@ extension manager.
 Listings
 ^^^^^^^^
 
-You can develop on the extension manager package and :ref:`extension_listings` with the 
+You can develop on the extension manager package and :ref:`extension_listings` with the
 example shipped in the ``packages/extensionmanager-extension/examples/listings`` folder.
 
 Follow the ``README.md`` instructions in that folder.


### PR DESCRIPTION
## References

A quick restructure of the docs to provide more guidance on where to find relevant resources.

This also adds a link to the new [JupyterLab Extension Examples](https://github.com/jupyterlab/extension-examples) repo.

See https://github.com/jupyterlab/jupyterlab/issues/7273 for more context.

## Code changes

Documentation only.

## User-facing changes

![image](https://user-images.githubusercontent.com/591645/80018243-05006080-84d6-11ea-9631-baf4542e7835.png)


## Backwards-incompatible changes

None