### PR TITLE
PR: Change optionsMap to a an array of tuples to be able to localize the options

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -246,25 +246,6 @@ const FACTORY = 'Notebook';
 const FORMAT_EXCLUDE = ['notebook', 'python', 'custom'];
 
 /**
- * The exluded Cell Inspector Raw NbConvert Formats
- * (returned from nbconvert's export list)
- */
-const RAW_FORMAT_EXCLUDE = ['pdf', 'slides', 'script', 'notebook', 'custom'];
-
-/**
- * The default Export To ... formats and their human readable labels.
- */
-const FORMAT_LABEL: { [k: string]: string } = {
-  html: 'HTML',
-  latex: 'LaTeX',
-  markdown: 'Markdown',
-  pdf: 'PDF',
-  rst: 'ReStructured Text',
-  script: 'Executable Script',
-  slides: 'Reveal.js Slides'
-};
-
-/**
  * The notebook widget tracker provider.
  */
 const trackerPlugin: JupyterFrontEndPlugin<INotebookTracker> = {
@@ -469,18 +450,32 @@ function activateNotebookTools(
   optionsMap.None = null;
   void services.nbconvert.getExportFormats().then(response => {
     if (response) {
+      /**
+       * The exluded Cell Inspector Raw NbConvert Formats
+       * (returned from nbconvert's export list)
+       */
+      const rawFormtExclude = ['pdf', 'slides', 'script', 'notebook', 'custom'];
+      let optionValueArray: any = [
+        [trans.__('PDF'), 'pdf'],
+        [trans.__('Slides'), 'slides'],
+        [trans.__('Script'), 'script'],
+        [trans.__('Notebook'), 'notebook'],
+        [trans.__('Custom'), 'custom']
+      ];
+
       // convert exportList to palette and menu items
       const formatList = Object.keys(response);
+      const formatLabels = getFormatLabels(translator);
       formatList.forEach(function(key) {
-        if (RAW_FORMAT_EXCLUDE.indexOf(key) === -1) {
-          const capCaseKey = key[0].toUpperCase() + key.substr(1);
-          const labelStr = FORMAT_LABEL[key] ? FORMAT_LABEL[key] : capCaseKey;
-          const mimeType = response[key].output_mimetype;
-          optionsMap[labelStr] = mimeType;
+        if (rawFormtExclude.indexOf(key) === -1) {
+          const altOption = trans.__(key[0].toUpperCase() + key.substr(1));
+          const option = formatLabels[key] ? formatLabels[key] : altOption;
+          const mimeTypeValue = response[key].output_mimetype;
+          optionValueArray.push([option, mimeTypeValue]);
         }
       });
       const nbConvert = NotebookTools.createNBConvertSelector(
-        optionsMap,
+        optionValueArray,
         translator
       );
       notebookTools.addItem({ tool: nbConvert, section: 'common', rank: 3 });
@@ -1251,7 +1246,7 @@ function addCommands(
     label: args => {
       const formatLabel = args['label'] as string;
       return args['isPalette']
-        ? trans.__('Export Notebook to %1', formatLabel)
+        ? trans.__('Export Notebook: %1', formatLabel)
         : formatLabel;
     },
     execute: args => {
@@ -2090,6 +2085,23 @@ function populatePalette(
 }
 
 /**
+ * The default Export To ... formats and their human readable labels.
+ */
+function getFormatLabels(translator?: ITranslator): { [k: string]: string } {
+  translator = translator || nullTranslator;
+  const trans = translator.load('jupyterlab');
+  return {
+    html: trans.__('HTML'),
+    latex: trans.__('LaTeX'),
+    markdown: trans.__('Markdown'),
+    pdf: trans.__('PDF'),
+    rst: trans.__('ReStructured Text'),
+    script: trans.__('Executable Script'),
+    slides: trans.__('Reveal.js Slides')
+  };
+}
+
+/**
  * Populates the application menus for the notebook.
  */
 function populateMenus(
@@ -2103,7 +2115,6 @@ function populateMenus(
 ): void {
   const trans = translator.load('jupyterlab');
   const { commands } = app;
-
   sessionDialogs = sessionDialogs || sessionContextDialogs;
 
   // Add undo/redo hooks to the edit menu.
@@ -2161,15 +2172,17 @@ function populateMenus(
   exportTo.title.label = trans.__('Export Notebook As…');
   void services.nbconvert.getExportFormats().then(response => {
     if (response) {
+      const formatLabels: any = getFormatLabels(translator);
+
       // Convert export list to palette and menu items.
       const formatList = Object.keys(response);
       formatList.forEach(function(key) {
-        const capCaseKey = key[0].toUpperCase() + key.substr(1);
-        const labelStr = FORMAT_LABEL[key] ? FORMAT_LABEL[key] : capCaseKey;
-        const args = {
+        const capCaseKey = trans.__(key[0].toUpperCase() + key.substr(1));
+        const labelStr = formatLabels[key] ? formatLabels[key] : capCaseKey;
+        let args = {
           format: key,
           label: labelStr,
-          isPalette: true
+          isPalette: false
         };
         if (FORMAT_EXCLUDE.indexOf(key) === -1) {
           exportTo.addItem({
@@ -2177,6 +2190,11 @@ function populateMenus(
             args: args
           });
           if (palette) {
+            args = {
+              format: key,
+              label: labelStr,
+              isPalette: true
+            };
             const category = trans.__('Notebook Operations');
             palette.addItem({
               command: CommandIDs.exportToFormat,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -451,10 +451,16 @@ function activateNotebookTools(
   void services.nbconvert.getExportFormats().then(response => {
     if (response) {
       /**
-       * The exluded Cell Inspector Raw NbConvert Formats
+       * The excluded Cell Inspector Raw NbConvert Formats
        * (returned from nbconvert's export list)
        */
-      const rawFormtExclude = ['pdf', 'slides', 'script', 'notebook', 'custom'];
+      const rawFormatExclude = [
+        'pdf',
+        'slides',
+        'script',
+        'notebook',
+        'custom'
+      ];
       let optionValueArray: any = [
         [trans.__('PDF'), 'pdf'],
         [trans.__('Slides'), 'slides'],
@@ -465,9 +471,9 @@ function activateNotebookTools(
 
       // convert exportList to palette and menu items
       const formatList = Object.keys(response);
-      const formatLabels = getFormatLabels(translator);
+      const formatLabels = Private.getFormatLabels(translator);
       formatList.forEach(function(key) {
-        if (rawFormtExclude.indexOf(key) === -1) {
+        if (rawFormatExclude.indexOf(key) === -1) {
           const altOption = trans.__(key[0].toUpperCase() + key.substr(1));
           const option = formatLabels[key] ? formatLabels[key] : altOption;
           const mimeTypeValue = response[key].output_mimetype;
@@ -2085,23 +2091,6 @@ function populatePalette(
 }
 
 /**
- * The default Export To ... formats and their human readable labels.
- */
-function getFormatLabels(translator?: ITranslator): { [k: string]: string } {
-  translator = translator || nullTranslator;
-  const trans = translator.load('jupyterlab');
-  return {
-    html: trans.__('HTML'),
-    latex: trans.__('LaTeX'),
-    markdown: trans.__('Markdown'),
-    pdf: trans.__('PDF'),
-    rst: trans.__('ReStructured Text'),
-    script: trans.__('Executable Script'),
-    slides: trans.__('Reveal.js Slides')
-  };
-}
-
-/**
  * Populates the application menus for the notebook.
  */
 function populateMenus(
@@ -2172,7 +2161,7 @@ function populateMenus(
   exportTo.title.label = trans.__('Export Notebook As…');
   void services.nbconvert.getExportFormats().then(response => {
     if (response) {
-      const formatLabels: any = getFormatLabels(translator);
+      const formatLabels: any = Private.getFormatLabels(translator);
 
       // Convert export list to palette and menu items.
       const formatList = Object.keys(response);
@@ -2500,5 +2489,29 @@ namespace Private {
        */
       translator?: ITranslator;
     }
+  }
+}
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+  /**
+   * The default Export To ... formats and their human readable labels.
+   */
+  export function getFormatLabels(
+    translator?: ITranslator
+  ): { [k: string]: string } {
+    translator = translator || nullTranslator;
+    const trans = translator.load('jupyterlab');
+    return {
+      html: trans.__('HTML'),
+      latex: trans.__('LaTeX'),
+      markdown: trans.__('Markdown'),
+      pdf: trans.__('PDF'),
+      rst: trans.__('ReStructured Text'),
+      script: trans.__('Executable Script'),
+      slides: trans.__('Reveal.js Slides')
+    };
   }
 }

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -38,17 +38,6 @@ import { NotebookPanel } from './panel';
 import { INotebookModel } from './model';
 import { INotebookTools, INotebookTracker } from './tokens';
 
-/**
- * A type alias for a readonly partial JSON tuples `[option, value]`.
- * `option` should be localized.
- *
- * Note: Partial here means that JSON object attributes can be `undefined`.
- */
-export declare type ReadonlyPartialJSONOptionValueArray = [
-  ReadonlyPartialJSONValue | undefined,
-  ReadonlyPartialJSONValue
-][];
-
 class RankedPanel<T extends Widget = Widget> extends Widget {
   constructor() {
     super();
@@ -276,6 +265,17 @@ export class NotebookTools extends Widget implements INotebookTools {
  * The namespace for NotebookTools class statics.
  */
 export namespace NotebookTools {
+  /**
+   * A type alias for a readonly partial JSON tuples `[option, value]`.
+   * `option` should be localized.
+   *
+   * Note: Partial here means that JSON object attributes can be `undefined`.
+   */
+  export type ReadonlyPartialJSONOptionValueArray = [
+    ReadonlyPartialJSONValue | undefined,
+    ReadonlyPartialJSONValue
+  ][];
+
   /**
    * The options used to create a NotebookTools object.
    */

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -38,6 +38,17 @@ import { NotebookPanel } from './panel';
 import { INotebookModel } from './model';
 import { INotebookTools, INotebookTracker } from './tokens';
 
+/**
+ * A type alias for a readonly partial JSON tuples `[option, value]`.
+ * `option` should be localized.
+ *
+ * Note: Partial here means that JSON object attributes can be `undefined`.
+ */
+export declare type ReadonlyPartialJSONOptionValueArray = [
+  ReadonlyPartialJSONValue | undefined,
+  ReadonlyPartialJSONValue
+][];
+
 class RankedPanel<T extends Widget = Widget> extends Widget {
   constructor() {
     super();
@@ -804,18 +815,23 @@ export namespace NotebookTools {
       key: string;
 
       /**
-       * The map of options to values.
+       * The map of values to options.
+       *
+       * Value corresponds to the unique identifier.
+       * Option corresponds to the localizable value to display.
+       *
+       * See: `<option value="volvo">Volvo</option>`
        *
        * #### Notes
        * If a value equals the default, choosing it may erase the key from the
        * metadata.
        */
-      optionsMap: ReadonlyPartialJSONObject;
+      optionValueArray: ReadonlyPartialJSONOptionValueArray;
 
       /**
        * The optional title of the selector - defaults to capitalized `key`.
        */
-      title?: string;
+      title: string;
 
       /**
        * The optional valid cell types - defaults to all valid types.
@@ -863,21 +879,17 @@ export namespace NotebookTools {
     translator = translator || nullTranslator;
     const trans = translator.load('jupyterlab');
     trans.__('');
-    // FIXME-TRANS: optionsMap needs to be reversed to have the id as the key
-    // not the translatable string. The name should change to reflect the
-    // breaking change othwerwise other extension devs might get unexected
-    // results
     const options: KeySelector.IOptions = {
       key: 'slideshow',
-      title: 'Slide Type',
-      optionsMap: {
-        '-': null,
-        Slide: 'slide',
-        'Sub-Slide': 'subslide',
-        Fragment: 'fragment',
-        Skip: 'skip',
-        Notes: 'notes'
-      },
+      title: trans.__('Slide Type'),
+      optionValueArray: [
+        ['-', null],
+        [trans.__('Slide'), 'slide'],
+        [trans.__('Sub-Slide'), 'subslide'],
+        [trans.__('Fragment'), 'fragment'],
+        [trans.__('Skip'), 'skip'],
+        [trans.__('Notes'), 'notes']
+      ],
       getter: cell => {
         const value = cell.model.metadata.get('slideshow') as
           | ReadonlyPartialJSONObject
@@ -907,11 +919,7 @@ export namespace NotebookTools {
    * Create an nbconvert selector.
    */
   export function createNBConvertSelector(
-    // FIXME-TRANS: optionsMap needs to be reversed to have the id as the key
-    // not the translatable string. The name should change to reflect the
-    // breaking change othwerwise other extension devs might get unexected
-    // results
-    optionsMap: ReadonlyPartialJSONObject,
+    optionValueArray: ReadonlyPartialJSONOptionValueArray,
     translator?: ITranslator
   ): KeySelector {
     translator = translator || nullTranslator;
@@ -919,7 +927,7 @@ export namespace NotebookTools {
     return new KeySelector({
       key: 'raw_mimetype',
       title: trans.__('Raw NBConvert Format'),
-      optionsMap: optionsMap,
+      optionValueArray: optionValueArray,
       validCellTypes: ['raw']
     });
   }
@@ -960,10 +968,13 @@ namespace Private {
     const name = options.key;
     const title = options.title || name[0].toLocaleUpperCase() + name.slice(1);
     const optionNodes: VirtualNode[] = [];
-    for (const label in options.optionsMap) {
-      const value = JSON.stringify(options.optionsMap[label]);
-      optionNodes.push(h.option({ value }, label));
-    }
+    let value: any;
+    let option: any;
+    each(options.optionValueArray, item => {
+      option = item[0];
+      value = JSON.stringify(item[1]);
+      optionNodes.push(h.option({ value }, option));
+    });
     const node = VirtualDOM.realize(
       h.div({}, h.label(title, h.select({}, optionNodes)))
     );

--- a/packages/notebook/test/notebooktools.spec.ts
+++ b/packages/notebook/test/notebooktools.spec.ts
@@ -7,8 +7,6 @@ import { Message } from '@lumino/messaging';
 
 import { TabPanel, Widget } from '@lumino/widgets';
 
-import { JSONValue } from '@lumino/coreutils';
-
 import { simulate } from 'simulate-event';
 
 import { CodeMirrorEditorFactory } from '@jupyterlab/codemirror';
@@ -383,10 +381,11 @@ describe('@jupyterlab/notebook', () => {
       beforeEach(() => {
         tool = new LogKeySelector({
           key: 'foo',
-          optionsMap: {
-            bar: 1,
-            baz: [1, 2, 'a']
-          }
+          title: 'Foo',
+          optionValueArray: [
+            ['bar', 1],
+            ['baz', [1, 2, 'a']]
+          ]
         });
         notebookTools.addItem({ tool });
         simulate(panel0.node, 'focus');
@@ -528,16 +527,16 @@ describe('@jupyterlab/notebook', () => {
 
     describe('NotebookTools.createNBConvertSelector()', () => {
       it('should create a raw mimetype selector', () => {
-        const optionsMap: { [key: string]: JSONValue } = {
-          None: '-',
-          LaTeX: 'text/latex',
-          reST: 'text/restructuredtext',
-          HTML: 'text/html',
-          Markdown: 'text/markdown',
-          Python: 'text/x-python'
-        };
-        optionsMap.None = '-';
-        const tool = NotebookTools.createNBConvertSelector(optionsMap);
+        const optionValueArray: any = [
+          [null, '-'],
+          ['LaTeX', 'text/latex'],
+          ['reST', 'text/restructuredtext'],
+          ['HTML', 'text/html'],
+          ['Markdown', 'text/markdown'],
+          ['Python', 'text/x-python']
+        ];
+        optionValueArray.push(['None', '-']);
+        const tool = NotebookTools.createNBConvertSelector(optionValueArray);
         tool.selectNode.selectedIndex = -1;
         notebookTools.addItem({ tool });
         simulate(panel0.node, 'focus');
@@ -557,15 +556,15 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should have no effect on a code cell', () => {
-        const optionsMap: { [key: string]: JSONValue } = {
-          None: '-',
-          LaTeX: 'text/latex',
-          reST: 'text/restructuredtext',
-          HTML: 'text/html',
-          Markdown: 'text/markdown',
-          Python: 'text/x-python'
-        };
-        const tool = NotebookTools.createNBConvertSelector(optionsMap);
+        const optionValueArray: any = [
+          ['None', '-'],
+          ['LaTeX', 'text/latex'],
+          ['reST', 'text/restructuredtext'],
+          ['HTML', 'text/html'],
+          ['Markdown', 'text/markdown'],
+          ['Python', 'text/x-python']
+        ];
+        const tool = NotebookTools.createNBConvertSelector(optionValueArray);
         tool.selectNode.selectedIndex = -1;
         notebookTools.addItem({ tool });
         simulate(panel0.node, 'focus');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

`NotebookTools.KeySelector.IOptions`

The `optionsMap` used in the `KeySelector` of the `notebooktools` has been renamed and restructured as an array of tuples, instead of an object.

These options are now localizable:

![image](https://user-images.githubusercontent.com/3627835/89972157-b14f8980-dc22-11ea-82e2-02397e8bff67.png)

## User-facing changes

The export as options on the `File` menu has been shortened to avoid redundancy. The text in the palette has changed from `Export Notebook to {something}` to `Export Notebook: {something}`, which makes translations work as it is not a full sentence but two parts that are translated independently. (that is why we need to make a harder sentence split with the `:`)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

### Before


### After
![image](https://user-images.githubusercontent.com/3627835/89972148-ac8ad580-dc22-11ea-87b7-b999d25b1cf2.png)

![image](https://user-images.githubusercontent.com/3627835/89972150-aeed2f80-dc22-11ea-9a0d-9c5e4276f4f0.png)

## Backwards-incompatible changes

OptionsMap that use the localizable string as the key. The names of these var will be changed to break (and force) the correct usage.

`KeySelector.IOptions.title` is no longer optional. We should encourage devs to give displayable/localizable names.

`KeySelector.IOptions.optionsMap` -> `KeySelector.IOptions.optionValueArray`


<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
