### PR TITLE
Target sys-prefix by default but allow you to specify user

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -471,22 +471,22 @@ def get_app_info(app_options=None):
     return handler.info
 
 
-def enable_extension(extension, app_options=None):
+def enable_extension(extension, app_options=None, user=False, sys_prefix=False):
     """Enable a JupyterLab extension.
 
     Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     handler = _AppHandler(app_options)
-    return handler.toggle_extension(extension, False)
+    return handler.toggle_extension(extension, False, user=user, sys_prefix=sys_prefix)
 
 
-def disable_extension(extension, app_options=None):
+def disable_extension(extension, app_options=None, user=False, sys_prefix=False):
     """Disable a JupyterLab package.
 
     Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     handler = _AppHandler(app_options)
-    return handler.toggle_extension(extension, True)
+    return handler.toggle_extension(extension, True, user=user, sys_prefix=sys_prefix)
 
 
 def check_extension(extension, installed=False, app_options=None):
@@ -975,14 +975,20 @@ class _AppHandler(object):
         self._write_build_config(config)
         return True
 
-    def toggle_extension(self, extension, value):
+    def toggle_extension(self, extension, value, user=False, sys_prefix=False):
         """Enable or disable a lab extension.
 
         Returns `True` if a rebuild is recommended, `False` otherwise.
         """
         lab_config = LabConfig()
         app_settings_dir = osp.join(self.app_dir, 'settings')
-        page_config = get_static_page_config(app_settings_dir=app_settings_dir, logger=self.logger)
+        if user:
+            level = 'user'
+        elif sys_prefix:
+            level = 'sys_prefix'
+        else:
+            level = 'system'
+        page_config = get_static_page_config(app_settings_dir=app_settings_dir, logger=self.logger, level=level)
 
         disabled = page_config.get('disabled_labextensions', {})
         did_something = False

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -294,7 +294,7 @@ def watch_dev(logger=None):
                           startup_regex=WEBPACK_EXPECT)
 
     return package_procs + [wp_proc]
-    
+
 
 class AppOptions(HasTraits):
     """Options object for build system"""
@@ -468,25 +468,26 @@ def get_app_info(app_options=None):
     """Get a dictionary of information about the app.
     """
     handler = _AppHandler(app_options)
+    handler._ensure_disabled_info()
     return handler.info
 
 
-def enable_extension(extension, app_options=None, user=False, sys_prefix=False):
+def enable_extension(extension, app_options=None, level='sys_prefix'):
     """Enable a JupyterLab extension.
 
     Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     handler = _AppHandler(app_options)
-    return handler.toggle_extension(extension, False, user=user, sys_prefix=sys_prefix)
+    return handler.toggle_extension(extension, False, level=level)
 
 
-def disable_extension(extension, app_options=None, user=False, sys_prefix=False):
+def disable_extension(extension, app_options=None, level='sys_prefix'):
     """Disable a JupyterLab package.
 
     Returns `True` if a rebuild is recommended, `False` otherwise.
     """
     handler = _AppHandler(app_options)
-    return handler.toggle_extension(extension, True, user=user, sys_prefix=sys_prefix)
+    return handler.toggle_extension(extension, True, level=level)
 
 
 def check_extension(extension, installed=False, app_options=None):
@@ -581,7 +582,7 @@ class _AppHandler(object):
         # Do this last since it relies on other attributes
         self.info = self._get_app_info()
 
-        
+
 
     def install_extension(self, extension, existing=None, pin=None):
         """Install an extension package into JupyterLab.
@@ -694,6 +695,7 @@ class _AppHandler(object):
     def list_extensions(self):
         """Print an output of the extensions.
         """
+        self._ensure_disabled_info()
         logger = self.logger
         info = self.info
 
@@ -704,7 +706,7 @@ class _AppHandler(object):
 
         if info['federated_extensions']:
             self._list_federated_extensions()
-  
+
         if info['extensions']:
             logger.info('Other labextensions (built into JupyterLab)')
             self._list_extensions(info, 'app')
