### PR TITLE
Fix handling of multiple notebooks for the debugger

### DIFF
--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -267,7 +267,10 @@ export class DebuggerHandler {
 
     const addToolbarButton = (): void => {
       if (!this._iconButtons[widget.id]) {
-        this._iconButtons[widget.id] = updateIconButton(widget, toggleDebugging);
+        this._iconButtons[widget.id] = updateIconButton(
+          widget,
+          toggleDebugging
+        );
       }
       if (!this._toggleButtons[widget.id]) {
         this._toggleButtons[widget.id] = updateToggleButton(
@@ -392,10 +395,10 @@ export class DebuggerHandler {
     ) => void;
   } = {};
   private _iconButtons: {
-    [id: string]: ToolbarButton | undefined
+    [id: string]: ToolbarButton | undefined;
   } = {};
   private _toggleButtons: {
-    [id: string]: Switch | undefined
+    [id: string]: Switch | undefined;
   } = {};
 }
 

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -266,32 +266,32 @@ export class DebuggerHandler {
     };
 
     const addToolbarButton = (): void => {
-      if (!this._iconButton) {
-        this._iconButton = updateIconButton(widget, toggleDebugging);
+      if (!this._iconButtons[widget.id]) {
+        this._iconButtons[widget.id] = updateIconButton(widget, toggleDebugging);
       }
-      if (!this._toggleButton) {
-        this._toggleButton = updateToggleButton(
+      if (!this._toggleButtons[widget.id]) {
+        this._toggleButtons[widget.id] = updateToggleButton(
           widget,
           this._service.isStarted,
           toggleDebugging
         );
       }
-      this._toggleButton.value = this._service.isStarted;
+      this._toggleButtons[widget.id]!.value = this._service.isStarted;
     };
 
     const removeToolbarButton = (): void => {
-      if (!this._iconButton) {
+      if (!this._iconButtons[widget.id]) {
         return;
       } else {
-        this._iconButton.dispose();
-        delete this._iconButton;
+        this._iconButtons[widget.id]!.dispose();
+        delete this._iconButtons[widget.id];
       }
 
-      if (!this._toggleButton) {
+      if (!this._toggleButtons[widget.id]) {
         return;
       } else {
-        this._toggleButton.dispose();
-        delete this._toggleButton;
+        this._toggleButtons[widget.id]!.dispose();
+        delete this._toggleButtons[widget.id];
       }
     };
 
@@ -305,15 +305,15 @@ export class DebuggerHandler {
         this._service.isStarted &&
         this._previousConnection?.id === connection?.id
       ) {
-        if (this._toggleButton) {
-          this._toggleButton.value = false;
+        if (this._toggleButtons[widget.id]) {
+          this._toggleButtons[widget.id]!.value = false;
         }
         this._service.session!.connection = connection;
         await this._service.stop();
         removeHandlers();
       } else {
-        if (this._toggleButton) {
-          this._toggleButton.value = true;
+        if (this._toggleButtons[widget.id]) {
+          this._toggleButtons[widget.id]!.value = true;
         }
         this._service.session!.connection = connection;
         this._previousConnection = connection;
@@ -391,8 +391,12 @@ export class DebuggerHandler {
       status: Kernel.Status
     ) => void;
   } = {};
-  private _iconButton?: ToolbarButton;
-  private _toggleButton?: Switch;
+  private _iconButtons: {
+    [id: string]: ToolbarButton | undefined
+  } = {};
+  private _toggleButtons: {
+    [id: string]: Switch | undefined
+  } = {};
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/9595

## Code changes

The icons and switch were not scoped per widget, so if a notebook already had a switch then the others wouldn't be created.

The logic of the debugger handler is getting a bit more complex. So it could be worth revisiting it at some point (this was also expressed a while ago in https://github.com/jupyterlab/debugger/issues/393)

## User-facing changes

![icons-switch-fix](https://user-images.githubusercontent.com/591645/104232934-503a1500-5451-11eb-95c1-ddffc81c47d4.gif)

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
