### PR TITLE
mybinder.org link for people who want to test their own branches in the developer guidelines

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -92,6 +92,10 @@ something (this may take a few minutes to load):
 
 .. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/jupyterlab/jupyterlab/master?urlpath=lab-dev/
+   
+If you want to test your own branch hosted on GitHub, just enter it on https://mybinder.org.
+If everything goes right, filling out the form takes about 2 minutes, and the build takes about 7 minutes 
+to complete.
 
 Installing Node.js and jlpm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Related: #9259, see there for earlier discussion. Briefly, I spent too much time figuring out how to test a simple change to fix #9255.

I think in my case, not seeing in the dev guidelines how to use binder to test my change (as opposed to testing master) was a crucial point where I got off track.

"test master with binder" being condensed into a nifty button in the dev guidelines (and everywhere else I saw it) suggested to me that testing my branch with binder would involve figuring out stuff, filling out lengthy forms, and creating accounts. To avoid this, I spent at least 40 minutes looking for alternatives and learning things I didn't like to know.

I guess a typical developer is more interested in testing a custom branch than in testing master. This PR adds information about how to do that.