### PR TITLE
Reload the application on manual state reset

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -373,9 +373,12 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
 
     commands.addCommand(CommandIDs.reset, {
       label: 'Reset Application State',
-      execute: async () => {
+      execute: async ({ reload }: { reload: boolean }) => {
         await db.clear();
         await save.invoke();
+        if (reload) {
+          router.reload();
+        }
       }
     });
 

--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -390,7 +390,11 @@ function activate(
     RESOURCES.forEach(args => {
       palette.addItem({ args, command: CommandIDs.open, category });
     });
-    palette.addItem({ command: 'apputils:reset', category });
+    palette.addItem({
+      args: { reload: true },
+      command: 'apputils:reset',
+      category
+    });
     palette.addItem({ command: CommandIDs.launchClassic, category });
   }
 }


### PR DESCRIPTION
When a user manually resets application state from the command palette instead of from the URL, the application needs to reload. This PR updates the removal of the reload from https://github.com/jupyterlab/jupyterlab/pull/8619 to special-case it when manually triggered.

## References
https://github.com/jupyterlab/jupyterlab/pull/8619

## Code changes
Adds a `reload` argument to the reset command and passes that through when invoked from the command palette.

## User-facing changes
The page reloads when the user invokes `Reset Application State` from the command palette.

## Backwards-incompatible changes
N/A