### PR TITLE
Update session and kernel manager data only if there was a real change.

### DIFF
--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -257,12 +257,13 @@ export class KernelManager extends BaseManager implements Kernel.IManager {
 
     if (
       this._models.size === models.length &&
-      every(models, x =>
-        JSONExt.deepEqual(
-          (this._models.get(x.id) as unknown) as JSONObject,
-          (x as unknown) as JSONObject
-        )
-      )
+      every(models, x => {
+        const existing = this._models.get(x.id);
+        if (!existing) {
+          return false;
+        }
+        return existing.name === x.name;
+      })
     ) {
       // Identical models list (presuming models does not contain duplicate
       // ids), so just return

--- a/packages/services/src/kernel/manager.ts
+++ b/packages/services/src/kernel/manager.ts
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { IIterator, iter, every } from '@lumino/algorithm';
-import { JSONExt, JSONObject } from '@lumino/coreutils';
 import { Poll } from '@lumino/polling';
 import { ISignal, Signal } from '@lumino/signaling';
 

--- a/packages/services/src/session/manager.ts
+++ b/packages/services/src/session/manager.ts
@@ -2,7 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { IIterator, iter, every } from '@lumino/algorithm';
-import { JSONExt, JSONObject } from '@lumino/coreutils';
 import { Poll } from '@lumino/polling';
 import { ISignal, Signal } from '@lumino/signaling';
 
@@ -267,12 +266,19 @@ export class SessionManager extends BaseManager implements Session.IManager {
 
     if (
       this._models.size === models.length &&
-      every(models, x =>
-        JSONExt.deepEqual(
-          (this._models.get(x.id) as unknown) as JSONObject,
-          (x as unknown) as JSONObject
-        )
-      )
+      every(models, x => {
+        const existing = this._models.get(x.id);
+        if (!existing) {
+          return false;
+        }
+        return (
+          existing.kernel?.id === x.kernel?.id &&
+          existing.kernel?.name === x.kernel?.name &&
+          existing.name === x.name &&
+          existing.path === x.path &&
+          existing.type === x.type
+        );
+      })
     ) {
       // Identical models list (presuming models does not contain duplicate
       // ids), so just return


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9133

## Code changes

The rest api returns more information than we expect (according to our typing), like a last activity indicator on a kernel, which always updates. This means that our existing deep compare of the model we have and the model on the server always updates what we have, which triggers a reconnection to the kernel.

An alternative to this approach of hand-coding which attributes is to strip these extra attributes off in the response validation stage, for example in https://github.com/jupyterlab/jupyterlab/blob/34cb2d3b372728327284a118df2e70e8e36c90ef/packages/services/src/session/validate.ts#L13. The advantage of doing that is that the objects we are passing around are comprehensively typed, and we know what we are getting, and there aren't undocumented attributes that are getting passed around and relied on that are not part of our official api. The disadvantage is that these extra attributes do seem pretty useful, but are not part of the official rest api spec, so perhaps we can let them live with the understanding that they are unofficial.

## User-facing changes

Websocket kernel connections are not continually created, as described in #9133

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
