### PR TITLE
Add hash to webpack requests to enable caching

### DIFF
--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -235,6 +235,13 @@ function generateConfig({
     );
   }
 
+  // Add version argument when in production so the Jupyter server
+  // does not cache the files in the static file handler.
+  let filename = '[name].[contenthash].js';
+  if (mode === 'production') {
+    filename += '?v=[contenthash]';
+  }
+
   const config = [
     merge(
       baseConfig,
@@ -243,7 +250,7 @@ function generateConfig({
         devtool,
         entry: {},
         output: {
-          filename: '[name].[contenthash].js',
+          filename,
           path: staticPath,
           publicPath: staticUrl || 'auto'
         },

--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -236,7 +236,7 @@ function generateConfig({
   }
 
   // Add version argument when in production so the Jupyter server
-  // does not cache the files in the static file handler.
+  // allows caching of files (i.e., does not set the CacheControl header to no-cache to prevent caching static files)
   let filename = '[name].[contenthash].js';
   if (mode === 'production') {
     filename += '?v=[contenthash]';

--- a/dev_mode/webpack.prod.config.js
+++ b/dev_mode/webpack.prod.config.js
@@ -6,6 +6,11 @@ const LicenseWebpackPlugin = require('license-webpack-plugin')
 config[0] = merge(config[0], {
   mode: 'production',
   devtool: 'source-map',
+  output: {
+    // Add version argument when in production so the Jupyter server
+    // does not cache the files the static file handler.
+    filename: '[name].[contenthash].js?v=[contenthash]'
+  },
   optimization: {
     minimize: false
   },

--- a/dev_mode/webpack.prod.config.js
+++ b/dev_mode/webpack.prod.config.js
@@ -8,7 +8,7 @@ config[0] = merge(config[0], {
   devtool: 'source-map',
   output: {
     // Add version argument when in production so the Jupyter server
-    // does not cache the files the static file handler.
+    // allows caching of files (i.e., does not set the CacheControl header to no-cache to prevent caching static files)
     filename: '[name].[contenthash].js?v=[contenthash]'
   },
   optimization: {


### PR DESCRIPTION
## References
Related to jupyterlab/jupyterlab#9762. cc @zhamujun

## Code changes
Add a version argument to generated webpack output for both the main build and prebuilt extensions when in production mode.
This is needed because the server is deciding whether to cache static files based on the existence of [this argument](https://github.com/jupyter-server/jupyter_server/blob/3220f4f79e58b7f377cec7416bd35ad0ea300fb2/jupyter_server/base/handlers.py#L661), which is also the behavior of tornado's [`StaticFileHandler`](https://www.tornadoweb.org/en/stable/web.html#tornado.web.StaticFileHandler). This same behavior exists when running using the [classic notebook server](https://github.com/jupyter/notebook/blob/6a3f4a79dd6de7569935c7516d7243b4c62b9e9e/notebook/base/handlers.py#L742).

The files generated by webpack are of the form `3341.cf37a29a49e9bc70ba18.js` (with no argument), but the requests it makes include the version argument, allowing the caching behavior to work.

## User-facing changes
JupyterLab will load faster when built in production mode (after the files are cached).

## Backwards-incompatible changes
N/A