### PR TITLE
Update server(s), nbclassic, pytest fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,9 +7,9 @@ import pytest
 
 
 pytest_plugins = [
-    'pytest_jupyter_server',
-    'pytest_jupyterlab',
-    'pytest_jupyterlab_server',
+    "jupyter_server.pytest_plugin",
+    "jupyterlab_server.pytest_plugin",
+    "jupyterlab.pytest_plugin"
 ]
 
 

--- a/jupyterlab/pytest_plugin.py
+++ b/jupyterlab/pytest_plugin.py
@@ -25,7 +25,7 @@ schemas_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, 'schemas'))
 workspaces_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, 'workspaces'))
 
 @pytest.fixture
-def make_lab_app(root_dir, template_dir, app_settings_dir, user_settings_dir, schemas_dir, workspaces_dir):
+def make_lab_app(jp_root_dir, jp_template_dir, app_settings_dir, user_settings_dir, schemas_dir, workspaces_dir):
     def _make_lab_app(**kwargs):
         class TestLabApp(LabApp):
             base_url = '/lab'
@@ -34,8 +34,8 @@ def make_lab_app(root_dir, template_dir, app_settings_dir, user_settings_dir, sc
                                 help='The default URL to redirect to from `/`')
             lab_config = LabConfig(
                 app_name = 'JupyterLab Test App',
-                static_dir = str(root_dir),
-                templates_dir = str(template_dir),
+                static_dir = str(jp_root_dir),
+                templates_dir = str(jp_template_dir),
                 app_url = '/lab',
                 app_settings_dir = str(app_settings_dir),
                 user_settings_dir = str(user_settings_dir),
@@ -46,7 +46,7 @@ def make_lab_app(root_dir, template_dir, app_settings_dir, user_settings_dir, sc
         return app
 
     # Create the index files.
-    index = template_dir.joinpath('index.html')
+    index = jp_template_dir.joinpath('index.html')
     index.write_text("""
 <!DOCTYPE html>
 <html>
@@ -56,10 +56,10 @@ def make_lab_app(root_dir, template_dir, app_settings_dir, user_settings_dir, sc
 <body>
     {# Copy so we do not modify the page_config with updates. #}
     {% set page_config_full = page_config.copy() %}
-    
+
     {# Set a dummy variable - we just want the side effect of the update. #}
     {% set _ = page_config_full.update(baseUrl=base_url, wsUrl=ws_url) %}
-    
+
       <script id="jupyter-config-data" type="application/json">
         {{ page_config_full | tojson }}
       </script>
@@ -83,23 +83,24 @@ def make_lab_app(root_dir, template_dir, app_settings_dir, user_settings_dir, sc
 
 
 @pytest.fixture
-def labapp(serverapp, make_lab_app):
+def labapp(jp_serverapp, make_lab_app):
     app = make_lab_app()
-    app._link_jupyter_server_extension(serverapp)
+    app._link_jupyter_server_extension(jp_serverapp)
     app.initialize()
     return app
 
 
 @pytest.fixture
-def fetch_long(http_server_client, auth_header, base_url):
+def fetch_long(http_server_client, jp_auth_header, jp_base_url):
     """fetch fixture that handles auth, base_url, and path"""
     def client_fetch(*parts, headers={}, params={}, **kwargs):
         # Handle URL strings
-        path_url = url_escape(url_path_join(base_url, *parts), plus=False)
+        path_url = url_escape(url_path_join(*parts), plus=False)
+        path_url = url_path_join(jp_base_url, path_url)
         params_url = urllib.parse.urlencode(params)
         url = path_url + "?" + params_url
         # Add auth keys to header
-        headers.update(auth_header)
+        headers.update(jp_auth_header)
         # Make request.
         return http_server_client.fetch(
             url, headers=headers, request_timeout=150, **kwargs

--- a/jupyterlab/tests/test_build_api.py
+++ b/jupyterlab/tests/test_build_api.py
@@ -12,7 +12,7 @@ from jupyterlab_server.tests.utils import expected_http_error
 
 
 @pytest.fixture
-def build_api_tester(serverapp, labapp, fetch_long):
+def build_api_tester(jp_serverapp, labapp, fetch_long):
     return BuildAPITester(labapp, fetch_long)
 
 

--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -778,10 +778,10 @@ class TestExtension(AppHandlerTest):
         assert sorted(updated) == [self.pkg_names['extension'], self.pkg_names['mimeextension']]
 
 
-def test_load_extension(serverapp, make_lab_app):
+def test_load_extension(jp_serverapp, make_lab_app):
     app = make_lab_app()
     stderr = sys.stderr
 #    sys.stderr = self.devnull
-    app._link_jupyter_server_extension(serverapp)
+    app._link_jupyter_server_extension(jp_serverapp)
     app.initialize()
     sys.stderr = stderr

--- a/setup.py
+++ b/setup.py
@@ -146,9 +146,9 @@ setup_args['install_requires'] = [
     'packaging',
     'tornado>=6.1.0',
     'jupyter_core',
-    'jupyterlab_server~=2.0.0rc5',
-    'jupyter_server~=1.0.1',
-    'nbclassic~=0.2.0',
+    'jupyterlab_server~=2.0.0rc9',
+    'jupyter_server~=1.1',
+    'nbclassic~=0.2',
     'jinja2>=2.10'
 ]
 
@@ -157,9 +157,9 @@ setup_args['extras_require'] = {
     'test': [
         'pytest>=6.0',
         'pytest-cov',
-        'pytest-tornasync',
         'pytest-console-scripts',
         'pytest-check-links',
+        'jupyterlab_server[test]~=2.0.0rc9',
         'requests',
         'wheel',
         'virtualenv'
@@ -187,10 +187,7 @@ setup_args['entry_points'] = {
         'jupyter-labextension = jupyterlab.labextensions:main',
         'jupyter-labhub = jupyterlab.labhubapp:main',
         'jlpm = jupyterlab.jlpmapp:main',
-    ],
-    'pytest11': [
-        'pytest_jupyterlab = jupyterlab.pytest_plugin'
-    ],
+    ]
 }
 
 


### PR DESCRIPTION
Updates `jupyter_server`, `jupyterlab_server`, and `nbclassic` dependencies.

Fixes https://github.com/jupyterlab/jupyterlab/issues/9473