### PR TITLE
[3.0.x] Fix Link in Release Script

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -107,7 +107,7 @@ These lines:
 ## Post release candidate checklist
 
 - [ ] Modify and run `python scripts/milestone_check.py` to check the issues assigned to this milestone
-- [ ] Write [release highlights](https://github.com/jupyterlab/jupyterlab/blob/master/docs/source/getting_started/changelog.rst), starting with:
+- [ ] Write [release highlights](docs/source/getting_started/changelog.rst), starting with:
   ```bash
   loghub jupyterlab/jupyterlab -m XXX -t $GITHUB_TOKEN --template scripts/release_template.txt
   ```


### PR DESCRIPTION
## References
In #9846 we moved `changelog.rst` -> `changelog.md`, causing this link to break.

## Code changes
Changes the link to a relative link, so it is self-consistent within its branch.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A