### PR TITLE
Clear the model and the signals upon continue response

### DIFF
--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -193,6 +193,8 @@ export class DebuggerService implements IDebugger, IDisposable {
         threadId: this._currentThread()
       });
       this._model.stoppedThreads.delete(this._currentThread());
+      this._clearModel();
+      this._clearSignals();
     } catch (err) {
       console.error('Error:', err.message);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## Code changes

The debugger should clear its model and signals after it receives a continue response instead of waiting for a `continued` event. As the DAP says, a debug adapter is not expected to send the `continued` event in response to a request that implies that execution continues, e.g. `launch` or `continue`.

