### PR TITLE
Restructure federated extensions to allow for package manager metadata

### DIFF
--- a/builder/src/build.ts
+++ b/builder/src/build.ts
@@ -26,6 +26,16 @@ export namespace Build {
     output: string;
 
     /**
+     * The directory for the schema directory, defaults to the output directory.
+     */
+    schemaOutput?: string;
+
+    /**
+     * The directory for the theme directory, defaults to the output directory
+     */
+    themeOutput?: string;
+
+    /**
      * The names of the packages to ensure.
      */
     packageNames: ReadonlyArray<string>;
@@ -103,7 +113,12 @@ export namespace Build {
   export function ensureAssets(
     options: IEnsureOptions
   ): webpack.Configuration[] {
-    const { output, packageNames } = options;
+    const {
+      output,
+      schemaOutput = output,
+      themeOutput = output,
+      packageNames
+    } = options;
 
     const themeConfig: webpack.Configuration[] = [];
 
@@ -147,7 +162,7 @@ export namespace Build {
         const schemas = glob.sync(
           path.join(path.join(packageDir, schemaDir), '*')
         );
-        const destination = path.join(output, 'schemas', name);
+        const destination = path.join(schemaOutput, 'schemas', name);
 
         // Remove the existing directory if necessary.
         if (fs.existsSync(destination)) {
@@ -187,7 +202,7 @@ export namespace Build {
           index: path.join(name, themePath)
         },
         output: {
-          path: path.resolve(path.join(output, 'themes', name)),
+          path: path.resolve(path.join(themeOutput, 'themes', name)),
           // we won't use these JS files, only the extracted CSS
           filename: '[name].js'
         },

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -40,8 +40,8 @@ function generateConfig({
     process.exit(1);
   }
 
-  let outputPath = data.jupyterlab['outputDir'];
-  outputPath = path.join(packagePath, outputPath);
+  const outputPath = path.join(packagePath, data.jupyterlab['outputDir']);
+  const staticPath = path.join(outputPath, 'static');
 
   // Handle the extension entry point and the lib entry point, if different
   const index = require.resolve(packagePath);
@@ -153,7 +153,9 @@ function generateConfig({
   const extras = Build.ensureAssets({
     packageNames: [],
     packagePaths: [packagePath],
-    output: outputPath
+    output: staticPath,
+    schemaOutput: outputPath,
+    themeOutput: outputPath
   });
 
   fs.copyFileSync(
@@ -165,7 +167,7 @@ function generateConfig({
     apply(compiler: any) {
       compiler.hooks.done.tap('Cleanup', () => {
         // Find the remoteEntry file and add it to the package.json metadata
-        const files = glob.sync(path.join(outputPath, 'remoteEntry.*.js'));
+        const files = glob.sync(path.join(staticPath, 'remoteEntry.*.js'));
         let newestTime = -1;
         let newestRemote = '';
         files.forEach(fpath => {
@@ -177,7 +179,7 @@ function generateConfig({
         });
         const data = readJSONFile(path.join(outputPath, 'package.json'));
         const _build: any = {
-          load: path.basename(newestRemote)
+          load: path.join('static', path.basename(newestRemote))
         };
         if (exposes['./extension'] !== undefined) {
           _build.extension = './extension';
@@ -201,7 +203,7 @@ function generateConfig({
       entry: {},
       output: {
         filename: '[name].[contenthash].js',
-        path: outputPath,
+        path: staticPath,
         publicPath: staticUrl || 'auto'
       },
       module: {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is a partial fix for #9231 (so far).

## Code changes

This changes how federated extensions are generated to put the js assets into a `static/` subdirectory, but keeping the schema and theme directories, and package.json and build log at the top level. This lets us have more control over what is written in the top level of the federated extension, which means we can now guarantee a package manager can put a new file there.

## User-facing changes

Should be none. In fact, this is backwards compatible with the existing federated extensions, 

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
