### PR TITLE
Remove the previous file_to_run logic

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -657,12 +657,6 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
         # Client-side code assumes notebookVersion is a JSON-encoded string
         page_config['notebookVersion'] = json.dumps(jpserver_version_info)
 
-        if self.serverapp.file_to_run:
-            relpath = os.path.relpath(self.serverapp.file_to_run, self.serverapp.root_dir)
-            uri = url_escape(ujoin('{}/tree'.format(self.app_url), *relpath.split(os.sep)))
-            self.default_url = uri
-            self.serverapp.file_to_run = ''
-
         self.log.info('JupyterLab extension loaded from %s' % HERE)
         self.log.info('JupyterLab application directory is %s' % self.app_dir)
 

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -9,14 +9,12 @@ import os
 import os.path as osp
 from os.path import join as pjoin
 import sys
-from jinja2 import Environment, FileSystemLoader
 
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from jupyter_core.application import NoStart
 from jupyterlab_server import slugify, WORKSPACE_EXTENSION
 from jupyter_server.serverapp import flags
-from jupyter_server.utils import url_path_join as ujoin, url_escape
-from jupyter_server.services.config.manager import ConfigManager, recursive_update
+from jupyter_server.utils import url_path_join as ujoin
 from jupyter_server._version import version_info as jpserver_version_info
 from traitlets import Bool, Instance, Unicode, default
 
@@ -28,7 +26,7 @@ from .debuglog import DebugLogFileMixin
 from .commands import (
     DEV_DIR, HERE,
     build, clean, get_app_dir, get_app_version, get_user_settings_dir,
-    get_workspaces_dir, AppOptions, pjoin, get_app_info,
+    get_workspaces_dir, AppOptions, pjoin,
     ensure_core, ensure_dev, watch, watch_dev, ensure_app
 )
 from .coreconfig import CoreConfig

--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,8 @@ setup_args['install_requires'] = [
     'tornado>=6.1.0',
     'jupyter_core',
     'jupyter_packaging~=0.7.3',
-    'jupyterlab_server~=2.2',
-    'jupyter_server~=1.2',
+    'jupyterlab_server~=2.3',
+    'jupyter_server~=1.4',
     'nbclassic~=0.2',
     'jinja2>=2.10'
 ]


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

`jupyter_server=1.4` with https://github.com/jupyter-server/jupyter_server/pull/415 and `jupyterlab_server=2.3` with https://github.com/jupyterlab/jupyterlab_server/pull/162 fix the main issue raised in https://github.com/jupyterlab/jupyterlab/issues/8959.

However JupyterLab still includes logic that uses and overrides the `file_to_run` trait. This interferes with other Jupyter server extensions such as [nbclassic](https://github.com/jupyterlab/nbclassic) that can also open files from the command line.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Remove the previous logic to handle files to open from the CLI.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

NBClassic users can open notebooks from the command line with:

```bash
jupyter nbclassic example.ipynb`
```

Without this change, they would be redirected to `/tree` if they also had `jupyterlab` installed in their environment.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