@@ -975,22 +977,17 @@ class _AppHandler(object):
         self._write_build_config(config)
         return True
 
-    def toggle_extension(self, extension, value, user=False, sys_prefix=False):
+    def toggle_extension(self, extension, value, level='sys_prefix'):
         """Enable or disable a lab extension.
 
         Returns `True` if a rebuild is recommended, `False` otherwise.
         """
         lab_config = LabConfig()
         app_settings_dir = osp.join(self.app_dir, 'settings')
-        if user:
-            level = 'user'
-        elif sys_prefix:
-            level = 'sys_prefix'
-        else:
-            level = 'system'
+
         page_config = get_static_page_config(app_settings_dir=app_settings_dir, logger=self.logger, level=level)
 
-        disabled = page_config.get('disabled_labextensions', {})
+        disabled = page_config.get('disabledExtensions', {})
         did_something = False
         is_disabled = disabled.get(extension, False)
         if value and not is_disabled:
@@ -1001,13 +998,14 @@ class _AppHandler(object):
             did_something = True
 
         if did_something:
-            page_config['disabled_labextensions'] = disabled
-            write_page_config(page_config)
+            page_config['disabledExtensions'] = disabled
+            write_page_config(page_config, level=level)
         return did_something
 
     def check_extension(self, extension, check_installed_only=False):
         """Check if a lab extension is enabled or disabled
         """
+        self._ensure_disabled_info()
         info = self.info
 
         if extension in info["core_extensions"]:
@@ -1068,13 +1066,6 @@ class _AppHandler(object):
         info['core_data'] = core_data = self.core_data
         info['extensions'] = extensions = self._get_extensions(core_data)
 
-        labextensions_path = self.labextensions_path
-        app_settings_dir = osp.join(self.app_dir, 'settings')
-        page_config = get_page_config(labextensions_path, app_settings_dir=app_settings_dir, logger=self.logger)
-
-        disabled = page_config.get('disabled_labextensions', {})
-        info['disabled'] = [name for name in disabled if disabled[name]]
-
         info['local_extensions'] = self._get_local_extensions()
         info['linked_packages'] = self._get_linked_packages()
         info['app_extensions'] = app = []
@@ -1096,18 +1087,29 @@ class _AppHandler(object):
         info['sys_dir'] = self.sys_dir
         info['app_dir'] = self.app_dir
 
-        info['core_extensions'] = core_extensions = _get_core_extensions(
-            self.core_data)
+        info['core_extensions'] = _get_core_extensions(self.core_data)
+
+        info['federated_extensions'] = get_federated_extensions(self.labextensions_path)
+        return info
+
+    def _ensure_disabled_info(self):
+        info = self.info
+        if 'disabled' in info:
+            return
+
+        labextensions_path = self.labextensions_path
+        app_settings_dir = osp.join(self.app_dir, 'settings')
+
+        page_config = get_page_config(labextensions_path, app_settings_dir=app_settings_dir, logger=self.logger)
+
+        info['disabled'] = page_config.get('disabledExtensions', [])
 
         disabled_core = []
-        for key in core_extensions:
+        for key in info['core_extensions']:
             if key in info['disabled']:
                 disabled_core.append(key)
 
         info['disabled_core'] = disabled_core
-
-        info['federated_extensions'] = get_federated_extensions(self.labextensions_path)
-        return info
 
     def _populate_staging(self, name=None, version=None, static_url=None,
                           clean=False):
@@ -1251,6 +1253,8 @@ class _AppHandler(object):
             jlab['linkedPackages'][key] = item['source']
             data['resolutions'][key] = format_path(path)
 
+        data['jupyterlab']['extensionMetadata'] = dict()
+
         # Handle extensions
         compat_errors = self._get_extension_compat()
         for (key, value) in extensions.items():
@@ -1273,6 +1277,9 @@ class _AppHandler(object):
                 if ext is True:
                     ext = ''
                 jlab[item + 's'][key] = ext
+
+                # Add metadata for the extension
+                data['jupyterlab']['extensionMetadata'][key] = jlab_data
 
         # Handle uninstalled core extensions.
         for item in self.info['uninstalled_core']:
