### PR TITLE
Add ToC entries for all headers in markdown cells

### DIFF
--- a/packages/toc/src/generators/notebook/get_markdown_heading.ts
+++ b/packages/toc/src/generators/notebook/get_markdown_heading.ts
@@ -26,37 +26,42 @@ type onClickFactory = (line: number) => () => void;
  * @param cellRef - cell reference
  * @returns notebook heading
  */
-function getMarkdownHeading(
+function getMarkdownHeadings(
   text: string,
   onClick: onClickFactory,
   dict: any,
   lastLevel: number,
   cellRef: Cell
-): INotebookHeading {
+): INotebookHeading[] {
   const clbk = onClick(0);
-  const heading = parseHeading(text);
-  if (heading) {
-    return {
-      text: heading.text,
-      level: heading.level,
-      numbering: generateNumbering(dict, heading.level),
-      onClick: clbk,
-      type: 'header',
-      cellRef: cellRef,
-      hasChild: false
-    };
+  let headings: INotebookHeading[] = [];
+  for (const line of text.split('\n')) {
+    const heading = parseHeading(line);
+    if (heading) {
+      headings.push({
+        text: heading.text,
+        level: heading.level,
+        numbering: generateNumbering(dict, heading.level),
+        onClick: clbk,
+        type: 'header',
+        cellRef: cellRef,
+        hasChild: false
+      });
+    } else {
+      headings.push({
+        text: text,
+        level: lastLevel + 1,
+        onClick: clbk,
+        type: 'markdown',
+        cellRef: cellRef,
+        hasChild: false
+      });
+    }
   }
-  return {
-    text: text,
-    level: lastLevel + 1,
-    onClick: clbk,
-    type: 'markdown',
-    cellRef: cellRef,
-    hasChild: false
-  };
+  return headings;
 }
 
 /**
  * Exports.
  */
-export { getMarkdownHeading };
+export { getMarkdownHeadings };

--- a/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
+++ b/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
@@ -29,7 +29,7 @@ type onClickFactory = (el: Element) => () => void;
  * @param cellRef - cell reference
  * @returns notebook heading
  */
-function getRenderedHTMLHeading(
+function getRenderedHTMLHeadings(
   node: HTMLElement,
   onClick: onClickFactory,
   sanitizer: ISanitizer,
@@ -37,53 +37,54 @@ function getRenderedHTMLHeading(
   lastLevel: number,
   numbering = false,
   cellRef: Cell
-): INotebookHeading | undefined {
+): INotebookHeading[] {
   let nodes = node.querySelectorAll('h1, h2, h3, h4, h5, h6, p');
-  if (nodes.length === 0) {
-    return;
-  }
-  let el = nodes[0];
-  if (el.nodeName.toLowerCase() === 'p') {
-    if (el.innerHTML) {
-      let html = sanitizer.sanitize(el.innerHTML, sanitizerOptions);
-      return {
-        level: lastLevel + 1,
-        html: html.replace('¶', ''),
-        text: el.textContent ? el.textContent : '',
-        onClick: onClick(el),
-        type: 'markdown',
-        cellRef: cellRef,
-        hasChild: false
-      };
-    }
-    return;
-  }
-  if (el.getElementsByClassName('numbering-entry').length > 0) {
-    el.removeChild(el.getElementsByClassName('numbering-entry')[0]);
-  }
-  let html = sanitizer.sanitize(el.innerHTML, sanitizerOptions);
-  html = html.replace('¶', '');
 
-  const level = parseInt(el.tagName[1], 10);
-  let nstr = generateNumbering(dict, level);
-  let nhtml = '';
-  if (numbering) {
-    nhtml = '<span class="numbering-entry">' + nstr + '</span>';
+  let headings: INotebookHeading[] = [];
+  for (const el of nodes) {
+    if (el.nodeName.toLowerCase() === 'p') {
+      if (el.innerHTML) {
+        let html = sanitizer.sanitize(el.innerHTML, sanitizerOptions);
+        headings.push({
+          level: lastLevel + 1,
+          html: html.replace('¶', ''),
+          text: el.textContent ? el.textContent : '',
+          onClick: onClick(el),
+          type: 'markdown',
+          cellRef: cellRef,
+          hasChild: false
+        });
+      }
+      continue;
+    }
+    if (el.getElementsByClassName('numbering-entry').length > 0) {
+      el.removeChild(el.getElementsByClassName('numbering-entry')[0]);
+    }
+    let html = sanitizer.sanitize(el.innerHTML, sanitizerOptions);
+    html = html.replace('¶', '');
+
+    const level = parseInt(el.tagName[1], 10);
+    let nstr = generateNumbering(dict, level);
+    let nhtml = '';
+    if (numbering) {
+      nhtml = '<span class="numbering-entry">' + nstr + '</span>';
+    }
+    el.innerHTML = nhtml + html;
+    headings.push({
+      level: level,
+      text: el.textContent ? el.textContent : '',
+      numbering: nstr,
+      html: html,
+      onClick: onClick(el),
+      type: 'header',
+      cellRef: cellRef,
+      hasChild: false
+    });
   }
-  el.innerHTML = nhtml + html;
-  return {
-    level: level,
-    text: el.textContent ? el.textContent : '',
-    numbering: nstr,
-    html: html,
-    onClick: onClick(el),
-    type: 'header',
-    cellRef: cellRef,
-    hasChild: false
-  };
+  return headings;
 }
 
 /**
  * Exports.
  */
-export { getRenderedHTMLHeading };
+export { getRenderedHTMLHeadings };

--- a/packages/toc/src/generators/notebook/index.ts
+++ b/packages/toc/src/generators/notebook/index.ts
@@ -19,8 +19,8 @@ import { INotebookHeading } from '../../utils/headings';
 import { OptionsManager } from './options_manager';
 import { getCodeCellHeading } from './get_code_cell_heading';
 import { getLastHeadingLevel } from './get_last_heading_level';
-import { getMarkdownHeading } from './get_markdown_heading';
-import { getRenderedHTMLHeading } from './get_rendered_html_heading';
+import { getMarkdownHeadings } from './get_markdown_heading';
+import { getRenderedHTMLHeadings } from './get_rendered_html_heading';
 import { appendHeading } from './append_heading';
 import { appendMarkdownHeading } from './append_markdown_heading';
 import { render } from './render';
@@ -148,7 +148,7 @@ function createNotebookGenerator(
               el.scrollIntoView();
             };
           };
-          let heading = getRenderedHTMLHeading(
+          let htmlHeadings = getRenderedHTMLHeadings(
             (cell as CodeCell).outputArea.widgets[j].node,
             onClick,
             sanitizer,
@@ -157,15 +157,17 @@ function createNotebookGenerator(
             options.numbering,
             cell
           );
-          [headings, prev, collapseLevel] = appendMarkdownHeading(
-            heading,
-            headings,
-            prev,
-            collapseLevel,
-            options.filtered,
-            collapsed,
-            options.showMarkdown
-          );
+          for (const heading of htmlHeadings) {
+            [headings, prev, collapseLevel] = appendMarkdownHeading(
+              heading,
+              headings,
+              prev,
+              collapseLevel,
+              options.filtered,
+              collapsed,
+              options.showMarkdown
+            );
+          }
         }
         continue;
       }
@@ -188,7 +190,7 @@ function createNotebookGenerator(
               }
             };
           };
-          heading = getRenderedHTMLHeading(
+          const htmlHeadings = getRenderedHTMLHeadings(
             cell.node,
             onClick,
             sanitizer,
@@ -197,6 +199,17 @@ function createNotebookGenerator(
             options.numbering,
             cell
           );
+          for (heading of htmlHeadings) {
+            [headings, prev, collapseLevel] = appendMarkdownHeading(
+              heading,
+              headings,
+              prev,
+              collapseLevel,
+              options.filtered,
+              collapsed,
+              options.showMarkdown
+            );
+          }
           // If not rendered, generate ToC items from the cell text...
         } else {
           const onClick = (line: number) => {
@@ -205,23 +218,25 @@ function createNotebookGenerator(
               cell.node.scrollIntoView();
             };
           };
-          heading = getMarkdownHeading(
+          const markdownHeadings = getMarkdownHeadings(
             model!.value.text,
             onClick,
             dict,
             lastLevel,
             cell
           );
+          for (heading of markdownHeadings) {
+            [headings, prev, collapseLevel] = appendMarkdownHeading(
+              heading,
+              headings,
+              prev,
+              collapseLevel,
+              options.filtered,
+              collapsed,
+              options.showMarkdown
+            );
+          }
         }
-        [headings, prev, collapseLevel] = appendMarkdownHeading(
-          heading,
-          headings,
-          prev,
-          collapseLevel,
-          options.filtered,
-          collapsed,
-          options.showMarkdown
-        );
       }
     }
     return headings;


### PR DESCRIPTION
## References
If a markdown cell in a notebook contains multiple headers, only the first header will appear as an entry in the ToC (see below)
![image](https://user-images.githubusercontent.com/6673460/99443296-9d35bb00-28e8-11eb-89f4-644b1e7695a5.png)

## Code changes
Changes the functions that process markdown cells in the ToC to iterate through all of the markdown to check for headers, rather than assuming the header is in the first line of a cell. 

## User-facing changes
This will change the ToC to include all headers in markdown cells (see below). 
![image](https://user-images.githubusercontent.com/6673460/99443200-7bd4cf00-28e8-11eb-9355-d21f9fc06110.png)

**Note**: When a header is clicked, it now highlights all of the ToC entries that are in the same cell as the "active cell" (see above). Not sure exactly the desired behavior here but thought I'd hear feedback before making a decision on highlighting.
