### PR TITLE
Fix usage test

### DIFF
--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -137,8 +137,9 @@ def update_extension(target, interactive=True):
 
     # Update style settings
     data.setdefault('styleModule', 'style/index.js')
-    if 'style/index.js' not in data['sideEffects']:
+    if 'sideEffects' in data and 'style/index.js' not in data['sideEffects']:
         data['sideEffects'].append('style/index.js')
+    if 'files' in data and 'style/index.js' not in data['files']:
         data['files'].append('style/index.js')
 
     # Update the root package.json file


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes the usage test breakage from #9515.

## Code changes

The usage test broke in #9515, probably in part because the mock package is pretty barebones and not reflecting a package that would have generated from the cookiecutter.

There are further questions, noted in https://github.com/jupyterlab/jupyterlab/issues/9514#issuecomment-754292298, about whether we want to encourage people to use styleModule right now, but since the cookie cutter does use it, it makes sense to fix this breakage rather than revert the change.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
