### PR TITLE
Use icons instead of a switch to toggle the single document mode

### DIFF
--- a/packages/statusbar-extension/package.json
+++ b/packages/statusbar-extension/package.json
@@ -47,8 +47,6 @@
     "@jupyterlab/settingregistry": "^3.0.0-rc.10",
     "@jupyterlab/statusbar": "^3.0.0-rc.10",
     "@jupyterlab/translation": "^3.0.0-rc.10",
-    "@jupyterlab/ui-components": "^3.0.0-rc.10",
-    "@lumino/commands": "^1.11.3",
     "@lumino/widgets": "^1.14.0"
   },
   "devDependencies": {

--- a/packages/statusbar-extension/tsconfig.json
+++ b/packages/statusbar-extension/tsconfig.json
@@ -38,9 +38,6 @@
     },
     {
       "path": "../translation"
-    },
-    {
-      "path": "../ui-components"
     }
   ]
 }

--- a/packages/statusbar/package.json
+++ b/packages/statusbar/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/translation": "^3.0.0-rc.10",
     "@jupyterlab/ui-components": "^3.0.0-rc.10",
     "@lumino/algorithm": "^1.3.3",
+    "@lumino/commands": "^1.11.3",
     "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",
     "@lumino/messaging": "^1.4.3",

--- a/packages/statusbar/src/defaults/index.ts
+++ b/packages/statusbar/src/defaults/index.ts
@@ -3,5 +3,6 @@
 
 export * from './lineCol';
 export * from './kernelStatus';
+export * from './mode';
 export * from './runningSessions';
 export * from './memoryUsage';

