### PR TITLE
Add url as a polyfill dependency for apputils.

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -29,7 +29,8 @@ const MISSING: Dict<string[]> = {
 };
 
 const UNUSED: Dict<string[]> = {
-  '@jupyterlab/apputils': ['@types/react'],
+  // url is a polyfill for sanitize-html
+  '@jupyterlab/apputils': ['@types/react', 'url'],
   '@jupyterlab/application': ['@fortawesome/fontawesome-free'],
   '@jupyterlab/apputils-extension': ['es6-promise'],
   '@jupyterlab/services': ['node-fetch', 'ws'],

--- a/buildutils/src/webpack-plugins.ts
+++ b/buildutils/src/webpack-plugins.ts
@@ -84,6 +84,9 @@ export namespace WPPlugin {
       callback: any,
       callbackUndelayed: any
     ) {
+      files = Array.from(files);
+      dirs = Array.from(dirs);
+
       const notIgnored = (path: string) => !this.ignored(path);
 
       const ignoredFiles = files.filter(this.ignored);

--- a/packages/apputils/package.json
+++ b/packages/apputils/package.json
@@ -58,7 +58,8 @@
     "@types/react": "~16.9.16",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
-    "sanitize-html": "~1.20.1"
+    "sanitize-html": "~1.20.1",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.0.0-alpha.1",

--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
+
+// sanitize-html uses the url package, so we depend on a standalone version of
+// it which acts as a polyfill for browsers.
 import sanitize from 'sanitize-html';
 
 export interface ISanitizer {


### PR DESCRIPTION



<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #8657

## Code changes

Adds a polyfill for `url` for the `sanitize-html` package.

We could have also added it in apputils-extension or in the main jlab build instead (given that it is a polyfill for the browser, so only used when actually bundling code with webpack). However, it may be most convenient as a dependency for apputils.


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
