### PR TITLE
Fixed source-map-loader warn when using watch

### DIFF
--- a/jupyterlab/staging/webpack.config.js
+++ b/jupyterlab/staging/webpack.config.js
@@ -237,7 +237,8 @@ module.exports = [
           test: /\.js$/,
           include: sourceMapRes,
           use: ['source-map-loader'],
-          enforce: 'pre'
+          enforce: 'pre',
+          exclude: [plib.join(process.cwd(), 'node_modules')]
         },
         { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
         { test: /\.js.map$/, use: 'file-loader' },


### PR DESCRIPTION
When using `--watch` while developing extensions the source-map-loader
throws the following warning on every file when lab rebuilds:

```
    WARNING in ./node_modules/@elyra/application/lib/icons.js
    Module Warning (from ./node_modules/source-map-loader/index.js):
    (Emitted value instead of an instance of Error) Cannot find source file '../src/icons.tsx': Error: Can't resolve '../src/icons.tsx' in '/Users/ajbozart/anaconda3/envs/elyra/share/jupyter/lab/staging/node_modules/@elyra/application/lib'
     @ ./node_modules/@elyra/application/lib/index.js 20:0-24 20:0-24
     @ ./node_modules/@elyra/code-snippet-extension-experimental/lib/index.js
     @ ./build/index.out.js
     @ multi whatwg-fetch ./build/index.out.js
```

## References

Previously raised in #7851 

## Code changes

Excludes `node_module` for the `source-map-loader` webpack module as suggested in various stack overflow discussions encountering this warning on other projects.
