### PR TITLE
Fix #9255

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1265,7 +1265,7 @@ export namespace NotebookActions {
         (cell as CodeCell).outputsScrolled = true;
       }
     });
-    Private.handleState(notebook, state);
+    Private.handleState(notebook, state, scrollIfNeeded = true);
   }
 
   /**

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1265,7 +1265,7 @@ export namespace NotebookActions {
         (cell as CodeCell).outputsScrolled = true;
       }
     });
-    Private.handleState(notebook, state, scrollIfNeeded = true);
+    Private.handleState(notebook, state, true);
   }
 
   /**


### PR DESCRIPTION
This fixes #9255. I tested that with binder.

Would a codebase expert confirm during PR review that the scrollIfNeeded parameter is set to the intended value for all other usages of handleState, and write this in the GH message?