### PR TITLE
Use span element to maintain ellipsis

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1959,7 +1959,7 @@ export namespace DirListing {
       if (text) {
         const indices = !model.indices ? [] : model.indices;
         let highlightedName = StringExt.highlight(model.name, indices, h.mark);
-        VirtualDOM.render(h.div(highlightedName), text);
+        VirtualDOM.render(h.span(highlightedName), text);
       }
 
       let modText = '';


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9074 

## Code changes

Replace inner div with span, which maintains word-wrap/overflow/ellipsis settings.

## User-facing changes

Before:
![image](https://user-images.githubusercontent.com/648190/94193762-bf7a0200-fe7e-11ea-83d3-55b0cf6eb2b0.png)

After:
![image](https://user-images.githubusercontent.com/648190/94193907-f223fa80-fe7e-11ea-9c8f-8c276afccf8e.png)


## Backwards-incompatible changes

None