### PR TITLE
Reduce yarn timeout

### DIFF
--- a/jupyterlab/staging/.yarnrc
+++ b/jupyterlab/staging/.yarnrc
@@ -1,3 +1,3 @@
 yarn-path "./yarn.js"
 ignore-optional true
-network-timeout "1000000"
+network-timeout "60000"

--- a/jupyterlab/staging/.yarnrc
+++ b/jupyterlab/staging/.yarnrc
@@ -1,3 +1,3 @@
 yarn-path "./yarn.js"
 ignore-optional true
-network-timeout "60000"
+network-timeout "300000"


### PR DESCRIPTION
Previous timeout was unintentionally high

## References

#9418 #8104

## Code changes

Changes yarn timeout configuration parameter to reflect 60 second timeout.
