### PR TITLE
Add cell id per notebook format 4.5

### DIFF
--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -36,10 +36,10 @@
     "docs": "typedoc src",
     "prepublishOnly": "npm run build",
     "test": "jest",
-    "test:watch": "jest --runInBand --watch",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
+    "test:watch": "jest --runInBand --watch",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -36,6 +36,7 @@
     "docs": "typedoc src",
     "prepublishOnly": "npm run build",
     "test": "jest",
+    "test:watch": "jest --runInBand --watch",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -164,7 +164,7 @@ export class CellModel extends CodeEditor.Model implements ICellModel {
   constructor(options: CellModel.IOptions) {
     super({ modelDB: options.modelDB });
 
-    this.id = options.id || UUID.uuid4();
+    this.id = options.id || (options.cell?.id as string) || UUID.uuid4();
 
     this.value.changed.connect(this.onGenericChange, this);
 

--- a/packages/cells/src/model.ts
+++ b/packages/cells/src/model.ts
@@ -424,7 +424,9 @@ export class RawCellModel extends AttachmentsCellModel {
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.IRawCell {
-    return super.toJSON() as nbformat.IRawCell;
+    const cell = super.toJSON() as nbformat.IRawCell;
+    cell.id = this.id;
+    return cell;
   }
 }
 
@@ -452,7 +454,9 @@ export class MarkdownCellModel extends AttachmentsCellModel {
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.IMarkdownCell {
-    return super.toJSON() as nbformat.IMarkdownCell;
+    const cell = super.toJSON() as nbformat.IMarkdownCell;
+    cell.id = this.id;
+    return cell;
   }
 }
 
@@ -565,6 +569,7 @@ export class CodeCellModel extends CellModel implements ICodeCellModel {
     const cell = super.toJSON() as nbformat.ICodeCell;
     cell.execution_count = this.executionCount || null;
     cell.outputs = this.outputs.toJSON();
+    cell.id = this.id;
     return cell;
   }
 

--- a/packages/cells/test/model.spec.ts
+++ b/packages/cells/test/model.spec.ts
@@ -48,11 +48,47 @@ describe('cells/model', () => {
         const cell: nbformat.IRawCell = {
           cell_type: 'raw',
           source: ['foo\n', 'bar\n', 'baz'],
-          metadata: { trusted: false }
+          metadata: { trusted: false },
+          id: 'cell_id'
         };
         const model = new CellModel({ cell });
         expect(model).toBeInstanceOf(CellModel);
         expect(model.value.text).toBe((cell.source as string[]).join(''));
+      });
+
+      it('should use the id argument', () => {
+        const cell: nbformat.IRawCell = {
+          cell_type: 'raw',
+          source: ['foo\n', 'bar\n', 'baz'],
+          metadata: { trusted: false },
+          id: 'cell_id'
+        };
+        const model = new CellModel({ cell, id: 'my_id' });
+        expect(model).toBeInstanceOf(CellModel);
+        expect(model.id).toBe('my_id');
+      });
+
+      it('should use the cell id if an id is not supplied', () => {
+        const cell: nbformat.IRawCell = {
+          cell_type: 'raw',
+          source: ['foo\n', 'bar\n', 'baz'],
+          metadata: { trusted: false },
+          id: 'cell_id'
+        };
+        const model = new CellModel({ cell });
+        expect(model).toBeInstanceOf(CellModel);
+        expect(model.id).toBe('cell_id');
+      });
+
+      it('should generate an id if an id or cell id is not supplied', () => {
+        const cell = {
+          cell_type: 'raw',
+          source: ['foo\n', 'bar\n', 'baz'],
+          metadata: { trusted: false }
+        };
+        const model = new CellModel({ cell });
+        expect(model).toBeInstanceOf(CellModel);
+        expect(model.id.length).toBeGreaterThan(0);
       });
     });
 
@@ -243,6 +279,20 @@ describe('cells/model', () => {
         expect(model.type).toBe('raw');
       });
     });
