### PR TITLE
Update MANIFEST.in to include package_data files.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,17 @@ include setup.py
 # Documentation
 graft docs
 exclude docs/\#*
+
+# We must include the package_data files since include_package_data=True
+# See https://github.com/pypa/setuptools/issues/1461
+include jupyterlab/staging/*
+include jupyterlab/staging/templates/*
+include jupyterlab/staging/.yarnrc
+graft jupyterlab/static
+graft jupyterlab/tests/mock_packages
+graft jupyterlab/themes
+graft jupyterlab/schemas
+recursive-include jupyterlab *.js
+
+prune jupyterlab/staging/node_modules
+prune jupyterlab/staging/build


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

In https://github.com/jupyter/jupyter-packaging/pull/66, jupyter_packaging switched (back) to using setuptools rather than distutils for sdist. We had problems before with the staging directory not being included when using the setuptools sdist (see https://github.com/conda-forge/jupyterlab-feedstock/pull/235 and https://github.com/jupyter/jupyter-packaging/pull/51). It seems that the real problem we were experiencing was that when you have include_package_data=True, setuptools apparently does not include package_data files that are not given in MANIFEST.in (see https://github.com/pypa/setuptools/issues/1461, for example).

This tries to get our packaging working with setuptools. We’ll be able to test this better when we actually do a release.

I tested with just running `python setup.py sdist` in a fresh checkout with jupyter_packaging 0.7.12, and it ended up building the javascript in the staging directory, and then it included the build and node_modules directory. Thus I prune these out explicitly here. However, I think our normal build process does not build in that directory, but rather copies over files from the dev_mode directory, so the prune may not be needed in our normal build process. It doesn’t hurt to have it in, though.

It may be that we can consolidate these include statements, for example, perhaps we can just do “graft jupyterlab/staging”. However, I went for simplicity in closely mirroring what we have in package_data in setup.py.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
