### PR TITLE
Remove initial extra _onMimeTypeChanged call

### DIFF
--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -121,7 +121,6 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     // Handle initial values for text, mimetype, and selections.
     doc.setValue(model.value.text);
     this.clearHistory();
-    this._onMimeTypeChanged();
     this._onCursorActivity();
     this._poll = new Poll({
       factory: async () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

The initial call to onMimeTypeChanged seems to be unnecessary, since there is a signal that triggers that when the actual rendermime is set a few lines below `model.mimeTypeChanged.connect(this._onMimeTypeChanged, this);`.

The `onMimeTypeChanged` call is expensive.

## User-facing changes

Apparently none

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
