### PR TITLE
Align Output Baseline with Prompt

### DIFF
--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -68,13 +68,6 @@
   margin-top: 5px;
 }
 
-/* Text output with the Out[] prompt needs a top padding to match the
- * alignment of the Out[] prompt itself.
- */
-.jp-OutputArea-executeResult .jp-RenderedText.jp-OutputArea-output {
-  padding-top: var(--jp-code-padding);
-}
-
 .jp-CodeCell.jp-mod-outputsScrolled .jp-Cell-outputArea {
   overflow-y: auto;
   max-height: 200px;

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -156,8 +156,12 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
   flex: 1 1 auto;
 }
 
-.jp-OutputArea-executeResult.jp-RenderedText {
+/* Text output with the Out[] prompt needs a top padding to match the
+ * alignment of the Out[] prompt itself.
+ */
+.jp-OutputArea-executeResult .jp-RenderedText.jp-OutputArea-output {
   padding-top: var(--jp-code-padding);
+  border-top: var(--jp-border-width) solid transparent;
 }
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
## References

Fixes #8560

## Code changes

The major change is adding `border-top` with `--jp-border-width` to the `.jp-OutputArea-executeResult`. Along the way, I noticed a `padding-top` rule in both the outputarea and cells packages because an initial fix in outputarea didn't stick due to cells' `widget.css`. To me, it seems like the rule should live in outputarea so I've deleted the original rule in `cells/widget.css` and updated the rule in `outputarea/base.css` to match the cells version.

## Discussion

This follows the change @ellisonbg made to originally align the baselines (3a9551e) by only adding `padding-top`. Note that the prompts and the input code area add padding **and** border on all sides. It seems like adding padding and border along the bottom is unnecessary and potentially wastes space, but it is somewhat inconsistent with the styles for the input and the prompts.

## User-facing changes

Before:

<img width="592" alt="Screen Shot 2020-06-12 at 2 37 33 PM" src="https://user-images.githubusercontent.com/2249780/84551933-ca949200-acd4-11ea-86ae-f8f8d4a765eb.png">

After #8553, #8555, and this PR:

<img width="582" alt="Screen Shot 2020-06-12 at 5 10 37 PM" src="https://user-images.githubusercontent.com/2249780/84551944-d2eccd00-acd4-11ea-9e14-fb58ad9a5871.png">

## Backwards-incompatible changes

None that I'm aware of