### PR TITLE
Fix examples and update webpack

### DIFF
--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -60,7 +60,7 @@
     "semver": "^6.3.0",
     "sort-package-json": "~1.31.0",
     "typescript": "~3.9.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-merge": "^5.1.1",
     "which": "^2.0.2"
   },

--- a/buildutils/src/build-extension.ts
+++ b/buildutils/src/build-extension.ts
@@ -20,9 +20,8 @@ import { run } from './utils';
 
 commander
   .description('Build an extension')
-  .usage('[options] <path>')
   .option('--prod', 'build in prod mode (default is dev)')
-  .option('--core-path <path>', 'the core package directory')
+  .requiredOption('--core-path <path>', 'the core package directory')
   .option('--watch')
   .action(async cmd => {
     let node_env = 'development';

--- a/buildutils/src/build-extension.ts
+++ b/buildutils/src/build-extension.ts
@@ -38,8 +38,7 @@ commander
       cmdText += ' --watch';
     }
     if (!cmd.corePath) {
-      console.error('no');
-      process.exit(1);
+      cmd.corePath = process.cwd();
     }
     const env = {
       PACKAGE_PATH: packagePath,

--- a/buildutils/src/build-extension.ts
+++ b/buildutils/src/build-extension.ts
@@ -22,7 +22,7 @@ commander
   .description('Build an extension')
   .usage('[options] <path>')
   .option('--prod', 'build in prod mode (default is dev)')
-  .option('--core-path', 'the core package directory')
+  .option('--core-path <path>', 'the core package directory')
   .option('--watch')
   .action(async cmd => {
     let node_env = 'development';

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -81,7 +81,7 @@
     "terser-webpack-plugin": "^2.3.0",
     "to-string-loader": "^1.1.6",
     "url-loader": "~3.0.0",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^4.2.2",

--- a/examples/app/main.py
+++ b/examples/app/main.py
@@ -25,12 +25,11 @@ def _jupyter_server_extension_points():
     ]
 
 class ExampleApp(LabServerApp):
-    extension_url = '/example'
+    extension_url = '/lab'
     name = __name__
     app_name = 'JupyterLab Example App'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     app_version = version
-    app_url = '/example'
     schemas_dir = os.path.join(HERE, 'build', 'schemas')
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')

--- a/examples/app/main.py
+++ b/examples/app/main.py
@@ -27,6 +27,7 @@ def _jupyter_server_extension_points():
 class ExampleApp(LabServerApp):
     extension_url = '/lab'
     name = __name__
+    load_other_extensions = False
     app_name = 'JupyterLab Example App'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     app_version = version

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -55,7 +55,7 @@
     "svg-url-loader": "~3.0.3",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/cell/main.py
+++ b/examples/cell/main.py
@@ -47,7 +47,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'example/'),
+            'frontendUrl': ujoin(self.base_url, 'lab/'),
         }
         return self.write(
             self.render_template(

--- a/examples/cell/main.py
+++ b/examples/cell/main.py
@@ -47,7 +47,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'lab/'),
+            'frontendUrl': ujoin(self.base_url, 'example/'),
         }
         return self.write(
             self.render_template(
@@ -62,7 +62,8 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/lab'
+    extension_url = '/example'
+    app_url = "/example"
     name = __name__
     load_other_extensions = False
     app_name = 'JupyterLab Example Cell'
@@ -79,7 +80,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/lab', ExampleHandler)
+            ('/example', ExampleHandler)
         )
 
 

--- a/examples/cell/main.py
+++ b/examples/cell/main.py
@@ -63,7 +63,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
-    name = 'main'
+    name = __name__
     app_name = 'JupyterLab Example Cell'
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')

--- a/examples/cell/main.py
+++ b/examples/cell/main.py
@@ -62,10 +62,9 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/example'
+    extension_url = '/lab'
     name = 'main'
     app_name = 'JupyterLab Example Cell'
-    app_url = '/example_app'
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')
     app_version = version
@@ -79,7 +78,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/example', ExampleHandler)
+            ('/lab', ExampleHandler)
         )
 
 

--- a/examples/cell/main.py
+++ b/examples/cell/main.py
@@ -64,6 +64,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
     name = __name__
+    load_other_extensions = False
     app_name = 'JupyterLab Example Cell'
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -30,7 +30,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/console/main.py
+++ b/examples/console/main.py
@@ -64,12 +64,11 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/example'
+    extension_url = '/lab'
 
     name = 'main'
     app_name = 'JupyterLab Example Console'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
-    app_url = '/example_app'
     schemas_dir = os.path.join(HERE, 'build', 'schemas')
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')
@@ -80,7 +79,7 @@ class ExampleApp(LabServerApp):
     def initialize_handlers(self):
         """Initialize JupyterLab handlers."""
         self.handlers.append(
-            ('example', ExampleHandler)
+            ('lab', ExampleHandler)
         )
 
 

--- a/examples/console/main.py
+++ b/examples/console/main.py
@@ -49,7 +49,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'lab/'),
+            'frontendUrl': ujoin(self.base_url, 'example/'),
         }
         return self.write(
             self.render_template(
@@ -64,7 +64,8 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/lab'
+    extension_url = '/example'
+    app_url = "/example"
     load_other_extensions = False
     name = __name__
     app_name = 'JupyterLab Example Console'
@@ -79,7 +80,7 @@ class ExampleApp(LabServerApp):
     def initialize_handlers(self):
         """Initialize JupyterLab handlers."""
         self.handlers.append(
-            ('lab', ExampleHandler)
+            ('/example', ExampleHandler)
         )
 
 

--- a/examples/console/main.py
+++ b/examples/console/main.py
@@ -65,7 +65,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
-
+    load_other_extensions = False
     name = __name__
     app_name = 'JupyterLab Example Console'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')

--- a/examples/console/main.py
+++ b/examples/console/main.py
@@ -49,7 +49,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'example/'),
+            'frontendUrl': ujoin(self.base_url, 'lab/'),
         }
         return self.write(
             self.render_template(

--- a/examples/console/main.py
+++ b/examples/console/main.py
@@ -66,7 +66,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
 
-    name = 'main'
+    name = __name__
     app_name = 'JupyterLab Example Console'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     schemas_dir = os.path.join(HERE, 'build', 'schemas')

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -28,7 +28,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -42,11 +42,12 @@ def main():
         """An app that launches an example and waits for it to start up, checking for
         JS console errors, JS errors, and Python logged errors.
         """
-        name = 'example'
-        extension_url = '/example'
-        default_url = '/example'
-        open_browser = Bool(False)
-#        base_url = '/foo/'
+        name = 'lab'
+        extension_url = '/lab'
+        default_url = '/lab'
+        serverapp_config = {
+            "open_browser": False
+        }
         ip = '127.0.0.1'
 
         def initialize_settings(self):
@@ -66,17 +67,6 @@ def main():
     App.__name__ = osp.basename(example_dir).capitalize() + 'Test'
     App.launch_instance()
 
-"""
-async def run_browser(url):
-    Run the browser test and return an exit code.
-    target = osp.join(get_app_dir(), 'example_test')
-    if not osp.exists(osp.join(target, 'node_modules')):
-        os.makedirs(target)
-        await run_async_process(["jlpm", "init", "-y"], cwd=target)
-        await run_async_process(["jlpm", "add", "puppeteer"], cwd=target)
-    shutil.copy(osp.join(here, 'chrome-example-test.js'), osp.join(target, 'chrome-example-test.js'))
-    await run_async_process(["node", "chrome-example-test.js", url], cwd=target)
-"""
 
 def run_browser(url):
     """Run the browser test and return an exit code.

--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -76,7 +76,7 @@ async def run_browser(url):
         if not osp.exists(target):
             os.makedirs(osp.join(target))
         await run_async_process(["npm", "init", "-y"], cwd=target)
-        await run_async_process(["npm", "install", "puppeteer^4"], cwd=target)
+        await run_async_process(["npm", "install", "puppeteer@^4"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-example-test.js'), osp.join(target, 'chrome-example-test.js'))
     await run_async_process(["node", "chrome-example-test.js", url], cwd=target)
 

--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -21,8 +21,7 @@ from tornado.ioloop import IOLoop
 from traitlets import Bool, Dict, Unicode
 from jupyter_server.serverapp import ServerApp
 from jupyterlab.labapp import get_app_dir
-from jupyterlab.browser_check import run_test
-# from jupyterlab.browser_check import run_async_process
+from jupyterlab.browser_check import run_test, run_async_process
 from jupyter_server.serverapp import ServerApp
 
 
@@ -68,17 +67,17 @@ def main():
     App.launch_instance()
 
 
-def run_browser(url):
+async def run_browser(url):
     """Run the browser test and return an exit code.
     """
+    # Run the browser test and return an exit code.
     target = osp.join(get_app_dir(), 'example_test')
     if not osp.exists(osp.join(target, 'node_modules')):
         os.makedirs(target)
-        subprocess.call(["jlpm", "init", "-y"], cwd=target)
-        subprocess.call(["jlpm", "add", "puppeteer"], cwd=target)
+        await run_async_process(["jlpm", "init", "-y"], cwd=target)
+        await run_async_process(["jlpm", "add", "puppeteer^4"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-example-test.js'), osp.join(target, 'chrome-example-test.js'))
-    return subprocess.check_call(["node", "chrome-example-test.js", url], cwd=target)
-
+    await run_async_process(["node", "chrome-example-test.js", url], cwd=target)
 
 if __name__ == '__main__':
     main()

--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -73,9 +73,10 @@ async def run_browser(url):
     # Run the browser test and return an exit code.
     target = osp.join(get_app_dir(), 'example_test')
     if not osp.exists(osp.join(target, 'node_modules')):
-        os.makedirs(target)
-        await run_async_process(["jlpm", "init", "-y"], cwd=target)
-        await run_async_process(["jlpm", "add", "puppeteer^4"], cwd=target)
+        if not osp.exists(target):
+            os.makedirs(osp.join(target))
+        await run_async_process(["npm", "init", "-y"], cwd=target)
+        await run_async_process(["npm", "install", "puppeteer^4"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-example-test.js'), osp.join(target, 'chrome-example-test.js'))
     await run_async_process(["node", "chrome-example-test.js", url], cwd=target)
 

--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -41,9 +41,7 @@ def main():
         """An app that launches an example and waits for it to start up, checking for
         JS console errors, JS errors, and Python logged errors.
         """
-        name = 'lab'
-        extension_url = '/lab'
-        default_url = '/lab'
+        name = __name__
         serverapp_config = {
             "open_browser": False
         }

--- a/examples/federated/core_package/index.js
+++ b/examples/federated/core_package/index.js
@@ -153,52 +153,9 @@ async function main() {
   });
   register.forEach(function(item) { lab.registerPluginModule(item); });
   lab.start({ ignorePlugins: ignorePlugins });
-
-  // Expose global app instance when in dev mode or when toggled explicitly.
-  var exposeAppInBrowser = (PageConfig.getOption('exposeAppInBrowser') || '').toLowerCase() === 'true';
-  var devMode = (PageConfig.getOption('devMode') || '').toLowerCase() === 'true';
-
-  if (exposeAppInBrowser || devMode) {
-    window.jupyterlab = lab;
-  }
-
-  // Handle a browser test.
-  var browserTest = PageConfig.getOption('browserTest');
-  if (browserTest.toLowerCase() === 'true') {
-    var el = document.createElement('div');
-    el.id = 'browserTest';
-    document.body.appendChild(el);
-    el.textContent = '[]';
-    el.style.display = 'none';
-    var errors = [];
-    var reported = false;
-    var timeout = 25000;
-
-    var report = function() {
-      if (reported) {
-        return;
-      }
-      reported = true;
-      el.className = 'completed';
-    }
-
-    window.onerror = function(msg, url, line, col, error) {
-      errors.push(String(error));
-      el.textContent = JSON.stringify(errors)
-    };
-    console.error = function(message) {
-      errors.push(String(message));
-      el.textContent = JSON.stringify(errors)
-    };
-
-    lab.restored
-      .then(function() { report(errors); })
-      .catch(function(reason) { report([`RestoreError: ${reason.message}`]); });
-
-    // Handle failures to restore after the timeout has elapsed.
-    window.setTimeout(function() { report(errors); }, timeout);
-  }
-
+  lab.restored.then(() => {
+    console.debug('Example started!');
+  });
 }
 
 window.addEventListener('load', main);

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -64,7 +64,7 @@
     "svg-url-loader": "~3.0.3",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   },

--- a/examples/federated/main.py
+++ b/examples/federated/main.py
@@ -8,7 +8,7 @@ import json
 import os
 from traitlets import Unicode
 
-HERE = os.path.dirname(__file__)
+HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Turn off the Jupyter configuration system so configuration files on disk do
 # not affect this app. This helps this app to truly be standalone.

--- a/examples/federated/main.py
+++ b/examples/federated/main.py
@@ -27,6 +27,7 @@ def _jupyter_server_extension_points():
 
 class ExampleApp(LabServerApp):
     name = __name__
+    load_other_extensions = False
     app_name = 'JupyterLab Example Federated App'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     app_version = version

--- a/examples/federated/main.py
+++ b/examples/federated/main.py
@@ -26,7 +26,7 @@ def _jupyter_server_extension_points():
     ]
 
 class ExampleApp(LabServerApp):
-    name = "lab"
+    name = __name__
     app_name = 'JupyterLab Example Federated App'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     app_version = version

--- a/examples/federated/md_package/index.js
+++ b/examples/federated/md_package/index.js
@@ -1,3 +1,154 @@
-import md from '@jupyterlab/markdownviewer-extension';
-
-export default md;
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { ILayoutRestorer } from '@jupyterlab/application';
+import { WidgetTracker } from '@jupyterlab/apputils';
+import {
+  MarkdownViewer,
+  MarkdownViewerFactory,
+  IMarkdownViewerTracker
+} from '@jupyterlab/markdownviewer';
+import {
+  IRenderMimeRegistry,
+  markdownRendererFactory
+} from '@jupyterlab/rendermime';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { PathExt } from '@jupyterlab/coreutils';
+/**
+ * The command IDs used by the markdownviewer plugin.
+ */
+let CommandIDs;
+(function(CommandIDs) {
+  CommandIDs.markdownPreview = 'markdownviewer:open';
+  CommandIDs.markdownEditor = 'markdownviewer:edit';
+})(CommandIDs || (CommandIDs = {}));
+/**
+ * The name of the factory that creates markdown viewer widgets.
+ */
+const FACTORY = 'Markdown Preview (Federated)';
+/**
+ * The markdown viewer plugin.
+ */
+const plugin = {
+  activate,
+  id: '@jupyterlab/example-federated-md:plugin',
+  provides: IMarkdownViewerTracker,
+  requires: [ILayoutRestorer, IRenderMimeRegistry, ISettingRegistry],
+  autoStart: true
+};
+/**
+ * Activate the markdown viewer plugin.
+ */
+function activate(app, restorer, rendermime, settingRegistry) {
+  const { commands, docRegistry } = app;
+  // Add the markdown renderer factory.
+  rendermime.addFactory(markdownRendererFactory);
+  const namespace = 'markdownviewer-widget';
+  const tracker = new WidgetTracker({
+    namespace
+  });
+  let config = Object.assign({}, MarkdownViewer.defaultConfig);
+  /**
+   * Update the settings of a widget.
+   */
+  function updateWidget(widget) {
+    Object.keys(config).forEach(k => {
+      let _a;
+      widget.setOption(
+        k,
+        (_a = config[k]) !== null && _a !== void 0 ? _a : null
+      );
+    });
+  }
+  /**
+   * Update the setting values.
+   */
+  function updateSettings(settings) {
+    config = settings.composite;
+    tracker.forEach(widget => {
+      updateWidget(widget.content);
+    });
+  }
+  // Fetch the initial state of the settings.
+  settingRegistry
+    .load(plugin.id)
+    .then(settings => {
+      settings.changed.connect(() => {
+        updateSettings(settings);
+      });
+      updateSettings(settings);
+    })
+    .catch(reason => {
+      console.error(reason.message);
+    });
+  // Register the MarkdownViewer factory.
+  const factory = new MarkdownViewerFactory({
+    rendermime,
+    name: FACTORY,
+    primaryFileType: docRegistry.getFileType('markdown'),
+    fileTypes: ['markdown'],
+    defaultRendered: ['markdown']
+  });
+  factory.widgetCreated.connect((sender, widget) => {
+    // Notify the widget tracker if restore data needs to update.
+    widget.context.pathChanged.connect(() => {
+      void tracker.save(widget);
+    });
+    // Handle the settings of new widgets.
+    updateWidget(widget.content);
+    void tracker.add(widget);
+  });
+  docRegistry.addWidgetFactory(factory);
+  // Handle state restoration.
+  void restorer.restore(tracker, {
+    command: 'docmanager:open',
+    args: widget => ({ path: widget.context.path, factory: FACTORY }),
+    name: widget => widget.context.path
+  });
+  commands.addCommand(CommandIDs.markdownPreview, {
+    label: 'Markdown Preview',
+    execute: args => {
+      const path = args['path'];
+      if (typeof path !== 'string') {
+        return;
+      }
+      return commands.execute('docmanager:open', {
+        path,
+        factory: FACTORY,
+        options: args['options']
+      });
+    }
+  });
+  commands.addCommand(CommandIDs.markdownEditor, {
+    execute: () => {
+      const widget = tracker.currentWidget;
+      if (!widget) {
+        return;
+      }
+      const path = widget.context.path;
+      return commands.execute('docmanager:open', {
+        path,
+        factory: 'Editor',
+        options: {
+          mode: 'split-right'
+        }
+      });
+    },
+    isVisible: () => {
+      const widget = tracker.currentWidget;
+      return (
+        (widget && PathExt.extname(widget.context.path) === '.md') || false
+      );
+    },
+    label: 'Show Markdown Editor'
+  });
+  app.contextMenu.addItem({
+    command: CommandIDs.markdownEditor,
+    selector: '.jp-RenderedMarkdown'
+  });
+  return tracker;
+}
+/**
+ * Export the plugin as default.
+ */
+export default plugin;
+//# sourceMappingURL=index.js.map

--- a/examples/federated/md_package/package.json
+++ b/examples/federated/md_package/package.json
@@ -26,12 +26,13 @@
     "svg-url-loader": "~3.0.3",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   },
   "jupyterlab": {
     "extension": true,
+    "schemaDir": "./schema",
     "outputDir": "../labextensions/@jupyterlab/example-federated-md"
   }
 }

--- a/examples/federated/md_package/schema/plugin.json
+++ b/examples/federated/md_package/schema/plugin.json
@@ -1,0 +1,68 @@
+{
+  "jupyter.lab.setting-icon": "ui-components:markdown",
+  "jupyter.lab.setting-icon-label": "Markdown Viewer",
+  "title": "Markdown Viewer",
+  "description": "Markdown viewer settings.",
+  "definitions": {
+    "fontFamily": {
+      "type": ["string", "null"]
+    },
+    "fontSize": {
+      "type": ["integer", "null"],
+      "minimum": 1,
+      "maximum": 100
+    },
+    "lineHeight": {
+      "type": ["number", "null"]
+    },
+    "lineWidth": {
+      "type": ["number", "null"]
+    },
+    "hideFrontMatter": {
+      "type": "boolean"
+    },
+    "renderTimeout": {
+      "type": "number"
+    }
+  },
+  "properties": {
+    "fontFamily": {
+      "title": "Font Family",
+      "description": "The font family used to render markdown.\nIf `null`, value from current theme is used.",
+      "$ref": "#/definitions/fontFamily",
+      "default": null
+    },
+    "fontSize": {
+      "title": "Font Size",
+      "description": "The size in pixel of the font used to render markdown.\nIf `null`, value from current theme is used.",
+      "$ref": "#/definitions/fontSize",
+      "default": null
+    },
+    "lineHeight": {
+      "title": "Line Height",
+      "description": "The line height used to render markdown.\nIf `null`, value from current theme is used.",
+      "$ref": "#/definitions/lineHeight",
+      "default": null
+    },
+    "lineWidth": {
+      "title": "Line Width",
+      "description": "The text line width expressed in CSS ch units.\nIf `null`, lines fit the viewport width.",
+      "$ref": "#/definitions/lineWidth",
+      "default": null
+    },
+    "hideFrontMatter": {
+      "title": "Hide Front Matter",
+      "description": "Whether to hide YAML front matter.\nThe YAML front matter must be placed at the top of the document,\nstarted by a line of three dashes (---) and ended by a line of\nthree dashes (---) or three points (...).",
+      "$ref": "#/definitions/hideFrontMatter",
+      "default": true
+    },
+    "renderTimeout": {
+      "title": "Render Timeout",
+      "description": "The render timeout in milliseconds.",
+      "$ref": "#/definitions/renderTimeout",
+      "default": 1000
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/examples/filebrowser/main.py
+++ b/examples/filebrowser/main.py
@@ -63,11 +63,10 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/example'
+    extension_url = '/lab'
 
     name = "main"
     app_name = 'JupyterLab Example File Browser'
-    app_url = '/example_app'
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')
     app_version = version
@@ -81,7 +80,7 @@ class ExampleApp(LabServerApp):
     def initialize_handlers(self):
         """Add example handler to Lab Server's handler list.
         """
-        self.handlers.append(('example', ExampleHandler))
+        self.handlers.append(('lab', ExampleHandler))
 
 
 if __name__ == '__main__':

--- a/examples/filebrowser/main.py
+++ b/examples/filebrowser/main.py
@@ -48,7 +48,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'lab/'),
+            'frontendUrl': ujoin(self.base_url, 'example/'),
         }
         return self.write(
             self.render_template(
@@ -63,7 +63,8 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/lab'
+    extension_url = '/example'
+    app_url = "/example"
     load_other_extensions = False
     name = __name__
     app_name = 'JupyterLab Example File Browser'
@@ -80,7 +81,7 @@ class ExampleApp(LabServerApp):
     def initialize_handlers(self):
         """Add example handler to Lab Server's handler list.
         """
-        self.handlers.append(('lab', ExampleHandler))
+        self.handlers.append(('/example', ExampleHandler))
 
 
 if __name__ == '__main__':

--- a/examples/filebrowser/main.py
+++ b/examples/filebrowser/main.py
@@ -64,7 +64,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
-
+    load_other_extensions = False
     name = __name__
     app_name = 'JupyterLab Example File Browser'
     static_dir = os.path.join(HERE, 'build')

--- a/examples/filebrowser/main.py
+++ b/examples/filebrowser/main.py
@@ -48,7 +48,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'example/'),
+            'frontendUrl': ujoin(self.base_url, 'lab/'),
         }
         return self.write(
             self.render_template(

--- a/examples/filebrowser/main.py
+++ b/examples/filebrowser/main.py
@@ -65,7 +65,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
 
-    name = "main"
+    name = __name__
     app_name = 'JupyterLab Example File Browser'
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -33,7 +33,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/notebook/main.py
+++ b/examples/notebook/main.py
@@ -69,11 +69,10 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/example'
+    extension_url = '/lab'
     name = 'main'
     app_name = 'JupyterLab Example Notebook'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
-    app_url = '/example_app'
     schemas_dir = os.path.join(HERE, 'build', 'schemas')
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')
@@ -85,7 +84,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/example', ExampleHandler)
+            ('/lab', ExampleHandler)
         )
 
 

--- a/examples/notebook/main.py
+++ b/examples/notebook/main.py
@@ -51,7 +51,7 @@ class ExampleHandler(
             'token': self.settings['token'],
             'notebookPath': 'test.ipynb',
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'example/'),
+            'frontendUrl': ujoin(self.base_url, 'lab/'),
             # FIXME: Don't use a CDN here
             'mathjaxUrl': "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js",
             'mathjaxConfig': "TeX-AMS_CHTML-full,Safeee"

--- a/examples/notebook/main.py
+++ b/examples/notebook/main.py
@@ -51,7 +51,7 @@ class ExampleHandler(
             'token': self.settings['token'],
             'notebookPath': 'test.ipynb',
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'lab/'),
+            'frontendUrl': ujoin(self.base_url, 'example/'),
             # FIXME: Don't use a CDN here
             'mathjaxUrl': "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js",
             'mathjaxConfig': "TeX-AMS_CHTML-full,Safeee"
@@ -69,7 +69,8 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/lab'
+    extension_url = '/example'
+    app_url = "/example"
     name = __name__
     app_name = 'JupyterLab Example Notebook'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
@@ -84,7 +85,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/lab', ExampleHandler)
+            ('/example', ExampleHandler)
         )
 
 

--- a/examples/notebook/main.py
+++ b/examples/notebook/main.py
@@ -70,7 +70,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
-    name = 'main'
+    name = __name__
     app_name = 'JupyterLab Example Notebook'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     schemas_dir = os.path.join(HERE, 'build', 'schemas')

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -34,7 +34,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/terminal/main.py
+++ b/examples/terminal/main.py
@@ -49,7 +49,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'example/'),
+            'frontendUrl': ujoin(self.base_url, 'lab/'),
             'terminalsAvailable': available
         }
         return self.write(

--- a/examples/terminal/main.py
+++ b/examples/terminal/main.py
@@ -49,7 +49,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'lab/'),
+            'frontendUrl': ujoin(self.base_url, 'example/'),
             'terminalsAvailable': available
         }
         return self.write(
@@ -64,7 +64,8 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/lab'
+    extension_url = '/example'
+    app_url = "/example"
     name = __name__
     load_other_extensions = False
     app_name = 'JupyterLab Example Terminal'
@@ -80,7 +81,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/lab', ExampleHandler)
+            ('/example', ExampleHandler)
         )
 
 if __name__ == '__main__':

--- a/examples/terminal/main.py
+++ b/examples/terminal/main.py
@@ -66,6 +66,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
     name = __name__
+    load_other_extensions = False
     app_name = 'JupyterLab Example Terminal'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     schemas_dir = os.path.join(HERE, 'build', 'schemas')

--- a/examples/terminal/main.py
+++ b/examples/terminal/main.py
@@ -64,11 +64,10 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/example'
+    extension_url = '/lab'
     name = __name__
     app_name = 'JupyterLab Example Terminal'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
-    app_url = '/example_app'
     schemas_dir = os.path.join(HERE, 'build', 'schemas')
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')
@@ -80,7 +79,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/example', ExampleHandler)
+            ('/lab', ExampleHandler)
         )
 
 if __name__ == '__main__':

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -25,7 +25,7 @@
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
     "watch": "~1.0.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -87,6 +87,8 @@ async def run_test_async(app, func):
     env_patch = TestEnv()
     env_patch.start()
 
+    app.log.info('Running async test')
+
     # The entry URL for browser tests is different in notebook >= 6.0,
     # since that uses a local HTML file to point the user at the app.
     if hasattr(app, 'browser_open_file'):

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -150,7 +150,8 @@ async def run_browser(url):
     """
     target = osp.join(get_app_dir(), 'browser_test')
     if not osp.exists(osp.join(target, 'node_modules')):
-        os.makedirs(osp.join(target, 'node_modules'))
+        if not osp.exists(target):
+            os.makedirs(osp.join(target))
         await run_async_process(["jlpm", "init", "-y"], cwd=target)
         await run_async_process(["jlpm", "add", "puppeteer@^4"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -159,8 +159,10 @@ class BrowserApp(LabApp):
     """An app the launches JupyterLab and waits for it to start up, checking for
     JS console errors, JS errors, and Python logged errors.
     """
-    name = __name__
-    open_browser = Bool(False)
+    name = "lab"
+    serverapp_config = {
+        "open_browser": False
+    }
     ip = '127.0.0.1'
     flags = test_flags
     aliases = test_aliases

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -168,7 +168,7 @@ class BrowserApp(LabApp):
     ip = '127.0.0.1'
     flags = test_flags
     aliases = test_aliases
-    test_browser = True
+    test_browser = Bool(True)
 
     def initialize_settings(self):
         self.settings.setdefault('page_config_data', dict())
@@ -181,17 +181,19 @@ class BrowserApp(LabApp):
         run_test(self.serverapp, func)
         super().initialize_handlers()
 
-if __name__ == '__main__':
-    skip_option = "--no-chrome-test"
-    if skip_option in sys.argv:
-        BrowserApp.test_browser = False
-        sys.argv.remove(skip_option)
-    def _jupyter_server_extension_points():
+
+def _jupyter_server_extension_points():
         return [
             {
                 'module': __name__,
                 'app': BrowserApp
             }
         ]
-    sys.modules[__name__]._jupyter_server_extension_points = _jupyter_server_extension_points
+
+if __name__ == '__main__':
+    skip_option = "--no-chrome-test"
+    if skip_option in sys.argv:
+        BrowserApp.test_browser = False
+        sys.argv.remove(skip_option)
+
     BrowserApp.launch_instance()

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -152,8 +152,8 @@ async def run_browser(url):
     if not osp.exists(osp.join(target, 'node_modules')):
         if not osp.exists(target):
             os.makedirs(osp.join(target))
-        await run_async_process(["jlpm", "init", "-y"], cwd=target)
-        await run_async_process(["jlpm", "add", "puppeteer@^4"], cwd=target)
+        await run_async_process(["npm", "init", "-y"], cwd=target)
+        await run_async_process(["npm", "install", "puppeteer@^4"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))
     await run_async_process(["node", "chrome-test.js", url], cwd=target)
 

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -148,7 +148,7 @@ async def run_browser(url):
     """
     target = osp.join(get_app_dir(), 'browser_test')
     if not osp.exists(osp.join(target, 'node_modules')):
-        os.makedirs(target)
+        os.makedirs(osp.join(target, 'node_modules'))
         await run_async_process(["jlpm", "init", "-y"], cwd=target)
         await run_async_process(["jlpm", "add", "puppeteer@^4"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -161,7 +161,7 @@ class BrowserApp(LabApp):
     """An app the launches JupyterLab and waits for it to start up, checking for
     JS console errors, JS errors, and Python logged errors.
     """
-    name = "lab"
+    name = __name__
     serverapp_config = {
         "open_browser": False
     }

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -521,6 +521,11 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     expose_app_in_browser = Bool(False, config=True,
         help="Whether to expose the global app instance to browser via window.jupyterlab")
 
+    # By default, open a browser for JupyterLab
+    serverapp_config = {
+        "open_browser": True
+    }
+
     @default('app_dir')
     def _default_app_dir(self):
         app_dir = get_app_dir()
@@ -616,9 +621,6 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     def initialize_handlers(self):
 
         handlers = []
-
-        # TODO(@echarles) Move this to configurable trait once jupyter_server supports it.
-        self.serverapp.open_browser = True
 
         # Set config for Jupyterlab
         page_config = self.serverapp.web_app.settings.setdefault('page_config_data', {})

--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -256,7 +256,9 @@ class JestApp(ProcessTestApp):
 
     test_config = Dict(dict(foo='bar'))
 
-    open_browser = False
+    serverapp_config = {
+        "open_browser": False
+    }
 
     @deprecated(removed_version=4)
     def get_command(self):

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -49,7 +49,7 @@
     "rimraf": "~3.0.0",
     "typescript": "~3.9.2",
     "url-loader": "~3.0.0",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/packages/services/examples/browser-require/main.py
+++ b/packages/services/examples/browser-require/main.py
@@ -36,7 +36,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'lab/'),
+            'frontendUrl': ujoin(self.base_url, 'example/'),
         }
         return self.write(
             self.render_template(
@@ -50,7 +50,8 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/lab'
+    extension_url = '/example'
+    app_url = "/example"
     name = __name__
     load_other_extensions = False
     app_name = 'JupyterLab Example Service'
@@ -66,7 +67,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/lab', ExampleHandler)
+            ('/example', ExampleHandler)
         )
 
 

--- a/packages/services/examples/browser-require/main.py
+++ b/packages/services/examples/browser-require/main.py
@@ -51,7 +51,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
-    name = 'main'
+    name = __name__
     app_name = 'JupyterLab Example Service'
     static_dir = os.path.join(HERE, 'static')
     templates_dir = os.path.join(HERE)

--- a/packages/services/examples/browser-require/main.py
+++ b/packages/services/examples/browser-require/main.py
@@ -36,7 +36,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'example/'),
+            'frontendUrl': ujoin(self.base_url, 'lab/'),
         }
         return self.write(
             self.render_template(
@@ -50,10 +50,9 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/example'
+    extension_url = '/lab'
     name = 'main'
     app_name = 'JupyterLab Example Service'
-    app_url = '/example_app'
     static_dir = os.path.join(HERE, 'static')
     templates_dir = os.path.join(HERE)
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
@@ -66,7 +65,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/example', ExampleHandler)
+            ('/lab', ExampleHandler)
         )
 
 

--- a/packages/services/examples/browser-require/main.py
+++ b/packages/services/examples/browser-require/main.py
@@ -52,6 +52,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
     name = __name__
+    load_other_extensions = False
     app_name = 'JupyterLab Example Service'
     static_dir = os.path.join(HERE, 'static')
     templates_dir = os.path.join(HERE)

--- a/packages/services/examples/browser/main.py
+++ b/packages/services/examples/browser/main.py
@@ -55,7 +55,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
-    name = 'main'
+    name = __name__
     app_name = 'JupyterLab Example Service'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     app_version = version

--- a/packages/services/examples/browser/main.py
+++ b/packages/services/examples/browser/main.py
@@ -56,6 +56,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
     name = __name__
+    load_other_extensions = False
     app_name = 'JupyterLab Example Service'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
     app_version = version

--- a/packages/services/examples/browser/main.py
+++ b/packages/services/examples/browser/main.py
@@ -40,7 +40,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'example/')
+            'frontendUrl': ujoin(self.base_url, 'lab/')
         }
         return self.write(
             self.render_template(
@@ -54,11 +54,10 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/example'
+    extension_url = '/lab'
     name = 'main'
     app_name = 'JupyterLab Example Service'
     app_settings_dir = os.path.join(HERE, 'build', 'application_settings')
-    app_url = '/example_app'
     app_version = version
     schemas_dir = os.path.join(HERE, 'build', 'schemas')
     static_dir = os.path.join(HERE, 'build')
@@ -71,7 +70,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/example', ExampleHandler)
+            ('/lab', ExampleHandler)
         )
 
 

--- a/packages/services/examples/browser/main.py
+++ b/packages/services/examples/browser/main.py
@@ -40,7 +40,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'lab/')
+            'frontendUrl': ujoin(self.base_url, 'example/')
         }
         return self.write(
             self.render_template(
@@ -54,7 +54,8 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/lab'
+    extension_url = '/example'
+    app_url = "/example"
     name = __name__
     load_other_extensions = False
     app_name = 'JupyterLab Example Service'
@@ -71,7 +72,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/lab', ExampleHandler)
+            ('/example', ExampleHandler)
         )
 
 

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typescript": "~3.9.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10"
   }
 }

--- a/packages/services/examples/typescript-browser-with-output/main.py
+++ b/packages/services/examples/typescript-browser-with-output/main.py
@@ -40,7 +40,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'main/'),
+            'frontendUrl': ujoin(self.base_url, 'lab/'),
         }
         return self.write(
             self.render_template(
@@ -54,10 +54,9 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/example'
-    name = 'main'
+    extension_url = '/lab'
+    name = 'lab'
     app_name = 'JupyterLab Example Service'
-    app_url = '/example_app'
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')
     app_version = version
@@ -71,7 +70,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/example', ExampleHandler)
+            ('/lab', ExampleHandler)
         )
 
 

--- a/packages/services/examples/typescript-browser-with-output/main.py
+++ b/packages/services/examples/typescript-browser-with-output/main.py
@@ -56,6 +56,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
     name = __name__
+    load_other_extensions = False
     app_name = 'JupyterLab Example Service'
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')

--- a/packages/services/examples/typescript-browser-with-output/main.py
+++ b/packages/services/examples/typescript-browser-with-output/main.py
@@ -40,7 +40,7 @@ class ExampleHandler(
             'baseUrl': self.base_url,
             'token': self.settings['token'],
             'fullStaticUrl': ujoin(self.base_url, 'static', self.name),
-            'frontendUrl': ujoin(self.base_url, 'lab/'),
+            'frontendUrl': ujoin(self.base_url, 'example/'),
         }
         return self.write(
             self.render_template(
@@ -54,7 +54,8 @@ class ExampleHandler(
 
 class ExampleApp(LabServerApp):
 
-    extension_url = '/lab'
+    extension_url = '/example'
+    app_url = "/example"
     name = __name__
     load_other_extensions = False
     app_name = 'JupyterLab Example Service'
@@ -71,7 +72,7 @@ class ExampleApp(LabServerApp):
         """Add example handler to Lab Server's handler list.
         """
         self.handlers.append(
-            ('/lab', ExampleHandler)
+            ('/example', ExampleHandler)
         )
 
 

--- a/packages/services/examples/typescript-browser-with-output/main.py
+++ b/packages/services/examples/typescript-browser-with-output/main.py
@@ -55,7 +55,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/lab'
-    name = 'lab'
+    name = __name__
     app_name = 'JupyterLab Example Service'
     static_dir = os.path.join(HERE, 'build')
     templates_dir = os.path.join(HERE, 'templates')

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -26,7 +26,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~1.0.1",
     "typescript": "~3.9.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10"
   }
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -71,7 +71,7 @@
     "ts-jest": "^25.2.1",
     "typedoc": "^0.17.7",
     "typescript": "~3.9.2",
-    "webpack": "5.0.0-beta.21",
+    "webpack": "~5.0.0-beta.22",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'ipython',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
-    'jupyterlab_server>=2.0.0a1',
+    'jupyterlab_server>=2.0.0a2',
     'jupyter_server>=1.0.0rc4',
     'nbclassic>=0.2.0rc3',
     'jinja2>=2.10'

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'ipython',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
-    'jupyterlab_server>=2.0.0a2',
+    'jupyterlab_server>=2.0.0a3',
     'jupyter_server>=1.0.0rc5',
     'nbclassic>=0.2.0rc3',
     'jinja2>=2.10'

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup_args['install_requires'] = [
     'ipython',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
     'jupyterlab_server>=2.0.0a2',
-    'jupyter_server>=1.0.0rc4',
+    'jupyter_server>=1.0.0rc5',
     'nbclassic>=0.2.0rc3',
     'jinja2>=2.10'
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7599,10 +7599,10 @@ enhanced-resolve@4.1.0, enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
-enhanced-resolve@5.0.0-beta.7:
-  version "5.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.7.tgz#174f085396ac8edc734253f5b6aa9a05cb0d73b2"
-  integrity sha512-4r9mhIEedx7IsNgutSPyFtD0hKukbknr8Fuee36IXg9dYcAeDLb7l6LzBAeiDBgUKeFv+OgMSkCyp/SGCZ5Xag==
+enhanced-resolve@5.0.0-beta.10:
+  version "5.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.10.tgz#3907c034f8e59446dfa5a89a1fd73db29aa0f246"
+  integrity sha512-vEyxvHv3f8xl7i7QmTQ6BqKY32acSPQ4dTZo8WRMtcqTDYH9YyXnDxqXsQqBLvdRHUiwl9nVivESiM1RcrxbKQ==
   dependencies:
     graceful-fs "^4.2.0"
     tapable "^2.0.0-beta.10"
@@ -17160,34 +17160,6 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@5.0.0-beta.21:
-  version "5.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-beta.21.tgz#3f46465e6f8d33950ae645eb98bb227b78d3ee52"
-  integrity sha512-ZgS5vUDphrjuakkQfT41q75dNavg8zUeTq0x31DvZG+z+OqR37u9BZFwytHM9U/I0vrnqm9vvBviyeHrAG3n0Q==
-  dependencies:
-    "@types/estree" "^0.0.45"
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/wasm-edit" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^7.3.0"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "5.0.0-beta.7"
-    eslint-scope "^5.0.0"
-    events "^3.0.0"
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.1.15"
-    json-parse-better-errors "^1.0.2"
-    loader-runner "^4.0.0"
-    mime-types "^2.1.26"
-    neo-async "^2.6.1"
-    pkg-dir "^4.2.0"
-    schema-utils "^2.5.0"
-    tapable "^2.0.0-beta.10"
-    terser-webpack-plugin "^3.0.2"
-    watchpack "2.0.0-beta.13"
-    webpack-sources "2.0.0-beta.8"
-
 webpack@^4.33.0, webpack@^4.38.0:
   version "4.41.4"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.4.tgz#4bec4125224bdf50efa8be6226c19047599cd034"
@@ -17216,6 +17188,34 @@ webpack@^4.33.0, webpack@^4.38.0:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.6.0"
     webpack-sources "^1.4.1"
+
+webpack@~5.0.0-beta.22:
+  version "5.0.0-beta.24"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-beta.24.tgz#03598047c635335883648f1d152fe48d38124059"
+  integrity sha512-08TefC7UyXhnR7r6Ebjgb/uGhnAUNpuKLLsG6Xm26I/H3gYHkpiON5LLWO0oBKAz7E5mg/fDWVz/rrB6Ysbj+g==
+  dependencies:
+    "@types/estree" "^0.0.45"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/wasm-edit" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    acorn "^7.3.0"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "5.0.0-beta.10"
+    eslint-scope "^5.0.0"
+    events "^3.0.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.15"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.0.0"
+    mime-types "^2.1.26"
+    neo-async "^2.6.1"
+    pkg-dir "^4.2.0"
+    schema-utils "^2.5.0"
+    tapable "^2.0.0-beta.10"
+    terser-webpack-plugin "^3.0.2"
+    watchpack "2.0.0-beta.13"
+    webpack-sources "2.0.0-beta.8"
 
 websocket-driver@>=0.5.1:
   version "0.7.3"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Follow up to #8772.  Fixes #8767 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Fixes missing `<path>` component in `build-extension`
- Fixes the usage of `open_browser`
- Cleans up `federated` example to run properly (examples tests were not actually running)
- Upgrades to webpack beta 22

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
