### PR TITLE
Lazy load CodeMirror theme stylesheets.

### DIFF
--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -167,6 +167,17 @@ function activateEditorCommands(
     }
 
     theme = (settings.get('theme').composite as string | null) || theme;
+
+    // Lazy loading of theme stylesheets
+    if (theme !== 'jupyter' && theme !== 'default') {
+      const filename =
+        theme === 'solarized light' || theme === 'solarized dark'
+          ? 'solarized'
+          : theme;
+
+      await import(`codemirror/theme/${filename}.css`);
+    }
+
     scrollPastEnd =
       (settings.get('scrollPastEnd').composite as boolean | null) ??
       scrollPastEnd;

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -72,20 +72,7 @@
       "codemirror": [
         "lib/codemirror.css",
         "addon/dialog/dialog.css",
-        "addon/fold/foldgutter.css",
-        "theme/material.css",
-        "theme/zenburn.css",
-        "theme/abcdef.css",
-        "theme/base16-light.css",
-        "theme/base16-dark.css",
-        "theme/dracula.css",
-        "theme/hopscotch.css",
-        "theme/mbo.css",
-        "theme/mdn-like.css",
-        "theme/seti.css",
-        "theme/solarized.css",
-        "theme/the-matrix.css",
-        "theme/xq-light.css"
+        "addon/fold/foldgutter.css"
       ]
     }
   }

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -11,18 +11,5 @@
 @import url('~codemirror/lib/codemirror.css');
 @import url('~codemirror/addon/dialog/dialog.css');
 @import url('~codemirror/addon/fold/foldgutter.css');
-@import url('~codemirror/theme/material.css');
-@import url('~codemirror/theme/zenburn.css');
-@import url('~codemirror/theme/abcdef.css');
-@import url('~codemirror/theme/base16-light.css');
-@import url('~codemirror/theme/base16-dark.css');
-@import url('~codemirror/theme/dracula.css');
-@import url('~codemirror/theme/hopscotch.css');
-@import url('~codemirror/theme/mbo.css');
-@import url('~codemirror/theme/mdn-like.css');
-@import url('~codemirror/theme/seti.css');
-@import url('~codemirror/theme/solarized.css');
-@import url('~codemirror/theme/the-matrix.css');
-@import url('~codemirror/theme/xq-light.css');
 
 @import url('./base.css');


### PR DESCRIPTION
For the motivations, see [my comment][1] on issue #4292.

[1]: https://github.com/jupyterlab/jupyterlab/issues/4292#issuecomment-636925353