### PR TITLE
DOC: Make code block background less ugly

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,9 +90,6 @@ language = None
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = []
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
-
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 


### PR DESCRIPTION
Before: https://jupyterlab.readthedocs.io/en/2.3.x/getting_started/installation.html
<img width="781" alt="Screen Shot 2021-06-01 at 1 43 16 PM" src="https://user-images.githubusercontent.com/3627835/120374577-5422e280-c2df-11eb-97b3-b60c6f53779f.png">

After: https://jupyterlab--9413.org.readthedocs.build/en/9413/getting_started/installation.html

![image](https://user-images.githubusercontent.com/3627835/120374589-5b49f080-c2df-11eb-90fd-18d45d392ea3.png)
