### PR TITLE
Remove unused requires for the tree-resolver plugin

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -341,13 +341,11 @@ const router: JupyterFrontEndPlugin<IRouter> = {
 const tree: JupyterFrontEndPlugin<JupyterFrontEnd.ITreeResolver> = {
   id: '@jupyterlab/application-extension:tree-resolver',
   autoStart: true,
-  requires: [JupyterFrontEnd.IPaths, IRouter, IWindowResolver],
+  requires: [IRouter],
   provides: JupyterFrontEnd.ITreeResolver,
   activate: (
     app: JupyterFrontEnd,
-    paths: JupyterFrontEnd.IPaths,
-    router: IRouter,
-    resolver: IWindowResolver
+    router: IRouter
   ): JupyterFrontEnd.ITreeResolver => {
     const { commands } = app;
     const set = new DisposableSet();


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Remove unused `requires` from the `@jupyterlab/application-extension:tree-resolver` plugin, to make it easier to reuse in other lab-based applications.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
