### PR TITLE
Implement a guard for pending user input to avoid deadlocks

### DIFF
--- a/jupyterlab/tests/echo_kernel.py
+++ b/jupyterlab/tests/echo_kernel.py
@@ -22,6 +22,13 @@ class EchoKernel(Kernel):
         if not silent:
             stream_content = {'name': 'stdout', 'text': code}
             self.send_response(self.iopub_socket, 'stream', stream_content)
+            # Send a input_request if code contains input command.
+            if code.index('input(') != -1:
+                self._input_request('Echo Prompt',
+                    self._parent_ident,
+                    self._parent_header,
+                    password=False,
+                )
 
         return {'status': 'ok',
                 # The base class increments the execution count

--- a/jupyterlab/tests/echo_kernel.py
+++ b/jupyterlab/tests/echo_kernel.py
@@ -18,12 +18,13 @@ class EchoKernel(Kernel):
     banner = "Echo kernel - as useful as a parrot"
 
     def do_execute(self, code, silent, store_history=True,
-            user_expressions=None, allow_stdin=False):
+                   user_expressions=None, allow_stdin=False):
         if not silent:
             stream_content = {'name': 'stdout', 'text': code}
             self.send_response(self.iopub_socket, 'stream', stream_content)
+
             # Send a input_request if code contains input command.
