### PR TITLE
test: cleanup eslint jest rules and files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,10 +55,6 @@ module.exports = {
     'no-case-declarations': 'warn',
     'no-useless-escape': 'off',
     'prefer-const': 'off',
-    'jest/no-jest-import': 'off',
-    'jest/no-export': 'warn',
-    'jest/no-try-expect': 'warn',
-    'jest/expect-expect': 'off',
     'react/prop-types': 'warn'
   },
   settings: {

--- a/packages/application/test/layoutrestorer.spec.ts
+++ b/packages/application/test/layoutrestorer.spec.ts
@@ -155,11 +155,10 @@ describe('apputils', () => {
           leftArea: { currentWidget: null, collapsed: true, widgets: null },
           rightArea: { collapsed: true, currentWidget: null, widgets: null }
         };
-        try {
-          await restorer.save(dehydrated);
-        } catch (e) {
-          expect(e).toBe('save() was called prematurely.');
-        }
+
+        await expect(restorer.save(dehydrated)).rejects.toBe(
+          'save() was called prematurely.'
+        );
       });
 
       it('should save data', async () => {

--- a/packages/apputils/test/commandpalette.spec.ts
+++ b/packages/apputils/test/commandpalette.spec.ts
@@ -1,6 +1,4 @@
 // Copyright (c) Jupyter Development Team.
-
-import 'jest';
 // Distributed under the terms of the Modified BSD License.
 
 // import { expect } from 'chai';

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -360,11 +360,8 @@ describe('filebrowser/model', () => {
         expect(contents.name).toBe(fname);
         const promise = model.upload(file);
         await dismissDialog();
-        try {
-          await promise;
-        } catch (e) {
-          expect(e).toBe('File not uploaded');
-        }
+
+        await expect(promise).rejects.toBe('File not uploaded');
       });
 
       it('should emit the fileChanged signal', async () => {
@@ -397,12 +394,10 @@ describe('filebrowser/model', () => {
         it('should not upload large file', async () => {
           const fname = UUID.uuid4() + '.html';
           const file = new File([new ArrayBuffer(LARGE_FILE_SIZE + 1)], fname);
-          try {
-            await model.upload(file);
-            throw new Error('Upload should have failed');
-          } catch (err) {
-            expect(err).toBe(`Cannot upload file (>15 MB). ${fname}`);
-          }
+
+          await expect(model.upload(file)).rejects.toBe(
+            `Cannot upload file (>15 MB). ${fname}`
+          );
         });
 
         afterAll(() => {

--- a/testutils/src/flakyIt.ts
+++ b/testutils/src/flakyIt.ts
@@ -32,6 +32,7 @@ async function runTest(fn: any): Promise<void> {
  * @param retries The number of retries
  * @param wait The time to wait in milliseconds between retries
  */
+/* eslint-disable jest/no-export */
 export function flakyIt(name: string, fn: any, retries = 3, wait = 1000): void {
   test(name, async () => {
     let latestError;
@@ -47,6 +48,7 @@ export function flakyIt(name: string, fn: any, retries = 3, wait = 1000): void {
     throw latestError;
   });
 }
+/* eslint-enable jest/no-export */
 
 flakyIt.only = it.only;
 flakyIt.skip = it.skip;


### PR DESCRIPTION
## Code changes

With the exception of one `jest/no-export` case, most of these eslint jest rules are quite reasonable to have and are fixable. So this PR cleans them up.

## User-facing changes

None

## Backwards-incompatible changes

None
