### PR TITLE
Virtual Notebook Tuning

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -377,11 +377,17 @@
       "type": "boolean",
       "default": true
     },
-    "nonObservedBottomMargin": {
-      "title": "Non-observed bottom margin",
-      "description": "Defines the non-observed bottom margin for the virtual notebook, set a positive number of pixels to render cells below the visible view",
+    "observedTopMargin": {
+      "title": "Observed top margin",
+      "description": "Defines the observed top margin for the virtual notebook, set a positive number of pixels to render cells above the visible view",
       "type": "string",
-      "default": "0px"
+      "default": "1000px"
+    },
+    "observedBottomMargin": {
+      "title": "Observed bottom margin",
+      "description": "Defines the observed bottom margin for the virtual notebook, set a positive number of pixels to render cells below the visible view",
+      "type": "string",
+      "default": "1000px"
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -645,7 +645,8 @@ function activateNotebookHandler(
       numberCellsToRenderDirectly: settings.get('numberCellsToRenderDirectly')
         .composite as number,
       renderCellOnIdle: settings.get('renderCellOnIdle').composite as boolean,
-      nonObservedBottomMargin: settings.get('nonObservedBottomMargin')
+      observedTopMargin: settings.get('observedTopMargin').composite as string,
+      observedBottomMargin: settings.get('observedBottomMargin')
         .composite as string
     };
     factory.shutdownOnClose = settings.get('kernelShutdown')

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -199,8 +199,7 @@ export class StaticNotebook extends Widget {
         {
           root: this.node,
           threshold: 1,
-          rootMargin:
-            '0px 0px ' + this.notebookConfig.nonObservedBottomMargin + ' 0px'
+          rootMargin: `${this.notebookConfig.observedTopMargin} 0px ${this.notebookConfig.observedBottomMargin} 0px`
         }
       );
     }
@@ -642,15 +641,6 @@ export class StaticNotebook extends Widget {
     cell.node.innerHTML = `
       <div class="jp-Cell-Placeholder">
         <div class="jp-Cell-Placeholder-wrapper">
-          <div class="jp-Cell-Placeholder-wrapper-inner">
-            <div class="jp-Cell-Placeholder-wrapper-body">
-              <div class="jp-Cell-Placeholder-h1"></div>
-              <div class="jp-Cell-Placeholder-h2"></div>
-              <div class="jp-Cell-Placeholder-content-1"></div>
-              <div class="jp-Cell-Placeholder-content-2"></div>
-              <div class="jp-Cell-Placeholder-content-3"></div>
-            </div>
-          </div>
         </div>
       </div>`;
     cell.inputHidden = true;
@@ -934,11 +924,18 @@ export namespace StaticNotebook {
     renderCellOnIdle: boolean;
 
     /**
-     * Defines the non-observed bottom margin for the
+     * Defines the observed top margin for the
      * virtual notebook, set a positive number of pixels
      * to render cells below the visible view.
      */
-    nonObservedBottomMargin: string;
+    observedTopMargin: string;
+
+    /**
+     * Defines the observed bottom margin for the
+     * virtual notebook, set a positive number of pixels
+     * to render cells below the visible view.
+     */
+    observedBottomMargin: string;
   }
 
   /**
@@ -950,7 +947,8 @@ export namespace StaticNotebook {
     recordTiming: false,
     numberCellsToRenderDirectly: 10,
     renderCellOnIdle: true,
-    nonObservedBottomMargin: '0px'
+    observedTopMargin: '1000px',
+    observedBottomMargin: '1000px'
   };
 
   /**

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -269,7 +269,6 @@
 |----------------------------------------------------------------------------*/
 
 .jp-Cell-Placeholder {
-  height: 200px !important;
   padding-left: 55px;
 }
 
@@ -283,7 +282,6 @@
 }
 
 .jp-Cell-Placeholder-wrapper-inner {
-  height: 150px;
   padding: 15px;
   position: relative;
 }


### PR DESCRIPTION
## References

Related to https://github.com/jupyterlab/jupyterlab/issues/8971

Follow-up of https://github.com/jupyterlab/jupyterlab/pull/8972

## Code changes

Smaller placeholders + observe 200px outside of the visible area to ensure cells are always rendered when the user changes his visible view via the scrollbar

## User-facing changes

The virtual notebook should bring a better user experience (edge cells don't remain non displayed in case of scrollbar usage)

## Backwards-incompatible changes

None
