### PR TITLE
Support macOptionIsMeta option in terminal

### DIFF
--- a/packages/terminal-extension/schema/plugin.json
+++ b/packages/terminal-extension/schema/plugin.json
@@ -24,6 +24,9 @@
     },
     "pasteWithCtrlV": {
       "type": "boolean"
+    },
+    "macOptionIsMeta": {
+      "type": "boolean"
     }
   },
   "properties": {
@@ -74,6 +77,12 @@
       "description": "Enable pasting with Ctrl+V.  This can be disabled to use Ctrl+V in the vi editor, for instance.  This setting has no effect on macOS, where Cmd+V is available",
       "type": "boolean",
       "default": true
+    },
+    "macOptionIsMeta": {
+      "title": "Treat option as meta key on macOS",
+      "description": "Option key on macOS can be used as meta key. This enables to use shortcuts such as option + f to move cursor forward one word",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -115,7 +115,7 @@ export namespace ITerminal {
     /**
      * Treat option as meta key on macOS.
      */
-    macOptionIsMeta: boolean;
+    macOptionIsMeta?: boolean;
   }
 
   /**

--- a/packages/terminal/src/tokens.ts
+++ b/packages/terminal/src/tokens.ts
@@ -111,6 +111,11 @@ export namespace ITerminal {
      * Whether to auto-fit the terminal to its host element size.
      */
     autoFit?: boolean;
+
+    /**
+     * Treat option as meta key on macOS.
+     */
+    macOptionIsMeta: boolean;
   }
 
   /**
@@ -127,7 +132,8 @@ export namespace ITerminal {
     initialCommand: '',
     screenReaderMode: false, // False by default, can cause scrollbar mouse interaction issues.
     pasteWithCtrlV: true,
-    autoFit: true
+    autoFit: true,
+    macOptionIsMeta: false
   };
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Closes #4236 (Terminal option/alt as meta key? ).

## Code changes

Add new option to terminal config.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Allow macOS users to use standard key binding such as option+f.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None