### PR TITLE
changed metrics url to use new api endpoint

### DIFF
--- a/packages/statusbar/src/defaults/memoryUsage.tsx
+++ b/packages/statusbar/src/defaults/memoryUsage.tsx
@@ -288,7 +288,7 @@ namespace Private {
   /**
    * The url endpoint for making requests to the server.
    */
-  const METRIC_URL = URLExt.join(SERVER_CONNECTION_SETTINGS.baseUrl, 'metrics');
+  const METRIC_URL = URLExt.join(SERVER_CONNECTION_SETTINGS.baseUrl, 'api/nbresuse/v1');
 
   /**
    * The shape of a response from the metrics server extension.


### PR DESCRIPTION
The metrics url is changed from `/metrics` to `/api/nbresuse/v1` in nbresuse==0.5+ so making this change.

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/yuvipanda/nbresuse/pull/45

This PR will use new endpoint for metrics that is planned to release in nbresuse.