### PR TITLE
Fix link syntax in the apod tutorial

### DIFF
--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -937,12 +937,12 @@ works.
 Publishing your extension
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can publish your Python package to the [pypi](https://pypi.org/) or
-[conda-forge](https://conda-forge.org/) repositories so users can easily
+You can publish your Python package to the `PyPI <https://pypi.org>`_ or
+`conda-forge <https://conda-forge.org>`_ repositories so users can easily
 install the extension using ``pip`` or ``conda``.
 
 You may want to also publish your extension as a JavaScript package to the
-[npm](https://www.npmjs.com/) package repository for several reasons:
+`npm <https://www.npmjs.com>`_ package repository for several reasons:
 
 1. Distributing an extension as an npm package allows users to compile the
    extension into JupyterLab explicitly (similar to how was done in JupyterLab


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/8905

## Code changes

Documentation changes.

### Before

![image](https://user-images.githubusercontent.com/591645/91851993-6abce000-ec60-11ea-8b13-275065818d8d.png)


### After

![image](https://user-images.githubusercontent.com/591645/91851977-61cc0e80-ec60-11ea-869c-6cccf1dd7089.png)


## User-facing changes

None

## Backwards-incompatible changes

None