### PR TITLE
[3.0.x] Clean up browser check

### DIFF
--- a/jupyterlab/browser_check.py
+++ b/jupyterlab/browser_check.py
@@ -180,6 +180,7 @@ class BrowserApp(LabApp):
     serverapp_config = {
         "base_url": "/foo/"
     }
+    default_url = "/lab?reset"
     ip = '127.0.0.1'
     flags = test_flags
     aliases = test_aliases


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Addresses error seen during 3.0.13 release - workspace file resulted in a 404 that caused `browser_check` to fail.


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Resets the JupyterLab layout state when running browser check.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
More robust `browser_check` for extension authors.

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
