### PR TITLE
Use getattr for optional attributes

### DIFF
--- a/jupyterlab/commands.py
+++ b/jupyterlab/commands.py
@@ -429,7 +429,7 @@ def clean(app_options=None):
     if app_dir == pjoin(HERE, 'core'):
         raise ValueError('Cannot clean the core app')
 
-    if app_options.all:
+    if getattr(app_options, 'all', False):
         logger.info('Removing everything in %s...', app_dir)
         _rmtree_star(app_dir, logger)
     else:
@@ -445,7 +445,7 @@ def clean(app_options=None):
                 logger.info('%s not present, skipping...', name)
 
     logger.info('Success!')
-    if app_options.all or app_options.extensions:
+    if getattr(app_options, 'all', False) or getattr(app_options, 'extensions', False):
         logger.info('All of your extensions have been removed, and will need to be reinstalled')
 
 


### PR DESCRIPTION
## References

Same as https://github.com/jupyterlab/jupyterlab/commit/83bd50278c104137a8e11d3fb43a4a75918dfd58 and https://github.com/jupyterlab/jupyterlab/commit/9188946d0da91e44be438a465d1e62f899dc45c3, but for 2.3.x branch.

## Code changes

Make 'all' and 'extensions' attributes for `lab clean` command optional.

## User-facing changes

None.

## Backwards-incompatible changes

None.

## Others

This is a try fix an issue with combining jupytelab==2.3.1 with jupyterlab_exec_time extension:
```
[SingleUserNotebookApp web:1787] 500 POST /user/msmarty5/zeus/lab/api/build?1617894968841 (10.216.1.4): 'AppOptions' object has no attribute 'all'
```
