### PR TITLE
Added ability to delete a document from titlebar context menu

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -62,6 +62,8 @@ namespace CommandIDs {
 
   export const rename = 'docmanager:rename';
 
+  export const del = 'docmanager:delete';
+
   export const restoreCheckpoint = 'docmanager:restore-checkpoint';
 
   export const save = 'docmanager:save';
@@ -759,6 +761,34 @@ function addLabCommands(
     }
   });
 
+  commands.addCommand(CommandIDs.del, {
+    label: () => `Delete ${fileType(contextMenuWidget(), docManager)}`,
+    isEnabled,
+    execute: async () => {
+      // Implies contextMenuWidget() !== null
+      if (isEnabled()) {
+        const context = docManager.contextForWidget(contextMenuWidget()!);
+        if (!context) {
+          return;
+        }
+        const result = await showDialog({
+          title: 'Delete',
+          body: `Are you sure you want to delete ${context.path}?`,
+          buttons: [
+            Dialog.cancelButton(),
+            Dialog.warnButton({ label: 'Delete' })
+          ]
+        });
+
+        if (result.button.accept) {
+          await app.commands.execute('docmanager:delete-file', {
+            path: context.path
+          });
+        }
+      }
+    }
+  });
+
   commands.addCommand(CommandIDs.showInFileBrowser, {
     label: () => `Show in File Browser`,
     isEnabled,
@@ -781,14 +811,19 @@ function addLabCommands(
     rank: 1
   });
   app.contextMenu.addItem({
-    command: CommandIDs.clone,
+    command: CommandIDs.del,
     selector: '[data-type="document-title"]',
     rank: 2
   });
   app.contextMenu.addItem({
-    command: CommandIDs.showInFileBrowser,
+    command: CommandIDs.clone,
     selector: '[data-type="document-title"]',
     rank: 3
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.showInFileBrowser,
+    selector: '[data-type="document-title"]',
+    rank: 4
   });
 }
 


### PR DESCRIPTION
## User-facing changes

Adds a context menu that helps users delete the notebook they are using. This is helpful as many users create "scratch" notebooks and want to be able to quickly delete them.

![image](https://user-images.githubusercontent.com/1813603/86965496-ad1ce180-c135-11ea-8acb-86edc9ba0bee.png)

![image](https://user-images.githubusercontent.com/1813603/86965479-a4c4a680-c135-11ea-877d-fd9c5fd7dc6f.png)

