### PR TITLE
Add icon to Create Console for Editor

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -38,8 +38,9 @@ import {
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import {
-  cutIcon,
+  consoleIcon,
   copyIcon,
+  cutIcon,
   markdownIcon,
   pasteIcon,
   redoIcon,
@@ -443,6 +444,7 @@ export namespace Commands {
         return getCreateConsoleFunction(commands)(widget, args);
       },
       isEnabled,
+      icon: consoleIcon,
       label: trans.__('Create Console for Editor')
     });
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Similar to #9840 but for `Create Console for Editor`

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add the icon to the command.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

![image](https://user-images.githubusercontent.com/591645/108683761-590f1380-74f2-11eb-963f-57ed5c2bc454.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
