### PR TITLE
Create newCellCreated signal + make block comment keyboard shortcut a setting

### DIFF
--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -42,6 +42,7 @@
     "@jupyterlab/docregistry": "^3.0.0-rc.4",
     "@jupyterlab/fileeditor": "^3.0.0-rc.4",
     "@jupyterlab/mainmenu": "^3.0.0-rc.4",
+    "@jupyterlab/notebook": "^3.0.0-rc.4",
     "@jupyterlab/settingregistry": "^3.0.0-rc.4",
     "@jupyterlab/statusbar": "^3.0.0-rc.4",
     "@jupyterlab/translation": "^3.0.0-rc.4",

--- a/packages/codemirror-extension/schema/commands.json
+++ b/packages/codemirror-extension/schema/commands.json
@@ -51,6 +51,18 @@
       "title": "Block Comment",
       "description": "Key command for block comment",
       "default": "Accel-/"
+    },
+    "indent": {
+      "type": "string",
+      "title": "Keyboard shortcut to indent",
+      "description": "Value is a string defining the keybinding",
+      "default": "Tab"
+    },
+    "deindent": {
+      "type": "string",
+      "title": "Keyboard shortcut to deindent",
+      "description": "Value is a string defining the keybinding",
+      "default": "Shift-Tab"
     }
   },
   "type": "object"

--- a/packages/codemirror-extension/schema/commands.json
+++ b/packages/codemirror-extension/schema/commands.json
@@ -45,6 +45,12 @@
       "title": "Ctrl-C",
       "description": "When enabled, which is the default, doing copy or cut when there is no selection will copy or cut the whole lines that have cursors on them.",
       "default": true
+    },
+    "toggleComment": {
+      "type": "string",
+      "title": "Block Comment",
+      "description": "Key command for block comment",
+      "default": "Accel-/"
     }
   },
   "type": "object"

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -186,6 +186,8 @@ function activateEditorCommands(
   } = CodeMirrorEditor.defaultConfig;
 
   let toggleComment = 'Accel-/';
+  let indent = 'Tab';
+  let deindent = 'Shift-Tab';
   /**
    * Update the setting values.
    */
@@ -229,6 +231,8 @@ function activateEditorCommands(
       (settings.get('lineWiseCopyCut').composite as boolean) ?? lineWiseCopyCut;
     toggleComment =
       (settings.get('toggleComment').composite as string) ?? toggleComment;
+    indent = (settings.get('indent').composite as string) ?? indent;
+    deindent = (settings.get('deindent').composite as string) ?? deindent;
   }
 
   /**
@@ -237,6 +241,8 @@ function activateEditorCommands(
   function updateExtraKeys(editor: CodeMirrorEditor) {
     let extraKeys = editor.getOption('extraKeys') as any;
     extraKeys[toggleComment] = 'toggleComment';
+    extraKeys[indent] = 'indentMoreOrinsertTab';
+    extraKeys[deindent] = 'indentLess';
     editor.setOption('extraKeys', extraKeys);
   }
   /**

--- a/packages/codemirror-extension/tsconfig.json
+++ b/packages/codemirror-extension/tsconfig.json
@@ -4,9 +4,7 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": [
-    "src/*"
-  ],
+  "include": ["src/*"],
   "references": [
     {
       "path": "../application"

--- a/packages/codemirror-extension/tsconfig.json
+++ b/packages/codemirror-extension/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "../application"
     },
     {
+      "path": "../cells"
+    },
+    {
       "path": "../codeeditor"
     },
     {
@@ -25,6 +28,9 @@
       "path": "../mainmenu"
     },
     {
+      "path": "../notebook"
+    },
+    {
       "path": "../settingregistry"
     },
     {
@@ -32,6 +38,9 @@
     },
     {
       "path": "../translation"
+    },
+    {
+      "path": "../cells"
     }
   ]
 }

--- a/packages/codemirror-extension/tsconfig.json
+++ b/packages/codemirror-extension/tsconfig.json
@@ -4,13 +4,12 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src/*"],
+  "include": [
+    "src/*"
+  ],
   "references": [
     {
       "path": "../application"
-    },
-    {
-      "path": "../cells"
     },
     {
       "path": "../codeeditor"
@@ -38,9 +37,6 @@
     },
     {
       "path": "../translation"
-    },
-    {
-      "path": "../cells"
     }
   ]
 }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -24,17 +24,13 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
       extraKeys: {
         'Cmd-Right': 'goLineRight',
         End: 'goLineRight',
-        'Cmd-Left': 'goLineLeft',
-        Tab: 'indentMoreOrinsertTab',
-        'Shift-Tab': 'indentLess'
+        'Cmd-Left': 'goLineLeft'
       },
       ...defaults
     };
     this.documentCodeMirrorConfig = {
       ...CodeMirrorEditor.defaultConfig,
       extraKeys: {
-        Tab: 'indentMoreOrinsertTab',
-        'Shift-Tab': 'indentLess',
         'Shift-Enter': () => {
           /* no-op */
         }

