### PR TITLE
Move the cloned outputs to a separate plugin

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -398,7 +398,7 @@ const widgetFactoryPlugin: JupyterFrontEndPlugin<NotebookWidgetFactory.IFactory>
 /**
  * The cloned output provider.
  */
-const clonedOutputPlugin: JupyterFrontEndPlugin<void> = {
+const clonedOutputsPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/notebook-extension:cloned-outputs',
   requires: [IDocumentManager, INotebookTracker, ITranslator],
   optional: [ILayoutRestorer],
@@ -417,7 +417,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   notebookTrustItem,
   widgetFactoryPlugin,
   logNotebookOutput,
-  clonedOutputPlugin
+  clonedOutputsPlugin
 ];
 export default plugins;
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -599,7 +599,7 @@ function activateClonedOutputs(
 
   const isEnabledAndSingleSelected = (): boolean => {
     return Private.isEnabledAndSingleSelected(shell, notebookTracker);
-  }
+  };
 
   commands.addCommand(CommandIDs.createOutputView, {
     label: trans.__('Create New View for Output'),
@@ -1033,11 +1033,11 @@ function addCommands(
 
   const isEnabled = (): boolean => {
     return Private.isEnabled(shell, tracker);
-  }
+  };
 
   const isEnabledAndSingleSelected = (): boolean => {
     return Private.isEnabledAndSingleSelected(shell, tracker);
-  }
+  };
 
   commands.addCommand(CommandIDs.runAndAdvance, {
     label: trans.__('Run Selected Cells'),
@@ -1388,10 +1388,7 @@ function addCommands(
           });
       }
     },
-    isEnabled: () => {
-      // Can't run if there are multiple cells selected
-      return isEnabledAndSingleSelected();
-    }
+    isEnabled: isEnabledAndSingleSelected
   });
   commands.addCommand(CommandIDs.restartRunAll, {
     label: trans.__('Restart Kernel and Run All Cells…'),
@@ -2426,7 +2423,10 @@ namespace Private {
   /**
    * Whether there is an active notebook.
    */
-  export function isEnabled(shell: JupyterFrontEnd.IShell, tracker: INotebookTracker): boolean {
+  export function isEnabled(
+    shell: JupyterFrontEnd.IShell,
+    tracker: INotebookTracker
+  ): boolean {
     return (
       tracker.currentWidget !== null &&
       tracker.currentWidget === shell.currentWidget
@@ -2436,7 +2436,10 @@ namespace Private {
   /**
    * Whether there is an notebook active, with a single selected cell.
    */
-  export function isEnabledAndSingleSelected(shell: JupyterFrontEnd.IShell, tracker: INotebookTracker): boolean {
+  export function isEnabledAndSingleSelected(
+    shell: JupyterFrontEnd.IShell,
+    tracker: INotebookTracker
+  ): boolean {
     if (!Private.isEnabled(shell, tracker)) {
       return false;
     }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2453,6 +2453,25 @@ namespace Private {
   }
 
   /**
+   * The default Export To ... formats and their human readable labels.
+   */
+  export function getFormatLabels(
+    translator: ITranslator
+  ): { [k: string]: string } {
+    translator = translator || nullTranslator;
+    const trans = translator.load('jupyterlab');
+    return {
+      html: trans.__('HTML'),
+      latex: trans.__('LaTeX'),
+      markdown: trans.__('Markdown'),
+      pdf: trans.__('PDF'),
+      rst: trans.__('ReStructured Text'),
+      script: trans.__('Executable Script'),
+      slides: trans.__('Reveal.js Slides')
+    };
+  }
+
+  /**
    * A widget hosting a cloned output area.
    */
   export class ClonedOutputArea extends Panel {
@@ -2536,29 +2555,5 @@ namespace Private {
        */
       translator?: ITranslator;
     }
-  }
-}
-
-/**
- * A namespace for private data.
- */
-namespace Private {
-  /**
-   * The default Export To ... formats and their human readable labels.
-   */
-  export function getFormatLabels(
-    translator: ITranslator
-  ): { [k: string]: string } {
-    translator = translator || nullTranslator;
-    const trans = translator.load('jupyterlab');
-    return {
-      html: trans.__('HTML'),
-      latex: trans.__('LaTeX'),
-      markdown: trans.__('Markdown'),
-      pdf: trans.__('PDF'),
-      rst: trans.__('ReStructured Text'),
-      script: trans.__('Executable Script'),
-      slides: trans.__('Reveal.js Slides')
-    };
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This makes it easier to reuse the notebook plugins in alternative JupyterLab distributions that only display a single widget in their main area.

For example in JupyterLab Classic: https://github.com/jtpio/jupyterlab-classic/issues/104

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Move the cloned outputs functionality to a separate plugin.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
