### PR TITLE
Do not display the splash screen in the application state plugin

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -308,13 +308,12 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
   autoStart: true,
   provides: IStateDB,
   requires: [JupyterFrontEnd.IPaths, IRouter, ITranslator],
-  optional: [ISplashScreen, IWindowResolver],
+  optional: [IWindowResolver],
   activate: (
     app: JupyterFrontEnd,
     paths: JupyterFrontEnd.IPaths,
     router: IRouter,
     translator: ITranslator,
-    splash: ISplashScreen | null,
     resolver: IWindowResolver | null
   ) => {
     const trans = translator.load('jupyterlab');
@@ -425,11 +424,6 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
           return;
         }
 
-        // If a splash provider exists, launch the splash screen.
-        const loading = splash
-          ? splash.show()
-          : new DisposableDelegate(() => undefined);
-
         // If the state database has already been resolved, resetting is
         // impossible without reloading.
         if (resolved) {
@@ -454,7 +448,6 @@ const state: JupyterFrontEndPlugin<IStateDB> = {
         } else {
           void cleared.then(() => {
             router.navigate(url);
-            loading.dispose();
           });
         }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The splash screen is displayed in the [theme manager](https://github.com/jupyterlab/jupyterlab/blob/05778d1534b383b31ed70657db157c97067c2353/packages/apputils/src/thememanager.ts#L401-L403) and in the application state plugins, which means the splash screen is actually displayed twice on application startup. Visually, this often appears as the Jupyter moons orbiting, then stopping and starting over again. The state manager does not know if the theme is light or dark, so does not know the right options for displaying the splash screen anyway.

This change lets the theme manager control the splash screen display.

## User-facing changes

The stuttering Jupyter moons on application startup now just orbit once and finish, rather than often halting and starting over again.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
