### PR TITLE
MNT: Python 3.10 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,26 @@ import sys
 
 # Our own imports
 from setupbase import (
-    create_cmdclass, ensure_python, find_packages, get_version,
+    create_cmdclass, find_packages, get_version,
     command_for_func, combine_commands, install_npm, HERE, run,
     skip_npm, which, log
 )
 
 from setuptools import setup
 from setuptools.command.develop import develop
+
+min_version = (3, 5)
+
+if sys.version_info < min_version:
+    error = """
+Python {0} or above is required, you are using Python {1}.
+
+This may be due to an out of date pip.
+
+Make sure you have pip >= 9.0.1.
+""".format('.'.join(str(n) for n in min_version),
+           '.'.join(str(n) for n in sys.version_info[:3]))
+    sys.exit(error)
 
 
 NAME = 'jupyterlab'
@@ -25,7 +38,6 @@ DESCRIPTION = 'The JupyterLab notebook server extension.'
 with open(pjoin(HERE, 'README.md')) as fid:
     LONG_DESCRIPTION = fid.read()
 
-ensure_python(['>=3.5'])
 
 data_files_spec = [
     ('share/jupyter/lab/static', '%s/static' % NAME, '**'),

--- a/setupbase.py
+++ b/setupbase.py
@@ -87,24 +87,6 @@ def get_version(file, name='__version__'):
     return version_ns[name]
 
 
-def ensure_python(specs):
-    """Given a list of range specifiers for python, ensure compatibility.
-    """
-    if not isinstance(specs, (list, tuple)):
-        specs = [specs]
-    v = sys.version_info
-    part = '%s.%s' % (v.major, v.minor)
-    for spec in specs:
-        if part == spec:
-            return
-        try:
-            if eval(part + spec):
-                return
-        except SyntaxError:
-            pass
-    raise ValueError('Python version %s unsupported' % part)
-
-
 def find_packages(top=HERE):
     """
     Find all of the packages.


### PR DESCRIPTION
Don't use string comparison for checking versions now that we have 3.10


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References


I have skipped opening an issue as there is not any design decisions
to make here.   The current jupyterlab master branch will not install
with cpython master branch due to identifying the version of python as
being too low.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

 - remove a string-based comparison helper function
 - adds a tuple-based version check directly to setup.py to catch old
   pip versions

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

 - None


## Backwards-incompatible changes

 - None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->