### PR TITLE
Merge cell attachments when merging cells

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -14,7 +14,7 @@ import {
   CodeCell,
   Cell,
   MarkdownCell,
-  IMarkdownCellModel
+  AttachmentsCellModel
 } from '@jupyterlab/cells';
 
 import * as nbformat from '@jupyterlab/nbformat';
@@ -206,9 +206,10 @@ export namespace NotebookActions {
         if (index !== active) {
           toDelete.push(child.model);
         }
-        // Merge attachments if the cell is a markdown cell
-        if (child.model.type === 'markdown') {
-          const model = (child as MarkdownCell).model;
+        // Merge attachments if the cell is a markdown cell or a raw cell
+        const type = child.model.type;
+        if (type === 'markdown' || type === 'raw') {
+          const model = child.model as AttachmentsCellModel;
           for (const key of model.attachments.keys) {
             attachments[key] = model.attachments.get(key)!.toJSON();
           }
@@ -238,8 +239,8 @@ export namespace NotebookActions {
     newModel.value.text = toMerge.join('\n\n');
     if (newModel.type === 'code') {
       (newModel as ICodeCellModel).outputs.clear();
-    } else if (newModel.type === 'markdown') {
-      (newModel as IMarkdownCellModel).attachments.fromJSON(attachments);
+    } else {
+      (newModel as AttachmentsCellModel).attachments.fromJSON(attachments);
     }
 
     // Make the changes while preserving history.

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -14,7 +14,6 @@ import {
   CodeCell,
   Cell,
   MarkdownCell,
-  AttachmentsCellModel,
   isMarkdownCellModel,
   isRawCellModel,
   isCodeCellModel

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -7,7 +7,7 @@ import { ISessionContext, SessionContext } from '@jupyterlab/apputils';
 
 import { CodeCell, MarkdownCell, RawCell } from '@jupyterlab/cells';
 
-import { IMimeBundle } from '@jupyterlab/nbformat';
+import { IMimeBundle, CellType } from '@jupyterlab/nbformat';
 
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
@@ -270,18 +270,21 @@ describe('@jupyterlab/notebook', () => {
         expect(widget.mode).toBe('command');
       });
 
-      it('should merge attachments if the last selected cell is a markdown cell', () => {
-        for (let i = 0; i < 2; i++) {
-          NotebookActions.changeCellType(widget, 'markdown');
-          const markdownCell = widget.widgets[i] as MarkdownCell;
-          const attachment: IMimeBundle = { 'text/plain': 'test' };
-          markdownCell.model.attachments.set(UUID.uuid4(), attachment);
-          widget.select(markdownCell);
+      it.each(['raw', 'markdown'])(
+        'should merge attachments if the last selected cell is a %s cell',
+        (type: CellType) => {
+          for (let i = 0; i < 2; i++) {
+            NotebookActions.changeCellType(widget, type);
+            const markdownCell = widget.widgets[i] as MarkdownCell;
+            const attachment: IMimeBundle = { 'text/plain': 'test' };
+            markdownCell.model.attachments.set(UUID.uuid4(), attachment);
+            widget.select(markdownCell);
+          }
+          NotebookActions.mergeCells(widget);
+          const model = (widget.activeCell as MarkdownCell).model;
+          expect(model.attachments.length).toBe(2);
         }
-        NotebookActions.mergeCells(widget);
-        const model = (widget.activeCell as MarkdownCell).model;
-        expect(model.attachments.length).toBe(2);
-      });
+      );
 
       it('should drop attachments if the last selected cell is a code cell', () => {
         NotebookActions.changeCellType(widget, 'markdown');

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -273,7 +273,7 @@ describe('@jupyterlab/notebook', () => {
       it('should merge attachments if the last selected cell is a markdown cell', () => {
         for (let i = 0; i < 2; i++) {
           NotebookActions.changeCellType(widget, 'markdown');
-          const markdownCell = widget.activeCell as MarkdownCell;
+          const markdownCell = widget.widgets[i] as MarkdownCell;
           const attachment: IMimeBundle = { 'text/plain': 'test' };
           markdownCell.model.attachments.set(UUID.uuid4(), attachment);
           widget.select(markdownCell);
@@ -284,7 +284,24 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should drop attachments if the last selected cell is a code cell', () => {
-        // TODO
+        NotebookActions.changeCellType(widget, 'markdown');
+        const markdownCell = widget.activeCell as MarkdownCell;
+        const attachment: IMimeBundle = { 'text/plain': 'test' };
+        markdownCell.model.attachments.set(UUID.uuid4(), attachment);
+
+        const codeCell = widget.widgets[1];
+        widget.select(codeCell);
+        NotebookActions.changeCellType(widget, 'code');
+        NotebookActions.deselectAll(widget);
+
+        widget.select(markdownCell);
+        widget.select(codeCell);
+
+        NotebookActions.mergeCells(widget);
+
+        const model = widget.activeCell!.model.toJSON();
+        expect(model.cell_type).toEqual('code');
+        expect(model.attachments).toBeUndefined();
       });
     });
 

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -5,15 +5,11 @@ import 'jest';
 
 import { ISessionContext, SessionContext } from '@jupyterlab/apputils';
 
-import { each } from '@lumino/algorithm';
-
 import { CodeCell, MarkdownCell, RawCell } from '@jupyterlab/cells';
 
-import { NotebookModel } from '../src';
+import { IMimeBundle } from '@jupyterlab/nbformat';
 
-import { NotebookActions } from '../src';
-
-import { Notebook } from '../src';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 import {
   acceptDialog,
@@ -21,10 +17,18 @@ import {
   dismissDialog,
   sleep
 } from '@jupyterlab/testutils';
-import { JSONObject, JSONArray } from '@lumino/coreutils';
 
 import { JupyterServer } from '@jupyterlab/testutils/lib/start_jupyter_server';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+
+import { each } from '@lumino/algorithm';
+
+import { JSONObject, JSONArray, UUID } from '@lumino/coreutils';
+
+import { NotebookModel } from '../src';
+
+import { NotebookActions } from '../src';
+
+import { Notebook } from '../src';
 
 import * as utils from './utils';
 
@@ -264,6 +268,23 @@ describe('@jupyterlab/notebook', () => {
         NotebookActions.mergeCells(widget);
         expect(widget.activeCell).toBeInstanceOf(RawCell);
         expect(widget.mode).toBe('command');
+      });
+
+      it('should merge attachments if the last selected cell is a markdown cell', () => {
+        for (let i = 0; i < 2; i++) {
+          NotebookActions.changeCellType(widget, 'markdown');
+          const markdownCell = widget.activeCell as MarkdownCell;
+          const attachment: IMimeBundle = { 'text/plain': 'test' };
+          markdownCell.model.attachments.set(UUID.uuid4(), attachment);
+          widget.select(markdownCell);
+        }
+        NotebookActions.mergeCells(widget);
+        const model = (widget.activeCell as MarkdownCell).model;
+        expect(model.attachments.length).toBe(2);
+      });
+
+      it('should drop attachments if the last selected cell is a code cell', () => {
+        // TODO
       });
     });
 


### PR DESCRIPTION
## References

Fixes #8414.

There are still a couple of things to check:

- [x] Should attachments also be merged for raw cells?
- [x] ~What about the uniqueness of attachments? See https://github.com/jupyterlab/jupyterlab/issues/8414#issuecomment-629306215~ -> can be done in a separate PR (see conversation below)

## Code changes

Extend `NotebookActions.mergeCells` to also merge attachments for markdown cells. 

## User-facing changes

### Before

![merge-cells-attachments](https://user-images.githubusercontent.com/591645/82073046-f07c4600-96d8-11ea-9b5f-c9eabe20e21b.gif)

### After

![merge-cells-attachments-3](https://user-images.githubusercontent.com/591645/82072833-97acad80-96d8-11ea-957c-ce006731219b.gif)

## Backwards-incompatible changes

None