### PR TITLE
Add isToggleable to toggleable commands

### DIFF
--- a/docs/source/developer/extension_points.rst
+++ b/docs/source/developer/extension_points.rst
@@ -44,6 +44,7 @@ Here is a sample block of code that adds a command to the application (given by 
       label: 'My Cool Command',
       isEnabled: true,
       isVisible: true,
+      isToggleable: true,
       isToggled: () => toggled,
       iconClass: 'some-css-icon-class',
       execute: () => {
@@ -54,6 +55,7 @@ Here is a sample block of code that adds a command to the application (given by 
 This example adds a new command, which, when triggered, calls the ``execute`` function.
 ``isEnabled`` indicates whether the command is enabled, and determines whether renderings of it are greyed out.
 ``isToggled`` indicates whether to render a check mark next to the command.
+``isToggleable`` indicates whether a command can be toggled for screenreaders.
 ``isVisible`` indicates whether to render the command at all.
 ``iconClass`` specifies a CSS class which can be used to display an icon next to renderings of the command.
 

--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -769,6 +769,7 @@ function addCommands(
         }
       }
     },
+    isToggleable: true,
     isToggled: () => !shell.leftCollapsed,
     isVisible: () => !shell.isEmpty('left')
   });
@@ -785,6 +786,7 @@ function addCommands(
         }
       }
     },
+    isToggleable: true,
     isToggled: () => !shell.rightCollapsed,
     isVisible: () => !shell.isEmpty('right')
   });
@@ -794,6 +796,7 @@ function addCommands(
     execute: () => {
       shell.presentationMode = !shell.presentationMode;
     },
+    isToggleable: true,
     isToggled: () => shell.presentationMode,
     isVisible: () => true
   });
@@ -815,6 +818,7 @@ function addCommands(
 
   app.commands.addCommand(CommandIDs.toggleMode, {
     label: trans.__('Single-Document Mode'),
+    isToggleable: true,
     isToggled: () => shell.mode === 'single-document',
     execute: () => {
       const args =

--- a/packages/apputils-extension/src/themesplugins.ts
+++ b/packages/apputils-extension/src/themesplugins.ts
@@ -96,6 +96,7 @@ export const themesPlugin: JupyterFrontEndPlugin<IThemeManager> = {
           ? trans.__('Use Theme: %1', displayName)
           : displayName;
       },
+      isToggleable: true,
       isToggled: args => args['theme'] === currentTheme,
       execute: args => {
         const theme = args['theme'] as string;
@@ -108,6 +109,7 @@ export const themesPlugin: JupyterFrontEndPlugin<IThemeManager> = {
 
     commands.addCommand(CommandIDs.themeScrollbars, {
       label: trans.__('Theme Scrollbars'),
+      isToggleable: true,
       isToggled: () => manager.isToggledThemeScrollbars(),
       execute: () => manager.toggleThemeScrollbars()
     });
@@ -116,6 +118,7 @@ export const themesPlugin: JupyterFrontEndPlugin<IThemeManager> = {
       label: args =>
         args['enabled'] ? `${args['font']}` : trans.__('waiting for fonts'),
       isEnabled: args => args['enabled'] as boolean,
+      isToggleable: true,
       isToggled: args => manager.getCSS(args['key'] as string) === args['font'],
       execute: args =>
         manager.setCSSOverride(args['key'] as string, args['font'] as string)

--- a/packages/apputils/test/toolbar.spec.ts
+++ b/packages/apputils/test/toolbar.spec.ts
@@ -154,6 +154,7 @@ describe('@jupyterlab/apputils', () => {
         iconClass: 'test-icon-class',
         className: 'test-log-class',
         isEnabled: () => enabled,
+        isToggleable: true,
         isToggled: () => toggled,
         isVisible: () => visible
       });

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -318,6 +318,7 @@ function activateEditorCommands(
         console.error(`Failed to set ${id}:${key} - ${reason.message}`);
       });
     },
+    isToggleable: true,
     isToggled: args => args['theme'] === theme
   });
 
@@ -335,6 +336,7 @@ function activateEditorCommands(
         console.error(`Failed to set ${id}:${key} - ${reason.message}`);
       });
     },
+    isToggleable: true,
     isToggled: args => args['keyMap'] === keyMap
   });
 
@@ -377,6 +379,7 @@ function activateEditorCommands(
       }
     },
     isEnabled,
+    isToggleable: true,
     isToggled: args => {
       const widget = tracker.currentWidget;
       if (!widget) {

--- a/packages/console-extension/src/foreign.ts
+++ b/packages/console-extension/src/foreign.ts
@@ -93,6 +93,7 @@ function activateForeign(
         handler.enabled = !handler.enabled;
       }
     },
+    isToggleable: true,
     isToggled: () =>
       tracker.currentWidget !== null &&
       !!Private.foreignHandlerProperty.get(tracker.currentWidget.console)

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -669,6 +669,7 @@ async function activateConsole(
         console.error(`Failed to set ${pluginId}:${key} - ${reason.message}`);
       }
     },
