### PR TITLE
Remove lookbehind from ToC MD regex for Safari

### DIFF
--- a/packages/toc/src/utils/parse_heading.ts
+++ b/packages/toc/src/utils/parse_heading.ts
@@ -88,7 +88,7 @@ function parseHeading(str: string): IHeading | null {
   }
   // Case: Markdown heading (alternative style)
   if (lines.length > 1) {
-    match = lines[1].match(/^([=]{2,}|[-]{2,})(?<!>)$/);
+    match = lines[1].match(/^ {0,3}([=]{2,}|[-]{2,})\s*$/);
     if (match) {
       return {
         text: lines[0].replace(/\[(.+)\]\(.+\)/g, '$1'), // take special care to parse Markdown links into raw text


### PR DESCRIPTION
## References

This PR fixes breaking issue #9961 while maintaining the fixes for issue elyra-ai/elyra#857 from PRs #9938 / #9943.

It also aligns the regex for setext headings with the CommonMark spec [here](https://spec.commonmark.org/0.29/#setext-headings) - up to 3 spaces indentation of the underline, any amount of whitespace after.

## Code changes

Original regex (doesn't exclude HTML comments):
`/^([=]{2,}|[-]{2,})/`

Breaking regex (fixes HTML comments but breaks Safari due to lookbehind, also not spec):
`/^([=]{2,}|[-]{2,})(?<!>)$/`

New regex:
`/^ {0,3}([=]{2,}|[-]{2,})\s*$/`

## User-facing changes

Safari users can use JupyterLab again.

## Backwards-incompatible changes

None.

---

[Edit] Fixed reference to original Elyra issue.