### PR TITLE
Allow to substitute the default completer renderer

### DIFF
--- a/packages/completer-extension/src/index.ts
+++ b/packages/completer-extension/src/index.ts
@@ -88,11 +88,12 @@ const manager: JupyterFrontEndPlugin<ICompletionManager> = {
 
     return {
       register: (
-        completable: ICompletionManager.ICompletable
+        completable: ICompletionManager.ICompletable,
+        renderer: Completer.IRenderer = Completer.defaultRenderer
       ): ICompletionManager.ICompletableAttributes => {
         const { connector, editor, parent } = completable;
         const model = new CompleterModel();
-        const completer = new Completer({ editor, model });
+        const completer = new Completer({ editor, model, renderer });
         const handler = new CompletionHandler({
           completer,
           connector

--- a/packages/completer/src/tokens.ts
+++ b/packages/completer/src/tokens.ts
@@ -10,6 +10,7 @@ import { Token } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
 
 import { CompletionHandler } from './handler';
+import { Completer } from './widget';
 
 /* tslint:disable */
 /**
@@ -30,7 +31,8 @@ export interface ICompletionManager {
    * @returns A completable object whose attributes can be updated as necessary.
    */
   register(
-    completable: ICompletionManager.ICompletable
+    completable: ICompletionManager.ICompletable,
+    renderer?: Completer.IRenderer
   ): ICompletionManager.ICompletableAttributes;
 }
 


### PR DESCRIPTION
## References

Closes #8926. There are parts o the completer that cannot be changed via CSS (see https://github.com/krassowski/jupyterlab-lsp/pull/322#issuecomment-683094734). Substituting the default renderer seems like the best solution, but was not possible before without replacing all of the completer-extension (which would mean maintaining and syncing loots of unneeded code in extensions wanting to modify the completer looks).

## Code changes

Adds an optional renderer argument to the register method of `ICompletionManager` token.

## User-facing changes

None

## Backwards-incompatible changes

None