### PR TITLE
Fix search provider not recognising text nodes

### DIFF
--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: JS
     strategy:
       matrix:
-        group: [js-services, js-application, js-apputils, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-toc, js-translation, js-ui-components, js-testutils]
+        group: [js-services, js-application, js-apputils, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-documentsearch, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-toc, js-translation, js-ui-components, js-testutils]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/packages/documentsearch/babel.config.js
+++ b/packages/documentsearch/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/packages/documentsearch/jest.config.js
+++ b/packages/documentsearch/jest.config.js
@@ -1,0 +1,2 @@
+const func = require('@jupyterlab/testutils/lib/jest-config');
+module.exports = func(__dirname);

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -28,8 +28,13 @@
   ],
   "scripts": {
     "build": "tsc -b",
+    "build:test": "tsc --build tsconfig.test.json",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "prepublishOnly": "npm run build",
+    "test": "jest",
+    "test:cov": "jest --collect-coverage",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
+    "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
     "watch": "tsc -w --listEmittedFiles"
   },
   "dependencies": {
@@ -51,7 +56,11 @@
     "react": "^17.0.1"
   },
   "devDependencies": {
+    "@jupyterlab/testutils": "^3.1.0-alpha.0",
+    "@types/jest": "^26.0.10",
+    "jest": "^26.4.2",
     "rimraf": "~3.0.0",
+    "ts-jest": "^26.3.0",
     "typescript": "~4.1.3"
   },
   "publishConfig": {

--- a/packages/documentsearch/src/index.ts
+++ b/packages/documentsearch/src/index.ts
@@ -9,5 +9,6 @@ export * from './interfaces';
 export * from './searchinstance';
 export * from './searchproviderregistry';
 export * from './tokens';
+export * from './providers/genericsearchprovider';
 export * from './providers/codemirrorsearchprovider';
 export * from './providers/notebooksearchprovider';

--- a/packages/documentsearch/src/providers/genericsearchprovider.ts
+++ b/packages/documentsearch/src/providers/genericsearchprovider.ts
@@ -164,8 +164,12 @@ export class GenericSearchProvider implements ISearchProvider<Widget> {
           0,
           start
         )}${node!.textContent!.slice(end)}`;
-        // Are we replacing from the start?
-        if (start === 0) {
+        // Are we replacing somewhere in the middle?
+        if (node?.nodeType == Node.TEXT_NODE) {
+          const endText = (node as Text).splitText(start);
+          node!.parentNode!.insertBefore(spannedNode, endText);
+          // Are we replacing from the start?
+        } else if (start === 0) {
           node!.parentNode!.prepend(spannedNode);
           // Are we replacing at the end?
         } else if (end === originalLength) {
@@ -173,11 +177,6 @@ export class GenericSearchProvider implements ISearchProvider<Widget> {
           // Are the two results are adjacent to each other?
         } else if (lastNodeAdded && end === subsections[idx + 1].start) {
           node!.parentNode!.insertBefore(spannedNode, lastNodeAdded);
-          // Ok, we are replacing somewhere in the middle
-        } else {
-          // We know this is Text as we filtered for this in the walker above
-          const endText = (node as Text).splitText(start);
-          node!.parentNode!.insertBefore(spannedNode, endText);
         }
         lastNodeAdded = spannedNode;
         newMatches.unshift({

--- a/packages/documentsearch/src/providers/genericsearchprovider.ts
+++ b/packages/documentsearch/src/providers/genericsearchprovider.ts
@@ -6,13 +6,13 @@ import { ISearchProvider, ISearchMatch } from '../interfaces';
 import { ISignal, Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 
-const FOUND_CLASSES = ['cm-string', 'cm-overlay', 'cm-searching'];
+export const FOUND_CLASSES = ['cm-string', 'cm-overlay', 'cm-searching'];
 const SELECTED_CLASSES = ['CodeMirror-selectedtext'];
 
 export class GenericSearchProvider implements ISearchProvider<Widget> {
   /**
    * We choose opt out as most node types should be searched (e.g. script).
-   * Even nodes like <data>, could have innerText we care about.
+   * Even nodes like <data>, could have textContent we care about.
    *
    * Note: nodeName is capitalized, so we do the same here
    */
@@ -158,7 +158,7 @@ export class GenericSearchProvider implements ISearchProvider<Widget> {
         // TODO: support tspan for svg when svg support is added
         const spannedNode = document.createElement('span');
         spannedNode.classList.add(...FOUND_CLASSES);
-        spannedNode.innerText = text;
+        spannedNode.textContent = text;
         // Splice the text out before we add it back in with a span
         node!.textContent = `${node!.textContent!.slice(
           0,
@@ -400,7 +400,7 @@ export class GenericSearchProvider implements ISearchProvider<Widget> {
   private _changed = new Signal<this, void>(this);
 }
 
-interface IGenericSearchMatch extends ISearchMatch {
+export interface IGenericSearchMatch extends ISearchMatch {
   readonly originalNode: Node;
   readonly spanElement: HTMLElement;
   /*

--- a/packages/documentsearch/test/documentsearchprovider.spec.ts
+++ b/packages/documentsearch/test/documentsearchprovider.spec.ts
@@ -1,0 +1,107 @@
+import {
+  GenericSearchProvider,
+  IGenericSearchMatch,
+  FOUND_CLASSES
+} from '@jupyterlab/documentsearch';
+import { Widget } from '@lumino/widgets';
+
+const MATCH_CLASSES = FOUND_CLASSES.join(' ');
+
+describe('documentsearch/genericsearchprovider', () => {
+  describe('GenericSearchProvider', () => {
+    let provider: GenericSearchProvider;
+    let widget: Widget;
+    let match: IGenericSearchMatch;
+
+    beforeEach(() => {
+      provider = new GenericSearchProvider();
+      widget = new Widget();
+    });
+
+    afterEach(async () => {
+      await provider.endSearch();
+      widget.dispose();
+    });
+
+    function getHTMLForMatch(match: IGenericSearchMatch): string | undefined {
+      return match.spanElement?.closest('pre')?.innerHTML;
+    }
+
+    async function queryOne(query: RegExp) {
+      let matches = (await provider.startQuery(
+        query,
+        widget
+      )) as IGenericSearchMatch[];
+      expect(matches).toHaveLength(1);
+      return matches[0];
+    }
+
+    describe('#startQuery()', () => {
+      it('should highlight text fragment nested in a node', async () => {
+        widget.node.innerHTML = '<pre>xyz</pre>';
+        match = await queryOne(/x/);
+        console.log(match.spanElement);
+        expect(getHTMLForMatch(match)).toBe(
+          `<span class="${MATCH_CLASSES}">x</span>yz`
+        );
+
+        match = await queryOne(/y/);
+        expect(getHTMLForMatch(match)).toBe(
+          `x<span class="${MATCH_CLASSES}">y</span>z`
+        );
+
+        match = await queryOne(/z/);
+        expect(getHTMLForMatch(match)).toBe(
+          `xy<span class="${MATCH_CLASSES}">z</span>`
+        );
+      });
+
+      it('should highlight in presence of nested spans adjacent to text nodes', async () => {
+        widget.node.innerHTML = '<pre><span>x</span>yz</pre>';
+        match = await queryOne(/x/);
+        expect(getHTMLForMatch(match)).toBe(
+          `<span><span class="${MATCH_CLASSES}">x</span></span>yz`
+        );
+
+        match = await queryOne(/y/);
+        expect(getHTMLForMatch(match)).toBe(
+          `<span>x</span><span class="${MATCH_CLASSES}">y</span>z`
+        );
+
+        match = await queryOne(/z/);
+        expect(getHTMLForMatch(match)).toBe(
+          `<span>x</span>y<span class="${MATCH_CLASSES}">z</span>`
+        );
+
+        widget.node.innerHTML = '<pre>x<span>y</span>z</pre>';
+        match = await queryOne(/x/);
+        expect(getHTMLForMatch(match)).toBe(
+          `<span class="${MATCH_CLASSES}">x</span><span>y</span>z`
+        );
+
+        match = await queryOne(/y/);
+        expect(getHTMLForMatch(match)).toBe(
+          `x<span><span class="${MATCH_CLASSES}">y</span></span>z`
+        );
+
+        match = await queryOne(/z/);
+        expect(getHTMLForMatch(match)).toBe(
+          `x<span>y</span><span class="${MATCH_CLASSES}">z</span>`
+        );
+      });
+
+      it('should slice out the match correctly in nested nodes', async () => {
+        widget.node.innerHTML = '<pre><span>xy</span>z</pre>';
+        match = await queryOne(/x/);
+        expect(getHTMLForMatch(match)).toBe(
+          `<span><span class="${MATCH_CLASSES}">x</span>y</span>z`
+        );
+
+        match = await queryOne(/y/);
+        expect(getHTMLForMatch(match)).toBe(
+          `<span>x<span class="${MATCH_CLASSES}">y</span></span>z`
+        );
+      });
+    });
+  });
+});

--- a/packages/documentsearch/test/documentsearchprovider.spec.ts
+++ b/packages/documentsearch/test/documentsearchprovider.spec.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
 import {
   GenericSearchProvider,
   IGenericSearchMatch,

--- a/packages/documentsearch/test/documentsearchprovider.spec.ts
+++ b/packages/documentsearch/test/documentsearchprovider.spec.ts
@@ -27,7 +27,7 @@ describe('documentsearch/genericsearchprovider', () => {
       return match.spanElement?.closest('pre')?.innerHTML;
     }
 
-    async function queryOne(query: RegExp) {
+    async function queryOne(query: RegExp): Promise<IGenericSearchMatch> {
       let matches = (await provider.startQuery(
         query,
         widget
@@ -40,7 +40,6 @@ describe('documentsearch/genericsearchprovider', () => {
       it('should highlight text fragment nested in a node', async () => {
         widget.node.innerHTML = '<pre>xyz</pre>';
         match = await queryOne(/x/);
-        console.log(match.spanElement);
         expect(getHTMLForMatch(match)).toBe(
           `<span class="${MATCH_CLASSES}">x</span>yz`
         );
@@ -87,6 +86,22 @@ describe('documentsearch/genericsearchprovider', () => {
         match = await queryOne(/z/);
         expect(getHTMLForMatch(match)).toBe(
           `x<span>y</span><span class="${MATCH_CLASSES}">z</span>`
+        );
+
+        widget.node.innerHTML = '<pre>xy<span>z</span></pre>';
+        match = await queryOne(/x/);
+        expect(getHTMLForMatch(match)).toBe(
+          `<span class="${MATCH_CLASSES}">x</span>y<span>z</span>`
+        );
+
+        match = await queryOne(/y/);
+        expect(getHTMLForMatch(match)).toBe(
+          `x<span class="${MATCH_CLASSES}">y</span><span>z</span>`
+        );
+
+        match = await queryOne(/z/);
+        expect(getHTMLForMatch(match)).toBe(
+          `xy<span><span class="${MATCH_CLASSES}">z</span></span>`
         );
       });
 

--- a/packages/documentsearch/tsconfig.test.json
+++ b/packages/documentsearch/tsconfig.test.json
@@ -1,0 +1,36 @@
+{
+  "extends": "../../tsconfigbase.test",
+  "include": ["src/*", "test/*"],
+  "references": [
+    {
+      "path": "../apputils"
+    },
+    {
+      "path": "../cells"
+    },
+    {
+      "path": "../codeeditor"
+    },
+    {
+      "path": "../codemirror"
+    },
+    {
+      "path": "../fileeditor"
+    },
+    {
+      "path": "../notebook"
+    },
+    {
+      "path": "../translation"
+    },
+    {
+      "path": "../ui-components"
+    },
+    {
+      "path": "."
+    },
+    {
+      "path": "../../testutils"
+    }
+  ]
+}


### PR DESCRIPTION
During generic search (used for searching of cell outputs) a copy of HTML node is being modified. The code trying to infer the position of analysed node was not working with text nodes if those were adjacent to an element (=non-text) node leading to displacement of text nodes in tracebacks and other formatted output.

## References

Fixes #8224 and fixes #9181.

## Code changes

- [x] checks for text node first, and only if it is not a text node then check for adjacency
- [x] add unit tests:
  - exposed exports of `genericsearchprovider` (`GenericSearchProvider`) and additionally exported `IGenericSearchMatch` and `FOUND_CLASSES` to make it possible to test it
  - I prepared the test cases in https://github.com/jupyterlab/jupyterlab/issues/8224#issuecomment-773663496
- [x] replace `innerText` with `textContent`:
   - `innerText` does not work in the node tests, and it is considered non-standard;
   - they have comparable browser support:
      - `textContent` is a tiny bit [better supported](https://caniuse.com/textcontent): 98.81%, not supported by IE 6-8;
      - `innerText` has a [comparable statistic](https://caniuse.com/innertext): 98.53%, not supported by Firefox 2-44
    - textContent was already in use in this function, so having both is detrimental to compatibility with old browsers

## User-facing changes

Search in tracebacks and other formatted output  does not deform these outputs.

## Backwards-incompatible changes

Additional interface, constant and a class are now exposed.

CC @saulshanabrook who [requested](https://github.com/jupyterlab/jupyterlab/pull/7258#issuecomment-568760914) to be tagged in bugs related to this feature.