### PR TITLE
Add codemirror singleton plugin

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -251,6 +251,7 @@
       "@jupyterlab/application",
       "@jupyterlab/apputils",
       "@jupyterlab/codeeditor",
+      "@jupyterlab/codemirror",
       "@jupyterlab/completer",
       "@jupyterlab/console",
       "@jupyterlab/coreutils",

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -149,7 +149,9 @@ function activateEditorServices(app: JupyterFrontEnd): IEditorServices {
  */
 function activateCodeMirror(app: JupyterFrontEnd): ICodeMirror {
   return {
-    get CodeMirror() { return CodeMirror }
+    get CodeMirror() { 
+      return CodeMirror;
+    }
   };
 }
 

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -148,11 +148,11 @@ function activateEditorServices(app: JupyterFrontEnd): IEditorServices {
  * Simplest implementation of the CodeMirror singleton provider.
  */
 class CodeMirrorSingleton implements ICodeMirror {
-  get CodeMirror() { 
+  get CodeMirror() {
     return CodeMirror;
   }
 }
-  
+
 /**
  * Set up the CodeMirror singleton.
  */

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -53,7 +53,7 @@ const codemirrorSingleton: JupyterFrontEndPlugin<ICodeMirror> = {
   id: '@jupyterlab/codemirror-extension:codemirror',
   provides: ICodeMirror,
   activate: activateCodeMirror
-}
+};
 
 /**
  * The editor services.
@@ -150,7 +150,7 @@ function activateEditorServices(app: JupyterFrontEnd): IEditorServices {
 function activateCodeMirror(app: JupyterFrontEnd): ICodeMirror {
   return {
     codemirrorSingleton: () => CodeMirror
-  }
+  };
 }
 
 /**

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -149,7 +149,7 @@ function activateEditorServices(app: JupyterFrontEnd): IEditorServices {
  */
 function activateCodeMirror(app: JupyterFrontEnd): ICodeMirror {
   return {
-    codemirrorSingleton: () => CodeMirror
+    get CodeMirror() { return CodeMirror }
   };
 }
 

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -19,7 +19,8 @@ import {
   editorServices,
   EditorSyntaxStatus,
   CodeMirrorEditor,
-  Mode
+  Mode,
+  ICodeMirror
 } from '@jupyterlab/codemirror';
 
 import { IDocumentWidget } from '@jupyterlab/docregistry';
@@ -45,6 +46,13 @@ namespace CommandIDs {
   export const find = 'codemirror:find';
 
   export const goToLine = 'codemirror:go-to-line';
+}
+
+/** The CodeMirror singleton. */
+const codemirrorSingleton: JupyterFrontEndPlugin<ICodeMirror> = {
+  id: '@jupyterlab/codemirror-extension:codemirror',
+  provides: ICodeMirror,
+  activate: activateCodeMirror
 }
 
 /**
@@ -116,7 +124,8 @@ export const editorSyntaxStatus: JupyterFrontEndPlugin<void> = {
 const plugins: JupyterFrontEndPlugin<any>[] = [
   commands,
   services,
-  editorSyntaxStatus
+  editorSyntaxStatus,
+  codemirrorSingleton
 ];
 export default plugins;
 
@@ -133,6 +142,15 @@ function activateEditorServices(app: JupyterFrontEnd): IEditorServices {
     void app.commands.execute('docmanager:save');
   };
   return editorServices;
+}
+
+/**
+ * Set up the CodeMirror singleton.
+ */
+function activateCodeMirror(app: JupyterFrontEnd): ICodeMirror {
+  return {
+    codemirrorSingleton: () => CodeMirror
+  }
 }
 
 /**

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -145,14 +145,19 @@ function activateEditorServices(app: JupyterFrontEnd): IEditorServices {
 }
 
 /**
+ * Simplest implementation of the CodeMirror singleton provider.
+ */
+class CodeMirrorSingleton implements ICodeMirror {
+  get CodeMirror() { 
+    return CodeMirror;
+  }
+}
+  
+/**
  * Set up the CodeMirror singleton.
  */
 function activateCodeMirror(app: JupyterFrontEnd): ICodeMirror {
-  return {
-    get CodeMirror() { 
-      return CodeMirror;
-    }
-  };
+  return new CodeMirrorSingleton();
 }
 
 /**

--- a/packages/codemirror/src/index.ts
+++ b/packages/codemirror/src/index.ts
@@ -13,6 +13,8 @@ export * from './factory';
 export * from './mimetype';
 export * from './syntaxstatus';
 
+export * from './tokens';
+
 /**
  * The default editor services.
  */
@@ -23,7 +25,7 @@ export const editorServices: IEditorServices = {
 
 /**
  * FIXME-TRANS: Maybe an option to be able to pass a translator to the factories?
- * 
+ *
 
 export function getEditorServices(translator: ITranslator): IEditorServices {
   return {

--- a/packages/codemirror/src/tokens.ts
+++ b/packages/codemirror/src/tokens.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { Token } from '@lumino/coreutils';
+
+import CodeMirror from 'codemirror';
+
+/* tslint:disable */
+/**
+ * The CodeMirror token.
+ */
+export const ICodeMirror = new Token<ICodeMirror>('@jupyterlab/codemirror:ICodeMirror');
+/* tslint:enable */
+
+/** The CodeMirror interface. */
+export interface ICodeMirror {
+  /**
+   * A singleton CodeMirror module, rexported.
+   */
+  codemirrorSingleton(): typeof CodeMirror;
+}

--- a/packages/codemirror/src/tokens.ts
+++ b/packages/codemirror/src/tokens.ts
@@ -9,7 +9,9 @@ import CodeMirror from 'codemirror';
 /**
  * The CodeMirror token.
  */
-export const ICodeMirror = new Token<ICodeMirror>('@jupyterlab/codemirror:ICodeMirror');
+export const ICodeMirror = new Token<ICodeMirror>(
+  '@jupyterlab/codemirror:ICodeMirror'
+);
 /* tslint:enable */
 
 /** The CodeMirror interface. */

--- a/packages/codemirror/src/tokens.ts
+++ b/packages/codemirror/src/tokens.ts
@@ -19,5 +19,5 @@ export interface ICodeMirror {
   /**
    * A singleton CodeMirror module, rexported.
    */
-  codemirrorSingleton(): typeof CodeMirror;
+  CodeMirror: typeof CodeMirror;
 }

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -231,6 +231,9 @@
       "path": "./packages/statusbar-extension"
     },
     {
+      "path": "./packages/tabmanager-extension"
+    },
+    {
       "path": "./packages/terminal"
     },
     {

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -231,9 +231,6 @@
       "path": "./packages/statusbar-extension"
     },
     {
-      "path": "./packages/tabmanager-extension"
-    },
-    {
       "path": "./packages/terminal"
     },
     {


### PR DESCRIPTION
## References

- suggested by @jasongrout on https://github.com/jupyterlab/jupyterlab/issues/9044#issuecomment-698000088
  - overview: federated extensions weren't getting the same `CodeMirror` module when importing, keeping mode registration from working

## Code changes

Adds a very basic `ICodeMirror`, exported by a new plugin. Federated extensions can require this token and get the `codeMirrorSingleton` which will be the **same** `CodeMirror` that first-party extensions would import.

It remains to be seen whether this will work _directly_ with CodeMirror extensions (e.g. `mode/simple`) but some workarounds are probably possible.

## User-facing changes

N/A

## Backwards-incompatible changes

N/A

## Alternatives

- Offer some proxy methods (e.g. `addMode`, `Mime`, etc.)
  - unfortunately, the useful part of the API is still quite large