### PR TITLE
Make extension dependency versions more permissive.

### DIFF
--- a/.github/workflows/windowstests.yml
+++ b/.github/workflows/windowstests.yml
@@ -49,10 +49,10 @@ jobs:
         env:
           GROUP: ${{ matrix.group }}
         run: |
-          bash ./scripts/ci_install.sh
+          cmd .\scripts\ci_install.bat
 
       - name: Run test ${{ matrix.group }}
         env:
           GROUP: ${{ matrix.group }}
         run: |
-          bash ./scripts/ci_script.sh
+          cmd .\scripts\ci_script.bat

--- a/builder/package.json
+++ b/builder/package.json
@@ -64,7 +64,7 @@
     "terser-webpack-plugin": "^4.1.0",
     "to-string-loader": "^1.1.6",
     "url-loader": "~4.1.0",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^5.1.2",
     "which": "^2.0.2",

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -78,9 +78,11 @@ function generateConfig({
     ...(coreData.resolutions ?? {})
   };
 
+  // Alow extensions to match a wider range than the core dependency
+  // To ensure forward compatibility.
   Object.keys(coreDeps).forEach(element => {
     shared[element] = {
-      requiredVersion: coreDeps[element],
+      requiredVersion: coreDeps[element].replace('~', '^'),
       import: false
     };
   });

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -48,7 +48,6 @@ const stylePath = path.join(
   path.dirname(require.resolve('@lumino/widgets/package.json')),
   'style'
 );
-console.log('\n\nSTYLE PATH IS:', stylePath, '\n\n');
 
 let phosphorAlias = {};
 

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -48,6 +48,7 @@ const stylePath = path.join(
   path.dirname(require.resolve('@lumino/widgets/package.json')),
   'style'
 );
+console.log('\n\nSTYLE PATH IS:', stylePath, '\n\n');
 
 let phosphorAlias = {};
 

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -185,7 +185,7 @@
     "svg-url-loader": "~6.0.0",
     "terser-webpack-plugin": "^4.1.0",
     "url-loader": "~4.1.0",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^5.1.2",

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -57,7 +57,7 @@
     "to-string-loader": "^1.1.6",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/cell/package.json
+++ b/examples/cell/package.json
@@ -30,7 +30,7 @@
     "typescript": "~4.0.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -28,7 +28,7 @@
     "typescript": "~4.0.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/federated/core_package/package.json
+++ b/examples/federated/core_package/package.json
@@ -169,7 +169,7 @@
     "to-string-loader": "^1.1.6",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10",
     "webpack-merge": "^5.1.2",
     "whatwg-fetch": "^3.0.0"

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -33,7 +33,7 @@
     "typescript": "~4.0.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -34,7 +34,7 @@
     "typescript": "~4.0.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.0.2",
     "url-loader": "~4.1.0",
     "watch": "~1.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10",
     "whatwg-fetch": "^3.0.0"
   }

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -663,7 +663,10 @@ class _AppHandler(object):
         # Build the app.
         if parts[1] != 'nobuild':
             dedupe_yarn(staging, self.logger)
-            ret = self._run(['node', YARN_PATH, 'run', command], cwd=staging)
+            starting_dir = os.getcwd()
+            os.chdir(staging)
+            ret = self._run(['node', YARN_PATH, 'run', command])
+            os.chdir(starting_dir)
             if ret != 0:
                 msg = 'JupyterLab failed to build'
                 self.logger.debug(msg)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -133,7 +133,7 @@ class LabBuildApp(JupyterApp, DebugLogFileMixin):
     dev_build = Bool(None, allow_none=True, config=True,
         help="Whether to build in dev mode. Defaults to True (dev mode) if there are any locally linked extensions, else defaults to False (prod mode).")
 
