### PR TITLE
Panel ranking

### DIFF
--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -291,7 +291,7 @@ and then adds the terminal to the right area:
       app.shell.add(terminal, 'right');
     });
 
-You can use a numeric rank to control the ordering of the left and right tabs:
+You can use a numeric rank to control the ordering of the lef t and right tabs:
 
 .. code:: typescript
 

--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -291,7 +291,7 @@ and then adds the terminal to the right area:
       app.shell.add(terminal, 'right');
     });
 
-You can use a numeric rank to control the ordering of the lef t and right tabs:
+You can use a numeric rank to control the ordering of the left and right tabs:
 
 .. code:: typescript
 

--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -291,6 +291,18 @@ and then adds the terminal to the right area:
       app.shell.add(terminal, 'right');
     });
 
+You can use a numeric rank to control the ordering of the left and right tabs:
+
+.. code:: typescript
+
+  app.shell.add(terminal, 'left', {rank: 600});
+
+The recommended ranges for this rank are:
+
+* 0-500: reserved for first-party JupyterLab extensions.
+* 501-899: reserved for third-party extensions.
+* 900: The default rank if none is specified.
+* 1000: The JupyterLab extension manager.
 
 Main Menu
 ~~~~~~~~~

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -932,7 +932,7 @@ const propertyInspector: JupyterFrontEndPlugin<IPropertyInspectorProvider> = {
     widget.title.icon = buildIcon;
     widget.title.caption = trans.__('Property Inspector');
     widget.id = 'jp-property-inspector';
-    labshell.add(widget, 'left');
+    labshell.add(widget, 'right', { rank: 100 });
     if (restorer) {
       restorer.add(widget, 'jp-property-inspector');
     }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -56,7 +56,7 @@ const ACTIVE_CLASS = 'jp-mod-active';
 /**
  * The default rank of items added to a sidebar.
  */
-const DEFAULT_RANK = 500;
+const DEFAULT_RANK = 900;
 
 const ACTIVITY_CLASS = 'jp-Activity';
 

--- a/packages/toc-extension/src/index.ts
+++ b/packages/toc-extension/src/index.ts
@@ -62,7 +62,7 @@ async function activateTOC(
   toc.title.icon = tocIcon;
   toc.title.caption = trans.__('Table of Contents');
   toc.id = 'table-of-contents';
-  labShell.add(toc, 'left', { rank: 700 });
+  labShell.add(toc, 'left', { rank: 400 });
 
   // Add the ToC widget to the application restorer:
   restorer.add(toc, '@jupyterlab/toc:plugin');


### PR DESCRIPTION
## References

Fixes #8940

## Code changes

Changes the rank of left/right panels as described in #8940.

## User-facing changes

Left/right panels will be reordered.

## Backwards-incompatible changes

No API breaking changes, third party extension may see a different relative location of their left/right panels compared to 2.0 but can continue to use the same numerical ranks.
