### PR TITLE
Module federation implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ jupyterlab/static
 jupyterlab/schemas
 jupyterlab/themes
 jupyterlab/imports.css
+jupyterlab/tests/**/static
 
 packages/nbconvert-css/style/
 packages/services/examples/node/config.json

--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -41,9 +41,12 @@
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
+    "@babel/core": "^7.10.2",
+    "@babel/preset-env": "^7.10.2",
     "@lumino/coreutils": "^1.4.3",
     "@yarnpkg/lockfile": "^1.1.0",
     "ajv": "^6.12.3",
+    "babel-loader": "^8.0.6",
     "child_process": "~1.0.2",
     "commander": "~4.0.1",
     "crypto": "~1.0.1",

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -175,6 +175,12 @@ function ensureJupyterlab(): string[] {
     } catch (e) {
       return;
     }
+
+    // TODO: reinstate once we update the extension-manager
+    if (data.name === '@jupyterlab/extensionmanager') {
+      return;
+    }
+
     coreData.set(data.name, data);
 
     // If the package has a tokens.ts file, make sure it is noted as a singleton

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -35,7 +35,7 @@ const UNUSED: Dict<string[]> = {
   '@jupyterlab/application': ['@fortawesome/fontawesome-free'],
   '@jupyterlab/apputils-extension': ['es6-promise'],
   '@jupyterlab/buildutils': [
-    '@babel/core@',
+    '@babel/core',
     '@babel/preset-env',
     'babel-loader'
   ],

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -34,6 +34,11 @@ const UNUSED: Dict<string[]> = {
   '@jupyterlab/apputils': ['@types/react', 'buffer', 'url'],
   '@jupyterlab/application': ['@fortawesome/fontawesome-free'],
   '@jupyterlab/apputils-extension': ['es6-promise'],
+  '@jupyterlab/buildutils': [
+    '@babel/core@',
+    '@babel/preset-env',
+    'babel-loader'
+  ],
   '@jupyterlab/services': ['node-fetch', 'ws'],
   '@jupyterlab/rendermime': ['@jupyterlab/mathjax2'],
   '@jupyterlab/testutils': [

--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -42,7 +42,7 @@ const notice =
 
 [
   'index.js',
-  //'webpack.config.js',   # removing as part of https://github.com/jupyterlab/jupyterlab/issues/8655
+  'webpack.config.js',
   'webpack.prod.config.js',
   'webpack.prod.minimize.config.js',
   'webpack.prod.release.config.js',

--- a/buildutils/src/webpack.config.base.ts
+++ b/buildutils/src/webpack.config.base.ts
@@ -40,6 +40,16 @@ const rules = [
     use: {
       loader: 'raw-loader'
     }
+  },
+  // Workaround for https://github.com/jupyterlab/jupyterlab/issues/8655
+  {
+    test: /vega-statistics\/src\/.*.js$/,
+    use: {
+      loader: 'babel-loader',
+      options: {
+        presets: ['@babel/preset-env']
+      }
+    }
   }
 ];
 

--- a/buildutils/src/webpack.config.base.ts
+++ b/buildutils/src/webpack.config.base.ts
@@ -6,7 +6,7 @@ import * as webpack from 'webpack';
 
 const rules = [
   { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-  { test: /\.html$/, use: 'file-loader' },
+  { test: /\.txt$/, use: 'raw-loader' },
   { test: /\.md$/, use: 'raw-loader' },
   { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
   { test: /\.js.map$/, use: 'file-loader' },

--- a/buildutils/src/webpack.config.ext.ts
+++ b/buildutils/src/webpack.config.ext.ts
@@ -123,6 +123,9 @@ module.exports = [
       path: outputPath,
       publicPath: `lab/extensions/${data.name}/`
     },
+    module: {
+      rules: [{ test: /\.html$/, use: 'file-loader' }]
+    },
     plugins: [
       new ModuleFederationPlugin({
         name: data.name,

--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -3,8 +3,6 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-require('es6-promise/auto');  // polyfill Promise on IE
-
 import {
   PageConfig
 } from '@jupyterlab/coreutils';
@@ -16,15 +14,71 @@ __webpack_public_path__ = PageConfig.getOption('fullStaticUrl') + '/';
 // This cannot be extracted because the public path is dynamic.
 require('./imports.css');
 
+
+function loadScript(url) {
+  return new Promise((resolve, reject) => {
+    const newScript = document.createElement('script');
+    newScript.onerror = reject;
+    newScript.onload = resolve;
+    newScript.async = true;
+    document.head.appendChild(newScript);
+    newScript.src = url;
+  });
+}
+
+async function loadComponent(url, scope, module) {
+  await loadScript(url);
+
+  // From MIT-licensed https://github.com/module-federation/module-federation-examples/blob/af043acd6be1718ee195b2511adf6011fba4233c/advanced-api/dynamic-remotes/app1/src/App.js#L6-L12
+  await __webpack_init_sharing__('default');
+  const container = window._JUPYTERLAB[scope];
+  // Initialize the container, it may provide shared modules and may need ours
+  await container.init(__webpack_share_scopes__.default);
+
+  const factory = await window._JUPYTERLAB[scope].get(module);
+  const Module = factory();
+  return Module;
+}
+
+
+
 /**
  * The main entry point for the application.
  */
-function main() {
+async function main() {
   var JupyterLab = require('@jupyterlab/application').JupyterLab;
   var disabled = [];
   var deferred = [];
   var ignorePlugins = [];
   var register = [];
+
+  // This is all the data needed to load and activate plugins. This should be
+  // gathered by the server and put onto the initial page template.
+  const extension_data = JSON.parse(
+    PageConfig.getOption('dynamic_extensions')
+  );
+  const mime_extension_data = JSON.parse(
+    PageConfig.getOption('dynamic_mime_extensions')
+  );
+
+  // Get dynamic plugins
+  const dynamicPromises = extension_data.map(data =>
+    loadComponent(
+      data.path,
+      data.name,
+      data.module
+    )
+  );
+  const dynamicPlugins = await Promise.all(dynamicPromises);
+
+  const dynamicMimePromises = mime_extension_data.map(data =>
+    loadComponent(
+      data.path,
+      data.name,
+      data.module
+    )
+  );
+  const dynamicMimePlugins = await Promise.all(dynamicMimePromises);
 
   // Handle the registered mime extensions.
   var mimeExtensions = [];
@@ -58,6 +112,9 @@ function main() {
   }
   {{/each}}
 
+  // Add the dyanmic mime extensions.
+  dynamicMimePlugins.forEach(plugin => { mimeExtensions.push(plugin); });
+
   // Handled the registered standard extensions.
   {{#each jupyterlab_extensions}}
   try {
@@ -85,6 +142,10 @@ function main() {
     console.error(e);
   }
   {{/each}}
+
+  // Add the dynamic extensions.
+  dynamicPlugins.forEach(plugin => { register.push(plugin) });
+
   var lab = new JupyterLab({
     mimeExtensions: mimeExtensions,
     disabled: {

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -115,7 +115,7 @@
     "@jupyterlab/docregistry": "~3.0.0-alpha.7",
     "@jupyterlab/documentsearch": "~3.0.0-alpha.7",
     "@jupyterlab/documentsearch-extension": "~3.0.0-alpha.7",
-    "@jupyterlab/extensionmanager": "~3.0.0-alpha.7",
+    "@jupyterlab/extensionmanager": "^3.0.0-alpha.7",
     "@jupyterlab/extensionmanager-extension": "~3.0.0-alpha.7",
     "@jupyterlab/filebrowser": "~3.0.0-alpha.7",
     "@jupyterlab/filebrowser-extension": "~3.0.0-alpha.7",

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -8,8 +8,11 @@ const fs = require('fs-extra');
 const Handlebars = require('handlebars');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
+const merge = require('webpack-merge');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
   .BundleAnalyzerPlugin;
+const baseConfig = require('@jupyterlab/buildutils/lib/webpack.config.base');
+const { ModuleFederationPlugin } = webpack.container;
 
 const Build = require('@jupyterlab/buildutils').Build;
 const WPPlugin = require('@jupyterlab/buildutils').WPPlugin;
@@ -47,27 +50,58 @@ if (fs.existsSync(buildDir)) {
 }
 fs.ensureDirSync(buildDir);
 
+const outputDir = plib.resolve(jlab.outputDir);
+
 // Build the assets
 const extraConfig = Build.ensureAssets({
   packageNames: packageNames,
-  output: jlab.outputDir
+  output: outputDir
 });
+
+// Build up singleton metadata for module federation.
+const singletons = {};
+
+package_data.jupyterlab.singletonPackages.forEach(element => {
+  singletons[element] = { singleton: true };
+});
+
+// Go through each external extension
+// add to mapping of extension and mime extensions, of package name
+// to path of the extension.
+for (const key in externalExtensions) {
+  const {
+    jupyterlab: { extension, mimeExtension }
+  } = require(`${key}/package.json`);
+  if (extension !== undefined) {
+    extensions[key] = extension === true ? '' : extension;
+  }
+  if (mimeExtension !== undefined) {
+    mimeExtensions[key] = mimeExtension === true ? '' : mimeExtension;
+  }
+}
 
 // Create the entry point file.
 const source = fs.readFileSync('index.js').toString();
 const template = Handlebars.compile(source);
-const data = {
+const extData = {
   jupyterlab_extensions: extensions,
   jupyterlab_mime_extensions: mimeExtensions
 };
-const result = template(data);
+const result = template(extData);
 
 fs.writeFileSync(plib.join(buildDir, 'index.out.js'), result);
 fs.copySync('./package.json', plib.join(buildDir, 'package.json'));
-fs.copySync(
-  plib.join(jlab.outputDir, 'imports.css'),
-  plib.join(buildDir, 'imports.css')
-);
+if (outputDir !== buildDir) {
+  fs.copySync(
+    plib.join(outputDir, 'imports.css'),
+    plib.join(buildDir, 'imports.css')
+  );
+}
+
+// Make a bootstrap entrypoint
+const entryPoint = plib.join(buildDir, 'bootstrap.js');
+const bootstrap = 'import("./index.out.js");';
+fs.writeFileSync(entryPoint, bootstrap);
 
 // Set up variables for the watch mode ignore plugins
 const watched = {};
@@ -155,7 +189,7 @@ const plugins = [
   }),
   new HtmlWebpackPlugin({
     chunksSortMode: 'none',
-    template: plib.join('templates', 'template.html'),
+    template: plib.join(__dirname, 'templates', 'template.html'),
     title: jlab.name || 'JupyterLab'
   }),
   new webpack.ids.HashedModuleIdsPlugin(),
@@ -163,9 +197,16 @@ const plugins = [
   new WPPlugin.FilterWatchIgnorePlugin(ignored),
   // custom plugin that copies the assets to the static directory
   new WPPlugin.FrontEndPlugin(buildDir, jlab.staticDir),
-  new webpack.DefinePlugin({
-    'process.env': '{}',
-    process: {}
+  new ModuleFederationPlugin({
+    library: {
+      type: 'var',
+      name: ['_JUPYTERLAB', 'CORE_LIBRARY_FEDERATION']
+    },
+    name: 'CORE_FEDERATION',
+    shared: {
+      ...package_data.resolutions,
+      ...singletons
+    }
   })
 ];
 
@@ -174,75 +215,14 @@ if (process.argv.includes('--analyze')) {
 }
 
 module.exports = [
-  {
+  merge(baseConfig, {
     mode: 'development',
     entry: {
-      main: ['whatwg-fetch', plib.resolve(buildDir, 'index.out.js')]
-    },
-    // Map Phosphor files to Lumino files.
-    resolve: {
-      alias: {
-        '@phosphor/algorithm$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/algorithm/dist/index.js'
-        ),
-        '@phosphor/application$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/application/dist/index.js'
-        ),
-        '@phosphor/commands$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/commands/dist/index.js'
-        ),
-        '@phosphor/coreutils$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/coreutils/dist/index.js'
-        ),
-        '@phosphor/disposable$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/disposable/dist/index.js'
-        ),
-        '@phosphor/domutils$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/domutils/dist/index.js'
-        ),
-        '@phosphor/dragdrop$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/dragdrop/dist/index.js'
-        ),
-        '@phosphor/dragdrop/style': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/widgets/style'
-        ),
-        '@phosphor/messaging$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/messaging/dist/index.js'
-        ),
-        '@phosphor/properties$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/properties/lib'
-        ),
-        '@phosphor/signaling': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/signaling/dist/index.js'
-        ),
-        '@phosphor/widgets/style': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/widgets/style'
-        ),
-        '@phosphor/virtualdom$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/virtualdom/dist/index.js'
-        ),
-        '@phosphor/widgets$': plib.resolve(
-          __dirname,
-          'node_modules/@lumino/widgets/dist/index.js'
-        )
-      }
+      main: ['whatwg-fetch', entryPoint]
     },
     output: {
       path: plib.resolve(buildDir),
-      publicPath: '{{page_config.fullStaticUrl}}/',
+      publicPath: 'static/lab/',
       filename: '[name].[chunkhash].js'
     },
     optimization: {
@@ -252,64 +232,19 @@ module.exports = [
     },
     module: {
       rules: [
-        { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-        { test: /\.md$/, use: 'raw-loader' },
-        { test: /\.txt$/, use: 'raw-loader' },
         {
           test: /\.js$/,
           include: sourceMapRes,
           use: ['source-map-loader'],
           enforce: 'pre'
-        },
-        { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
-        { test: /\.js.map$/, use: 'file-loader' },
-        {
-          test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=application/font-woff'
-        },
-        {
-          test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=application/font-woff'
-        },
-        {
-          test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=application/octet-stream'
-        },
-        {
-          test: /\.otf(\?v=\d+\.\d+\.\d+)?$/,
-          use: 'url-loader?limit=10000&mimetype=application/octet-stream'
-        },
-        { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
-        {
-          // In .css files, svg is loaded as a data URI.
-          test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-          issuer: /\.css$/,
-          use: {
-            loader: 'svg-url-loader',
-            options: { encoding: 'none', limit: 10000 }
-          }
-        },
-        {
-          // In .ts and .tsx files (both of which compile to .js), svg files
-          // must be loaded as a raw string instead of data URIs.
-          test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-          issuer: /\.js$/,
-          use: {
-            loader: 'raw-loader'
-          }
         }
       ]
     },
-    watchOptions: {
-      poll: 500,
-      aggregateTimeout: 1000
-    },
-    // node: {
-    //   fs: 'empty'
-    // },
-    bail: true,
     devtool: 'inline-source-map',
     externals: ['node-fetch', 'ws'],
     plugins
-  }
+  })
 ].concat(extraConfig);
+
+const logPath = plib.join(buildDir, 'build_log.json');
+fs.writeFileSync(logPath, JSON.stringify(module.exports, null, '  '));

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -39,9 +39,9 @@ Implementation
   - The command produces a set of static assets that are shipped along with a package (notionally on ``pip``/``conda``)
   - It needs to be a Python cli so it can use the dependency metadata from the active JupyterLab
   - The assets include a module federation ``remoteEntry.js``, generated bundles, and some other files that we use
-     - ``package.orig.json`` is the original ``package.json`` file that we use to gather metadata about the package
-     - ``build_log.json`` has all of the webpack options used to build the extension, for debugging purposes
-     - we use the existing ``@jupyterlab/buildutils -> build`` to generate the ``imports.css``, ``schemas`` and ``themes`` file structure
+  - ``package.orig.json`` is the original ``package.json`` file that we use to gather metadata about the package
+  - ``build_log.json`` has all of the webpack options used to build the extension, for debugging purposes
+  - we use the existing ``@jupyterlab/buildutils -> build`` to generate the ``imports.css``, ``schemas`` and ``themes`` file structure
 - We add a schema for the valid ``jupyterlab`` metadata for an extension's ``package.json`` describing the available options
 - We add a ``labextensions`` handler in ``jupyterlab_server`` that loads static assets from ``labextensions`` paths, following a similar logic to how ``nbextensions`` are discovered and loaded from disk
 - We augment the ``settings`` and ``themes`` handlers in ``jupyterlab_server`` to load from the new ``labextensions`` locations, favoring the dynamic extension locations over the bundled ones

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -20,7 +20,58 @@ A JupyterLab application is comprised of:
 -  A core Application object
 -  Plugins
 
-Extensions are distributed as JavaScript packages, so you can write extensions in JavaScript or any language that compiles to JavaScript. We recommend writing extensions in `TypeScript <https://www.typescriptlang.org/>`_, which is used for the JupyterLab core extensions and many popular community extensions.
+Starting in JupyterLab 3.0, extensions are distributed at ``pip`` or 
+``conda`` packages that contain federated JavaScript bundles.  You can write extensions in JavaScript or any language that compiles to JavaScript. We recommend writing extensions in `TypeScript <https://www.typescriptlang.org/>`_, which is used for the JupyterLab core extensions and many popular community extensions.  You use our build tool to generate the bundles that are shipped with the package, typically through a cookiecutter.
+
+
+Goals of the Dynamic Extension System
+--------------------------------------
+- Users should be able to install and use extensions without requiring ``node`` or a build step
+- Extension authors should be able to easily build and distribute extensions
+- The existing capabilities of built-in extensions should still work
+- Administrators should regain the ability to set global configuration and packages where possible
+- Dynamic extensions should layer on top of existing extensions similar to how  ``pip install --user`` works
+- Extensions should be discoverable
+
+Implementation
+--------------
+- We provide a ``jupyter labextensions build`` script that is used to build bundles
+  - The command produces a set of static assets that are shipped along with a package (notionally on ``pip``/``conda``)
+  - It needs to be a Python cli so it can use the dependency metadata from the active JupyterLab
+  - The assets include a module federation ``remoteEntry.js``, generated bundles, and some other files that we use
+     - ``package.orig.json`` is the original ``package.json`` file that we use to gather metadata about the package
+     - ``build_log.json`` has all of the webpack options used to build the extension, for debugging purposes
+     - we use the existing ``@jupyterlab/buildutils -> build`` to generate the ``imports.css``, ``schemas`` and ``themes`` file structure
+- We add a schema for the valid ``jupyterlab`` metadata for an extension's ``package.json`` describing the available options
+- We add a ``labextensions`` handler in ``jupyterlab_server`` that loads static assets from ``labextensions`` paths, following a similar logic to how ``nbextensions`` are discovered and loaded from disk
+- We augment the ``settings`` and ``themes`` handlers in ``jupyterlab_server`` to load from the new ``labextensions`` locations, favoring the dynamic extension locations over the bundled ones
+- We add a ``labextension develop`` command used to install an in-development extension into JupyterLab.  The default behavior is to create a symlink in the ``sys-prefix/share/jupyter/labextensions/package-name`` to the static directory of the extension
+- We provide a ``cookiecutter`` that handles all of the scaffolding for an extension author, including the shipping of ``data_files`` so that when the user installs the package, the static assets end up in ``share/jupyter/labextensions``
+- We handle disabling of lab extensions using a trait on the ``LabApp`` class, so it can be set by admins and overridden by users.  Extensions are automatically enabled when installed, and must be explicitly disabled.  The disabled config can consist of a package name or a plugin regex pattern
+- Extensions can provide ``disabled`` metadata that can be used to replace an entire extension or individual plugins
+- ``page_config`` and ``overrides`` are also handled with traits so that admins can provide defaults and users can provide overrides
+- We will update the ``extension-manager`` to target metadata on ``pypi``/``conda`` and consume those packages.
+
+Tools
+-----
+- ``jupyter labexension build`` python command line tool
+- ``jupyter labextension develop`` python command line tool
+- ``cookiecutter`` for extension authors
+
+Workflow for extension authors
+------------------------------
+- Use the ``cookiecutter`` to create the extension
+- Run ``jupyter labextension develop`` to build and symlink the files
+- Run ``jupyter labextension watch`` to start watching
+- Run ``jupyter lab``
+- Make changes to source
+- Refresh the application page
+- When finished, publish the package to ``pypi``/``conda``
+
+
+.. note::
+   These docs are under construction as we iterate and update tutorials and cookiecutters.
+
 
 Tutorials
 ~~~~~~~~~

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -814,12 +814,3 @@ release process, but this could also be done manually.
 Technically, a package that contains only a JupyterLab extension could be created
 and published on ``conda-forge``, but it would not be discoverable by the JupyterLab
 extension manager.
-
-
-Listings
-^^^^^^^^
-
-You can develop on the extension manager package and :ref:`extension_listings` with the
-example shipped in the ``packages/extensionmanager-extension/examples/listings`` folder.
-
-Follow the ``README.md`` instructions in that folder.

--- a/docs/source/getting_started/changelog.rst
+++ b/docs/source/getting_started/changelog.rst
@@ -135,7 +135,7 @@ User-facing changes
 ^^^^^^^^^^^^^^^^^^^
 
 * Display the extension manager in the left sidebar by default. Users will need to acknowledge the disclaimer in the extension manager before using it. (`#8050 <https://github.com/jupyterlab/jupyterlab/pull/8050>`__, `#8145 <https://github.com/jupyterlab/jupyterlab/pull/8145>`__)
-* Added :ref:`blacklist and whitelist support <extension_listings>` for the extension manager (`#7989 <https://github.com/jupyterlab/jupyterlab/pull/7989>`__)
+* Added ``blacklist and whitelist support <extension_listings>`` for the extension manager (`#7989 <https://github.com/jupyterlab/jupyterlab/pull/7989>`__)
 
 * Automatically link URLs in notebook output text (`#8075 <https://github.com/jupyterlab/jupyterlab/pull/8075>`__, `#7393 <https://github.com/jupyterlab/jupyterlab/issues/7393>`__)
 * Added a "Restart Kernel and Run All Cells…" button to the notebook toolbar (`#8024 <https://github.com/jupyterlab/jupyterlab/pull/8024>`__)

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -16,13 +16,11 @@ or privileged than any custom extension.
     :local:
     :depth: 1
 
-JupyterLab extensions are `npm <https://www.npmjs.com/>`__ packages (the
-standard package format in Javascript development). You can search for the
-keyword `jupyterlab-extension
-<https://www.npmjs.com/search?q=keywords%3Ajupyterlab-extension>`__ on the
-npm registry to find extensions. For information about developing extensions,
+Starting in JupyterLab 3.0, extensions are typically ``pip`` or ``conda``
+packages that are dynamically loaded by the application (no more build step). You can search using ``pip search "jupyterlab extension"`` to find extensions. For information about developing extensions,
 see the :ref:`developer documentation <developer_extensions>`.
-
+Once an extension is installed, you can refresh a running application
+or launch a new application to use the new extension.
 
 .. note::
 
@@ -30,7 +28,10 @@ see the :ref:`developer documentation <developer_extensions>`.
    developer API is not stable and will evolve in the near future.
 
 
-In order to install JupyterLab extensions, you need to have `Node.js
+Built-in Extensions
+--------------------
+
+In order to install JupyterLab built in (bundled) extensions, you need to have `Node.js
 <https://nodejs.org/>`__ installed.
 
 If you use ``conda`` with ``conda-forge`` packages, you can get it with:
@@ -49,152 +50,6 @@ If you use `Homebrew <https://brew.sh/>`__ on Mac OS X:
 
 You can also download Node.js from the `Node.js website <https://nodejs.org/>`__ and
 install it directly.
-
-
-Using the Extension Manager
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To manage your extensions, you can use the extension manager. By default, the
-manager is disabled. You can enable it by searching **Extension Manager** in the command palette.
-
-.. figure:: images/extension_manager_enable_manager.png
-   :align: center
-   :class: jp-screenshot
-
-   **Figure:** Enable extension manager by searching in the command palette
-
-You can also enable it with the following steps:
-
-
-   - Go into advanced settings editor.
-   - Open the Extension Manager section.
-   - Add the entry "enabled": true.
-   - Save the settings.
-   - If prompted whether you are sure, read the warning, and click "Enable"
-     if you are still sure.
-
-Once enabled, you should see a new tab appear in the :ref:`left sidebar <left-sidebar>`.
-
-
-.. figure:: images/extension_manager_default.png
-   :align: center
-   :class: jp-screenshotls 
-
-   **Figure:** The default view has three components: a search bar, an "Installed"
-   section, and a "Discover" section.
-
-
-Disclaimer
-^^^^^^^^^^
-
-.. danger::
-
-    Installing an extension allows it to execute arbitrary code on the
-    server, kernel, and in the client's browser. Therefore we ask you 
-    to explicitly acknowledge this.
-
-
-By default, the disclaimer is not acknowledged.
-
-.. figure:: images/listings/disclaimer_unchecked.png
-   :align: center
-   :class: jp-screenshot
-
-   **Figure:** User has not acknowledged the disclaimer
-
-
-As the disclaimer is not acknowledged, you can search for an extension,
-but can not install it (no install button is available).
-
-.. figure:: images/listings/disclaimer_unchecked_noinstall.png
-   :align: center
-   :class: jp-screenshot
-
-   **Figure:** With Disclaimer unchecked, you can not install an extension
-
-
-To install an extension, you first have to explicitly acknowledge the disclaimer.
-Once done, this will remain across sessions and the user does not have to 
-check it again.
-
-.. figure:: images/listings/disclaimer_checked.png
-   :align: center
-   :class: jp-screenshot
-
-   **Figure:** Disclaimer checked
-
-For ease of use, you can hide the disclaimer so it takes less space on
-your screen.
-
-.. figure:: images/listings/disclaimer_hidden.png
-   :align: center
-   :class: jp-screenshot
-
-   **Figure:** Disclaimer is hidden
-
-
-Finding Extensions
-^^^^^^^^^^^^^^^^^^
-
-You can use the extension manager to find extensions for JupyterLab. To discovery
-freely among the currently available extensions, expand the "Discovery" section.
-This triggers a search for all JupyterLab extensions on the NPM registry, and
-the results are listed according to the `registry's sort order
-<https://docs.npmjs.com/searching-for-and-choosing-packages-to-download#package-search-rank-criteria>`__.
-An exception to this sort order is that extensions released by the Jupyter
-organization are always placed first. These extensions are distinguished by
-a small Jupyter icon next to their name.
-
-
-.. image:: images/extension_manager_discover.png
-   :align: center
-   :class: jp-screenshot
-   :alt: Screenshot showing the discovery extension listing.
-
-
-Alternatively, you can limit your discovery by using the search bar. This
-performs a free-text search of JupyterLab extensions on the NPM registry.
-
-.. image:: images/extension_manager_search.png
-   :align: center
-   :class: jp-screenshot
-   :alt: Screenshot showing an example search result
-
-
-Installing an Extension
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Once you have found an extension that you think is interesting, install
-it by clicking the "Install" button of the extension list entry.
-
-
-.. danger::
-
-    Installing an extension allows it to execute arbitrary code on the
-    server, kernel, and in the client's browser. You should therefore
-    avoid installing extensions you do not trust, and watch out for
-    any extensions trying to masquerade as a trusted extension.
-
-
-A short while after starting the install of an extension, a drop-down should
-appear under the search bar indicating that the extension has been
-downloaded, but that a rebuild is needed to complete the installation.
-
-
-.. image:: images/extension_manager_rebuild.png
-   :align: center
-   :class: jp-screenshot
-   :alt: Screenshot showing the rebuild indicator
-
-
-If you want to install/uninstall other extensions as well, you can ignore
-the rebuild notice until you have made all the changes you want. Once satisfied,
-click the 'Rebuild' button to start a rebuild in the background.
-Once the rebuild completes, a dialog will pop up, indicating that a reload of
-the page is needed in order to load the latest build into the browser.
-
-If you ignore the rebuild notice by mistake, simply refresh your browser
-window to trigger a new rebuild check.
 
 
 Disabling Rebuild Checks
@@ -220,182 +75,6 @@ in any of the ``config`` locations returned by ``jupyter --paths``.
     }
 
 
-Managing Installed Extensions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When there are some installed extensions, they will be shown in the "Installed"
-section. These can then be uninstalled or disabled. Disabling an extension will
-prevent it from being activated, but without rebuilding the application.
-
-
-Companion packages
-^^^^^^^^^^^^^^^^^^
-
-During installation of an extension, JupyterLab will inspect the package
-metadata for any
-:ref:`instructions on companion packages <ext-author-companion-packages>`.
-Companion packages can be:
-
-   - Notebook server extensions (or any other packages that need to be
-     installed on the Notebook server).
-   - Kernel packages. An example of companion packages for the
-     kernel are Jupyter Widget packages, like the `ipywidgets <https://ipywidgets.readthedocs.io/en/stable>`__
-     Python package for the
-     `@jupyter-widgets/jupyterlab-manager package <https://www.npmjs.com/package/@jupyter-widgets/jupyterlab-manager>`__.
-
-If JupyterLab finds instructions for companion packages, it will present
-a dialog to notify you about these. These are informational only, and it
-will be up to you to take these into account or not.
-
-
-.. _extension_listings:
-
-Listings
-~~~~~~~~
-
-When searching extensions, JupyterLab displays the complete search result and 
-the user is free to install any extension. This is the :ref:`default_mode`.
-
-To bring more security, you or your administrator can enable ``blocked extensions`` or ``allowed extensions``
-mode. JupyterLab will check the extensions against the defined listings.
-
-.. warning::
-
-    Only one mode at a time is allowed. If you or your server administrator configures
-    both blocked and allowed extensions listings, the JupyterLab server will not start.
-
-
-.. figure:: images/listings/simultaneous_blocked_allowed_listings.png
-   :align: center
-   :class: jp-screenshot
-
-   **Figure:** Simultaneous blocked and allowed listings
-
-
-The following details the behavior for the :ref:`blocked_extension_mode` and the :ref:`allowed_extensions_mode`.
-The details to enable configure the listings can be read :ref:`listings_conf`. 
-
-.. _default_mode:
-
-Default mode
-^^^^^^^^^^^^
-
-In the ``default`` mode, no listing is enabled and the search behavior is unchanged and
-is the one described previously.
-
-.. _blocked_extension_mode:
-
-Blocked Extension mode
-^^^^^^^^^^^^^^^^^^^^^^
-
-Extensions can be freely downloaded without going through a vetting process.
-However, users can add malicious extensions to a blocked extension. The extension manager 
-will show all extensions except for those that have 
-been explicitly added to the blocked extension. Therfore, the extension manager 
-does not allow you to install blocked extensioned extensions.
-
-If you, or your administrator, has enabled the blocked extension mode,
-JupyterLab will use the blocked extension and remove all blocked extensioned
-extensions from your search result.
-
-If you have installed an extension before it has been blocked extensioned,
-the extension entry in the installed list will be highlighted
-in red. It is recommended that you uninstall it. You can move
-your mouse on the question mark icon to read the instructions.
-
-.. figure:: images/listings/installed_blocked_extensions.png
-   :align: center
-   :class: jp-screenshot
-
-   **Figure:** Blocked Extension installed which should be removed
-
-
-.. _allowed_extensions_mode:
-
-Allowed Extensions mode
-^^^^^^^^^^^^^^^^^^^^^^^
-
-A allowed extensions listing maintains a set of approved extensions that users can freely 
-search and install. Extensions need to go through some sort of vetting process 
-before they are added to the allowed extensions. When using a allowed extensions, the extension manager 
-will only show extensions that have been explicitly added to the allowed extensions.
-
-If you, or your administrator, has enabled the allowed extensions mode
-JupyterLab will use the allowed extensions and only show extensions present
-in the withelist. The other extensions will not be show in the search result.
-
-If you have installed a allowed extensions extension and at some point
-in time that extension is removed from the allowed extensions, the extension entry 
-in the installed list will be highlighted in red. It is recommended that 
-you uninstall it. You can move your mouse on the question mark icon to
-read the instructions.
-
-.. figure:: images/listings/installed_allowed_extensions.png
-   :align: center
-   :class: jp-screenshot
-
-   **Figure:** The second of the installed extensions was removed from the allowed extensions and should be removed
-
-.. _listings_conf:
-
-Listing Configuration
-^^^^^^^^^^^^^^^^^^^^^
-
-You or your administrator can use the following traits to define the listings loading.
-
-- ``blocked_extension_uris``: A list of comma-separated URIs to fetch a blocked extension file from
-- ``allowed_extensions_uris``: A list of comma-separated URIs to fetch a allowed extensions file from
-- ``listings_refresh_seconds``: The interval delay in seconds to refresh the lists
-- ``listings_request_options``: The optional kwargs to use for the listings HTTP requests
-
-For example, to enable blocked extension, launch the server with ``--LabServerApp.blocked_extension_uris=http://example.com/blocked extension.json`` where ``http://example.com/blocked extension.json`` is a blocked extension JSON file as described below.
-
-The details for the listings_request_options are listed
-on `this page <https://2.python-requests.org/en/v2.7.0/api/#requests.request>`__  
-(for example, you could pass ``{'timeout': 10}`` to change the HTTP request timeout value).
-
-The listings are json files hosted on the URIs you have given.
-
-For each entry, you have to define the `name` of the extension as published in the NPM registry.
-The ``name`` attribute supports regular expressions.
-
-Optionally, you can also add some more fields for your records (``type``, ``reason``, ``creation_date``,
-``last_update_date``). These optional fields are not used in the user interface.
-
-This is an example of a blocked extension file.
-
-.. code:: json
-
-   {
-   "blocked extension": [
-      {
-         "name": "@jupyterlab-examples/launcher",
-         "type": "jupyterlab",
-         "reason": "@jupyterlab-examples/launcher is blocked extensioned for test purpose - Do NOT take this for granted!!!",
-         "creation_date": "2020-03-11T03:28:56.782Z",
-         "last_update_date":  "2020-03-11T03:28:56.782Z"
-      }
-   ]
-   }
-
-
-In the following allowed extensions example a ``@jupyterlab/*`` will allowed extensions 
-all jupyterlab organization extensions.
-
-.. code:: json
-
-   {
-   "allowed extensions": [
-      {
-         "name": "@jupyterlab/*",
-         "type": "jupyterlab",
-         "reason": "All @jupyterlab org extensions are allowed extensions, of course...",
-         "creation_date": "2020-03-11T03:28:56.782Z",
-         "last_update_date":  "2020-03-11T03:28:56.782Z"
-      }
-   ]
-   }
-
 
 
 Using the Terminal
@@ -406,9 +85,8 @@ using the ``jupyter labextension`` entry point. In general, a simple help text
 is available by typing ``jupyter labextension --help``.
 
 
-Installing Extensions
-^^^^^^^^^^^^^^^^^^^^^
-
+Installing Built-in Extensions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can install new extensions into the application
 using the command:

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1000,6 +1000,7 @@ class _AppHandler(object):
             did_something = True
         if did_something:
             page_config['disabled_labextensions'] = disabled
+            cm = ConfigManager()
             cm.set('page_config', page_config)
         return did_something
 

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -6,7 +6,7 @@
 import contextlib
 from distutils.version import LooseVersion
 import errno
-import glob
+from glob import glob
 import hashlib
 import itertools
 import json
@@ -25,15 +25,16 @@ from urllib.request import Request, urlopen, urljoin, quote
 from urllib.error import URLError
 import warnings
 
-from jupyter_core.paths import jupyter_config_path
+from jupyter_core.paths import jupyter_config_path, jupyter_path
 from jupyterlab_server.process import which, Process, WatchHelper, list2cmdline
-from jupyter_server.extension.serverextension import GREEN_ENABLED, GREEN_OK, RED_DISABLED, RED_X
+from notebook.nbextensions import GREEN_ENABLED, GREEN_OK, RED_DISABLED, RED_X
 from traitlets import HasTraits, Bool, Unicode, Instance, default
 
-from .semver import Range, gte, lt, lte, gt, make_semver
-from .jlpmapp import YARN_PATH, HERE
-from .coreconfig import _get_default_core_data, CoreConfig
+from jupyterlab.semver import Range, gte, lt, lte, gt, make_semver
+from jupyterlab.jlpmapp import YARN_PATH, HERE
+from jupyterlab.coreconfig import _get_default_core_data, CoreConfig
 
+from .manager import ConfigManager
 
 # The regex for expecting the webpack output.
 WEBPACK_EXPECT = re.compile(r'.*/index.out.js')
@@ -292,6 +293,12 @@ def watch_dev(logger=None):
                           startup_regex=WEBPACK_EXPECT)
 
     return package_procs + [wp_proc]
+
+
+def get_page_config():
+    """Get the page config for the application"""
+    cm = ConfigManager()
+    return cm.get('page_config')
 
 
 class AppOptions(HasTraits):
@@ -686,41 +693,48 @@ class _AppHandler(object):
 
         print('JupyterLab v%s' % info['version'])
 
-        if info['extensions']:
+        if info['dynamic_exts'] or info['extensions']:
             info['compat_errors'] = self._get_extension_compat()
-            print('Known labextensions:')
+
+        if info['dynamic_exts']:
+            self._list_dynamic_extensions()
+        else:
+            logger.info('No dynamic extensions found')
+
+        if info['extensions']:
+            logger.info('Installed labextensions:')
             self._list_extensions(info, 'app')
             self._list_extensions(info, 'sys')
         else:
-            print('No installed extensions')
+            logger.info('No installed extensions found')
 
         local = info['local_extensions']
         if local:
-            print('\n   local extensions:')
+            logger.info('\n   local extensions:')
             for name in sorted(local):
-                print('        %s: %s' % (name, local[name]))
+                logger.info('        %s: %s' % (name, local[name]))
 
         linked_packages = info['linked_packages']
         if linked_packages:
-            print('\n   linked packages:')
+            logger.info('\n   linked packages:')
             for key in sorted(linked_packages):
                 source = linked_packages[key]['source']
-                print('        %s: %s' % (key, source))
+                logger.info('        %s: %s' % (key, source))
 
         uninstalled_core = info['uninstalled_core']
         if uninstalled_core:
-            print('\nUninstalled core extensions:')
-            [print('    %s' % item) for item in sorted(uninstalled_core)]
+            logger.info('\nUninstalled core extensions:')
+            [logger.info('    %s' % item) for item in sorted(uninstalled_core)]
 
         disabled_core = info['disabled_core']
         if disabled_core:
-            print('\nDisabled core extensions:')
-            [print('    %s' % item) for item in sorted(disabled_core)]
+            logger.info('\nDisabled core extensions:')
+            [logger.info('    %s' % item) for item in sorted(disabled_core)]
 
         messages = self.build_check(fast=True)
         if messages:
-            print('\nBuild recommended, please run `jupyter lab build`:')
-            [print('    %s' % item) for item in messages]
+            logger.info('\nBuild recommended, please run `jupyter lab build`:')
+            [logger.info('    %s' % item) for item in messages]
 
     def build_check(self, fast=False):
         """Determine whether JupyterLab should be built.
@@ -798,25 +812,46 @@ class _AppHandler(object):
 
         Returns `True` if a rebuild is recommended, `False` otherwise.
         """
+        info = self.info
+        logger = self.logger
+
+        # Handle dynamic extensions first
+        if name in info['dynamic_exts']:
+            data = info['dynamic_exts'].pop(name)
+            target = os.path.dirname(data['ext_dir'])
+            logger.info("Removing: %s" % target)
+            if os.path.isdir(target) and not os.path.islink(target):
+                shutil.rmtree(target)
+            else:
+                os.remove(target)
+            # Remove empty parent dir if necessary
+            if '/' in data['name']:
+                files = os.listdir(os.path.dirname(target))
+                if not len(files):
+                    target = os.path.dirname(target)
+                    if os.path.isdir(target) and not os.path.islink(target):
+                        shutil.rmtree(target)
+            return False
+
         # Allow for uninstalled core extensions.
-        if name in self.info['core_extensions']:
+        if name in info['core_extensions']:
             config = self._read_build_config()
             uninstalled = config.get('uninstalled_core_extensions', [])
             if name not in uninstalled:
-                self.logger.info('Uninstalling core extension %s' % name)
+                logger.info('Uninstalling core extension %s' % name)
                 uninstalled.append(name)
                 config['uninstalled_core_extensions'] = uninstalled
                 self._write_build_config(config)
                 return True
             return False
 
-        local = self.info['local_extensions']
+        local = info['local_extensions']
 
-        for (extname, data) in self.info['extensions'].items():
+        for (extname, data) in info['extensions'].items():
             path = data['path']
             if extname == name:
                 msg = 'Uninstalling %s from %s' % (name, osp.dirname(path))
-                self.logger.info(msg)
+                logger.info(msg)
                 os.remove(path)
                 # Handle local extensions.
                 if extname in local:
@@ -826,7 +861,7 @@ class _AppHandler(object):
                     self._write_build_config(config)
                 return True
 
-        self.logger.warn('No labextension named "%s" installed' % name)
+        logger.warn('No labextension named "%s" installed' % name)
         return False
 
     def uninstall_all_extensions(self):
@@ -954,17 +989,18 @@ class _AppHandler(object):
 
         Returns `True` if a rebuild is recommended, `False` otherwise.
         """
-        config = self._read_page_config()
-        disabled = config.setdefault('disabledExtensions', [])
+        page_config = get_page_config()
+        disabled = page_config.get('disabled_labextensions', {})
         did_something = False
         if value and extension not in disabled:
-            disabled.append(extension)
+            disabled[extension] = True
             did_something = True
         elif not value and extension in disabled:
-            disabled.remove(extension)
+            del disabled[extension]
             did_something = True
         if did_something:
-            self._write_page_config(config)
+            page_config['disabled_labextensions'] = disabled
+            cm.set('page_config', page_config)
         return did_something
 
     def check_extension(self, extension, check_installed_only=False):
@@ -1029,8 +1065,8 @@ class _AppHandler(object):
         info = dict()
         info['core_data'] = core_data = self.core_data
         info['extensions'] = extensions = self._get_extensions(core_data)
-        page_config = self._read_page_config()
-        info['disabled'] = page_config.get('disabledExtensions', [])
+
+        info['disabled'] = list(get_page_config().get('disabled_labextensions', {}))
         info['local_extensions'] = self._get_local_extensions()
         info['linked_packages'] = self._get_linked_packages()
         info['app_extensions'] = app = []
@@ -1061,6 +1097,21 @@ class _AppHandler(object):
                 disabled_core.append(key)
 
         info['disabled_core'] = disabled_core
+
+        dynamic_exts = dict()
+        dynamic_ext_dirs = dict()
+        for ext_dir in jupyter_path('labextensions'):
+            ext_pattern = ext_dir + '/**/package.orig.json'
+            for ext_path in [path for path in glob(ext_pattern, recursive=True)]:
+                with open(ext_path) as fid:
+                    data = json.load(fid)
+                if data['name'] not in dynamic_exts:
+                    data['ext_dir'] = ext_dir
+                    data['is_local'] = False
+                    dynamic_exts[data['name']] = data
+                    dynamic_ext_dirs[ext_dir] = True
+        info['dynamic_exts'] = dynamic_exts
+        info['dynamic_ext_dirs'] = dynamic_ext_dirs
         return info
 
     def _populate_staging(self, name=None, version=None, static_url=None,
@@ -1305,7 +1356,7 @@ class _AppHandler(object):
         """
         extensions = dict()
         location = 'app' if dname == self.app_dir else 'sys'
-        for target in glob.glob(pjoin(dname, 'extensions', '*.tgz')):
+        for target in glob(pjoin(dname, 'extensions', '*.tgz')):
             data = read_package(target)
             deps = data.get('dependencies', dict())
             name = data['name']
@@ -1341,7 +1392,14 @@ class _AppHandler(object):
         """
         compat = dict()
         core_data = self.info['core_data']
+        seen = dict()
+        for (name, data) in self.info['dynamic_exts'].items():
+            deps = data['dependencies']
+            compat[name] = _validate_compatibility(name, deps, core_data)
+            seen[name] = True
         for (name, data) in self.info['extensions'].items():
+            if name in seen:
+                continue
             deps = data['dependencies']
             compat[name] = _validate_compatibility(name, deps, core_data)
         return compat
@@ -1362,7 +1420,7 @@ class _AppHandler(object):
         if not osp.exists(dname):
             return info
 
-        for path in glob.glob(pjoin(dname, '*.tgz')):
+        for path in glob(pjoin(dname, '*.tgz')):
             path = osp.abspath(path)
             data = read_package(path)
             name = data['name']
@@ -1409,6 +1467,8 @@ class _AppHandler(object):
 
         logger.info('   %s dir: %s' % (ext_type, dname))
         for name in sorted(names):
+            if name in info['dynamic_exts']:
+                continue
             data = info['extensions'][name]
             version = data['version']
             errors = info['compat_errors'][name]
@@ -1435,6 +1495,38 @@ class _AppHandler(object):
         # Write all errors at end:
         _log_multiple_compat_errors(logger, error_accumulator)
 
+    def _list_dynamic_extensions(self):
+        info = self.info
+        logger = self.logger
+
+        error_accumulator = {}
+
+        for ext_dir in info['dynamic_ext_dirs']:
+            logger.info(ext_dir)
+            for name in info['dynamic_exts']:
+                data = info['dynamic_exts'][name]
+                if data['ext_dir'] != ext_dir:
+                    continue
+                version = data['version']
+                errors = info['compat_errors'][name]
+                extra = ''
+                if _is_disabled(name, info['disabled']):
+                    extra += ' %s' % RED_DISABLED
+                else:
+                    extra += ' %s' % GREEN_ENABLED
+                if errors:
+                    extra += ' %s' % RED_X
+                else:
+                    extra += ' %s' % GREEN_OK
+                if data['is_local']:
+                    extra += '*'
+                logger.info('        %s v%s%s' % (name, version, extra))
+                if errors:
+                    error_accumulator[name] = (version, errors)
+
+        # Write all errors at end:
+        _log_multiple_compat_errors(logger, error_accumulator)
+
     def _read_build_config(self):
         """Get the build config data for the app dir.
         """
@@ -1450,24 +1542,6 @@ class _AppHandler(object):
         """
         self._ensure_app_dirs()
         target = pjoin(self.app_dir, 'settings', 'build_config.json')
-        with open(target, 'w') as fid:
-            json.dump(config, fid, indent=4)
-
-    def _read_page_config(self):
-        """Get the page config data for the app dir.
-        """
-        target = pjoin(self.app_dir, 'settings', 'page_config.json')
-        if not osp.exists(target):
-            return {}
-        else:
-            with open(target) as fid:
-                return json.load(fid)
-
-    def _write_page_config(self, config):
-        """Write the build config to the app dir.
-        """
-        self._ensure_app_dirs()
-        target = pjoin(self.app_dir, 'settings', 'page_config.json')
         with open(target, 'w') as fid:
             json.dump(config, fid, indent=4)
 
@@ -1577,7 +1651,7 @@ class _AppHandler(object):
             msg = '"%s" is not a valid npm package'
             raise ValueError(msg % source)
 
-        path = glob.glob(pjoin(tempdir, '*.tgz'))[0]
+        path = glob(pjoin(tempdir, '*.tgz'))[0]
         info['data'] = read_package(path)
         if is_dir:
             info['sha'] = sha = _tarsum(path)

--- a/jupyterlab/dynamic_labextensions.py
+++ b/jupyterlab/dynamic_labextensions.py
@@ -1,0 +1,311 @@
+# coding: utf-8
+"""Utilities for installing Javascript extensions for the notebook"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import print_function
+
+import os
+import os.path as osp
+import shutil
+import sys
+import tarfile
+import zipfile
+from os.path import basename, join as pjoin, normpath
+import subprocess
+
+from urllib.parse import urlparse
+from urllib.request import urlretrieve
+from jupyter_core.paths import (
+    jupyter_data_dir, jupyter_config_path, jupyter_path,
+    SYSTEM_JUPYTER_PATH, ENV_JUPYTER_PATH,
+)
+from jupyter_core.utils import ensure_dir_exists
+from ipython_genutils.py3compat import string_types, cast_unicode_py2
+from ipython_genutils.tempdir import TemporaryDirectory
+from notebook.config_manager import BaseJSONConfigManager
+
+from traitlets.utils.importstring import import_item
+
+DEPRECATED_ARGUMENT = object()
+
+HERE = osp.abspath(osp.dirname(__file__))
+
+
+#------------------------------------------------------------------------------
+# Public API
+#------------------------------------------------------------------------------
+
+def develop_labextension(path, symlink=True, overwrite=False,
+                        user=False, labextensions_dir=None,
+                        destination=None, 
+                        logger=None, sys_prefix=False
+                        ):
+    """Install a dynamic extension for JupyterLab
+    
+    Stages files and/or directories into the labextensions directory.
+    By default, this compares modification time, and only stages files that need updating.
+    If `overwrite` is specified, matching files are purged before proceeding.
+    
+    Parameters
+    ----------
+    
+    path : path to file, directory, zip or tarball archive, or URL to install
+        By default, the file will be installed with its base name, so '/path/to/foo'
+        will install to 'labextensions/foo'. See the destination argument below to change this.
+        Archives (zip or tarballs) will be extracted into the labextensions directory.
+    user : bool [default: False]
+        Whether to install to the user's labextensions directory.
+        Otherwise do a system-wide install (e.g. /usr/local/share/jupyter/labextensions).
+    overwrite : bool [default: False]
+        If True, always install the files, regardless of what may already be installed.
+    symlink : bool [default: True]
+        If True, create a symlink in labextensions, rather than copying files.
+        Windows support for symlinks requires a permission bit which only admin users
+        have by default, so don't rely on it.
+    labextensions_dir : str [optional]
+        Specify absolute path of labextensions directory explicitly.
+    destination : str [optional]
+        name the labextension is installed to.  For example, if destination is 'foo', then
+        the source file will be installed to 'labextensions/foo', regardless of the source name.
+    logger : Jupyter logger [optional]
+        Logger instance to use
+    """
+    # the actual path to which we eventually installed
+    full_dest = None
+
+    labext = _get_labextension_dir(user=user, sys_prefix=sys_prefix, labextensions_dir=labextensions_dir)
+    # make sure labextensions dir exists
+    ensure_dir_exists(labext)
+    
+    if isinstance(path, (list, tuple)):
+        raise TypeError("path must be a string pointing to a single extension to install; call this function multiple times to install multiple extensions")
+    
+    path = cast_unicode_py2(path)
+
+    if not destination:
+        destination = basename(normpath(path))
+    destination = cast_unicode_py2(destination)
+
+    full_dest = normpath(pjoin(labext, destination))
+    if overwrite and os.path.lexists(full_dest):
+        if logger:
+            logger.info("Removing: %s" % full_dest)
+        if os.path.isdir(full_dest) and not os.path.islink(full_dest):
+            shutil.rmtree(full_dest)
+        else:
+            os.remove(full_dest)
+
+    # Make sure the parent directory exists
+    os.makedirs(os.path.dirname(full_dest), exist_ok=True)
+
+    if symlink:
+        path = os.path.abspath(path)
+        if not os.path.exists(full_dest):
+            if logger:
+                logger.info("Symlinking: %s -> %s" % (full_dest, path))
+            os.symlink(path, full_dest)
+        elif not os.path.islink(full_dest):
+            raise ValueError("%s exists and is not a symlink" % path)
+
+    elif os.path.isdir(path):
+        path = pjoin(os.path.abspath(path), '') # end in path separator
+        for parent, dirs, files in os.walk(path):
+            dest_dir = pjoin(full_dest, parent[len(path):])
+            if not os.path.exists(dest_dir):
+                if logger:
+                    logger.info("Making directory: %s" % dest_dir)
+                os.makedirs(dest_dir)
+            for file_name in files:
+                src = pjoin(parent, file_name)
+                dest_file = pjoin(dest_dir, file_name)
+                _maybe_copy(src, dest_file, logger=logger)
+    else:
+        src = path
+        _maybe_copy(src, full_dest, logger=logger)
+
+    return full_dest
+
+
+def develop_labextension_py(module, user=False, sys_prefix=False, overwrite=False, symlink=True, labextensions_dir=None, logger=None):
+    """Develop a labextension bundled in a Python package.
+
+    Returns a list of installed/updated directories.
+
+    See develop_labextension for parameter information."""
+    m, labexts = _get_labextension_metadata(module)
+    base_path = os.path.split(m.__file__)[0]
+
+    full_dests = []
+
+    for labext in labexts:
+        src = os.path.join(base_path, labext['src'])
+        dest = labext['dest']
+        if logger:
+            logger.info("Installing %s -> %s" % (src, dest))
+
+        if not os.path.exists(src):
+            build_labextension(src, logger=logger)
+
+        full_dest = develop_labextension(
+            src, overwrite=overwrite, symlink=symlink,
+            user=user, sys_prefix=sys_prefix, labextensions_dir=labextensions_dir,
+            destination=dest, logger=logger
+            )
+        full_dests.append(full_dest)
+
+    return full_dests
+
+
+def build_labextension(path, logger=None):
+    """Build a labextension in the given path"""
+    # TODO: when porting to core, this will be in static/package.json
+    core_path = osp.join(HERE, 'core_package')
+    path = os.path.abspath(path)
+    if not osp.exists(osp.join(path, 'node_modules')):
+        subprocess.check_call(['jlpm'], cwd=path)
+    if logger:
+        logger.info('Building extension in %s' % path)
+    subprocess.check_call(['jlpm', 'run', 'build:extension', path], cwd=core_path)
+
+
+def watch_labextension(path, logger=None):
+    """Watch a labextension in a given path"""
+    core_path = osp.join(HERE, 'core_package')
+    path = os.path.abspath(path)
+    if not osp.exists(osp.join(path, 'node_modules')):
+        subprocess.check_call(['jlpm'], cwd=path)
+    if logger:
+        logger.info('Watching extension in %s' % path)
+    subprocess.check_call(['jlpm', 'run', 'watch:extension', path], cwd=core_path)
+
+
+#------------------------------------------------------------------------------
+# Private API
+#------------------------------------------------------------------------------
+
+
+def _should_copy(src, dest, logger=None):
+    """Should a file be copied, if it doesn't exist, or is newer?
+
+    Returns whether the file needs to be updated.
+
+    Parameters
+    ----------
+
+    src : string
+        A path that should exist from which to copy a file
+    src : string
+        A path that might exist to which to copy a file
+    logger : Jupyter logger [optional]
+        Logger instance to use
+    """
+    if not os.path.exists(dest):
+        return True
+    if os.stat(src).st_mtime - os.stat(dest).st_mtime > 1e-6:
+        # we add a fudge factor to work around a bug in python 2.x
+        # that was fixed in python 3.x: https://bugs.python.org/issue12904
+        if logger:
+            logger.warn("Out of date: %s" % dest)
+        return True
+    if logger:
+        logger.info("Up to date: %s" % dest)
+    return False
+
+
+def _maybe_copy(src, dest, logger=None):
+    """Copy a file if it needs updating.
+
+    Parameters
+    ----------
+
+    src : string
+        A path that should exist from which to copy a file
+    src : string
+        A path that might exist to which to copy a file
+    logger : Jupyter logger [optional]
+        Logger instance to use
+    """
+    if _should_copy(src, dest, logger=logger):
+        if logger:
+            logger.info("Copying: %s -> %s" % (src, dest))
+        shutil.copy2(src, dest)
+
+
+def _get_labextension_dir(user=False, sys_prefix=False, prefix=None, labextensions_dir=None):
+    """Return the labextension directory specified
+
+    Parameters
+    ----------
+
+    user : bool [default: False]
+        Get the user's .jupyter/labextensions directory
+    sys_prefix : bool [default: False]
+        Get sys.prefix, i.e. ~/.envs/my-env/share/jupyter/labextensions
+    prefix : str [optional]
+        Get custom prefix
+    labextensions_dir : str [optional]
+        Get what you put in
+    """
+    conflicting = [
+        ('user', user),
+        ('prefix', prefix),
+        ('labextensions_dir', labextensions_dir),
+        ('sys_prefix', sys_prefix),
+    ]
+    conflicting_set = ['{}={!r}'.format(n, v) for n, v in conflicting if v]
+    if len(conflicting_set) > 1:
+        raise ArgumentConflict(
+            "cannot specify more than one of user, sys_prefix, prefix, or labextensions_dir, but got: {}"
+            .format(', '.join(conflicting_set)))
+    if user:
+        labext = pjoin(jupyter_data_dir(), u'labextensions')
+    elif sys_prefix:
+        labext = pjoin(ENV_JUPYTER_PATH[0], u'labextensions')
+    elif prefix:
+        labext = pjoin(prefix, 'share', 'jupyter', 'labextensions')
+    elif labextensions_dir:
+        labext = labextensions_dir
+    else:
+        labext = pjoin(SYSTEM_JUPYTER_PATH[0], 'labextensions')
+    return labext
+
+
+def _get_labextension_metadata(module):
+    """Get the list of labextension paths associated with a Python module.
+
+    Returns a tuple of (the module path,             [{
+        'src': 'mockextension',
+        'dest': '_mockdestination'
+    }])
+
+    Parameters
+    ----------
+
+    module : str
+        Importable Python module exposing the
+        magic-named `_jupyter_labextension_paths` function
+    """
+    try:
+        m = import_item(module)
+    except Exception:
+        m = None
+
+    if not hasattr(m, '_jupyter_labextension_paths'):
+        if osp.exists(osp.abspath(module)):
+            from setuptools import find_packages
+            packages = find_packages(module)
+            if not packages:
+                raise ValueError('Could not find module %s' % module)
+            m = import_item(packages[0])
+
+    if not hasattr(m, '_jupyter_labextension_paths'):
+        raise KeyError('The Python module {} is not a valid labextension, '
+                       'it is missing the `_jupyter_labextension_paths()` method.'.format(module))
+    labexts = m._jupyter_labextension_paths()
+    return m, labexts
+
+
+if __name__ == '__main__':
+    main()

--- a/jupyterlab/dynamic_labextensions.py
+++ b/jupyterlab/dynamic_labextensions.py
@@ -160,25 +160,26 @@ def develop_labextension_py(module, user=False, sys_prefix=False, overwrite=Fals
 
 def build_labextension(path, logger=None):
     """Build a labextension in the given path"""
-    # TODO: when porting to core, this will be in static/package.json
-    core_path = osp.join(HERE, 'core_package')
+    core_path = osp.join(HERE, 'staging')
     path = os.path.abspath(path)
     if not osp.exists(osp.join(path, 'node_modules')):
         subprocess.check_call(['jlpm'], cwd=path)
     if logger:
         logger.info('Building extension in %s' % path)
-    subprocess.check_call(['jlpm', 'run', 'build:extension', path], cwd=core_path)
+    builder = osp.join('node_modules', '.bin', 'build-labextension')
+    subprocess.check_call(['node', builder, '--core-path', core_path,  path], cwd=path)
 
 
 def watch_labextension(path, logger=None):
     """Watch a labextension in a given path"""
-    core_path = osp.join(HERE, 'core_package')
+    core_path = osp.join(HERE, 'staging')
     path = os.path.abspath(path)
     if not osp.exists(osp.join(path, 'node_modules')):
         subprocess.check_call(['jlpm'], cwd=path)
     if logger:
         logger.info('Watching extension in %s' % path)
-    subprocess.check_call(['jlpm', 'run', 'watch:extension', path], cwd=core_path)
+    builder = osp.join('node_modules', '.bin', 'build-labextension')
+    subprocess.check_call(['node', builder, '--core-path', core_path,  '--watch', path], cwd=path)
 
 
 #------------------------------------------------------------------------------

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -689,6 +689,20 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
             api_token = os.getenv('JUPYTERHUB_API_TOKEN', '')
             page_config['token'] = api_token
 
+        # Handle dynamic extensions
+        info = get_app_info()
+        dynamic_extensions = page_config['dynamic_extensions'] = []
+        dynamic_mime_extension = page_config['dynamic_mime_extensions'] = []
+        for (ext, ext_data) in info.get('dynamic_exts', dict()).items():
+            name = ext_data['name']
+            path = "lab/extensions/%s/remoteEntry.js" % name
+            module = "./extension"
+            load_data = dict(name=name, path=path, module=module)
+            if ext_data['jupyterlab'].get('extension'):
+                dynamic_extensions.append(load_data)
+            else:
+                dynamic_mime_extension.append(load_data)
+
         # Update Jupyter Server's webapp settings with jupyterlab settings.
         self.serverapp.web_app.settings['page_config_data'] = page_config
 

--- a/jupyterlab/manager.py
+++ b/jupyterlab/manager.py
@@ -5,7 +5,7 @@
 
 import os.path
 
-from notebook.config_manager import BaseJSONConfigManager, recursive_update
+from jupyter_server.config_manager import BaseJSONConfigManager, recursive_update
 from jupyter_core.paths import jupyter_config_dir, jupyter_config_path
 from traitlets import Unicode, Instance, List, observe, default
 from traitlets.config import LoggingConfigurable

--- a/jupyterlab/manager.py
+++ b/jupyterlab/manager.py
@@ -1,0 +1,58 @@
+"""Manager to read and modify frontend config data in JSON files.
+"""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os.path
+
+from notebook.config_manager import BaseJSONConfigManager, recursive_update
+from jupyter_core.paths import jupyter_config_dir, jupyter_config_path
+from traitlets import Unicode, Instance, List, observe, default
+from traitlets.config import LoggingConfigurable
+
+
+class ConfigManager(LoggingConfigurable):
+    """Config Manager used for storing notebook frontend config"""
+
+    # Public API
+
+    def get(self, section_name):
+        """Get the config from all config sections."""
+        config = {}
+        # step through back to front, to ensure front of the list is top priority
+        for p in self.read_config_path[::-1]:
+            cm = BaseJSONConfigManager(config_dir=p)
+            recursive_update(config, cm.get(section_name))
+        return config
+
+    def set(self, section_name, data):
+        """Set the config only to the user's config."""
+        return self.write_config_manager.set(section_name, data)
+
+    def update(self, section_name, new_data):
+        """Update the config only to the user's config."""
+        return self.write_config_manager.update(section_name, new_data)
+
+    # Private API
+
+    read_config_path = List(Unicode())
+
+    @default('read_config_path')
+    def _default_read_config_path(self):
+        return [os.path.join(p, 'labconfig') for p in jupyter_config_path()]
+
+    write_config_dir = Unicode()
+
+    @default('write_config_dir')
+    def _default_write_config_dir(self):
+        return os.path.join(jupyter_config_dir(), 'labconfig')
+
+    write_config_manager = Instance(BaseJSONConfigManager)
+
+    @default('write_config_manager')
+    def _default_write_config_manager(self):
+        return BaseJSONConfigManager(config_dir=self.write_config_dir)
+
+    @observe('write_config_dir')
+    def _update_write_config_dir(self, change):
+        self.write_config_manager = BaseJSONConfigManager(config_dir=self.write_config_dir)

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -6,6 +6,7 @@
     "build": "webpack",
     "build:dev": "jlpm run build",
     "build:dev:minimize": "jlpm run build:dev",
+    "build:extension": "build-labextension --core-path .",
     "build:prod": "ensure-max-old-space webpack --config webpack.prod.config.js",
     "build:prod:minimize": "ensure-max-old-space webpack --config webpack.prod.minimize.config.js",
     "build:prod:release": "ensure-max-old-space webpack --config webpack.prod.release.config.js",

--- a/jupyterlab/tests/mock_packages/extension/mock_package.py
+++ b/jupyterlab/tests/mock_packages/extension/mock_package.py
@@ -1,0 +1,13 @@
+import json
+import os.path as osp
+
+HERE = osp.abspath(osp.dirname(__file__))
+
+with open(osp.join(HERE, 'package.json')) as fid:
+    data = json.load(fid)
+
+def _jupyter_labextension_paths():
+    return [{
+        'src': data['jupyterlab'].get('outputDir', 'static'),
+        'dest': data['name']
+    }]

--- a/jupyterlab/tests/mock_packages/extension/package.json
+++ b/jupyterlab/tests/mock_packages/extension/package.json
@@ -5,6 +5,9 @@
   "dependencies": {
     "@jupyterlab/launcher": "^3.0.0-alpha.7"
   },
+  "devDependencies": {
+    "@jupyterlab/buildutils": "^3.0.0-alpha.7"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/jupyterlab/tests/mock_packages/extension/setup.py
+++ b/jupyterlab/tests/mock_packages/extension/setup.py
@@ -1,0 +1,15 @@
+import json
+import os.path as osp
+
+name = 'mock_package'
+HERE = osp.abspath(osp.dirname(__file__))
+
+with open(osp.join(HERE, 'package.json')) as fid:
+    data = json.load(fid)
+
+from setuptools import setup
+
+setup(name=name,
+      version=data['version'],
+      py_modules = [name]
+     )

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -95,7 +95,8 @@ class AppHandlerTest(TestCase):
             shutil.copytree(src, dest, ignore=ignore)
 
             # Make a node modules folder so npm install is not called.
-            os.makedirs(pjoin(dest, 'node_modules'))
+            if not os.path.exists(pjoin(dest, 'node_modules')):
+                os.makedirs(pjoin(dest, 'node_modules'))
 
             setattr(self, 'mock_' + name, dest)
             with open(pjoin(dest, 'package.json')) as fid:

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -150,6 +150,8 @@ fi
 if [[ $GROUP == usage ]]; then
     # Run the integrity script to link binary files
     jlpm integrity
+    # Make sure the links end up in all workspaces
+    jlpm
 
     # Test the cli apps.
     jupyter lab clean --debug

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -148,6 +148,9 @@ fi
 
 
 if [[ $GROUP == usage ]]; then
+    # Run the integrity script to link binary files
+    jlpm integrity
+
     # Test the cli apps.
     jupyter lab clean --debug
     jupyter lab build --debug

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -150,8 +150,6 @@ fi
 if [[ $GROUP == usage ]]; then
     # Run the integrity script to link binary files
     jlpm integrity
-    # Make sure the links end up in all workspaces
-    jlpm
 
     # Test the cli apps.
     jupyter lab clean --debug
@@ -172,7 +170,10 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
     # Test with a dynamic install
     pip install -e ./extension
-    jupyter labextension build ./extension
+    pushd extension
+    # make sure we pick up node_modules/.bin
+    jlpm
+    jupyter labextension build .
     jupyter labextension develop mock_package
     jupyter labextension list 1>labextensions 2>&1
     cat labextensions | grep "@jupyterlab/mock-extension.*enabled.*OK"
@@ -181,6 +182,7 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension uninstall @jupyterlab/mock-extension --debug
     jupyter labextension list list 1>labextensions 2>&1
     cat labextensions | grep "No dynamic extensions found"
+    popd
     popd
     jupyter lab workspaces export > workspace.json --debug
     jupyter lab workspaces import --name newspace workspace.json --debug

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -157,6 +157,7 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension unlink extension --no-build --debug
     jupyter labextension link extension --no-build --debug
     jupyter labextension unlink  @jupyterlab/mock-extension --no-build --debug
+    # Test with a full install
     jupyter labextension install extension  --no-build --debug
     jupyter labextension list --debug
     jupyter labextension disable @jupyterlab/mock-extension --debug
@@ -164,6 +165,13 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension disable @jupyterlab/notebook-extension --debug
     jupyter labextension uninstall @jupyterlab/mock-extension --no-build --debug
     jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
+    # Test with a dynamic install
+    jupyter labextension build extension
+    jupyter labextension develop extension
+    jupyter labextension list --debug
+    jupyter labextension disable @jupyterlab/mock-extension --debug
+    jupyter labextension enable @jupyterlab/mock-extension --debug 
+    jupyter labextension uninstall @jupyterlab/mock-extension --debug
     popd
     jupyter lab workspaces export > workspace.json --debug
     jupyter lab workspaces import --name newspace workspace.json --debug

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -166,12 +166,16 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension uninstall @jupyterlab/mock-extension --no-build --debug
     jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
     # Test with a dynamic install
+    pip install -e ./extension
     jupyter labextension build extension
-    jupyter labextension develop extension
-    jupyter labextension list --debug
+    jupyter labextension develop mock_package
+    jupyter labextension list 1>labextensions 2>&1
+    cat labextensions | grep "@jupyterlab/mock-extension.*enabled.*OK"
     jupyter labextension disable @jupyterlab/mock-extension --debug
     jupyter labextension enable @jupyterlab/mock-extension --debug 
     jupyter labextension uninstall @jupyterlab/mock-extension --debug
+    jupyter labextension list list 1>labextensions 2>&1
+    cat labextensions | grep "No dynamic extensions found"
     popd
     jupyter lab workspaces export > workspace.json --debug
     jupyter lab workspaces import --name newspace workspace.json --debug

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -170,9 +170,11 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
     # Test with a dynamic install
     pip install -e ./extension
+    # FIXME: binaries are not properly getting to all workspaces
     pushd extension
-    # make sure we pick up node_modules/.bin
-    jlpm
+    mkdir -p node_modules/.bin
+    cp ../../../../node_modules/.bin/build-labextension node_modules/.bin
+
     jupyter labextension build .
     jupyter labextension develop mock_package
     jupyter labextension list 1>labextensions 2>&1

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -173,7 +173,7 @@ if [[ $GROUP == usage ]]; then
     # FIXME: binaries are not properly getting to all workspaces
     pushd extension
     mkdir -p node_modules/.bin
-    cp ../../../../node_modules/.bin/build-labextension node_modules/.bin
+    cp -r ../../../../node_modules/.bin node_modules/.bin
 
     jupyter labextension build .
     jupyter labextension develop mock_package

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -86,8 +86,7 @@ if [[ $GROUP == integrity2 ]]; then
     jlpm run build:src
 
     # Make sure we can build for release
-    # disabled for now pending https://github.com/jupyterlab/jupyterlab/issues/8655
-    #jlpm run build:dev:prod:release
+    jlpm run build:dev:prod:release
 
     # Make sure the storybooks build.
     jlpm run build:storybook

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -173,7 +173,7 @@ if [[ $GROUP == usage ]]; then
     # FIXME: binaries are not properly getting to all workspaces
     pushd extension
     mkdir -p node_modules/.bin
-    cp -r ../../../../node_modules/.bin node_modules/.bin
+    cp -r ../../../../node_modules/.bin node_modules
 
     jupyter labextension build .
     jupyter labextension develop mock_package

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -170,7 +170,7 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
     # Test with a dynamic install
     pip install -e ./extension
-    jupyter labextension build extension
+    jupyter labextension build mock_package
     jupyter labextension develop mock_package
     jupyter labextension list 1>labextensions 2>&1
     cat labextensions | grep "@jupyterlab/mock-extension.*enabled.*OK"

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -170,7 +170,7 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
     # Test with a dynamic install
     pip install -e ./extension
-    jupyter labextension build mock_package
+    jupyter labextension build ./extension
     jupyter labextension develop mock_package
     jupyter labextension list 1>labextensions 2>&1
     cat labextensions | grep "@jupyterlab/mock-extension.*enabled.*OK"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses #7468 

- [x] Update `dev_mode` in `jupyterlab`
  - [x]  Port `core_package` index and webpack changes to `jupyterlab/_dev_mode`
  - [x] Update `update-core-mode` to use the new files
- [x] Port the cli and main app parts in `jupyterlab`
  - [x] Port the `commands.py` and sibling files to `jupyterlab/jupyterlab`
  - [x] Port the changes from `main.py` to `jupyterlab/labapp.py`
- [x] Add notes from module federation [readme](https://github.com/jupyterlab/jupyterlab-module-federation/blob/223800f2ee42b8b005c1ce6a204bd7dd9cafa2f4/README.md) to docs
- [x] Add tests for the cli: `develop`, `build`,`list` and `watch` with `-h` in the `usage` test - use the existing mock extension
- [x] Remove extension manager from installed extensions and its associated docs for now - cf https://github.com/jupyterlab/jupyterlab/issues/8804
  
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Use module federation in main application and add supporting CLI tools

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users are able to install and use extensions without requiring node or a build step

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
