### PR TITLE
Dim dot files in filebrowser

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -944,6 +944,7 @@ export class DirListing extends Widget {
       this._manager.openOrReveal(path);
     }
   }
+
   /**
    * Handle the `'keydown'` event for the widget.
    */
@@ -1872,7 +1873,11 @@ export namespace DirListing {
 
       node.title = hoverText;
       node.setAttribute('data-file-type', name);
-
+      if (model.name.startsWith('.')) {
+        node.setAttribute('data-is-dot', 'true');
+      } else {
+        node.removeAttribute('data-is-dot');
+      }
       // If an item is being edited currently, its text node is unavailable.
       if (text && text.textContent !== model.name) {
         text.textContent = model.name;

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -156,6 +156,10 @@
   user-select: none;
 }
 
+.jp-DirListing-item[data-is-dot] {
+  opacity: 75%;
+}
+
 .jp-DirListing-item.jp-mod-selected {
   color: white;
   background: var(--jp-brand-color1);


### PR DESCRIPTION
## References
#8257 Adding a visual clue for distinguishing hidden files and folders in the file browser window

## Code changes
Very minor. I added a css rule and an attribute to DirListing Item.

## User-facing changes
![Light theme](https://user-images.githubusercontent.com/13181907/81357921-f94e9580-90a2-11ea-9e99-a2133f5f642d.png)

![Dark theme](https://user-images.githubusercontent.com/13181907/81358007-3b77d700-90a3-11ea-885c-31628c55744b.png)

## Backwards-incompatible changes
None
