### PR TITLE
Improve single document mode to address classic notebook usage cases

### DIFF
--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -94,8 +94,11 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
           this.shell.collapseRight();
           return;
         }
-        this.shell.mode = 'multiple-document';
-        this.shell.expandLeft();
+        if (this.shell.mode === 'single-document') {
+          this.shell.collapseLeft();
+        } else {
+          this.shell.expandLeft();
+        }
       }, this);
       Private.setFormat(this);
     });

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -282,7 +282,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
 
     // Setup single-document-mode title bar
     const titleWidget = (this._titleWidget = new Widget());
-    titleWidget.id = 'jp-TitlePanel-title';
+    titleWidget.id = 'jp-title-panel-title';
     this.add(titleWidget, 'title');
     if (this._dockPanel.mode == 'multiple-document') {
       this._titleHandler.panel.hide();

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import { MainAreaWidget } from '@jupyterlab/apputils';
+
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 
 import { classes, DockPanelSvg, LabIcon } from '@jupyterlab/ui-components';
@@ -77,7 +79,14 @@ export namespace ILabShell {
   /**
    * The areas of the application shell where widgets can reside.
    */
-  export type Area = 'main' | 'header' | 'top' | 'left' | 'right' | 'bottom';
+  export type Area =
+    | 'main'
+    | 'header'
+    | 'top'
+    | 'title'
+    | 'left'
+    | 'right'
+    | 'bottom';
 
   /**
    * The restorable description of an area within the main dock panel.
@@ -174,6 +183,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     this.id = 'main';
 
     const headerPanel = (this._headerPanel = new BoxPanel());
+    const titleHandler = (this._titleHandler = new Private.PanelHandler());
     const topHandler = (this._topHandler = new Private.PanelHandler());
     const bottomPanel = (this._bottomPanel = new BoxPanel());
     const hboxPanel = new BoxPanel();
@@ -186,6 +196,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     const rootLayout = new BoxLayout();
 
     headerPanel.id = 'jp-header-panel';
+    titleHandler.panel.id = 'jp-title-panel';
     topHandler.panel.id = 'jp-top-panel';
     bottomPanel.id = 'jp-bottom-panel';
     hboxPanel.id = 'jp-main-content-panel';
@@ -233,17 +244,21 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     hsplitPanel.setRelativeSizes([1, 2.5, 1]);
 
     BoxLayout.setStretch(headerPanel, 0);
+    BoxLayout.setStretch(titleHandler.panel, 0);
     BoxLayout.setStretch(topHandler.panel, 0);
     BoxLayout.setStretch(hboxPanel, 1);
     BoxLayout.setStretch(bottomPanel, 0);
 
     rootLayout.addWidget(headerPanel);
+    rootLayout.addWidget(titleHandler.panel);
     rootLayout.addWidget(topHandler.panel);
     rootLayout.addWidget(hboxPanel);
     rootLayout.addWidget(bottomPanel);
 
-    // initially hiding header and bottom panel when no elements inside
+    // initially hiding header and bottom panel when no elements inside,
+    // and the title panel as we only show that in single document mode.
     this._headerPanel.hide();
+    this._titleHandler.panel.hide();
     this._bottomPanel.hide();
 
     this.layout = rootLayout;
@@ -264,6 +279,22 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       this._onLayoutModified,
       this
     );
+
+    // Setup single-document-mode title bar
+    const titleWidget = (this._titleWidget = new Widget());
+    titleWidget.id = 'jp-TitlePanel-title';
+    this.add(titleWidget, 'title');
+    if (this._dockPanel.mode == 'multiple-document') {
+      this._titleHandler.panel.hide();
+    }
+
+    this.activeChanged.connect((sender, args) => {
+      let newValue = args.newValue as MainAreaWidget;
+      if (newValue) {
+        this._titleWidget.node.innerHTML =
+          '<h1>' + newValue.content.title.label + '</h1>';
+      }
+    });
   }
 
   /**
@@ -357,6 +388,13 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
 
       // Set the mode data attribute on the application shell node.
       this.node.dataset.shellMode = mode;
+      // Show the title panel
+      this._titleHandler.panel.show();
+      const newValue = this.activeWidget as MainAreaWidget;
+      if (newValue) {
+        this._titleWidget.node.innerHTML =
+          '<h1>' + newValue.content.title.label + '</h1>';
+      }
       return;
     }
 
@@ -397,6 +435,8 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
 
     // Set the mode data attribute on the applications shell node.
     this.node.dataset.shellMode = mode;
+    // Hide the title panel
+    this._titleHandler.panel.hide();
   }
 
   /**
@@ -536,6 +576,8 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
         return this._addToHeaderArea(widget, options);
       case 'top':
         return this._addToTopArea(widget, options);
+      case 'title':
+        return this._addToTitleArea(widget, options);
       case 'bottom':
         return this._addToBottomArea(widget, options);
       default:
@@ -567,6 +609,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       return;
     }
     this._layoutDebouncer.dispose();
+    this._titleWidget.dispose();
     super.dispose();
   }
 
@@ -843,6 +886,29 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   }
 
   /**
+   * Add a widget to the title content area.
+   *
+   * #### Notes
+   * Widgets must have a unique `id` property, which will be used as the DOM id.
+   */
+  private _addToTitleArea(
+    widget: Widget,
+    options?: DocumentRegistry.IOpenOptions
+  ): void {
+    if (!widget.id) {
+      console.error('Widgets added to app shell must have unique id property.');
+      return;
+    }
+    options = options || {};
+    const rank = options.rank ?? DEFAULT_RANK;
+    this._titleHandler.addWidget(widget, rank);
+    this._onLayoutModified();
+    if (this._titleHandler.panel.isHidden) {
+      this._titleHandler.panel.show();
+    }
+  }
+
+  /**
    * Add a widget to the header content area.
    *
    * #### Notes
@@ -1009,6 +1075,8 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   private _tracker = new FocusTracker<Widget>();
   private _headerPanel: Panel;
   private _topHandler: Private.PanelHandler;
+  private _titleHandler: Private.PanelHandler;
+  private _titleWidget: Widget;
   private _bottomPanel: Panel;
   private _mainOptionsCache = new Map<Widget, DocumentRegistry.IOpenOptions>();
   private _sideOptionsCache = new Map<Widget, DocumentRegistry.IOpenOptions>();

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -44,6 +44,7 @@ body {
   background: var(--jp-layout-color1);
   display: flex;
   min-height: var(--jp-private-menubar-height);
+  overflow: visible;
 }
 
 #jp-bottom-panel {
@@ -59,3 +60,4 @@ body {
 @import './tabs.css';
 @import './buttons.css';
 @import './sidepanel.css';
+@import './titlepanel.css';

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -35,6 +35,10 @@ body {
   padding: 0;
 }
 
+#jp-main-dock-panel[data-mode='single-document'] .jp-MainAreaWidget {
+  border: none;
+}
+
 #jp-top-panel {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color0);
   background: var(--jp-layout-color1);

--- a/packages/application/style/titlepanel.css
+++ b/packages/application/style/titlepanel.css
@@ -1,0 +1,29 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+:root {
+  --jp-private-title-panel-height: 28px;
+}
+
+#jp-title-panel {
+  min-height: var(--jp-private-title-panel-height);
+  width: 100%;
+  display: flex;
+  background: var(--jp-layout-color1);
+  overflow: visible;
+}
+
+#jp-TitlePanel-title {
+  margin-left: 40px;
+}
+
+#jp-TitlePanel-title h1 {
+  font-size: 18px;
+  color: var(--jp-ui-font-color0);
+  margin: 0;
+  font-weight: normal;
+  font-family: var(--jp-ui-font-family);
+  line-height: var(--jp-private-title-panel-height);
+}

--- a/packages/application/style/titlepanel.css
+++ b/packages/application/style/titlepanel.css
@@ -15,11 +15,11 @@
   overflow: visible;
 }
 
-#jp-TitlePanel-title {
+#jp-title-panel-title {
   margin-left: 40px;
 }
 
-#jp-TitlePanel-title h1 {
+#jp-title-panel-title h1 {
   font-size: 18px;
   color: var(--jp-ui-font-color0);
   margin: 0;

--- a/packages/application/test/shell.spec.ts
+++ b/packages/application/test/shell.spec.ts
@@ -406,4 +406,16 @@ describe('LabShell', () => {
       expect(state.mainArea?.mode).toBe('multiple-document');
     });
   });
+
+  describe('#titlePanel', () => {
+    it('should be hidden in multiple document mode and visible in single document mode', () => {
+      const widget = new Widget();
+      widget.id = 'foo';
+      shell.add(widget, 'right', { rank: 10 });
+      shell.mode = 'multiple-document';
+      expect(widget.isVisible).toBe(false);
+      shell.mode = 'single-document';
+      expect(widget.isVisible).toBe(false);
+    });
+  });
 });

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -70,8 +70,10 @@ class ToolbarLayout extends PanelLayout {
       // accommodate them.
       if (some(this.widgets, w => !w.isHidden)) {
         this.parent!.node.style.minHeight = 'var(--jp-private-toolbar-height)';
+        this.parent!.removeClass('jp-Toolbar-micro');
       } else {
         this.parent!.node.style.minHeight = '';
+        this.parent!.addClass('jp-Toolbar-micro');
       }
     }
 

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -108,7 +108,12 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   .jp-MainAreaWidget
   > .jp-Toolbar.jp-Toolbar-micro {
   padding: 0;
+  min-height: 0;
+}
+
+#jp-main-dock-panel[data-mode='single-document']
+  .jp-MainAreaWidget
+  > .jp-Toolbar {
   border: none;
   box-shadow: none;
-  min-height: 0;
 }

--- a/packages/apputils/style/toolbar.css
+++ b/packages/apputils/style/toolbar.css
@@ -103,3 +103,12 @@ button.jp-ToolbarButtonComponent .jp-ToolbarButtonComponent-label {
   padding-left: 2px;
   color: var(--jp-ui-font-color1);
 }
+
+#jp-main-dock-panel[data-mode='single-document']
+  .jp-MainAreaWidget
+  > .jp-Toolbar.jp-Toolbar-micro {
+  padding: 0;
+  border: none;
+  box-shadow: none;
+  min-height: 0;
+}

--- a/packages/console/style/base.css
+++ b/packages/console/style/base.css
@@ -12,16 +12,6 @@
   min-height: 120px;
 }
 
-.jp-ConsolePanel::before {
-  content: '';
-  display: block;
-  height: var(--jp-toolbar-micro-height);
-  background: var(--jp-toolbar-background);
-  border-bottom: 1px solid var(--jp-toolbar-border-color);
-  box-shadow: var(--jp-toolbar-box-shadow);
-  z-index: 1;
-}
-
 .jp-CodeConsole {
   height: 100%;
   padding: 0;

--- a/packages/mainmenu-extension/style/index.css
+++ b/packages/mainmenu-extension/style/index.css
@@ -3,4 +3,20 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.jp-LabShell[data-shell-mode='single-document'] #jp-top-panel #jp-MainLogo {
+  animation-duration: 1s;
+  animation-name: logo-slideup;
+  animation-fill-mode: forwards;
+}
+
+@keyframes logo-slideup {
+  from {
+    top: 0;
+  }
+
+  to {
+    top: -28px;
+  }
+}
+
 @import url('~@jupyterlab/mainmenu/style/index.css');

--- a/packages/mainmenu-extension/style/index.css
+++ b/packages/mainmenu-extension/style/index.css
@@ -4,19 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 .jp-LabShell[data-shell-mode='single-document'] #jp-top-panel #jp-MainLogo {
-  animation-duration: 1s;
-  animation-name: logo-slideup;
-  animation-fill-mode: forwards;
-}
-
-@keyframes logo-slideup {
-  from {
-    top: 0;
-  }
-
-  to {
-    top: -28px;
-  }
+  top: -28px;
 }
 
 @import url('~@jupyterlab/mainmenu/style/index.css');


### PR DESCRIPTION
This is a beginning to improve JupyterLab's single document mode to address the usage cases of the classic notebook. In particular, this PR simplifies the single document layout and adds a document title header to the page. The user can switch from the normal JupyterLab layout (which we call multiple document mode) to this single document mode using Command+Shift+D or the View menu. The result is a user experience that is closer to the intent of the classic notebook by being more "document oriented." Here is an animated GIF of the transition:

![jlab-sdm](https://user-images.githubusercontent.com/27600/83992955-e0860980-a906-11ea-8568-2e6ba5585ce8.gif)

## References

https://github.com/jupyterlab/jupyterlab/issues/8292

## Code changes

Adds a new title panel to the overall layout of the shell, between the header and top panels. Currently, this is a private shell panel, with no public extension points.

## Backwards-incompatible changes

None.
