### PR TITLE
Only Autoinsert Single Completion Items on Tab

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -283,16 +283,6 @@ export class Completer extends Widget {
       return null;
     }
 
-    // If there is only one option, signal and bail.
-    // We don't test the filtered `items`, as that
-    // is too aggressive of completer behavior, it can
-    // lead to double typing of an option.
-    if (items.length === 1) {
-      this._selected.emit(items[0].insertText || items[0].label);
-      this.reset();
-      return null;
-    }
-
     // Clear the node.
     let node = this.node;
     node.textContent = '';
@@ -427,6 +417,13 @@ export class Completer extends Widget {
         event.stopImmediatePropagation();
         const model = this._model;
         if (!model) {
+          return;
+        }
+        // Autoinsert single completions on manual request (tab)
+        const items = model.completionItems && model.completionItems();
+        if (items && items.length === 1) {
+          this._selected.emit(items[0].insertText || items[0].label);
+          this.reset();
           return;
         }
         const populated = this._populateSubset();

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -918,6 +918,31 @@ describe('completer/widget', () => {
         anchor.dispose();
       });
 
+      it('should insert single completion item insertText on tab', async () => {
+        const anchor = createEditorWidget();
+        const model = new CompleterModel();
+        const options: Completer.IOptions = {
+          editor: anchor.editor,
+          model
+        };
+        let value = '';
+        const listener = (sender: any, selected: string) => {
+          value = selected;
+        };
+        model.setCompletionItems!([{ label: 'foo', insertText: 'bar' }]);
+        Widget.attach(anchor, document.body);
+
+        const widget = new Completer(options);
+
+        widget.selected.connect(listener);
+        Widget.attach(widget, document.body);
+        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+        simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab key
+        expect(value).toBe('bar');
+        widget.dispose();
+        anchor.dispose();
+      });
+
       describe('mousedown', () => {
         it('should trigger a selected signal on mouse down', () => {
           const anchor = createEditorWidget();

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -893,6 +893,31 @@ describe('completer/widget', () => {
         });
       });
 
+      it('should insert single completion item on tab', async () => {
+        const anchor = createEditorWidget();
+        const model = new CompleterModel();
+        const options: Completer.IOptions = {
+          editor: anchor.editor,
+          model
+        };
+        let value = '';
+        const listener = (sender: any, selected: string) => {
+          value = selected;
+        };
+        model.setCompletionItems!([{ label: 'foo' }]);
+        Widget.attach(anchor, document.body);
+
+        const widget = new Completer(options);
+
+        widget.selected.connect(listener);
+        Widget.attach(widget, document.body);
+        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+        simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab key
+        expect(value).toBe('foo');
+        widget.dispose();
+        anchor.dispose();
+      });
+
       describe('mousedown', () => {
         it('should trigger a selected signal on mouse down', () => {
           const anchor = createEditorWidget();
@@ -1216,82 +1241,6 @@ describe('completer/widget', () => {
         expect(value).toBe('');
         MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
         expect(value).toBe('foo');
-        widget.dispose();
-        anchor.dispose();
-      });
-
-      it('should emit label if there is only one completion item and insert Text is not set', () => {
-        let anchor = createEditorWidget();
-        let model = new CompleterModel();
-        let coords = { left: 0, right: 0, top: 100, bottom: 120 };
-        let request: Completer.ITextState = {
-          column: 0,
-          lineHeight: 0,
-          charWidth: 0,
-          line: 0,
-          coords: coords as CodeEditor.ICoordinate,
-          text: 'f'
-        };
-
-        let value = '';
-        let options: Completer.IOptions = {
-          editor: anchor.editor,
-          model
-        };
-        let listener = (sender: any, selected: string) => {
-          value = selected;
-        };
-
-        Widget.attach(anchor, document.body);
-        model.original = request;
-        model.setCompletionItems!([{ label: 'foo' }]);
-
-        let widget = new Completer(options);
-        widget.selected.connect(listener);
-        Widget.attach(widget, document.body);
-
-        expect(value).toBe('');
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(value).toBe('foo');
-
-        widget.dispose();
-        anchor.dispose();
-      });
-
-      it('should emit insert text if there is only one completion item and insert Text is set', () => {
-        let anchor = createEditorWidget();
-        let model = new CompleterModel();
-        let coords = { left: 0, right: 0, top: 100, bottom: 120 };
-        let request: Completer.ITextState = {
-          column: 0,
-          lineHeight: 0,
-          charWidth: 0,
-          line: 0,
-          coords: coords as CodeEditor.ICoordinate,
-          text: 'f'
-        };
-
-        let value = '';
-        let options: Completer.IOptions = {
-          editor: anchor.editor,
-          model
-        };
-        let listener = (sender: any, selected: string) => {
-          value = selected;
-        };
-
-        Widget.attach(anchor, document.body);
-        model.original = request;
-        model.setCompletionItems!([{ label: 'foo', insertText: 'bar' }]);
-
-        let widget = new Completer(options);
-        widget.selected.connect(listener);
-        Widget.attach(widget, document.body);
-
-        expect(value).toBe('');
-        MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
-        expect(value).toBe('bar');
-
         widget.dispose();
         anchor.dispose();
       });


### PR DESCRIPTION
## References
Resolves https://github.com/jupyterlab/jupyterlab/issues/8255, without needing a settings change.

## Code changes
Rather than signaling and bailing when the item node is created, we only signal and bail after a tab press is detected, signifying the user explicitly wanting a completion. We also only apply this to the new completions API path by checking for the presence of `completionItems` in the model, and only removing the logic from its item node creation path.

## User-facing changes
Previously, JupyterLab would auto-insert single completions from completer extensions, even if the user did not explicitly trigger a completion via tab. With this change, the completer menu is active even on single suggestions, unless tab is explicitly pressed.

## Backwards-incompatible changes
There should be no backwards incompatible changes. Consumers of the old completer API should not be impacted by this change.
