### PR TITLE
Incrementally improve JupyterLab mobile UX

### DIFF
--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -76,6 +76,8 @@ export abstract class JupyterFrontEnd<
       selector: 'body',
       rank: Infinity
     });
+
+    this.format = 'desktop';
   }
 
   /**
@@ -126,6 +128,7 @@ export abstract class JupyterFrontEnd<
   }
   set format(format: JupyterFrontEnd.Format) {
     if (this._format !== format) {
+      document.body.dataset['format'] = format;
       this._format = format;
       this._formatChanged.emit(format);
     }
@@ -211,7 +214,7 @@ export abstract class JupyterFrontEnd<
   }
 
   private _contextMenuEvent: MouseEvent;
-  private _format: JupyterFrontEnd.Format = 'desktop';
+  private _format: JupyterFrontEnd.Format;
   private _formatChanged = new Signal<this, JupyterFrontEnd.Format>(this);
 }
 

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -31,12 +31,15 @@ export type JupyterFrontEndPlugin<T> = IPlugin<JupyterFrontEnd, T>;
  *
  * @typeparam `T` - The `shell` type. Defaults to `JupyterFrontEnd.IShell`.
  *
+ * @typeparam `U` - The type for supported format names. Defaults to `string`.
+ *
  * #### Notes
  * This type is useful as a generic application against which front-end plugins
- * can be authored. It inherits from the phosphor `Application`.
+ * can be authored. It inherits from the Lumino `Application`.
  */
 export abstract class JupyterFrontEnd<
