### PR TITLE
Support for lowercase search queries in the file browser

### DIFF
--- a/packages/filebrowser/src/search.tsx
+++ b/packages/filebrowser/src/search.tsx
@@ -36,19 +36,12 @@ interface IScore {
    * The indices of the text matches.
    */
   indices: number[] | null;
-
-  /**
-   * The command item associated with the match.
-   */
-  item: Contents.IModel;
 }
 
 /**
  * Perform a fuzzy search on a single item.
  */
-function fuzzySearch(item: Contents.IModel, query: string): IScore | null {
-  let source = `${item.name}`;
-
+function fuzzySearch(source: string, query: string): IScore | null {
   // Set up the match score and indices array.
   let score = Infinity;
   let indices: number[] | null = null;
@@ -91,8 +84,7 @@ function fuzzySearch(item: Contents.IModel, query: string): IScore | null {
   // Handle a split match.
   return {
     score,
-    indices,
-    item
+    indices
   };
 }
 
@@ -116,7 +108,9 @@ const FilterBox = (props: IFilterBoxProps) => {
     props.listing.model.setFilter((item: Contents.IModel) => {
       if (props.useFuzzyFilter) {
         // Run the fuzzy search for the item and query.
-        let score = fuzzySearch(item, target.value);
+        const name = item.name.toLowerCase();
+        const query = target.value.toLowerCase();
+        let score = fuzzySearch(name, query);
         // Ignore the item if it is not a match.
         if (!score) {
           item.indices = [];


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is a proposal to expand the file browser search functionality to also match items on lowercase queries.

As a follow-up to https://github.com/jupyterlab/jupyterlab/pull/8615 that added this feature.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Lowercase the item and search query before applying the fuzzy search filter.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

### Before

![fuzzy-filebrowser-search-lowercase-default](https://user-images.githubusercontent.com/591645/101653177-59ddf080-3a3f-11eb-9b8f-7c3a7db2e207.gif)


### After

![fuzzy-filebrowser-search-lowercase](https://user-images.githubusercontent.com/591645/101653185-5c404a80-3a3f-11eb-8425-303fd5104c83.gif)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
