### PR TITLE
Fix display of ?? help

### DIFF
--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -38,10 +38,6 @@
 }
 
 /* console foregrounds and backgrounds */
-.jp-RenderedText pre span {
-  display: inline-block;
-}
-
 .jp-RenderedText pre .ansi-black-fg {
   color: #3e424d;
 }

--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -7,6 +7,11 @@
 | RenderedText
 |----------------------------------------------------------------------------*/
 
+:root {
+  /* This is the padding value to fill the gaps between lines containing spans with background color. */
+  --jp-private-code-span-padding: calc( (var(--jp-code-line-height) - 1) * var(--jp-code-font-size) / 2 );
+}
+
 .jp-RenderedText {
   text-align: left;
   padding-left: var(--jp-code-padding);
@@ -65,27 +70,35 @@
 
 .jp-RenderedText pre .ansi-black-bg {
   background-color: #3e424d;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-red-bg {
   background-color: #e75c58;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-green-bg {
   background-color: #00a250;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-yellow-bg {
   background-color: #ddb62b;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-blue-bg {
   background-color: #208ffb;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-magenta-bg {
   background-color: #d160c4;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-cyan-bg {
   background-color: #60c6c8;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-white-bg {
   background-color: #c5c1b4;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-black-intense-fg {
@@ -115,27 +128,35 @@
 
 .jp-RenderedText pre .ansi-black-intense-bg {
   background-color: #282c36;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-red-intense-bg {
   background-color: #b22b31;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-green-intense-bg {
   background-color: #007427;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-yellow-intense-bg {
   background-color: #b27d12;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-blue-intense-bg {
   background-color: #0065ca;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-magenta-intense-bg {
   background-color: #a03196;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-cyan-intense-bg {
   background-color: #258f8f;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 .jp-RenderedText pre .ansi-white-intense-bg {
   background-color: #a1a6b2;
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-default-inverse-fg {
@@ -143,6 +164,7 @@
 }
 .jp-RenderedText pre .ansi-default-inverse-bg {
   background-color: var(--jp-inverse-layout-color0);
+  padding: var(--jp-private-code-span-padding) 0;
 }
 
 .jp-RenderedText pre .ansi-bold {

--- a/packages/rendermime/style/base.css
+++ b/packages/rendermime/style/base.css
@@ -9,7 +9,9 @@
 
 :root {
   /* This is the padding value to fill the gaps between lines containing spans with background color. */
-  --jp-private-code-span-padding: calc( (var(--jp-code-line-height) - 1) * var(--jp-code-font-size) / 2 );
+  --jp-private-code-span-padding: calc(
+    (var(--jp-code-line-height) - 1) * var(--jp-code-font-size) / 2
+  );
 }
 
 .jp-RenderedText {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is yet another solution to #7760 that avoids the problems we see from the solution in #8555 (noted in #9600).

Fixes #9600

## Code changes

In #8555, we tried to solve #7760 by setting spans to have inline-block display. However, this makes the newlines in the spans ignored, i.e., they don't cause linebreaks. This leads to really bad formatting, like noted in #9600.

This reverts #8555 and instead expands the background-colored spans by adding padding above and below to match the line height (as long as the lineheight is a multiple like 1.03 or something).

## User-facing changes

Fixes #7760:

<img width="616" alt="Screen Shot 2021-01-13 at 10 30 12 PM" src="https://user-images.githubusercontent.com/192614/104553122-f1120700-55ee-11eb-9ad7-bbedba2aee11.png">

Fixes #9600:
<img width="691" alt="Screen Shot 2021-01-13 at 10 30 22 PM" src="https://user-images.githubusercontent.com/192614/104553135-f8391500-55ee-11eb-8699-d05eebb0dc93.png">

Another example from https://nbsphinx.readthedocs.io/en/material-theme/code-cells.html#ANSI-Colors:

<img width="617" alt="Screen Shot 2021-01-13 at 10 48 39 PM" src="https://user-images.githubusercontent.com/192614/104554902-c5445080-55f1-11eb-9dde-28e9da88e8d2.png">



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
