### PR TITLE
Add a clarifying comment for the download plugin.

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -300,7 +300,11 @@ const factory: JupyterFrontEndPlugin<IFileBrowserFactory> = {
 };
 
 /**
- * A plugin providing download + copy download link commands in the context menu
+ * A plugin providing download + copy download link commands in the context menu.
+ *
+ * Disabling this plugin will NOT disable downloading files from the server.
+ * Users will still be able to retrieve files from the file download URLs the
+ * server provides.
  */
 const downloadPlugin: JupyterFrontEndPlugin<void> = {
   id: '@jupyterlab/filebrowser-extension:download',


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Expands on the changes from #10066.

## Code changes

This expands on the changes in #10066, where the download entries are separated into a separate plugin that can be disabled. There have been a fair number of requests to disable downloading, which is impossible to do without server changes. This commit adds a comment clarifying that disabling this new plugin is more of a UX change rather than a functional change.

For more conversation around this, see #5274.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
