### PR TITLE
Fix labextension build

### DIFF
--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -192,7 +192,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        build_labextension(self.extra_args[0], logger=self.log, app_dir=self.app_dir)
+        build_labextension(self.extra_args[0], logger=self.log)
 
 
 class WatchLabExtensionApp(BaseExtensionApp):
@@ -200,7 +200,7 @@ class WatchLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        watch_labextension(self.extra_args[0], logger=self.log, app_dir=self.app_dir)
+        watch_labextension(self.extra_args[0], logger=self.log)
 
 
 class UpdateLabExtensionApp(BaseExtensionApp):

--- a/jupyterlab/tests/mock_packages/extension/package.json
+++ b/jupyterlab/tests/mock_packages/extension/package.json
@@ -5,6 +5,9 @@
   "dependencies": {
     "@jupyterlab/launcher": "^3.0.0-alpha.9"
   },
+  "devDependencies": {
+    "@jupyterlab/buildutils": "3.0.0-alpha.9"
+  },
   "jupyterlab": {
     "extension": true
   }

--- a/jupyterlab/tests/mock_packages/extension/package.json
+++ b/jupyterlab/tests/mock_packages/extension/package.json
@@ -6,7 +6,7 @@
     "@jupyterlab/launcher": "^3.0.0-alpha.9"
   },
   "devDependencies": {
-    "@jupyterlab/buildutils": "3.0.0-alpha.9"
+    "@jupyterlab/buildutils": "^3.0.0-alpha.9"
   },
   "jupyterlab": {
     "extension": true

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -95,7 +95,8 @@ class AppHandlerTest(TestCase):
             shutil.copytree(src, dest, ignore=ignore)
 
             # Make a node modules folder so npm install is not called.
-            os.makedirs(pjoin(dest, 'node_modules'))
+            if not os.path.exists(pjoin(dest, 'node_modules')):
+                os.makedirs(pjoin(dest, 'node_modules'))
 
             setattr(self, 'mock_' + name, dest)
             with open(pjoin(dest, 'package.json')) as fid:

--- a/setup.py
+++ b/setup.py
@@ -156,8 +156,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'ipython',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
-    'jupyterlab_server>=2.0.0b0',
-    'jupyter_server>=1.0.0rc5',
+    'jupyterlab_server~=2.0.0b1',
     'nbclassic>=0.2.0rc3',
     'jinja2>=2.10'
 ]

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup_args['install_requires'] = [
     'ipython',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
     'jupyterlab_server~=2.0.0b1',
-    'nbclassic>=0.2.0rc3',
+    'nbclassic~=0.2.0rc4',
     'jinja2>=2.10'
 ]
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Follow up to #8810  

See discussion in https://github.com/jupyterlab/jupyterlab-module-federation/pull/62#issuecomment-672726652 for why we need to use `@jupyterlab/buildutils` in the extension package itself.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Make the build fully contained in the extension directory with a compatibility check on `@jupyterlab/buildutils`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Extension authors will need a `devDependency` or `dependency` on `@jupyterlab/buildutils` but it will be compatibility-checked with the current JupyterLab.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
Reverts previous attempt to build in `staging`.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
