### PR TITLE
Do not make unnecessary npm registry requests

### DIFF
--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -746,7 +746,10 @@ export class ListModel extends VDomModel {
    */
   protected async update(refreshInstalled = false) {
     if (ListModel.isDisclaimed()) {
-      const [searchMap, installedMap] = await Promise.all([this.performSearch(), this.queryInstalled(refreshInstalled)])
+      const [searchMap, installedMap] = await Promise.all([
+        this.performSearch(),
+        this.queryInstalled(refreshInstalled)
+      ]);
 
       // Map results to attributes:
       const installed: IEntry[] = [];

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -889,7 +889,7 @@ export class ListModel extends VDomModel {
 
   protected translator: ITranslator;
   private _app: JupyterFrontEnd;
-  private _query: string | null = null;
+  private _query: string | null = ''; // TODO: we may not need the null case?
   private _page: number = 0;
   private _pagination: number = 250;
   private _totalEntries: number = 0;

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -745,32 +745,28 @@ export class ListModel extends VDomModel {
    * Emits the `stateChanged` signal on successful completion.
    */
   protected async update(refreshInstalled = false) {
-    // Start both queries before awaiting:
+    if (ListModel.isDisclaimed()) {
+      // Start both queries before awaiting:
+      const [searchMap, installedMap] = await Promise.all([this.performSearch(), this.queryInstalled(refreshInstalled)])
 
-    const searchMapPromise = this.performSearch();
-    const installedMapPromise = this.queryInstalled(refreshInstalled);
-
-    // Await results:
-    const searchMap = await searchMapPromise;
-    const installedMap = await installedMapPromise;
-
-    // Map results to attributes:
-    const installed: IEntry[] = [];
-    for (const key of Object.keys(installedMap)) {
-      installed.push(installedMap[key]);
-    }
-    this._installed = installed.sort(Private.comparator);
-
-    const searchResult: IEntry[] = [];
-    for (const key of Object.keys(searchMap)) {
-      // Filter out installed entries from search results:
-      if (installedMap[key] === undefined) {
-        searchResult.push(searchMap[key]);
-      } else {
-        searchResult.push(installedMap[key]);
+      // Map results to attributes:
+      const installed: IEntry[] = [];
+      for (const key of Object.keys(installedMap)) {
+        installed.push(installedMap[key]);
       }
+      this._installed = installed.sort(Private.comparator);
+
+      const searchResult: IEntry[] = [];
+      for (const key of Object.keys(searchMap)) {
+        // Filter out installed entries from search results:
+        if (installedMap[key] === undefined) {
+          searchResult.push(searchMap[key]);
+        } else {
+          searchResult.push(installedMap[key]);
+        }
+      }
+      this._searchResult = searchResult.sort(Private.comparator);
     }
-    this._searchResult = searchResult.sort(Private.comparator);
 
     // Signal updated state
     this.stateChanged.emit(undefined);

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -746,7 +746,6 @@ export class ListModel extends VDomModel {
    */
   protected async update(refreshInstalled = false) {
     if (ListModel.isDisclaimed()) {
-      // Start both queries before awaiting:
       const [searchMap, installedMap] = await Promise.all([this.performSearch(), this.queryInstalled(refreshInstalled)])
 
       // Map results to attributes:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

@chwrtlprmft pointed out this issue with npm requests on #9911

## Code changes

The extension manager makes an initial npm registry search request even if the disclaimer is still showing (so search results will not show). Since we enable the extension manager by default, this means that JLab is making an external npm registry network request by default, then not using it.

This changes things so that:

1. An npm registry request is only made if the extension manager disclaimer has been agreed to (so by default, the network request is not made)
2. Fixes an issue where I was seeing a double request because of how initial query values worked.

## User-facing changes

After this, a default fresh install of JLab will not make an npm registry request.

## Backwards-incompatible changes

None. I think this should be considered for backport to 3.0.x.
