### PR TITLE
Add support for Gitpod editor

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,7 +18,7 @@ github:
     addLabel: false
 tasks:
   - init: pip3 install -e . && yarn install && yarn run build
-    command: jupyter lab --dev-mode --watch --LabApp.token=''
+    command: pip3 install -e . && jupyter lab --dev-mode --watch --LabApp.token=''
 ports:
   - port: 8888
     onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: pip install -e . && yarn install
+    command: jupyter lab --dev-mode --watch

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,7 +18,9 @@ github:
     addLabel: false
 tasks:
   - init: pip3 install -e . && yarn install && yarn run build
-    command: pip3 install -e . && jupyter lab --dev-mode --watch --LabApp.token=''
+    command: pip3 install -e . && jupyter lab --dev-mode --watch --LabApp.token='' --LabApp.allow_origin=*
 ports:
   - port: 8888
     onOpen: open-browser
+
+# --LabApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,21 @@
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false
 tasks:
   - init: pip install -e . && yarn install
     command: jupyter lab --dev-mode --watch

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,5 +17,8 @@ github:
     # add a label once the prebuild is ready to pull requests (defaults to false)
     addLabel: false
 tasks:
-  - init: pip install -e . && yarn install
-    command: jupyter lab --dev-mode --watch
+  - init: pip3 install -e . && yarn install && yarn run build
+    command: jupyter lab --dev-mode --watch --LabApp.token=''
+ports:
+  - port: 8888
+    onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,10 +20,15 @@ tasks:
   - init: pip3 install -e . && yarn install && yarn run build
     # for some reason,have to re-install on start, or else it doesn't find the python package
     # Set no token and allow any origin, so that you can open it in a new tab.
-    command: pip3 install -e . && jupyter lab --dev-mode --watch --LabApp.token='' --LabApp.allow_origin=*
+    command: >
+      pip3 install -e . &&
+      jupyter lab
+      --dev-mode
+      --watch
+      --LabApp.token=''
+      --LabApp.allow_origin=*
+      --LabApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'
 ports:
   - port: 8888
     # Running it in an iframe doesn't work. Can experiment with iframe ancestors.     
     onOpen: open-browser
-
-# --LabApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,7 +19,8 @@ github:
 tasks:
   - init: pip3 install -e . && yarn install && yarn run build
     # for some reason,have to re-install on start, or else it doesn't find the python package
-    # Set no token and allow any origin, so that you can open it in a new tab.
+    # Set no token and allow any origin, so that you can open it in a new tab
+    # Disable iframe security so can load in the editor as well
     command: >
       pip3 install -e . &&
       jupyter lab
@@ -30,5 +31,3 @@ tasks:
       --LabApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'
 ports:
   - port: 8888
-    # Running it in an iframe doesn't work. Can experiment with iframe ancestors.     
-    onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,18 +9,21 @@ github:
     # enable for pull requests coming from forks (defaults to false)
     pullRequestsFromForks: true
     # add a check to pull requests (defaults to true)
-    addCheck: true
+    addCheck: false
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
-    addComment: true
+    addComment: false
     # add a "Review in Gitpod" button to the pull request's description (defaults to false)
     addBadge: false
     # add a label once the prebuild is ready to pull requests (defaults to false)
     addLabel: false
 tasks:
   - init: pip3 install -e . && yarn install && yarn run build
+    # for some reason,have to re-install on start, or else it doesn't find the python package
+    # Set no token and allow any origin, so that you can open it in a new tab.
     command: pip3 install -e . && jupyter lab --dev-mode --watch --LabApp.token='' --LabApp.allow_origin=*
 ports:
   - port: 8888
+    # Running it in an iframe doesn't work. Can experiment with iframe ancestors.     
     onOpen: open-browser
 
 # --LabApp.tornado_settings='{"headers": {"Content-Security-Policy": "frame-ancestors *"}}'

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/3818244?urlpath=lab/tree/demo)
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/saulshanabrook/jupyterlab/-/tree/gitpod)
+
 An extensible environment for interactive and reproducible computing, based on the
 Jupyter Notebook and Architecture. [Currently ready for users.](https://blog.jupyter.org/jupyterlab-is-ready-for-users-5a6f039b8906)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/3818244?urlpath=lab/tree/demo)
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/saulshanabrook/jupyterlab)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jupyterlab/jupyterlab)
 
 An extensible environment for interactive and reproducible computing, based on the
 Jupyter Notebook and Architecture. [Currently ready for users.](https://blog.jupyter.org/jupyterlab-is-ready-for-users-5a6f039b8906)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/3818244?urlpath=lab/tree/demo)
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/saulshanabrook/jupyterlab/-/tree/gitpod)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/saulshanabrook/jupyterlab)
 
 An extensible environment for interactive and reproducible computing, based on the
 Jupyter Notebook and Architecture. [Currently ready for users.](https://blog.jupyter.org/jupyterlab-is-ready-for-users-5a6f039b8906)


### PR DESCRIPTION
Getting set up to contribute to JupyterLab can be time-consuming and daunting for new contributors. [Gitpod](https://gitpod.io/) is a way to edit open-source projects, in your browser, for free. It is similar to Github Codespaces, but unlike codespaces, is available for anyone. I have added a file to set up Gitpod, so that anyone could use it to edit JupyterLab and push their changes back.



This also enables "prebuilds" so that on every push to different branches, it will rebuild the project, so that when it opens up, it's pretty quick to start up! It takes under two minutes from my timing.

It doesn't enable any Github checks or comments for prebuilds on PRs, do avoid adding more noise. Although we could do that here, or at a later date. 

To try out this PR, [launch Gitpod from my fork](https://gitpod.io/#https://github.com/saulshanabrook/jupyterlab). Here is a GIF of trying it out!

![2021-03-01 13 02 54](https://user-images.githubusercontent.com/1186124/109544698-de1b9f00-7a95-11eb-9b34-91b74f5381f2.gif)


You can see that the first automatic launch doesn't work (I think because the domain isn't right. Might be able to fix this). But if you click and open the port, either in the iframe or in a new page, that does work.

If this is merged in then new users can try it out, even if it isn't perfect. Until then, it's a little hard for new contributors to user gitpod, since they have to add this commit first, then add on top of it. 

## References

Replaces outdated PR I opened a while ago https://github.com/jupyterlab/jupyterlab/pull/7896

## Code changes

Adds config file for Gitpod and adds a link to readme

## User-facing changes

<img width="2048" alt="Screen Shot 2021-03-01 at 12 59 25 PM" src="https://user-images.githubusercontent.com/1186124/109538394-069f9b00-7a8e-11eb-8b1a-3efe338ef5bc.png">

## Backwards-incompatible changes

None