### PR TITLE
Move CodeMirror HTML tree and related CSS to shadow DOM

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -78,6 +78,7 @@
     "style-loader": "~1.0.1",
     "svg-url-loader": "~3.0.3",
     "terser-webpack-plugin": "^2.3.0",
+    "to-string-loader": "^1.1.6",
     "url-loader": "~3.0.0",
     "webpack": "^4.41.2",
     "webpack-bundle-analyzer": "^3.6.0",

--- a/packages/codeeditor/test/widget.spec.ts
+++ b/packages/codeeditor/test/widget.spec.ts
@@ -135,7 +135,7 @@ describe('CodeEditorWrapper', () => {
         const editor = widget.editor as LogEditor;
         MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
         editor.methods = [];
-        simulate(editor.editor.getInputField(), 'focus');
+        simulate(editor.editor.getInputField(), 'focus', { composed: true });
         expect(editor.methods).toEqual(['refresh']);
       });
     });
@@ -197,7 +197,7 @@ describe('CodeEditorWrapper', () => {
       editor.methods = [];
       MessageLoop.sendMessage(widget, Widget.ResizeMessage.UnknownSize);
       expect(editor.methods).toEqual([]);
-      simulate(editor.editor.getInputField(), 'focus');
+      simulate(editor.editor.getInputField(), 'focus', { composed: true });
       expect(editor.methods).toEqual(['refresh']);
     });
   });

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -167,17 +167,6 @@ function activateEditorCommands(
     }
 
     theme = (settings.get('theme').composite as string | null) || theme;
-
-    // Lazy loading of theme stylesheets
-    if (theme !== 'jupyter' && theme !== 'default') {
-      const filename =
-        theme === 'solarized light' || theme === 'solarized dark'
-          ? 'solarized'
-          : theme;
-
-      await import(`codemirror/theme/${filename}.css`);
-    }
-
     scrollPastEnd =
       (settings.get('scrollPastEnd').composite as boolean | null) ??
       scrollPastEnd;
