### PR TITLE
Add tests for mocks and jupyter server

### DIFF
--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: JS
     strategy:
       matrix:
-        group: [js-services, js-application, js-apputils, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-docmanager, js-docregistry, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-ui-components]
+        group: [js-services, js-application, js-apputils, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-docmanager, js-docregistry, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-ui-components, js-testutils]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -271,6 +271,10 @@ export async function ensurePackage(
   const tsConfigTestPath = path.join(pkgPath, 'tsconfig.test.json');
   if (fs.existsSync(tsConfigTestPath)) {
     const testReferences: { [key: string]: string } = { ...references };
+
+    // Add a reference to self to build the local package as well.
+    testReferences['.'] = '.';
+
     Object.keys(devDeps).forEach(name => {
       if (!(name in locals)) {
         return;
@@ -282,17 +286,16 @@ export async function ensurePackage(
       const ref = path.relative(pkgPath, locals[name]);
       testReferences[name] = ref.split(path.sep).join('/');
     });
-    if (Object.keys(testReferences).length > 0) {
-      const tsConfigTestData = utils.readJSONFile(tsConfigTestPath);
-      tsConfigTestData.references = [];
-      Object.keys(testReferences).forEach(name => {
-        tsConfigTestData.references.push({ path: testReferences[name] });
-      });
-      Object.keys(references).forEach(name => {
-        tsConfigTestData.references.push({ path: testReferences[name] });
-      });
-      utils.writeJSONFile(tsConfigTestPath, tsConfigTestData);
-    }
+
+    const tsConfigTestData = utils.readJSONFile(tsConfigTestPath);
+    tsConfigTestData.references = [];
+    Object.keys(testReferences).forEach(name => {
+      tsConfigTestData.references.push({ path: testReferences[name] });
+    });
+    Object.keys(references).forEach(name => {
+      tsConfigTestData.references.push({ path: testReferences[name] });
+    });
+    utils.writeJSONFile(tsConfigTestPath, tsConfigTestData);
   }
 
   // Get a list of all the published files.

--- a/buildutils/template/tsconfig.test.json
+++ b/buildutils/template/tsconfig.test.json
@@ -3,6 +3,9 @@
   "include": ["src/*", "test/*"],
   "references": [
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "build:packages:scope": "lerna run build",
     "build:src": "lerna run build --scope \"@jupyterlab/!(test-|example-|application-top)*\" --concurrency 1",
     "build:storybook": "lerna run build:storybook --concurrency 1",
-    "build:test": "lerna run build --scope \"@jupyterlab/test-*\" --concurrency 1",
     "build:test:scope": "lerna run build --concurrency 1",
     "build:testutils": "cd testutils && jlpm run build",
     "build:utils": "cd buildutils && jlpm run build",

--- a/packages/application/tsconfig.test.json
+++ b/packages/application/tsconfig.test.json
@@ -27,6 +27,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/apputils/tsconfig.test.json
+++ b/packages/apputils/tsconfig.test.json
@@ -18,6 +18,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/cells/tsconfig.test.json
+++ b/packages/cells/tsconfig.test.json
@@ -39,6 +39,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/codeeditor/tsconfig.test.json
+++ b/packages/codeeditor/tsconfig.test.json
@@ -15,6 +15,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/codemirror/tsconfig.test.json
+++ b/packages/codemirror/tsconfig.test.json
@@ -21,6 +21,9 @@
       "path": "../statusbar"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/completer/tsconfig.test.json
+++ b/packages/completer/tsconfig.test.json
@@ -21,6 +21,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/console/tsconfig.test.json
+++ b/packages/console/tsconfig.test.json
@@ -30,6 +30,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/coreutils/tsconfig.test.json
+++ b/packages/coreutils/tsconfig.test.json
@@ -3,6 +3,9 @@
   "include": ["src/*", "test/*"],
   "references": [
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     }
   ]

--- a/packages/csvviewer/tsconfig.test.json
+++ b/packages/csvviewer/tsconfig.test.json
@@ -12,6 +12,9 @@
       "path": "../docregistry"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/docmanager/tsconfig.test.json
+++ b/packages/docmanager/tsconfig.test.json
@@ -18,6 +18,9 @@
       "path": "../statusbar"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/docregistry/test/default.spec.ts
+++ b/packages/docregistry/test/default.spec.ts
@@ -22,7 +22,7 @@ import {
 
 import { ServiceManager } from '@jupyterlab/services';
 
-import { createFileContext, sleep } from '@jupyterlab/testutils';
+import { sleep } from '@jupyterlab/testutils';
 
 import * as Mock from '@jupyterlab/testutils/lib/mock';
 
@@ -179,7 +179,7 @@ describe('docregistry/default', () => {
         expect(factory.canStartKernel).toBe(true);
       });
 
-      it('should have toolbar items', () => {
+      it('should have toolbar items', async () => {
         const factory = new WidgetFactory({
           name: 'test',
           fileTypes: ['text'],
@@ -194,7 +194,7 @@ describe('docregistry/default', () => {
             }
           ]
         });
-        const context = createFileContext();
+        const context = await Mock.createFileContext();
         const widget = factory.createNew(context);
         const widget2 = factory.createNew(context);
         expect(toArray(widget.toolbar.names())).toEqual(['foo', 'bar']);
@@ -229,16 +229,16 @@ describe('docregistry/default', () => {
     });
 
     describe('#createNew()', () => {
-      it('should create a new widget given a document model and a context', () => {
+      it('should create a new widget given a document model and a context', async () => {
         const factory = createFactory();
-        const context = createFileContext();
+        const context = await Mock.createFileContext();
         const widget = factory.createNew(context);
         expect(widget).toBeInstanceOf(Widget);
       });
 
-      it('should take an optional source widget for cloning', () => {
+      it('should take an optional source widget for cloning', async () => {
         const factory = createFactory();
-        const context = createFileContext();
+        const context = await Mock.createFileContext();
         const widget = factory.createNew(context);
         const clonedWidget: IDocumentWidget = factory.createNew(
           context,
@@ -552,8 +552,8 @@ describe('docregistry/default', () => {
     let content: Widget;
     let widget: DocumentWidget;
 
-    const setup = () => {
-      context = createFileContext(undefined, manager);
+    const setup = async () => {
+      context = await Mock.createFileContext(false, manager);
       content = new Widget();
       widget = new DocumentWidget({ context, content });
     };
@@ -572,14 +572,11 @@ describe('docregistry/default', () => {
 
       it('should update the title when the path changes', async () => {
         const path = UUID.uuid4() + '.jl';
-        await context.initialize(true);
         await manager.contents.rename(context.path, path);
         expect(widget.title.label).toBe(path);
       });
 
       it('should add the dirty class when the model is dirty', async () => {
-        await context.initialize(true);
-        await context.ready;
         context.model.fromString('bar');
         expect(widget.title.className).toContain('jp-mod-dirty');
       });
@@ -593,22 +590,33 @@ describe('docregistry/default', () => {
       beforeEach(setup);
 
       it('should resolve after the reveal and context ready promises', async () => {
+        const thisContext = new Context({
+          manager,
+          factory: new TextModelFactory(),
+          path: UUID.uuid4()
+        });
         const x = Object.create(null);
         const reveal = sleep(300, x);
-        const contextReady = Promise.all([context.ready, x]);
-        const widget = new DocumentWidget({ context, content, reveal });
+        const contextReady = Promise.all([thisContext.ready, x]);
+        const widget = new DocumentWidget({
+          context: thisContext,
+          content,
+          reveal
+        });
         expect(widget.isRevealed).toBe(false);
 
         // Our promise should resolve before the widget reveal promise.
         expect(await Promise.race([widget.revealed, reveal])).toBe(x);
         // The context ready promise should also resolve first.
-        void context.initialize(true);
+        void thisContext.initialize(true);
         expect(await Promise.race([widget.revealed, contextReady])).toEqual([
           undefined,
           x
         ]);
         // The widget.revealed promise should finally resolve.
         expect(await widget.revealed).toBeUndefined();
+
+        thisContext.dispose();
       });
     });
   });

--- a/packages/docregistry/test/mimedocument.spec.ts
+++ b/packages/docregistry/test/mimedocument.spec.ts
@@ -53,8 +53,8 @@ const fooFactory: IRenderMime.IRendererFactory = {
 describe('docregistry/mimedocument', () => {
   let dContext: Context<DocumentRegistry.IModel>;
 
-  beforeEach(() => {
-    dContext = Mock.createFileContext();
+  beforeEach(async () => {
+    dContext = await Mock.createFileContext();
   });
 
   afterEach(() => {
@@ -100,7 +100,6 @@ describe('docregistry/mimedocument', () => {
           renderTimeout: 1000,
           dataType: 'string'
         });
-        void dContext.initialize(true);
         await widget.ready;
         const layout = widget.layout as BoxLayout;
         expect(layout.widgets.length).toBe(1);
@@ -110,7 +109,6 @@ describe('docregistry/mimedocument', () => {
     describe('contents changed', () => {
       it('should change the document contents', async () => {
         RENDERMIME.addFactory(fooFactory);
-        await dContext.initialize(true);
         const emission = testEmission(dContext.model.contentChanged, {
           test: () => {
             expect(dContext.model.toString()).toBe('bar');

--- a/packages/docregistry/tsconfig.test.json
+++ b/packages/docregistry/tsconfig.test.json
@@ -30,6 +30,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/filebrowser/tsconfig.test.json
+++ b/packages/filebrowser/tsconfig.test.json
@@ -27,6 +27,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/fileeditor/tsconfig.test.json
+++ b/packages/fileeditor/tsconfig.test.json
@@ -18,6 +18,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/imageviewer/test/widget.spec.ts
+++ b/packages/imageviewer/test/widget.spec.ts
@@ -161,14 +161,14 @@ describe('ImageViewer', () => {
 
 describe('ImageViewerFactory', () => {
   describe('#createNewWidget', () => {
-    it('should create an image document widget', () => {
+    it('should create an image document widget', async () => {
       const factory = new ImageViewerFactory({
         name: 'Image',
         modelName: 'base64',
         fileTypes: ['png'],
         defaultFor: ['png']
       });
-      const context = createFileContext(
+      const context = await createFileContext(
         IMAGE.path,
         new Mock.ServiceManagerMock()
       );

--- a/packages/imageviewer/tsconfig.test.json
+++ b/packages/imageviewer/tsconfig.test.json
@@ -12,6 +12,9 @@
       "path": "../docregistry"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/inspector/tsconfig.test.json
+++ b/packages/inspector/tsconfig.test.json
@@ -21,6 +21,9 @@
       "path": "../statedb"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/logconsole/tsconfig.test.json
+++ b/packages/logconsole/tsconfig.test.json
@@ -21,6 +21,9 @@
       "path": "../services"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/mainmenu/tsconfig.test.json
+++ b/packages/mainmenu/tsconfig.test.json
@@ -12,6 +12,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/nbformat/tsconfig.test.json
+++ b/packages/nbformat/tsconfig.test.json
@@ -3,6 +3,9 @@
   "include": ["src/*", "test/*"],
   "references": [
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     }
   ]

--- a/packages/notebook/tsconfig.test.json
+++ b/packages/notebook/tsconfig.test.json
@@ -36,6 +36,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/observables/tsconfig.test.json
+++ b/packages/observables/tsconfig.test.json
@@ -3,6 +3,9 @@
   "include": ["src/*", "test/*"],
   "references": [
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     }
   ]

--- a/packages/outputarea/tsconfig.test.json
+++ b/packages/outputarea/tsconfig.test.json
@@ -21,6 +21,9 @@
       "path": "../services"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/rendermime/test/registry.spec.ts
+++ b/packages/rendermime/test/registry.spec.ts
@@ -69,13 +69,7 @@ describe('rendermime/registry', () => {
   let RESOLVER: IRenderMime.IResolver;
 
   beforeAll(async () => {
-    const fileContext = Mock.createFileContext(true);
-    await fileContext.initialize(true);
-
-    // The context initialization kicks off a sessionContext initialization,
-    // but does not wait for it. We need to wait for it so our url resolver
-    // has access to the session.
-    await fileContext.sessionContext.initialize();
+    const fileContext = await Mock.createFileContext(true);
     RESOLVER = fileContext.urlResolver;
   });
 

--- a/packages/rendermime/tsconfig.test.json
+++ b/packages/rendermime/tsconfig.test.json
@@ -24,6 +24,9 @@
       "path": "../services"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../mathjax2"
     },
     {

--- a/packages/services/tsconfig.test.json
+++ b/packages/services/tsconfig.test.json
@@ -18,6 +18,9 @@
       "path": "../statedb"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/settingregistry/tsconfig.test.json
+++ b/packages/settingregistry/tsconfig.test.json
@@ -6,6 +6,9 @@
       "path": "../statedb"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/statedb/tsconfig.test.json
+++ b/packages/statedb/tsconfig.test.json
@@ -3,6 +3,9 @@
   "include": ["src/*", "test/*"],
   "references": [
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     }
   ]

--- a/packages/statusbar/tsconfig.test.json
+++ b/packages/statusbar/tsconfig.test.json
@@ -18,6 +18,9 @@
       "path": "../ui-components"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/terminal/tsconfig.test.json
+++ b/packages/terminal/tsconfig.test.json
@@ -9,6 +9,9 @@
       "path": "../services"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/packages/ui-components/tsconfig.test.json
+++ b/packages/ui-components/tsconfig.test.json
@@ -6,6 +6,9 @@
       "path": "../coreutils"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../../testutils"
     },
     {

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -19,7 +19,7 @@ fi
 
 if [[ $GROUP == js* ]]; then
 
-    if [[ $GROUP === "js-testutils" ]]; then
+    if [[ $GROUP == "js-testutils" ]]; then
         pushd testutils
     else
         # extract the group name

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -19,23 +19,19 @@ fi
 
 if [[ $GROUP == js* ]]; then
 
-    # extract the group name
-    export PKG="${GROUP#*-}"
-    pushd packages/${PKG}
+    if [[ $GROUP === "js-testutils" ]]; then
+        pushd testutils
+    else
+        # extract the group name
+        export PKG="${GROUP#*-}"
+        pushd packages/${PKG}
+    fi
+
     jlpm run build:test; true
 
     export FORCE_COLOR=1
     CMD="jlpm run test:cov"
     $CMD || $CMD || $CMD
-    jlpm run clean
-fi
-
-if [[ $GROUP == jsscope ]]; then
-
-    jlpm build:packages
-    jlpm build:test
-    FORCE_COLOR=1 jlpm test:scope --loglevel success --scope $JSTESTGROUP
-
     jlpm run clean
 fi
 

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -19,20 +19,13 @@ fi
 
 if [[ $GROUP == js* ]]; then
 
-    if [[ $GROUP == js-* ]]; then
-        # extract the group name
-        export PKG="${GROUP#*-}"
-        pushd packages/${PKG}
-        jlpm run build; true
-        jlpm run build:test; true
-        CMD="jlpm run test:cov"
-    else
-        jlpm build:packages
-        jlpm build:test
-        CMD="jlpm test:cov --loglevel success"
-    fi
+    # extract the group name
+    export PKG="${GROUP#*-}"
+    pushd packages/${PKG}
+    jlpm run build:test; true
 
     export FORCE_COLOR=1
+    CMD="jlpm run test:cov"
     $CMD || $CMD || $CMD
     jlpm run clean
 fi

--- a/testutils/babel.config.js
+++ b/testutils/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/babel.config');

--- a/testutils/jest.config.js
+++ b/testutils/jest.config.js
@@ -1,0 +1,2 @@
+const func = require('./lib/jest-config');
+module.exports = func(__dirname);

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "build:test": "tsc -b && tsc --build tsconfig.test.json",
+    "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "prepublishOnly": "npm run build",
     "test": "jest",

--- a/testutils/package.json
+++ b/testutils/package.json
@@ -26,9 +26,14 @@
   },
   "scripts": {
     "build": "tsc -b",
+    "build:test": "tsc -b && tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "prepublishOnly": "npm run build",
-    "watch": "tsc --watch"
+    "test": "jest",
+    "test:cov": "jest --collect-coverage",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
+    "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
+    "watch": "tsc -b --watch"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^2.1.0",

--- a/testutils/src/mock.ts
+++ b/testutils/src/mock.ts
@@ -679,13 +679,16 @@ export const MockShellFuture = jest.fn<
 /**
  * Create a context for a file.
  */
-export function createFileContext(startKernel = false): Context {
+export async function createFileContext(
+  startKernel = false,
+  manager?: ServiceManager.IManager
+): Promise<Context> {
   const path = UUID.uuid4() + '.txt';
-  const manager = new ServiceManagerMock();
+  manager = manager || new ServiceManagerMock();
   const factory = new TextModelFactory();
 
-  return new Context({
-    manager,
+  const context = new Context({
+    manager: manager || new ServiceManagerMock(),
     factory,
     path,
     kernelPreference: {
@@ -694,6 +697,9 @@ export function createFileContext(startKernel = false): Context {
       autoStartDefault: startKernel
     }
   });
+  await context.initialize(true);
+  await context.sessionContext.initialize();
+  return context;
 }
 
 /**

--- a/testutils/src/mock.ts
+++ b/testutils/src/mock.ts
@@ -187,7 +187,7 @@ export const KernelMock = jest.fn<
       });
       return newKernel;
     }),
-    info: Promise.resolve(void 0),
+    info: Promise.resolve(Private.getInfo(model!.name!)),
     shutdown: jest.fn(() => Promise.resolve(void 0)),
     requestHistory: jest.fn(() => {
       const historyReply = KernelMessage.createMessage({
@@ -776,6 +776,24 @@ namespace Private {
     return KERNELSPECS.find(val => {
       return val.name === name;
     });
+  }
+
+  // Get the kernel info for kernel name
+  export function getInfo(
+    name: string
+  ): KernelMessage.IInfoReplyMsg['content'] {
+    return {
+      protocol_version: '1',
+      implementation: 'foo',
+      implementation_version: '1',
+      language_info: {
+        version: '1',
+        name
+      },
+      banner: 'hello, world!',
+      help_links: [],
+      status: 'ok'
+    };
   }
 
   export function changeKernel(

--- a/testutils/src/start_jupyter_server.ts
+++ b/testutils/src/start_jupyter_server.ts
@@ -35,15 +35,15 @@ export class JupyterServer {
   /**
    * Start the server.
    *
-   * @returns A promise that resolves when the server has started
+   * @returns A promise that resolves with the url of the server
    *
    * @throws Error if another server is still running.
    */
-  async start(): Promise<void> {
+  async start(): Promise<string> {
     if (Private.child !== null) {
       throw Error('Previous server was not disposed');
     }
-    const startDelegate = new PromiseDelegate<void>();
+    const startDelegate = new PromiseDelegate<string>();
 
     const env = {
       JUPYTER_CONFIG_DIR: Private.handleConfig(),
@@ -81,7 +81,8 @@ export class JupyterServer {
       handleOutput(String(data));
     });
 
-    await startDelegate.promise;
+    const url = await startDelegate.promise;
+    return url;
   }
 
   /**
@@ -273,13 +274,13 @@ namespace Private {
    */
   export async function connect(
     baseUrl: string,
-    startDelegate: PromiseDelegate<void>
+    startDelegate: PromiseDelegate<string>
   ): Promise<void> {
     // eslint-disable-next-line
     while (true) {
       try {
         await fetch(URLExt.join(baseUrl, 'api'));
-        startDelegate.resolve(void 0);
+        startDelegate.resolve(baseUrl);
         return;
       } catch (e) {
         // spin until we can connect to the server.

--- a/testutils/test/mock.spec.ts
+++ b/testutils/test/mock.spec.ts
@@ -630,16 +630,12 @@ describe('mock', () => {
 
   describe('createFileContext()', () => {
     it('should create a context without a kernel', async () => {
-      const context = Mock.createFileContext();
-      await context.initialize(true);
-      await context.sessionContext.initialize();
+      const context = await Mock.createFileContext();
       expect(context.sessionContext.session).toBe(null);
     });
 
     it('should create a context with a kernel', async () => {
-      const context = Mock.createFileContext(true);
-      await context.initialize(true);
-      await context.sessionContext.initialize();
+      const context = await Mock.createFileContext(true);
       expect(context.sessionContext.session!.kernel!.name).toBe(
         Mock.DEFAULT_NAME
       );

--- a/testutils/test/mock.spec.ts
+++ b/testutils/test/mock.spec.ts
@@ -1,0 +1,648 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import 'jest';
+
+import * as Mock from '../src/mock';
+import { KernelMessage } from '@jupyterlab/services';
+import { toArray } from '@lumino/algorithm';
+
+describe('mock', () => {
+  describe('createSimpleSessionContext()', () => {
+    it('should create a session context', () => {
+      const context = Mock.createSimpleSessionContext();
+      expect(context.session!.kernel!.name).toEqual(Mock.DEFAULT_NAME);
+    });
+
+    it('should accept a session model', () => {
+      const context = Mock.createSimpleSessionContext({
+        name: 'hi',
+        path: 'foo',
+        type: 'bar',
+        kernel: { name: 'fizz' }
+      });
+      expect(context.name).toEqual('hi');
+      expect(context.path).toEqual('foo');
+      expect(context.type).toEqual('bar');
+      expect(context.session!.kernel!.name).toEqual('fizz');
+    });
+  });
+
+  describe('updateKernelStatus()', () => {
+    it('should update the kernel status', () => {
+      const context = Mock.createSimpleSessionContext();
+      let called = false;
+      context.statusChanged.connect((_, status) => {
+        if (status === 'dead') {
+          called = true;
+        }
+      });
+      Mock.updateKernelStatus(context, 'dead');
+      expect(context.session!.kernel!.status).toEqual('dead');
+      expect(called).toEqual(true);
+    });
+  });
+
+  describe('emitIopubMessage', () => {
+    it('should emit an iopub message', () => {
+      const context = Mock.createSimpleSessionContext();
+      const source = KernelMessage.createMessage({
+        channel: 'iopub',
+        msgType: 'execute_input',
+        session: 'foo',
+        username: 'bar',
+        msgId: 'fizz',
+        content: {
+          code: 'hello, world!',
+          execution_count: 0
+        }
+      });
+      let called = false;
+      context.iopubMessage.connect((_, msg) => {
+        expect(msg).toBe(source);
+        called = true;
+      });
+      Mock.emitIopubMessage(context, source);
+      expect(called).toBe(true);
+    });
+  });
+
+  describe('cloneKernel()', () => {
+    it('should clone a kernel', () => {
+      const kernel0 = new Mock.KernelMock({});
+      const kernel1 = Mock.cloneKernel(kernel0);
+      expect(kernel0.id).toBe(kernel1.id);
+      expect(kernel0.clientId).not.toBe(kernel1.clientId);
+    });
+  });
+
+  describe('KernelMock', () => {
+    describe('.constructor()', () => {
+      it('should create a mock kernel', () => {
+        const kernel = new Mock.KernelMock({});
+        expect(kernel.name).toBe(Mock.DEFAULT_NAME);
+      });
+
+      it('should take options', () => {
+        const kernel = new Mock.KernelMock({ model: { name: 'foo' } });
+        expect(kernel.name).toBe('foo');
+      });
+    });
+
+    describe('.spec()', () => {
+      it('should resolve with a kernel spec', async () => {
+        const kernel = new Mock.KernelMock({});
+        const spec = await kernel.spec;
+        expect(spec!.name).toBe(Mock.DEFAULT_NAME);
+      });
+    });
+
+    describe('.dispose()', () => {
+      it('should be a no-op', () => {
+        const kernel = new Mock.KernelMock({});
+        kernel.dispose();
+      });
+    });
+
+    describe('.clone()', () => {
+      it('should clone the kernel', () => {
+        const kernel0 = new Mock.KernelMock({});
+        const kernel1 = kernel0.clone();
+        expect(kernel0.id).toBe(kernel1.id);
+        expect(kernel0.clientId).not.toBe(kernel1.clientId);
+      });
+    });
+
+    describe('.info', () => {
+      it('should resolve with undefined', async () => {
+        const kernel = new Mock.KernelMock({});
+        const info = await kernel.info;
+        expect(info).toBeUndefined();
+      });
+    });
+
+    describe('.shutdown()', () => {
+      it('should be a no-op', async () => {
+        const kernel = new Mock.KernelMock({});
+        await kernel.shutdown();
+      });
+    });
+
+    describe('.requestHistory()', () => {
+      it('should get the history info', async () => {
+        const kernel = new Mock.KernelMock({});
+        const reply = await kernel.requestHistory({} as any);
+        expect(reply.content.status).toBe('ok');
+      });
+    });
+
+    describe('.restart()', () => {
+      it('should be a no-op', async () => {
+        const kernel = new Mock.KernelMock({});
+        await kernel.restart();
+      });
+    });
+
+    describe('.requestExecute()', () => {
+      it('should request execution', async () => {
+        const kernel = new Mock.KernelMock({});
+        let called = false;
+        kernel.iopubMessage.connect((_, msg) => {
+          if (msg.header.msg_type === 'execute_input') {
+            called = true;
+          }
+        });
+        const future = kernel.requestExecute({ code: 'foo ' });
+        await future.done;
+        expect(called).toBe(true);
+      });
+    });
+  });
+
+  describe('SessionConnectionMock', () => {
+    describe('.constructor()', () => {
+      it('should create a new SessionConnectionMock', () => {
+        const session = new Mock.SessionConnectionMock({}, null);
+        expect(session.kernel!.name).toBe(Mock.DEFAULT_NAME);
+      });
+
+      it('should take options', () => {
+        const kernel = new Mock.KernelMock({});
+        const session = new Mock.SessionConnectionMock(
+          { model: { name: 'foo' } },
+          kernel
+        );
+        expect(session.kernel).toBe(kernel);
+        expect(session.name).toBe('foo');
+      });
+    });
+
+    describe('.dispose()', () => {
+      it('should be a no-op', () => {
+        const session = new Mock.SessionConnectionMock({}, null);
+        session.dispose();
+      });
+    });
+
+    describe('.changeKernel()', () => {
+      it('should change the kernel', async () => {
+        const session = new Mock.SessionConnectionMock({}, null);
+        const oldId = session.kernel!.id;
+        const kernel = await session.changeKernel({ name: Mock.DEFAULT_NAME });
+        expect(kernel!.id).not.toBe(oldId);
+      });
+    });
+
+    describe('.shutdown()', () => {
+      it('should be a no-op', async () => {
+        const session = new Mock.SessionConnectionMock({}, null);
+        await session.shutdown();
+      });
+    });
+
+    describe('.setPath()', () => {
+      it('should set the path', async () => {
+        const session = new Mock.SessionConnectionMock({}, null);
+        let called = false;
+        session.propertyChanged.connect((_, args) => {
+          if (args === 'path') {
+            called = true;
+          }
+        });
+        await session.setPath('foo');
+        expect(session.path).toBe('foo');
+        expect(called).toBe(true);
+      });
+    });
+
+    describe('.setType()', () => {
+      it('should set the type', async () => {
+        const session = new Mock.SessionConnectionMock({}, null);
+        let called = false;
+        session.propertyChanged.connect((_, args) => {
+          if (args === 'type') {
+            called = true;
+          }
+        });
+        await session.setType('foo');
+        expect(session.type).toBe('foo');
+        expect(called).toBe(true);
+      });
+    });
+
+    describe('.setName()', () => {
+      it('should set the name', async () => {
+        const session = new Mock.SessionConnectionMock({}, null);
+        let called = false;
+        session.propertyChanged.connect((_, args) => {
+          if (args === 'name') {
+            called = true;
+          }
+        });
+        await session.setName('foo');
+        expect(session.name).toBe('foo');
+        expect(called).toBe(true);
+      });
+    });
+  });
+
+  describe('SessionContextMock', () => {
+    describe('.constructor()', () => {
+      it('should create a new context', () => {
+        const context = new Mock.SessionContextMock({}, null);
+        expect(context.session!.kernel!.name).toBe(Mock.DEFAULT_NAME);
+      });
+
+      it('should accept options', () => {
+        const session = new Mock.SessionConnectionMock({}, null);
+        const context = new Mock.SessionContextMock({ path: 'foo' }, session);
+        expect(context.session).toBe(session);
+        expect(context.path).toBe('foo');
+      });
+    });
+
+    describe('.dispose()', () => {
+      it('should be a no-op', () => {
+        const context = new Mock.SessionContextMock({}, null);
+        context.dispose();
+      });
+    });
+
+    describe('.initialize()', () => {
+      it('should be a no-op', async () => {
+        const context = new Mock.SessionContextMock({}, null);
+        await context.initialize();
+      });
+    });
+
+    describe('.ready', () => {
+      it('should be a no-op', async () => {
+        const context = new Mock.SessionContextMock({}, null);
+        await context.ready;
+      });
+    });
+
+    describe('.changeKernel()', () => {
+      it('should change the kernel', async () => {
+        const context = new Mock.SessionContextMock({}, null);
+        const oldId = context.session!.kernel!.id;
+        const kernel = await context.changeKernel({ name: Mock.DEFAULT_NAME });
+        expect(kernel!.id).not.toBe(oldId);
+      });
+    });
+
+    describe('.shutdown()', () => {
+      it('should be a no-op', async () => {
+        const context = new Mock.SessionContextMock({}, null);
+        await context.shutdown();
+      });
+    });
+  });
+
+  describe('ContentsManagerMock', () => {
+    describe('.constructor()', () => {
+      it('should create a new mock', () => {
+        const manager = new Mock.ContentsManagerMock();
+        expect(manager.localPath('foo')).toBe('foo');
+      });
+    });
+
+    describe('.newUntitled', () => {
+      it('should create a new text file', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        let called = false;
+        manager.fileChanged.connect((_, args) => {
+          if (args.type === 'new') {
+            called = true;
+          }
+        });
+        const contents = await manager.newUntitled();
+        expect(contents.type).toBe('file');
+        expect(called).toBe(true);
+      });
+
+      it('should create a new notebook', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        const contents = await manager.newUntitled({ type: 'notebook' });
+        expect(contents.type).toBe('notebook');
+      });
+    });
+
+    describe('.createCheckpoint()', () => {
+      it('should create a checkpoint', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        const content = await manager.newUntitled();
+        const checkpoint = await manager.createCheckpoint(content.path);
+        expect(checkpoint.id).toBeTruthy();
+      });
+    });
+
+    describe('.listCheckpoints()', () => {
+      it('should list the checkpoints', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        const content = await manager.newUntitled();
+        const checkpoint = await manager.createCheckpoint(content.path);
+        const checkpoints = await manager.listCheckpoints(content.path);
+        expect(checkpoints[0].id).toBe(checkpoint.id);
+      });
+    });
+
+    describe('.deleteCheckpoint', () => {
+      it('should delete a checkpoints', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        const content = await manager.newUntitled();
+        const checkpoint = await manager.createCheckpoint(content.path);
+        await manager.deleteCheckpoint(content.path, checkpoint.id);
+        const checkpoints = await manager.listCheckpoints(content.path);
+        expect(checkpoints.length).toBe(0);
+      });
+    });
+
+    describe('.restoreCheckpoint()', () => {
+      it('should restore the contents', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        const content = await manager.newUntitled();
+        await manager.save(content.path, { content: 'foo' });
+        const checkpoint = await manager.createCheckpoint(content.path);
+        await manager.save(content.path, { content: 'bar' });
+        await manager.restoreCheckpoint(content.path, checkpoint.id);
+        const newContent = await manager.get(content.path);
+        expect(newContent.content).toBe('foo');
+      });
+    });
+
+    describe('.getModelDBFactory()', () => {
+      it('should return null', () => {
+        const manager = new Mock.ContentsManagerMock();
+        expect(manager.getModelDBFactory('foo')).toBe(null);
+      });
+    });
+
+    describe('.normalize()', () => {
+      it('should normalize a path', () => {
+        const manager = new Mock.ContentsManagerMock();
+        expect(manager.normalize('foo/bar/../baz')).toBe('foo/baz');
+      });
+    });
+
+    describe('.localPath', () => {
+      it('should get the local path of a file', () => {
+        const manager = new Mock.ContentsManagerMock();
+        const defaultDrive = manager.driveName('foo');
+        expect(manager.localPath(`${defaultDrive}foo/bar`)).toBe('foo/bar');
+      });
+    });
+
+    describe('.get()', () => {
+      it('should get the file contents', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        const content = await manager.newUntitled();
+        await manager.save(content.path, { content: 'foo' });
+        const newContent = await manager.get(content.path);
+        expect(newContent.content).toBe('foo');
+      });
+    });
+
+    describe('.driveName()', () => {
+      it('should get the drive name of the path', () => {
+        const manager = new Mock.ContentsManagerMock();
+        const defaultDrive = manager.driveName('foo');
+        expect(manager.driveName(`${defaultDrive}/bar`)).toBe(defaultDrive);
+      });
+    });
+
+    describe('.rename()', () => {
+      it('should rename the file', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        let called = false;
+        manager.fileChanged.connect((_, args) => {
+          if (args.type === 'rename') {
+            expect(args.newValue!.path).toBe('foo');
+            called = true;
+          }
+        });
+        const contents = await manager.newUntitled();
+        await manager.rename(contents.path, 'foo');
+        expect(called).toBe(true);
+      });
+    });
+
+    describe('.delete()', () => {
+      it('should delete the file', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        let called = false;
+        manager.fileChanged.connect((_, args) => {
+          if (args.type === 'delete') {
+            expect(args.newValue).toBe(null);
+            called = true;
+          }
+        });
+        const contents = await manager.newUntitled();
+        await manager.delete(contents.path);
+        expect(called).toBe(true);
+      });
+    });
+
+    describe('.save()', () => {
+      it('should save the file', async () => {
+        const manager = new Mock.ContentsManagerMock();
+        let called = false;
+        manager.fileChanged.connect((_, args) => {
+          if (args.type === 'save') {
+            expect(args.newValue!.content).toBe('bar');
+            called = true;
+          }
+        });
+        const contents = await manager.newUntitled();
+        await manager.save(contents.path, { content: 'bar' });
+        expect(called).toBe(true);
+      });
+    });
+
+    describe('.dispose()', () => {
+      it('should be a no-op', () => {
+        const manager = new Mock.ContentsManagerMock();
+        manager.dispose();
+      });
+    });
+  });
+
+  describe('SessionManagerMock', () => {
+    describe('.constructor()', () => {
+      it('should create a new session manager', () => {
+        const manager = new Mock.SessionManagerMock();
+        expect(manager.isReady).toBe(true);
+      });
+    });
+
+    describe('.startNew()', () => {
+      it('should start a new session', async () => {
+        const manager = new Mock.SessionManagerMock();
+        const session = await manager.startNew({
+          path: 'foo',
+          name: 'foo',
+          type: 'bar',
+          kernel: { name: Mock.DEFAULT_NAME }
+        });
+        expect(session.kernel!.name).toBe(Mock.DEFAULT_NAME);
+      });
+    });
+
+    describe('.connectTo()', () => {
+      it('should connect to a session', async () => {
+        const manager = new Mock.SessionManagerMock();
+        const session = await manager.connectTo({
+          model: {
+            id: 'fizz',
+            path: 'foo',
+            type: 'bar',
+            name: 'baz',
+            kernel: { name: Mock.DEFAULT_NAME, id: 'fuzz' }
+          }
+        });
+        expect(session.kernel!.name).toBe(Mock.DEFAULT_NAME);
+      });
+    });
+
+    describe('.stopIfNeeded()', () => {
+      it('should remove a running kernel', async () => {
+        const manager = new Mock.SessionManagerMock();
+        const session = await manager.startNew({
+          path: 'foo',
+          name: 'foo',
+          type: 'bar',
+          kernel: { name: Mock.DEFAULT_NAME }
+        });
+        expect(toArray(manager.running()).length).toBe(1);
+        await manager.stopIfNeeded(session.path);
+        expect(toArray(manager.running()).length).toBe(0);
+      });
+    });
+
+    describe('.refreshRunning()', () => {
+      it('should be a no-op', async () => {
+        const manager = new Mock.SessionManagerMock();
+        await manager.refreshRunning();
+      });
+    });
+
+    describe('.running()', () => {
+      it('should be an iterable of running sessions', async () => {
+        const manager = new Mock.SessionManagerMock();
+        await manager.startNew({
+          path: 'foo',
+          name: 'foo',
+          type: 'bar',
+          kernel: { name: Mock.DEFAULT_NAME }
+        });
+        expect(toArray(manager.running()).length).toBe(1);
+      });
+    });
+  });
+
+  describe('KernelSpecManagerMock', () => {
+    describe('.constructor', () => {
+      it('should create a new mock', () => {
+        const manager = new Mock.KernelSpecManagerMock();
+        expect(manager.isReady).toBe(true);
+      });
+    });
+
+    describe('.specs', () => {
+      it('should be the kernel specs', () => {
+        const manager = new Mock.KernelSpecManagerMock();
+        expect(manager.specs!.default).toBe(Mock.DEFAULT_NAME);
+      });
+    });
+
+    describe('.refreshSpecs()', () => {
+      it('should be a no-op', async () => {
+        const manager = new Mock.KernelSpecManagerMock();
+        await manager.refreshSpecs();
+      });
+    });
+  });
+
+  describe('ServiceManagerMock', () => {
+    describe('.constructor()', () => {
+      it('should create a new mock', () => {
+        const manager = new Mock.ServiceManagerMock();
+        expect(manager.isReady).toBe(true);
+      });
+    });
+
+    describe('.ready', () => {
+      it('should resolve', async () => {
+        const manager = new Mock.ServiceManagerMock();
+        await manager.ready;
+      });
+    });
+
+    describe('.contents', () => {
+      it('should be a contents manager', () => {
+        const manager = new Mock.ServiceManagerMock();
+        expect(manager.contents.normalize).toBeTruthy();
+      });
+    });
+
+    describe('.sessions', () => {
+      it('should be a sessions manager', () => {
+        const manager = new Mock.ServiceManagerMock();
+        expect(manager.sessions.isReady).toBe(true);
+      });
+    });
+
+    describe('.kernelspecs', () => {
+      it('should be a kernelspecs manager', () => {
+        const manager = new Mock.ServiceManagerMock();
+        expect(manager.kernelspecs.isReady).toBe(true);
+      });
+    });
+
+    describe('.dispose()', () => {
+      it('should be a no-op', () => {
+        const manager = new Mock.ServiceManagerMock();
+        manager.dispose();
+      });
+    });
+  });
+
+  describe('MockShellFuture', () => {
+    it('should create a new mock', async () => {
+      const msg = KernelMessage.createMessage({
+        channel: 'shell',
+        msgType: 'execute_reply',
+        session: 'foo',
+        username: 'bar',
+        msgId: 'fizz',
+        content: {
+          user_expressions: {},
+          execution_count: 0,
+          status: 'ok'
+        }
+      });
+      const future = new Mock.MockShellFuture(msg);
+      const reply = await future.done;
+      expect(reply).toBe(msg);
+      future.dispose();
+    });
+  });
+
+  describe('createFileContext()', () => {
+    it('should create a context without a kernel', async () => {
+      const context = Mock.createFileContext();
+      await context.initialize(true);
+      await context.sessionContext.initialize();
+      expect(context.sessionContext.session).toBe(null);
+    });
+
+    it('should create a context with a kernel', async () => {
+      const context = Mock.createFileContext(true);
+      await context.initialize(true);
+      await context.sessionContext.initialize();
+      expect(context.sessionContext.session!.kernel!.name).toBe(
+        Mock.DEFAULT_NAME
+      );
+    });
+  });
+});

--- a/testutils/test/mock.spec.ts
+++ b/testutils/test/mock.spec.ts
@@ -114,10 +114,10 @@ describe('mock', () => {
     });
 
     describe('.info', () => {
-      it('should resolve with undefined', async () => {
+      it('should resolve with info', async () => {
         const kernel = new Mock.KernelMock({});
         const info = await kernel.info;
-        expect(info).toBeUndefined();
+        expect(info.language_info.name).toBe(Mock.DEFAULT_NAME);
       });
     });
 

--- a/testutils/test/start_jupyter_server.spec.ts
+++ b/testutils/test/start_jupyter_server.spec.ts
@@ -10,6 +10,7 @@ import { URLExt } from '@jupyterlab/coreutils';
 
 describe('JupyterServer', () => {
   it('should start the server', async () => {
+    jest.setTimeout(20000);
     const server = new JupyterServer();
     const url = await server.start();
     await fetch(URLExt.join(url, 'api'));

--- a/testutils/test/start_jupyter_server.spec.ts
+++ b/testutils/test/start_jupyter_server.spec.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import 'jest';
+
+const fetch = require('node-fetch');
+
+import { JupyterServer } from '../src';
+import { URLExt } from '@jupyterlab/coreutils';
+
+describe('JupyterServer', () => {
+  it('should start the server', async () => {
+    const server = new JupyterServer();
+    const url = await server.start();
+    await fetch(URLExt.join(url, 'api'));
+    await server.shutdown();
+  });
+});

--- a/testutils/tsconfig.test.json
+++ b/testutils/tsconfig.test.json
@@ -33,6 +33,9 @@
       "path": "../packages/services"
     },
     {
+      "path": "."
+    },
+    {
       "path": "../packages/apputils"
     },
     {

--- a/testutils/tsconfig.test.json
+++ b/testutils/tsconfig.test.json
@@ -1,0 +1,66 @@
+{
+  "extends": "../tsconfigbase.test",
+  "include": ["src/*", "test/*"],
+  "references": [
+    {
+      "path": "../packages/apputils"
+    },
+    {
+      "path": "../packages/cells"
+    },
+    {
+      "path": "../packages/codeeditor"
+    },
+    {
+      "path": "../packages/codemirror"
+    },
+    {
+      "path": "../packages/coreutils"
+    },
+    {
+      "path": "../packages/docregistry"
+    },
+    {
+      "path": "../packages/nbformat"
+    },
+    {
+      "path": "../packages/notebook"
+    },
+    {
+      "path": "../packages/rendermime"
+    },
+    {
+      "path": "../packages/services"
+    },
+    {
+      "path": "../packages/apputils"
+    },
+    {
+      "path": "../packages/cells"
+    },
+    {
+      "path": "../packages/codeeditor"
+    },
+    {
+      "path": "../packages/codemirror"
+    },
+    {
+      "path": "../packages/coreutils"
+    },
+    {
+      "path": "../packages/docregistry"
+    },
+    {
+      "path": "../packages/nbformat"
+    },
+    {
+      "path": "../packages/notebook"
+    },
+    {
+      "path": "../packages/rendermime"
+    },
+    {
+      "path": "../packages/services"
+    }
+  ]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -16,6 +16,7 @@
     "packages/**/stories/*",
     "scripts/*",
     "jupyterlab/*",
-    "jupyterlab/staging/*"
+    "jupyterlab/staging/*",
+    "testutils/**/*"
   ]
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #8361 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Adds a test suite to testutils covering mocks and `JupyterServer`.
- Cleans up the mocks a bit in the process.
- Adds the local package as a reference for `tsconfig.test.json` so we make sure the local package is built when running `build:test`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
