### PR TITLE
Fix #7525 by setting yarn.lock permissions

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -13,6 +13,7 @@ import os
 import os.path as osp
 import re
 import shutil
+import stat
 import site
 import subprocess
 import sys
@@ -1306,6 +1307,7 @@ class _AppHandler(object):
                 f.write(template)
         elif not osp.exists(lock_path):
             shutil.copy(lock_template, lock_path)
+            os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
 
     def _get_package_template(self, silent=False):
         """Get the template the for staging package.json file.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

https://github.com/jupyterlab/jupyterlab/issues/7525

## Code changes

<!-- Describe the code changes and how they address the issue. -->

When `yarn.lock` is copied during labextension install, the file is given write permissions because the installation requires that.

## User-facing changes

None.

## Backwards-incompatible changes

None.