### PR TITLE
Make the single document title widget work for widgets that are not main area widgets

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -821,7 +821,9 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
    */
   private _updateTitlePanelTitle() {
     let current = this.currentWidget;
-    this._titleWidget.node.children[0].textContent = current ? current.title.label : '';
+    const h1 = this._titleWidget.node.children[0] as HTMLHeadElement;
+    h1.textContent = current ? current.title.label : '';
+    h1.title = current ? current.title.caption : '';
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { MainAreaWidget } from '@jupyterlab/apputils';
-
 import { DocumentRegistry, DocumentWidget } from '@jupyterlab/docregistry';
 
 import { classes, DockPanelSvg, LabIcon } from '@jupyterlab/ui-components';
@@ -293,6 +291,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     // Setup single-document-mode title bar
     const titleWidget = (this._titleWidget = new Widget());
     titleWidget.id = 'jp-title-panel-title';
+    titleWidget.node.appendChild(document.createElement('h1'));
     this.add(titleWidget, 'title');
     if (this._dockPanel.mode == 'multiple-document') {
       this._titleHandler.panel.hide();
@@ -305,16 +304,16 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       let oldValue = args.oldValue;
 
       // Stop watching the title of the previously current widget
-      if (oldValue && oldValue instanceof MainAreaWidget) {
-        oldValue.content.title.changed.disconnect(
+      if (oldValue) {
+        oldValue.title.changed.disconnect(
           this._updateTitlePanelTitle,
           this
         );
       }
 
       // Start watching the title of the new current widget
-      if (newValue && newValue instanceof MainAreaWidget) {
-        newValue.content.title.changed.connect(
+      if (newValue) {
+        newValue.title.changed.connect(
           this._updateTitlePanelTitle,
           this
         );
@@ -822,10 +821,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
    */
   private _updateTitlePanelTitle() {
     let current = this.currentWidget;
-    if (current && current instanceof MainAreaWidget) {
-      this._titleWidget.node.innerHTML =
-        '<h1>' + current.content.title.label + '</h1>';
-    }
+    this._titleWidget.node.children[0].textContent = current ? current.title.label : '';
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -305,18 +305,12 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
 
       // Stop watching the title of the previously current widget
       if (oldValue) {
-        oldValue.title.changed.disconnect(
-          this._updateTitlePanelTitle,
-          this
-        );
+        oldValue.title.changed.disconnect(this._updateTitlePanelTitle, this);
       }
 
       // Start watching the title of the new current widget
       if (newValue) {
-        newValue.title.changed.connect(
-          this._updateTitlePanelTitle,
-          this
-        );
+        newValue.title.changed.connect(this._updateTitlePanelTitle, this);
         this._updateTitlePanelTitle();
       }
 


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Fix html injection opportunity in the title widget

Also, make the single document title widget work for widgets that are not main area widgets.

Main area widgets continue to work since they automatically mirror their .content title attributes.

## User-facing changes

None

## Backwards-incompatible changes

None
