### PR TITLE
File editor right-click

### DIFF
--- a/packages/fileeditor-extension/package.json
+++ b/packages/fileeditor-extension/package.json
@@ -39,6 +39,7 @@
     "@jupyterlab/application": "^2.2.0-alpha.0",
     "@jupyterlab/apputils": "^2.2.0-alpha.0",
     "@jupyterlab/codeeditor": "^2.2.0-alpha.0",
+    "@jupyterlab/codemirror": "^2.2.0-alpha.0",
     "@jupyterlab/console": "^2.2.0-alpha.0",
     "@jupyterlab/coreutils": "^4.2.0-alpha.0",
     "@jupyterlab/docregistry": "^2.2.0-alpha.0",

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -610,7 +610,8 @@ export namespace Commands {
         if (!widget) {
           return false;
         }
-        // TODO: Enable based if any undo events are stored
+        // Ideally enable it when there are undo events stored
+        // Reference issue #8590: Code mirror editor could expose the history of undo/redo events
         return true;
       },
       icon: undoIcon.bindprops({ stylesheet: 'menuItem' }),
@@ -646,7 +647,8 @@ export namespace Commands {
         if (!widget) {
           return false;
         }
-        // TODO: Enable based if any undo events are stored
+        // Ideally enable it when there are redo events stored
+        // Reference issue #8590: Code mirror editor could expose the history of undo/redo events
         return true;
       },
       icon: redoIcon.bindprops({ stylesheet: 'menuItem' }),
@@ -751,7 +753,7 @@ export namespace Commands {
           return;
         }
 
-        const editor: CodeEditor.IEditor = widget && widget.editor;
+        const editor: CodeEditor.IEditor = widget.editor;
 
         // Get data from clipboard
         const clipboard = window.navigator.clipboard;
@@ -762,9 +764,7 @@ export namespace Commands {
           editor.replaceSelection && editor.replaceSelection(clipboardData);
         }
       },
-      isEnabled: () => {
-        return Boolean(isEnabled() && tracker.currentWidget?.content);
-      },
+      isEnabled: () => Boolean(isEnabled() && tracker.currentWidget?.content),
       icon: pasteIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'Paste'
     });
@@ -789,9 +789,7 @@ export namespace Commands {
         const editor = widget.editor as CodeMirrorEditor;
         editor.execCommand('selectAll');
       },
