### PR TITLE
Show writable attribute in filebrowser's hover text

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1868,6 +1868,7 @@ export namespace DirListing {
           '\nModified: ' +
           Time.format(new Date(model.last_modified), 'YYYY-MM-DD HH:mm:ss');
       }
+      hoverText += '\nWritable: ' + model.writable;
 
       node.title = hoverText;
       node.setAttribute('data-file-type', name);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#8380
## Code changes
Minor changes that should not affect anything else

## User-facing changes
Add one tiny line at the bottom of the hover text
Writable: false or Writable: true

## Backwards-incompatible changes
Nothing