### PR TITLE
Remove the explicit path to the mock extension used in the integrity script

### DIFF
--- a/buildutils/src/ensure-repo.ts
+++ b/buildutils/src/ensure-repo.ts
@@ -443,9 +443,7 @@ export async function ensureIntegrity(): Promise<boolean> {
   // Pick up all the package versions.
   const paths = utils.getLernaPaths();
 
-  // These two are not part of the workspaces but should be kept
-  // in sync.
-  paths.push('./jupyterlab/tests/mock_packages/extension');
+  // This package is not part of the workspaces but should be kept in sync.
   paths.push('./jupyterlab/tests/mock_packages/mimeextension');
 
   const cssImports: Dict<string[]> = {};


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Remove the explicit path to the `extension` mock package, since it is already part of the `workspaces`:

https://github.com/jupyterlab/jupyterlab/blob/3f31704fabd627adcdfb0dad4b3b01efee9d1c90/package.json#L19

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
