### PR TITLE
Let webpack automatically determine the required version of dependencies

### DIFF
--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -76,7 +76,6 @@ Object.keys(data.dependencies).forEach(element => {
   if (!shared[element]) {
     shared[element] = {};
   }
-  shared[element].requiredVersion = data.dependencies[element];
 });
 
 // Remove non-shared.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

In some cases, like our federation example when we are testing itself and install the middle package into the md package as a local package on disk (so the dependency points to `../middle_package`), we are passing in wrong version numbers to webpack because we blindly pull them from package.json, even if they aren't really version numbers, but paths.

I think we should let webpack try to guess versions of dependencies. With https://github.com/webpack/webpack/pull/11359, it will know to follow paths of local installs, for example.


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
