### PR TITLE
Automatically close “answered” issues if they have no activity for 30 days

### DIFF
--- a/.github/answered.yml
+++ b/.github/answered.yml
@@ -1,0 +1,20 @@
+# This action automatically schedules issues to be closed that have been
+# labeled as answered if there is no activity on them for 30 days. This takes
+# care of the common usecase of an issue being answered to the best of our
+# ability and no other follow-up from the submitter.
+name: 'Close answered issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          skip-stale-issue-message: true
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: 'status:Closing as Answered'
+          only-issue-labels: 'status:Answered'


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Often we have questions opened as issues that we have answered, but then there is no follow-up from the submitter. This enables us to indicate we have answered the question, and then the issue is scheduled to be closed after 30 days, presumably answered.

We could add a message before closure, but when we did that for the resolved-locked issues, it seemed to be mostly annoying without doing any good, so I opted for a silent scheduling, then closure a week later. The issue won't be locked for another 6 months of inactivity, so the submitter can always comment again and we can reopen it.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
