### PR TITLE
Move flaky tests to a separate workflow on CI

### DIFF
--- a/.github/workflows/linuxjs-flaky-tests.yml
+++ b/.github/workflows/linuxjs-flaky-tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: JS
     strategy:
       matrix:
-        group: [js-services, js-apputils]
+        group: [s-apputils]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/linuxjs-flaky-tests.yml
+++ b/.github/workflows/linuxjs-flaky-tests.yml
@@ -1,4 +1,4 @@
-name: Linux JS Tests
+name: Linux JS Flaky Tests
 
 on: [push, pull_request]
 
@@ -7,7 +7,7 @@ jobs:
     name: JS
     strategy:
       matrix:
-        group: [js-services, js-application, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-documentsearch, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-toc, js-translation, js-ui-components, js-testutils]
+        group: [js-services, js-apputils]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -52,3 +52,4 @@ jobs:
           GROUP: ${{ matrix.group }}
         run: |
           bash ./scripts/ci_script.sh
+

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -13,7 +13,6 @@ import {
   KernelSpec,
   KernelSpecAPI,
   KernelManager,
-  KernelAPI
 } from '../../src';
 
 import {

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -57,8 +57,7 @@ describe('Kernel.IKernel', () => {
   });
 
   afterAll(async () => {
-    const models = await KernelAPI.listRunning();
-    await Promise.all(models.map(m => KernelAPI.shutdownKernel(m.id)));
+    await kernelManager.shutdownAll();
   });
 
   describe('#disposed', () => {

--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -12,7 +12,7 @@ import {
   KernelMessage,
   KernelSpec,
   KernelSpecAPI,
-  KernelManager,
+  KernelManager
 } from '../../src';
 
 import {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

The long term motivation is to be able to reach a full green CI some time soon.

For now, this change moves some of the known flaky tests to their own workflow, so they can easily be restarted without re-running everything else. The current list includes:

- `js-services`
- `js-apputils` 

![image](https://user-images.githubusercontent.com/591645/105869423-818d1600-5ff7-11eb-8c78-a1fb47a46f27.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

CI

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
