### PR TITLE
Add Reconnect to Kernel main menu item, and notebook implementation.

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -68,6 +68,8 @@ export namespace CommandIDs {
 
   export const interruptKernel = 'kernelmenu:interrupt';
 
+  export const reconnectToKernel = 'kernelmenu:reconnect-to-kernel';
+
   export const restartKernel = 'kernelmenu:restart';
 
   export const restartKernelAndClear = 'kernelmenu:restart-and-clear';
@@ -512,6 +514,16 @@ export function createKernelMenu(
     execute: Private.delegateExecute(app, menu.kernelUsers, 'interruptKernel')
   });
 
+  commands.addCommand(CommandIDs.reconnectToKernel, {
+    label: trans.__('Reconnect to Kernel'),
+    isEnabled: Private.delegateEnabled(
+      app,
+      menu.kernelUsers,
+      'reconnectToKernel'
+    ),
+    execute: Private.delegateExecute(app, menu.kernelUsers, 'reconnectToKernel')
+  });
+
   commands.addCommand(CommandIDs.restartKernel, {
     label: trans.__('Restart Kernel…'),
     isEnabled: Private.delegateEnabled(app, menu.kernelUsers, 'restartKernel'),
@@ -591,6 +603,7 @@ export function createKernelMenu(
 
   menu.addGroup([{ command: CommandIDs.interruptKernel }], 0);
   menu.addGroup(restartGroup, 1);
+  menu.addGroup([{ command: CommandIDs.reconnectToKernel }], 1.5);
   menu.addGroup(
     [
       { command: CommandIDs.shutdownKernel },

--- a/packages/mainmenu/src/kernel.ts
+++ b/packages/mainmenu/src/kernel.ts
@@ -56,6 +56,11 @@ export namespace IKernelMenu {
     interruptKernel?: (widget: T) => Promise<void>;
 
     /**
+     * A function to reconnect to the kernel
+     */
+    reconnectToKernel?: (widget: T) => Promise<void>;
+
+    /**
      * A function to restart the kernel, which
      * returns a promise of whether the kernel was restarted.
      */

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2213,6 +2213,13 @@ function populateMenus(
       }
       return Promise.resolve(void 0);
     },
+    reconnectToKernel: current => {
+      const kernel = current.sessionContext.session?.kernel;
+      if (kernel) {
+        return kernel.reconnect();
+      }
+      return Promise.resolve(void 0);
+    },
     restartKernelAndClearLabel: (n: number) =>
       trans.__('Restart Kernel and Clear All Outputs…'),
     restartKernel: current =>


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9353

## Code changes

Adds a main menu item for reconnecting to a kernel, and a notebook implementation

## User-facing changes

<img width="465" alt="Screen Shot 2020-11-17 at 11 32 30 AM" src="https://user-images.githubusercontent.com/192614/99438405-9d25c300-28c8-11eb-8a37-42e5397304b0.png">

I put this in the menu between restart and shutdown, consistent with where it is in the classic notebook menu:

<img width="234" alt="Screen Shot 2020-11-17 at 2 14 29 PM" src="https://user-images.githubusercontent.com/192614/99457079-411a6900-28df-11eb-8448-0083d36d7a9b.png">


I first put it just below interrupt, since it is not as drastic of an action as restart, but I moved it to be consistent with the classic notebook since I think it probably is not used nearly as often as the restart menu items.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
