### PR TITLE
Make the input and output prompts take less space on mobile

### DIFF
--- a/packages/cells/style/inputarea.css
+++ b/packages/cells/style/inputarea.css
@@ -27,7 +27,6 @@
 }
 
 .jp-InputPrompt {
-  flex: 0 0 var(--jp-cell-prompt-width);
   color: var(--jp-cell-inprompt-font-color);
   font-family: var(--jp-cell-prompt-font-family);
   padding: var(--jp-code-padding);
@@ -47,4 +46,8 @@
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+body[data-format='desktop'] .jp-InputPrompt {
+  flex: 0 0 var(--jp-cell-prompt-width);
 }

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -25,7 +25,6 @@
 }
 
 .jp-OutputPrompt {
-  flex: 0 0 var(--jp-cell-prompt-width);
   color: var(--jp-cell-outprompt-font-color);
   font-family: var(--jp-cell-prompt-font-family);
   padding: var(--jp-code-padding);
@@ -44,6 +43,10 @@
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+body[data-format='desktop'] .jp-OutputPrompt {
+  flex: 0 0 var(--jp-cell-prompt-width);
 }
 
 .jp-OutputArea-output {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/3275

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

CSS changes.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

No visual changes in desktop mode.

In mobile mode:

### Before

![image](https://user-images.githubusercontent.com/591645/101213081-1c154c80-367a-11eb-9560-d997f9e20cd8.png)


### After

![image](https://user-images.githubusercontent.com/591645/101213027-0738b900-367a-11eb-93f9-bc67908461a1.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
