### PR TITLE
Set input area overflow to hidden

### DIFF
--- a/packages/cells/style/inputarea.css
+++ b/packages/cells/style/inputarea.css
@@ -11,10 +11,12 @@
 .jp-InputArea {
   display: flex;
   flex-direction: row;
+  overflow: hidden;
 }
 
 .jp-InputArea-editor {
   flex: 1 1 auto;
+  overflow: hidden;
 }
 
 .jp-InputArea-editor {


### PR DESCRIPTION
In nbconvert, we had to add these properties on top of JupyterLab's CSS. Cf https://github.com/jupyter/nbconvert/pull/1422.

It displays fine in the notebook plugin of lab because the overflow hidden is inheritted from Lumino's styling, but nbconvert does not use lumino selectors or CSS.

Since this is the only instance (so far) of extra styling we needed to have on top of JupyterLab's I thought it would make sense for it to be upstream.