### PR TITLE
Fix Services Tests

### DIFF
--- a/packages/services/test/kernel/ikernel.spec.ts
+++ b/packages/services/test/kernel/ikernel.spec.ts
@@ -23,7 +23,7 @@ import {
   flakyIt as it
 } from '@jupyterlab/testutils';
 
-import { KernelTester, handleRequest } from '../utils';
+import { FakeKernelManager, KernelTester, handleRequest } from '../utils';
 
 const server = new JupyterServer();
 
@@ -42,7 +42,7 @@ describe('Kernel.IKernel', () => {
 
   beforeAll(async () => {
     jest.setTimeout(20000);
-    kernelManager = new KernelManager();
+    kernelManager = new FakeKernelManager();
     specs = await KernelSpecAPI.getSpecs();
   });
 
@@ -345,11 +345,16 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should get a restarting status', async () => {
-      const emission = testEmission(defaultKernel.statusChanged, {
-        find: () => defaultKernel.status === 'restarting'
+      const kernel = await kernelManager.startNew();
+      await kernel.info;
+      const emission = testEmission(kernel.statusChanged, {
+        find: () => kernel.status === 'restarting'
       });
-      await defaultKernel.restart();
+      await kernel.requestKernelInfo();
+      await kernel.restart();
       await emission;
+      await kernel.requestKernelInfo();
+      await kernel.shutdown();
     });
 
     it('should get a busy status', async () => {
@@ -618,11 +623,16 @@ describe('Kernel.IKernel', () => {
 
   describe('#restart()', () => {
     beforeEach(async () => {
-      await defaultKernel.info;
+      await defaultKernel.requestKernelInfo();
     });
 
     it('should restart and resolve with a valid server response', async () => {
-      await defaultKernel.restart();
+      const kernel = await kernelManager.startNew();
+      await kernel.info;
+      await kernel.requestKernelInfo();
+      await kernel.restart();
+      await kernel.requestKernelInfo();
+      await kernel.shutdown();
     });
 
     it('should fail if the kernel does not restart', async () => {
@@ -653,12 +663,16 @@ describe('Kernel.IKernel', () => {
     });
 
     it('should dispose of existing comm and future objects', async () => {
-      const comm = defaultKernel.createComm('test');
-      const future = defaultKernel.requestExecute({ code: 'foo' });
-      await defaultKernel.restart();
-      await defaultKernel.info;
+      const kernel = await kernelManager.startNew();
+      await kernel.info;
+      await kernel.requestKernelInfo();
+      const comm = kernel.createComm('test');
+      const future = kernel.requestExecute({ code: 'foo' });
+      await kernel.restart();
+      await kernel.requestKernelInfo();
       expect(future.isDisposed).toBe(true);
       expect(comm.isDisposed).toBe(true);
+      await kernel.shutdown();
     });
   });
 

--- a/packages/services/test/session/isession.spec.ts
+++ b/packages/services/test/session/isession.spec.ts
@@ -382,7 +382,6 @@ describe('session', () => {
         expect(session.kernel).not.toBe(previous);
         expect(session.kernel).not.toBe(kernel);
         previous.dispose();
-        await KernelAPI.shutdownKernel(kernel.id);
       });
 
       it('should update the session path if it has changed', async () => {

--- a/packages/services/test/utils.ts
+++ b/packages/services/test/utils.ts
@@ -278,13 +278,22 @@ class SocketTester implements IService {
   protected settings: ServerConnection.ISettings;
 }
 
+export class FakeKernelManager extends KernelManager {
+  // Override requestRunning since we aren't starting kernels
+  // on the server.
+  // This prevents kernel connections from being culled.
+  requestRunning(): Promise<void> {
+    return Promise.resolve(void 0);
+  }
+}
+
 /**
  * Kernel class test rig.
  */
 export class KernelTester extends SocketTester {
   constructor() {
     super();
-    this._kernelManager = new KernelManager({
+    this._kernelManager = new FakeKernelManager({
       serverSettings: this.serverSettings
     });
   }


### PR DESCRIPTION
Fixes services tests, which have been failing in CI for months.

## Code changes

- Prevent the culling of fake kernels created by `KernelTester`
- Make sure there are no outstanding futures when restarting, because canceled shell futures raise an error
- Let the session shut down the kernel in a sessions test to avoid server error for a kernel that was shut down directly

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
