### PR TITLE
Add document name and workspaces to title Bar

### DIFF
--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -307,16 +307,28 @@ async function updateTabTitle(
   trans: TranslationBundle
 ) {
   const data: any = await db.toJSON();
-  // Number of restorable items, minus the layout restorer data
   let current: string = data['layout-restorer:data']?.main?.current;
-  current = current.split(':')[1];
-  if (workspace.startsWith('auto-')) {
-    const count: number = Object.keys(data).length - 1;
-    document.title = `${
-      count > 0 ? `${current} (${workspace}:${count}) -` : ''
-    } JupyterLab`;
+  if (current === undefined) {
+    document.title = `JupyterLab${
+      workspace.startsWith('auto-') ? ` (${workspace})` : ``
+    }`;
   } else {
-    document.title = `${current} - JupyterLab`;
+    console.log(current);
+
+    //First 15 characters of current documnet name
+    current = current.split(':')[1].slice(0, 15);
+
+    //Number of restorable items, minus the layout restorer data
+    const count: number = Object.keys(data).length - 1;
+    if (workspace.startsWith('auto-')) {
+      document.title = `${current} (${workspace}${
+        count > 1 ? ` : ${count}` : ``
+      }) - JupyterLab`;
+    } else {
+      document.title = `${current}${
+        count - 1 > 1 ? ` (${count - 1})` : ``
+      } - JupyterLab`;
+    }
   }
 }
 

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -313,13 +313,11 @@ async function updateTabTitle(
       workspace.startsWith('auto-') ? ` (${workspace})` : ``
     }`;
   } else {
-    console.log(current);
-
     //First 15 characters of current documnet name
     current = current.split(':')[1].slice(0, 15);
-
     //Number of restorable items, minus the layout restorer data
     const count: number = Object.keys(data).length - 1;
+
     if (workspace.startsWith('auto-')) {
       document.title = `${current} (${workspace}${
         count > 1 ? ` : ${count}` : ``

--- a/packages/apputils-extension/src/index.ts
+++ b/packages/apputils-extension/src/index.ts
@@ -312,7 +312,9 @@ async function updateTabTitle(
   current = current.split(':')[1];
   if (workspace.startsWith('auto-')) {
     const count: number = Object.keys(data).length - 1;
-    document.title = `${current} (${workspace}:${count}) - JupyterLab`;
+    document.title = `${
+      count > 0 ? `${current} (${workspace}:${count}) -` : ''
+    } JupyterLab`;
   } else {
     document.title = `${current} - JupyterLab`;
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Following up from #8851, this PR is even with JupyterLab 3 and changed title bar format for workspaces
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->


<!-- For visual changes, include before and after screenshots here. -->
This PR tries to 
- provide a way to differentiate default and non-default workspaces from the title bar
- make title bar more informative (showing the active document and the number of opened documents), in an easy-to-read format. 

Changes in title bar (all use cases):
- default workspace: 
   - no document opened: `JupyterLab`
   - one document opened: `document_name - JupyterLab`
   - more than one document opened: `active_document (number of documents) - JupyterLab`

- non-default workspace: 
   - no document opened: `JupyterLab (worksapce name)`
   - one document opened: `document_name (worksapce name) - JupyterLab`
   - more than one document opened: `active_document (worksapce name : number of documents) - JupyterLab`

`active document` and `number of documents` both would change as they update, with the intention to make title bar be somewhat informative in a easy-to-read format  

note: document_name shows at most the first 15 characters

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
