### PR TITLE
Fix label for "Create Console for Editor"

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -1197,7 +1197,7 @@ export namespace Commands {
     ) => Promise<void> = getCreateConsoleFunction(commands);
     menu.fileMenu.consoleCreators.add({
       tracker,
-      createConsoleLabel: (n: number) => trans.__('Editor'),
+      createConsoleLabel: (n: number) => trans.__('Create Console for Editor'),
       createConsole
     } as IFileMenu.IConsoleCreator<IDocumentWidget<FileEditor>>);
   }


### PR DESCRIPTION
## References

Fixes #9793

## Code changes

None

## User-facing changes

Correct labels shows up in the tab context menu.

## Backwards-incompatible changes

None. The string "Create Console for Editor" is already used in context menu of the file editor (as compared to context menu of the tab) so no new translations needed.