### PR TITLE
API for custom toolbars/headers in Notebook widgets

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -24,7 +24,8 @@ import {
   Printing,
   sessionContextDialogs,
   ISanitizer,
-  defaultSanitizer
+  defaultSanitizer,
+  MainAreaWidget
 } from '@jupyterlab/apputils';
 
 import { URLExt, PageConfig } from '@jupyterlab/coreutils';
@@ -68,6 +69,8 @@ namespace CommandIDs {
   export const resetOnLoad = 'apputils:reset-on-load';
 
   export const runFirstEnabled = 'apputils:run-first-enabled';
+
+  export const toggleHeader = 'apputils:toggle-header';
 }
 
 /**
@@ -294,6 +297,41 @@ const print: JupyterFrontEndPlugin<void> = {
         }
       }
     });
+  }
+};
+
+export const toggleHeader: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/apputils-extension:toggle-header',
+  autoStart: true,
+  requires: [ITranslator],
+  optional: [ICommandPalette],
+  activate: (
+    app: JupyterFrontEnd,
+    translator: ITranslator,
+    palette: ICommandPalette | null
+  ) => {
+    const trans = translator.load('jupyterlab');
+
+    const category: string = trans.__('Main Area');
+    app.commands.addCommand(CommandIDs.toggleHeader, {
+      label: trans.__('Show Header'),
+      isEnabled: () => app.shell.currentWidget instanceof MainAreaWidget,
+      isToggled: () => {
+        const widget = app.shell.currentWidget;
+        return widget instanceof MainAreaWidget
+          ? !widget.customHeader.isHidden
+          : false;
+      },
+      execute: async () => {
+        const widget = app.shell.currentWidget;
+        if (widget instanceof MainAreaWidget) {
+          widget.customHeader.setHidden(!widget.customHeader.isHidden);
+        }
+      }
+    });
+    if (palette) {
+      palette.addItem({ command: CommandIDs.toggleHeader, category });
+    }
   }
 };
 
@@ -540,6 +578,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   sessionDialogs,
   themesPlugin,
   themesPaletteMenuPlugin,
+  toggleHeader,
   utilityCommands,
   workspacesPlugin
 ];

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -314,8 +314,10 @@ export const toggleHeader: JupyterFrontEndPlugin<void> = {
 
     const category: string = trans.__('Main Area');
     app.commands.addCommand(CommandIDs.toggleHeader, {
-      label: trans.__('Show Header'),
-      isEnabled: () => app.shell.currentWidget instanceof MainAreaWidget,
+      label: trans.__('Show Header Above Content'),
+      isEnabled: () =>
+        app.shell.currentWidget instanceof MainAreaWidget &&
+        app.shell.currentWidget.contentHeader.widgets.length > 0,
       isToggled: () => {
         const widget = app.shell.currentWidget;
         return widget instanceof MainAreaWidget

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -319,13 +319,13 @@ export const toggleHeader: JupyterFrontEndPlugin<void> = {
       isToggled: () => {
         const widget = app.shell.currentWidget;
         return widget instanceof MainAreaWidget
-          ? !widget.customHeader.isHidden
+          ? !widget.contentHeader.isHidden
           : false;
       },
       execute: async () => {
         const widget = app.shell.currentWidget;
         if (widget instanceof MainAreaWidget) {
-          widget.customHeader.setHidden(!widget.customHeader.isHidden);
+          widget.contentHeader.setHidden(!widget.contentHeader.isHidden);
         }
       }
     });

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -5,7 +5,7 @@ import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
 import { Message, MessageLoop } from '@lumino/messaging';
 
-import { BoxLayout, Widget } from '@lumino/widgets';
+import { BoxLayout, BoxPanel, Widget } from '@lumino/widgets';
 
 import { Spinner } from './spinner';
 
@@ -44,13 +44,19 @@ export class MainAreaWidget<T extends Widget = Widget>
     const toolbar = (this._toolbar = options.toolbar || new Toolbar());
     toolbar.node.setAttribute('role', 'navigation');
     toolbar.node.setAttribute('aria-label', trans.__('notebook actions'));
+
+    const header = (this.header =
+      options.header ||
+      new BoxPanel({ direction: 'top-to-bottom', spacing: 0 }));
     const spinner = this._spinner;
+
+    header.addWidget(toolbar);
 
     const layout = (this.layout = new BoxLayout({ spacing: 0 }));
     layout.direction = 'top-to-bottom';
     BoxLayout.setStretch(toolbar, 0);
     BoxLayout.setStretch(content, 1);
-    layout.addWidget(toolbar);
+    layout.addWidget(header);
     layout.addWidget(content);
 
     if (!content.id) {
@@ -233,6 +239,7 @@ export class MainAreaWidget<T extends Widget = Widget>
 
   private _content: T;
   private _toolbar: Toolbar;
+  public header: BoxPanel;
   private _changeGuard = false;
   private _spinner = new Spinner();
 
@@ -257,6 +264,12 @@ export namespace MainAreaWidget {
      * The toolbar to use for the widget.  Defaults to an empty toolbar.
      */
     toolbar?: Toolbar;