-    minimize = Bool(True, config=True,
+    minimize = Bool(os.name != 'nt', config=True,
         help="Whether to use a minifier during the Webpack build (defaults to True). Only affects production builds.")
 
     pre_clean = Bool(False, config=True,

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -133,7 +133,7 @@ class LabBuildApp(JupyterApp, DebugLogFileMixin):
     dev_build = Bool(None, allow_none=True, config=True,
         help="Whether to build in dev mode. Defaults to True (dev mode) if there are any locally linked extensions, else defaults to False (prod mode).")
 
-    minimize = Bool(os.name != 'nt', config=True,
+    minimize = Bool(True, config=True,
         help="Whether to use a minifier during the Webpack build (defaults to True). Only affects production builds.")
 
     pre_clean = Bool(False, config=True,

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -94,7 +94,7 @@ def update_extension(target, interactive=True):
         temp_data = json.load(fid)
 
     for (key, value) in temp_data['devDependencies'].items():
-        data['devDependencies'][key] = value
+        data['devDependencies'][key] = value.replace('~', '^')
 
     # Ask the user whether to upgrade the scripts automatically
     warnings = []
@@ -124,9 +124,9 @@ def update_extension(target, interactive=True):
     data.setdefault('devDependencies', dict())
     for (key, value) in root_jlab_data['resolutions'].items():
         if key in data['dependencies']:
-            data['dependencies'][key] = value
+            data['dependencies'][key] = value.replace('~', '^')
         if key in data['devDependencies']:
-            data['devDependencies'][key] = value
+            data['devDependencies'][key] = value.replace('~', '^')
 
     # Sort the entries
     for key in ['scripts', 'dependencies', 'devDependencies']:

--- a/packages/nbconvert-css/package.json
+++ b/packages/nbconvert-css/package.json
@@ -49,7 +49,7 @@
     "rimraf": "~3.0.0",
     "typescript": "~4.0.2",
     "url-loader": "~4.1.0",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/packages/services/examples/browser/package.json
+++ b/packages/services/examples/browser/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "rimraf": "~3.0.0",
     "typescript": "~4.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10"
   }
 }

--- a/packages/services/examples/typescript-browser-with-output/package.json
+++ b/packages/services/examples/typescript-browser-with-output/package.json
@@ -26,7 +26,7 @@
     "rimraf": "~3.0.0",
     "style-loader": "~1.2.1",
     "typescript": "~4.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10"
   }
 }

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -71,7 +71,7 @@
     "ts-jest": "^26.3.0",
     "typedoc": "0.17.0-3",
     "typescript": "~4.0.2",
-    "webpack": "~5.0.0-beta.31",
+    "webpack": "~5.0.0-rc.0",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/scripts/ci_install.bat
+++ b/scripts/ci_install.bat
@@ -1,0 +1,21 @@
+REM create jupyter base dir (needed for config retrieval)
+mkdir %USERPROFILE%\.jupyter
+
+REM Install and enable the server extension
+pip install -q --upgrade pip --user
+pip --version
+pip install jupyter_packaging
+REM Show a verbose install if the install fails, for debugging
+pip install -e ".[test]" || pip install -v -e ".[test]"
+jlpm versions
+jlpm config current
+jupyter server extension enable jupyterlab
+REM TODO: batch script grepping
+
+REM TODO: remove when we no longer support classic notebook
+jupyter serverextension enable jupyterlab
+REM TODO: batch script grepping
+
+IF "%GROUP%"=="integrity" (
+    pip install notebook==4.3.1
+)

--- a/scripts/ci_script.bat
+++ b/scripts/ci_script.bat
@@ -1,0 +1,21 @@
+
+python -c "from jupyterlab.commands import build_check; build_check()"
+
+
+IF "%GROUP%"=="python" (
+    jupyter lab build --debug
+    REM Run the python tests
+    py.test
+)
+
+IF "%GROUP%"=="integrity" (
+    REM Run the integrity script first
+    jlpm run integrity --force
+
+    REM Check yarn.lock file
+    jlpm check --integrity
+
+    REM Run a browser check in dev mode
+    jlpm run build
+    python -m jupyterlab.browser_check --dev-mode
+)

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -106,7 +106,7 @@ if [[ $GROUP == integrity2 ]]; then
     jlpm run build:storybook
 
     # Make sure we have CSS that can be converted with postcss
