### PR TITLE
✏ Fix small typo in getting started docs, proxy

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -170,7 +170,7 @@ These variables are automatically used by many open-source tools (like ``conda``
 
     # For Windows
     set HTTP_PROXY=http://USER:PWD@proxy.company.com:PORT
-    set HTTPS_PROXY=https://USER:PWD@proxy.comp any.com:PORT
+    set HTTPS_PROXY=https://USER:PWD@proxy.company.com:PORT
 
     # For Linux / MacOS
     export HTTP_PROXY=http://USER:PWD@proxy.company.com:PORT


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

It's just a small typo, an extra space in `proxy.comp any.com`, in the install guide, in the section about proxies.

From:

```
set HTTPS_PROXY=https://USER:PWD@proxy.comp any.com:PORT
```

To:

```
set HTTPS_PROXY=https://USER:PWD@proxy.company.com:PORT
```

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