+
+    /**
+     * The layout to contain the toolbar and other bars above content.
+     * Defaults to an empty BoxLayout.
+     */
+    header?: BoxPanel;
 
     /**
      * An optional promise for when the content is ready to be revealed.

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -45,8 +45,8 @@ export class MainAreaWidget<T extends Widget = Widget>
     toolbar.node.setAttribute('role', 'navigation');
     toolbar.node.setAttribute('aria-label', trans.__('notebook actions'));
     const spinner = this._spinner;
-    const customHeader = (this._customHeader =
-      options.customHeader ||
+    const contentHeader = (this._contentHeader =
+      options.contentHeader ||
       new BoxPanel({
         direction: 'top-to-bottom',
         spacing: 0
@@ -55,10 +55,10 @@ export class MainAreaWidget<T extends Widget = Widget>
     const layout = (this.layout = new BoxLayout({ spacing: 0 }));
     layout.direction = 'top-to-bottom';
     BoxLayout.setStretch(toolbar, 0);
-    BoxLayout.setStretch(customHeader, 0);
+    BoxLayout.setStretch(contentHeader, 0);
     BoxLayout.setStretch(content, 1);
     layout.addWidget(toolbar);
-    layout.addWidget(customHeader);
+    layout.addWidget(contentHeader);
     layout.addWidget(content);
 
     if (!content.id) {
@@ -143,8 +143,8 @@ export class MainAreaWidget<T extends Widget = Widget>
    * A panel for widgets that sit between the toolbar and the content.
    * Imagine a formatting toolbar, notification headers, etc.
    */
