### PR TITLE
Include federated extensions in extension manager from the api

### DIFF
--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -23,7 +23,7 @@ from ..commands import (
 
 
 def _make_extension_entry(name, description, url, enabled, core, latest_version,
-                          installed_version, status, installed=None):
+                          installed_version, status, pkg_type, installed=None, install=None):
     """Create an extension entry that can be sent to the client"""
     ret = dict(
         name=name,
@@ -34,9 +34,12 @@ def _make_extension_entry(name, description, url, enabled, core, latest_version,
         latest_version=latest_version,
         installed_version=installed_version,
         status=status,
+        pkg_type=pkg_type
     )
     if installed is not None:
         ret['installed'] = installed
+    if install is not None:
+        ret['install'] = install
     return ret
 
 
@@ -87,7 +90,28 @@ class ExtensionManager(object):
         build_check_info = _build_check_info(app_options)
         _ensure_compat_errors(info, app_options)
         extensions = []
-        # TODO: Ensure loops can run in parallel
+
+        # TODO: the three for-loops below can be run concurrently
+        for name, data in info['federated_extensions'].items():
+            status = 'ok'
+            pkg_info = data #yield self._get_pkg_info(name, data)
+            if info['compat_errors'].get(name, None):
+                status = 'error'
+            extensions.append(_make_extension_entry(
+                name=name,
+                description=pkg_info.get('description', ''),
+                url=data.get('url', ''),
+                enabled=(name not in info['disabled']),
+                core=False,
+                # Use wanted version to ensure we limit ourselves
+                # within semver restrictions
+                latest_version=data['version'],
+                installed_version=data['version'],
+                status=status,
+                install=data['install'],
+                pkg_type='federated'
+            ))
+
         for name, data in info['extensions'].items():
             status = 'ok'
             pkg_info = yield self._get_pkg_info(name, data)
@@ -108,6 +132,7 @@ class ExtensionManager(object):
                 latest_version=pkg_info['latest_version'],
                 installed_version=data['version'],
                 status=status,
+                pkg_type='source'
             ))
         for name in build_check_info['uninstall']:
             data = yield self._get_scheduled_uninstall_info(name)
@@ -122,6 +147,7 @@ class ExtensionManager(object):
                     latest_version=data['version'],
                     installed_version=data['version'],
                     status='warning',
+                    pkg_type='source'
                 ))
         raise gen.Return(extensions)
 

--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -109,7 +109,7 @@ class ExtensionManager(object):
                 installed_version=data['version'],
                 status=status,
                 install=data.get('install', {}),
-                pkg_type='federated'
+                pkg_type='source'
             ))
 
         for name, data in info['extensions'].items():
@@ -132,7 +132,7 @@ class ExtensionManager(object):
                 latest_version=pkg_info['latest_version'],
                 installed_version=data['version'],
                 status=status,
-                pkg_type='source'
+                pkg_type='pre-built'
             ))
         for name in build_check_info['uninstall']:
             data = yield self._get_scheduled_uninstall_info(name)

--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -109,7 +109,7 @@ class ExtensionManager(object):
                 installed_version=data['version'],
                 status=status,
                 install=data.get('install', {}),
-                pkg_type='source'
+                pkg_type='prebuilt'
             ))
 
         for name, data in info['extensions'].items():
@@ -132,7 +132,7 @@ class ExtensionManager(object):
                 latest_version=pkg_info['latest_version'],
                 installed_version=data['version'],
                 status=status,
-                pkg_type='prebuilt'
+                pkg_type='source'
             ))
         for name in build_check_info['uninstall']:
             data = yield self._get_scheduled_uninstall_info(name)
@@ -147,7 +147,7 @@ class ExtensionManager(object):
                     latest_version=data['version'],
                     installed_version=data['version'],
                     status='warning',
-                    pkg_type='source'
+                    pkg_type='prebuilt'
                 ))
         raise gen.Return(extensions)
 

--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -132,7 +132,7 @@ class ExtensionManager(object):
                 latest_version=pkg_info['latest_version'],
                 installed_version=data['version'],
                 status=status,
