### PR TITLE
Implemented variable inspection when the debugger has started

### DIFF
--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -159,7 +159,8 @@ export class DebuggerHandler {
     ): void => {
       if (
         msg.parent_header != {} &&
-        (msg.parent_header as KernelMessage.IHeader).msg_type == 'execute_request' &&
+        (msg.parent_header as KernelMessage.IHeader).msg_type ==
+          'execute_request' &&
         this._service.isStarted &&
         !this._service.hasStoppedThreads()
       ) {
@@ -365,10 +366,7 @@ export class DebuggerHandler {
       this._service.session.connection = connection;
     }
     await this._service.restoreState(false);
-    if (
-      this._service.isStarted &&
-      !this._service.hasStoppedThreads()
-    ) {
+    if (this._service.isStarted && !this._service.hasStoppedThreads()) {
       await this._service.displayDefinedVariables();
     }
     addToolbarButton();

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -19,7 +19,7 @@ import { FileEditor } from '@jupyterlab/fileeditor';
 
 import { NotebookPanel } from '@jupyterlab/notebook';
 
-import { Kernel, Session } from '@jupyterlab/services';
+import { Kernel, Session, KernelMessage } from '@jupyterlab/services';
 
 import { nullTranslator, ITranslator } from '@jupyterlab/translation';
 
@@ -122,6 +122,7 @@ export class DebuggerHandler {
     if (!connection) {
       delete this._kernelChangedHandlers[widget.id];
       delete this._statusChangedHandlers[widget.id];
+      delete this._iopubMessageHandlers[widget.id];
       return this._update(widget, connection);
     }
 
@@ -151,6 +152,26 @@ export class DebuggerHandler {
     }
     connection.statusChanged.connect(statusChanged);
     this._statusChangedHandlers[widget.id] = statusChanged;
+
+    const iopubMessage = (
+      _: Session.ISessionConnection,
+      msg: KernelMessage.IIOPubMessage
+    ): void => {
+      if (
+        msg.parent_header != {} &&
+        (msg.parent_header as KernelMessage.IHeader).msg_type == 'execute_request' &&
+        this._service.isStarted &&
+        !this._service.hasStoppedThreads()
+      ) {
+        void this._service.displayDefinedVariables();
+      }
+    };
+    const iopubMessageHandler = this._iopubMessageHandlers[widget.id];
+    if (iopubMessageHandler) {
+      connection.iopubMessage.disconnect(iopubMessageHandler);
+    }
+    connection.iopubMessage.connect(iopubMessage);
+    this._iopubMessageHandlers[widget.id] = iopubMessage;
 
     return this._update(widget, connection);
   }
@@ -249,6 +270,7 @@ export class DebuggerHandler {
       delete this._handlers[widget.id];
       delete this._kernelChangedHandlers[widget.id];
       delete this._statusChangedHandlers[widget.id];
+      delete this._iopubMessageHandlers[widget.id];
       delete this._contextKernelChangedHandlers[widget.id];
 
       // Clear the model if the handler being removed corresponds
@@ -321,6 +343,7 @@ export class DebuggerHandler {
         this._service.session!.connection = connection;
         this._previousConnection = connection;
         await this._service.restoreState(true);
+        await this._service.displayDefinedVariables();
         createHandler();
       }
     };
@@ -342,6 +365,12 @@ export class DebuggerHandler {
       this._service.session.connection = connection;
     }
     await this._service.restoreState(false);
+    if (
+      this._service.isStarted &&
+      !this._service.hasStoppedThreads()
+    ) {
+      await this._service.displayDefinedVariables();
+    }
     addToolbarButton();
 
     // check the state of the debug session
@@ -392,6 +421,12 @@ export class DebuggerHandler {
     [id: string]: (
       sender: Session.ISessionConnection,
       status: Kernel.Status
+    ) => void;
+  } = {};
+  private _iopubMessageHandlers: {
+    [id: string]: (
+      sender: Session.ISessionConnection,
+      msg: KernelMessage.IIOPubMessage
     ) => void;
   } = {};
   private _iconButtons: {

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -250,6 +250,26 @@ export class DebuggerService implements IDebugger, IDisposable {
   }
 
   /**
+   * Requests all the defined variables and display them in the
+   * table view.
+   */
+  async displayDefinedVariables(): Promise<void> {
+    if (!this.session) {
+      throw new Error('No active debugger session');
+    }
+    const inspectReply = await this.session.sendRequest('inspectVariables', {});
+    const variables = inspectReply.body.variables;
+
+    const variableScopes = [
+      {
+        name: 'Globals',
+        variables: variables
+      }
+    ];
+    this._model.variables.scopes = variableScopes;
+  }
+
+  /**
    * Restart the debugger.
    */
   async restart(): Promise<void> {

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -81,6 +81,12 @@ export interface IDebugger {
   ): Promise<DebugProtocol.Variable[]>;
 
   /**
+   * Requests all the defined variables and display them in the
+   * table view.
+   */
+  displayDefinedVariables(): Promise<void>;
+
+  /**
    * Request whether debugging is available for the given session connection.
    *
    * @param connection The session connection.
@@ -362,6 +368,7 @@ export namespace IDebugger {
       goto: DebugProtocol.GotoArguments;
       gotoTargets: DebugProtocol.GotoTargetsArguments;
       initialize: DebugProtocol.InitializeRequestArguments;
+      inspectVariables: {};
       launch: DebugProtocol.LaunchRequestArguments;
       loadedSources: DebugProtocol.LoadedSourcesArguments;
       modules: DebugProtocol.ModulesArguments;
@@ -404,6 +411,7 @@ export namespace IDebugger {
       goto: DebugProtocol.GotoResponse;
       gotoTargets: DebugProtocol.GotoTargetsResponse;
       initialize: DebugProtocol.InitializeResponse;
+      inspectVariables: IInspectVariablesResponse;
       launch: DebugProtocol.LaunchResponse;
       loadedSources: DebugProtocol.LoadedSourcesResponse;
       modules: DebugProtocol.ModulesResponse;
@@ -472,6 +480,12 @@ export namespace IDebugger {
     export interface IDumpCellResponse extends DebugProtocol.Response {
       body: {
         sourcePath: string;
+      };
+    }
+
+    export interface IInspectVariablesResponse extends DebugProtocol.Response {
+      body: {
+        variables: DebugProtocol.Variable[];
       };
     }
 

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -51,7 +51,7 @@ fi
 
 # The debugger tests require a kernel that supports debugging
 if [[ $GROUP == js-debugger ]]; then
-    pip install xeus-python">=0.12.3,<0.13.0"
+    pip install xeus-python">=0.9.0,<0.10.0"
 fi
 
 # Pin the jedi dependency to prevent a temporary breakage

--- a/scripts/ci_install.sh
+++ b/scripts/ci_install.sh
@@ -51,7 +51,7 @@ fi
 
 # The debugger tests require a kernel that supports debugging
 if [[ $GROUP == js-debugger ]]; then
-    pip install xeus-python">=0.9.0,<0.10.0"
+    pip install xeus-python">=0.12.3,<0.13.0"
 fi
 
 # Pin the jedi dependency to prevent a temporary breakage


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#9114 

## Code changes

This implementation is specific to the debugger package. The frontned now sends an `inspectVariables` request to the backend when the debugger has started and the code has not hit a breakpoint.

This can change can be tested with `xeus-python 0.12.2` or with this [branch of ipykernel](https://github.com/JohanMabille/ipykernel/tree/inspect).

There are still some issues (thus the WIP status):
- infinite loop of sending `inspectVariables` when the user restars the kernel
- defining variables such as dict breaks the behavior (nothing is displayed anymore, but the backend doe snot emit any error).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

When the debugger has started, the user can now see the variables that have been defined so far in the variables panel of the debugger sidebar.

![inspect_variables](https://user-images.githubusercontent.com/6754742/113901742-714f9f00-97cf-11eb-9eb1-3fe345d1f973.gif)

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

The kernel must support the `inspectVariable` request. This means upgrading to xeus-python 0.12.3 in the tests (this can be done in another PR). There is no impact on ipykernel since the debugger will be supported in the next release only, and the support for `inspectVariables` has been implemented.