### PR TITLE
Fix focus issues with command palette

### DIFF
--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -102,8 +102,13 @@ export class ModalCommandPalette extends Panel {
       case 'keydown':
         this._evtKeydown(event as KeyboardEvent);
         break;
-      case 'blur':
-        this.hideAndReset();
+      case 'focus':
+        // if the focus shifted outside of this DOM element, hide and reset.
+        const target = event.target as HTMLElement;
+        if (!this.node.contains(target as HTMLElement)) {
+          event.stopPropagation();
+          this.hideAndReset();
+        }
         break;
       case 'contextmenu':
         event.preventDefault();
@@ -120,7 +125,6 @@ export class ModalCommandPalette extends Panel {
   protected onAfterAttach(msg: Message): void {
     this.node.addEventListener('keydown', this, true);
     this.node.addEventListener('contextmenu', this, true);
-    this.node.addEventListener('blur', this, true);
   }
 
   /**
@@ -129,7 +133,14 @@ export class ModalCommandPalette extends Panel {
   protected onAfterDetach(msg: Message): void {
     this.node.removeEventListener('keydown', this, true);
     this.node.removeEventListener('contextmenu', this, true);
-    this.node.removeEventListener('blur', this, true);
+  }
+
+  protected onBeforeHide(msg: Message): void {
+    document.removeEventListener('focus', this, true);
+  }
+
+  protected onAfterShow(msg: Message): void {
+    document.addEventListener('focus', this, true);
   }
 
   /**

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -231,9 +231,6 @@
       "path": "./packages/statusbar-extension"
     },
     {
-      "path": "./packages/tabmanager-extension"
-    },
-    {
       "path": "./packages/terminal"
     },
     {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9121

## Code changes

 Only reset command palette if focus is shifting outside of the palette. This uses the same ideas from our dialog box to have natural behavior in clicking in and outside of the palette.

## User-facing changes

![palette](https://user-images.githubusercontent.com/192614/96934920-f0e2ef00-1477-11eb-958d-49cb28bfedf8.gif)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
