### PR TITLE
Enable horizontal scrolling for toolbars

### DIFF
--- a/packages/application/style/scrollbar.css
+++ b/packages/application/style/scrollbar.css
@@ -20,6 +20,13 @@
   scrollbar-color: rgba(var(--jp-scrollbar-thumb-color), 0.5) transparent;
 }
 
+/* tiny scrollbar */
+
+.jp-scrollbar-tiny {
+  scrollbar-color: rgba(var(--jp-scrollbar-thumb-color), 0.5) transparent;
+  scrollbar-width: thin;
+}
+
 /*
  * Webkit scrollbar styling
  */
@@ -83,6 +90,29 @@
   .CodeMirror-vscrollbar::-webkit-scrollbar-track:vertical {
   border-top: var(--jp-scrollbar-endpad) solid transparent;
   border-bottom: var(--jp-scrollbar-endpad) solid transparent;
+}
+
+/* tiny scrollbar */
+
+.jp-scrollbar-tiny::-webkit-scrollbar,
+.jp-scrollbar-tiny::-webkit-scrollbar-corner {
+  background-color: transparent;
+  height: 4px;
+  width: 4px;
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-thumb {
+  background: rgba(var(--jp-scrollbar-thumb-color), 0.5);
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-track:horizontal {
+  border-left: 0px solid transparent;
+  border-right: 0px solid transparent;
+}
+
+.jp-scrollbar-tiny::-webkit-scrollbar-track:vertical {
+  border-top: 0px solid transparent;
+  border-bottom: 0px solid transparent;
 }
 
 /*

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -178,6 +178,7 @@ export class Toolbar<T extends Widget = Widget> extends Widget {
   constructor() {
     super();
     this.addClass(TOOLBAR_CLASS);
+    this.addClass('jp-scrollbar-tiny');
     this.layout = new ToolbarLayout();
   }
 

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -736,14 +736,18 @@ namespace Private {
           container: this.node,
           title: `Kernel ${Text.titleCase(status)}`,
 
-          stylesheet: 'toolbarButton'
+          stylesheet: 'toolbarButton',
+          alignSelf: 'normal',
+          height: '24px'
         });
       } else {
         circleEmptyIcon.element({
           container: this.node,
           title: `Kernel ${Text.titleCase(status)}`,
 
-          stylesheet: 'toolbarButton'
+          stylesheet: 'toolbarButton',
+          alignSelf: 'normal',
+          height: '24px'
         });
       }
     }

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -21,6 +21,10 @@
   min-height: var(--jp-toolbar-micro-height);
   padding: 2px;
   z-index: 1;
+  overflow-x: hidden;
+}
+
+.jp-Toolbar:hover {
   overflow-x: auto;
 }
 

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -21,6 +21,7 @@
   min-height: var(--jp-toolbar-micro-height);
   padding: 2px;
   z-index: 1;
+  overflow-x: auto;
 }
 
 /* Toolbar items */


### PR DESCRIPTION
## References

This is a small step in the direction of https://github.com/jupyterlab/jupyterlab/issues/3275, to make JupyterLab more accessible on mobile.

More precisely about the notebook toolbar as mentioned in this comment: https://github.com/jupyterlab/jupyterlab/issues/3275#issuecomment-618470517

The idea is to be able to reach all the buttons of the toolbar on a mobile device (see screencast below).

## Code changes

CSS change to enable scrolling for the toolbars.

## User-facing changes

### Before

See https://github.com/jupyterlab/jupyterlab/issues/3275#issuecomment-618470517.

![Screen Shot 2020-05-12 at 20 47 49](https://user-images.githubusercontent.com/591645/81733237-f7fdde00-9491-11ea-9d5e-fe3c6181b33a.png)


### After

In the dev tools in mobile device mode:

![toolbar-scroll-firefox](https://user-images.githubusercontent.com/591645/81733090-bb31e700-9491-11ea-96ab-a4b1695b8e3c.gif)

On mobile (after scrolling to the right):

![image](https://user-images.githubusercontent.com/591645/81732961-8e7dcf80-9491-11ea-9678-8ec9a9be9512.png)

## Backwards-incompatible changes

None