### PR TITLE
Remove superfluous page reload on workspace reset

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -376,7 +376,6 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
       execute: async () => {
         await db.clear();
         await save.invoke();
-        router.reload();
       }
     });
 


### PR DESCRIPTION
When the `reset` query string parameter is passed in via the URL to delete the contents of a workspace, the page reload is not necessary and makes page load time slower and more jarring, so it can be removed.

cc: @ellisonbg, this is relevant to your recent work.

## Code changes
Removes the `router.reload();` call in the command that clears a workspace.

## User-facing changes
Workspace `reset` is faster.

## Backwards-incompatible changes
N/A