### PR TITLE
Remove deprecated extension from release test

### DIFF
--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -22,7 +22,6 @@ python -m jupyterlab.browser_check
 
 jupyter labextension install @jupyterlab/fasta-extension --no-build
 jupyter labextension install @jupyterlab/geojson-extension --no-build
-jupyter labextension install @jupyterlab/plotly-extension --no-build
 jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
 jupyter labextension install bqplot --no-build
 jupyter labextension install jupyter-leaflet --no-build


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyter-renderers/pull/208.  The plotly extension is now maintained by plotly as `jupyterlab-plotly`.  Removing it from our release check.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Remove `@jupyterlab/plotly-extension` from release test.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
