### PR TITLE
Update codemirror to fix issues with Julia

### DIFF
--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -45,7 +45,7 @@
     "@jupyterlab/settingregistry": "^2.1.0",
     "@jupyterlab/statusbar": "^2.1.0",
     "@lumino/widgets": "^1.11.1",
-    "codemirror": "~5.49.2"
+    "codemirror": "~5.53.2"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -46,7 +46,7 @@
     "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1",
-    "codemirror": "~5.49.2",
+    "codemirror": "~5.53.2",
     "react": "~16.9.0"
   },
   "devDependencies": {

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -45,7 +45,7 @@
     "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
     "@lumino/widgets": "^1.11.1",
-    "codemirror": "~5.49.2",
+    "codemirror": "~5.53.2",
     "react": "~16.9.0"
   },
   "devDependencies": {

--- a/tests/test-codemirror/package.json
+++ b/tests/test-codemirror/package.json
@@ -16,7 +16,7 @@
     "@jupyterlab/codemirror": "^2.1.0",
     "@jupyterlab/testutils": "^2.1.0",
     "chai": "^4.2.0",
-    "codemirror": "~5.49.2",
+    "codemirror": "~5.53.2",
     "jest": "^25.2.3",
     "jest-junit": "^10.0.0",
     "simulate-event": "~1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5986,10 +5986,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@~5.49.2:
-  version "5.49.2"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.49.2.tgz#c84fdaf11b19803f828b0c67060c7bc6d154ccad"
-  integrity sha512-dwJ2HRPHm8w51WB5YTF9J7m6Z5dtkqbU9ntMZ1dqXyFB9IpjoUFDj80ahRVEoVanfIp6pfASJbOlbWdEf8FOzQ==
+codemirror@~5.53.2:
+  version "5.53.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.53.2.tgz#9799121cf8c50809cca487304e9de3a74d33f428"
+  integrity sha512-wvSQKS4E+P8Fxn/AQ+tQtJnF1qH5UOlxtugFLpubEZ5jcdH2iXTVinb+Xc/4QjshuOxRm4fUsU2QPF1JJKiyXA==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## References
Addresses #8267.

## Code changes
Updated codemirror dependency

## User-facing changes
Julia should now work with zero-prefixed integers.


## Backwards-incompatible changes
None
