### PR TITLE
Update upgrade script to use labextension for outputDir

### DIFF
--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -113,7 +113,7 @@ def update_extension(target, interactive=True):
         warnings.append('package.json scripts must be updated manually')
 
     # Set the output directory
-    data['jupyterlab']['outputDir'] = python_name + '/static'
+    data['jupyterlab']['outputDir'] = python_name + '/labextension'
 
     # Look for resolutions in JupyterLab metadata and upgrade those as well
     root_jlab_package = pkg_resources.resource_filename('jupyterlab', 'staging/package.json')

--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -113,7 +113,7 @@ def update_extension(target, interactive=True):
         warnings.append('package.json scripts must be updated manually')
 
     # Set the output directory
-    data['jupyterlab']['outputDir'] = python_name + '/labextension'
+    data['jupyterlab']['outputDir'] = temp_data['jupyterlab']['outputDir']
 
     # Look for resolutions in JupyterLab metadata and upgrade those as well
     root_jlab_package = pkg_resources.resource_filename('jupyterlab', 'staging/package.json')


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/extension-cookiecutter-ts/pull/109

At the moment, using the upgrade script would use `static` in the `package.json`, which causes the `pip install -e .` command to fail.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