@@ -1452,6 +1459,7 @@ class _AppHandler(object):
     def _list_extensions(self, info, ext_type):
         """List the extensions of a given type.
         """
+        self._ensure_disabled_info()
         logger = self.logger
         names = info['%s_extensions' % ext_type]
         if not names:
@@ -1495,6 +1503,7 @@ class _AppHandler(object):
         logger.info('')
 
     def _list_federated_extensions(self):
+        self._ensure_disabled_info()
         info = self.info
         logger = self.logger
 

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -80,12 +80,10 @@ install_aliases = copy(aliases)
 install_aliases['pin-version-as'] = 'InstallLabExtensionApp.pin'
 
 enable_aliases = copy(aliases)
-enable_aliases['user'] = 'EnableLabExtensionsApp.user'
-enable_aliases['sys-prefix'] = 'EnableLabExtensionsApp.sys_prefix'
+enable_aliases['level'] = 'EnableLabExtensionsApp.level'
 
 disable_aliases = copy(aliases)
-disable_aliases['user'] = 'DisableLabExtensionsApp.user'
-disable_aliases['sys-prefix'] = 'DisableLabExtensionsApp.sys_prefix'
+disable_aliases['level'] = 'DisableLabExtensionsApp.level'
 
 VERSION = get_app_version()
 
@@ -184,7 +182,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
 class DevelopLabExtensionApp(BaseExtensionApp):
     desciption = "Develop labextension"
     flags = develop_flags
-    
+
     user = Bool(False, config=True, help="Whether to do a user install")
     sys_prefix = Bool(True, config=True, help="Use the sys.prefix as the prefix")
     overwrite = Bool(False, config=True, help="Whether to overwrite files")
@@ -334,7 +332,7 @@ class ListLabExtensionsApp(BaseExtensionApp):
 
     def run_task(self):
         list_extensions(app_options=AppOptions(
-            app_dir=self.app_dir, logger=self.log, core_config=self.core_config, 
+            app_dir=self.app_dir, logger=self.log, core_config=self.core_config,
             labextensions_path=self.labextensions_path))
 
 
@@ -342,28 +340,26 @@ class EnableLabExtensionsApp(BaseExtensionApp):
     description = "Enable labextension(s) by name"
     aliases = enable_aliases
 
-    user = Bool(False, config=True, help="Whether to do a user install")
-    sys_prefix = Bool(True, config=True, help="Use the sys.prefix as the prefix")
+    level = Unicode('sys_prefix', help="Level at which to enable: sys_prefix, user, system").tag(config=True)
 
     def run_task(self):
         app_options = AppOptions(
-            app_dir=self.app_dir, logger=self.log, core_config=self.core_config, 
+            app_dir=self.app_dir, logger=self.log, core_config=self.core_config,
             labextensions_path=self.labextensions_path)
-        [enable_extension(arg, app_options=app_options, user=self.user, sys_prefix=self.sys_prefix) for arg in self.extra_args]
+        [enable_extension(arg, app_options=app_options, level=self.level) for arg in self.extra_args]
 
 
 class DisableLabExtensionsApp(BaseExtensionApp):
     description = "Disable labextension(s) by name"
     aliases = disable_aliases
 
-    user = Bool(False, config=True, help="Whether to do a user install")
-    sys_prefix = Bool(True, config=True, help="Use the sys.prefix as the prefix")
+    level = Unicode('sys_prefix', help="Level at which to enable: sys_prefix, user, system").tag(config=True)
 
     def run_task(self):
         app_options = AppOptions(
-            app_dir=self.app_dir, logger=self.log, core_config=self.core_config, 
+            app_dir=self.app_dir, logger=self.log, core_config=self.core_config,
             labextensions_path=self.labextensions_path)
-        [disable_extension(arg, app_options=app_options, user=self.user, sys_prefix=self.sys_prefix) for arg in self.extra_args]
+        [disable_extension(arg, app_options=app_options, level=self.level) for arg in self.extra_args]
 
 
 class CheckLabExtensionsApp(BaseExtensionApp):
