### PR TITLE
🐛 Fix handling of disposed widgets after closing a panel in tutorial

### DIFF
--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -819,8 +819,9 @@ Finally, rewrite the ``activate`` function so that it:
       app.commands.addCommand(command, {
         label: 'Random Astronomy Picture',
         execute: () => {
-          if (!widget) {
+          if (!widget || widget.isDisposed) {
             // Create a new widget if one does not exist
+            // or if the previous one was disposed after closing the panel
             const content = new APODWidget();
             widget = new MainAreaWidget({content});
             widget.id = 'apod-jupyterlab';


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

This is a change in a code example in the docs, not in the JupyterLab core.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

The tutorial [Let’s Make an Astronomy Picture of the Day JupyterLab Extension](https://jupyterlab.readthedocs.io/en/stable/developer/extension_tutorial.html#restore-panel-state-when-the-browser-refreshes) ends in a version of the code that creates the widget if it doesn't exist but doesn't account for "disposed" (I just learned that term from the console error) widgets after closing the panel.

So, the widget is indeed restored after refreshing the window, but if the panel is closed and re-opened again, then:

* It no longer has a title
* Is not closable
* An error is thrown in the console

<!-- For visual changes, include before and after screenshots here. -->

Here's a screenshot after those steps, with the last state of the extension from the tutorial:

![JupyterLab - Google Chrome_066](https://user-images.githubusercontent.com/1326112/85916914-84ebd380-b855-11ea-944c-9c60085bfb7f.png)

---

After the fix, it can be closed and re-opened again, preserving the title, and it is still restored after refreshing the window.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
