### PR TITLE
Update default sharing config to be strictVersion: true.

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -162,14 +162,15 @@ const shared = {};
 
 // Make sure any resolutions are shared
 for (let [pkg, requiredVersion] of Object.entries(package_data.resolutions)) {
-  shared[pkg] = { requiredVersion };
+  shared[pkg] = { requiredVersion, strictVersion: true };
 }
 
 // Add any extension packages that are not in resolutions (i.e., installed from npm)
 for (let pkg of extensionPackages) {
   if (!shared[pkg]) {
     shared[pkg] = {
-      requiredVersion: require(`${pkg}/package.json`).version
+      requiredVersion: require(`${pkg}/package.json`).version,
+      strictVersion: true
     };
   }
 }
@@ -186,7 +187,7 @@ for (let pkg of extensionPackages) {
   } = require(`${pkg}/package.json`);
   for (let [dep, requiredVersion] of Object.entries(dependencies)) {
     if (!shared[dep]) {
-      pkgShared[dep] = { requiredVersion };
+      pkgShared[dep] = { requiredVersion, strictVersion: true };
     }
   }
 
@@ -196,6 +197,9 @@ for (let pkg of extensionPackages) {
       delete pkgShared[dep];
     } else {
       if ('bundled' in config) {
+        if (config.bundled === false) {
+          config.import = false;
+        }
         config.import = config.bundled;
         delete config.bundled;
       }


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

See the discussion at https://github.com/jupyterlab/jupyterlab/issues/9496

## Code changes

By default, webpack has strictVersion default to false if singleton is true or if import is false. We want strictVersion to be true always by default.

Setting this as 3.1, as I won't have time to adequately test ramifications of this change before 3.0, and I think it won't be a huge disruptive change anyway.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
