### PR TITLE
Reconnect to kernel on restart action

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -982,10 +982,15 @@ export class KernelConnection implements Kernel.IKernelConnection {
     this._clearKernelState();
     this._updateStatus('restarting');
 
-    // Kick off an async kernel request to eventually reset the kernel status.
-    // We do this with a setTimeout so that it comes after the microtask
-    // logic in _handleMessage for restarting/autostarting status updates.
+    // Reconnect to a new websocket and kick off an async kernel request to
+    // eventually reset the kernel status. We do this with a setTimeout so
+    // that it comes after the microtask logic in _handleMessage for
+    // restarting/autostarting status updates.
     setTimeout(() => {
+      // We must reconnect since the kernel connection information may have
+      // changed, and the server only refreshes its zmq connection when a new
+      // websocket is opened.
+      void this.reconnect();
       void this.requestKernelInfo();
     }, 0);
   }


### PR DESCRIPTION
This pull request addresses the issue raised in #8103 and closed by #8432.  That change was not sufficient as the `reconnect()` was embedded within the `_handleRestart()` method - which is conditionally called as a result of execution states of `autorestarting` or `restarting`, only the latter of which is returned by the server and only when the kernel is _automatically restarted_.  No execution status is returned from the server upon completion of a _manual restart_ request.  As a result, the fixed code will never be reached upon a manual restart.

Please note that relative to the originating issue, neither JupyterHub nor (arguably) Enterprise Gateway are related.  The issue is really about whether a kernel's ZMQ ports are refreshed on manual restarts.  For local kernels, that is atypical.  For remote kernels deployed across managed clusters, it is the norm since the kernel's physical location is likely to change.  EG happens to be a way kernels are deployed across a cluster.

This issue does not occur when using the Notebook UI - whose [kernel restart behavior includes the reconnect sequence](https://github.com/jupyterlab/jupyterlab/issues/8013#issuecomment-615912531).  As a result, this change brings parity with Notebook.

## References

JupyterHub+JupyterLab+JupyterEnterpriseGateway Restart Kernel hangs #8013

Reconnect a websocket when a kernel is restarted. #8432

## Code changes

We now explicitly call `reconnect()` immediately following the conclusion of the kernel restart request.  This change was recommended by @blink1073 in https://github.com/jupyterlab/jupyterlab/issues/8013#issuecomment-617314966.

## User-facing changes

Restarts of kernels, irrespective of location, now yield a working (connected) kernel.

## Backwards-incompatible changes

None - this change introduces parity with the Notebook UI wrt kernel restarts.