### PR TITLE
Make debugger sidebar customizable

### DIFF
--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -334,7 +334,7 @@ const variables: JupyterFrontEndPlugin<void> = {
 /**
  * The main debugger UI plugin.
  */
-const main: JupyterFrontEndPlugin<IDebugger.ISidebar | void> = {
+const main: JupyterFrontEndPlugin<IDebuggerSidebar> = {
   id: '@jupyterlab/debugger-extension:main',
   provides: IDebuggerSidebar,
   requires: [IDebugger, IEditorServices, ITranslator],
@@ -358,7 +358,7 @@ const main: JupyterFrontEndPlugin<IDebugger.ISidebar | void> = {
     settingRegistry: ISettingRegistry | null,
     themeManager: IThemeManager | null,
     debuggerSources: IDebugger.ISources | null
-  ): Promise<IDebugger.ISidebar | void> => {
+  ): Promise<IDebuggerSidebar> => {
     const trans = translator.load('jupyterlab');
     const { commands, shell, serviceManager } = app;
     const { kernelspecs } = serviceManager;

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -332,33 +332,81 @@ const variables: JupyterFrontEndPlugin<void> = {
 };
 
 /**
- * The main debugger UI plugin.
+ * Debugger sidebar provider plugin.
  */
-const main: JupyterFrontEndPlugin<IDebuggerSidebar> = {
-  id: '@jupyterlab/debugger-extension:main',
+const sidebar: JupyterFrontEndPlugin<IDebugger.ISidebar> = {
+  id: '@jupyterlab/debugger-extension:sidebar',
   provides: IDebuggerSidebar,
   requires: [IDebugger, IEditorServices, ITranslator],
-  optional: [
-    ILabShell,
-    ILayoutRestorer,
-    ICommandPalette,
-    ISettingRegistry,
-    IThemeManager,
-    IDebuggerSources
-  ],
+  optional: [IThemeManager, ISettingRegistry],
   autoStart: true,
   activate: async (
     app: JupyterFrontEnd,
     service: IDebugger,
     editorServices: IEditorServices,
     translator: ITranslator,
+    themeManager: IThemeManager | null,
+    settingRegistry: ISettingRegistry | null
+  ): Promise<IDebugger.ISidebar> => {
+    const { commands } = app;
+    const CommandIDs = Debugger.CommandIDs;
+
+    const callstackCommands = {
+      registry: commands,
+      continue: CommandIDs.debugContinue,
+      terminate: CommandIDs.terminate,
+      next: CommandIDs.next,
+      stepIn: CommandIDs.stepIn,
+      stepOut: CommandIDs.stepOut
+    };
+
+    const sidebar = new Debugger.Sidebar({
+      service,
+      callstackCommands,
+      editorServices,
+      themeManager,
+      translator
+    });
+
+    if (settingRegistry) {
+      const setting = await settingRegistry.load(main.id);
+      const updateSettings = (): void => {
+        const filters = setting.get('variableFilters').composite as {
+          [key: string]: string[];
+        };
+        const kernel = service.session?.connection?.kernel?.name ?? '';
+        if (kernel && filters[kernel]) {
+          sidebar.variables.filter = new Set<string>(filters[kernel]);
+        }
+      };
+      updateSettings();
+      setting.changed.connect(updateSettings);
+      service.sessionChanged.connect(updateSettings);
+    }
+
+    return sidebar;
+  }
+};
+
+/**
+ * The main debugger UI plugin.
+ */
+const main: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/debugger-extension:main',
+  requires: [IDebugger, IEditorServices, ITranslator, IDebuggerSidebar],
+  optional: [ILabShell, ILayoutRestorer, ICommandPalette, IDebuggerSources],
+  autoStart: true,
+  activate: async (
+    app: JupyterFrontEnd,
+    service: IDebugger,
+    editorServices: IEditorServices,
+    translator: ITranslator,
+    sidebar: IDebugger.ISidebar,
     labShell: ILabShell | null,
     restorer: ILayoutRestorer | null,
     palette: ICommandPalette | null,
-    settingRegistry: ISettingRegistry | null,
-    themeManager: IThemeManager | null,
     debuggerSources: IDebugger.ISources | null
-  ): Promise<IDebuggerSidebar> => {
+  ): Promise<void> => {
     const trans = translator.load('jupyterlab');
     const { commands, shell, serviceManager } = app;
     const { kernelspecs } = serviceManager;
@@ -444,40 +492,6 @@ const main: JupyterFrontEndPlugin<IDebuggerSidebar> = {
         await service.stepOut();
       }
     });
-
-    const callstackCommands = {
-      registry: commands,
-      continue: CommandIDs.debugContinue,
-      terminate: CommandIDs.terminate,
-      next: CommandIDs.next,
-      stepIn: CommandIDs.stepIn,
-      stepOut: CommandIDs.stepOut
-    };
-
-    const sidebar = new Debugger.Sidebar({
-      service,
-      callstackCommands,
-      editorServices,
-      themeManager,
-      translator
-    });
-
-    if (settingRegistry) {
-      const setting = await settingRegistry.load(main.id);
-      const updateSettings = (): void => {
-        const filters = setting.get('variableFilters').composite as {
-          [key: string]: string[];
-        };
-        const kernel = service.session?.connection?.kernel?.name ?? '';
-        if (kernel && filters[kernel]) {
-          sidebar.variables.filter = new Set<string>(filters[kernel]);
-        }
-      };
-
-      updateSettings();
-      setting.changed.connect(updateSettings);
-      service.sessionChanged.connect(updateSettings);
-    }
 
     service.eventMessage.connect((_, event): void => {
       commands.notifyCommandChanged();
@@ -586,8 +600,6 @@ const main: JupyterFrontEndPlugin<IDebuggerSidebar> = {
         onCurrentSourceOpened(null, source);
       });
     }
-
-    return sidebar;
   }
 };
 
@@ -600,6 +612,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   files,
   notebooks,
   variables,
+  sidebar,
   main,
   sources,
   configuration

--- a/packages/debugger-extension/src/index.ts
+++ b/packages/debugger-extension/src/index.ts
@@ -25,7 +25,8 @@ import {
   Debugger,
   IDebugger,
   IDebuggerConfig,
-  IDebuggerSources
+  IDebuggerSources,
+  IDebuggerSidebar
 } from '@jupyterlab/debugger';
 
 import { DocumentWidget } from '@jupyterlab/docregistry';
@@ -333,8 +334,9 @@ const variables: JupyterFrontEndPlugin<void> = {
 /**
  * The main debugger UI plugin.
  */
-const main: JupyterFrontEndPlugin<void> = {
+const main: JupyterFrontEndPlugin<IDebugger.ISidebar | void> = {
   id: '@jupyterlab/debugger-extension:main',
+  provides: IDebuggerSidebar,
   requires: [IDebugger, IEditorServices, ITranslator],
   optional: [
     ILabShell,
@@ -356,7 +358,7 @@ const main: JupyterFrontEndPlugin<void> = {
     settingRegistry: ISettingRegistry | null,
     themeManager: IThemeManager | null,
     debuggerSources: IDebugger.ISources | null
-  ): Promise<void> => {
+  ): Promise<IDebugger.ISidebar | void> => {
     const trans = translator.load('jupyterlab');
     const { commands, shell, serviceManager } = app;
     const { kernelspecs } = serviceManager;
@@ -584,6 +586,8 @@ const main: JupyterFrontEndPlugin<void> = {
         onCurrentSourceOpened(null, source);
       });
     }
+
+    return sidebar;
   }
 };
 

--- a/packages/debugger/src/index.ts
+++ b/packages/debugger/src/index.ts
@@ -3,4 +3,9 @@
 
 export { Debugger } from './debugger';
 
-export { IDebugger, IDebuggerConfig, IDebuggerSources } from './tokens';
+export {
+  IDebugger,
+  IDebuggerConfig,
+  IDebuggerSources,
+  IDebuggerSidebar
+} from './tokens';

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -93,34 +93,34 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
   /**
    * Add a panel at the end of the sidebar.
    *
-   * @param panel - The panel to add to the sidebar.
+   * @param widget - The widget to add to the sidebar.
    *
    * #### Notes
    * If the widget is already contained in the sidebar, it will be moved.
    */
-  addPanel(panel: Panel) {
-    this.body.addWidget(panel);
+  addPanel(widget: Widget) {
+    this.body.addWidget(widget);
   }
 
   /**
    * Insert a panel at the specified index.
    *
-   * @param index - The index at which to insert the panel.
+   * @param index - The index at which to insert the widget.
    *
-   * @param panel - The panel to insert into to the sidebar.
+   * @param widget - The widget to insert into to the sidebar.
    *
    * #### Notes
    * If the widget is already contained in the sidebar, it will be moved.
    */
-  insertPanel(index: number, panel: Panel) {
-    this.body.insertWidget(index, panel);
+  insertPanel(index: number, widget: Widget) {
+    this.body.insertWidget(index, widget);
   }
 
   /**
    * A read-only array of the sidebar panels.
    */
-  get panels(): Panel[] {
-    return this.body.widgets as Panel[];
+  get panels(): readonly Widget[] {
+    return this.body.widgets;
   }
 
   /**

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -84,26 +84,27 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
     this._body.addClass('jp-DebuggerSidebar-body');
     this.addWidget(this._body);
 
-    this.addPanel(this.variables);
-    this.addPanel(this.callstack);
-    this.addPanel(this.breakpoints);
-    this.addPanel(this.sources);
+    this.addItem(this.variables);
+    this.addItem(this.callstack);
+    this.addItem(this.breakpoints);
+    this.addItem(this.sources);
   }
 
   /**
-   * Add a panel at the end of the sidebar.
+   * Add an item at the end of the sidebar.
    *
    * @param widget - The widget to add to the sidebar.
    *
    * #### Notes
    * If the widget is already contained in the sidebar, it will be moved.
+   * The item can be removed from the sidebar by setting its parent to `null`.
    */
-  addPanel(widget: Widget) {
+  addItem(widget: Widget) {
     this._body.addWidget(widget);
   }
 
   /**
-   * Insert a panel at the specified index.
+   * Insert an item at the specified index.
    *
    * @param index - The index at which to insert the widget.
    *
@@ -111,15 +112,16 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
    *
    * #### Notes
    * If the widget is already contained in the sidebar, it will be moved.
+   * The item can be removed from the sidebar by setting its parent to `null`.
    */
-  insertPanel(index: number, widget: Widget) {
+  insertItem(index: number, widget: Widget) {
     this._body.insertWidget(index, widget);
   }
 
   /**
-   * A read-only array of the sidebar panels.
+   * A read-only array of the sidebar items.
    */
-  get panels(): readonly Widget[] {
+  get items(): readonly Widget[] {
     return this._body.widgets;
   }
 

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -79,10 +79,10 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
       header.title.label = title;
     });
 
-    this.body = new SplitPanel();
-    this.body.orientation = 'vertical';
-    this.body.addClass('jp-DebuggerSidebar-body');
-    this.addWidget(this.body);
+    this._body = new SplitPanel();
+    this._body.orientation = 'vertical';
+    this._body.addClass('jp-DebuggerSidebar-body');
+    this.addWidget(this._body);
 
     this.addPanel(this.variables);
     this.addPanel(this.callstack);
@@ -99,7 +99,7 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
    * If the widget is already contained in the sidebar, it will be moved.
    */
   addPanel(widget: Widget) {
-    this.body.addWidget(widget);
+    this._body.addWidget(widget);
   }
 
   /**
@@ -113,14 +113,14 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
    * If the widget is already contained in the sidebar, it will be moved.
    */
   insertPanel(index: number, widget: Widget) {
-    this.body.insertWidget(index, widget);
+    this._body.insertWidget(index, widget);
   }
 
   /**
    * A read-only array of the sidebar panels.
    */
   get panels(): readonly Widget[] {
-    return this.body.widgets;
+    return this._body.widgets;
   }
 
   /**
@@ -161,7 +161,7 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
   /**
    * Container for debugger panels.
    */
-  private body: SplitPanel;
+  private _body: SplitPanel;
 }
 
 /**

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -24,7 +24,7 @@ import { IDebugger } from './tokens';
 /**
  * A debugger sidebar.
  */
-export class DebuggerSidebar extends Panel {
+export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
   /**
    * Instantiate a new Debugger.Sidebar
    *
@@ -33,7 +33,7 @@ export class DebuggerSidebar extends Panel {
   constructor(options: DebuggerSidebar.IOptions) {
     super();
     this.id = 'jp-debugger-sidebar';
-    this.title.iconRenderer = bugIcon;
+    this.title.icon = bugIcon;
     this.addClass('jp-DebuggerSidebar');
 
     const {
@@ -79,16 +79,48 @@ export class DebuggerSidebar extends Panel {
       header.title.label = title;
     });
 
-    const body = new SplitPanel();
+    this.body = new SplitPanel();
+    this.body.orientation = 'vertical';
+    this.body.addClass('jp-DebuggerSidebar-body');
+    this.addWidget(this.body);
 
-    body.orientation = 'vertical';
-    body.addWidget(this.variables);
-    body.addWidget(this.callstack);
-    body.addWidget(this.breakpoints);
-    body.addWidget(this.sources);
-    body.addClass('jp-DebuggerSidebar-body');
+    this.addPanel(this.variables);
+    this.addPanel(this.callstack);
+    this.addPanel(this.breakpoints);
+    this.addPanel(this.sources);
+  }
 
-    this.addWidget(body);
+  /**
+   * Add a panel at the end of the sidebar.
+   *
+   * @param panel - The panel to add to the sidebar.
+   *
+   * #### Notes
+   * If the widget is already contained in the sidebar, it will be moved.
+   */
+  addPanel(panel: Panel) {
+    this.body.addWidget(panel);
+  }
+
+  /**
+   * Insert a panel at the specified index.
+   *
+   * @param index - The index at which to insert the panel.
+   *
+   * @param panel - The panel to insert into to the sidebar.
+   *
+   * #### Notes
+   * If the widget is already contained in the sidebar, it will be moved.
+   */
+  insertPanel(index: number, panel: Panel) {
+    this.body.insertWidget(index, panel);
+  }
+
+  /**
+   * A read-only array of the sidebar panels.
+   */
+  get panels(): Panel[] {
+    return this.body.widgets as Panel[];
   }
 
   /**
@@ -125,6 +157,11 @@ export class DebuggerSidebar extends Panel {
    * The sources widget.
    */
   readonly sources: SourcesPanel;
+
+  /**
+   * Container for debugger panels.
+   */
+  private body: SplitPanel;
 }
 
 /**

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -11,7 +11,7 @@ import { IObservableDisposable } from '@lumino/disposable';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
-import { Panel } from '@lumino/widgets';
+import { Widget } from '@lumino/widgets';
 
 import { DebugProtocol } from 'vscode-debugprotocol';
 
@@ -493,17 +493,17 @@ export namespace IDebugger {
     /**
      * Add panel at the end of the sidebar.
      */
-    addPanel(panel: Panel): void;
+    addPanel(widget: Widget): void;
 
     /**
      * Insert panel at a specified index.
      */
-    insertPanel(index: number, panel: Panel): void;
+    insertPanel(index: number, widget: Widget): void;
 
     /**
      * Return all panels that were added to sidebar.
      */
-    readonly panels: Panel[];
+    readonly panels: readonly Widget[];
   }
 
   /**

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -489,7 +489,7 @@ export namespace IDebugger {
   /**
    * Debugger sidebar interface.
    */
-  export interface ISidebar {
+  export interface ISidebar extends Widget {
     /**
      * Add panel at the end of the sidebar.
      */
@@ -767,7 +767,6 @@ export const IDebuggerSources = new Token<IDebugger.ISources>(
 /**
  * The debugger configuration token.
  */
-export type IDebuggerSidebar = IDebugger.ISidebar | undefined;
-export const IDebuggerSidebar = new Token<IDebuggerSidebar>(
+export const IDebuggerSidebar = new Token<IDebugger.ISidebar>(
   '@jupyterlab/debugger:IDebuggerSidebar'
 );

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -11,6 +11,8 @@ import { IObservableDisposable } from '@lumino/disposable';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
+import { Panel } from '@lumino/widgets';
+
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 /**
@@ -485,6 +487,26 @@ export namespace IDebugger {
   }
 
   /**
+   * Debugger sidebar interface.
+   */
+  export interface ISidebar {
+    /**
+     * Add panel at the end of the sidebar.
+     */
+    addPanel(panel: Panel): void;
+
+    /**
+     * Insert panel at a specified index.
+     */
+    insertPanel(index: number, panel: Panel): void;
+
+    /**
+     * Return all panels that were added to sidebar.
+     */
+    readonly panels: Panel[];
+  }
+
+  /**
    * A utility to find text editors used by the debugger.
    */
   export namespace ISources {
@@ -740,4 +762,11 @@ export const IDebuggerConfig = new Token<IDebugger.IConfig>(
  */
 export const IDebuggerSources = new Token<IDebugger.ISources>(
   '@jupyterlab/debugger:IDebuggerSources'
+);
+
+/**
+ * The debugger configuration token.
+ */
+export const IDebuggerSidebar = new Token<IDebugger.ISidebar>(
+  '@jupyterlab/debugger:IDebuggerSidebar'
 );

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -491,19 +491,19 @@ export namespace IDebugger {
    */
   export interface ISidebar extends Widget {
     /**
-     * Add panel at the end of the sidebar.
+     * Add item at the end of the sidebar.
      */
-    addPanel(widget: Widget): void;
+    addItem(widget: Widget): void;
 
     /**
-     * Insert panel at a specified index.
+     * Insert item at a specified index.
      */
-    insertPanel(index: number, widget: Widget): void;
+    insertItem(index: number, widget: Widget): void;
 
     /**
-     * Return all panels that were added to sidebar.
+     * Return all items that were added to sidebar.
      */
-    readonly panels: readonly Widget[];
+    readonly items: readonly Widget[];
   }
 
   /**

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -767,6 +767,7 @@ export const IDebuggerSources = new Token<IDebugger.ISources>(
 /**
  * The debugger configuration token.
  */
-export const IDebuggerSidebar = new Token<IDebugger.ISidebar>(
+export type IDebuggerSidebar = IDebugger.ISidebar | undefined;
+export const IDebuggerSidebar = new Token<IDebuggerSidebar>(
   '@jupyterlab/debugger:IDebuggerSidebar'
 );


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
This is a followup to: https://github.com/jupyterlab/debugger/pull/533

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Converting `main` plugin into a IDebuggerSidebar provider that will expose an interface to allow customization of the sidebar.
The consumer will be able to add panels at the bottom of the sidebar with `addPanel` and insert panels at a specific index with `insertPanel`. They will also be able to retreive the list of the panels currently added to sidebar with `panels` property.

Also, there is a minor fix for deprecated property (replaced iconRenderer with icon)

<!-- Describe the code changes and how they address the issue. -->
