### PR TITLE
Require tornado>=6.1.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,6 +8,5 @@ dependencies:
   - numpy
   - pip
   - python=3.8
-  - tornado>=6.1
   - vega_datasets
   - xeus-python

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup_args = dict(
 setup_args['install_requires'] = [
     'ipython',
     'packaging',
-    'tornado!=6.0.0, !=6.0.1, !=6.0.2',
+    'tornado>=6.1.0',
     'jupyter_core',
     'jupyterlab_server~=2.0.0rc5',
     'jupyter_server~=1.0.1',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/9449

Requiring `tornado>=6.1.0` in JupyterLab might be a more resilient fix, since the issue brought in #9449 seems to be happening in a couple of places. For example with repo2docker / Binder, which include tornado 6.0.4:

https://github.com/jupyterhub/repo2docker/blob/560b1d96a0e39cb8de53cb41a7c2d8d23384eb82/repo2docker/buildpacks/conda/environment.py-3.8.frozen.yml#L104

And then installing `jupyterlab` with pip.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
