### PR TITLE
Use blobs to set the svg source of an image in the image viewer

### DIFF
--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -105,10 +105,10 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
   /**
    * Dispose of resources held by the image viewer.
    */
-   dispose(): void {
+  dispose(): void {
     if (this._img.src) {
-        URL.revokeObjectURL(this._img.src || '');
-      }
+      URL.revokeObjectURL(this._img.src || '');
+    }
     super.dispose();
   }
 
@@ -193,7 +193,7 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
     if (cm.format === 'base64') {
       this._img.src = `data:${this._mimeType};base64,${content}`;
     } else {
-      const a = new Blob([content], {type: this._mimeType});
+      const a = new Blob([content], { type: this._mimeType });
       this._img.src = URL.createObjectURL(a);
     }
     URL.revokeObjectURL(oldurl);

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -178,11 +178,15 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
     if (!cm) {
       return;
     }
+    const oldurl = this._img.src || '';
     let content = context.model.toString();
-    if (cm.format !== 'base64') {
-      content = btoa(content);
+    if (cm.format === 'base64') {
+      this._img.src = `data:${this._mimeType};base64,${content}`;
+    } else {
+      const a = new Blob([content], {type: this._mimeType});
+      this._img.src = URL.createObjectURL(a);
     }
-    this._img.src = `data:${this._mimeType};base64,${content}`;
+    URL.revokeObjectURL(oldurl);
   }
 
   /**

--- a/packages/imageviewer/src/widget.ts
+++ b/packages/imageviewer/src/widget.ts
@@ -103,6 +103,16 @@ export class ImageViewer extends Widget implements Printing.IPrintable {
   }
 
   /**
+   * Dispose of resources held by the image viewer.
+   */
+   dispose(): void {
+    if (this._img.src) {
+        URL.revokeObjectURL(this._img.src || '');
+      }
+    super.dispose();
+  }
+
+  /**
    * Reset rotation and flip transformations.
    */
   resetRotationFlip(): void {

--- a/packages/imageviewer/test/widget.spec.ts
+++ b/packages/imageviewer/test/widget.spec.ts
@@ -37,10 +37,11 @@ class LogImage extends ImageViewer {
 }
 
 // jsdom does not have createObjectURL and revokeObjectURL, so we define them.
-function noOp () { }
 if (typeof window.URL.createObjectURL === 'undefined') {
-  Object.defineProperty(window.URL, 'createObjectURL', { value: noOp})
-  Object.defineProperty(window.URL, 'revokeObjectURL', { value: noOp})
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const noOp = () => {};
+  Object.defineProperty(window.URL, 'createObjectURL', { value: noOp });
+  Object.defineProperty(window.URL, 'revokeObjectURL', { value: noOp });
 }
 
 /**

--- a/packages/imageviewer/test/widget.spec.ts
+++ b/packages/imageviewer/test/widget.spec.ts
@@ -36,6 +36,13 @@ class LogImage extends ImageViewer {
   }
 }
 
+// jsdom does not have createObjectURL and revokeObjectURL, so we define them.
+function noOp () { }
+if (typeof window.URL.createObjectURL === 'undefined') {
+  Object.defineProperty(window.URL, 'createObjectURL', { value: noOp})
+  Object.defineProperty(window.URL, 'revokeObjectURL', { value: noOp})
+}
+
 /**
  * The common image model.
  */


### PR DESCRIPTION




<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #10014

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This avoids errors that apparently are typical with using the built in btoa() with unicode text by using a blob and object url.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
