### PR TITLE
Allow Dialogs to be resized

### DIFF
--- a/packages/apputils/style/dialog.css
+++ b/packages/apputils/style/dialog.css
@@ -40,6 +40,7 @@
    * relative to this base size */
   font-size: var(--jp-ui-font-size1);
   color: var(--jp-ui-font-color1);
+  resize: both;
 }
 
 .jp-Dialog-button {


### PR DESCRIPTION
Make Dialogs resizeable

## References

Addresses issue #8300 

## Code changes

This PR adds the [`resize` CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/resize) to the `.jp-Dialog-content` node of the Dialog.

## User-facing changes

This results in a resize handle being visible a Dialog's lower right corner. Dragging the resize handle allows the user to resize the Dialog.

Before:
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/13156555/80557504-1ac5c800-89a5-11ea-82e4-7bf7192b7797.png">

After:
<img width="776" alt="image" src="https://user-images.githubusercontent.com/13156555/80557580-6a0bf880-89a5-11ea-996c-af838a3ea948.png">


## Backwards-incompatible changes

n/a
