### PR TITLE
Add debugger to the GitHub labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -84,6 +84,12 @@ pkg:csvviewer:
   - packages/csvviewer-extension/**/*
   - packages/csvviewer-extension/*
 
+pkg:debugger:
+  - packages/debugger/**/*
+  - packages/debugger/*
+  - packages/debugger-extension/**/*
+  - packages/debugger-extension/*
+
 pkg:docmanager:
   - packages/docmanager/**/*
   - packages/docmanager/*


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Looks like the GitHub labeler config was missing information about the `debugger` extension.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None