### PR TITLE
Remove visible 1px border for terminal

### DIFF
--- a/packages/terminal/style/base.css
+++ b/packages/terminal/style/base.css
@@ -11,11 +11,3 @@
 .jp-Terminal-body {
   padding: 8px;
 }
-
-[data-jp-theme-light='true'] .xterm .xterm-screen canvas {
-  border: 1px solid white;
-}
-
-[data-jp-theme-light='false'] .xterm .xterm-screen canvas {
-  border: 1px solid black;
-}


### PR DESCRIPTION
As discussed in #9529, the border is unnecessary and can be distracting depending on the combination of colors/background of the theme and terminal. 

As per @jasongrout's suggestion, removing the border rules altogether rather than trying to fiddle with matching its color to the theme/terminal.

Closes #9529.