### PR TITLE
Sets terminateDebuggee to false

### DIFF
--- a/packages/debugger/src/session.ts
+++ b/packages/debugger/src/session.ts
@@ -133,7 +133,7 @@ export class DebuggerSession implements IDebugger.ISession {
   async stop(): Promise<void> {
     await this.sendRequest('disconnect', {
       restart: false,
-      terminateDebuggee: true
+      terminateDebuggee: false
     });
     this._isStarted = false;
   }

--- a/packages/debugger/test/service.spec.ts
+++ b/packages/debugger/test/service.spec.ts
@@ -171,6 +171,7 @@ describe('DebuggerService', () => {
     ].join('\n');
 
     let breakpoints: IDebugger.IBreakpoint[];
+    let sourceBreakpoints: IDebugger.IBreakpoint[];
     let sourceId: string;
 
     beforeEach(async () => {
@@ -186,6 +187,13 @@ describe('DebuggerService', () => {
           source: {
             path: sourceId
           }
+        };
+      });
+      // create the list of source breakpoints expected from a restore
+      sourceBreakpoints = breakpoints.map(breakpoint => {
+        return {
+          line: breakpoint.line,
+          verified: breakpoint.verified
         };
       });
       await service.updateBreakpoints(code, breakpoints);
@@ -209,7 +217,7 @@ describe('DebuggerService', () => {
         expect(bpList1.length).toEqual(0);
         await service.restoreState(true);
         const bpList2 = model.breakpoints.getBreakpoints(sourceId);
-        expect(bpList2).toEqual(breakpoints);
+        expect(bpList2).toEqual(sourceBreakpoints);
       });
     });
 
@@ -224,7 +232,7 @@ describe('DebuggerService', () => {
         const bpList = model.breakpoints.getBreakpoints(sourceId);
         breakpoints[0].id = 2;
         breakpoints[1].id = 3;
-        expect(bpList).toEqual(breakpoints);
+        expect(bpList).toEqual(sourceBreakpoints);
       });
     });
 

--- a/packages/debugger/test/session.spec.ts
+++ b/packages/debugger/test/session.spec.ts
@@ -106,7 +106,7 @@ describe('Debugger.Session', () => {
       await debugSession.stop();
       const { success, message } = reply;
       expect(success).toBe(false);
-      expect(message).toContain('Unable to find thread for evaluation');
+      expect(message).toBeTruthy();
     });
   });
 });

--- a/packages/debugger/test/session.spec.ts
+++ b/packages/debugger/test/session.spec.ts
@@ -73,7 +73,9 @@ describe('Debugger.Session', () => {
       });
       await debugSession.start();
       await debugSession.stop();
-      expect(events).toEqual(['output', 'initialized', 'process']);
+      expect(events).toEqual(
+        expect.arrayContaining(['output', 'initialized', 'process'])
+      );
     });
   });
 

--- a/packages/debugger/test/session.spec.ts
+++ b/packages/debugger/test/session.spec.ts
@@ -303,14 +303,6 @@ describe('protocol', () => {
     });
   });
 
-  describe('#loadedSources', () => {
-    it.skip('should *not* retrieve the list of loaded sources', async () => {
-      // `loadedSources` is not supported at the moment "unknown command"
-      const reply = await debugSession.sendRequest('loadedSources', {});
-      expect(reply.success).toBe(false);
-    });
-  });
-
   describe('#source', () => {
     it('should retrieve the source of the dumped code cell', async () => {
       const stackFramesReply = await debugSession.sendRequest('stackTrace', {

--- a/packages/debugger/test/session.spec.ts
+++ b/packages/debugger/test/session.spec.ts
@@ -230,8 +230,10 @@ describe('protocol', () => {
         frameId
       });
       const scopes = scopesReply.body.scopes;
-      expect(scopes.length).toEqual(1);
-      expect(scopes[0].name).toEqual('Locals');
+      expect(scopes.length).toBeGreaterThanOrEqual(1);
+
+      const locals = scopes.find(scope => scope.name === 'Locals');
+      expect(locals).toBeTruthy();
     });
   });
 

--- a/packages/debugger/test/session.spec.ts
+++ b/packages/debugger/test/session.spec.ts
@@ -304,7 +304,7 @@ describe('protocol', () => {
   });
 
   describe('#loadedSources', () => {
-    it('should *not* retrieve the list of loaded sources', async () => {
+    it.skip('should *not* retrieve the list of loaded sources', async () => {
       // `loadedSources` is not supported at the moment "unknown command"
       const reply = await debugSession.sendRequest('loadedSources', {});
       expect(reply.success).toBe(false);

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -52,5 +52,5 @@ fi
 
 # The debugger tests require a kernel that supports debugging
 if [[ $GROUP == js-debugger ]]; then
-    pip install -U xeus-python>=0.8
+    pip install xeus-python">=0.9.0,<0.10.0"
 fi


### PR DESCRIPTION
Stopping the debugger should not terminate the kernel. We noticed this bug when switching from PTVSD to debugpy in xeus-python. PTVSD does not take this argument into account (that's a bug), but debugpy does.