### PR TITLE
Do not error if requiredVersion is not provided.

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -240,7 +240,7 @@ Object.assign(shared, mergedShare);
 // imported package. This assumes (for simplicity) that the version we get
 // importing was installed from the file.
 for (let [key, { requiredVersion }] of Object.entries(shared)) {
-  if (requiredVersion.startsWith('file:')) {
+  if (requiredVersion?.startsWith('file:')) {
     shared[key].requiredVersion = require(`${key}/package.json`).version;
   }
 }

--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -240,7 +240,7 @@ Object.assign(shared, mergedShare);
 // imported package. This assumes (for simplicity) that the version we get
 // importing was installed from the file.
 for (let [key, { requiredVersion }] of Object.entries(shared)) {
-  if (requiredVersion?.startsWith('file:')) {
+  if (requiredVersion && requiredVersion.startsWith('file:')) {
     shared[key].requiredVersion = require(`${key}/package.json`).version;
   }
 }


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

If a package overrides the sharing config for a dependency, it might have forgotton to give the requiredVersion (so requiredVersion is undefined). In this case, don't error (which is what currently is done with an undefined error), but instead just go with the default webpack behavior.

I found this by playing around with the `sharedPackages` key, and forgetting to add `requiredVersion`...

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