-      isEnabled: () => {
-        return Boolean(isEnabled() && tracker.currentWidget?.content);
-      },
+      isEnabled: () => Boolean(isEnabled() && tracker.currentWidget?.content),
       label: 'Select All'
     });
   }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -13,6 +13,8 @@ import {
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+
 import { IConsoleTracker } from '@jupyterlab/console';
 
 import { MarkdownCodeBlocks, PathExt } from '@jupyterlab/coreutils';
@@ -81,6 +83,8 @@ export namespace CommandIDs {
   export const copy = 'fileeditor:copy';
 
   export const paste = 'fileeditor:paste';
+
+  export const selectAll = 'fileeditor:select-all';
 }
 
 /**
@@ -209,6 +213,8 @@ export namespace Commands {
     addCopyCommand(commands, tracker, isEnabled);
 
     addPasteCommand(commands, tracker, isEnabled);
+
+    addSelectAllCommand(commands, tracker, isEnabled);
   }
 
   /**
@@ -583,10 +589,9 @@ export namespace Commands {
         // Get the selected code from the editor.
         const start = editor.getOffsetAt(selectionObj.start);
         const end = editor.getOffsetAt(selectionObj.end);
-        const code = editor.model.value.text.substring(start, end);
+        const text = editor.model.value.text.substring(start, end);
 
-        // Copy code selection to system clipboard
-        Clipboard.copyToSystem(code);
+        Clipboard.copyToSystem(text);
       },
       isEnabled: () => {
         if (!isEnabled()) {
@@ -641,6 +646,32 @@ export namespace Commands {
       },
       icon: pasteIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'Paste'
+    });
+  }
+
+  /**
+   * Add select all command
+   */
+  export function addSelectAllCommand(
+    commands: CommandRegistry,
+    tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
+    isEnabled: () => boolean
+  ) {
+    commands.addCommand(CommandIDs.selectAll, {
+      execute: () => {
+        const widget = tracker.currentWidget?.content;
+
+        if (!widget) {
+          return;
+        }
+
+        const editor = widget.editor as CodeMirrorEditor;
+        editor.execCommand('selectAll');
+      },
+      isEnabled: () => {
+        return Boolean(isEnabled() && tracker.currentWidget?.content);
+      },
+      label: 'Select All'
     });
   }
 
@@ -1022,6 +1053,7 @@ export namespace Commands {
     addMarkdownPreviewToContextMenu(app);
     addCopyCommandToContextMenu(app);
     addPasteCommandToContextMenu(app);
+    addSelectAllCommandToContextMenu(app);
   }
 
   /**
@@ -1063,6 +1095,17 @@ export namespace Commands {
       command: CommandIDs.paste,
       selector: '.jp-FileEditor',
       rank: 2
+    });
+  }
+
+  /**
+   * Add a Select All item to the File Editor context menu
+   */
+  export function addSelectAllCommandToContextMenu(app: JupyterFrontEnd) {
+    app.contextMenu.addItem({
+      command: CommandIDs.selectAll,
+      selector: '.jp-FileEditor',
+      rank: 3
     });
   }
 }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -637,17 +637,7 @@ export namespace Commands {
         }
       },
       isEnabled: () => {
-        if (!isEnabled()) {
-          return false;
-        }
-
-        const widget = tracker.currentWidget?.content;
-
-        if (!widget) {
-          return false;
-        }
-
-        return true;
+        return Boolean(isEnabled() && tracker.currentWidget?.content);
       },
       icon: pasteIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'Paste'

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -542,7 +542,7 @@ export namespace Commands {
   }
 
   /**
-   * Add the command
+   * Add markdown preview command
    */
   export function addMarkdownPreviewCommand(
     commands: CommandRegistry,
@@ -588,13 +588,8 @@ export namespace Commands {
           return;
         }
 
-        const editor = widget.editor;
-        const selectionObj = widget.editor.getSelection();
-
-        // Get the selected code from the editor.
-        const start = editor.getOffsetAt(selectionObj.start);
-        const end = editor.getOffsetAt(selectionObj.end);
-        const text = editor.model.value.text.substring(start, end);
+        const editor = widget.editor as CodeMirrorEditor;
+        const text = getTextSelection(editor);
 
         Clipboard.copyToSystem(text);
         editor.replaceSelection && editor.replaceSelection('');
@@ -611,11 +606,7 @@ export namespace Commands {
         }
 
         // Enable command if there is a text selection in the editor
-        const selectionObj = widget.editor.getSelection();
-        const { start, end } = selectionObj;
-        const selected = start.column !== end.column || start.line !== end.line;
-
-        return selected;
+        return isSelected(widget.editor as CodeMirrorEditor);
       },
       icon: cutIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'Cut'
@@ -638,13 +629,8 @@ export namespace Commands {
           return;
         }
 
-        const editor = widget.editor;
-        const selectionObj = widget.editor.getSelection();
-
-        // Get the selected code from the editor.
-        const start = editor.getOffsetAt(selectionObj.start);
-        const end = editor.getOffsetAt(selectionObj.end);
-        const text = editor.model.value.text.substring(start, end);
+        const editor = widget.editor as CodeMirrorEditor;
+        const text = getTextSelection(editor);
 
         Clipboard.copyToSystem(text);
       },
@@ -660,11 +646,7 @@ export namespace Commands {
         }
 
         // Enable command if there is a text selection in the editor
-        const selectionObj = widget.editor.getSelection();
-        const { start, end } = selectionObj;
-        const selected = start.column !== end.column || start.line !== end.line;
-
-        return selected;
+        return isSelected(widget.editor as CodeMirrorEditor);
       },
       icon: copyIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'Copy'
@@ -686,13 +668,15 @@ export namespace Commands {
         if (!widget) {
           return;
         }
+
         const editor: CodeEditor.IEditor = widget && widget.editor;
 
         // Get data from clipboard
         const clipboard = window.navigator.clipboard;
         const clipboardData: string = await clipboard.readText();
+
         if (clipboardData) {
-          // Paste data to editor
+          // Paste data to the editor
           editor.replaceSelection && editor.replaceSelection(clipboardData);
         }
       },
