### PR TITLE
vim support in the notebook

### DIFF
--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -47,6 +47,8 @@
     "@jupyterlab/settingregistry": "^3.0.0-rc.4",
     "@jupyterlab/statusbar": "^3.0.0-rc.4",
     "@jupyterlab/translation": "^3.0.0-rc.4",
+    "@lumino/commands": "^1.11.3",
+    "@lumino/disposable": "^1.4.3",
     "@lumino/widgets": "^1.14.0",
     "codemirror": "~5.57.0"
   },

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -37,11 +37,13 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^3.0.0-rc.4",
+    "@jupyterlab/cells": "^3.0.0-rc.4",
     "@jupyterlab/codeeditor": "^3.0.0-rc.4",
     "@jupyterlab/codemirror": "^3.0.0-rc.4",
     "@jupyterlab/docregistry": "^3.0.0-rc.4",
     "@jupyterlab/fileeditor": "^3.0.0-rc.4",
     "@jupyterlab/mainmenu": "^3.0.0-rc.4",
+    "@jupyterlab/notebook": "^3.0.0-rc.4",
     "@jupyterlab/settingregistry": "^3.0.0-rc.4",
     "@jupyterlab/statusbar": "^3.0.0-rc.4",
     "@jupyterlab/translation": "^3.0.0-rc.4",

--- a/packages/codemirror-extension/schema/commands.json
+++ b/packages/codemirror-extension/schema/commands.json
@@ -57,6 +57,12 @@
       "title": "Block Comment on MacOS keyboard",
       "description": "Key command for block comment with MacOS",
       "default": "Cmd-/"
+    },
+    "vim:CtrlC-to-copy": {
+      "type": "boolean",
+      "title": "Ctrl-C Copies in Vim mode",
+      "description": "If true disable the default vim action for Ctrl-C to allow copying using the keyboard.",
+      "default": true
     }
   },
   "type": "object"

--- a/packages/codemirror-extension/schema/commands.json
+++ b/packages/codemirror-extension/schema/commands.json
@@ -45,6 +45,18 @@
       "title": "Ctrl-C",
       "description": "When enabled, which is the default, doing copy or cut when there is no selection will copy or cut the whole lines that have cursors on them.",
       "default": true
