### PR TITLE
use jupyterhub make_singleuser_app mixin when available

### DIFF
--- a/jupyterlab/labhubapp.py
+++ b/jupyterlab/labhubapp.py
@@ -4,11 +4,38 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from jupyterhub.singleuser import SingleUserNotebookApp
+import os
+
+from jupyter_server.serverapp import ServerApp
+from traitlets import default
+
+from .labapp import LabApp
+
+if not os.environ.get("JUPYTERHUB_SINGLEUSER_APP"):
+    # setting this env prior to import of jupyterhub.singleuser avoids unnecessary import of notebook
+    os.environ["JUPYTERHUB_SINGLEUSER_APP"] = "jupyter_server.serverapp.ServerApp"
+
+try:
+    from jupyterhub.singleuser.mixins import make_singleuser_app
+except ImportError:
+    # backward-compat with jupyterhub < 1.3
+    from jupyterhub.singleuser import SingleUserNotebookApp as SingleUserServerApp
+else:
+    SingleUserServerApp = make_singleuser_app(ServerApp)
 
 
-class SingleUserLabApp(SingleUserNotebookApp):
-    default_url = '/lab'
+class SingleUserLabApp(SingleUserServerApp):
+    @default("default_url")
+    def _default_url(self):
+        return "/lab"
+
+    def find_server_extensions(self):
+        """unconditionally enable jupyterlab server extension
+
+        never called if using legacy SingleUserNotebookApp
+        """
+        super().find_server_extensions()
+        self.jpserver_extensions[LabApp.get_extension_package()] = True
 
 
 def main(argv=None):


### PR DESCRIPTION
## References

closes #8807

new feature in jupyterhub 1.3 for supporting ServerApp-based entrypoints (https://github.com/jupyterhub/jupyterhub/pull/3128)

## Code changes

when available, use `make_singleuser_app` mixin (new in jupyterhub 1.3) provided
to wrap ServerApp instead of extending the legacy NotebookApp.

I'm not 100% sure the old NotebookApp fully works with jupyterlab 3.0, so it could be unconditional and raise an ImportError requiring jupyterhub 1.3 for jupyter-labhub if make_singleuser_app is unavailable.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

JupyterHub configuration:

```python
c.Spawner.cmd = ["jupyter", "labhub"]
```

should be all that's needed to enable jupyterlab in jupyterhub. It used to be the case, and will e again with this change.


## Backwards-incompatible changes

None