### PR TITLE
Add indication that file browser can be expanded in narrow state

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -128,6 +128,11 @@ const NAME_ID_CLASS = 'jp-id-name';
 const MODIFIED_ID_CLASS = 'jp-id-modified';
 
 /**
+ * The class name added to the narrow column header cell.
+ */
+const NARROW_ID_CLASS = 'jp-id-narrow';
+
+/**
  * The mime type for a contents drag object.
  */
 const CONTENTS_MIME = 'application/x-jupyter-icontents';
@@ -1776,11 +1781,15 @@ export namespace DirListing {
       translator = translator || nullTranslator;
       const trans = translator.load('jupyterlab');
       const name = this._createHeaderItemNode(trans.__('Name'));
+      const narrow = document.createElement('div');
       const modified = this._createHeaderItemNode(trans.__('Last Modified'));
       name.classList.add(NAME_ID_CLASS);
       name.classList.add(SELECTED_CLASS);
       modified.classList.add(MODIFIED_ID_CLASS);
+      narrow.classList.add(NARROW_ID_CLASS);
+      narrow.textContent = '...';
       node.appendChild(name);
+      node.appendChild(narrow);
       node.appendChild(modified);
 
       // set the initial caret icon

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -165,6 +165,7 @@
   padding: 4px 4px;
   border-left: var(--jp-border-width) solid var(--jp-border-color2);
   text-align: right;
+  color: var(--jp-border-color2);
 }
 
 .jp-DirListing-narrow .jp-id-narrow {

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -159,6 +159,18 @@
   text-align: right;
 }
 
+.jp-id-narrow {
+  display: none;
+  flex: 0 0 5px;
+  padding: 4px 4px;
+  border-left: var(--jp-border-width) solid var(--jp-border-color2);
+  text-align: right;
+}
+
+.jp-DirListing-narrow .jp-id-narrow {
+  display: block;
+}
+
 .jp-DirListing-narrow .jp-id-modified,
 .jp-DirListing-narrow .jp-DirListing-itemModified {
   display: none;


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Addresses UX concerns in #8497

## Code changes

Show a little ellipsis indicator on the file browser header bar in narrow mode to indicate that it can be expanded.

## User-facing changes

![ellipsis](https://user-images.githubusercontent.com/648190/94199344-ad03c680-fe86-11ea-9fc0-3de3704e26e9.gif)

## Backwards-incompatible changes

None.