### PR TITLE
Move js-services to the flaky CI workflow

### DIFF
--- a/.github/workflows/linuxjs-flaky-tests.yml
+++ b/.github/workflows/linuxjs-flaky-tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: JS
     strategy:
       matrix:
-        group: [s-apputils]
+        group: [js-apputils, js-services]
       fail-fast: false
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/linuxjs-tests.yml
+++ b/.github/workflows/linuxjs-tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: JS
     strategy:
       matrix:
-        group: [js-services, js-application, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-documentsearch, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-toc, js-translation, js-ui-components, js-testutils]
+        group: [js-application, js-cells, js-codeeditor, js-codemirror, js-completer, js-console, js-coreutils, js-csvviewer, js-debugger, js-docmanager, js-docregistry, js-documentsearch, js-filebrowser, js-fileeditor, js-imageviewer, js-inspector, js-logconsole, js-mainmenu, js-nbformat, js-notebook, js-observables, js-outputarea, js-rendermime,  js-settingregistry, js-statedb, js-statusbar, js-terminal, js-toc, js-translation, js-ui-components, js-testutils]
       fail-fast: false
     runs-on: ubuntu-20.04
     timeout-minutes: 20


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

It looks like the `js-services` tests have started to fail recently (time out).

For example in https://github.com/jupyterlab/jupyterlab/pull/9930: https://github.com/jupyterlab/jupyterlab/pull/9930/checks?check_run_id=2175245918

And in https://github.com/jupyterlab/jupyterlab/pull/9984: https://github.com/jupyterlab/jupyterlab/pull/9984/checks?check_run_id=2170596815

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

CI workflow change so it's easier to restart the flaky jobs:

![image](https://user-images.githubusercontent.com/591645/112154986-20438680-8be5-11eb-898f-5ac9234ae6ff.png)


<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
