### PR TITLE
Fix escaping of urls and paths

### DIFF
--- a/packages/rendermime/src/registry.ts
+++ b/packages/rendermime/src/registry.ts
@@ -364,14 +364,14 @@ export namespace RenderMimeRegistry {
      * Get the download url of a given absolute url path.
      *
      * #### Notes
-     * This URL may include a query parameter.
+     * The returned URL may include a query parameter.
      */
-    async getDownloadUrl(url: string): Promise<string> {
-      if (this.isLocal(url)) {
+    async getDownloadUrl(urlPath: string): Promise<string> {
+      if (this.isLocal(urlPath)) {
         // decode url->path before passing to contents api
-        return this._contents.getDownloadUrl(decodeURI(url));
+        return this._contents.getDownloadUrl(decodeURIComponent(urlPath));
       }
-      return url;
+      return urlPath;
     }
 
     /**

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -803,7 +803,7 @@ namespace Private {
       .resolveUrl(href)
       .then(urlPath => {
         // decode encoded url from url to api path
-        const path = decodeURI(urlPath);
+        const path = decodeURIComponent(urlPath);
         // Handle the click override.
         if (linkHandler) {
           linkHandler.handleLink(anchor, path, hash);

--- a/packages/rendermime/test/registry.spec.ts
+++ b/packages/rendermime/test/registry.spec.ts
@@ -443,11 +443,11 @@ describe('rendermime/registry', () => {
         });
 
         it('should resolve URLs with escapes', async () => {
-          expect(await resolverSession.resolveUrl('has%20space')).toContain(
-            urlParent + '/has%20space'
-          );
-          expect(await resolverPath.resolveUrl('has%20space')).toContain(
-            urlParent + '/has%20space'
+          expect(
+            await resolverSession.resolveUrl('has%20space%23hash')
+          ).toContain(urlParent + '/has%20space%23hash');
+          expect(await resolverPath.resolveUrl('has%20space%23hash')).toContain(
+            urlParent + '/has%20space%23hash'
           );
         });
       });
@@ -461,8 +461,10 @@ describe('rendermime/registry', () => {
         });
 
         it('should resolve escapes correctly', async () => {
-          const contextPromise = resolverPath.getDownloadUrl('foo%2520test');
-          const contentsPromise = contents.getDownloadUrl('foo%20test');
+          const contextPromise = resolverPath.getDownloadUrl(
+            'foo%20%23%2520test'
+          );
+          const contentsPromise = contents.getDownloadUrl('foo #%20test');
           const values = await Promise.all([contextPromise, contentsPromise]);
           expect(values[0]).toBe(values[1]);
         });


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9895

## Code changes

First, we make tests fail, demonstrating the underlying problem in #9895. Then we fix the errors by using `encode/decodeURIComponent`, which handles many more characters than the previously-used `encode/decodeURI`. The idea here is that the urls passed into these functions represent paths (i.e., uri components), not full urls.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
