### PR TITLE
Add "author_name" to cookiecutter

### DIFF
--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -105,6 +105,7 @@ are using to fetch pictures).
 ::
 
     author_name []: Your Name
+    author_email []: your@name.org
     python_name [myextension]: jupyterlab_apod
     labextension_name [myextension]: jupyterlab_apod
     project_short_description [A JupyterLab extension.]: Show a random NASA Astronomy Picture of the Day in a JupyterLab panel


### PR DESCRIPTION
We have just added "author_name" to the cookiecutter template. Would be nice to reflect the changes here. :)

More information: https://github.com/jupyterlab/extension-cookiecutter-ts/pull/140
