### PR TITLE
Adds package installation info to labextension list and uninstall output

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -816,24 +816,6 @@ class _AppHandler(object):
         info = self.info
         logger = self.logger
 
-        # Handle federated extensions first
-        if name in info['federated_exts']:
-            data = info['federated_exts'].pop(name)
-            target = data['ext_path']
-            logger.info("Removing: %s" % target)
-            if os.path.isdir(target) and not os.path.islink(target):
-                shutil.rmtree(target)
-            else:
-                os.remove(target)
-            # Remove empty parent dir if necessary
-            if '/' in data['name']:
-                files = os.listdir(os.path.dirname(target))
-                if not len(files):
-                    target = os.path.dirname(target)
-                    if os.path.isdir(target) and not os.path.islink(target):
-                        shutil.rmtree(target)
-            return False
-
         # Allow for uninstalled core extensions.
         if name in info['core_extensions']:
             config = self._read_build_config()
@@ -861,6 +843,9 @@ class _AppHandler(object):
                     del data[extname]
                     self._write_build_config(config)
                 return True
+
+        if name in info['federated_exts']:
+            logger.warn('%s was installed with a package manager. Use the same package manager to uninstall this extension.' % name)
 
         logger.warn('No labextension named "%s" installed' % name)
         return False

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -817,7 +817,10 @@ class _AppHandler(object):
         logger = self.logger
 
         if name in info['federated_extensions']:
-            logger.warn('%s was installed with a package manager. Use the same package manager to uninstall this extension.' % name)
+            if info['federated_extensions'][name].get('metadata', dict()).get('uninstallInstructions', None):
+                logger.error('JupyterLab cannot uninstall this extension. %s' % info['federated_extensions'][name]['metadata']['uninstallInstructions'])
+            else:
+                logger.error('JupyterLab cannot uninstall %s since it was installed outside of JupyterLab. Use the same method used to install this extension to uninstall this extension.' % name)
             return False
 
         # Allow for uninstalled core extensions.
@@ -1515,6 +1518,13 @@ class _AppHandler(object):
                     extra += ' %s' % GREEN_OK
                 if data['is_local']:
                     extra += '*'
+
+                md = data.get('metadata')
+                if md:
+                    extra += ' (%s, %s)' % (
+                        md['packageManager'],
+                        md['packageName']
+                    )
                 logger.info('        %s v%s%s' % (name, version, extra))
                 if errors:
                     error_accumulator[name] = (version, errors)

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -816,6 +816,10 @@ class _AppHandler(object):
         info = self.info
         logger = self.logger
 
+        if name in info['federated_exts']:
+            logger.warn('%s was installed with a package manager. Use the same package manager to uninstall this extension.' % name)
+            return False
+
         # Allow for uninstalled core extensions.
         if name in info['core_extensions']:
             config = self._read_build_config()
@@ -843,9 +847,6 @@ class _AppHandler(object):
                     del data[extname]
                     self._write_build_config(config)
                 return True
