### PR TITLE
Trim notebook large output for better performance

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -573,8 +573,12 @@ export namespace Cell {
     /**
      * Whether this cell is a placeholder for future rendering.
      */
-
     placeholder?: boolean;
+
+    /**
+     * The maximum number of output items to display on top and bottom of cell output.
+     */
+    maximumTopBottomOutput?: number;
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -576,9 +576,9 @@ export namespace Cell {
     placeholder?: boolean;
 
     /**
-     * The maximum number of output items to display on top and bottom of cell output.
+     * The maximum number of output items to display in cell output.
      */
-    maximumTopBottomOutput?: number;
+    maxNumberOutputs?: number;
   }
 
   /**

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -716,7 +716,8 @@ export class CodeCell extends Cell {
       const output = (this._output = new OutputArea({
         model: model.outputs,
         rendermime,
-        contentFactory: contentFactory
+        contentFactory: contentFactory,
+        maxNumberOutputs: options.maxNumberOutputs
       }));
       output.addClass(CELL_OUTPUT_AREA_CLASS);
       // Set a CSS if there are no outputs, and connect a signal for future

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -389,9 +389,9 @@
       "type": "string",
       "default": "1000px"
     },
-    "maxTopBottomCellOutput": {
-      "title": "The maximum number of output cells to display in the top and bottom for cells",
-      "description": "Defines the maximum number of output cells to display in the top and bottom for cells with many outputs. Output in between will be trimmed and not displayed.",
+    "maxNumberOutputs": {
+      "title": "The maximum number of output cells to to be rendered in the output area. Set to 0 to have the complete display.",
+      "description": "Defines the maximum number of output cells to to to be rendered in the output area for cells with many outputs. The output area will have a head and a tail, and the outputs between will be trimmed and not displayed unless the user clicks on the information message.",
       "type": "number",
       "default": 10
     }

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -388,6 +388,12 @@
       "description": "Defines the observed bottom margin for the virtual notebook, set a positive number of pixels to render cells below the visible view",
       "type": "string",
       "default": "1000px"
+    },
+    "maxTopBottomCellOutput": {
+      "title": "The maximum number of output cells to display in the top and bottom for cells",
+      "description": "Defines the maximum number of output cells to display in the top and bottom for cells with many outputs. Output in between will be trimmed and not displayed.",
+      "type": "number",
+      "default": 10
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -393,7 +393,7 @@
       "title": "The maximum number of output cells to to be rendered in the output area. Set to 0 to have the complete display.",
       "description": "Defines the maximum number of output cells to to to be rendered in the output area for cells with many outputs. The output area will have a head and a tail, and the outputs between will be trimmed and not displayed unless the user clicks on the information message.",
       "type": "number",
-      "default": 10
+      "default": 50
     }
   },
   "additionalProperties": false,

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -667,7 +667,8 @@ function activateNotebookHandler(
       renderCellOnIdle: settings.get('renderCellOnIdle').composite as boolean,
       observedTopMargin: settings.get('observedTopMargin').composite as string,
       observedBottomMargin: settings.get('observedBottomMargin')
-        .composite as string
+        .composite as string,
+      maxNumberOutputs: settings.get('maxNumberOutputs').composite as number
     };
     factory.shutdownOnClose = settings.get('kernelShutdown')
       .composite as boolean;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -957,7 +957,7 @@ export namespace StaticNotebook {
     renderCellOnIdle: true,
     observedTopMargin: '1000px',
     observedBottomMargin: '1000px',
-    maxNumberOutputs: 10
+    maxNumberOutputs: 50
   };
 
   /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -594,7 +594,8 @@ export class StaticNotebook extends Widget {
       rendermime,
       contentFactory,
       updateEditorOnShow: false,
-      placeholder: false
+      placeholder: false,
+      maxNumberOutputs: this.notebookConfig.maxNumberOutputs
     };
     const cell = this.contentFactory.createCodeCell(options, this);
     cell.syncCollapse = true;
@@ -938,6 +939,11 @@ export namespace StaticNotebook {
      * to render cells below the visible view.
      */
     observedBottomMargin: string;
+
+    /**
+     * Defines the maximum number of outputs per cell.
+     */
+    maxNumberOutputs: number;
   }
 
   /**
@@ -950,7 +956,8 @@ export namespace StaticNotebook {
     numberCellsToRenderDirectly: 20,
     renderCellOnIdle: true,
     observedTopMargin: '1000px',
-    observedBottomMargin: '1000px'
+    observedBottomMargin: '1000px',
+    maxNumberOutputs: 10
   };
 
   /**

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -87,7 +87,7 @@ export interface IOutputAreaModel extends IDisposable {
   /**
    * The maximum number of output items to display on top and bottom of cell output.
    */
