### PR TITLE
Chunk the jupyterlab and lumino modules together when building the core application

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -293,7 +293,13 @@ module.exports = [
     },
     optimization: {
       splitChunks: {
-        chunks: 'all'
+        chunks: 'all',
+        cacheGroups: {
+          jlab_core: {
+            test: /[\\/]node_modules[\\/]@(jupyterlab|lumino)[\\/]/,
+            name: 'jlab_core'
+          }
+        }
       }
     },
     module: {


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This continues the exploration into making our initial load fewer files (with module federation, this has exploded into more than 100 files for stock jlab). This groups the core jlab and lumino dependencies into a js bundle.

- [x] Check to make sure that the codemirror vim bindings and vega dependencies are still loaded asynchronously.

## User-facing changes

This cuts a stock build of jlab from 114 js file requests down to 25 requests.


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
