### PR TITLE
Use the same font-family for cell prompt and code

### DIFF
--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -267,7 +267,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
 
   --jp-cell-prompt-width: 64px;
-  --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
+  --jp-cell-prompt-font-family: var(--jp-code-font-family-default);
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1;
   --jp-cell-prompt-not-active-opacity: 1;

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -265,7 +265,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-cell-editor-active-border-color: var(--jp-brand-color1);
 
   --jp-cell-prompt-width: 64px;
-  --jp-cell-prompt-font-family: 'Source Code Pro', monospace;
+  --jp-cell-prompt-font-family: var(--jp-code-font-family-default);
   --jp-cell-prompt-letter-spacing: 0px;
   --jp-cell-prompt-opacity: 1;
   --jp-cell-prompt-not-active-opacity: 0.5;


### PR DESCRIPTION
## References

Fixes #8552

## Code changes

Switch from a hard-coded value to use the already existing `--jp-code-font-family-default` variable to ensure consistency between the font-family values for cell prompt and code.

## User-facing changes

Before:

<img width="273" alt="Screen Shot 2020-06-12 at 12 38 00 PM" src="https://user-images.githubusercontent.com/2249780/84533101-16334580-acad-11ea-86e7-2053e8e5798f.png">

After:

<img width="240" alt="Screen Shot 2020-06-12 at 1 03 43 PM" src="https://user-images.githubusercontent.com/2249780/84533171-319e5080-acad-11ea-9354-72074d94be8a.png">

## Backwards-incompatible changes

None that I'm aware of