### PR TITLE
Install npm

### DIFF
--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -32,7 +32,7 @@ Built-in Extensions
 --------------------
 
 In order to install JupyterLab built in (bundled) extensions, you need to have `Node.js
-<https://nodejs.org/>`__ installed.
+<https://nodejs.org/>`__ and npm installed.
 
 If you use ``conda`` with ``conda-forge`` packages, you can get it with:
 
@@ -51,6 +51,13 @@ If you use `Homebrew <https://brew.sh/>`__ on Mac OS X:
 You can also download Node.js from the `Node.js website <https://nodejs.org/>`__ and
 install it directly.
 
+You can get npm with:
+
+.. code:: bash
+
+    conda install npm
+
+Then it's ok.
 
 Disabling Rebuild Checks
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
If you want to use labextension, you must install npm with "conda install npm".

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
