### PR TITLE
Add missing default_url fields to more examples

### DIFF
--- a/packages/services/examples/browser-require/main.py
+++ b/packages/services/examples/browser-require/main.py
@@ -52,6 +52,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/example'
     app_url = "/example"
+    default_url = '/example'
     name = __name__
     load_other_extensions = False
     app_name = 'JupyterLab Example Service'

--- a/packages/services/examples/browser/main.py
+++ b/packages/services/examples/browser/main.py
@@ -55,6 +55,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/example'
+    default_url = '/example'
     app_url = "/example"
     name = __name__
     load_other_extensions = False

--- a/packages/services/examples/typescript-browser-with-output/main.py
+++ b/packages/services/examples/typescript-browser-with-output/main.py
@@ -56,6 +56,7 @@ class ExampleApp(LabServerApp):
 
     extension_url = '/example'
     app_url = "/example"
+    default_url = '/example'
     name = __name__
     load_other_extensions = False
     app_name = 'JupyterLab Example Service'


### PR DESCRIPTION

## References
Follow up to jupyterlab/jupyterlab#9731

## Code changes

Adds `default_url` to the relevant services examples.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A