### PR TITLE
Fix API Docs Links

### DIFF
--- a/docs/source/developer/documents.rst
+++ b/docs/source/developer/documents.rst
@@ -18,21 +18,21 @@ is backed by a file stored on disk (i.e. uses Contents API).
 Overview of document architecture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A 'document' in JupyterLab is represented by a model instance implementing the `IModel <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.imodel.html>`__ interface. The model interface is intentionally fairly small, and concentrates on representing the data in the document and signaling changes to that data. Each model has an associated `context <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.icontext.html>`__ instance as well. The context for a model is the bridge between the internal data of the document, stored in the model, and the file metadata and operations possible on the file, such as save and revert. Since many objects will need both the context and the model, the context contains a reference to the model as its `.model` attribute.
+A 'document' in JupyterLab is represented by a model instance implementing the `IModel <https://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_index_.documentregistry.imodel.html>`__ interface. The model interface is intentionally fairly small, and concentrates on representing the data in the document and signaling changes to that data. Each model has an associated `context <https://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_index_.documentregistry.icontext.html>`__ instance as well. The context for a model is the bridge between the internal data of the document, stored in the model, and the file metadata and operations possible on the file, such as save and revert. Since many objects will need both the context and the model, the context contains a reference to the model as its `.model` attribute.
 
 A single file path can have multiple different models (and hence different contexts) representing the file. For example, a notebook can be opened with a notebook model and with a text model. Different models for the same file path do not directly communicate with each other.
 
-`Document widgets <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html>`__ represent a view of a document model. There can be multiple document widgets associated with a single document model, and they naturally stay in sync with each other since they are views on the same underlying data model.
+`Document widgets <https://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_index_.documentregistry.html>`__ represent a view of a document model. There can be multiple document widgets associated with a single document model, and they naturally stay in sync with each other since they are views on the same underlying data model.
 
 
 The `Document
-Registry <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html>`__
+Registry <https://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_index_.documentregistry.html>`__
 is where document types and factories are registered. Plugins can
 require a document registry instance and register their content types
 and providers.
 
 The `Document
-Manager <https://jupyterlab.github.io/jupyterlab/docmanager/classes/documentmanager.html>`__
+Manager <https://jupyterlab.github.io/jupyterlab/classes/_docmanager_src_index_.documentmanager.html>`__
 uses the Document Registry to create models and widgets for documents.
 The Document Manager handles the lifecycle of documents for the application.
 
@@ -46,8 +46,8 @@ Document Registry
 -  widget factories for specific model factories
 -  widget extension factories
 
-`Widget Factories <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html#addwidgetfactory>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Widget Factories <https://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_index_.documentregistry.html#addwidgetfactory>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Create a widget for a given file.
 
@@ -55,16 +55,16 @@ Create a widget for a given file.
 
 -  The notebook widget factory that creates NotebookPanel widgets.
 
-`Model Factories <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html#addmodelfactory>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Model Factories <https://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_index_.documentregistry.html#addmodelfactory>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Create a model for a given file.
 
 Models are generally differentiated by the contents options used to
 fetch the model (e.g. text, base64, notebook).
 
-`Widget Extension Factories <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html#addwidgetextension>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Widget Extension Factories <https://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_index_.documentregistry.html#addwidgetextension>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Adds additional functionality to a widget type. An extension instance is
 created for each widget instance, enabling the extension to add
@@ -75,11 +75,11 @@ functionality to each widget or observe the widget and/or its context.
 -  The ipywidgets extension that is created for NotebookPanel widgets.
 -  Adding a button to the toolbar of each NotebookPanel widget.
 
-`File Types <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html#addfiletype>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`File Types <https://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_index_.documentregistry.html#addfiletype>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`Document Models <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.imodel.html>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Document Models <https://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_index_.documentregistry.imodel.html>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Created by the model factories and passed to widget factories and widget
 extension factories. Models are the way in which we interact with the
@@ -87,8 +87,8 @@ data of a document. For a simple text file, we typically only use the
 ``to/fromString()`` methods. A more complex document like a Notebook
 contains more points of interaction like the Notebook metadata.
 
-`Document Contexts <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.icontext.html>`__
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Document Contexts <https://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_index_.documentregistry.icontext.html>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Created by the Document Manager and passed to widget factories and
 widget extensions. The context contains the model as one of its

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -61,7 +61,7 @@ A plugin adds a core functionality to the application:
 -  Plugins require and provide ``Token`` objects, which are used to
    provide a typed value to the plugin's ``activate()`` method.
 -  The module providing plugin(s) must meet the
-   `JupyterLab.IPluginModule <https://jupyterlab.github.io/jupyterlab/application/interfaces/jupyterlab.ipluginmodule.html>`__
+   `JupyterLab.IPluginModule <https://jupyterlab.github.io/jupyterlab/interfaces/_application_src_index_.jupyterlab.ipluginmodule.html>`__
    interface, by exporting a plugin object or array of plugin objects as
    the default export.
 
