### PR TITLE
Adding a mime extension to the webpack config

### DIFF
--- a/buildutils/src/webpack.config.ext.ts
+++ b/buildutils/src/webpack.config.ext.ts
@@ -33,15 +33,24 @@ let outputPath = data.jupyterlab['outputDir'];
 outputPath = path.join(packagePath, outputPath);
 
 // Handle the extension entry point and the lib entry point, if different
-let extEntry = data.jupyterlab.extension || data.jupyterlab.mimeExtension;
 const index = require.resolve(packagePath);
-const exposes = {
-  './index': index,
-  './extension': index
+const exposes: { [id: string]: string } = {
+  './index': index
 };
 
-if (extEntry !== true) {
-  exposes['./extension'] = path.join(packagePath, extEntry);
+if (data.jupyterlab.extension === true) {
+  exposes['./extension'] = index;
+} else if (typeof data.jupyterlab.extension === 'string') {
+  exposes['./extension'] = path.join(packagePath, data.jupyterlab.extension);
+}
+
+if (data.jupyterlab.mimeExtension === true) {
+  exposes['./mimeExtension'] = index;
+} else if (typeof data.jupyterlab.mimeExtension === 'string') {
+  exposes['./mimeExtension'] = path.join(
+    packagePath,
+    data.jupyterlab.mimeExtension
+  );
 }
 
 const coreData = require(path.join(corePath, 'package.json'));

--- a/buildutils/src/webpack.config.ext.ts
+++ b/buildutils/src/webpack.config.ext.ts
@@ -53,6 +53,10 @@ if (data.jupyterlab.mimeExtension === true) {
   );
 }
 
+if (data.style) {
+  exposes['./style'] = path.join(packagePath, data.style);
+}
+
 const coreData = require(path.join(corePath, 'package.json'));
 
 const shared: any = {};
@@ -138,7 +142,7 @@ module.exports = [
     output: {
       filename: '[name].[chunkhash].js',
       path: outputPath,
-      publicPath: `lab/extensions/${data.name}/`
+      publicPath: `/lab/extensions/${data.name}/`
     },
     module: {
       rules: [{ test: /\.html$/, use: 'file-loader' }]

--- a/examples/federated/core_package/index.js
+++ b/examples/federated/core_package/index.js
@@ -106,12 +106,6 @@ async function main() {
     }
   });
 
-  // Handle the registered mime extensions.
-  var mimeExtensions = [];
-  var extension;
-  var extMod;
-  var plugins = [];
-
   /**
    * Iterate over active plugins in an extension.
    * 
@@ -142,6 +136,8 @@ async function main() {
     }
   }
 
+  // Handle the registered mime extensions.
+  const mimeExtensions = [];
   {{#each jupyterlab_mime_extensions}}
   try {
     for (let plugin of activePlugins(require('{{@key}}/{{this}}'))) {
@@ -192,8 +188,8 @@ async function main() {
      console.error(reason);
     });
 
-  var lab = new JupyterLab({
-    mimeExtensions: mimeExtensions,
+  const lab = new JupyterLab({
+    mimeExtensions,
     disabled: {
       matches: disabled,
       patterns: PageConfig.Extension.disabled

--- a/examples/federated/core_package/index.js
+++ b/examples/federated/core_package/index.js
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { PageConfig } from '@jupyterlab/coreutils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 // This must be after the public path is set.
 // This cannot be extracted because the public path is dynamic.
@@ -56,7 +56,7 @@ async function main() {
   // TODO: deconflict these with builtins?
   const dynamicPromises = extension_data.map(data =>
     loadComponent(
-      data.path,
+      `${URLExt.join(PageConfig.getOption('fullLabextensionsUrl'), data.name, 'remoteEntry.js')}`,
       data.name,
       data.module
     )
@@ -65,7 +65,7 @@ async function main() {
 
   const dynamicMimePromises = mime_extension_data.map(data =>
     loadComponent(
-      data.path,
+      `${URLExt.join(PageConfig.getOption('fullLabextensionsUrl'), data.name, 'remoteEntry.js')}`,
       data.name,
       data.module
     )

--- a/examples/federated/core_package/index.js
+++ b/examples/federated/core_package/index.js
@@ -71,7 +71,7 @@ async function main() {
 
   // Get dynamic plugins
   // TODO: deconflict these with builtins?
-  extension_data.map((data) => {
+  const loadComponentPromises = extension_data.map((data) => {
     const loadComponentPromise = loadComponent(
       `${URLExt.join(PageConfig.getOption('fullLabextensionsUrl'), data.name, 'remoteEntry.js')}`,
       data.name
@@ -93,6 +93,7 @@ async function main() {
     }
     return loadComponentPromise;
   });
+  await Promise.all(loadComponentPromises);
 
   // Handle the registered mime extensions.
   var mimeExtensions = [];

--- a/examples/federated/example.cert
+++ b/examples/federated/example.cert
@@ -1,0 +1,1 @@
+{"given": "My Name", "event": "Event"}

--- a/examples/federated/main.py
+++ b/examples/federated/main.py
@@ -50,11 +50,13 @@ class ExampleApp(LabServerApp):
         web_app.settings.setdefault('terminals_available', True)
 
         # Add labextension metadata
-        dynamic_extensions = page_config['dynamic_extensions'] = []
-        dynamic_mime_extension = page_config['dynamic_mime_extensions'] = []
-        name = "@jupyterlab/example-federated-md"
-        dynamic_extensions.append(dict(name=name, module="./extension"))
-        dynamic_mime_extension.append(dict(name=name, module="./mimeExtension"))
+        extension = {
+            'name': '@jupyterlab/example-federated-md',
+            'plugin': './extension',
+            'mimePlugin': './mimeExtension',
+            'style': './style'
+        }
+        page_config['dynamic_extensions'] = [extension];
 
         super().initialize_handlers()
 

--- a/examples/federated/main.py
+++ b/examples/federated/main.py
@@ -53,9 +53,8 @@ class ExampleApp(LabServerApp):
         dynamic_extensions = page_config['dynamic_extensions'] = []
         dynamic_mime_extension = page_config['dynamic_mime_extensions'] = []
         name = "@jupyterlab/example-federated-md"
-        path = "lab/extensions/%s/remoteEntry.js" % name
-        load_data = dict(name=name, path=path, module="./extension")
-        dynamic_extensions.append(load_data)
+        dynamic_extensions.append(dict(name=name, module="./extension"))
+        dynamic_mime_extension.append(dict(name=name, module="./mimeExtension"))
 
         super().initialize_handlers()
 

--- a/examples/federated/md_package/mime.js
+++ b/examples/federated/md_package/mime.js
@@ -1,10 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
-
-import { JSONObject } from '@lumino/coreutils';
-
 import { Widget } from '@lumino/widgets';
 
 /**

--- a/examples/federated/md_package/mime.js
+++ b/examples/federated/md_package/mime.js
@@ -1,0 +1,91 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
+
+import { JSONObject } from '@lumino/coreutils';
+
+import { Widget } from '@lumino/widgets';
+
+/**
+ * The default mime type for the extension.
+ */
+const MIME_TYPE = 'application/vnd.jupyterlab.certificate';
+
+/**
+ * The class name added to the extension.
+ */
+const CLASS_NAME = 'mimerenderer-certificate';
+
+/**
+ * A widget for rendering certificate.
+ */
+export class OutputWidget extends Widget {
+  /**
+   * Construct a new output widget.
+   */
+  constructor(options) {
+    super();
+    this._mimeType = options.mimeType;
+    this.addClass(CLASS_NAME);
+  }
+
+  /**
+   * Render certificate into this widget's node.
+   */
+  renderModel(model) {
+    let data = model.data[this._mimeType];
+    // this.node.textContent = JSON.stringify(data);
+    let given = data['given'];
+    let event = data['event'];
+
+    this.node.innerHTML = `
+<div class="certificate">
+  <div class="paper">
+    <div class="title">Certificate</div>
+    <div class="text">${given}</div>
+    <div class="text">For mastery of JupyterLab</div>
+    <div class="text">${event}</div>
+  </div>
+  <div class="medal"></div>
+  <div class="ribbon ribbon1"></div>
+  <div class="ribbon ribbon2"></div>
+</div>
+`;
+    return Promise.resolve();
+  }
+}
+
+/**
+ * A mime renderer factory for certificate data.
+ */
+export const rendererFactory = {
+  safe: true,
+  mimeTypes: [MIME_TYPE],
+  createRenderer: options => new OutputWidget(options)
+};
+
+/**
+ * Extension definition.
+ */
+const extension = {
+  id: 'certificate-extension:plugin',
+  rendererFactory,
+  rank: 0,
+  dataType: 'json',
+  fileTypes: [
+    {
+      name: 'certificate',
+      mimeTypes: [MIME_TYPE],
+      extensions: ['.cert']
+    }
+  ],
+  documentWidgetFactoryOptions: {
+    name: 'Certificate',
+    primaryFileType: 'certificate',
+    fileTypes: ['certificate'],
+    defaultFor: ['certificate']
+  }
+};
+
+export default extension;

--- a/examples/federated/md_package/package.json
+++ b/examples/federated/md_package/package.json
@@ -2,6 +2,8 @@
   "name": "@jupyterlab/example-federated-md",
   "version": "2.1.1-alpha.8",
   "private": true,
+  "main": "./index.js",
+  "style": "./style/index.css",
   "scripts": {
     "build": "npm run clean && build-labextension --core-path ../core_package .",
     "clean": "rimraf build",
@@ -33,6 +35,7 @@
   "jupyterlab": {
     "extension": true,
     "schemaDir": "./schema",
-    "outputDir": "../labextensions/@jupyterlab/example-federated-md"
+    "outputDir": "../labextensions/@jupyterlab/example-federated-md",
+    "mimeExtension": "./mime.js"
   }
 }

--- a/examples/federated/md_package/style/index.css
+++ b/examples/federated/md_package/style/index.css
@@ -1,0 +1,73 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.mimerenderer-certificate > .certificate {
+  background-color: #07618b;
+  border-radius: 20px 20px 20px 20px;
+  box-shadow: 0px 5px 10px 0px;
+  height: 250px;
+  margin-left: 35%;
+  margin-top: 10%;
+  position: relative;
+  width: 350px;
+}
+
+.mimerenderer-certificate > .certificate > .paper {
+  background: #e0e0e0;
+  border-radius: 5px 5px 5px 5px;
+  height: 200px;
+  left: 25px;
+  position: absolute;
+  top: 25px;
+  width: 300px;
+}
+
+.mimerenderer-certificate > .certificate > .paper > .title {
+  background: #e0e0e0;
+  font-weight: bold;
+  height: 30px;
+  margin-top: 20px;
+  text-align: center;
+  z-index: 999;
+}
+
+.mimerenderer-certificate > .certificate > .paper > .text {
+  margin-top: 20px;
+  padding: 0px;
+  text-align: center;
+  z-index: 200;
+}
+
+.mimerenderer-certificate > .certificate > .medal {
+  background: #c9992e;
+  border-radius: 50%;
+  font-size: 2em;
+  height: 20px;
+  left: 30px;
+  padding: 10px 10px 10px 10px;
+  position: absolute;
+  top: 30px;
+  width: 20px;
+  z-index: 30;
+}
+
+.mimerenderer-certificate > .certificate > .ribbon {
+  background-color: #9bdbf6;
+  border-right: 1px solid white;
+  height: 40px;
+  left: 43px;
+  position: absolute;
+  top: 38px;
+  width: 15px;
+  z-index: 1;
+}
+
+.mimerenderer-certificate > .certificate > .ribbon1 {
+  transform: rotate(30deg);
+}
+
+.mimerenderer-certificate > .certificate > .ribbon2 {
+  transform: rotate(150deg);
+}

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -699,13 +699,10 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         dynamic_mime_extension = page_config['dynamic_mime_extensions'] = []
         for (ext, ext_data) in info.get('dynamic_exts', dict()).items():
             name = ext_data['name']
-            path = "lab/extensions/%s/remoteEntry.js" % name
-            module = "./extension"
-            load_data = dict(name=name, path=path, module=module)
             if ext_data['jupyterlab'].get('extension'):
-                dynamic_extensions.append(load_data)
-            else:
-                dynamic_mime_extension.append(load_data)
+                dynamic_extensions.append(dict(name=name, module="./extension"))
+            if ext_data['jupyterlab'].get('mimeExtension'):
+                dynamic_mime_extension.append(dict(name=name, module="./mimeExtension"))
 
         # Update Jupyter Server's webapp settings with jupyterlab settings.
         self.serverapp.web_app.settings['page_config_data'] = page_config

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -695,14 +695,18 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
 
         # Handle dynamic extensions
         info = get_app_info()
-        dynamic_extensions = page_config['dynamic_extensions'] = []
-        dynamic_mime_extension = page_config['dynamic_mime_extensions'] = []
+        extensions = page_config['dynamic_extensions'] = []
         for (ext, ext_data) in info.get('dynamic_exts', dict()).items():
-            name = ext_data['name']
+            extension = {
+                'name': ext_data['name']
+            }
             if ext_data['jupyterlab'].get('extension'):
-                dynamic_extensions.append(dict(name=name, module="./extension"))
+                extension['plugin'] = './extension'
             if ext_data['jupyterlab'].get('mimeExtension'):
-                dynamic_mime_extension.append(dict(name=name, module="./mimeExtension"))
+                extension['mimePlugin'] = './mimeExtension'
+            if ext_data.get('style'):
+                extension['style'] = './style'
+            extensions.append(extension)
 
         # Update Jupyter Server's webapp settings with jupyterlab settings.
         self.serverapp.web_app.settings['page_config_data'] = page_config


### PR DESCRIPTION
## References

Adds to: #7468 

## Code changes

- We making it possible for package to include normal and mime extension
- We are moving script loading path logic from server to front end

## TODO

- [x] Introduce new css exposed endpoint for the extension style
- [x] Rework how extensions are loaded so each remote entry is loaded once, then the module promises are constructed
- [x] Port example app changes to https://github.com/jupyterlab/jupyterlab/blob/master/dev_mode/index.js
