### PR TITLE
Add feature request template + slight reorg in readme

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,7 +11,6 @@ Welcome! Thanks for thinking of a way to improve JupyterLab. If this solves a pr
 Before creating a new feature request please search the issues for relevant feature requests.
 -->
 
-
 ### Problem
 
 <!-- Provide a clear and concise description of what problem this feature will solve. For example:
@@ -33,4 +32,3 @@ Before creating a new feature request please search the issues for relevant feat
 
 * Another project [...] solved this by [...]
 -->
-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature Request
+about: Suggest something to add to JupyterLab
+labels: type:Enhancement
+---
+
+<!--
+Welcome! Thanks for thinking of a way to improve JupyterLab. If this solves a problem for you, then it probably solves that problem for lots of people! So the whole community will benefit from this request.
+
+
+Before creating a new feature request please search the issues for relevant feature requests.
+-->
+
+
+### Problem
+
+<!-- Provide a clear and concise description of what problem this feature will solve. For example:
+
+* I'm always frustrated when [...] because [...]
+* I would like it if [...] happened when I [...] because [...]
+-->
+
+### Proposed Solution
+
+<!-- Provide a clear and concise description of a way to accomplish what you want. For example:
+
+* Add an option so that when [...]  [...] will happen
+ -->
+
+### Additional context
+
+<!-- Add any other context or screenshots about the feature request here. You can also include links to examples of other programs that have something similar to your request. For example:
+
+* Another project [...] solved this by [...]
+-->
+

--- a/README.md
+++ b/README.md
@@ -103,11 +103,25 @@ See our [documentation](http://jupyterlab.readthedocs.io/en/latest/getting_start
 
 ---
 
+## Getting help
+
+We encourage you to ask questions on the [Discourse forum](https://discourse.jupyter.org/c/jupyterlab). A question answered there can become a useful resource for others.
+
+### Bug report
+
+To report a bug please read the [guidelines](https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html) and then open a [Github issue](https://github.com/jupyterlab/jupyterlab/issues/new?template=bug_report.md). To keep resolved issues self-contained, the [lock bot](https://github.com/apps/lock) will lock closed issues as resolved after a period of inactivity. If related discussion is still needed after an issue is locked, please open a new issue and reference the old issue.
+
+### Feature request
+
+We also welcome suggestions for new features as they help make the project more useful for everyone. To request a feature please use the [feature request template](https://github.com/jupyterlab/jupyterlab/issues/new?template=feature_request.md).
+
+---
+
 ## Development
 
 ### Contributing
 
-To contribute to the project, please read the [contributor documentation](CONTRIBUTING.md).
+To contribute code or documentation to the project, please read the [contributor documentation](https://jupyterlab.readthedocs.io/en/latest/developer/contributing.html).
 
 JupyterLab follows the Jupyter [Community Guides](https://jupyter.readthedocs.io/en/latest/community/content-community.html).
 
@@ -151,12 +165,6 @@ This list is provided to give the reader context on who we are and how our team 
 To be listed, please submit a pull request with your information.
 
 ---
-
-## Getting help
-
-We encourage you to ask questions on the [Discourse forum](https://discourse.jupyter.org/c/jupyterlab). A question answered there can become a useful resource for others.
-
-Please use the [GitHub issues page](https://github.com/jupyterlab/jupyterlab/issues) to provide feedback or submit a bug report. To keep resolved issues self-contained, the [lock bot](https://github.com/apps/lock) will lock closed issues as resolved after a period of inactivity. If related discussion is still needed after an issue is locked, please open a new issue and reference the old issue.
 
 ### Weekly Dev Meeting
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab/issues/8226
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->


## User-facing changes
- Added a new template to github issues for feature requests
- Moved the Getting Help section from the bottom to right after the installation instructions
    - Split into two parts, bug reports and feature requests
- Updated the link to the contributor documentation.
    - It currently leads to CONTRIBUTING.md which then leads to the stable branch of documentation which is significantly different than the latest branch: https://jupyterlab.readthedocs.io/en/stable/developer/contributing.html vs https://jupyterlab.readthedocs.io/en/latest/developer/contributing.html