### PR TITLE
Fix browser check with Jupyter Server 1.2.3

### DIFF
--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -43,6 +43,7 @@ def main():
         """
         name = __name__
         open_browser = False
+        default_url = "/foo"
 
         serverapp_config = {
             "base_url": "/foo/",

--- a/examples/example_check.py
+++ b/examples/example_check.py
@@ -43,7 +43,7 @@ def main():
         """
         name = __name__
         open_browser = False
-        default_url = "/foo"
+        default_url = "/foo" + mod.ExampleApp.extension_url
 
         serverapp_config = {
             "base_url": "/foo/",

--- a/examples/federated/main.py
+++ b/examples/federated/main.py
@@ -25,6 +25,7 @@ def _jupyter_server_extension_points():
     ]
 
 class ExampleApp(LabServerApp):
+    extension_url = '/lab'
     name = 'lab'
     load_other_extensions = False
     app_name = 'JupyterLab Example App with Prebuilt Extensions'

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -175,7 +175,9 @@ class BrowserApp(LabApp):
     JS console errors, JS errors, and Python logged errors.
     """
     name = __name__
+    app_name = "JupyterLab Browser Check"
     open_browser = False
+    default_url = "/foo/lab"
 
     serverapp_config = {
         "base_url": "/foo/"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Looks like the browser check (`python -m jupyterlab.browser_check`) started failing with the latest `jupyter-server==1.2.3`.

Example run with the JS cookiecutter daily CI job: https://github.com/jupyterlab/extension-cookiecutter-js/runs/1795365189

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add `default_url` to `BrowserApp`

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

This should be compatible with previous releases of `jupyter-server` too.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
