### PR TITLE
Fix race condition in session startup

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -805,9 +805,9 @@ export class SessionContext implements ISessionContext {
       this._pendingKernelName = model.name;
     }
 
-    if (this._session) {
+    if (this._session && !this._isTerminating) {
       await this._shutdownSession();
-    } else {
+    } else if (!this._session) {
       this._kernelChanged.emit({
         name: 'kernel',
         oldValue: null,
@@ -851,7 +851,7 @@ export class SessionContext implements ISessionContext {
       // Update the name in case it has changed since we launched the session.
       await session.setName(this._name);
 
-      if (this._session) {
+      if (this._session && !this._isTerminating) {
         await this._shutdownSession();
       }
       return this._handleNewSession(session);

--- a/testutils/src/start_jupyter_server.ts
+++ b/testutils/src/start_jupyter_server.ts
@@ -208,7 +208,7 @@ namespace Private {
 
     const configDir = mktempDir('config');
     const configPath = path.join(configDir, 'jupyter_server_config.json');
-    const notebook_dir = createNotebookDir();
+    const root_dir = createNotebookDir();
 
     const app_dir = createAppDir();
     const user_settings_dir = mktempDir('settings');
@@ -219,11 +219,13 @@ namespace Private {
         user_settings_dir,
         workspaces_dir,
         app_dir,
-        open_browser: false
+        open_browser: false,
+        log_level: 'DEBUG'
       },
       ServerApp: {
         token,
-        notebook_dir
+        root_dir,
+        log_level: 'DEBUG'
       },
       MultiKernelManager: {
         default_kernel_name: 'echo'


### PR DESCRIPTION
## References
Fixes jupyterlab/jupyterlab#9758

## Code changes
Handles the case of a session that is in the process of terminating, avoiding a duplicate DELETE call, which had been resulting in 410 errors.

Also adds debug output from the server for tests and replaces deprecated `notebook_dir` trait with `root_dir`.

## User-facing changes
Less chance of an error due to a race condition when changing kernels.

## Backwards-incompatible changes
N/A