### PR TITLE
PR: TOC current position

### DIFF
--- a/packages/toc/src/generators/notebook/get_code_cell_heading.ts
+++ b/packages/toc/src/generators/notebook/get_code_cell_heading.ts
@@ -31,9 +31,14 @@ function getCodeCellHeading(
   executionCount: string,
   lastLevel: number,
   cellRef: Cell,
-  index: number
+  index: number = -1
 ): INotebookHeading {
   let headings: INotebookHeading[] = [];
+  if (index == -1) {
+    console.warn(
+      'Deprecation warning! index argument will become mandatory in the next version'
+    );
+  }
   if (text) {
     const lines = text.split('\n');
     const len = Math.min(lines.length, 3);

--- a/packages/toc/src/generators/notebook/get_code_cell_heading.ts
+++ b/packages/toc/src/generators/notebook/get_code_cell_heading.ts
@@ -22,6 +22,7 @@ type onClickFactory = (line: number) => () => void;
  * @param executionCount - execution count
  * @param lastLevel - last heading level
  * @param cellRef - cell reference
+ * @param index - index of referenced cell relative to other cells in the notebook
  * @returns notebook heading
  */
 function getCodeCellHeading(

--- a/packages/toc/src/generators/notebook/get_code_cell_heading.ts
+++ b/packages/toc/src/generators/notebook/get_code_cell_heading.ts
@@ -29,7 +29,8 @@ function getCodeCellHeading(
   onClick: onClickFactory,
   executionCount: string,
   lastLevel: number,
-  cellRef: Cell
+  cellRef: Cell,
+  index: number
 ): INotebookHeading {
   let headings: INotebookHeading[] = [];
   if (text) {
@@ -48,7 +49,8 @@ function getCodeCellHeading(
       type: 'code',
       prompt: executionCount,
       cellRef: cellRef,
-      hasChild: false
+      hasChild: false,
+      index: index
     });
   }
   return headings[0];

--- a/packages/toc/src/generators/notebook/get_code_cell_heading.ts
+++ b/packages/toc/src/generators/notebook/get_code_cell_heading.ts
@@ -34,7 +34,7 @@ function getCodeCellHeading(
   index: number = -1
 ): INotebookHeading {
   let headings: INotebookHeading[] = [];
-  if (index == -1) {
+  if (index === -1) {
     console.warn(
       'Deprecation warning! index argument will become mandatory in the next version'
     );

--- a/packages/toc/src/generators/notebook/get_markdown_heading.ts
+++ b/packages/toc/src/generators/notebook/get_markdown_heading.ts
@@ -37,7 +37,7 @@ function getMarkdownHeadings(
 ): INotebookHeading[] {
   const clbk = onClick(0);
   let headings: INotebookHeading[] = [];
-  if (index == -1) {
+  if (index === -1) {
     console.warn(
       'Deprecation warning! index argument will become mandatory in the next version'
     );

--- a/packages/toc/src/generators/notebook/get_markdown_heading.ts
+++ b/packages/toc/src/generators/notebook/get_markdown_heading.ts
@@ -24,6 +24,7 @@ type onClickFactory = (line: number) => () => void;
  * @param dict - numbering dictionary
  * @param lastLevel - last level
  * @param cellRef - cell reference
+ * @param index - index of referenced cell relative to other cells in the notebook
  * @returns notebook heading
  */
 function getMarkdownHeadings(

--- a/packages/toc/src/generators/notebook/get_markdown_heading.ts
+++ b/packages/toc/src/generators/notebook/get_markdown_heading.ts
@@ -31,7 +31,8 @@ function getMarkdownHeadings(
   onClick: onClickFactory,
   dict: any,
   lastLevel: number,
-  cellRef: Cell
+  cellRef: Cell,
+  index: number
 ): INotebookHeading[] {
   const clbk = onClick(0);
   let headings: INotebookHeading[] = [];
@@ -45,7 +46,8 @@ function getMarkdownHeadings(
         onClick: clbk,
         type: 'header',
         cellRef: cellRef,
-        hasChild: false
+        hasChild: false,
+        index
       });
     } else {
       headings.push({
@@ -54,7 +56,8 @@ function getMarkdownHeadings(
         onClick: clbk,
         type: 'markdown',
         cellRef: cellRef,
-        hasChild: false
+        hasChild: false,
+        index
       });
     }
   }

--- a/packages/toc/src/generators/notebook/get_markdown_heading.ts
+++ b/packages/toc/src/generators/notebook/get_markdown_heading.ts
@@ -33,10 +33,15 @@ function getMarkdownHeadings(
   dict: any,
   lastLevel: number,
   cellRef: Cell,
-  index: number
+  index: number = -1
 ): INotebookHeading[] {
   const clbk = onClick(0);
   let headings: INotebookHeading[] = [];
+  if (index == -1) {
+    console.warn(
+      'Deprecation warning! index argument will become mandatory in the next version'
+    );
+  }
   for (const line of text.split('\n')) {
     const heading = parseHeading(line);
     if (heading) {

--- a/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
+++ b/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
@@ -27,6 +27,7 @@ type onClickFactory = (el: Element) => () => void;
  * @param lastLevel - last level
  * @param numbering - boolean indicating whether to enable numbering
  * @param cellRef - cell reference
+ * @param index - index of referenced cell relative to other cells in the notebook
  * @returns notebook heading
  */
 function getRenderedHTMLHeadings(

--- a/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
+++ b/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
@@ -42,7 +42,7 @@ function getRenderedHTMLHeadings(
 ): INotebookHeading[] {
   let nodes = node.querySelectorAll('h1, h2, h3, h4, h5, h6, p');
 
-  if (index == -1) {
+  if (index === -1) {
     console.warn(
       'Deprecation warning! index argument will become mandatory in the next version'
     );

--- a/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
+++ b/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
@@ -36,7 +36,8 @@ function getRenderedHTMLHeadings(
   dict: INumberingDictionary,
   lastLevel: number,
   numbering = false,
-  cellRef: Cell
+  cellRef: Cell,
+  index: number
 ): INotebookHeading[] {
   let nodes = node.querySelectorAll('h1, h2, h3, h4, h5, h6, p');
 
@@ -52,7 +53,8 @@ function getRenderedHTMLHeadings(
           onClick: onClick(el),
           type: 'markdown',
           cellRef: cellRef,
-          hasChild: false
+          hasChild: false,
+          index: index
         });
       }
       continue;
@@ -79,7 +81,8 @@ function getRenderedHTMLHeadings(
       onClick: onClick(el),
       type: 'header',
       cellRef: cellRef,
-      hasChild: false
+      hasChild: false,
+      index: index
     });
   }
   return headings;

--- a/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
+++ b/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
@@ -38,10 +38,15 @@ function getRenderedHTMLHeadings(
   lastLevel: number,
   numbering = false,
   cellRef: Cell,
-  index: number
+  index: number = -1
 ): INotebookHeading[] {
   let nodes = node.querySelectorAll('h1, h2, h3, h4, h5, h6, p');
 
+  if (index == -1) {
+    console.warn(
+      'Deprecation warning! index argument will become mandatory in the next version'
+    );
+  }
   let headings: INotebookHeading[] = [];
   for (const el of nodes) {
     if (el.nodeName.toLowerCase() === 'p') {

--- a/packages/toc/src/generators/notebook/index.ts
+++ b/packages/toc/src/generators/notebook/index.ts
@@ -78,10 +78,11 @@ function createNotebookGenerator(
    *
    * @private
    * @param item - heading to render
+   * @param toc - list of all headers to render
    * @returns rendered item
    */
-  function renderItem(item: INotebookHeading) {
-    return render(options, tracker, item);
+  function renderItem(item: INotebookHeading, toc: INotebookHeading[]) {
+    return render(options, tracker, item, toc);
   }
 
   /**
@@ -103,7 +104,6 @@ function createNotebookGenerator(
     for (let i = 0; i < panel.content.widgets.length; i++) {
       let cell: Cell = panel.content.widgets[i];
       let model = cell.model;
-
       let collapsed = model.metadata.get('toc-hr-collapsed') as boolean;
       collapsed = collapsed || false;
 
@@ -122,7 +122,8 @@ function createNotebookGenerator(
             onClick,
             executionCount,
             getLastHeadingLevel(headings),
-            cell
+            cell,
+            i
           );
           [headings, prev] = appendHeading(
             headings,
@@ -155,7 +156,8 @@ function createNotebookGenerator(
             dict,
             getLastHeadingLevel(headings),
             options.numbering,
-            cell
+            cell,
+            i
           );
           for (const heading of htmlHeadings) {
             [headings, prev, collapseLevel] = appendMarkdownHeading(
@@ -197,7 +199,8 @@ function createNotebookGenerator(
             dict,
             lastLevel,
             options.numbering,
-            cell
+            cell,
+            i
           );
           for (heading of htmlHeadings) {
             [headings, prev, collapseLevel] = appendMarkdownHeading(
@@ -223,7 +226,8 @@ function createNotebookGenerator(
             onClick,
             dict,
             lastLevel,
-            cell
+            cell,
+            i
           );
           for (heading of markdownHeadings) {
             [headings, prev, collapseLevel] = appendMarkdownHeading(

--- a/packages/toc/src/generators/notebook/index.ts
+++ b/packages/toc/src/generators/notebook/index.ts
@@ -81,7 +81,7 @@ function createNotebookGenerator(
    * @param toc - list of all headers to render
    * @returns rendered item
    */
-  function renderItem(item: INotebookHeading, toc: INotebookHeading[]) {
+  function renderItem(item: INotebookHeading, toc: INotebookHeading[] = []) {
     return render(options, tracker, item, toc);
   }
 

--- a/packages/toc/src/generators/notebook/render.tsx
+++ b/packages/toc/src/generators/notebook/render.tsx
@@ -74,8 +74,8 @@ function render(
             <ellipsesIcon.react />
           </div>
         ) : (
-          <div />
-        );
+            <div />
+          );
 
         // Render the heading item:
         jsx = (
@@ -86,8 +86,8 @@ function render(
               (tracker.activeCell === item.cellRef
                 ? ' toc-active-cell'
                 : previousHeader(tracker, item, toc)
-                ? ' toc-active-cell'
-                : '')
+                  ? ' toc-active-cell'
+                  : '')
             }
           >
             {button}
@@ -134,8 +134,8 @@ function render(
             <ellipsesIcon.react />
           </div>
         ) : (
-          <div />
-        );
+            <div />
+          );
         jsx = (
           <div
             className={
@@ -144,8 +144,8 @@ function render(
               (tracker.activeCell === item.cellRef
                 ? ' toc-active-cell'
                 : previousHeader(tracker, item, toc)
-                ? ' toc-active-cell'
-                : '')
+                  ? ' toc-active-cell'
+                  : '')
             }
           >
             {button}
@@ -215,16 +215,21 @@ function previousHeader(
   item: INotebookHeading,
   toc: INotebookHeading[]
 ) {
-  let activeCellIndex = tracker.currentWidget!.content.activeCellIndex;
-  let headerIndex = item.index;
-  if (headerIndex < activeCellIndex) {
-    let tocIndexOfNextHeader = toc.indexOf(item) + 1;
-    if (tocIndexOfNextHeader >= toc.length) {
-      return true;
-    }
-    let nextHeaderIndex = toc[tocIndexOfNextHeader].index;
-    if (nextHeaderIndex != null && nextHeaderIndex > activeCellIndex) {
-      return true;
+  if (item.index > -1) {
+    let activeCellIndex = tracker.currentWidget!.content.activeCellIndex;
+    let headerIndex = item.index;
+    // header index has to be less than the active cell index
+    if (headerIndex < activeCellIndex) {
+      let tocIndexOfNextHeader = toc.indexOf(item) + 1;
+      // return true if header is the last header
+      if (tocIndexOfNextHeader >= toc.length) {
+        return true;
+      }
+      // return true if the next header cells index is greater than the active cells index
+      let nextHeaderIndex = toc[tocIndexOfNextHeader].index;
+      if (nextHeaderIndex != null && nextHeaderIndex > activeCellIndex) {
+        return true;
+      }
     }
   }
   return false;

--- a/packages/toc/src/generators/notebook/render.tsx
+++ b/packages/toc/src/generators/notebook/render.tsx
@@ -16,6 +16,7 @@ import { OptionsManager } from './options_manager';
  * @param options - generator options
  * @param tracker - notebook tracker
  * @param item - notebook heading
+ * @param toc - current list of notebook headings
  * @returns rendered item
  */
 function render(
@@ -200,6 +201,15 @@ function render(
   }
 }
 
+/**
+ * Used to find the nearest above heading to an active notebook cell
+ *
+ * @private
+ * @param tracker - notebook tracker
+ * @param item - notebook heading
+ * @param toc - current list of notebook headings
+ * @returns true if heading is nearest above a selected cell, otherwise false
+ */
 function previousHeader(
   tracker: INotebookTracker,
   item: INotebookHeading,

--- a/packages/toc/src/generators/notebook/render.tsx
+++ b/packages/toc/src/generators/notebook/render.tsx
@@ -21,7 +21,8 @@ import { OptionsManager } from './options_manager';
 function render(
   options: OptionsManager,
   tracker: INotebookTracker,
-  item: INotebookHeading
+  item: INotebookHeading,
+  toc: INotebookHeading[]
 ) {
   let jsx;
   if (item.type === 'markdown' || item.type === 'header') {
@@ -81,7 +82,11 @@ function render(
             className={
               'toc-entry-holder ' +
               fontSizeClass +
-              (tracker.activeCell === item.cellRef ? ' toc-active-cell' : '')
+              (tracker.activeCell === item.cellRef
+                ? ' toc-active-cell'
+                : previousHeader(tracker, item, toc)
+                ? ' toc-active-cell'
+                : '')
             }
           >
             {button}
@@ -135,7 +140,11 @@ function render(
             className={
               'toc-entry-holder ' +
               fontSizeClass +
-              (tracker.activeCell === item.cellRef ? ' toc-active-cell' : '')
+              (tracker.activeCell === item.cellRef
+                ? ' toc-active-cell'
+                : previousHeader(tracker, item, toc)
+                ? ' toc-active-cell'
+                : '')
             }
           >
             {button}
@@ -189,6 +198,26 @@ function render(
       options.updateWidget();
     }
   }
+}
+
+function previousHeader(
+  tracker: INotebookTracker,
+  item: INotebookHeading,
+  toc: INotebookHeading[]
+) {
+  let activeCellIndex = tracker.currentWidget!.content.activeCellIndex;
+  let headerIndex = item.index;
+  if (headerIndex < activeCellIndex) {
+    let tocIndexOfNextHeader = toc.indexOf(item) + 1;
+    if (tocIndexOfNextHeader >= toc.length) {
+      return true;
+    }
+    let nextHeaderIndex = toc[tocIndexOfNextHeader].index;
+    if (nextHeaderIndex != null && nextHeaderIndex > activeCellIndex) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/toc/src/generators/notebook/render.tsx
+++ b/packages/toc/src/generators/notebook/render.tsx
@@ -23,7 +23,7 @@ function render(
   options: OptionsManager,
   tracker: INotebookTracker,
   item: INotebookHeading,
-  toc: INotebookHeading[]
+  toc: INotebookHeading[] = []
 ) {
   let jsx;
   if (item.type === 'markdown' || item.type === 'header') {
@@ -74,8 +74,8 @@ function render(
             <ellipsesIcon.react />
           </div>
         ) : (
-            <div />
-          );
+          <div />
+        );
 
         // Render the heading item:
         jsx = (
@@ -86,8 +86,8 @@ function render(
               (tracker.activeCell === item.cellRef
                 ? ' toc-active-cell'
                 : previousHeader(tracker, item, toc)
-                  ? ' toc-active-cell'
-                  : '')
+                ? ' toc-active-cell'
+                : '')
             }
           >
             {button}
@@ -134,8 +134,8 @@ function render(
             <ellipsesIcon.react />
           </div>
         ) : (
-            <div />
-          );
+          <div />
+        );
         jsx = (
           <div
             className={
@@ -144,8 +144,8 @@ function render(
               (tracker.activeCell === item.cellRef
                 ? ' toc-active-cell'
                 : previousHeader(tracker, item, toc)
-                  ? ' toc-active-cell'
-                  : '')
+                ? ' toc-active-cell'
+                : '')
             }
           >
             {button}
@@ -215,7 +215,7 @@ function previousHeader(
   item: INotebookHeading,
   toc: INotebookHeading[]
 ) {
-  if (item.index > -1) {
+  if (item.index > -1 || toc?.length) {
     let activeCellIndex = tracker.currentWidget!.content.activeCellIndex;
     let headerIndex = item.index;
     // header index has to be less than the active cell index
@@ -226,8 +226,8 @@ function previousHeader(
         return true;
       }
       // return true if the next header cells index is greater than the active cells index
-      let nextHeaderIndex = toc[tocIndexOfNextHeader].index;
-      if (nextHeaderIndex != null && nextHeaderIndex > activeCellIndex) {
+      let nextHeaderIndex = toc?.[tocIndexOfNextHeader].index;
+      if (nextHeaderIndex > activeCellIndex) {
         return true;
       }
     }

--- a/packages/toc/src/registry.ts
+++ b/packages/toc/src/registry.ts
@@ -162,6 +162,7 @@ export namespace TableOfContentsRegistry {
      * -   If not present, a default renderer will be used.
      *
      * @param item - heading
+     * @param toc - list of headings
      * @returns JSX element
      */
     itemRenderer?: (item: IHeading, toc: IHeading[]) => JSX.Element | null;

--- a/packages/toc/src/registry.ts
+++ b/packages/toc/src/registry.ts
@@ -5,7 +5,7 @@ import { IWidgetTracker } from '@jupyterlab/apputils';
 import { Token } from '@lumino/coreutils';
 import { Signal, ISignal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
-import { IHeading } from './utils/headings';
+import { IHeading, INotebookHeading } from './utils/headings';
 
 /**
  * Interface describing the table of contents registry.
@@ -165,7 +165,10 @@ export namespace TableOfContentsRegistry {
      * @param toc - list of headings
      * @returns JSX element
      */
-    itemRenderer?: (item: IHeading, toc: IHeading[]) => JSX.Element | null;
+    itemRenderer?: (
+      item: IHeading,
+      toc: INotebookHeading[]
+    ) => JSX.Element | null;
 
     /**
      * Returns a toolbar component.

--- a/packages/toc/src/registry.ts
+++ b/packages/toc/src/registry.ts
@@ -164,7 +164,7 @@ export namespace TableOfContentsRegistry {
      * @param item - heading
      * @returns JSX element
      */
-    itemRenderer?: (item: IHeading) => JSX.Element | null;
+    itemRenderer?: (item: IHeading, toc: IHeading[]) => JSX.Element | null;
 
     /**
      * Returns a toolbar component.

--- a/packages/toc/src/toc.tsx
+++ b/packages/toc/src/toc.tsx
@@ -118,9 +118,10 @@ export class TableOfContents extends Widget {
         title = PathExt.basename(context.localPath);
       }
     }
-    let itemRenderer: (item: IHeading) => JSX.Element | null = (
-      item: IHeading
-    ) => {
+    let itemRenderer: (
+      item: IHeading,
+      toc: IHeading[]
+    ) => JSX.Element | null = (item: IHeading) => {
       return <span>{item.text}</span>;
     };
     if (this._current && this._current.generator.itemRenderer) {

--- a/packages/toc/src/toc_item.tsx
+++ b/packages/toc/src/toc_item.tsx
@@ -14,13 +14,16 @@ interface IProperties {
    * Heading to render.
    */
   heading: IHeading;
-
+  /**
+   * List of headings to use for rendering current position in toc
+   */
   toc: IHeading[];
 
   /**
    * Renders a heading.
    *
    * @param item - heading
+   * @param toc - list of headings
    * @returns rendered heading
    */
   itemRenderer: (item: IHeading, toc: IHeading[]) => JSX.Element | null;

--- a/packages/toc/src/toc_item.tsx
+++ b/packages/toc/src/toc_item.tsx
@@ -15,13 +15,15 @@ interface IProperties {
    */
   heading: IHeading;
 
+  toc: IHeading[];
+
   /**
    * Renders a heading.
    *
    * @param item - heading
    * @returns rendered heading
    */
-  itemRenderer: (item: IHeading) => JSX.Element | null;
+  itemRenderer: (item: IHeading, toc: IHeading[]) => JSX.Element | null;
 }
 
 /**
@@ -43,7 +45,7 @@ class TOCItem extends React.Component<IProperties, IState> {
    * @returns rendered entry
    */
   render() {
-    const { heading } = this.props;
+    const { heading, toc } = this.props;
 
     // Create an onClick handler for the TOC item
     // that scrolls the anchor into view.
@@ -53,7 +55,7 @@ class TOCItem extends React.Component<IProperties, IState> {
       heading.onClick();
     };
 
-    let content = this.props.itemRenderer(heading);
+    let content = this.props.itemRenderer(heading, toc);
     return content && <li onClick={onClick}>{content}</li>;
   }
 }

--- a/packages/toc/src/toc_tree.tsx
+++ b/packages/toc/src/toc_tree.tsx
@@ -39,7 +39,7 @@ interface IProperties extends React.Props<TOCTree> {
    * @param item - heading
    * @returns rendered heading
    */
-  itemRenderer: (item: IHeading) => JSX.Element | null;
+  itemRenderer: (item: IHeading, toc: IHeading[]) => JSX.Element | null;
 }
 
 /**
@@ -67,6 +67,7 @@ class TOCTree extends React.Component<IProperties, IState> {
       return (
         <TOCItem
           heading={el}
+          toc={this.props.toc}
           itemRenderer={this.props.itemRenderer}
           key={`${el.text}-${el.level}-${i++}`}
         />

--- a/packages/toc/src/toc_tree.tsx
+++ b/packages/toc/src/toc_tree.tsx
@@ -37,6 +37,7 @@ interface IProperties extends React.Props<TOCTree> {
    * Renders a heading item.
    *
    * @param item - heading
+   * @param toc - list of headings in toc to use for rendering current position
    * @returns rendered heading
    */
   itemRenderer: (item: IHeading, toc: IHeading[]) => JSX.Element | null;

--- a/packages/toc/src/utils/headings.ts
+++ b/packages/toc/src/utils/headings.ts
@@ -76,6 +76,10 @@ interface INotebookHeading extends INumberedHeading {
    * Boolean indicating whether a heading has a child node.
    */
   hasChild?: boolean;
+
+  /**
+   * index of reference cell in the notebook
+   */
   index: number;
 }
 

--- a/packages/toc/src/utils/headings.ts
+++ b/packages/toc/src/utils/headings.ts
@@ -76,6 +76,7 @@ interface INotebookHeading extends INumberedHeading {
    * Boolean indicating whether a heading has a child node.
    */
   hasChild?: boolean;
+  index: number;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #8815
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Adds `index` as variable for `INotebookHeader` to hold the index of the reference cell in the notebook relative to the other cells
- adds `toc`, an array of headers, as an argument to the notebook toc renderer to use to determine a headers location relative to the other headers and a currently selected cell
- adds a function to the renderer.tsx file to determine if a header is the nearest above header to an active cell
- changes to various classes/functions in to pass the new arguments to the `render` function
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
### Before
If an active cell is not a header, the toc gives no indication of which section of the toc a user is in.
![image](https://user-images.githubusercontent.com/13774419/114754353-7a3bf580-9d26-11eb-9971-092443221dee.png)

### After
Heading  for section where a cell is active has a blue box next to it showing that it is the current section a user is in.
![image](https://user-images.githubusercontent.com/13774419/114753323-57f5a800-9d25-11eb-8205-841e43110c3d.png)

## Backwards-incompatible changes
I don't believe there are any
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
