### PR TITLE
Add extension upgrade script

### DIFF
--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -172,13 +172,13 @@ class CleanupPlugin {
     compiler.hooks.done.tap('Cleanup', () => {
       // Find the remoteEntry file and add it to the package.json metadata
       const files = glob.sync(path.join(outputPath, 'remoteEntry.*.js'));
-      let bestTime = -1;
+      let newestTime = -1;
       let newestRemote = '';
       files.forEach(fpath => {
         const mtime = fs.statSync(fpath).mtime.getTime();
-        if (mtime > bestTime) {
+        if (mtime > newestTime) {
           newestRemote = fpath;
-          bestTime = mtime;
+          newestTime = mtime;
         }
       });
       const data = readJSONFile(path.join(outputPath, 'package.json'));

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -27,7 +27,7 @@ import warnings
 
 from jupyter_core.paths import jupyter_config_path, jupyter_path
 from jupyterlab_server.process import which, Process, WatchHelper, list2cmdline
-from jupyterlab_server.config import LabConfig, get_page_config, get_dynamic_extensions, get_static_page_config
+from jupyterlab_server.config import LabConfig, get_page_config, get_dynamic_extensions, get_static_page_config, write_page_config
 from notebook.nbextensions import GREEN_ENABLED, GREEN_OK, RED_DISABLED, RED_X
 from traitlets import HasTraits, Bool, Dict, Instance, List, Unicode, default
 

--- a/jupyterlab/dynamic_labextensions.py
+++ b/jupyterlab/dynamic_labextensions.py
@@ -27,10 +27,11 @@ from jupyter_core.utils import ensure_dir_exists
 from ipython_genutils.py3compat import string_types, cast_unicode_py2
 from ipython_genutils.tempdir import TemporaryDirectory
 from jupyter_server.config_manager import BaseJSONConfigManager
+from jupyterlab_server.config import get_dynamic_extensions
 
 from traitlets.utils.importstring import import_item
 
-from .commands import build, AppOptions, _test_overlap, _get_dynamic_extensions
+from .commands import build, AppOptions, _test_overlap
 
 
 DEPRECATED_ARGUMENT = object()
@@ -182,7 +183,7 @@ def build_labextension(path, logger=None, development=False, static_url=None):
     subprocess.check_call(arguments, cwd=ext_path)
 
 
-def watch_labextension(path, logger=None, development=True):
+def watch_labextension(path, labextensions_path, logger=None, development=True):
     """Watch a labextension in a given path"""
     core_path = osp.join(HERE, 'staging')
     ext_path = osp.abspath(path)
@@ -191,7 +192,7 @@ def watch_labextension(path, logger=None, development=True):
         logger.info('Building extension in %s' % path)
 
     # Check to see if we need to create a symlink
-    dynamic_ext_dirs, dynamic_exts = _get_dynamic_extensions()
+    dynamic_exts = get_dynamic_extensions(labextensions_path)
 
     with open(pjoin(ext_path, 'package.json')) as fid:
         ext_data = json.load(fid)

--- a/jupyterlab/dynamic_labextensions.py
+++ b/jupyterlab/dynamic_labextensions.py
@@ -30,7 +30,7 @@ from jupyter_server.config_manager import BaseJSONConfigManager
 
 from traitlets.utils.importstring import import_item
 
-from .commands import build, AppOptions, _test_overlap
+from .commands import build, AppOptions, _test_overlap, _get_dynamic_extensions
 
 
 DEPRECATED_ARGUMENT = object()
@@ -182,7 +182,7 @@ def build_labextension(path, logger=None, development=False, static_url=None):
     subprocess.check_call(arguments, cwd=ext_path)
 
 
-def watch_labextension(path, logger=None, development=False):
+def watch_labextension(path, logger=None, development=True):
     """Watch a labextension in a given path"""
     core_path = osp.join(HERE, 'staging')
     ext_path = osp.abspath(path)
@@ -190,11 +190,27 @@ def watch_labextension(path, logger=None, development=False):
     if logger:
         logger.info('Building extension in %s' % path)
 
+    # Check to see if we need to create a symlink
+    dynamic_ext_dirs, dynamic_exts = _get_dynamic_extensions()
+
+    with open(pjoin(ext_path, 'package.json')) as fid:
+        ext_data = json.load(fid)
+    
+    os.makedirs(ext_data['jupyterlab']['outputDir'], exist_ok=True)
+
+    if ext_data['name'] not in dynamic_exts:
+        full_dest = develop_labextension(ext_path, sys_prefix=True)
+    else:
+        full_dest = pjoin(dynamic_exts[ext_data['name']]['ext_dir'], ext_data['name'])
+        if not osp.islink(full_dest):
+            shutil.rmtree(full_dest)
+            os.symlink(ext_path, full_dest)
+
+    builder = _ensure_builder(ext_path, core_path)
     arguments = ['node', builder, '--core-path', core_path,  '--watch', ext_path]
     if development:
         arguments.append('--development')
 
-    builder = _ensure_builder(ext_path, core_path)
     subprocess.check_call(arguments, cwd=ext_path)
 
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -28,7 +28,7 @@ from .debuglog import DebugLogFileMixin
 from .commands import (
     DEV_DIR, HERE,
     build, clean, get_app_dir, get_app_version, get_user_settings_dir,
-    get_workspaces_dir, AppOptions, pjoin, get_app_info, get_page_config,
+    get_workspaces_dir, AppOptions, pjoin, get_app_info,
     ensure_core, ensure_dev, watch, watch_dev, ensure_app
 )
 from .coreconfig import CoreConfig
@@ -636,11 +636,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         handlers = []
 
         # Set config for Jupyterlab
-        page_config_settings = self.serverapp.web_app.settings.setdefault('page_config_data', {})
-        page_config_options = AppOptions(logger=self.log, app_dir=self.app_dir)
-        page_config = get_page_config(app_options=page_config_options)
-        recursive_update(page_config, page_config_settings)
-
+        page_config = self.serverapp.web_app.settings.setdefault('page_config_data', {})
         page_config.setdefault('buildAvailable', not self.core_mode and not self.dev_mode)
         page_config.setdefault('buildCheck', not self.core_mode and not self.dev_mode)
         page_config['devMode'] = self.dev_mode

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -209,7 +209,10 @@ class WatchLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        watch_labextension(self.extra_args[0], logger=self.log, development=self.development)
+        # TODO: get the config for labextensions paths from LabApp
+        from jupyter_core.paths import jupyter_path
+        labextensions_path = jupyter_path('labextensions')
+        watch_labextension(self.extra_args[0], labextensions_path, logger=self.log, development=self.development)
 
 
 class UpdateLabExtensionApp(BaseExtensionApp):
@@ -298,8 +301,12 @@ class ListLabExtensionsApp(BaseExtensionApp):
     description = "List the installed labextensions"
 
     def run_task(self):
+        # TODO: get the config for labextensions paths from LabApp
+        import pdb; pdb.set_trace()
+        from jupyter_core.paths import jupyter_path
+        labextensions_path = jupyter_path('labextensions')
         list_extensions(app_options=AppOptions(
-            app_dir=self.app_dir, logger=self.log, core_config=self.core_config))
+            app_dir=self.app_dir, logger=self.log, core_config=self.core_config, labextensions_path=labextensions_path))
 
 
 class EnableLabExtensionsApp(BaseExtensionApp):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -204,7 +204,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
 class WatchLabExtensionApp(BaseExtensionApp):
     description = "Watch labextension"
 
-    development = Bool(False, config=True,
+    development = Bool(True, config=True,
         help="Build in development mode")
 
     def run_task(self):

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -14,7 +14,8 @@ from copy import copy
 
 from jupyter_core.application import JupyterApp, base_flags, base_aliases
 from jupyter_core.paths import jupyter_path
-
+from jupyterlab.coreconfig import CoreConfig
+from jupyterlab.debuglog import DebugLogFileMixin
 from traitlets import Bool, Instance, Unicode
 
 from .commands import (
@@ -23,10 +24,8 @@ from .commands import (
     link_package, unlink_package, build, get_app_version, HERE,
     update_extension, AppOptions,
 )
-from jupyterlab.coreconfig import CoreConfig
-from jupyterlab.debuglog import DebugLogFileMixin
-
 from .dynamic_labextensions import develop_labextension_py, build_labextension, watch_labextension
+from .labapp import LabApp
 
 
 flags = dict(base_flags)
@@ -209,9 +208,10 @@ class WatchLabExtensionApp(BaseExtensionApp):
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        # TODO: get the config for labextensions paths from LabApp
-        from jupyter_core.paths import jupyter_path
-        labextensions_path = jupyter_path('labextensions')
+        # Get the labextensions path config from the LabApp
+        lab = LabApp()
+        lab.load_config_file()
+        labextensions_path = lab.extra_labextensions_path + lab.labextensions_path
         watch_labextension(self.extra_args[0], labextensions_path, logger=self.log, development=self.development)
 
 
@@ -301,10 +301,10 @@ class ListLabExtensionsApp(BaseExtensionApp):
     description = "List the installed labextensions"
 
     def run_task(self):
-        # TODO: get the config for labextensions paths from LabApp
-        import pdb; pdb.set_trace()
-        from jupyter_core.paths import jupyter_path
-        labextensions_path = jupyter_path('labextensions')
+        # Get the labextensions path config from the LabApp
+        lab = LabApp()
+        lab.load_config_file()
+        labextensions_path = lab.extra_labextensions_path + lab.labextensions_path
         list_extensions(app_options=AppOptions(
             app_dir=self.app_dir, logger=self.log, core_config=self.core_config, labextensions_path=labextensions_path))
 

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -16,7 +16,7 @@ from jupyter_core.application import JupyterApp, base_flags, base_aliases
 from jupyter_core.paths import jupyter_path
 from jupyterlab.coreconfig import CoreConfig
 from jupyterlab.debuglog import DebugLogFileMixin
-from traitlets import Bool, Instance, Unicode
+from traitlets import Bool, Instance, Unicode, default
 
 from .commands import (
     install_extension, uninstall_extension, list_extensions,

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -16,7 +16,7 @@ from jupyter_core.application import JupyterApp, base_flags, base_aliases
 from jupyter_core.paths import jupyter_path
 from jupyterlab.coreconfig import CoreConfig
 from jupyterlab.debuglog import DebugLogFileMixin
-from traitlets import Bool, Instance, Unicode, default
+from traitlets import Bool, Instance, List, Unicode, default
 
 from .commands import (
     install_extension, uninstall_extension, list_extensions,
@@ -97,6 +97,8 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
 
     should_clean = Bool(False, config=True,
         help="Whether temporary files should be cleaned up after building jupyterlab")
+
+    labextensions_path = List(Unicode(), help='The standard paths to look in for dynamic JupyterLab extensions')
 
     @default('labextensions_path')
     def _default_labextensions_path(self):

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -105,7 +105,8 @@ def update_extension(target, interactive=True):
         data.setdefault('scripts', dict())
         for (key, value) in temp_data['scripts'].items():
             data['scripts'][key] = value
-        del data['scripts']['install-ext']
+        if 'install-ext' in data['scripts']:
+            del data['scripts']['install-ext']
     else:
         warnings.append('package.json scripts must be updated manually')
 

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -7,6 +7,11 @@ import shutil
 import sys
 import subprocess
 
+try:
+    import cookiecutter
+except ImportError:
+    raise RuntimeError("Please install cookiecutter")
+
 
 COOKIECUTTER_BRANCH = "3.0"
 

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -87,6 +87,7 @@ def update_extension(target, interactive=True):
         choice = 'y'
     if choice.upper().startswith('Y'):
         warnings.append('Updated scripts in package.json')
+        data.setdefault('scripts', dict())
         for (key, value) in temp_data['scripts'].items():
             data['scripts'][key] = value
     else:
@@ -100,6 +101,8 @@ def update_extension(target, interactive=True):
     with open(root_jlab_package) as fid:
         root_jlab_data = json.load(fid)
     
+    data.setdefault('dependencies', dict())
+    data.setdefault('devDependencies', dict())
     for (key, value) in root_jlab_data['resolutions'].items():
         if key in data['dependencies']:
             data['dependencies'][key] = value
@@ -108,8 +111,11 @@ def update_extension(target, interactive=True):
 
     # Sort the entries
     for key in ['scripts', 'dependencies', 'devDependencies']:
-        data[key] = dict(sorted(data[key].items()))
-
+        if data[key]:
+            data[key] = dict(sorted(data[key].items()))
+        else:
+            del data[key]
+            
     # Update the root package.json file
     with open(package_file, 'w') as fid:
         json.dump(data, fid, indent=2)

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -1,0 +1,163 @@
+import json
+import os
+import os.path as osp
+from pathlib import Path
+import pkg_resources
+import shutil
+import sys
+import subprocess
+
+
+COOKIECUTTER_BRANCH = "3.0"
+
+
+def update_extension(target, interactive=True):
+    """Update an extension to the current JupyterLab
+
+    target: str 
+        Path to the extension directory containing the extension
+    interactive: bool [default: true]
+        Whether to ask before overwriting content
+    
+    """
+    # Input is a directory with a package.json or the current directory
+    # Use the cookiecutter as the source
+    # Pull in the relevant config
+    # Pull in the Python parts if possible
+    # Pull in the scripts if possible
+    target = osp.abspath(target)
+    package_file = osp.join(target, 'package.json')
+    setup_file = osp.join(target, 'setup.py')
+    if not osp.exists(package_file):
+        raise RuntimeError('No package.json exists in %s' % target)
+
+    # Infer the options from the current directory
+    with open(package_file) as fid:
+        data = json.load(fid)
+    
+    if osp.exists(setup_file):
+        python_name = subprocess.check_output([sys.executable, 'setup.py', '--name'], cwd=target).decode('utf8').strip()
+    else:
+        python_name = data['name']
+        if '@' in python_name:
+            python_name = python_name[1:].replace('/', '_')
+    
+    arg_data = dict(
+        author_name = data.get('author', '<author_name>'),
+        labextension_name = data['name'],
+        project_short_description = data.get('description', '<description>'),
+        has_server_extension = 'y' if osp.exists(setup_file) else 'n',
+        has_binder = 'y' if osp.exists(osp.join(target, 'binder')) else 'n',
+        repository = data.get('repository', {}).get('url', '<repository'),
+        python_name = python_name
+    )
+
+    args = ['%s=%s' % (key, value) for (key, value) in arg_data.items()]
+    repo = 'https://github.com/jupyterlab/extension-cookiecutter-ts'
+
+    extension_dir = osp.join(target, '_temp_extension')
+    if osp.exists(extension_dir):
+        shutil.rmtree(extension_dir)
+
+    if not interactive:
+        args.append('--no-input')
+
+    subprocess.run(['cookiecutter', repo, '--checkout', COOKIECUTTER_BRANCH, '-o', extension_dir] + args, cwd=target)
+
+    python_name = os.listdir(extension_dir)[0]
+    extension_dir = osp.join(extension_dir, python_name)
+
+    # From the created package.json, grab the builder dependency
+    with open(osp.join(extension_dir, 'package.json')) as fid:
+        temp_data = json.load(fid)
+    
+    for (key, value) in temp_data['devDependencies'].items():
+        data['devDependencies'][key] = value
+
+    # Ask the user whether to upgrade the scripts automatically
+    warnings = []
+    if interactive:
+        choice = input('overwrite scripts in package.json? [n]: ')
+    else:
+        choice = 'y'
+    if choice.upper().startswith('Y'):
+        warnings.append('Updated scripts in package.json')
+        for (key, value) in temp_data['scripts'].items():
+            data['scripts'][key] = value
+    else:
+        warnings.append('package.json scripts must be updated manually')
+
+    # Set the output directory
+    data['jupyterlab']['outputDir'] = python_name + '/static'
+
+    # Look for resolutions in JupyterLab metadata and upgrade those as well
+    root_jlab_package = pkg_resources.resource_filename('jupyterlab', 'staging/package.json')
+    with open(root_jlab_package) as fid:
+        root_jlab_data = json.load(fid)
+    
+    for (key, value) in root_jlab_data['resolutions'].items():
+        if key in data['dependencies']:
+            data['dependencies'][key] = value
+        if key in data['devDependencies']:
+            data['devDependences'][key] = value
+
+    # Sort the entries
+    for key in ['scripts', 'dependencies', 'devDependencies']:
+        data[key] = dict(sorted(data[key].items()))
+
+    # Update the root package.json file
+    with open(package_file, 'w') as fid:
+        json.dump(data, fid, indent=2)
+
+    # For the other files, ask about whether to override (when it exists)
+    # At the end, list the files that were: added, overridden, skipped
+    path = Path(extension_dir)
+    for p in path.rglob("*"):
+        relpath = osp.relpath(p, path)
+        if relpath == "package.json":
+            continue
+        if p.is_dir():
+            continue
+        file_target = osp.join(target, relpath)
+        if not osp.exists(file_target):
+            os.makedirs(osp.dirname(file_target), exist_ok=True)
+            shutil.copy(p, file_target)
+        else:
+            with open(p) as fid:
+                old_data = fid.read()
+            with open(file_target) as fid:
+                new_data = fid.read()
+            if old_data == new_data:
+                continue
+            if interactive:
+                choice = input('overwrite "%s"? [n]: ' % relpath)
+            else:
+                choice = 'y'
+            if choice.upper().startswith('Y'):
+                shutil.copy(p, file_target)
+            else:
+                warnings.append('skipped %s' % relpath)
+
+    # Print out all warnings
+    for warning in warnings:
+        print('**', warning)
+
+    print('** Remove _temp_extensions directory when finished')
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='Upgrade a JupyterLab extension')
+
+    parser.add_argument('--no-input',
+                       action='store_true',
+                       help='whether to prompt for information')
+
+    parser.add_argument('path',
+                       action='store',
+                       type=str,
+                       help='the target path')
+
+    args = parser.parse_args()
+
+    update_extension(args.path, args.no_input==False)

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -90,6 +90,7 @@ def update_extension(target, interactive=True):
         data.setdefault('scripts', dict())
         for (key, value) in temp_data['scripts'].items():
             data['scripts'][key] = value
+        del data['scripts']['install-ext']
     else:
         warnings.append('package.json scripts must be updated manually')
 

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -229,6 +229,7 @@ if [[ $GROUP == usage ]]; then
     jlpm run get:dependency react-native
 
     # Use the extension upgrade script
+    pip install cookiecutter
     python -m jupyterlab.upgrade_extension --no-input jupyterlab/tests/mock_packages/extension
 
     # Test theme creation - make sure we can add it as a package, build,

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -228,6 +228,9 @@ if [[ $GROUP == usage ]]; then
     jlpm run get:dependency typescript
     jlpm run get:dependency react-native
 
+    # Use the extension upgrade script
+    python -m jupyterlab.upgrade_extension --no-input jupyterlab/tests/mock_packages/extension
+
     # Test theme creation - make sure we can add it as a package, build,
     # and run browser
     pip install -q pexpect

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'ipython',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
-    'jupyterlab_server~=2.0.0b5',
+    'jupyterlab_server~=2.0.0b7',
     'jupyter_server~=1.0.0rc13',
     'nbclassic~=0.2.0rc4',
     'jinja2>=2.10'


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes #8870 
Fixes #8869 
Relies on https://github.com/jupyterlab/jupyterlab_server/pull/123

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Adds a script for extension authors `python -m jupyterlab.upgrade_extension` to automatically upgrade their scripts.
They are prompted before files are overwritten.
- Fixes handling of watch mode and makes watch mode easier for extension authors

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Easier for extension authors to upgrade their scripts.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
