### PR TITLE
Move open_browser to the top level configs of classes.

### DIFF
--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -42,8 +42,9 @@ def main():
         JS console errors, JS errors, and Python logged errors.
         """
         name = __name__
+        open_browser = False
+
         serverapp_config = {
-            "open_browser": False,
             "base_url": "/foo/",
             "root_dir": osp.abspath(example_dir)
         }

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -175,8 +175,9 @@ class BrowserApp(LabApp):
     JS console errors, JS errors, and Python logged errors.
     """
     name = __name__
+    open_browser = False
+
     serverapp_config = {
-        "open_browser": False,
         "base_url": "/foo/"
     }
     ip = '127.0.0.1'

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -546,11 +546,6 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
     expose_app_in_browser = Bool(False, config=True,
         help="Whether to expose the global app instance to browser via window.jupyterlab")
 
-    # By default, open a browser for JupyterLab
-    serverapp_config = {
-        "open_browser": True
-    }
-
     @default('app_dir')
     def _default_app_dir(self):
         app_dir = get_app_dir()

--- a/jupyterlab/labhubapp.py
+++ b/jupyterlab/labhubapp.py
@@ -519,7 +519,6 @@ class OverrideSingleUserNotebookApp(SingleUserNotebookApp):
 
     # Disable the default jupyterlab extension and enable ourself
     serverapp_config = {
-        "open_browser": True,
         "jpserver_extensions": { "jupyterlab": False, "jupyterlab.labhubapp": True }
     }
 

--- a/jupyterlab/tests/test_app.py
+++ b/jupyterlab/tests/test_app.py
@@ -256,10 +256,6 @@ class JestApp(ProcessTestApp):
 
     test_config = Dict(dict(foo='bar'))
 
-    serverapp_config = {
-        "open_browser": False
-    }
-
     @deprecated(removed_version=4)
     def get_command(self):
         """Get the command to run"""

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup_args['install_requires'] = [
     'tornado>=6.1.0',
     'jupyter_core',
     'jupyterlab_server~=2.0',
-    'jupyter_server~=1.1',
+    'jupyter_server~=1.2',
     'nbclassic~=0.2',
     'jinja2>=2.10'
 ]


### PR DESCRIPTION






<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9579

See https://github.com/jupyter-server/jupyter_server/pull/375

## Code changes

This follows on changes to Jupyter Server and ExtensionApp which moves open_browser to the ExtensionApp config.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
