### PR TITLE
PR: add setOptions to code mirror set options in batch inside an operation

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -215,11 +215,13 @@ export class Cell extends Widget {
 
     // Editor settings
     if (options.editorConfig) {
+      let editorOptions: any = {};
       Object.keys(options.editorConfig).forEach(
         (key: keyof CodeEditor.IConfig) => {
-          this.editor.setOption(key, options.editorConfig?.[key] ?? null);
+          editorOptions[key] = options.editorConfig?.[key] ?? null;
         }
       );
+      this.editor.setOptions(editorOptions);
     }
 
     model.metadata.changed.connect(this.onMetadataChanged, this);

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -427,7 +427,7 @@ export namespace CodeEditor {
     /**
      * Set config options for the editor.
      */
-    setOptions(options: any): void;
+    setOptions<K extends keyof IConfig>(options: IConfigOptions<K>[]): void;
 
     /**
      * Returns the content for the given line number.
@@ -681,6 +681,13 @@ export namespace CodeEditor {
     rulers: [],
     codeFolding: false
   };
+
+  /**
+   * The options used to set several options at once with setOptions.
+   */
+  export interface IConfigOptions<K extends keyof IConfig> {
+    K: IConfig[K];
+  }
 
   /**
    * The options used to initialize an editor.

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -425,6 +425,11 @@ export namespace CodeEditor {
     setOption<K extends keyof IConfig>(option: K, value: IConfig[K]): void;
 
     /**
+     * Set config options for the editor.
+     */
+    setOptions(options: any): void;
+
+    /**
      * Returns the content for the given line number.
      *
      * @param line - The line of interest.

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -195,20 +195,23 @@ function activateEditorCommands(
       (settings.get('lineWiseCopyCut').composite as boolean) ?? lineWiseCopyCut;
   }
 
+  const editorOptions: any = {
+    keyMap,
+    theme,
+    scrollPastEnd,
+    styleActiveLine,
+    styleSelectedText,
+    selectionPointer,
+    lineWiseCopyCut
+  };
+
   /**
    * Update the settings of the current tracker instances.
    */
   function updateTracker(): void {
     tracker.forEach(widget => {
       if (widget.content.editor instanceof CodeMirrorEditor) {
-        const cm = widget.content.editor.editor;
-        cm.setOption('keyMap', keyMap);
-        cm.setOption('theme', theme);
-        cm.setOption('scrollPastEnd', scrollPastEnd);
-        cm.setOption('styleActiveLine', styleActiveLine);
-        cm.setOption('styleSelectedText', styleSelectedText);
-        cm.setOption('selectionPointer', selectionPointer);
-        cm.setOption('lineWiseCopyCut', lineWiseCopyCut);
+        widget.content.editor.setOptions(editorOptions);
       }
     });
   }
@@ -233,14 +236,7 @@ function activateEditorCommands(
    */
   tracker.widgetAdded.connect((sender, widget) => {
     if (widget.content.editor instanceof CodeMirrorEditor) {
-      const cm = widget.content.editor.editor;
-      cm.setOption('keyMap', keyMap);
-      cm.setOption('theme', theme);
-      cm.setOption('scrollPastEnd', scrollPastEnd);
-      cm.setOption('styleActiveLine', styleActiveLine);
-      cm.setOption('styleSelectedText', styleSelectedText);
-      cm.setOption('selectionPointer', selectionPointer);
-      cm.setOption('lineWiseCopyCut', lineWiseCopyCut);
+      widget.content.editor.setOptions(editorOptions);
     }
   });
 

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -306,7 +306,9 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
    * the costly update at the end, and not after every option
    * is set.
    */
-  setOptions(options: any) {
+  setOptions<K extends keyof CodeMirrorEditor.IConfig>(
+    options: CodeMirrorEditor.IConfigOptions<K>[]
+  ): void {
     const editor = this._editor;
     editor.startOperation();
     for (let key in options) {
@@ -717,17 +719,12 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     } else {
       delete extraKeys['Backspace'];
     }
+    this.setOption('extraKeys', extraKeys);
 
-    // TODO: should we provide a hook for when the
-    // mode is done being set?
-    void Mode.ensure(mime).then(
-      spec => {
-        this.setOptions({ extraKeys: extraKeys, mode: spec?.mime ?? 'null' });
-      },
-      reason => {
-        this.setOption('extraKeys', extraKeys);
-      }
-    );
+    // TODO: should we provide a hook for when the mode is done being set?
+    void Mode.ensure(mime).then(spec => {
+      this.setOption('mode', spec?.mime ?? 'null');
+    });
   }
 
   /**
@@ -1304,6 +1301,13 @@ export namespace CodeMirrorEditor {
     foldGutter: false,
     handlePaste: true
   };
+
+  /**
+   * The options used to set several options at once with setOptions.
+   */
+  export interface IConfigOptions<K extends keyof IConfig> {
+    K: IConfig[K];
+  }
 
   /**
    * Add a command to CodeMirror.

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -299,6 +299,25 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   }
 
   /**
+   * Set config options for the editor.
+   *
+   * This method is prefered when setting several options. The
+   * options are set within an operation, which only performs
+   * the costly update at the end, and not after every option
+   * is set.
+   */
+  setOptions(options: any) {
+    const editor = this._editor;
+    editor.startOperation();
+    for (let key in options) {
+      editor.operation(() => {
+        this.setOption(key as any, options[key]);
+      });
+    }
+    editor.endOperation();
+  }
+
+  /**
    * Returns the content for the given line number.
    */
   getLine(line: number): string | undefined {
@@ -691,11 +710,6 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   private _onMimeTypeChanged(): void {
     const mime = this._model.mimeType;
     const editor = this._editor;
-    // TODO: should we provide a hook for when the
-    // mode is done being set?
-    void Mode.ensure(mime).then(spec => {
-      editor.setOption('mode', spec?.mime ?? 'null');
-    });
     const extraKeys = editor.getOption('extraKeys') || {};
     const isCode = mime !== 'text/plain' && mime !== 'text/x-ipythongfm';
     if (isCode) {
@@ -703,7 +717,17 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     } else {
       delete extraKeys['Backspace'];
     }
-    editor.setOption('extraKeys', extraKeys);
+
+    // TODO: should we provide a hook for when the
+    // mode is done being set?
+    void Mode.ensure(mime).then(
+      spec => {
+        this.setOptions({ extraKeys: extraKeys, mode: spec?.mime ?? 'null' });
+      },
+      reason => {
+        this.setOption('extraKeys', extraKeys);
+      }
+    );
   }
 
   /**

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -172,11 +172,13 @@ export namespace Commands {
   export function updateWidget(widget: FileEditor): void {
     const transientConfigs = ['lineNumbers', 'lineWrap', 'matchBrackets'];
     const editor = widget.editor;
+    let editorOptions: any = {};
     Object.keys(config).forEach((key: keyof CodeEditor.IConfig) => {
       if (!transientConfigs.includes(key)) {
-        editor.setOption(key, config[key]);
+        editorOptions[key] = config[key];
       }
     });
+    editor.setOptions(editorOptions);
   }
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -740,9 +740,11 @@ export class StaticNotebook extends Widget {
           config = this._editorConfig.raw;
           break;
       }
+      let editorOptions: any = {};
       Object.keys(config).forEach((key: keyof CodeEditor.IConfig) => {
-        cell.editor.setOption(key, config[key] ?? null);
+        editorOptions[key] = config[key] ?? null;
       });
+      cell.editor.setOptions(editorOptions);
       cell.editor.refresh();
     }
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

Related to https://github.com/jupyterlab/benchmarks/issues/49#issuecomment-726146404


<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes


<!-- Describe the code changes and how they address the issue. -->

add setOptions to code mirror set options in batch inside an operation.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

None

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None