### PR TITLE
Add peerDependencies to the shared packages

### DIFF
--- a/builder/src/extensionConfig.ts
+++ b/builder/src/extensionConfig.ts
@@ -89,8 +89,12 @@ function generateConfig({
     };
   });
 
-  // Add package dependencies.
-  Object.keys(data.dependencies).forEach(element => {
+  // Add package dependencies and peerDependencies
+  const dependencies = {
+    ...data.dependencies,
+    ...(data.peerDependencies ?? {})
+  };
+  Object.keys(dependencies).forEach(element => {
     // TODO: make sure that the core dependency semver range is a subset of our
     // data.depencies version range for any packages in the core deps.
     if (!shared[element]) {

--- a/buildutils/src/update-dependency.ts
+++ b/buildutils/src/update-dependency.ts
@@ -152,7 +152,7 @@ async function handlePackage(
   }
 
   // Update dependencies as appropriate.
-  for (const dtype of ['dependencies', 'devDependencies']) {
+  for (const dtype of ['dependencies', 'devDependencies', 'peerDependencies']) {
     const deps = data[dtype] || {};
     if (typeof name === 'string') {
       const dep = name;

--- a/jupyterlab/tests/mock_packages/interop/consumer/package.json
+++ b/jupyterlab/tests/mock_packages/interop/consumer/package.json
@@ -2,11 +2,11 @@
   "name": "@jupyterlab/mock-consumer",
   "version": "3.1.0-alpha.3",
   "private": true,
-  "dependencies": {
-    "@jupyterlab/mock-token": "^3.1.0-alpha.3"
-  },
   "devDependencies": {
     "@jupyterlab/builder": "^3.1.0-alpha.3"
+  },
+  "peerDependencies": {
+    "@jupyterlab/mock-token": "^3.1.0-alpha.3"
   },
   "jupyterlab": {
     "extension": true,

--- a/jupyterlab/tests/mock_packages/interop/provider/package.json
+++ b/jupyterlab/tests/mock_packages/interop/provider/package.json
@@ -2,11 +2,11 @@
   "name": "@jupyterlab/mock-provider",
   "version": "3.1.0-alpha.3",
   "private": true,
-  "dependencies": {
-    "@jupyterlab/mock-token": "^3.1.0-alpha.3"
-  },
   "devDependencies": {
     "@jupyterlab/builder": "^3.1.0-alpha.3"
+  },
+  "peerDependencies": {
+    "@jupyterlab/mock-token": "^3.1.0-alpha.3"
   },
   "jupyterlab": {
     "extension": true


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9724 

Start experimenting with `peerDependencies` added to the shared package configuration by default

If we continue with this we'll want to:

- [x] Add a test extension that specifies `peerDependencies` only (or both `dependencies` and `peerDependencies`)
- [ ] Document this (and recommend `peerDependencies`) 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add both `dependencies` and `peerDependencies` to the shared packages.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
