### PR TITLE
Scroll into view after delete

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -266,7 +266,7 @@ export namespace NotebookActions {
     const state = Private.getState(notebook);
 
     Private.deleteCells(notebook);
-    Private.handleState(notebook, state);
+    Private.handleState(notebook, state, true);
   }
 
   /**


### PR DESCRIPTION
## References
Fixes #7822
## Code changes

Scrolls cell into view after deleting

## User-facing changes

Before when you deleted a cell it would not move focus to highlight the newly selected cell. Now it will.

## Backwards-incompatible changes

None.
