### PR TITLE
Renamed variable that clashed with a module 

### DIFF
--- a/dev_mode/webpack.config.js
+++ b/dev_mode/webpack.config.js
@@ -130,29 +130,29 @@ function maybeSync(localPath, name, rest) {
  * in a package contained by the Jupyterlab repo. Used to ignore
  * files during a `--watch` build.
  */
-function ignored(path) {
-  path = path.resolve(path);
-  if (path in ignoreCache) {
+function ignored(checkedPath) {
+  checkedPath = path.resolve(checkedPath);
+  if (checkedPath in ignoreCache) {
     // Bail if already found.
-    return ignoreCache[path];
+    return ignoreCache[checkedPath];
   }
 
   // Limit the watched files to those in our local linked package dirs.
   let ignore = true;
   Object.keys(watched).some(name => {
     const rootPath = watched[name];
-    const contained = path.indexOf(rootPath + path.sep) !== -1;
-    if (path !== rootPath && !contained) {
+    const contained = checkedPath.indexOf(rootPath + path.sep) !== -1;
+    if (checkedPath !== rootPath && !contained) {
       return false;
     }
-    const rest = path.slice(rootPath.length);
+    const rest = checkedPath.slice(rootPath.length);
     if (rest.indexOf('node_modules') === -1) {
       ignore = false;
-      maybeSync(path, name, rest);
+      maybeSync(checkedPath, name, rest);
     }
     return true;
   });
-  ignoreCache[path] = ignore;
+  ignoreCache[checkedPath] = ignore;
   return ignore;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
https://github.com/jupyterlab/jupyterlab/issues/9639

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Local variable `path` clashed with module `path` exported under the same name resulting in an unhandled exception when running `jupyter lab --watch`. Renamed local variable.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None.