### PR TITLE
Ensure Python name without `-`

### DIFF
--- a/jupyterlab/upgrade_extension.py
+++ b/jupyterlab/upgrade_extension.py
@@ -44,8 +44,10 @@ def update_extension(target, interactive=True):
         python_name = subprocess.check_output([sys.executable, 'setup.py', '--name'], cwd=target).decode('utf8').strip()
     else:
         python_name = data['name']
-        if '@' in python_name:
-            python_name = python_name[1:].replace('/', '_').replace('-', '_')
+        if python_name.startswith('@'):
+            python_name = python_name[1:].replace('/', '_')
+
+    python_name = python_name.replace('-', '_')
     
     output_dir = osp.join(target, '_temp_extension')
     if osp.exists(output_dir):


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fix #9560
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
This force the replacement of `-` by `_` in python name (even if the python package
as `-` in it as that is tolerated as long as the folder is not named with `-`)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A