### PR TITLE
Do not special-case logic for MainAreaWidget.

### DIFF
--- a/packages/running-extension/package.json
+++ b/packages/running-extension/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^3.0.0-rc.1",
-    "@jupyterlab/apputils": "^3.0.0-rc.1",
     "@jupyterlab/coreutils": "^5.0.0-rc.1",
     "@jupyterlab/docregistry": "^3.0.0-rc.1",
     "@jupyterlab/running": "^3.0.0-rc.1",

--- a/packages/running-extension/src/opentabs.ts
+++ b/packages/running-extension/src/opentabs.ts
@@ -9,8 +9,6 @@ import { ISignal, Signal } from '@lumino/signaling';
 
 import { ILabShell } from '@jupyterlab/application';
 
-import { MainAreaWidget } from '@jupyterlab/apputils';
-
 import { IRunningSessions, IRunningSessionManagers } from '@jupyterlab/running';
 
 import { ITranslator } from '@jupyterlab/translation';

--- a/packages/running-extension/src/opentabs.ts
+++ b/packages/running-extension/src/opentabs.ts
@@ -41,10 +41,8 @@ class OpenTabsSignaler {
    * @param widget A widget whose title may change.
    */
   addWidget(widget: Widget): void {
-    if (widget instanceof MainAreaWidget) {
-      widget.content.title.changed.connect(this._emitTabsChanged, this);
-      this._widgets.push(widget);
-    }
+    widget.title.changed.connect(this._emitTabsChanged, this);
+    this._widgets.push(widget);
   }
 
   /**
@@ -52,7 +50,7 @@ class OpenTabsSignaler {
    */
   private _emitTabsChanged(): void {
     this._widgets.forEach(widget => {
-      widget.content.title.changed.disconnect(this._emitTabsChanged, this);
+      widget.title.changed.disconnect(this._emitTabsChanged, this);
     });
     this._widgets = [];
     this._tabsChanged.emit(void 0);
@@ -60,7 +58,7 @@ class OpenTabsSignaler {
 
   private _tabsChanged = new Signal<this, void>(this);
   private _labShell: ILabShell;
-  private _widgets: MainAreaWidget[] = [];
+  private _widgets: Widget[] = [];
 }
 
 /**
@@ -113,14 +111,8 @@ export function addOpenTabsSessionManager(
       this._widget.close();
     }
     icon() {
-      let icon = fileIcon;
-      if (this._widget instanceof MainAreaWidget) {
-        const widgetIcon = this._widget.title.icon;
-        if (widgetIcon instanceof LabIcon) {
-          icon = widgetIcon as LabIcon;
-        }
-      }
-      return icon;
+      const widgetIcon = this._widget.title.icon;
+      return widgetIcon instanceof LabIcon ? widgetIcon : fileIcon;
     }
     label() {
       return this._widget.title.label;

--- a/packages/running-extension/tsconfig.json
+++ b/packages/running-extension/tsconfig.json
@@ -10,9 +10,6 @@
       "path": "../application"
     },
     {
-      "path": "../apputils"
-    },
-    {
       "path": "../coreutils"
     },
     {


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Since MainAreaWidget automatically reflects the title of the .content, we do not have to special-case logic for MainAreaWidgets.

## User-facing changes


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
