### PR TITLE
Cherry pick 2.1.2 changelog onto master

### DIFF
--- a/docs/source/getting_started/changelog.rst
+++ b/docs/source/getting_started/changelog.rst
@@ -3,6 +3,23 @@
 JupyterLab Changelog
 ====================
 
+`v2.1.x <https://github.com/jupyterlab/jupyterlab/milestone/55>`__
+------------------------------------------------------------------
+
+v2.1.2
+^^^^^^
+* Fix icon sidebar height for third party extensions (`#8333 <https://github.com/jupyterlab/jupyterlab/pull/8333>`__)
+* Pin JupyterLab server requirement more tightly (`#8330 <https://github.com/jupyterlab/jupyterlab/pull/8330>`__)
+* Scrolls cells into view after deletion (`#8287 <https://github.com/jupyterlab/jupyterlab/pull/8287>`__)
+* Sets data attribute on file type in filebrowser (`#8275 <https://github.com/jupyterlab/jupyterlab/pull/8275>`__)
+
+
+v2.1.1
+^^^^^^
+* Pin puppeteer to fix ci (`#8260 <https://github.com/jupyterlab/jupyterlab/pull/8260>`__)
+* Fix Save As for files without sessions (`#8248 <https://github.com/jupyterlab/jupyterlab/pull/8248>`__)
+
+
 `v2.1.0 <https://github.com/jupyterlab/jupyterlab/releases/tag/v2.1.0>`__
 ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Cherry pick of https://github.com/jupyterlab/jupyterlab/commit/bc95c579c9ea24b9b159571887a6e09590a6e8b0.

Alternatively we could start building the 2.1.x branch's changelog! But we aren't for now, so that at least shows those changes on master.