-  T extends JupyterFrontEnd.IShell = JupyterFrontEnd.IShell
+  T extends JupyterFrontEnd.IShell = JupyterFrontEnd.IShell,
+  U extends string = string
 > extends Application<T> {
   /**
    * Construct a new JupyterFrontEnd object.
@@ -76,8 +79,6 @@ export abstract class JupyterFrontEnd<
       selector: 'body',
       rank: Infinity
     });
-
-    this.format = 'desktop';
   }
 
   /**
@@ -123,10 +124,10 @@ export abstract class JupyterFrontEnd<
   /**
    * The application form factor, e.g., `desktop` or `mobile`.
    */
-  get format(): JupyterFrontEnd.Format {
+  get format(): U {
     return this._format;
   }
-  set format(format: JupyterFrontEnd.Format) {
+  set format(format: U) {
     if (this._format !== format) {
       this._format = format;
       document.body.dataset['format'] = format;
@@ -137,7 +138,7 @@ export abstract class JupyterFrontEnd<
   /**
    * A signal that emits when the application form factor changes.
    */
-  get formatChanged(): ISignal<this, JupyterFrontEnd.Format> {
+  get formatChanged(): ISignal<this, U> {
     return this._formatChanged;
   }
 
@@ -214,19 +215,14 @@ export abstract class JupyterFrontEnd<
   }
 
   private _contextMenuEvent: MouseEvent;
-  private _format: JupyterFrontEnd.Format;
-  private _formatChanged = new Signal<this, JupyterFrontEnd.Format>(this);
+  private _format: U;
+  private _formatChanged = new Signal<this, U>(this);
 }
 
 /**
  * The namespace for `JupyterFrontEnd` class statics.
  */
 export namespace JupyterFrontEnd {
-  /**
-   * The application form factor, e.g., `desktop` or `mobile`.
-   */
-  export type Format = 'desktop' | 'mobile';
-
   /**
    * The options used to initialize a JupyterFrontEnd.
    */

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -128,8 +128,8 @@ export abstract class JupyterFrontEnd<
   }
   set format(format: JupyterFrontEnd.Format) {
     if (this._format !== format) {
-      document.body.dataset['format'] = format;
       this._format = format;
+      document.body.dataset['format'] = format;
       this._formatChanged.emit(format);
     }
   }

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -135,7 +135,7 @@ export abstract class JupyterFrontEnd<
   }
 
   /**
-   * A signal that emits with the application form factor changes.
+   * A signal that emits when the application form factor changes.
    */
   get formatChanged(): ISignal<this, JupyterFrontEnd.Format> {
     return this._formatChanged;

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -124,6 +124,12 @@ export abstract class JupyterFrontEnd<
   get format(): JupyterFrontEnd.Format {
     return this._format;
   }
+  set format(format: JupyterFrontEnd.Format) {
+    if (this._format !== format) {
+      this._format = format;
+      this._formatChanged.emit(format);
+    }
+  }
 
   /**
    * A signal that emits with the application form factor changes.

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -15,6 +15,8 @@ import { Application, IPlugin } from '@lumino/application';
 
 import { Token } from '@lumino/coreutils';
 
+import { ISignal, Signal } from '@lumino/signaling';
+
 import { Widget } from '@lumino/widgets';
 
 /**
@@ -97,6 +99,11 @@ export abstract class JupyterFrontEnd<
   readonly commandLinker: CommandLinker;
 
   /**
+   * The application context menu.
+   */
+  readonly contextMenu: ContextMenuSvg;
+
+  /**
    * The document registry instance used by the application.
    */
   readonly docRegistry: DocumentRegistry;
@@ -110,6 +117,20 @@ export abstract class JupyterFrontEnd<
    * The service manager used by the application.
    */
   readonly serviceManager: ServiceManager;
+
+  /**
+   * The application form factor, e.g., `desktop` or `mobile`.
+   */
+  get format(): JupyterFrontEnd.Format {
+    return this._format;
+  }
+
+  /**
+   * A signal that emits with the application form factor changes.
+   */
+  get formatChanged(): ISignal<this, JupyterFrontEnd.Format> {
+    return this._formatChanged;
+  }
 
   /**
    * Walks up the DOM hierarchy of the target of the active `contextmenu`
@@ -183,15 +204,20 @@ export abstract class JupyterFrontEnd<
     }
   }
 
-  readonly contextMenu: ContextMenuSvg;
-
   private _contextMenuEvent: MouseEvent;
+  private _format: JupyterFrontEnd.Format = 'desktop';
+  private _formatChanged = new Signal<this, JupyterFrontEnd.Format>(this);
 }
 
 /**
  * The namespace for `JupyterFrontEnd` class statics.
  */
 export namespace JupyterFrontEnd {
+  /**
+   * The application form factor, e.g., `desktop` or `mobile`.
+   */
+  export type Format = 'desktop' | 'mobile';
+
   /**
    * The options used to initialize a JupyterFrontEnd.
    */

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -23,8 +23,16 @@ import { Widget } from '@lumino/widgets';
  * The type for all JupyterFrontEnd application plugins.
  *
  * @typeparam T - The type that the plugin `provides` upon being activated.
+ *
+ * @typeparam U - The type of the application shell.
+ *
+ * @typeparam V - The type that defines the application formats.
  */
-export type JupyterFrontEndPlugin<T> = IPlugin<JupyterFrontEnd, T>;
+export type JupyterFrontEndPlugin<
+  T,
+  U extends JupyterFrontEnd.IShell = JupyterFrontEnd.IShell,
+  V extends string = 'desktop' | 'mobile'
+> = IPlugin<JupyterFrontEnd<U, V>, T>;
 
 /**
  * The base Jupyter front-end application class.
@@ -39,7 +47,7 @@ export type JupyterFrontEndPlugin<T> = IPlugin<JupyterFrontEnd, T>;
  */
 export abstract class JupyterFrontEnd<
   T extends JupyterFrontEnd.IShell = JupyterFrontEnd.IShell,
-  U extends string = string
+  U extends string = 'desktop' | 'mobile'
 > extends Application<T> {
   /**
    * Construct a new JupyterFrontEnd object.

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -22,7 +22,7 @@ import { LabStatus } from './status';
 /**
  * JupyterLab is the main application class. It is instantiated once and shared.
  */
-export class JupyterLab extends JupyterFrontEnd<ILabShell> {
+export class JupyterLab extends JupyterFrontEnd<ILabShell, JupyterLab.Format> {
   /**
    * Construct a new JupyterLab object.
    */
@@ -204,6 +204,11 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
  */
 export namespace JupyterLab {
   /**
+   * The JupyterLab application form factor, e.g., `desktop` or `mobile`.
+   */
+  export type Format = 'desktop' | 'mobile';
+
+  /**
    * The options used to initialize a JupyterLab object.
    */
   export interface IOptions
@@ -316,7 +321,7 @@ namespace Private {
    *
    * @param app The front-end application whose format is set.
    */
-  export function setFormat(app: JupyterFrontEnd): void {
+  export function setFormat(app: JupyterLab): void {
     app.format = window.matchMedia(MOBILE_QUERY).matches ? 'mobile' : 'desktop';
   }
 }

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -86,17 +86,19 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
       }
     }
 
-    this.formatChanged.connect((_, format) => {
-      if (format === 'mobile') {
-        this.shell.mode = 'single-document';
-        this.shell.collapseLeft();
-        this.shell.collapseRight();
-        return;
-      }
-      this.shell.mode = 'multiple-document';
-      this.shell.expandLeft();
-    }, this);
-    Private.setFormat(this);
+    void this.restored.then(() => {
+      this.formatChanged.connect((_, format) => {
+        if (format === 'mobile') {
+          this.shell.mode = 'single-document';
+          this.shell.collapseLeft();
+          this.shell.collapseRight();
+          return;
+        }
+        this.shell.mode = 'multiple-document';
+        this.shell.expandLeft();
+      }, this);
+      Private.setFormat(this);
+    });
   }
 
   /**

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -87,8 +87,12 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
     }
 
     this.formatChanged.connect((_, format) => {
-      this.shell.mode =
-        format === 'mobile' ? 'single-document' : 'multiple-document';
+      if (format === 'mobile') {
+        this.shell.mode = 'single-document';
+        this.shell.collapseLeft();
+        this.shell.collapseRight();
+        return;
+      }
     }, this);
     Private.setFormat(this);
   }

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -86,6 +86,10 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
       }
     }
 
+    this.formatChanged.connect((_, format) => {
+      this.shell.mode =
+        format === 'mobile' ? 'single-document' : 'multiple-document';
+    }, this);
     Private.setFormat(this);
   }
 

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -9,7 +9,7 @@ import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 
 import { Token } from '@lumino/coreutils';
 
-import { Debouncer } from '@lumino/polling';
+import { Throttler } from '@lumino/polling';
 
 import { JupyterFrontEnd, JupyterFrontEndPlugin } from './frontend';
 
@@ -93,6 +93,8 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
         this.shell.collapseRight();
         return;
       }
+      this.shell.mode = 'multiple-document';
+      this.shell.expandLeft();
     }, this);
     Private.setFormat(this);
   }
@@ -188,7 +190,7 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
     });
   }
 
-  private _formatter = new Debouncer(() => {
+  private _formatter = new Throttler(() => {
     Private.setFormat(this);
   }, 250);
   private _info: JupyterLab.IInfo;

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -9,6 +9,8 @@ import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 
 import { Token } from '@lumino/coreutils';
 
+import { Debouncer } from '@lumino/polling';
+
 import { JupyterFrontEnd, JupyterFrontEndPlugin } from './frontend';
 
 import { createRendermimePlugins } from './mimerenderers';
@@ -83,6 +85,8 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
         this.registerPlugin(plugin);
       }
     }
+
+    Private.setFormat(this);
   }
 
   /**
@@ -131,6 +135,18 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
   }
 
   /**
+   * Handle the DOM events for the application.
+   *
+   * @param event - The DOM event sent to the application.
+   */
+  handleEvent(event: Event): void {
+    if (event.type === 'resize') {
+      void this._formatter.invoke();
+    }
+    super.handleEvent(event);
+  }
+
+  /**
    * Register plugins from a plugin module.
    *
    * @param mod - The plugin module to register.
@@ -164,6 +180,9 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
     });
   }
 
+  private _formatter = new Debouncer(() => {
+    Private.setFormat(this);
+  }, 250);
   private _info: JupyterLab.IInfo;
   private _paths: JupyterFrontEnd.IPaths;
 }
@@ -268,5 +287,20 @@ export namespace JupyterLab {
      * The default export.
      */
     default: JupyterFrontEndPlugin<any> | JupyterFrontEndPlugin<any>[];
+  }
+}
+
+/**
+ * A namespace for module-private functionality.
+ */
+namespace Private {
+  /**
+   * Sets the `format` of a Jupyter front-end application.
+   *
+   * @param app The front-end application whose format is set.
+   */
+  export function setFormat(app: JupyterFrontEnd): void {
+    console.log('setting the format');
+    app.format = 'desktop';
   }
 }

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -305,7 +305,7 @@ namespace Private {
   /**
    * Media query for mobile devices.
    */
-  const MEDIA_QUERY = 'only screen and (max-width: 760px)';
+  const MOBILE_QUERY = 'only screen and (max-width: 760px)';
 
   /**
    * Sets the `format` of a Jupyter front-end application.
@@ -313,6 +313,6 @@ namespace Private {
    * @param app The front-end application whose format is set.
    */
   export function setFormat(app: JupyterFrontEnd): void {
-    app.format = window.matchMedia(MEDIA_QUERY).matches ? 'mobile' : 'desktop';
+    app.format = window.matchMedia(MOBILE_QUERY).matches ? 'mobile' : 'desktop';
   }
 }

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -140,10 +140,10 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
    * @param event - The DOM event sent to the application.
    */
   handleEvent(event: Event): void {
+    super.handleEvent(event);
     if (event.type === 'resize') {
       void this._formatter.invoke();
     }
-    super.handleEvent(event);
   }
 
   /**
@@ -295,12 +295,16 @@ export namespace JupyterLab {
  */
 namespace Private {
   /**
+   * Media query for mobile devices.
+   */
+  const MEDIA_QUERY = 'only screen and (max-width: 760px)';
+
+  /**
    * Sets the `format` of a Jupyter front-end application.
    *
    * @param app The front-end application whose format is set.
    */
   export function setFormat(app: JupyterFrontEnd): void {
-    console.log('setting the format');
-    app.format = 'desktop';
+    app.format = window.matchMedia(MEDIA_QUERY).matches ? 'mobile' : 'desktop';
   }
 }

--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -22,7 +22,7 @@ import { LabStatus } from './status';
 /**
  * JupyterLab is the main application class. It is instantiated once and shared.
  */
-export class JupyterLab extends JupyterFrontEnd<ILabShell, JupyterLab.Format> {
+export class JupyterLab extends JupyterFrontEnd<ILabShell> {
   /**
    * Construct a new JupyterLab object.
    */
@@ -204,11 +204,6 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell, JupyterLab.Format> {
  */
 export namespace JupyterLab {
   /**
-   * The JupyterLab application form factor, e.g., `desktop` or `mobile`.
-   */
-  export type Format = 'desktop' | 'mobile';
-
-  /**
    * The options used to initialize a JupyterLab object.
    */
   export interface IOptions
@@ -303,7 +298,9 @@ export namespace JupyterLab {
     /**
      * The default export.
      */
-    default: JupyterFrontEndPlugin<any> | JupyterFrontEndPlugin<any>[];
+    default:
+      | JupyterFrontEndPlugin<any, any, any>
+      | JupyterFrontEndPlugin<any, any, any>[];
   }
 }
 

--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -42,7 +42,7 @@ export const IMimeDocumentTracker = new Token<IMimeDocumentTracker>(
  */
 export function createRendermimePlugins(
   extensions: IRenderMime.IExtensionModule[]
-): JupyterFrontEndPlugin<void | IMimeDocumentTracker>[] {
+): JupyterFrontEndPlugin<void | IMimeDocumentTracker, any, any>[] {
   const plugins: JupyterFrontEndPlugin<void | IMimeDocumentTracker>[] = [];
 
   const namespace = 'application-mimedocuments';

--- a/packages/application/src/status.ts
+++ b/packages/application/src/status.ts
@@ -25,12 +25,12 @@ export interface ILabStatus {
   /**
    * A signal for when application changes its busy status.
    */
-  readonly busySignal: ISignal<JupyterFrontEnd, boolean>;
+  readonly busySignal: ISignal<JupyterFrontEnd<any, any>, boolean>;
 
   /**
    * A signal for when application changes its dirty status.
    */
-  readonly dirtySignal: ISignal<JupyterFrontEnd, boolean>;
+  readonly dirtySignal: ISignal<JupyterFrontEnd<any, any>, boolean>;
 
   /**
    * Whether the application is busy.
@@ -64,7 +64,7 @@ export class LabStatus implements ILabStatus {
   /**
    * Construct a new  status object.
    */
-  constructor(app: JupyterFrontEnd) {
+  constructor(app: JupyterFrontEnd<any, any>) {
     this._busySignal = new Signal(app);
     this._dirtySignal = new Signal(app);
   }

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -51,7 +51,6 @@ body {
 @import './datagrid.css';
 @import './dockpanel.css';
 @import './menus.css';
-@import './mobile.css';
 @import './scrollbar.css';
 @import './tabs.css';
 @import './buttons.css';

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -47,6 +47,7 @@ body {
 @import './datagrid.css';
 @import './dockpanel.css';
 @import './menus.css';
+@import './mobile.css';
 @import './scrollbar.css';
 @import './tabs.css';
 @import './buttons.css';

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -31,6 +31,10 @@ body {
   padding: 5px;
 }
 
+#jp-main-dock-panel[data-mode='single-document'] {
+  padding: 0;
+}
+
 #jp-top-panel {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color0);
   background: var(--jp-layout-color1);

--- a/packages/application/style/mobile.css
+++ b/packages/application/style/mobile.css
@@ -1,0 +1,8 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+body[data-format='mobile'] {
+  background-color: red;
+}

--- a/packages/application/style/mobile.css
+++ b/packages/application/style/mobile.css
@@ -1,8 +1,0 @@
-/*-----------------------------------------------------------------------------
-| Copyright (c) Jupyter Development Team.
-| Distributed under the terms of the Modified BSD License.
-|----------------------------------------------------------------------------*/
-
-body[data-format='mobile'] {
-  background-color: red;
-}

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -99,7 +99,7 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
       mainMenu.viewMenu.addGroup([{ command }], 1);
     }
 
-    let ready: Promise<void>;
+    let ready = app.restored;
     if (settingRegistry) {
       const loadSettings = settingRegistry.load(STATUSBAR_PLUGIN_ID);
       const updateSettings = (settings: ISettingRegistry.ISettings): void => {
@@ -117,8 +117,6 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
         .catch((reason: Error) => {
           console.error(reason.message);
         });
-    } else {
-      ready = app.restored;
     }
 
     // Hide the status bar in the mobile format.

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -74,6 +74,15 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
       });
     }
 
+    // Hide the status bar in the mobile format.
+    app.formatChanged.connect((_, format) => {
+      if (format === 'mobile') {
+        statusBar.setHidden(true);
+      } else {
+        statusBar.setHidden(false);
+      }
+    });
+
     const category: string = 'Main Area';
     const command: string = 'statusbar:toggle';
 


### PR DESCRIPTION
This pull request opens some introductory work into supporting a better mobile experience in JupyterLab. It is an incremental step toward a more coherent mobile experience.

## References
#3275 

## Code changes
- Mobile device detection is based on matching this `@media` query: `only screen and (max-width: 760px)`
- Adds attribute `JupyterFrontEnd#format`, and signal `JupyterFrontEnd#formatChanged`
- Adds a new `@typeparam` to `JupyterFrontEnd` to allow a sub-class to define the `format` types an application supports. A sub-class can add or modify the application `format` options:
  ![multiple-format](https://user-images.githubusercontent.com/159529/82718242-42087000-9c99-11ea-8db2-df4931198636.gif)

## User-facing changes
If the media query matches a mobile browser after a resize or on page load, JupyterLab loads the `mobile` format, i.e., it switches the `DockPanel` to `single-document` mode and sets the status bar to hidden.

Desktop to mobile transition:
![desktop-mobile-transition](https://user-images.githubusercontent.com/159529/82658940-c5857b00-9c1f-11ea-82a0-0824b75da7cc.gif)


Rendering in mobile Safari:
![mobile-safari](https://user-images.githubusercontent.com/159529/82628424-ba612980-9be4-11ea-8577-e9a9283e3ea4.jpeg)


## Backwards-incompatible changes
N/A

cc: @ajbozarth @jtpio @telamonian @tgeorgeux