### PR TITLE
Ignore timeout errors when preloading settings.

### DIFF
--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -542,8 +542,10 @@ export class SettingRegistry implements ISettingRegistry {
           // Apply a transformation to the plugin if necessary.
           await this._load(await this._transform('fetch', plugin));
         } catch (errors) {
-          /* Ignore preload errors. */
-          console.warn('Ignored setting registry preload errors.', errors);
+          /* Ignore preload timeout errors silently. */
+          if (errors[0]?.keyword !== 'timeout') {
+            console.warn('Ignored setting registry preload errors.', errors);
+          }
         }
       })
     );


### PR DESCRIPTION




<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9587

CC @afshin 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

As discussed in #9587, we ignore timeout errors when preloading settings.

We may want to investigate further if we want to change how we do these timeouts. FYI, on my computer with a local server, I'm seeing the shortcuts and docmanager setting api calls taking about 670ms each for the network request.


## User-facing changes

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