-                pkg_type='pre-built'
+                pkg_type='prebuilt'
             ))
         for name in build_check_info['uninstall']:
             data = yield self._get_scheduled_uninstall_info(name)

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -671,7 +671,7 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         self.log.info('JupyterLab extension loaded from %s' % HERE)
         self.log.info('JupyterLab application directory is %s' % self.app_dir)
 
-        build_handler_options = AppOptions(logger=self.log, app_dir=self.app_dir)
+        build_handler_options = AppOptions(logger=self.log, app_dir=self.app_dir, labextensions_path = self.extra_labextensions_path + self.labextensions_path)
         builder = Builder(self.core_mode, app_options=build_handler_options)
         build_handler = (build_path, BuildHandler, {'builder': builder})
         handlers.append(build_handler)

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -79,6 +79,11 @@ export interface IEntry {
   blockedExtensionsEntry: IListEntry | undefined;
 
   allowedExtensionsEntry: IListEntry | undefined;
+
+  /**
+   * The package type (source or pre-built).
+   */
+  pkg_type: 'source' | 'pre-built';
 }
 
 /**
@@ -124,6 +129,11 @@ export interface IInstalledEntry {
    * A flag indicating the status of an installed extension.
    */
   status: 'ok' | 'warning' | 'error' | 'deprecated' | null;
+
+  /**
+   * The package type (source or pre-built).
+   */
+  pkg_type: 'source' | 'pre-built';
 }
 
 /**
@@ -522,7 +532,8 @@ export class ListModel extends VDomModel {
         latest_version: pkg.version,
         installed_version: '',
         blockedExtensionsEntry: isblockedExtensions,
-        allowedExtensionsEntry: isallowedExtensions
+        allowedExtensionsEntry: isallowedExtensions,
+        pkg_type: 'pre-built'
       };
     }
     return entries;
@@ -557,7 +568,8 @@ export class ListModel extends VDomModel {
             allowedExtensionsEntry: this.isListed(
               pkg.name,
               this._allowedExtensionsArray
-            )
+            ),
+            pkg_type: pkg.pkg_type
           };
         })
       );

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -81,9 +81,9 @@ export interface IEntry {
   allowedExtensionsEntry: IListEntry | undefined;
 
   /**
-   * The package type (source or prebuilt).
+   * The package type (prebuilt or source).
    */
-  pkg_type: 'source' | 'prebuilt';
+  pkg_type: 'prebuilt' | 'source';
 
   /**
    * The information about extension installation.
@@ -157,9 +157,9 @@ export interface IInstalledEntry {
   status: 'ok' | 'warning' | 'error' | 'deprecated' | null;
 
   /**
-   * The package type (source or prebuilt).
+   * The package type (prebuilt or source).
    */
-  pkg_type: 'source' | 'prebuilt';
+  pkg_type: 'prebuilt' | 'source';
 
   /**
    * The information about extension installation.
@@ -585,7 +585,7 @@ export class ListModel extends VDomModel {
         installed_version: '',
         blockedExtensionsEntry: isblockedExtensions,
         allowedExtensionsEntry: isallowedExtensions,
-        pkg_type: 'prebuilt',
+        pkg_type: 'source',
         install: undefined
       };
     }

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -81,9 +81,35 @@ export interface IEntry {
   allowedExtensionsEntry: IListEntry | undefined;
 
   /**
-   * The package type (source or pre-built).
+   * The package type (source or prebuilt).
    */
-  pkg_type: 'source' | 'pre-built';
+  pkg_type: 'source' | 'prebuilt';
+
+  /**
+   * The information about extension installation.
+   */
+  install: IInstall | undefined;
+}
+
+/**
+ * Information about extension installation.
+ */
+export interface IInstall {
+  /**
+   * The used pacakge manager (e.g. pip, conda...)
+   */
+  packageManager: string | undefined;
+
+  /**
+   * The package name as known by the package manager.
+   */
+  packageName: string | undefined;
+
+  /**
+   * The uninstallation instructions as a comprehensive
+   * text for the end user.
+   */
+  uninstallInstructions: string | undefined;
 }
 
 /**
@@ -131,9 +157,35 @@ export interface IInstalledEntry {
   status: 'ok' | 'warning' | 'error' | 'deprecated' | null;
 
   /**
-   * The package type (source or pre-built).
+   * The package type (source or prebuilt).
    */
