### PR TITLE
Increase the link expiry to one week

### DIFF
--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -48,7 +48,9 @@ if [[ $GROUP == docs ]]; then
     mkdir -p ${CACHE_DIR}
     echo "Existing cache:"
     ls -ltr ${CACHE_DIR}
-    args="--check-links --check-links-cache --check-links-cache-expire-after 86400 --check-links-cache-name ${CACHE_DIR}/cache"
+    # Expire links after a week
+    LINKS_EXPIRE=604800
+    args="--check-links --check-links-cache --check-links-cache-expire-after ${LINKS_EXPIRE} --check-links-cache-name ${CACHE_DIR}/cache"
     args="--ignore docs/build/html/genindex.html --ignore docs/build/html/search.html ${args}"
     py.test $args --links-ext .html -k .html docs/build/html || py.test $args --links-ext .html -k .html --lf docs/build/html
 
@@ -57,7 +59,7 @@ if [[ $GROUP == docs ]]; then
     jlpm docs
 
     # Run the link check on md files - allow for a link to fail once (--lf means only run last failed)
-    args="--check-links --check-links-cache --check-links-cache-expire-after 86400 --check-links-cache-name ${CACHE_DIR}/cache"
+    args="--check-links --check-links-cache --check-links-cache-expire-after ${LINKS_EXPIRE} --check-links-cache-name ${CACHE_DIR}/cache"
     py.test $args --links-ext .md -k .md . || py.test $args --links-ext .md -k .md --lf .
 fi
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Follow up to #8354.  The one day expiry was too long, leading to initial PR runs with no effective cache.  Bumping to one week.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Increase expiry of link cache.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Faster CI.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
