### PR TITLE
Fix off by one error in benchmark samples

### DIFF
--- a/benchmarks/src/index.ts
+++ b/benchmarks/src/index.ts
@@ -124,7 +124,7 @@ function writeOutput({
 
     await waitForLaunch();
 
-    for (let n = 0; n <= MAX_N; n += MAX_N / NUMBER_SAMPLES) {
+    for (let n = 0; n <= MAX_N; n += MAX_N / (NUMBER_SAMPLES - 1)) {
       // stop testing if we don't have atleast two tests to keep running
       if (notebooks.length - tooLong.size < 2) {
         break;


### PR DESCRIPTION
The change in N should be 1 - the total number of samples, because we also include 0. For example, if NUMBER_SAMPLES is 3 and MAX_N is 10, the three should be at n= 0, 5, and 10  so the diff between them should be 5 = 10 / (3 - 1).

## References

None
## Code changes

Fixes bug in benchmark code

## User-facing changes

None
## Backwards-incompatible changes

None
