### PR TITLE
Remove content factory pattern

### DIFF
--- a/packages/cells/src/inputarea.ts
+++ b/packages/cells/src/inputarea.ts
@@ -48,17 +48,17 @@ export class InputArea extends Widget {
     super();
     this.addClass(INPUT_AREA_CLASS);
     const model = (this.model = options.model);
-    const contentFactory = (this.contentFactory =
-      options.contentFactory || InputArea.defaultContentFactory);
 
     // Prompt
-    const prompt = (this._prompt = contentFactory.createInputPrompt());
+    const prompt = (this._prompt = new InputPrompt());
     prompt.addClass(INPUT_AREA_PROMPT_CLASS);
 
     // Editor
+    this._editorFactory =
+      options.editorFactory || InputArea.defaultEditorFactory;
     const editorOptions = {
       model,
-      factory: contentFactory.editorFactory,
+      factory: this.editorFactory,
       updateOnShow: options.updateOnShow
     };
     const editor = (this._editor = new CodeEditorWrapper(editorOptions));
@@ -74,10 +74,9 @@ export class InputArea extends Widget {
    */
   readonly model: ICellModel;
 
-  /**
-   * The content factory used by the widget.
-   */
-  readonly contentFactory: InputArea.IContentFactory;
+  get editorFactory(): CodeEditor.Factory {
+    return this._editorFactory;
+  }
 
   /**
    * Get the CodeEditorWrapper used by the cell.
@@ -147,6 +146,7 @@ export class InputArea extends Widget {
   private _prompt: IInputPrompt;
   private _editor: CodeEditorWrapper;
   private _rendered: Widget;
+  private _editorFactory: CodeEditor.Factory;
 }
 
 /**
@@ -163,85 +163,14 @@ export namespace InputArea {
     model: ICellModel;
 
     /**
-     * The content factory used by the widget to create children.
-     *
-     * Defaults to one that uses CodeMirror.
+     * The editor factory used to create editor instances.
      */
-    contentFactory?: IContentFactory;
+    editorFactory?: CodeEditor.Factory;
 
     /**
      * Whether to send an update request to the editor when it is shown.
      */
     updateOnShow?: boolean;
-  }
-
-  /**
-   * An input area widget content factory.
-   *
-   * The content factory is used to create children in a way
-   * that can be customized.
-   */
-  export interface IContentFactory {
-    /**
-     * The editor factory we need to include in `CodeEditorWratter.IOptions`.
-     *
-     * This is a separate readonly attribute rather than a factory method as we need
-     * to pass it around.
-     */
-    readonly editorFactory: CodeEditor.Factory;
-
-    /**
-     * Create an input prompt.
-     */
-    createInputPrompt(): IInputPrompt;
-  }
-
-  /**
-   * Default implementation of `IContentFactory`.
-   *
-   * This defaults to using an `editorFactory` based on CodeMirror.
-   */
-  export class ContentFactory implements IContentFactory {
-    /**
-     * Construct a `ContentFactory`.
-     */
-    constructor(options: ContentFactory.IOptions = {}) {
-      this._editor = options.editorFactory || defaultEditorFactory;
-    }
-
-    /**
-     * Return the `CodeEditor.Factory` being used.
-     */
-    get editorFactory(): CodeEditor.Factory {
-      return this._editor;
-    }
-
-    /**
-     * Create an input prompt.
-     */
-    createInputPrompt(): IInputPrompt {
-      return new InputPrompt();
-    }
-
-    private _editor: CodeEditor.Factory;
-  }
-
-  /**
-   * A namespace for the input area content factory.
-   */
-  export namespace ContentFactory {
-    /**
-     * Options for the content factory.
-     */
-    export interface IOptions {
-      /**
-       * The editor factory used by the content factory.
-       *
-       * If this is not passed, a default CodeMirror editor factory
-       * will be used.
-       */
-      editorFactory?: CodeEditor.Factory;
-    }
   }
 
   /**
@@ -256,11 +185,6 @@ export namespace InputArea {
    * The default editor factory singleton based on CodeMirror.
    */
   export const defaultEditorFactory: CodeEditor.Factory = _createDefaultEditorFactory();
-
-  /**
-   * The default `ContentFactory` instance.
-   */
-  export const defaultContentFactory = new ContentFactory({});
 }
 
 /** ****************************************************************************

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -101,7 +101,6 @@ const tracker: JupyterFrontEndPlugin<IConsoleTracker> = {
   id: '@jupyterlab/console-extension:tracker',
   provides: IConsoleTracker,
   requires: [
-    ConsolePanel.IContentFactory,
     IEditorServices,
     ILayoutRestorer,
     IFileBrowserFactory,
@@ -120,23 +119,9 @@ const tracker: JupyterFrontEndPlugin<IConsoleTracker> = {
 };
 
 /**
- * The console widget content factory.
- */
-const factory: JupyterFrontEndPlugin<ConsolePanel.IContentFactory> = {
-  id: '@jupyterlab/console-extension:factory',
-  provides: ConsolePanel.IContentFactory,
-  requires: [IEditorServices],
-  autoStart: true,
-  activate: (app: JupyterFrontEnd, editorServices: IEditorServices) => {
-    const editorFactory = editorServices.factoryService.newInlineEditor;
-    return new ConsolePanel.ContentFactory({ editorFactory });
-  }
-};
-
-/**
  * Export the plugins as the default.
  */
