### PR TITLE
[BugFix] `ArgumentConflict` is not defined

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -22,6 +22,7 @@ from jupyter_core.paths import (
 from jupyter_core.utils import ensure_dir_exists
 from ipython_genutils.py3compat import cast_unicode_py2
 from jupyterlab_server.config import get_federated_extensions
+from jupyter_server.extension.serverextension import ArgumentConflict
 
 from .commands import _test_overlap
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
#9759 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
adds import of `ArgumentConflict`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A