### PR TITLE
Fix scroll positions when clearing outputs

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1059,7 +1059,7 @@ export namespace NotebookActions {
         (child as CodeCell).outputHidden = false;
       }
     });
-    Private.handleState(notebook, state);
+    Private.handleState(notebook, state, true);
   }
 
   /**
@@ -1085,7 +1085,7 @@ export namespace NotebookActions {
         (child as CodeCell).outputHidden = false;
       }
     });
-    Private.handleState(notebook, state);
+    Private.handleState(notebook, state, true);
   }
 
   /**
@@ -1185,7 +1185,7 @@ export namespace NotebookActions {
         (cell as CodeCell).outputHidden = true;
       }
     });
-    Private.handleState(notebook, state);
+    Private.handleState(notebook, state, true);
   }
 
   /**
@@ -1225,7 +1225,7 @@ export namespace NotebookActions {
         (cell as CodeCell).outputHidden = true;
       }
     });
-    Private.handleState(notebook, state);
+    Private.handleState(notebook, state, true);
   }
 
   /**


### PR DESCRIPTION
## References

Fixes #9331

## Code changes

After clearing output, this scrolls the cell back into view

## User-facing changes

Per above, this keeps the focus on the selected cell, not where the scrollbar was

## Backwards-incompatible changes

N/A
