### PR TITLE
Remove absolute document search pane width

### DIFF
--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -203,7 +203,6 @@
   display: flex;
   background-color: var(--jp-layout-color0);
   font-size: var(--jp-ui-font-size1);
-  width: 186px;
   margin: 2px;
 }
 

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -17,7 +17,6 @@
   top: 0;
   right: 0;
   z-index: 7;
-  width: 405px;
   padding: 2px;
   font-size: var(--jp-ui-font-size1);
 }

--- a/packages/documentsearch/style/base.css
+++ b/packages/documentsearch/style/base.css
@@ -17,6 +17,7 @@
   top: 0;
   right: 0;
   z-index: 7;
+  min-width: 405px;
   padding: 2px;
   font-size: var(--jp-ui-font-size1);
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Closes #9178

## Code changes

Remove the absolute search pane width. See #9178 for details.

## User-facing changes

Search pane now fits correctly to the `<input>` size. On browsers with a small default `<input>`, this removes the blank space to the right of it. On browsers with a large default `<input>`, this prevents the icons in the search pane being hidden by being set to zero width.

## Backwards-incompatible changes

None
