### PR TITLE
Add default shortcuts for moving cells

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -216,6 +216,16 @@
       "command": "notebook:undo-cell-action",
       "keys": ["Z"],
       "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:move-cell-up",
+      "keys": ["Ctrl Shift ArrowUp"],
+      "selector": ".jp-Notebook:focus"
+    },
+    {
+      "command": "notebook:move-cell-down",
+      "keys": ["Ctrl Shift ArrowDown"],
+      "selector": ".jp-Notebook:focus"
     }
   ],
   "title": "Notebook",


### PR DESCRIPTION
This is a dupe of https://github.com/jupyterlab/jupyterlab/pull/9031 created to merge with master

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/7447
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Added shortcuts to control moving notebook cells up/down
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Users can now use `Ctrl Shift Up/Down` to move the cell in focus by one cell in either direction
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
