### PR TITLE
Change user references from single-document mode to Simple Interface (mode)

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -795,7 +795,7 @@ directly quoting a word in the UI:
 -  Files tab
 -  Running panel
 -  Tabs panel
--  Single-Document Mode
+-  Simple Interface mode
 
 The capitalized words match the label of the UI element the user is
 clicking on because there does not exist a good colloquial name for the

--- a/docs/source/getting_started/changelog.rst
+++ b/docs/source/getting_started/changelog.rst
@@ -30,9 +30,9 @@ A new visual debugger
 JupyterLab now ships with a debugger front-end by default, available for kernels that support the new debugging protocol.  See the `documentation <https://jupyterlab.readthedocs.io/en/latest/user/debugger.html>`__ for more details.
 
 
-Improvements to Single Document Mode and Mobile 
-"""""""""""""""""""""""""""""""""""""""""""""""
-The single-document user interface is now more streamlined. JupyterLab now supports showing the current file in use in the browser URL bar, similar to the classic Jupyter Notebook.
+Improvements to Simple Interface mode and Mobile 
+""""""""""""""""""""""""""""""""""""""""""""""""
+The Simple Interface mode (previously Single Document Mode) is now more streamlined. JupyterLab now supports showing the current file in use in the browser URL bar, similar to the classic Jupyter Notebook.
 
 
 Table of Contents is now in core

--- a/docs/source/user/interface.rst
+++ b/docs/source/user/interface.rst
@@ -101,8 +101,8 @@ marked with a colored top border (blue by default).
 
 .. _tabs:
 
-Tabs and Single-Document Mode
------------------------------
+Tabs and Simple Interface Mode
+------------------------------
 
 The Tabs panel in the left sidebar lists the open documents or
 activities in the main work area:
@@ -120,9 +120,9 @@ The same information is also available in the Tabs menu:
 .. _tabs-singledocument:
 
 It is often useful to focus on a single document or activity without closing
-other tabs in the main work area. Single-document mode enable this, while making
-it simple to return to your multi-activity layout in the main work area.
-Toggle single-document mode using the View menu:
+other tabs in the main work area. Simple Interface mode enables this, while making
+it easy to return to your multi-activity layout in the main work area.
+Toggle Simple Interface mode using the View menu:
 
 .. raw:: html
 
@@ -130,7 +130,7 @@ Toggle single-document mode using the View menu:
     <iframe src="https://www.youtube-nocookie.com/embed/DO7NOenMQC0?rel=0&amp;showinfo=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
   </div>
 
-When you leave single-document mode, the original layout of the main
+When you leave Simple Interface mode, the original layout of the main
 area is restored.
 
 Context Menus

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -816,7 +816,7 @@ function addCommands(
   });
 
   app.commands.addCommand(CommandIDs.toggleMode, {
-    label: trans.__('Single-Document Mode'),
+    label: trans.__('Simple Interface'),
     isToggled: () => shell.mode === 'single-document',
     execute: () => {
       const args =

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -298,7 +298,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       rootLayout.insertWidget(2, this._menuHandler.panel);
     }
 
-    // Wire up signals to update the title panel of the single document mode to
+    // Wire up signals to update the title panel of the simple interface mode to
     // follow the title of this.currentWidget
     this.currentChanged.connect((sender, args) => {
       let newValue = args.newValue;

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -386,7 +386,7 @@ export const runningSessionsItem: JupyterFrontEndPlugin<void> = {
 };
 
 /**
- * The single-document mode switch in the top area.
+ * The simple interface mode switch in the status bar.
  */
 const modeSwitch: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/statusbar-extension:mode-switch',
@@ -416,9 +416,9 @@ const modeSwitch: JupyterFrontEndPlugin<void> = {
       );
       if (binding) {
         const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
-        modeSwitch.caption = trans.__('Single-Document Mode (%1)', ks);
+        modeSwitch.caption = trans.__('Simple Interface (%1)', ks);
       } else {
-        modeSwitch.caption = trans.__('Single-Document Mode');
+        modeSwitch.caption = trans.__('Simple Interface');
       }
     };
     updateModeSwitchTitle();
@@ -426,7 +426,7 @@ const modeSwitch: JupyterFrontEndPlugin<void> = {
       updateModeSwitchTitle();
     });
 
-    modeSwitch.label = trans.__('Mode');
+    modeSwitch.label = trans.__('Simple');
 
     statusBar.registerStatusItem(
       '@jupyterlab/statusbar-extension:mode-switch',


### PR DESCRIPTION
## References

Fixes #9378

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

This makes it more clear the scope of the toggle (the entire interface), makes it less technical (“simple” vs “single-document”), and makes it more general than just documents.

![simple](https://user-images.githubusercontent.com/192614/99749878-276e5280-2a94-11eb-879c-15a0b83777ea.gif)

@ellisonbg and I were brainstorming what might be better than saying "Mode" or "Single-Document Mode", and this is what we came up with.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
