### PR TITLE
Increase the pause between publishing and using npm packages to 5 minutes

### DIFF
--- a/buildutils/src/publish.ts
+++ b/buildutils/src/publish.ts
@@ -58,13 +58,11 @@ commander
     });
 
     // Pause to allow npm some time to update their servers to list the published packages.
-    const pause = 10000;
+    const pause = 5; // minutes
     console.log(
-      `Pausing ${
-        pause / 1000
-      } seconds after publishing to allow npmjs.com to update their package listing.`
+      `Pausing ${pause} minutes after publishing to allow npmjs.com to update their package listing.`
     );
-    await sleep(pause);
+    await sleep(pause * 60 * 1000);
 
     // Update core mode.  This cannot be done until the JS packages are
     // released.


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

I still saw the problem in #9122 in releasing 3.0rc8. This follows up on #9288.

This has not been tested in a release.

## Code changes

Increase the pause between publishing and using npm packages to 5 minutes. Surely 5 minutes is enough time to update npm listings if this is an npm caching issue, especially since immediately quitting the process and rerunning the publish works just fine.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
