### PR TITLE
Fix the display of breakpoints on restore

### DIFF
--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -617,7 +617,11 @@ export class DebuggerService implements IDebugger, IDisposable {
         const { breakpoints, source } = val;
         map.set(
           source,
-          breakpoints.map(point => ({ ...point, verified: true }))
+          breakpoints.map(point => ({
+            ...point,
+            source: { path: source },
+            verified: true
+          }))
         );
         return map;
       },

--- a/packages/debugger/test/debugger.spec.ts
+++ b/packages/debugger/test/debugger.spec.ts
@@ -241,6 +241,17 @@ describe('Debugger', () => {
 
       expect(len2).toEqual(len1 + 1);
     });
+
+    it('should contain the path after a restore', async () => {
+      await service.restoreState(true);
+      const node = sidebar.breakpoints.node;
+      const items = node.querySelectorAll('.jp-DebuggerBreakpoint-source');
+      items.forEach(item => {
+        // TODO: replace by toEqual when there is an alternative to the rtl
+        // breakpoint display
+        expect(item.innerHTML).toContain(path.slice(1));
+      });
+    });
   });
 
   describe('#sources', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/9822

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The issue was that the breakpoints were not correctly mapped during the restore process.

According to the protocol the `debugInfo` response returns a list of source breakpoints: https://jupyter-client.readthedocs.io/en/stable/messaging.html#additions-to-the-dap

And the source breakpoints don't include the path to the source (just the line as mandatory option): https://microsoft.github.io/debug-adapter-protocol/specification#Types_SourceBreakpoint 

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

### Before

https://user-images.githubusercontent.com/591645/108372632-4ef1ca00-71ff-11eb-9097-f105b351b93d.mp4

### After

https://user-images.githubusercontent.com/591645/108406893-4b703a00-7223-11eb-9449-373c51fad696.mp4

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
