### PR TITLE
Set sidebar icon height

### DIFF
--- a/packages/ui-components/src/style/icon.ts
+++ b/packages/ui-components/src/style/icon.ts
@@ -388,7 +388,7 @@ export namespace LabIconStyle {
         }
       },
       element: {
-        // width no height
+        height: 'auto',
         width: '20px'
       },
       options: {


### PR DESCRIPTION
Currently icons in the side bar have no height set. This causes the
icons to use the height in the svg itself. For icons in lab whose
height are hardcoded to 16px this is not an issue, but some extensions
can't edit the height in the svg files and this can cause the icon
height to be very large and cause issues with automated test suites.

## References

This issue was first found in https://github.com/jupyterlab/jupyterlab-git/issues/604 and a workaround was found and used in https://github.com/elyra-ai/elyra/pull/463 inspired by discussion on https://github.com/jupyterlab/jupyterlab-git/pull/618

## Code changes

This PR sets the `height` of sidebar icons to `auto` which removes
any specific height from the svg.

## User-facing changes

This PR does not affect any core extensiosn and is solely to better
support external extensions.
