### PR TITLE
Build packages individually for RTD

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,7 +121,7 @@ def build_api_docs(out_dir):
     else:
         print("Building jupyterlab API docs")
         check_call(jlpm, cwd=root)
-        check_call(jlpm + ["build:packages"], cwd=root)
+        check_call(jlpm + ["build:src"], cwd=root)
         check_call(jlpm + ["docs"], cwd=root)
 
     dest_dir = os.path.join(out_dir, "api")

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -231,9 +231,6 @@
       "path": "./packages/statusbar-extension"
     },
     {
-      "path": "./packages/tabmanager-extension"
-    },
-    {
       "path": "./packages/terminal"
     },
     {


### PR DESCRIPTION
Builds are failing in RTD due to running out of memory, this lowers the memory footprint.

## References
https://readthedocs.org/projects/jupyterlab/builds/12145227/

## Code changes

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
