### PR TITLE
Remove input-checkbox style

### DIFF
--- a/packages/extensionmanager/style/base.css
+++ b/packages/extensionmanager/style/base.css
@@ -355,17 +355,6 @@
 }
 
 /*
-  Companion packages dialog
-*/
-
-input[type='checkbox'] {
-  appearance: checkbox;
-  -webkit-appearance: checkbox;
-  -moz-appearance: checkbox;
-  height: auto;
-}
-
-/*
   Generic dialog
 */
 .jp-extensionmanager-dialog .jp-extensionmanager-dialog-subheader {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #9170
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

The input checkbox was used in the legacy extension discovery package. This style slip in during the import in JupyterLab core.

Reference: https://github.com/vidartf/jupyterlab_discovery/blob/master/src/companions.tsx#L138

I push a PR to address #9170. So it will be easier to backport on 2.x instead of including it in #8804.

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Remove unused generic style rule.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None