### PR TITLE
Show the debugger toggle button before restoring the state

### DIFF
--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -298,8 +298,8 @@ export class DebuggerHandler {
         : null;
       this._service.session.connection = connection;
     }
-    await this._service.restoreState(false);
     addToolbarButton();
+    await this._service.restoreState(false);
 
     // check the state of the debug session
     if (!this._service.isStarted) {


### PR DESCRIPTION
## References

Port of https://github.com/jupyterlab/debugger/pull/539

## Code changes

Given a kernel that supports debugging, this change switches the order of the two following actions:

- restore the state using the `debugInfo` request
- add the button to the notebook toolbar

This makes it easier for kernel authors that are progressively implementing the protocol to see that the kernel is correctly supported by the debugger extension.

Otherwise we would wait for the response here:

https://github.com/jupyterlab/jupyterlab/blob/f29e2f4b37e15465d324c4fc632e31a083a41c60/packages/debugger/src/handler.ts#L301

And never show the button.

With this change, the button can be displayed in the toolbar:

![image](https://user-images.githubusercontent.com/591645/92914976-6943a280-f42c-11ea-91e8-84d6bab036c1.png)

Even though the `debugInfo` request has not been implemented yet:

![image](https://user-images.githubusercontent.com/591645/92915024-7791be80-f42c-11ea-98ad-041665df2206.png)

## User-facing changes

None

## Backwards-incompatible changes

None
