### PR TITLE
Set the name after the session has started

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -768,6 +768,9 @@ export class SessionContext implements ISessionContext {
       // Change to the real path.
       await session.setPath(this._path);
 
+      // Update the name in case it has changed since we launched the session.
+      await session.setName(this._name);
+
       if (this._session) {
         await this._shutdownSession();
       }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses #8289 in master.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Sets the name after a long-running session starts.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
If the user changes the file name while the session is starting, the name will change in the running panel after the session is finished starting.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
