### PR TITLE
Fixed incorrect link to GitHub milestone

### DIFF
--- a/docs/source/getting_started/changelog.rst
+++ b/docs/source/getting_started/changelog.rst
@@ -7,7 +7,7 @@ v3.0
 ----
 
 See the `JupyterLab
-3.0 <https://github.com/jupyterlab/jupyterlab/milestone/3.0?closed=1>`__
+3.0 <https://github.com/jupyterlab/jupyterlab/milestone/48?closed=1>`__
 milestone on GitHub for the full list of pull requests and issues closed.
 
 


### PR DESCRIPTION
The top link to the GitHub milestone for JupyterLab 3.0 was going to milestone 3 (SciPy2016) rather than milestone 48 (JupyterLab 3.0).

## References
Sorry there's no issue for this, but it does seem like it would be good have a working link to the milestone in the docs!

## Code changes
None -- just docs.

## User-facing changes
Fixes an incorrect link in documentation.

## Backwards-incompatible changes
None