### PR TITLE
Enable Caching in Production Minimized Mode

### DIFF
--- a/dev_mode/webpack.prod.minimize.config.js
+++ b/dev_mode/webpack.prod.minimize.config.js
@@ -7,6 +7,11 @@ const config = require('./webpack.config');
 config[0] = merge(config[0], {
   mode: 'production',
   devtool: 'source-map',
+  output: {
+    // Add version argument when in production so the Jupyter server
+    // allows caching of files (i.e., does not set the CacheControl header to no-cache to prevent caching static files)
+    filename: '[name].[contenthash].js?v=[contenthash]'
+  },
   optimization: {
     minimize: true,
     minimizer: [


### PR DESCRIPTION
## References
Follow up to jupyterlab/jupyterlab#9776

## Code changes
Add a version argument to generated webpack output for both the main build and prebuilt extensions when in production minimized mode. The minimized production support was missing in #9776.

## User-facing changes
JupyterLab will load faster when built in production minimized mode (after the files are cached).

## Backwards-incompatible changes
N/A
