### PR TITLE
Updating the Zoom link per today's Dev Meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,5 +177,5 @@ We have videoconference meetings every week where we discuss what we have been w
 Anyone is welcome to attend, if they would like to discuss a topic or just to listen in.
 
 - When: Wednesdays [9AM Pacific Time](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=San%20Francisco&)
-- Where: [`jovyan` Zoom](https://zoom.us/my/jovyan)
+- Where: [`jovyan` Zoom](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09)
 - What: [Meeting notes](https://hackmd.io/Y7fBMQPSQ1C08SDGI-fwtg?both)


### PR DESCRIPTION
Updated Zoom link to include passcode. This will allow people to join the call without linking through the Team Compass

## References

I didn't see an issue for this

## Code changes

Just the readme

## User-facing changes

Just the readme
