### PR TITLE
By default, keep record timing metadata

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -373,7 +373,7 @@
       "title": "Recording timing",
       "description": "Should timing data be recorded in cell metadata",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "maxNumberOutputs": {
       "title": "The maximum number of output cells to to be rendered in the output area. Set to 0 to have the complete display.",


### PR DESCRIPTION
## References

https://github.com/jupyterlab/jupyterlab/issues/9510

## Code changes

Cell metadata has been very stable for the last year, we should just record it by default. While https://github.com/deshaw/jupyterlab-execute-time is one render for this, it's also just useful to have in the inspector.

## User-facing changes

In the notebook, more metadata will be stored.

## Backwards-incompatible changes

N/A