### PR TITLE
Fix rebuild of dynamic extension and add discovery metadata to schema

### DIFF
--- a/builder/metadata_schema.json
+++ b/builder/metadata_schema.json
@@ -72,6 +72,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "discovery": {
+      "title": "Discovery metadata",
+      "description": "Discovery metadata used to for companion packages",
+      "type": "object"
     }
   },
   "additionalProperties": false,

--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -124,6 +124,7 @@ shared[data.name] = {
 if (fs.existsSync(outputPath)) {
   const outputFiles = fs.readdirSync(outputPath);
   outputFiles.forEach(filePath => {
+    filePath = path.join(outputPath, filePath);
     if (fs.statSync(filePath).isFile()) {
       fs.unlinkSync(filePath);
     } else {

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -184,6 +184,7 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
     # Test with a dynamic install
     jupyter labextension develop extension --debug
+    jupyter labextension build extension
     jupyter labextension list 1>labextensions 2>&1
     cat labextensions | grep "@jupyterlab/mock-extension.*enabled.*OK"
     jupyter labextension disable @jupyterlab/mock-extension --debug


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
See while working on https://github.com/jupyterlab/extension-cookiecutter-ts/pull/73.  `readdirSync` gives the file names, not the full path, causing a rebuild of dynamic extensions to fail.  Also, we were not accounting for `discovery` metadata in `package.json`

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Clean up handling of re-build of a dynamic extension.
Add `discovery` metadata to our schema

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Re-running `jupyter labextension build` works

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
