### PR TITLE
[1.2.x] Set a data attribute for the file type in the file browser

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1826,15 +1826,21 @@ export namespace DirListing {
           icon.className = `${ITEM_ICON_CLASS} ${fileType.iconClass || ''}`;
           icon.textContent = fileType.iconLabel || '';
         }
+        // Set a data attribute so we can target the node
+        node.setAttribute('data-file-type', fileType.name);
       } else {
         // use default icon as CSS background image
         icon.className = ITEM_ICON_CLASS;
         icon.textContent = '';
         // clean up the svg icon annotation, if any
         delete icon.dataset.icon;
+
+        // Set a data attribute so we can target the node
+        node.setAttribute('data-file-type', '');
       }
 
       node.title = model.name;
+
       // If an item is being edited currently, its text node is unavailable.
       if (text && text.textContent !== model.name) {
         text.textContent = model.name;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses #8273 for 1.2.x.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Adds a `data-file-type` attribute to a file browser listing item that follows the name of the file type.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Extension authors can use this to target file browser nodes in CSS, specifically for context menu items.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
