### PR TITLE
Use styleModule in prebuilt extensions

### DIFF
--- a/builder/src/build.ts
+++ b/builder/src/build.ts
@@ -148,9 +148,9 @@ export namespace Build {
       if (!data.jupyterlab.themePath) {
         // We prefer the styleModule key if it exists, falling back to
         // the normal style key.
-        if (data.styleModule) {
+        if (typeof data.styleModule === 'string') {
           cssImports.push(`${name}/${data.styleModule}`);
-        } else if (data.style) {
+        } else if (typeof data.style === 'string') {
           cssImports.push(`${name}/${data.style}`);
         }
       }

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -64,16 +64,10 @@ function generateConfig({
     );
   }
 
-  if (data.style) {
-    let style = path.join(packagePath, data.style);
-    if (path.extname(style) === '.css') {
-      // See if there is a corresponding js file we can load instead
-      const jsFile = `${style.slice(0, style.length - 4)}.js`;
-      if (fs.existsSync(jsFile)) {
-        style = jsFile;
-      }
-    }
-    exposes['./style'] = style;
+  if (typeof data.styleModule === 'string') {
+    exposes['./style'] = path.join(packagePath, data.styleModule);
+  } else if (typeof data.style === 'string') {
+    exposes['./style'] = path.join(packagePath, data.style);
   }
 
   const coreData = require(path.join(corePath, 'package.json'));

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -49,19 +49,18 @@ function generateConfig({
     './index': index
   };
 
-  if (data.jupyterlab.extension === true) {
+  const extension = data.jupyterlab.extension;
+  if (extension === true) {
     exposes['./extension'] = index;
-  } else if (typeof data.jupyterlab.extension === 'string') {
-    exposes['./extension'] = path.join(packagePath, data.jupyterlab.extension);
+  } else if (typeof extension === 'string') {
+    exposes['./extension'] = path.join(packagePath, extension);
   }
 
-  if (data.jupyterlab.mimeExtension === true) {
+  const mimeExtension = data.jupyterlab.mimeExtension;
+  if (mimeExtension === true) {
     exposes['./mimeExtension'] = index;
-  } else if (typeof data.jupyterlab.mimeExtension === 'string') {
-    exposes['./mimeExtension'] = path.join(
-      packagePath,
-      data.jupyterlab.mimeExtension
-    );
+  } else if (typeof mimeExtension === 'string') {
+    exposes['./mimeExtension'] = path.join(packagePath, mimeExtension);
   }
 
   if (typeof data.styleModule === 'string') {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9459

Follow up on #9427

## Code changes

In #9427, we introduced a new styleModule key instead of guessing about there being a js file corresponding to a style file. That change did not propagate to prebuilt extensions. This commit fixes prebuilt extensions to use styleModule if available.

Still draft while I modify one of the examples to use styleModule and at least manually check that it is working.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
