### PR TITLE
Pulled notebook export UI into separate extension so it can be disabled easily

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -396,51 +396,51 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
       isEnabled
     });
 
-    if (mainMenu) {
-      // Add a notebook group to the File menu.
-      const exportTo = new Menu({ commands });
-      exportTo.title.label = trans.__('Export Notebook As…');
-      void services.nbconvert.getExportFormats().then(response => {
-        if (response) {
-          const formatLabels: any = Private.getFormatLabels(translator);
+    // Add a notebook group to the File menu.
+    const exportTo = new Menu({ commands });
+    exportTo.title.label = trans.__('Export Notebook As…');
+    void services.nbconvert.getExportFormats().then(response => {
+      if (response) {
+        const formatLabels: any = Private.getFormatLabels(translator);
 
-          // Convert export list to palette and menu items.
-          const formatList = Object.keys(response);
-          formatList.forEach(function (key) {
-            const capCaseKey = trans.__(key[0].toUpperCase() + key.substr(1));
-            const labelStr = formatLabels[key] ? formatLabels[key] : capCaseKey;
-            let args = {
-              format: key,
-              label: labelStr,
-              isPalette: false
-            };
-            if (FORMAT_EXCLUDE.indexOf(key) === -1) {
-              exportTo.addItem({
+        // Convert export list to palette and menu items.
+        const formatList = Object.keys(response);
+        formatList.forEach(function (key) {
+          const capCaseKey = trans.__(key[0].toUpperCase() + key.substr(1));
+          const labelStr = formatLabels[key] ? formatLabels[key] : capCaseKey;
+          let args = {
+            format: key,
+            label: labelStr,
+            isPalette: false
+          };
+          if (FORMAT_EXCLUDE.indexOf(key) === -1) {
+            exportTo.addItem({
+              command: CommandIDs.exportToFormat,
+              args: args
+            });
+            if (palette) {
+              args = {
+                format: key,
+                label: labelStr,
+                isPalette: true
+              };
+              const category = trans.__('Notebook Operations');
+              palette.addItem({
                 command: CommandIDs.exportToFormat,
-                args: args
+                category,
+                args
               });
-              if (palette) {
-                args = {
-                  format: key,
-                  label: labelStr,
-                  isPalette: true
-                };
-                const category = trans.__('Notebook Operations');
-                palette.addItem({
-                  command: CommandIDs.exportToFormat,
-                  category,
-                  args
-                });
-              }
             }
-          });
+          }
+        });
+        if (mainMenu) {
           const fileGroup = [
             { type: 'submenu', submenu: exportTo } as Menu.IItemOptions
           ];
           mainMenu.fileMenu.addGroup(fileGroup, 10);
         }
-      });
-    }
+      }
+    });
   }
 };
 

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -64,8 +64,6 @@ import { IPropertyInspectorProvider } from '@jupyterlab/property-inspector';
 
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
-import { ServiceManager } from '@jupyterlab/services';
-
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import { IStateDB } from '@jupyterlab/statedb';
@@ -257,7 +255,7 @@ const FORMAT_EXCLUDE = ['notebook', 'python', 'custom'];
 const trackerPlugin: JupyterFrontEndPlugin<INotebookTracker> = {
   id: '@jupyterlab/notebook-extension:tracker',
   provides: INotebookTracker,
-  requires: [INotebookWidgetFactory, IDocumentManager, ITranslator],
+  requires: [INotebookWidgetFactory, ITranslator],
   optional: [
     ICommandPalette,
     IFileBrowserFactory,
@@ -938,7 +936,6 @@ function activateCodeConsole(
 function activateNotebookHandler(
   app: JupyterFrontEnd,
   factory: NotebookWidgetFactory.IFactory,
-  docManager: IDocumentManager,
   translator: ITranslator,
   palette: ICommandPalette | null,
   browserFactory: IFileBrowserFactory | null,
@@ -970,7 +967,7 @@ function activateNotebookHandler(
   addCommands(app, tracker, translator, sessionDialogs);
 
   if (palette) {
-    populatePalette(palette, services, translator);
+    populatePalette(palette, translator);
   }
 
   let id = 0; // The ID counter for notebook panels.
@@ -1061,15 +1058,7 @@ function activateNotebookHandler(
 
   // Add main menu notebook menu.
   if (mainMenu) {
-    populateMenus(
-      app,
-      mainMenu,
-      tracker,
-      services,
-      translator,
-      palette,
-      sessionDialogs
-    );
+    populateMenus(app, mainMenu, tracker, translator, sessionDialogs);
   }
 
   // Utility function to create a new notebook.
@@ -2114,7 +2103,6 @@ function addCommands(
  */
 function populatePalette(
   palette: ICommandPalette,
-  services: ServiceManager,
   translator: ITranslator
 ): void {
   const trans = translator.load('jupyterlab');
@@ -2209,9 +2197,7 @@ function populateMenus(
   app: JupyterFrontEnd,
   mainMenu: IMainMenu,
   tracker: INotebookTracker,
-  services: ServiceManager,
   translator: ITranslator,
-  palette: ICommandPalette | null,
   sessionDialogs: ISessionContextDialogs | null
 ): void {
   const trans = translator.load('jupyterlab');

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -398,7 +398,6 @@ export const exportPlugin: JupyterFrontEndPlugin<void> = {
       isEnabled
     });
 
-
     if (mainMenu) {
       // Add a notebook group to the File menu.
       const exportTo = new Menu({ commands });


### PR DESCRIPTION
## References

Addresses #5274. Technically, export isn't the exact same as download, but I figured if a user wants to disable download it's highly likely they'll want to disable export as well.

## Code changes

1. I pulled all export UI code in notebook-extension into a separate plugin so that it can be disabled easily if a user wants to customize a JL environment to not have those features available. Specifically, notebook-extension adds the "export notebook as" commands to the file menu and command palette, so all those commands can now be easily set to not display.
2. I pulled out the getCurrent function into a separate function so that it could be used in the new export plugin as well as the original one it lived in. This required adding a few arguments to make things work out.
3. I removed some unused imports across the extension.

## User-facing changes

No user-facing changes with the extension enabled as is. If @jupyterlab/notebook-extension:export is disabled (the ID for the new plugin), then the file menu and command palette will no longer show any export commands:

![image](https://user-images.githubusercontent.com/26827404/114634445-62596880-9c77-11eb-9218-c852c6ff2035.png)
![image](https://user-images.githubusercontent.com/26827404/114634463-6ab1a380-9c77-11eb-9fa3-470d0b238bef.png)

## Backwards-incompatible changes

None
