### PR TITLE
Disable Shut Down All button if there is no running kernel or terminal

### DIFF
--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -1,11 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Token } from '@lumino/coreutils';
-import { DisposableDelegate, IDisposable } from '@lumino/disposable';
-import { ISignal } from '@lumino/signaling';
-import * as React from 'react';
-
 import {
   Dialog,
   ReactWidget,
@@ -13,8 +8,18 @@ import {
   ToolbarButtonComponent,
   UseSignal
 } from '@jupyterlab/apputils';
+
 import { nullTranslator, ITranslator } from '@jupyterlab/translation';
+
 import { closeIcon, LabIcon, refreshIcon } from '@jupyterlab/ui-components';
+
+import { Token } from '@lumino/coreutils';
+
+import { DisposableDelegate, IDisposable } from '@lumino/disposable';
+
+import { ISignal } from '@lumino/signaling';
+
+import * as React from 'react';
 
 /**
  * The class name added to a running widget.
@@ -241,12 +246,22 @@ function Section(props: {
       <>
         <header className={SECTION_HEADER_CLASS}>
           <h2>{props.manager.name}</h2>
-          <button
-            className={`${SHUTDOWN_ALL_BUTTON_CLASS} jp-mod-styled`}
-            onClick={onShutdown}
-          >
-            {shutdownAllLabel}
-          </button>
+          <UseSignal signal={props.manager.runningChanged}>
+            {() => {
+              const disabled = props.manager.running().length === 0;
+              return (
+                <button
+                  className={`${SHUTDOWN_ALL_BUTTON_CLASS} jp-mod-styled ${
+                    disabled && 'jp-mod-disabled'
+                  }`}
+                  disabled={disabled}
+                  onClick={onShutdown}
+                >
+                  {shutdownAllLabel}
+                </button>
+              );
+            }}
+          </UseSignal>
         </header>
 
         <div className={CONTAINER_CLASS}>

--- a/packages/running/style/base.css
+++ b/packages/running/style/base.css
@@ -147,3 +147,11 @@
   box-shadow: none;
   background-color: var(--jp-layout-color2);
 }
+
+.jp-RunningSessions-shutdownAll.jp-mod-styled.jp-mod-disabled {
+  color: var(--jp-ui-font-color2);
+}
+
+.jp-RunningSessions-shutdownAll.jp-mod-styled.jp-mod-disabled:hover {
+  background: none;
+}


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jtpio/jupyterlab-classic/issues/48

This is a small UI tweak to not prompt the user with the shut down dialog if there is no running kernel or terminal.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Check the list of running sessions to decide whether to disable the button or not.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

### Before

![running-disable-before](https://user-images.githubusercontent.com/591645/102138962-7625c700-3e5d-11eb-9d04-5cf9716d1822.gif)

### After

![running-disable-after](https://user-images.githubusercontent.com/591645/102138869-54c4db00-3e5d-11eb-9365-e7ece578967e.gif)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
