### PR TITLE
Add missing return signatures in debugger sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ storybook-static
 __pycache__
 *.egg-info
 .ipynb_checkpoints
+pip-wheel-metadata
 
 # xeus-python debug logs
 xpython_debug_logs

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -404,7 +404,7 @@ function activateEditorCommands(
     ['sublime', trans.__('sublime')],
     ['vim', trans.__('vim')],
     ['emacs', trans.__('emacs')]
-  ].forEach(([name, displayName])=> {
+  ].forEach(([name, displayName]) => {
     keyMapMenu.addItem({
       command: CommandIDs.changeKeyMap,
       args: { keyMap: name, displayName: displayName }

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -99,7 +99,7 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
    * If the widget is already contained in the sidebar, it will be moved.
    * The item can be removed from the sidebar by setting its parent to `null`.
    */
-  addItem(widget: Widget) {
+  addItem(widget: Widget): void {
     this._body.addWidget(widget);
   }
 
@@ -114,7 +114,7 @@ export class DebuggerSidebar extends Panel implements IDebugger.ISidebar {
    * If the widget is already contained in the sidebar, it will be moved.
    * The item can be removed from the sidebar by setting its parent to `null`.
    */
-  insertItem(index: number, widget: Widget) {
+  insertItem(index: number, widget: Widget): void {
     this._body.insertWidget(index, widget);
   }
 


### PR DESCRIPTION
Adds missing return signatures in debugger sidebar.

cc: @mnowacki-b 

## References

https://github.com/jupyterlab/jupyterlab/commit/113ae9c057d99c92bbad779d0138c1a43355955a#r42789776

https://github.com/jupyterlab/jupyterlab/commit/113ae9c057d99c92bbad779d0138c1a43355955a#r42789780

## Code changes

Added docs.

## User-facing changes

N/A

## Backwards-incompatible changes

N/A
