### PR TITLE
Changed the expression to "Server unavailable or unreachable"  instead of "Server Not Running"

### DIFF
--- a/packages/hub-extension/src/index.ts
+++ b/packages/hub-extension/src/index.ts
@@ -150,7 +150,7 @@ const connectionlost: JupyterFrontEndPlugin<IConnectionLost> = {
       }
       showingError = true;
       const result = await showDialog({
-        title: trans.__('Server Not Running'),
+        title: trans.__('Server unavailable or unreachable'),
         body: trans.__(
           'Your server at %1 is not running.\nWould you like to restart it?',
           baseUrl


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
#9324 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

