### PR TITLE
Fix the open tabs handling of MainAreaWidget icons

### DIFF
--- a/packages/running-extension/src/opentabs.ts
+++ b/packages/running-extension/src/opentabs.ts
@@ -116,7 +116,7 @@ export function addOpenTabsSessionManager(
       let icon = fileIcon;
       if (this._widget instanceof MainAreaWidget) {
         const widgetIcon = this._widget.title.icon;
-        if (icon instanceof LabIcon) {
+        if (widgetIcon instanceof LabIcon) {
           icon = widgetIcon as LabIcon;
         }
       }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/extension-examples/issues/126

## Code changes

Use the main area widget icon when choosing an icon for the open tab entry.

## User-facing changes

### Before

Opening the contextual help would make the open tabs panel disappear, with an error logged in the dev tools console:

![opentabs-icon-issue](https://user-images.githubusercontent.com/591645/94483944-f4b68500-01db-11eb-8aa4-b9f8469f91f4.gif)

### After

![opentabs-icon-fix](https://user-images.githubusercontent.com/591645/94483956-f97b3900-01db-11eb-9756-3b3c8c4a2a02.gif)

## Backwards-incompatible changes

None
