### PR TITLE
DocRegistry FileType pattern matching doesn't work

### DIFF
--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -663,7 +663,7 @@ export class DocumentRegistry implements IDisposable {
 
     // Look for a pattern match first.
     let ft = find(this._fileTypes, ft => {
-      return !!(ft.pattern && ft.pattern.match(name) !== null);
+      return !!(ft.pattern && name.match(ft.pattern) !== null);
     });
     if (ft) {
       fts.push(ft);

--- a/packages/docregistry/test/registry.spec.ts
+++ b/packages/docregistry/test/registry.spec.ts
@@ -655,6 +655,20 @@ describe('docregistry/registry', () => {
         const ft = registry.getFileTypesForPath('foo/bar/baz.PY');
         expect(ft[0].name).toBe('python');
       });
+
+      it('should support pattern matching', () => {
+        registry.addFileType({
+          name: 'test',
+          extensions: ['.temp'],
+          pattern: '.*\\.test$'
+        });
+
+        const ft = registry.getFileTypesForPath('foo/bar/baz.test');
+        expect(ft[0].name).toBe('test');
+
+        const ft2 = registry.getFileTypesForPath('foo/bar/baz.temp');
+        expect(ft2[0].name).toBe('test');
+      });
     });
   });
 });


### PR DESCRIPTION
The pattern matching for discovering a filetype in the docregistry
has the match call inversed. This feature seems to have always been
broken since being added 4 years ago, it was probably missed since
the feature is not used in core.

## References

This was discovered while trying to override the icons for python and R on https://github.com/elyra-ai/elyra/pull/1452 