### PR TITLE
Eliminate eager sharing

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -160,43 +160,9 @@ function ignored(path) {
 // Set up module federation sharing config
 const shared = {};
 
-// Core packages and their transitive dependencies are loaded eagerly so they
-// can be bundled more effectively.
-const eagerPackages = new Set();
-
-/**
- * Recursively add pkg and all transitive dependencies to the cache set.
- */
-function transitiveDependencies(pkg, cache) {
-  if (cache.has(pkg)) {
-    return;
-  }
-  cache.add(pkg);
-  // Some packages do interesing things with their exports, so requiring
-  // pkg/package.json does not always work.
-  try {
-    let { dependencies = {} } = require(`${pkg}/package.json`);
-    for (dep of Object.keys(dependencies)) {
-      transitiveDependencies(dep, cache);
-    }
-  } catch (e) {
-    console.log(`Error adding dependencies of ${pkg} to eagerly shared packages`);
-  }
-}
-
-const linkedPackages = Object.keys(jlab.linkedPackages);
-for (pkg of Object.keys(package_data.resolutions)) {
-  if (!linkedPackages.includes(pkg)) {
-    transitiveDependencies(pkg, eagerPackages);
-  }
-}
-
 // Make sure any resolutions are shared
 for (let [pkg, requiredVersion] of Object.entries(package_data.resolutions)) {
   shared[pkg] = { requiredVersion };
-  if (eagerPackages.has(pkg)) {
-    shared[pkg].eager = true;
-  }
 }
 
 // Add any extension packages that are not in resolutions (i.e., installed from npm)
@@ -205,9 +171,6 @@ for (let pkg of extensionPackages) {
     shared[pkg] = {
       requiredVersion: require(`${pkg}/package.json`).version
     };
-    if (eagerPackages.has(pkg)) {
-      shared[pkg].eager = true;
-    }
   }
 }
 
@@ -215,9 +178,7 @@ for (let pkg of extensionPackages) {
 // are not already in the shared config. This means that if there is a
 // conflict, the resolutions package version is the one that is shared.
 const extraShared = [];
-// dependencies of eager shared packages must also be eager.
 for (let pkg of extensionPackages) {
-  let eager = eagerPackages.has(pkg);
   let pkgShared = {};
   let {
     dependencies = {},
@@ -226,13 +187,6 @@ for (let pkg of extensionPackages) {
   for (let [dep, requiredVersion] of Object.entries(dependencies)) {
     if (!shared[dep]) {
       pkgShared[dep] = { requiredVersion };
-      if (eager) {
-        pkgShared[dep].eager = true;
-      }
-    } else if (eager) {
-      // Even if we already have this dependency, make sure it is eager if it
-      // is the dependency of an eager package.
-      shared[dep].eager = true;
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9343

## Code changes

The first commit calculates the transitive closure of dependencies for eager packages to try to work around the problems we are having with eager packages having async dependencies. This sort of works, but still runs into some corner cases calculating the dependency tree.

So in the end, we eliminate the eager dependencies.

Instead, I've been experimenting with options to the `splitChunks` plugin. For example:

```js
    optimization: {
      splitChunks: {
        chunks: "all",
        maxAsyncRequests: 1,
        maxInitialRequests: 1,
        cacheGroups: {
          commons: {
            test: /[\\/]node_modules[\\/]/,
            name: 'vendors',
            chunks: 'all',
            maxSize: 10000000
          }
        }
      },
    },
```
or even the more conservative
```js
    optimization: {
      splitChunks: {
        chunks: "all",
        maxAsyncRequests: 1,
        maxInitialRequests: 1,
        cacheGroups: {
          commons: {
            test: /[\\/]node_modules[\\/]@(jupyterlab|lumino)[\\/]/,
            chunks: 'all',
            name: 'corejlab',
            maxSize: 10000000
          }
        }
      },
```
gives similar optimizations of just a few bundles that are loaded at jlab startup.

Perhaps we can separately set, say, the lumino dependencies to eager, since they don't have dependencies (so they are very self-contained).

## User-facing changes

For now, we're back to around 100 js files loaded async at startup.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
