### PR TITLE
Update labextension build cli to include a parameter for setting the webpack publicPath option

### DIFF
--- a/builder/src/build-extension.ts
+++ b/builder/src/build-extension.ts
@@ -22,6 +22,7 @@ commander
   .description('Build an extension')
   .option('--prod', 'build in prod mode (default is dev)')
   .requiredOption('--core-path <path>', 'the core package directory')
+  .option('--public-webpack-path <path>', 'webpack output public path')
   .option('--watch')
   .action(async cmd => {
     let node_env = 'development';
@@ -42,7 +43,8 @@ commander
     const env = {
       PACKAGE_PATH: packagePath,
       NODE_ENV: node_env,
-      CORE_PATH: path.resolve(cmd.corePath)
+      CORE_PATH: path.resolve(cmd.corePath),
+      PUBLIC_WEBPACK_PATH: cmd.publicWebpackPath,
     };
     run(cmdText, { env: { ...process.env, ...env } });
   });

--- a/builder/src/build-extension.ts
+++ b/builder/src/build-extension.ts
@@ -44,7 +44,7 @@ commander
       PACKAGE_PATH: packagePath,
       NODE_ENV: node_env,
       CORE_PATH: path.resolve(cmd.corePath),
-      STATIC_PATH: cmd.staticPath,
+      STATIC_PATH: cmd.staticPath
     };
     run(cmdText, { env: { ...process.env, ...env } });
   });

--- a/builder/src/build-extension.ts
+++ b/builder/src/build-extension.ts
@@ -22,7 +22,7 @@ commander
   .description('Build an extension')
   .option('--prod', 'build in prod mode (default is dev)')
   .requiredOption('--core-path <path>', 'the core package directory')
-  .option('--public-webpack-path <path>', 'webpack output public path')
+  .option('--static-path <path>', 'static path for build assets')
   .option('--watch')
   .action(async cmd => {
     let node_env = 'development';
@@ -44,7 +44,7 @@ commander
       PACKAGE_PATH: packagePath,
       NODE_ENV: node_env,
       CORE_PATH: path.resolve(cmd.corePath),
-      PUBLIC_WEBPACK_PATH: cmd.publicWebpackPath,
+      STATIC_PATH: cmd.staticPath,
     };
     run(cmdText, { env: { ...process.env, ...env } });
   });

