### PR TITLE
Allow downloads in iframe "sandbox"

### DIFF
--- a/packages/apputils/src/iframe.ts
+++ b/packages/apputils/src/iframe.ts
@@ -104,6 +104,7 @@ export namespace IFrame {
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox
    */
   export type SandboxExceptions =
+    | 'allow-downloads'
     | 'allow-forms'
     | 'allow-modals'
     | 'allow-orientation-lock'


### PR DESCRIPTION
chrome requires this to be allowed to download items from an iframe. 
I'm using voila and ipywidgets and came across this issue.
See this PR/issue for more information:
https://github.com/voila-dashboards/voila/pull/744#issuecomment-748920213

( I went through the contrib questions and I felt all were answered above)