@@ -728,6 +712,29 @@ export namespace Commands {
       },
       label: 'Select All'
     });
+  }
+
+  /**
+   * Helper function to check if there is a text selection in the editor
+   */
+  function isSelected(editor: CodeMirrorEditor) {
+    const selectionObj = editor.getSelection();
+    const { start, end } = selectionObj;
+    const selected = start.column !== end.column || start.line !== end.line;
+
+    return selected;
+  }
+
+  /**
+   * Helper function to get text selection from the editor
+   */
+  function getTextSelection(editor: CodeMirrorEditor) {
+    const selectionObj = editor.getSelection();
+    const start = editor.getOffsetAt(selectionObj.start);
+    const end = editor.getOffsetAt(selectionObj.end);
+    const text = editor.model.value.text.substring(start, end);
+
+    return text;
   }
 
   /**

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -1230,7 +1230,7 @@ export namespace Commands {
     app.contextMenu.addItem({
       command: CommandIDs.undo,
       selector: '.jp-FileEditor',
-      rank: 0
+      rank: 1
     });
   }
 
@@ -1241,7 +1241,7 @@ export namespace Commands {
     app.contextMenu.addItem({
       command: CommandIDs.redo,
       selector: '.jp-FileEditor',
-      rank: 0
+      rank: 2
     });
   }
 
@@ -1252,7 +1252,7 @@ export namespace Commands {
     app.contextMenu.addItem({
       command: CommandIDs.cut,
       selector: '.jp-FileEditor',
-      rank: 1
+      rank: 3
     });
   }
 
@@ -1263,7 +1263,7 @@ export namespace Commands {
     app.contextMenu.addItem({
       command: CommandIDs.copy,
       selector: '.jp-FileEditor',
-      rank: 2
+      rank: 4
     });
   }
 
@@ -1274,7 +1274,7 @@ export namespace Commands {
     app.contextMenu.addItem({
       command: CommandIDs.paste,
       selector: '.jp-FileEditor',
-      rank: 3
+      rank: 5
     });
   }
 
@@ -1285,7 +1285,7 @@ export namespace Commands {
     app.contextMenu.addItem({
       command: CommandIDs.selectAll,
       selector: '.jp-FileEditor',
-      rank: 4
+      rank: 6
     });
   }
 }

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -40,6 +40,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import {
   markdownIcon,
   textEditorIcon,
+  undoIcon,
   cutIcon,
   copyIcon,
   pasteIcon
@@ -80,6 +81,8 @@ export namespace CommandIDs {
   export const runAllCode = 'fileeditor:run-all';
 
   export const markdownPreview = 'fileeditor:markdown-preview';
+
+  export const undo = 'fileeditor:undo';
 
   export const cut = 'fileeditor:cut';
 
@@ -212,6 +215,8 @@ export namespace Commands {
 
     // Add a command for creating a new Markdown file.
     addCreateNewMarkdownCommand(commands, browserFactory);
+
+    addUndoCommand(commands, tracker, isEnabled);
 
     addCutCommand(commands, tracker, isEnabled);
 
@@ -569,6 +574,42 @@ export namespace Commands {
         );
       },
       label: 'Show Markdown Preview'
+    });
+  }
+
+  /**
+   * Add undo command
+   */
+  export function addUndoCommand(
+    commands: CommandRegistry,
+    tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
+    isEnabled: () => boolean
+  ) {
+    commands.addCommand(CommandIDs.undo, {
+      execute: () => {
+        const widget = tracker.currentWidget?.content;
+
+        if (!widget) {
+          return;
+        }
+
+        widget.editor.undo();
+      },
+      isEnabled: () => {
+        if (!isEnabled()) {
+          return false;
+        }
+
+        const widget = tracker.currentWidget?.content;
+
+        if (!widget) {
+          return false;
+        }
+        // TODO: Enable based if any undo events are stored
+        return true;
+      },
+      icon: undoIcon.bindprops({ stylesheet: 'menuItem' }),
+      label: 'Undo'
     });
   }
 