@@ -375,7 +371,7 @@ class CheckLabExtensionsApp(BaseExtensionApp):
 
     def run_task(self):
         app_options = AppOptions(
-            app_dir=self.app_dir, logger=self.log, core_config=self.core_config, 
+            app_dir=self.app_dir, logger=self.log, core_config=self.core_config,
             labextensions_path=self.labextensions_path)
         all_enabled = all(
             check_extension(

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -79,6 +79,14 @@ aliases['debug-log-path'] = 'DebugLogFileMixin.debug_log_path'
 install_aliases = copy(aliases)
 install_aliases['pin-version-as'] = 'InstallLabExtensionApp.pin'
 
+enable_aliases = copy(aliases)
+enable_aliases['user'] = 'EnableLabExtensionsApp.user'
+enable_aliases['sys-prefix'] = 'EnableLabExtensionsApp.sys_prefix'
+
+disable_aliases = copy(aliases)
+disable_aliases['user'] = 'DisableLabExtensionsApp.user'
+disable_aliases['sys-prefix'] = 'DisableLabExtensionsApp.sys_prefix'
+
 VERSION = get_app_version()
 
 
@@ -332,22 +340,30 @@ class ListLabExtensionsApp(BaseExtensionApp):
 
 class EnableLabExtensionsApp(BaseExtensionApp):
     description = "Enable labextension(s) by name"
+    aliases = enable_aliases
+
+    user = Bool(False, config=True, help="Whether to do a user install")
+    sys_prefix = Bool(True, config=True, help="Use the sys.prefix as the prefix")
 
     def run_task(self):
         app_options = AppOptions(
             app_dir=self.app_dir, logger=self.log, core_config=self.core_config, 
             labextensions_path=self.labextensions_path)
-        [enable_extension(arg, app_options=app_options) for arg in self.extra_args]
+        [enable_extension(arg, app_options=app_options, user=self.user, sys_prefix=self.sys_prefix) for arg in self.extra_args]
 
 
 class DisableLabExtensionsApp(BaseExtensionApp):
     description = "Disable labextension(s) by name"
+    aliases = disable_aliases
+
+    user = Bool(False, config=True, help="Whether to do a user install")
+    sys_prefix = Bool(True, config=True, help="Use the sys.prefix as the prefix")
 
     def run_task(self):
         app_options = AppOptions(
             app_dir=self.app_dir, logger=self.log, core_config=self.core_config, 
             labextensions_path=self.labextensions_path)
-        [disable_extension(arg, app_options=app_options) for arg in self.extra_args]
+        [disable_extension(arg, app_options=app_options, user=self.user, sys_prefix=self.sys_prefix) for arg in self.extra_args]
 
 
 class CheckLabExtensionsApp(BaseExtensionApp):

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup_args['install_requires'] = [
     'packaging',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
     'jupyter_core',
-    'jupyterlab_server~=2.0.0rc3',
+    'jupyterlab_server~=2.0.0rc5',
     'jupyter_server~=1.0.1',
     'nbclassic~=0.2.0',
     'jinja2>=2.10'

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup_args['install_requires'] = [
     'packaging',
     'tornado!=6.0.0, !=6.0.1, !=6.0.2',
     'jupyter_core',
-    'jupyterlab_server~=2.0.0rc1',
+    'jupyterlab_server~=2.0.0rc3',
     'jupyter_server~=1.0.1',
     'nbclassic~=0.2.0',
     'jinja2>=2.10'


### PR DESCRIPTION
## References
Partially solves https://github.com/jupyterlab/jupyterlab/issues/9240
Depends on https://github.com/jupyterlab/jupyterlab_server/pull/137

## Code changes
- Make a `level` parameter for enable and disable extensions
- Include source extension metadata in the built application `package.json` so it can be used by `jupyterlab_server`.
- Will follow up with a PR against #9252 with the documentation changes

## User-facing changes
N/A

## Backwards-incompatible changes
