### PR TITLE
Fix the Table of Contents header styling

### DIFF
--- a/packages/toc/style/index.css
+++ b/packages/toc/style/index.css
@@ -38,7 +38,7 @@
   flex-direction: column;
   background: var(--jp-layout-color1);
   color: var(--jp-ui-font-color1);
-  font-size: var(--jp-ui-font-size0);
+  font-size: var(--jp-ui-font-size1);
   height: 100%;
 }
 
@@ -49,7 +49,7 @@
   font-weight: 600;
   letter-spacing: 1px;
   margin: 0px;
-  padding: 12px 0 4px 12px;
+  padding: 8px 12px;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

## Code changes

Ad-hoc CSS change to make the table of contents header look similar to the other headers.

## User-facing changes

### Before

![toc-header-before](https://user-images.githubusercontent.com/591645/92924484-52f01380-f439-11ea-8fb1-c3ef8c7dc637.gif)

### After

![toc-header-after](https://user-images.githubusercontent.com/591645/92924488-55526d80-f439-11ea-8690-438be17867af.gif)

## Backwards-incompatible changes

None
