### PR TITLE
Fix ToC markdown bug for HTML comments

### DIFF
--- a/packages/toc/src/utils/parse_heading.ts
+++ b/packages/toc/src/utils/parse_heading.ts
@@ -88,7 +88,7 @@ function parseHeading(str: string): IHeading | null {
   }
   // Case: Markdown heading (alternative style)
   if (lines.length > 1) {
-    match = lines[1].match(/^([=]{2,}|[-]{2,})/);
+    match = lines[1].match(/^([=]{2,}|[-]{2,})(?<!>)$/);
     if (match) {
       return {
         text: lines[0].replace(/\[(.+)\]\(.+\)/g, '$1'), // take special care to parse Markdown links into raw text


### PR DESCRIPTION
## Code changes
Adjusts the regex used to detect markdown headings in the ToC to account for HTML comments. The ToC was recognizing the last line of an html comment as a markdown heading. 

## User-facing changes
Before changes:
![image](https://user-images.githubusercontent.com/6673460/111006198-fa4ef400-8351-11eb-86ec-6c90e098df37.png)

After changes:
![image](https://user-images.githubusercontent.com/6673460/111006156-e4413380-8351-11eb-9d5d-db3929b062e7.png)

## Backwards-incompatible changes
None