### PR TITLE
Remove the extension path, not the entire extension directory, when uninstalling an extension

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -826,7 +826,7 @@ class _AppHandler(object):
         # Handle dynamic extensions first
         if name in info['dynamic_exts']:
             data = info['dynamic_exts'].pop(name)
-            target = os.path.dirname(data['ext_dir'])
+            target = data['ext_path']
             logger.info("Removing: %s" % target)
             if os.path.isdir(target) and not os.path.islink(target):
                 shutil.rmtree(target)
@@ -1116,6 +1116,7 @@ class _AppHandler(object):
                     data = json.load(fid)
                 if data['name'] not in dynamic_exts:
                     data['ext_dir'] = ext_dir
+                    data['ext_path'] = os.path.dirname(ext_path)
                     data['is_local'] = False
                     dynamic_exts[data['name']] = data
                     dynamic_ext_dirs[ext_dir] = True


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References


## Code changes

`jupyter labextension uninstall` was removing the entire `share/jupyter` directory, instead of just the extension directory, for dynamic extensions. This fixes the problem.


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
