### PR TITLE
Improve UX when a user restarts their Notebook server via JupyterHub

### DIFF
--- a/packages/hub-extension/src/index.ts
+++ b/packages/hub-extension/src/index.ts
@@ -64,7 +64,7 @@ function activateHubExtension(
   // If hubServerName is set, use JupyterHub 1.0 URL.
   const restartUrl = hubServerName
     ? hubHost + URLExt.join(hubPrefix, 'spawn', hubUser, hubServerName)
-    : hubHost + URLExt.join(hubPrefix, `spawn?next=${hubPrefix}home`);
+    : hubHost + URLExt.join(hubPrefix, 'spawn');
 
   const { commands } = app;
 


### PR DESCRIPTION
## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Resolves #10031.

Some work was also done to support redirection to `/hub/spawn/:username/:servername` in [PR #6931](https://github.com/jupyterlab/jupyterlab/pull/6931). Before that, the URL had been constructed as follows:

```
const restartUrl =
    hubHost + URLExt.join(hubPrefix, `spawn?next=${hubPrefix}home`);
```

As a result of the PR mentioned above, this had been changed to support the immediate redirection to a named server:

```
const restartUrl = hubServerName
    ? hubHost + URLExt.join(hubPrefix, 'spawn', hubUser, hubServerName)
    : hubHost + URLExt.join(hubPrefix, `spawn?next=${hubPrefix}home`);
```

Thus, the URL used in case of a default (unnamed) server hadn't been changed.

I would imagine that the initial version of the URL had that redirection to Hub Control Panel to support the case when a user's named server has been shut down, the user clicks the restart button, their default server is being spawned and then the user is redirected to the Hub Control Panel to restart the named server manually instead, although the default server has been spawned too.

So, I think it makes sense to redirect the user to their newly created server immediately since the `/hub/spawn[/:username[/:servername]]` request does spawn either a named server or a default server anyway according to [the JupyterHub URLs docs](https://jupyterhub.readthedocs.io/en/stable/reference/urls.html#spawning).

## Code changes

<!-- Describe the code changes and how they address the issue. -->
This pull request shortens the `restartUrl` within `hub-extension` in case of a default (unnamed) server that has been shut down, so that a user is not redirected to the Hub Control Panel but to their newly created notebook server instead.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
As a result, if a user clicks the "Restart Server" button, they won't be redirected to the Hub Control Panel where they would have to click the "Start Server" button one more time. Instead, they will be redirected to their server immediately.

<!-- For visual changes, include before and after screenshots here. -->

[A GIF showing how it currently works (6 MB)](https://user-images.githubusercontent.com/79568556/113262804-b197b480-92d9-11eb-85f2-cd278563eb28.gif)

[A GIF with the improvement demo (7 MB)](https://user-images.githubusercontent.com/79568556/113262892-ca07cf00-92d9-11eb-8f4b-a1fac0f16e3a.gif)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
The `/hub/spawn` URL has been redirecting users to their default servers since the very beginning. Therefore, I think there shouldn't be any compatibility issues.
