### PR TITLE
Add tests for the ToC

### DIFF
--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: JS
     strategy:
       matrix:
-        group: [js-services, js-application, js-apputils, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-ui-components, js-testutils]
+        group: [js-services, js-application, js-apputils, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-toc, js-ui-components, js-testutils]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/packages/toc/babel.config.js
+++ b/packages/toc/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/packages/toc/jest.config.js
+++ b/packages/toc/jest.config.js
@@ -1,0 +1,2 @@
+const func = require('@jupyterlab/testutils/lib/jest-config');
+module.exports = func(__dirname);

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -27,12 +27,16 @@
   "types": "lib/index.d.ts",
   "style": "style/index.css",
   "scripts": {
-    "build": "tsc",
-    "clean": "rimraf lib",
-    "precommit": "lint-staged",
+    "build": "tsc -b",
+    "build:test": "tsc --build tsconfig.test.json",
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "docs": "typedoc src",
     "prepublishOnly": "npm run build",
-    "prettier": "prettier --write '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
-    "watch": "tsc -w"
+    "test": "jest",
+    "test:cov": "jest --collect-coverage",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
+    "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
+    "watch": "tsc -b --watch"
   },
   "lint-staged": {
     "**/*{.ts,.tsx,.css,.json,.md}": [
@@ -59,11 +63,17 @@
     "react-dom": "~16.9.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.5.0",
+    "@babel/preset-env": "^7.7.6",
+    "@types/jest": "^24.0.23",
     "@types/react": "~16.9.16",
     "@types/react-dom": "~16.9.4",
+    "@jupyterlab/testutils": "^3.0.0-alpha.4",
+    "jest": "^25.2.3",
     "lint-staged": "^8.2.1",
     "prettier": "^1.19.1",
     "rimraf": "~3.0.0",
+    "ts-jest": "^25.2.1",
     "tslint": "^5.20.1",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.1.0",

--- a/packages/toc/test/toc.spec.ts
+++ b/packages/toc/test/toc.spec.ts
@@ -34,7 +34,7 @@ import {
 } from '@jupyterlab/markdownviewer';
 
 let manager: DocumentManager;
-let widget: ToC.TableOfContents;
+let tocWidget: ToC.TableOfContents;
 let registry: DocumentRegistry;
 let services: ServiceManager.IManager;
 let factory: TextModelFactory;
@@ -97,11 +97,11 @@ describe('@jupyterlab/toc', () => {
   describe('TableOfContents', () => {
     describe('#constructor', () => {
       it('should construct a new ToC widget', () => {
-        widget = new ToC.TableOfContents({
+        tocWidget = new ToC.TableOfContents({
           docmanager: manager,
           rendermime: new RenderMimeRegistry()
         });
-        expect(widget).toBeInstanceOf(ToC.TableOfContents);
+        expect(tocWidget).toBeInstanceOf(ToC.TableOfContents);
       });
     });
   });
@@ -124,7 +124,7 @@ describe('@jupyterlab/toc', () => {
         });
         notebookGenerator = ToC.createNotebookGenerator(
           notebookTracker,
-          widget,
+          tocWidget,
           NBTestUtils.defaultRenderMime().sanitizer
         );
       });
@@ -144,10 +144,11 @@ describe('@jupyterlab/toc', () => {
       });
 
       it('should change current', async () => {
-        widget.current = {
+        tocWidget.current = {
           widget: notebookWidget,
           generator: notebookGenerator
         };
+        expect(tocWidget.current.widget).toBeInstanceOf(NotebookPanel);
       });
     });
 
@@ -164,7 +165,7 @@ describe('@jupyterlab/toc', () => {
         });
         markdownGenerator = ToC.createMarkdownGenerator(
           markdownTracker,
-          widget,
+          tocWidget,
           NBTestUtils.defaultRenderMime().sanitizer
         );
       });
@@ -184,10 +185,11 @@ describe('@jupyterlab/toc', () => {
       });
 
       it('should change current', async () => {
-        widget.current = {
+        tocWidget.current = {
           widget: markdownWidget,
           generator: markdownGenerator
         };
+        expect(tocWidget.current.widget).toBeInstanceOf(DocumentWidget);
       });
     });
 
