### PR TITLE
Remove outdated note on ipywidgets

### DIFF
--- a/docs/source/extension/notebook.rst
+++ b/docs/source/extension/notebook.rst
@@ -280,5 +280,3 @@ to render the corresponding model, which returns a JavaScript promise.
 The renderer creates a container *lumino widget* which it hands back
 synchronously to the OutputArea, and then fills the container with the
 rendered *ipywidget* when the promise resolves.
-
-Note: The ipywidgets third party extension has not yet been released.


### PR DESCRIPTION
## References

Remove outdated note on ipywidgets not being released yet: https://gitter.im/jupyterlab/jupyterlab?at=6015abf555359c58bf0ede3c

## Code changes

None

## User-facing changes

Documentation updated

## Backwards-incompatible changes

None