### PR TITLE
Add the celltags extension to the `app` example

### DIFF
--- a/examples/app/index.js
+++ b/examples/app/index.js
@@ -18,6 +18,7 @@ const styles = import('./build/style.js');
 const extensions = [
   import('@jupyterlab/application-extension'),
   import('@jupyterlab/apputils-extension'),
+  import('@jupyterlab/celltags-extension'),
   import('@jupyterlab/codemirror-extension'),
   import('@jupyterlab/completer-extension'),
   import('@jupyterlab/console-extension'),

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -12,6 +12,7 @@
     "@jupyterlab/application-extension": "^3.1.0-alpha.4",
     "@jupyterlab/apputils-extension": "^3.1.0-alpha.4",
     "@jupyterlab/builder": "^3.1.0-alpha.4",
+    "@jupyterlab/celltags-extension": "^3.1.0-alpha.4",
     "@jupyterlab/codemirror-extension": "^3.1.0-alpha.4",
     "@jupyterlab/completer-extension": "^3.1.0-alpha.4",
     "@jupyterlab/console-extension": "^3.1.0-alpha.4",
@@ -66,6 +67,7 @@
     "extensions": [
       "@jupyterlab/application-extension",
       "@jupyterlab/apputils-extension",
+      "@jupyterlab/celltags-extension",
       "@jupyterlab/codemirror-extension",
       "@jupyterlab/completer-extension",
       "@jupyterlab/console-extension",


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Similar to #10053

This adds the `@jupyterlab/celltags-extension` to the `app` example.

![image](https://user-images.githubusercontent.com/591645/114360364-3950af00-9b75-11eb-8edc-b675889ea610.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Example change.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
