### PR TITLE
Use new API endpoint for nbresuse metrics from

### DIFF
--- a/packages/statusbar-extension/README.md
+++ b/packages/statusbar-extension/README.md
@@ -18,6 +18,5 @@ Component Interactions
 - [nbresuse](https://github.com/yuvipanda/nbresuse)
 
 ```bash
-pip install nbresuse
-jupyter serverextension enable --py nbresuse
+pip install nbresuse>=0.4.0
 ```

--- a/packages/statusbar/src/defaults/memoryUsage.tsx
+++ b/packages/statusbar/src/defaults/memoryUsage.tsx
@@ -304,7 +304,7 @@ namespace Private {
   /**
    * The url endpoint for making requests to the server.
    */
-  const METRIC_URL = URLExt.join(SERVER_CONNECTION_SETTINGS.baseUrl, 'metrics');
+  const METRIC_URL = URLExt.join(SERVER_CONNECTION_SETTINGS.baseUrl, 'api/materials/v1');
 
   /**
    * The shape of a response from the metrics server extension.

--- a/packages/statusbar/src/defaults/memoryUsage.tsx
+++ b/packages/statusbar/src/defaults/memoryUsage.tsx
@@ -304,7 +304,10 @@ namespace Private {
   /**
    * The url endpoint for making requests to the server.
    */
-  const METRIC_URL = URLExt.join(SERVER_CONNECTION_SETTINGS.baseUrl, 'api/materials/v1');
+  const METRIC_URL = URLExt.join(
+    SERVER_CONNECTION_SETTINGS.baseUrl,
+    'api/metrics/v1'
+  );
 
   /**
    * The shape of a response from the metrics server extension.


### PR DESCRIPTION
- /metrics endpoint is 'soft deprecated' with
  https://github.com/yuvipanda/nbresuse/pull/68, so we should move
  to the new API endpoint.
- Require nbresuse>=0.4.0 in the README to reflect this
- Remove explicit request to enable nbresuse serverextension, as
  it is automatically done now.

## References

https://github.com/yuvipanda/nbresuse/pull/68

## User-facing changes

Should be none!

## Backwards-incompatible changes

If merged as is, jupyterlab statusbar will no longer be compatible
with nbresuse<0.4.0