### PR TITLE
Accessible color contrast for brand, accent, and state colors

### DIFF
--- a/packages/theme-light-extension/style/variables.css
+++ b/packages/theme-light-extension/style/variables.css
@@ -217,36 +217,36 @@ all of MD as it is not optimized for dense, information rich UIs.
 
   /* Brand/accent */
 
-  --jp-brand-color0: var(--md-blue-700);
-  --jp-brand-color1: var(--md-blue-500);
+  --jp-brand-color0: var(--md-blue-900);
+  --jp-brand-color1: var(--md-blue-700);
   --jp-brand-color2: var(--md-blue-300);
   --jp-brand-color3: var(--md-blue-100);
   --jp-brand-color4: var(--md-blue-50);
 
-  --jp-accent-color0: var(--md-green-700);
-  --jp-accent-color1: var(--md-green-500);
+  --jp-accent-color0: var(--md-green-900);
+  --jp-accent-color1: var(--md-green-700);
   --jp-accent-color2: var(--md-green-300);
   --jp-accent-color3: var(--md-green-100);
 
   /* State colors (warn, error, success, info) */
 
-  --jp-warn-color0: var(--md-orange-700);
-  --jp-warn-color1: var(--md-orange-500);
+  --jp-warn-color0: var(--md-orange-900);
+  --jp-warn-color1: var(--md-orange-700);
   --jp-warn-color2: var(--md-orange-300);
   --jp-warn-color3: var(--md-orange-100);
 
-  --jp-error-color0: var(--md-red-700);
-  --jp-error-color1: var(--md-red-500);
+  --jp-error-color0: var(--md-red-900);
+  --jp-error-color1: var(--md-red-700);
   --jp-error-color2: var(--md-red-300);
   --jp-error-color3: var(--md-red-100);
 
-  --jp-success-color0: var(--md-green-700);
-  --jp-success-color1: var(--md-green-500);
+  --jp-success-color0: var(--md-green-900);
+  --jp-success-color1: var(--md-green-700);
   --jp-success-color2: var(--md-green-300);
   --jp-success-color3: var(--md-green-100);
 
-  --jp-info-color0: var(--md-cyan-700);
-  --jp-info-color1: var(--md-cyan-500);
+  --jp-info-color0: var(--md-cyan-900);
+  --jp-info-color1: var(--md-cyan-700);
   --jp-info-color2: var(--md-cyan-300);
   --jp-info-color3: var(--md-cyan-100);
 


### PR DESCRIPTION
## References
Reflects current state of #8832. 

## Code changes
Adjusts light theme's brand, accent, and state colors. `color0` changes from  md 700s to md 900s and `color1` changes from`md 500s to 700s. This creates sufficient color contrast for white text and ui elements as defined by WCAG 2.1.

## User-facing changes
This impacts many parts of the UI, but only changes the value of the colors. Some of the most noticeable areas are dialog buttons, cell collapsers, and file browser highlight color like the following.

<img width="1387" alt="Darker blue for cell collapser, file browser button, and file browser highlight" src="https://user-images.githubusercontent.com/50221806/97062639-ad0fe880-1550-11eb-81e8-2bd86080c15e.png">

<img width="642" alt="Darker blue hover state for cell collapser" src="https://user-images.githubusercontent.com/50221806/97062649-c4e76c80-1550-11eb-9d4e-51aa038ad53a.png">

<img width="482" alt="Darker red for restart dialog button" src="https://user-images.githubusercontent.com/50221806/97062685-e7798580-1550-11eb-90e5-ae0d7c12365f.png">

## Backwards-incompatible changes

None.
