### PR TITLE
Add command palette to View menu, and reorders single doc mode + presentation mode.

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -677,12 +677,22 @@ export function createViewMenu(
     execute: Private.delegateExecute(app, menu.editorViewers, 'toggleWordWrap')
   });
 
+  menu.addGroup([{ command: 'apputils:activate-command-palette' }], 0);
+
+  menu.addGroup(
+    [
+      { command: 'application:toggle-mode' },
+      { command: 'application:toggle-presentation-mode' }
+    ],
+    1
+  );
+
   menu.addGroup(
     [
       { command: 'application:toggle-left-area' },
       { command: 'application:toggle-right-area' }
     ],
-    0
+    2
   );
 
   const editorViewerGroup = [
@@ -693,15 +703,6 @@ export function createViewMenu(
     return { command };
   });
   menu.addGroup(editorViewerGroup, 10);
-
-  // Add the command for toggling single-document mode.
-  menu.addGroup(
-    [
-      { command: 'application:toggle-presentation-mode' },
-      { command: 'application:toggle-mode' }
-    ],
-    1000
-  );
 }
 
 /**


### PR DESCRIPTION
## References

Pairs with #8809 to make the Command Palette more discoverable.

## Code changes

* Adds command palette to top of view menu.
* Move presentation mode and single doc mode higher in view menu.

## User-facing changes

Before:

![Screen Shot 2020-09-18 at 12 50 12 PM](https://user-images.githubusercontent.com/27600/93649263-6c0c3d80-f9c0-11ea-97d5-b3fdef749305.png)

After:

![Screen Shot 2020-09-18 at 3 02 39 PM](https://user-images.githubusercontent.com/27600/93649269-71698800-f9c0-11ea-95f1-9df7ec34334e.png)

## Backwards-incompatible changes

None