-  pkg_type: 'source' | 'pre-built';
+  pkg_type: 'source' | 'prebuilt';
+
+  /**
+   * The information about extension installation.
+   */
+  install: IInstallEntry | undefined;
+}
+
+/**
+ * Information about extension installation.
+ */
+export interface IInstallEntry {
+  /**
+   * The used pacakge manager (e.g. pip, conda...)
+   */
+  packageManager: string | undefined;
+
+  /**
+   * The package name as known by the package manager.
+   */
+  packageName: string | undefined;
+
+  /**
+   * The uninstallation instructions as a comprehensive
+   * text for the end user.
+   */
+  uninstallInstructions: string | undefined;
 }
 
 /**
@@ -533,7 +585,8 @@ export class ListModel extends VDomModel {
         installed_version: '',
         blockedExtensionsEntry: isblockedExtensions,
         allowedExtensionsEntry: isallowedExtensions,
-        pkg_type: 'pre-built'
+        pkg_type: 'prebuilt',
+        install: undefined
       };
     }
     return entries;
@@ -569,7 +622,12 @@ export class ListModel extends VDomModel {
               pkg.name,
               this._allowedExtensionsArray
             ),
-            pkg_type: pkg.pkg_type
+            pkg_type: pkg.pkg_type,
+            install: {
+              packageManager: pkg.install?.packageManager,
+              packageName: pkg.install?.packageName,
+              uninstallInstructions: pkg.install?.uninstallInstructions
+            }
           };
         })
       );

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -5,8 +5,6 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 
 import { VDomModel } from '@jupyterlab/apputils';
 
-import { PageConfig } from '@jupyterlab/coreutils';
-
 import {
   KernelSpec,
   ServerConnection,
@@ -72,11 +70,6 @@ export interface IEntry {
    * The latest version of the extension.
    */
   latest_version: string;
