### PR TITLE
Added data attribute to parameter cells

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -164,6 +164,16 @@ const RENDER_TIMEOUT = 1000;
  */
 const CONTENTS_MIME_RICH = 'application/x-jupyter-icontentsrich';
 
+/*
+ * The parameters tag
+ */
+const PARAMETERS_TAG = 'parameters';
+
+/*
+ * The class applied to cells with the the parameters tag.
+ */
+const PARAMETERS_CELL_CLASS = 'parameter-cell';
+
 /** ****************************************************************************
  * Cell
  ******************************************************************************/
@@ -521,6 +531,23 @@ export class Cell extends Widget {
       case 'editable':
         if (this.syncEditable) {
           this.loadEditableState();
+        }
+        break;
+      case 'tags':
+        if (args.type == 'add') {
+          if (Array.isArray(args.newValue)) {
+            if (args.newValue.includes(PARAMETERS_TAG)) {
+              this.addClass(PARAMETERS_CELL_CLASS);
+            }
+          }
+        } else if (args.type == 'remove') {
+          if (Array.isArray(args.newValue)) {
+            if (!args.newValue.includes(PARAMETERS_TAG)) {
+              this.removeClass(PARAMETERS_CELL_CLASS);
+            }
+          } else if (typeof args.newValue === 'undefined') {
+            this.removeClass(PARAMETERS_CELL_CLASS);
+          }
         }
         break;
       default:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

This is my first contribution to jupyterlab so please let me know if there's anything I need to fix or do differently next time!

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Issue #8298
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Added to the [onMetadataChanged](https://github.com/ricwillis98/jupyterlab/blob/6cd7fc4a6003a23143035da8291cc55da8114bf9/packages/cells/src/widget.ts#L992) Cell method to check if the tag [parameters](https://github.com/ricwillis98/jupyterlab/blob/6cd7fc4a6003a23143035da8291cc55da8114bf9/packages/cells/src/widget.ts#L170) was added to the cell. If so, the [parameter-cell](https://github.com/ricwillis98/jupyterlab/blob/6cd7fc4a6003a23143035da8291cc55da8114bf9/packages/cells/src/widget.ts#L175) class is added to the cells CSS.

## User-facing changes

None

## Backwards-incompatible changes

None
