### PR TITLE
Add first attempt at a CodeCell partial input collapse state

### DIFF
--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -43,6 +43,18 @@
   flex: 1 1 auto;
 }
 
+.jp-Cell-inputAreaCollapsed .CodeMirror {
+  max-height: 24px;
+}
+
+.jp-Cell-inputAreaCollapsed .CodeMirror-line {
+  display: none;
+}
+
+.jp-Cell-inputAreaCollapsed .CodeMirror-line:nth-child(1) {
+  display: initial;
+}
+
 /*-----------------------------------------------------------------------------
 | Collapser
 |----------------------------------------------------------------------------*/


### PR DESCRIPTION
## References

Mainly: 
- https://github.com/jupyterlab/jupyterlab/issues/4083
I think I have seen duplicates of this issue.

## Changes

This adds an intermediate visual state to CodeCell which implements a 'partial collapsing' behaviour as follows:
 
`Upon clicking the collapser, the inputArea collapses down to the first line, if the first line is a comment, thereby leaving it visible. Clicking the collapser again displays the 3 pips as per usual. `

![image](https://user-images.githubusercontent.com/6711199/91112511-3b640d00-e67b-11ea-97d3-b6be69a5e9d9.png)

Notes:
- The state is maintained between reloads using metadata. 
- The partial collapsing is achieved using CSS.
- Hack: because it overrides the inputHidden setter to make use of the existing collapser click events as is. 
- Hack: because I had to use ['_editor'] from the inputArea to access the CodeMirror instance.  Using `.editor` seems to throw an error.

## General
This implementation is just an MVP, and was partly a learning exercise to help me get au fait with the codebase. However, judging by some comments I've seen I think there might be a desire among users for a feature like this. As such, I was hoping I'd be able to achieve one of two outcomes, if possible:
- Get me some tips for making this into an extension
- Be told everything you'd need me to do to get it merged

Let me know how you'd like me to proceed.

Thanks