### PR TITLE
Optional sessionContext for ConsoleHistory

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -32,6 +32,10 @@ bumped their major version (following semver convention):
    See https://github.com/jupyterlab/jupyterlab/pull/11537 for more details.
 - ``@jupyterlab/toc:plugin`` renamed ``@jupyterlab/toc-extension:registry``
    This may impact application configuration (for instance if the plugin was disabled).
+- ``@jupyterlab/console`` from 3.x to 4.x
+   The type of ``IConsoleHistory.sessionContext`` has been updated to ``ISessionContext | null`` instead of ``ISessionContext``.
+   This might break the compilation of plugins accessing the ``sessionContext`` from a ``ConsoleHistory``,
+   in particular those with the strict null checks enabled.
 - ``@jupyterlab/notebook`` from 3.x to 4.x
    The ``NotebookPanel._onSave`` method is now ``private``.
 - ``@jupyterlab/shared-models`` from 3.x to 4.x

--- a/packages/console/src/history.ts
+++ b/packages/console/src/history.ts
@@ -14,7 +14,7 @@ export interface IConsoleHistory extends IDisposable {
   /**
    * The session context used by the foreign handler.
    */
-  readonly sessionContext: ISessionContext;
+  readonly sessionContext: ISessionContext | null;
 
   /**
    * The current editor used by the history widget.
@@ -74,15 +74,18 @@ export class ConsoleHistory implements IConsoleHistory {
    * Construct a new console history object.
    */
   constructor(options: ConsoleHistory.IOptions) {
-    this.sessionContext = options.sessionContext;
-    void this._handleKernel();
-    this.sessionContext.kernelChanged.connect(this._handleKernel, this);
+    const { sessionContext } = options;
+    if (sessionContext) {
+      this.sessionContext = sessionContext;
+      void this._handleKernel();
+      this.sessionContext.kernelChanged.connect(this._handleKernel, this);
+    }
   }
 
   /**
    * The client session used by the foreign handler.
    */
-  readonly sessionContext: ISessionContext;
+  readonly sessionContext: ISessionContext | null;
 
   /**
    * The current editor used by the history manager.
@@ -293,7 +296,7 @@ export class ConsoleHistory implements IConsoleHistory {
    * Handle the current kernel changing.
    */
   private async _handleKernel(): Promise<void> {
-    const kernel = this.sessionContext.session?.kernel;
+    const kernel = this.sessionContext?.session?.kernel;
     if (!kernel) {
       this._history.length = 0;
       return;
@@ -350,7 +353,7 @@ export namespace ConsoleHistory {
     /**
      * The client session used by the foreign handler.
      */
-    sessionContext: ISessionContext;
+    sessionContext?: ISessionContext;
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Make the `sessionContext` attribute of `IConsoleHistory` optional.

This might help make the `ConsoleHistory` more reusable in other contexts such as the one described in https://github.com/jupyterlab/jupyterlab/pull/9930.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Interface change to make the `sessionContext` attribute of `IConsoleHistory` optional.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

Update the type of `sessionContext` to `ISessionContext | null` instead of `ISessionContext`.

This will break plugins depending on `ConsoleHistory`, especially those with strict null checks enabled.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
