### PR TITLE
[2.2.x] Do not use token parameters in websocket urls

### DIFF
--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -231,6 +231,13 @@ class JestApp(ProcessTestApp):
 
     open_browser = False
 
+    token = ""
+
+    disable_check_xsrf = True
+
+    allow_origin = "*"
+
+
     @deprecated(removed_version=4)
     def get_command(self):
         """Get the command to run"""
@@ -273,8 +280,7 @@ class JestApp(ProcessTestApp):
             cmd += ['--silent']
 
         config = dict(baseUrl=self.connection_url,
-                      terminalsAvailable=str(terminalsAvailable),
-                      token=self.token)
+                      terminalsAvailable=str(terminalsAvailable))
         config.update(**self.test_config)
 
         td = tempfile.mkdtemp()
@@ -295,6 +301,9 @@ class KarmaTestApp(ProcessTestApp):
     karma_pattern = Unicode('src/*.spec.ts*')
     karma_base_dir = Unicode('')
     karma_coverage_dir = Unicode('')
+    token = ""
+    disable_check_xsrf = True
+    allow_origin = "*"
 
     @deprecated(removed_version=4)
     def get_command(self):
@@ -302,7 +311,7 @@ class KarmaTestApp(ProcessTestApp):
         terminalsAvailable = self.web_app.settings['terminals_available']
         # Compatibility with Notebook 4.2.
         token = getattr(self, 'token', '')
-        config = dict(baseUrl=self.connection_url, token=token,
+        config = dict(baseUrl=self.connection_url, 
                       terminalsAvailable=str(terminalsAvailable),
                       foo='bar')
 

--- a/packages/services/examples/node/main.py
+++ b/packages/services/examples/node/main.py
@@ -12,11 +12,15 @@ HERE = osp.dirname(osp.realpath(__file__))
 
 class NodeApp(ProcessApp):
 
+    token = ""
+    disable_check_xsrf = True
+    allow_origin = "*"
+
     def get_command(self):
         """Get the command and kwargs to run.
         """
         # Run the node script with command arguments.
-        config = dict(baseUrl=self.connection_url, token=self.token)
+        config = dict(baseUrl=self.connection_url)
 
         with open(osp.join(HERE, 'config.json'), 'w') as fid:
             json.dump(config, fid)

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1210,11 +1210,6 @@ export class KernelConnection implements Kernel.IKernelConnection {
       partialUrl,
       'channels?session_id=' + encodeURIComponent(this._clientId)
     );
-    // If token authentication is in use.
-    const token = settings.token;
-    if (token !== '') {
-      url = url + `&token=${encodeURIComponent(token)}`;
-    }
 
     this._ws = new settings.WebSocket(url);
 

--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -265,10 +265,6 @@ export class TerminalConnection implements Terminal.ITerminalConnection {
       encodeURIComponent(name)
     );
 
-    const token = settings.token;
-    if (token !== '') {
-      url = url + `?token=${encodeURIComponent(token)}`;
-    }
     this._ws = new settings.WebSocket(url);
 
     this._ws.onmessage = this._onWSMessage;

--- a/testutils/src/start_jupyter_server.ts
+++ b/testutils/src/start_jupyter_server.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-import { PromiseDelegate, UUID } from '@lumino/coreutils';
+import { PromiseDelegate } from '@lumino/coreutils';
 import { sleep } from './common';
 
 /**
@@ -202,8 +202,6 @@ namespace Private {
    */
   export function handleConfig(): string {
     // Set up configuration.
-    const token = UUID.uuid4();
-    PageConfig.setOption('token', token);
     PageConfig.setOption('terminalsAvailable', 'true');
 
     const configDir = mktempDir('config');
@@ -216,7 +214,13 @@ namespace Private {
 
     const configData = {
       LabApp: { user_settings_dir, workspaces_dir, app_dir },
-      NotebookApp: { token, open_browser: false, notebook_dir },
+      NotebookApp: {
+        token: '',
+        open_browser: false,
+        notebook_dir,
+        disable_check_xsrf: true,
+        allow_origin: '*'
+      },
       MultiKernelManager: {
         default_kernel_name: 'echo',
         shutdown_wait_time: 1.0


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Backport of #8835 to the 2.2.x branch

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Removes `token` parameter from websocket URLs for terminals and kernels.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
