### PR TITLE
Pause after publishing packages to allow npm time to update their listing

### DIFF
--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -10,6 +10,8 @@ import * as path from 'path';
 import { handlePackage } from './update-dist-tag';
 import * as utils from './utils';
 
+const sleep = (wait: number) => new Promise(resolve => setTimeout(resolve, wait));
+
 // Specify the program signature.
 commander
   .description('Publish the JS packages and prep the Python package')
@@ -52,6 +54,11 @@ commander
         utils.run(cmd);
       });
     });
+
+    // Pause to allow npm some time to update their servers to list the published packages.
+    const pause = 10000;
+    console.log(`Pausing ${pause/1000} seconds after publishing to allow npmjs.com to update their package listing.`)
+    await sleep(pause);
 
     // Update core mode.  This cannot be done until the JS packages are
     // released.

--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -10,7 +10,9 @@ import * as path from 'path';
 import { handlePackage } from './update-dist-tag';
 import * as utils from './utils';
 
-const sleep = (wait: number) => new Promise(resolve => setTimeout(resolve, wait));
+async function sleep(wait: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, wait));
+}
 
 // Specify the program signature.
 commander
@@ -57,7 +59,11 @@ commander
 
     // Pause to allow npm some time to update their servers to list the published packages.
     const pause = 10000;
-    console.log(`Pausing ${pause/1000} seconds after publishing to allow npmjs.com to update their package listing.`)
+    console.log(
+      `Pausing ${
+        pause / 1000
+      } seconds after publishing to allow npmjs.com to update their package listing.`
+    );
     await sleep(pause);
 
     // Update core mode.  This cannot be done until the JS packages are


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is an attempt to work around the problem in #9122. It has not been tested in a release yet.

## Code changes

Adds a pause after publishing packages to give npm a chance to update their listings.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
