### PR TITLE
[2.1.x] Set a data attribute for the file type in the file browser

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1829,7 +1829,7 @@ export namespace DirListing {
       model: Contents.IModel,
       fileType: DocumentRegistry.IFileType = DocumentRegistry.defaultTextFileType
     ): void {
-      const { icon, iconClass } = fileType;
+      const { icon, iconClass, name } = fileType;
 
       const iconContainer = DOMUtils.findElement(node, ITEM_ICON_CLASS);
       const text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
@@ -1870,6 +1870,7 @@ export namespace DirListing {
       }
 
       node.title = hoverText;
+      node.setAttribute('data-file-type', name);
 
       // If an item is being edited currently, its text node is unavailable.
       if (text && text.textContent !== model.name) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses #8273 for 2.1.x.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Adds a `data-file-type` attribute to a file browser listing item that follows the name of the file type.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Extension authors can use this to target file browser nodes in CSS, specifically for context menu items.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
