### PR TITLE
Fix mimerender test example and test in CI

### DIFF
--- a/jupyterlab/tests/mock_packages/mimeextension/index.js
+++ b/jupyterlab/tests/mock_packages/mimeextension/index.js
@@ -13,6 +13,7 @@ var factory = {
 };
 
 module.exports = {
+  id: '@jupyterlab/mock-mime-extension:plugin',
   mimeType: 'text/plain',
   rendererFactory: factory,
   widgetFactoryOptions: {

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -180,8 +180,11 @@ if [[ $GROUP == usage ]]; then
     jupyter labextension unlink  @jupyterlab/mock-mime-extension --no-build --debug
 
     # Test with a source package install
-    jupyter labextension install mimeextension  --no-build --debug
+    jupyter labextension install mimeextension --debug
     jupyter labextension list --debug
+    jupyter labextension list 1>labextensions 2>&1
+    cat labextensions | grep "@jupyterlab/mock-mime-extension.*enabled.*OK"
+    python -m jupyterlab.browser_check
     jupyter labextension disable @jupyterlab/mock-mime-extension --debug
     jupyter labextension enable @jupyterlab/mock-mime-extension --debug
     jupyter labextension uninstall @jupyterlab/mock-mime-extension --no-build --debug


### PR DESCRIPTION
The `mimeextension` test example was missing an `id` and was therefore not a valid plugin.

## Code changes
Fixes the `mimeextension` and makes sure it loads properly in the browser in CI.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