-
-        if name in info['federated_exts']:
-            logger.warn('%s was installed with a package manager. Use the same package manager to uninstall this extension.' % name)
 
         logger.warn('No labextension named "%s" installed' % name)
         return False

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1379,11 +1379,11 @@ class _AppHandler(object):
         """
         compat = dict()
         core_data = self.info['core_data']
-        seen = dict()
+        seen = set()
         for (name, data) in self.info['federated_exts'].items():
             deps = data['dependencies']
             compat[name] = _validate_compatibility(name, deps, core_data)
-            seen[name] = True
+            seen.add(name)
         for (name, data) in self.info['extensions'].items():
             if name in seen:
                 continue

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -698,10 +698,10 @@ class _AppHandler(object):
 
         logger.info('JupyterLab v%s' % info['version'])
 
-        if info['federated_exts'] or info['extensions']:
+        if info['federated_extensions'] or info['extensions']:
             info['compat_errors'] = self._get_extension_compat()
 
-        if info['federated_exts']:
+        if info['federated_extensions']:
             self._list_federated_extensions()
   
         if info['extensions']:
@@ -816,7 +816,7 @@ class _AppHandler(object):
         info = self.info
         logger = self.logger
 
-        if name in info['federated_exts']:
+        if name in info['federated_extensions']:
             logger.warn('%s was installed with a package manager. Use the same package manager to uninstall this extension.' % name)
             return False
 
@@ -1096,8 +1096,7 @@ class _AppHandler(object):
 
         info['disabled_core'] = disabled_core
 
-        federated_exts = get_federated_extensions(self.labextensions_path)
-        info['federated_exts'] = federated_exts
+        info['federated_extensions'] = get_federated_extensions(self.labextensions_path)
         return info
 
     def _populate_staging(self, name=None, version=None, static_url=None,
@@ -1380,7 +1379,7 @@ class _AppHandler(object):
         compat = dict()
         core_data = self.info['core_data']
         seen = set()
-        for (name, data) in self.info['federated_exts'].items():
+        for (name, data) in self.info['federated_extensions'].items():
             deps = data['dependencies']
             compat[name] = _validate_compatibility(name, deps, core_data)
             seen.add(name)
@@ -1454,7 +1453,7 @@ class _AppHandler(object):
 
         logger.info('   %s dir: %s' % (ext_type, dname))
         for name in sorted(names):
-            if name in info['federated_exts']:
+            if name in info['federated_extensions']:
                 continue
             data = info['extensions'][name]
             version = data['version']
@@ -1492,15 +1491,15 @@ class _AppHandler(object):
         error_accumulator = {}
 
         ext_dirs = dict((p, False) for p in self.labextensions_path)
-        for value in info['federated_exts'].values():
+        for value in info['federated_extensions'].values():
             ext_dirs[value['ext_dir']] = True
 
         for ext_dir, has_exts in ext_dirs.items():
             if not has_exts:
                 continue
             logger.info(ext_dir)
-            for name in info['federated_exts']:
-                data = info['federated_exts'][name]
+            for name in info['federated_extensions']:
+                data = info['federated_extensions'][name]
                 if data['ext_dir'] != ext_dir:
                     continue
                 version = data['version']

--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -194,15 +194,15 @@ def watch_labextension(path, labextensions_path, logger=None, development=False,
         logger.info('Building extension in %s' % path)
 
     # Check to see if we need to create a symlink
-    federated_exts = get_federated_extensions(labextensions_path)
+    federated_extensions = get_federated_extensions(labextensions_path)
 
     with open(pjoin(ext_path, 'package.json')) as fid:
         ext_data = json.load(fid)
 
-    if ext_data['name'] not in federated_exts:
+    if ext_data['name'] not in federated_extensions:
         develop_labextension_py(ext_path, sys_prefix=True)
     else:
-        full_dest = pjoin(federated_exts[ext_data['name']]['ext_dir'], ext_data['name'])
+        full_dest = pjoin(federated_extensions[ext_data['name']]['ext_dir'], ext_data['name'])
         output_dir = pjoin(ext_path, ext_data['jupyterlab'].get('outputDir', 'static'))
         if not osp.islink(full_dest):
             shutil.rmtree(full_dest)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Helps fix #9231 

## Code changes

This adds the info supplied by https://github.com/jupyterlab/jupyterlab_server/pull/132 to the `jupyter labextension list` and `jupyter labextension uninstall` commands.

## User-facing changes

The users understand better how extensions were installed and how to uninstall them.

```
% jupyter labextension uninstall @jupyter-widgets/jupyterlab-manager
JupyterLab cannot uninstall this extension. Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab_widgets

% jupyter labextension list
JupyterLab v3.0.0rc6
/[snip]/share/jupyter/labextensions
        jupyterlab_apod v0.1.0 enabled OK (python, jupyterlab_apod)
        @jupyter-widgets/jupyterlab-manager v3.0.0-alpha.2 enabled OK (python, jupyterlab_widgets)
```

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
