### PR TITLE
Add the toc extension to the `app` example

### DIFF
--- a/examples/app/index.js
+++ b/examples/app/index.js
@@ -41,6 +41,7 @@ const extensions = [
   import('@jupyterlab/terminal-extension'),
   import('@jupyterlab/theme-dark-extension'),
   import('@jupyterlab/theme-light-extension'),
+  import('@jupyterlab/toc-extension'),
   import('@jupyterlab/tooltip-extension'),
   import('@jupyterlab/translation-extension'),
   import('@jupyterlab/ui-components-extension')

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -35,6 +35,7 @@
     "@jupyterlab/terminal-extension": "^3.1.0-alpha.3",
     "@jupyterlab/theme-dark-extension": "^3.1.0-alpha.3",
     "@jupyterlab/theme-light-extension": "^3.1.0-alpha.3",
+    "@jupyterlab/toc-extension": "^5.1.0-alpha.3",
     "@jupyterlab/tooltip-extension": "^3.1.0-alpha.3",
     "@jupyterlab/translation": "^3.1.0-alpha.3",
     "@jupyterlab/translation-extension": "^3.1.0-alpha.3",
@@ -90,6 +91,7 @@
       "@jupyterlab/terminal-extension",
       "@jupyterlab/theme-dark-extension",
       "@jupyterlab/theme-light-extension",
+      "@jupyterlab/toc-extension",
       "@jupyterlab/tooltip-extension",
       "@jupyterlab/translation-extension",
       "@jupyterlab/ui-components-extension"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

It appeared to be missing from the `app` example: https://github.com/jupyterlab/jupyterlab/tree/master/examples/app


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users running the `app` example will now see the table of contents:

![image](https://user-images.githubusercontent.com/591645/113986753-dea21500-984d-11eb-9c44-a6ec6a0d38f1.png)


<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
