### PR TITLE
Require 'package' instead of 'package/' so webpack activates sharing

### DIFF
--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -149,7 +149,8 @@ async function main() {
   const mimeExtensions = [];
   {{#each jupyterlab_mime_extensions}}
   try {
-    for (let plugin of activePlugins(require('{{@key}}/{{this}}'))) {
+    let ext = require('{{@key}}{{#if this}}/{{this}}{{/if}}');
+    for (let plugin of activePlugins(ext)) {
       mimeExtensions.push(plugin);
     }
   } catch (e) {
@@ -172,7 +173,8 @@ async function main() {
   // Handled the registered standard extensions.
   {{#each jupyterlab_extensions}}
   try {
-    for (let plugin of activePlugins(require('{{@key}}/{{this}}'))) {
+    let ext = require('{{@key}}{{#if this}}/{{this}}{{/if}}');
+    for (let plugin of activePlugins(ext)) {
       register.push(plugin);
     }
   } catch (e) {


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This addresses the underlying problem in at least part of #9289.

## Code changes

Webpack module federation was not creating shared modules for the direct extensions, only for their dependencies. For example, @jupyterlab/application was packaged as a shared module, but @jupyterlab/application-extension was not.

The reasoning here is a bit subtle. The problem came down to how these top-level extensions were imported. The template made the require statements similar to @jupyterlab/application-extension/, with a trailing slash (which was nominally a slash between the package name and the actual import in the package, but mostly that actual import was an empty string, so we’d just be left with a trailing slash). However, webpack interpreted that trailing slash as indicating the import was only for paths starting with the package name, and not as a top-level package import. This meant that webpack did not see that these modules were being used, so did not include them in the list of modules packaged as shared modules. In other words, these top-level imports were treated as this case:

https://github.com/webpack/webpack/blob/7415a618460795874fdf95c8f03363ea96709d52/lib/sharing/ProvideSharedPlugin.js#L97-L99

instead of as this case:

https://github.com/webpack/webpack/blob/7415a618460795874fdf95c8f03363ea96709d52/lib/sharing/ProvideSharedPlugin.js#L100-L102

The fix here is simple - only put the slash in the require statement if we actually have a path to import.


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
