### PR TITLE
Create ensureVimKeymap function

### DIFF
--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -151,6 +151,13 @@ class CodeMirrorSingleton implements ICodeMirror {
   get CodeMirror() {
     return CodeMirror;
   }
+
+  async ensureVimKeymap() {
+    if (!("Vim" in (CodeMirror as any))){
+      // @ts-expect-error
+      await import('codemirror/keymap/vim.js');
+    }
+  }
 }
 
 /**

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -69,7 +69,7 @@ const services: JupyterFrontEndPlugin<IEditorServices> = {
  */
 const commands: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/codemirror-extension:commands',
-  requires: [IEditorTracker, ISettingRegistry, ITranslator],
+  requires: [IEditorTracker, ISettingRegistry, ITranslator, ICodeMirror],
   optional: [IMainMenu],
   activate: activateEditorCommands,
   autoStart: true
@@ -153,7 +153,7 @@ class CodeMirrorSingleton implements ICodeMirror {
   }
 
   async ensureVimKeymap() {
-    if (!("Vim" in (CodeMirror as any))){
+    if (!('Vim' in (CodeMirror as any))) {
       // @ts-expect-error
       await import('codemirror/keymap/vim.js');
     }
@@ -175,6 +175,7 @@ function activateEditorCommands(
   tracker: IEditorTracker,
   settingRegistry: ISettingRegistry,
   translator: ITranslator,
+  codeMirror: ICodeMirror,
   mainMenu: IMainMenu | null
 ): void {
   const trans = translator.load('jupyterlab');
@@ -199,8 +200,7 @@ function activateEditorCommands(
 
     // Lazy loading of vim mode
     if (keyMap === 'vim') {
-      // @ts-expect-error
-      await import('codemirror/keymap/vim.js');
+      await codeMirror.ensureVimKeymap();
     }
 
     theme = (settings.get('theme').composite as string | null) || theme;

--- a/packages/codemirror/src/tokens.ts
+++ b/packages/codemirror/src/tokens.ts
@@ -20,4 +20,10 @@ export interface ICodeMirror {
    * A singleton CodeMirror module, rexported.
    */
   CodeMirror: typeof CodeMirror;
+
+  /**
+   * A function to allow extensions to ensure that
+   * the vim keymap has been imported
+   */
+  ensureVimKeymap: () => Promise<void>;
 }


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
See https://github.com/jupyterlab/jupyterlab/issues/9124#issuecomment-708089235 

Traditionally the `jupyterlab-vim` extension has loaded the vim keymap to ensure it's presence as jlab loads it lazily. However, it seems that this will not work for a federated extension.  This  PR introduces a function to allow 3rd party extensions to ensure that the vim keymap has been loaded and attached to the correct codemirror. I think that this is necessary to allow the `jupyterlab-vim` extension to continue working on jlab 3.0



## Code changes

added an `ensureVimKeymap` function to `ICodeMirror`

There is no need for equivalent functions for `emacs` and `sublime` as jlab always loads those keymaps

## User-facing changes
N/A
## Backwards-incompatible changes
new property on ICodeMirror
