### PR TITLE
Add possibility to make websocket token auth optional

### DIFF
--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -720,6 +720,12 @@ class LabApp(NBClassicConfigShimMixin, LabServerApp):
             api_token = os.getenv('JUPYTERHUB_API_TOKEN', '')
             page_config['token'] = api_token
 
+        try:
+            page_config['websocketEnableTokenAuth'] = self.serverapp.websocket_enable_token_auth
+        except AttributeError:
+            # in case of elder version of jupyter server
+            page_config['websocketEnableTokenAuth'] = False
+
         # Update Jupyter Server's webapp settings with jupyterlab settings.
         self.serverapp.web_app.settings['page_config_data'] = page_config
 

--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -226,6 +226,13 @@ export namespace PageConfig {
   }
 
   /**
+   * Check if use token for websocket auth
+   */
+  export function getWebsocketTokenAuthEnabled(): boolean {
+    return getOption('websocketEnableTokenAuth').toLowerCase() == 'true';
+  }
+
+  /**
    * Get the authorization token for a Jupyter application.
    */
   export function getToken(): string {

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -245,6 +245,7 @@ namespace Private {
       token: PageConfig.getToken(),
       appUrl: PageConfig.getOption('appUrl'),
       appendToken:
+        PageConfig.getWebsocketTokenAuthEnabled() ||
         typeof window === 'undefined' ||
         process.env.JEST_WORKER_ID !== undefined,
       ...options,


### PR DESCRIPTION
Related pull request - https://github.com/jupyter-server/jupyter_server/pull/427
Added possibility to setup websocket token auth in case of custom cookie settings

Related to issue https://github.com/jupyterlab/jupyterlab/issues/9070

