### PR TITLE
Fix styling of single-document mode switch in menu bar

### DIFF
--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -58,7 +58,8 @@ body {
 
 #jp-single-document-mode {
   margin: 0px 8px;
-  align-self: center;
+  display: flex;
+  align-items: center;
 }
 
 /* Sibling imports */

--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -89,6 +89,8 @@ button.jp-mod-styled.jp-mod-warn:active {
 .jp-slider-sdm {
   border: none;
   height: 20px;
+  background-color: transparent;
+  color: var(--jp-ui-font-color1);
 }
 
 .jp-slider:hover {
@@ -100,23 +102,23 @@ button.jp-mod-styled.jp-mod-warn:active {
 }
 
 .jp-slider-track {
-  display: flex;
-  align-items: center;
   cursor: pointer;
   background-color: var(--jp-border-color1);
   -webkit-transition: 0.4s;
   transition: 0.4s;
   border-radius: 34px;
-  height: 15px;
+  height: 16px;
   width: 35px;
+  position: relative;
 }
 
 .jp-slider-track::before {
   content: '';
+  position: absolute;
   height: 10px;
   width: 10px;
-  margin-left: 5px;
-  margin-right: 50%;
+  margin: 3px;
+  left: 0px;
   background-color: white;
   -webkit-transition: 0.4s;
   transition: 0.4s;
@@ -128,6 +130,6 @@ button.jp-mod-styled.jp-mod-warn:active {
 }
 
 .jp-slider[aria-checked='true'] .jp-slider-track::before {
-  margin-left: 50%;
-  margin-right: 5px;
+  /* track width (35) - margins (3 + 3) - thumb width (10) */
+  left: 19px;
 }


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References


## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

- Make text centered in menu bar
- transparent background matches menu bar (hover still shows background, similar to menu items)
- use theme font color
- switch thumb position now symmetric when on and off
- switch position uses absolute positioning
- switch slightly taller so margins are integer pixels


Before (on, off, hover):
<img width="361" alt="Screen Shot 2020-11-03 at 12 21 11 AM" src="https://user-images.githubusercontent.com/192614/97962888-f0493300-1d6a-11eb-94b0-d56239c5fdd6.png">
<img width="358" alt="Screen Shot 2020-11-03 at 12 21 28 AM" src="https://user-images.githubusercontent.com/192614/97962889-f0e1c980-1d6a-11eb-842e-e9c20e4e7846.png">
<img width="371" alt="Screen Shot 2020-11-03 at 12 21 45 AM" src="https://user-images.githubusercontent.com/192614/97962891-f17a6000-1d6a-11eb-8bdf-40a3c0160064.png">

After (on, off, hover):
<img width="342" alt="Screen Shot 2020-11-03 at 12 23 19 AM" src="https://user-images.githubusercontent.com/192614/97962913-fb03c800-1d6a-11eb-9f65-104d0ab4469a.png">
<img width="355" alt="Screen Shot 2020-11-03 at 12 22 55 AM" src="https://user-images.githubusercontent.com/192614/97962920-fc34f500-1d6a-11eb-887a-ea5d60c5ebb8.png">
<img width="360" alt="Screen Shot 2020-11-03 at 12 23 09 AM" src="https://user-images.githubusercontent.com/192614/97962918-fb9c5e80-1d6a-11eb-94de-3716a006cdbe.png">

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