--- a/packages/codemirror/src/factory.ts
+++ b/packages/codemirror/src/factory.ts
@@ -26,9 +26,7 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
         End: 'goLineRight',
         'Cmd-Left': 'goLineLeft',
         Tab: 'indentMoreOrinsertTab',
-        'Shift-Tab': 'indentLess',
-        'Cmd-/': 'toggleComment',
-        'Ctrl-/': 'toggleComment'
+        'Shift-Tab': 'indentLess'
       },
       ...defaults
     };
@@ -37,8 +35,6 @@ export class CodeMirrorEditorFactory implements IEditorFactoryService {
       extraKeys: {
         Tab: 'indentMoreOrinsertTab',
         'Shift-Tab': 'indentLess',
-        'Cmd-/': 'toggleComment',
-        'Ctrl-/': 'toggleComment',
         'Shift-Enter': () => {
           /* no-op */
         }

--- a/packages/notebook/src/notebooktools.ts
+++ b/packages/notebook/src/notebooktools.ts
@@ -98,9 +98,11 @@ export class NotebookTools extends Widget implements INotebookTools {
       this
     );
     this._tracker.activeCellChanged.connect(this._onActiveCellChanged, this);
+    this._tracker.newCellCreated.connect(this._onNewCellCreated, this);
     this._tracker.selectionChanged.connect(this._onSelectionChanged, this);
     this._onActiveNotebookPanelChanged();
     this._onActiveCellChanged();
+    this._onNewCellCreated();
     this._onSelectionChanged();
   }
 
@@ -204,6 +206,15 @@ export class NotebookTools extends Widget implements INotebookTools {
     }
     each(this._toolChildren(), widget => {
       MessageLoop.sendMessage(widget, NotebookTools.ActiveCellMessage);
+    });
+  }
+
+  /**
+   * Handle the creation of a new cell
+   */
+  private _onNewCellCreated(): void {
+    each(this._toolChildren(), widget => {
+      MessageLoop.sendMessage(widget, NotebookTools.NewCellMessage);
     });
   }
 
@@ -322,6 +333,11 @@ export namespace NotebookTools {
    * A singleton conflatable `'activecell-changed'` message.
    */
   export const ActiveCellMessage = new ConflatableMessage('activecell-changed');
+
+  /**
+   * A singleton conflatable `'new-cell-created'` message.
+   */
+  export const NewCellMessage = new ConflatableMessage('new-cell-created');
 
   /**
    * A singleton conflatable `'selection-changed'` message.

--- a/packages/notebook/src/tokens.ts
+++ b/packages/notebook/src/tokens.ts
@@ -100,6 +100,12 @@ export interface INotebookTracker extends IWidgetTracker<NotebookPanel> {
   readonly activeCellChanged: ISignal<this, Cell | null>;
 
   /**
+   * A signal emitted when a new cell is created.
+   *
+   */
+  readonly newCellCreated: ISignal<this, Cell | null>;
+
+  /**
    * A signal emitted when the selection state changes.
    */
   readonly selectionChanged: ISignal<this, void>;

--- a/packages/notebook/src/tracker.ts
+++ b/packages/notebook/src/tracker.ts
@@ -39,6 +39,13 @@ export class NotebookTracker
   }
 
   /**
+   * A signal emitted when a new cell is created.
+   */
+  get newCellCreated(): ISignal<this, Cell | null> {
+    return this._newCellCreated;
+  }
+
+  /**
    * A signal emitted when the selection state changes.
    */
   get selectionChanged(): ISignal<this, void> {
@@ -53,6 +60,7 @@ export class NotebookTracker
   add(panel: NotebookPanel): Promise<void> {
     const promise = super.add(panel);
     panel.content.activeCellChanged.connect(this._onActiveCellChanged, this);
+    panel.content.newCellCreated.connect(this._onNewCellCreated, this);
     panel.content.selectionChanged.connect(this._onSelectionChanged, this);
     return promise;
   }
@@ -92,6 +100,14 @@ export class NotebookTracker
     }
   }
 
