### PR TITLE
Pull dynamic extension loading data from the webpack compilation

### DIFF
--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -182,7 +182,7 @@ module.exports = [
       [data.name]: publicpath
     },
     output: {
-      filename: '[name].[chunkhash].js',
+      filename: '[name].[contenthash].js',
       path: outputPath
     },
     module: {
@@ -195,7 +195,7 @@ module.exports = [
           type: 'var',
           name: ['_JUPYTERLAB', data.name]
         },
-        filename: 'remoteEntry.js',
+        filename: 'remoteEntry.[contenthash].js',
         exposes,
         shared
       })

--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -183,7 +183,7 @@ class CleanupPlugin {
       }
       const data = readJSONFile(path.join(outputPath, 'package.json'));
       const _build: any = {
-        load: path.basename(files[0]),
+        load: path.basename(files[0])
       };
       if (exposes['./extension'] !== undefined) {
         _build.extension = './extension';

--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -81,8 +81,8 @@ async function main() {
     PageConfig.getOption('dynamic_extensions')
   );
 
-  const dynamicPluginPromises = [];
-  const dynamicMimePluginPromises = [];
+  const dynamicExtensionPromises = [];
+  const dynamicMimeExtensionPromises = [];
   const dynamicStylePromises = [];
 
   // We first load all dynamic components so that the shared module
@@ -90,7 +90,7 @@ async function main() {
   // components should be actually used.
   const extensions = await Promise.allSettled(extension_data.map( async data => {
     await loadComponent(
-      `${URLExt.join(PageConfig.getOption('fullLabextensionsUrl'), data.name, 'remoteEntry.js')}`,
+      `${URLExt.join(PageConfig.getOption('fullLabextensionsUrl'), data.name, data.load)}`,
       data.name
     );
     return data;
@@ -104,11 +104,11 @@ async function main() {
     }
 
     const data = p.value;
-    if (data.plugin) {
-      dynamicPluginPromises.push(createModule(data.name, data.plugin));
+    if (data.extension) {
+      dynamicExtensionPromises.push(createModule(data.name, data.extension));
     }
-    if (data.mimePlugin) {
-      dynamicMimePluginPromises.push(createModule(data.name, data.mimePlugin));
+    if (data.mimeExtension) {
+      dynamicMimeExtensionPromises.push(createModule(data.name, data.mimeExtension));
     }
     if (data.style) {
       dynamicStylePromises.push(createModule(data.name, data.style));
@@ -158,8 +158,8 @@ async function main() {
   {{/each}}
 
   // Add the dynamic mime extensions.
-  const dynamicMimePlugins = await Promise.allSettled(dynamicMimePluginPromises);
-  dynamicMimePlugins.forEach(p => {
+  const dynamicMimeExtensions = await Promise.allSettled(dynamicMimeExtensionPromises);
+  dynamicMimeExtensions.forEach(p => {
     if (p.status === "fulfilled") {
       for (let plugin of activePlugins(p.value)) {
         mimeExtensions.push(plugin);
@@ -181,8 +181,8 @@ async function main() {
   {{/each}}
 
   // Add the dynamic extensions.
-  const dynamicPlugins = await Promise.allSettled(dynamicPluginPromises);
-  dynamicPlugins.forEach(p => {
+  const dynamicExtensions = await Promise.allSettled(dynamicExtensionPromises);
+  dynamicExtensions.forEach(p => {
     if (p.status === "fulfilled") {
       for (let plugin of activePlugins(p.value)) {
         register.push(plugin);

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -192,7 +192,6 @@ const plugins = [
     template: plib.join(__dirname, 'templates', 'template.html'),
     title: jlab.name || 'JupyterLab'
   }),
-  new webpack.ids.HashedModuleIdsPlugin(),
   // custom plugin for ignoring files during a `--watch` build
   new WPPlugin.FilterWatchIgnorePlugin(ignored),
   // custom plugin that copies the assets to the static directory
@@ -223,7 +222,7 @@ module.exports = [
     output: {
       path: plib.resolve(buildDir),
       publicPath: '{{page_config.fullStaticUrl}}/',
-      filename: '[name].[chunkhash].js'
+      filename: '[name].[contenthash].js'
     },
     optimization: {
       splitChunks: {

--- a/docs/source/developer/extension_dev.rst
+++ b/docs/source/developer/extension_dev.rst
@@ -38,9 +38,8 @@ Implementation
 - We provide a ``jupyter labextensions build`` script that is used to build bundles
   - The command produces a set of static assets that are shipped along with a package (notionally on ``pip``/``conda``)
   - It needs to be a Python cli so it can use the dependency metadata from the active JupyterLab
-  - The assets include a module federation ``remoteEntry.js``, generated bundles, and some other files that we use
-  - ``package.orig.json`` is the original ``package.json`` file that we use to gather metadata about the package
-  - ``build_log.json`` has all of the webpack options used to build the extension, for debugging purposes
+  - The assets include a module federation ``remoteEntry.*.js``, generated bundles, and some other files that we use
+  - ``package.json`` is the original ``package.json`` file that we use to gather metadata about the package, with some included build metadata
   - we use the existing ``@jupyterlab/builder -> build`` to generate the ``imports.css``, ``schemas`` and ``themes`` file structure
 - We add a schema for the valid ``jupyterlab`` metadata for an extension's ``package.json`` describing the available options
 - We add a ``labextensions`` handler in ``jupyterlab_server`` that loads static assets from ``labextensions`` paths, following a similar logic to how ``nbextensions`` are discovered and loaded from disk

--- a/examples/federated/core_package/index.js
+++ b/examples/federated/core_package/index.js
@@ -72,8 +72,8 @@ async function main() {
     PageConfig.getOption('dynamic_extensions')
   );
 
-  const dynamicPluginPromises = [];
-  const dynamicMimePluginPromises = [];
+  const dynamicExtensionPromises = [];
+  const dynamicMimeExtensionPromises = [];
   const dynamicStylePromises = [];
 
   // We first load all dynamic components so that the shared module
@@ -81,7 +81,7 @@ async function main() {
   // components should be actually used.
   const extensions = await Promise.allSettled(extension_data.map( async data => {
     await loadComponent(
-      `${URLExt.join(PageConfig.getOption('fullLabextensionsUrl'), data.name, 'remoteEntry.js')}`,
+      `${URLExt.join(PageConfig.getOption('fullLabextensionsUrl'), data.name, data.load)}`,
       data.name
     );
     return data;
@@ -95,11 +95,11 @@ async function main() {
     }
 
     const data = p.value;
-    if (data.plugin) {
-      dynamicPluginPromises.push(createModule(data.name, data.plugin));
+    if (data.extension) {
+      dynamicExtensionPromises.push(createModule(data.name, data.extension));
     }
-    if (data.mimePlugin) {
-      dynamicMimePluginPromises.push(createModule(data.name, data.mimePlugin));
+    if (data.mimeExtension) {
+      dynamicMimeExtensionPromises.push(createModule(data.name, data.mimeExtension));
     }
     if (data.style) {
       dynamicStylePromises.push(createModule(data.name, data.style));
@@ -149,8 +149,8 @@ async function main() {
   {{/each}}
 
   // Add the dynamic mime extensions.
-  const dynamicMimePlugins = await Promise.allSettled(dynamicMimePluginPromises);
-  dynamicMimePlugins.forEach(p => {
+  const dynamicMimeExtensions = await Promise.allSettled(dynamicMimeExtensionPromises);
+  dynamicMimeExtensions.forEach(p => {
     if (p.status === "fulfilled") {
       for (let plugin of activePlugins(p.value)) {
         mimeExtensions.push(plugin);
@@ -172,8 +172,8 @@ async function main() {
   {{/each}}
 
   // Add the dynamic extensions.
-  const dynamicPlugins = await Promise.allSettled(dynamicPluginPromises);
-  dynamicPlugins.forEach(p => {
+  const dynamicExtensions = await Promise.allSettled(dynamicExtensionPromises);
+  dynamicExtensions.forEach(p => {
     if (p.status === "fulfilled") {
       for (let plugin of activePlugins(p.value)) {
         register.push(plugin);

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1110,7 +1110,7 @@ class _AppHandler(object):
         dynamic_exts = dict()
         dynamic_ext_dirs = dict()
         for ext_dir in jupyter_path('labextensions'):
-            ext_pattern = ext_dir + '/**/package.orig.json'
+            ext_pattern = ext_dir + '/**/package.json'
             for ext_path in [path for path in glob(ext_pattern, recursive=True)]:
                 with open(ext_path) as fid:
                     data = json.load(fid)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -709,15 +709,17 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         info = get_app_info()
         extensions = page_config['dynamic_extensions'] = []
         for (ext, ext_data) in info.get('dynamic_exts', dict()).items():
+            extbuild = ext_data['_build']
             extension = {
-                'name': ext_data['name']
+                'name': ext_data['name'],
+                'load': extbuild['load']
             }
-            if ext_data['jupyterlab'].get('extension'):
-                extension['plugin'] = './extension'
-            if ext_data['jupyterlab'].get('mimeExtension'):
-                extension['mimePlugin'] = './mimeExtension'
-            if ext_data.get('style'):
-                extension['style'] = './style'
+            if 'extension' in extbuild:
+                extension['extension'] = extbuild['extension']
+            if 'mimeExtension' in extbuild:
+                extension['mimeExtension'] = extbuild['mimeExtension']
+            if 'style' in extbuild:
+                extension['style'] = extbuild['style']
             extensions.append(extension)
 
         # Update Jupyter Server's webapp settings with jupyterlab settings.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #8842

## Code changes

Tweaked the webpack config several ways:

1. Use the new content hashing algorithm and better default module id generation for file names.
2. Embed the information needed to load a dynamic extension in the extension's bundled package.json. This means we can change the build process and the generated build metadata will continue to tell the frontend how to load the extension.
3. Generate a content hash for remoteEntry so it can be cached.

## User-facing changes

Hopefully none

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
