### PR TITLE
Handle quit_button when launched as an extension

### DIFF
--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -145,6 +145,9 @@ def load_jupyter_server_extension(nbapp):
     page_config['devMode'] = dev_mode
     page_config['token'] = nbapp.token
 
+    # Handle quit button with support for Notebook < 5.6
+    page_config'quitButton'] = getattr(nbapp, 'quit_button', False)
+
     # Client-side code assumes notebookVersion is a JSON-encoded string
     page_config['notebookVersion'] = dumps(version_info)
     page_config['exposeAppInBrowser'] = getattr(nbapp, 'expose_app_in_browser', False)

--- a/jupyterlab/extension.py
+++ b/jupyterlab/extension.py
@@ -146,7 +146,7 @@ def load_jupyter_server_extension(nbapp):
     page_config['token'] = nbapp.token
 
     # Handle quit button with support for Notebook < 5.6
-    page_config'quitButton'] = getattr(nbapp, 'quit_button', False)
+    page_config['quitButton'] = getattr(nbapp, 'quit_button', False)
 
     # Client-side code assumes notebookVersion is a JSON-encoded string
     page_config['notebookVersion'] = dumps(version_info)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -483,15 +483,6 @@ class LabApp(NotebookApp):
     expose_app_in_browser = Bool(False, config=True,
         help="Whether to expose the global app instance to browser via window.jupyterlab")
 
-    def init_webapp(self, *args, **kwargs):
-        super().init_webapp(*args, **kwargs)
-        settings = self.web_app.settings
-        if 'page_config_data' not in settings:
-            settings['page_config_data'] = {}
-
-        # Handle quit button with support for Notebook < 5.6
-        settings['page_config_data']['quitButton'] = getattr(self, 'quit_button', False)
-
     def init_server_extensions(self):
         """Load any extensions specified by config.
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #8483 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Moves handling of `quit_button` trait to the extension so it will be used when lab is launched as an extension.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Quit button logic works when running as `jupyter notebook`.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
