### PR TITLE
Mention mamba as a means to install JupyterLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,19 @@ Read the current JupyterLab documentation on [ReadTheDocs](http://jupyterlab.rea
 
 ### Installation
 
-JupyterLab can be installed using `conda` or `pip`. For more detailed instructions, consult the [installation guide](http://jupyterlab.readthedocs.io/en/stable/getting_started/installation.html).
+JupyterLab can be installed using [conda](https://docs.conda.io/en/latest/), [mamba](https://mamba.readthedocs.io/en/latest/) or [pip](https://docs.python.org/3.6/installing/index.html). For more detailed instructions, consult the [installation guide](http://jupyterlab.readthedocs.io/en/stable/getting_started/installation.html).
 
 Project installation instructions from the git sources are available in the [contributor documentation](CONTRIBUTING.md).
 
-### conda
+### mamba and conda
 
-If you use `conda`, you can install it with:
+If you use `mamba` or `conda`, you can install it with:
+
+```shell
+mamba install -c conda-forge jupyterlab
+```
+
+or
 
 ```shell
 conda install -c conda-forge jupyterlab

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-JupyterLab can be installed using ``conda``, ``pip``, ``pipenv`` or ``docker``.
+JupyterLab can be installed using ``conda``, ``mamba``, ``pip``, ``pipenv`` or ``docker``.
 
 conda
 -----
@@ -13,6 +13,15 @@ If you use ``conda``, you can install it with:
 .. code:: bash
 
     conda install -c conda-forge jupyterlab
+
+mamba
+-----
+
+If you use ``mamba``, you can install it with:
+
+.. code:: bash
+
+    mamba install -c conda-forge jupyterlab
 
 pip
 ---


### PR DESCRIPTION
Mamba performs significantly faster than conda for installing packages from conda-forge, since the channel has a very large package index.

Note: mamba also powers mybinder, so this helps dogfooding things a bit more.