### PR TITLE
Added the explanation for editing the PATH variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you use `pip`, you can install it with:
 pip install jupyterlab
 ```
 
-If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`.
+If installing using `pip install --user`, you must add the user-level `bin` directory to your `PATH` environment variable in order to launch `jupyter lab`. If you are using a Unix derivative (FreeBSD, GNU / Linux, OS X), you can achieve this by using `export PATH="$HOME/.local/bin:$PATH"` command.
 
 #### Installing with Previous Versions of Jupyter Notebook
 
@@ -81,6 +81,8 @@ jupyter lab
 ```
 
 JupyterLab will open automatically in the browser. See the [documentation](http://jupyterlab.readthedocs.io/en/stable/getting_started/starting.html) for additional details.
+
+If you encounter an error like "Command 'jupyter' not found", please make sure `PATH` environment variable is set correctly. Alternatively, you can start up JupyterLab using `~/.local/bin/jupyter lab` without changing the `PATH` environment variable.
 
 ### Prerequisites and Supported Browsers
 


### PR DESCRIPTION
## References

#7151 Explicitly state how to editing PATH for pip install --user
#8259 Improvements to the installation steps in the README and CONTRIBUTING files (Partially for the README file part)

## Code changes
This was a change in the documentation.

## User-facing changes
Before:
<img width="934" alt="Screen Shot 2020-04-29 at 3 32 40 PM" src="https://user-images.githubusercontent.com/10498874/80638627-bc452c00-8a2e-11ea-8499-f4d784b319f5.png">
<img width="940" alt="Screen Shot 2020-04-29 at 3 32 50 PM" src="https://user-images.githubusercontent.com/10498874/80638631-be0eef80-8a2e-11ea-8096-5991de043ac0.png">

After:
<img width="934" alt="Screen Shot 2020-04-29 at 3 33 48 PM" src="https://user-images.githubusercontent.com/10498874/80638689-d717a080-8a2e-11ea-9819-0da2f4ab3f40.png">
<img width="943" alt="Screen Shot 2020-04-29 at 3 33 43 PM" src="https://user-images.githubusercontent.com/10498874/80638692-d848cd80-8a2e-11ea-98c6-f1aeb8c5f458.png">


## Backwards-incompatible changes
I am not aware of any.
