### PR TITLE
Update phosphor aliases

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -180,31 +180,31 @@ module.exports = [
       alias: {
         '@phosphor/algorithm$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/algorithm/lib/index.js'
+          'node_modules/@lumino/algorithm/dist/index.js'
         ),
         '@phosphor/application$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/application/lib/index.js'
+          'node_modules/@lumino/application/dist/index.js'
         ),
         '@phosphor/commands$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/commands/lib/index.js'
+          'node_modules/@lumino/commands/dist/index.js'
         ),
         '@phosphor/coreutils$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/coreutils/lib/index.js'
+          'node_modules/@lumino/coreutils/dist/index.js'
         ),
         '@phosphor/disposable$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/disposable/lib/index.js'
+          'node_modules/@lumino/disposable/dist/index.js'
         ),
         '@phosphor/domutils$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/domutils/lib/index.js'
+          'node_modules/@lumino/domutils/dist/index.js'
         ),
         '@phosphor/dragdrop$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/dragdrop/lib/index.js'
+          'node_modules/@lumino/dragdrop/dist/index.js'
         ),
         '@phosphor/dragdrop/style': plib.resolve(
           __dirname,
@@ -212,7 +212,7 @@ module.exports = [
         ),
         '@phosphor/messaging$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/messaging/lib/index.js'
+          'node_modules/@lumino/messaging/dist/index.js'
         ),
         '@phosphor/properties$': plib.resolve(
           __dirname,
@@ -220,7 +220,7 @@ module.exports = [
         ),
         '@phosphor/signaling': plib.resolve(
           __dirname,
-          'node_modules/@lumino/signaling/lib/index.js'
+          'node_modules/@lumino/signaling/dist/index.js'
         ),
         '@phosphor/widgets/style': plib.resolve(
           __dirname,
@@ -228,11 +228,11 @@ module.exports = [
         ),
         '@phosphor/virtualdom$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/virtualdom/lib/index.js'
+          'node_modules/@lumino/virtualdom/dist/index.js'
         ),
         '@phosphor/widgets$': plib.resolve(
           __dirname,
-          'node_modules/@lumino/widgets/lib/index.js'
+          'node_modules/@lumino/widgets/dist/index.js'
         )
       }
     },


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Update our phosphor aliases for compatibility with https://github.com/jupyterlab/lumino/pull/40.  Seen during attempted release of 2.1.5.

```
ModuleNotFoundError: Module not found: Error: Can't resolve '@phosphor/widgets' in '.../miniconda/envs/jlabrelease_2.1.x_test/share/jupyter/lab/staging/node_modules/bqplot/lib'
```
