### PR TITLE
transition header element to div.header for accessibility

### DIFF
--- a/packages/debugger/src/panels/breakpoints/header.ts
+++ b/packages/debugger/src/panels/breakpoints/header.ts
@@ -15,7 +15,9 @@ export class BreakpointsHeader extends Widget {
    * Instantiate a new BreakpointsHeader.
    */
   constructor(translator?: ITranslator) {
-    super({ node: document.createElement('header') });
+    super({ node: document.createElement('div') });
+    this.node.classList.add('jp-stack-panel-header');
+
     translator = translator || nullTranslator;
     const trans = translator.load('jupyterlab');
 

--- a/packages/debugger/src/panels/callstack/header.ts
+++ b/packages/debugger/src/panels/callstack/header.ts
@@ -15,7 +15,9 @@ export class CallstackHeader extends Widget {
    * Instantiate a new CallstackHeader.
    */
   constructor(translator?: ITranslator) {
-    super({ node: document.createElement('header') });
+    super({ node: document.createElement('div') });
+    this.node.classList.add('jp-stack-panel-header');
+
     translator = translator || nullTranslator;
     const trans = translator.load('jupyterlab');
 

--- a/packages/debugger/src/panels/sources/header.tsx
+++ b/packages/debugger/src/panels/sources/header.tsx
@@ -21,7 +21,9 @@ export class SourcesHeader extends Widget {
    * @param model The model for the Sources.
    */
   constructor(model: IDebugger.Model.ISources, translator?: ITranslator) {
-    super({ node: document.createElement('header') });
+    super({ node: document.createElement('div') });
+    this.node.classList.add('jp-stack-panel-header');
+
     translator = translator || nullTranslator;
     const trans = translator.load('jupyterlab');
 

--- a/packages/debugger/src/panels/variables/header.ts
+++ b/packages/debugger/src/panels/variables/header.ts
@@ -15,7 +15,9 @@ export class VariablesHeader extends Widget {
    * Instantiate a new VariablesHeader.
    */
   constructor(translator?: ITranslator) {
-    super({ node: document.createElement('header') });
+    super({ node: document.createElement('div') });
+    this.node.classList.add('jp-stack-panel-header');
+
     translator = translator || nullTranslator;
     const trans = translator.load('jupyterlab');
 

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -224,7 +224,7 @@ namespace Private {
    */
   export function createHeader(): HTMLElement {
     const header = document.createElement('div');
-    header.classList.add('header');
+    header.classList.add('jp-stack-panel-header');
 
     const title = document.createElement('h2');
 

--- a/packages/debugger/src/sidebar.ts
+++ b/packages/debugger/src/sidebar.ts
@@ -223,7 +223,9 @@ namespace Private {
    * Create a sidebar header node.
    */
   export function createHeader(): HTMLElement {
-    const header = document.createElement('header');
+    const header = document.createElement('div');
+    header.classList.add('header');
+
     const title = document.createElement('h2');
 
     title.textContent = '-';

--- a/packages/debugger/style/sidebar.css
+++ b/packages/debugger/style/sidebar.css
@@ -17,7 +17,7 @@
   height: 100%;
 }
 
-.jp-DebuggerSidebar .header {
+.jp-DebuggerSidebar .jp-stack-panel-header {
   border-bottom: solid var(--jp-border-width) var(--jp-border-color1);
   box-shadow: var(--jp-toolbar-box-shadow);
   display: flex;
@@ -27,11 +27,11 @@
   height: 24px;
 }
 
-.jp-DebuggerSidebar > .header {
+.jp-DebuggerSidebar > .jp-stack-panel-header {
   background-color: var(--jp-layout-color1);
 }
 
-.jp-DebuggerSidebar .header h2 {
+.jp-DebuggerSidebar .jp-stack-panel-header h2 {
   text-transform: uppercase;
   font-weight: 600;
   font-size: var(--jp-ui-font-size0);
@@ -40,12 +40,12 @@
   padding-right: 4px;
 }
 
-.jp-DebuggerSidebar-body .header {
+.jp-DebuggerSidebar-body .jp-stack-panel-header {
   border-top: solid var(--jp-border-width) var(--jp-border-color1);
   background-color: var(--jp-layout-color2);
 }
 
-.jp-DebuggerSidebar-body .jp-DebuggerVariables .header {
+.jp-DebuggerSidebar-body .jp-DebuggerVariables .jp-stack-panel-header {
   border-top: none;
 }
 

--- a/packages/debugger/style/sidebar.css
+++ b/packages/debugger/style/sidebar.css
@@ -17,7 +17,7 @@
   height: 100%;
 }
 
-.jp-DebuggerSidebar header {
+.jp-DebuggerSidebar .header {
   border-bottom: solid var(--jp-border-width) var(--jp-border-color1);
   box-shadow: var(--jp-toolbar-box-shadow);
   display: flex;
@@ -27,11 +27,11 @@
   height: 24px;
 }
 
-.jp-DebuggerSidebar > header {
+.jp-DebuggerSidebar > .header {
   background-color: var(--jp-layout-color1);
 }
 
-.jp-DebuggerSidebar header h2 {
+.jp-DebuggerSidebar .header h2 {
   text-transform: uppercase;
   font-weight: 600;
   font-size: var(--jp-ui-font-size0);
@@ -40,12 +40,12 @@
   padding-right: 4px;
 }
 
-.jp-DebuggerSidebar-body header {
+.jp-DebuggerSidebar-body .header {
   border-top: solid var(--jp-border-width) var(--jp-border-color1);
   background-color: var(--jp-layout-color2);
 }
 
-.jp-DebuggerSidebar-body .jp-DebuggerVariables header {
+.jp-DebuggerSidebar-body .jp-DebuggerVariables .header {
   border-top: none;
 }
 

--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -36,7 +36,7 @@
   margin-left: 12px;
 }
 
-.jp-DebuggerVariables header .jp-Toolbar {
+.jp-DebuggerVariables .header .jp-Toolbar {
   margin-left: auto;
 }
 

--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -36,7 +36,7 @@
   margin-left: 12px;
 }
 
-.jp-DebuggerVariables .header .jp-Toolbar {
+.jp-DebuggerVariables .jp-stack-panel-header .jp-Toolbar {
   margin-left: auto;
 }
 

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -581,7 +581,7 @@ export class CollapsibleSection extends React.Component<
     }
     return (
       <>
-        <div className="header">
+        <div className="jp-stack-panel-header">
           <ToolbarButtonComponent
             icon={icon}
             onClick={() => {

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -581,7 +581,7 @@ export class CollapsibleSection extends React.Component<
     }
     return (
       <>
-        <header>
+        <div className="header">
           <ToolbarButtonComponent
             icon={icon}
             onClick={() => {
@@ -590,7 +590,7 @@ export class CollapsibleSection extends React.Component<
           />
           <span className={className}>{this.props.header}</span>
           {!this.props.disabled && this.props.headerElements}
-        </header>
+        </div>
         <Collapse isOpen={isOpen}>{this.props.children}</Collapse>
       </>
     );

--- a/packages/extensionmanager/style/base.css
+++ b/packages/extensionmanager/style/base.css
@@ -49,7 +49,7 @@
   Section headers
 */
 
-.jp-extensionmanager-view header {
+.jp-extensionmanager-view .header {
   display: flex;
   justify-content: space-between;
   flex: 0 0 auto;
@@ -65,34 +65,35 @@
   padding: 4px;
 }
 
-.jp-extensionmanager-view header > .jp-ToolbarButtonComponent {
+.jp-extensionmanager-view .header > .jp-ToolbarButtonComponent {
   padding: 0px 2px;
 }
 
-.jp-extensionmanager-view header .jp-extensionmanager-headerText {
+.jp-extensionmanager-view .header .jp-extensionmanager-headerText {
   flex: 1 0 auto;
   margin: 0px 4px;
 }
 
-.jp-extensionmanager-view header .jp-extensionmanager-headerTextDisabled {
+.jp-extensionmanager-view .header .jp-extensionmanager-headerTextDisabled {
   flex: 1 0 auto;
   margin: 0px 4px;
   color: var(--jp-layout-color3);
 }
 
-.jp-extensionmanager-view header > .jp-ToolbarButtonComponent {
+.jp-extensionmanager-view .header > .jp-ToolbarButtonComponent {
   border: 1px solid transparent;
   background-color: var(--jp-layout-color1);
   color: var(--jp-ui-font-color1);
 }
 
-.jp-extensionmanager-view header > .jp-ToolbarButtonComponent:hover {
+.jp-extensionmanager-view .header > .jp-ToolbarButtonComponent:hover {
   /* border: 1px solid var(--jp-brand-color1); */
 }
 
 /*
   Listing messages
 */
+
 .jp-extensionmanager-listingmessage {
   background-color: var(--jp-brand-color1);
   color: var(--jp-ui-inverse-font-color1);
@@ -104,6 +105,7 @@
 /*
   Error messages
 */
+
 .jp-extensionmanager-view .jp-extensionmanager-error pre {
   white-space: pre-wrap;
 }
@@ -174,6 +176,7 @@
   display: flex;
   justify-content: center;
 }
+
 /*
   Entry layout and styling
 */
@@ -199,6 +202,7 @@
 }
 
 /* Precedence order update/error/warning matters! */
+
 .jp-extensionmanager-entry.jp-extensionmanager-entry-update {
   border-left: solid 8px var(--jp-brand-color2);
   padding-left: 4px;
@@ -357,6 +361,7 @@
 /*
   Generic dialog
 */
+
 .jp-extensionmanager-dialog .jp-extensionmanager-dialog-subheader {
   font-size: var(--jp-ui-font-size1);
   font-weight: 600;

--- a/packages/extensionmanager/style/base.css
+++ b/packages/extensionmanager/style/base.css
@@ -49,7 +49,7 @@
   Section headers
 */
 
-.jp-extensionmanager-view .header {
+.jp-extensionmanager-view .jp-stack-panel-header {
   display: flex;
   justify-content: space-between;
   flex: 0 0 auto;
@@ -65,28 +65,34 @@
   padding: 4px;
 }
 
-.jp-extensionmanager-view .header > .jp-ToolbarButtonComponent {
+.jp-extensionmanager-view .jp-stack-panel-header > .jp-ToolbarButtonComponent {
   padding: 0px 2px;
 }
 
-.jp-extensionmanager-view .header .jp-extensionmanager-headerText {
+.jp-extensionmanager-view
+  .jp-stack-panel-header
+  .jp-extensionmanager-headerText {
   flex: 1 0 auto;
   margin: 0px 4px;
 }
 
-.jp-extensionmanager-view .header .jp-extensionmanager-headerTextDisabled {
+.jp-extensionmanager-view
+  .jp-stack-panel-header
+  .jp-extensionmanager-headerTextDisabled {
   flex: 1 0 auto;
   margin: 0px 4px;
   color: var(--jp-layout-color3);
 }
 
-.jp-extensionmanager-view .header > .jp-ToolbarButtonComponent {
+.jp-extensionmanager-view .jp-stack-panel-header > .jp-ToolbarButtonComponent {
   border: 1px solid transparent;
   background-color: var(--jp-layout-color1);
   color: var(--jp-ui-font-color1);
 }
 
-.jp-extensionmanager-view .header > .jp-ToolbarButtonComponent:hover {
+.jp-extensionmanager-view
+  .jp-stack-panel-header
+  > .jp-ToolbarButtonComponent:hover {
   /* border: 1px solid var(--jp-brand-color1); */
 }
 

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -248,7 +248,7 @@ function Section(props: {
   return (
     <div className={SECTION_CLASS}>
       <>
-        <div className={`${SECTION_HEADER_CLASS} header`}>
+        <div className={`${SECTION_HEADER_CLASS} jp-stack-panel-header`}>
           <h2>{props.manager.name}</h2>
           <UseSignal signal={props.manager.runningChanged}>
             {() => {

--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -248,7 +248,7 @@ function Section(props: {
   return (
     <div className={SECTION_CLASS}>
       <>
-        <header className={SECTION_HEADER_CLASS}>
+        <div className={`${SECTION_HEADER_CLASS} header`}>
           <h2>{props.manager.name}</h2>
           <UseSignal signal={props.manager.runningChanged}>
             {() => {
@@ -266,7 +266,7 @@ function Section(props: {
               );
             }}
           </UseSignal>
-        </header>
+        </div>
 
         <div className={CONTAINER_CLASS}>
           <List

--- a/packages/toc/src/toc.tsx
+++ b/packages/toc/src/toc.tsx
@@ -128,7 +128,7 @@ export class TableOfContents extends Widget {
     }
     let jsx = (
       <div className="jp-TableOfContents">
-        <header>{title}</header>
+        <div className="header">{title}</div>
       </div>
     );
     if (this._current && this._current.generator) {

--- a/packages/toc/src/toc.tsx
+++ b/packages/toc/src/toc.tsx
@@ -128,7 +128,7 @@ export class TableOfContents extends Widget {
     }
     let jsx = (
       <div className="jp-TableOfContents">
-        <div className="header">{title}</div>
+        <div className="jp-stack-panel-header">{title}</div>
       </div>
     );
     if (this._current && this._current.generator) {

--- a/packages/toc/src/toc_tree.tsx
+++ b/packages/toc/src/toc_tree.tsx
@@ -74,7 +74,7 @@ class TOCTree extends React.Component<IProperties, IState> {
     });
     return (
       <div className="jp-TableOfContents">
-        <div className="header">{this.props.title}</div>
+        <div className="jp-stack-panel-header">{this.props.title}</div>
         {Toolbar && <Toolbar />}
         <ul className="jp-TableOfContents-content">{list}</ul>
       </div>

--- a/packages/toc/src/toc_tree.tsx
+++ b/packages/toc/src/toc_tree.tsx
@@ -74,7 +74,7 @@ class TOCTree extends React.Component<IProperties, IState> {
     });
     return (
       <div className="jp-TableOfContents">
-        <header>{this.props.title}</header>
+        <div className="header">{this.props.title}</div>
         {Toolbar && <Toolbar />}
         <ul className="jp-TableOfContents-content">{list}</ul>
       </div>

--- a/packages/toc/style/base.css
+++ b/packages/toc/style/base.css
@@ -38,7 +38,7 @@
   height: 100%;
 }
 
-.jp-TableOfContents header {
+.jp-TableOfContents .header {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
   flex: 0 0 auto;
   font-size: var(--jp-ui-font-size0);

--- a/packages/toc/style/base.css
+++ b/packages/toc/style/base.css
@@ -38,7 +38,7 @@
   height: 100%;
 }
 
-.jp-TableOfContents .header {
+.jp-TableOfContents .jp-stack-panel-header {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
   flex: 0 0 auto;
   font-size: var(--jp-ui-font-size0);


### PR DESCRIPTION
## References

these changes remediate overlapping issues mentioned in #9491 #9399 #9622

these changes complement those in #9622 by @marthacryan and effect different files.

## Code changes

there are `<header>` tags that impact usability with assistive devices. these changes use `<div class="header">` as an alternative. the css style are updated accordingly.

## User-facing changes

There are no visual impacts on this PR, only benefits to folks with assistive devices.

## Backwards-incompatible changes

:shrug: 
