### PR TITLE
Set the relative sizes of left/main/right areas in afterAttach.

### DIFF
--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -198,7 +198,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     const dockPanel = (this._dockPanel = new DockPanelSvg());
     MessageLoop.installMessageHook(dockPanel, this._dockChildHook);
 
-    const hsplitPanel = new SplitPanel();
+    const hsplitPanel = (this._hsplitPanel = new SplitPanel());
     const leftHandler = (this._leftHandler = new Private.SideBarHandler());
     const rightHandler = (this._rightHandler = new Private.SideBarHandler());
     const rootLayout = new BoxLayout();
@@ -246,10 +246,6 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
 
     rootLayout.direction = 'top-to-bottom';
     rootLayout.spacing = 0; // TODO make this configurable?
-    // Use relative sizing to set the width of the side panels.
-    // This will still respect the min-size of children widget in the stacked
-    // panel.
-    hsplitPanel.setRelativeSizes([1, 2.5, 1]);
 
     BoxLayout.setStretch(headerPanel, 0);
     BoxLayout.setStretch(menuHandler.panel, 0);
@@ -820,6 +816,9 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
    */
   protected onAfterAttach(msg: Message): void {
     this.node.dataset.shellMode = this.mode;
+    // Use relative sizing to set the width of the side panels. This will
+    // still respect the min-width of children.
+    this._hsplitPanel.setRelativeSizes([1, 2.5, 1]);
   }
 
   /**
@@ -1169,6 +1168,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   private _restored = new PromiseDelegate<ILabShell.ILayout>();
   private _rightHandler: Private.SideBarHandler;
   private _tracker = new FocusTracker<Widget>();
+  private _hsplitPanel: SplitPanel;
   private _headerPanel: Panel;
   private _topHandler: Private.PanelHandler;
   private _menuHandler: Private.PanelHandler;

--- a/packages/theme-dark-extension/style/variables.css
+++ b/packages/theme-dark-extension/style/variables.css
@@ -369,7 +369,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Sidebar-related styles */
 
-  --jp-sidebar-min-width: 250px;
+  --jp-sidebar-min-width: 180px;
 
   /* Search-related styles */
 

--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -366,7 +366,7 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Sidebar-related styles */
 
-  --jp-sidebar-min-width: 250px;
+  --jp-sidebar-min-width: 180px;
 
   /* Search-related styles */
 


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

Expands on #9287

## Code changes

In #9287, we noticed there seemed to be a race condition when setting the relative sizes on construction, where sometimes those relative sizes were being applied in an update that did not have the proper full width.

Setting the relative sizes in after-attach *may* circumvent this race condition, and make sure that the relative sizes always apply after we really have the proper width.

With this, we set the minimum size back to 180px, which is what it was before #9287.

## User-facing changes



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
