### PR TITLE
Allow customization of default kernel activity

### DIFF
--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -40,7 +40,7 @@
     },
     "showAllKernelActivity": {
       "title": "Kernel activity",
-      "description": "Whether the default behavior of console shows all kernel activity or default activity",
+      "description": "Whether the default behavior of console shows all\nkernel activity or default activity.",
       "type": "boolean",
       "default": false
     }

--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -38,12 +38,11 @@
       "enum": ["notebook", "terminal"],
       "default": "notebook"
     },
-    "kernelActivity": {
+    "showAllKernelActivity": {
       "title": "Kernel activity",
-      "description": "Whether the console should show all or minimal kernel activity",
-      "type": "string",
-      "enum": ["all", "minimal"],
-      "default": "minimal"
+      "description": "Whether the console should show all kernel activity or default activity",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -37,6 +37,13 @@
       "type": "string",
       "enum": ["notebook", "terminal"],
       "default": "notebook"
+    },
+    "kernelActivity": {
+      "title": "Kernel activity",
+      "description": "Whether the console should show all or minimal kernel activity",
+      "type": "string",
+      "enum": ["all", "minimal"],
+      "default": "minimal"
     }
   },
   "additionalProperties": false,

--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -39,8 +39,8 @@
       "default": "notebook"
     },
     "showAllKernelActivity": {
-      "title": "Kernel activity",
-      "description": "Whether the default behavior of console shows all\nkernel activity or default activity.",
+      "title": "Show All Kernel Activity",
+      "description": "Whether the console defaults to showing all\nkernel activity or just kernel activity originating from itself.",
       "type": "boolean",
       "default": false
     }

--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -40,7 +40,7 @@
     },
     "showAllKernelActivity": {
       "title": "Kernel activity",
-      "description": "Whether the console should show all kernel activity or default activity",
+      "description": "Whether the default behavior of console shows all kernel activity or default activity",
       "type": "boolean",
       "default": false
     }

--- a/packages/console-extension/src/foreign.ts
+++ b/packages/console-extension/src/foreign.ts
@@ -54,6 +54,7 @@ function activateForeign(
       .get('@jupyterlab/console-extension:tracker', 'kernelActivity')
       .then(({ composite }) => {
         let kernelActivity = composite as string;
+        // if default kernel activity is all, foreign handler is enabled
         handler.enabled = kernelActivity === 'all';
       });
 

--- a/packages/console-extension/src/foreign.ts
+++ b/packages/console-extension/src/foreign.ts
@@ -50,7 +50,7 @@ function activateForeign(
     });
     Private.foreignHandlerProperty.set(console, handler);
 
-    // If showAllKernelActivity is enabled, foreign handler is enabled.
+    // Property showAllKernelActivity configures foreign handler enabled on start.
     void settingRegistry
       .get('@jupyterlab/console-extension:tracker', 'showAllKernelActivity')
       .then(({ composite }) => {

--- a/packages/console-extension/src/foreign.ts
+++ b/packages/console-extension/src/foreign.ts
@@ -15,6 +15,8 @@ import {
   ForeignHandler
 } from '@jupyterlab/console';
 
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
 import { AttachedProperty } from '@lumino/properties';
 
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
@@ -24,7 +26,7 @@ import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
  */
 export const foreign: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/console-extension:foreign',
-  requires: [IConsoleTracker],
+  requires: [IConsoleTracker, ISettingRegistry],
   optional: [ICommandPalette],
   activate: activateForeign,
   autoStart: true
@@ -35,6 +37,7 @@ export default foreign;
 function activateForeign(
   app: JupyterFrontEnd,
   tracker: IConsoleTracker,
+  settingRegistry: ISettingRegistry,
   palette: ICommandPalette | null
 ) {
   const { shell } = app;
@@ -46,6 +49,14 @@ function activateForeign(
       parent: console
     });
     Private.foreignHandlerProperty.set(console, handler);
+
+    settingRegistry
+      .get('@jupyterlab/console-extension:tracker', 'kernelActivity')
+      .then(({ composite }) => {
+        let kernelActivity = composite as string;
+        handler.enabled = kernelActivity === 'all';
+      });
+
     console.disposed.connect(() => {
       handler.dispose();
     });

--- a/packages/console-extension/src/foreign.ts
+++ b/packages/console-extension/src/foreign.ts
@@ -50,12 +50,12 @@ function activateForeign(
     });
     Private.foreignHandlerProperty.set(console, handler);
 
-    settingRegistry
-      .get('@jupyterlab/console-extension:tracker', 'kernelActivity')
+    // If showAllKernelActivity is enabled, foreign handler is enabled.
+    void settingRegistry
+      .get('@jupyterlab/console-extension:tracker', 'showAllKernelActivity')
       .then(({ composite }) => {
-        let kernelActivity = composite as string;
-        // if default kernel activity is all, foreign handler is enabled
-        handler.enabled = kernelActivity === 'all';
+        const showAllKernelActivity = composite as boolean;
+        handler.enabled = showAllKernelActivity;
       });
 
     console.disposed.connect(() => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
#8364

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

- Addition of kernelActivity to code console properties
- Console extension's foreign plugin has access to SettingsRegistry

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

User can now set a default kernelActivity. Default is set to minimal.

## Backwards-incompatible changes

None