-  maximumTopBottomOutput?: number;
+  maxNumberOutputs?: number;
 }
 
 /**

--- a/packages/outputarea/src/model.ts
+++ b/packages/outputarea/src/model.ts
@@ -83,6 +83,11 @@ export interface IOutputAreaModel extends IDisposable {
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.IOutput[];
+
+  /**
+   * The maximum number of output items to display on top and bottom of cell output.
+   */
+  maximumTopBottomOutput?: number;
 }
 
 /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -106,7 +106,7 @@ export class OutputArea extends Widget {
       options.contentFactory || OutputArea.defaultContentFactory;
     this.layout = new PanelLayout();
     this.trimmedOutputModels = new Array<IOutputModel>();
-    this.maxNumberOutputs = options.maxNumberOutputs || 20;
+    this.maxNumberOutputs = options.maxNumberOutputs || 0;
     this.headTailNumberOutputs = Math.round(this.maxNumberOutputs / 2);
     this.headEndIndex = this.headTailNumberOutputs;
     for (let i = 0; i < model.length; i++) {
@@ -446,7 +446,7 @@ export class OutputArea extends Widget {
     if (index === 0) {
       this.trimmedOutputModels = new Array<IOutputModel>();
     }
-    if (index === this.maxNumberOutputs) {
+    if (index === this.maxNumberOutputs && this.maxNumberOutputs !== 0) {
       // TODO Improve style of the display message.
       const separatorModel = this.model.contentFactory.createOutputModel({
         value: {
@@ -456,7 +456,7 @@ export class OutputArea extends Widget {
               <a style="margin: 10px; text-decoration: none;">
                 <pre>Output of this cell has been trimmed on the initial display.</pre>
                 <pre>Displaying the first ${this.maxNumberOutputs} top and last bottom outputs.</pre>
-                <pre>Click on this messsage, or run again this cell, to get the complete output.</pre>
+                <pre>Click on this message to get the complete output.</pre>
               </a>
               `
           }
@@ -471,13 +471,13 @@ export class OutputArea extends Widget {
     }
     const output = this._createOutput(model);
     const layout = this.layout as PanelLayout;
-    if (index < this.maxNumberOutputs) {
+    if (index < this.maxNumberOutputs || this.maxNumberOutputs === 0) {
       layout.insertWidget(index, output);
     } else if (index >= this.maxNumberOutputs) {
       layout.removeWidgetAt(this.headTailNumberOutputs + 1);
       layout.insertWidget(index, output);
     }
-    if (index >= this.headTailNumberOutputs) {
+    if (index >= this.headTailNumberOutputs && this.maxNumberOutputs !== 0) {
       this.trimmedOutputModels.push(model);
     }
   }

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -492,7 +492,6 @@ export class OutputArea extends Widget {
       this._insertOutput(i, o);
       i++;
     });
-    //    this.update()
   }
 
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -109,7 +109,6 @@ export class OutputArea extends Widget {
     this.maxNumberOutputs = options.maxNumberOutputs || 20;
     this.headTailNumberOutputs = Math.round(this.maxNumberOutputs / 2);
     this.headEndIndex = this.headTailNumberOutputs;
-    this.tailBeginIndex = this.headTailNumberOutputs;
     for (let i = 0; i < model.length; i++) {
       const output = model.get(i);
       this._insertOutput(i, output);
@@ -154,11 +153,6 @@ export class OutputArea extends Widget {
    * The index for the end of the head in case of trim mode.
    */
   private headEndIndex: number = -1;
-
-  /*
-   * The index for the begin of the tail in case of trim mode.
-   */
-  private tailBeginIndex: number = -1;
 
   /**
    * A read-only sequence of the chidren widgets in the output area.

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -81,7 +81,7 @@ const STDIN_PROMPT_CLASS = 'jp-Stdin-prompt';
 const STDIN_INPUT_CLASS = 'jp-Stdin-input';
 
 /*
- * The ratio of outputs compared to maximumTopBottomOutput
+ * The ratio of outputs compared to maxNumberOutputsTopDown
  * for which the trim mode should be enabled.
  */
 const TRIMMED_RATIO = 10;
@@ -111,14 +111,14 @@ export class OutputArea extends Widget {
     this.contentFactory =
       options.contentFactory || OutputArea.defaultContentFactory;
     this.layout = new PanelLayout();
-    this.maximumTopBottomOutput = options.maximumTopBottomOutput || 10;
+    this.maxNumberOutputsTopDown = (options.maxNumberOutputs || 20) / 2;
     this.trimmedOutputModels = new Array<IOutputModel>();
     if (
-      this.maximumTopBottomOutput > 0 &&
-      model.length > this.maximumTopBottomOutput * TRIMMED_RATIO
+      this.maxNumberOutputsTopDown > 0 &&
+      model.length > this.maxNumberOutputsTopDown * TRIMMED_RATIO
     ) {
-      this.headEndIndex = this.maximumTopBottomOutput;
-      this.tailBeginIndex = model.length - this.maximumTopBottomOutput;
+      this.headEndIndex = this.maxNumberOutputsTopDown;
+      this.tailBeginIndex = model.length - this.maxNumberOutputsTopDown;
     }
     for (let i = 0; i < model.length; i++) {
       const output = model.get(i);
@@ -152,7 +152,7 @@ export class OutputArea extends Widget {
    * The maximum outputs to show at the top and
    * bottom of the output area in case of trim mode.
    */
-  private maximumTopBottomOutput: number;
+  private maxNumberOutputsTopDown: number;
 
   /*
    * The index for the end of the head in case of trim mode.
@@ -465,7 +465,7 @@ export class OutputArea extends Widget {
             'text/html': `
               <a style="margin: 10px; text-decoration: none;">
                 <pre>Output of this cell has been trimmed on the initial display.</pre>
-                <pre>Total outputs is ${this.model.length}, displaying the first ${this.maximumTopBottomOutput} top and last ${this.maximumTopBottomOutput} bottom outputs.</pre>
+                <pre>Total outputs is ${this.model.length}, displaying the first ${this.maxNumberOutputsTopDown} top and last ${this.maxNumberOutputsTopDown} bottom outputs.</pre>
                 <pre>Click on this messsage or run again this cell to get the complete output.</pre>
               </a>
               `
@@ -473,7 +473,7 @@ export class OutputArea extends Widget {
         }
       });
       const onClick = () =>
-        this._showTrimmedOutputs(this.maximumTopBottomOutput);
+        this._showTrimmedOutputs(this.maxNumberOutputsTopDown);
       const separator = this.createOutputItem(separatorModel);
       separator!.node.addEventListener('click', onClick);
       const layout = this.layout as PanelLayout;
@@ -511,12 +511,12 @@ export class OutputArea extends Widget {
    * Remove the information message related to the trimmed output
    * and show all previously trimmed outputs.
    */
-  private _showTrimmedOutputs(maximumTopBottomOutput: number) {
+  private _showTrimmedOutputs(maxNumberOutputsTopDown: number) {
     const layout = this.layout as PanelLayout;
-    layout.removeWidgetAt(maximumTopBottomOutput);
+    layout.removeWidgetAt(maxNumberOutputsTopDown);
     for (let i = 0; i < this.trimmedOutputModels.length; i++) {
       const output = this._createOutput(this.trimmedOutputModels[i]);
-      layout.insertWidget(maximumTopBottomOutput + i, output);
+      layout.insertWidget(maxNumberOutputsTopDown + i, output);
     }
   }
 
@@ -630,6 +630,9 @@ export class OutputArea extends Widget {
     // API responses that contain a pager are special cased and their type
     // is overridden from 'execute_reply' to 'display_data' in order to
     // render output.
+
+    console.log('---', msg);
+
     const model = this.model;
     const content = msg.content;
     if (content.status !== 'ok') {
@@ -709,7 +712,7 @@ export namespace OutputArea {
     /**
      * The maximum number of output items to display on top and bottom of cell output.
      */
-    maximumTopBottomOutput?: number;
+    maxNumberOutputs?: number;
   }
 
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -147,12 +147,12 @@ export class OutputArea extends Widget {
    * The maximum outputs to show in the trimmed
    * output head and tail areas.
    */
-  private headTailNumberOutputs: number = -1;
+  private headTailNumberOutputs: number;
 
   /*
    * The index for the end of the head in case of trim mode.
    */
-  private headEndIndex: number = -1;
+  private headEndIndex: number;
 
   /**
    * A read-only sequence of the chidren widgets in the output area.
@@ -438,16 +438,16 @@ export class OutputArea extends Widget {
 
   /**
    * Render and insert a single output into the layout.
+   *
+   * @param index - The index of the output to be inserted.
+   * @param model - The model of the output to be inserted.
    */
-  private _insertOutput(
-    index: number,
-    model: IOutputModel,
-    force?: boolean
-  ): void {
+  private _insertOutput(index: number, model: IOutputModel): void {
     if (index === 0) {
       this.trimmedOutputModels = new Array<IOutputModel>();
     }
-    if (index === this.maxNumberOutputs && !force) {
+    if (index === this.maxNumberOutputs) {
+      // TODO Improve style of the display message.
       const separatorModel = this.model.contentFactory.createOutputModel({
         value: {
           output_type: 'display_data',
@@ -471,9 +471,7 @@ export class OutputArea extends Widget {
     }
     const output = this._createOutput(model);
     const layout = this.layout as PanelLayout;
-    if (force) {
-      layout.insertWidget(index, output);
-    } else if (index < this.maxNumberOutputs) {
+    if (index < this.maxNumberOutputs) {
       layout.insertWidget(index, output);
     } else if (index >= this.maxNumberOutputs) {
       layout.removeWidgetAt(this.headTailNumberOutputs + 1);

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -64,6 +64,12 @@
       "path": "./packages/csvviewer-extension"
     },
     {
+      "path": "./packages/debugger"
+    },
+    {
+      "path": "./packages/debugger-extension"
+    },
+    {
       "path": "./packages/docmanager"
     },
     {
@@ -238,10 +244,22 @@
       "path": "./packages/theme-light-extension"
     },
     {
+      "path": "./packages/toc"
+    },
+    {
+      "path": "./packages/toc-extension"
+    },
+    {
       "path": "./packages/tooltip"
     },
     {
       "path": "./packages/tooltip-extension"
+    },
+    {
+      "path": "./packages/translation"
+    },
+    {
+      "path": "./packages/translation-extension"
     },
     {
       "path": "./packages/ui-components"

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -64,12 +64,6 @@
       "path": "./packages/csvviewer-extension"
     },
     {
-      "path": "./packages/debugger"
-    },
-    {
-      "path": "./packages/debugger-extension"
-    },
-    {
       "path": "./packages/docmanager"
     },
     {
@@ -244,22 +238,10 @@
       "path": "./packages/theme-light-extension"
     },
     {
-      "path": "./packages/toc"
-    },
-    {
-      "path": "./packages/toc-extension"
-    },
-    {
       "path": "./packages/tooltip"
     },
     {
       "path": "./packages/tooltip-extension"
-    },
-    {
-      "path": "./packages/translation"
-    },
-    {
-      "path": "./packages/translation-extension"
     },
     {
       "path": "./packages/ui-components"


### PR DESCRIPTION
## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/9593

## Code changes

Add a `maximumTopBottomOutput` notebook setting and trim outputs that are larger than a predefined multiple of that maximumTopBottomOutput value. A relevant message is shown to the user. If the user runs again the cell, he will get the complete output.

## User-facing changes

Opening a notebook, the user will be shown with a message for large outputs.

<img width="870" alt="Screenshot 2021-01-11 at 12 17 33" src="https://user-images.githubusercontent.com/226720/104179177-ba2fcb80-540b-11eb-9d47-b447b5b3b780.png">

<img width="820" alt="Screenshot 2021-01-11 at 12 26 03" src="https://user-images.githubusercontent.com/226720/104179190-bdc35280-540b-11eb-96e5-3e7204679935.png">


## Backwards-incompatible changes

None.
