### PR TITLE
include js api in sphinx docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,8 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	# clean api build as well
+	-rm -rf "$(SOURCEDIR)/../api"
+	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/developer/api.rst
+++ b/docs/source/developer/api.rst
@@ -1,0 +1,11 @@
+JupyterLab API Reference
+========================
+
+.. this doc exists as a resolvable link target
+.. which statically included files are not
+
+.. meta::
+    :http-equiv=refresh: 0;url=../api/index.html
+
+The JupyterLab API reference docs are `here <../api/index.html>`_
+if you are not redirected automatically.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,4 +65,5 @@ JupyterLab is the next-generation web-based user interface for Project Jupyter. 
    developer/terminology
    developer/extension_tutorial
    developer/extension_migration
+   developer/api
 


### PR DESCRIPTION
run build with jlpm and stage directly to the output directory

link from a placeholder rst file with automatic redirect

Two benefits:

1. version history of the API docs as releases are tagged
2. automatic building of latest, whereas the gh-pages branch appears to be updated manually


## Code changes

<!-- Describe the code changes and how they address the issue. -->

sphinx conf.py calls out to `jlpm docs` to build the docs and stages result from `docs/api` to `$build_dir/api` so they are included in sphinx builds.

## User-facing changes

typedoc API docs will be available on readthedocs at https://jupyterlab.readthedocs.io/en/latest/api


hopefully the readthedocs CI status will show us if this works (it works locally, but RTD can always be a little different)