### PR TITLE
Add hover scrolling to menu, like toolbar.

### DIFF
--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -23,6 +23,10 @@
   font-size: var(--jp-ui-font-size1);
 }
 
+.lm-MenuBar:hover {
+  overflow-x: auto;
+}
+
 .lm-MenuBar-menu {
   transform: translateY(calc(-2 * var(--jp-border-width)));
 }

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -136,6 +136,7 @@ const plugin: JupyterFrontEndPlugin<IMainMenu> = {
 
     const menu = new MainMenu(commands);
     menu.id = 'jp-MainMenu';
+    menu.addClass('jp-scrollbar-tiny');
 
     const logo = new Widget();
     jupyterIcon.element({


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This looks terrible, but makes it functional when you need to scroll the menu bar because of a narrow window.

<img width="310" alt="Screen Shot 2020-09-29 at 6 51 15 AM" src="https://user-images.githubusercontent.com/192614/94574878-7502d780-0228-11eb-9fad-82a15b9734e2.png">

For comparison, here is the toolbar showing the same hover scrolling (this is existing behavior, not introduced in this PR):

<img width="314" alt="Screen Shot 2020-09-29 at 7 51 41 AM" src="https://user-images.githubusercontent.com/192614/94575085-b3989200-0228-11eb-9161-e4ec7ba81277.png">

I debated hiding the scrollbar to make mouse scrolling work, but decided against it for functionality reasons.

Arguably having the scroll only appear on hover is also really bad, but it is better than not appearing at all.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
