### PR TITLE
Simplified multicursor backspace code

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1399,18 +1399,8 @@ namespace Private {
           doc.replaceRange('', from, head);
         } else {
           // delete non-tabs
-          if (head.ch === 0) {
-            if (head.line !== 0) {
-              const from = CodeMirror.Pos(
-                head.line - 1,
-                doc.getLine(head.line - 1).length
-              );
-              doc.replaceRange('', from, head);
-            }
-          } else {
-            const from = CodeMirror.Pos(head.line, head.ch - 1);
-            doc.replaceRange('', from, head);
-          }
+          const from = cm.findPosH(head, -1, 'char', false);
+          doc.replaceRange('', from, head);
         }
       }
     }


### PR DESCRIPTION
Hi guys,

I was working on https://github.com/jupyter/notebook/pull/5516 and realized there is a simpler implementation of #7401.

This change doesn't fix any issues, but it uses a codemirror library rather than a custom implementation, simplifying the code and probably making it more robust.

This is currently based on master, but I can rebase if you need me to
