### PR TITLE
Virtual notebook with a window

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -197,12 +197,12 @@ export class Cell extends Widget {
       model,
       contentFactory,
       updateOnShow: options.updateEditorOnShow,
-      placeholder: options.placeholder
+      placeholder: options.inputPlaceholder
     }));
     input.addClass(CELL_INPUT_AREA_CLASS);
     inputWrapper.addWidget(inputCollapser);
     inputWrapper.addWidget(input);
-    if (options.placeholder) {
+    if (options.inputPlaceholder) {
       input.node.innerHTML = `<div class="jp-Cell-Placeholder">
         <pre>${options.model.value.text}</pre>
       </div>`;
@@ -459,7 +459,8 @@ export class Cell extends Widget {
     return new constructor({
       model: this.model,
       contentFactory: this.contentFactory,
-      placeholder: false
+      outputPlaceholder: false,
+      inputPlaceholder: false
     });
   }
 
@@ -576,9 +577,14 @@ export namespace Cell {
     updateEditorOnShow?: boolean;
 
     /**
-     * Whether this cell is a placeholder for future rendering.
+     * Whether this input cell is a placeholder for future rendering.
      */
-    placeholder?: boolean;
+    inputPlaceholder?: boolean;
+
+    /**
+     * Whether this output cell is a placeholder for future rendering.
+     */
+    outputPlaceholder?: boolean;
 
     /**
      * The maximum number of output items to display in cell output.
@@ -712,33 +718,33 @@ export class CodeCell extends Cell {
     const contentFactory = this.contentFactory;
     const model = this.model;
 
-    //    if (!options.placeholder) {
-    // Insert the output before the cell footer.
-    const outputWrapper = (this._outputWrapper = new Panel());
-    outputWrapper.addClass(CELL_OUTPUT_WRAPPER_CLASS);
-    const outputCollapser = new OutputCollapser();
-    outputCollapser.addClass(CELL_OUTPUT_COLLAPSER_CLASS);
-    const output = (this._output = new OutputArea({
-      model: model.outputs,
-      rendermime,
-      contentFactory: contentFactory,
-      maxNumberOutputs: options.maxNumberOutputs
-    }));
-    output.addClass(CELL_OUTPUT_AREA_CLASS);
-    // Set a CSS if there are no outputs, and connect a signal for future
-    // changes to the number of outputs. This is for conditional styling
-    // if there are no outputs.
-    if (model.outputs.length === 0) {
-      this.addClass(NO_OUTPUTS_CLASS);
+    if (!options.outputPlaceholder) {
+      // Insert the output before the cell footer.
+      const outputWrapper = (this._outputWrapper = new Panel());
+      outputWrapper.addClass(CELL_OUTPUT_WRAPPER_CLASS);
+      const outputCollapser = new OutputCollapser();
+      outputCollapser.addClass(CELL_OUTPUT_COLLAPSER_CLASS);
+      const output = (this._output = new OutputArea({
+        model: model.outputs,
+        rendermime,
+        contentFactory: contentFactory,
+        maxNumberOutputs: options.maxNumberOutputs
+      }));
+      output.addClass(CELL_OUTPUT_AREA_CLASS);
+      // Set a CSS if there are no outputs, and connect a signal for future
+      // changes to the number of outputs. This is for conditional styling
+      // if there are no outputs.
+      if (model.outputs.length === 0) {
+        this.addClass(NO_OUTPUTS_CLASS);
+      }
+      output.outputLengthChanged.connect(this._outputLengthHandler, this);
+      outputWrapper.addWidget(outputCollapser);
+      outputWrapper.addWidget(output);
+      (this.layout as PanelLayout).insertWidget(2, outputWrapper);
+      this._outputPlaceholder = new OutputPlaceholder(() => {
+        this.outputHidden = !this.outputHidden;
+      });
     }
-    output.outputLengthChanged.connect(this._outputLengthHandler, this);
-    outputWrapper.addWidget(outputCollapser);
-    outputWrapper.addWidget(output);
-    (this.layout as PanelLayout).insertWidget(2, outputWrapper);
-    this._outputPlaceholder = new OutputPlaceholder(() => {
-      this.outputHidden = !this.outputHidden;
-    });
-    //    }
     model.stateChanged.connect(this.onStateChanged, this);
   }
 
@@ -935,7 +941,8 @@ export class CodeCell extends Cell {
       model: this.model,
       contentFactory: this.contentFactory,
       rendermime: this._rendermime,
-      placeholder: false
+      inputPlaceholder: false,
+      outputPlaceholder: false
     });
   }
 
@@ -1605,7 +1612,8 @@ export class RawCell extends Cell {
     return new constructor({
       model: this.model,
       contentFactory: this.contentFactory,
-      placeholder: false
+      inputPlaceholder: false,
+      outputPlaceholder: false
     });
   }
 

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -202,6 +202,11 @@ export class Cell extends Widget {
     input.addClass(CELL_INPUT_AREA_CLASS);
     inputWrapper.addWidget(inputCollapser);
     inputWrapper.addWidget(input);
+    if (options.placeholder) {
+      input.node.innerHTML = `<div class="jp-Cell-Placeholder">
+        <pre>${options.model.value.text}</pre>
+      </div>`;
+    }
     (this.layout as PanelLayout).addWidget(inputWrapper);
 
     this._inputPlaceholder = new InputPlaceholder(() => {
@@ -707,33 +712,33 @@ export class CodeCell extends Cell {
     const contentFactory = this.contentFactory;
     const model = this.model;
 
-    if (!options.placeholder) {
-      // Insert the output before the cell footer.
-      const outputWrapper = (this._outputWrapper = new Panel());
-      outputWrapper.addClass(CELL_OUTPUT_WRAPPER_CLASS);
-      const outputCollapser = new OutputCollapser();
-      outputCollapser.addClass(CELL_OUTPUT_COLLAPSER_CLASS);
-      const output = (this._output = new OutputArea({
-        model: model.outputs,
-        rendermime,
-        contentFactory: contentFactory,
-        maxNumberOutputs: options.maxNumberOutputs
-      }));
-      output.addClass(CELL_OUTPUT_AREA_CLASS);
-      // Set a CSS if there are no outputs, and connect a signal for future
-      // changes to the number of outputs. This is for conditional styling
-      // if there are no outputs.
-      if (model.outputs.length === 0) {
-        this.addClass(NO_OUTPUTS_CLASS);
-      }
-      output.outputLengthChanged.connect(this._outputLengthHandler, this);
-      outputWrapper.addWidget(outputCollapser);
-      outputWrapper.addWidget(output);
-      (this.layout as PanelLayout).insertWidget(2, outputWrapper);
-      this._outputPlaceholder = new OutputPlaceholder(() => {
-        this.outputHidden = !this.outputHidden;
-      });
+    //    if (!options.placeholder) {
+    // Insert the output before the cell footer.
+    const outputWrapper = (this._outputWrapper = new Panel());
+    outputWrapper.addClass(CELL_OUTPUT_WRAPPER_CLASS);
+    const outputCollapser = new OutputCollapser();
+    outputCollapser.addClass(CELL_OUTPUT_COLLAPSER_CLASS);
+    const output = (this._output = new OutputArea({
+      model: model.outputs,
+      rendermime,
+      contentFactory: contentFactory,
+      maxNumberOutputs: options.maxNumberOutputs
+    }));
+    output.addClass(CELL_OUTPUT_AREA_CLASS);
+    // Set a CSS if there are no outputs, and connect a signal for future
+    // changes to the number of outputs. This is for conditional styling
+    // if there are no outputs.
+    if (model.outputs.length === 0) {
+      this.addClass(NO_OUTPUTS_CLASS);
     }
+    output.outputLengthChanged.connect(this._outputLengthHandler, this);
+    outputWrapper.addWidget(outputCollapser);
+    outputWrapper.addWidget(output);
+    (this.layout as PanelLayout).insertWidget(2, outputWrapper);
+    this._outputPlaceholder = new OutputPlaceholder(() => {
+      this.outputHidden = !this.outputHidden;
+    });
+    //    }
     model.stateChanged.connect(this.onStateChanged, this);
   }
 

--- a/packages/console/src/widget.ts
+++ b/packages/console/src/widget.ts
@@ -236,7 +236,8 @@ export class CodeConsole extends Widget {
     const banner = (this._banner = new RawCell({
       model,
       contentFactory: this.contentFactory,
-      placeholder: false
+      inputPlaceholder: false,
+      outputPlaceholder: false
     })).initializeState();
     banner.addClass(BANNER_CLASS);
     banner.readOnly = true;
@@ -732,7 +733,13 @@ export class CodeConsole extends Widget {
     const modelFactory = this.modelFactory;
     const model = modelFactory.createCodeCell({});
     const rendermime = this.rendermime;
-    return { model, rendermime, contentFactory, placeholder: false };
+    return {
+      model,
+      rendermime,
+      contentFactory,
+      inputPlaceholder: false,
+      outputPlaceholder: false
+    };
   }
 
   /**

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -367,7 +367,7 @@
     },
     "renderWithWindow": {
       "title": "EXPERIMENTAL Render the notebook with a window display for the cells",
-      "description": "EXPERIMENT Define if the notebook cells should be rendered with the windowing feature to have faster tab switching. Set this to true only if you are facing issue with fast tab switching, for example using keyboard shortcuts. If this is set to true, and if you vertically scroll fast in the displayed notebook, you may face visual glitches in the cell display as we replace cells which come inside and outside the viewport.",
+      "description": "EXPERIMENTAL Define if the notebook cells should be rendered with the windowing feature to have faster tab switching. Set this to true only if you are facing issue with fast tab switching, for example using keyboard shortcuts. If this is set to true, and if you vertically scroll fast in the displayed notebook, you may face visual effects in the cell display as we replace cells which come inside and outside the viewport. If you want to mitigate the visual effect, set observedBottomMargin and observedTopMargin to higher values, e.g. 2000px. If you set this to true, it is recommended to set renderCellOnIdle to false.",
       "type": "boolean",
       "default": false
     },

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -365,6 +365,12 @@
       "type": "boolean",
       "default": false
     },
+    "renderWithWindow": {
+      "title": "EXPERIMENTAL Render the notebook with a window display for the cells",
+      "description": "EXPERIMENT Define if the notebook cells should be rendered with the windowing feature to have faster tab switching. Set this to true only if you are facing issue with fast tab switching, for example using keyboard shortcuts. If this is set to true, and if you vertically scroll fast in the displayed notebook, you may face visual glitches in the cell display as we replace cells which come inside and outside the viewport.",
+      "type": "boolean",
+      "default": false
+    },
     "numberCellsToRenderDirectly": {
       "title": "Number of cells to render directly",
       "description": "Define the number of cells to render directly when virtual notebook intersection observer is available",

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -662,6 +662,7 @@ function activateNotebookHandler(
       scrollPastEnd: settings.get('scrollPastEnd').composite as boolean,
       defaultCell: settings.get('defaultCell').composite as nbformat.CellType,
       recordTiming: settings.get('recordTiming').composite as boolean,
+      renderWithWindow: settings.get('renderWithWindow').composite as boolean,
       numberCellsToRenderDirectly: settings.get('numberCellsToRenderDirectly')
         .composite as number,
       renderCellOnIdle: settings.get('renderCellOnIdle').composite as boolean,

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -632,7 +632,8 @@ export class StaticNotebook extends Widget {
       rendermime,
       contentFactory,
       updateEditorOnShow: false,
-      placeholder: false,
+      inputPlaceholder: false,
+      outputlaceholder: false,
       maxNumberOutputs: this.notebookConfig.maxNumberOutputs
     };
     const cell = this.contentFactory.createCodeCell(options, this);
@@ -655,7 +656,8 @@ export class StaticNotebook extends Widget {
       rendermime,
       contentFactory,
       updateEditorOnShow: false,
-      placeholder: false
+      inputPlaceholder: false,
+      outputPlaceholder: false
     };
     const cell = this.contentFactory.createMarkdownCell(options, this);
     cell.syncCollapse = true;
@@ -682,7 +684,8 @@ export class StaticNotebook extends Widget {
           rendermime,
           contentFactory,
           updateEditorOnShow: false,
-          placeholder: true
+          inputPlaceholder: true,
+          outputPlaceholder: !this.notebookConfig.renderWithWindow
         };
         widget = this.contentFactory.createCodeCell(codeOptions, this);
         widget.model.mimeType = this._mimetype;
@@ -694,7 +697,8 @@ export class StaticNotebook extends Widget {
           rendermime,
           contentFactory,
           updateEditorOnShow: false,
-          placeholder: true
+          inputPlaceholder: true,
+          outputPlaceholder: !this.notebookConfig.renderWithWindow
         };
         widget = this.contentFactory.createMarkdownCell(markdownOptions, this);
         if (model.value.text === '') {
@@ -708,24 +712,11 @@ export class StaticNotebook extends Widget {
           rendermime,
           contentFactory,
           updateEditorOnShow: false,
-          placeholder: true
+          inputPlaceholder: true,
+          outputPlaceholder: !this.notebookConfig.renderWithWindow
         };
         widget = this.contentFactory.createRawCell(rawOptions, this);
     }
-    /*
-    widget.node.innerHTML = `<div class="jp-Cell-Placeholder">
-        <pre>${widget.model.value.text}</pre>
-    </div>`
-    */
-    /*
-    cell.node.innerHTML = `
-      <div class="jp-Cell-Placeholder">
-        <div class="jp-Cell-Placeholder-wrapper">
-        </div>
-      </div>
-    </div>`;
-    */
-    //    widget.inputHidden = true;
     widget.syncCollapse = true;
     widget.syncEditable = true;
     return widget;
@@ -742,7 +733,8 @@ export class StaticNotebook extends Widget {
       model,
       contentFactory,
       updateEditorOnShow: false,
-      placeholder: false
+      inputPlaceholder: false,
+      outputPlaceholder: false
     };
     const cell = this.contentFactory.createRawCell(options, this);
     cell.syncCollapse = true;

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -277,7 +277,10 @@
 |----------------------------------------------------------------------------*/
 
 .jp-Cell-Placeholder {
-  padding-left: 55px;
+  /* padding-left: 55px; */
+  margin-left: 65px;
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-content-font-color2);
 }
 
 .jp-Cell-Placeholder-wrapper {


### PR DESCRIPTION
## References

Related to https://github.com/jupyterlab/jupyterlab/issues/8971

Follow-up of https://github.com/jupyterlab/jupyterlab/pull/8972

This allows the user to enable an experimental feature to support window rendering with the virtual notebook.

## Code changes

Notebook widget has more logic to implement a window experimental feature. A new experimental setting `renderWithWindow` set by default to false allows the user to enable the windowing feature.

In the window rendering mode, cells are only rendered in the defined viewport (configurable via observedTopMargin and observedBottomMargin). The cells outside of that viewport are placeholders for the inputcell (codemirror), and normal outputs.


The `renderWithWindow` setting is defined as `EXPERIMENTAL Define if the notebook cells should be rendered with the windowing feature to have faster tab switching. Set this to true only if you are facing issue with fast tab switching, for example using keyboard shortcuts. If this is set to true, and if you vertically scroll fast in the displayed notebook, you may face visual effects in the cell display as we replace cells which come inside and outside the viewport. If you want to mitigate the visual effect, set observedBottomMargin and observedTopMargin to higher values, e.g. 2000px. If you set this to true, it is recommended to set renderCellOnIdle to false.``

## User-facing changes

The following screen capture shows that the cells are changed from placeholder from real cell if the user scrolls fast. The user can define a large top/bottom margin to mitigate this.

![Kapture 2021-03-10 at 06 58 10](https://user-images.githubusercontent.com/226720/110590346-f49db680-8177-11eb-9658-4a04f6b1db1c.gif)

## Backwards-incompatible changes

None
