### PR TITLE
Add link to source extension list of metadata in prebuilt extensions

### DIFF
--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -180,6 +180,7 @@ See the `JupyterLab Light Theme <https://github.com/jupyterlab/jupyterlab/tree/m
 
 See the `TypeScript theme cookiecutter <https://github.com/jupyterlab/theme-cookiecutter>`__ for a quick start to developing a theme plugin.
 
+.. _source_extensions:
 
 Source Extensions
 -----------------
@@ -458,7 +459,7 @@ Prebuilt Extensions
 package.json metadata
 ^^^^^^^^^^^^^^^^^^^^^
 
-In addition to the package metadata for source extensions, prebuilt extensions have extra ``jupyterlab`` metadata.
+In addition to the package metadata for :ref:`source extensions <source_extensions>`, prebuilt extensions have extra ``jupyterlab`` metadata.
 
 * ``outputDir``: :ref:`outputDir`
 * ``webpackConfig``: :ref:`webpackConfig`


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Add link to source extension list of metadata in prebuilt extensions. I missed the link and couldn't find information about the `extension` metadata keyword when researching prebuilt extensions.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