-const plugins: JupyterFrontEndPlugin<any>[] = [factory, tracker, foreign];
+const plugins: JupyterFrontEndPlugin<any>[] = [tracker, foreign];
 export default plugins;
 
 /**
@@ -144,7 +129,6 @@ export default plugins;
  */
 async function activateConsole(
   app: JupyterFrontEnd,
-  contentFactory: ConsolePanel.IContentFactory,
   editorServices: IEditorServices,
   restorer: ILayoutRestorer,
   browserFactory: IFileBrowserFactory,
@@ -258,7 +242,6 @@ async function activateConsole(
 
     const panel = new ConsolePanel({
       manager,
-      contentFactory,
       mimeTypeService: editorServices.mimeTypeService,
       rendermime,
       setBusy: (status && (() => status.setBusy())) ?? undefined,

--- a/packages/console/src/panel.ts
+++ b/packages/console/src/panel.ts
@@ -16,7 +16,7 @@ import {
 import { ServiceManager } from '@jupyterlab/services';
 import { consoleIcon } from '@jupyterlab/ui-components';
 
-import { Token, UUID } from '@lumino/coreutils';
+import { UUID } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { Message } from '@lumino/messaging';
 import { Panel } from '@lumino/widgets';
@@ -48,8 +48,6 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
       modelFactory,
       sessionContext
     } = options;
-    const contentFactory = (this.contentFactory =
-      options.contentFactory || ConsolePanel.defaultContentFactory);
     const count = Private.count++;
     if (!path) {
       path = `${basePath || ''}/console-${count}-${UUID.uuid4()}`;
@@ -73,11 +71,10 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
     });
     rendermime = rendermime.clone({ resolver });
 
-    this.console = contentFactory.createConsole({
+    this.console = new CodeConsole({
       rendermime,
       sessionContext: sessionContext,
       mimeTypeService,
-      contentFactory,
       modelFactory
     });
     this.content.addWidget(this.console);
@@ -99,11 +96,6 @@ export class ConsolePanel extends MainAreaWidget<Panel> {
     this.title.closable = true;
     this.id = `console-${count}`;
   }
-
-  /**
-   * The content factory used by the console panel.
-   */
-  readonly contentFactory: ConsolePanel.IContentFactory;
 
   /**
    * The console widget used by the panel.
@@ -178,11 +170,6 @@ export namespace ConsolePanel {
     rendermime: IRenderMimeRegistry;
 
     /**
-     * The content factory for the panel.
-     */
-    contentFactory: IContentFactory;
-
-    /**
      * The service manager used by the panel.
      */
     manager: ServiceManager.IManager;
@@ -227,53 +214,6 @@ export namespace ConsolePanel {
      */
     setBusy?: () => IDisposable;
   }
-
-  /**
-   * The console panel renderer.
-   */
-  export interface IContentFactory extends CodeConsole.IContentFactory {
-    /**
-     * Create a new console panel.
-     */
-    createConsole(options: CodeConsole.IOptions): CodeConsole;
-  }
-
-  /**
-   * Default implementation of `IContentFactory`.
-   */
-  export class ContentFactory extends CodeConsole.ContentFactory
-    implements IContentFactory {
-    /**
-     * Create a new console panel.
-     */
-    createConsole(options: CodeConsole.IOptions): CodeConsole {
-      return new CodeConsole(options);
-    }
-  }
-
-  /**
-   * A namespace for the console panel content factory.
-   */
-  export namespace ContentFactory {
-    /**
-     * Options for the code console content factory.
-     */
-    export interface IOptions extends CodeConsole.ContentFactory.IOptions {}
-  }
-
-  /**
-   * A default code console content factory.
-   */
-  export const defaultContentFactory: IContentFactory = new ContentFactory();
-
-  /* tslint:disable */
-  /**
-   * The console renderer token.
-   */
-  export const IContentFactory = new Token<IContentFactory>(
-    '@jupyterlab/console:IContentFactory'
-  );
-  /* tslint:enable */
 }
 
 /**

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -114,8 +114,6 @@ export class CodeConsole extends Widget {
     this._content = new Panel();
     this._input = new Panel();
 
-    this.contentFactory =
-      options.contentFactory || CodeConsole.defaultContentFactory;
     this.modelFactory = options.modelFactory || CodeConsole.defaultModelFactory;
     this.rendermime = options.rendermime;
     this.sessionContext = options.sessionContext;
@@ -155,11 +153,6 @@ export class CodeConsole extends Widget {
   get promptCellCreated(): ISignal<this, CodeCell> {
     return this._promptCellCreated;
   }
-
-  /**
-   * The content factory used by the console.
-   */
-  readonly contentFactory: CodeConsole.IContentFactory;
 
   /**
    * The model factory for the console widget.
@@ -234,8 +227,7 @@ export class CodeConsole extends Widget {
     const model = this.modelFactory.createRawCell({});
     model.value.text = '...';
     const banner = (this._banner = new RawCell({
-      model,
-      contentFactory: this.contentFactory
+      model
     })).initializeState();
     banner.addClass(BANNER_CLASS);
     banner.readOnly = true;
@@ -257,9 +249,8 @@ export class CodeConsole extends Widget {
    * Create a new cell with the built-in factory.
    */
   createCodeCell(): CodeCell {
-    const factory = this.contentFactory;
     const options = this._createCodeCellOptions();
-    const cell = factory.createCodeCell(options);
+    const cell = new CodeCell(options).initializeState();
     cell.readOnly = true;
     cell.model.mimeType = this._mimetype;
     return cell;
@@ -598,9 +589,8 @@ export class CodeConsole extends Widget {
     }
 
     // Create the new prompt cell.
-    const factory = this.contentFactory;
     const options = this._createCodeCellOptions();
-    promptCell = factory.createCodeCell(options);
+    promptCell = new CodeCell(options).initializeState();
     promptCell.model.mimeType = this._mimetype;
     promptCell.addClass(PROMPT_CLASS);
 
@@ -727,11 +717,10 @@ export class CodeConsole extends Widget {
    * Create the options used to initialize a code cell widget.
    */
   private _createCodeCellOptions(): CodeCell.IOptions {
-    const contentFactory = this.contentFactory;
     const modelFactory = this.modelFactory;
     const model = modelFactory.createCodeCell({});
     const rendermime = this.rendermime;
-    return { model, rendermime, contentFactory };
+    return { model, rendermime };
   }
 
   /**
@@ -849,11 +838,6 @@ export namespace CodeConsole {
    */
   export interface IOptions {
     /**
-     * The content factory for the console widget.
-     */
-    contentFactory: IContentFactory;
-
-    /**
      * The model factory for the console widget.
      */
     modelFactory?: IModelFactory;
@@ -873,70 +857,6 @@ export namespace CodeConsole {
      */
     mimeTypeService: IEditorMimeTypeService;
   }
-
-  /**
-   * A content factory for console children.
-   */
-  export interface IContentFactory extends Cell.IContentFactory {
-    /**
-     * Create a new code cell widget.
-     */
-    createCodeCell(options: CodeCell.IOptions): CodeCell;
-
-    /**
-     * Create a new raw cell widget.
-     */
-    createRawCell(options: RawCell.IOptions): RawCell;
-  }
-
-  /**
-   * Default implementation of `IContentFactory`.
-   */
-  export class ContentFactory extends Cell.ContentFactory
-    implements IContentFactory {
-    /**
-     * Create a new code cell widget.
-     *
-     * #### Notes
-     * If no cell content factory is passed in with the options, the one on the
-     * notebook content factory is used.
-     */
-    createCodeCell(options: CodeCell.IOptions): CodeCell {
-      if (!options.contentFactory) {
-        options.contentFactory = this;
-      }
-      return new CodeCell(options).initializeState();
-    }
-
-    /**
-     * Create a new raw cell widget.
-     *
-     * #### Notes
-     * If no cell content factory is passed in with the options, the one on the
-     * notebook content factory is used.
-     */
-    createRawCell(options: RawCell.IOptions): RawCell {
-      if (!options.contentFactory) {
-        options.contentFactory = this;
-      }
-      return new RawCell(options).initializeState();
-    }
-  }
-
-  /**
-   * A namespace for the code console content factory.
-   */
-  export namespace ContentFactory {
-    /**
-     * An initialize options for `ContentFactory`.
-     */
-    export interface IOptions extends Cell.IContentFactory {}
-  }
-
-  /**
-   * A default content factory for the code console.
-   */
-  export const defaultContentFactory: IContentFactory = new ContentFactory();
 
   /**
    * A model factory for a console widget.

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -10,6 +10,7 @@ import {
   CodeCell,
   CodeCellModel,
   ICodeCellModel,
+  InputArea,
   isCodeCellModel,
   IRawCellModel,
   RawCell,
@@ -114,6 +115,8 @@ export class CodeConsole extends Widget {
     this._content = new Panel();
     this._input = new Panel();
 
+    this.editorFactory =
+      options.editorFactory || InputArea.defaultEditorFactory;
     this.modelFactory = options.modelFactory || CodeConsole.defaultModelFactory;
     this.rendermime = options.rendermime;
     this.sessionContext = options.sessionContext;
@@ -158,6 +161,8 @@ export class CodeConsole extends Widget {
    * The model factory for the console widget.
    */
   readonly modelFactory: CodeConsole.IModelFactory;
+
+  readonly editorFactory: CodeEditor.Factory;
 
   /**
    * The rendermime instance used by the console.
@@ -227,7 +232,8 @@ export class CodeConsole extends Widget {
     const model = this.modelFactory.createRawCell({});
     model.value.text = '...';
     const banner = (this._banner = new RawCell({
-      model
+      model,
+      editorFactory: this.editorFactory
     })).initializeState();
     banner.addClass(BANNER_CLASS);
     banner.readOnly = true;
@@ -720,7 +726,8 @@ export class CodeConsole extends Widget {
     const modelFactory = this.modelFactory;
     const model = modelFactory.createCodeCell({});
     const rendermime = this.rendermime;
-    return { model, rendermime };
+    const editorFactory = this.editorFactory;
+    return { model, rendermime, editorFactory };
   }
 
   /**
@@ -841,6 +848,11 @@ export namespace CodeConsole {
      * The model factory for the console widget.
      */
     modelFactory?: IModelFactory;
+
+    /**
+     * The editor factory used to create editor instances.
+     */
+    editorFactory?: CodeEditor.Factory;
 
     /**
      * The mime renderer for the console widget.

--- a/packages/logconsole/src/widget.ts
+++ b/packages/logconsole/src/widget.ts
@@ -98,6 +98,13 @@ class LogConsoleOutputArea extends OutputArea {
   readonly model: LoggerOutputAreaModel;
 
   /**
+   * Customize the default IOutputPrompt instance.
+   */
+  protected createOutputPrompt(): IOutputPrompt {
+    return new LogConsoleOutputPrompt();
+  }
+
+  /**
    * Create an output item with a prompt and actual output
    */
   protected createOutputItem(model: LogOutputModel): Widget | null {

--- a/packages/logconsole/src/widget.ts
+++ b/packages/logconsole/src/widget.ts
@@ -126,19 +126,6 @@ class LogConsoleOutputArea extends OutputArea {
 }
 
 /**
- * Implementation of `IContentFactory` for Output Area
- * which creates custom output prompts.
- */
-class LogConsoleContentFactory extends OutputArea.ContentFactory {
-  /**
-   * Create the output prompt for the widget.
-   */
-  createOutputPrompt(): LogConsoleOutputPrompt {
-    return new LogConsoleOutputPrompt();
-  }
-}
-
-/**
  * Implements a panel which supports pinning the position to the end if it is
  * scrolled to the end.
  *
@@ -421,7 +408,6 @@ export class LogConsolePanel extends StackedPanel {
       if (!this._outputAreas.has(viewId)) {
         const outputArea = new LogConsoleOutputArea({
           rendermime: logger.rendermime,
-          contentFactory: new LogConsoleContentFactory(),
           model: logger.outputAreaModel
         });
         outputArea.id = viewId;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -283,20 +283,6 @@ const trackerPlugin: JupyterFrontEndPlugin<INotebookTracker> = {
 };
 
 /**
- * The notebook cell factory provider.
- */
-const factory: JupyterFrontEndPlugin<NotebookPanel.IContentFactory> = {
-  id: '@jupyterlab/notebook-extension:factory',
-  provides: NotebookPanel.IContentFactory,
-  requires: [IEditorServices],
-  autoStart: true,
-  activate: (app: JupyterFrontEnd, editorServices: IEditorServices) => {
-    const editorFactory = editorServices.factoryService.newInlineEditor;
-    return new NotebookPanel.ContentFactory({ editorFactory });
-  }
-};
-
-/**
  * The notebook tools extension.
  */
 const tools: JupyterFrontEndPlugin<INotebookTools> = {
@@ -393,11 +379,7 @@ export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
 const widgetFactoryPlugin: JupyterFrontEndPlugin<NotebookWidgetFactory.IFactory> = {
   id: '@jupyterlab/notebook-extension:widget-factory',
   provides: INotebookWidgetFactory,
-  requires: [
-    NotebookPanel.IContentFactory,
-    IEditorServices,
-    IRenderMimeRegistry
-  ],
+  requires: [IEditorServices, IRenderMimeRegistry],
   activate: activateWidgetFactory,
   autoStart: true
 };
@@ -406,7 +388,7 @@ const widgetFactoryPlugin: JupyterFrontEndPlugin<NotebookWidgetFactory.IFactory>
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
-  factory,
+  // factory,
   trackerPlugin,
   tools,
   commandEditItem,
@@ -508,10 +490,10 @@ function activateNotebookTools(
  */
 function activateWidgetFactory(
   app: JupyterFrontEnd,
-  contentFactory: NotebookPanel.IContentFactory,
   editorServices: IEditorServices,
   rendermime: IRenderMimeRegistry
 ): NotebookWidgetFactory.IFactory {
+  const editorFactory = editorServices.factoryService.newInlineEditor;
   const factory = new NotebookWidgetFactory({
     name: FACTORY,
     fileTypes: ['notebook'],
@@ -520,7 +502,7 @@ function activateWidgetFactory(
     preferKernel: true,
     canStartKernel: true,
     rendermime: rendermime,
-    contentFactory,
+    editorFactory,
     editorConfig: StaticNotebook.defaultEditorConfig,
     notebookConfig: StaticNotebook.defaultNotebookConfig,
     mimeTypeService: editorServices.mimeTypeService

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -458,7 +458,7 @@ export namespace NotebookTools {
         ? (activeCell.promptNode.cloneNode(true) as HTMLElement)
         : undefined;
       const prompt = new Widget({ node: promptNode });
-      const factory = activeCell.contentFactory.editorFactory;
+      const factory = activeCell.editorFactory;
 
       const cellModel = (this._cellModel = activeCell.model);
       cellModel.value.changed.connect(this._onValueChanged, this);

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -6,9 +6,6 @@ import { isMarkdownCellModel } from '@jupyterlab/cells';
 import { Kernel, KernelMessage, Session } from '@jupyterlab/services';
 
 import { each } from '@lumino/algorithm';
-
-import { Token } from '@lumino/coreutils';
-
 import {
   ISessionContext,
   Printing,
@@ -263,41 +260,4 @@ export namespace NotebookPanel {
      */
     kernelShutdown: boolean;
   }
-
-  /**
-   * A content factory interface for NotebookPanel.
-   */
-  export interface IContentFactory extends Notebook.IContentFactory {
-    /**
-     * Create a new content area for the panel.
-     */
-    createNotebook(options: Notebook.IOptions): Notebook;
-  }
-
-  /**
-   * The default implementation of an `IContentFactory`.
-   */
-  export class ContentFactory extends Notebook.ContentFactory
-    implements IContentFactory {
-    /**
-     * Create a new content area for the panel.
-     */
-    createNotebook(options: Notebook.IOptions): Notebook {
-      return new Notebook(options);
-    }
-  }
-
-  /**
-   * Default content factory for the notebook panel.
-   */
-  export const defaultContentFactory: ContentFactory = new ContentFactory();
-
-  /* tslint:disable */
-  /**
-   * The notebook renderer token.
-   */
-  export const IContentFactory = new Token<IContentFactory>(
-    '@jupyterlab/notebook:IContentFactory'
-  );
-  /* tslint:enable */
 }

--- a/packages/notebook/src/widgetfactory.ts
+++ b/packages/notebook/src/widgetfactory.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { InputArea } from '@jupyterlab/cells';
+
 import { IEditorMimeTypeService, CodeEditor } from '@jupyterlab/codeeditor';
 
 import { ABCWidgetFactory, DocumentRegistry } from '@jupyterlab/docregistry';
@@ -19,8 +21,6 @@ import {
   ISessionContextDialogs,
   sessionContextDialogs
 } from '@jupyterlab/apputils';
-
-import { InputArea } from '@jupyterlab/cells/src';
 
 /**
  * A widget factory for notebook panels.

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -342,11 +342,11 @@ export class OutputArea extends Widget {
     panel.addClass(OUTPUT_AREA_ITEM_CLASS);
     panel.addClass(OUTPUT_AREA_STDIN_ITEM_CLASS);
 
-    const prompt = new OutputPrompt();
+    const prompt = this.createOutputPrompt();
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
 
-    const input = new Stdin({
+    const input = this.createStdin({
       prompt: stdinPrompt,
       password,
       future
@@ -432,7 +432,7 @@ export class OutputArea extends Widget {
 
     panel.addClass(OUTPUT_AREA_ITEM_CLASS);
 
-    const prompt = new OutputPrompt();
+    const prompt = this.createOutputPrompt();
     prompt.executionCount = model.executionCount;
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
@@ -440,6 +440,20 @@ export class OutputArea extends Widget {
     output.addClass(OUTPUT_AREA_OUTPUT_CLASS);
     panel.addWidget(output);
     return panel;
+  }
+
+  /**
+   * Create an OutputPrompt instance.
+   */
+  protected createOutputPrompt(): IOutputPrompt {
+    return new OutputPrompt();
+  }
+
+  /**
+   * Create an Stdin widget instance.
+   */
+  protected createStdin(options: Stdin.IOptions): IStdin {
+    return new Stdin(options);
   }
 
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -102,8 +102,6 @@ export class OutputArea extends Widget {
     const model = (this.model = options.model);
     this.addClass(OUTPUT_AREA_CLASS);
     this.rendermime = options.rendermime;
-    this.contentFactory =
-      options.contentFactory || OutputArea.defaultContentFactory;
     this.layout = new PanelLayout();
     for (let i = 0; i < model.length; i++) {
       const output = model.get(i);
@@ -117,11 +115,6 @@ export class OutputArea extends Widget {
    * The model used by the widget.
    */
   readonly model: IOutputAreaModel;
-
-  /**
-   * The content factory used by the widget.
-   */
-  readonly contentFactory: OutputArea.IContentFactory;
 
   /**
    * The rendermime instance used by the widget.
@@ -342,7 +335,6 @@ export class OutputArea extends Widget {
     future: Kernel.IShellFuture
   ): void {
     // Add an output widget to the end.
-    const factory = this.contentFactory;
     const stdinPrompt = msg.content.prompt;
     const password = msg.content.password;
 
@@ -350,11 +342,11 @@ export class OutputArea extends Widget {
     panel.addClass(OUTPUT_AREA_ITEM_CLASS);
     panel.addClass(OUTPUT_AREA_STDIN_ITEM_CLASS);
 
-    const prompt = factory.createOutputPrompt();
+    const prompt = new OutputPrompt();
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
 
-    const input = factory.createStdin({
+    const input = new Stdin({
       prompt: stdinPrompt,
       password,
       future
@@ -440,7 +432,7 @@ export class OutputArea extends Widget {
 
     panel.addClass(OUTPUT_AREA_ITEM_CLASS);
 
-    const prompt = this.contentFactory.createOutputPrompt();
+    const prompt = new OutputPrompt();
     prompt.executionCount = model.executionCount;
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
@@ -601,11 +593,6 @@ export namespace OutputArea {
     model: IOutputAreaModel;
 
     /**
-     * The content factory used by the widget to create children.
-     */
-    contentFactory?: IContentFactory;
-
-    /**
      * The rendermime instance used by the widget.
      */
     rendermime: IRenderMimeRegistry;
@@ -656,48 +643,6 @@ export namespace OutputArea {
       return !!metadata['isolated'];
     }
   }
-
-  /**
-   * An output area widget content factory.
-   *
-   * The content factory is used to create children in a way
-   * that can be customized.
-   */
-  export interface IContentFactory {
-    /**
-     * Create an output prompt.
-     */
-    createOutputPrompt(): IOutputPrompt;
-
-    /**
-     * Create an stdin widget.
-     */
-    createStdin(options: Stdin.IOptions): IStdin;
-  }
-
-  /**
-   * The default implementation of `IContentFactory`.
-   */
-  export class ContentFactory implements IContentFactory {
-    /**
-     * Create the output prompt for the widget.
-     */
-    createOutputPrompt(): IOutputPrompt {
-      return new OutputPrompt();
-    }
-
-    /**
-     * Create an stdin widget.
-     */
-    createStdin(options: Stdin.IOptions): IStdin {
-      return new Stdin(options);
-    }
-  }
-
-  /**
-   * The default `ContentFactory` instance.
-   */
-  export const defaultContentFactory = new ContentFactory();
 }
 
 /** ****************************************************************************


### PR DESCRIPTION
## References

Addresses #8236

## Code changes

This removes the content factory pattern from the notebook, console and logconsole widgets and extensions.

## User-facing changes

No end-user facing changes.

## Backwards-incompatible changes

Extension authors using the content factory APIs to extend the views will be unable to do so after this PR. Another extension mechanism will be implemented in its place.
