### PR TITLE
Fix integration with JupyterHub

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -730,6 +730,10 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         self.handlers.extend(handlers)
         super().initialize_handlers()
 
+    def initialize(self, argv=None):
+        """Subclass because the ExtensionApp.initialize() method does not take arguments"""
+        super().initialize()
+
 #-----------------------------------------------------------------------------
 # Main entry point
 #-----------------------------------------------------------------------------

--- a/jupyterlab/labhubapp.py
+++ b/jupyterlab/labhubapp.py
@@ -59,6 +59,8 @@ flags.update(
     }
 )
 
+
+
 if make_singleuser_app:
 
     class SingleUserNotebookMixin(LabApp):
@@ -510,8 +512,23 @@ else:
             env.loader = ChoiceLoader([FunctionLoader(get_page), orig_loader])
 
 
+
+# Overrides for Jupyter Server Extension config
+class OverrideSingleUserNotebookApp(SingleUserNotebookApp):
+    name = 'labhub'
+
+    # Disable the default jupyterlab extension and enable ourself
+    serverapp_config = {
+        "open_browser": True,
+        "jpserver_extensions": { "jupyterlab": False, "jupyterlab.labhubapp": True }
+    }
+
+
+load_jupyter_server_extension = OverrideSingleUserNotebookApp._load_jupyter_server_extension
+
+
 def main(argv=None):
-    return SingleUserNotebookApp.launch_instance(argv)
+    return OverrideSingleUserNotebookApp.launch_instance(argv)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix integration with JupyterHub

## References
Fixes #9517


## Code changes
Adds Jupyter Server extension config to the `jupyter-labhub` app that disables the regular JupyterLab extension and
enables itself. Previously the core JupyterLab plugin was running, which doesn't have the JupyterHub integrations.

## User-facing changes

JupyterHub now works with JupyterLab 3.0:

![103796883-62f5b980-500d-11eb-8479-9cc58f075d11](https://user-images.githubusercontent.com/159529/103799312-d665ee00-5042-11eb-8b76-fb782c05f86f.png)

## Backwards-incompatible changes
N/A
