### PR TITLE
Fix parsing of empty CSV files

### DIFF
--- a/packages/csvviewer/src/model.ts
+++ b/packages/csvviewer/src/model.ts
@@ -457,7 +457,8 @@ export class DSVModel extends DataModel implements IDisposable {
 
     // Copy the new offsets into a new row offset array.
     const oldRowOffsets = this._rowOffsets;
-    this._rowOffsets = new Uint32Array(this._rowCount);
+    // Always store at least one offset, even if data is empty
+    this._rowOffsets = new Uint32Array(this._rowCount || 1);
     this._rowOffsets.set(oldRowOffsets);
     this._rowOffsets.set(offsets, oldRowCount - 1);
 

--- a/packages/csvviewer/test/model.spec.ts
+++ b/packages/csvviewer/test/model.spec.ts
@@ -19,7 +19,7 @@ const CSV_TEST_FILES = [
   ],
 
   [
-    'empty',
+    'empty_values',
     readCSV('csv-spectrum/csvs/empty.csv'),
     require('csv-spectrum/json/empty.json')
   ],
@@ -29,6 +29,8 @@ const CSV_TEST_FILES = [
     readCSV('csv-spectrum/csvs/empty_crlf.csv'),
     require('csv-spectrum/json/empty_crlf.json')
   ],
+
+  ['empty_file', '', []],
 
   [
     'escaped_quotes',

--- a/packages/csvviewer/test/parse.spec.ts
+++ b/packages/csvviewer/test/parse.spec.ts
@@ -436,6 +436,21 @@ describe('csvviewer/parse', () => {
       expect(results.ncols).toEqual(3);
       expect(results.offsets).toEqual([0, 2, 5]);
     });
+
+    it('handles empty file', () => {
+      const data = ``;
+      const options = { data, rowDelimiter: '\n' };
+      let results;
+
+      results = parser({ ...options, columnOffsets: false });
+      expect(results.nrows).toEqual(0);
+      expect(results.offsets).toEqual([]);
+
+      results = parser({ ...options, columnOffsets: true });
+      expect(results.nrows).toEqual(0);
+      expect(results.ncols).toEqual(0);
+      expect(results.offsets).toEqual([]);
+    });
   });
 });
 


### PR DESCRIPTION
## References

Fixes #9531

## Code changes

- Added CSV parser test for empty file (not strictly required, since it was not broken, but may help to prevent regresions)
- Added DSVModel test for empty CSV file (`constructor → parseAsync → _computeRowOffsets` contained the culprit)
- Renamed name of the test case using [empty.csv](https://github.com/maxogden/csv-spectrum/blob/master/csvs/empty.csv) from csv-spectrum to `empty_values` as it was misleading/ambiguous (it was testing empty values, not an empty file)

## User-facing changes

Opening empty CSV files works.

## Backwards-incompatible changes

None