### PR TITLE
Loosen pin on jupyter-packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup_args['install_requires'] = [
     'packaging',
     'tornado>=6.1.0',
     'jupyter_core',
-    'jupyter_packaging~=0.7.3',
+    'jupyter_packaging~=0.7',
     'jupyterlab_server~=2.3',
     'jupyter_server~=1.4',
     'nbclassic~=0.2',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Fixes https://github.com/jupyterlab/jupyterlab/issues/9992

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Loosens pin on `jupyter_packaging`, since the API will not change until 1.0.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->