### PR TITLE
Remove @types/webpack (shipped with webpack 5)

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -75,7 +75,6 @@
     "@types/glob": "^7.1.1",
     "@types/node": "^14.6.1",
     "@types/supports-color": "^5.3.0",
-    "@types/webpack": "^4.41.0",
     "@types/which": "^1.3.2",
     "rimraf": "~3.0.0",
     "typescript": "~4.0.2"

--- a/buildutils/package.json
+++ b/buildutils/package.json
@@ -60,7 +60,6 @@
     "@types/inquirer": "^7.3.1",
     "@types/node": "^14.6.1",
     "@types/prettier": "^2.1.0",
-    "@types/webpack": "^4.41.0",
     "@types/which": "^1.3.2",
     "rimraf": "~3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3384,7 +3384,7 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@^4.41.0", "@types/webpack@^4.41.8":
+"@types/webpack@^4.41.8":
   version "4.41.21"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.21.tgz#cc685b332c33f153bb2f5fc1fa3ac8adeb592dee"
   integrity sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/9148

(https://github.com/jupyterlab/jupyterlab/pull/9148#issuecomment-707073748)
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

From the release notes: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#typescript-typings

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
