### PR TITLE
feat: CommandLinker Support in Markdown cells

### DIFF
--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -627,6 +627,7 @@ class Sanitizer implements ISanitizer {
       br: ['clear'],
       button: [
         'accesskey',
+        'data-commandlinker-args',
         'data-commandlinker-command',
         'disabled',
         'name',

--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -625,7 +625,15 @@ class Sanitizer implements ISanitizer {
       bdo: ['dir'],
       blockquote: ['cite'],
       br: ['clear'],
-      button: ['accesskey', 'disabled', 'name', 'tabindex', 'type', 'value'],
+      button: [
+        'accesskey',
+        'data-commandlinker-command',
+        'disabled',
+        'name',
+        'tabindex',
+        'type',
+        'value'
+      ],
       canvas: ['height', 'width'],
       caption: ['align'],
       col: ['align', 'char', 'charoff', 'span', 'valign', 'width'],

--- a/tests/test-apputils/src/sanitizer.spec.ts
+++ b/tests/test-apputils/src/sanitizer.spec.ts
@@ -39,6 +39,14 @@ describe('defaultSanitizer', () => {
       expect(defaultSanitizer.sanitize(a)).to.equal(expected);
     });
 
+    it('should allow the `data-commandlinker-command` attribute for button tags', () => {
+      const button =
+        '<button data-commandlinker-command="terminal:create-new" onClick={some evil code}>Create Terminal</button>';
+      const expectedButton =
+        '<button data-commandlinker-command="terminal:create-new">Create Terminal</button>';
+      expect(defaultSanitizer.sanitize(button)).toBe(expectedButton);
+    });
+
     it('should allow the class attribute for code tags', () => {
       const code = '<code class="foo">bar</code>';
       expect(defaultSanitizer.sanitize(code)).to.equal(code);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
[ISSUE-9899](https://github.com/jupyterlab/jupyterlab/issues/9899)
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- `sanitizer` allows `button` to have `data-commandlinker-command` `data-commandlinker-args` attribute
- add related test
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
In Markdown, if a button has `data-commandlinker-command`, `data-commandlinker-args`, it should execute JL commands.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

**Before**:

https://user-images.githubusercontent.com/11983489/110221927-b3f62280-7e83-11eb-912c-6e7b49789c9b.mov


**After**:

https://user-images.githubusercontent.com/11983489/110220910-b35a8d80-7e7d-11eb-9d6a-8367924294db.mov

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
