### PR TITLE
Allow for lazily retrieved documentation (with a getter)

### DIFF
--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -415,6 +415,8 @@ export class CompleterModel implements Completer.IModel {
         );
         results.push({
           ...item,
+          // Allow for lazily retrieved documentation (with a getter)
+          documentation: item.documentation,
           label: marked.join(''),
           // If no insertText is present, preserve original label value
           // by setting it as the insertText.


### PR DESCRIPTION
## References

495369d0111e559cca4468a172ca7b9ad6504718 collapsed the `ICompletionItem` copy operation to spread syntax, which is not equivalent to copying each property, as with the spread syntax the getters are not called and the dynamically generated values do not get passed.

This PR proposes to partially revert the change in order to preserve dynamically generated documentation for completer items and adds an appropriate comment for the future.

## Code changes

Overwrite documentation property with documentation (potentially) retrieved from a getter.

## User-facing changes

None

## Backwards-incompatible changes

None