### PR TITLE
Add websocket token auth in case of different ws domain

### DIFF
--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -26,6 +26,9 @@ export namespace URLExt {
     return urlparse(url);
   }
 
+  export function getHostName(url: string): string {
+    return urlparse(url).hostname;
+  }
   /**
    * Normalize a url.
    */

--- a/packages/coreutils/src/url.ts
+++ b/packages/coreutils/src/url.ts
@@ -26,6 +26,13 @@ export namespace URLExt {
     return urlparse(url);
   }
 
+  /**
+   * Parse URL and retrieve hostname
+   *
+   * @param url - The URL string to parse
+   *
+   * @return a hostname string value
+   */
   export function getHostName(url: string): string {
     return urlparse(url).hostname;
   }

--- a/packages/services/src/serverconnection.ts
+++ b/packages/services/src/serverconnection.ts
@@ -246,7 +246,8 @@ namespace Private {
       appUrl: PageConfig.getOption('appUrl'),
       appendToken:
         typeof window === 'undefined' ||
-        process.env.JEST_WORKER_ID !== undefined,
+        process.env.JEST_WORKER_ID !== undefined ||
+        URLExt.getHostName(pageBaseUrl) !== URLExt.getHostName(wsUrl),
       ...options,
       baseUrl,
       wsUrl


### PR DESCRIPTION
Related issues:
https://github.com/jupyterlab/jupyterlab/issues/9070
https://github.com/jupyterlab/jupyterlab/pull/9080

As user I want to have possibility to use ws on another domain, this PR added one more check to appendToken method.