### PR TITLE
Add missing return types to fileeditor-extension/src/commands.ts

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -191,7 +191,7 @@ export namespace Commands {
     isEnabled: () => boolean,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     browserFactory: IFileBrowserFactory
-  ) {
+  ): void {
     // Add a command to change font size.
     addChangeFontSizeCommand(commands, settingRegistry, trans, id);
 
@@ -242,7 +242,7 @@ export namespace Commands {
     settingRegistry: ISettingRegistry,
     trans: TranslationBundle,
     id: string
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.changeFontSize, {
       execute: args => {
         const delta = Number(args['delta']);
@@ -278,7 +278,7 @@ export namespace Commands {
     trans: TranslationBundle,
     id: string,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.lineNumbers, {
       execute: () => {
         config.lineNumbers = !config.lineNumbers;
@@ -303,7 +303,7 @@ export namespace Commands {
     trans: TranslationBundle,
     id: string,
     isEnabled: () => boolean
-  ) {
+  ): void {
     type wrappingMode = 'on' | 'off' | 'wordWrapColumn' | 'bounded';
 
     commands.addCommand(CommandIDs.lineWrap, {
@@ -332,7 +332,7 @@ export namespace Commands {
     settingRegistry: ISettingRegistry,
     trans: TranslationBundle,
     id: string
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.changeTabs, {
       label: args => args['name'] as string,
       execute: args => {
@@ -361,7 +361,7 @@ export namespace Commands {
     trans: TranslationBundle,
     id: string,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.matchBrackets, {
       execute: () => {
         config.matchBrackets = !config.matchBrackets;
@@ -385,7 +385,7 @@ export namespace Commands {
     settingRegistry: ISettingRegistry,
     trans: TranslationBundle,
     id: string
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.autoClosingBrackets, {
       execute: () => {
         config.autoClosingBrackets = !config.autoClosingBrackets;
@@ -408,7 +408,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.replaceSelection, {
       execute: args => {
         const text: string = (args['text'] as string) || '';
@@ -431,7 +431,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.createConsole, {
       execute: args => {
         const widget = tracker.currentWidget;
@@ -455,7 +455,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.runCode, {
       execute: () => {
         // Run the appropriate code, taking into account a ```fenced``` code block.
@@ -526,7 +526,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.runAllCode, {
       execute: () => {
         const widget = tracker.currentWidget?.content;
@@ -570,7 +570,7 @@ export namespace Commands {
     commands: CommandRegistry,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.markdownPreview, {
       execute: () => {
         const widget = tracker.currentWidget;
@@ -604,7 +604,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.undo, {
       execute: () => {
         const widget = tracker.currentWidget?.content;
@@ -642,7 +642,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.redo, {
       execute: () => {
         const widget = tracker.currentWidget?.content;
@@ -680,7 +680,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.cut, {
       execute: () => {
         const widget = tracker.currentWidget?.content;
@@ -722,7 +722,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.copy, {
       execute: () => {
         const widget = tracker.currentWidget?.content;
@@ -763,7 +763,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.paste, {
       execute: async () => {
         const widget = tracker.currentWidget?.content;
@@ -797,7 +797,7 @@ export namespace Commands {
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle,
     isEnabled: () => boolean
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.selectAll, {
       execute: () => {
         const widget = tracker.currentWidget?.content;
@@ -866,7 +866,7 @@ export namespace Commands {
     commands: CommandRegistry,
     browserFactory: IFileBrowserFactory,
     trans: TranslationBundle
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.createNew, {
       label: args =>
         args['isPalette'] ? trans.__('New Text File') : trans.__('Text File'),
@@ -886,7 +886,7 @@ export namespace Commands {
     commands: CommandRegistry,
     browserFactory: IFileBrowserFactory,
     trans: TranslationBundle
-  ) {
+  ): void {
     commands.addCommand(CommandIDs.createNewMarkdown, {
       label: args =>
         args['isPalette']
@@ -907,7 +907,7 @@ export namespace Commands {
   export function addLauncherItems(
     launcher: ILauncher,
     trans: TranslationBundle
-  ) {
+  ): void {
     addCreateNewToLauncher(launcher, trans);
 
     addCreateNewMarkdownToLauncher(launcher, trans);
@@ -919,7 +919,7 @@ export namespace Commands {
   export function addCreateNewToLauncher(
     launcher: ILauncher,
     trans: TranslationBundle
-  ) {
+  ): void {
     launcher.add({
       command: CommandIDs.createNew,
       category: trans.__('Other'),
@@ -933,7 +933,7 @@ export namespace Commands {
   export function addCreateNewMarkdownToLauncher(
     launcher: ILauncher,
     trans: TranslationBundle
-  ) {
+  ): void {
     launcher.add({
       command: CommandIDs.createNewMarkdown,
       category: trans.__('Other'),
@@ -947,7 +947,7 @@ export namespace Commands {
   export function addPaletteItems(
     palette: ICommandPalette,
     trans: TranslationBundle
-  ) {
+  ): void {
     addChangeTabsCommandsToPalette(palette, trans);
 
     addCreateNewCommandToPalette(palette, trans);
@@ -963,7 +963,7 @@ export namespace Commands {
   export function addChangeTabsCommandsToPalette(
     palette: ICommandPalette,
     trans: TranslationBundle
-  ) {
+  ): void {
     const paletteCategory = trans.__('Text Editor');
     const args: JSONObject = {
       insertSpaces: false,
@@ -989,7 +989,7 @@ export namespace Commands {
   export function addCreateNewCommandToPalette(
     palette: ICommandPalette,
     trans: TranslationBundle
-  ) {
+  ): void {
     const paletteCategory = trans.__('Text Editor');
     palette.addItem({
       command: CommandIDs.createNew,
@@ -1004,7 +1004,7 @@ export namespace Commands {
   export function addCreateNewMarkdownCommandToPalette(
     palette: ICommandPalette,
     trans: TranslationBundle
-  ) {
+  ): void {
     const paletteCategory = trans.__('Text Editor');
     palette.addItem({
       command: CommandIDs.createNewMarkdown,
@@ -1019,7 +1019,7 @@ export namespace Commands {
   export function addChangeFontSizeCommandsToPalette(
     palette: ICommandPalette,
     trans: TranslationBundle
-  ) {
+  ): void {
     const paletteCategory = trans.__('Text Editor');
     const command = CommandIDs.changeFontSize;
 
@@ -1040,7 +1040,7 @@ export namespace Commands {
     trans: TranslationBundle,
     consoleTracker: IConsoleTracker | null,
     sessionDialogs: ISessionContextDialogs | null
-  ) {
+  ): void {
     // Add the editing commands to the settings menu.
     addEditingCommandsToSettingsMenu(menu, commands, trans);
 
@@ -1080,7 +1080,7 @@ export namespace Commands {
     menu: IMainMenu,
     commands: CommandRegistry,
     trans: TranslationBundle
-  ) {
+  ): void {
     const tabMenu = new Menu({ commands });
     tabMenu.title.label = trans.__('Text Editor Indentation');
     const args: JSONObject = {
@@ -1120,14 +1120,14 @@ export namespace Commands {
   /**
    * Add a Create New File command to the File menu
    */
-  export function addCreateNewFileToFileMenu(menu: IMainMenu) {
+  export function addCreateNewFileToFileMenu(menu: IMainMenu): void {
     menu.fileMenu.newMenu.addGroup([{ command: CommandIDs.createNew }], 30);
   }
 
   /**
    * Add a Create New Markdown File command to the File menu
    */
-  export function addCreateNewMarkdownFileToFileMenu(menu: IMainMenu) {
+  export function addCreateNewMarkdownFileToFileMenu(menu: IMainMenu): void {
     menu.fileMenu.newMenu.addGroup(
       [{ command: CommandIDs.createNewMarkdown }],
       30
@@ -1140,7 +1140,7 @@ export namespace Commands {
   export function addUndoRedoToEditMenu(
     menu: IMainMenu,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>
-  ) {
+  ): void {
     menu.editMenu.undoers.add({
       tracker,
       undo: widget => {
@@ -1159,7 +1159,7 @@ export namespace Commands {
     menu: IMainMenu,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle
-  ) {
+  ): void {
     menu.viewMenu.editorViewers.add({
       tracker,
       toggleLineNumbers: widget => {
@@ -1192,7 +1192,7 @@ export namespace Commands {
     commands: CommandRegistry,
     tracker: WidgetTracker<IDocumentWidget<FileEditor>>,
     trans: TranslationBundle
-  ) {
+  ): void {
     const createConsole: (
       widget: IDocumentWidget<FileEditor>
     ) => Promise<void> = getCreateConsoleFunction(commands);
@@ -1213,7 +1213,7 @@ export namespace Commands {
     consoleTracker: IConsoleTracker,
     trans: TranslationBundle,
     sessionDialogs: ISessionContextDialogs | null
-  ) {
+  ): void {
     menu.runMenu.codeRunners.add({
       tracker,
       runLabel: (n: number) => trans.__('Run Code'),
@@ -1247,7 +1247,7 @@ export namespace Commands {
   /**
    * Wrapper function for adding the default items to the File Editor context menu
    */
-  export function addContextMenuItems(app: JupyterFrontEnd) {
+  export function addContextMenuItems(app: JupyterFrontEnd): void {
     addCreateConsoleToContextMenu(app);
     addMarkdownPreviewToContextMenu(app);
     addUndoCommandToContextMenu(app);
@@ -1261,7 +1261,7 @@ export namespace Commands {
   /**
    * Add a Create Console item to the File Editor context menu
    */
-  export function addCreateConsoleToContextMenu(app: JupyterFrontEnd) {
+  export function addCreateConsoleToContextMenu(app: JupyterFrontEnd): void {
     app.contextMenu.addItem({
       command: CommandIDs.createConsole,
       selector: '.jp-FileEditor'
@@ -1271,7 +1271,7 @@ export namespace Commands {
   /**
    * Add a Markdown Preview item to the File Editor context menu
    */
-  export function addMarkdownPreviewToContextMenu(app: JupyterFrontEnd) {
+  export function addMarkdownPreviewToContextMenu(app: JupyterFrontEnd): void {
     app.contextMenu.addItem({
       command: CommandIDs.markdownPreview,
       selector: '.jp-FileEditor'
@@ -1281,7 +1281,7 @@ export namespace Commands {
   /**
    * Add a Undo item to the File Editor context menu
    */
-  export function addUndoCommandToContextMenu(app: JupyterFrontEnd) {
+  export function addUndoCommandToContextMenu(app: JupyterFrontEnd): void {
     app.contextMenu.addItem({
       command: CommandIDs.undo,
       selector: '.jp-FileEditor',
@@ -1292,7 +1292,7 @@ export namespace Commands {
   /**
    * Add a Redo item to the File Editor context menu
    */
-  export function addRedoCommandToContextMenu(app: JupyterFrontEnd) {
+  export function addRedoCommandToContextMenu(app: JupyterFrontEnd): void {
     app.contextMenu.addItem({
       command: CommandIDs.redo,
       selector: '.jp-FileEditor',
@@ -1303,7 +1303,7 @@ export namespace Commands {
   /**
    * Add a Cut item to the File Editor context menu
    */
-  export function addCutCommandToContextMenu(app: JupyterFrontEnd) {
+  export function addCutCommandToContextMenu(app: JupyterFrontEnd): void {
     app.contextMenu.addItem({
       command: CommandIDs.cut,
       selector: '.jp-FileEditor',
@@ -1314,7 +1314,7 @@ export namespace Commands {
   /**
    * Add a Copy item to the File Editor context menu
    */
-  export function addCopyCommandToContextMenu(app: JupyterFrontEnd) {
+  export function addCopyCommandToContextMenu(app: JupyterFrontEnd): void {
     app.contextMenu.addItem({
       command: CommandIDs.copy,
       selector: '.jp-FileEditor',
@@ -1325,7 +1325,7 @@ export namespace Commands {
   /**
    * Add a Paste item to the File Editor context menu
    */
-  export function addPasteCommandToContextMenu(app: JupyterFrontEnd) {
+  export function addPasteCommandToContextMenu(app: JupyterFrontEnd): void {
     app.contextMenu.addItem({
       command: CommandIDs.paste,
       selector: '.jp-FileEditor',
@@ -1336,7 +1336,7 @@ export namespace Commands {
   /**
    * Add a Select All item to the File Editor context menu
    */
-  export function addSelectAllCommandToContextMenu(app: JupyterFrontEnd) {
+  export function addSelectAllCommandToContextMenu(app: JupyterFrontEnd): void {
     app.contextMenu.addItem({
       command: CommandIDs.selectAll,
       selector: '.jp-FileEditor',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Partially addresses #9392

Fixes a couple of ESLint warnings noticed while doing #9843.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add return types to some functions.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
