### PR TITLE
Force navigation after cloning to follow /tree paths

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -362,7 +362,7 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
 
           // After the state has been cloned, navigate to the URL.
           void cloned.then(() => {
-            router.navigate(url);
+            router.navigate(url, { hard: true });
           });
 
           return cloned;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Closes: https://github.com/jupyterlab/jupyterlab/issues/8740

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds `{hard: true}` to `router.navigate` after cloning occurs. 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

When workspaces are cloned (because of sharable links opened in the same browser, etc) we now open to the destination notebook in the url. 

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
