### PR TITLE
PR: Add slash to publicPath

### DIFF
--- a/dev_mode/publicpath.js
+++ b/dev_mode/publicpath.js
@@ -1,0 +1,37 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// We dynamically set the webpack public path based on the page config
+// settings from the JupyterLab app. We copy some of the pageconfig parsing
+// logic in @jupyterlab/coreutils below, since this must run before any other
+// files are loaded (including @jupyterlab/coreutils).
+
+/**
+ * Get global configuration data for the Jupyter application.
+ *
+ * @param name - The name of the configuration option.
+ *
+ * @returns The config value or an empty string if not found.
+ *
+ * #### Notes
+ * All values are treated as strings.
+ * For browser based applications, it is assumed that the page HTML
+ * includes a script tag with the id `jupyter-config-data` containing the
+ * configuration as valid JSON.  In order to support the classic Notebook,
+ * we fall back on checking for `body` data of the given `name`.
+ */
+function getOption(name) {
+  let configData = Object.create(null);
+  // Use script tag if available.
+  if (typeof document !== 'undefined' && document) {
+    const el = document.getElementById('jupyter-config-data');
+
+    if (el) {
+      configData = JSON.parse(el.textContent || '{}');
+    }
+  }
+  return configData[name] || '';
+}
+
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = getOption('fullStaticUrl') + '/';

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -222,7 +222,7 @@ module.exports = [
     },
     output: {
       path: plib.resolve(buildDir),
-      publicPath: 'static/lab/',
+      publicPath: '/static/lab/',
       filename: '[name].[chunkhash].js'
     },
     optimization: {

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -218,11 +218,11 @@ module.exports = [
   merge(baseConfig, {
     mode: 'development',
     entry: {
-      main: ['whatwg-fetch', entryPoint]
+      main: ['./publicpath', 'whatwg-fetch', entryPoint]
     },
     output: {
       path: plib.resolve(buildDir),
-      publicPath: '/static/lab/',
+      publicPath: '{{page_config.fullStaticUrl}}/',
       filename: '[name].[chunkhash].js'
     },
     optimization: {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

Not sure if this is the right fix, but seems to solve the issues for `dev_mode` / `staging`

https://webpack.js.org/configuration/output/#outputpublicpath
```js
module.exports = {
  //...
  output: {
    // One of the below
    publicPath: 'https://cdn.example.com/assets/', // CDN (always HTTPS)
    publicPath: '//cdn.example.com/assets/', // CDN (same protocol)
    publicPath: '/assets/', // server-relative
    publicPath: 'assets/', // relative to HTML page
    publicPath: '../assets/', // relative to HTML page
    publicPath: '', // relative to HTML page (same directory)
  }
};
```
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/8833#issuecomment-675429539
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
