### PR TITLE
Refactor build conventions

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "jlpm run clean && webpack",
     "build:dev": "jlpm run build",
-    "build:dev:minimize": "jlpm run build:dev",
     "build:prod": "webpack --config webpack.prod.config.js",
     "build:prod:minimize": "webpack --config webpack.prod.minimize.config.js",
     "build:prod:release": "webpack --config webpack.prod.release.config.js",

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -170,7 +170,10 @@ for (let [key, requiredVersion] of Object.entries(package_data.resolutions)) {
 // Add any extension packages that are not in resolutions (i.e., installed from npm)
 for (let pkg of extensionPackages) {
   if (shared[pkg] === undefined) {
-    shared[pkg] = { requiredVersion: require(`${pkg}/package.json`).version, eager: true };
+    shared[pkg] = {
+      requiredVersion: require(`${pkg}/package.json`).version,
+      eager: true
+    };
   }
 }
 

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -162,13 +162,15 @@ const shared = {};
 
 // Make sure any resolutions are shared
 for (let [key, requiredVersion] of Object.entries(package_data.resolutions)) {
-  shared[key] = { requiredVersion };
+  // eager so that built-in extensions can be bundled together into just a few
+  // js files to load
+  shared[key] = { requiredVersion, eager: true };
 }
 
 // Add any extension packages that are not in resolutions (i.e., installed from npm)
 for (let pkg of extensionPackages) {
   if (shared[pkg] === undefined) {
-    shared[pkg] = { requiredVersion: require(`${pkg}/package.json`).version };
+    shared[pkg] = { requiredVersion: require(`${pkg}/package.json`).version, eager: true };
   }
 }
 
@@ -184,7 +186,7 @@ for (let pkg of extensionPackages) {
   } = require(`${pkg}/package.json`);
   for (let [dep, requiredVersion] of Object.entries(dependencies)) {
     if (!shared[dep]) {
-      pkgShared[dep] = { requiredVersion };
+      pkgShared[dep] = { requiredVersion, eager: true };
     }
   }
 

--- a/dev_mode/webpack.prod.minimize.config.js
+++ b/dev_mode/webpack.prod.minimize.config.js
@@ -6,6 +6,7 @@ config[0] = merge(config[0], {
   mode: 'production',
   devtool: 'source-map',
   optimization: {
+    minimize: true,
     minimizer: [
       new TerserPlugin({
         parallel: true,

--- a/jupyterlab/handlers/build_handler.py
+++ b/jupyterlab/handlers/build_handler.py
@@ -100,13 +100,13 @@ class Builder(object):
             app_dir=app_dir, logger=logger, kill_event=kill_event,
             core_config=core_config)
         try:
-            return build(command='build', app_options=app_options)
+            return build(app_options=app_options)
         except Exception as e:
             if self._kill_event.is_set():
                 return
             self.log.warn('Build failed, running a clean and rebuild')
             clean(app_options=app_options)
-            return build(command='build', app_options=app_options)
+            return build(app_options=app_options)
 
 
 class BuildHandler(ExtensionHandlerMixin, APIHandler):

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -93,7 +93,7 @@ jupyter --paths
 Explanation:
 
 - `dev-build`: This option controls whether a `dev` or a more streamlined
-`production` build is used. This option will default to `False` (ie the
+`production` build is used. This option will default to `False` (i.e., the
 `production` build) for most users. However, if you have any labextensions
 installed from local files, this option will instead default to `True`.
 Explicitly setting `dev-build` to `False` will ensure that the `production`
@@ -131,23 +131,15 @@ class LabBuildApp(JupyterApp, DebugLogFileMixin):
         help="The version of the built application")
 
     dev_build = Bool(None, allow_none=True, config=True,
-        help="Whether to build in dev mode. Defaults to True (dev mode) if there are any locally linked extensions, else defaults to False (prod mode).")
+        help="Whether to build in dev mode. Defaults to True (dev mode) if there are any locally linked extensions, else defaults to False (production mode).")
 
     minimize = Bool(True, config=True,
-        help="Whether to use a minifier during the Webpack build (defaults to True). Only affects production builds.")
+        help="Whether to minimize a production build (defaults to True).")
 
     pre_clean = Bool(False, config=True,
         help="Whether to clean before building (defaults to False)")
 
     def start(self):
-        parts = ['build']
-        parts.append('none' if self.dev_build is None else
-                     'dev' if self.dev_build else
-                     'prod')
-        if self.minimize:
-            parts.append('minimize')
-        command = ':'.join(parts)
-
         app_dir = self.app_dir or get_app_dir()
         app_options = AppOptions(
             app_dir=app_dir, logger=self.log, core_config=self.core_config
@@ -159,8 +151,9 @@ class LabBuildApp(JupyterApp, DebugLogFileMixin):
                 clean(app_options=app_options)
             self.log.info('Building in %s', app_dir)
             try:
+                production = None if self.dev_build is None else not self.dev_build
                 build(name=self.name, version=self.version,
-                  command=command, app_options=app_options)
+                  app_options=app_options, production = production, minimize=self.minimize)
             except Exception as e:
                 print(buildFailureMsg)
                 raise e

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -64,6 +64,15 @@ build_aliases['debug-log-path'] = 'DebugLogFileMixin.debug_log_path'
 
 build_flags = dict(flags)
 
+build_flags['dev-build'] = (
+    {'LabBuildApp': {'dev_build': True}},
+    "Build in development mode."
+)
+build_flags['no-minimize'] = (
+    {'LabBuildApp': {'minimize': False}},
+    "Do not minimize a production build."
+)
+
 version = __version__
 app_version = get_app_version()
 if version != app_version:

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -33,6 +33,14 @@ flags['no-build'] = (
     {'BaseExtensionApp': {'should_build': False}},
     "Defer building the app after the action."
 )
+flags['dev-build'] = (
+    {'BaseExtensionApp': {'dev_build': True}},
+    "Build in development mode."
+)
+flags['no-minimize'] = (
+    {'BaseExtensionApp': {'minimize': False}},
+    "Do not minimize a production build."
+)
 flags['clean'] = (
     {'BaseExtensionApp': {'should_clean': True}},
     "Cleanup intermediate files after the action."

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -93,7 +93,7 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
         help="Whether to build in dev mode. Defaults to True (dev mode) if there are any locally linked extensions, else defaults to False (production mode).")
 
     minimize = Bool(True, config=True,
-        help="Whether to use a minifier during the Webpack build (defaults to True). Only affects production builds.")
+        help="Whether to minimize a production build (defaults to True).")
 
     should_clean = Bool(False, config=True,
         help="Whether temporary files should be cleaned up after building jupyterlab")
@@ -112,17 +112,11 @@ class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
         with self.debug_logging():
             ans = self.run_task()
             if ans and self.should_build:
-                parts = ['build']
-                parts.append('none' if self.dev_build is None else
-                             'dev' if self.dev_build else
-                             'prod')
-                if self.minimize:
-                    parts.append('minimize')
-                command = ':'.join(parts)
+                production = None if self.dev_build is None else not self.dev_build
                 app_options = AppOptions(app_dir=self.app_dir, logger=self.log,
                       core_config=self.core_config)
                 build(clean_staging=self.should_clean,
-                      command=command, app_options=app_options)
+                      production = production, minimize = self.minimize, app_options=app_options)
 
     def run_task(self):
         pass


### PR DESCRIPTION
## References

Fixes #9304.

This builds on #9310, so that should be reviewed/merged first.

## Code changes

- Refactors the signature of our internal build command to take options rather than parsing a string
- Cleans up the various permutations of options (e.g., it doesn't claim to be doing a dev minimize build anymore)
- ~~Since we do not distinguish between locally-installed extensions and extensions installed from npm, it seems we were *always* defaulting to a dev build if any extensions were installed. Now, we default to a production build when extensions are installed.~~ *Edit: I was mistaken - production builds happen automatically when it makes sense*
- Set webpack to share dependencies of built-in extensions eagerly. This allows webpack to combine extensions into fewer larger bundles.

## User-facing changes

- Add `--no-minimize` and `--dev-build` convenience flags to `jupyter lab build` and `jupyter labextension` commands
- Builds combine more js into fewer larger files, resulting in far fewer requests from the browser.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
