### PR TITLE
Pin to tornado>=6.1 on Binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,5 +8,6 @@ dependencies:
   - numpy
   - pip
   - python=3.8
+  - tornado>=6.1
   - vega_datasets
   - xeus-python


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes the Binder dev setup.

The environment seems to be using 6.0.4 by default:

![image](https://user-images.githubusercontent.com/591645/101762814-2f8f4000-3ade-11eb-82ae-2647fa7bc8e2.png)

Which then leads to the following error when doing the `pip install -e .`:

![image](https://user-images.githubusercontent.com/591645/101762902-4fbeff00-3ade-11eb-8383-e15b226adb19.png)

Which is related to the following change in jupyter server: https://github.com/jupyter-server/jupyter_server/pull/355

![image](https://user-images.githubusercontent.com/591645/101762920-55b4e000-3ade-11eb-8221-5268783e6f7e.png)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

None

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
