### PR TITLE
fix release_test, squash all non-eslint CI warnings 

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,6 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -49,7 +49,7 @@ jobs:
         config-file: ./.github/codeql/codeql-config.yml
 
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   triage:
     name: Update PR Labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - if: github.repository == 'jupyterlab/jupyterlab'
         uses: paulfantom/periodic-labeler@dffbc90404f371f76444a69221c2f7ad079e2319

--- a/.github/workflows/linuxjs-flaky-tests.yml
+++ b/.github/workflows/linuxjs-flaky-tests.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         group: [s-apputils]
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -52,4 +52,3 @@ jobs:
           GROUP: ${{ matrix.group }}
         run: |
           bash ./scripts/ci_script.sh
-

--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         group: [js-services, js-application, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-documentsearch, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-toc, js-translation, js-ui-components, js-testutils]
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -18,6 +18,7 @@ jobs:
             python: 3.6
           - group: release_check
             python: 3.6
+            upload-output: true
           - group: docs
             python: 3.6
           - group: usage
@@ -88,3 +89,10 @@ jobs:
           GROUP: ${{ matrix.group }}
         run: |
           bash ./scripts/ci_script.sh
+
+      - name: Upload ${{ matrix.group }} results
+        if: ${{ matrix.upload-output && always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.group }} ${{ github.run_number }}
+          path: ./build/${{ matrix.group }}_output

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -9,6 +9,9 @@ jobs:
       matrix:
         group: [integrity, integrity2, integrity3, release_check, docs, usage, usage2, python, examples, interop, nonode, linkcheck, lint]
         python: [3.6, 3.8]
+        include:
+          - group: release_check
+            upload-output: true
         exclude:
           - group: integrity
             python: 3.6
@@ -18,7 +21,6 @@ jobs:
             python: 3.6
           - group: release_check
             python: 3.6
-            upload-output: true
           - group: docs
             python: 3.6
           - group: usage

--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -37,7 +37,7 @@ jobs:
             python: 3.6
       fail-fast: false
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: dessant/lock-threads@v2
         with:

