### PR TITLE
add comma in extension_points.rst to fix syntax error of code

### DIFF
--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -85,7 +85,7 @@ Here is an example showing how to add a command to the command palette (given by
 
     palette.addItem({
       command: commandID,
-      category: 'my-category'
+      category: 'my-category',
       args: {}
     });
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

[#8744](https://github.com/jupyterlab/jupyterlab/issues/8744)
## Code changes

There is a syntax error in typescript code in the docs/source/developer/extension_points.rst
original code:

    palette.addItem({
      command: commandID,
      category: 'my-category'
      args: {}
    });

I added a comma after 'my-category' to fix it.

## User-facing changes

no

## Backwards-incompatible changes

no