--- a/packages/statusbar/src/defaults/mode.tsx
+++ b/packages/statusbar/src/defaults/mode.tsx
@@ -1,0 +1,152 @@
+import { ReactWidget } from '@jupyterlab/apputils';
+
+import { TranslationBundle } from '@jupyterlab/translation';
+
+import { fileIcon, inspectorIcon } from '@jupyterlab/ui-components';
+
+import { CommandRegistry } from '@lumino/commands';
+
+import { DockPanel } from '@lumino/widgets';
+
+import React, { useEffect, useState } from 'react';
+
+import { classes } from 'typestyle';
+
+import { interactiveItem, noUserSelect } from '..';
+
+/**
+ * A React component to toggle the shell mode.
+ *
+ * @param {object} props The component props.
+ * @param props.shell The shell.
+ * @param props.commands The command registry.
+ * @param props.trans The translation bundle.
+ */
+function ModeSwitchComponent({
+  shell,
+  commands,
+  trans
+}: {
+  shell: ModeSwitch.IShell;
+  commands: CommandRegistry;
+  trans: TranslationBundle;
+}): JSX.Element {
+  const [caption, setCaption] = useState('');
+
+  const onClick = () => {
+    const newMode =
+      shell.mode === 'multiple-document'
+        ? 'single-document'
+        : 'multiple-document';
+    shell.mode = newMode;
+    updateTitle();
+  };
+
+  const updateTitle = () => {
+    const binding = commands.keyBindings.find(
+      b => b.command === 'application:toggle-mode'
+    );
+    const title =
+      shell.mode === 'single-document'
+        ? 'Multiple-Document Mode'
+        : 'Single-Document Mode';
+    if (binding) {
+      const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
+      setCaption(trans.__(`${title} (%1)`, ks));
+    } else {
+      setCaption(trans.__(title));
+    }
+  };
+
+  useEffect(() => {
+    commands.keyBindingChanged.connect(updateTitle);
+    updateTitle();
+
+    return () => {
+      commands.keyBindingChanged.disconnect(updateTitle);
+    };
+  }, [shell.mode]);
+
+  return (
+    <div title={caption} onClick={onClick} className={classes(noUserSelect)}>
+      {shell.mode === 'multiple-document' ? (
+        <fileIcon.react left={'1px'} top={'3px'} stylesheet={'statusBar'} />
+      ) : (
+        <inspectorIcon.react
+          left={'1px'}
+          top={'3px'}
+          stylesheet={'statusBar'}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * A class that exposes a component to toggle the shell mode.
+ */
+export class ModeSwitch extends ReactWidget {
+  /**
+   * Construct a new ModeSwitch.
+   */
+  constructor(options: ModeSwitch.IOptions) {
+    super();
+    this._commands = options.commands;
+    this._shell = options.shell;
+    this._trans = options.trans;
+
+    this.addClass(interactiveItem);
+  }
+
+  /**
+   * Render a ModeSwitch component.
+   */
+  render(): JSX.Element {
+    return (
+      <ModeSwitchComponent
+        commands={this._commands}
+        shell={this._shell}
+        trans={this._trans}
+      />
+    );
+  }
+
+  private _commands: CommandRegistry;
+  private _trans: TranslationBundle;
+  private _shell: ModeSwitch.IShell;
+}
+
+/**
+ * A namespace for ModeSwitch statics.
+ */
+export namespace ModeSwitch {
+  /**
+   * Instantiation options for a ModeSwitch.
+   */
+  export interface IOptions {
+    /**
+     * The command registry.
+     */
+    commands: CommandRegistry;
+
+    /**
+     * The translation bundle.
+     */
+    trans: TranslationBundle;
+
+    /**
+     * A simplified shell with access to its mode
+     */
+    shell: ModeSwitch.IShell;
+  }
+
+  /**
+   * A simplified shell interface to access and modify the mode.
+   */
+  export interface IShell {
+    /**
+     * The mode for the shell.
+     */
+    mode: DockPanel.Mode;
+  }
+}

--- a/packages/statusbar/src/style/statusbar.ts
+++ b/packages/statusbar/src/style/statusbar.ts
@@ -14,7 +14,8 @@ const itemPadding = {
 const interactiveHover = {
   $nest: {
     '&:hover': {
-      backgroundColor: vars.hoverColor
+      backgroundColor: vars.hoverColor,
+      cursor: vars.hoverCursor
     }
   }
 };
@@ -60,3 +61,7 @@ export const item = style(
 
 export const clickedItem = style(clicked);
 export const interactiveItem = style(interactiveHover);
+
+export const noUserSelect = style({
+  userSelect: 'none'
+});

--- a/packages/statusbar/src/style/variables.ts
+++ b/packages/statusbar/src/style/variables.ts
@@ -4,6 +4,7 @@ import { Property } from 'csstype';
 
 export default {
   hoverColor: 'var(--jp-layout-color3)',
+  hoverCursor: 'pointer',
   clickColor: 'var(--jp-brand-color1)',
   backgroundColor: 'var(--jp-layout-color2)',
   height: '24px',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/9117

https://discourse.jupyter.org/t/seeking-feedback-jupyterlab-single-document-mode-switch-position/6715

Since there were quite a few comments on using icons instead of a switch to toggle the mode, here is a proof-of-concept PR that implements this idea.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Switch to using icons instead of a switch.

For now using:

- the file icon for the single document mode
- the inspector icon for the multiple document mode

If we want to continue with this, we can think of using different icons and adding them to `ui-components`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

To play with the 2 options on Binder:

- Using the latest commit on master with the SDM switch in the status bar: https://mybinder.org/v2/gh/jupyterlab/jupyterlab/71a6d84164f04c982768669b4b01a172e05309c3?urlpath=lab-dev
- Using the PR with the Binder dev mode, with icons instead of a switch: https://mybinder.org/v2/gh/jtpio/jupyterlab/icons-sdm?urlpath=lab-dev

### Before (switch)

![sdm-switch-statusbar](https://user-images.githubusercontent.com/591645/98399029-1f5cee80-2062-11eb-9531-ac1277017cd1.gif)

### After (icons)

![sdm-icons-left](https://user-images.githubusercontent.com/591645/99863030-8c14d480-2b9c-11eb-98c2-f6a6fc1101cd.gif)

#### Another proposal for placing the icon to the right

![sdm-icon-right](https://user-images.githubusercontent.com/591645/99863079-cf6f4300-2b9c-11eb-96e1-50aa191e8ad8.gif)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