--- a/builder/src/duplicate-package-checker-webpack-plugin.d.ts
+++ b/builder/src/duplicate-package-checker-webpack-plugin.d.ts
@@ -13,11 +13,13 @@ declare module 'duplicate-package-checker-webpack-plugin';
 
 // Then we expand the definition with the things we use.
 declare module 'duplicate-package-checker-webpack-plugin' {
+  import * as webpack from 'webpack';
+
   export = DuplicatePackageCheckerWebpackPlugin;
 
   class DuplicatePackageCheckerWebpackPlugin {
     constructor(options?: DuplicatePackageCheckerWebpackPlugin.Options);
-    apply(compiler: any): void;
+    apply(compiler: webpack.Compiler): void;
   }
 
   namespace DuplicatePackageCheckerWebpackPlugin {

--- a/buildutils/src/utils.ts
+++ b/buildutils/src/utils.ts
@@ -137,7 +137,7 @@ export function fromTemplate(
   templ: string,
   subs: Dict<string>,
   options: { autoindent?: boolean; end?: string } = {}
-) {
+): string {
   // default options values
   const autoindent =
     options.autoindent === undefined ? true : options.autoindent;
@@ -166,7 +166,7 @@ export function fromTemplate(
  *
  * Call a command, checking its status.
  */
-export function checkStatus(cmd: string) {
+export function checkStatus(cmd: string): number | null {
   const data = childProcess.spawnSync(cmd, { shell: true });
   return data.status;
 }
@@ -174,7 +174,7 @@ export function checkStatus(cmd: string) {
 /**
  * Get the current version of JupyterLab
  */
-export function getPythonVersion() {
+export function getPythonVersion(): string {
   const cmd = 'python setup.py --version';
   return run(cmd, { stdio: 'pipe' }, true);
 }
@@ -182,7 +182,7 @@ export function getPythonVersion() {
 /**
  * Get the current version of a package
  */
-export function getJSVersion(pkg: string) {
+export function getJSVersion(pkg: string): string {
   const filePath = path.resolve(
     path.join('.', 'packages', pkg, 'package.json')
   );
@@ -193,7 +193,7 @@ export function getJSVersion(pkg: string) {
 /**
  * Pre-bump.
  */
-export function prebump() {
+export function prebump(): void {
   // Ensure bump2version is installed (active fork of bumpversion)
   run('python -m pip install bump2version');
 
@@ -215,7 +215,7 @@ ${status}`
 /**
  * Post-bump.
  */
-export function postbump() {
+export function postbump(): void {
   // Get the current version.
   const curr = getPythonVersion();
 
@@ -313,7 +313,7 @@ export function getPackageGraph(): DepGraph<Dict<unknown>> {
  * We could just use "require(`${depName}/package.json`)", however this won't work for modules
  * that are not hoisted to the top level.
  */
-function requirePackage(parentModule: string, module: string) {
+function requirePackage(parentModule: string, module: string): NodeRequire {
   const packagePath = `${module}/package.json`;
   let parentModulePath: string;
   // This will fail when the parent module cannot be loaded, like `@jupyterlab/test-root`
@@ -331,7 +331,7 @@ function requirePackage(parentModule: string, module: string) {
 /**
  * Ensure the given path uses '/' as path separator.
  */
-export function ensureUnixPathSep(source: string) {
+export function ensureUnixPathSep(source: string): string {
   if (path.sep === '/') {
     return source;
   }

--- a/dev_mode/bootstrap.js
+++ b/dev_mode/bootstrap.js
@@ -75,9 +75,11 @@ async function loadComponent(url, scope) {
   await loadScript(url);
 
   // From https://webpack.js.org/concepts/module-federation/#dynamic-remote-containers
+  // eslint-disable-next-line no-undef
   await __webpack_init_sharing__('default');
   const container = window._JUPYTERLAB[scope];
   // Initialize the container, it may provide shared modules and may need ours
+  // eslint-disable-next-line no-undef
   await container.init(__webpack_share_scopes__.default);
 }
 

--- a/docs/source/extension/extension_tutorial.rst
+++ b/docs/source/extension/extension_tutorial.rst
@@ -63,7 +63,7 @@ new environment named ``jupyterlab-ext``.
 
 .. code:: bash
 
-    conda create -n jupyterlab-ext --override-channels --strict-channel-priority -c conda-forge -c anaconda jupyterlab=3 cookiecutter nodejs jupyter-packaging git
+    conda create -n jupyterlab-ext --override-channels --strict-channel-priority -c conda-forge -c nodefaults jupyterlab=3 cookiecutter nodejs jupyter-packaging git
 
 Now activate the new environment so that all further commands you run
 work out of that environment.

--- a/docs/source/getting_started/issue.rst
+++ b/docs/source/getting_started/issue.rst
@@ -10,16 +10,16 @@ Diagnosing an Issue
 
 If you find a problem in JupyterLab, please follow the steps below to diagnose and report the issue. Following these steps helps you diagnose if the problem is likely from JupyterLab or from a different project.
 
-1. Try to reproduce the issue in a new environment with the latest official JupyterLab installed and no extra packages. 
+1. Try to reproduce the issue in a new environment with the latest official JupyterLab installed and no extra packages.
 
    If you are using conda:
 
      1. create a new environment::
 
-         conda create -n jlab-test --override-channels --strict-channel-priority -c conda-forge -c anaconda jupyterlab
+         conda create -n jlab-test --override-channels --strict-channel-priority -c conda-forge -c nodefaults jupyterlab
 
      2. Activate the environment::
-       
+
          conda activate jlab-test
 
      3. Start JupyterLab::

--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -154,7 +154,7 @@ async def run_browser(url):
         if not osp.exists(target):
             os.makedirs(osp.join(target))
         await run_async_process(["jlpm", "init", "-y"], cwd=target)
-        await run_async_process(["jlpm", "add", "puppeteer@^4"], cwd=target)
+        await run_async_process(["jlpm", "add", "puppeteer@^7"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))
     await run_async_process(["node", "chrome-test.js", url], cwd=target)
 
@@ -166,7 +166,7 @@ def run_browser_sync(url):
     if not osp.exists(osp.join(target, 'node_modules')):
         os.makedirs(target)
         subprocess.call(["jlpm", "init", "-y"], cwd=target)
-        subprocess.call(["jlpm", "add", "puppeteer@^2"], cwd=target)
+        subprocess.call(["jlpm", "add", "puppeteer@^7"], cwd=target)
     shutil.copy(osp.join(here, 'chrome-test.js'), osp.join(target, 'chrome-test.js'))
     return subprocess.check_call(["node", "chrome-test.js", url], cwd=target)
 

--- a/jupyterlab/chrome-test.js
+++ b/jupyterlab/chrome-test.js
@@ -1,12 +1,22 @@
 const puppeteer = require('puppeteer');
 const inspect = require('util').inspect;
 const path = require('path');
+const fs = require('fs');
 
 const URL = process.argv[2];
 const OUTPUT_VAR = 'JLAB_BROWSER_CHECK_OUTPUT';
 const OUTPUT = process.env[OUTPUT_VAR];
 
 let nextScreenshot = 0;
+const screenshotStem = `screenshot-${+new Date()}`;
+
+if (OUTPUT) {
+  console.log(`Screenshots will be saved in ${OUTPUT}...`);
+  if (!fs.existsSync(OUTPUT)) {
+    console.log(`Creating ${OUTPUT}...`);
+    fs.mkdirSync(OUTPUT, { recursive: true });
+  }
+}
 
 async function main() {
   /* eslint-disable no-console */
@@ -23,9 +33,14 @@ async function main() {
     if (!OUTPUT) {
       return;
     }
+    const screenshotPath = path.join(
+      OUTPUT,
+      `${screenshotStem}-${++nextScreenshot}.png`
+    );
+    console.log(`Capturing screenshot ${screenshotPath}...`);
     await page.screenshot({
       type: 'png',
-      path: path.join(OUTPUT, `screenshot-${++nextScreenshot}.png`)
+      path: screenshotPath
     });
   }
 

--- a/jupyterlab/chrome-test.js
+++ b/jupyterlab/chrome-test.js
@@ -30,7 +30,7 @@ async function main() {
   let testError = null;
 
   try {
-    await page.waitForSelector('.completed');
+    await page.waitForSelector('.completed', { timeout: 100000 });
   } catch (e) {
     testError = e;
   }

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -9,7 +9,7 @@ else
     WORK_DIR=$(mktemp -d -t ${JLAB_REL_ENV}XXXXX)
     cd $WORK_DIR
 
-    conda create --override-channels --strict-channel-priority -c conda-forge -c anaconda -y -n $JLAB_REL_ENV jupyter-packaging nodejs twine
+    conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n $JLAB_REL_ENV jupyter-packaging nodejs twine
     conda activate $JLAB_REL_ENV
 
     git clone git@github.com:jupyterlab/jupyterlab.git

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -10,10 +10,6 @@ set -ex
 JLAB_TEST_ENV="${CONDA_DEFAULT_ENV}_test"
 TEST_DIR=$(mktemp -d -t ${JLAB_TEST_ENV}XXXXX)
 
-# make a folder for output
-JLAB_BROWSER_CHECK_OUTPUT=$(pwd)/build/${GROUP}_output
-mkdir -p $JLAB_BROWSER_CHECK_OUTPUT
-
 conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" 'nodejs>=10,!=13.*,!=15.*,!=17.*' pip wheel setuptools
 conda activate "$JLAB_TEST_ENV"
 
@@ -23,7 +19,7 @@ cp examples/notebooks/*.ipynb $TEST_DIR/
 
 pushd $TEST_DIR
 
-python -m jupyterlab.browser_check || python -m jupyterlab.browser_check
+JLAB_BROWSER_CHECK_OUTPUT=$(pwd)/build/${GROUP}_output python -m jupyterlab.browser_check
 
 jupyter lab clean --all
 
@@ -50,7 +46,7 @@ pushd $TEST_DIR
 jupyter lab build
 
 # retry once, much flake
-python -m jupyterlab.browser_check || python -m jupyterlab.browser_check
+JLAB_BROWSER_CHECK_OUTPUT=$(pwd)/build/${GROUP}_output python -m jupyterlab.browser_check
 
 # if not running on github actions, start JupyterLab
 if [[ -z "${GITHUB_ACTIONS}" ]]; then

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -10,7 +10,7 @@ set -ex
 JLAB_TEST_ENV="${CONDA_DEFAULT_ENV}_test"
 TEST_DIR=$(mktemp -d -t ${JLAB_TEST_ENV}XXXXX)
 
-conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" nodejs pip wheel setuptools
+conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" 'nodejs>=10,!=13,<15' pip wheel setuptools
 conda activate "$JLAB_TEST_ENV"
 
 python -m pip install $(ls dist/*.whl)

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -10,10 +10,10 @@ set -ex
 JLAB_TEST_ENV="${CONDA_DEFAULT_ENV}_test"
 TEST_DIR=$(mktemp -d -t ${JLAB_TEST_ENV}XXXXX)
 
-conda create --override-channels --strict-channel-priority -c conda-forge -c anaconda -y -n "$JLAB_TEST_ENV" notebook nodejs twine
+conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" nodejs
 conda activate "$JLAB_TEST_ENV"
 
-python -m pip install --find-links=dist --no-index jupyterlab
+python -m pip install $(ls dist/*.whl)
 
 cp examples/notebooks/*.ipynb $TEST_DIR/
 
@@ -28,7 +28,7 @@ popd
 
 pushd $TEST_DIR
 
-conda install --override-channels --strict-channel-priority -c conda-forge -c anaconda -y ipywidgets altair matplotlib vega_datasets jupyterlab_widgets
+conda install --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y ipywidgets altair matplotlib vega_datasets jupyterlab_widgets
 
 jupyter lab build
 python -m jupyterlab.browser_check

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -17,8 +17,13 @@ python -m pip install $(ls dist/*.whl)
 
 cp examples/notebooks/*.ipynb $TEST_DIR/
 
-python -m jupyterlab.browser_check
+pushd $TEST_DIR
+
+python -m jupyterlab.browser_check || python -m jupyterlab.browser_check
+
 jupyter lab clean --all
+
+popd
 
 pushd jupyterlab/tests/mock_packages
 jupyter labextension install mimeextension --no-build --debug

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -10,7 +10,7 @@ set -ex
 JLAB_TEST_ENV="${CONDA_DEFAULT_ENV}_test"
 TEST_DIR=$(mktemp -d -t ${JLAB_TEST_ENV}XXXXX)
 
-conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" 'nodejs>=10,!=13,<15' pip wheel setuptools
+conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" 'nodejs>=10,!=13.*,!=15.*,!=17.*' pip wheel setuptools
 conda activate "$JLAB_TEST_ENV"
 
 python -m pip install $(ls dist/*.whl)

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -10,6 +10,10 @@ set -ex
 JLAB_TEST_ENV="${CONDA_DEFAULT_ENV}_test"
 TEST_DIR=$(mktemp -d -t ${JLAB_TEST_ENV}XXXXX)
 
+# make a folder for output
+JLAB_BROWSER_CHECK_OUTPUT=$(pwd)/build/${GROUP}_output
+mkdir -p $JLAB_BROWSER_CHECK_OUTPUT
+
 conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" 'nodejs>=10,!=13.*,!=15.*,!=17.*' pip wheel setuptools
 conda activate "$JLAB_TEST_ENV"
 

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -7,6 +7,8 @@
 set -ex
 . $(conda info --base)/etc/profile.d/conda.sh
 
+OUTPUT_DIR=$(pwd)/build/${GROUP}_output
+
 JLAB_TEST_ENV="${CONDA_DEFAULT_ENV}_test"
 TEST_DIR=$(mktemp -d -t ${JLAB_TEST_ENV}XXXXX)
 
@@ -19,7 +21,7 @@ cp examples/notebooks/*.ipynb $TEST_DIR/
 
 pushd $TEST_DIR
 
-JLAB_BROWSER_CHECK_OUTPUT=$(pwd)/build/${GROUP}_output python -m jupyterlab.browser_check
+JLAB_BROWSER_CHECK_OUTPUT=${OUTPUT_DIR} python -m jupyterlab.browser_check
 
 jupyter lab clean --all
 
@@ -45,8 +47,7 @@ pushd $TEST_DIR
 
 jupyter lab build
 
-# retry once, much flake
-JLAB_BROWSER_CHECK_OUTPUT=$(pwd)/build/${GROUP}_output python -m jupyterlab.browser_check
+JLAB_BROWSER_CHECK_OUTPUT=${OUTPUT_DIR} python -m jupyterlab.browser_check
 
 # if not running on github actions, start JupyterLab
 if [[ -z "${GITHUB_ACTIONS}" ]]; then

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -13,7 +13,7 @@ TEST_DIR=$(mktemp -d -t ${JLAB_TEST_ENV}XXXXX)
 conda create --override-channels --strict-channel-priority -c conda-forge -c anaconda -y -n "$JLAB_TEST_ENV" notebook nodejs twine
 conda activate "$JLAB_TEST_ENV"
 
-pip install dist/*.whl
+python -m pip install --find-links=dist --no-index jupyterlab
 
 cp examples/notebooks/*.ipynb $TEST_DIR/
 

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -30,8 +30,13 @@ pushd $TEST_DIR
 
 conda install --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y ipywidgets altair matplotlib-base vega_datasets jupyterlab_widgets
 
+popd
+
 # re-install, because pip
 python -m pip install $(ls dist/*.whl)
+
+# back to testing
+pushd $TEST_DIR
 
 jupyter lab build
 python -m jupyterlab.browser_check

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -10,7 +10,7 @@ set -ex
 JLAB_TEST_ENV="${CONDA_DEFAULT_ENV}_test"
 TEST_DIR=$(mktemp -d -t ${JLAB_TEST_ENV}XXXXX)
 
-conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" nodejs
+conda create --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y -n "$JLAB_TEST_ENV" nodejs pip wheel setuptools
 conda activate "$JLAB_TEST_ENV"
 
 python -m pip install $(ls dist/*.whl)
@@ -28,7 +28,7 @@ popd
 
 pushd $TEST_DIR
 
-conda install --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y ipywidgets altair matplotlib vega_datasets jupyterlab_widgets
+conda install --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y ipywidgets altair matplotlib-base vega_datasets jupyterlab_widgets
 
 jupyter lab build
 python -m jupyterlab.browser_check

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -39,7 +39,9 @@ python -m pip install $(ls dist/*.whl)
 pushd $TEST_DIR
 
 jupyter lab build
-python -m jupyterlab.browser_check
+
+# retry once, much flake
+python -m jupyterlab.browser_check || python -m jupyterlab.browser_check
 
 # if not running on github actions, start JupyterLab
 if [[ -z "${GITHUB_ACTIONS}" ]]; then

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -30,6 +30,9 @@ pushd $TEST_DIR
 
 conda install --override-channels --strict-channel-priority -c conda-forge -c nodefaults -y ipywidgets altair matplotlib-base vega_datasets jupyterlab_widgets
 
+# re-install, because pip
+python -m pip install $(ls dist/*.whl)
+
 jupyter lab build
 python -m jupyterlab.browser_check
 


### PR DESCRIPTION
## References

- discovered while working on #9779

## Code changes

- in trying to get release_test running in CI:
  - [x] uses a subshell to list wheels in release_check
    - got past `n'est c'est un wheel`, _but still failing_
    - re-installs wheel after the "big" solve of examples (not sure what the offender was)
  - [x] drops any use of `-c anaconda`, adds `-c nodefaults`
    - :shrug: 
  - [x] raised (and harmonized) runtime install :scream: pin of puppeteer to `^7` 
  - [x] pins conda-installed node to LTS 
    - got to installing, _but still failing_
  - [x] adds `JLAB_BROWSER_CHECK_OUTPUT` to `chrome-test`, captures screenshots and enables dumping browser log to stdout
    - got to white rectangle screenshot, _but still failing_
      - slightly more output (`n is undefined`?)
      - this is easy to roll back, but i like it
      - or we could put it under the python-level `--debug`, might be less surprising, but was expedient
  - [x] upgraded ci to use `ubuntu-20.04`
    - **made release_test work, without CI warnings** :tada:  
- ...due to that success...
  - [x] removed some CodeQL setup about `HEAD^2` yielding warnings
    - it now speaks merge commit natively
  - [x] added return types to builder's `utils.ts`
  - [x] fixed `any` usage in duplicate checker 
  - [x] added some highly-specific eslint skips for magic `__webpack` references in dev_mode bootstrap   

now, as of  f441705, appears to :heavy_check_mark: without any CI warnings, excepting:

- the remaining mountain of eslint warnings, because it only shows 10 at a time :pouting_cat: 

## User-facing changes

n/a

## Backwards-incompatible changes

- it's _possible_ puppeteer's underlying compatibility changed