### PR TITLE
Use favicons provided by jupyter_server

### DIFF
--- a/dev_mode/templates/error.html
+++ b/dev_mode/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | escape}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/dev_mode/templates/partial.html
+++ b/dev_mode/templates/partial.html
@@ -9,6 +9,6 @@
   </script>
 
   {% block favicon %}
-  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/base/images/favicon.ico" class="idle favicon">
-  <link rel="" type="image/x-icon" href="{{ base_url | escape }}static/base/images/favicon-busy-1.ico" class="busy favicon">
+  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon.ico" class="idle favicon">
+  <link rel="" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon-busy-1.ico" class="busy favicon">
   {% endblock %}

--- a/examples/app/templates/error.html
+++ b/examples/app/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/examples/cell/templates/error.html
+++ b/examples/cell/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/examples/console/templates/error.html
+++ b/examples/console/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/examples/federated/templates/error.html
+++ b/examples/federated/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/examples/filebrowser/templates/error.html
+++ b/examples/filebrowser/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/examples/notebook/templates/error.html
+++ b/examples/notebook/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/examples/terminal/templates/error.html
+++ b/examples/terminal/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/jupyterlab/staging/templates/error.html
+++ b/jupyterlab/staging/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | escape}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/jupyterlab/staging/templates/partial.html
+++ b/jupyterlab/staging/templates/partial.html
@@ -9,6 +9,6 @@
   </script>
 
   {% block favicon %}
-  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/base/images/favicon.ico" class="idle favicon">
-  <link rel="" type="image/x-icon" href="{{ base_url | escape }}static/base/images/favicon-busy-1.ico" class="busy favicon">
+  <link rel="icon" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon.ico" class="idle favicon">
+  <link rel="" type="image/x-icon" href="{{ base_url | escape }}static/favicons/favicon-busy-1.ico" class="busy favicon">
   {% endblock %}

--- a/packages/extensionmanager-extension/examples/listings/templates/error.html
+++ b/packages/extensionmanager-extension/examples/listings/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/packages/services/examples/browser/templates/error.html
+++ b/packages/services/examples/browser/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/packages/services/examples/node/templates/error.html
+++ b/packages/services/examples/node/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 

--- a/packages/services/examples/typescript-browser-with-output/templates/error.html
+++ b/packages/services/examples/typescript-browser-with-output/templates/error.html
@@ -10,7 +10,7 @@ Distributed under the terms of the Modified BSD License.
 
   <title>{% block title %}{{page_title | e}}{% endblock %}</title>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/favicons/favicon.ico">{% endblock %}
 
 </head>
 


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/8794

This changes in all html pages the link for favicons (default, running...) to use the one provided by jupyter_server (see https://github.com/jupyter/jupyter_server/pull/284)

@blink1073  We will need for this a new jupyterlab_server that will depend on a jupyter_server>=1.0.0rc7
