### PR TITLE
Reconnect a websocket when a kernel is restarted.

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -983,10 +983,15 @@ export class KernelConnection implements Kernel.IKernelConnection {
     this._clearKernelState();
     this._updateStatus('restarting');
 
-    // Kick off an async kernel request to eventually reset the kernel status.
-    // We do this with a setTimeout so that it comes after the microtask
-    // logic in _handleMessage for restarting/autostarting status updates.
+    // Reconnect to a new websocket and kick off an async kernel request to
+    // eventually reset the kernel status. We do this with a setTimeout so
+    // that it comes after the microtask logic in _handleMessage for
+    // restarting/autostarting status updates.
     setTimeout(() => {
+      // We must reconnect since the kernel connection information may have
+      // changed, and the server only refreshes its zmq connection when a new
+      // websocket is opened.
+      void this.reconnect();
       void this.requestKernelInfo();
     }, 0);
   }


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

See https://github.com/jupyterlab/jupyterlab/issues/8013



## Code changes

Reconnect to a restarted kernel.

In some cases, a kernel may use different zmq ports when it is restarted. The current Jupyter Notebook server checks these zmq ports only when a websocket connection is created. We work around this problem by reconnecting when a kernel is restarted. Ideally the Notebook Server would maintain the same websocket connection and just change the zmq ports as needed.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
