### PR TITLE
Move the Single Document Switch to the status bar

### DIFF
--- a/packages/application-extension/package.json
+++ b/packages/application-extension/package.json
@@ -45,7 +45,6 @@
     "@jupyterlab/translation": "^3.0.0-rc.10",
     "@jupyterlab/ui-components": "^3.0.0-rc.10",
     "@lumino/algorithm": "^1.3.3",
-    "@lumino/commands": "^1.11.3",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",
     "@lumino/widgets": "^1.14.0",

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -39,11 +39,9 @@ import { IStateDB } from '@jupyterlab/statedb';
 
 import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 
-import { buildIcon, jupyterIcon, Switch } from '@jupyterlab/ui-components';
+import { buildIcon, jupyterIcon } from '@jupyterlab/ui-components';
 
 import { each, iter, toArray } from '@lumino/algorithm';
-
-import { CommandRegistry } from '@lumino/commands';
 
 import { PromiseDelegate } from '@lumino/coreutils';
 
@@ -961,59 +959,6 @@ const JupyterLogo: JupyterFrontEndPlugin<void> = {
 };
 
 /**
- * The single-document mode switch in the top area.
- */
-const modeSwitch: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/application-extension:mode-switch',
-  requires: [ILabShell, ITranslator],
-  activate: (
-    app: JupyterFrontEnd,
-    shell: ILabShell,
-    translator: ITranslator
-  ) => {
-    const trans = translator.load('jupyterlab');
-
-    const spacer = new Widget();
-    spacer.id = 'jp-top-spacer';
-    spacer.node.style.flexGrow = '1';
-    shell.add(spacer, 'top', { rank: 1000 });
-
-    const modeSwitch = new Switch();
-    modeSwitch.id = 'jp-single-document-mode';
-
-    modeSwitch.valueChanged.connect((_, args) => {
-      shell.mode = args.newValue ? 'single-document' : 'multiple-document';
-    });
-    shell.modeChanged.connect((_, mode) => {
-      modeSwitch.value = mode === 'single-document';
-    });
-    modeSwitch.value = shell.mode === 'single-document';
-
-    // Show the current file browser shortcut in its title.
-    const updateModeSwitchTitle = () => {
-      const binding = app.commands.keyBindings.find(
-        b => b.command === CommandIDs.toggleMode
-      );
-      if (binding) {
-        const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
-        modeSwitch.caption = trans.__('Single-Document Mode (%1)', ks);
-      } else {
-        modeSwitch.caption = trans.__('Single-Document Mode');
-      }
-    };
-    updateModeSwitchTitle();
-    app.commands.keyBindingChanged.connect(() => {
-      updateModeSwitchTitle();
-    });
-
-    modeSwitch.label = trans.__('Mode');
-
-    shell.add(modeSwitch, 'top', { rank: 1010 });
-  },
-  autoStart: true
-};
-
-/**
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
@@ -1029,8 +974,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   info,
   paths,
   propertyInspector,
-  JupyterLogo,
-  modeSwitch
+  JupyterLogo
 ];
 
 export default plugins;

--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -47,6 +47,8 @@
     "@jupyterlab/settingregistry": "^3.0.0-rc.10",
     "@jupyterlab/statusbar": "^3.0.0-rc.10",
     "@jupyterlab/translation": "^3.0.0-rc.10",
+    "@jupyterlab/ui-components": "^3.0.0-rc.10",
+    "@lumino/commands": "^1.11.3",
     "@lumino/widgets": "^1.14.0"
   },
   "devDependencies": {

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -389,7 +389,7 @@ export const runningSessionsItem: JupyterFrontEndPlugin<void> = {
  * The single-document mode switch in the top area.
  */
 const modeSwitch: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/application-extension:mode-switch',