-    jlpm global add postcss-cli
+    jlpm global add postcss postcss-cli
 
     jlpm config set prefix ~/.yarn
     ~/.yarn/bin/postcss packages/**/style/*.css --dir /tmp

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -12,6 +12,7 @@ fi
 
 
 if [[ $GROUP == python ]]; then
+    jupyter lab build --debug
     # Run the python tests
     py.test
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -6862,14 +6862,6 @@ endent@^2.0.1:
     fast-json-parse "^1.0.3"
     objectorarray "^1.0.4"
 
-enhanced-resolve@5.0.0-beta.12:
-  version "5.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0-beta.12.tgz#ddc2eab710a5f973e1350fd3c0f721df550ec59b"
-  integrity sha512-lEjGWKw3CAvoCZcXP2QBf74D7azAqSop2uOSN2nqOiqmy9h4F3Ci2OaGkxfifrnltv7MAtQApWycZOmzGwDovg==
-  dependencies:
-    graceful-fs "^4.2.0"
-    tapable "^2.0.0-beta.10"
-
 enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz#3b806f3bfafc1ec7de69551ef93cca46c1704126"
@@ -6878,6 +6870,14 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
     tapable "^1.0.0"
+
+enhanced-resolve@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.0.0.tgz#4737e6ebd4f2fd13fe23f4cec9d02146afc2c527"
+  integrity sha512-6F037vvK16tgLlRgUx6ZEZISMysNvnnk09SILFrx3bNa1UsSLpIXFzWOmtiDxf1ISPAG6/wHBI61PEkeuTLVNA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.0.0"
 
 enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
@@ -14556,10 +14556,10 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tapable@^2.0.0-beta.10, tapable@^2.0.0-beta.11:
-  version "2.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.0.0-beta.11.tgz#5a6bd5e0353fad4da9e94942206bb596639e8cf7"
-  integrity sha512-cAhRzCvMdyJsxmdrSXG8/SUlJG4WJUxD/csuYAybUFjKVt74Y6pTyZ/I1ZK+enmCkWZN0JWxh14G69temaGSiA==
+tapable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.0.0.tgz#a49c3d6a8a2bb606e7db372b82904c970d537a08"
+  integrity sha512-bjzn0C0RWoffnNdTzNi7rNDhs1Zlwk2tRXgk8EiHKAOX1Mag3d6T0Y5zNa7l9CJ+EoUne/0UHdwS8tMbkh9zDg==
 
 tar@^4, tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
@@ -15874,14 +15874,6 @@ watchpack-chokidar2@^2.0.0:
   dependencies:
     chokidar "^2.1.8"
 
-watchpack@2.0.0-beta.15:
-  version "2.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.0.0-beta.15.tgz#0e69c8e5d680c7b4c181db3f70e500ca84cef794"
-  integrity sha512-zyhhC7vEajo5fZEUxlhVpC1uLAOs088zy8RwzcMp8YucTBirNCNmTFQWVeoKxKNNqEfYUBQdVzW3wfItcc/eUQ==
-  dependencies:
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.1.2"
-
 watchpack@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.4.tgz#6e9da53b3c80bb2d6508188f5b200410866cd30b"
@@ -15892,6 +15884,14 @@ watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
+
+watchpack@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.0.0.tgz#b12248f32f0fd4799b7be0802ad1f6573a45955c"
+  integrity sha512-xSdCxxYZWNk3VK13bZRYhsQpfa8Vg63zXG+3pyU8ouqSLRCv4IGXIp9Kr226q6GBkGRlZrST2wwKtjfKz2m7Cg==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
 
 wcwidth@^1.0.0:
   version "1.0.1"
@@ -15998,14 +15998,6 @@ webpack-merge@^5.1.2:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@2.0.0-beta.10:
-  version "2.0.0-beta.10"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.0.0-beta.10.tgz#f603355c5518141976601bfd620a3a5a01ac7b5d"
-  integrity sha512-HxeYa9Q6nMk3MtSbi5mKUUV+gOxYlGQwujKbeK0JQ+SmLSMgC4cQkZ+xpsWvsUtTvskDwpKvuVLpE9eW7vn0IQ==
-  dependencies:
-    source-list-map "^2.0.1"
-    source-map "^0.6.1"
-
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -16013,6 +16005,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.0.0.tgz#602d4bc7ff2e630ceb753a09ef49f260fa4ae7f0"
+  integrity sha512-CpCkDjEKa5vYVRDFDRABBkBomz+82lz9bpXViN1LBc8L/WDXvSyELKcBvBnTeDEiRfMJCGAFG9+04406PLSsIA==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack-virtual-modules@^0.2.2:
   version "0.2.2"
@@ -16050,10 +16050,10 @@ webpack@^4.43.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@~5.0.0-beta.31:
-  version "5.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-beta.31.tgz#e5af7fbb3dde9a427e3862f839c7c77cdafa34ba"
-  integrity sha512-NIjAfyvXBmHnnYB9hMSAq/utO3fkBw07cs7DTRGcqAccQBXV3NYpz9nEdu7Vf8oTbVvTsmXJ8swgCUqaI3LaTw==
+webpack@~5.0.0-rc.0:
+  version "5.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.0.0-rc.0.tgz#166f6d9cd65912ff021695d82256b2f1e6e858ee"
+  integrity sha512-tHUFu4vaZxJuyKYf8FKkDZmxnf0txy6twNewxUlviFo+GYjFoGW3szD71cOw0NtJBiyGAQ9zLGVzfb2pXBSKVA==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.45"
@@ -16063,7 +16063,7 @@ webpack@~5.0.0-beta.31:
     "@webassemblyjs/wasm-parser" "1.9.0"
     acorn "^7.4.0"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "5.0.0-beta.12"
+    enhanced-resolve "^5.0.0"
     eslint-scope "^5.1.0"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
@@ -16074,10 +16074,10 @@ webpack@~5.0.0-beta.31:
     neo-async "^2.6.2"
     pkg-dir "^4.2.0"
     schema-utils "^2.7.0"
-    tapable "^2.0.0-beta.11"
+    tapable "^2.0.0"
     terser-webpack-plugin "^4.1.0"
-    watchpack "2.0.0-beta.15"
-    webpack-sources "2.0.0-beta.10"
+    watchpack "^2.0.0"
+    webpack-sources "^2.0.0"
 
 whatwg-encoding@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
- Fixes #8936 (build on Windows)
- Allow extensions build for 3.0 to work with 3.x
- Upgrade `webpack` to version 5.0.0-rc.0

## References
cf. https://github.com/jupyterlab/extension-cookiecutter-ts/pull/93