### PR TITLE
replace connection lost dialogue

### DIFF
--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -1,24 +1,19 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { showErrorMessage } from '@jupyterlab/apputils';
-
 import { ServerConnection, ServiceManager } from '@jupyterlab/services';
 
 import { IConnectionLost } from './tokens';
 
 /**
- * A default connection lost handler, which brings up an error dialog.
+ * A default connection lost handler, which does nothing, but
+ * may be overriden by application extensions
  */
 export const ConnectionLost: IConnectionLost = async function(
   manager: ServiceManager.IManager,
   err: ServerConnection.NetworkError
 ): Promise<void> {
-  const title = 'Server Connection Error';
-  const networkMsg =
-    'A connection to the Jupyter server could not be established.\n' +
-    'JupyterLab will continue trying to reconnect.\n' +
-    'Check your network connection or Jupyter server configuration.\n';
-
-  return showErrorMessage(title, { message: networkMsg });
+  return new Promise((res, rej) => {
+    /* do nothing */
+  });
 };

--- a/packages/application/src/connectionlost.ts
+++ b/packages/application/src/connectionlost.ts
@@ -7,7 +7,7 @@ import { IConnectionLost } from './tokens';
 
 /**
  * A default connection lost handler, which does nothing, but
- * may be overriden by application extensions
+ * may be overriden by application extensions.
  */
 export const ConnectionLost: IConnectionLost = async function(
   manager: ServiceManager.IManager,

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -131,6 +131,11 @@ export interface ISessionContext extends IObservableDisposable {
   readonly kernelDisplayName: string;
 
   /**
+   * The connection status of the current kernel.
+   */
+  readonly kernelConnectionStatus: Kernel.ConnectionStatus | undefined;
+
+  /**
    * A sensible status to display
    *
    * #### Notes
@@ -475,6 +480,13 @@ export class SessionContext implements ISessionContext {
       this.specsManager.specs?.kernelspecs[kernel.name]?.display_name ??
       kernel.name
     );
+  }
+
+  /**
+   * The connection status of the current kernel.
+   */
+  get kernelConnectionStatus(): Kernel.ConnectionStatus | undefined {
+    return this.session?.kernel?.connectionStatus;
   }
 
   /**

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -4,8 +4,9 @@
 import { Text } from '@jupyterlab/coreutils';
 import {
   Button,
+  circleCrossIcon,
   circleEmptyIcon,
-  circleIcon,
+  circleTickIcon,
   classes,
   LabIcon,
   refreshIcon,
@@ -727,36 +728,24 @@ namespace Private {
         return;
       }
 
-      const status = sessionContext.kernelDisplayStatus;
+      let icon: LabIcon;
+      const connection_status = sessionContext.kernelConnectionStatus;
+
+      if (connection_status === undefined) {
+        icon = circleEmptyIcon;
+      } else if (connection_status === 'connected') {
+        icon = circleTickIcon;
+      } else {
+        icon = circleCrossIcon;
+      }
 
       // set the icon
-      if (this._isBusy(status)) {
-        circleIcon.element({
-          container: this.node,
-          title: `Kernel ${Text.titleCase(status)}`,
+      icon.element({
+        container: this.node,
+        title: `Kernel ${Text.titleCase(sessionContext.kernelDisplayStatus)}`,
 
-          stylesheet: 'toolbarButton'
-        });
-      } else {
-        circleEmptyIcon.element({
-          container: this.node,
-          title: `Kernel ${Text.titleCase(status)}`,
-
-          stylesheet: 'toolbarButton'
-        });
-      }
-    }
-
-    /**
-     * Check if status should be shown as busy.
-     */
-    private _isBusy(status: ISessionContext.KernelDisplayStatus): boolean {
-      return (
-        status === 'busy' ||
-        status === 'starting' ||
-        status === 'restarting' ||
-        status === 'initializing'
-      );
+        stylesheet: 'toolbarButton'
+      });
     }
   }
 }

