### PR TITLE
Actually run examples tests

### DIFF
--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -94,7 +94,7 @@ async def run_test_async(app, func):
 
     # Allow a synchronous function to be passed in.
     if inspect.iscoroutinefunction(func):
-        test = asyncio.create_task(func(url))
+        test = func(url)
     else:
         loop = asyncio.get_event_loop()
         executor = ThreadPoolExecutor()

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -93,8 +93,8 @@ async def run_test_async(app, func):
         url = app.display_url
 
     # Allow a synchronous function to be passed in.
-    if inspect.isawaitable(func):
-        test = func(url)
+    if inspect.iscoroutinefunction(func):
+        test = asyncio.create_task(func(url))
     else:
         loop = asyncio.get_event_loop()
         executor = ThreadPoolExecutor()


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #8296 

```
Starting Chrome Headless
Navigating to page: file:///Users/stslve/Library/Jupyter/runtime/nbserver-26423-open.html
Waiting for page to load...
Page loaded
[I 16:13:58.873 CellTest] Kernel started: 5cdd4b56-e2db-4f1c-b93c-694e97c27b63
>> Starting WebSocket: ws://127.0.0.1:8890/foo/api/kernels/5cdd4b56-e2db-4f1c-b93c-694e97c27b63
>> Example started!
Example test complete!
[I 16:13:58.951 CellTest] Test Complete
[I 16:13:58.951 CellTest] Exiting normally
[I 16:13:58.951 CellTest] Stopping server...
[I 16:13:58.953 CellTest] Shutting down 1 kernel
```

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Fixes our test for whether to run the test function as a coroutine.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Examples remain functional.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
