### PR TITLE
Fix command palette blur test in apputils

### DIFF
--- a/packages/apputils/test/commandpalette.spec.ts
+++ b/packages/apputils/test/commandpalette.spec.ts
@@ -75,11 +75,11 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('#blur()', () => {
-      it('should hide and reset when blurred', () => {
+    describe('#focus()', () => {
+      it('should hide and reset when focus is shifted', () => {
         MessageLoop.sendMessage(modalPalette, Widget.Msg.ActivateRequest);
         palette.inputNode.value = 'Search string...';
-        simulate(modalPalette.node, 'blur');
+        simulate(document.body, 'focus');
         expect(modalPalette.isVisible).toBe(false);
         expect(palette.inputNode.value).toEqual('');
       });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9285 

For extra context, it looks like the test failure started from e2403289b9dc8ba9b8acdef9a31d90d8009a90e3

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Tests change.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
