### PR TITLE
Remove `husky` dependencies from `toc` and `toc-extension`

### DIFF
--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -53,7 +53,6 @@
     "@jupyterlab/toc": "^4.2.0-alpha.0"
   },
   "devDependencies": {
-    "husky": "^2.7.0",
     "lint-staged": "^8.2.1",
     "prettier": "^1.19.1",
     "rimraf": "~3.0.0",

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -60,7 +60,6 @@
   "devDependencies": {
     "@types/react": "~16.9.16",
     "@types/react-dom": "~16.9.4",
-    "husky": "^2.7.0",
     "lint-staged": "^8.2.1",
     "prettier": "^1.19.1",
     "rimraf": "~3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8249,22 +8249,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-2.7.0.tgz#c0a9a6a3b51146224e11bba0b46bba546e461d05"
-  integrity sha512-LIi8zzT6PyFpcYKdvWRCn/8X+6SuG2TgYYMrM6ckEYhlp44UcEduVymZGIZNLiwOUjrEud+78w/AsAiqJA/kRg==
-  dependencies:
-    cosmiconfig "^5.2.0"
-    execa "^1.0.0"
-    find-up "^3.0.0"
-    get-stdin "^7.0.0"
-    is-ci "^2.0.0"
-    pkg-dir "^4.1.0"
-    please-upgrade-node "^3.1.1"
-    read-pkg "^5.1.1"
-    run-node "^1.0.0"
-    slash "^3.0.0"
-
 husky@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/husky/-/husky-3.1.0.tgz#5faad520ab860582ed94f0c1a77f0f04c90b57c0"
@@ -12726,7 +12710,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-read-pkg@^5.1.1, read-pkg@^5.2.0:
+read-pkg@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
   integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==


### PR DESCRIPTION
Remove `husky` dev dependencies from `toc` and `toc-extension` packages.
