### PR TITLE
Built-in extensions using federated dependencies

### DIFF
--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -39,7 +39,7 @@ const notice =
 
 [
   'index.js',
-  'boostrap.js',
+  'bootstrap.js',
   'publicpath.js',
   'webpack.config.js',
   'webpack.prod.config.js',

--- a/buildutils/src/update-core-mode.ts
+++ b/buildutils/src/update-core-mode.ts
@@ -39,6 +39,7 @@ const notice =
 
 [
   'index.js',
+  'boostrap.js',
   'publicpath.js',
   'webpack.config.js',
   'webpack.prod.config.js',

--- a/dev_mode/bootstrap.js
+++ b/dev_mode/bootstrap.js
@@ -81,7 +81,7 @@ async function loadComponent(url, scope) {
   await container.init(__webpack_share_scopes__.default);
 }
 
-(async function bootstrap() {
+void (async function bootstrap() {
   // This is all the data needed to load and activate plugins. This should be
   // gathered by the server and put onto the initial page template.
   const extension_data = getOption('federated_extensions');

--- a/dev_mode/bootstrap.js
+++ b/dev_mode/bootstrap.js
@@ -1,0 +1,115 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+// We copy some of the pageconfig parsing logic in @jupyterlab/coreutils
+// below, since this must run before any other files are loaded (including
+// @jupyterlab/coreutils).
+
+/**
+ * Get global configuration data for the Jupyter application.
+ *
+ * @param name - The name of the configuration option.
+ *
+ * @returns The config value or an empty string if not found.
+ *
+ * #### Notes
+ * All values are treated as strings. For browser based applications, it is
+ * assumed that the page HTML includes a script tag with the id
+ * `jupyter-config-data` containing the configuration as valid JSON.
+ */
+let _CONFIG_DATA = null;
+function getOption(name) {
+  if (_CONFIG_DATA === null) {
+    let configData;
+    // Use script tag if available.
+    if (typeof document !== 'undefined' && document) {
+      const el = document.getElementById('jupyter-config-data');
+
+      if (el) {
+        configData = JSON.parse(el.textContent || '{}');
+      }
+    }
+    _CONFIG_DATA = configData ?? Object.create(null);
+  }
+
+  return _CONFIG_DATA[name] || '';
+}
+
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = getOption('fullStaticUrl') + '/';
+
+// Promise.allSettled polyfill, until our supported browsers implement it
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled
+if (Promise.allSettled === undefined) {
+  Promise.allSettled = promises =>
+    Promise.all(
+      promises.map(promise =>
+        promise.then(
+          value => ({
+            status: 'fulfilled',
+            value
+          }),
+          reason => ({
+            status: 'rejected',
+            reason
+          })
+        )
+      )
+    );
+}
+
+function loadScript(url) {
+  return new Promise((resolve, reject) => {
+    const newScript = document.createElement('script');
+    newScript.onerror = reject;
+    newScript.onload = resolve;
+    newScript.async = true;
+    document.head.appendChild(newScript);
+    newScript.src = url;
+  });
+}
+
+async function loadComponent(url, scope) {
+  await loadScript(url);
+
+  // From https://webpack.js.org/concepts/module-federation/#dynamic-remote-containers
+  await __webpack_init_sharing__('default');
+  const container = window._JUPYTERLAB[scope];
+  // Initialize the container, it may provide shared modules and may need ours
+  await container.init(__webpack_share_scopes__.default);
+}
+
+(async function bootstrap() {
+  // This is all the data needed to load and activate plugins. This should be
+  // gathered by the server and put onto the initial page template.
+  const extension_data = getOption('federated_extensions');
+
+  // We first load all federated components so that the shared module
+  // deduplication can run and figure out which shared modules from all
+  // components should be actually used. We have to do this before importing
+  // and using the module that actually uses these components so that all
+  // dependencies are initialized.
+  let labExtensionUrl = getOption('fullLabextensionsUrl');
+  const extensions = await Promise.allSettled(
+    extension_data.map(async data => {
+      await loadComponent(
+        `${labExtensionUrl}/${data.name}/${data.load}`,
+        data.name
+      );
+    })
+  );
+
+  extensions.forEach(p => {
+    if (p.status === 'rejected') {
+      // There was an error loading the component
+      console.error(p.reason);
+    }
+  });
+
+  // Now that all federated containers are initialized with the main
+  // container, we can import the main function.
+  let main = (await import('./index.out.js')).main;
+  window.addEventListener('load', main);
+})();

--- a/dev_mode/index.js
+++ b/dev_mode/index.js
@@ -3,57 +3,12 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import {
-  PageConfig,
-  URLExt,
-} from '@jupyterlab/coreutils';
+import { PageConfig } from '@jupyterlab/coreutils';
 
-// eslint-disable-next-line no-undef
-__webpack_public_path__ = PageConfig.getOption('fullStaticUrl') + '/';
-
-// Promise.allSettled polyfill, until our supported browsers implement it
-// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled
-if (Promise.allSettled === undefined) {
-  Promise.allSettled = promises =>
-    Promise.all(
-      promises.map(promise =>
-        promise
-          .then(value => ({
-            status: "fulfilled",
-            value,
-          }), reason => ({
-            status: "rejected",
-            reason,
-          }))
-      )
-    );
-}
 
 // This must be after the public path is set.
 // This cannot be extracted because the public path is dynamic.
 require('./imports.css');
-
-
-function loadScript(url) {
-  return new Promise((resolve, reject) => {
-    const newScript = document.createElement('script');
-    newScript.onerror = reject;
-    newScript.onload = resolve;
-    newScript.async = true;
-    document.head.appendChild(newScript);
-    newScript.src = url;
-  });
-}
-
-async function loadComponent(url, scope) {
-  await loadScript(url);
-
-  // From MIT-licensed https://github.com/module-federation/module-federation-examples/blob/af043acd6be1718ee195b2511adf6011fba4233c/advanced-api/dynamic-remotes/app1/src/App.js#L6-L12
-  await __webpack_init_sharing__('default');
-  const container = window._JUPYTERLAB[scope];
-  // Initialize the container, it may provide shared modules and may need ours
-  await container.init(__webpack_share_scopes__.default);
-}
 
 async function createModule(scope, module) {
   try {
@@ -68,42 +23,24 @@ async function createModule(scope, module) {
 /**
  * The main entry point for the application.
  */
-async function main() {
+export async function main() {
   var JupyterLab = require('@jupyterlab/application').JupyterLab;
   var disabled = [];
   var deferred = [];
   var ignorePlugins = [];
   var register = [];
 
-  // This is all the data needed to load and activate plugins. This should be
-  // gathered by the server and put onto the initial page template.
-  const extension_data = JSON.parse(
-    PageConfig.getOption('federated_extensions')
-  );
 
   const federatedExtensionPromises = [];
   const federatedMimeExtensionPromises = [];
   const federatedStylePromises = [];
 
-  // We first load all federated components so that the shared module
-  // deduplication can run and figure out which shared modules from all
-  // components should be actually used.
-  const extensions = await Promise.allSettled(extension_data.map( async data => {
-    await loadComponent(
-      `${URLExt.join(PageConfig.getOption('fullLabextensionsUrl'), data.name, data.load)}`,
-      data.name
-    );
-    return data;
-  }));
+  // Start initializing the federated extensions
+  const extensions = JSON.parse(
+    PageConfig.getOption('federated_extensions')
+  );
 
-  extensions.forEach(p => {
-    if (p.status === "rejected") {
-      // There was an error loading the component
-      console.error(p.reason);
-      return;
-    }
-
-    const data = p.value;
+  extensions.forEach(data => {
     if (data.extension) {
       federatedExtensionPromises.push(createModule(data.name, data.extension));
     }
@@ -262,4 +199,3 @@ async function main() {
 
 }
 
-window.addEventListener('load', main);

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -166,9 +166,9 @@ for (let [key, requiredVersion] of Object.entries(package_data.resolutions)) {
 }
 
 // Add any extension packages that are not in resolutions (i.e., installed from npm)
-for (let pkg in extensionPackages) {
+for (let pkg of extensionPackages) {
   if (shared[pkg] === undefined) {
-    shared[pkg] = { requiredVersion: package_data.dependencies[pkg] };
+    shared[pkg] = { requiredVersion: require(`${pkg}/package.json`).version };
   }
 }
 

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -66,8 +66,10 @@ const extData = {
 };
 fs.writeFileSync(plib.join(buildDir, 'index.out.js'), template(extData));
 
+// Create the bootstrap file that loads federated extensions and calls the
+// initialization logic in index.out.js
 const entryPoint = plib.join(buildDir, 'bootstrap.js');
-fs.writeFileSync(entryPoint, 'import("./index.out.js");');
+fs.copySync('./bootstrap.js', entryPoint);
 
 fs.copySync('./package.json', plib.join(buildDir, 'package.json'));
 if (outputDir !== buildDir) {
@@ -161,7 +163,7 @@ const shared = {};
 for (let [key, requiredVersion] of Object.entries(package_data.resolutions)) {
   // eager so that built-in extensions can be bundled together into just a few
   // js files to load
-  shared[key] = { requiredVersion, eager: true };
+  shared[key] = { requiredVersion };
 }
 
 // Add dependencies and sharedPackage config from extension packages if they
@@ -176,7 +178,7 @@ for (let pkg of extensionPackages) {
   } = require(`${pkg}/package.json`);
   for (let [dep, requiredVersion] of Object.entries(dependencies)) {
     if (!shared[dep]) {
-      pkgShared[dep] = { requiredVersion, eager: true };
+      pkgShared[dep] = { requiredVersion };
     }
   }
 

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -170,7 +170,9 @@ for (let [key, requiredVersion] of Object.entries(package_data.resolutions)) {
   if (requiredVersion.startsWith('file:')) {
     requiredVersion = require(`${key}/package.json`).version;
   }
-  shared[key] = { requiredVersion };
+  // eager so that built-in extensions can be bundled together into just a few
+  // js files to load
+  shared[key] = { requiredVersion, eager: true };
 }
 
 // Add singleton package information

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -20,22 +20,10 @@ const package_data = require('./package.json');
 
 // Handle the extensions.
 const jlab = package_data.jupyterlab;
-// TODO: what exactly are externalExtensions?
 const { extensions, mimeExtensions, externalExtensions } = jlab;
-const packageNames = [
-  ...Object.keys(extensions),
-  ...Object.keys(mimeExtensions),
-  ...Object.keys(externalExtensions)
-];
 
-// Go through each external extension
-// add to mapping of extension and mime extensions, of package name
-// to path of the extension.
-
-// TODO: what is this really doing? I thought extensions and mimeExtensions
-// was a list of packages, but this seems to be the entry points to these
-// things? If they are lists of packages, why is this not done before the
-// packageNames thing above is constructed?
+// Add external extensions to the extensions/mimeExtensions data as
+// appropriate
 for (const key in externalExtensions) {
   const {
     jupyterlab: { extension, mimeExtension }
@@ -59,7 +47,10 @@ const outputDir = plib.resolve(jlab.outputDir);
 
 // Build the assets
 const extraConfig = Build.ensureAssets({
-  packageNames: packageNames,
+  // Deduplicate the extension package names
+  packageNames: [
+    ...new Set([...Object.keys(extensions), ...Object.keys(mimeExtensions)])
+  ],
   output: outputDir
 });
 

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -160,10 +160,16 @@ function ignored(path) {
 // Set up module federation sharing config
 const shared = {};
 
+// Make sure any resolutions are shared
 for (let [key, requiredVersion] of Object.entries(package_data.resolutions)) {
-  // eager so that built-in extensions can be bundled together into just a few
-  // js files to load
   shared[key] = { requiredVersion };
+}
+
+// Add any extension packages that are not in resolutions (i.e., installed from npm)
+for (let pkg in extensionPackages) {
+  if (shared[pkg] === undefined) {
+    shared[pkg] = { requiredVersion: package_data.dependencies[pkg] };
+  }
 }
 
 // Add dependencies and sharedPackage config from extension packages if they

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -1127,7 +1127,7 @@ class _AppHandler(object):
                 _rmtree(staging, self.logger)
                 os.makedirs(staging)
 
-        for fname in ['index.js', 'publicpath.js',
+        for fname in ['index.js', 'bootstrap.js', 'publicpath.js',
                       'webpack.config.js',
                       'webpack.prod.config.js',
                       'webpack.prod.minimize.config.js',


### PR DESCRIPTION
## References

This fixes the last half of #9289. It allows built-in extensions to use dependencies shared by federated extensions. It also cleans up the built-in extension configuration.

## Code changes

* Load federated extensions in a bootstrap phase, before the main application imports compiled plugins and starts the application. This ensures that if a compiled plugin requires something provided by a federated extension, it will be able to get it.
* Treat compiled extensions (including core extensions) and federated extensions similarly when it comes to sharing config. We always default to sharing all direct dependencies, and we allow for any plugin to have a customized `jupyterlab.sharedConfig` key listing sharing config that overrides these defaults.

We are careful to merge the extension sharing config for the compiled build. We never override the core set of resolutions (those are always shared), and any shared config that says to bundle a dependency takes precedence over a config saying not to bundle a dependency.

## User-facing changes

Compiled extensions can use federated dependencies. For example, with this, a user should be able to `jupyter labextension install` an ipywidgets plugin with the `jupyterlab_widgets` federated extension base widget package. The ipywidgets plugin should be able to use the ipywidgets manager provided by the federated extension.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
