### PR TITLE
Add text-based image viewer for SVG, fix token doc

### DIFF
--- a/packages/imageviewer/src/tokens.ts
+++ b/packages/imageviewer/src/tokens.ts
@@ -10,14 +10,14 @@ import { Token } from '@lumino/coreutils';
 import { ImageViewer } from './widget';
 
 /**
- * A class that tracks editor widgets.
+ * A class that tracks image widgets.
  */
 export interface IImageTracker
   extends IWidgetTracker<IDocumentWidget<ImageViewer>> {}
 
 /* tslint:disable */
 /**
- * The editor tracker token.
+ * The image tracker token.
  */
 export const IImageTracker = new Token<IImageTracker>(
   '@jupyterlab/imageviewer:IImageTracker'

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -47,7 +47,6 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
         return;
       }
       const contents = context.contentsModel!;
-      this._format = contents.format === 'base64' ? ';base64' : '';
       this._mimeType = contents.mimetype;
       this._render();
       context.model.contentChanged.connect(this.update, this);
@@ -179,8 +178,11 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
     if (!cm) {
       return;
     }
-    const content = context.model.toString();
-    this._img.src = `data:${this._mimeType}${this._format},${content}`;
+    let content = context.model.toString();
+    if (cm.format !== 'base64') {
+      content = btoa(content);
+    }
+    this._img.src = `data:${this._mimeType};base64,${content}`;
   }
 
   /**
@@ -196,7 +198,6 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
     this._img.style.filter = `invert(${this._colorinversion})`;
   }
 
-  private _format: string;
   private _mimeType: string;
   private _scale = 1;
   private _matrix = [1, 0, 0, 1];


### PR DESCRIPTION
## References

- fixes #8494

## Code changes

- adds an `Image (Text)` factory
- defaults SVG to use it, so that you can see live changes to the svg when it renders
- fixes token docs

## User-facing changes

- None, in particular, other than an additional (default) option for opening svg

![Screenshot from 2020-05-28 23-34-04](https://user-images.githubusercontent.com/45380/83218329-c8123400-a13b-11ea-9137-6b91a29dbc08.png)

## Backwards-incompatible changes

Might break `xbm`, but then maybe it's [not that useful anyway](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types#XBM_X_Window_System_Bitmap_file). I could dig up any other text-based formats that browsers generally support natively (without some library).