@@ -202,7 +204,7 @@ describe('@jupyterlab/toc', () => {
         });
         markdownGenerator = ToC.createRenderedMarkdownGenerator(
           markdownTracker,
-          widget,
+          tocWidget,
           NBTestUtils.defaultRenderMime().sanitizer
         );
       });
@@ -222,10 +224,11 @@ describe('@jupyterlab/toc', () => {
       });
 
       it('should change current', async () => {
-        widget.current = {
+        tocWidget.current = {
           widget: markdownWidget,
           generator: markdownGenerator
         };
+        expect(tocWidget.current.widget).toBeInstanceOf(MarkdownDocument);
       });
     });
 
@@ -258,10 +261,11 @@ describe('@jupyterlab/toc', () => {
       });
 
       it('should change current', async () => {
-        widget.current = {
+        tocWidget.current = {
           widget: latexWidget,
           generator: latexGenerator
         };
+        expect(tocWidget.current.widget).toBeInstanceOf(DocumentWidget);
       });
     });
 
@@ -294,10 +298,11 @@ describe('@jupyterlab/toc', () => {
       });
 
       it('should change current', async () => {
-        widget.current = {
+        tocWidget.current = {
           widget: pythonWidget,
           generator: pythonGenerator
         };
+        expect(tocWidget.current.widget).toBeInstanceOf(DocumentWidget);
       });
     });
   });

--- a/packages/toc/test/toc.spec.ts
+++ b/packages/toc/test/toc.spec.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import 'jest';
+
+import {
+  NotebookPanel,
+  NotebookTracker,
+  NotebookWidgetFactory,
+  NotebookModelFactory
+} from '@jupyterlab/notebook';
+import { DocumentManager } from '@jupyterlab/docmanager';
+import * as ToC from '@jupyterlab/toc';
+import { RenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ServiceManager } from '@jupyterlab/services';
+import { DocumentRegistry, TextModelFactory } from '@jupyterlab/docregistry';
+import { UUID } from '@lumino/coreutils';
+
+import { NBTestUtils, Mock, defaultRenderMime } from '@jupyterlab/testutils';
+
+let manager: DocumentManager;
+let widget: ToC.TableOfContents;
+let registry: DocumentRegistry;
+let services: ServiceManager.IManager;
+let factory: TextModelFactory;
+
+beforeAll(async () => {
+  jest.setTimeout(20000);
+  const opener: DocumentManager.IWidgetOpener = {
+    open: widget => {
+      // no-op
+    }
+  };
+  factory = new TextModelFactory();
+  registry = new DocumentRegistry({
+    textModelFactory: factory
+  });
+  const contentFactory = NBTestUtils.createNotebookPanelFactory();
+  const notebookFactory = new NotebookModelFactory({});
+  registry.addModelFactory(notebookFactory);
+  registry.addWidgetFactory(
+    new NotebookWidgetFactory({
+      modelName: 'notebook',
+      contentFactory,
+      fileTypes: ['notebook'],
+      rendermime: defaultRenderMime(),
+      mimeTypeService: NBTestUtils.mimeTypeService,
+      name: 'notebook'
+    })
+  );
+  services = new Mock.ServiceManagerMock();
+  manager = new DocumentManager({
+    registry,
+    opener,
+    manager: services
+  });
+});
+
+describe('@jupyterlab/toc', () => {
+  describe('TableOfContents', () => {
+    describe('#constructor', () => {
+      it('should construct a new ToC widget', () => {
+        widget = new ToC.TableOfContents({
+          docmanager: manager,
+          rendermime: new RenderMimeRegistry()
+        });
+        expect(widget).toBeInstanceOf(ToC.TableOfContents);
+      });
+    });
+  });
+
+  describe('TableOfContentsRegistry', () => {
+    let registry: ToC.TableOfContentsRegistry;
+
+    beforeAll(() => {
+      registry = new ToC.TableOfContentsRegistry();
+    });
+
+    describe('IGenerator<NotebookPanel>', () => {
+      let notebookTracker: NotebookTracker;
+      let notebookGenerator: ToC.TableOfContentsRegistry.IGenerator<NotebookPanel>;
+      let notebookWidget: NotebookPanel;
+
+      it('should create a notebook generator', () => {
+        notebookTracker = new NotebookTracker({
+          namespace: 'notebook'
+        });
+        notebookGenerator = ToC.createNotebookGenerator(
+          notebookTracker,
+          widget,
+          NBTestUtils.defaultRenderMime().sanitizer
+        );
+      });
+
+      it('should add a notebook generator to the registry', () => {
+        registry.add(notebookGenerator);
+      });
+
+      it('should find the notebook generator', async () => {
+        const path = UUID.uuid4() + '.ipynb';
+        const newNotebookWidget = manager.createNew(path, 'notebook');
+        expect(newNotebookWidget).toBeInstanceOf(NotebookPanel);
+        notebookWidget = newNotebookWidget as NotebookPanel;
+        await notebookTracker.add(notebookWidget);
+        const foundNotebookGenerator = registry.find(notebookWidget);
+        expect(foundNotebookGenerator).toBeDefined();
+      });
+
+      it('should change current', async () => {
+        widget.current = {
+          widget: notebookWidget,
+          generator: notebookGenerator
+        };
+      });
+    });
+  });
+});