+    isToggleable: true,
     isToggled: args => args['interactionMode'] === interactionMode
   });
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -687,6 +687,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.toggleAutosave, {
     label: trans.__('Autosave Documents'),
+    isToggleable: true,
     isToggled: () => docManager.autosave,
     execute: () => {
       const value = !docManager.autosave;

--- a/packages/extensionmanager-extension/src/index.ts
+++ b/packages/extensionmanager-extension/src/index.ts
@@ -96,6 +96,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
           void registry.set(plugin.id, 'enabled', !enabled);
         }
       },
+      isToggleable: true,
       isToggled: () => enabled,
       isEnabled: () => serviceManager.builder.isAvailable
     });

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -879,6 +879,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.toggleNavigateToCurrentDirectory, {
     label: trans.__('Show Active File in File Browser'),
+    isToggleable: true,
     isToggled: () => browser.navigateToCurrentDirectory,
     execute: () => {
       const value = !browser.navigateToCurrentDirectory;

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -289,6 +289,7 @@ export namespace Commands {
           });
       },
       isEnabled,
+      isToggleable: true,
       isToggled: () => config.lineNumbers,
       label: trans.__('Line Numbers')
     });
@@ -316,6 +317,7 @@ export namespace Commands {
           });
       },
       isEnabled,
+      isToggleable: true,
       isToggled: args => {
         const lineWrap = (args['mode'] as wrappingMode) || 'off';
         return config.lineWrap === lineWrap;
@@ -344,6 +346,7 @@ export namespace Commands {
             console.error(`Failed to set ${id}: ${reason.message}`);
           });
       },
+      isToggleable: true,
       isToggled: args => {
         const insertSpaces = !!args['insertSpaces'];
         const size = (args['size'] as number) || 4;
@@ -373,6 +376,7 @@ export namespace Commands {
       },
       label: trans.__('Match Brackets'),
       isEnabled,
+      isToggleable: true,
       isToggled: () => config.matchBrackets
     });
   }
@@ -396,6 +400,7 @@ export namespace Commands {
           });
       },
       label: trans.__('Auto Close Brackets for Text Editor'),
+      isToggleable: true,
       isToggled: () => config.autoClosingBrackets
     });
   }

--- a/packages/htmlviewer-extension/src/index.tsx
+++ b/packages/htmlviewer-extension/src/index.tsx
@@ -110,6 +110,7 @@ function activateHTMLViewer(
   app.commands.addCommand(CommandIDs.trustHTML, {
     label: trans.__('Trust HTML File'),
     isEnabled: () => !!tracker.currentWidget,
+    isToggleable: true,
     isToggled: () => {
       const current = tracker.currentWidget;
       if (!current) {

--- a/packages/logconsole-extension/src/index.tsx
+++ b/packages/logconsole-extension/src/index.tsx
@@ -214,6 +214,7 @@ function activateLogConsole(
         createLogConsoleWidget(options);
       }
     },
+    isToggleable: true,
     isToggled: () => {
       return logConsoleWidget !== null;
     }

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -636,6 +636,7 @@ export function createViewMenu(
       menu.editorViewers,
       'toggleLineNumbers'
     ),
+    isToggleable: true,
     isToggled: Private.delegateToggled(
       app,
       menu.editorViewers,
@@ -655,6 +656,7 @@ export function createViewMenu(
       menu.editorViewers,
       'toggleMatchBrackets'
     ),
+    isToggleable: true,
     isToggled: Private.delegateToggled(
       app,
       menu.editorViewers,
@@ -674,6 +676,7 @@ export function createViewMenu(
       menu.editorViewers,
       'toggleWordWrap'
     ),
+    isToggleable: true,
     isToggled: Private.delegateToggled(
       app,
       menu.editorViewers,
@@ -837,6 +840,7 @@ export function createTabsMenu(
       const widget = find(app.shell.widgets('main'), w => w.id === id);
       return (widget && widget.title.label) || '';
     },
+    isToggleable: true,
     isToggled: args => {
       const id = args['id'] || '';
       return !!app.shell.currentWidget && app.shell.currentWidget.id === id;

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -97,6 +97,7 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
           );
         }
       },
+      isToggleable: true,
       isToggled: () => statusBar.isVisible
     });
 

--- a/packages/terminal-extension/src/index.ts
+++ b/packages/terminal-extension/src/index.ts
@@ -440,6 +440,7 @@ export function addCommands(
         : displayName;
     },
     caption: trans.__('Set the terminal theme'),
+    isToggleable: true,
     isToggled: args => {
       const { theme } = options;
       return args['theme'] === theme;

--- a/packages/translation-extension/src/index.ts
+++ b/packages/translation-extension/src/index.ts
@@ -131,6 +131,7 @@ const langMenu: JupyterFrontEndPlugin<void> = {
                 caption: label,
                 isEnabled: () => !toggled,
                 isVisible: () => true,
+                isToggleable: true,
                 isToggled: () => toggled,
                 execute: () => {
                   return showDialog({


### PR DESCRIPTION
Fixes #9365. Adds the `isToggleable` flag to all toggleable commands to enable screenreaders recognizing toggleable commands. 