### PR TITLE
Updated the installation documentation on Read the Docs to match the readme file on the repo

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -26,7 +26,8 @@ If you use ``pip``, you can install it with:
 
 If installing using ``pip install --user``, you must add the user-level
 ``bin`` directory to your ``PATH`` environment variable in order to launch
-``jupyter lab``.
+``jupyter lab``. If you are using a Unix derivative (FreeBSD, GNU / Linux, 
+OS X), you can achieve this by using ``export PATH="$HOME/.local/bin:$PATH"`` command.
 
 pipenv
 ~~~~~~


### PR DESCRIPTION
## References
#8259 Improvements to the installation steps in the README and CONTRIBUTING files
 
## Code changes
This was a change in the documentation.

## User-facing changes
Outdated Read the Docs file:
<img width="716" alt="Screen Shot 2020-05-06 at 11 13 33 PM" src="https://user-images.githubusercontent.com/10498874/81250718-a7990300-8fef-11ea-8814-fabafe55ea56.png">

Readme file on the repo:
<img width="950" alt="Screen Shot 2020-05-06 at 11 13 50 PM" src="https://user-images.githubusercontent.com/10498874/81250723-aa93f380-8fef-11ea-8e5b-226d8a166d73.png">

## Backwards-incompatible changes
I am not aware of any.