@@ -113,7 +113,7 @@ Jupyter Front-End Shell
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The Jupyter front-end
-`shell <https://jupyterlab.github.io/jupyterlab/application/interfaces/jupyterfrontend.ishell.html>`__
+`shell <https://jupyterlab.github.io/jupyterlab/interfaces/_application_src_index_.jupyterfrontend.ishell.html>`__
 is used to add and interact with content in the application. The ``IShell``
 interface provides an ``add()`` method for adding widgets to the application.
 In JupyterLab, the application shell consists of:
@@ -345,7 +345,7 @@ Mime renderer extensions are more declarative than standard extensions.
 The extension is treated the same from the command line perspective
 (``jupyter labextension install`` ), but it does not directly create
 JupyterLab plugins. Instead it exports an interface given in the
-`rendermime-interfaces <https://jupyterlab.github.io/jupyterlab/rendermime-interfaces/interfaces/irendermime.iextension.html>`__
+`rendermime-interfaces <https://jupyterlab.github.io/jupyterlab/interfaces/_rendermime_interfaces_src_index_.irendermime.iextension.html>`__
 package.
 
 The JupyterLab repo has an example mime renderer extension for

--- a/docs/source/developer/notebook.rst
+++ b/docs/source/developer/notebook.rst
@@ -19,9 +19,9 @@ The most complicated plugin included in the **JupyterLab application**
 is the **Notebook plugin**.
 
 The
-`NotebookWidgetFactory <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebookwidgetfactory.html>`__
+`NotebookWidgetFactory <https://jupyterlab.github.io/jupyterlab/classes/_notebook_src_index_.notebookwidgetfactory.html>`__
 constructs a new
-`NotebookPanel <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebookpanel.html>`__
+`NotebookPanel <https://jupyterlab.github.io/jupyterlab/classes/_notebook_src_index_.notebookpanel.html>`__
 from a model and populates the toolbar with default widgets.
 
 Structure of the Notebook plugin
@@ -34,11 +34,11 @@ Model
 ^^^^^
 
 The
-`NotebookModel <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebookmodel.html>`__
+`NotebookModel <https://jupyterlab.github.io/jupyterlab/classes/_notebook_src_index_.notebookmodel.html>`__
 contains an observable list of cells.
 
 A `cell
-model <https://jupyterlab.github.io/jupyterlab/cells/classes/cellmodel.html>`__
+model <https://jupyterlab.github.io/jupyterlab/classes/_cells_src_index_.cellmodel.html>`__
 can be:
 
 -  a code cell
@@ -65,7 +65,7 @@ Metadata
 
 The notebook model and the cell model (i.e. notebook cells) support
 getting and setting metadata through an
-`IObservableJSON <https://jupyterlab.github.io/jupyterlab/observables/modules/iobservablejson.html>`__
+`IObservableJSON <https://jupyterlab.github.io/jupyterlab/modules/_observables_src_index_.iobservablejson.html>`__
 object. You can use this to get and set notebook/cell metadata,
 as well as subscribe to changes to it.
 
@@ -77,9 +77,9 @@ a new NotebookPanel from the model. The NotebookPanel widget is added to
 the DockPanel. The **NotebookPanel** contains:
 
 -  a
-   `Toolbar <https://jupyterlab.github.io/jupyterlab/apputils/classes/toolbar.html>`__
+   `Toolbar <https://jupyterlab.github.io/jupyterlab/classes/_apputils_src_index_.toolbar.html>`__
 -  a `Notebook
-   widget <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebook.html>`__.
+   widget <https://jupyterlab.github.io/jupyterlab/classes/_notebook_src_index_.notebook.html>`__.
 
 The NotebookPanel also adds completion logic.
 
@@ -96,7 +96,7 @@ Higher level actions using NotebookActions
 ''''''''''''''''''''''''''''''''''''''''''
 
 Higher-level actions are contained in the
-`NotebookActions <https://jupyterlab.github.io/jupyterlab/notebook/classes/notebookactions.html>`__
+`NotebookActions <https://jupyterlab.github.io/jupyterlab/classes/_notebook_src_index_.notebookactions.html>`__
 namespace, which has functions, when given a notebook widget, to run a
 cell and select the next cell, merge or split cells at the cursor,
 delete selected cells, etc.
