### PR TITLE
Use the new webpack 5 ‘auto’ publicPath

### DIFF
--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -202,7 +202,7 @@ function generateConfig({
       output: {
         filename: '[name].[contenthash].js',
         path: outputPath,
-        publicPath: staticUrl || "auto"
+        publicPath: staticUrl || 'auto'
       },
       module: {
         rules: [{ test: /\.html$/, use: 'file-loader' }]

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -161,31 +161,6 @@ function generateConfig({
     path.join(outputPath, 'package.json')
   );
 
-  const webpackPublicPathString = staticUrl
-    ? `"${staticUrl}"`
-    : `getOption('fullLabextensionsUrl') + '/${data.name}/'`;
-  const publicpath = path.join(outputPath, 'publicPath.js');
-  fs.writeFileSync(
-    publicpath,
-    `
-  function getOption(name) {
-    let configData = Object.create(null);
-    // Use script tag if available.
-    if (typeof document !== 'undefined' && document) {
-      const el = document.getElementById('jupyter-config-data');
-  
-      if (el) {
-        configData = JSON.parse(el.textContent || '{}');
-      }
-    }
-    return configData[name] || '';
-  }
-  
-  // eslint-disable-next-line no-undef
-  __webpack_public_path__ = ${webpackPublicPathString};
-  `
-  );
-
   class CleanupPlugin {
     apply(compiler: any) {
       compiler.hooks.done.tap('Cleanup', () => {
@@ -215,11 +190,6 @@ function generateConfig({
         }
         data.jupyterlab._build = _build;
         writeJSONFile(path.join(outputPath, 'package.json'), data);
-
-        // Remove our temporary public path file if not in watch mode
-        if (!watchMode) {
-          fs.removeSync(publicpath);
-        }
       });
     }
   }
@@ -228,15 +198,11 @@ function generateConfig({
     merge(baseConfig, {
       mode,
       devtool,
-      // This entry point ensures that the public path code is run when
-      // remoteEntry is loaded. See
-      // https://github.com/webpack/webpack/issues/10352#issuecomment-675649389
-      entry: {
-        [data.name]: publicpath
-      },
+      entry: {},
       output: {
         filename: '[name].[contenthash].js',
-        path: outputPath
+        path: outputPath,
+        publicPath: staticUrl || "auto"
       },
       module: {
         rules: [{ test: /\.html$/, use: 'file-loader' }]


### PR DESCRIPTION

## References

Fixes #9043

## Code changes

This removes a hardcoded assumption about where the lab extensions live in the server url namespace, making things more flexible for the future.

I left in the public path calculations for the core build because we can change them later. Fixing this now in the extension building scripts means that extension bundles built for 3.0 will continue to work even if we change the assumptions about how lab extension static assets are provided to the system, i.e., it removes a hard-coded assumption from extension bundles.

## User-facing changes

None

## Backwards-incompatible changes

None
