### PR TITLE
Add a 2.x -> 3.x migration guide

### DIFF
--- a/docs/source/developer/extension_migration_2_3.rst
+++ b/docs/source/developer/extension_migration_2_3.rst
@@ -98,6 +98,14 @@ The upgrade script also updates the dependencies in ``package.json`` to the ``^3
 
 On the diff above, we see that additional development scripts are also added, as they are used by the new extension system workflow.
 
+The diff also shows the new ``@jupyterlab/builder`` as a ``devDependency``.
+``@jupyterlab/builder`` is a package required to build the extension as a federated extension.
+It hides away internal dependencies such as ``webpack``, and produces the assets that can then be distributed as part of a Python package.
+
+Extension developers do not need to interact with ``@jupyterlab/builder`` directly, but instead can use the
+``jupyter labextension build`` command. This command is run automatically as part of the ``build`` script
+(``jlpm run build``).
+
 Publishing the extension to PyPI and conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developer/extension_migration_2_3.rst
+++ b/docs/source/developer/extension_migration_2_3.rst
@@ -30,6 +30,58 @@ Then at the root folder of the extension, run:
 
    python -m jupyterlab.upgrade_extension .
 
+The upgrade script creates the necessary files for packaging the JupyterLab extension as a Python package, such as
+``setup.py`` and ``pyproject.toml``.
+
+The upgrade script also updates the dependencies in ``package.json`` to the ``^3.0.0`` packages. Here is an example diff:
+
+.. code:: diff
+
+   index 6f1562f..3fcdf37 100644
+   --- a/package.json
+   +++ b/package.json
+   @@ -29,9 +29,13 @@
+      "scripts": {
+   -    "build": "tsc",
+   -    "build:labextension": "npm run clean:labextension && mkdirp myextension/labextension && cd myextension/labextension && npm pack ../..",
+   -    "clean": "rimraf lib tsconfig.tsbuildinfo",
+   +    "build": "jlpm run build:lib && jlpm run build:labextension:dev",
+   +    "build:prod": "jlpm run build:lib && jlpm run build:labextension",
+   +    "build:lib": "tsc",
+   +    "build:labextension": "jupyter labextension build .",
+   +    "build:labextension:dev": "jupyter labextension build --development True .",
+   +    "clean": "rimraf lib tsconfig.tsbuildinfo myextension/labextension",
+   +    "clean:all": "jlpm run clean:lib && jlpm run clean:labextension",
+      "clean:labextension": "rimraf myextension/labextension",
+      "eslint": "eslint . --ext .ts,.tsx --fix",
+      "eslint:check": "eslint . --ext .ts,.tsx",
+   @@ -59,12 +63,12 @@
+      ]
+      },
+      "dependencies": {
+   -    "@jupyterlab/application": "^2.0.0",
+   -    "@jupyterlab/apputils": "^2.0.0",
+   -    "@jupyterlab/observables": "^3.0.0",
+   +    "@jupyterlab/builder": "^3.0.0",
+   +    "@jupyterlab/application": "^3.0.0",
+   +    "@jupyterlab/apputils": "^3.0.0",
+   +    "@jupyterlab/observables": "^3.0.0",
+      "@lumino/algorithm": "^1.2.3",
+      "@lumino/commands": "^1.10.1",
+      "@lumino/disposable": "^1.3.5",
+   @@ -99,6 +103,13 @@
+   -    "typescript": "~3.8.3"
+   +    "typescript": "~4.0.1"
+      },
+      "jupyterlab": {
+   -    "extension": "lib/plugin"
+   +    "extension": "lib/plugin",
+   +    "outputDir": "myextension/labextension/"
+      }
+   }
+
+
+On the diff above, we see that additional development scripts are also added, as they are used by the new extension system workflow.
 
 Publishing the extension to PyPI and conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/developer/extension_migration_2_3.rst
+++ b/docs/source/developer/extension_migration_2_3.rst
@@ -113,3 +113,9 @@ Starting from JupyterLab 3.0, extensions can be distributed as a Python package.
 
 The extension tutorial provides explanations to package the extension so it can be
 published on PyPI and conda forge: :ref:`extension_tutorial_publish`.
+
+.. note::
+
+   While publishing to PyPI is the new recommended way for distributing extensions to users,
+   it is still useful to continue publishing extensions to ``npm`` as well,
+   so other developers can extend them in their own extensions.

--- a/docs/source/developer/extension_migration_2_3.rst
+++ b/docs/source/developer/extension_migration_2_3.rst
@@ -106,6 +106,8 @@ Extension developers do not need to interact with ``@jupyterlab/builder`` direct
 ``jupyter labextension build`` command. This command is run automatically as part of the ``build`` script
 (``jlpm run build``).
 
