### PR TITLE
Handle hyphens and switch to importlib in the develop script

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function
 
+import importlib
 import json
 import os
 import os.path as osp
@@ -28,8 +29,6 @@ from ipython_genutils.py3compat import string_types, cast_unicode_py2
 from ipython_genutils.tempdir import TemporaryDirectory
 from jupyter_server.config_manager import BaseJSONConfigManager
 from jupyterlab_server.config import get_federated_extensions
-
-from traitlets.utils.importstring import import_item
 
 from .commands import build, AppOptions, _test_overlap
 
@@ -361,7 +360,7 @@ def _get_labextension_metadata(module):
         magic-named `_jupyter_labextension_paths` function
     """
     try:
-        m = import_item(module)
+        m = importlib.import_module(module)
     except Exception:
         m = None
 
@@ -376,6 +375,9 @@ def _get_labextension_metadata(module):
                 from setuptools import find_packages
                 package = find_packages(mod_path)[0]
 
+            # Replace hyphens with underscores to match Python convention
+            package = package.replace('-', '_')
+
             # Make sure the package is installed
             import pkg_resources
             try:
@@ -384,7 +386,7 @@ def _get_labextension_metadata(module):
                 subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-e', mod_path])
                 sys.path.insert(0, mod_path)
 
-            m = import_item(package)
+            m = importlib.import_module(package)
 
     if not hasattr(m, '_jupyter_labextension_paths'):
         raise KeyError('The Python module {} is not a valid labextension, '

--- a/jupyterlab/tests/mock_packages/extension/setup.py
+++ b/jupyterlab/tests/mock_packages/extension/setup.py
@@ -1,7 +1,7 @@
 import json
 import os.path as osp
 
-name = 'mock_package'
+name = 'mock-package'
 HERE = osp.abspath(osp.dirname(__file__))
 
 with open(osp.join(HERE, 'package.json')) as fid:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#9421 

This should address the common case of `_` and `-` in Python package names and distribution names when using the `jupyter labextension develop` command.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
