### PR TITLE
[1.2.x] Fix watch mode and add CI Test

### DIFF
--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -31,7 +31,10 @@ test_flags['dev-mode'] = (
     {'BrowserApp': {'dev_mode': True}},
     "Start the app in dev mode."
 )
-
+test_flags['watch'] = (
+    {'BrowserApp': {'watch': True}},
+    "Start the app in watch mode."
+)
 
 test_aliases = dict(aliases)
 test_aliases['app-dir'] = 'BrowserApp.app_dir'

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -176,7 +176,7 @@ def load_jupyter_server_extension(nbapp):
             logger.info(DEV_NOTE)
 
     # Make sure the app dir exists.
-    else:
+    elif not watch_mode:
         msgs = ensure_app(app_dir)
         if msgs:
             [logger.error(msg) for msg in msgs]

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -221,6 +221,10 @@ if [[ $GROUP == usage ]]; then
     # Make sure the deprecated `selenium_check` command still works
     python -m jupyterlab.selenium_check
 
+    # Make sure we can run watch mode with no built application
+    jupyter lab clean
+    python -m jupyterlab.browser_check --watch
+
     # Make sure we can non-dev install.
     pip install virtualenv
     virtualenv -p $(which python3) test_install


### PR DESCRIPTION
Fix watch mode and add CI test

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Backport of #8394 


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Restores logic in `webpack.config.js` for locally linked packages. 
- Also fixes a bug where if you didn't have an existing `static` directory, `jupyter lab --watch` would fail because it was checking for the `static` directory at startup.
- Adds a CI check to make sure we can start in watch mode with no `static` directory

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Extension authors get watch mode back.  Watch mode is more robust.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None 

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
