### PR TITLE
Enable mimedocument to use an optional specific renderer

### DIFF
--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -152,7 +152,8 @@ export function createRendermimePlugin(
           defaultFor: option.defaultFor,
           defaultRendered: option.defaultRendered,
           toolbarFactory,
-          translator
+          translator,
+          factory: item.rendererFactory
         });
         registry.addWidgetFactory(factory);
 

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -283,6 +283,7 @@ export class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument> {
     this._renderTimeout = options.renderTimeout || 1000;
     this._dataType = options.dataType || 'string';
     this._fileType = options.primaryFileType;
+    this._factory = options.factory;
   }
 
   /**
@@ -295,7 +296,19 @@ export class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument> {
     const rendermime = this._rendermime.clone({
       resolver: context.urlResolver
     });
-    const renderer = rendermime.createRenderer(mimeType);
+
+    let renderer: IRenderMime.IRenderer;
+    if (this._factory && this._factory.mimeTypes.includes(mimeType)) {
+      renderer = this._factory.createRenderer({
+        mimeType,
+        resolver: rendermime.resolver,
+        sanitizer: rendermime.sanitizer,
+        linkHandler: rendermime.linkHandler,
+        latexTypesetter: rendermime.latexTypesetter,
+      });
+    } else {
+      renderer = rendermime.createRenderer(mimeType);
+    }
 
     const content = new MimeContent({
       context,
@@ -318,6 +331,7 @@ export class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument> {
   private _renderTimeout: number;
   private _dataType: 'string' | 'json';
   private _fileType: DocumentRegistry.IFileType | undefined;
+  private _factory: IRenderMime.IRendererFactory | undefined;
 }
 
 /**
@@ -348,6 +362,11 @@ export namespace MimeDocumentFactory {
      * Preferred data type from the model.
      */
     dataType?: 'string' | 'json';
+
+    /**
+     * Optional renderer to use (overriding the renderer in the registry)
+     */
+    factory?: IRenderMime.IRendererFactory
   }
 }
 

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -304,7 +304,7 @@ export class MimeDocumentFactory extends ABCWidgetFactory<MimeDocument> {
         resolver: rendermime.resolver,
         sanitizer: rendermime.sanitizer,
         linkHandler: rendermime.linkHandler,
-        latexTypesetter: rendermime.latexTypesetter,
+        latexTypesetter: rendermime.latexTypesetter
       });
     } else {
       renderer = rendermime.createRenderer(mimeType);
@@ -366,7 +366,7 @@ export namespace MimeDocumentFactory {
     /**
      * Optional renderer to use (overriding the renderer in the registry)
      */
-    factory?: IRenderMime.IRendererFactory
+    factory?: IRenderMime.IRendererFactory;
   }
 }
 


### PR DESCRIPTION
## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

After a mime extension creates a mime document renderer for a specific filetype, the renderer may be overridden in the rendermime registry. However, we still want to use the specific extension renderer, even if it is not in the registry anymore.

I noticed this when writing a quick extension to provide a new markdown renderer, which was overridden in the registry by the markdownviewer-extension. My extension created a new viewer that was still available in the UX, but the new viewer used the overridden renderer, not my extension's renderer, which was really confusing.

This is not a blocker for 3.0, but if it is reviewed and merged, great!

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
