### PR TITLE
Backport PR #9847 on branch 3.0.x (Remove the previous file_to_run lo…

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -9,14 +9,12 @@ import os
 import os.path as osp
 from os.path import join as pjoin
 import sys
-from jinja2 import Environment, FileSystemLoader
 
 from jupyter_core.application import JupyterApp, base_aliases, base_flags
 from jupyter_core.application import NoStart
 from jupyterlab_server import slugify, WORKSPACE_EXTENSION
 from jupyter_server.serverapp import flags
-from jupyter_server.utils import url_path_join as ujoin, url_escape
-from jupyter_server.services.config.manager import ConfigManager, recursive_update
+from jupyter_server.utils import url_path_join as ujoin
 from jupyter_server._version import version_info as jpserver_version_info
 from traitlets import Bool, Instance, Unicode, default
 
@@ -28,7 +26,7 @@ from .debuglog import DebugLogFileMixin
 from .commands import (
     DEV_DIR, HERE,
     build, clean, get_app_dir, get_app_version, get_user_settings_dir,
-    get_workspaces_dir, AppOptions, pjoin, get_app_info,
+    get_workspaces_dir, AppOptions, pjoin,
     ensure_core, ensure_dev, watch, watch_dev, ensure_app
 )
 from .coreconfig import CoreConfig
@@ -656,12 +654,6 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
 
         # Client-side code assumes notebookVersion is a JSON-encoded string
         page_config['notebookVersion'] = json.dumps(jpserver_version_info)
-
-        if self.serverapp.file_to_run:
-            relpath = os.path.relpath(self.serverapp.file_to_run, self.serverapp.root_dir)
-            uri = url_escape(ujoin('{}/tree'.format(self.app_url), *relpath.split(os.sep)))
-            self.default_url = uri
-            self.serverapp.file_to_run = ''
 
         self.log.info('JupyterLab extension loaded from %s' % HERE)
         self.log.info('JupyterLab application directory is %s' % self.app_dir)

--- a/setup.py
+++ b/setup.py
@@ -146,8 +146,9 @@ setup_args['install_requires'] = [
     'packaging',
     'tornado>=6.1.0',
     'jupyter_core',
-    'jupyterlab_server~=2.0',
-    'jupyter_server~=1.2',
+    'jupyter_packaging~=0.7.3',
+    'jupyterlab_server~=2.3',
+    'jupyter_server~=1.4',
     'nbclassic~=0.2',
     'jinja2>=2.10'
 ]


### PR DESCRIPTION
Manual backport of jupyterlab/jupyterlab#9847: Remove the previous `file_to_run` logic