@@ -1113,6 +1154,7 @@ export namespace Commands {
   export function addContextMenuItems(app: JupyterFrontEnd) {
     addCreateConsoleToContextMenu(app);
     addMarkdownPreviewToContextMenu(app);
+    addUndoCommandToContextMenu(app);
     addCutCommandToContextMenu(app);
     addCopyCommandToContextMenu(app);
     addPasteCommandToContextMenu(app);
@@ -1136,6 +1178,17 @@ export namespace Commands {
     app.contextMenu.addItem({
       command: CommandIDs.markdownPreview,
       selector: '.jp-FileEditor'
+    });
+  }
+
+  /**
+   * Add a Undo item to the File Editor context menu
+   */
+  export function addUndoCommandToContextMenu(app: JupyterFrontEnd) {
+    app.contextMenu.addItem({
+      command: CommandIDs.undo,
+      selector: '.jp-FileEditor',
+      rank: 0
     });
   }
 

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -38,12 +38,13 @@ import {
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import {
-  markdownIcon,
-  textEditorIcon,
-  undoIcon,
   cutIcon,
   copyIcon,
-  pasteIcon
+  markdownIcon,
+  pasteIcon,
+  redoIcon,
+  textEditorIcon,
+  undoIcon
 } from '@jupyterlab/ui-components';
 
 import { CommandRegistry } from '@lumino/commands';
@@ -83,6 +84,8 @@ export namespace CommandIDs {
   export const markdownPreview = 'fileeditor:markdown-preview';
 
   export const undo = 'fileeditor:undo';
+
+  export const redo = 'fileeditor:redo';
 
   export const cut = 'fileeditor:cut';
 
@@ -217,6 +220,8 @@ export namespace Commands {
     addCreateNewMarkdownCommand(commands, browserFactory);
 
     addUndoCommand(commands, tracker, isEnabled);
+
+    addRedoCommand(commands, tracker, isEnabled);
 
     addCutCommand(commands, tracker, isEnabled);
 
@@ -610,6 +615,42 @@ export namespace Commands {
       },
       icon: undoIcon.bindprops({ stylesheet: 'menuItem' }),
       label: 'Undo'
+    });
+  }
+
+  /**
+   * Add redo command
+   */
+  export function addRedoCommand(
+    commands: CommandRegistry,
+    tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
+    isEnabled: () => boolean
+  ) {
+    commands.addCommand(CommandIDs.redo, {
+      execute: () => {
+        const widget = tracker.currentWidget?.content;
+
+        if (!widget) {
+          return;
+        }
+
+        widget.editor.redo();
+      },
+      isEnabled: () => {
+        if (!isEnabled()) {
+          return false;
+        }
+
+        const widget = tracker.currentWidget?.content;
+
+        if (!widget) {
+          return false;
+        }
+        // TODO: Enable based if any undo events are stored
+        return true;
+      },
+      icon: redoIcon.bindprops({ stylesheet: 'menuItem' }),
+      label: 'Redo'
     });
   }
 
@@ -1155,6 +1196,7 @@ export namespace Commands {
     addCreateConsoleToContextMenu(app);
     addMarkdownPreviewToContextMenu(app);
     addUndoCommandToContextMenu(app);
+    addRedoCommandToContextMenu(app);
     addCutCommandToContextMenu(app);
     addCopyCommandToContextMenu(app);
     addPasteCommandToContextMenu(app);
@@ -1187,6 +1229,17 @@ export namespace Commands {
   export function addUndoCommandToContextMenu(app: JupyterFrontEnd) {
     app.contextMenu.addItem({
       command: CommandIDs.undo,
+      selector: '.jp-FileEditor',
+      rank: 0
+    });
+  }
+
+  /**
+   * Add a Redo item to the File Editor context menu
+   */
+  export function addRedoCommandToContextMenu(app: JupyterFrontEnd) {
+    app.contextMenu.addItem({
+      command: CommandIDs.redo,
       selector: '.jp-FileEditor',
       rank: 0
     });

--- a/packages/fileeditor-extension/tsconfig.json
+++ b/packages/fileeditor-extension/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../codeeditor"
     },
     {
+      "path": "../codemirror"
+    },
+    {
       "path": "../console"
     },
     {

--- a/packages/ui-components/src/icon/iconimports.ts
+++ b/packages/ui-components/src/icon/iconimports.ts
@@ -59,6 +59,7 @@ import pasteSvgstr from '../../style/icons/toolbar/paste.svg';
 import pythonSvgstr from '../../style/icons/filetype/python.svg';
 import rKernelSvgstr from '../../style/icons/filetype/r-kernel.svg';
 import reactSvgstr from '../../style/icons/filetype/react.svg';
+import redoSvgstr from '../../style/icons/toolbar/redo.svg';
 import refreshSvgstr from '../../style/icons/toolbar/refresh.svg';
 import regexSvgstr from '../../style/icons/search/regex.svg';
 import runSvgstr from '../../style/icons/toolbar/run.svg';
@@ -128,6 +129,7 @@ export const pasteIcon = new LabIcon({ name: 'ui-components:paste', svgstr: past
 export const pythonIcon = new LabIcon({ name: 'ui-components:python', svgstr: pythonSvgstr });
 export const rKernelIcon = new LabIcon({ name: 'ui-components:r-kernel', svgstr: rKernelSvgstr });
 export const reactIcon = new LabIcon({ name: 'ui-components:react', svgstr: reactSvgstr });
+export const redoIcon = new LabIcon({ name: 'ui-components:redo', svgstr: redoSvgstr });
 export const refreshIcon = new LabIcon({ name: 'ui-components:refresh', svgstr: refreshSvgstr });
 export const regexIcon = new LabIcon({ name: 'ui-components:regex', svgstr: regexSvgstr });
 export const runIcon = new LabIcon({ name: 'ui-components:run', svgstr: runSvgstr });

--- a/packages/ui-components/style/deprecated.css
+++ b/packages/ui-components/style/deprecated.css
@@ -63,6 +63,7 @@
   --jp-icon-python: url('icons/filetype/python.svg');
   --jp-icon-r-kernel: url('icons/filetype/r-kernel.svg');
   --jp-icon-react: url('icons/filetype/react.svg');
+  --jp-icon-redo: url('icons/toolbar/redo.svg');
   --jp-icon-refresh: url('icons/toolbar/refresh.svg');
   --jp-icon-regex: url('icons/search/regex.svg');
   --jp-icon-run: url('icons/toolbar/run.svg');
@@ -235,6 +236,9 @@
 }
 .jp-ReactIcon {
   background-image: var(--jp-icon-react);
+}
+.jp-RedoIcon {
+  background-image: var(--jp-icon-redo);
 }
 .jp-RefreshIcon {
   background-image: var(--jp-icon-refresh);

--- a/packages/ui-components/style/icons/toolbar/redo.svg
+++ b/packages/ui-components/style/icons/toolbar/redo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg" style="transform:rotateY(180deg);">
+  <g class="jp-icon3" fill="#616161">
+    <path d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"/>
+  </g>
+</svg>

--- a/packages/ui-components/style/icons/toolbar/redo.svg
+++ b/packages/ui-components/style/icons/toolbar/redo.svg
@@ -1,5 +1,5 @@
-<svg viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg" style="transform:rotateY(180deg);">
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="16">
   <g class="jp-icon3" fill="#616161">
-    <path d="M12.5 8c-2.65 0-5.05.99-6.9 2.6L2 7v9h9l-3.62-3.62c1.39-1.16 3.16-1.88 5.12-1.88 3.54 0 6.55 2.31 7.6 5.5l2.37-.78C21.08 11.03 17.15 8 12.5 8z"/>
+      <path d="M0 0h24v24H0z" fill="none"/><path d="M18.4 10.6C16.55 8.99 14.15 8 11.5 8c-4.65 0-8.58 3.03-9.96 7.22L3.9 16c1.05-3.19 4.05-5.5 7.6-5.5 1.95 0 3.73.72 5.12 1.88L13 16h9V7l-3.6 3.6z"/>
   </g>
 </svg>


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#2778 - Improve the right-click menu of the editor
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
New commands added to file editor right-click menu:
- Undo
- Redo (new icon added)
- Cut
- Copy
- Paste
- Select all

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
When right clicking on a file editor with a text selection:
![image](https://user-images.githubusercontent.com/25207344/84947222-d8bd2680-b0b7-11ea-98da-e4907f9131ba.png)

When there is no text selection, cut and copy buttons are disabled

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
