### PR TITLE
Throws an error if the kernel cannot start the debugger

### DIFF
--- a/packages/debugger/src/session.ts
+++ b/packages/debugger/src/session.ts
@@ -109,7 +109,7 @@ export class DebuggerSession implements IDebugger.ISession {
    * Start a new debug session
    */
   async start(): Promise<void> {
-    await this.sendRequest('initialize', {
+    const reply = await this.sendRequest('initialize', {
       clientID: 'jupyterlab',
       clientName: 'JupyterLab',
       adapterID: this.connection?.kernel?.name ?? '',
@@ -121,6 +121,10 @@ export class DebuggerSession implements IDebugger.ISession {
       supportsRunInTerminalRequest: true,
       locale: document.documentElement.lang
     });
+
+    if (!reply.success) {
+      throw new Error(`Could not start the debugger: ${reply.message}`);
+    }
 
     this._isStarted = true;
 


### PR DESCRIPTION
## References

This PR fixes an issue revealed in #9414 

## Code changes

To start the debugger, the frontend sends an `initialize` request followed by an `attach` request. The current implementation does not take into account a failure of the initialize request. This PR changes this behavior and throws an exception upon failure of the initialize request.

## User-facing changes

The user is now warned when the kernel fails to start the debugger.

