### PR TITLE
Upgrade html-webpack-plugin to support webpack 5

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -174,7 +174,7 @@
     "glob": "~7.1.6",
     "handlebars": "^4.5.3",
     "html-loader": "~1.3.0",
-    "html-webpack-plugin": "~4.3.0",
+    "html-webpack-plugin": "^5.0.0-beta.6",
     "mini-css-extract-plugin": "~1.3.2",
     "raw-loader": "~4.0.0",
     "rimraf": "~3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8580,7 +8580,7 @@ html-minifier@^3.5.8:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
-html-webpack-plugin@^4.2.1, html-webpack-plugin@~4.3.0:
+html-webpack-plugin@^4.2.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.3.0.tgz#53bf8f6d696c4637d5b656d3d9863d89ce8174fd"
   integrity sha512-C0fzKN8yQoVLTelcJxZfJCE+aAvQiY2VUf3UuKrR4a9k5UMWYOtpDLsaXwATbcVCnI05hUS7L9ULQHWLZhyi3w==
@@ -8594,6 +8594,18 @@ html-webpack-plugin@^4.2.1, html-webpack-plugin@~4.3.0:
     pretty-error "^2.1.1"
     tapable "^1.1.3"
     util.promisify "1.0.0"
+
+html-webpack-plugin@^5.0.0-beta.6:
+  version "5.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.0.0-beta.6.tgz#aab868a3c1607828699ebbbb44cde9d6f3615cb3"
+  integrity sha512-wjdhOnJlo5c8uN3OahRm2eaLKL8gEQ4ZNOkwQc8BStyudpFLTsg28m6wbf00keXiRPesk2Pad9CYeKpxbffApg==
+  dependencies:
+    "@types/html-minifier-terser" "^5.0.0"
+    html-minifier-terser "^5.0.1"
+    loader-utils "^2.0.0"
+    lodash "^4.17.20"
+    pretty-error "^2.1.1"
+    tapable "^2.0.0"
 
 htmlparser2@^3.3.0:
   version "3.10.1"


### PR DESCRIPTION







## References

This should hopefully do the following.

Fixes #9649
Fixes #9533

## Code changes

We are seeing compile errors sometimes with webpack. In #9649, a fix of updating html-webpack-plugin was proposed and seemed to help. jantimon/html-webpack-plugin@d722b9b seems like a relevant fix in the plugin.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
