### PR TITLE
Move the code consoles functionalities for the notebook to a separate plugin

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -674,13 +674,15 @@ function activateClonedOutputs(
 function activateCodeConsole(
   app: JupyterFrontEnd,
   tracker: INotebookTracker,
-  translator: ITranslator,
+  translator: ITranslator
 ): void {
   const trans = translator.load('jupyterlab');
   const { commands, shell } = app;
 
   // Get the current widget and activate unless the args specify otherwise.
-  const getCurrent = (args: ReadonlyPartialJSONObject): NotebookPanel | null => {
+  const getCurrent = (
+    args: ReadonlyPartialJSONObject
+  ): NotebookPanel | null => {
     const widget = tracker.currentWidget;
     const activate = args['activate'] !== false;
 
@@ -689,7 +691,7 @@ function activateCodeConsole(
     }
 
     return widget;
-  }
+  };
 
   const isEnabled = (): boolean => Private.isEnabled(shell, tracker);
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -679,26 +679,12 @@ function activateCodeConsole(
   const trans = translator.load('jupyterlab');
   const { commands, shell } = app;
 
-  // Get the current widget and activate unless the args specify otherwise.
-  const getCurrent = (
-    args: ReadonlyPartialJSONObject
-  ): NotebookPanel | null => {
-    const widget = tracker.currentWidget;
-    const activate = args['activate'] !== false;
-
-    if (activate && widget) {
-      shell.activateById(widget.id);
-    }
-
-    return widget;
-  };
-
   const isEnabled = (): boolean => Private.isEnabled(shell, tracker);
 
   commands.addCommand(CommandIDs.createConsole, {
     label: trans.__('New Console for Notebook'),
     execute: args => {
-      const current = getCurrent({ ...args, activate: false });
+      const current = tracker.currentWidget;
 
       if (!current) {
         return;
@@ -718,7 +704,7 @@ function activateCodeConsole(
     execute: async args => {
       // Default to not activating the notebook (thereby putting the notebook
       // into command mode)
-      const current = getCurrent({ activate: false, ...args });
+      const current = tracker.currentWidget;
 
       if (!current) {
         return;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -407,6 +407,16 @@ const clonedOutputsPlugin: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * A plugin for code consoles functionalities.
+ */
+const codeConsolePlugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/notebook-extension:code-console',
+  requires: [INotebookTracker, ITranslator],
+  activate: activateCodeConsole,
+  autoStart: true
+};
+
+/**
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
@@ -417,7 +427,8 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   notebookTrustItem,
   widgetFactoryPlugin,
   logNotebookOutput,
-  clonedOutputsPlugin
+  clonedOutputsPlugin,
+  codeConsolePlugin
 ];
 export default plugins;
 
@@ -654,6 +665,171 @@ function activateClonedOutputs(
       });
     },
     isEnabled: isEnabledAndSingleSelected
+  });
+}
+
+/**
+ * Activate the plugin to add code console functionalities
+ */
+function activateCodeConsole(
+  app: JupyterFrontEnd,
+  tracker: INotebookTracker,
+  translator: ITranslator,
+): void {
+  const trans = translator.load('jupyterlab');
+  const { commands, shell } = app;
+
+  // Get the current widget and activate unless the args specify otherwise.
+  const getCurrent = (args: ReadonlyPartialJSONObject): NotebookPanel | null => {
+    const widget = tracker.currentWidget;
+    const activate = args['activate'] !== false;
+
+    if (activate && widget) {
+      shell.activateById(widget.id);
+    }
+
+    return widget;
+  }
+
+  const isEnabled = (): boolean => Private.isEnabled(shell, tracker);
+
+  commands.addCommand(CommandIDs.createConsole, {
+    label: trans.__('New Console for Notebook'),
+    execute: args => {
+      const current = getCurrent({ ...args, activate: false });
+
+      if (!current) {
+        return;
+      }
+
+      return Private.createConsole(
+        commands,
+        current,
+        args['activate'] as boolean
+      );
+    },
+    isEnabled
+  });
+
+  commands.addCommand(CommandIDs.runInConsole, {
+    label: trans.__('Run Selected Text or Current Line in Console'),
+    execute: async args => {
+      // Default to not activating the notebook (thereby putting the notebook
+      // into command mode)
+      const current = getCurrent({ activate: false, ...args });
+
+      if (!current) {
+        return;
+      }
+
+      const { context, content } = current;
+
+      const cell = content.activeCell;
+      const metadata = cell?.model.metadata.toJSON();
+      const path = context.path;
+      // ignore action in non-code cell
+      if (!cell || cell.model.type !== 'code') {
+        return;
+      }
+
+      let code: string;
+      const editor = cell.editor;
+      const selection = editor.getSelection();
+      const { start, end } = selection;
+      const selected = start.column !== end.column || start.line !== end.line;
+
+      if (selected) {
+        // Get the selected code from the editor.
+        const start = editor.getOffsetAt(selection.start);
+        const end = editor.getOffsetAt(selection.end);
+        code = editor.model.value.text.substring(start, end);
+      } else {
+        // no selection, find the complete statement around the current line
+        const cursor = editor.getCursorPosition();
+        const srcLines = editor.model.value.text.split('\n');
+        let curLine = selection.start.line;
+        while (
+          curLine < editor.lineCount &&
+          !srcLines[curLine].replace(/\s/g, '').length
+        ) {
+          curLine += 1;
+        }
+        // if curLine > 0, we first do a search from beginning
+        let fromFirst = curLine > 0;
+        let firstLine = 0;
+        let lastLine = firstLine + 1;
+        // eslint-disable-next-line
+        while (true) {
+          code = srcLines.slice(firstLine, lastLine).join('\n');
+          const reply = await current.context.sessionContext.session?.kernel?.requestIsComplete(
+            {
+              // ipython needs an empty line at the end to correctly identify completeness of indented code
+              code: code + '\n\n'
+            }
+          );
+          if (reply?.content.status === 'complete') {
+            if (curLine < lastLine) {
+              // we find a block of complete statement containing the current line, great!
+              while (
+                lastLine < editor.lineCount &&
+                !srcLines[lastLine].replace(/\s/g, '').length
+              ) {
+                lastLine += 1;
+              }
+              editor.setCursorPosition({
+                line: lastLine,
+                column: cursor.column
+              });
+              break;
+            } else {
+              // discard the complete statement before the current line and continue
+              firstLine = lastLine;
+              lastLine = firstLine + 1;
+            }
+          } else if (lastLine < editor.lineCount) {
+            // if incomplete and there are more lines, add the line and check again
+            lastLine += 1;
+          } else if (fromFirst) {
+            // we search from the first line and failed, we search again from current line
+            firstLine = curLine;
+            lastLine = curLine + 1;
+            fromFirst = false;
+          } else {
+            // if we have searched both from first line and from current line and we
+            // cannot find anything, we submit the current line.
+            code = srcLines[curLine];
+            while (
+              curLine + 1 < editor.lineCount &&
+              !srcLines[curLine + 1].replace(/\s/g, '').length
+            ) {
+              curLine += 1;
+            }
+            editor.setCursorPosition({
+              line: curLine + 1,
+              column: cursor.column
+            });
+            break;
+          }
+        }
+      }
+
+      if (!code) {
+        return;
+      }
+
+      await commands.execute('console:open', {
+        activate: false,
+        insertMode: 'split-bottom',
+        path
+      });
+      await commands.execute('console:inject', {
+        activate: false,
+        code,
+        path,
+        metadata
+      });
+    },
+    isEnabled
   });
 }
 
@@ -1075,126 +1251,6 @@ function addCommands(
 
         return NotebookActions.runAndInsert(content, context.sessionContext);
       }
-    },
-    isEnabled
-  });
-  commands.addCommand(CommandIDs.runInConsole, {
-    label: trans.__('Run Selected Text or Current Line in Console'),
-    execute: async args => {
-      // Default to not activating the notebook (thereby putting the notebook
-      // into command mode)
-      const current = getCurrent({ activate: false, ...args });
-
-      if (!current) {
-        return;
-      }
-
-      const { context, content } = current;
-
-      const cell = content.activeCell;
-      const metadata = cell?.model.metadata.toJSON();
-      const path = context.path;
-      // ignore action in non-code cell
-      if (!cell || cell.model.type !== 'code') {
-        return;
-      }
-
-      let code: string;
-      const editor = cell.editor;
-      const selection = editor.getSelection();
-      const { start, end } = selection;
-      const selected = start.column !== end.column || start.line !== end.line;
-
-      if (selected) {
-        // Get the selected code from the editor.
-        const start = editor.getOffsetAt(selection.start);
-        const end = editor.getOffsetAt(selection.end);
-        code = editor.model.value.text.substring(start, end);
-      } else {
-        // no selection, find the complete statement around the current line
-        const cursor = editor.getCursorPosition();
-        const srcLines = editor.model.value.text.split('\n');
-        let curLine = selection.start.line;
-        while (
-          curLine < editor.lineCount &&
-          !srcLines[curLine].replace(/\s/g, '').length
-        ) {
-          curLine += 1;
-        }
-        // if curLine > 0, we first do a search from beginning
-        let fromFirst = curLine > 0;
-        let firstLine = 0;
-        let lastLine = firstLine + 1;
-        // eslint-disable-next-line
-        while (true) {
-          code = srcLines.slice(firstLine, lastLine).join('\n');
-          const reply = await current.context.sessionContext.session?.kernel?.requestIsComplete(
-            {
-              // ipython needs an empty line at the end to correctly identify completeness of indented code
-              code: code + '\n\n'
-            }
-          );
-          if (reply?.content.status === 'complete') {
-            if (curLine < lastLine) {
-              // we find a block of complete statement containing the current line, great!
-              while (
-                lastLine < editor.lineCount &&
-                !srcLines[lastLine].replace(/\s/g, '').length
-              ) {
-                lastLine += 1;
-              }
-              editor.setCursorPosition({
-                line: lastLine,
-                column: cursor.column
-              });
-              break;
-            } else {
-              // discard the complete statement before the current line and continue
-              firstLine = lastLine;
-              lastLine = firstLine + 1;
-            }
-          } else if (lastLine < editor.lineCount) {
-            // if incomplete and there are more lines, add the line and check again
-            lastLine += 1;
-          } else if (fromFirst) {
-            // we search from the first line and failed, we search again from current line
-            firstLine = curLine;
-            lastLine = curLine + 1;
-            fromFirst = false;
-          } else {
-            // if we have searched both from first line and from current line and we
-            // cannot find anything, we submit the current line.
-            code = srcLines[curLine];
-            while (
-              curLine + 1 < editor.lineCount &&
-              !srcLines[curLine + 1].replace(/\s/g, '').length
-            ) {
-              curLine += 1;
-            }
-            editor.setCursorPosition({
-              line: curLine + 1,
-              column: cursor.column
-            });
-            break;
-          }
-        }
-      }
-
-      if (!code) {
-        return;
-      }
-
-      await commands.execute('console:open', {
-        activate: false,
-        insertMode: 'split-bottom',
-        path
-      });
-      await commands.execute('console:inject', {
-        activate: false,
-        code,
-        path,
-        metadata
-      });
     },
     isEnabled
   });
@@ -1785,23 +1841,6 @@ function addCommands(
       if (kernel) {
         return kernel.reconnect();
       }
-    },
-    isEnabled
-  });
-  commands.addCommand(CommandIDs.createConsole, {
-    label: trans.__('New Console for Notebook'),
-    execute: args => {
-      const current = getCurrent({ ...args, activate: false });
-
-      if (!current) {
-        return;
-      }
-
-      return Private.createConsole(
-        commands,
-        current,
-        args['activate'] as boolean
-      );
     },
     isEnabled
   });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlab/jupyterlab/pull/9845

This makes it easier to reuse the notebook plugins in alternative JupyterLab distributions that only display a single widget in their main area.

Addresses the second part of https://github.com/jtpio/jupyterlab-classic/issues/104

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Move the code consoles functionalities to a separate plugin in the notebook extension.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None for JupyterLab users.

Other JupyterLab distributions will be able to not include this new plugin their build, to now show features that are not supported.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
