### PR TITLE
Fix usage tests refusing to uninstall federated extensions

### DIFF
--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -174,17 +174,17 @@ if [[ $GROUP == usage ]]; then
     jupyter lab build --debug
     jupyter lab path --debug
     pushd jupyterlab/tests/mock_packages
-    jupyter labextension link extension --no-build --debug
-    jupyter labextension unlink extension --no-build --debug
-    jupyter labextension link extension --no-build --debug
-    jupyter labextension unlink  @jupyterlab/mock-extension --no-build --debug
+    jupyter labextension link mimeextension --no-build --debug
+    jupyter labextension unlink mimeextension --no-build --debug
+    jupyter labextension link mimeextension --no-build --debug
+    jupyter labextension unlink  @jupyterlab/mock-mime-extension --no-build --debug
     # Test with a full install
-    jupyter labextension install extension  --no-build --debug
+    jupyter labextension install mimeextension  --no-build --debug
     jupyter labextension list --debug
-    jupyter labextension disable @jupyterlab/mock-extension --debug
-    jupyter labextension enable @jupyterlab/mock-extension --debug
+    jupyter labextension disable @jupyterlab/mock-mime-extension --debug
+    jupyter labextension enable @jupyterlab/mock-mime-extension --debug
     jupyter labextension disable @jupyterlab/notebook-extension --debug
-    jupyter labextension uninstall @jupyterlab/mock-extension --no-build --debug
+    jupyter labextension uninstall @jupyterlab/mock-mime-extension --no-build --debug
     jupyter labextension uninstall @jupyterlab/notebook-extension --no-build --debug
     # Test with a dynamic install
     jupyter labextension develop extension --debug
@@ -196,10 +196,10 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension build extension --static-url /foo/
     jupyter labextension disable @jupyterlab/mock-extension --debug
     jupyter labextension enable @jupyterlab/mock-extension --debug
-    jupyter labextension uninstall @jupyterlab/mock-extension --debug
+    # jupyter labextension uninstall @jupyterlab/mock-extension --debug
     jupyter labextension list 1>labextensions 2>&1
     # bail if mock-extension was listed
-    cat labextensions | grep -q "mock-extension" && exit 1
+    # cat labextensions | grep -q "mock-extension" && exit 1
     popd
 
     jupyter lab workspaces export > workspace.json --debug

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -196,10 +196,10 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension build extension --static-url /foo/
     jupyter labextension disable @jupyterlab/mock-extension --debug
     jupyter labextension enable @jupyterlab/mock-extension --debug
-    # jupyter labextension uninstall @jupyterlab/mock-extension --debug
+    jupyter labextension uninstall @jupyterlab/mock-extension --debug
     jupyter labextension list 1>labextensions 2>&1
-    # bail if mock-extension was listed
-    # cat labextensions | grep -q "mock-extension" && exit 1
+    # check the federated extension is still listed after jupyter labextension uninstall
+    cat labextensions | grep -q "mock-extension"
     popd
 
     jupyter lab workspaces export > workspace.json --debug


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9280 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- Test `jupyter labextension uninstall` with  `mock-mime-extension` instead of the federated `mock-extension`
- Test `jupyter labextension uninstall` fails with a federated extension

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
