### PR TITLE
Do not bundle core jlab packages in extensions

### DIFF
--- a/builder/src/webpack.config.ext.ts
+++ b/builder/src/webpack.config.ext.ts
@@ -71,14 +71,17 @@ const coreDeps: any = {
   ...(coreData.resolutions ?? {})
 };
 
-// TODO: make sure that using an || in package.json translates to a looser requirement here.
-// TODO: make sure that the version of jlab compiling matches what we have in the dependencies
 Object.keys(coreDeps).forEach(element => {
-  shared[element] = { requiredVersion: coreDeps[element] };
+  shared[element] = {
+    requiredVersion: coreDeps[element],
+    import: false
+  };
 });
 
 // Add package dependencies.
 Object.keys(data.dependencies).forEach(element => {
+  // TODO: make sure that the core dependency semver range is a subset of our
+  // data.depencies version range for any packages in the core deps.
   if (!shared[element]) {
     shared[element] = {};
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The default extension building system will bundle any non-singleton core jlab packages, bloating the size of jlab extensions. This defaults to not bundling the core jlab extensions, since they will be provided by the system.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
