### PR TITLE
Rename the celltags plugin id to @jupyterlab/celltags

### DIFF
--- a/packages/celltags-extension/src/index.ts
+++ b/packages/celltags-extension/src/index.ts
@@ -11,7 +11,7 @@ import { TagTool } from '@jupyterlab/celltags';
  * Initialization data for the celltags extension.
  */
 const celltags: JupyterFrontEndPlugin<void> = {
-  id: 'celltags',
+  id: '@jupyterlab/celltags',
   autoStart: true,
   requires: [INotebookTools, INotebookTracker],
   activate: (


### PR DESCRIPTION
## References

Follow-up to the move to core: https://github.com/jupyterlab/jupyterlab/pull/7407

## Code changes

Rename the id of the `celltags` plugin to match the naming convention used for the other core plugins.

Even though this shouldn't affect many users and extensions, we might as well get it in before 3.0.

## User-facing changes

None

## Backwards-incompatible changes

It looks like it could be a breaking change for example if the plugin has been disabled, or if some custom lab builds rely on it.