### PR TITLE
Added config for debugging python + ts in one compound vscode launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,6 @@ MANIFEST
 # ms IDE stuff
 *.code-workspace
 .history
-.vscode
+.vscode/*
+!.vscode
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,8 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    // to debug jupyterlab running in a venv or conda env:
+    //   - set up Python env in your workspace as per https://code.visualstudio.com/docs/python/environments
+    //   - uncomment the "envFile" line below
+    //   - configure the .vscode/jupyterlab_venv.env file as needed
     "version": "0.2.0",
     "configurations": [
         {
@@ -16,7 +17,11 @@
                 "--NotebookApp.token=''",
                 "--port=9999"
             ],
+            "justMyCode": false,
             "module": "jupyterlab.labapp",
+
+            // set environment variables for jupyter/lab config
+            // "envFile": "${workspaceFolder}/.vscode/jupyterlab_venv.env",
 
             // can potentially run frontend using serverReadyAction instead
             // of using compound job, currently not configurable enough
@@ -36,9 +41,12 @@
             "sourceMapPathOverrides": {
                 "webpack:///../*": "${webRoot}/*"
             },
-            "timeout": 30000,
+            "timeout": 180000,
             "url": "http://localhost:9999",
-            "webRoot": "${workspaceFolder}"
+            "webRoot": "${workspaceFolder}",
+
+            // debug using a specific copy of chrome/chromium
+            // "runtimeExecutable": "<path-to-your-chrome-or-chromium>",
         },
     ],
     "compounds": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,53 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "jlab backend",
+            "type": "python",
+            "request": "launch",
+
+            "args": [
+                "--dev-mode",
+                "--notebook-dir=${env:HOME}",
+                "--no-browser",
+                "--NotebookApp.token=''",
+                "--port=9999"
+            ],
+            "module": "jupyterlab.labapp",
+
+            // can potentially run frontend using serverReadyAction instead
+            // of using compound job, currently not configurable enough
+            //
+            // "serverReadyAction": {
+            //     "pattern": "http://localhost:(\\S+)",
+            //     "uriFormat": "http://localhost:%s",
+            //     "action": "debugWithChrome",
+            //     "webRoot": "${workspaceFolder}"
+            // },
+        },
+        {
+            "name": "jlab frontend",
+            "type": "chrome",
+            "request": "launch",
+
+            "sourceMapPathOverrides": {
+                "webpack:///../*": "${webRoot}/*"
+            },
+            "timeout": 30000,
+            "url": "http://localhost:9999",
+            "webRoot": "${workspaceFolder}"
+        },
+    ],
+    "compounds": [
+        {
+            "name": "jlab all",
+            "configurations": [
+                "jlab backend",
+                "jlab frontend"
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
     "version": "0.2.0",
     "configurations": [
         {
+            // debug the jlab server without a browser
             "name": "jlab backend",
             "type": "python",
             "request": "launch",
@@ -22,18 +23,29 @@
 
             // set environment variables for jupyter/lab config
             // "envFile": "${workspaceFolder}/.vscode/jupyterlab_venv.env",
-
-            // can potentially run frontend using serverReadyAction instead
-            // of using compound job, currently not configurable enough
-            //
-            // "serverReadyAction": {
-            //     "pattern": "http://localhost:(\\S+)",
-            //     "uriFormat": "http://localhost:%s",
-            //     "action": "debugWithChrome",
-            //     "webRoot": "${workspaceFolder}"
-            // },
         },
         {
+            // debug the jlab server (in watch mode) without a browser
+            "name": "jlab backend --watch",
+            "type": "python",
+            "request": "launch",
+
+            "args": [
+                "--watch",
+                "--dev-mode",
+                "--notebook-dir=${env:HOME}",
+                "--no-browser",
+                "--NotebookApp.token=''",
+                "--port=9999"
+            ],
+            "justMyCode": false,
+            "module": "jupyterlab.labapp",
+
+            // set environment variables for jupyter/lab config
+            // "envFile": "${workspaceFolder}/.vscode/jupyterlab_venv.env",
+        },
+        {
+            // debug a browser pointed at our jlab server
             "name": "jlab frontend",
             "type": "chrome",
             "request": "launch",
@@ -47,15 +59,52 @@
 
             // debug using a specific copy of chrome/chromium
             // "runtimeExecutable": "<path-to-your-chrome-or-chromium>",
-        },
+        }
     ],
     "compounds": [
         {
-            "name": "jlab all",
+            // debug jlab server and browser together
+            "name": "jlab",
             "configurations": [
                 "jlab backend",
                 "jlab frontend"
             ]
+        },
+        {
+            // debug jlab server (in watch mode) and browser together
+            "name": "jlab --watch",
+            "configurations": [
+                "jlab backend --watch",
+                "jlab frontend"
+            ]
         }
     ]
+
+    // some extra configurations, useful for troubleshooting
+    // jupyter-related vscode debug configs
+    //
+    // "configurations": [
+    //     {
+    //         "name": "(troubleshoot) jupyter paths",
+    //         "type": "python",
+    //         "request": "launch",
+    //         "args": [
+    //             "--paths",
+    //         ],
+    //         "justMyCode": false,
+    //         "module": "jupyter_core.command",
+    //         "envFile": "${workspaceFolder}/.vscode/jupyterlab_venv.env",
+    //     },
+    //     {
+    //         "name": "(troubleshoot) jupyter serverextensions",
+    //         "type": "python",
+    //         "request": "launch",
+    //         "args": [
+    //             "list",
+    //         ],
+    //         "justMyCode": false,
+    //         "module": "notebook.serverextensions",
+    //         "envFile": "${workspaceFolder}/.vscode/jupyterlab_venv.env",
+    //     }
+    // ]
 }


### PR DESCRIPTION
## References

cf #3979
fixes #8321

Adds a `.vscode/launch.json` that contains config for launching both the jupyterlab backend and frontend as one compound debug job. Allows for setting breakpoints in both the python and typescript sources. You can even go back and forth between the two!

This PR is marked as draft while I figure out how to add support for debugging jlab running in a virtual environment (my typical use case). I think it can be done in a reasonably universal way using [input variables](https://code.visualstudio.com/docs/editor/variables-reference#_input-variables).

In the meantime, the launch.json in the current version of this PR should be working for standard jlab installs. Can anyone who's interested please try it out and confirm that it also works for them?

**updated**

```json5
{
    // to debug jupyterlab running in a venv or conda env:
    //   - set up Python env in your workspace as per https://code.visualstudio.com/docs/python/environments
    //   - uncomment the "envFile" line below
    //   - configure the .vscode/jupyterlab_venv.env file as needed
    "version": "0.2.0",
    "configurations": [
        {
            "name": "jlab backend",
            "type": "python",
            "request": "launch",

            "args": [
                "--dev-mode",
                "--notebook-dir=${env:HOME}",
                "--no-browser",
                "--NotebookApp.token=''",
                "--port=9999"
            ],
            "justMyCode": false,
            "module": "jupyterlab.labapp",

            // set environment variables for jupyter/lab config
            // "envFile": "${workspaceFolder}/.vscode/jupyterlab_venv.env",
        },
        {
            "name": "jlab frontend",
            "type": "chrome",
            "request": "launch",

            "sourceMapPathOverrides": {
                "webpack:///../*": "${webRoot}/*"
            },
            "timeout": 180000,
            "url": "http://localhost:9999",
            "webRoot": "${workspaceFolder}",

            // debug using a specific copy of chrome/chromium
            // "runtimeExecutable": "<path-to-your-chrome-or-chromium>",
        },
    ],
    "compounds": [
        {
            "name": "jlab all",
            "configurations": [
                "jlab backend",
                "jlab frontend"
            ]
        }
    ]
}
```

## Code changes

Adds `.vscode/launch.json`

## User-facing changes

NA

## Backwards-incompatible changes

NA