+For more details about the new file structure and packaging of the extension, check out the extension tutorial: :ref:`extension_tutorial`
+
 Publishing the extension to PyPI and conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developer/extension_migration_2_3.rst
+++ b/docs/source/developer/extension_migration_2_3.rst
@@ -5,8 +5,23 @@ JupyterLab 2.x to 3.x Extension Migration Guide
 
 This is a migration guide for updating extensions that support JupyterLab 2.x to work in JupyterLab 3.x.
 
-Upgrading Library Versions
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Upgrading library versions manually
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To update the extensions so it is compatible with the 3.0 release, update the compatibility
+range of the ``@jupyterlab`` dependencies in the ``package.json``. The diff should be similar to:
+
+.. code:: diff
+
+   index 6f1562f..3fcdf37 100644
+   --- a/package.json
+   +++ b/package.json
+      "dependencies": {
+   -    "@jupyterlab/application": "^2.0.0",
+   +    "@jupyterlab/application": "^3.0.0",
+
+Upgrading library versions using the upgrade script
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 JupyterLab 3.0 provides a script to upgrade an existing extension to use the new extension system and packaging.
 
@@ -86,4 +101,7 @@ On the diff above, we see that additional development scripts are also added, as
 Publishing the extension to PyPI and conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+Starting from JupyterLab 3.0, extensions can be distributed as a Python package.
+
+The extension tutorial provides explanations to package the extension so it can be
+published on PyPI and conda forge: :ref:`extension_tutorial_publish`.

--- a/docs/source/developer/extension_migration_2_3.rst
+++ b/docs/source/developer/extension_migration_2_3.rst
@@ -8,7 +8,28 @@ This is a migration guide for updating extensions that support JupyterLab 2.x to
 Upgrading Library Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO
+JupyterLab 3.0 provides a script to upgrade an existing extension to use the new extension system and packaging.
+
+First, make sure to update to JupyterLab 3.0 with ``pip``:
+
+.. code:: bash
+
+   pip install jupyterlab -U
+
+
+Or with ``conda``:
+
+.. code:: bash
+
+   conda install -c conda-forge jupyterlab=3
+
+
+Then at the root folder of the extension, run:
+
+.. code:: bash
+
+   python -m jupyterlab.upgrade_extension .
+
 
 Publishing the extension to PyPI and conda-forge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/developer/extension_migration_2_3.rst
+++ b/docs/source/developer/extension_migration_2_3.rst
@@ -1,0 +1,16 @@
+.. _extension_migration_2_3:
+
+JupyterLab 2.x to 3.x Extension Migration Guide
+------------------------------------------------
+
+This is a migration guide for updating extensions that support JupyterLab 2.x to work in JupyterLab 3.x.
+
+Upgrading Library Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO
+
+Publishing the extension to PyPI and conda-forge
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TODO

--- a/docs/source/developer/extension_tutorial.rst
+++ b/docs/source/developer/extension_tutorial.rst
@@ -934,6 +934,9 @@ You should see a fresh JupyterLab browser tab appear. When it does,
 execute the *Random Astronomy Picture* command to check that your extension
 works.
 
+
+.. _extension_tutorial_publish:
+
 Publishing your extension
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,5 +65,6 @@ JupyterLab is the next-generation web-based user interface for Project Jupyter. 
    developer/terminology
    developer/extension_tutorial
    developer/extension_migration
+   developer/extension_migration_2_3
    developer/api
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

Opening this PR early to give it some visibility. Several folks have asked on Twitter, Discourse and also at JupyterCon about the upcoming 3.x migration and how they could benefit from not having to rebuild JupyterLab after installing extensions.

Most are particularly interested in the new extension system, so we should probably document it here in this migration guide, or point to other pages of the documentation such as the extension tutorial or the changelog.

Also having a section explaining how to package the extension and publish it to PyPI and conda forge would be useful.

Some of this documentation can be added to https://github.com/jupyterlab/extension-cookiecutter-ts.

Anyone willing to add some information to the guide, feel free to push to the branch directly or add comments and suggestions here.

## References

Fixes #9118. 

## Code changes

Documentation changes for extension developers.

- [x] Mention the upgrade script
- [x] Show an example diff after running the upgrade script?
- [x] Mention what the new `@jupyterlab/builder` package is
- [x] ~Add instructions to publish to PyPI~ -> point to https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/developer/extension_tutorial.rst#packaging-your-extension
- [x] ~Add pointers to publish on conda forge~

## User-facing changes

None

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
