### PR TITLE
Reconnect to kernel on manual restart

### DIFF
--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1393,7 +1393,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
         0,
         1e3 * (Math.pow(2, this._reconnectAttempt) - 1)
       );
-      console.error(
+      console.warn(
         `Connection lost, reconnecting in ${Math.floor(
           timeout / 1000
         )} seconds.`

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -440,6 +440,9 @@ export class KernelConnection implements Kernel.IKernelConnection {
     this._updateStatus('restarting');
     this._kernelSession = RESTARTING_KERNEL_SESSION;
     await restapi.restartKernel(this.id, this.serverSettings);
+    // Reconnect to the kernel to address cases where kernel ports
+    // have changed during the restart.
+    await this.reconnect();
   }
 
   /**


### PR DESCRIPTION
_This is a "redo" of PR #9371 which inadvertently included the wrong commit!  The commit it included was related to the #8432 referenced below.  I don't know how this happened other than I may have used the same branch name when working on this months later.  I am very sorry.  It is important that this be included in the 3.0 release.  Special (special) thanks to @ricklamers for catching this mistake!_
_(@blink1073 - I guess my first lab PR was fake news!)_

This pull request addresses the issue raised in #8103 and closed by #8432.  That change was not sufficient as the `reconnect()` was embedded within the `_handleRestart()` method - which is conditionally called as a result of execution states of `autorestarting` or `restarting`, only the latter of which is returned by the server and only when the kernel is _automatically restarted_.  No execution status is returned from the server upon completion of a _manual restart_ request.  As a result, the fixed code will never be reached upon a manual restart.

Please note that relative to the originating issue, neither JupyterHub nor (arguably) Enterprise Gateway are related.  The issue is really about whether a kernel's ZMQ ports are refreshed on manual restarts.  For local kernels, that is atypical.  For remote kernels deployed across managed clusters, it is the norm since the kernel's physical location is likely to change.  EG happens to be a way kernels are deployed across a cluster.

This issue does not occur when using the Notebook UI - whose [kernel restart behavior includes the reconnect sequence](https://github.com/jupyterlab/jupyterlab/issues/8013#issuecomment-615912531).  As a result, this change brings parity with Notebook.

## References

JupyterHub+JupyterLab+JupyterEnterpriseGateway Restart Kernel hangs #8013

Reconnect a websocket when a kernel is restarted. #8432

## Code changes

We now explicitly call `reconnect()` immediately following the conclusion of the kernel restart request.  This change was recommended by @blink1073 in https://github.com/jupyterlab/jupyterlab/issues/8013#issuecomment-617314966.

## User-facing changes

Restarts of kernels, irrespective of location, now yield a working (connected) kernel.

## Backwards-incompatible changes

None - this change introduces parity with the Notebook UI wrt kernel restarts.