### PR TITLE
Add link for prebuilt extensions too

### DIFF
--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -235,11 +235,12 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
       <div className="jp-extensionmanager-entry-description">
         <div className="jp-extensionmanager-entry-title">
           <div className="jp-extensionmanager-entry-name">
-            {entry.pkg_type == 'prebuilt' && <div>{entry.name}</div>}
-            {entry.pkg_type == 'source' && (
+            {entry.url ? (
               <a href={entry.url} target="_blank" rel="noopener noreferrer">
                 {entry.name}
               </a>
+            ) : (
+              <div>{entry.name}</div>
             )}
           </div>
           {entry.blockedExtensionsEntry && (


### PR DESCRIPTION
## Code changes

Replaces check for extension type with check for the actual necessary data.

Existing code sets `url` to `''` if there is none, and since `''` is falsy in JS, this works out.

## User-facing changes

Prebuilt extension titles will link to the extension’s URL target
