### PR TITLE
Rename the logconsole:nboutput plugin id

### DIFF
--- a/packages/logconsole-extension/src/nboutput.ts
+++ b/packages/logconsole-extension/src/nboutput.ts
@@ -19,7 +19,7 @@ import { KernelMessage } from '@jupyterlab/services';
  */
 export const logNotebookOutput: JupyterFrontEndPlugin<void> = {
   activate: activateNBOutput,
-  id: 'logconsole:nboutput',
+  id: '@jupyterlab/logconsole:nboutput',
   requires: [ILoggerRegistry, INotebookTracker],
   autoStart: true
 };


### PR DESCRIPTION
## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/8728

## Code changes

Rename `logconsole:nboutput` to `@jupyterlab/logconsole:nboutput`, to match the naming convention used for the other core plugins.

## User-facing changes

None

## Backwards-incompatible changes

There can be a plugin id mismatch if the plugin had been disabled, or if some custom lab builds rely on the explicit id of the plugin.