### PR TITLE
Close correct tab with Close Tab

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -604,11 +604,14 @@ function addCommands(app: JupyterLab, palette: ICommandPalette | null): void {
 
   commands.addCommand(CommandIDs.close, {
     label: () => 'Close Tab',
-    isEnabled: () =>
-      !!shell.currentWidget && shell.currentWidget.title.closable,
+    isEnabled: () => {
+      const widget = contextMenuWidget();
+      return !!widget && widget.title.closable;
+    },
     execute: () => {
-      if (shell.currentWidget) {
-        shell.currentWidget.close();
+      const widget = contextMenuWidget();
+      if (widget) {
+        widget.close();
       }
     }
   });


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes: https://github.com/jupyterlab/jupyterlab/issues/8509

Right clicking to close a tab will now close the tab that was clicked on even if two tabs share a name. The keyboard shortcut behavior is maintained. 

![closing-correct-tab](https://user-images.githubusercontent.com/10111092/83976692-8e72c300-a8c9-11ea-83a0-3295a6bbb990.gif)
![closing-preview](https://user-images.githubusercontent.com/10111092/83976694-903c8680-a8c9-11ea-970f-083cb396211f.gif)
![closing-keyboard-shortcut](https://user-images.githubusercontent.com/10111092/83976696-916db380-a8c9-11ea-8e71-659bac4a46b4.gif)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Use `contextMenuWidget` to determine which tab to close in the `Close Tab` command. This function falls back to the active widget if there is no context menu active so the keyborad shortcut behavior is maintained.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Right click to close tab will now always close the tab that was clicked on.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
Yes? This can change the effect of the close tab command. But i'm not sure if that counts as part of the API, and also it is fixing a bug so maybe no?
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
