### PR TITLE
Fix invisible breakpoint in debugger

### DIFF
--- a/packages/debugger/src/handlers/editor.ts
+++ b/packages/debugger/src/handlers/editor.ts
@@ -220,7 +220,7 @@ export class EditorHandler implements IDisposable {
   private _getBreakpoints(): IDebugger.IBreakpoint[] {
     const code = this._editor.model.value.text;
     return this._debuggerService.model.breakpoints.getBreakpoints(
-      this._path ?? this._debuggerService.getCodeId(code)
+      this._path || this._debuggerService.getCodeId(code)
     );
   }
 


### PR DESCRIPTION
The styling for the breakpoint is still broken but it appears now. This will render correctly once we resolve the editor shadow DOM changes one way or the other: https://github.com/jupyterlab/jupyterlab/issues/8907

## User-facing changes

Breakpoints now show up.

## Backwards-incompatible changes

N/A