+  private _onNewCellCreated(sender: Notebook, cell: Cell): void {
+    // Check if the new cell creation change happened for the current notebook.
+    if (this.currentWidget && this.currentWidget.content === sender) {
+      this._activeCell = cell || null;
+      this._newCellCreated.emit(cell);
+    }
+  }
+
   private _onSelectionChanged(sender: Notebook): void {
     // Check if the selection change happened for the current notebook.
     if (this.currentWidget && this.currentWidget.content === sender) {
@@ -101,5 +117,6 @@ export class NotebookTracker
 
   private _activeCell: Cell | null = null;
   private _activeCellChanged = new Signal<this, Cell | null>(this);
+  private _newCellCreated = new Signal<this, Cell | null>(this);
   private _selectionChanged = new Signal<this, void>(this);
 }

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -875,6 +875,13 @@ export class Notebook extends StaticNotebook {
   }
 
   /**
+   * A signal emitted when a new cell is created
+   */
+  get newCellCreated(): ISignal<this, Cell> {
+    return this._newCellCreated;
+  }
+
+  /**
    * A signal emitted when the state of the notebook changes.
    */
   get stateChanged(): ISignal<this, IChangedArgs<any>> {
@@ -1482,6 +1489,7 @@ export class Notebook extends StaticNotebook {
       index <= this.activeCellIndex
         ? this.activeCellIndex + 1
         : this.activeCellIndex;
+    this._newCellCreated.emit(cell);
   }
 
   /**
@@ -2160,6 +2168,7 @@ export class Notebook extends StaticNotebook {
   } | null = null;
   private _mouseMode: 'select' | 'couldDrag' | null = null;
   private _activeCellChanged = new Signal<this, Cell>(this);
+  private _newCellCreated = new Signal<this, Cell>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);
   private _selectionChanged = new Signal<this, void>(this);
 

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -231,6 +231,9 @@
       "path": "./packages/statusbar-extension"
     },
     {
+      "path": "./packages/tabmanager-extension"
+    },
+    {
       "path": "./packages/terminal"
     },
     {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Extracts the `newCellCreated` and block comment changes from https://github.com/jupyterlab/jupyterlab/pull/9068

Closes: https://github.com/jupyterlab/jupyterlab/issues/4778
Closes: https://github.com/jupyterlab/jupyterlab/issues/8882
also see: https://github.com/jupyterlab/jupyterlab/issues/7579#issuecomment-630290277

## Code changes
1. Created a `newCellCreated` signal
   - This is also helpful to 3rd party extensions e.g. the vim keymaps
2. Used that signal to update the `extraKeys` to allow the keyboard shortcut for `blockComment` to become a setting
3. set `indent` and `deindent` as settings
   - Mentioned in https://github.com/jupyterlab/jupyterlab/issues/4778#issuecomment-401433293
Is it possible to move that setting into the shortcuts extension? I couldn't figure out how to do that so it is under the `Codemirror` section of the settings.

## User-facing changes

You can now set whatever keys you want to be block comment.

For example, add this to the `CodeMirror` settings:
```
    "toggleComment": "Ctrl-5",
    "indent": "Ctrl-8",
    "deindent": "Ctrl-9",
```
## Backwards-incompatible changes

I guess that any extension that uses the jlab codemirror factory to create an editor separate from the notebook or fileeditor will now be responsible for assigning those shortcuts.