--- a/packages/statusbar/src/defaults/kernelStatus.tsx
+++ b/packages/statusbar/src/defaults/kernelStatus.tsx
@@ -63,7 +63,7 @@ namespace KernelStatusComponent {
     status?: string;
 
     /**
-     * Style for the status line
+     * Style for the status line.
      */
     classes: string[];
   }
@@ -142,7 +142,7 @@ export namespace KernelStatus {
     }
 
     /**
-     * extra classes to style the component
+     * extra classes to style the component.
      */
     get classes(): string[] {
       let extra_classes = [];

--- a/packages/statusbar/src/defaults/kernelStatus.tsx
+++ b/packages/statusbar/src/defaults/kernelStatus.tsx
@@ -7,7 +7,7 @@ import { ISessionContext, VDomRenderer, VDomModel } from '@jupyterlab/apputils';
 
 import { Text } from '@jupyterlab/coreutils';
 
-import { Session } from '@jupyterlab/services';
+import { Session, Kernel } from '@jupyterlab/services';
 
 import { interactiveItem, TextItem } from '..';
 
@@ -28,6 +28,7 @@ function KernelStatusComponent(
       onClick={props.handleClick}
       source={`${props.kernelName}${statusText}`}
       title={`Change kernel for ${props.activityName}`}
+      className={props.classes.join(' ')}
     />
   );
 }
@@ -60,6 +61,11 @@ namespace KernelStatusComponent {
      * The status of the kernel.
      */
     status?: string;
+
+    /**
+     * Style for the status line
+     */
+    classes: string[];
   }
 }
 
@@ -89,6 +95,7 @@ export class KernelStatus extends VDomRenderer<KernelStatus.Model> {
           kernelName={this.model.kernelName}
           activityName={this.model.activityName}
           handleClick={this._handleClick}
+          classes={this.model.classes}
         />
       );
     }
@@ -132,6 +139,24 @@ export namespace KernelStatus {
       }
       this._activityName = val;
       this.stateChanged.emit(void 0);
+    }
+
+    /**
+     * extra classes to style the component
+     */
+    get classes(): string[] {
+      let extra_classes = [];
+      if (typeof this.status === 'string') {
+        if (
+          this._CiriticalKernelStatus.includes(this.status as Kernel.Status)
+        ) {
+          extra_classes.push('kernel-status-critical');
+        }
+        if (this.status === 'connecting') {
+          extra_classes.push('waiting-dots');
+        }
+      }
+      return extra_classes;
     }
 
     /**
@@ -196,6 +221,12 @@ export namespace KernelStatus {
     private _kernelName: string = 'No Kernel!';
     private _kernelStatus: string | undefined = '';
     private _sessionContext: ISessionContext | null = null;
+    private _CiriticalKernelStatus: ISessionContext.KernelDisplayStatus[] = [
+      'disconnected',
+      'connecting',
+      'dead',
+      'unknown'
+    ];
   }
 
   /**

--- a/packages/statusbar/src/defaults/kernelStatusComponent.css
+++ b/packages/statusbar/src/defaults/kernelStatusComponent.css
@@ -1,5 +1,5 @@
 /**
-* font style for a critical kernel status
+* font style for a critical kernel status.
 */
 .kernel-status-critical {
   color: red !important;
@@ -7,7 +7,7 @@
 }
 
 /**
-* waiting dots animation
+* waiting dots animation.
 */
 .waiting-dots:after {
   content: ' .';

--- a/packages/statusbar/src/defaults/kernelStatusComponent.css
+++ b/packages/statusbar/src/defaults/kernelStatusComponent.css
@@ -2,7 +2,7 @@
 * font style for a critical kernel status.
 */
 .kernel-status-critical {
-  color: red !important;
+  color: #c00000 !important;
   font-weight: bold !important;
 }
 
@@ -21,14 +21,14 @@
     text-shadow: 0.25em 0 0 rgba(0, 0, 0, 0), 0.5em 0 0 rgba(0, 0, 0, 0);
   }
   40% {
-    color: red;
+    color: #c00000;
     text-shadow: 0.25em 0 0 rgba(0, 0, 0, 0), 0.5em 0 0 rgba(0, 0, 0, 0);
   }
   60% {
-    text-shadow: 0.25em 0 0 red, 0.5em 0 0 rgba(0, 0, 0, 0);
+    text-shadow: 0.25em 0 0 #c00000, 0.5em 0 0 rgba(0, 0, 0, 0);
   }
   80%,
   100% {
-    text-shadow: 0.25em 0 0 red, 0.5em 0 0 red;
+    text-shadow: 0.25em 0 0 #c00000, 0.5em 0 0 #c00000;
   }
 }

