### PR TITLE
Change main menu ranks to allow for Application menu to L of File

### DIFF
--- a/packages/mainmenu/src/mainmenu.ts
+++ b/packages/mainmenu/src/mainmenu.ts
@@ -45,11 +45,11 @@ export class MainMenu extends MenuBar implements IMainMenu {
     this.viewMenu = new ViewMenu({ commands });
     this.tabsMenu = new TabsMenu({ commands });
 
-    this.addMenu(this.fileMenu.menu, { rank: 0 });
-    this.addMenu(this.editMenu.menu, { rank: 1 });
-    this.addMenu(this.viewMenu.menu, { rank: 2 });
-    this.addMenu(this.runMenu.menu, { rank: 3 });
-    this.addMenu(this.kernelMenu.menu, { rank: 4 });
+    this.addMenu(this.fileMenu.menu, { rank: 1 });
+    this.addMenu(this.editMenu.menu, { rank: 2 });
+    this.addMenu(this.viewMenu.menu, { rank: 3 });
+    this.addMenu(this.runMenu.menu, { rank: 4 });
+    this.addMenu(this.kernelMenu.menu, { rank: 5 });
     this.addMenu(this.tabsMenu.menu, { rank: 500 });
     this.addMenu(this.settingsMenu.menu, { rank: 999 });
     this.addMenu(this.helpMenu.menu, { rank: 1000 });


### PR DESCRIPTION
## Code changes

Increment the rank of the first 5 main menus from 0-4 to 1-5 to allow for extensions to add a menu in the 0 slot to the left of the File menu.

## User-facing changes

Will allow extensions to add a rank 0 menu to the L of the main menu.

## Backwards-incompatible changes

Extensions that have been adding a rank 5 menu will collide with the builtin kernel menu.
