### PR TITLE
Put exposeAppInBrowser and quitButton values back in page config

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -642,6 +642,8 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         page_config.setdefault('buildCheck', not self.core_mode and not self.dev_mode)
         page_config['devMode'] = self.dev_mode
         page_config['token'] = self.serverapp.token
+        page_config['exposeAppInBrowser'] = self.expose_app_in_browser
+        page_config['quitButton'] = self.serverapp.quit_button
 
         # Client-side code assumes notebookVersion is a JSON-encoded string
         page_config['notebookVersion'] = json.dumps(jpserver_version_info)


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The page config values were lost somewhere in the 3.0 development, so the server options were not taking effect.

This fixes a regression from 2.x.

## User-facing changes

`ServerApp.quit_button` and `--expose-app-in-browser` now do something in 3.0.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
