### PR TITLE
Remove the notebook 5.1 check for large uploads

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -3,7 +3,7 @@
 
 import { showDialog, Dialog } from '@jupyterlab/apputils';
 
-import { IChangedArgs, PathExt, PageConfig } from '@jupyterlab/coreutils';
+import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
 
 import { IDocumentManager, shouldOverwrite } from '@jupyterlab/docmanager';
 
@@ -396,27 +396,14 @@ export class FileBrowserModel implements IDisposable {
    * @returns A promise containing the new file contents model.
    *
    * #### Notes
-   * On Notebook version < 5.1.0, this will fail to upload files that are too
-   * big to be sent in one request to the server. On newer versions, it will
-   * ask for confirmation then upload the file in 1 MB chunks.
+   * This will ask for confirmation, then upload the file in 1 MB chunks.
    */
   async upload(file: File): Promise<Contents.IModel> {
-    const supportsChunked = PageConfig.getNotebookVersion() >= [5, 1, 0];
     const largeFile = file.size > LARGE_FILE_SIZE;
-
-    if (largeFile && !supportsChunked) {
-      const msg = this._trans.__(
-        'Cannot upload file (>%1 MB). %2',
-        LARGE_FILE_SIZE / (1024 * 1024),
-        file.name
-      );
-      console.warn(msg);
-      throw msg;
-    }
 
     const err = 'File not uploaded';
     if (largeFile && !(await this._shouldUploadLarge(file))) {
-      throw 'Cancelled large file upload';
+      throw 'Canceled large file upload';
     }
     await this._uploadCheckDisposed();
     await this.refresh();
@@ -428,7 +415,7 @@ export class FileBrowserModel implements IDisposable {
       throw err;
     }
     await this._uploadCheckDisposed();
-    const chunkedUpload = supportsChunked && file.size > CHUNK_SIZE;
+    const chunkedUpload = file.size > CHUNK_SIZE;
     return await this._upload(file, chunkedUpload);
   }
 

--- a/packages/filebrowser/test/model.spec.ts
+++ b/packages/filebrowser/test/model.spec.ts
@@ -3,8 +3,6 @@
 
 import expect from 'expect';
 
-import { PageConfig } from '@jupyterlab/coreutils';
-
 import { DocumentManager, IDocumentManager } from '@jupyterlab/docmanager';
 
 import { DocumentRegistry, TextModelFactory } from '@jupyterlab/docregistry';
@@ -26,7 +24,7 @@ import { toArray } from '@lumino/algorithm';
 
 import { UUID } from '@lumino/coreutils';
 
-import { FileBrowserModel, CHUNK_SIZE, LARGE_FILE_SIZE } from '../src';
+import { FileBrowserModel, CHUNK_SIZE } from '../src';
 
 /**
  * A contents manager that delays requests by less each time it is called
@@ -381,40 +379,7 @@ describe('filebrowser/model', () => {
         expect(called).toBe(true);
       });
 
-      describe('older notebook version', () => {
-        let prevNotebookVersion: string;
-
-        beforeAll(() => {
-          prevNotebookVersion = PageConfig.setOption(
-            'notebookVersion',
-            JSON.stringify([5, 0, 0])
-          );
-        });
-
-        it('should not upload large file', async () => {
-          const fname = UUID.uuid4() + '.html';
-          const file = new File([new ArrayBuffer(LARGE_FILE_SIZE + 1)], fname);
-
-          await expect(model.upload(file)).rejects.toBe(
-            `Cannot upload file (>15 MB). ${fname}`
-          );
-        });
-
-        afterAll(() => {
-          PageConfig.setOption('notebookVersion', prevNotebookVersion);
-        });
-      });
-
-      describe('newer notebook version', () => {
-        let prevNotebookVersion: string;
-
-        beforeAll(() => {
-          prevNotebookVersion = PageConfig.setOption(
-            'notebookVersion',
-            JSON.stringify([5, 1, 0])
-          );
-        });
-
+      describe('large uploads', () => {
         for (const ending of ['.txt', '.ipynb']) {
           for (const size of [
             CHUNK_SIZE - 1,
@@ -498,10 +463,6 @@ describe('filebrowser/model', () => {
           ]);
           expect(toArray(model.uploads())).toEqual([]);
           await uploaded;
-        });
-
-        afterAll(() => {
-          PageConfig.setOption('notebookVersion', prevNotebookVersion);
         });
       });
     });


### PR DESCRIPTION

## References

Fixes #9601

## Code changes

In JLab 3, we are using Jupyter Server, which unfortunately advertises its own version as the notebook version (1.2.1, for example). This trips up this notebook version test.

Since we do not support the notebook server for JupyterLab 3, we can eliminate the version check entirely.

I also normalized the spelling of 'canceled' in the error message to what we are using elsewhere in jlab.

## User-facing changes

Large uploads (>15MB) are supported in JLab 3.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
