### PR TITLE
Revert opening in new tab in single-document mode

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -257,13 +257,6 @@ Available file types:
     // regenerate the settings description with the available options.
     registry.changed.connect(() => settingRegistry.reload(pluginId));
 
-    if (labShell) {
-      labShell.modeChanged.connect((_, args) => {
-        docManager.mode = args;
-      });
-      docManager.mode = labShell.mode;
-    }
-
     return docManager;
   }
 };

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -257,10 +257,12 @@ Available file types:
     // regenerate the settings description with the available options.
     registry.changed.connect(() => settingRegistry.reload(pluginId));
 
-    docManager.mode = labShell!.mode;
-    labShell!.modeChanged.connect((_, args) => {
-      docManager.mode = args as string;
-    });
+    if (labShell) {
+      labShell.modeChanged.connect((_, args) => {
+        docManager.mode = args;
+      });
+      docManager.mode = labShell.mode;
+    }
 
     return docManager;
   }

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -3,7 +3,7 @@
 
 import { ISessionContext, sessionContextDialogs } from '@jupyterlab/apputils';
 
-import { PathExt, PageConfig } from '@jupyterlab/coreutils';
+import { PathExt } from '@jupyterlab/coreutils';
 
 import { UUID } from '@lumino/coreutils';
 
@@ -25,7 +25,7 @@ import { AttachedProperty } from '@lumino/properties';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
-import { DockPanel, Widget } from '@lumino/widgets';
+import { Widget } from '@lumino/widgets';
 
 import { SaveHandler } from './savehandler';
 
@@ -80,22 +80,6 @@ export class DocumentManager implements IDocumentManager {
    */
   get activateRequested(): ISignal<this, string> {
     return this._activateRequested;
-  }
-
-  /**
-   * The document mode of the document manager, either 'single-document' or 'multiple-document'.
-   *
-   * This is usually synced with the `mode` attribute of the shell.
-   */
-  get mode(): DockPanel.Mode {
-    return this._mode;
-  }
-
-  /**
-   * Set the mode of the document manager, either 'single-document' or 'multiple-document'.
-   */
-  set mode(value: DockPanel.Mode) {
-    this._mode = value;
   }
 
   /**
@@ -539,15 +523,6 @@ export class DocumentManager implements IDocumentManager {
     return registry.getWidgetFactory(widgetName);
   }
 
-  private _openInNewWorkspace(path: string) {
-    const newUrl = PageConfig.getUrl({
-      mode: this.mode,
-      workspace: 'default',
-      treePath: path
-    });
-    window.open(newUrl);
-  }
-
   /**
    * Creates a new document, or loads one from disk, depending on the `which` argument.
    * If `which==='create'`, then it creates a new document. If `which==='open'`,
@@ -630,7 +605,6 @@ export class DocumentManager implements IDocumentManager {
   private _isDisposed = false;
   private _autosave = true;
   private _autosaveInterval = 120;
-  private _mode: DockPanel.Mode = 'multiple-document';
   private _when: Promise<void>;
   private _setBusy: (() => IDisposable) | undefined;
   private _dialogs: ISessionContext.IDialogs;

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -25,7 +25,7 @@ import { AttachedProperty } from '@lumino/properties';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
-import { Widget } from '@lumino/widgets';
+import { DockPanel, Widget } from '@lumino/widgets';
 
 import { SaveHandler } from './savehandler';
 
@@ -87,14 +87,14 @@ export class DocumentManager implements IDocumentManager {
    *
    * This is usually synced with the `mode` attribute of the shell.
    */
-  get mode(): string {
+  get mode(): DockPanel.Mode {
     return this._mode;
   }
 
   /**
    * Set the mode of the document manager, either 'single-document' or 'multiple-document'.
    */
-  set mode(value: string) {
+  set mode(value: DockPanel.Mode) {
     this._mode = value;
   }
 
@@ -634,7 +634,7 @@ export class DocumentManager implements IDocumentManager {
   private _isDisposed = false;
   private _autosave = true;
   private _autosaveInterval = 120;
-  private _mode = '';
+  private _mode: DockPanel.Mode = 'multiple-document';
   private _when: Promise<void>;
   private _setBusy: (() => IDisposable) | undefined;
   private _dialogs: ISessionContext.IDialogs;

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -392,16 +392,12 @@ export class DocumentManager implements IDocumentManager {
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions
   ): IDocumentWidget | undefined {
-    if (this.mode == 'single-document' && options?.maybeNewWorkspace) {
-      this._openInNewWorkspace(path);
-    } else {
-      const widget = this.findWidget(path, widgetName);
-      if (widget) {
-        this._opener.open(widget, options || {});
-        return widget;
-      }
-      return this.open(path, widgetName, kernel, options || {});
+    const widget = this.findWidget(path, widgetName);
+    if (widget) {
+      this._opener.open(widget, options || {});
+      return widget;
     }
+    return this.open(path, widgetName, kernel, options || {});
   }
 
   /**

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -42,14 +42,6 @@ export interface IDocumentManager extends IDisposable {
   readonly activateRequested: ISignal<this, string>;
 
   /**
-   * The mode of the document manager, either 'single-document' or
-   * 'multiple-document' and usually matches that of the shell. When this
-   * is 'single-document' the document manager will open documents in a
-   * separate browser tab.
-   */
-  mode: string;
-
-  /**
    * Whether to autosave documents.
    */
   autosave: boolean;

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1077,12 +1077,6 @@ export namespace DocumentRegistry {
      * This field may be used or ignored depending on shell implementation.
      */
     rank?: number;
-
-    /**
-     * If the document manager is in single document mode, open the document in
-     * a new browser tab and JupyterLab workspace.
-     */
-    maybeNewWorkspace?: boolean;
   }
 
   /**

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -984,9 +984,7 @@ export class DirListing extends Widget {
         );
     } else {
       const path = item.path;
-      this._manager.openOrReveal(path, 'default', undefined, {
-        maybeNewWorkspace: true
-      });
+      this._manager.openOrReveal(path);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This fixes #9323 and reverts part of #8715.

I'm opening this as draft (could be review/merged or closed) pending discussion/decision on #9323.

## Code changes

Reverts the filebrowser opening behavior introduced in #8715, along with the relevant state introduced for this behavior.

## User-facing changes

Reverts the filebrowser opening behavior introduced in #8715 so that opening a new file in single-document mode opens the file in the current browser tab rather than opening a new browser tab. See #9323 for more discussion.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