--- a/packages/toc/test/toc.spec.ts
+++ b/packages/toc/test/toc.spec.ts
@@ -179,8 +179,8 @@ describe('@jupyterlab/toc', () => {
         expect(newMarkdownWidget).toBeInstanceOf(DocumentWidget);
         markdownWidget = newMarkdownWidget as IDocumentWidget<FileEditor>;
         await markdownTracker.add(markdownWidget);
-        const foundNotebookGenerator = registry.find(markdownWidget);
-        expect(foundNotebookGenerator).toBeDefined();
+        const foundMarkdownGenerator = registry.find(markdownWidget);
+        expect(foundMarkdownGenerator).toBeDefined();
       });
 
       it('should change current', async () => {
@@ -217,8 +217,8 @@ describe('@jupyterlab/toc', () => {
         expect(newMarkdownWidget).toBeInstanceOf(MarkdownDocument);
         markdownWidget = newMarkdownWidget as MarkdownDocument;
         await markdownTracker.add(markdownWidget);
-        const foundNotebookGenerator = registry.find(markdownWidget);
-        expect(foundNotebookGenerator).toBeDefined();
+        const foundMarkdownGenerator = registry.find(markdownWidget);
+        expect(foundMarkdownGenerator).toBeDefined();
       });
 
       it('should change current', async () => {
@@ -253,14 +253,50 @@ describe('@jupyterlab/toc', () => {
         expect(newLatexWidget).toBeInstanceOf(DocumentWidget);
         latexWidget = newLatexWidget as IDocumentWidget<FileEditor>;
         await latexTracker.add(latexWidget);
-        const foundNotebookGenerator = registry.find(latexWidget);
-        expect(foundNotebookGenerator).toBeDefined();
+        const foundLatexGenerator = registry.find(latexWidget);
+        expect(foundLatexGenerator).toBeDefined();
       });
 
       it('should change current', async () => {
         widget.current = {
           widget: latexWidget,
           generator: latexGenerator
+        };
+      });
+    });
+
+    describe('Python Generator: IGenerator<IDocumentWidget<FileEditor>>', () => {
+      let pythonTracker: WidgetTracker<IDocumentWidget<FileEditor>>;
+      let pythonGenerator: ToC.TableOfContentsRegistry.IGenerator<IDocumentWidget<
+        FileEditor
+      >>;
+      let pythonWidget: IDocumentWidget<FileEditor>;
+
+      it('should create a python generator', () => {
+        pythonTracker = new WidgetTracker<IDocumentWidget<FileEditor>>({
+          namespace: 'python'
+        });
+        pythonGenerator = ToC.createPythonGenerator(pythonTracker);
+      });
+
+      it('should add a python generator to the registry', () => {
+        registry.add(pythonGenerator);
+      });
+
+      it('should find the python generator', async () => {
+        const path = UUID.uuid4() + '.py';
+        const newPythonWidget = manager.createNew(path);
+        expect(newPythonWidget).toBeInstanceOf(DocumentWidget);
+        pythonWidget = newPythonWidget as IDocumentWidget<FileEditor>;
+        await pythonTracker.add(pythonWidget);
+        const foundPythonGenerator = registry.find(pythonWidget);
+        expect(foundPythonGenerator).toBeDefined();
+      });
+
+      it('should change current', async () => {
+        widget.current = {
+          widget: pythonWidget,
+          generator: pythonGenerator
         };
       });
     });

--- a/packages/toc/test/toc.spec.ts
+++ b/packages/toc/test/toc.spec.ts
@@ -228,5 +228,41 @@ describe('@jupyterlab/toc', () => {
         };
       });
     });
