### PR TITLE
Update to Webpack 5b21

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -56,7 +56,7 @@
     "semver": "^6.3.0",
     "sort-package-json": "~1.31.0",
     "typescript": "~3.9.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "which": "^2.0.2"
   },
   "devDependencies": {

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -79,7 +79,7 @@
     "svg-url-loader": "~3.0.3",
     "terser-webpack-plugin": "^2.3.0",
     "url-loader": "~3.0.0",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^4.2.2",

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -55,7 +55,7 @@
     "svg-url-loader": "~3.0.3",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -30,7 +30,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -28,7 +28,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -44,7 +44,7 @@
     "svg-url-loader": "~3.0.3",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/federated/md_package/package.json
+++ b/examples/federated/md_package/package.json
@@ -27,7 +27,7 @@
     "svg-url-loader": "~3.0.3",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -33,7 +33,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -34,7 +34,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -25,7 +25,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -49,7 +49,7 @@
     "rimraf": "~3.0.0",
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typescript": "~3.9.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10"
   }
 }

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -26,7 +26,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~1.0.1",
     "typescript": "~3.9.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10"
   }
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -71,7 +71,7 @@
     "ts-jest": "^25.2.1",
     "typedoc": "^0.17.7",
     "typescript": "~3.9.2",
-    "webpack": "5.0.0-beta.18",
+    "webpack": "5.0.0-beta.21",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,10 +2832,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.41.tgz#fd90754150b57432b72bf560530500597ff04421"
   integrity sha512-rIAmXyJlqw4KEBO7+u9gxZZSQHaCNnIzYrnNmYVpgfJhxTqO0brCX0SYpqUTkVI5mwwUwzmtspLBGBKroMeynA==
 
-"@types/estree@0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.42.tgz#8d0c1f480339efedb3e46070e22dd63e0430dd11"
-  integrity sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==
+"@types/estree@^0.0.45":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
+  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
 
 "@types/events@*":
   version "3.0.0"
@@ -3633,15 +3633,15 @@ acorn@^6.0.1, acorn@^6.0.7, acorn@^6.2.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
   integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
-acorn@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
-  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
-
 acorn@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
   integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+
+acorn@^7.3.0:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
+  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -10346,10 +10346,10 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-runner@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-3.1.0.tgz#e9440e5875f2ad2f968489cd2c7b59a4f2847fcb"
-  integrity sha512-wE/bOCdTKMR2rm7Xxh+eirDOmN7Vx7hntWgiTayuFPtF8MgsFDo49SP8kkYz8IVlEBTOtR7P+XI7bE1xjo/IkA==
+loader-runner@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.0.0.tgz#02abcfd9fe6ff7a5aeb3547464746c4dc6ba333d"
+  integrity sha512-Rqf48ufrr48gFjnaqss04QesoXB7VenbpFFIV/0yOKGnpbejrVlOPqTsoX42FG5goXM5Ixekcs4DqDzHOX2z7Q==
 
 loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@~1.2.3:
   version "1.2.3"
@@ -16163,17 +16163,17 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@5.0.0-beta.18:
-  version "5.0.0-beta.18"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-beta.18.tgz#ce49483c05cd9a130c133b68aba01d85c2193d58"
-  integrity sha512-v+kyUEA1sQnSP6gcchyEY/Jufb1XEbniCmA7uXvWXWFPQnN51ChW8liF0FgUre8yYI5jRqVsNHFw3H9rGCB8qw==
+webpack@5.0.0-beta.21:
+  version "5.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-beta.21.tgz#3f46465e6f8d33950ae645eb98bb227b78d3ee52"
+  integrity sha512-ZgS5vUDphrjuakkQfT41q75dNavg8zUeTq0x31DvZG+z+OqR37u9BZFwytHM9U/I0vrnqm9vvBviyeHrAG3n0Q==
   dependencies:
-    "@types/estree" "0.0.42"
+    "@types/estree" "^0.0.45"
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/helper-module-context" "1.9.0"
     "@webassemblyjs/wasm-edit" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^7.0.0"
+    acorn "^7.3.0"
     chrome-trace-event "^1.0.2"
     enhanced-resolve "5.0.0-beta.7"
     eslint-scope "^5.0.0"
@@ -16181,7 +16181,7 @@ webpack@5.0.0-beta.18:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.15"
     json-parse-better-errors "^1.0.2"
-    loader-runner "^3.1.0"
+    loader-runner "^4.0.0"
     mime-types "^2.1.26"
     neo-async "^2.6.1"
     pkg-dir "^4.2.0"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Progress on #7468 

## Code changes

This updates us to webpack 5 beta 21, which supports module sharing for prerelease versions.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
