### PR TITLE
Slow Terminating Kernels

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -759,6 +759,7 @@ namespace Private {
       return (
         status === 'busy' ||
         status === 'starting' ||
+        status === 'terminating' ||
         status === 'restarting' ||
         status === 'initializing'
       );

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1578,6 +1578,22 @@ namespace Private {
         break;
       case 'code':
         if (sessionContext) {
+          if (sessionContext.isTerminating) {
+            void showDialog({
+              title: 'Kernel Terminating',
+              body: `The kernel for ${sessionContext.session?.path} appears to be terminating. You can not run any cell for now.`,
+              buttons: [Dialog.okButton()]
+            });
+            break;
+          }
+          if (sessionContext.isRestarting) {
+            void showDialog({
+              title: 'Kernel Restarting',
+              body: `The kernel for ${sessionContext.session?.path} appears to be restarting. You can not run any cell for now.`,
+              buttons: [Dialog.okButton()]
+            });
+            break;
+          }
           const deletedCells = notebook.model?.deletedCells ?? [];
           return CodeCell.execute(cell as CodeCell, sessionContext, {
             deletedCells,

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1586,14 +1586,6 @@ namespace Private {
             });
             break;
           }
-          if (sessionContext.isRestarting) {
-            void showDialog({
-              title: 'Kernel Restarting',
-              body: `The kernel for ${sessionContext.session?.path} appears to be restarting. You can not run any cell for now.`,
-              buttons: [Dialog.okButton()]
-            });
-            break;
-          }
           const deletedCells = notebook.model?.deletedCells ?? [];
           return CodeCell.execute(cell as CodeCell, sessionContext, {
             deletedCells,

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -535,6 +535,7 @@ export type Status =
   | 'starting'
   | 'idle'
   | 'busy'
+  | 'terminating'
   | 'restarting'
   | 'autorestarting'
   | 'dead';


### PR DESCRIPTION
## References

This fixes https://github.com/jupyterlab/jupyterlab/issues/8477 (Race Condition with Slow Restarting Kernels)

## Code changes

A new field `isTerminating` and new method `shudownKernel` are added on the session context, and the needed signals are emitted based on the kernel status so the Kernel Indicator is updated.

## User-facing changes

The Kernel Indicator shows now `terminating` and `restarting` status. In those status, a code cell can not be executed.

![kernel-terminating-restarting](https://user-images.githubusercontent.com/226720/84566070-966daf80-ad6e-11ea-815b-5f48136b524b.gif)

## Backwards-incompatible changes

None
