### PR TITLE
Add get_ipython to the debugger variable filter list

### DIFF
--- a/packages/debugger-extension/schema/main.json
+++ b/packages/debugger-extension/schema/main.json
@@ -37,6 +37,7 @@
       "default": {
         "xpython": [
           "display",
+          "get_ipython",
           "ptvsd",
           "_xpython_get_connection_filename",
           "_xpython_launch",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Port of https://github.com/jupyterlab/debugger/pull/543

## Code changes

Settings change: add get_ipython to the debugger variable filter list.

## User-facing changes

### Before

![image](https://user-images.githubusercontent.com/591645/93443483-98e12780-f8d0-11ea-880c-0b46af31aeee.png)


### After

![image](https://user-images.githubusercontent.com/591645/93442590-591a4000-f8d0-11ea-8596-047421b6a9d2.png)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None