### PR TITLE
Update CI script timeouts

### DIFF
--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -10,6 +10,7 @@ jobs:
         group: [js-services, js-application, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-documentsearch, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-toc, js-translation, js-ui-components, js-testutils]
       fail-fast: false
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -7,16 +7,20 @@ jobs:
     name: Linux
     strategy:
       matrix:
-        group: [integrity, integrity2, docs, usage, python, examples, interop, nonode, linkcheck, lint]
+        group: [integrity, integrity2, integrity3, docs, usage, usage2, python, examples, interop, nonode, linkcheck, lint]
         python: [3.6, 3.8]
         exclude:
           - group: integrity
             python: 3.6
           - group: integrity2
             python: 3.6
+          - group: integrity3
+            python: 3.6
           - group: docs
             python: 3.6
           - group: usage
+            python: 3.6
+          - group: usage2
             python: 3.6
           - group: linkcheck
             python: 3.6
@@ -27,7 +31,7 @@ jobs:
           - group: examples
             python: 3.6
       fail-fast: false
-    timeout-minutes: 120
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/windowstests.yml
+++ b/.github/workflows/windowstests.yml
@@ -10,6 +10,7 @@ jobs:
         group: [integrity, python]
       fail-fast: false
     runs-on: windows-latest
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -122,6 +122,10 @@ if [[ $GROUP == integrity2 ]]; then
     python -m build .
     twine check dist/*
 
+fi
+
+
+if [[ $GROUP == integrity3 ]]; then
     # Make sure we can bump the version
     # This must be done at the end so as not to interfere
     # with the other checks
@@ -272,6 +276,11 @@ if [[ $GROUP == usage ]]; then
     python -m jupyterlab.browser_check --dev-mode
     jlpm run remove:package foo
     jlpm run integrity
+
+fi
+
+
+if [[ $GROUP == usage2 ]]; then
 
     ## Test app directory support being a symlink
     mkdir tmp


### PR DESCRIPTION
Breaks up our usage and integrity2 scripts that were our longest running, and imposes tighter time limits on our CI tests.

## Code changes
Updates CI script and action workflow files

## User-facing changes
N/A

## Backwards-incompatible changes
N/A