### PR TITLE
Pull docmanager download UI into separate plugin so that it can be disabled easily

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -336,13 +336,35 @@ export const pathStatusPlugin: JupyterFrontEndPlugin<void> = {
   }
 };
 
+export const downloadPlugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/docmanager-extension:download',
+  autoStart: true,
+  requires: [IDocumentManager, ISettingRegistry, ITranslator],
+  activate: (
+    _: JupyterFrontEnd,
+    translator: ITranslator,
+    palette: ICommandPalette | null,
+    mainMenu: IMainMenu | null,
+  ) => {
+    const trans = translator.load('jupyterlab');
+    const category = trans.__('File Operations');
+    if (palette) {
+      palette.addItem({ command: CommandIDs.download, category })
+    }
+    if (mainMenu) {
+      mainMenu.fileMenu.addGroup([{ command: CommandIDs.download }], 6);
+    }
+  }
+}
+
 /**
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
   docManagerPlugin,
   pathStatusPlugin,
-  savingStatusPlugin
+  savingStatusPlugin,
+  downloadPlugin,
 ];
 export default plugins;
 
@@ -718,7 +740,7 @@ function addCommands(
       CommandIDs.restoreCheckpoint,
       CommandIDs.save,
       CommandIDs.saveAs,
-      CommandIDs.download,
+      // CommandIDs.download,
       CommandIDs.toggleAutosave
     ].forEach(command => {
       palette.addItem({ command, category });
@@ -727,7 +749,7 @@ function addCommands(
 
   if (mainMenu) {
     mainMenu.settingsMenu.addGroup([{ command: CommandIDs.toggleAutosave }], 5);
-    mainMenu.fileMenu.addGroup([{ command: CommandIDs.download }], 6);
+    // mainMenu.fileMenu.addGroup([{ command: CommandIDs.download }], 6);
   }
 }
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -336,6 +336,9 @@ export const pathStatusPlugin: JupyterFrontEndPlugin<void> = {
   }
 };
 
+/**
+ * A plugin providing download commands in the file menu and command palette.
+ */
 export const downloadPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/docmanager-extension:download',
   autoStart: true,

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -345,7 +345,7 @@ export const downloadPlugin: JupyterFrontEndPlugin<void> = {
     translator: ITranslator,
     palette: ICommandPalette | null,
     mainMenu: IMainMenu | null,
-    docManager: IDocumentManager,
+    docManager: IDocumentManager
   ) => {
     const trans = translator.load('jupyterlab');
     const { commands, shell } = app;
@@ -375,13 +375,13 @@ export const downloadPlugin: JupyterFrontEndPlugin<void> = {
 
     const category = trans.__('File Operations');
     if (palette) {
-      palette.addItem({ command: CommandIDs.download, category })
+      palette.addItem({ command: CommandIDs.download, category });
     }
     if (mainMenu) {
       mainMenu.fileMenu.addGroup([{ command: CommandIDs.download }], 6);
     }
   }
-}
+};
 
 /**
  * Export the plugins as default.
@@ -390,7 +390,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   docManagerPlugin,
   pathStatusPlugin,
   savingStatusPlugin,
-  downloadPlugin,
+  downloadPlugin
 ];
 export default plugins;
 

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -342,13 +342,14 @@ export const pathStatusPlugin: JupyterFrontEndPlugin<void> = {
 export const downloadPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/docmanager-extension:download',
   autoStart: true,
-  requires: [ITranslator, ICommandPalette, IMainMenu, IDocumentManager],
+  requires: [ITranslator, IDocumentManager],
+  optional: [ICommandPalette, IMainMenu],
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator,
+    docManager: IDocumentManager,
     palette: ICommandPalette | null,
-    mainMenu: IMainMenu | null,
-    docManager: IDocumentManager
+    mainMenu: IMainMenu | null
   ) => {
     const trans = translator.load('jupyterlab');
     const { commands, shell } = app;


### PR DESCRIPTION
## References

Partially addresses #5274, I'll be making additional PRs to pull download UI into separate plugins for other extensions.

## Code changes

Pulled all download UI code in docmanager-extension into a separate plugin so that it can be disabled easily if a user wants to customize a JL environment to not have those features available. Specifically, docmanager-extension adds the download option into the file menu, and command palette, so those two places can now be easily modified to not display download as an option.

## User-facing changes

No user-facing changes with the extension enabled as is. If @jupyterlab/docmanager-extension:download is disabled (the ID for the new plugin), then the file menu and command palette no longer show download as an option:
![image](https://user-images.githubusercontent.com/26827404/114105371-78cf8080-9881-11eb-8b01-be2574cd4bcc.png)
![image](https://user-images.githubusercontent.com/26827404/114105397-8422ac00-9881-11eb-8333-ab9438f507bd.png)


## Backwards-incompatible changes

None
