### PR TITLE
Uncaught TypeError when switching kernels

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -490,14 +490,16 @@ export class SessionContext implements ISessionContext {
         }) ||
         '';
       if (name) {
-        name = this.specsManager.specs!.kernelspecs[name]!.display_name;
+        name = this.specsManager.specs?.kernelspecs[name]?.display_name ?? name;
         return name;
       }
       return Private.NO_KERNEL;
     }
     if (this._pendingKernelName) {
-      return this.specsManager.specs!.kernelspecs[this._pendingKernelName]!
-        .display_name;
+      return (
+        this.specsManager.specs?.kernelspecs[this._pendingKernelName]
+          ?.display_name ?? this._pendingKernelName
+      );
     }
     if (!kernel) {
       return Private.NO_KERNEL;


### PR DESCRIPTION
Fix for issue: https://github.com/jupyterlab/jupyterlab/issues/8726

Removing assumptions that all kernel spec are available when `SessionContext#kernelDisplayName` is called.
- When the spec is not available return `this._pendingKernelName`
