### PR TITLE
Fix watch mode and add CI test

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -88,6 +88,8 @@ const sourceMapRes = Object.values(watched).reduce((res, name) => {
 
 /**
  * Sync a local path to a linked package path if they are files and differ.
+ * This is used by `jupyter lab --watch` to synchronize linked packages
+ * and has no effect in `jupyter lab --dev-mode --watch`.
  */
 function maybeSync(localPath, name, rest) {
   const stats = fs.statSync(localPath);

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -87,6 +87,30 @@ const sourceMapRes = Object.values(watched).reduce((res, name) => {
 }, []);
 
 /**
+ * Sync a local path to a linked package path if they are files and differ.
+ */
+function maybeSync(localPath, name, rest) {
+  const stats = fs.statSync(localPath);
+  if (!stats.isFile(localPath)) {
+    return;
+  }
+  const source = fs.realpathSync(plib.join(jlab.linkedPackages[name], rest));
+  if (source === fs.realpathSync(localPath)) {
+    return;
+  }
+  fs.watchFile(source, { interval: 500 }, function(curr) {
+    if (!curr || curr.nlink === 0) {
+      return;
+    }
+    try {
+      fs.copySync(source, localPath);
+    } catch (err) {
+      console.error(err);
+    }
+  });
+}
+
+/**
  * A filter function set up to exclude all files that are not
  * in a package contained by the Jupyterlab repo. Used to ignore
  * files during a `--watch` build.
@@ -109,6 +133,7 @@ function ignored(path) {
     const rest = path.slice(rootPath.length);
     if (rest.indexOf('node_modules') === -1) {
       ignore = false;
+      maybeSync(path, name, rest);
     }
     return true;
   });

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -33,7 +33,10 @@ test_flags['dev-mode'] = (
     {'BrowserApp': {'dev_mode': True}},
     "Start the app in dev mode."
 )
-
+test_flags['watch'] = (
+    {'BrowserApp': {'watch': True}},
+    "Start the app in watch mode."
+)
 
 test_aliases = dict(aliases)
 test_aliases['app-dir'] = 'BrowserApp.app_dir'

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -176,7 +176,7 @@ def load_jupyter_server_extension(nbapp):
             logger.info(DEV_NOTE)
 
     # Make sure the app dir exists.
-    else:
+    elif not watch_mode:
         msgs = ensure_app(app_dir)
         if msgs:
             [logger.error(msg) for msg in msgs]

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -216,6 +216,10 @@ if [[ $GROUP == usage ]]; then
     python -m jupyterlab.browser_check
     jupyter labextension list --debug
 
+    # Make sure we can run watch mode with no built application
+    jupyter lab clean
+    python -m jupyterlab.browser_check --watch
+
     # Make sure we can non-dev install.
     virtualenv -p $(which python3) test_install
     ./test_install/bin/pip install -q ".[test]"  # this populates <sys_prefix>/share/jupyter/lab


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
In #8210 I made the mistake of removing the logic that allows locally linked extensions to work in watch mode.  Note that the change was in master and 1.2.x but not 2.1.x.


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Restores logic in `webpack.config.js` for locally linked packages. 
- Also fixes a bug where if you didn't have an existing `static` directory, `jupyter lab --watch` would fail because it was checking for the `static` directory at startup.
- Adds a CI check to make sure we can start in watch mode with no `static` directory

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Extension authors get watch mode back.  Watch mode is more robust.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None 

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
