### PR TITLE
Add a polyfill for path in the base webpack config 

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -54,6 +54,7 @@
     "fs-extra": "^9.0.1",
     "glob": "~7.1.6",
     "mini-css-extract-plugin": "~0.11.0",
+    "path-browserify": "^1.0.0",
     "raw-loader": "~4.0.0",
     "style-loader": "~1.2.1",
     "supports-color": "^7.2.0",

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -77,7 +77,11 @@ module.exports = {
   module: { rules },
   resolve: {
     alias: phosphorAlias,
-    fallback: { url: false, buffer: false }
+    fallback: {
+      url: false,
+      buffer: false,
+      path: require.resolve('path-browserify')
+    }
   },
   watchOptions: {
     poll: 500,

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -56,6 +56,7 @@ const UNUSED: Dict<string[]> = {
     'babel-loader',
     'css-loader',
     'file-loader',
+    'path-browserify',
     'raw-loader',
     'style-loader',
     'svg-url-loader',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9345

## Code changes

Adds a polyfill for the nodejs path module. When the world has migrated to webpack 5 and fixed their polyfill issues, we can pull this out. See #9345 for more discussion.


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
