### PR TITLE
Improve whitelist figure description in documentation

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -334,7 +334,7 @@ read the instructions.
    :align: center
    :class: jp-screenshot
 
-   **Figure:** Whitelisted installed extension which should be removed
+   **Figure:** The second of the installed extensions was removed from the whitelist and should be removed
 
 .. _listings_conf:
 


### PR DESCRIPTION
The whitelist figure description does not seem to make sense to me. If the extension is whitelisted it should not be removed. It seems to have been copy-pasted from the blacklisted figure description and not adjusted afterwards. Not a native speaker, so may not sound great, just initiating the conversation on this minor point - please feel to propose a better wording.

## References

None

## Code changes

None

## User-facing changes

**Before**
![Screenshot from 2020-06-04 21-31-31](https://user-images.githubusercontent.com/5832902/83807401-f0091680-a6aa-11ea-8f13-6ec2cb8226dd.png)


**After**
![Screenshot from 2020-06-04 21-32-24](https://user-images.githubusercontent.com/5832902/83807415-f26b7080-a6aa-11ea-9042-1a3958df9942.png)


## Backwards-incompatible changes

None