+  id: '@jupyterlab/statusbar-extension:mode-switch',
   requires: [ILabShell, ITranslator, IStatusBar],
   activate: (
     app: JupyterFrontEnd,
@@ -429,7 +429,7 @@ const modeSwitch: JupyterFrontEndPlugin<void> = {
     modeSwitch.label = trans.__('Mode');
 
     statusBar.registerStatusItem(
-      '@jupyterlab/application-extension:mode-switch',
+      '@jupyterlab/statusbar-extension:mode-switch',
       {
         item: modeSwitch,
         align: 'left',

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -26,6 +26,8 @@ import { IDocumentWidget } from '@jupyterlab/docregistry';
 
 import { FileEditor, IEditorTracker } from '@jupyterlab/fileeditor';
 
+import { IMainMenu } from '@jupyterlab/mainmenu';
+
 import {
   INotebookTracker,
   Notebook,
@@ -41,11 +43,13 @@ import {
   StatusBar
 } from '@jupyterlab/statusbar';
 
-import { IMainMenu } from '@jupyterlab/mainmenu';
-
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import { ITranslator } from '@jupyterlab/translation';
+
+import { Switch } from '@jupyterlab/ui-components';
+
+import { CommandRegistry } from '@lumino/commands';
 
 import { Title, Widget } from '@lumino/widgets';
 
@@ -381,12 +385,69 @@ export const runningSessionsItem: JupyterFrontEndPlugin<void> = {
   }
 };
 
+/**
+ * The single-document mode switch in the top area.
+ */
+const modeSwitch: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/application-extension:mode-switch',
+  requires: [ILabShell, ITranslator, IStatusBar],
+  activate: (
+    app: JupyterFrontEnd,
+    shell: ILabShell,
+    translator: ITranslator,
+    statusBar: IStatusBar
+  ) => {
+    const trans = translator.load('jupyterlab');
+    const modeSwitch = new Switch();
+    modeSwitch.id = 'jp-single-document-mode';
+
+    modeSwitch.valueChanged.connect((_, args) => {
+      shell.mode = args.newValue ? 'single-document' : 'multiple-document';
+    });
+    shell.modeChanged.connect((_, mode) => {
+      modeSwitch.value = mode === 'single-document';
+    });
+    modeSwitch.value = shell.mode === 'single-document';
+
+    // Show the current file browser shortcut in its title.
+    const updateModeSwitchTitle = () => {
+      const binding = app.commands.keyBindings.find(
+        b => b.command === 'application:toggle-mode'
+      );
+      if (binding) {
+        const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
+        modeSwitch.caption = trans.__('Single-Document Mode (%1)', ks);
+      } else {
+        modeSwitch.caption = trans.__('Single-Document Mode');
+      }
+    };
+    updateModeSwitchTitle();
+    app.commands.keyBindingChanged.connect(() => {
+      updateModeSwitchTitle();
+    });
+
+    modeSwitch.label = trans.__('Mode');
+
+    statusBar.registerStatusItem(
+      '@jupyterlab/application-extension:mode-switch',
+      {
+        item: modeSwitch,
+        align: 'left',
+        isActive: () => true,
+        rank: -1
+      }
+    );
+  },
+  autoStart: true
+};
+
 const plugins: JupyterFrontEndPlugin<any>[] = [
   statusBar,
   lineColItem,
   kernelStatus,
   runningSessionsItem,
-  memoryUsageItem
+  memoryUsageItem,
+  modeSwitch
 ];
 
 export default plugins;

--- a/packages/statusbar-extension/tsconfig.json
+++ b/packages/statusbar-extension/tsconfig.json
@@ -38,6 +38,9 @@
     },
     {
       "path": "../translation"
+    },
+    {
+      "path": "../ui-components"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#9117 and #9105

This is more of an experimental PR to have an idea of what it would look like having the Single Document Switch in the status bar instead of the top area. And also be easily tested on Binder.

Since the status bar already has icons, some of the ideas mentioned in #9117 about using icons as an alternative to the switch might be relevant.

## Code changes

Move the single document switch to the status bar, still in its own plugin.

## User-facing changes

To play with the 2 options on Binder:

- Using JupyterLab 3.0.0rc7 with the SDM switch in the top area: https://mybinder.org/v2/gist/jtpio/8d392846c2f3ee6fab38cdfab5a364ec/master?urlpath=/lab
- Using the PR with the Binder dev mode, with the SDM switch in the status bar: https://mybinder.org/v2/gh/jtpio/jupyterlab/sdm-switch?urlpath=lab-dev

### Before (switch upper right)

![UyvprsSO1j](https://user-images.githubusercontent.com/1839645/98969196-396c5600-24d4-11eb-9629-3ebb0b1f036a.gif)

### After (switch in status bar)

![sdm-switch-statusbar](https://user-images.githubusercontent.com/591645/98399029-1f5cee80-2062-11eb-9531-ac1277017cd1.gif)

## Backwards-incompatible changes

None
