### PR TITLE
Add Markdown icon for Show Markdown Preview

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -591,6 +591,7 @@ export namespace Commands {
           (widget && PathExt.extname(widget.context.path) === '.md') || false
         );
       },
+      icon: markdownIcon,
       label: trans.__('Show Markdown Preview')
     });
   }


### PR DESCRIPTION
## References

This is a proposal to add the Markdown icon to the context menu. It would make it easier to locate this option. This icon is already being used for "New Markdown File" in file browser context menu.

## Code changes

N/A

## User-facing changes

Before:

![Screenshot from 2021-02-21 15-52-15](https://user-images.githubusercontent.com/5832902/108630521-151dff00-745d-11eb-9f56-50f1fd95ae46.png)

After:

![Screenshot from 2021-02-21 15-51-37](https://user-images.githubusercontent.com/5832902/108630527-194a1c80-745d-11eb-9c0c-1f7dcc0ef2cc.png)

## Backwards-incompatible changes

N/A