### PR TITLE
Do not use token parameters in websocket urls

### DIFF
--- a/packages/services/examples/node/main.py
+++ b/packages/services/examples/node/main.py
@@ -21,6 +21,11 @@ def _jupyter_server_extension_points():
 class NodeApp(ProcessApp):
 
     name = __name__
+    serverapp_config = dict(
+        disable_check_xsrf = True,
+        allow_origin = "*",
+        token=""
+    )
 
     def get_command(self):
         """Get the command and kwargs to run.
@@ -28,8 +33,7 @@ class NodeApp(ProcessApp):
         # Run the node script with command arguments.
         config = dict(
             baseUrl='http://localhost:{}{}'.format(self.serverapp.port, self.settings['base_url']),
-            token=self.settings['token']
-            )
+            token="")
 
         with open(osp.join(HERE, 'config.json'), 'w') as fid:
             json.dump(config, fid)

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1210,11 +1210,6 @@ export class KernelConnection implements Kernel.IKernelConnection {
       partialUrl,
       'channels?session_id=' + encodeURIComponent(this._clientId)
     );
-    // If token authentication is in use.
-    const token = settings.token;
-    if (token !== '') {
-      url = url + `&token=${encodeURIComponent(token)}`;
-    }
 
     this._ws = new settings.WebSocket(url);
 

--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -265,10 +265,6 @@ export class TerminalConnection implements Terminal.ITerminalConnection {
       encodeURIComponent(name)
     );
 
-    const token = settings.token;
-    if (token !== '') {
-      url = url + `?token=${encodeURIComponent(token)}`;
-    }
     this._ws = new settings.WebSocket(url);
 
     this._ws.onmessage = this._onWSMessage;

--- a/testutils/src/start_jupyter_server.ts
+++ b/testutils/src/start_jupyter_server.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-import { PromiseDelegate, UUID } from '@lumino/coreutils';
+import { PromiseDelegate } from '@lumino/coreutils';
 import { sleep } from './common';
 
 /**
@@ -202,8 +202,7 @@ namespace Private {
    */
   export function handleConfig(): string {
     // Set up configuration.
-    const token = UUID.uuid4();
-    PageConfig.setOption('token', token);
+    PageConfig.setOption('token', '');
     PageConfig.setOption('terminalsAvailable', 'true');
 
     const configDir = mktempDir('config');
@@ -216,7 +215,13 @@ namespace Private {
 
     const configData = {
       LabApp: { user_settings_dir, workspaces_dir, app_dir },
-      ServerApp: { token, open_browser: false, notebook_dir },
+      ServerApp: {
+        token: '',
+        open_browser: false,
+        notebook_dir,
+        disable_check_xsrf: true,
+        allow_origin: '*'
+      },
       MultiKernelManager: {
         default_kernel_name: 'echo'
       },


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #8813.  Classic notebook does not add them and I verified that we can still open notebooks and terminals without them.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Removes `token` parameter from websocket URLs for terminals and kernels.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
