### PR TITLE
Remove the auto-switch to “mobile” mode, and behavior switches associated with mobile mode

### DIFF
--- a/packages/application/src/lab.ts
+++ b/packages/application/src/lab.ts
@@ -9,8 +9,6 @@ import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 
 import { Token } from '@lumino/coreutils';
 
-import { Throttler } from '@lumino/polling';
-
 import { JupyterFrontEnd, JupyterFrontEndPlugin } from './frontend';
 
 import { createRendermimePlugins } from './mimerenderers';
@@ -85,18 +83,6 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
         this.registerPlugin(plugin);
       }
     }
-
-    void this.restored.then(() => {
-      this.formatChanged.connect((_, format) => {
-        if (format === 'mobile') {
-          this.shell.mode = 'single-document';
-          this.shell.collapseLeft();
-          this.shell.collapseRight();
-          return;
-        }
-      }, this);
-      Private.setFormat(this);
-    });
   }
 
   /**
@@ -145,18 +131,6 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
   }
 
   /**
-   * Handle the DOM events for the application.
-   *
-   * @param event - The DOM event sent to the application.
-   */
-  handleEvent(event: Event): void {
-    super.handleEvent(event);
-    if (event.type === 'resize') {
-      void this._formatter.invoke();
-    }
-  }
-
-  /**
    * Register plugins from a plugin module.
    *
    * @param mod - The plugin module to register.
@@ -190,9 +164,6 @@ export class JupyterLab extends JupyterFrontEnd<ILabShell> {
     });
   }
 
-  private _formatter = new Throttler(() => {
-    Private.setFormat(this);
-  }, 250);
   private _info: JupyterLab.IInfo;
   private _paths: JupyterFrontEnd.IPaths;
 }
@@ -297,24 +268,5 @@ export namespace JupyterLab {
     default:
       | JupyterFrontEndPlugin<any, any, any>
       | JupyterFrontEndPlugin<any, any, any>[];
-  }
-}
-
-/**
- * A namespace for module-private functionality.
- */
-namespace Private {
-  /**
-   * Media query for mobile devices.
-   */
-  const MOBILE_QUERY = 'only screen and (max-width: 760px)';
-
-  /**
-   * Sets the `format` of a Jupyter front-end application.
-   *
-   * @param app The front-end application whose format is set.
-   */
-  export function setFormat(app: JupyterLab): void {
-    app.format = window.matchMedia(MOBILE_QUERY).matches ? 'mobile' : 'desktop';
   }
 }

--- a/packages/statusbar-extension/src/index.ts
+++ b/packages/statusbar-extension/src/index.ts
@@ -111,7 +111,6 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
       mainMenu.viewMenu.addGroup([{ command }], 1);
     }
 
-    let ready = app.restored;
     if (settingRegistry) {
       const loadSettings = settingRegistry.load(STATUSBAR_PLUGIN_ID);
       const updateSettings = (settings: ISettingRegistry.ISettings): void => {
@@ -119,7 +118,7 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
         statusBar.setHidden(!visible);
       };
 
-      ready = Promise.all([loadSettings, app.restored])
+      Promise.all([loadSettings, app.restored])
         .then(([settings]) => {
           updateSettings(settings);
           settings.changed.connect(settings => {
@@ -130,19 +129,6 @@ const statusBar: JupyterFrontEndPlugin<IStatusBar> = {
           console.error(reason.message);
         });
     }
-
-    // Hide the status bar in the mobile format.
-    void ready.then(() => {
-      const handleFormat = () => {
-        if (app.format === 'mobile') {
-          statusBar.setHidden(true);
-        } else {
-          statusBar.setHidden(false);
-        }
-      };
-      app.formatChanged.connect(handleFormat);
-      handleFormat();
-    });
 
     return statusBar;
   },


### PR DESCRIPTION





<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9567

Reverts part of #8456

CC @afshin @ellisonbg @krassowski 

## Code changes

See https://github.com/jupyterlab/jupyterlab/issues/9567 for an extensive discussion about this. In short, the existing auto-switching behavior was disruptive to desktop users, and conflated issues of responsive layout, mobile platform, and simple interface. The plan is to take a step back and design an approach that disentangles each of these concerns better as a 4.0 roadmap item.

I kept the api of the `format` attribute. Since this fixes user complaints that have come up in 3.0, I think it could be merged and backported to a 3.0.x patch release.

## User-facing changes

Resizing a window will no longer switch to simple interface, hide the sidebars and status bar.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
