### PR TITLE
Fixes error when applying `jupyterlab.upgrade_extension` on Windows

### DIFF
--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -153,9 +153,9 @@ def update_extension(target, interactive=True):
             os.makedirs(osp.dirname(file_target), exist_ok=True)
             shutil.copy(p, file_target)
         else:
-            with open(p) as fid:
+            with open(p, "rb") as fid:
                 old_data = fid.read()
-            with open(file_target) as fid:
+            with open(file_target, "rb") as fid:
                 new_data = fid.read()
             if old_data == new_data:
                 continue


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9508

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Read file as binary.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

N/A

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

N/A