### PR TITLE
Make ILabShell optional in the filebrowser factory plugin

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -158,8 +158,8 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
   activate: activateFactory,
   id: '@jupyterlab/filebrowser-extension:factory',
   provides: IFileBrowserFactory,
-  requires: [ILabShell, IDocumentManager, ITranslator],
-  optional: [IStateDB, IRouter, JupyterFrontEnd.ITreeResolver]
+  requires: [IDocumentManager, ITranslator],
+  optional: [ILabShell, IStateDB, IRouter, JupyterFrontEnd.ITreeResolver]
 };
 
 /**
@@ -238,9 +238,9 @@ export default plugins;
  */
 async function activateFactory(
   app: JupyterFrontEnd,
-  labShell: ILabShell,
   docManager: IDocumentManager,
   translator: ITranslator,
+  labShell: ILabShell | null,
   state: IStateDB | null,
   router: IRouter | null,
   tree: JupyterFrontEnd.ITreeResolver | null
@@ -265,27 +265,29 @@ async function activateFactory(
     const widget = new FileBrowser({ id, model, restore, translator });
 
     // Add a launcher toolbar item.
-    const launcher = new ToolbarButton({
-      icon: addIcon,
-      onClick: () => {
-        if (
-          labShell.mode === 'multiple-document' &&
-          commands.hasCommand('launcher:create')
-        ) {
-          return Private.createLauncher(commands, widget);
-        } else {
-          const newUrl = PageConfig.getUrl({
-            mode: labShell.mode,
-            workspace: PageConfig.defaultWorkspace,
-            treePath: model.path
-          });
-          window.open(newUrl, '_blank');
-        }
-      },
-      tooltip: trans.__('New Launcher'),
-      actualOnClick: true
-    });
-    widget.toolbar.insertItem(0, 'launch', launcher);
+    if (labShell) {
+      const launcher = new ToolbarButton({
+        icon: addIcon,
+        onClick: () => {
+          if (
+            labShell.mode === 'multiple-document' &&
+            commands.hasCommand('launcher:create')
+          ) {
+            return Private.createLauncher(commands, widget);
+          } else {
+            const newUrl = PageConfig.getUrl({
+              mode: labShell.mode,
+              workspace: PageConfig.defaultWorkspace,
+              treePath: model.path
+            });
+            window.open(newUrl, '_blank');
+          }
+        },
+        tooltip: trans.__('New Launcher'),
+        actualOnClick: true
+      });
+      widget.toolbar.insertItem(0, 'launch', launcher);
+    }
 
     // Track the newly created file browser.
     void tracker.add(widget);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This makes it easier for other lab-based application to reuse the `@jupyterlab/filebrowser-extension:factory` plugin directly.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Make a dependency `optional`instead of `require`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
