### PR TITLE
Add link caching

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -7,7 +7,7 @@ jobs:
     name: Linux
     strategy:
       matrix:
-        group: [integrity, integrity2, docs, usage, docs2, python,  nonode]
+        group: [integrity, integrity2, docs, usage, python,  nonode]
         python: [3.5, 3.8]
         exclude:
           - group: integrity
@@ -16,11 +16,8 @@ jobs:
             python: 3.5
           - group: docs
             python: 3.5
-          - group: docs2
-            python: 3.5
-          - group: changelog
-            python: 3.5
       fail-fast: false
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -28,10 +25,12 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
+
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+
       - name: Cache pip on Linux
         uses: actions/cache@v1
         if: startsWith(runner.os, 'Linux')
@@ -41,7 +40,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python }}
 
-      # Cache yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -54,11 +52,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Cache checked links build
+        uses: actions/cache@v1
+        if: ${{ matrix.group == 'docs' }}
+        with:
+          path: ~/.cache/pytest-link-check
+          key: ${{ runner.os }}-link-check-${{ hashFiles('**/*.rst') }}
+          restore-keys: |
+            ${{ runner.os }}-link-check-
+
       - name: Install dependencies
         env:
           GROUP: ${{ matrix.group }}
         run: |
           bash ./scripts/ci_install.sh
+
       - name: Run test ${{ matrix.group }}
         env:
           GROUP: ${{ matrix.group }}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ sphinx-copybutton
 sphinx_rtd_theme
 recommonmark
 pytest
-pytest-check-links
+pytest-check-links[cache]>=0.4.1
 jsx-lexer


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Partially addresses #8117.  Utilizes the new caching options in `pytest-check-links` (thanks @bollwyvl!).

Docs builds go from >1hr total to a single ~10 minute build with a cache.  I increased the time limit to 90 so as our change log grows we have some space when the cache is busted.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Changes to CI script and GH Actions workflow

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
CI builds will be much faster.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
