### PR TITLE
Revert creating a new browser tab for a new launcher when in simple interface

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -162,7 +162,7 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
   id: '@jupyterlab/filebrowser-extension:factory',
   provides: IFileBrowserFactory,
   requires: [IDocumentManager, ITranslator],
-  optional: [ILabShell, IStateDB, IRouter, JupyterFrontEnd.ITreeResolver]
+  optional: [IStateDB, IRouter, JupyterFrontEnd.ITreeResolver]
 };
 
 /**
@@ -243,7 +243,6 @@ async function activateFactory(
   app: JupyterFrontEnd,
   docManager: IDocumentManager,
   translator: ITranslator,
-  labShell: ILabShell | null,
   state: IStateDB | null,
   router: IRouter | null,
   tree: JupyterFrontEnd.ITreeResolver | null
@@ -268,29 +267,17 @@ async function activateFactory(
     const widget = new FileBrowser({ id, model, restore, translator });
 
     // Add a launcher toolbar item.
-    if (labShell) {
-      const launcher = new ToolbarButton({
-        icon: addIcon,
-        onClick: () => {
-          if (
-            labShell.mode === 'multiple-document' &&
-            commands.hasCommand('launcher:create')
-          ) {
-            return Private.createLauncher(commands, widget);
-          } else {
-            const newUrl = PageConfig.getUrl({
-              mode: labShell.mode,
-              workspace: PageConfig.defaultWorkspace,
-              treePath: model.path
-            });
-            window.open(newUrl, '_blank');
-          }
-        },
-        tooltip: trans.__('New Launcher'),
-        actualOnClick: true
-      });
-      widget.toolbar.insertItem(0, 'launch', launcher);
-    }
+    const launcher = new ToolbarButton({
+      icon: addIcon,
+      onClick: () => {
+        if (commands.hasCommand('launcher:create')) {
+          return Private.createLauncher(commands, widget);
+        }
+      },
+      tooltip: trans.__('New Launcher'),
+      actualOnClick: true
+    });
+    widget.toolbar.insertItem(0, 'launch', launcher);
 
     // Track the newly created file browser.
     void tracker.add(widget);


### PR DESCRIPTION
## References



Thanks to @krassowski for bringing this up at https://github.com/jupyterlab/jupyterlab/issues/9567#issuecomment-765074022

## Code changes

This reverts part of f151dddc9a1364b27d11f8f0bb285ba88442e076  (see https://github.com/jupyterlab/jupyterlab/commit/f151dddc9a1364b27d11f8f0bb285ba88442e076#diff-8c7e52adc72ce433f77a37e6418721fb38204c7bab00d78fc89e67bd49176044R263-R268, part of #8715 ), consistent with the decisions made in #9323 and #9334

## User-facing changes

Makes "New Launcher" launch a jlab tab rather than a browser tab in the Simple Interface.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
