### PR TITLE
Change inspector detail_level to 1

### DIFF
--- a/packages/inspector/src/kernelconnector.ts
+++ b/packages/inspector/src/kernelconnector.ts
@@ -44,7 +44,7 @@ export class KernelConnector extends DataConnector<
     const contents: KernelMessage.IInspectRequestMsg['content'] = {
       code: request.text,
       cursor_pos: request.offset,
-      detail_level: 0
+      detail_level: 1
     };
 
     return kernel.requestInspect(contents).then(msg => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

[Jupyter introspection](https://jupyter-client.readthedocs.io/en/stable/messaging.html#introspection)

## Code changes

This PR changes the context help `detail_level` to 1.

Tooltip inspector currently uses `detail_level = 0` as does the context help inspector which is shown in its own pane. Seems like the context help inspector should provide more detail than what is expected of a tooltip. It doesn't appear that `detail_level = 1` is currently available to the user in JupyterLab.

## User-facing changes

Kernels like IPython that support `detail_level` will provide more help documentation. For example here is `detail_level = 0`

```
Signature:   help(*args, **kwds)
Type:        _Helper
String form: Type help() for interactive help, or help(object) for help about object.
Namespace:   Python builtin
File:        /usr/lib/python3.8/_sitebuiltins.py
Docstring:  
Define the builtin 'help'.

This is a wrapper around pydoc.help that provides a helpful message
when 'help' is typed at the Python interactive prompt.

Calling help() at the Python prompt starts an interactive help session.
Calling help(thing) prints help for the python object 'thing'.
```

And here is `detail_level = 1`

```
Signature:   help(*args, **kwds)
Type:        _Helper
String form: Type help() for interactive help, or help(object) for help about object.
Namespace:   Python builtin
File:        /usr/lib/python3.8/_sitebuiltins.py
Source:     
class _Helper(object):
    """Define the builtin 'help'.

    This is a wrapper around pydoc.help that provides a helpful message
    when 'help' is typed at the Python interactive prompt.

    Calling help() at the Python prompt starts an interactive help session.
    Calling help(thing) prints help for the python object 'thing'.
    """

    def __repr__(self):
        return "Type help() for interactive help, " \
               "or help(object) for help about object."
    def __call__(self, *args, **kwds):
        import pydoc
        return pydoc.help(*args, **kwds)
```

## Backwards-incompatible changes

More detail provided. No API differences.
