### PR TITLE
List the dynamic extensions in the extension manager

### DIFF
--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -5,6 +5,8 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 
 import { VDomModel } from '@jupyterlab/apputils';
 
+import { PageConfig } from '@jupyterlab/coreutils';
+
 import {
   KernelSpec,
   ServerConnection,
@@ -70,6 +72,11 @@ export interface IEntry {
    * The latest version of the extension.
    */
   latest_version: string;
+
+  /**
+   * Whether the extension is federated or not.
+   */
+  federated: boolean;
 
   /**
    * The installed version of the extension.
@@ -521,6 +528,7 @@ export class ListModel extends VDomModel {
         status: null,
         latest_version: pkg.version,
         installed_version: '',
+        federated: false,
         blockedExtensionsEntry: isblockedExtensions,
         allowedExtensionsEntry: isallowedExtensions
       };
@@ -550,6 +558,7 @@ export class ListModel extends VDomModel {
             status: pkg.status,
             latest_version: pkg.latest_version,
             installed_version: pkg.installed_version,
+            federated: false,
             blockedExtensionsEntry: this.isListed(
               pkg.name,
               this._blockedExtensionsArray
@@ -688,6 +697,21 @@ export class ListModel extends VDomModel {
     const installed: IEntry[] = [];
     for (const key of Object.keys(installedMap)) {
       installed.push(installedMap[key]);
+    }
+    for (const federated_extension of JSON.parse(PageConfig.getOption('federated_extensions'))) {
+      installed.push({
+        name: federated_extension['name'],
+        description: '',
+        url: federated_extension['load'],
+        installed: true,
+        enabled: true,
+        status: null,
+        latest_version: '',
+        installed_version: '',
+        federated: true,
+        blockedExtensionsEntry: undefined,
+        allowedExtensionsEntry: undefined,
+      });
     }
     this._installed = installed.sort(Private.comparator);
 

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
-import { VDomRenderer, ToolbarButtonComponent } from '@jupyterlab/apputils';
+import { VDomRenderer, ToolbarButtonComponent, Dialog, showDialog } from '@jupyterlab/apputils';
 import { ServiceManager } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import {
@@ -277,59 +277,90 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
           <div className="jp-extensionmanager-entry-description">
             {entry.description}
           </div>
-          <div className="jp-extensionmanager-entry-buttons">
-            {!entry.installed &&
-              !entry.blockedExtensionsEntry &&
-              !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
-              ListModel.isDisclaimed() && (
+          {entry.federated && entry.installed &&
+            <div className="jp-extensionmanager-entry-buttons">
+              <Button
+                onClick={() => showDialog({
+                  title,
+                  body: <div>
+                      <p>
+                        {trans.__(`This is a Federated Extension. To uninstall it, please
+                read the user guide on https://jupyterlab.readthedocs.io/en/stable/user/extensions.html`)}
+                      </p>
+                    </div>
+                  ,
+                  buttons: [
+                    Dialog.okButton({
+                      label: trans.__('OK'),
+                      caption: trans.__('OK')
+                    })
+                  ]
+                }).then(result => {
+                  return result.button.accept;
+                })
+              }
+                minimal
+                small
+              >
+                {trans.__('About')}
+              </Button>
+            </div>
+          }
+          {!entry.federated &&
+            <div className="jp-extensionmanager-entry-buttons">
+              {!entry.installed &&
+                !entry.blockedExtensionsEntry &&
+                !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
+                ListModel.isDisclaimed() && (
+                  <Button
+                    onClick={() => props.performAction('install', entry)}
+                    minimal
+                    small
+                  >
+                    {trans.__('Install')}
+                  </Button>
+                )}
+              {ListModel.entryHasUpdate(entry) &&
+                !entry.blockedExtensionsEntry &&
+                !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
+                ListModel.isDisclaimed() && (
+                  <Button
+                    onClick={() => props.performAction('install', entry)}
+                    minimal
+                    small
+                  >
+                    {trans.__('Update')}
+                  </Button>
+                )}
+              {entry.installed && (
                 <Button
-                  onClick={() => props.performAction('install', entry)}
+                  onClick={() => props.performAction('uninstall', entry)}
                   minimal
                   small
                 >
-                  {trans.__('Install')}
+                  {trans.__('Uninstall')}
                 </Button>
               )}
-            {ListModel.entryHasUpdate(entry) &&
-              !entry.blockedExtensionsEntry &&
-              !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
-              ListModel.isDisclaimed() && (
+              {entry.enabled && (
                 <Button
-                  onClick={() => props.performAction('install', entry)}
+                  onClick={() => props.performAction('disable', entry)}
                   minimal
                   small
                 >
-                  {trans.__('Update')}
+                  {trans.__('Disable')}
                 </Button>
               )}
-            {entry.installed && (
-              <Button
-                onClick={() => props.performAction('uninstall', entry)}
-                minimal
-                small
-              >
-                {trans.__('Uninstall')}
-              </Button>
-            )}
-            {entry.enabled && (
-              <Button
-                onClick={() => props.performAction('disable', entry)}
-                minimal
-                small
-              >
-                {trans.__('Disable')}
-              </Button>
-            )}
-            {entry.installed && !entry.enabled && (
-              <Button
-                onClick={() => props.performAction('enable', entry)}
-                minimal
-                small
-              >
-                {trans.__('Enable')}
-              </Button>
-            )}
-          </div>
+              {entry.installed && !entry.enabled && (
+                <Button
+                  onClick={() => props.performAction('enable', entry)}
+                  minimal
+                  small
+                >
+                  {trans.__('Enable')}
+                </Button>
+              )}
+            </div>
+          }
         </div>
       </div>
     </li>


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/8804

## Code changes

Use the PageConfig to list the dynamic extensions.

## User-facing changes

<img width="465" alt="Screenshot 2020-10-28 at 12 18 40" src="https://user-images.githubusercontent.com/226720/97430800-b1a21b80-1919-11eb-9074-dbff51dc3c74.png">

This is the idea, but needs polishing on the used terms, content to be displayed and link (the link for now point to a remoteEntry). 

Good to know: With dynamic extensions, we don't the same level of details for now as the static extensions. We only have the name and the link to the remoteEntry.js.

cc/ @jasongrout @isabela-pf @tgeorgeux 

## Backwards-incompatible changes

None.

