### PR TITLE
fix: use process/browser module as real polyfill

### DIFF
--- a/builder/package.json
+++ b/builder/package.json
@@ -55,6 +55,7 @@
     "glob": "~7.1.6",
     "mini-css-extract-plugin": "~1.3.2",
     "path-browserify": "^1.0.0",
+    "process": "^0.11.10",
     "raw-loader": "~4.0.0",
     "style-loader": "~2.0.0",
     "supports-color": "^7.2.0",

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -83,7 +83,7 @@ module.exports = {
       url: false,
       buffer: false,
       path: require.resolve('path-browserify'),
-      process: require.resolve("process/")
+      process: require.resolve('process/')
     }
   },
   watchOptions: {
@@ -92,7 +92,7 @@ module.exports = {
   },
   plugins: [
     new webpack.ProvidePlugin({
-      process: 'process/browser',
-    }),
+      process: 'process/browser'
+    })
   ]
 };

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -82,8 +82,9 @@ module.exports = {
     fallback: {
       url: false,
       buffer: false,
+      // See https://github.com/webpack/webpack/blob/3471c776059ac2d26593ea39f9c47c1874253dbb/lib/ModuleNotFoundError.js#L13-L42
       path: require.resolve('path-browserify'),
-      process: require.resolve('process/')
+      process: require.resolve('process/browser')
     }
   },
   watchOptions: {

--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -82,7 +82,8 @@ module.exports = {
     fallback: {
       url: false,
       buffer: false,
-      path: require.resolve('path-browserify')
+      path: require.resolve('path-browserify'),
+      process: require.resolve("process/")
     }
   },
   watchOptions: {
@@ -90,11 +91,8 @@ module.exports = {
     aggregateTimeout: 1000
   },
   plugins: [
-    new webpack.DefinePlugin({
-      // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
-      'process.env': '{}',
-      // Needed for various packages using cwd(), like the path polyfill
-      process: { cwd: () => '/' }
-    })
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+    }),
   ]
 };

--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -57,6 +57,7 @@ const UNUSED: Dict<string[]> = {
     'css-loader',
     'file-loader',
     'path-browserify',
+    'process',
     'raw-loader',
     'style-loader',
     'svg-url-loader',


### PR DESCRIPTION
For the ipywebrtc/jupyter-webrtc widget, I need the real process polyfill. Would this be ok?