+    describe('#toJSON()', () => {
+      it('should return a raw cell encapsulation of the model value', () => {
+        const cell: nbformat.IRawCell = {
+          cell_type: 'raw',
+          source: 'foo',
+          metadata: {},
+          id: 'cell_id'
+        };
+        const model = new RawCellModel({ cell });
+        const serialized = model.toJSON();
+        expect(serialized).not.toBe(cell);
+        expect(serialized).toEqual(cell);
+      });
+    });
   });
 
   describe('MarkdownCellModel', () => {
@@ -250,6 +300,20 @@ describe('cells/model', () => {
       it('should be set with type "markdown"', () => {
         const model = new MarkdownCellModel({});
         expect(model.type).toBe('markdown');
+      });
+    });
+    describe('#toJSON()', () => {
+      it('should return a markdown cell encapsulation of the model value', () => {
+        const cell: nbformat.IMarkdownCell = {
+          cell_type: 'markdown',
+          source: 'foo',
+          metadata: {},
+          id: 'cell_id'
+        };
+        const model = new MarkdownCellModel({ cell });
+        const serialized = model.toJSON();
+        expect(serialized).not.toBe(cell);
+        expect(serialized).toEqual(cell);
       });
     });
   });
@@ -433,7 +497,8 @@ describe('cells/model', () => {
             } as nbformat.IDisplayData
           ],
           source: 'foo',
-          metadata: { trusted: false }
+          metadata: { trusted: false },
+          id: 'cell_id'
         };
         const model = new CodeCellModel({ cell });
         const serialized = model.toJSON();

