### PR TITLE
Add jupyter_core as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ setup_args['install_requires'] = [
     'ipython',
     'packaging',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
+    'jupyter_core',
     'jupyterlab_server~=2.0.0rc1',
     'jupyter_server~=1.0.1',
     'nbclassic~=0.2.0',


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

We realized this at https://github.com/jupyterlab/jupyterlab/issues/9240

## Code changes

Add jupyter_core as a dependency

We import it, but apparently forgot to require it.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