-
-  /**
-   * Whether the extension is federated or not.
-   */
-  federated: boolean;
 
   /**
    * The installed version of the extension.
@@ -528,7 +521,6 @@ export class ListModel extends VDomModel {
         status: null,
         latest_version: pkg.version,
         installed_version: '',
-        federated: false,
         blockedExtensionsEntry: isblockedExtensions,
         allowedExtensionsEntry: isallowedExtensions
       };
@@ -558,7 +550,6 @@ export class ListModel extends VDomModel {
             status: pkg.status,
             latest_version: pkg.latest_version,
             installed_version: pkg.installed_version,
-            federated: false,
             blockedExtensionsEntry: this.isListed(
               pkg.name,
               this._blockedExtensionsArray
@@ -697,23 +688,6 @@ export class ListModel extends VDomModel {
     const installed: IEntry[] = [];
     for (const key of Object.keys(installedMap)) {
       installed.push(installedMap[key]);
-    }
-    for (const federated_extension of JSON.parse(
-      PageConfig.getOption('federated_extensions')
-    )) {
-      installed.push({
-        name: federated_extension['name'],
-        description: '',
-        url: federated_extension['load'],
-        installed: true,
-        enabled: true,
-        status: null,
-        latest_version: '',
-        installed_version: '',
-        federated: true,
-        blockedExtensionsEntry: undefined,
-        allowedExtensionsEntry: undefined
-      });
     }
     this._installed = installed.sort(Private.comparator);
 

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -2,12 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
-import {
-  VDomRenderer,
-  ToolbarButtonComponent,
-  Dialog,
-  showDialog
-} from '@jupyterlab/apputils';
+import { VDomRenderer, ToolbarButtonComponent } from '@jupyterlab/apputils';
 import { ServiceManager } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import {
@@ -282,101 +277,59 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
           <div className="jp-extensionmanager-entry-description">
             {entry.description}
           </div>
-          {entry.federated && entry.installed && (
-            <div className="jp-extensionmanager-entry-buttons">
+          <div className="jp-extensionmanager-entry-buttons">
+            {!entry.installed &&
+              !entry.blockedExtensionsEntry &&
+              !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
+              ListModel.isDisclaimed() && (
+                <Button
+                  onClick={() => props.performAction('install', entry)}
+                  minimal
+                  small
+                >
+                  {trans.__('Install')}
+                </Button>
+              )}
+            {ListModel.entryHasUpdate(entry) &&
+              !entry.blockedExtensionsEntry &&
+              !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
+              ListModel.isDisclaimed() && (
+                <Button
+                  onClick={() => props.performAction('install', entry)}
+                  minimal
+                  small
+                >
+                  {trans.__('Update')}
+                </Button>
+              )}
+            {entry.installed && (
               <Button
-                onClick={() =>
-                  showDialog({
-                    title,
-                    body: (
-                      <div>
-                        <p>
-                          {trans.__(`This is a Federated Extension. To uninstall it, please
-                read the user guide on:`)}
-                        </p>
-                        <p>
-                          <a
-                            href="https://jupyterlab.readthedocs.io/en/stable/user/extensions.html"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            https://jupyterlab.readthedocs.io/en/stable/user/extensions.html
-                          </a>
-                        </p>
-                      </div>
-                    ),
-                    buttons: [
-                      Dialog.okButton({
-                        label: trans.__('OK'),
-                        caption: trans.__('OK')
-                      })
-                    ]
-                  }).then(result => {
-                    return result.button.accept;
-                  })
-                }
+                onClick={() => props.performAction('uninstall', entry)}
                 minimal
                 small
               >
-                {trans.__('About')}
+                {trans.__('Uninstall')}
               </Button>
-            </div>
-          )}
-          {!entry.federated && (
-            <div className="jp-extensionmanager-entry-buttons">
-              {!entry.installed &&
-                !entry.blockedExtensionsEntry &&
-                !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
-                ListModel.isDisclaimed() && (
-                  <Button
-                    onClick={() => props.performAction('install', entry)}
-                    minimal
-                    small
-                  >
-                    {trans.__('Install')}
-                  </Button>
-                )}
-              {ListModel.entryHasUpdate(entry) &&
-                !entry.blockedExtensionsEntry &&
-                !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
-                ListModel.isDisclaimed() && (
-                  <Button
-                    onClick={() => props.performAction('install', entry)}
-                    minimal
-                    small
-                  >
-                    {trans.__('Update')}
-                  </Button>
-                )}
-              {entry.installed && (
-                <Button
-                  onClick={() => props.performAction('uninstall', entry)}
-                  minimal
-                  small
-                >
-                  {trans.__('Uninstall')}
-                </Button>
-              )}
-              {entry.enabled && (
-                <Button
-                  onClick={() => props.performAction('disable', entry)}
-                  minimal
-                  small
-                >
-                  {trans.__('Disable')}
-                </Button>
-              )}
-              {entry.installed && !entry.enabled && (
-                <Button
-                  onClick={() => props.performAction('enable', entry)}
-                  minimal
-                  small
-                >
-                  {trans.__('Enable')}
-                </Button>
-              )}
-            </div>
-          )}
+            )}
+            {entry.enabled && (
+              <Button
+                onClick={() => props.performAction('disable', entry)}
+                minimal
+                small
+              >
+                {trans.__('Disable')}
+              </Button>
+            )}
+            {entry.installed && !entry.enabled && (
+              <Button
+                onClick={() => props.performAction('enable', entry)}
+                minimal
+                small
+              >
+                {trans.__('Enable')}
+              </Button>
+            )}
+          </div>
         </div>
       </div>
     </li>

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -236,7 +236,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
         <div className="jp-extensionmanager-entry-title">
           <div className="jp-extensionmanager-entry-name">
             {entry.pkg_type == 'source' && <div>{entry.name}</div>}
-            {entry.pkg_type == 'pre-built' && (
+            {entry.pkg_type == 'prebuilt' && (
               <a href={entry.url} target="_blank" rel="noopener noreferrer">
                 {entry.name}
               </a>
@@ -287,7 +287,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
           </div>
           <div className="jp-extensionmanager-entry-buttons">
             {!entry.installed &&
-              entry.pkg_type == 'pre-built' &&
+              entry.pkg_type == 'prebuilt' &&
               !entry.blockedExtensionsEntry &&
               !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
               ListModel.isDisclaimed() && (
@@ -300,7 +300,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 </Button>
               )}
             {ListModel.entryHasUpdate(entry) &&
-              entry.pkg_type == 'pre-built' &&
+              entry.pkg_type == 'prebuilt' &&
               !entry.blockedExtensionsEntry &&
               !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
               ListModel.isDisclaimed() && (
@@ -312,7 +312,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                   {trans.__('Update')}
                 </Button>
               )}
-            {entry.installed && entry.pkg_type == 'pre-built' && (
+            {entry.installed && entry.pkg_type == 'prebuilt' && (
               <Button
                 onClick={() => props.performAction('uninstall', entry)}
                 minimal
@@ -321,7 +321,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 {trans.__('Uninstall')}
               </Button>
             )}
-            {entry.enabled && entry.pkg_type == 'pre-built' && (
+            {entry.enabled && entry.pkg_type == 'prebuilt' && (
               <Button
                 onClick={() => props.performAction('disable', entry)}
                 minimal
@@ -330,17 +330,15 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 {trans.__('Disable')}
               </Button>
             )}
-            {entry.installed &&
-              entry.pkg_type == 'pre-built' &&
-              !entry.enabled && (
-                <Button
-                  onClick={() => props.performAction('enable', entry)}
-                  minimal
-                  small
-                >
-                  {trans.__('Enable')}
-                </Button>
-              )}
+            {entry.installed && entry.pkg_type == 'prebuilt' && !entry.enabled && (
+              <Button
+                onClick={() => props.performAction('enable', entry)}
+                minimal
+                small
+              >
+                {trans.__('Enable')}
+              </Button>
+            )}
             {entry.installed && entry.pkg_type == 'source' && (
               <div className="jp-extensionmanager-entry-buttons">
                 <Button
@@ -348,21 +346,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                     showDialog({
                       title,
                       body: (
-                        <div>
-                          <p>
-                            {trans.__(`This is a Source Extension. To uninstall it, please
-                  read the user guide on:`)}
-                          </p>
-                          <p>
-                            <a
-                              href="https://jupyterlab.readthedocs.io/en/stable/user/extensions.html"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              https://jupyterlab.readthedocs.io/en/stable/user/extensions.html
-                            </a>
-                          </p>
-                        </div>
+                        <div>{getSourceUninstallInstruction(entry, trans)}</div>
                       ),
                       buttons: [
                         Dialog.okButton({
@@ -385,6 +369,40 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
         </div>
       </div>
     </li>
+  );
+}
+
+function getSourceUninstallInstruction(
+  entry: IEntry,
+  trans: TranslationBundle
+): JSX.Element {
+  if (entry.install?.uninstallInstructions) {
+    return (
+      <div>
+        <p>
+          {trans.__(`This is a Source Extension. To uninstall it, please
+    apply following instructions.`)}
+        </p>
+        <p>{entry.install?.uninstallInstructions}</p>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <p>
+        {trans.__(`This is a Source Extension. To uninstall it, please
+    read the user guide on:`)}
+      </p>
+      <p>
+        <a
+          href="https://jupyterlab.readthedocs.io/en/stable/user/extensions.html"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          https://jupyterlab.readthedocs.io/en/stable/user/extensions.html
+        </a>
+      </p>
+    </div>
   );
 }
 

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -235,8 +235,8 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
       <div className="jp-extensionmanager-entry-description">
         <div className="jp-extensionmanager-entry-title">
           <div className="jp-extensionmanager-entry-name">
-            {entry.pkg_type == 'source' && <div>{entry.name}</div>}
-            {entry.pkg_type == 'prebuilt' && (
+            {entry.pkg_type == 'prebuilt' && <div>{entry.name}</div>}
+            {entry.pkg_type == 'source' && (
               <a href={entry.url} target="_blank" rel="noopener noreferrer">
                 {entry.name}
               </a>
@@ -287,7 +287,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
           </div>
           <div className="jp-extensionmanager-entry-buttons">
             {!entry.installed &&
-              entry.pkg_type == 'prebuilt' &&
+              entry.pkg_type == 'source' &&
               !entry.blockedExtensionsEntry &&
               !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
               ListModel.isDisclaimed() && (
@@ -300,7 +300,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 </Button>
               )}
             {ListModel.entryHasUpdate(entry) &&
-              entry.pkg_type == 'prebuilt' &&
+              entry.pkg_type == 'source' &&
               !entry.blockedExtensionsEntry &&
               !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
               ListModel.isDisclaimed() && (
@@ -312,7 +312,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                   {trans.__('Update')}
                 </Button>
               )}
-            {entry.installed && entry.pkg_type == 'prebuilt' && (
+            {entry.installed && entry.pkg_type == 'source' && (
               <Button
                 onClick={() => props.performAction('uninstall', entry)}
                 minimal
@@ -321,7 +321,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 {trans.__('Uninstall')}
               </Button>
             )}
-            {entry.enabled && entry.pkg_type == 'prebuilt' && (
+            {entry.enabled && entry.pkg_type == 'source' && (
               <Button
                 onClick={() => props.performAction('disable', entry)}
                 minimal
@@ -330,7 +330,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 {trans.__('Disable')}
               </Button>
             )}
-            {entry.installed && entry.pkg_type == 'prebuilt' && !entry.enabled && (
+            {entry.installed && entry.pkg_type == 'source' && !entry.enabled && (
               <Button
                 onClick={() => props.performAction('enable', entry)}
                 minimal
@@ -339,14 +339,16 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 {trans.__('Enable')}
               </Button>
             )}
-            {entry.installed && entry.pkg_type == 'source' && (
+            {entry.installed && entry.pkg_type == 'prebuilt' && (
               <div className="jp-extensionmanager-entry-buttons">
                 <Button
                   onClick={() =>
                     showDialog({
                       title,
                       body: (
-                        <div>{getSourceUninstallInstruction(entry, trans)}</div>
+                        <div>
+                          {getprebuiltUninstallInstruction(entry, trans)}
+                        </div>
                       ),
                       buttons: [
                         Dialog.okButton({
@@ -372,7 +374,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
   );
 }
 
-function getSourceUninstallInstruction(
+function getprebuiltUninstallInstruction(
   entry: IEntry,
   trans: TranslationBundle
 ): JSX.Element {
@@ -380,7 +382,7 @@ function getSourceUninstallInstruction(
     return (
       <div>
         <p>
-          {trans.__(`This is a Source Extension. To uninstall it, please
+          {trans.__(`This is a prebuilt extension. To uninstall it, please
     apply following instructions.`)}
         </p>
         <p>{entry.install?.uninstallInstructions}</p>
@@ -390,7 +392,7 @@ function getSourceUninstallInstruction(
   return (
     <div>
       <p>
-        {trans.__(`This is a Source Extension. To uninstall it, please
+        {trans.__(`This is a prebuilt extension. To uninstall it, please
     read the user guide on:`)}
       </p>
       <p>

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -385,7 +385,7 @@ function getprebuiltUninstallInstruction(
           {trans.__(`This is a prebuilt extension. To uninstall it, please
     apply following instructions.`)}
         </p>
-        <p>{entry.install?.uninstallInstructions}</p>
+        <p>{trans.__(entry.install?.uninstallInstructions)}</p>
       </div>
     );
   }

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -2,7 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { JupyterFrontEnd } from '@jupyterlab/application';
-import { VDomRenderer, ToolbarButtonComponent } from '@jupyterlab/apputils';
+import {
+  VDomRenderer,
+  ToolbarButtonComponent,
+  Dialog,
+  showDialog
+} from '@jupyterlab/apputils';
 import { ServiceManager } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import {
@@ -230,9 +235,12 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
       <div className="jp-extensionmanager-entry-description">
         <div className="jp-extensionmanager-entry-title">
           <div className="jp-extensionmanager-entry-name">
-            <a href={entry.url} target="_blank" rel="noopener noreferrer">
-              {entry.name}
-            </a>
+            {entry.pkg_type == 'source' && <div>{entry.name}</div>}
+            {entry.pkg_type == 'pre-built' && (
+              <a href={entry.url} target="_blank" rel="noopener noreferrer">
+                {entry.name}
+              </a>
+            )}
           </div>
           {entry.blockedExtensionsEntry && (
             <ToolbarButtonComponent
@@ -279,6 +287,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
           </div>
           <div className="jp-extensionmanager-entry-buttons">
             {!entry.installed &&
+              entry.pkg_type == 'pre-built' &&
               !entry.blockedExtensionsEntry &&
               !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
               ListModel.isDisclaimed() && (
@@ -291,6 +300,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 </Button>
               )}
             {ListModel.entryHasUpdate(entry) &&
+              entry.pkg_type == 'pre-built' &&
               !entry.blockedExtensionsEntry &&
               !(!entry.allowedExtensionsEntry && listMode === 'allow') &&
               ListModel.isDisclaimed() && (
@@ -302,7 +312,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                   {trans.__('Update')}
                 </Button>
               )}
-            {entry.installed && (
+            {entry.installed && entry.pkg_type == 'pre-built' && (
               <Button
                 onClick={() => props.performAction('uninstall', entry)}
                 minimal
@@ -311,7 +321,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 {trans.__('Uninstall')}
               </Button>
             )}
-            {entry.enabled && (
+            {entry.enabled && entry.pkg_type == 'pre-built' && (
               <Button
                 onClick={() => props.performAction('disable', entry)}
                 minimal
@@ -320,14 +330,56 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                 {trans.__('Disable')}
               </Button>
             )}
-            {entry.installed && !entry.enabled && (
-              <Button
-                onClick={() => props.performAction('enable', entry)}
-                minimal
-                small
-              >
-                {trans.__('Enable')}
-              </Button>
+            {entry.installed &&
+              entry.pkg_type == 'pre-built' &&
+              !entry.enabled && (
+                <Button
+                  onClick={() => props.performAction('enable', entry)}
+                  minimal
+                  small
+                >
+                  {trans.__('Enable')}
+                </Button>
+              )}
+            {entry.installed && entry.pkg_type == 'source' && (
+              <div className="jp-extensionmanager-entry-buttons">
+                <Button
+                  onClick={() =>
+                    showDialog({
+                      title,
+                      body: (
+                        <div>
+                          <p>
+                            {trans.__(`This is a Source Extension. To uninstall it, please
+                  read the user guide on:`)}
+                          </p>
+                          <p>
+                            <a
+                              href="https://jupyterlab.readthedocs.io/en/stable/user/extensions.html"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              https://jupyterlab.readthedocs.io/en/stable/user/extensions.html
+                            </a>
+                          </p>
+                        </div>
+                      ),
+                      buttons: [
+                        Dialog.okButton({
+                          label: trans.__('OK'),
+                          caption: trans.__('OK')
+                        })
+                      ]
+                    }).then(result => {
+                      return result.button.accept;
+                    })
+                  }
+                  minimal
+                  small
+                >
+                  {trans.__('About')}
+                </Button>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9367

## Code changes

Adds prebuilt (federated) extensions to the extension api

@echarles is planning to use this to upgrade the support for federated extensions in the extension manager, for example having uninstall instructions, etc.

Here is an example response from the extension api now, with `jupyterlab_apod` installed as a prebuilt extension and `@jupyter-widgets/jupyterlab-manager` installed as a source extension:

```json
[
    {
        "name": "jupyterlab_apod",
        "description": "",
        "url": "",
        "enabled": true,
        "core": false,
        "latest_version": "0.1.0",
        "installed_version": "0.1.0",
        "status": "ok",
        "pkg_type": "federated",
        "install": {
            "packageManager": "python",
            "packageName": "jupyterlab_apod",
            "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab_apod"
        }
    },
    {
        "name": "@jupyter-widgets/jupyterlab-manager",
        "description": "The JupyterLab extension providing Jupyter widgets.",
        "url": "https://github.com/jupyter-widgets/ipywidgets",
        "enabled": true,
        "core": false,
        "latest_version": "3.0.0-alpha.2",
        "installed_version": "3.0.0-alpha.2",
        "status": "ok",
        "pkg_type": "source"
    }
]
```


## User-facing changes



## Backwards-incompatible changes

