### PR TITLE
Fix watch mode for external extensions

### DIFF
--- a/builder/src/webpack-plugins.ts
+++ b/builder/src/webpack-plugins.ts
@@ -110,7 +110,7 @@ export namespace WPPlugin {
         close: () => watcher.close(),
         pause: () => watcher.pause(),
         getContextTimeInfoEntries: () => {
-          const dirTimestamps = watcher.getContextInfoEntries();
+          const dirTimestamps = watcher.getContextTimeInfoEntries();
           for (const path of ignoredDirs) {
             dirTimestamps.set(path, IGNORE_TIME_ENTRY);
           }


### PR DESCRIPTION
## References

Issue found and opened in the Elyra repo: https://github.com/elyra-ai/elyra/issues/1338

Bug fixed in webpack in commit https://github.com/webpack/webpack/commit/4d08446159919e5ca130f40432e107cf280ba3a6

## Code changes

Webpack fixed this bug in a non-exported class, `FilterIgnoringWatchFileSystem`, that we keep a
"copy" of. I have included their fix in our copy of the class.

This addresses an error causing watch mode to fail to work when
using it with external extensions (not in dev mode), see the elyra issue for full stack trace
