### PR TITLE
#8600: Added UTF-8 encoding parameter to create process

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -87,6 +87,7 @@ class ProgressProcess(Process):
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
             universal_newlines=True,
+            encoding='utf-8',
         )
         self._kill_event = kill_event or Event()
 


### PR DESCRIPTION
## References

Fixes [#8600 ](https://github.com/jupyterlab/jupyterlab/issues/8600)

## Code changes

Added the encoding parameter with UTF-8 to use this on systems where the default encoding is not UTF-8 (Ex: Windows 10)


