### PR TITLE
Fixed static_url_prefix, added classic notebook flags+aliases, and bumped jupyterlab_server dependency

### DIFF
--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -43,7 +43,8 @@ def main():
         """
         name = __name__
         serverapp_config = {
-            "open_browser": False
+            "open_browser": False,
+            "base_url": "/foo/"
         }
         ip = '127.0.0.1'
 

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -164,7 +164,8 @@ class BrowserApp(LabApp):
     """
     name = __name__
     serverapp_config = {
-        "open_browser": False
+        "open_browser": False,
+        "base_url": "/foo/"
     }
     ip = '127.0.0.1'
     flags = test_flags

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -448,13 +448,13 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         jupyter lab --certfile=mycert.pem # use SSL/TLS certificate
     """
 
-    aliases['app-dir'] = 'LabApp.app_dir'
+    aliases = aliases
     aliases.update({
         'watch': 'LabApp.watch',
-        'open_browser': 'ServerApp.open_browser',
-        'base_url': 'ServerApp.base_url'
     })
+    aliases['app-dir'] = 'LabApp.app_dir'
 
+    flags = flags
     flags['core-mode'] = (
         {'LabApp': {'core_mode': True}},
         "Start the app in core mode."

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -14,7 +14,7 @@ from jinja2 import Environment, FileSystemLoader
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from jupyter_core.application import NoStart
 from jupyterlab_server import slugify, WORKSPACE_EXTENSION
-from jupyter_server.serverapp import aliases, flags
+from jupyter_server.serverapp import flags
 from jupyter_server.utils import url_path_join as ujoin
 from jupyter_server._version import version_info as jpserver_version_info
 from traitlets import Bool, Instance, Unicode, default
@@ -408,6 +408,20 @@ class LabWorkspaceApp(JupyterApp):
         except NoStart:
             pass
         self.exit(0)
+
+
+aliases = dict(base_aliases)
+aliases.update({
+    'ip': 'ServerApp.ip',
+    'port': 'ServerApp.port',
+    'port-retries': 'ServerApp.port_retries',
+    'keyfile': 'ServerApp.keyfile',
+    'certfile': 'ServerApp.certfile',
+    'client-ca': 'ServerApp.client_ca',
+    'notebook-dir': 'ServerApp.root_dir',
+    'browser': 'ServerApp.browser',
+    'pylab': 'ServerApp.pylab',
+})
 
 
 class LabApp(NBClassicConfigShimMixin, LabServerApp):

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -451,8 +451,9 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     aliases['app-dir'] = 'LabApp.app_dir'
     aliases.update({
         'watch': 'LabApp.watch',
+        'open_browser': 'ServerApp.open_browser',
+        'base_url': 'ServerApp.base_url'
     })
-
 
     flags['core-mode'] = (
         {'LabApp': {'core_mode': True}},
@@ -526,7 +527,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     def _default_app_dir(self):
         app_dir = get_app_dir()
         if self.core_mode:
-            app_dir = HERE 
+            app_dir = HERE
             self.log.info('Running JupyterLab in core mode')
         elif self.dev_mode:
             app_dir = DEV_DIR
@@ -563,8 +564,8 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     def _default_static_dir(self):
         return pjoin(self.app_dir, 'static')
 
-    @property
-    def static_url_prefix(self):
+    @default('static_url_prefix')
+    def _default_static_url_prefix(self):
         if self.override_static_url:
             return self.override_static_url
         else:

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'ipython',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
-    'jupyterlab_server~=2.0.0b1',
+    'jupyterlab_server~=2.0.0b3',
     'nbclassic~=0.2.0rc4',
     'jinja2>=2.10'
 ]
@@ -164,9 +164,9 @@ setup_args['install_requires'] = [
 
 setup_args['extras_require'] = {
     'test': [
-        'pytest==5.3.2', 
-        'pytest-cov', 
-        'pytest-tornasync', 
+        'pytest==5.3.2',
+        'pytest-cov',
+        'pytest-tornasync',
         'pytest-console-scripts',
         'pytest-check-links',
         'requests',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

Addresses #8856 and a few other things...

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
This includes a few, minor jupyter_server migration issues. 

1. Brings in the flags and aliases from jupyter_server and attaches them to the main jupyterlab app.
2. make `static_url_prefix` a default for the configurable trait on jupyter_server.
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Allows users to use the classic notebook server flags like `--port`, `--ip`, `--base_url`, etc.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None

Pinging @blink1073 and @echarles 