### PR TITLE
Set the Tabs menu title by default

### DIFF
--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -151,9 +151,13 @@ const plugin: JupyterFrontEndPlugin<IMainMenu> = {
     createViewMenu(app, menu.viewMenu, trans);
     createHelpMenu(app, menu.helpMenu, trans);
 
+    // Set the Tabs Title so it's visible also in other shells
+    const tabsMenu = menu.tabsMenu;
+    tabsMenu.menu.title.label = trans.__('Tabs');
+
     // The tabs menu relies on lab shell functionality.
     if (labShell) {
-      createTabsMenu(app, menu.tabsMenu, labShell, trans);
+      createTabsMenu(app, tabsMenu, labShell, trans);
     }
 
     // Create commands to open the main application menus.
@@ -808,7 +812,6 @@ export function createTabsMenu(
   trans: TranslationBundle
 ): void {
   const commands = app.commands;
-  menu.menu.title.label = trans.__('Tabs');
 
   // Add commands for cycling the active tabs.
   menu.addGroup(


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Set the Tabs menu title even if not in a `ILabShell`. This lets other lab-based applications reuse `IMainMenu` as-is, including the "Tabs" entry.

Otherwise in applications that use a different shell but still want to add entries to the "Tabs" menu, the title will be empty:

![image](https://user-images.githubusercontent.com/591645/101633632-d238b780-3a27-11eb-9218-d9b034c67fdd.png)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for JupyterLab users.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