@@ -201,14 +190,14 @@ function activateEditorCommands(
   function updateTracker(): void {
     tracker.forEach(widget => {
       if (widget.content.editor instanceof CodeMirrorEditor) {
-        const cm = widget.content.editor.editor;
-        cm.setOption('keyMap', keyMap);
-        cm.setOption('theme', theme);
-        cm.setOption('scrollPastEnd', scrollPastEnd);
-        cm.setOption('styleActiveLine', styleActiveLine);
-        cm.setOption('styleSelectedText', styleSelectedText);
-        cm.setOption('selectionPointer', selectionPointer);
-        cm.setOption('lineWiseCopyCut', lineWiseCopyCut);
+        const { editor } = widget.content;
+        editor.setOption('keyMap', keyMap);
+        editor.setOption('lineWiseCopyCut', lineWiseCopyCut);
+        editor.setOption('scrollPastEnd', scrollPastEnd);
+        editor.setOption('selectionPointer', selectionPointer);
+        editor.setOption('styleActiveLine', styleActiveLine);
+        editor.setOption('styleSelectedText', styleSelectedText);
+        editor.setOption('theme', theme);
       }
     });
   }
@@ -233,14 +222,14 @@ function activateEditorCommands(
    */
   tracker.widgetAdded.connect((sender, widget) => {
     if (widget.content.editor instanceof CodeMirrorEditor) {
-      const cm = widget.content.editor.editor;
-      cm.setOption('keyMap', keyMap);
-      cm.setOption('theme', theme);
-      cm.setOption('scrollPastEnd', scrollPastEnd);
-      cm.setOption('styleActiveLine', styleActiveLine);
-      cm.setOption('styleSelectedText', styleSelectedText);
-      cm.setOption('selectionPointer', selectionPointer);
-      cm.setOption('lineWiseCopyCut', lineWiseCopyCut);
+      const { editor } = widget.content;
+      editor.setOption('keyMap', keyMap);
+      editor.setOption('lineWiseCopyCut', lineWiseCopyCut);
+      editor.setOption('selectionPointer', selectionPointer);
+      editor.setOption('scrollPastEnd', scrollPastEnd);
+      editor.setOption('styleActiveLine', styleActiveLine);
+      editor.setOption('styleSelectedText', styleSelectedText);
+      editor.setOption('theme', theme);
     }
   });
 

--- a/packages/codemirror/style/base.css
+++ b/packages/codemirror/style/base.css
@@ -17,7 +17,7 @@
   padding: 0 var(--jp-code-padding);
 }
 
-.jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-dialog {
+:host([data-type='inline']) .CodeMirror-dialog {
   background-color: var(--jp-layout-color0);
   color: var(--jp-content-font-color1);
 }
@@ -32,17 +32,17 @@
   padding: 0 8px;
 }
 
-.jp-CodeMirrorEditor {
+:host {
   cursor: text;
 }
 
-.jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
+:host([data-type='inline']) .CodeMirror-cursor {
   border-left: var(--jp-code-cursor-width0) solid var(--jp-editor-cursor-color);
 }
 
 /* When zoomed out 67% and 33% on a screen of 1440 width x 900 height */
 @media screen and (min-width: 2138px) and (max-width: 4319px) {
-  .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
+  :host([data-type='inline']) .CodeMirror-cursor {
     border-left: var(--jp-code-cursor-width1) solid
       var(--jp-editor-cursor-color);
   }
@@ -50,7 +50,7 @@
 
 /* When zoomed out less than 33% */
 @media screen and (min-width: 4320px) {
-  .jp-CodeMirrorEditor[data-type='inline'] .CodeMirror-cursor {
+  :host([data-type='inline']) .CodeMirror-cursor {
     border-left: var(--jp-code-cursor-width2) solid
       var(--jp-editor-cursor-color);
   }
@@ -112,117 +112,4 @@
 
 .jp-CodeMirror-ruler {
   border-left: 1px dashed var(--jp-border-color2);
-}
-
-/**
- * Here is our jupyter theme for CodeMirror syntax highlighting
- * This is used in our marked.js syntax highlighting and CodeMirror itself
- * The string "jupyter" is set in ../codemirror/widget.DEFAULT_CODEMIRROR_THEME
- * This came from the classic notebook, which came form highlight.js/GitHub
- */
-
-/**
- * CodeMirror themes are handling the background/color in this way. This works
- * fine for CodeMirror editors outside the notebook, but the notebook styles
- * these things differently.
- */
-.CodeMirror.cm-s-jupyter {
-  background: var(--jp-layout-color0);
-  color: var(--jp-content-font-color1);
-}
-
-/* In the notebook, we want this styling to be handled by its container */
-.jp-CodeConsole .CodeMirror.cm-s-jupyter,
-.jp-Notebook .CodeMirror.cm-s-jupyter {
-  background: transparent;
-}
-
-.cm-s-jupyter .CodeMirror-cursor {
-  border-left: var(--jp-code-cursor-width0) solid var(--jp-editor-cursor-color);
-}
-.cm-s-jupyter span.cm-keyword {
-  color: var(--jp-mirror-editor-keyword-color);
-  font-weight: bold;
-}
-.cm-s-jupyter span.cm-atom {
-  color: var(--jp-mirror-editor-atom-color);
-}
-.cm-s-jupyter span.cm-number {
-  color: var(--jp-mirror-editor-number-color);
-}
-.cm-s-jupyter span.cm-def {
-  color: var(--jp-mirror-editor-def-color);
-}
-.cm-s-jupyter span.cm-variable {
-  color: var(--jp-mirror-editor-variable-color);
-}
-.cm-s-jupyter span.cm-variable-2 {
-  color: var(--jp-mirror-editor-variable-2-color);
-}
-.cm-s-jupyter span.cm-variable-3 {
-  color: var(--jp-mirror-editor-variable-3-color);
-}
-.cm-s-jupyter span.cm-punctuation {
-  color: var(--jp-mirror-editor-punctuation-color);
-}
-.cm-s-jupyter span.cm-property {
-  color: var(--jp-mirror-editor-property-color);
-}
-.cm-s-jupyter span.cm-operator {
-  color: var(--jp-mirror-editor-operator-color);
-  font-weight: bold;
-}
-.cm-s-jupyter span.cm-comment {
-  color: var(--jp-mirror-editor-comment-color);
-  font-style: italic;
-}
-.cm-s-jupyter span.cm-string {
-  color: var(--jp-mirror-editor-string-color);
-}
-.cm-s-jupyter span.cm-string-2 {
-  color: var(--jp-mirror-editor-string-2-color);
-}
-.cm-s-jupyter span.cm-meta {
-  color: var(--jp-mirror-editor-meta-color);
-}
-.cm-s-jupyter span.cm-qualifier {
-  color: var(--jp-mirror-editor-qualifier-color);
-}
-.cm-s-jupyter span.cm-builtin {
-  color: var(--jp-mirror-editor-builtin-color);
-}
-.cm-s-jupyter span.cm-bracket {
-  color: var(--jp-mirror-editor-bracket-color);
-}
-.cm-s-jupyter span.cm-tag {
-  color: var(--jp-mirror-editor-tag-color);
-}
-.cm-s-jupyter span.cm-attribute {
-  color: var(--jp-mirror-editor-attribute-color);
-}
-.cm-s-jupyter span.cm-header {
-  color: var(--jp-mirror-editor-header-color);
-}
-.cm-s-jupyter span.cm-quote {
-  color: var(--jp-mirror-editor-quote-color);
-}
-.cm-s-jupyter span.cm-link {
-  color: var(--jp-mirror-editor-link-color);
-}
-.cm-s-jupyter span.cm-error {
-  color: var(--jp-mirror-editor-error-color);
-}
-.cm-s-jupyter span.cm-hr {
-  color: #999;
-}
-
-.cm-s-jupyter span.cm-tab {
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);
-  background-position: right;
-  background-repeat: no-repeat;
-}
-
-.cm-s-jupyter .CodeMirror-activeline-background,
-.cm-s-jupyter .CodeMirror-gutter {
-  background-color: var(--jp-layout-color2);
 }

--- a/packages/codemirror/style/index.css
+++ b/packages/codemirror/style/index.css
@@ -8,8 +8,3 @@
 @import url('~@jupyterlab/apputils/style/index.css');
 @import url('~@jupyterlab/codeeditor/style/index.css');
 @import url('~@jupyterlab/statusbar/style/index.css');
-@import url('~codemirror/lib/codemirror.css');
-@import url('~codemirror/addon/dialog/dialog.css');
-@import url('~codemirror/addon/fold/foldgutter.css');
-
-@import url('./base.css');

--- a/packages/codemirror/style/jupyter-theme.css
+++ b/packages/codemirror/style/jupyter-theme.css
@@ -1,0 +1,110 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+/**
+ * Here is our jupyter theme for CodeMirror syntax highlighting
+ * This is used in our marked.js syntax highlighting and CodeMirror itself
+ * The string "jupyter" is set in ../codemirror/widget.DEFAULT_CODEMIRROR_THEME
+ * This came from the classic notebook, which came form highlight.js/GitHub
+ */
+
+:host {
+  background: var(--jp-layout-color0);
+  color: var(--jp-content-font-color1);
+}
+
+.CodeMirror {
+  background: transparent;
+}
+
+.cm-s-jupyter .CodeMirror-cursor {
+  border-left: var(--jp-code-cursor-width0) solid var(--jp-editor-cursor-color);
+}
+.cm-s-jupyter span.cm-keyword {
+  color: var(--jp-mirror-editor-keyword-color);
+  font-weight: bold;
+}
+.cm-s-jupyter span.cm-atom {
+  color: var(--jp-mirror-editor-atom-color);
+}
+.cm-s-jupyter span.cm-number {
+  color: var(--jp-mirror-editor-number-color);
+}
+.cm-s-jupyter span.cm-def {
+  color: var(--jp-mirror-editor-def-color);
+}
+.cm-s-jupyter span.cm-variable {
+  color: var(--jp-mirror-editor-variable-color);
+}
+.cm-s-jupyter span.cm-variable-2 {
+  color: var(--jp-mirror-editor-variable-2-color);
+}
+.cm-s-jupyter span.cm-variable-3 {
+  color: var(--jp-mirror-editor-variable-3-color);
+}
+.cm-s-jupyter span.cm-punctuation {
+  color: var(--jp-mirror-editor-punctuation-color);
+}
+.cm-s-jupyter span.cm-property {
+  color: var(--jp-mirror-editor-property-color);
+}
+.cm-s-jupyter span.cm-operator {
+  color: var(--jp-mirror-editor-operator-color);
+  font-weight: bold;
+}
+.cm-s-jupyter span.cm-comment {
+  color: var(--jp-mirror-editor-comment-color);
+  font-style: italic;
+}
+.cm-s-jupyter span.cm-string {
+  color: var(--jp-mirror-editor-string-color);
+}
+.cm-s-jupyter span.cm-string-2 {
+  color: var(--jp-mirror-editor-string-2-color);
+}
+.cm-s-jupyter span.cm-meta {
+  color: var(--jp-mirror-editor-meta-color);
+}
+.cm-s-jupyter span.cm-qualifier {
+  color: var(--jp-mirror-editor-qualifier-color);
+}
+.cm-s-jupyter span.cm-builtin {
+  color: var(--jp-mirror-editor-builtin-color);
+}
+.cm-s-jupyter span.cm-bracket {
+  color: var(--jp-mirror-editor-bracket-color);
+}
+.cm-s-jupyter span.cm-tag {
+  color: var(--jp-mirror-editor-tag-color);
+}
+.cm-s-jupyter span.cm-attribute {
+  color: var(--jp-mirror-editor-attribute-color);
+}
+.cm-s-jupyter span.cm-header {
+  color: var(--jp-mirror-editor-header-color);
+}
+.cm-s-jupyter span.cm-quote {
+  color: var(--jp-mirror-editor-quote-color);
+}
+.cm-s-jupyter span.cm-link {
+  color: var(--jp-mirror-editor-link-color);
+}
+.cm-s-jupyter span.cm-error {
+  color: var(--jp-mirror-editor-error-color);
+}
+.cm-s-jupyter span.cm-hr {
+  color: #999;
+}
+
+.cm-s-jupyter span.cm-tab {
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);
+  background-position: right;
+  background-repeat: no-repeat;
+}
+
+.cm-s-jupyter .CodeMirror-activeline-background,
+.cm-s-jupyter .CodeMirror-gutter {
+  background-color: var(--jp-layout-color2);
+}

--- a/packages/codemirror/style/shadow.css
+++ b/packages/codemirror/style/shadow.css
@@ -1,0 +1,10 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+@import url('~codemirror/lib/codemirror.css');
+@import url('~codemirror/addon/dialog/dialog.css');
+@import url('~codemirror/addon/fold/foldgutter.css');
+
+@import url('./base.css');

--- a/packages/codemirror/test/editor.spec.ts
+++ b/packages/codemirror/test/editor.spec.ts
@@ -280,16 +280,16 @@ describe('CodeMirrorEditor', () => {
   describe('#handleEvent', () => {
     describe('focus', () => {
       it('should add the focus class to the host', () => {
-        simulate(editor.editor.getInputField(), 'focus');
+        simulate(editor.editor.getInputField(), 'focus', { composed: true });
         expect(host.classList.contains('jp-mod-focused')).toBe(true);
       });
     });
 
     describe('blur', () => {
       it('should remove the focus class from the host', () => {
-        simulate(editor.editor.getInputField(), 'focus');
+        simulate(editor.editor.getInputField(), 'focus', { composed: true });
         expect(host.classList.contains('jp-mod-focused')).toBe(true);
-        simulate(editor.editor.getInputField(), 'blur');
+        simulate(editor.editor.getInputField(), 'blur', { composed: true });
         expect(host.classList.contains('jp-mod-focused')).toBe(false);
       });
     });

--- a/testutils/src/jest-config.ts
+++ b/testutils/src/jest-config.ts
@@ -4,6 +4,8 @@ module.exports = function(baseDir: string) {
   return {
     preset: 'ts-jest/presets/js-with-babel',
     moduleNameMapper: {
+      '^!!to-string-loader!css-loader!.+\\.css':
+        '@jupyterlab/testutils/lib/jest-style-mock.js',
       '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
       '\\.(gif|ttf|eot)$': '@jupyterlab/testutils/lib/jest-file-mock.js'
     },

--- a/testutils/src/jest-style-mock.ts
+++ b/testutils/src/jest-style-mock.ts
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6442,6 +6442,11 @@ emojis-list@^2.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
 emotion-theming@^10.0.14:
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/emotion-theming/-/emotion-theming-10.0.27.tgz#1887baaec15199862c89b1b984b79806f2b9ab10"
@@ -10028,6 +10033,15 @@ loader-utils@^0.2.16:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
+
+loader-utils@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
+  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^1.0.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -14523,6 +14537,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+to-string-loader@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/to-string-loader/-/to-string-loader-1.1.6.tgz#230529ccc63dd0ecca052a85e1fb82afe946b0ab"
+  integrity sha512-VNg62//PS1WfNwrK3n7t6wtK5Vdtx/qeYLLEioW46VMlYUwAYT6wnfB+OwS2FMTCalIHu0tk79D3RXX8ttmZTQ==
+  dependencies:
+    loader-utils "^1.0.0"
 
 toggle-selection@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
For the idea behind this, see [my comment][1] to issue #4292.

Moving CodeMirror HTML tree and related CSS to Shadow DOM, reduces the time spent to calculate style. The amount of the reduction depends on the notebook, but often it is more than 30%.

Moreover, this can be considered a test bench for a more general use of the shadow DOM.

[1]: https://github.com/jupyterlab/jupyterlab/issues/4292#issuecomment-636925353