### PR TITLE
Add border at top of single-document open menus

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -31,7 +31,8 @@
   padding: 0px 8px;
   border-left: var(--jp-border-width) solid transparent;
   border-right: var(--jp-border-width) solid transparent;
-  line-height: var(--jp-private-menubar-height);
+  border-top: var(--jp-border-width) solid transparent;
+  line-height: calc(var(--jp-private-menubar-height) - var(--jp-border-width));
 }
 
 .lm-MenuBar-item.lm-mod-active {
@@ -44,6 +45,12 @@
   border-left: var(--jp-border-width) solid var(--jp-border-color1);
   border-right: var(--jp-border-width) solid var(--jp-border-color1);
   box-shadow: var(--jp-elevation-z6);
+}
+
+.jp-LabShell[data-shell-mode='single-document']
+  .lm-MenuBar.lm-mod-active
+  .lm-MenuBar-item.lm-mod-active {
+  border-top: var(--jp-border-width) solid var(--jp-border-color1);
 }
 
 .lm-MenuBar-item.lm-mod-disabled {


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9065



## Code changes

Because adding a border at the top changed the heights, I had to modify a few other things as well to get the menu heights to work out. The text is still one pixel below where it was, but in the limited time I had, I didn't figure out how to center the text back to the height it was (changing one thing often had unintended consequences elsewhere).

## User-facing changes

Before:
<img width="598" alt="Screen Shot 2020-09-28 at 5 08 06 PM" src="https://user-images.githubusercontent.com/192614/94497832-4693e680-01ad-11eb-87e5-ff7d5e95ac12.png">

After:
<img width="594" alt="Screen Shot 2020-09-28 at 5 07 14 PM" src="https://user-images.githubusercontent.com/192614/94497840-4c89c780-01ad-11eb-801d-362e43ba9344.png">


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
