### PR TITLE
Do not show Dialog If It Has Been Disposed

### DIFF
--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -153,6 +153,10 @@ export class Dialog<T> extends Widget {
     const promises = Promise.all(Private.launchQueue);
     Private.launchQueue.push(this._promise.promise);
     return promises.then(() => {
+      // Do not show Dialog if it was disposed of before it was at the front of the launch queue
+      if (!this._promise){
+        return;
+      }
       Widget.attach(this, this._host);
       return promise.promise;
     });

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -155,7 +155,7 @@ export class Dialog<T> extends Widget {
     return promises.then(() => {
       // Do not show Dialog if it was disposed of before it was at the front of the launch queue
       if (!this._promise) {
-        return Promise.resolve({button: Dialog.cancelButton(), value: null});
+        return Promise.resolve({ button: Dialog.cancelButton(), value: null });
       }
       Widget.attach(this, this._host);
       return promise.promise;

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -144,7 +144,7 @@ export class Dialog<T> extends Widget {
    *
    * @returns a promise that resolves with the result of the dialog.
    */
-  launch(): Promise<Dialog.IResult<T> | undefined> {
+  launch(): Promise<Dialog.IResult<T>> {
     // Return the existing dialog if already open.
     if (this._promise) {
       return this._promise.promise;
@@ -155,7 +155,7 @@ export class Dialog<T> extends Widget {
     return promises.then(() => {
       // Do not show Dialog if it was disposed of before it was at the front of the launch queue
       if (!this._promise) {
-        return;
+        return Promise.resolve({button: Dialog.cancelButton(), value: null});
       }
       Widget.attach(this, this._host);
       return promise.promise;

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -144,7 +144,7 @@ export class Dialog<T> extends Widget {
    *
    * @returns a promise that resolves with the result of the dialog.
    */
-  launch(): Promise<Dialog.IResult<T>> {
+  launch(): Promise<Dialog.IResult<T> | undefined> {
     // Return the existing dialog if already open.
     if (this._promise) {
       return this._promise.promise;
@@ -154,7 +154,7 @@ export class Dialog<T> extends Widget {
     Private.launchQueue.push(this._promise.promise);
     return promises.then(() => {
       // Do not show Dialog if it was disposed of before it was at the front of the launch queue
-      if (!this._promise){
+      if (!this._promise) {
         return;
       }
       Widget.attach(this, this._host);


### PR DESCRIPTION
I filed an issue concerning a bug I discovered that resulted from a custom JupyterLab extension we have created here internally at Twitter. More information can be found in the ticket details including a brief example which could illustrate the point. 

TLDR; If a `Dialog` is launched and disposed of before it can be attached to the DOM based on the `LaunchQueue`, an non interactive `Dialog` is shown. This was happening in a situation where we present a authentication dialog on completion of `app.restored` and after this dialog is launched, the "Clear Workspace" Dialog is both shown and disposed of before the authentication dialog is resolved by the end user.

https://github.com/jupyterlab/jupyterlab/issues/8920

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This change is implemented to prevent a `Dialog` from being attached to the DOM if it was disposed of before it went to the front of the `LaunchQueue` to be shown. 
