### PR TITLE
Add ability to toggle last modified column of file browser

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -124,7 +124,7 @@ namespace CommandIDs {
   export const toggleNavigateToCurrentDirectory =
     'filebrowser:toggle-navigate-to-current-directory';
 
-  export const toggleShowLastModified = 'filebrowser:toggle-show-last-modified';
+  export const toggleLastModified = 'filebrowser:toggle-last-modified';
 }
 
 /**
@@ -820,7 +820,7 @@ function addCommands(
     }
   });
 
-  commands.addCommand(CommandIDs.toggleShowLastModified, {
+  commands.addCommand(CommandIDs.toggleLastModified, {
     label: 'Toggle Last Modified Column',
     execute: () => {
       const header = DOMUtils.findElement(document.body, 'jp-id-modified');
@@ -1035,7 +1035,7 @@ function addCommands(
     rank: 13
   });
   app.contextMenu.addItem({
-    command: CommandIDs.toggleShowLastModified,
+    command: CommandIDs.toggleLastModified,
     selector: '.jp-DirListing-header',
     rank: 14
   });

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -821,7 +821,7 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.toggleShowLastModified, {
-    label: 'Show Last Modified',
+    label: 'Toggle Last Modified Column',
     execute: () => {
       const header = DOMUtils.findElement(document.body, 'jp-id-modified');
       const column = DOMUtils.findElements(

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -16,7 +16,8 @@ import {
   WidgetTracker,
   ICommandPalette,
   InputDialog,
-  showErrorMessage
+  showErrorMessage,
+  DOMUtils
 } from '@jupyterlab/apputils';
 
 import { PageConfig, PathExt, URLExt } from '@jupyterlab/coreutils';
@@ -122,6 +123,8 @@ namespace CommandIDs {
 
   export const toggleNavigateToCurrentDirectory =
     'filebrowser:toggle-navigate-to-current-directory';
+
+  export const toggleShowLastModified = 'filebrowser:toggle-show-last-modified';
 }
 
 /**
@@ -817,6 +820,28 @@ function addCommands(
     }
   });
 
+  commands.addCommand(CommandIDs.toggleShowLastModified, {
+    label: 'Show Last Modified',
+    execute: () => {
+      const header = DOMUtils.findElement(document.body, 'jp-id-modified');
+      const column = DOMUtils.findElements(
+        document.body,
+        'jp-DirListing-itemModified'
+      );
+      if (header.classList.contains('jp-LastModified-hidden')) {
+        header.classList.remove('jp-LastModified-hidden');
+        for (let i = 0; i < column.length; i++) {
+          column[i].classList.remove('jp-LastModified-hidden');
+        }
+      } else {
+        header.classList.add('jp-LastModified-hidden');
+        for (let i = 0; i < column.length; i++) {
+          column[i].classList.add('jp-LastModified-hidden');
+        }
+      }
+    }
+  });
+
   if (mainMenu) {
     mainMenu.settingsMenu.addGroup(
       [{ command: CommandIDs.toggleNavigateToCurrentDirectory }],
@@ -1008,6 +1033,11 @@ function addCommands(
     command: CommandIDs.copyDownloadLink,
     selector: selectorNotDir,
     rank: 13
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.toggleShowLastModified,
+    selector: '.jp-DirListing-header',
+    rank: 14
   });
 }
 

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -236,3 +236,7 @@
 .jp-FileDialog .jp-new-name-title {
   margin-top: 12px;
 }
+
+.jp-LastModified-hidden {
+  display: none;
+}


### PR DESCRIPTION
## References
Addresses (half of) #8081 

## Code changes
Adds a command, context menu item, and CSS class to toggle whether the last modified column of file browser shows.

## User-facing changes
Context menu appears on the header of file browser, with option to hide/show last modified column.

## Backwards-incompatible changes
None
