### PR TITLE
Move title panel to inside the center content area

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -258,8 +258,8 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     BoxLayout.setStretch(bottomPanel, 0);
 
     rootLayout.addWidget(headerPanel);
-    rootLayout.addWidget(titleHandler.panel);
     rootLayout.addWidget(topHandler.panel);
+    rootLayout.addWidget(titleHandler.panel);
     rootLayout.addWidget(hboxPanel);
     rootLayout.addWidget(bottomPanel);
 

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -195,9 +195,8 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     const bottomPanel = (this._bottomPanel = new BoxPanel());
     const hboxPanel = new BoxPanel();
 
-    const titleHandler = (this._titleHandler = new Private.PanelHandler());
     const centerPanel = new BoxPanel();
-
+    const titleHandler = (this._titleHandler = new Private.PanelHandler());
     const dockPanel = (this._dockPanel = new DockPanelSvg());
     MessageLoop.installMessageHook(dockPanel, this._dockChildHook);
 
@@ -234,6 +233,9 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     hsplitPanel.orientation = 'horizontal';
     bottomPanel.direction = 'bottom-to-top';
 
+    BoxLayout.setStretch(titleHandler.panel, 0);
+    BoxLayout.setStretch(dockPanel, 1);
+
     SplitPanel.setStretch(leftHandler.stackedPanel, 0);
     SplitPanel.setStretch(centerPanel, 1);
     SplitPanel.setStretch(rightHandler.stackedPanel, 0);
@@ -242,11 +244,8 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     BoxPanel.setStretch(hsplitPanel, 1);
     BoxPanel.setStretch(rightHandler.sideBar, 0);
 
-    BoxLayout.setStretch(titleHandler.panel, 0);
-    BoxLayout.setStretch(dockPanel, 1);
     centerPanel.addWidget(titleHandler.panel);
     centerPanel.addWidget(dockPanel);
-
 
     hsplitPanel.addWidget(leftHandler.stackedPanel);
     hsplitPanel.addWidget(centerPanel);

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -191,10 +191,13 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     this.id = 'main';
 
     const headerPanel = (this._headerPanel = new BoxPanel());
-    const titleHandler = (this._titleHandler = new Private.PanelHandler());
     const topHandler = (this._topHandler = new Private.PanelHandler());
     const bottomPanel = (this._bottomPanel = new BoxPanel());
     const hboxPanel = new BoxPanel();
+
+    const titleHandler = (this._titleHandler = new Private.PanelHandler());
+    const centerPanel = new BoxPanel();
+
     const dockPanel = (this._dockPanel = new DockPanelSvg());
     MessageLoop.installMessageHook(dockPanel, this._dockChildHook);
 
@@ -208,6 +211,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     topHandler.panel.id = 'jp-top-panel';
     bottomPanel.id = 'jp-bottom-panel';
     hboxPanel.id = 'jp-main-content-panel';
+    centerPanel.id = 'jp-main-center-panel';
     dockPanel.id = 'jp-main-dock-panel';
     hsplitPanel.id = 'jp-main-split-panel';
 
@@ -220,24 +224,32 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     rightHandler.stackedPanel.id = 'jp-right-stack';
 
     hboxPanel.spacing = 0;
+    centerPanel.spacing = 0;
     dockPanel.spacing = 5;
     hsplitPanel.spacing = 1;
 
     headerPanel.direction = 'top-to-bottom';
     hboxPanel.direction = 'left-to-right';
+    centerPanel.direction = 'top-to-bottom';
     hsplitPanel.orientation = 'horizontal';
     bottomPanel.direction = 'bottom-to-top';
 
     SplitPanel.setStretch(leftHandler.stackedPanel, 0);
-    SplitPanel.setStretch(dockPanel, 1);
+    SplitPanel.setStretch(centerPanel, 1);
     SplitPanel.setStretch(rightHandler.stackedPanel, 0);
 
     BoxPanel.setStretch(leftHandler.sideBar, 0);
     BoxPanel.setStretch(hsplitPanel, 1);
     BoxPanel.setStretch(rightHandler.sideBar, 0);
 
+    BoxLayout.setStretch(titleHandler.panel, 0);
+    BoxLayout.setStretch(dockPanel, 1);
+    centerPanel.addWidget(titleHandler.panel);
+    centerPanel.addWidget(dockPanel);
+
+
     hsplitPanel.addWidget(leftHandler.stackedPanel);
