### PR TITLE
webpack builder: set bail to false

### DIFF
--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -75,7 +75,7 @@ try {
 const watch = process.argv.includes('--watch');
 
 module.exports = {
-  bail:  !watch,
+  bail: !watch,
   module: { rules },
   resolve: {
     alias: phosphorAlias,

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -73,7 +73,7 @@ try {
 }
 
 module.exports = {
-  bail: true,
+  bail: false,
   module: { rules },
   resolve: {
     alias: phosphorAlias,

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -72,8 +72,10 @@ try {
   // no Phosphor shims required
 }
 
+const watch = process.argv.includes('--watch');
+
 module.exports = {
-  bail: false,
+  bail:  !watch,
   module: { rules },
   resolve: {
     alias: phosphorAlias,


### PR DESCRIPTION
## References

Fixes: https://github.com/jupyterlab/jupyterlab/issues/9435

## Code changes

Set `bail` to `false` in the `webpack.config` of the `builder` package.

## User-facing changes

None

## Backwards-incompatible changes

None