### PR TITLE
Make the filebrowser plugins more reusable

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -233,7 +233,7 @@ export const fileUploadStatus: JupyterFrontEndPlugin<void> = {
 /**
  * A plugin to add a launcher button to the file browser toolbar
  */
-export const toolbarButton: JupyterFrontEndPlugin<void> = {
+export const launcherToolbarButton: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/filebrowser-extension:launcher-toolbar-button',
   autoStart: true,
   requires: [IFileBrowserFactory, ITranslator],
@@ -1280,6 +1280,6 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   shareFile,
   fileUploadStatus,
   browserWidget,
-  toolbarButton
+  launcherToolbarButton
 ];
 export default plugins;

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -360,13 +360,13 @@ function activateBrowser(
     updateBrowserTitle();
   });
 
-  void Promise.all([app.restored, browser.model.restored]).then(() => {
-    if (treePathUpdater) {
+  if (treePathUpdater) {
+    void Promise.all([app.restored, browser.model.restored]).then(() => {
       browser.model.pathChanged.connect((sender, args) => {
         treePathUpdater(args.newValue);
       });
-    }
-  });
+    });
+  }
 }
 
 function activateWidget(

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -167,7 +167,7 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
 /**
  * A plugin to activate the file browser widget in a ILabShell
  */
-const lab: JupyterFrontEndPlugin<void> = {
+const browserWidget: JupyterFrontEndPlugin<void> = {
   activate: activateWidget,
   id: '@jupyterlab/filebrowser-extension:widget',
   requires: [IDocumentManager, IFileBrowserFactory, ITranslator, ILabShell],
@@ -243,7 +243,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   browser,
   shareFile,
   fileUploadStatus,
-  lab
+  browserWidget
 ];
 export default plugins;
 

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -143,7 +143,13 @@ const browser: JupyterFrontEndPlugin<void> = {
   activate: activateBrowser,
   id: '@jupyterlab/filebrowser-extension:browser',
   requires: [IFileBrowserFactory, ITranslator],
-  optional: [ILayoutRestorer, ISettingRegistry, ITreePathUpdater, ICommandPalette, IMainMenu],
+  optional: [
+    ILayoutRestorer,
+    ISettingRegistry,
+    ITreePathUpdater,
+    ICommandPalette,
+    IMainMenu
+  ],
   autoStart: true
 };
 
@@ -166,7 +172,7 @@ const lab: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/filebrowser-extension:widget',
   requires: [IDocumentManager, IFileBrowserFactory, ITranslator, ILabShell],
   optional: [ISettingRegistry],
-  autoStart: true,
+  autoStart: true
 };
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/9439 and https://github.com/jupyterlab/jupyterlab/pull/9664

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Alternative frontends that would like to reuse the file browser component need to copy quite a bit of logic for `filebrowser-extension` plugins.

This is the case with JupyterLab Classic, which currently vendors a good chunk of the filebrowser plugins:

https://github.com/jtpio/jupyterlab-classic/blob/d8dfe9c1e9bd9873a68bdd43d4e581636ecf0e45/packages/tree-extension/src/index.ts

This is mostly because the `filebrowser-extension:browser` plugin requires an `ILabShell` to add the browser to the `left` area:

https://github.com/jupyterlab/jupyterlab/blob/74ccaf4b02c6540c974c8d337b492a0badeb9e8e/packages/filebrowser-extension/src/index.ts#L367

This change makes some of the plugin dependencies as `optional`, and moves the `ILabShell` specific logic to a separate plugin. A plugin that can then be ignored and replaced by another one in alternative frontends, so they can for example add the file browser to the `main` area but still keep all the commands added by the other core plugins.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

This change adds a new plugin to the `filebrowser-extension` package. It also changes the logic of the `browser` plugin, which doesn't add the browser widget to the `labShell` anymore. This might be breaking if we consider plugins to be part of the surface API, and if other applications reuse this exact plugin as is and expect it to add the browser widget to the shell. If so, then they would need to also include the new plugin in their build.

Also the `browser` plugin still doesn't provide any token, so this part doesn't change.
 
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
