### PR TITLE
Load app_version next to running on jupyter_server

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -539,8 +539,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
 
     @default('app_version')
     def _default_app_version(self):
-        info = get_app_info(app_options=AppOptions(app_dir=self.app_dir))
-        return info['version']
+        return app_version
 
     @default('cache_files')
     def _default_cache_files(self):
@@ -613,8 +612,6 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
 
 
     def initialize_settings(self):
-        # FIXME: why isn't the default being applied?
-        self.app_version = self._default_app_version()
         super().initialize_settings()
 
 


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/8812

Please merge https://github.com/jupyterlab/jupyterlab_server/pull/117 and release a new jupyterlab_server before merging this.

Examples have also been tested and are also showing correct version.

<img width="421" alt="Screenshot 2020-08-24 at 09 16 57" src="https://user-images.githubusercontent.com/226720/91016265-ce099b00-e5ec-11ea-90c1-cd2674c0cb02.png">