### PR TITLE
Make sure adding or removing a cell tag actually replaces the tag list, so a changed signal is emitted for the cell metadata

### DIFF
--- a/packages/celltags/package.json
+++ b/packages/celltags/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/cells": "^3.0.0-alpha.4",
     "@jupyterlab/notebook": "^3.0.0-alpha.4",
     "@jupyterlab/ui-components": "^3.0.0-alpha.4",
+    "@lumino/algorithm": "^1.2.3",
     "@lumino/coreutils": "^1.4.3",
     "@lumino/widgets": "^1.11.1"
   },

--- a/packages/celltags/src/addwidget.ts
+++ b/packages/celltags/src/addwidget.ts
@@ -1,7 +1,5 @@
 import { Widget } from '@lumino/widgets';
-
 import { addIcon } from '@jupyterlab/ui-components';
-
 import { TagTool } from './tool';
 
 /**

--- a/packages/celltags/src/tool.ts
+++ b/packages/celltags/src/tool.ts
@@ -74,17 +74,10 @@ export class TagTool extends NotebookTools.Tool {
       return;
     }
 
-    let tags = cell.model.metadata.get('tags') as string[];
-    const newTags = name.split(/[,\s]+/);
-    if (tags === undefined) {
-      tags = [];
-    }
-    for (let i = 0; i < newTags.length; i++) {
-      if (newTags[i] !== '' && tags.indexOf(newTags[i]) < 0) {
-        tags.push(newTags[i]);
-      }
-    }
-    cell.model.metadata.set('tags', tags);
+    const oldTags = (cell.model.metadata.get('tags') as string[]) || [];
+    let tagsToAdd = name.split(/[,\s]+/);
+    tagsToAdd = tagsToAdd.filter(tag => tag !== '' && !oldTags.includes(tag));
+    cell.model.metadata.set('tags', oldTags.concat(tagsToAdd));
     this.refreshTags();
     this.loadActiveTags();
   }
@@ -101,11 +94,8 @@ export class TagTool extends NotebookTools.Tool {
       return;
     }
 
-    const tags = cell.model.metadata.get('tags') as string[];
-    const idx = tags.indexOf(name);
-    if (idx > -1) {
-      tags.splice(idx, 1);
-    }
+    const oldTags = cell.model.metadata.get('tags') as string[];
+    let tags = oldTags.filter(tag => tag !== name);
     cell.model.metadata.set('tags', tags);
     if (tags.length === 0) {
       cell.model.metadata.delete('tags');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Closes #8534.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
`addTag` and `removeTag` in the cell tags tool widget were mutating the tag list instead of replacing it, so change signals were only emitted when adding a tag to a cell with no tags or removing a tag from a cell with one tag. I also tidied up the rest of `celltags`.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None.