### PR TITLE
File Browser Filter

### DIFF
--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -32,7 +32,7 @@ import { DocumentManager } from '@jupyterlab/docmanager';
 
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 
-import { FileBrowser, FileBrowserModel } from '@jupyterlab/filebrowser';
+import { FileBrowser, FilterFileBrowserModel } from '@jupyterlab/filebrowser';
 
 import { FileEditorFactory } from '@jupyterlab/fileeditor';
 
@@ -89,7 +89,7 @@ function createApp(manager: ServiceManager.IManager): void {
 
   const commands = new CommandRegistry();
 
-  const fbModel = new FileBrowserModel({
+  const fbModel = new FilterFileBrowserModel({
     manager: docManager
   });
   const fbWidget = new FileBrowser({

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -65,7 +65,7 @@ export class SearchBar extends React.Component<
           placeholder={this.props.placeholder}
           onChange={this.handleChange}
           value={this.state.value}
-          rightIcon="search"
+          rightIcon="ui-components:search"
           disabled={this.props.disabled}
         />
       </div>

--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -21,6 +21,12 @@
       "title": "Navigate to current directory",
       "description": "Whether to automatically navigate to a document's current directory",
       "default": false
+    },
+    "useFuzzyFilter": {
+      "type": "boolean",
+      "title": "Filter on file name with a fuzzy search",
+      "description": "Whether to apply fuzzy algorithm while filtering on file names",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -25,7 +25,7 @@ import { PageConfig, PathExt, URLExt } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 
 import {
-  FileBrowserModel,
+  FilterFileBrowserModel,
   FileBrowser,
   FileUploadStatus,
   IFileBrowserFactory
@@ -125,6 +125,8 @@ namespace CommandIDs {
     'filebrowser:toggle-navigate-to-current-directory';
 
   export const toggleLastModified = 'filebrowser:toggle-last-modified';
+
+  export const search = 'filebrowser:search';
 }
 
 /**
@@ -240,7 +242,7 @@ async function activateFactory(
     id: string,
     options: IFileBrowserFactory.IOptions = {}
   ) => {
-    const model = new FileBrowserModel({
+    const model = new FilterFileBrowserModel({
       auto: options.auto ?? true,
       manager: docManager,
       driveName: options.driveName || '',
@@ -840,6 +842,11 @@ function addCommands(
         }
       }
     }
+  });
+
+  commands.addCommand(CommandIDs.search, {
+    label: 'Search on File Names',
+    execute: () => alert('search')
   });
 
   if (mainMenu) {

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -354,6 +354,7 @@ function activateBrowser(
     });
 
     let navigateToCurrentDirectory: boolean = false;
+    let useFuzzyFilter: boolean = true;
 
     void settingRegistry
       .load('@jupyterlab/filebrowser-extension:browser')
@@ -367,6 +368,12 @@ function activateBrowser(
         navigateToCurrentDirectory = settings.get('navigateToCurrentDirectory')
           .composite as boolean;
         browser.navigateToCurrentDirectory = navigateToCurrentDirectory;
+        settings.changed.connect(settings => {
+          useFuzzyFilter = settings.get('useFuzzyFilter').composite as boolean;
+          browser.useFuzzyFilter = useFuzzyFilter;
+        });
+        useFuzzyFilter = settings.get('useFuzzyFilter').composite as boolean;
+        browser.useFuzzyFilter = useFuzzyFilter;
       });
 
     // Whether to automatically navigate to a document's current directory

--- a/packages/filebrowser/package.json
+++ b/packages/filebrowser/package.json
@@ -56,6 +56,7 @@
     "@lumino/messaging": "^1.3.3",
     "@lumino/polling": "^1.1.1",
     "@lumino/signaling": "^1.3.5",
+    "@lumino/virtualdom": "^1.6.1",
     "@lumino/widgets": "^1.11.1",
     "react": "~16.9.0"
   },

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -312,7 +312,8 @@ export class FileBrowser extends Widget {
     this._filenameSearcher = FilenameSearcher({
       listing: this._listing,
       useFuzzyFilter: this._useFuzzyFilter,
-      placeholder: 'Filter files by name'
+      placeholder: 'Filter files by name',
+      forceRefresh: true
     });
     this._filenameSearcher.addClass(FILTERBOX_CLASS);
 

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -39,6 +39,11 @@ const FILE_BROWSER_CLASS = 'jp-FileBrowser';
 const CRUMBS_CLASS = 'jp-FileBrowser-crumbs';
 
 /**
+ * The class name added to the filebrowser filterbox node.
+ */
+const FILTERBOX_CLASS = 'jp-FileBrowser-filterBox';
+
+/**
  * The class name added to the filebrowser toolbar node.
  */
 const TOOLBAR_CLASS = 'jp-FileBrowser-toolbar';
@@ -106,7 +111,7 @@ export class FileBrowser extends Widget {
     this._crumbs.addClass(CRUMBS_CLASS);
     this.toolbar.addClass(TOOLBAR_CLASS);
     this._listing.addClass(LISTING_CLASS);
-    this._filenameSearcher.addClass(CRUMBS_CLASS);
+    this._filenameSearcher.addClass(FILTERBOX_CLASS);
 
     this.layout = new PanelLayout();
     this.layout.addWidget(this.toolbar);

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -105,7 +105,7 @@ export class FileBrowser extends Widget {
 
     this._filenameSearcher = FilenameSearcher({
       listing: this._listing,
-      placeholder: 'Search on filename'
+      placeholder: 'Filter files by name'
     });
 
     this._crumbs.addClass(CRUMBS_CLASS);

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -110,13 +110,13 @@ export class FileBrowser extends Widget {
 
     this._crumbs.addClass(CRUMBS_CLASS);
     this.toolbar.addClass(TOOLBAR_CLASS);
-    this._listing.addClass(LISTING_CLASS);
     this._filenameSearcher.addClass(FILTERBOX_CLASS);
+    this._listing.addClass(LISTING_CLASS);
 
     this.layout = new PanelLayout();
     this.layout.addWidget(this.toolbar);
-    this.layout.addWidget(this._crumbs);
     this.layout.addWidget(this._filenameSearcher);
+    this.layout.addWidget(this._crumbs);
     this.layout.addWidget(this._listing);
 
     if (options.restore !== false) {

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -105,6 +105,7 @@ export class FileBrowser extends Widget {
 
     this._filenameSearcher = FilenameSearcher({
       listing: this._listing,
+      useFuzzyFilter: this._useFuzzyFilter,
       placeholder: 'Filter files by name'
     });
 
@@ -302,6 +303,28 @@ export class FileBrowser extends Widget {
     this._navigateToCurrentDirectory = value;
   }
 
+  /**
+   * Whether to use fuzzy filtering on file names.
+   */
+  set useFuzzyFilter(value: boolean) {
+    this._useFuzzyFilter = value;
+
+    this._filenameSearcher = FilenameSearcher({
+      listing: this._listing,
+      useFuzzyFilter: this._useFuzzyFilter,
+      placeholder: 'Filter files by name'
+    });
+    this._filenameSearcher.addClass(FILTERBOX_CLASS);
+
+    this.layout.removeWidget(this._filenameSearcher);
+    this.layout.removeWidget(this._crumbs);
+    this.layout.removeWidget(this._listing);
+
+    this.layout.addWidget(this._filenameSearcher);
+    this.layout.addWidget(this._crumbs);
+    this.layout.addWidget(this._listing);
+  }
+
   // Override Widget.layout with a more specific PanelLayout type.
   layout: PanelLayout;
 
@@ -311,6 +334,7 @@ export class FileBrowser extends Widget {
   private _manager: IDocumentManager;
   private _directoryPending: boolean;
   private _navigateToCurrentDirectory: boolean;
+  private _useFuzzyFilter: boolean = true;
 }
 
 /**

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -12,11 +12,7 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 
 import { Contents, ServerConnection } from '@jupyterlab/services';
 
-import {
-  newFolderIcon,
-  refreshIcon,
-  searchIcon
-} from '@jupyterlab/ui-components';
+import { newFolderIcon, refreshIcon } from '@jupyterlab/ui-components';
 
 import { IIterator } from '@lumino/algorithm';
 
@@ -88,14 +84,6 @@ export class FileBrowser extends Widget {
     });
     const uploader = new Uploader({ model });
 
-    const searcher = new ToolbarButton({
-      icon: searchIcon,
-      onClick: () => {
-        this._toggleBrowserLayout();
-      },
-      tooltip: 'Filter files by name'
-    });
-
     const refresher = new ToolbarButton({
       icon: refreshIcon,
       onClick: () => {
@@ -106,7 +94,6 @@ export class FileBrowser extends Widget {
 
     this.toolbar.addItem('newFolder', newFolder);
     this.toolbar.addItem('upload', uploader);
-    this.toolbar.addItem('search', searcher);
     this.toolbar.addItem('refresher', refresher);
 
     this._listing = new DirListing({ model, renderer });
@@ -122,7 +109,10 @@ export class FileBrowser extends Widget {
     this._filenameSearcher.addClass(CRUMBS_CLASS);
 
     this.layout = new PanelLayout();
-    this._showBrowserLayout();
+    this.layout.addWidget(this.toolbar);
+    this.layout.addWidget(this._crumbs);
+    this.layout.addWidget(this._filenameSearcher);
+    this.layout.addWidget(this._listing);
 
     if (options.restore !== false) {
       void model.restore(this.id);
@@ -279,31 +269,6 @@ export class FileBrowser extends Widget {
     return this._listing.modelForClick(event);
   }
 
-  private _toggleBrowserLayout(): void {
-    if (this._layoutMode === 'search') {
-      this._layoutMode = 'tree';
-    } else {
-      this._layoutMode = 'search';
-    }
-    this._showBrowserLayout();
-    void this.model.refresh();
-  }
-
-  private _showBrowserLayout(): void {
-    if (this._layoutMode === 'tree') {
-      this.layout.removeWidget(this._filenameSearcher);
-      this.layout.addWidget(this.toolbar);
-      this.layout.addWidget(this._crumbs);
-      this.layout.addWidget(this._listing);
-    } else {
-      this.layout.removeWidget(this._crumbs);
-      this.layout.removeWidget(this._listing);
-      this.layout.addWidget(this.toolbar);
-      this.layout.addWidget(this._filenameSearcher);
-      this.layout.addWidget(this._listing);
-    }
-  }
-
   /**
    * Handle a connection lost signal from the model.
    */
@@ -335,7 +300,6 @@ export class FileBrowser extends Widget {
   // Override Widget.layout with a more specific PanelLayout type.
   layout: PanelLayout;
 
-  private _layoutMode: 'tree' | 'search' = 'tree';
   private _crumbs: BreadCrumbs;
   private _listing: DirListing;
   private _filenameSearcher: ReactWidget;

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -93,7 +93,7 @@ export class FileBrowser extends Widget {
       onClick: () => {
         this._toggleBrowserLayout();
       },
-      tooltip: 'Search on File Names'
+      tooltip: 'Filter files by name'
     });
 
     const refresher = new ToolbarButton({

--- a/packages/filebrowser/src/index.ts
+++ b/packages/filebrowser/src/index.ts
@@ -7,5 +7,6 @@ export * from './tokens';
 export * from './listing';
 export * from './model';
 export * from './opendialog';
+export * from './search';
 export * from './upload';
 export * from './uploadstatus';

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -32,6 +32,7 @@ import {
 import {
   ArrayExt,
   ArrayIterator,
+  StringExt,
   each,
   filter,
   find,
@@ -51,6 +52,8 @@ import { Message, MessageLoop } from '@lumino/messaging';
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { Widget } from '@lumino/widgets';
+
+import { VirtualDOM, h } from '@lumino/virtualdom';
 
 import { FilterFileBrowserModel } from './model';
 
@@ -1886,8 +1889,10 @@ export namespace DirListing {
         node.removeAttribute('data-is-dot');
       }
       // If an item is being edited currently, its text node is unavailable.
-      if (text && text.textContent !== model.name) {
-        text.textContent = model.name;
+      if (text) {
+        const indices = !model.indices ? [] : model.indices;
+        let highlightedName = StringExt.highlight(model.name, indices, h.mark);
+        VirtualDOM.render(h.div(highlightedName), text);
       }
 
       let modText = '';

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -10,6 +10,8 @@ import {
 
 import { PathExt, Time } from '@jupyterlab/coreutils';
 
+import {} from '@jupyterlab/apputils';
+
 import {
   IDocumentManager,
   isValidFileName,
@@ -50,7 +52,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 
 import { Widget } from '@lumino/widgets';
 
-import { FileBrowserModel } from './model';
+import { FilterFileBrowserModel } from './model';
 
 /**
  * The class name added to DirListing widget.
@@ -228,7 +230,7 @@ export class DirListing extends Widget {
   /**
    * Get the model used by the listing.
    */
-  get model(): FileBrowserModel {
+  get model(): FilterFileBrowserModel {
     return this._model;
   }
 
@@ -788,15 +790,18 @@ export class DirListing extends Widget {
     each(this._model.sessions(), session => {
       const index = ArrayExt.firstIndexOf(paths, session.path);
       const node = nodes[index];
-      let name = session.kernel?.name;
-      const specs = this._model.specs;
+      // Node may have been filtered out.
+      if (node) {
+        let name = session.kernel?.name;
+        const specs = this._model.specs;
 
-      node.classList.add(RUNNING_CLASS);
-      if (specs && name) {
-        const spec = specs.kernelspecs[name];
-        name = spec ? spec.display_name : 'unknown';
+        node.classList.add(RUNNING_CLASS);
+        if (specs && name) {
+          const spec = specs.kernelspecs[name];
+          name = spec ? spec.display_name : 'unknown';
+        }
+        node.title = `${node.title}\nKernel: ${name}`;
       }
-      node.title = `${node.title}\nKernel: ${name}`;
     });
 
     this._prevPath = this._model.path;
@@ -1489,7 +1494,7 @@ export class DirListing extends Widget {
    * Handle a `fileChanged` signal from the model.
    */
   private _onFileChanged(
-    sender: FileBrowserModel,
+    sender: FilterFileBrowserModel,
     args: Contents.IChangedArgs
   ) {
     const newValue = args.newValue;
@@ -1527,7 +1532,7 @@ export class DirListing extends Widget {
     });
   }
 
-  private _model: FileBrowserModel;
+  private _model: FilterFileBrowserModel;
   private _editNode: HTMLInputElement;
   private _items: HTMLElement[] = [];
   private _sortedItems: Contents.IModel[] = [];
@@ -1567,7 +1572,7 @@ export namespace DirListing {
     /**
      * A file browser model instance.
      */
-    model: FileBrowserModel;
+    model: FilterFileBrowserModel;
 
     /**
      * A renderer for file items.

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -231,6 +231,7 @@ export class FileBrowserModel implements IDisposable {
   async refresh(): Promise<void> {
     await this._poll.refresh();
     await this._poll.tick;
+    this._refreshed.emit(void 0);
   }
 
   /**
@@ -701,6 +702,11 @@ export class FilterFileBrowserModel extends FileBrowserModel {
         return this._filter(value);
       }
     });
+  }
+
+  setFilter(filter: (value: Contents.IModel) => boolean) {
+    this._filter = filter;
+    void this.refresh();
   }
 
   private _filter: (value: Contents.IModel) => boolean;

--- a/packages/filebrowser/src/search.tsx
+++ b/packages/filebrowser/src/search.tsx
@@ -52,10 +52,12 @@ function fuzzySearch(item: Contents.IModel, query: string): IScore | null {
   let indices: number[] | null = null;
 
   // The regex for search word boundaries
-  let rgx = /\b\w/g;
+  const rgx = /\b\w/g;
+
+  let continueSearch = true;
 
   // Search the source by word boundary.
-  while (true) {
+  while (continueSearch) {
     // Find the next word boundary in the source.
     let rgxMatch = rgx.exec(source);
 

--- a/packages/filebrowser/src/search.tsx
+++ b/packages/filebrowser/src/search.tsx
@@ -36,7 +36,7 @@ const FilterBox = (props: IFilterBoxProps) => {
   return (
     <InputGroup
       type="text"
-      rightIcon="search"
+      rightIcon="ui-components:search"
       placeholder={props.placeholder}
       onChange={handleChange}
       value={filter}

--- a/packages/filebrowser/src/search.tsx
+++ b/packages/filebrowser/src/search.tsx
@@ -30,6 +30,9 @@ interface IScore {
    */
   score: number;
 
+  /**
+   * The indices of the text matches.
+   */
   indices: number[] | null;
 
   /**

--- a/packages/filebrowser/src/search.tsx
+++ b/packages/filebrowser/src/search.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import React, { useState } from 'react';
+
+import { InputGroup } from '@jupyterlab/ui-components';
+
+import { ReactWidget } from '@jupyterlab/apputils';
+
+import { Contents } from '@jupyterlab/services';
+
+import { DirListing } from './listing';
+
+/**
+ * The class name added to the filebrowser crumbs node.
+ */
+export interface IFilterBoxProps {
+  listing: DirListing;
+  placeholder?: string;
+}
+
+const FilterBox = (props: IFilterBoxProps) => {
+  const [filter, setFilter] = useState('');
+
+  /**
+   * Handler for search input changes.
+   */
+  const handleChange = (e: React.FormEvent<HTMLElement>) => {
+    const target = e.target as HTMLInputElement;
+    setFilter(target.value);
+    props.listing.model.setFilter(
+      (value: Contents.IModel) => value.name.indexOf(target.value) !== -1
+    );
+  };
+
+  return (
+    <InputGroup
+      type="text"
+      rightIcon="search"
+      placeholder={props.placeholder}
+      onChange={handleChange}
+      value={filter}
+    />
+  );
+};
+
+/**
+ * A widget which hosts a ...
+ */
+export const FilenameSearcher = (props: IFilterBoxProps) => {
+  return ReactWidget.create(
+    <FilterBox listing={props.listing} placeholder={props.placeholder} />
+  );
+};

--- a/packages/filebrowser/src/search.tsx
+++ b/packages/filebrowser/src/search.tsx
@@ -20,6 +20,7 @@ export interface IFilterBoxProps {
   listing: DirListing;
   useFuzzyFilter: boolean;
   placeholder?: string;
+  forceRefresh?: boolean;
 }
 
 /**
@@ -98,11 +99,13 @@ function fuzzySearch(item: Contents.IModel, query: string): IScore | null {
 const FilterBox = (props: IFilterBoxProps) => {
   const [filter, setFilter] = useState('');
 
-  useEffect(() => {
-    props.listing.model.setFilter((item: Contents.IModel) => {
-      return true;
-    });
-  }, []);
+  if (props.forceRefresh) {
+    useEffect(() => {
+      props.listing.model.setFilter((item: Contents.IModel) => {
+        return true;
+      });
+    }, []);
+  }
 
   /**
    * Handler for search input changes.
@@ -152,6 +155,7 @@ export const FilenameSearcher = (props: IFilterBoxProps) => {
       listing={props.listing}
       useFuzzyFilter={props.useFuzzyFilter}
       placeholder={props.placeholder}
+      forceRefresh={props.forceRefresh}
     />
   );
 };

--- a/packages/filebrowser/src/search.tsx
+++ b/packages/filebrowser/src/search.tsx
@@ -127,8 +127,7 @@ const FilterBox = (props: IFilterBoxProps) => {
         item.indices = [];
         return false;
       }
-      const indices = [...Array(target.value.length).keys()].slice(i);
-      item.indices = indices;
+      item.indices = [...Array(target.value.length).keys()].map(x => x + i);
       return true;
     });
   };

--- a/packages/filebrowser/src/search.tsx
+++ b/packages/filebrowser/src/search.tsx
@@ -128,7 +128,7 @@ const FilterBox = (props: IFilterBoxProps) => {
 };
 
 /**
- * A widget which hosts a ...
+ * A widget which hosts a input textbox to filter on file names.
  */
 export const FilenameSearcher = (props: IFilterBoxProps) => {
   return ReactWidget.create(

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -244,3 +244,7 @@
 .jp-LastModified-hidden {
   display: none;
 }
+
+.jp-FileBrowser-filterBox {
+  padding: 4px;
+}

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -139,6 +139,12 @@
   background-color: var(--jp-layout-color1);
 }
 
+.jp-DirListing-content mark {
+  color: var(--jp-ui-font-color0);
+  background-color: transparent;
+  font-weight: bold;
+}
+
 /* Style the directory listing content when a user drops a file to upload */
 .jp-DirListing.jp-mod-native-drop .jp-DirListing-content {
   outline: 5px dashed rgba(128, 128, 128, 0.5);

--- a/packages/json-extension/src/component.tsx
+++ b/packages/json-extension/src/component.tsx
@@ -58,7 +58,7 @@ export class Component extends React.Component<IProps, IState> {
           placeholder="Filter..."
           onChange={this.handleChange}
           value={this.state.value}
-          rightIcon="search"
+          rightIcon="ui-components:search"
         />
         <JSONTree
           data={data}

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -101,6 +101,11 @@ export namespace Contents {
      * The size of then file in bytes.
      */
     readonly size?: number;
+
+    /**
+     * The indices of the matched characters in the name.
+     */
+    indices?: ReadonlyArray<number> | null;
   }
 
   /**

--- a/packages/ui-components/src/blueprint.tsx
+++ b/packages/ui-components/src/blueprint.tsx
@@ -7,10 +7,6 @@ import {
   IButtonProps as IBPButtonProps
 } from '@blueprintjs/core/lib/cjs/components/button/buttons';
 import {
-  Icon as BPIcon,
-  IIconProps
-} from '@blueprintjs/core/lib/cjs/components/icon/icon';
-import {
   Collapse as BPCollapse,
   ICollapseProps
 } from '@blueprintjs/core/lib/cjs/components/collapse/collapse';
@@ -26,6 +22,7 @@ import {
   Checkbox as BPCheckbox,
   ICheckboxProps
 } from '@blueprintjs/core/lib/cjs/components/forms/controls';
+import { LabIcon } from './icon';
 export { Intent } from '@blueprintjs/core/lib/cjs/common/intent';
 
 import { classes } from './utils';
@@ -36,7 +33,7 @@ interface IButtonProps extends IBPButtonProps {
 }
 
 interface IInputGroupProps extends IBPInputGroupProps {
-  rightIcon?: IIconProps['icon'];
+  rightIcon?: string;
 }
 
 type CommonProps<T> = React.DOMAttributes<T>;
@@ -60,7 +57,7 @@ export const InputGroup = (props: IInputGroupProps & CommonProps<any>) => {
         className={classes(props.className, 'jp-InputGroup')}
         rightElement={
           <div className="jp-InputGroupAction">
-            <BPIcon className={'jp-BPIcon'} icon={props.rightIcon} />
+            <LabIcon.resolveReact icon={props.rightIcon} />
           </div>
         }
       />


### PR DESCRIPTION
## References

This PR adresses https://github.com/jupyterlab/jupyterlab/issues/8157.

For now, only the files of the current folder are considered, see also the TODO section hereafter.

## Code changes

- Changes in `filebrowser` and `filebrowser-extension` TS packages.
- Use `FilterFileBrowserModel` instead of `FileBrowserModel` and create a `search.ts` for input text

## User-facing changes

![filefilter](https://user-images.githubusercontent.com/226720/85788354-1f9cc300-b72d-11ea-8374-14abd7c59e22.gif)

## Backwards-incompatible changes

None.

## TODO

- [ ] Fix CSS issue when file listing is larger than the display layout.
- [ ] Consider to filter on folders (the existing `FilterFileBrowserModel` keeps the folders.
- [ ] Consider to filter on subfolders if this feature is required.
- [ ] Consider highlighting in the filenames the given filter.
