### PR TITLE
Use CSS contain=strict to display a notebook

### DIFF
--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -32,11 +32,15 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
   constructor(options: MainAreaWidget.IOptions<T>) {
     super(options);
     this.addClass('jp-MainAreaWidget');
+    // Set contain=strict to avoid many forced layout rendering while addding cells.
+    // Don't forget to remove the CSS class when your remove the spinner to allow
+    // the content to be rendered.
+    // @see https://github.com/jupyterlab/jupyterlab/issues/9381
+    this.addClass('jp-MainAreaWidget-ContainStrict');
     this.id = DOMUtils.createDomID();
 
     const content = (this._content = options.content);
     const toolbar = (this._toolbar = options.toolbar || new Toolbar());
-    const spinner = this._spinner;
 
     const layout = (this.layout = new BoxLayout({ spacing: 0 }));
     layout.direction = 'top-to-bottom';
@@ -56,7 +60,7 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
     this.title.changed.connect(this._updateContentTitle, this);
 
     if (options.reveal) {
-      this.node.appendChild(spinner.node);
+      this.node.appendChild(this._spinner.node);
       this._revealed = options.reveal
         .then(() => {
           if (content.isDisposed) {
@@ -64,9 +68,8 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
             return;
           }
           content.disposed.connect(() => this.dispose());
-          const active = document.activeElement === spinner.node;
-          this.node.removeChild(spinner.node);
-          spinner.dispose();
+          const active = document.activeElement === this._spinner.node;
+          this._disposeSpinner()
           this._isRevealed = true;
           if (active) {
             this._focusContent();
@@ -80,8 +83,7 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
           pre.textContent = String(e);
           error.node.appendChild(pre);
           BoxLayout.setStretch(error, 1);
-          this.node.removeChild(spinner.node);
-          spinner.dispose();
+          this._disposeSpinner()
           content.dispose();
           this._content = null!;
           toolbar.dispose();
@@ -92,7 +94,8 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
         });
     } else {
       // Handle no reveal promise.
-      spinner.dispose();
+      this._spinner.dispose();
+      this.removeClass('jp-MainAreaWidget-ContainStrict');
       content.disposed.connect(() => this.dispose());
       this._isRevealed = true;
       this._revealed = Promise.resolve(undefined);
@@ -164,6 +167,12 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
     if (this._content) {
       MessageLoop.sendMessage(this._content, msg);
     }
+  }
+
+  private _disposeSpinner() {
+    this.node.removeChild(this._spinner.node);
+    this._spinner.dispose();  
+    this.removeClass('jp-MainAreaWidget-ContainStrict');
   }
 
   /**

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -69,7 +69,7 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
           }
           content.disposed.connect(() => this.dispose());
           const active = document.activeElement === this._spinner.node;
-          this._disposeSpinner()
+          this._disposeSpinner();
           this._isRevealed = true;
           if (active) {
             this._focusContent();
@@ -83,7 +83,7 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
           pre.textContent = String(e);
           error.node.appendChild(pre);
           BoxLayout.setStretch(error, 1);
-          this._disposeSpinner()
+          this._disposeSpinner();
           content.dispose();
           this._content = null!;
           toolbar.dispose();
@@ -171,7 +171,7 @@ export class MainAreaWidget<T extends Widget = Widget> extends Widget
 
   private _disposeSpinner() {
     this.node.removeChild(this._spinner.node);
-    this._spinner.dispose();  
+    this._spinner.dispose();
     this.removeClass('jp-MainAreaWidget-ContainStrict');
   }
 

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -47,6 +47,14 @@
   min-height: var(--jp-notebook-scroll-padding);
 }
 
+.jp-MainAreaWidget-ContainStrict .jp-Notebook * {
+  contain: strict;
+}
+
+.jp-Notebook-render * {
+  contain: none !important;
+}
+
 .jp-Notebook .jp-Cell {
   overflow: visible;
 }


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/9381

## Code changes

In mainareawidget, add a CSS class before displaying the notebook, and removing it after.

## User-facing changes

Notebook loads faster

## Backwards-incompatible changes

None