### PR TITLE
Better handling of extensions that provide both prebuilt and source extensions.

### DIFF
--- a/jupyterlab/handlers/build_handler.py
+++ b/jupyterlab/handlers/build_handler.py
@@ -29,6 +29,7 @@ class Builder(object):
         self.core_mode = core_mode
         self.app_dir = app_options.app_dir
         self.core_config = app_options.core_config
+        self.labextensions_path = app_options.labextensions_path
 
     @gen.coroutine
     def get_status(self):
@@ -39,7 +40,7 @@ class Builder(object):
 
         try:
             messages = yield self._run_build_check(
-                self.app_dir, self.log, self.core_config)
+                self.app_dir, self.log, self.core_config, self.labextensions_path)
             status = 'needed' if messages else 'stable'
             if messages:
                 self.log.warn('Build recommended')
@@ -66,7 +67,7 @@ class Builder(object):
             self._kill_event = evt = Event()
             try:
                 yield self._run_build(
-                    self.app_dir, self.log, evt, self.core_config)
+                    self.app_dir, self.log, evt, self.core_config, self.labextensions_path)
                 future.set_result(True)
             except Exception as e:
                 if str(e) == 'Aborted':
@@ -90,15 +91,15 @@ class Builder(object):
         self.canceled = True
 
     @run_on_executor
-    def _run_build_check(self, app_dir, logger, core_config):
+    def _run_build_check(self, app_dir, logger, core_config, labextensions_path):
         return build_check(app_options=AppOptions(
-            app_dir=app_dir, logger=logger, core_config=core_config))
+            app_dir=app_dir, logger=logger, core_config=core_config, labextensions_path=labextensions_path))
 
     @run_on_executor
-    def _run_build(self, app_dir, logger, kill_event, core_config):
+    def _run_build(self, app_dir, logger, kill_event, core_config, labextensions_path):
         app_options = AppOptions(
             app_dir=app_dir, logger=logger, kill_event=kill_event,
-            core_config=core_config)
+            core_config=core_config, labextensions_path=abextensions_path)
         try:
             return build(app_options=app_options)
         except Exception as e:

--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -113,6 +113,8 @@ class ExtensionManager(object):
             ))
 
         for name, data in info['extensions'].items():
+            if name in info['shadowed_exts']:
+                continue
             status = 'ok'
             pkg_info = yield self._get_pkg_info(name, data)
             if info['compat_errors'].get(name, None):


### PR DESCRIPTION
## References
Fixes #9277 

## Code changes
- Adds handling of prebuilt extensions in the build api handler check to prevent showing a build notice for a shadowed source extension.
- Ignores shadowed source extensions in the extension manager api handler to prevent showing shadowed source extensions.

## User-facing changes
Better handling of extensions that provide both prebuilt and source extensions.

## Backwards-incompatible changes
N/A