### PR TITLE
Specify that we recomend typescript over JS for extensions

### DIFF
--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -2,7 +2,6 @@
 
 Extension Developer Guide
 -------------------------
-
 JupyterLab can be extended in four ways via:
 
 -  **application plugins (top level):** Application plugins extend the
@@ -20,6 +19,9 @@ A JupyterLab application is comprised of:
 
 -  A core Application object
 -  Plugins
+
+We recommend writing extensions in Typescript, but technically it doesn't matter what you write them in
+as long as they can be packaged as standard Javascript. 
 
 Tutorials
 ~~~~~~~~~

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -21,6 +21,7 @@ A JupyterLab application is comprised of:
 -  Plugins
 
 Extensions are distributed as JavaScript packages, so you can write extensions in JavaScript or any language that compiles to JavaScript. We recommend writing extensions in TypeScript, which is used for the JupyterLab core extensions and many popular community extensions.
+
 Tutorials
 ~~~~~~~~~
 

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -20,9 +20,7 @@ A JupyterLab application is comprised of:
 -  A core Application object
 -  Plugins
 
-We recommend writing extensions in Typescript, but technically it doesn't matter what you write them in
-as long as they can be packaged as standard Javascript. 
-
+Extensions are distributed as JavaScript packages, so you can write extensions in JavaScript or any language that compiles to JavaScript. We recommend writing extensions in TypeScript, which is used for the JupyterLab core extensions and many popular community extensions.
 Tutorials
 ~~~~~~~~~
 

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -20,7 +20,7 @@ A JupyterLab application is comprised of:
 -  A core Application object
 -  Plugins
 
-Extensions are distributed as JavaScript packages, so you can write extensions in JavaScript or any language that compiles to JavaScript. We recommend writing extensions in [TypeScript](https://www.typescriptlang.org/), which is used for the JupyterLab core extensions and many popular community extensions.
+Extensions are distributed as JavaScript packages, so you can write extensions in JavaScript or any language that compiles to JavaScript. We recommend writing extensions in `TypeScript <https://www.typescriptlang.org/>`_, which is used for the JupyterLab core extensions and many popular community extensions.
 
 Tutorials
 ~~~~~~~~~

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -20,7 +20,7 @@ A JupyterLab application is comprised of:
 -  A core Application object
 -  Plugins
 
-Extensions are distributed as JavaScript packages, so you can write extensions in JavaScript or any language that compiles to JavaScript. We recommend writing extensions in TypeScript, which is used for the JupyterLab core extensions and many popular community extensions.
+Extensions are distributed as JavaScript packages, so you can write extensions in JavaScript or any language that compiles to JavaScript. We recommend writing extensions in [TypeScript](https://www.typescriptlang.org/), which is used for the JupyterLab core extensions and many popular community extensions.
 
 Tutorials
 ~~~~~~~~~


### PR DESCRIPTION
While it's true that you can write extension in JS, most/all public ones are written in Typescript. So socially you really have to write them in typescript to feel at home. We should make that explicit and be honest about that.