--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -149,7 +149,9 @@ fs.copyFileSync(
 // into remoteEntry.js. We should either delete it, or figure out a way to
 // have the entry point below be dynamically generated text without having to
 // write to a file.
-const webpackPublicPathString = staticPath ? `"${staticPath}"` : `getOption('fullLabextensionsUrl') + '/${data.name}/'`;
+const webpackPublicPathString = staticPath
+  ? `"${staticPath}"`
+  : `getOption('fullLabextensionsUrl') + '/${data.name}/'`;
 const publicpath = path.join(outputPath, 'publicPath.js');
 fs.writeFileSync(
   publicpath,
@@ -181,7 +183,7 @@ module.exports = [
     },
     output: {
       filename: '[name].[chunkhash].js',
-      path: outputPath,
+      path: outputPath
     },
     module: {
       rules: [{ test: /\.html$/, use: 'file-loader' }]

--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -14,6 +14,7 @@ const { ModuleFederationPlugin } = webpack.container;
 const packagePath: string = process.env.PACKAGE_PATH || '';
 const nodeEnv: string = process.env.NODE_ENV || '';
 const corePath: string = process.env.CORE_PATH || '';
+const outputPublicPath: string = process.env.PUBLIC_WEBPACK_PATH || '';
 
 if (nodeEnv === 'production') {
   baseConfig.mode = 'production';
@@ -179,7 +180,8 @@ module.exports = [
     },
     output: {
       filename: '[name].[chunkhash].js',
-      path: outputPath
+      path: outputPath,
+      publicPath: outputPublicPath
     },
     module: {
       rules: [{ test: /\.html$/, use: 'file-loader' }]

--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -14,7 +14,7 @@ const { ModuleFederationPlugin } = webpack.container;
 const packagePath: string = process.env.PACKAGE_PATH || '';
 const nodeEnv: string = process.env.NODE_ENV || '';
 const corePath: string = process.env.CORE_PATH || '';
-const outputPublicPath: string = process.env.PUBLIC_WEBPACK_PATH || '';
+const staticPath: string = process.env.STATIC_PATH || '';
 
 if (nodeEnv === 'production') {
   baseConfig.mode = 'production';
@@ -149,6 +149,7 @@ fs.copyFileSync(
 // into remoteEntry.js. We should either delete it, or figure out a way to
 // have the entry point below be dynamically generated text without having to
 // write to a file.
+const webpackPublicPathString = staticPath ? `"${staticPath}"` : `getOption('fullLabextensionsUrl') + '/${data.name}/'`;
 const publicpath = path.join(outputPath, 'publicPath.js');
 fs.writeFileSync(
   publicpath,
@@ -167,7 +168,7 @@ function getOption(name) {
 }
 
 // eslint-disable-next-line no-undef
-__webpack_public_path__ = getOption('fullLabextensionsUrl') + '/${data.name}/';
+__webpack_public_path__ = ${webpackPublicPathString};
 `
 );
 
@@ -181,7 +182,6 @@ module.exports = [
     output: {
       filename: '[name].[chunkhash].js',
       path: outputPath,
-      publicPath: outputPublicPath
     },
     module: {
       rules: [{ test: /\.html$/, use: 'file-loader' }]

--- a/jupyterlab/dynamic_labextensions.py
+++ b/jupyterlab/dynamic_labextensions.py
@@ -163,7 +163,7 @@ def develop_labextension_py(module, user=False, sys_prefix=False, overwrite=Fals
     return full_dests
 
 
-def build_labextension(path, logger=None):
+def build_labextension(path, logger=None, public_webpack_path=None):
     """Build a labextension in the given path"""
     core_path = osp.join(HERE, 'staging')
     ext_path = osp.abspath(path)
@@ -172,7 +172,12 @@ def build_labextension(path, logger=None):
         logger.info('Building extension in %s' % path)
 
     builder = _ensure_builder(ext_path, core_path)
-    subprocess.check_call(['node', builder, '--core-path', core_path,  ext_path], cwd=ext_path)
+
+    arguments = ['node', builder, '--core-path', core_path,  ext_path]
+    if public_webpack_path is not None:
+        arguments.extend(['--public-webpack-path', public_webpack_path])
+
+    subprocess.check_call(arguments, cwd=ext_path)
 
 
 def watch_labextension(path, app_dir=None, logger=None):

--- a/jupyterlab/dynamic_labextensions.py
+++ b/jupyterlab/dynamic_labextensions.py
@@ -163,7 +163,7 @@ def develop_labextension_py(module, user=False, sys_prefix=False, overwrite=Fals
     return full_dests
 
 
-def build_labextension(path, logger=None, public_webpack_path=None):
+def build_labextension(path, logger=None, static_path=None):
     """Build a labextension in the given path"""
     core_path = osp.join(HERE, 'staging')
     ext_path = osp.abspath(path)
@@ -174,8 +174,8 @@ def build_labextension(path, logger=None, public_webpack_path=None):
     builder = _ensure_builder(ext_path, core_path)
 
     arguments = ['node', builder, '--core-path', core_path,  ext_path]
-    if public_webpack_path is not None:
-        arguments.extend(['--public-webpack-path', public_webpack_path])
+    if static_path is not None:
+        arguments.extend(['--static-path', static_path])
 
     subprocess.check_call(arguments, cwd=ext_path)
 

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -193,9 +193,13 @@ class BuildLabExtensionApp(BaseExtensionApp):
     static_path = Unicode('', config=True,
         help="Sets the path for static assets when building")
 
+    aliases = {
+        'static-path': 'BuildLabExtensionApp.static_path'
+    }
+
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        build_labextension(self.extra_args[0], logger=self.log, static_path=self.static_path)
+        build_labextension(self.extra_args[0], logger=self.log, static_path=self.static_path or None)
 
 
 class WatchLabExtensionApp(BaseExtensionApp):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -190,9 +190,12 @@ class DevelopLabExtensionApp(BaseExtensionApp):
 class BuildLabExtensionApp(BaseExtensionApp):
     description = "Build labextension"
 
+    public_webpack_path = Unicode('', config=True,
+        help="Sets the base path for webpack to use for all app assets")
+
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        build_labextension(self.extra_args[0], logger=self.log)
+        build_labextension(self.extra_args[0], logger=self.log, public_webpack_path=self.public_webpack_path)
 
 
 class WatchLabExtensionApp(BaseExtensionApp):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -190,12 +190,12 @@ class DevelopLabExtensionApp(BaseExtensionApp):
 class BuildLabExtensionApp(BaseExtensionApp):
     description = "Build labextension"
 
-    public_webpack_path = Unicode('', config=True,
-        help="Sets the base path for webpack to use for all app assets")
+    static_path = Unicode('', config=True,
+        help="Sets the path for static assets when building")
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        build_labextension(self.extra_args[0], logger=self.log, public_webpack_path=self.public_webpack_path)
+        build_labextension(self.extra_args[0], logger=self.log, static_path=self.static_path)
 
 
 class WatchLabExtensionApp(BaseExtensionApp):

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -185,8 +185,10 @@ if [[ $GROUP == usage ]]; then
     # Test with a dynamic install
     jupyter labextension develop extension --debug
     jupyter labextension build extension
+    python -m jupyterlab.browser_check
     jupyter labextension list 1>labextensions 2>&1
     cat labextensions | grep "@jupyterlab/mock-extension.*enabled.*OK"
+    jupyter labextension build extension --static-path /foo/
     jupyter labextension disable @jupyterlab/mock-extension --debug
     jupyter labextension enable @jupyterlab/mock-extension --debug 
     jupyter labextension uninstall @jupyterlab/mock-extension --debug


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Updated the labextension build cli options to support `public_webpack_path`
- Update `build-extension.ts` script to support the `public_webpack_path` option and sets an environment variable for the webpack cli to use
- Update `webpack.config.ext.ts` to read in `PUBLIC_WEBPACK_PATH` from env variable and to set it on the webpack config output options

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
