### PR TITLE
@jupyterlab/rendermime: upgraded `marked` dep past vulnerability

### DIFF
--- a/packages/rendermime/package.json
+++ b/packages/rendermime/package.json
@@ -56,7 +56,7 @@
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.16.1",
     "lodash.escape": "^4.0.1",
-    "marked": "^1.1.1"
+    "marked": "^2.0.0"
   },
   "devDependencies": {
     "@jupyterlab/mathjax2": "^3.1.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10835,15 +10835,15 @@ marked@^0.3.9:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
   integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
 
-marked@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
-  integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
-
 marked@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.6.tgz#fa55cf38ab3585005c9fb3c1ebfb3d4590c29fdc"
   integrity sha512-7vVuSEZ8g/HH3hK/BH/+7u/NJj7x9VY4EHzujLDcqAQLiOUeFJYAsfSAyoWtR17lKrx7b08qyIno4lffwrzTaA==
+
+marked@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.0.tgz#9662bbcb77ebbded0662a7be66ff929a8611cee5"
+  integrity sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==
 
 marky@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
## References

fixes #9808

Upgrades `marked` dep from `@jupyterlab/rendermime` past a version with a known security vulnerability

## Code changes

NA

## User-facing changes

NA

## Backwards-incompatible changes

NA