### PR TITLE
security docs: link to jupyter-server instead of jupyter-noteboook

### DIFF
--- a/docs/source/getting_started/starting.rst
+++ b/docs/source/getting_started/starting.rst
@@ -36,5 +36,5 @@ from ``/lab`` to ``/tree``.
 
 JupyterLab has the same security model as the classic Jupyter Notebook;
 for more information see the `security
-section <https://jupyter-notebook.readthedocs.io/en/stable/security.html>`__
+section <https://jupyter-server.readthedocs.io/en/stable/operators/security.html>`__
 of the classic Notebook's documentation.

--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -160,7 +160,7 @@ export interface IBaseCellMetadata extends PartialJSONObject {
    * This is not strictly part of the nbformat spec, but it is added by
    * the contents manager.
    *
-   * See https://jupyter-notebook.readthedocs.io/en/latest/security.html.
+   * See https://jupyter-server.readthedocs.io/en/latest/operators/security.html.
    */
   trusted: boolean;
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1393,7 +1393,7 @@ export namespace NotebookActions {
         )}
         <br />
         {trans.__(
-          'For more information, see the <a href="https://jupyter-notebook.readthedocs.io/en/stable/security.html">%1</a>',
+          'For more information, see the <a href="https://jupyter-server.readthedocs.io/en/stable/operators/security.html">%1</a>',
           trans.__('Jupyter security documentation')
         )}
       </p>


### PR DESCRIPTION
More work for https://github.com/jupyterlab/jupyterlab/issues/8856

This simply update the links in `docs/source/getting_started/starting.rst` and `packages/notebook/src/actions.tsx` to point to jupyter_server RTD webiste instead of notebook RTD.