### PR TITLE
Update the upgrade script to not replace dev deps to caret

### DIFF
--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -94,7 +94,7 @@ def update_extension(target, interactive=True):
         temp_data = json.load(fid)
 
     for (key, value) in temp_data['devDependencies'].items():
-        data['devDependencies'][key] = value.replace('~', '^')
+        data['devDependencies'][key] = value
 
     # Ask the user whether to upgrade the scripts automatically
     warnings = []


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/commit/aee97d8a9577635622e7e2c75714c7d4f7929623#r42794778

cc @jasongrout 

## Code changes

Changes to the extension upgrade script.

The script would otherwise upgrade `devDependencies` such as `typescript`:

```diff
-"typescript": "~3.9.0",
+"typescript": "^3.9.0",
```

## User-facing changes

None

## Backwards-incompatible changes

None