### PR TITLE
[Fix] `Copy shareable link` command - fix the filename encoding (for files with spaces in the name)

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -435,14 +435,13 @@ const shareFile: JupyterFrontEndPlugin<void> = {
         if (!model) {
           return;
         }
-        const path = encodeURI(model.path);
 
         Clipboard.copyToSystem(
           URLExt.normalize(
             PageConfig.getUrl({
               mode: 'single-document',
               workspace: PageConfig.defaultWorkspace,
-              treePath: path
+              treePath: model.path
             })
           )
         );


### PR DESCRIPTION
Copy shareable link command encodes the url properly when file have a blank space in the name.

✅ Closes: #9953

## References

Issue numbers this pull request addresses: *#9953*

## Code changes

Remove the *double* encoding of the file url in the *shareFile* command (that caused invalid links to files with space[s] in the name, due to double encoding). The issue manifested for files with *blank spaces* resulting in encoded spaces as `%2520` rather than `%20`. 
`URLExt.normalize` method already has the parsing / encoding the url logic, so the redundant filename encoding is removed, in order for the method to produce a valid shareable link.

## User-facing changes

This PR fixes the issue regarding the *copy shareable link* command, in the `filebrowser-extension` package.
`Copy shareable link` should now produce a valid links, with proper encodings.

## Backwards-incompatible changes

There are no backwards-incompatible issues or concerns recognised.

### Changes
* `shareFile` method in *filebrowser-extension* package,
* *Copy shareable link* command produces links with valid encodings (for files with spaces in the name).

### Checklist
After the changes I ensured that:
 * no stylistic or unwanted errors are present, by running `jlpm run prettier && jlpm run eslint`,
 * no tests are failing, by running `jlpm test`,
 * build passes with no issues, by running `jlpm build`,
 * checked the changes locally by:
   * setting up the development environment,
   * running the `jupyterlab` locally,
   * creating a file with a *blank space* in the name (`test file with blank space`),
   * ensured that the *Copy shareable link* produces a valid url (that leads to a newly created file).

### Done
- [x] Included links to related issues/PRs