-            if code.index('input(') != -1:
+            if allow_stdin and code and code.find('input(') != -1:
                 self._input_request('Echo Prompt',
                     self._parent_ident,
                     self._parent_header,

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -400,7 +400,7 @@ export class SessionContext implements ISessionContext {
   }
 
   /**
-   * A flag indicating if the session phas ending input, proxied from the kernel.
+   * A flag indicating if the session has ending input, proxied from the kernel.
    */
   get pendingInput(): boolean {
     return this._pendingInput;
@@ -893,10 +893,7 @@ export class SessionContext implements ISessionContext {
         this._onConnectionStatusChanged,
         this
       );
-      session.pendingInput.connect(
-        this._onPendingInput,
-        this
-      );
+      session.pendingInput.connect(this._onPendingInput, this);
       session.iopubMessage.connect(this._onIopubMessage, this);
       session.unhandledMessage.connect(this._onUnhandledMessage, this);
 

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1106,12 +1106,9 @@ export class SessionContext implements ISessionContext {
   private _connectionStatusChanged = new Signal<this, Kernel.ConnectionStatus>(
     this
   );
-
   private translator: ITranslator;
   private _trans: TranslationBundle;
-
   private _pendingInput = false;
-
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _propertyChanged = new Signal<this, 'path' | 'name' | 'type'>(this);

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1861,7 +1861,9 @@ namespace Private {
           if (sessionContext.pendingInput) {
             void showDialog({
               title: trans.__('Waiting on User Input'),
-              body: trans.__('Did not run selected cell because there is a cell waiting on input! Submit your input and try again.'),
+              body: trans.__(
+                'Did not run selected cell because there is a cell waiting on input! Submit your input and try again.'
+              ),
               buttons: [Dialog.okButton({ label: trans.__('Ok') })]
             });
             return Promise.resolve(false);

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1860,9 +1860,9 @@ namespace Private {
           }
           if (sessionContext.pendingInput) {
             void showDialog({
-              title: 'Waiting on User Input',
-              body: `Did not run selected cell because there is a cell waiting on input! Submit your input and try again.`,
-              buttons: [Dialog.okButton()]
+              title: trans.__('Waiting on User Input'),
+              body: trans.__('Did not run selected cell because there is a cell waiting on input! Submit your input and try again.'),
+              buttons: [Dialog.okButton({ label: trans.__('Ok') })]
             });
             return Promise.resolve(false);
           }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1839,17 +1839,6 @@ namespace Private {
     translator = translator || nullTranslator;
     const trans = translator.load('jupyterlab');
 
-    if (cell instanceof CodeCell) {
-      if ((cell as CodeCell).outputArea.hasPendingInput) {
-        void showDialog({
-          title: 'Waiting on Input',
-          body: `Please submit your input before running again this cell`,
-          buttons: [Dialog.okButton()]
-        });
-        return Promise.resolve(false);
-      }
-    }
-
     switch (cell.model.type) {
       case 'markdown':
         (cell as MarkdownCell).rendered = true;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1869,6 +1869,14 @@ namespace Private {
             });
             break;
           }
+          if (sessionContext.pendingInput) {
+            void showDialog({
+              title: 'Waiting on User Input',
+              body: `Please submit your input before running this cell`,
+              buttons: [Dialog.okButton()]
+            });
+            return Promise.resolve(false);
+          }
           const deletedCells = notebook.model?.deletedCells ?? [];
           return CodeCell.execute(cell as CodeCell, sessionContext, {
             deletedCells,

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1839,6 +1839,17 @@ namespace Private {
     translator = translator || nullTranslator;
     const trans = translator.load('jupyterlab');
 
+    if (cell instanceof CodeCell) {
+      if ((cell as CodeCell).outputArea.hasPendingInput) {
+        void showDialog({
+          title: 'Waiting on Input',
+          body: `Please submit your input before running again this cell`,
+          buttons: [Dialog.okButton()]
+        });
+        return Promise.resolve(false);
+      }
+    }
+
     switch (cell.model.type) {
       case 'markdown':
         (cell as MarkdownCell).rendered = true;

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1872,7 +1872,7 @@ namespace Private {
           if (sessionContext.pendingInput) {
             void showDialog({
               title: 'Waiting on User Input',
-              body: `Please submit your input before running this cell`,
+              body: `Did not run selected cell because there is a cell waiting on input! Submit your input and try again.`,
               buttons: [Dialog.okButton()]
             });
             return Promise.resolve(false);

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -393,7 +393,7 @@ export class OutputArea extends Widget {
     });
 
     const dialog = new Dialog<Promise<string>>({
-      title: 'We need your input',
+      title: 'Your input is requested',
       body: modalInput,
       buttons
     });
@@ -897,6 +897,9 @@ export class Stdin extends Widget implements IStdin {
     return this._promise.promise.then(() => this._value);
   }
 
+  /**
+   * Submit and get the  value of the Stdin widget.
+   */
   getValue(): Promise<string> {
     this.submit();
     return this.value;

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -204,7 +204,6 @@ export class OutputArea extends Widget {
     // Handle stdin.
     value.onStdin = msg => {
       if (KernelMessage.isInputRequestMsg(msg)) {
-        this.hasPendingInput = true;
         this.onInputRequest(msg, value);
       }
     };
@@ -372,7 +371,6 @@ export class OutputArea extends Widget {
     panel.addWidget(prompt);
 
     const input = factory.createStdin({
-      outputArea: this,
       prompt: stdinPrompt,
       password,
       future
@@ -633,20 +631,12 @@ export class OutputArea extends Widget {
     model.add(output);
   };
 
-  get hasPendingInput(): boolean {
-    return this._hasPendingInput;
-  }
-  set hasPendingInput(value: boolean) {
-    this._hasPendingInput = value;
-  }
-
   private _minHeightTimeout: number | null = null;
   private _future: Kernel.IShellFuture<
     KernelMessage.IExecuteRequestMsg,
     KernelMessage.IExecuteReplyMsg
   >;
   private _displayIdMap = new Map<string, number[]>();
-  private _hasPendingInput = false;
 }
 
 export class SimplifiedOutputArea extends OutputArea {
@@ -862,7 +852,6 @@ export class Stdin extends Widget implements IStdin {
     this.addClass(STDIN_CLASS);
     this._input = this.node.getElementsByTagName('input')[0];
     this._input.focus();
-    this._outputArea = options.outputArea;
     this._future = options.future;
     this._value = options.prompt + ' ';
   }
@@ -888,7 +877,6 @@ export class Stdin extends Widget implements IStdin {
     const input = this._input;
     if (event.type === 'keydown') {
       if ((event as KeyboardEvent).keyCode === 13) {
-        this._outputArea.hasPendingInput = false;
         // Enter
         this._future.sendInputReply({
           status: 'ok',
@@ -926,7 +914,6 @@ export class Stdin extends Widget implements IStdin {
     this._input.removeEventListener('keydown', this);
   }
 
-  private _outputArea: OutputArea;
   private _future: Kernel.IShellFuture;
   private _input: HTMLInputElement;
   private _value: string;
@@ -938,11 +925,6 @@ export namespace Stdin {
    * The options to create a stdin widget.
    */
   export interface IOptions {
-    /**
-     * The outputArea hosting the Stdin widget.
-     */
-    outputArea: OutputArea;
-
     /**
      * The prompt text.
      */

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -898,9 +898,10 @@ export class Stdin extends Widget implements IStdin {
   }
 
   /**
-   * Submit and get the  value of the Stdin widget.
+   * Submit and get the value of the Stdin widget.
    */
   getValue(): Promise<string> {
+    console.log('WHAT THE FUCK!');
     this.submit();
     return this.value;
   }
@@ -924,6 +925,9 @@ export class Stdin extends Widget implements IStdin {
     }
   }
 
+  /*
+   * Submit input value.
+   */
   submit() {
     const input = this._input;
     this._future.sendInputReply({

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ISessionContext } from '@jupyterlab/apputils';
+import { Dialog, ISessionContext } from '@jupyterlab/apputils';
 import * as nbformat from '@jupyterlab/nbformat';
 import { IOutputModel, IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
@@ -380,6 +380,40 @@ export class OutputArea extends Widget {
 
     const layout = this.layout as PanelLayout;
     layout.addWidget(panel);
+
+    const buttons = [
+      Dialog.cancelButton({ label: 'Cancel' }),
+      Dialog.okButton({ label: 'Select' })
+    ];
+
+    const modalInput = factory.createStdin({
+      prompt: stdinPrompt,
+      password,
+      future
+    });
+
+    const dialog = new Dialog<Promise<string>>({
+      title: 'We need your input',
+      body: modalInput,
+      buttons
+    });
+
+    void dialog.launch().then(result => {
+      if (result.button.accept) {
+        const value = result.value;
+        if (value) {
+          void value.then(v => {
+            // Use stdin as the stream so it does not get combined with stdout.
+            this.model.add({
+              output_type: 'stream',
+              name: 'stdin',
+              text: v + '\n'
+            });
+            panel.dispose();
+          });
+        }
+      }
+    });
 
     /**
      * Wait for the stdin to complete, add it to the model (so it persists)
@@ -859,8 +893,13 @@ export class Stdin extends Widget implements IStdin {
   /**
    * The value of the widget.
    */
-  get value() {
+  get value(): Promise<string> {
     return this._promise.promise.then(() => this._value);
+  }
+
+  getValue(): Promise<string> {
+    this.submit();
+    return this.value;
   }
 
   /**
@@ -874,22 +913,26 @@ export class Stdin extends Widget implements IStdin {
    * not be called directly by user code.
    */
   handleEvent(event: Event): void {
-    const input = this._input;
     if (event.type === 'keydown') {
       if ((event as KeyboardEvent).keyCode === 13) {
         // Enter
-        this._future.sendInputReply({
-          status: 'ok',
-          value: input.value
-        });
-        if (input.type === 'password') {
-          this._value += Array(input.value.length + 1).join('·');
-        } else {
-          this._value += input.value;
-        }
-        this._promise.resolve(void 0);
+        this.submit();
       }
     }
+  }
+
+  submit() {
+    const input = this._input;
+    this._future.sendInputReply({
+      status: 'ok',
+      value: input.value
+    });
+    if (input.type === 'password') {
+      this._value += Array(input.value.length + 1).join('·');
+    } else {
+      this._value += input.value;
+    }
+    this._promise.resolve(void 0);
   }
 
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -204,6 +204,7 @@ export class OutputArea extends Widget {
     // Handle stdin.
     value.onStdin = msg => {
       if (KernelMessage.isInputRequestMsg(msg)) {
+        this.hasPendingInput = true;
         this.onInputRequest(msg, value);
       }
     };
@@ -371,6 +372,7 @@ export class OutputArea extends Widget {
     panel.addWidget(prompt);
 
     const input = factory.createStdin({
+      outputArea: this,
       prompt: stdinPrompt,
       password,
       future
@@ -631,12 +633,20 @@ export class OutputArea extends Widget {
     model.add(output);
   };
 
+  get hasPendingInput(): boolean {
+    return this._hasPendingInput;
+  }
+  set hasPendingInput(value: boolean) {
+    this._hasPendingInput = value;
+  }
+
   private _minHeightTimeout: number | null = null;
   private _future: Kernel.IShellFuture<
     KernelMessage.IExecuteRequestMsg,
     KernelMessage.IExecuteReplyMsg
   >;
   private _displayIdMap = new Map<string, number[]>();
+  private _hasPendingInput = false;
 }
 
 export class SimplifiedOutputArea extends OutputArea {
@@ -852,6 +862,7 @@ export class Stdin extends Widget implements IStdin {
     this.addClass(STDIN_CLASS);
     this._input = this.node.getElementsByTagName('input')[0];
     this._input.focus();
+    this._outputArea = options.outputArea;
     this._future = options.future;
     this._value = options.prompt + ' ';
   }
@@ -877,6 +888,7 @@ export class Stdin extends Widget implements IStdin {
     const input = this._input;
     if (event.type === 'keydown') {
       if ((event as KeyboardEvent).keyCode === 13) {
+        this._outputArea.hasPendingInput = false;
         // Enter
         this._future.sendInputReply({
           status: 'ok',
@@ -914,6 +926,7 @@ export class Stdin extends Widget implements IStdin {
     this._input.removeEventListener('keydown', this);
   }
 
+  private _outputArea: OutputArea;
   private _future: Kernel.IShellFuture;
   private _input: HTMLInputElement;
   private _value: string;
@@ -925,6 +938,11 @@ export namespace Stdin {
    * The options to create a stdin widget.
    */
   export interface IOptions {
+    /**
+     * The outputArea hosting the Stdin widget.
+     */
+    outputArea: OutputArea;
+
     /**
      * The prompt text.
      */

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -145,6 +145,13 @@ export class KernelConnection implements Kernel.IKernelConnection {
   }
 
   /**
+   * A signal emitted when a kernel has pending inputs from the user.
+   */
+  get pendingInput(): ISignal<this, boolean> {
+    return this._pendingInput;
+  }
+
+  /**
    * The id of the server-side kernel.
    */
   get id(): string {
@@ -816,6 +823,9 @@ export class KernelConnection implements Kernel.IKernelConnection {
 
     this._sendMessage(msg);
     this._anyMessage.emit({ msg, direction: 'send' });
+
+    this.hasPendingInput = false;
+
   }
 
   /**
@@ -1502,6 +1512,14 @@ export class KernelConnection implements Kernel.IKernelConnection {
     }
   };
 
+  get hasPendingInput(): boolean {
+    return this._hasPendingInput;
+  }
+  set hasPendingInput(value: boolean) {
+    this._hasPendingInput = value;
+    this._pendingInput.emit(value);
+  }
+
   private _id = '';
   private _name = '';
   private _status: KernelMessage.Status = 'unknown';
@@ -1542,10 +1560,12 @@ export class KernelConnection implements Kernel.IKernelConnection {
   private _disposed = new Signal<this, void>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _anyMessage = new Signal<this, Kernel.IAnyMessageArgs>(this);
+  private _pendingInput = new Signal<this, boolean>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _displayIdToParentIds = new Map<string, string[]>();
   private _msgIdToDisplayIds = new Map<string, string[]>();
   private _msgChain: Promise<void> = Promise.resolve();
+  private _hasPendingInput = false;
   private _noOp = () => {
     /* no-op */
   };

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -825,7 +825,6 @@ export class KernelConnection implements Kernel.IKernelConnection {
     this._anyMessage.emit({ msg, direction: 'send' });
 
     this.hasPendingInput = false;
-
   }
 
   /**

--- a/packages/services/src/kernel/future.ts
+++ b/packages/services/src/kernel/future.ts
@@ -238,6 +238,7 @@ export abstract class KernelFutureHandler<
   }
 
   private async _handleStdin(msg: KernelMessage.IStdinMessage): Promise<void> {
+    this._kernel.hasPendingInput = true;
     const stdin = this._stdin;
     if (stdin) {
       // tslint:disable-next-line:await-promise

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -111,6 +111,14 @@ export interface IKernelConnection extends IObservableDisposable {
   handleComms: boolean;
 
   /**
+   * Whether the kernel connection has pending input.
+   *
+   * #### Notes
+   * TODO(@echarles)
+   */
+  hasPendingInput: boolean;
+
+  /**
    * Send a shell message to the kernel.
    *
    * @param msg - The fully-formed shell message to send.
@@ -485,6 +493,11 @@ export interface IKernelConnection extends IObservableDisposable {
    * message should be treated as read-only.
    */
   anyMessage: ISignal<this, IAnyMessageArgs>;
+
+  /**
+   * A signal emitted when a kernel has pending inputs from the user.
+   */
+  pendingInput: ISignal<this, boolean>;
 
   /**
    * The server settings for the kernel.

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -114,7 +114,10 @@ export interface IKernelConnection extends IObservableDisposable {
    * Whether the kernel connection has pending input.
    *
    * #### Notes
-   * TODO(@echarles)
+   * This is a guard to avoid deadlock is the user asks input
+   * as second time before submitting his first input
+   *
+   * See https://github.com/jupyterlab/jupyterlab/issues/8632
    */
   hasPendingInput: boolean;
 

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -71,6 +71,13 @@ export class SessionConnection implements Session.ISessionConnection {
   }
 
   /**
+   * A signal proxied from the kernel pending input.
+   */
+  get pendingInput(): ISignal<this, boolean> {
+    return this._pendingInput;
+  }
+
+  /**
    * A signal proxied from the kernel about iopub kernel messages.
    */
   get iopubMessage(): ISignal<this, KernelMessage.IIOPubMessage> {
@@ -315,6 +322,7 @@ export class SessionConnection implements Session.ISessionConnection {
     this._kernel = kc;
     kc.statusChanged.connect(this.onKernelStatus, this);
     kc.connectionStatusChanged.connect(this.onKernelConnectionStatus, this);
+    kc.pendingInput.connect(this.onPendingInput, this);
     kc.unhandledMessage.connect(this.onUnhandledMessage, this);
     kc.iopubMessage.connect(this.onIOPubMessage, this);
     kc.anyMessage.connect(this.onAnyMessage, this);
@@ -338,6 +346,16 @@ export class SessionConnection implements Session.ISessionConnection {
     state: Kernel.ConnectionStatus
   ) {
     this._connectionStatusChanged.emit(state);
+  }
+
+  /**
+   * Handle a change in the pendingInput.
+   */
+  protected onPendingInput(
+    sender: Kernel.IKernelConnection,
+    state: boolean
+  ) {
+    this._pendingInput.emit(state);
   }
 
   /**
@@ -416,6 +434,7 @@ export class SessionConnection implements Session.ISessionConnection {
   private _connectionStatusChanged = new Signal<this, Kernel.ConnectionStatus>(
     this
   );
+  private _pendingInput = new Signal<this, boolean>(this);
   private _iopubMessage = new Signal<this, KernelMessage.IIOPubMessage>(this);
   private _unhandledMessage = new Signal<this, KernelMessage.IMessage>(this);
   private _anyMessage = new Signal<this, Kernel.IAnyMessageArgs>(this);

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -351,10 +351,7 @@ export class SessionConnection implements Session.ISessionConnection {
   /**
    * Handle a change in the pendingInput.
    */
-  protected onPendingInput(
-    sender: Kernel.IKernelConnection,
-    state: boolean
-  ) {
+  protected onPendingInput(sender: Kernel.IKernelConnection, state: boolean) {
     this._pendingInput.emit(state);
   }
 

--- a/packages/services/src/session/session.ts
+++ b/packages/services/src/session/session.ts
@@ -56,6 +56,12 @@ export interface ISessionConnection extends IObservableDisposable {
   connectionStatusChanged: ISignal<this, Kernel.ConnectionStatus>;
 
   /**
+   * The kernel pendingInput signal, proxied from the current
+   * kernel.
+   */
+  pendingInput: ISignal<this, boolean>;
+
+  /**
    * The kernel iopubMessage signal, proxied from the current kernel.
    */
   iopubMessage: ISignal<this, KernelMessage.IIOPubMessage>;

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -92,6 +92,27 @@ describe('Kernel.IKernel', () => {
     });
   });
 
+  describe('#pendingInput', () => {
+    it('should be a signal following input request', async () => {
+      let called = false;
+      defaultKernel.pendingInput.connect((sender, args) => {
+        if (!called) {
+          called = true;
+          defaultKernel.sendInputReply({ status: 'ok', value: 'foo' });
+        }
+      });
+      const code = `input("Input something")`;
+      await defaultKernel.requestExecute(
+        {
+          code: code,
+          allow_stdin: true
+        },
+        true
+      ).done;
+      expect(called).toBe(true);
+    });
+  });
+
   describe('#iopubMessage', () => {
     it('should be emitted for an iopub message', async () => {
       let called = false;

--- a/testutils/src/mock.ts
+++ b/testutils/src/mock.ts
@@ -245,8 +245,13 @@ export const KernelMock = jest.fn<
     Kernel.IKernelConnection,
     Kernel.Status
   >(thisObject);
+  const pendingInputSignal = new Signal<Kernel.IKernelConnection, boolean>(
+    thisObject
+  );
   (thisObject as any).statusChanged = statusChangedSignal;
   (thisObject as any).iopubMessage = iopubMessageSignal;
+  (thisObject as any).pendingInput = pendingInputSignal;
+  (thisObject as any).hasPendingInput = false;
   return thisObject;
 });
 
@@ -329,12 +334,20 @@ export const SessionConnectionMock = jest.fn<
     KernelMessage.IMessage
   >(thisObject);
 
+  const pendingInputSignal = new Signal<Session.ISessionConnection, boolean>(
+    thisObject
+  );
+
   kernel!.iopubMessage.connect((_, args) => {
     iopubMessageSignal.emit(args);
   }, thisObject);
 
   kernel!.statusChanged.connect((_, args) => {
     statusChangedSignal.emit(args);
+  }, thisObject);
+
+  kernel!.pendingInput.connect((_, args) => {
+    pendingInputSignal.emit(args);
   }, thisObject);
 
   (thisObject as any).disposed = disposedSignal;
@@ -344,6 +357,7 @@ export const SessionConnectionMock = jest.fn<
   (thisObject as any).kernelChanged = kernelChangedSignal;
   (thisObject as any).iopubMessage = iopubMessageSignal;
   (thisObject as any).unhandledMessage = unhandledMessageSignal;
+  (thisObject as any).pendingInput = pendingInputSignal;
   return thisObject;
 });
 
@@ -420,12 +434,17 @@ export const SessionContextMock = jest.fn<
     kernelChangedSignal.emit(args);
   });
 
+  session!.pendingInput.connect((_, args) => {
+    (thisObject as any).pendingInput = args;
+  });
+
   (thisObject as any).statusChanged = statusChangedSignal;
   (thisObject as any).kernelChanged = kernelChangedSignal;
   (thisObject as any).iopubMessage = iopubMessageSignal;
   (thisObject as any).propertyChanged = propertyChangedSignal;
   (thisObject as any).disposed = disposedSignal;
   (thisObject as any).session = session;
+  (thisObject as any).pendingInput = false;
 
   return thisObject;
 });


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/8632

## Code changes

Add hadPendingInput flag on the OutputArea as guard against multiple cell run while waiting on user input.

## User-facing changes

If you invoke a second time the cell run before submitting your cell input, a message is shown and the cell is not run to avoid the deadlock.

<img width="574" alt="Screenshot 2020-07-24 at 09 52 42" src="https://user-images.githubusercontent.com/226720/88371323-176b8e00-cd94-11ea-9141-81d24257d29f.png">

## Backwards-incompatible changes

None
