### PR TITLE
Disable large uploads for notebook server < 5.1

### DIFF
--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -3,7 +3,7 @@
 
 import { showDialog, Dialog } from '@jupyterlab/apputils';
 
-import { IChangedArgs, PathExt } from '@jupyterlab/coreutils';
+import { IChangedArgs, PathExt, PageConfig } from '@jupyterlab/coreutils';
 
 import { IDocumentManager, shouldOverwrite } from '@jupyterlab/docmanager';
 
@@ -396,14 +396,27 @@ export class FileBrowserModel implements IDisposable {
    * @returns A promise containing the new file contents model.
    *
    * #### Notes
-   * This will ask for confirmation, then upload the file in 1 MB chunks.
+   * On Notebook version < 5.1.0, this will fail to upload files that are too
+   * big to be sent in one request to the server. On newer versions, it will
+   * ask for confirmation then upload the file in 1 MB chunks.
    */
   async upload(file: File): Promise<Contents.IModel> {
+    const supportsChunked = PageConfig.getNotebookVersion() >= [5, 1, 0];
     const largeFile = file.size > LARGE_FILE_SIZE;
+
+    if (largeFile && !supportsChunked) {
+      const msg = this._trans.__(
+        'Cannot upload file (>%1 MB). %2',
+        LARGE_FILE_SIZE / (1024 * 1024),
+        file.name
+      );
+      console.warn(msg);
+      throw msg;
+    }
 
     const err = 'File not uploaded';
     if (largeFile && !(await this._shouldUploadLarge(file))) {
-      throw 'Canceled large file upload';
+      throw 'Cancelled large file upload';
     }
     await this._uploadCheckDisposed();
     await this.refresh();
@@ -415,7 +428,7 @@ export class FileBrowserModel implements IDisposable {
       throw err;
     }
     await this._uploadCheckDisposed();
-    const chunkedUpload = file.size > CHUNK_SIZE;
+    const chunkedUpload = supportsChunked && file.size > CHUNK_SIZE;
     return await this._upload(file, chunkedUpload);
   }
 

--- a/packages/filebrowser/src/model.ts
+++ b/packages/filebrowser/src/model.ts
@@ -397,11 +397,19 @@ export class FileBrowserModel implements IDisposable {
    *
    * #### Notes
    * On Notebook version < 5.1.0, this will fail to upload files that are too
-   * big to be sent in one request to the server. On newer versions, it will
-   * ask for confirmation then upload the file in 1 MB chunks.
+   * big to be sent in one request to the server. On newer versions, or on
+   * Jupyter Server, it will ask for confirmation then upload the file in 1 MB
+   * chunks.
    */
   async upload(file: File): Promise<Contents.IModel> {
-    const supportsChunked = PageConfig.getNotebookVersion() >= [5, 1, 0];
+    // We do not support Jupyter Notebook version less than 4, and Jupyter
+    // Server advertises itself as version 1 and supports chunked
+    // uploading. We assume any version less than 4.0.0 to be Jupyter Server
+    // instead of Jupyter Notebook.
+    const serverVersion = PageConfig.getNotebookVersion();
+    const supportsChunked =
+      serverVersion < [4, 0, 0] /* Jupyter Server */ ||
+      serverVersion >= [5, 1, 0]; /* Jupyter Notebook >= 5.1.0 */
     const largeFile = file.size > LARGE_FILE_SIZE;
 
     if (largeFile && !supportsChunked) {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9601.

Fixes #9616.

Fixes #9626.

## Code changes

In #9616, I did not realize that JupyterLab still supports the Jupyter Notebook server. This fix supports Jupyter Notebook as a server.

Jupyter Server advertises itself as notebook version 1.2 or so at the time of this commit. JupyterLab 2 supports Jupyter Notebook >=4.3.1. Thus we assume that if we get a version number less than 4, we are actually talking to Jupyter Server, and chunked uploading is supported.

Eventually this code should be removed when JupyterLab no longer supports Jupyter Notebook server, and hopefully that is before Jupyter Server 4.0.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
