### PR TITLE
Make ITreePathUpdater optional in file browser plugin

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -144,10 +144,9 @@ const browser: JupyterFrontEndPlugin<void> = {
     ILabShell,
     ILayoutRestorer,
     ISettingRegistry,
-    ITreePathUpdater,
     ITranslator
   ],
-  optional: [ICommandPalette, IMainMenu],
+  optional: [ITreePathUpdater, ICommandPalette, IMainMenu],
   autoStart: true
 };
 
@@ -315,8 +314,8 @@ function activateBrowser(
   labShell: ILabShell,
   restorer: ILayoutRestorer,
   settingRegistry: ISettingRegistry,
-  treePathUpdater: ITreePathUpdater,
   translator: ITranslator,
+  treePathUpdater: ITreePathUpdater | null,
   commandPalette: ICommandPalette | null,
   mainMenu: IMainMenu | null
 ): void {
@@ -427,9 +426,11 @@ function activateBrowser(
       }
     });
 
-    browser.model.pathChanged.connect((sender, args) => {
-      treePathUpdater(args.newValue);
-    });
+    if (treePathUpdater) {
+      browser.model.pathChanged.connect((sender, args) => {
+        treePathUpdater(args.newValue);
+      });
+    }
 
     maybeCreate();
   });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/9439, but for `ITreePathUpdater` in the `@jupyterlab/filebrowser-extension:browser` plugin.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Make `ITreePathUpdater` optional instead of required.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
