### PR TITLE
Do not take focus away from search panel (for navigateToCurrentDirectory)

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -387,7 +387,6 @@ const browserWidget: JupyterFrontEndPlugin<void> = {
             const { path } = context;
             try {
               await Private.navigateToPath(path, factory, translator);
-              labShell.currentWidget?.activate();
             } catch (reason) {
               console.warn(
                 `${CommandIDs.goToPath} failed to open: ${path}`,


### PR DESCRIPTION
## References

Fixes #9701

## Code changes

Removed `labShell.currentWidget?.activate();` call that was causing this issue.

It was originally introduced in https://github.com/jupyterlab/jupyterlab/pull/5880/files#diff-8c7e52adc72ce433f77a37e6418721fb38204c7bab00d78fc89e67bd49176044R304

Design-wise I believe that if any operation in file browser steals focus it should be refactored in a way that it stops doing so rather than having the manual re-focus on previously active widget (because it is just error-prone logic that can averted if the browser does not steal the focus). The good news is that it appears that the browser does not steel the focus (although it might have been doing so at the time this line was introduced).

## User-facing changes

Clicking on search bar in another document retains focus when `navigateToCurrentDirectory` is enabled.

## Backwards-incompatible changes

None