### PR TITLE
Fix debug flag handling in build command

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -62,7 +62,7 @@ build_aliases['dev-build'] = 'LabBuildApp.dev_build'
 build_aliases['minimize'] = 'LabBuildApp.minimize'
 build_aliases['debug-log-path'] = 'DebugLogFileMixin.debug_log_path'
 
-build_flags = dict(flags)
+build_flags = dict(base_flags)
 
 build_flags['dev-build'] = (
     {'LabBuildApp': {'dev_build': True}},


### PR DESCRIPTION

## References
Fixes jupyterlab/jupyterlab#9710

## Code changes
Fixes handling of flags for `jupyter lab build`.

## User-facing changes
`jupyter lab build --debug` will now properly show output.

## Backwards-incompatible changes
N/A