### PR TITLE
Add data attribute to papermill parameter cells

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -326,6 +326,9 @@ export class Cell extends Widget {
     this.readOnly = this.model.metadata.get('editable') === false;
   }
 
+  /**
+   * Checks if cell has the papermill 'parameters' tag, and sets a CSS attribute accordingly.
+   */
   checkParameters() {
     if (this.model.metadata.has('parameters')) {
       this.node.setAttribute('data-parameter-cell', 'true');
@@ -532,7 +535,7 @@ export class Cell extends Widget {
         break;
       case 'tags':
         this.checkParameters();
-        break; ////
+        break;
       default:
         break;
     }

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -167,7 +167,6 @@ const CONTENTS_MIME_RICH = 'application/x-jupyter-icontentsrich';
 /** ****************************************************************************
  * Cell
  ******************************************************************************/
-
 /**
  * A base cell widget.
  */
@@ -325,6 +324,14 @@ export class Cell extends Widget {
    */
   loadEditableState() {
     this.readOnly = this.model.metadata.get('editable') === false;
+  }
+
+  checkParameters() {
+    if (this.model.metadata.has('parameters')) {
+      this.node.setAttribute('data-parameter-cell', 'true');
+    } else {
+      this.node.removeAttribute('data-parameter-cell');
+    }
   }
 
   /**
@@ -523,6 +530,9 @@ export class Cell extends Widget {
           this.loadEditableState();
         }
         break;
+      case 'tags':
+        this.checkParameters();
+        break; ////
       default:
         break;
     }


### PR DESCRIPTION
## References

#8298 Add Data Attribute to Parameter Cells

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Create a new case in the Metadata change handler that checks for a 'tags' key in the metadata. Then, this case calls a new function checkParameters() which checks if the metadata has a 'parameters' tag, and sets or removes a 'data-parameter-cell' attribute in the cell's CSS.

## User-facing changes

None

## Backwards-incompatible changes

None I am aware of
