### PR TITLE
Fix watch mode

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -37,7 +37,7 @@ from jupyterlab.coreconfig import _get_default_core_data, CoreConfig
 
 
 # The regex for expecting the webpack output.
-WEBPACK_EXPECT = re.compile(r'.*/index.out.js')
+WEBPACK_EXPECT = re.compile(r'.*theme-light-extension/style/index.css')
 
 # The dev mode directory.
 DEV_DIR = osp.abspath(os.path.join(HERE, '..', 'dev_mode'))


### PR DESCRIPTION


## References

Fixes #9089 

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This fixes `jupyter lab --dev-mode --watch`

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
