### PR TITLE
[2.1.x] Fix Jupyterlab manager extension

### DIFF
--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -97,7 +97,7 @@ class ExtensionManager(object):
                         status = 'warning'
             extensions.append(_make_extension_entry(
                 name=name,
-                description=pkg_info['description'],
+                description=pkg_info.get('description', ''),
                 url=data['url'],
                 enabled=(name not in info['disabled']),
                 core=False,
@@ -112,7 +112,7 @@ class ExtensionManager(object):
             if data is not None:
                 extensions.append(_make_extension_entry(
                     name=name,
-                    description=data['description'],
+                    description=data.get('description', ''),
                     url=data.get('homepage', ''),
                     installed=False,
                     enabled=False,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #7095.  Backport of c0584b3 from  #8213. 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Internal cleanup of extension manager server code.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
No 500 errors when a package is missing a description field.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