-  get customHeader(): BoxPanel {
-    return this._customHeader;
+  get contentHeader(): BoxPanel {
+    return this._contentHeader;
   }
 
   /**
@@ -251,12 +251,12 @@ export class MainAreaWidget<T extends Widget = Widget>
   MainAreaWidget's layout:
   - this.layout, a BoxLayout, from parent
     - this._toolbar, a Toolbar
-    - this._customHeader, a BoxPanel, empty by default
+    - this._contentHeader, a BoxPanel, empty by default
     - this._content
   */
   private _content: T;
   private _toolbar: Toolbar;
-  private _customHeader: BoxPanel;
+  private _contentHeader: BoxPanel;
 
   private _changeGuard = false;
   private _spinner = new Spinner();
@@ -287,7 +287,7 @@ export namespace MainAreaWidget {
      * The layout to sit underneath the toolbar and above the content,
      * and that extensions can populate. Defaults to an empty BoxPanel.
      */
-    customHeader?: BoxPanel;
+    contentHeader?: BoxPanel;
 
     /**
      * An optional promise for when the content is ready to be revealed.

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -44,19 +44,21 @@ export class MainAreaWidget<T extends Widget = Widget>
     const toolbar = (this._toolbar = options.toolbar || new Toolbar());
     toolbar.node.setAttribute('role', 'navigation');
     toolbar.node.setAttribute('aria-label', trans.__('notebook actions'));
-
-    const header = (this.header =
-      options.header ||
-      new BoxPanel({ direction: 'top-to-bottom', spacing: 0 }));
     const spinner = this._spinner;
-
-    header.addWidget(toolbar);
+    const customHeader = (this._customHeader =
+      options.customHeader ||
+      new BoxPanel({
+        direction: 'top-to-bottom',
+        spacing: 0
+      }));
 
     const layout = (this.layout = new BoxLayout({ spacing: 0 }));
     layout.direction = 'top-to-bottom';
     BoxLayout.setStretch(toolbar, 0);
+    BoxLayout.setStretch(customHeader, 0);
     BoxLayout.setStretch(content, 1);
-    layout.addWidget(header);
+    layout.addWidget(toolbar);
+    layout.addWidget(customHeader);
     layout.addWidget(content);
 
     if (!content.id) {
@@ -135,6 +137,14 @@ export class MainAreaWidget<T extends Widget = Widget>
    */
   get toolbar(): Toolbar {
     return this._toolbar;
+  }
+
+  /**
+   * A panel for widgets that sit between the toolbar and the content.
+   * Imagine a formatting toolbar, notification headers, etc.
+   */
+  get customHeader(): BoxPanel {
+    return this._customHeader;
   }
 
   /**
@@ -237,9 +247,17 @@ export class MainAreaWidget<T extends Widget = Widget>
     this.content.activate();
   }
 
+  /*
+  MainAreaWidget's layout:
+  - this.layout, a BoxLayout, from parent
+    - this._toolbar, a Toolbar
+    - this._customHeader, a BoxPanel, empty by default
+    - this._content
+  */
   private _content: T;
   private _toolbar: Toolbar;
-  public header: BoxPanel;
+  private _customHeader: BoxPanel;
+
   private _changeGuard = false;
   private _spinner = new Spinner();
 
@@ -266,10 +284,10 @@ export namespace MainAreaWidget {
     toolbar?: Toolbar;
 
     /**
-     * The layout to contain the toolbar and other bars above content.
-     * Defaults to an empty BoxLayout.
+     * The layout to sit underneath the toolbar and above the content,
+     * and that extensions can populate. Defaults to an empty BoxPanel.
      */
-    header?: BoxPanel;
+    customHeader?: BoxPanel;
 
     /**
      * An optional promise for when the content is ready to be revealed.

--- a/packages/apputils/test/mainareawidget.spec.ts
+++ b/packages/apputils/test/mainareawidget.spec.ts
@@ -28,11 +28,11 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('customHeader', () => {
+    describe('contentHeader', () => {
       it('should exist and have correct type', () => {
         const content = new Widget();
         const widget = new MainAreaWidget({ content });
-        expect(widget.customHeader).toBeInstanceOf(BoxPanel);
+        expect(widget.contentHeader).toBeInstanceOf(BoxPanel);
       });
     });
 

--- a/packages/apputils/test/mainareawidget.spec.ts
+++ b/packages/apputils/test/mainareawidget.spec.ts
@@ -5,7 +5,7 @@ import { MainAreaWidget, Toolbar } from '@jupyterlab/apputils';
 
 import { MessageLoop } from '@lumino/messaging';
 
-import { Widget } from '@lumino/widgets';
+import { BoxPanel, Widget } from '@lumino/widgets';
 
 describe('@jupyterlab/apputils', () => {
   describe('MainAreaWidget', () => {
@@ -24,8 +24,17 @@ describe('@jupyterlab/apputils', () => {
         const toolbar = new Toolbar();
         const widget = new MainAreaWidget({ content, toolbar });
         expect(widget.hasClass('jp-MainAreaWidget')).toBe(true);
+        expect(widget.toolbar).toBe(toolbar);
       });
     });
+
+    describe('customHeader', ()=>{
+      it('should exist and have correct type', ()=>{
+        const content = new Widget();
+        const widget = new MainAreaWidget({ content });
+        expect(widget.customHeader).toBeInstanceOf(BoxPanel);
+      });
+    })
 
     describe('#onActivateRequest()', () => {
       it('should focus on activation', () => {

--- a/packages/apputils/test/mainareawidget.spec.ts
+++ b/packages/apputils/test/mainareawidget.spec.ts
@@ -28,13 +28,13 @@ describe('@jupyterlab/apputils', () => {
       });
     });
 
-    describe('customHeader', ()=>{
-      it('should exist and have correct type', ()=>{
+    describe('customHeader', () => {
+      it('should exist and have correct type', () => {
         const content = new Widget();
         const widget = new MainAreaWidget({ content });
         expect(widget.customHeader).toBeInstanceOf(BoxPanel);
       });
-    })
+    });
 
     describe('#onActivateRequest()', () => {
       it('should focus on activation', () => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -378,6 +378,42 @@ export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
   }
 };
 
+export const toggleHeader: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/apputils-extension:toggle-header',
+  autoStart: true,
+  requires: [ITranslator],
+  optional: [ICommandPalette],
+  activate: (
+    app: JupyterFrontEnd,
+    translator: ITranslator,
+    palette: ICommandPalette | null
+  ) => {
+    const trans = translator.load('jupyterlab');
+
+    const command = 'apputils:toggle-header';
+    const category: string = trans.__('Main Area');
+    app.commands.addCommand(command, {
+      label: trans.__('Show Header'),
+      isEnabled: () => app.shell.currentWidget instanceof MainAreaWidget,
+      isToggled: () => {
+        const widget = app.shell.currentWidget;
+        return widget instanceof MainAreaWidget
+          ? !widget.customHeader.isHidden
+          : false;
+      },
+      execute: async () => {
+        const widget = app.shell.currentWidget;
+        if (widget instanceof MainAreaWidget) {
+          widget.customHeader.setHidden(!widget.customHeader.isHidden);
+        }
+      }
+    });
+    if (palette) {
+      palette.addItem({ command, category });
+    }
+  }
+};
+
 /**
  * The notebook widget factory provider.
  */
@@ -428,7 +464,8 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   widgetFactoryPlugin,
   logNotebookOutput,
   clonedOutputsPlugin,
-  codeConsolePlugin
+  codeConsolePlugin,
+  toggleHeader
 ];
 export default plugins;
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -378,42 +378,6 @@ export const notebookTrustItem: JupyterFrontEndPlugin<void> = {
   }
 };
 
-export const toggleHeader: JupyterFrontEndPlugin<void> = {
-  id: '@jupyterlab/apputils-extension:toggle-header',
-  autoStart: true,
-  requires: [ITranslator],
-  optional: [ICommandPalette],
-  activate: (
-    app: JupyterFrontEnd,
-    translator: ITranslator,
-    palette: ICommandPalette | null
-  ) => {
-    const trans = translator.load('jupyterlab');
-
-    const command = 'apputils:toggle-header';
-    const category: string = trans.__('Main Area');
-    app.commands.addCommand(command, {
-      label: trans.__('Show Header'),
-      isEnabled: () => app.shell.currentWidget instanceof MainAreaWidget,
-      isToggled: () => {
-        const widget = app.shell.currentWidget;
-        return widget instanceof MainAreaWidget
-          ? !widget.customHeader.isHidden
-          : false;
-      },
-      execute: async () => {
-        const widget = app.shell.currentWidget;
-        if (widget instanceof MainAreaWidget) {
-          widget.customHeader.setHidden(!widget.customHeader.isHidden);
-        }
-      }
-    });
-    if (palette) {
-      palette.addItem({ command, category });
-    }
-  }
-};
-
 /**
  * The notebook widget factory provider.
  */
@@ -464,8 +428,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   widgetFactoryPlugin,
   logNotebookOutput,
   clonedOutputsPlugin,
-  codeConsolePlugin,
-  toggleHeader
+  codeConsolePlugin
 ];
 export default plugins;
 


### PR DESCRIPTION
## References

This PR addresses #9982.

## Code changes

We now insert an empty `BoxPanel` between the toolbar and the content of `MainAreaWidget`. We also provide a getter to this BoxPanel called `customHeader` so extensions can populate this panel as they see fit. The new panel is provided as a commons in the hope that extensions will cooperatively use it.

## User-facing changes

No user-visible changes as is. (The feature does enable others to create user-visible changes, of course.)

## Backwards-incompatible changes

None. `MainAreaWidget`'s `toolbar` and `content` members are still present and weren't disturbed.

## Questions

This PR places all three widgets—the toolbar, the `customHeaders` panel, and the actual content—inside a single layout. Is there any benefit to potentially grouping the toolbar and the `customHeaders` panel into another panel? Would that be more future-proof?

## Testing
Added a unit test to ensure that a `MainAreaWidget` has a `customHeaders` field that has the expected type of `BoxPanel`.

I also touched up an existing test that wanted to test that `MainAreaWidget` constructor could accept a toolbar—the test wasn't actually ensuring that the toolbar was used in any way, so I added an assertion to exercise that. I hope that improves the test.