### PR TITLE
Added Pipfile to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ __pycache__
 *.egg-info
 .ipynb_checkpoints
 pip-wheel-metadata
+Pipfile
+Pipfile.lock
 
 # xeus-python debug logs
 xpython_debug_logs


### PR DESCRIPTION
Jupyter encourages conda installation, though some contributors will install it via pipenv. Adding the Pipfile to the gitignore will make life easier for the pipenv users, like myself, so they don't have to constantly dodge committing their files to their forks.