### PR TITLE
PR: Add options to add prefix to strings

### DIFF
--- a/packages/translation-extension/schema/plugin.json
+++ b/packages/translation-extension/schema/plugin.json
@@ -10,6 +10,18 @@
       "title": "Language locale",
       "description": "Set the interface display language. Examples: 'es_CO', 'fr'.",
       "default": "en"
+    },
+    "stringsPrefix": {
+      "type": "string",
+      "title": "Localized strings prefix",
+      "description": "Add a prefix to localized strings.",
+      "default": "!!"
+    },
+    "displayStringsPrefix": {
+      "type": "boolean",
+      "title": "Display localized strings prefix",
+      "description": "Display the `stringsPrefix` on localized strings.",
+      "default": false
     }
   }
 }

--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -54,7 +54,12 @@ const translator: JupyterFrontEndPlugin<ITranslator> = {
   activate: async (app: JupyterFrontEnd, settings: ISettingRegistry) => {
     const setting = await settings.load(PLUGIN_ID);
     const currentLocale: string = setting.get('locale').composite as string;
-    const translationManager = new TranslationManager();
+    let stringsPrefix: string = setting.get('stringsPrefix')
+      .composite as string;
+    const displayStringsPrefix: boolean = setting.get('displayStringsPrefix')
+      .composite as boolean;
+    stringsPrefix = displayStringsPrefix ? stringsPrefix : '';
+    const translationManager = new TranslationManager(stringsPrefix);
     await translationManager.fetch(currentLocale);
     return translationManager;
   }

--- a/packages/translation/src/gettext.ts
+++ b/packages/translation/src/gettext.ts
@@ -92,6 +92,11 @@ interface IOptions {
   pluralForms?: string;
 
   /**
+   * The string prefix to add to localized strings.
+   */
+  stringsPrefix?: string;
+
+  /**
    * Plural form function.
    */
   pluralFunc?: PluralForm;
@@ -132,7 +137,8 @@ class Gettext {
       pluralFunc: function (n: number) {
         return { nplurals: 2, plural: n != 1 ? 1 : 0 };
       },
-      contextDelimiter: String.fromCharCode(4) // \u0004
+      contextDelimiter: String.fromCharCode(4), // \u0004
+      stringsPrefix: ''
     };
 
     // Ensure the correct separator is used
@@ -140,6 +146,7 @@ class Gettext {
     this._domain = options.domain || this._defaults.domain;
     this._contextDelimiter =
       options.contextDelimiter || this._defaults.contextDelimiter;
+    this._stringsPrefix = options.stringsPrefix || this._defaults.stringsPrefix;
     this._pluralFuncs = {};
     this._dictionary = {};
     this._pluralForms = {};
@@ -206,6 +213,24 @@ class Gettext {
    */
   getDomain(): string {
     return this._domain;
+  }
+
+  /**
+   * Set current strings prefix.
+   *
+   * @param prefix - The string prefix to set.
+   */
+  setStringsPrefix(prefix: string): void {
+    this._stringsPrefix = prefix;
+  }
+
+  /**
+   * Get current strings prefix.
+   *
+   * @return The strings prefix.
+   */
+  getStringsPrefix(): string {
+    return this._stringsPrefix;
   }
 
   /**
@@ -563,7 +588,10 @@ class Gettext {
   ): string {
     // Singular is very easy, just pass dictionary message through strfmt
     if (!options.pluralForm)
-      return Gettext.strfmt(this.removeContext(messages[0]), ...args);
+      return (
+        this._stringsPrefix +
+        Gettext.strfmt(this.removeContext(messages[0]), ...args)
+      );
 
     let plural;
 
@@ -591,9 +619,12 @@ class Gettext {
     )
       plural.plural = 0;
 
-    return Gettext.strfmt(
-      this.removeContext(messages[plural.plural]),
-      ...[n].concat(args)
+    return (
+      this._stringsPrefix +
+      Gettext.strfmt(
+        this.removeContext(messages[plural.plural]),
+        ...[n].concat(args)
+      )
     );
   }
 
@@ -621,6 +652,7 @@ class Gettext {
     this._dictionary[domain][locale] = messages;
   }
 
+  private _stringsPrefix: string;
   private _pluralForms: any;
   private _dictionary: any;
   private _locale: string;

--- a/packages/translation/src/manager.ts
+++ b/packages/translation/src/manager.ts
@@ -8,8 +8,10 @@ import { ITranslator, TranslationBundle, TranslatorConnector } from './tokens';
  * Translation Manager
  */
 export class TranslationManager implements ITranslator {
-  constructor() {
+  constructor(stringsPrefix?: string) {
     this._connector = new TranslatorConnector();
+    this._stringsPrefix = stringsPrefix || '';
+    this._englishBundle = new Gettext({ stringsPrefix: this._stringsPrefix });
   }
 
   /**
@@ -40,7 +42,8 @@ export class TranslationManager implements ITranslator {
         if (!(domain in this._translationBundles)) {
           let translationBundle = new Gettext({
             domain: domain,
-            locale: this._currentLocale
+            locale: this._currentLocale,
+            stringsPrefix: this._stringsPrefix
           });
           if (domain in this._domainData) {
             let metadata = this._domainData[domain][''];
@@ -63,7 +66,8 @@ export class TranslationManager implements ITranslator {
   private _connector: TranslatorConnector;
   private _currentLocale: string;
   private _domainData: any = {};
-  private _englishBundle = new Gettext();
+  private _englishBundle: Gettext;
   private _languageData: any;
+  private _stringsPrefix: string;
   private _translationBundles: any = {};
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Adds some settings to the Translation-extension package so it is easier to debug localizing strings.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

Adds some options to the Translation-extension package so it is easier to debug localizing strings.

<img width="1440" alt="Screen Shot 2020-09-01 at 21 08 39" src="https://user-images.githubusercontent.com/3627835/91923997-4fb99280-ec97-11ea-9ad5-6404c5391ba8.png">


<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None