### PR TITLE
Allow overrides.json to override default shortcuts.

### DIFF
--- a/packages/settingregistry/src/settingregistry.ts
+++ b/packages/settingregistry/src/settingregistry.ts
@@ -949,7 +949,10 @@ export namespace SettingRegistry {
     // disabled shortcuts first). If a shortcut has already been added by the
     // user preferences, filter it out too (this includes shortcuts that are
     // disabled by user preferences).
-    defaults = [...defaults.filter(s => !!s.disabled), ...defaults.filter(s => !s.disabled)].filter(shortcut => {
+    defaults = [
+      ...defaults.filter(s => !!s.disabled),
+      ...defaults.filter(s => !s.disabled)
+    ].filter(shortcut => {
       const keys = CommandRegistry.normalizeKeys(shortcut).join(
         RECORD_SEPARATOR
       );

--- a/packages/shortcuts-extension/src/index.ts
+++ b/packages/shortcuts-extension/src/index.ts
@@ -80,7 +80,8 @@ const shortcuts: JupyterFrontEndPlugin<void> = {
           loaded[plugin] = shortcuts;
           return shortcuts;
         })
-        .reduce((acc, val) => acc.concat(val), [])
+        .concat([schema.properties!.shortcuts.default as any[]])
+        .reduce((acc, val) => acc.concat(val), []) // flatten one level
         .sort((a, b) => a.command.localeCompare(b.command));
 
       schema.properties!.shortcuts.description = trans.__(


### PR DESCRIPTION
## References

Fixes https://discourse.jupyter.org/t/keyboard-shortcuts-with-overrides-json/5751 and https://discourse.jupyter.org/t/some-configs-in-overrides-json-does-not-work-as-i-intended/3955

## Code changes

Shortcuts were throwing away any defaults given by the shortcut plugin settings or overrides.json. This adds them back into the default shortcuts, and also allows default shortcuts to disable each other silently. This allows overrides.json to disable default shortcuts as well as add new default shortcuts.

## User-facing changes

Users can override default shortcuts with overrides.json.

This behavior is slightly different than the normal overrides.json behavior. Normally, the overrides.json values overwrite the plugin defaults, so the user never sees the plugin defaults. In this PR, we instead *add* the overrides.json shortcuts, merging them into the existing defaults, rather than overwriting the existing defaults. I think this makes more sense for shortcuts, which are assembled from many different plugins.

To test, you can create a `dev_mode/settings/overrides.json` file like this:

```json
{
  "@jupyterlab/apputils-extension:themes": {
      "theme": "JupyterLab Dark"
  },
  "@jupyterlab/shortcuts-extension:shortcuts": {
      "shortcuts": [
      {
          "command": "imageviewer:flip-horizontal",
          "keys": [
              "X"
          ],
          "selector": ".jp-ImageViewer"
      },
      {
        "command": "imageviewer:flip-horizontal",
        "keys": [
            "H"
        ],
        "selector": ".jp-ImageViewer",
        "disabled": true
    }
    ]
  }
}
```
You can know it is active by the default dark theme. Look at the shortcuts, and you'll see the two additional shortcuts, and then try the shortcuts in the imageviewer to verify that "X" now flips horizontally and "H" does not.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