-    hsplitPanel.addWidget(dockPanel);
+    hsplitPanel.addWidget(centerPanel);
     hsplitPanel.addWidget(rightHandler.stackedPanel);
 
     hboxPanel.addWidget(leftHandler.sideBar);
@@ -252,14 +264,12 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     hsplitPanel.setRelativeSizes([1, 2.5, 1]);
 
     BoxLayout.setStretch(headerPanel, 0);
-    BoxLayout.setStretch(titleHandler.panel, 0);
     BoxLayout.setStretch(topHandler.panel, 0);
     BoxLayout.setStretch(hboxPanel, 1);
     BoxLayout.setStretch(bottomPanel, 0);
 
     rootLayout.addWidget(headerPanel);
     rootLayout.addWidget(topHandler.panel);
-    rootLayout.addWidget(titleHandler.panel);
     rootLayout.addWidget(hboxPanel);
     rootLayout.addWidget(bottomPanel);
 

--- a/packages/application/style/menus.css
+++ b/packages/application/style/menus.css
@@ -17,7 +17,7 @@
 |----------------------------------------------------------------------------*/
 
 .lm-MenuBar {
-  padding-left: 5px;
+  padding-left: 8px;
   background: var(--jp-layout-color1);
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);

--- a/packages/application/style/titlepanel.css
+++ b/packages/application/style/titlepanel.css
@@ -4,7 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 :root {
-  --jp-private-title-panel-height: 28px;
+  --jp-private-title-panel-height: 36px;
 }
 
 #jp-title-panel {
@@ -16,11 +16,11 @@
 }
 
 #jp-title-panel-title {
-  margin-left: 40px;
+  margin-left: 10px;
 }
 
 #jp-title-panel-title h1 {
-  font-size: 18px;
+  font-size: 20px;
   color: var(--jp-ui-font-color0);
   margin: 0;
   font-weight: normal;

--- a/packages/mainmenu-extension/style/index.css
+++ b/packages/mainmenu-extension/style/index.css
@@ -3,8 +3,4 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-.jp-LabShell[data-shell-mode='single-document'] #jp-top-panel #jp-MainLogo {
-  top: -28px;
-}
-
 @import url('~@jupyterlab/mainmenu/style/index.css');


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes issues brought up in #9105

#9274 is an alternative to this PR that preserves the existing title-at-the-top behavior.

After playing with both alternatives a bit, I like #9274 (combined with #9270) over this PR.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This prevents the menu from jumping up and down when toggling single-document mode. Also, it mirrors where the tabs are in normal mode, so it’s easy to see the correspondence between the tab title and the titlebar.

This is an experiment to see if it improves the UX overall, at least good enough to ship for 3.0. It also takes out some hacks we had with the icon to the left of the menu floating up above the bar it was on, etc.

Jumping from before (see #9105):

![sdm-click](https://user-images.githubusercontent.com/591645/94660397-e5335b00-0305-11eb-8af4-df1c4985c3db.gif)

No jumping now:

![sdm](https://user-images.githubusercontent.com/192614/97973433-e8918a80-1d7a-11eb-91c2-ed0bade8b9ee.gif)


### Before
![Screenshot_2020-11-03 JupyterLab(4)](https://user-images.githubusercontent.com/192614/97972851-0a3e4200-1d7a-11eb-8af3-d2fbab7c0ecb.png)
![Screenshot_2020-11-03 JupyterLab(3)](https://user-images.githubusercontent.com/192614/97972856-0c080580-1d7a-11eb-8ee2-134eedd472ec.png)


![Screenshot_2020-11-03 JupyterLab(5)](https://user-images.githubusercontent.com/192614/97972845-06122480-1d7a-11eb-82dc-4e03102377e6.png)

### After

![Screenshot_2020-11-03 JupyterLab(2)](https://user-images.githubusercontent.com/192614/97972949-2b9f2e00-1d7a-11eb-838c-fd1b56937a10.png)
![Screenshot_2020-11-03 JupyterLab(1)](https://user-images.githubusercontent.com/192614/97972956-2e9a1e80-1d7a-11eb-8fd2-6c6cdd9b1bf9.png)
![Screenshot_2020-11-03 JupyterLab](https://user-images.githubusercontent.com/192614/97972962-3063e200-1d7a-11eb-9c22-962c63e61c53.png)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