--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -219,6 +219,11 @@ export interface IRawCellMetadata extends IBaseCellMetadata {
  */
 export interface IRawCell extends IBaseCell {
   /**
+   * A string field representing the identifier of this particular cell.
+   */
+  id: string;
+
+  /**
    * String identifying the type of cell.
    */
   cell_type: 'raw';
@@ -238,6 +243,11 @@ export interface IRawCell extends IBaseCell {
  * A markdown cell.
  */
 export interface IMarkdownCell extends IBaseCell {
+  /**
+   * A string field representing the identifier of this particular cell.
+   */
+  id: string;
+
   /**
    * String identifying the type of cell.
    */
@@ -283,6 +293,11 @@ export interface ICodeCellMetadata extends IBaseCellMetadata {
  * A code cell.
  */
 export interface ICodeCell extends IBaseCell {
+  /**
+   * A string field representing the identifier of this particular cell.
+   */
+  id: string;
+
   /**
    * String identifying the type of cell.
    */

--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -220,8 +220,11 @@ export interface IRawCellMetadata extends IBaseCellMetadata {
 export interface IRawCell extends IBaseCell {
   /**
    * A string field representing the identifier of this particular cell.
+   *
+   * Notebook format 4.4 requires no id field, but format 4.5 requires an id
+   * field. We need to handle both cases, so we make id optional here.
    */
-  id: string;
+  id?: string;
 
   /**
    * String identifying the type of cell.
@@ -245,8 +248,11 @@ export interface IRawCell extends IBaseCell {
 export interface IMarkdownCell extends IBaseCell {
   /**
    * A string field representing the identifier of this particular cell.
+   *
+   * Notebook format 4.4 requires no id field, but format 4.5 requires an id
+   * field. We need to handle both cases, so we make id optional here.
    */
-  id: string;
+  id?: string;
 
   /**
    * String identifying the type of cell.
@@ -295,8 +301,11 @@ export interface ICodeCellMetadata extends IBaseCellMetadata {
 export interface ICodeCell extends IBaseCell {
   /**
    * A string field representing the identifier of this particular cell.
+   *
+   * Notebook format 4.4 requires no id field, but format 4.5 requires an id
+   * field. We need to handle both cases, so we make id optional here.
    */
-  id: string;
+  id?: string;
 
   /**
    * String identifying the type of cell.

--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -19,7 +19,7 @@ export const MAJOR_VERSION: number = 4;
 /**
  * The minor version of the notebook format.
  */
-export const MINOR_VERSION: number = 4;
+export const MINOR_VERSION: number = 5;
 
 /**
  * The kernelspec metadata.
@@ -57,6 +57,16 @@ export interface INotebookContent extends PartialJSONObject {
   nbformat_minor: number;
   nbformat: number;
   cells: ICell[];
+}
+
+/**
+ * The notebook content for format 4.4.
+ */
+export interface INotebookContent44 extends PartialJSONObject {
+  metadata: INotebookMetadata;
+  nbformat_minor: 4;
+  nbformat: 4;
+  cells: Omit<ICell, 'id'>[];
 }
 
 /**

--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -12,14 +12,14 @@
 import { PartialJSONObject, JSONExt } from '@lumino/coreutils';
 
 /**
- * The major version of the notebook format.
+ * The earliest major version of the notebook format we support.
  */
 export const MAJOR_VERSION: number = 4;
 
 /**
- * The minor version of the notebook format.
+ * The earliest minor version of the notebook format we support.
  */
-export const MINOR_VERSION: number = 5;
+export const MINOR_VERSION: number = 4;
 
 /**
  * The kernelspec metadata.
@@ -57,16 +57,6 @@ export interface INotebookContent extends PartialJSONObject {
   nbformat_minor: number;
   nbformat: number;
   cells: ICell[];
-}
-
-/**
- * The notebook content for format 4.4.
- */
-export interface INotebookContent44 extends PartialJSONObject {
-  metadata: INotebookMetadata;
-  nbformat_minor: 4;
-  nbformat: 4;
-  cells: Omit<ICell, 'id'>[];
 }
 
 /**

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -35,6 +35,7 @@
     "docs": "typedoc src",
     "prepublishOnly": "npm run build",
     "test": "jest",
+    "test:watch": "jest --runInBand --watch",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",

--- a/packages/notebook/package.json
+++ b/packages/notebook/package.json
@@ -35,10 +35,10 @@
     "docs": "typedoc src",
     "prepublishOnly": "npm run build",
     "test": "jest",
-    "test:watch": "jest --runInBand --watch",
     "test:cov": "jest --collect-coverage",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:debug:watch": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
+    "test:watch": "jest --runInBand --watch",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -191,9 +191,13 @@ export class NotebookModel extends DocumentModel implements INotebookModel {
    */
   toJSON(): nbformat.INotebookContent {
     const cells: nbformat.ICell[] = [];
-    for (let i = 0; i < (this.cells?.length || 0); i++) {
-      const cell = this.cells.get(i);
-      cells.push(cell.toJSON());
+    for (let i = 0; i < (this.cells?.length ?? 0); i++) {
+      const cell = this.cells.get(i).toJSON();
+      if (this._nbformat ===4 && this._nbformatMinor <=4) {
+        // strip cell ids if we have notebook format 4.0-4.4
+        delete cell.id;
+      }
+      cells.push(cell);
     }
     this._ensureMetadata();
     const metadata = Object.create(null) as nbformat.INotebookMetadata;

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -193,7 +193,7 @@ export class NotebookModel extends DocumentModel implements INotebookModel {
     const cells: nbformat.ICell[] = [];
     for (let i = 0; i < (this.cells?.length ?? 0); i++) {
       const cell = this.cells.get(i).toJSON();
-      if (this._nbformat ===4 && this._nbformatMinor <=4) {
+      if (this._nbformat === 4 && this._nbformatMinor <= 4) {
         // strip cell ids if we have notebook format 4.0-4.4
         delete cell.id;
       }

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -221,16 +221,21 @@ export class NotebookModel extends DocumentModel implements INotebookModel {
   fromJSON(value: nbformat.INotebookContent): void {
     const cells: ICellModel[] = [];
     const factory = this.contentFactory;
+    const useId = value.nbformat === 4 && value.nbformat_minor >= 5;
     for (const cell of value.cells) {
+      const options: CellModel.IOptions = { cell };
+      if (useId) {
+        options.id = (cell as any).id;
+      }
       switch (cell.cell_type) {
         case 'code':
-          cells.push(factory.createCodeCell({ cell }));
+          cells.push(factory.createCodeCell(options));
           break;
         case 'markdown':
-          cells.push(factory.createMarkdownCell({ cell }));
+          cells.push(factory.createMarkdownCell(options));
           break;
         case 'raw':
-          cells.push(factory.createRawCell({ cell }));
+          cells.push(factory.createRawCell(options));
           break;
         default:
           continue;

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -386,11 +386,14 @@ export class StaticNotebook extends Widget {
     }
     this._updateMimetype();
     const cells = newValue.cells;
+
+    // If there are no cells, create an empty cell
     if (!cells.length) {
       cells.push(
         newValue.contentFactory.createCell(this.notebookConfig.defaultCell, {})
       );
     }
+
     each(cells, (cell: ICellModel, i: number) => {
       this._insertCell(i, cell);
     });

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -650,7 +650,7 @@ describe('@jupyterlab/notebook', () => {
       });
 
       it('should clear the existing selection', async () => {
-        const next = widget.widgets[2];
+        const next = widget.widgets[3];
         widget.select(next);
         const result = await NotebookActions.runAndAdvance(
           widget,

--- a/packages/notebook/test/model.spec.ts
+++ b/packages/notebook/test/model.spec.ts
@@ -74,7 +74,7 @@ describe('@jupyterlab/notebook', () => {
         model.cells.push(cell);
         model.fromJSON(utils.DEFAULT_CONTENT);
         expect(ArrayExt.firstIndexOf(toArray(model.cells), cell)).toBe(-1);
-        expect(model.cells.length).toBe(6);
+        expect(model.cells.length).toBe(7);
       });
 
       it('should allow undoing a change', () => {
@@ -259,7 +259,7 @@ describe('@jupyterlab/notebook', () => {
         model.fromJSON(utils.DEFAULT_CONTENT);
         const text = model.toString();
         const data = JSON.parse(text);
-        expect(data.cells.length).toBe(6);
+        expect(data.cells.length).toBe(7);
       });
     });
 
@@ -267,7 +267,7 @@ describe('@jupyterlab/notebook', () => {
       it('should deserialize the model from a string', () => {
         const model = new NotebookModel();
         model.fromString(JSON.stringify(utils.DEFAULT_CONTENT));
-        expect(model.cells.length).toBe(6);
+        expect(model.cells.length).toBe(7);
       });
 
       it('should set the dirty flag', () => {
@@ -283,17 +283,43 @@ describe('@jupyterlab/notebook', () => {
         const model = new NotebookModel();
         model.fromJSON(utils.DEFAULT_CONTENT);
         const data = model.toJSON();
-        expect(data.cells.length).toBe(6);
+        expect(data.cells.length).toBe(7);
+      });
+      it('should serialize format 4.4 or earlier without cell ids', () => {
+        const model = new NotebookModel();
+        model.fromJSON(utils.DEFAULT_CONTENT);
+        const data = model.toJSON();
+        expect(data.nbformat).toBe(4);
+        expect(data.nbformat_minor).toBeLessThanOrEqual(4);
+        expect(data.cells.length).toBe(7);
+        expect(data.cells[0].id).toBeUndefined();
+      });
+      it('should serialize format 4.5 or later with cell ids', () => {
+        const model = new NotebookModel();
+        model.fromJSON(utils.DEFAULT_CONTENT_45);
+        const data = model.toJSON();
+        expect(data.cells.length).toBe(7);
+        expect(data.cells[0].id).toBe('cell_1');
       });
     });
 
     describe('#fromJSON()', () => {
-      it('should serialize the model from JSON', () => {
+      it('should serialize the model from format<=4.4 JSON', () => {
         const model = new NotebookModel();
         model.fromJSON(utils.DEFAULT_CONTENT);
-        expect(model.cells.length).toBe(6);
+        expect(model.cells.length).toBe(7);
         expect(model.nbformat).toBe(utils.DEFAULT_CONTENT.nbformat);
         expect(model.nbformatMinor).toBe(nbformat.MINOR_VERSION);
+      });
+
+      it('should serialize the model from format 4.5 JSON', () => {
+        const model = new NotebookModel();
+        const json = utils.DEFAULT_CONTENT_45;
+        model.fromJSON(json);
+        expect(model.cells.length).toBe(7);
+        expect(model.nbformat).toBe(json.nbformat);
+        expect(model.nbformatMinor).toBe(json.nbformat_minor);
+        expect(model.cells.get(0).id).toBe('cell_1');
       });
 
       it('should set the dirty flag', () => {

--- a/packages/notebook/test/utils.ts
+++ b/packages/notebook/test/utils.ts
@@ -69,6 +69,7 @@ export function populateNotebook(notebook: Notebook): void {
 }
 
 export const DEFAULT_CONTENT = NBTestUtils.DEFAULT_CONTENT;
+export const DEFAULT_CONTENT_45 = NBTestUtils.DEFAULT_CONTENT_45;
 export const editorFactory = NBTestUtils.editorFactory;
 export const mimeTypeService = NBTestUtils.mimeTypeService;
 export const defaultEditorConfig = NBTestUtils.defaultEditorConfig;

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -262,7 +262,7 @@ describe('@jupyter/notebook', () => {
         const model = new NotebookModel();
         model.fromJSON(utils.DEFAULT_CONTENT);
         widget.model = model;
-        expect(widget.widgets.length).toBe(6);
+        expect(widget.widgets.length).toBe(model.cells.length);
       });
 
       it('should add a default cell if the notebook model is empty', () => {
@@ -324,7 +324,7 @@ describe('@jupyter/notebook', () => {
         it('should handle an add', () => {
           const cell = widget.model!.contentFactory.createCodeCell({});
           widget.model!.cells.push(cell);
-          expect(widget.widgets.length).toBe(7);
+          expect(widget.widgets.length).toBe(widget.model!.cells.length);
           const child = widget.widgets[0];
           expect(child.hasClass('jp-Notebook-cell')).toBe(true);
         });
@@ -335,9 +335,13 @@ describe('@jupyter/notebook', () => {
           cell1.value.text = '# Hello';
           widget.model!.cells.push(cell1);
           widget.model!.cells.push(cell2);
-          expect(widget.widgets.length).toBe(8);
-          const child1 = widget.widgets[6] as MarkdownCell;
-          const child2 = widget.widgets[7] as MarkdownCell;
+          expect(widget.widgets.length).toBe(widget.model!.cells.length);
+          const child1 = widget.widgets[
+            widget.model!.cells.length - 2
+          ] as MarkdownCell;
+          const child2 = widget.widgets[
+            widget.model!.cells.length - 1
+          ] as MarkdownCell;
           expect(child1.rendered).toBe(true);
           expect(child2.rendered).toBe(false);
         });
@@ -447,7 +451,7 @@ describe('@jupyter/notebook', () => {
         const widget = createWidget();
         expect(widget.widgets.length).toBe(1);
         widget.model!.fromJSON(utils.DEFAULT_CONTENT);
-        expect(widget.widgets.length).toBe(6);
+        expect(widget.widgets.length).toBe(utils.DEFAULT_CONTENT.cells.length);
       });
     });
 
@@ -752,7 +756,7 @@ describe('@jupyter/notebook', () => {
         widget.activeCellIndex = -2;
         expect(widget.activeCellIndex).toBe(0);
         widget.activeCellIndex = 100;
-        expect(widget.activeCellIndex).toBe(5);
+        expect(widget.activeCellIndex).toBe(widget.model!.cells.length - 1);
       });
 
       it('should emit the `stateChanged` signal', () => {
@@ -1218,7 +1222,8 @@ describe('@jupyter/notebook', () => {
         });
 
         it('should not extend a selection if there is text selected in the output', () => {
-          widget.activeCellIndex = 2;
+          const codeCellIndex = 3;
+          widget.activeCellIndex = codeCellIndex;
 
           // Set a selection in the active cell outputs.
           const selection = window.getSelection()!;
@@ -1227,8 +1232,10 @@ describe('@jupyter/notebook', () => {
           );
 
           // Shift click below, which should not extend cells selection.
-          simulate(widget.widgets[4].node, 'mousedown', { shiftKey: true });
-          expect(widget.activeCellIndex).toBe(2);
+          simulate(widget.widgets[codeCellIndex + 2].node, 'mousedown', {
+            shiftKey: true
+          });
+          expect(widget.activeCellIndex).toBe(codeCellIndex);
           expect(selected(widget)).toEqual([]);
         });
 

--- a/testutils/default-45.json
+++ b/testutils/default-45.json
@@ -57,11 +57,7 @@
       "metadata": {
         "tags": []
       },
-      "source": [
-        "Raw Cell\n",
-        "\n",
-        "Second line"
-      ]
+      "source": ["Raw Cell\n", "\n", "Second line"]
     },
 
     {

--- a/testutils/default-45.json
+++ b/testutils/default-45.json
@@ -1,6 +1,7 @@
 {
   "cells": [
     {
+      "id": "cell_1",
       "cell_type": "code",
       "execution_count": 1,
       "metadata": {
@@ -37,6 +38,7 @@
       ]
     },
     {
+      "id": "cell_2",
       "cell_type": "markdown",
       "metadata": {
         "tags": []
@@ -50,13 +52,20 @@
       ]
     },
     {
+      "id": "cell_3",
       "cell_type": "raw",
       "metadata": {
         "tags": []
       },
-      "source": ["Raw Cell\n", "\n", "Second line"]
+      "source": [
+        "Raw Cell\n",
+        "\n",
+        "Second line"
+      ]
     },
+
     {
+      "id": "cell_4",
       "cell_type": "code",
       "execution_count": 2,
       "metadata": {
@@ -75,6 +84,7 @@
       "source": ["this is a syntax error"]
     },
     {
+      "id": "cell_5",
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -84,6 +94,7 @@
       "source": ["print('test')"]
     },
     {
+      "id": "cell_6",
       "cell_type": "code",
       "execution_count": 4,
       "metadata": {
@@ -126,6 +137,7 @@
       ]
     },
     {
+      "id": "cell_7",
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -156,5 +168,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 1
+  "nbformat_minor": 5
 }

--- a/testutils/src/notebook-utils.ts
+++ b/testutils/src/notebook-utils.ts
@@ -75,6 +75,7 @@ export namespace NBTestUtils {
   ];
 
   export const DEFAULT_CONTENT: nbformat.INotebookContent = require('../default.json') as nbformat.INotebookContent;
+  export const DEFAULT_CONTENT_45: nbformat.INotebookContent = require('../default-45.json') as nbformat.INotebookContent;
 
   export const defaultEditorConfig = { ...StaticNotebook.defaultEditorConfig };
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Closes #9729. Fixes #9645.  

## Code changes

- Adds `id` field to `RawCellModel`,  `CodeCellModel`, and `MarkdownCellModel`'s interface and `toJSON` methods to support the cell IDs of notebook format 4.5

---  

@jasongrout I've been poking around at adding cell IDs and could use some help. I'm not very familiar with the Jupyter Lab codebase, and I'm also not much of a Javascript/Typescript programmer. 

One of the things I've encountered is that the cell models already had an internal `id` field that's a UUID, so there's some potential collision there that I don't really know the best way to handle. Maybe the new format's cell IDs should replace the UUIDs? 

Currently, I'm successfully writing stable IDs to notebook files on save (they're not being regenerated), but it seems to be the UUIDs rather than the JEP ids. Somewhere it seems like they're being dropped on deserialization, or maybe overwritten? Not sure what I'm missing.  