### PR TITLE
Enable jupyter labextension build/watch to work for custom jupyterlab distributions

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -163,9 +163,10 @@ def develop_labextension_py(module, user=False, sys_prefix=False, overwrite=True
     return full_dests
 
 
-def build_labextension(path, logger=None, development=False, static_url=None, source_map = False):
+def build_labextension(path, logger=None, development=False, static_url=None, source_map = False, core_path=None):
     """Build a labextension in the given path"""
-    core_path = osp.join(HERE, 'staging')
+    if core_path is None:
+        core_path = osp.join(HERE, 'staging')
     ext_path = osp.abspath(path)
 
     if logger:
@@ -186,7 +187,8 @@ def build_labextension(path, logger=None, development=False, static_url=None, so
 
 def watch_labextension(path, labextensions_path, logger=None, development=False, source_map=False):
     """Watch a labextension in a given path"""
-    core_path = osp.join(HERE, 'staging')
+    if core_path is None:
+        core_path = osp.join(HERE, 'staging')
     ext_path = osp.abspath(path)
 
     if logger:

--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -185,7 +185,7 @@ def build_labextension(path, logger=None, development=False, static_url=None, so
     subprocess.check_call(arguments, cwd=ext_path)
 
 
-def watch_labextension(path, labextensions_path, logger=None, development=False, source_map=False):
+def watch_labextension(path, labextensions_path, logger=None, development=False, source_map=False, core_path=None):
     """Watch a labextension in a given path"""
     if core_path is None:
         core_path = osp.join(HERE, 'staging')

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -87,6 +87,7 @@ disable_aliases['level'] = 'DisableLabExtensionsApp.level'
 
 VERSION = get_app_version()
 
+HERE = os.path.abspath(os.path.dirname(__file__))
 
 class BaseExtensionApp(JupyterApp, DebugLogFileMixin):
     version = VERSION
@@ -211,15 +212,20 @@ class BuildLabExtensionApp(BaseExtensionApp):
     source_map = Bool(False, config=True,
         help="Generage source maps")
 
+    core_path = Unicode(os.path.join(HERE, 'staging'), config=True,
+        help="Directory containing core application package.json file")
+
     aliases = {
         'static-url': 'BuildLabExtensionApp.static_url',
         'development': 'BuildLabExtensionApp.development',
-        'source-map': 'BuildLabExtensionApp.source_map'
+        'source-map': 'BuildLabExtensionApp.source_map',
+        'core-path': 'BuildLabExtensionApp.core_path'
     }
 
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
-        build_labextension(self.extra_args[0], logger=self.log, development=self.development, static_url=self.static_url or None, source_map = self.source_map)
+        build_labextension(self.extra_args[0], logger=self.log, development=self.development, static_url=self.static_url or None, source_map = self.source_map,
+        core_path = self.core_path or None)
 
 
 class WatchLabExtensionApp(BaseExtensionApp):
@@ -231,15 +237,19 @@ class WatchLabExtensionApp(BaseExtensionApp):
     source_map = Bool(False, config=True,
         help="Generage source maps")
 
+    core_path = Unicode(os.path.join(HERE, 'staging'), config=True,
+        help="Directory containing core application package.json file")
+
     aliases = {
         'development': 'BuildLabExtensionApp.development',
-        'source-map': 'BuildLabExtensionApp.source_map'
-
+        'source-map': 'BuildLabExtensionApp.source_map',
+        'core-path': 'BuildLabExtensionApp.core_path'
     }
     def run_task(self):
         self.extra_args = self.extra_args or [os.getcwd()]
         labextensions_path = self.labextensions_path
-        watch_labextension(self.extra_args[0], labextensions_path, logger=self.log, development=self.development, source_map=self.source_map)
+        watch_labextension(self.extra_args[0], labextensions_path, logger=self.log, development=self.development, source_map=self.source_map,
+        core_path = self.core_path or None)
 
 
 class UpdateLabExtensionApp(BaseExtensionApp):

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -194,6 +194,7 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension list 1>labextensions 2>&1
     cat labextensions | grep "@jupyterlab/mock-extension.*enabled.*OK"
     jupyter labextension build extension --static-url /foo/
+    jupyter labextension build extension --core-path ../../../examples/federated/core_package
     jupyter labextension disable @jupyterlab/mock-extension --debug
     jupyter labextension enable @jupyterlab/mock-extension --debug
     jupyter labextension uninstall @jupyterlab/mock-extension --debug


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Currently, jupyter labextension build/watch only work for building prebuilt extensions for core jupyterlab itself. For example, the federated example directly calls the npm builder itself, and cannot use jupyter labextension build because it is pointing to the wrong core package.json file.

This adds an option to jupyter labextension build/watch to give the core package directory. If a custom JupyterLab app follows the same conventions in its package.json metadata, you can prebuild extensions for it by pointing to its package directory with --core-path: `jupyter labextension build --core-path=/my/custom/jlab/package /my/extension/to/build`

I still left the example using the npm package builder by default to show how it can be done if you have access to the appropriate package.json.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
