### PR TITLE
Add missing default_url fields to examples

### DIFF
--- a/examples/app/main.py
+++ b/examples/app/main.py
@@ -25,7 +25,9 @@ def _jupyter_server_extension_points():
     ]
 
 class ExampleApp(LabServerApp):
+
     extension_url = '/lab'
+    default_url = '/lab'
     name = __name__
     load_other_extensions = False
     app_name = 'JupyterLab Example App'

--- a/examples/cell/main.py
+++ b/examples/cell/main.py
@@ -63,6 +63,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/example'
+    default_url = '/example'
     app_url = "/example"
     name = __name__
     load_other_extensions = False

--- a/examples/console/main.py
+++ b/examples/console/main.py
@@ -64,6 +64,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/example'
+    default_url = '/example'
     app_url = "/example"
     load_other_extensions = False
     name = __name__

--- a/examples/filebrowser/main.py
+++ b/examples/filebrowser/main.py
@@ -63,6 +63,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/example'
+    default_url = '/example'
     app_url = "/example"
     load_other_extensions = False
     name = __name__

--- a/examples/notebook/main.py
+++ b/examples/notebook/main.py
@@ -69,6 +69,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/example'
+    default_url = '/example'
     app_url = "/example"
     name = __name__
     load_other_extensions = False

--- a/examples/terminal/main.py
+++ b/examples/terminal/main.py
@@ -64,6 +64,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/example'
+    default_url = '/example'
     app_url = "/example"
     name = __name__
     load_other_extensions = False


### PR DESCRIPTION
Adds missing `default_url` field to JupyterLab examples.

## References

## Code changes

## User-facing changes
N/A

## Backwards-incompatible changes
N/A