### PR TITLE
Use get_package_url from jupyterlab-server

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -37,6 +37,20 @@ from jupyterlab.jlpmapp import YARN_PATH, HERE
 from jupyterlab.coreconfig import _get_default_core_data, CoreConfig
 
 
+try:
+    from jupyterlab_server.config import get_package_url
+except ImportError:
+    def get_package_url(data):
+        # homepage, repository  are optional
+        if 'homepage' in data:
+            url = data['homepage']
+        elif 'repository' in data and isinstance(data['repository'], dict):
+            url = data['repository'].get('url', '')
+        else:
+            url = ''
+        return url
+
+
 # The regex for expecting the webpack output.
 WEBPACK_EXPECT = re.compile(r'.*theme-light-extension/style/index.css')
 
@@ -1404,13 +1418,7 @@ class _AppHandler(object):
                 alias = filename[len(PIN_PREFIX):-len(".tgz")]
             else:
                 alias = None
-            # homepage, repository  are optional
-            if 'homepage' in data:
-                url = data['homepage']
-            elif 'repository' in data and isinstance(data['repository'], dict):
-                url = data['repository'].get('url', '')
-            else:
-                url = ''
+            url = get_package_url(data)
             extensions[alias or name] = dict(path=path,
                                     filename=osp.basename(path),
                                     url=url,

--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -28,27 +28,13 @@ import warnings
 
 from jupyter_core.paths import jupyter_config_path, jupyter_path
 from jupyterlab_server.process import which, Process, WatchHelper, list2cmdline
-from jupyterlab_server.config import LabConfig, get_page_config, get_federated_extensions, get_static_page_config, write_page_config
+from jupyterlab_server.config import LabConfig, get_page_config, get_federated_extensions, get_package_url, get_static_page_config, write_page_config
 from jupyter_server.extension.serverextension import GREEN_ENABLED, GREEN_OK, RED_DISABLED, RED_X
 from traitlets import HasTraits, Bool, Dict, Instance, List, Unicode, default
 
 from jupyterlab.semver import Range, gte, lt, lte, gt, make_semver
 from jupyterlab.jlpmapp import YARN_PATH, HERE
 from jupyterlab.coreconfig import _get_default_core_data, CoreConfig
-
-
-try:
-    from jupyterlab_server.config import get_package_url
-except ImportError:
-    def get_package_url(data):
-        # homepage, repository  are optional
-        if 'homepage' in data:
-            url = data['homepage']
-        elif 'repository' in data and isinstance(data['repository'], dict):
-            url = data['repository'].get('url', '')
-        else:
-            url = ''
-        return url
 
 
 # The regex for expecting the webpack output.

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup_args['install_requires'] = [
     'packaging',
     'tornado>=6.1.0',
     'jupyter_core',
-    'jupyterlab_server~=2.0',
+    'jupyterlab_server~=2.2',
     'jupyter_server~=1.2',
     'nbclassic~=0.2',
     'jinja2>=2.10'
@@ -159,7 +159,7 @@ setup_args['extras_require'] = {
         'pytest-cov',
         'pytest-console-scripts',
         'pytest-check-links',
-        'jupyterlab_server[test]~=2.0',
+        'jupyterlab_server[test]~=2.2',
         'requests',
         'wheel',
         'virtualenv'


### PR DESCRIPTION
## References

As described in https://github.com/jupyterlab/jupyterlab_server/pull/154 (which once merged will enable to show description and urls for federated extensions) the logic of getting urls for packages could be moved to the `jupyterlab_server` (which https://github.com/jupyterlab/jupyterlab_server/pull/154 does). I am opening this PR so that the logic for choosing URLs for federated and source extensions do not diverge in future versions.

## Code changes

- move package URL selection logic to `get_package_url()` in jupyterlab_server
 
## User-facing changes

None (except those mentioned in the referenced PR).

## Backwards-incompatible changes

- Imports a new public function from `jupyterlab_server` thus requires it to be 2.2+