--- a/packages/statusbar/src/defaults/kernelStatusComponent.css
+++ b/packages/statusbar/src/defaults/kernelStatusComponent.css
@@ -1,0 +1,34 @@
+/**
+* font style for a critical kernel status
+*/
+.kernel-status-critical {
+  color: red !important;
+  font-weight: bold !important;
+}
+
+/**
+* waiting dots animation
+*/
+.waiting-dots:after {
+  content: ' .';
+  animation: dots 1s steps(5, end) infinite;
+}
+
+@keyframes dots {
+  0%,
+  20% {
+    color: rgba(0, 0, 0, 0);
+    text-shadow: 0.25em 0 0 rgba(0, 0, 0, 0), 0.5em 0 0 rgba(0, 0, 0, 0);
+  }
+  40% {
+    color: red;
+    text-shadow: 0.25em 0 0 rgba(0, 0, 0, 0), 0.5em 0 0 rgba(0, 0, 0, 0);
+  }
+  60% {
+    text-shadow: 0.25em 0 0 red, 0.5em 0 0 rgba(0, 0, 0, 0);
+  }
+  80%,
+  100% {
+    text-shadow: 0.25em 0 0 red, 0.5em 0 0 red;
+  }
+}

--- a/packages/statusbar/style/index.css
+++ b/packages/statusbar/style/index.css
@@ -6,3 +6,5 @@
 @import url('~@lumino/widgets/style/index.css');
 @import url('~@jupyterlab/ui-components/style/index.css');
 @import url('~@jupyterlab/apputils/style/index.css');
+
+@import url('../src/defaults/kernelStatusComponent.css');

--- a/packages/ui-components/src/icon/iconimports.ts
+++ b/packages/ui-components/src/icon/iconimports.ts
@@ -20,8 +20,10 @@ import caretUpEmptyThinSvgstr from '../../style/icons/arrow/caret-up-empty-thin.
 import caretUpSvgstr from '../../style/icons/arrow/caret-up.svg';
 import caseSensitiveSvgstr from '../../style/icons/search/case-sensitive.svg';
 import checkSvgstr from '../../style/icons/toolbar/check.svg';
+import circleCrossSvgstr from '../../style/icons/toolbar/circle-cross.svg';
 import circleEmptySvgstr from '../../style/icons/toolbar/circle-empty.svg';
 import circleSvgstr from '../../style/icons/toolbar/circle.svg';
+import circleTickSvgstr from '../../style/icons/toolbar/circle-tick.svg';
 import clearSvgstr from '../../style/icons/toolbar/clear.svg';
 import closeSvgstr from '../../style/icons/toolbar/close.svg';
 import consoleSvgstr from '../../style/icons/filetype/console.svg';