+
+    describe('Latex Generator: IGenerator<IDocumentWidget<FileEditor>>', () => {
+      let latexTracker: WidgetTracker<IDocumentWidget<FileEditor>>;
+      let latexGenerator: ToC.TableOfContentsRegistry.IGenerator<IDocumentWidget<
+        FileEditor
+      >>;
+      let latexWidget: IDocumentWidget<FileEditor>;
+
+      it('should create a latex generator', () => {
+        latexTracker = new WidgetTracker<IDocumentWidget<FileEditor>>({
+          namespace: 'latex'
+        });
+        latexGenerator = ToC.createLatexGenerator(latexTracker);
+      });
+
+      it('should add a latex generator to the registry', () => {
+        registry.add(latexGenerator);
+      });
+
+      it('should find the latex generator', async () => {
+        const path = UUID.uuid4() + '.tex';
+        const newLatexWidget = manager.createNew(path);
+        expect(newLatexWidget).toBeInstanceOf(DocumentWidget);
+        latexWidget = newLatexWidget as IDocumentWidget<FileEditor>;
+        await latexTracker.add(latexWidget);
+        const foundNotebookGenerator = registry.find(latexWidget);
+        expect(foundNotebookGenerator).toBeDefined();
+      });
+
+      it('should change current', async () => {
+        widget.current = {
+          widget: latexWidget,
+          generator: latexGenerator
+        };
+      });
+    });
   });
 });

--- a/packages/toc/tsconfig.test.json
+++ b/packages/toc/tsconfig.test.json
@@ -1,0 +1,72 @@
+{
+  "extends": "../../tsconfigbase.test",
+  "include": ["src/*", "test/*"],
+  "references": [
+    {
+      "path": "../apputils"
+    },
+    {
+      "path": "../cells"
+    },
+    {
+      "path": "../coreutils"
+    },
+    {
+      "path": "../docmanager"
+    },
+    {
+      "path": "../docregistry"
+    },
+    {
+      "path": "../fileeditor"
+    },
+    {
+      "path": "../markdownviewer"
+    },
+    {
+      "path": "../notebook"
+    },
+    {
+      "path": "../rendermime"
+    },
+    {
+      "path": "../ui-components"
+    },
+    {
+      "path": "."
+    },
+    {
+      "path": "../../testutils"
+    },
+    {
+      "path": "../apputils"
+    },
+    {
+      "path": "../cells"
+    },
+    {
+      "path": "../coreutils"
+    },
+    {
+      "path": "../docmanager"
+    },
+    {
+      "path": "../docregistry"
+    },
+    {
+      "path": "../fileeditor"
+    },
+    {
+      "path": "../markdownviewer"
+    },
+    {
+      "path": "../notebook"
+    },
+    {
+      "path": "../rendermime"
+    },
+    {
+      "path": "../ui-components"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #8558. Adds standard jest tests for the Table of Contents. 
Tests for these things:
- Creates a `TableOfContents` widget
- Tests the following for all generators (notebook, markdown, markdown viewer, latex, python)
  - Create generator
  - Add generator to the `TableOfContentsRegistry`
  - Find the generator (given a `DocumentWidget`)
  - Change the `current` widget of the `TableOfContents`