### PR TITLE
Doc change of labhubapp back to jupyterhub-singleuser

### DIFF
--- a/docs/source/getting_started/changelog.rst
+++ b/docs/source/getting_started/changelog.rst
@@ -154,7 +154,7 @@ User-facing changes
 
 * Added options for ``jupyter lab clean`` to clean specific parts of the build, such as ``--extensions``, ``--settings``, ``--static``, and ``--all`` (`#7583 <https://github.com/jupyterlab/jupyterlab/pull/7583>`__, `#6734 <https://github.com/jupyterlab/jupyterlab/pull/6734>`__)
 * Removed the vega 4 and vega-lite 2 renderers (vega 5 and vega-lite 4 is included in JupyterLab by default). These legacy renderers may be available via custom extensions (`#7650 <https://github.com/jupyterlab/jupyterlab/pull/7650>`__, `#7523 <https://github.com/jupyterlab/jupyterlab/issues/7523>`__, `#7658 <https://github.com/jupyterlab/jupyterlab/pull/7658>`__)
-* JupyterHub users should use the ``c.Spawner.default_url = '/lab'`` setting instead of the deprecated and now removed ``labhubapp`` (`#7724 <https://github.com/jupyterlab/jupyterlab/pull/7724>`__)
+* JupyterHub users should use the ``c.Spawner.default_url = '/lab'`` setting and execute ``jupyterhub-singleuser`` instead of the deprecated and now removed ``labhubapp`` (`#7724 <https://github.com/jupyterlab/jupyterlab/pull/7724>`__).
 
 For developers
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
## References

Fix #7067

## Code changes

Update changelog.rst to describe jupyterhub-singleuser needs to be called to invoke jupyter lab.

## User-facing changes

None

## Backwards-incompatible changes

None