+    },
+    "toggleComment": {
+      "type": "string",
+      "title": "Block Comment",
+      "description": "Key command for block comment",
+      "default": "Ctrl-/"
+    },
+    "toggleCommentMac": {
+      "type": "string",
+      "title": "Block Comment on MacOS keyboard",
+      "description": "Key command for block comment with MacOS",
+      "default": "Cmd-/"
     }
   },
   "type": "object"

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -195,6 +195,12 @@ function activateEditorCommands(
   ): Promise<void> {
     keyMap = (settings.get('keyMap').composite as string | null) || keyMap;
     if (keyMap === 'vim') {
+      // This setup for vim in the notebook is derived from extension built by
+      // members of the community
+      // https://github.com/lambdalisue/jupyter-vim-binding (Jupyter notebook)
+      // https://github.com/jwkvam/jupyterlab-vim (JupyterLab 0.x + 1.x)
+      // https://github.com/axelfahy/jupyterlab-vim (JupyterLab 2.x)
+
       // @ts-expect-error
       await import('codemirror/keymap/vim.js');
       const vim = (CodeMirror as any).Vim;

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -13,7 +13,7 @@ import {
 
 import { IEditMenu, IMainMenu } from '@jupyterlab/mainmenu';
 
-import { MarkdownCell } from '@jupyterlab/cells';
+import { setupKeymap } from './keymaps';
 
 import { IEditorServices } from '@jupyterlab/codeeditor';
 
@@ -186,6 +186,7 @@ function activateEditorCommands(
     selectionPointer,
     lineWiseCopyCut
   } = CodeMirrorEditor.defaultConfig;
+  commands;
 
   let toggleComment = 'Ctrl-/';
   let toggleCommentMac = 'Cmd-/';
@@ -196,123 +197,7 @@ function activateEditorCommands(
     settings: ISettingRegistry.ISettings
   ): Promise<void> {
     keyMap = (settings.get('keyMap').composite as string | null) || keyMap;
-    if (keyMap === 'vim') {
-      // This setup for vim in the notebook is derived from extension built by
-      // members of the community
-      // https://github.com/lambdalisue/jupyter-vim-binding (Jupyter notebook)
-      // https://github.com/jwkvam/jupyterlab-vim (JupyterLab 0.x + 1.x)
-      // https://github.com/axelfahy/jupyterlab-vim (JupyterLab 2.x)
-
-      // @ts-expect-error
-      await import('codemirror/keymap/vim.js');
-      const vim = (CodeMirror as any).Vim;
-      vim.defineMotion(
-        'moveByLinesOrCell',
-        (cm: any, head: any, motionArgs: any, vim: any) => {
-          let cur = head;
-          let endCh = cur.ch;
-          let currentCell = notebookTracker.activeCell;
-          // TODO: these references will be undefined
-          // Depending what our last motion was, we may want to do different
-          // things. If our last motion was moving vertically, we want to
-          // preserve the HPos from our last horizontal move.  If our last motion
-          // was going to the end of a line, moving vertically we should go to
-          // the end of the line, etc.
-          switch (vim.lastMotion) {
-            case 'moveByLines':
-            case 'moveByDisplayLines':
-            case 'moveByScroll':
-            case 'moveToColumn':
-            case 'moveToEol':
-            // JUPYTER PATCH: add our custom method to the motion cases
-            // eslint-disable-next-line no-fallthrough
-            case 'moveByLinesOrCell':
-              endCh = vim.lastHPos;
-              break;
-            default:
-              vim.lastHPos = endCh;
-          }
-          let repeat = motionArgs.repeat + (motionArgs.repeatOffset || 0);
-          let line = motionArgs.forward ? cur.line + repeat : cur.line - repeat;
-          let first = cm.firstLine();
-          let last = cm.lastLine();
-          // Vim cancels linewise motions that start on an edge and move beyond
-          // that edge. It does not cancel motions that do not start on an edge.
-
-          // JUPYTER PATCH BEGIN
-          // here we insert the jumps to the next cells
-          if (line < first || line > last) {
-            // var currentCell = ns.notebook.get_selected_cell();
-            // var currentCell = tracker.activeCell;
-            // var key = '';
-            if (currentCell?.model.type === 'markdown') {
-              (currentCell as MarkdownCell).rendered = true;
-            }
-            if (motionArgs.forward) {
-              void commands.execute('notebook:move-cursor-down');
-            } else {
-              void commands.execute('notebook:move-cursor-up');
-            }
-            return;
-          }
-          vim.lastHSPos = cm.charCoords(
-            CodeMirror.Pos(line, endCh),
-            'div'
-          ).left;
-          return (CodeMirror as any).Pos(line, endCh);
-        }
-      );
-      vim.mapCommand(
-        'k',
-        'motion',
-        'moveByLinesOrCell',
-        { forward: false, linewise: true },
-        { context: 'normal' }
-      );
-      vim.mapCommand(
-        'j',
-        'motion',
-        'moveByLinesOrCell',
-        { forward: true, linewise: true },
-        { context: 'normal' }
-      );
-      CodeMirror.prototype.save = () => {
-        void commands.execute('docmanager:save');
-      };
-      vim.defineEx('quit', 'q', function (cm: any) {
-        void commands.execute('notebook:enter-command-mode');
-      });
-      vim.defineAction('splitCell', (cm: any, actionArgs: any) => {
-        void commands.execute('notebook:split-cell-at-cursor');
-      });
-      vim.mapCommand('-', 'action', 'splitCell', {}, { extra: 'normal' });
-      commands.addKeyBinding({
-        selector: '.jp-Notebook.jp-mod-editMode',
-        keys: ['Ctrl J'],
-        command: 'notebook:move-cursor-down'
-      });
-      commands.addKeyBinding({
-        selector: '.jp-Notebook.jp-mod-editMode',
-        keys: ['Ctrl K'],
-        command: 'notebook:move-cursor-up'
-      });
-      commands.addKeyBinding({
-        selector: '.jp-Notebook.jp-mod-editMode',
-        keys: ['Escape'],
-        command: 'codemirror:leave-vim-insert-mode'
-      });
-      commands.addKeyBinding({
-        selector: '.jp-Notebook.jp-mod-editMode',
-        keys: ['Shift Escape'],
-        command: 'notebook:enter-command-mode'
-      });
-    } else {
-      commands.addKeyBinding({
-        selector: '.jp-Notebook.jp-mod-editMode',
-        keys: ['Escape'],
-        command: 'notebook:enter-command-mode'
-      });
-    }
+    await setupKeymap(keyMap, commands, notebookTracker);
     theme = (settings.get('theme').composite as string | null) || theme;
     // Lazy loading of theme stylesheets
     if (theme !== 'jupyter' && theme !== 'default') {

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -187,6 +187,8 @@ function activateEditorCommands(
     lineWiseCopyCut
   } = CodeMirrorEditor.defaultConfig;
 
+  let toggleComment = 'Ctrl-/';
+  let toggleCommentMac = 'Cmd-/';
   /**
    * Update the setting values.
    */
@@ -337,6 +339,11 @@ function activateEditorCommands(
       selectionPointer;
     lineWiseCopyCut =
       (settings.get('lineWiseCopyCut').composite as boolean) ?? lineWiseCopyCut;
+    toggleComment =
+      (settings.get('toggleComment').composite as string) ?? toggleComment;
+    toggleCommentMac =
+      (settings.get('toggleCommentMac').composite as string) ??
+      toggleCommentMac;
   }
 
   /**
@@ -353,6 +360,10 @@ function activateEditorCommands(
         editor.setOption('styleActiveLine', styleActiveLine);
         editor.setOption('styleSelectedText', styleSelectedText);
         editor.setOption('theme', theme);
+        let extraKeys = editor.getOption('extraKeys') as any;
+        extraKeys[toggleComment] = 'toggleComment';
+        extraKeys[toggleCommentMac] = 'toggleComment';
+        editor.setOption('extraKeys', extraKeys);
       }
     });
   }
@@ -369,6 +380,10 @@ function activateEditorCommands(
           cm.setOption('theme', theme);
           cm.setOption('styleActiveLine', styleActiveLine);
           cm.setOption('lineWiseCopyCut', lineWiseCopyCut);
+          let extraKeys = cm.getOption('extraKeys') as any;
+          extraKeys[toggleComment] = 'toggleComment';
+          extraKeys[toggleCommentMac] = 'toggleComment';
+          cm.setOption('extraKeys', extraKeys);
         }
       });
     });
@@ -393,6 +408,10 @@ function activateEditorCommands(
           editor.setOption('keyMap', keyMap);
           editor.setOption('styleActiveLine', styleActiveLine);
           editor.setOption('lineWiseCopyCut', lineWiseCopyCut);
+          let extraKeys = editor.getOption('extraKeys') as any;
+          extraKeys[toggleComment] = 'toggleComment';
+          extraKeys[toggleCommentMac] = 'toggleComment';
+          editor.setOption('extraKeys', extraKeys);
         }
       });
     })

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -13,7 +13,7 @@ import {
 
 import { IEditMenu, IMainMenu } from '@jupyterlab/mainmenu';
 
-import { Cell, MarkdownCell } from '@jupyterlab/cells';
+import { MarkdownCell } from '@jupyterlab/cells';
 
 import { IEditorServices } from '@jupyterlab/codeeditor';
 
@@ -186,6 +186,7 @@ function activateEditorCommands(
     selectionPointer,
     lineWiseCopyCut
   } = CodeMirrorEditor.defaultConfig;
+
   /**
    * Update the setting values.
    */
@@ -202,7 +203,7 @@ function activateEditorCommands(
         (cm: any, head: any, motionArgs: any, vim: any) => {
           let cur = head;
           let endCh = cur.ch;
-          let currentCell = activeCell;
+          let currentCell = notebookTracker.activeCell;
           // TODO: these references will be undefined
           // Depending what our last motion was, we may want to do different
           // things. If our last motion was moving vertically, we want to
@@ -427,11 +428,10 @@ function activateEditorCommands(
     });
   });
 
-  let activeCell: Cell | null = null;
-
   commands.addCommand('codemirror:leave-vim-insert-mode', {
     label: 'Leave VIM Insert Mode',
     execute: args => {
+      const activeCell = notebookTracker.activeCell;
       if (activeCell) {
         let editor = activeCell.editor as CodeMirrorEditor;
         (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -25,6 +25,8 @@ import {
   ICodeMirror
 } from '@jupyterlab/codemirror';
 
+import { IDisposable } from '@lumino/disposable';
+
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 
 import { IEditorTracker, FileEditor } from '@jupyterlab/fileeditor';
@@ -190,6 +192,8 @@ function activateEditorCommands(
 
   let toggleComment = 'Ctrl-/';
   let toggleCommentMac = 'Cmd-/';
+  let removeKeymaps: IDisposable[] = [];
+
   /**
    * Update the setting values.
    */
@@ -197,7 +201,7 @@ function activateEditorCommands(
     settings: ISettingRegistry.ISettings
   ): Promise<void> {
     keyMap = (settings.get('keyMap').composite as string | null) || keyMap;
-    await setupKeymap(keyMap, commands, notebookTracker);
+    removeKeymaps = await setupKeymap(keyMap, commands, notebookTracker, removeKeymaps);
     theme = (settings.get('theme').composite as string | null) || theme;
     // Lazy loading of theme stylesheets
     if (theme !== 'jupyter' && theme !== 'default') {

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -192,6 +192,7 @@ function activateEditorCommands(
 
   let toggleComment = 'Ctrl-/';
   let toggleCommentMac = 'Cmd-/';
+  let vimDisableCtrlC = true;
   let removeKeymaps: IDisposable[] = [];
 
   /**
@@ -238,6 +239,9 @@ function activateEditorCommands(
     toggleCommentMac =
       (settings.get('toggleCommentMac').composite as string) ??
       toggleCommentMac;
+    vimDisableCtrlC =
+      (settings.get('vim:CtrlC-to-copy').composite as boolean) ??
+      vimDisableCtrlC;
   }
 
   /**
@@ -253,6 +257,9 @@ function activateEditorCommands(
     const extraKeys = editor.getOption('extraKeys') || {};
     extraKeys[toggleComment] = 'toggleComment';
     extraKeys[toggleCommentMac] = 'toggleComment';
+    if (vimDisableCtrlC && keyMap === 'vim') {
+      extraKeys['Ctrl-C'] = false;
+    }
     editor.setOption('extraKeys', extraKeys);
   }
 
@@ -307,8 +314,8 @@ function activateEditorCommands(
       // connect to signal here to ensure vim keymap has
       // been imported in case we need it
       /**
-      * Handle settings of Notebook cells
-      */
+       * Handle settings of Notebook cells
+       */
       notebookTracker.newCellCreated.connect((sender, cell) => {
         if (cell?.inputArea.editor instanceof CodeMirrorEditor) {
           setEditorOptions(cell.inputArea.editor);
@@ -320,7 +327,6 @@ function activateEditorCommands(
       updateFileEditorTracker();
       updateNotebookTracker();
     });
-
 
   /**
    * A test for whether the tracker has an active widget.

--- a/packages/codemirror-extension/src/keymaps.ts
+++ b/packages/codemirror-extension/src/keymaps.ts
@@ -114,6 +114,16 @@ export async function setupKeymap(
         keys: ['Ctrl K'],
         command: 'notebook:move-cursor-up'
       }),
+      commands.addCommand('codemirror:leave-vim-insert-mode', {
+        label: 'Leave VIM Insert Mode',
+        execute: args => {
+          const activeCell = notebookTracker.activeCell;
+          if (activeCell) {
+            let editor = activeCell.editor as CodeMirrorEditor;
+            (CodeMirror as any).Vim.handleKey(editor.editor, '<Esc>');
+          }
+        }
+      }),
       commands.addKeyBinding({
         selector: '.jp-Notebook.jp-mod-editMode',
         keys: ['Escape'],

--- a/packages/codemirror-extension/src/keymaps.ts
+++ b/packages/codemirror-extension/src/keymaps.ts
@@ -1,0 +1,125 @@
+import CodeMirror from 'codemirror';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import { MarkdownCell } from '@jupyterlab/cells';
+import { CommandRegistry } from '@lumino/commands';
+
+export async function setupKeymap(
+  keyMap: string,
+  commands: CommandRegistry,
+  notebookTracker: INotebookTracker
+): Promise<void> {
+  if (keyMap === 'vim') {
+    // This setup for vim in the notebook is derived from extension built by
+    // members of the community
+    // https://github.com/lambdalisue/jupyter-vim-binding (Jupyter notebook)
+    // https://github.com/jwkvam/jupyterlab-vim (JupyterLab 0.x + 1.x)
+    // https://github.com/axelfahy/jupyterlab-vim (JupyterLab 2.x)
+
+    // @ts-expect-error
+    await import('codemirror/keymap/vim.js');
+    const vim = (CodeMirror as any).Vim;
+    vim.defineMotion(
+      'moveByLinesOrCell',
+      (cm: any, head: any, motionArgs: any, vim: any) => {
+        let cur = head;
+        let endCh = cur.ch;
+        let currentCell = notebookTracker.activeCell;
+        // TODO: these references will be undefined
+        // Depending what our last motion was, we may want to do different
+        // things. If our last motion was moving vertically, we want to
+        // preserve the HPos from our last horizontal move.  If our last motion
+        // was going to the end of a line, moving vertically we should go to
+        // the end of the line, etc.
+        switch (vim.lastMotion) {
+          case 'moveByLines':
+          case 'moveByDisplayLines':
+          case 'moveByScroll':
+          case 'moveToColumn':
+          case 'moveToEol':
+          // JUPYTER PATCH: add our custom method to the motion cases
+          // eslint-disable-next-line no-fallthrough
+          case 'moveByLinesOrCell':
+            endCh = vim.lastHPos;
+            break;
+          default:
+            vim.lastHPos = endCh;
+        }
+        let repeat = motionArgs.repeat + (motionArgs.repeatOffset || 0);
+        let line = motionArgs.forward ? cur.line + repeat : cur.line - repeat;
+        let first = cm.firstLine();
+        let last = cm.lastLine();
+        // Vim cancels linewise motions that start on an edge and move beyond
+        // that edge. It does not cancel motions that do not start on an edge.
+
+        // JUPYTER PATCH BEGIN
+        // here we insert the jumps to the next cells
+        if (line < first || line > last) {
+          // var currentCell = ns.notebook.get_selected_cell();
+          // var currentCell = tracker.activeCell;
+          // var key = '';
+          if (currentCell?.model.type === 'markdown') {
+            (currentCell as MarkdownCell).rendered = true;
+          }
+          if (motionArgs.forward) {
+            void commands.execute('notebook:move-cursor-down');
+          } else {
+            void commands.execute('notebook:move-cursor-up');
+          }
+          return;
+        }
+        vim.lastHSPos = cm.charCoords(CodeMirror.Pos(line, endCh), 'div').left;
+        return (CodeMirror as any).Pos(line, endCh);
+      }
+    );
+    vim.mapCommand(
+      'k',
+      'motion',
+      'moveByLinesOrCell',
+      { forward: false, linewise: true },
+      { context: 'normal' }
+    );
+    vim.mapCommand(
+      'j',
+      'motion',
+      'moveByLinesOrCell',
+      { forward: true, linewise: true },
+      { context: 'normal' }
+    );
+    CodeMirror.prototype.save = () => {
+      void commands.execute('docmanager:save');
+    };
+    vim.defineEx('quit', 'q', function (cm: any) {
+      void commands.execute('notebook:enter-command-mode');
+    });
+    vim.defineAction('splitCell', (cm: any, actionArgs: any) => {
+      void commands.execute('notebook:split-cell-at-cursor');
+    });
+    vim.mapCommand('-', 'action', 'splitCell', {}, { extra: 'normal' });
+    commands.addKeyBinding({
+      selector: '.jp-Notebook.jp-mod-editMode',
+      keys: ['Ctrl J'],
+      command: 'notebook:move-cursor-down'
+    });
+    commands.addKeyBinding({
+      selector: '.jp-Notebook.jp-mod-editMode',
+      keys: ['Ctrl K'],
+      command: 'notebook:move-cursor-up'
+    });
+    commands.addKeyBinding({
+      selector: '.jp-Notebook.jp-mod-editMode',
+      keys: ['Escape'],
+      command: 'codemirror:leave-vim-insert-mode'
+    });
+    commands.addKeyBinding({
+      selector: '.jp-Notebook.jp-mod-editMode',
+      keys: ['Shift Escape'],
+      command: 'notebook:enter-command-mode'
+    });
+  } else {
+    commands.addKeyBinding({
+      selector: '.jp-Notebook.jp-mod-editMode',
+      keys: ['Escape'],
+      command: 'notebook:enter-command-mode'
+    });
+  }
+}

--- a/packages/codemirror-extension/tsconfig.json
+++ b/packages/codemirror-extension/tsconfig.json
@@ -38,9 +38,6 @@
     },
     {
       "path": "../translation"
-    },
-    {
-      "path": "../cells"
     }
   ]
 }

--- a/packages/codemirror-extension/tsconfig.json
+++ b/packages/codemirror-extension/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../mainmenu"
     },
     {
+      "path": "../notebook"
+    },
+    {
       "path": "../settingregistry"
     },
     {

--- a/packages/codemirror-extension/tsconfig.json
+++ b/packages/codemirror-extension/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "../application"
     },
     {
+      "path": "../cells"
+    },
+    {
       "path": "../codeeditor"
     },
     {
@@ -35,6 +38,9 @@
     },
     {
       "path": "../translation"
+    },
+    {
+      "path": "../cells"
     }
   ]
 }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -26,9 +26,7 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
         End: 'goLineRight',
         'Cmd-Left': 'goLineLeft',
         Tab: 'indentMoreOrinsertTab',
-        'Shift-Tab': 'indentLess',
-        'Cmd-/': 'toggleComment',
-        'Ctrl-/': 'toggleComment'
+        'Shift-Tab': 'indentLess'
       },
       ...defaults
     };
@@ -37,8 +35,6 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
       extraKeys: {
         Tab: 'indentMoreOrinsertTab',
         'Shift-Tab': 'indentLess',
-        'Cmd-/': 'toggleComment',
-        'Ctrl-/': 'toggleComment',
         'Shift-Enter': () => {
           /* no-op */
         }

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -68,7 +68,7 @@
       "selector": ".jp-Notebook:focus"
     },
     {
-      "command": "notebook:delete-cell",
+      "command": "notebook:cut-cell",
       "keys": ["D", "D"],
       "selector": ".jp-Notebook:focus"
     },

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -48,6 +48,16 @@
       "selector": ".jp-Notebook:focus"
     },
     {
+      "command": "notebook:move-cell-down",
+      "keys": ["Ctrl J"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:move-cell-up",
+      "keys": ["Ctrl K"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
       "command": "notebook:copy-cell",
       "keys": ["C"],
       "selector": ".jp-Notebook:focus"

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -153,6 +153,16 @@
       "selector": ".jp-Notebook:focus"
     },
     {
+      "command": "notebook:paste-cell-above",
+      "keys": ["Shift P"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:paste-cell-below",
+      "keys": ["P"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
       "command": "notebook:paste-cell-below",
       "keys": ["V"],
       "selector": ".jp-Notebook:focus"

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -98,9 +98,11 @@ export class NotebookTools extends Widget implements INotebookTools {
       this
     );
     this._tracker.activeCellChanged.connect(this._onActiveCellChanged, this);
+    this._tracker.newCellCreated.connect(this._onNewCellCreated, this);
     this._tracker.selectionChanged.connect(this._onSelectionChanged, this);
     this._onActiveNotebookPanelChanged();
     this._onActiveCellChanged();
+    this._onNewCellCreated();
     this._onSelectionChanged();
   }
 
@@ -204,6 +206,15 @@ export class NotebookTools extends Widget implements INotebookTools {
     }
     each(this._toolChildren(), widget => {
       MessageLoop.sendMessage(widget, NotebookTools.ActiveCellMessage);
+    });
+  }
+
+  /**
+   * Handle the creation of a new cell
+   */
+  private _onNewCellCreated(): void {
+    each(this._toolChildren(), widget => {
+      MessageLoop.sendMessage(widget, NotebookTools.NewCellMessage);
     });
   }
 
@@ -322,6 +333,11 @@ export namespace NotebookTools {
    * A singleton conflatable `'activecell-changed'` message.
    */
   export const ActiveCellMessage = new ConflatableMessage('activecell-changed');
+
+  /**
+   * A singleton conflatable `'new-cell-created'` message.
+   */
+  export const NewCellMessage = new ConflatableMessage('new-cell-created');
 
   /**
    * A singleton conflatable `'selection-changed'` message.

--- a/packages/notebook/src/tokens.ts
+++ b/packages/notebook/src/tokens.ts
@@ -100,6 +100,12 @@ export interface INotebookTracker extends IWidgetTracker<NotebookPanel> {
   readonly activeCellChanged: ISignal<this, Cell | null>;
 
   /**
+   * A signal emitted when a new cell is created.
+   *
+   */
+  readonly newCellCreated: ISignal<this, Cell | null>;
+
+  /**
    * A signal emitted when the selection state changes.
    */
   readonly selectionChanged: ISignal<this, void>;

--- a/packages/notebook/src/tracker.ts
+++ b/packages/notebook/src/tracker.ts
@@ -39,6 +39,13 @@ export class NotebookTracker
   }
 
   /**
+   * A signal emitted when a new cell is created.
+   */
+  get newCellCreated(): ISignal<this, Cell | null> {
+    return this._newCellCreated;
+  }
+
+  /**
    * A signal emitted when the selection state changes.
    */
   get selectionChanged(): ISignal<this, void> {
@@ -53,6 +60,7 @@ export class NotebookTracker
   add(panel: NotebookPanel): Promise<void> {
     const promise = super.add(panel);
     panel.content.activeCellChanged.connect(this._onActiveCellChanged, this);
+    panel.content.newCellCreated.connect(this._onNewCellCreated, this);
     panel.content.selectionChanged.connect(this._onSelectionChanged, this);
     return promise;
   }
@@ -92,6 +100,14 @@ export class NotebookTracker
     }
   }
 
+  private _onNewCellCreated(sender: Notebook, cell: Cell): void {
+    // Check if the new cell creation change happened for the current notebook.
+    if (this.currentWidget && this.currentWidget.content === sender) {
+      this._activeCell = cell || null;
+      this._newCellCreated.emit(cell);
+    }
+  }
+
   private _onSelectionChanged(sender: Notebook): void {
     // Check if the selection change happened for the current notebook.
     if (this.currentWidget && this.currentWidget.content === sender) {
@@ -101,5 +117,6 @@ export class NotebookTracker
 
   private _activeCell: Cell | null = null;
   private _activeCellChanged = new Signal<this, Cell | null>(this);
+  private _newCellCreated = new Signal<this, Cell | null>(this);
   private _selectionChanged = new Signal<this, void>(this);
 }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -875,6 +875,13 @@ export class Notebook extends StaticNotebook {
   }
 
   /**
+   * A signal emitted when a new cell is created
+   */
+  get newCellCreated(): ISignal<this, Cell> {
+    return this._newCellCreated;
+  }
+
+  /**
    * A signal emitted when the state of the notebook changes.
    */
   get stateChanged(): ISignal<this, IChangedArgs<any>> {
@@ -1482,6 +1489,7 @@ export class Notebook extends StaticNotebook {
       index <= this.activeCellIndex
         ? this.activeCellIndex + 1
         : this.activeCellIndex;
+    this._newCellCreated.emit(cell);
   }
 
   /**
@@ -2160,6 +2168,7 @@ export class Notebook extends StaticNotebook {
   } | null = null;
   private _mouseMode: 'select' | 'couldDrag' | null = null;
   private _activeCellChanged = new Signal<this, Cell>(this);
+  private _newCellCreated = new Signal<this, Cell>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);
   private _selectionChanged = new Signal<this, void>(this);
 

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -231,6 +231,9 @@
       "path": "./packages/statusbar-extension"
     },
     {
+      "path": "./packages/tabmanager-extension"
+    },
+    {
       "path": "./packages/terminal"
     },
     {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is a rebase and continuation of https://github.com/jupyterlab/jupyterlab/pull/8706

On top of the work by @echarles I have:
1. Created a `newCellCreated` signal
   - and subsequently used to set keymaps in the cells
2. Made moving between cells work properly
3. Pulled in a few more commands from the extension so that it behaves as expected

In order to keep this slim I only pulled in the minimal set of commands that I thought are essential for the vim in the notebook experience. I imagine the remainder can be set by users using the shortcut settings or by an extension.

I'd also be happy to add the following:
- [ ] emacs (https://github.com/kpe/jupyterlab-emacskeys)
    - @kpe
- [x] sublime (https://github.com/ryantam626/jupyterlab_sublime)
    - @ryantam626 
- [ ] yank(copy) to system clipboard https://github.com/ianhi/jupyterlab_vim-system-clipboard-support

Thoughts?

~I'd also like add better attribution of the source of the vim keymaps https://github.com/jwkvam/jupyterlab-vim as I seem to have lost those comments somewhere along the way.~ (edit:  done)

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
1. Add a `newCellCreated` signal to the notebook tracker
2. added more keyboard commands associated with vim mode
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Choosing vim from the settings menu will now affect both the text editor and the notebook . This addresses problem one from https://github.com/jupyterlab/jupyterlab/issues/8592

## Backwards-incompatible changes
No? I don't think so.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