@@ -105,25 +105,25 @@ Widget hierarchy
 ''''''''''''''''
 
 A Notebook widget contains a list of `cell
-widgets <https://jupyterlab.github.io/jupyterlab/cells/classes/cell.html>`__,
+widgets <https://jupyterlab.github.io/jupyterlab/classes/_cells_src_index_.cell.html>`__,
 corresponding to the cell models in its cell list.
 
 -  Each cell widget contains an
-   `InputArea <https://jupyterlab.github.io/jupyterlab/cells/classes/inputarea.html>`__,
+   `InputArea <https://jupyterlab.github.io/jupyterlab/classes/_cells_src_index_.inputarea.html>`__,
 
    -  which contains n
-      `CodeEditorWrapper <https://jupyterlab.github.io/jupyterlab/codeeditor/classes/codeeditorwrapper.html>`__,
+      `CodeEditorWrapper <https://jupyterlab.github.io/jupyterlab/classes/_codeeditor_src_index_.codeeditorwrapper.html>`__,
 
       -  which contains a JavaScript CodeMirror instance.
 
 A
-`CodeCell <https://jupyterlab.github.io/jupyterlab/cells/classes/codecell.html>`__
+`CodeCell <https://jupyterlab.github.io/jupyterlab/classes/_cells_src_index_.codecell.html>`__
 also contains an
-`OutputArea <https://jupyterlab.github.io/jupyterlab/outputarea/classes/outputarea.html>`__.
+`OutputArea <https://jupyterlab.github.io/jupyterlab/classes/_outputarea_src_index_.outputarea.html>`__.
 An OutputArea is responsible for rendering the outputs in the
-`OutputAreaModel <https://jupyterlab.github.io/jupyterlab/outputarea/classes/outputareamodel.html>`__
+`OutputAreaModel <https://jupyterlab.github.io/jupyterlab/classes/_outputarea_src_index_.outputareamodel.html>`__
 list. An OutputArea uses a notebook-specific
-`RenderMimeRegistry <https://jupyterlab.github.io/jupyterlab/rendermime/classes/rendermimeregistry.html>`__
+`RenderMimeRegistry <https://jupyterlab.github.io/jupyterlab/classes/_rendermime_src_index_.rendermimeregistry.html>`__
 object to render ``display_data`` output messages.
 
 Rendering output messages
@@ -262,9 +262,9 @@ intrinsic relation between *lumino widgets* and *ipython widgets*.
 
 The *ipywidgets* extension registers a factory for a notebook *widget*
 extension using the `Document
-Registry <https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentregistry.html>`__.
+Registry <https://jupyterlab.github.io/jupyterlab/classes/_docregistry_src_index_.documentregistry.html>`__.
 The ``createNew()`` function is called with a NotebookPanel and
-`DocumentContext <https://jupyterlab.github.io/jupyterlab/docregistry/interfaces/documentregistry.icontext.html>`__.
+`DocumentContext <https://jupyterlab.github.io/jupyterlab/interfaces/_docregistry_src_index_.documentregistry.icontext.html>`__.
 The plugin then creates a ipywidget manager (which uses the context to
 interact the kernel and kernel's comm manager). The plugin then
 registers an ipywidget renderer with the notebook instance's rendermime

--- a/docs/source/developer/ui_components.rst
+++ b/docs/source/developer/ui_components.rst
@@ -12,7 +12,7 @@
 Reusing JupyterLab UI
 =====================
 
-The `@jupyterlab/ui-components <http://jupyterlab.github.io/jupyterlab/ui-components/index.html>`__
+The `@jupyterlab/ui-components <https://jupyterlab.github.io/jupyterlab/modules/_ui_components_src_index_.html>`__
 package provides UI elements that are widely used in JupyterLab core,
 and that can be reused in your own extensions.
 

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -8,7 +8,7 @@ then run "jlpm docs:init" to refresh the built docs
 # @jupyterlab/ui-components
 
 The
-[@jupyterlab/ui-components](http://jupyterlab.github.io/jupyterlab/ui-components/index.html)
+[@jupyterlab/ui-components](https://jupyterlab.github.io/jupyterlab/modules/_ui_components_src_index_.html)
 package provides UI elements that are widely used in JupyterLab core,
 and that can be reused in your own extensions.
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #8616

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Updates links in docs.

Used the following script:

```python
import glob
import re

files = glob.glob('docs/**/*.rst', recursive=True)

for f in files:
    
    with open(f) as fid:
        data = fid.read()

    while True:
        match = re.search('https://jupyterlab.github.io/jupyterlab/(\w+)/interfaces/', data)
        if match is None:
            break
        section = match.groups()[0]
        print(f, section)
        data = data.replace(match.group(), f'https://jupyterlab.github.io/jupyterlab/interfaces/_{section}_src_index_.')
    
    while True:
        match = re.search('https://jupyterlab.github.io/jupyterlab/(\w+)/classes/', data)
        if match is None:
            break
        section = match.groups()[0]
        print(f, section)
        data = data.replace(match.group(), f'https://jupyterlab.github.io/jupyterlab/classes/_{section}_src_index_.')

    with open(f, 'w') as fid:
        fid.write(data)

```

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Fixes docs CI build

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
