### PR TITLE
PR: Add a standalone TranslationManager to be used outside of jlab plugins

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -268,6 +268,12 @@ pkg:tooltip:
   - packages/tooltip-extension/**/*
   - packages/tooltip-extension/*
 
+pkg:translation:
+  - packages/translation/**/*
+  - packages/translation/*
+  - packages/translation-extension/**/*
+  - packages/translation-extension/*
+
 pkg:ui-components:
   - packages/ui-components/**/*
   - packages/ui-components/*

--- a/packages/translation/src/index.ts
+++ b/packages/translation/src/index.ts
@@ -4,5 +4,6 @@
 // Note: keep in alphabetical order...
 export * from './base';
 export * from './gettext';
+export * from './manager';
 export * from './server';
 export * from './tokens';

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { Gettext } from './gettext';
+import { ITranslator, TranslationBundle, TranslatorConnector } from './tokens';
+
+/**
+ * Translation Manager
+ */
+class TranslationManager implements ITranslator {
+  constructor() {
+    this._connector = new TranslatorConnector();
+  }
+
+  /**
+   * Fetch the localization data from the server.
+   *
+   * @param locale The language locale to use for translations.
+   */
+  async fetch(locale: string) {
+    this._currentLocale = locale;
+    this._languageData = await this._connector.fetch({ language: locale });
+    this._domainData = this._languageData?.data || {};
+    const message: string = this._languageData?.message;
+    if (message && locale !== 'en') {
+      console.warn(message);
+    }
+  }
+
+  /**
+   * Load translation bundles for a given domain.
+   *
+   * @param domain The translation domain to use for translations.
+   */
+  load(domain: string): TranslationBundle {
+    if (this._domainData) {
+      if (this._currentLocale == 'en') {
+        return this._englishBundle;
+      } else {
+        if (!(domain in this._translationBundles)) {
+          let translationBundle = new Gettext({
+            domain: domain,
+            locale: this._currentLocale
+          });
+          if (domain in this._domainData) {
+            let metadata = this._domainData[domain][''];
+            if ('plural_forms' in metadata) {
+              metadata.pluralForms = metadata.plural_forms;
+              delete metadata.plural_forms;
+              this._domainData[domain][''] = metadata;
+            }
+            translationBundle.loadJSON(this._domainData[domain], domain);
+          }
+          this._translationBundles[domain] = translationBundle;
+        }
+        return this._translationBundles[domain];
+      }
+    } else {
+      return this._englishBundle;
+    }
+  }
+
+  private _connector: TranslatorConnector;
+  private _currentLocale: string;
+  private _domainData: any = {};
+  private _englishBundle = new Gettext();
+  private _languageData: any;
+  private _translationBundles: any = {};
+}
+
+export { TranslationManager };

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -7,7 +7,7 @@ import { ITranslator, TranslationBundle, TranslatorConnector } from './tokens';
 /**
  * Translation Manager
  */
-class TranslationManager implements ITranslator {
+export class TranslationManager implements ITranslator {
   constructor() {
     this._connector = new TranslatorConnector();
   }
@@ -67,5 +67,3 @@ class TranslationManager implements ITranslator {
   private _languageData: any;
   private _translationBundles: any = {};
 }
-
-export { TranslationManager };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds a standalone TranslationManager so examples in the repo that do not rely on plugins can use translations.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
