### PR TITLE
Support token authentication for terminal websocket communication

### DIFF
--- a/packages/services/examples/node/main.py
+++ b/packages/services/examples/node/main.py
@@ -22,9 +22,7 @@ class NodeApp(ProcessApp):
 
     name = __name__
     serverapp_config = dict(
-        disable_check_xsrf = True,
-        allow_origin = "*",
-        token=""
+        allow_origin = "*"
     )
 
     def get_command(self):
@@ -33,7 +31,7 @@ class NodeApp(ProcessApp):
         # Run the node script with command arguments.
         config = dict(
             baseUrl='http://localhost:{}{}'.format(self.serverapp.port, self.settings['base_url']),
-            token="")
+            token=self.settings['token'])
 
         with open(osp.join(HERE, 'config.json'), 'w') as fid:
             json.dump(config, fid)

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1216,6 +1216,12 @@ export class KernelConnection implements Kernel.IKernelConnection {
       'channels?session_id=' + encodeURIComponent(this._clientId)
     );
 
+    // If token authentication is in use.
+    const token = settings.token;
+    if (settings.appendToken && token !== '') {
+      url = url + `&token=${encodeURIComponent(token)}`;
+    }
+
     this._ws = new settings.WebSocket(url);
 
     // Ensure incoming binary messages are not Blobs

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -77,6 +77,12 @@ export namespace ServerConnection {
     readonly token: string;
 
     /**
+     * Whether to append a token to a Websocket url.  The default is `false` in the browser
+     * and `true` in node or jest.
+     */
+    readonly appendToken: boolean;
+
+    /**
      * The `fetch` method to use.
      */
     readonly fetch: (
@@ -238,6 +244,9 @@ namespace Private {
       WebSocket: WEBSOCKET,
       token: PageConfig.getToken(),
       appUrl: PageConfig.getOption('appUrl'),
+      appendToken:
+        typeof window === 'undefined' ||
+        process.env.JEST_WORKER_ID !== undefined,
       ...options,
       baseUrl,
       wsUrl

--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -265,6 +265,10 @@ export class TerminalConnection implements Terminal.ITerminalConnection {
       encodeURIComponent(name)
     );
 
+    if (settings.token !== undefined) {
+      url += `?token=${encodeURIComponent(settings.token)}`;
+    }
+
     this._ws = new settings.WebSocket(url);
 
     this._ws.onmessage = this._onWSMessage;

--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -265,8 +265,10 @@ export class TerminalConnection implements Terminal.ITerminalConnection {
       encodeURIComponent(name)
     );
 
-    if (settings.token !== undefined) {
-      url += `?token=${encodeURIComponent(settings.token)}`;
+    // If token authentication is in use.
+    const token = settings.token;
+    if (settings.appendToken && token !== '') {
+      url = url + `?token=${encodeURIComponent(token)}`;
     }
 
     this._ws = new settings.WebSocket(url);

--- a/testutils/src/start_jupyter_server.ts
+++ b/testutils/src/start_jupyter_server.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
-import { PromiseDelegate } from '@lumino/coreutils';
+import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import { sleep } from './common';
 
 /**
@@ -202,7 +202,8 @@ namespace Private {
    */
   export function handleConfig(): string {
     // Set up configuration.
-    PageConfig.setOption('token', '');
+    const token = UUID.uuid4();
+    PageConfig.setOption('token', token);
     PageConfig.setOption('terminalsAvailable', 'true');
 
     const configDir = mktempDir('config');
@@ -221,10 +222,8 @@ namespace Private {
         open_browser: false
       },
       ServerApp: {
-        token: '',
-        notebook_dir,
-        disable_check_xsrf: true,
-        allow_origin: '*'
+        token,
+        notebook_dir
       },
       MultiKernelManager: {
         default_kernel_name: 'echo'


### PR DESCRIPTION
## References
This is a suggested patch for #9070 

## Code changes
Right before establishing the websocket connection, the code adds an extra query parameter for websocket authentication.

## User-facing changes
There is no user-facing changes.

## Backwards-incompatible changes
This is backward compatible.