### PR TITLE
Fix handling of disabledExtension strings

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -730,10 +730,16 @@ class _AppHandler(object):
             logger.info('\nUninstalled core extensions:')
             [logger.info('    %s' % item) for item in sorted(uninstalled_core)]
 
-        disabled = info['disabled']
+        all_exts = list(info['federated_extensions']) + list(info['extensions']) + list(info['core_extensions'])
+        # Ignore disabled extensions that are not installed
+        disabled = [i for i in info['disabled'] if i.partition(':')[0] in all_exts]
         if disabled:
             logger.info('\nDisabled extensions:')
-            [logger.info('    %s' % item) for item in sorted(disabled)]
+            for item in sorted(disabled):
+                # Show that all plugins will be disabled if the whole extension matches
+                if item in all_exts:
+                    item += ' (all plugins)'
+                logger.info('    %s' % item)
 
         # Here check if modules are improperly shadowed
         improper_shadowed = []

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -276,13 +276,11 @@ export namespace PageConfig {
      * #### Notes
      * This is intended for `deferredExtensions` and `disabledExtensions`.
      */
-    function populate(key: string): { raw: string; rule: RegExp }[] {
+    function populate(key: string): string[] {
       try {
         const raw = getOption(key);
         if (raw) {
-          return JSON.parse(raw).map((pattern: string) => {
-            return { raw: pattern, rule: new RegExp(pattern) };
-          });
+          return JSON.parse(raw);
         }
       } catch (error) {
         console.warn(`Unable to parse ${key}.`, error);
@@ -306,7 +304,14 @@ export namespace PageConfig {
      * @param id - The plugin ID.
      */
     export function isDeferred(id: string): boolean {
-      return deferred.some(val => val.raw === id || val.rule.test(id));
+      // Check for either a full plugin id match or an extension
+      // name match.
+      const separatorIndex = id.indexOf(':');
+      let extName = '';
+      if (separatorIndex !== -1) {
+        extName = id.slice(0, separatorIndex);
+      }
+      return deferred.some(val => val === id || (extName && val === extName));
     }
 
     /**
@@ -315,7 +320,14 @@ export namespace PageConfig {
      * @param id - The plugin ID.
      */
     export function isDisabled(id: string): boolean {
-      return disabled.some(val => val.raw === id || val.rule.test(id));
+      // Check for either a full plugin id match or an extension
+      // name match.
+      const separatorIndex = id.indexOf(':');
+      let extName = '';
+      if (separatorIndex !== -1) {
+        extName = id.slice(0, separatorIndex);
+      }
+      return disabled.some(val => val === id || (extName && val === extName));
     }
   }
 }


### PR DESCRIPTION
## References
Fixes #9455

## Code changes
- Disabled and deferred extensions no longer support regexes
- Plugins can be disabled or deferred using the full plugin id or the name of the extension

## User-facing changes
Remove chances for collision or confusion in disabled config

## Backwards-incompatible changes
No longer allow regex syntax for disabled and deferred config