### PR TITLE
Remove pink background from tracebacks

### DIFF
--- a/packages/rendermime/src/outputmodel.ts
+++ b/packages/rendermime/src/outputmodel.ts
@@ -283,7 +283,7 @@ namespace Private {
     } else if (nbformat.isError(output)) {
       bundle['application/vnd.jupyter.error'] = output;
       const traceback = output.traceback.join('\n');
-      bundle['application/vnd.jupyter.stderr'] =
+      bundle['application/vnd.jupyter.stdout'] =
         traceback || `${output.ename}: ${output.evalue}`;
     }
     return convertBundle(bundle);


### PR DESCRIPTION

## References

Fixes #7892.

## Code changes

Change `stderr` to `stdout`.

## User-facing changes

Less ugliness.

![image](https://user-images.githubusercontent.com/705404/100903007-b718f580-34c5-11eb-8cd6-59ffbc32652b.png)

## Backwards-incompatible changes

None.