### PR TITLE
Implement a simple checkbox for single-document mode in the menu bar.

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -266,7 +266,6 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     // initially hiding header and bottom panel when no elements inside,
     // and the title panel as we only show that in single document mode.
     this._headerPanel.hide();
-    this._titleHandler.panel.hide();
     this._bottomPanel.hide();
 
     this.layout = rootLayout;
@@ -293,9 +292,36 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     titleWidget.id = 'jp-title-panel-title';
     titleWidget.node.appendChild(document.createElement('h1'));
     this.add(titleWidget, 'title');
-    if (this._dockPanel.mode == 'multiple-document') {
+
+    if (this._dockPanel.mode === 'multiple-document') {
       this._titleHandler.panel.hide();
     }
+
+    // Set up single-document mode switch in menu bar
+    const spacer = new Widget();
+    spacer.id = 'jp-top-spacer';
+    this.add(spacer, 'top', { rank: 1000 });
+
+    const label = document.createElement('label');
+    label.textContent = 'Single-Document Mode';
+    label.title = 'Single-Document Mode';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = 'single-document';
+    checkbox.title = 'Single-Document Mode';
+    this.modeChanged.connect((_, mode) => {
+      checkbox.checked = mode === 'single-document';
+    });
+    checkbox.checked = this.mode === 'single-document';
+    checkbox.addEventListener('change', () => {
+      this.mode = checkbox.checked ? 'single-document' : 'multiple-document';
+    });
+    label.appendChild(checkbox);
+
+    const checkWidget = new Widget();
+    checkWidget.node.appendChild(label);
+    checkWidget.id = 'jp-single-document-mode';
+    this.add(checkWidget, 'top', { rank: 1010 });
 
     // Wire up signals to update the title panel of the single document mode to
     // follow the title of this.currentWidget

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -52,6 +52,15 @@ body {
   display: flex;
 }
 
+#jp-top-spacer {
+  flex-grow: 1;
+}
+
+#jp-single-document-mode {
+  margin: 0px 8px;
+  align-self: center;
+}
+
 /* Sibling imports */
 @import './datagrid.css';
 @import './dockpanel.css';


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #8292

## Code changes



## User-facing changes

Adds a checkbox for single-document mode in the top area.

Styling obviously could be better, especially switching to a more normal toggle switch.

<img width="772" alt="Screen Shot 2020-09-29 at 1 10 28 PM" src="https://user-images.githubusercontent.com/192614/94610455-2e77a200-0255-11eb-83f9-f292aadfbf7d.png">
<img width="772" alt="Screen Shot 2020-09-29 at 1 10 17 PM" src="https://user-images.githubusercontent.com/192614/94610458-30416580-0255-11eb-9b0d-82062b2be0d7.png">


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
