### PR TITLE
[2.3.x] Perf: 20cells to render directly

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -369,7 +369,7 @@
       "title": "Number of cells to render directly",
       "description": "Define the number of cells to render directly when virtual notebook intersection observer is available",
       "type": "number",
-      "default": 7
+      "default": 20
     },
     "renderCellOnIdle": {
       "title": "Render cell on browser idle time",

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -945,7 +945,7 @@ export namespace StaticNotebook {
     scrollPastEnd: true,
     defaultCell: 'code',
     recordTiming: false,
-    numberCellsToRenderDirectly: 10,
+    numberCellsToRenderDirectly: 20,
     renderCellOnIdle: true,
     observedTopMargin: '1000px',
     observedBottomMargin: '1000px'


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/9416

## Code changes

Default values for `numberCellsToRenderDirectly` in `notebook-extension/schema/tracker.json` and `notebook/src/widget.ts` set to 10.

## User-facing changes

More cells to be rendered directly. Thank to https://github.com/jupyterlab/jupyterlab/pull/9382 and https://github.com/jupyterlab/jupyterlab/pull/9394 we should not loose peformance.

## Backwards-incompatible changes

None.