@@ -89,8 +91,10 @@ export const caretUpEmptyThinIcon = new LabIcon({ name: 'ui-components:caret-up-
 export const caretUpIcon = new LabIcon({ name: 'ui-components:caret-up', svgstr: caretUpSvgstr });
 export const caseSensitiveIcon = new LabIcon({ name: 'ui-components:case-sensitive', svgstr: caseSensitiveSvgstr });
 export const checkIcon = new LabIcon({ name: 'ui-components:check', svgstr: checkSvgstr });
+export const circleCrossIcon = new LabIcon({ name: 'ui-components:circle-cross', svgstr: circleCrossSvgstr });
 export const circleEmptyIcon = new LabIcon({ name: 'ui-components:circle-empty', svgstr: circleEmptySvgstr });
 export const circleIcon = new LabIcon({ name: 'ui-components:circle', svgstr: circleSvgstr });
+export const circleTickIcon = new LabIcon({ name: 'ui-components:circle-tick', svgstr: circleTickSvgstr });
 export const clearIcon = new LabIcon({ name: 'ui-components:clear', svgstr: clearSvgstr });
 export const closeIcon = new LabIcon({ name: 'ui-components:close', svgstr: closeSvgstr });
 export const consoleIcon = new LabIcon({ name: 'ui-components:console', svgstr: consoleSvgstr });

--- a/packages/ui-components/src/icon/labicon.tsx
+++ b/packages/ui-components/src/icon/labicon.tsx
@@ -321,7 +321,12 @@ export class LabIcon implements LabIcon.ILabIcon, VirtualElement.IRenderer {
 
     // check if icon element is already set
     const maybeSvgElement = container?.firstChild as HTMLElement;
-    if (maybeSvgElement?.dataset?.iconId === this._uuid) {
+    if (
+      maybeSvgElement?.dataset?.iconId === this._uuid &&
+      container?.title === title &&
+      container?.textContent === label &&
+      container?.tagName === tag
+    ) {
       // return the existing icon element
       return maybeSvgElement;
     }

--- a/packages/ui-components/style/deprecated.css
+++ b/packages/ui-components/style/deprecated.css
@@ -24,7 +24,9 @@
   --jp-icon-caret-up: url('icons/arrow/caret-up.svg');
   --jp-icon-case-sensitive: url('icons/search/case-sensitive.svg');
   --jp-icon-check: url('icons/toolbar/check.svg');
+  --jp-icon-circle-cross: url('icons/toolbar/circle-cross.svg');
   --jp-icon-circle-empty: url('icons/toolbar/circle-empty.svg');
+  --jp-icon-circle-tick: url('icons/toolbar/circle-tick.svg');
   --jp-icon-circle: url('icons/toolbar/circle.svg');
   --jp-icon-clear: url('icons/toolbar/clear.svg');
   --jp-icon-close: url('icons/toolbar/close.svg');
@@ -119,11 +121,17 @@
 .jp-CheckIcon {
   background-image: var(--jp-icon-check);
 }
+.jp-CircleCrossIcon {
+  background-image: var(--jp-icon-circle-cross);
+}
 .jp-CircleEmptyIcon {
   background-image: var(--jp-icon-circle-empty);
 }
 .jp-CircleIcon {
   background-image: var(--jp-icon-circle);
+}
+.jp-CircleTickIcon {
+  background-image: var(--jp-icon-circle-tick);
 }
 .jp-ClearIcon {
   background-image: var(--jp-icon-clear);

--- a/packages/ui-components/style/icons/toolbar/circle-cross.svg
+++ b/packages/ui-components/style/icons/toolbar/circle-cross.svg
@@ -1,18 +1,18 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="200mm" height="200mm" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <g transform="translate(0,-97)">
-  <circle cx="100" cy="197" r="100" fill="#8a0000" stroke-width=".68207"/>
-  <circle cx="100" cy="197" r="97" fill="#c00000" stroke-width=".82224"/>
-  <rect transform="rotate(45)" x="153.15" y="60.319" width="113.72" height="16.541" ry="2.5478" fill="#fff" stroke-width=".25406"/>
-  <rect transform="rotate(-45)" x="-125.45" y="201.74" width="113.72" height="16.541" ry="2.5478" fill="#fff" stroke-width=".25406"/>
- </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" viewBox="0 0 24 24">
+  <g class="jp-icon3">
+    <circle cx="12" cy="12" r="9"
+            fill="#C00000"
+            stroke="#A30000"
+            stroke-width="2"/>
+
+    <g transform="translate(5 11)">
+        <rect width="14" height="2" rx="0.5"
+            fill="white"
+            transform="rotate(45, 7, 1)"/>
+
+        <rect width="14" height="2" rx="0.5"
+            fill="white"
+            transform="rotate(-45, 7, 1)"/>
+    </g>
+  </g>
 </svg>

--- a/packages/ui-components/style/icons/toolbar/circle-cross.svg
+++ b/packages/ui-components/style/icons/toolbar/circle-cross.svg
@@ -1,0 +1,18 @@
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="200mm" height="200mm" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g transform="translate(0,-97)">
+  <circle cx="100" cy="197" r="100" fill="#8a0000" stroke-width=".68207"/>
+  <circle cx="100" cy="197" r="97" fill="#c00000" stroke-width=".82224"/>
+  <rect transform="rotate(45)" x="153.15" y="60.319" width="113.72" height="16.541" ry="2.5478" fill="#fff" stroke-width=".25406"/>
+  <rect transform="rotate(-45)" x="-125.45" y="201.74" width="113.72" height="16.541" ry="2.5478" fill="#fff" stroke-width=".25406"/>
+ </g>
+</svg>

--- a/packages/ui-components/style/icons/toolbar/circle-tick.svg
+++ b/packages/ui-components/style/icons/toolbar/circle-tick.svg
@@ -1,0 +1,20 @@
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="200mm" height="200mm" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g>
+  <circle cx="100" cy="100" r="100" fill="#017d39" stroke-width=".4187"/>
+  <circle cx="100" cy="100" r="97" fill="#00b050" stroke-width=".25661"/>
+  <g transform="matrix(1.0099 0 0 1 -6.6322 -2.162)" fill="#fff">
+   <rect transform="rotate(135)" x="-69.76" y="-165.28" width="114.29" height="16.382" ry="2.9053" stroke-width=".27202"/>
+   <rect transform="rotate(45)" x="108.14" y="28.151" width="57.147" height="16.382" ry="2.9053" stroke-width=".19234"/>
+  </g>
+ </g>
+</svg>

--- a/packages/ui-components/style/icons/toolbar/circle-tick.svg
+++ b/packages/ui-components/style/icons/toolbar/circle-tick.svg
@@ -1,20 +1,22 @@
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="200mm" height="200mm" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
- <metadata>
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-    <dc:format>image/svg+xml</dc:format>
-    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:title/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <g>
-  <circle cx="100" cy="100" r="100" fill="#017d39" stroke-width=".4187"/>
-  <circle cx="100" cy="100" r="97" fill="#00b050" stroke-width=".25661"/>
-  <g transform="matrix(1.0099 0 0 1 -6.6322 -2.162)" fill="#fff">
-   <rect transform="rotate(135)" x="-69.76" y="-165.28" width="114.29" height="16.382" ry="2.9053" stroke-width=".27202"/>
-   <rect transform="rotate(45)" x="108.14" y="28.151" width="57.147" height="16.382" ry="2.9053" stroke-width=".19234"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" viewBox="0 0 24 24">
+  <g class="jp-icon3">
+    <circle cx="12" cy="12" r="9"
+            fill="#00b050"
+            stroke="#017d39"
+            stroke-width="2"/>
+
+    <g transform="translate(5.636038969321072 16.949747468305834)">
+      <rect width="6" height="2" rx="0.5"
+            x="-0.17157287525381015"
+            y="-3.82842712474619"
+            fill="white"
+            transform="rotate(45, 2.82842712474619, -2.82842712474619)"/>
+
+      <rect width="12" height="2" rx="0.5"
+            x="1.7781745930520225"
+            y="-5.949747468305833"
+            fill="white"
+            transform="rotate(-45, 7.7781745930520225, -4.949747468305833)"/>
+    </g>
   </g>
- </g>
 </svg>


### PR DESCRIPTION
remove the dialogue that appears when a connection to the server is lost, and replace it with styling to the kernelStatusComponent in the status bar.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

fixes: #8374
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Replace the default handler of the connection lost signal with a stump method
- Add some CSS styling to the kernelStatusComponent so that critical kernel statuses (connecting, disconnected, unknown, dead) show up in bold red

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
before:
![image](https://user-images.githubusercontent.com/5771435/81415218-6e27db00-9148-11ea-921b-91443a57e5f9.png)

after:
![image](https://user-images.githubusercontent.com/5771435/81415245-7849d980-9148-11ea-9753-2c4a8f19b16f.png)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
