### PR TITLE
Update console message for when fullMathjaxUrl is missing from the page config

### DIFF
--- a/packages/mathjax2-extension/src/index.ts
+++ b/packages/mathjax2-extension/src/index.ts
@@ -23,13 +23,14 @@ const plugin: JupyterFrontEndPlugin<ILatexTypesetter> = {
   autoStart: true,
   provides: ILatexTypesetter,
   activate: () => {
-    const url = PageConfig.getOption('fullMathjaxUrl');
-    const config = PageConfig.getOption('mathjaxConfig');
+    const [urlParam, configParam] = ['fullMathjaxUrl', 'mathjaxConfig'];
+    const url = PageConfig.getOption(urlParam);
+    const config = PageConfig.getOption(configParam);
 
     if (!url) {
       const message =
-        `${plugin.id} uses 'mathJaxUrl' and 'mathjaxConfig' in PageConfig ` +
-        `to operate but 'mathJaxUrl' was not found.`;
+        `${plugin.id} uses '${urlParam}' and '${configParam}' in PageConfig ` +
+        `to operate but '${urlParam}' was not found.`;
 
       throw new Error(message);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## Code changes

Minor change to update the console message to mention `fullMathjaxUrl` instead of `mathJaxUrl` if it is missing from the page config.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
