### PR TITLE
Add cur extension for url-loader

### DIFF
--- a/buildutils/src/build.ts
+++ b/buildutils/src/build.ts
@@ -186,7 +186,7 @@ export namespace Build {
               use: [{ loader: 'svg-url-loader', options: { encoding: 'none' } }]
             },
             {
-              test: /\.(png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+              test: /\.(cur|png|jpg|gif|ttf|woff|woff2|eot)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
               use: [{ loader: 'url-loader', options: { limit: 10000 } }]
             }
           ]


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

https://developer.mozilla.org/en-US/docs/Web/CSS/cursor

## Code changes

CSS cursor attribute allows multiple files as fallbacks including Windows cursors (`.cur`), PNG, etc. Some packages in npm come packaged with `.cur` files and therefore will fail in webpack during installation.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

## Backwards-incompatible changes

None