### PR TITLE
Make PDF viewer extension recognize pdf files

### DIFF
--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1368,7 +1368,7 @@ export namespace DocumentRegistry {
         icon: markdownIcon
       },
       {
-        name: 'pdf',
+        name: 'PDF',
         displayName: trans.__('PDF File'),
         extensions: ['.pdf'],
         mimeTypes: ['application/pdf'],


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
fixes: https://github.com/jupyterlab/jupyterlab/issues/9261

## Code changes

changed all the `PDF`s in the pdf-extension to lowercase to match what is in the docregistry:
https://github.com/jupyterlab/jupyterlab/blob/13c1964250d2772739fe3688360e4ef3f25564c0/packages/docregistry/src/registry.ts#L1371-L1375

Did this become case-sensitive in jlab3 but not in 2?
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
You can open pdf files in jlab again.

Without this you get the UTF-8 errors that show up when jlab defaults to trying to open using the fileeditor:
![image](https://user-images.githubusercontent.com/10111092/97911876-fa8f1100-1d19-11eb-8f27-2a1c1aa3c1bd.png)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
