### PR TITLE
Make the command palette modal

### DIFF
--- a/packages/apputils-extension/schema/palette.json
+++ b/packages/apputils-extension/schema/palette.json
@@ -8,7 +8,14 @@
       "selector": "body"
     }
   ],
-  "additionalProperties": false,
-  "properties": {},
-  "type": "object"
+  "properties": {
+    "modal": {
+      "title": "Modal Command Palette",
+      "description": "Whether the command palette should be modal or in the left panel.",
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "type": "object",
+  "additionalProperties": false
 }

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -4,7 +4,6 @@
 |----------------------------------------------------------------------------*/
 
 import {
-  ILayoutRestorer,
   IRouter,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -512,7 +511,7 @@ const utilityCommands: JupyterFrontEndPlugin<void> = {
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
   palette,
-  paletteRestorer,
+  // paletteRestorer,
   print,
   resolver,
   settingsPlugin,

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -4,6 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import {
+  ILayoutRestorer,
   IRouter,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -83,18 +84,18 @@ const palette: JupyterFrontEndPlugin<ICommandPalette> = {
  * causes the command palette to be unavailable to other extensions earlier
  * in the application load cycle.
  */
-const paletteRestorer: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/apputils-extension:palette-restorer',
-  autoStart: true,
-  requires: [ILayoutRestorer, ITranslator],
-  activate: (
-    app: JupyterFrontEnd,
-    restorer: ILayoutRestorer,
-    translator: ITranslator
-  ) => {
-    Palette.restore(app, restorer, translator);
-  }
-};
+// const paletteRestorer: JupyterFrontEndPlugin<void> = {
+//   id: '@jupyterlab/apputils-extension:palette-restorer',
+//   autoStart: true,
+//   requires: [ILayoutRestorer, ITranslator],
+//   activate: (
+//     app: JupyterFrontEnd,
+//     restorer: ILayoutRestorer,
+//     translator: ITranslator
+//   ) => {
+//     Palette.restore(app, restorer, translator);
+//   }
+// };
 
 /**
  * The default window name resolver provider.

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -4,7 +4,6 @@
 |----------------------------------------------------------------------------*/
 
 import {
-  ILayoutRestorer,
   IRouter,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -74,28 +73,6 @@ const palette: JupyterFrontEndPlugin<ICommandPalette> = {
     return Palette.activate(app, translator);
   }
 };
-
-/**
- * The default command palette's restoration extension.
- *
- * #### Notes
- * The command palette's restoration logic is handled separately from the
- * command palette provider extension because the layout restorer dependency
- * causes the command palette to be unavailable to other extensions earlier
- * in the application load cycle.
- */
-// const paletteRestorer: JupyterFrontEndPlugin<void> = {
-//   id: '@jupyterlab/apputils-extension:palette-restorer',
-//   autoStart: true,
-//   requires: [ILayoutRestorer, ITranslator],
-//   activate: (
-//     app: JupyterFrontEnd,
-//     restorer: ILayoutRestorer,
-//     translator: ITranslator
-//   ) => {
-//     Palette.restore(app, restorer, translator);
-//   }
-// };
 
 /**
  * The default window name resolver provider.
@@ -512,7 +489,6 @@ const utilityCommands: JupyterFrontEndPlugin<void> = {
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
   palette,
-  // paletteRestorer,
   print,
   resolver,
   settingsPlugin,

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -98,17 +98,17 @@ export namespace Palette {
     settingRegistry: ISettingRegistry | null
   ): ICommandPalette {
     const { commands, shell } = app;
-    console.log('Activating command palette');
     const trans = translator.load('jupyterlab');
     const palette = Private.createPalette(app, translator);
     const modalPalette = new ModalCommandPalette({ commandPalette: palette });
-    let modal = true;
+    let modal = false;
+
+    shell.add(palette, 'left', { rank: 300 });
 
     if (settingRegistry) {
       const loadSettings = settingRegistry.load(PALETTE_PLUGIN_ID);
       const updateSettings = (settings: ISettingRegistry.ISettings): void => {
         const newModal = settings.get('modal').composite as boolean;
-        console.log('update settings', modal, newModal);
         if (modal && !newModal) {
           palette.parent = null;
           modalPalette.detach();
@@ -175,7 +175,6 @@ export namespace Palette {
     restorer: ILayoutRestorer,
     translator: ITranslator
   ): void {
-    console.log('restoring palette');
     const palette = Private.createPalette(app, translator);
     // Let the application restorer track the command palette for restoration of
     // application state (e.g. setting the command palette as the current side bar
@@ -201,7 +200,6 @@ namespace Private {
     translator: ITranslator
   ): CommandPalette {
     if (!palette) {
-      console.log('Creating palette');
       // use a renderer tweaked to use inline svg icons
       palette = new CommandPalette({
         commands: app.commands,

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -9,12 +9,12 @@ import { DisposableDelegate, IDisposable } from '@lumino/disposable';
 import { CommandPalette } from '@lumino/widgets';
 
 import { ILayoutRestorer, JupyterFrontEnd } from '@jupyterlab/application';
-import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import {
   ICommandPalette,
   IPaletteItem,
   ModalCommandPalette
 } from '@jupyterlab/apputils';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { CommandPaletteSvg, paletteIcon } from '@jupyterlab/ui-components';
 
 /**
@@ -137,8 +137,6 @@ export namespace Palette {
     // application state (e.g. setting the command palette as the current side bar
     // widget).
     restorer.add(palette, 'command-palette');
-  }
-    return new Palette(palette);
   }
 }
 

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -9,8 +9,12 @@ import { DisposableDelegate, IDisposable } from '@lumino/disposable';
 import { CommandPalette } from '@lumino/widgets';
 
 import { ILayoutRestorer, JupyterFrontEnd } from '@jupyterlab/application';
-import { ICommandPalette, IPaletteItem } from '@jupyterlab/apputils';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import {
+  ICommandPalette,
+  IPaletteItem,
+  ModalCommandPalette
+} from '@jupyterlab/apputils';
 import { CommandPaletteSvg, paletteIcon } from '@jupyterlab/ui-components';
 
 /**
@@ -85,6 +89,7 @@ export namespace Palette {
     const { commands, shell } = app;
     const trans = translator.load('jupyterlab');
     const palette = Private.createPalette(app, translator);
+    const modalPalette = new ModalCommandPalette({ commandPalette: palette });
 
     // Show the current palette shortcut in its title.
     const updatePaletteTitle = () => {
@@ -106,7 +111,7 @@ export namespace Palette {
 
     commands.addCommand(CommandIDs.activate, {
       execute: () => {
-        shell.activateById(palette.id);
+        modalPalette.show();
       },
       label: trans.__('Activate Command Palette')
     });
@@ -132,6 +137,8 @@ export namespace Palette {
     // application state (e.g. setting the command palette as the current side bar
     // widget).
     restorer.add(palette, 'command-palette');
+  }
+    return new Palette(palette);
   }
 }
 

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -8,7 +8,7 @@ import { CommandRegistry } from '@lumino/commands';
 import { DisposableDelegate, IDisposable } from '@lumino/disposable';
 import { CommandPalette } from '@lumino/widgets';
 
-import { ILayoutRestorer, JupyterFrontEnd } from '@jupyterlab/application';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 import {
   ICommandPalette,
   IPaletteItem,
@@ -86,7 +86,7 @@ export namespace Palette {
     app: JupyterFrontEnd,
     translator: ITranslator
   ): ICommandPalette {
-    const { commands, shell } = app;
+    const { commands } = app;
     const trans = translator.load('jupyterlab');
     const palette = Private.createPalette(app, translator);
     const modalPalette = new ModalCommandPalette({ commandPalette: palette });
@@ -111,32 +111,14 @@ export namespace Palette {
 
     commands.addCommand(CommandIDs.activate, {
       execute: () => {
-        modalPalette.show();
+        modalPalette.activate();
       },
       label: trans.__('Activate Command Palette')
     });
 
     palette.inputNode.placeholder = trans.__('SEARCH');
 
-    shell.add(palette, 'left', { rank: 300 });
-
     return new Palette(palette, translator);
-  }
-
-  /**
-   * Restore the command palette.
-   */
-  export function restore(
-    app: JupyterFrontEnd,
-    restorer: ILayoutRestorer,
-    translator: ITranslator
-  ): void {
-    const palette = Private.createPalette(app, translator);
-
-    // Let the application restorer track the command palette for restoration of
-    // application state (e.g. setting the command palette as the current side bar
-    // widget).
-    restorer.add(palette, 'command-palette');
   }
 }
 

--- a/packages/apputils-extension/src/palette.ts
+++ b/packages/apputils-extension/src/palette.ts
@@ -116,6 +116,7 @@ export namespace Palette {
         } else if (!modal && newModal) {
           palette.parent = null;
           modalPalette.palette = palette;
+          palette.show();
           modalPalette.attach();
         }
         modal = newModal;

--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -58,9 +58,7 @@ export class ModalCommandPalette extends Panel {
     this.addClass('jp-ModalCommandPalette');
     this.id = 'modal-command-palette';
     this._commandPalette = options.commandPalette;
-    this._commandPalette.addClass('jp-ModalCommandPalette-command-palette');
     this.addWidget(this._commandPalette);
-    this.attach();
     this._commandPalette.commands.commandExecuted.connect(() => {
       if (this.isAttached && this.isVisible) {
         this.hideAndReset();

--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -7,6 +7,8 @@ import { Token } from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
 
+import { Message } from '@lumino/messaging';
+
 import { CommandPalette, Widget, Panel } from '@lumino/widgets';
 
 /* tslint:disable */
@@ -47,6 +49,9 @@ export interface ICommandPalette {
   addItem(options: IPaletteItem): IDisposable;
 }
 
+/**
+ * Wrap the command palette in a modal to make it more usable.
+ */
 export class ModalCommandPalette extends Panel {
   constructor(options: ModalCommandPalette.IOptions) {
     super();
@@ -57,7 +62,85 @@ export class ModalCommandPalette extends Panel {
     this._commandPalette.addClass('jp-ModalCommandPalette-command-palette');
     this.addWidget(this._commandPalette);
     Widget.attach(this, this._host);
+    this._commandPalette.commands.commandExecuted.connect(() => {
+      if (this.isAttached && this.isVisible) {
+        this.hideAndReset();
+      }
+    });
+    this.hideAndReset();
+  }
+
+  /**
+   * Hide the modal command palette and reset its search.
+   */
+  hideAndReset(): void {
     this.hide();
+    this._commandPalette.inputNode.value = '';
+    this._commandPalette.refresh();
+  }
+
+  /**
+   * Handle incoming events.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+      case 'keydown':
+        this._evtKeydown(event as KeyboardEvent);
+        break;
+      case 'blur':
+        this.hideAndReset();
+        break;
+      case 'contextmenu':
+        event.preventDefault();
+        event.stopPropagation();
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   *  A message handler invoked on an `'after-attach'` message.
+   */
+  protected onAfterAttach(msg: Message): void {
+    this.node.addEventListener('keydown', this, true);
+    this.node.addEventListener('contextmenu', this, true);
+    this.node.addEventListener('blur', this, true);
+  }
+
+  /**
+   *  A message handler invoked on an `'after-detach'` message.
+   */
+  protected onAfterDetach(msg: Message): void {
+    this.node.removeEventListener('keydown', this, true);
+    this.node.removeEventListener('contextmenu', this, true);
+    this.node.removeEventListener('blur', this, true);
+  }
+
+  /**
+   * A message handler invoked on an `'activate-request'` message.
+   */
+  protected onActivateRequest(msg: Message): void {
+    if (this.isAttached) {
+      this.show();
+      this._commandPalette.activate();
+    }
+  }
+
+  /**
+   * Handle the `'keydown'` event for the widget.
+   */
+  protected _evtKeydown(event: KeyboardEvent): void {
+    // Check for escape key
+    switch (event.keyCode) {
+      case 27: // Escape.
+        event.stopPropagation();
+        event.preventDefault();
+        this.hideAndReset();
+        break;
+      default:
+        break;
+    }
   }
 
   private _host: HTMLElement;

--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -57,17 +57,34 @@ export class ModalCommandPalette extends Panel {
     super();
     this.addClass('jp-ModalCommandPalette');
     this.id = 'modal-command-palette';
-    this._host = document.body;
     this._commandPalette = options.commandPalette;
     this._commandPalette.addClass('jp-ModalCommandPalette-command-palette');
     this.addWidget(this._commandPalette);
-    Widget.attach(this, this._host);
+    this.attach();
     this._commandPalette.commands.commandExecuted.connect(() => {
       if (this.isAttached && this.isVisible) {
         this.hideAndReset();
       }
     });
     this.hideAndReset();
+  }
+
+  get palette(): CommandPalette {
+    return this._commandPalette;
+  }
+
+  set palette(value: CommandPalette) {
+    this._commandPalette = value;
+    this.addWidget(value);
+    this.hideAndReset();
+  }
+
+  attach(): void {
+    Widget.attach(this, document.body);
+  }
+
+  detach(): void {
+    Widget.detach(this);
   }
 
   /**
@@ -143,7 +160,6 @@ export class ModalCommandPalette extends Panel {
     }
   }
 
-  private _host: HTMLElement;
   private _commandPalette: CommandPalette;
 }
 

--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -7,7 +7,7 @@ import { Token } from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
 
-import { CommandPalette } from '@lumino/widgets';
+import { CommandPalette, Widget, Panel } from '@lumino/widgets';
 
 /* tslint:disable */
 /**
@@ -45,4 +45,27 @@ export interface ICommandPalette {
    * @returns A disposable that will remove the item from the palette.
    */
   addItem(options: IPaletteItem): IDisposable;
+}
+
+export class ModalCommandPalette extends Panel {
+  constructor(options: ModalCommandPalette.IOptions) {
+    super();
+    this.addClass('jp-ModalCommandPalette');
+    this.id = 'modal-command-palette';
+    this._host = document.body;
+    this._commandPalette = options.commandPalette;
+    this._commandPalette.addClass('jp-ModalCommandPalette-command-palette');
+    this.addWidget(this._commandPalette);
+    Widget.attach(this, this._host);
+    this.hide();
+  }
+
+  private _host: HTMLElement;
+  private _commandPalette: CommandPalette;
+}
+
+export namespace ModalCommandPalette {
+  export interface IOptions {
+    commandPalette: CommandPalette;
+  }
 }

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -15,6 +15,20 @@
 | Overall styles
 |----------------------------------------------------------------------------*/
 
+.lm-CommandPalette {
+  padding-bottom: 0px;
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color1);
+  /* This is needed so that all font sizing of children done in ems is
+   * relative to this base size */
+  font-size: var(--jp-ui-font-size1);
+}
+
+/*-----------------------------------------------------------------------------
+| Modal variant
+|----------------------------------------------------------------------------*/
+
+
 .jp-ModalCommandPalette {
   position: absolute;
   z-index: 10000;
@@ -32,13 +46,21 @@
   max-height: 40vh;
 }
 
-.lm-CommandPalette {
-  padding-bottom: 0px;
-  color: var(--jp-ui-font-color1);
-  background: var(--jp-layout-color1);
-  /* This is needed so that all font sizing of children done in ems is
-   * relative to this base size */
-  font-size: var(--jp-ui-font-size1);
+.jp-ModalCommandPalette .lm-CommandPalette .lm-close-icon::after {
+  display: none;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-CommandPalette-header {
+  display: none;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-CommandPalette-item {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette .lm-CommandPalette-item.lm-mod-disabled {
+  display: none;
 }
 
 /*-----------------------------------------------------------------------------
@@ -117,7 +139,6 @@
   margin-top: 8px;
   padding: 8px 0 8px 12px;
   text-transform: uppercase;
-  display: none;
 }
 
 .lm-CommandPalette-header.lm-mod-active {
@@ -132,8 +153,6 @@
 
 .lm-CommandPalette-item {
   padding: 4px 12px 4px 4px;
-  margin-left: 4px;
-  margin-right: 4px;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   font-weight: 400;
@@ -142,7 +161,6 @@
 
 .lm-CommandPalette-item.lm-mod-disabled {
   color: var(--jp-ui-font-color3);
-  display: none;
 }
 
 .lm-CommandPalette-item.lm-mod-active {

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -28,7 +28,6 @@
 | Modal variant
 |----------------------------------------------------------------------------*/
 
-
 .jp-ModalCommandPalette {
   position: absolute;
   z-index: 10000;
@@ -59,7 +58,9 @@
   margin-right: 4px;
 }
 
-.jp-ModalCommandPalette .lm-CommandPalette .lm-CommandPalette-item.lm-mod-disabled {
+.jp-ModalCommandPalette
+  .lm-CommandPalette
+  .lm-CommandPalette-item.lm-mod-disabled {
   display: none;
 }
 

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -23,10 +23,14 @@
   margin: 0;
   padding: 4px;
   width: 40%;
-  max-height: 40%;
+  /* max-height: 40%; */
   box-shadow: var(--jp-elevation-z4);
   border-radius: 4px;
   background: var(--jp-layout-color0);
+}
+
+.jp-ModalCommandPalette .lm-CommandPalette {
+  max-height: 40vh;
 }
 
 .lm-CommandPalette {
@@ -129,6 +133,8 @@
 
 .lm-CommandPalette-item {
   padding: 4px 12px 4px 4px;
+  margin-left: 4px;
+  margin-right: 4px;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
   font-weight: 400;

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -15,6 +15,20 @@
 | Overall styles
 |----------------------------------------------------------------------------*/
 
+.jp-ModalCommandPalette {
+  position: absolute;
+  z-index: 10000;
+  top: 38px;
+  left: 30%;
+  margin: 0;
+  padding: 4px;
+  width: 40%;
+  max-height: 40%;
+  box-shadow: var(--jp-elevation-z4);
+  border-radius: 4px;
+  background: var(--jp-layout-color0);
+}
+
 .lm-CommandPalette {
   padding-bottom: 0px;
   color: var(--jp-ui-font-color1);
@@ -100,6 +114,7 @@
   margin-top: 8px;
   padding: 8px 0 8px 12px;
   text-transform: uppercase;
+  display: none;
 }
 
 .lm-CommandPalette-header.lm-mod-active {
@@ -122,6 +137,7 @@
 
 .lm-CommandPalette-item.lm-mod-disabled {
   color: var(--jp-ui-font-color3);
+  display: none;
 }
 
 .lm-CommandPalette-item.lm-mod-active {

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -23,7 +23,6 @@
   margin: 0;
   padding: 4px;
   width: 40%;
-  /* max-height: 40%; */
   box-shadow: var(--jp-elevation-z4);
   border-radius: 4px;
   background: var(--jp-layout-color0);

--- a/packages/apputils/test/commandpalette.spec.ts
+++ b/packages/apputils/test/commandpalette.spec.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Jupyter Development Team.
+
+import 'jest';
+// Distributed under the terms of the Modified BSD License.
+
+// import { expect } from 'chai';
+
+import { CommandRegistry } from '@lumino/commands';
+
+import { JSONObject } from '@lumino/coreutils';
+
+import { MessageLoop } from '@lumino/messaging';
+
+import { Widget } from '@lumino/widgets';
+
+import { CommandPalette } from '@lumino/widgets';
+
+import { CommandPaletteSvg, paletteIcon } from '@jupyterlab/ui-components';
+
+import { ModalCommandPalette } from '@jupyterlab/apputils';
+
+import { nullTranslator, ITranslator } from '@jupyterlab/translation';
+
+import { simulate } from 'simulate-event';
+
+describe('@jupyterlab/apputils', () => {
+  describe('ModalCommandPalette', () => {
+    let commands: CommandRegistry;
+    let translator: ITranslator;
+    let palette: CommandPalette;
+    let modalPalette: ModalCommandPalette;
+
+    beforeEach(() => {
+      commands = new CommandRegistry();
+      translator = nullTranslator;
+      palette = new CommandPalette({
+        commands: commands,
+        renderer: CommandPaletteSvg.defaultRenderer
+      });
+      palette.id = 'command-palette';
+      palette.title.icon = paletteIcon;
+      const trans = translator.load('jupyterlab');
+      palette.title.label = trans.__('Commands');
+      modalPalette = new ModalCommandPalette({ commandPalette: palette });
+    });
+
+    describe('#constructor()', () => {
+      it('should create a new command palette', () => {
+        expect(palette).toBeInstanceOf(CommandPalette);
+      });
+      it('should create a new modal command palette', () => {
+        expect(modalPalette).toBeInstanceOf(ModalCommandPalette);
+      });
+      it('should attach to the document body', () => {
+        expect(document.body.contains(modalPalette.node)).toBe(true);
+      });
+      it('should start hidden', () => {
+        expect(modalPalette.isHidden).toBe(true);
+      });
+    });
+
+    describe('#activate()', () => {
+      it('should become visible when activated', () => {
+        MessageLoop.sendMessage(modalPalette, Widget.Msg.ActivateRequest);
+        expect(modalPalette.isVisible).toBe(true);
+      });
+    });
+
+    describe('#hideAndReset()', () => {
+      it('should become hidden and clear the input when calling hideAndReset', () => {
+        MessageLoop.sendMessage(modalPalette, Widget.Msg.ActivateRequest);
+        palette.inputNode.value = 'Search string...';
+        modalPalette.hideAndReset();
+        expect(modalPalette.isVisible).toBe(false);
+        expect(palette.inputNode.value).toEqual('');
+      });
+    });
+
+    describe('#blur()', () => {
+      it('should hide and reset when blurred', () => {
+        MessageLoop.sendMessage(modalPalette, Widget.Msg.ActivateRequest);
+        palette.inputNode.value = 'Search string...';
+        simulate(modalPalette.node, 'blur');
+        expect(modalPalette.isVisible).toBe(false);
+        expect(palette.inputNode.value).toEqual('');
+      });
+    });
+
+    describe('#escape()', () => {
+      it('should hide and reset when ESC is pressed', () => {
+        MessageLoop.sendMessage(modalPalette, Widget.Msg.ActivateRequest);
+        palette.inputNode.value = 'Search string...';
+        simulate(modalPalette.node, 'keydown', { keyCode: 27 });
+        expect(modalPalette.isVisible).toBe(false);
+        expect(palette.inputNode.value).toEqual('');
+      });
+    });
+
+    describe('#execute()', () => {
+      it('should hide and reset when a command is executed', () => {
+        commands.addCommand('mock-command', {
+          execute: (args: JSONObject) => {
+            return args;
+          }
+        });
+        MessageLoop.sendMessage(modalPalette, Widget.Msg.ActivateRequest);
+        void commands.execute('mock-command');
+        expect(modalPalette.isVisible).toBe(false);
+        expect(palette.inputNode.value).toEqual('');
+      });
+    });
+  });
+});

--- a/packages/apputils/test/commandpalette.spec.ts
+++ b/packages/apputils/test/commandpalette.spec.ts
@@ -42,6 +42,7 @@ describe('@jupyterlab/apputils', () => {
       const trans = translator.load('jupyterlab');
       palette.title.label = trans.__('Commands');
       modalPalette = new ModalCommandPalette({ commandPalette: palette });
+      modalPalette.attach();
     });
 
     describe('#constructor()', () => {


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/7039

## Code changes

Adds a `ModalCommandPalette` that wraps the existing command palette widget, removes from left panel.

## User-facing changes

![Screen Shot 2020-08-10 at 10 52 12 PM](https://user-images.githubusercontent.com/27600/89862544-0de87100-db5d-11ea-9d5e-6817c9504666.png)


## Backwards-incompatible changes

None
