### PR TITLE
Make Table of Contents extension not rewrite all notebook headers.

### DIFF
--- a/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
+++ b/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
@@ -65,11 +65,12 @@ function getRenderedHTMLHeadings(
 
     const level = parseInt(el.tagName[1], 10);
     let nstr = generateNumbering(dict, level);
-    let nhtml = '';
     if (numbering) {
-      nhtml = '<span class="numbering-entry">' + nstr + '</span>';
+      const nhtml = document.createElement('span');
+      nhtml.classList.add('numbering-entry');
+      nhtml.textContent = nstr ?? '';
+      el.insertBefore(nhtml, el.firstChild);
     }
-    el.innerHTML = nhtml + html;
     headings.push({
       level: level,
       text: el.textContent ? el.textContent : '',


### PR DESCRIPTION




<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9926

## Code changes

Before this commit, the table of contents extension was rewriting all notebook headers with its own sanitization settings (different from the default sanitizer) just to get the auto-numbering in the notebook document. This change instead leaves the rendered header alone and just prepends the auto-generated number.

## User-facing changes



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
