### PR TITLE
Increase size of docstring pop up tooltip

### DIFF
--- a/packages/tooltip/style/base.css
+++ b/packages/tooltip/style/base.css
@@ -9,6 +9,7 @@
   font-size: var(--jp-ui-font-size0);
   box-shadow: var(--jp-elevation-z6);
   max-width: 750px;
+  max-height: 750px;
   z-index: 10001;
   padding: 4px;
   display: flex;

--- a/packages/tooltip/style/base.css
+++ b/packages/tooltip/style/base.css
@@ -8,7 +8,7 @@
   border: var(--jp-border-width) solid var(--jp-border-color1);
   font-size: var(--jp-ui-font-size0);
   box-shadow: var(--jp-elevation-z6);
-  max-width: 650px;
+  max-width: 750px;
   z-index: 10001;
   padding: 4px;
   display: flex;

--- a/packages/tooltip/style/base.css
+++ b/packages/tooltip/style/base.css
@@ -9,7 +9,7 @@
   font-size: var(--jp-ui-font-size0);
   box-shadow: var(--jp-elevation-z6);
   max-width: 750px;
-  max-height: 750px;
+  max-height: 350px;
   z-index: 10001;
   padding: 4px;
   display: flex;


### PR DESCRIPTION
The docstring pop up/tooltip (Shift + Tab) currently wraps lines that are over 75 characters. Many libraries have docstrings that are just a bit longer than this. I believe the common longer lengths include 77, 80, and 82, and I suggest changing the default width to wrap at 83 characters instead to avoid line spillover which makes the doscstring hard to read, see screenshots below

Current behavior:
![image](https://user-images.githubusercontent.com/4560057/94982359-b2988680-04ee-11eb-9ea7-6482720b4ba3.png)

Suggested behavior:
![image](https://user-images.githubusercontent.com/4560057/94982382-d9ef5380-04ee-11eb-8d8a-892a2b788113.png)

Increasing the width from 650 px to 750 px wraps at the 84 th char, so docstrings <=84 chars width will be displayed as intended by the library author. 

---

The second commit I made is a suggestion to also increase the height of the tooltip. Especially when many libraries have started to stack their function parameters vertically, I think getting increased vertical real estate to read the docstrings would be great. Since the JupyterLab tooltip only shows up after pressing Shift +TAB, I also don't think one needs to worry as much about a large tooltip covering other areas of the code, since it is only there when explicitly called for and then facilitating reading of the docstring would take priority over covering code further down imo.

Suggested behavior with height increase:
![image](https://user-images.githubusercontent.com/4560057/94982610-dbba1680-04f0-11eb-9912-a2ad4847bcf3.png)

close #9085 

