### PR TITLE
Move documentation panel rendering to renderer

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -608,9 +608,11 @@ export class Completer extends Widget {
     }
     docPanel.textContent = '';
     if (activeItem.documentation) {
-      let pre = document.createElement('pre');
-      pre.textContent = activeItem.documentation;
-      docPanel.appendChild(pre);
+      if (!this._renderer.createDocumentationNode) {
+        return;
+      }
+      let node = this._renderer.createDocumentationNode(activeItem);
+      docPanel.appendChild(node);
       docPanel.setAttribute('style', '');
     } else {
       docPanel.setAttribute('style', 'display:none');
@@ -849,6 +851,14 @@ export namespace Completer {
       typeMap: TypeMap,
       orderedTypes: string[]
     ): HTMLLIElement;
+
+    /**
+     * Create a documentation node (a `pre` element by default) for
+     * documentation panel.
+     */
+    createDocumentationNode?(
+      activeItem: CompletionHandler.ICompletionItem
+    ): HTMLElement;
   }
 
   /**
@@ -891,6 +901,17 @@ export namespace Completer {
         typeMap[item.raw] || '',
         orderedTypes
       );
+    }
+
+    /**
+     * Create a documentation node for documentation panel.
+     */
+    createDocumentationNode(
+      activeItem: CompletionHandler.ICompletionItem
+    ): HTMLElement {
+      let pre = document.createElement('pre');
+      pre.textContent = activeItem.documentation || '';
+      return pre;
     }
 
     /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -608,10 +608,12 @@ export class Completer extends Widget {
     }
     docPanel.textContent = '';
     if (activeItem.documentation) {
+      let node: HTMLElement;
       if (!this._renderer.createDocumentationNode) {
-        return;
+        node = Completer.defaultRenderer.createDocumentationNode(activeItem);
+      } else {
+        node = this._renderer.createDocumentationNode(activeItem);
       }
-      let node = this._renderer.createDocumentationNode(activeItem);
       docPanel.appendChild(node);
       docPanel.setAttribute('style', '');
     } else {

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -23,7 +23,11 @@ import { framePromise, sleep } from '@jupyterlab/testutils';
 
 const TEST_ITEM_CLASS = 'jp-TestItem';
 
+const TEST_DOC_CLASS = 'jp-TestDoc';
+
 const ITEM_CLASS = 'jp-Completer-item';
+
+const DOC_PANEL_CLASS = 'jp-Completer-docpanel';
 
 const ACTIVE_CLASS = 'jp-mod-active';
 
@@ -53,6 +57,14 @@ class CustomRenderer extends Completer.Renderer {
     const li = super.createItemNode(item, typeMap, orderedTypes);
     li.classList.add(TEST_ITEM_CLASS);
     return li;
+  }
+
+  createDocumentationNode(
+    item: CompletionHandler.ICompletionItem
+  ): HTMLElement {
+    const element = super.createDocumentationNode!(item);
+    element.classList.add(TEST_DOC_CLASS);
+    return element;
   }
 }
 
@@ -124,7 +136,7 @@ describe('completer/widget', () => {
           renderer: new CustomRenderer()
         };
         options.model!.setCompletionItems!([
-          { label: 'foo' },
+          { label: 'foo', documentation: 'foo does bar' },
           { label: 'bar' }
         ]);
 
@@ -136,6 +148,12 @@ describe('completer/widget', () => {
         expect(items).toHaveLength(2);
         expect(Array.from(items[0].classList)).toEqual(
           expect.arrayContaining([TEST_ITEM_CLASS])
+        );
+
+        let panel = widget.node.querySelector(`.${DOC_PANEL_CLASS}`)!;
+        expect(panel.children).toHaveLength(1);
+        expect(Array.from(panel.firstElementChild!.classList)).toEqual(
+          expect.arrayContaining([TEST_DOC_CLASS])
         );
       });
     });


### PR DESCRIPTION
## References

#8930 exposed the `Completer.IRenderer` to the world so that extensions can now customize the completer rendering. The `IRenderer` handles both the legacy `createItemNode` and the new `createCompletionItemNode`, however the new documentation panel node creation is currently hard-coded in the `Completer` widget `_updateDocPanel` preventing customization; the default rendering is very limited (a `pre` element, no markdown support etc).

## Code changes

- creates new `IRender.createDocumentationNode(item)` method
- extracts the default implementation from the completer widget

## User-facing changes

JupyterLab-LSP users will see nicely rendered markdown documentation as in:

![R-docs-with-prefetch](https://user-images.githubusercontent.com/5832902/105634237-fbd16500-5e54-11eb-9d56-7a1b1ad3965b.gif)

## Backwards-incompatible changes

The extensions that implement custom `Completer.IRenderer` will need to add `createDocumentationNode` if they do not inherit from the default `Completer.Renderer`. I am not aware of any extension doing so. @edzkite would this affect you?