### PR TITLE
MathJax: change font from STIX-Web to TeX

### DIFF
--- a/packages/mathjax2/src/index.ts
+++ b/packages/mathjax2/src/index.ts
@@ -96,7 +96,7 @@ export class MathJaxTypesetter implements IRenderMime.ILatexTypesetter {
         availableFonts: [],
         imageFont: null,
         preferredFont: null,
-        webFont: 'STIX-Web',
+        webFont: 'TeX',
         styles: { '.MathJax_Display': { margin: 0 } },
         linebreaks: { automatic: true }
       },


### PR DESCRIPTION
## References

#5192

https://github.com/jupyter/notebook/pull/5998

## Code changes

Just changing `STIX-Web` to `TeX`.

## User-facing changes

Much nicer font for equations.

## Backwards-incompatible changes

none