### PR TITLE
[1.2.x] Fix docs and integrity

### DIFF
--- a/buildutils/src/ensure-package.ts
+++ b/buildutils/src/ensure-package.ts
@@ -374,7 +374,7 @@ export async function ensureUiComponents(
   const iconModelDeclarations = _iconModelDeclarations.join(',\n');
 
   // generate the actual contents of the iconImports file
-  const iconImportsPath = path.join(iconSrcDir, 'iconImports.ts');
+  const iconImportsPath = path.join(iconSrcDir, 'iconimports.ts');
   const iconImportsContents = utils.fromTemplate(
     HEADER_TEMPLATE + ICON_IMPORTS_TEMPLATE,
     { funcName, iconImportStatements, iconModelDeclarations }

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -335,6 +335,10 @@ export async function ensureIntegrity(): Promise<boolean> {
 
   // Validate each package.
   for (let name in locals) {
+    // application-top is handled elsewhere
+    if (name === '@jupyterlab/application-top') {
+      continue;
+    }
     let unused = UNUSED[name] || [];
     // Allow jest-junit to be unused in the test suite.
     if (name.indexOf('@jupyterlab/test-') === 0) {
@@ -381,17 +385,13 @@ export async function ensureIntegrity(): Promise<boolean> {
   // Handle the JupyterLab application top package.
   pkgMessages = ensureJupyterlab();
   if (pkgMessages.length > 0) {
-    let pkgName = '@jupyterlab/application-top';
-    if (!messages[pkgName]) {
-      messages[pkgName] = [];
-    }
-    messages[pkgName] = messages[pkgName].concat(pkgMessages);
+    messages['@application/top'] = pkgMessages;
   }
 
   // Handle any messages.
   if (Object.keys(messages).length > 0) {
     console.log(JSON.stringify(messages, null, 2));
-    if ('--force' in process.argv) {
+    if (process.argv.indexOf('--force') !== -1) {
       console.log(
         '\n\nPlease run `jlpm run integrity` locally and commit the changes'
       );

--- a/docs/source/getting_started/changelog.rst
+++ b/docs/source/getting_started/changelog.rst
@@ -7,7 +7,7 @@ JupyterLab Changelog
 ---------------------------------------------------------------------------
 
 v1.2.15
-~~~~~~~
+^^^^^^^
 * Fix watch mode and add CI Test (`#8396 <https://github.com/jupyterlab/jupyterlab/pull/8396>`__)
 
 v1.2.14

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -42,12 +42,6 @@
     "@jupyterlab/rendermime": "^1.2.8"
   },
   "devDependencies": {
-    "@jupyterlab/apputils": "^1.2.8",
-    "@jupyterlab/cells": "^1.2.9",
-    "@jupyterlab/codemirror": "^1.2.8",
-    "@jupyterlab/notebook": "^1.2.9",
-    "@jupyterlab/outputarea": "^1.2.9",
-    "@jupyterlab/rendermime": "^1.2.8",
     "css-loader": "~2.1.1",
     "file-loader": "~3.0.1",
     "mini-css-extract-plugin": "~0.6.0",

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+# Make sure the docs build
+pushd docs
+pip install -r requirements.txt
+make html
+popd
+
 # Init conda
 . $(conda info --base)/etc/profile.d/conda.sh
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes broken build in 1.2.x and backports some integrity fixes.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Fixes changelog syntax, adds docs build to release test.
- Also backports relevant integrity fixes from #7651 - `ensure_repo` and duplicate deps in `nbconvert-css`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
