### PR TITLE
Modify ansi color fix

### DIFF
--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -38,6 +38,10 @@
 }
 
 /* console foregrounds and backgrounds */
+.jp-RenderedText pre span {
+  display: inline-block;
+}
+
 .jp-RenderedText pre .ansi-black-fg {
   color: #3e424d;
 }

--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -22,7 +22,6 @@
   border: none;
   margin: 0px;
   padding: 0px;
-  line-height: normal;
 }
 
 .jp-RenderedText pre a:link {


### PR DESCRIPTION
## References

Fixes #8554

## Code changes

Reverts PR #7832 and uses a different solution. It seems like the issue with the gaps between ansi color blocks may be impacted by the use of spans. Setting the display to `inline-block` seems to alleviate them. See [StackOverflow: Line height and background color (Span vs Div)](https://stackoverflow.com/questions/31602428/line-height-and-background-color-span-vs-div). Note that there are other potential solutions, and it is worth understanding if the CSS rule for `.jpRenderedText pre span` affects any other situations. If so, this may also be addressed by baking it into the specific ansi rules or by adding a new mixin class.

## User-facing changes

The screenshot uses the test from #7760. Before:
<img width="413" alt="Screen Shot 2020-06-12 at 2 07 30 PM" src="https://user-images.githubusercontent.com/2249780/84537895-429f8f80-acb6-11ea-93b9-83213083cff7.png">
After:
<img width="415" alt="Screen Shot 2020-06-12 at 2 07 48 PM" src="https://user-images.githubusercontent.com/2249780/84537905-47fcda00-acb6-11ea-862e-436c1e938a4a.png">

Also, the list output from #8554. Before:
<img width="323" alt="Screen Shot 2020-06-12 at 1 48 42 PM" src="https://user-images.githubusercontent.com/2249780/84537936-53500580-acb6-11ea-901a-2539ab5f35f5.png">
After:
<img width="331" alt="Screen Shot 2020-06-12 at 2 08 07 PM" src="https://user-images.githubusercontent.com/2249780/84537944-56e38c80-acb6-11ea-95ba-ef03ba0ad7df.png">

## Backwards-incompatible changes

Not aware of any