### PR TITLE
make #8200 backwards compatible

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -639,7 +639,7 @@ export namespace CodeEditor {
     /**
      * Whether the editor should handle paste events.
      */
-    handlePaste: boolean;
+    handlePaste?: boolean;
 
     /**
      * The column where to break text line.

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -166,7 +166,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     // Turn off paste handling in codemirror since sometimes we want to
     // replace it with our own.
     editor.on('paste', (instance: CodeMirror.Editor, event: any) => {
-      if (!this._config['handlePaste']) {
+      if (this._config['handlePaste'] !== undefined && !this._config['handlePaste']) {
         event.codemirrorIgnore = true;
       }
     });
@@ -1276,7 +1276,8 @@ export namespace CodeMirrorEditor {
     styleSelectedText: true,
     selectionPointer: false,
     rulers: [],
-    foldGutter: false
+    foldGutter: false,
+    handlePaste: true
   };
 
   /**

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -166,7 +166,10 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     // Turn off paste handling in codemirror since sometimes we want to
     // replace it with our own.
     editor.on('paste', (instance: CodeMirror.Editor, event: any) => {
-      if (this._config['handlePaste'] !== undefined && !this._config['handlePaste']) {
+      if (
+        this._config['handlePaste'] !== undefined &&
+        !this._config['handlePaste']
+      ) {
         event.codemirrorIgnore = true;
       }
     });

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -166,10 +166,8 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     // Turn off paste handling in codemirror since sometimes we want to
     // replace it with our own.
     editor.on('paste', (instance: CodeMirror.Editor, event: any) => {
-      if (
-        this._config['handlePaste'] !== undefined &&
-        !this._config['handlePaste']
-      ) {
+      const handlePaste = this._config['handlePaste'] ?? true;
+      if (!handlePaste) {
         event.codemirrorIgnore = true;
       }
     });


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab/pull/8200 introduced backwards incompatible changes by adding a non-optional property to the codeeditor interface, see https://github.com/jupyterlab/jupyterlab/pull/8200#pullrequestreview-414030521

cc. @edzkite would this fix your issue?

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
I made `handlePaste` optional for the Codeeditor IConfig. I also added a definition of it to the codemirror IConfig because I couldn't compile it without errors. This does result in handlePaste being defined in multiple places. I'm suspicious of this but unfortunately don't understand interfaces well enough to know another approach. 

## Backwards-incompatible changes
Hopefully none! that would be very self defeating.

:+1:  to including what qualifies as backwards incompatible in the PR template
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
