### PR TITLE
Fix last modified column toggle, allow to set it permanently

### DIFF
--- a/packages/filebrowser-extension/schema/browser.json
+++ b/packages/filebrowser-extension/schema/browser.json
@@ -27,6 +27,12 @@
       "title": "Filter on file name with a fuzzy search",
       "description": "Whether to apply fuzzy algorithm while filtering on file names",
       "default": true
+    },
+    "showLastModifiedColumn": {
+      "type": "boolean",
+      "title": "Show last modified column",
+      "description": "Whether to show the last modified column",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -177,8 +177,12 @@ export class FileBrowser extends Widget {
   }
 
   set showLastModifiedColumn(value: boolean) {
-    this._listing.setColumnVisibility('last_modified', value);
-    this._showLastModifiedColumn = value;
+    if (this._listing.setColumnVisibility) {
+      this._listing.setColumnVisibility('last_modified', value);
+      this._showLastModifiedColumn = value;
+    } else {
+      console.warn('Listing does not support toggling column visibility');
+    }
   }
 
   /**

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -170,6 +170,18 @@ export class FileBrowser extends Widget {
   }
 
   /**
+   * Whether to show the last modified column
+   */
+  get showLastModifiedColumn(): boolean {
+    return this._showLastModifiedColumn;
+  }
+
+  set showLastModifiedColumn(value: boolean) {
+    this._listing.setColumnVisibility('last_modified', value);
+    this._showLastModifiedColumn = value;
+  }
+
+  /**
    * Whether to use fuzzy filtering on file names.
    */
   set useFuzzyFilter(value: boolean) {
@@ -361,6 +373,7 @@ export class FileBrowser extends Widget {
   private _manager: IDocumentManager;
   private _directoryPending: boolean;
   private _navigateToCurrentDirectory: boolean;
+  private _showLastModifiedColumn: boolean = true;
   private _useFuzzyFilter: boolean = true;
 }
 

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -10,8 +10,6 @@ import {
 
 import { PathExt, Time } from '@jupyterlab/coreutils';
 
-import {} from '@jupyterlab/apputils';
-
 import {
   IDocumentManager,
   isValidFileName,
@@ -133,6 +131,11 @@ const MODIFIED_ID_CLASS = 'jp-id-modified';
 const NARROW_ID_CLASS = 'jp-id-narrow';
 
 /**
+ * The class name added to the modified column header cell and modified item cell when hidden.
+ */
+const MODIFIED_COLUMN_HIDDEN = 'jp-LastModified-hidden';
+
+/**
  * The mime type for a contents drag object.
  */
 const CONTENTS_MIME = 'application/x-jupyter-icontents';
@@ -228,7 +231,11 @@ export class DirListing extends Widget {
     this._renderer = options.renderer || DirListing.defaultRenderer;
 
     const headerNode = DOMUtils.findElement(this.node, HEADER_CLASS);
-    this._renderer.populateHeaderNode(headerNode, this.translator);
+    this._renderer.populateHeaderNode(
+      headerNode,
+      this.translator,
+      this._hiddenColumns
+    );
     this._manager.activateRequested.connect(this._onActivateRequested, this);
   }
 
@@ -777,7 +784,7 @@ export class DirListing extends Widget {
 
     // Add any missing item nodes.
     while (nodes.length < items.length) {
-      const node = renderer.createItemNode();
+      const node = renderer.createItemNode(this._hiddenColumns);
       node.classList.add(ITEM_CLASS);
       nodes.push(node);
       content.appendChild(node);
@@ -794,7 +801,13 @@ export class DirListing extends Widget {
     items.forEach((item, i) => {
       const node = nodes[i];
       const ft = this._manager.registry.getFileTypeForModel(item);
-      renderer.updateItemNode(node, item, ft, this.translator);
+      renderer.updateItemNode(
+        node,
+        item,
+        ft,
+        this.translator,
+        this._hiddenColumns
+      );
       if (this._selection[item.name]) {
         node.classList.add(SELECTED_CLASS);
         if (this._isCut && this._model.path === this._prevPath) {
@@ -844,6 +857,21 @@ export class DirListing extends Widget {
     const { width } =
       msg.width === -1 ? this.node.getBoundingClientRect() : msg;
     this.toggleClass('jp-DirListing-narrow', width < 250);
+  }
+
+  setColumnVisibility(name: DirListing.ToggleableColumn, visible: boolean) {
+    if (visible) {
+      this._hiddenColumns.delete(name);
+    } else {
+      this._hiddenColumns.add(name);
+    }
+
+    this.headerNode.innerHTML = '';
+    this._renderer.populateHeaderNode(
+      this.headerNode,
+      this.translator,
+      this._hiddenColumns
+    );
   }
 
   /**
@@ -1611,6 +1639,7 @@ export class DirListing extends Widget {
   private _searchPrefixTimer = -1;
   private _inRename = false;
   private _isDirty = false;
+  private _hiddenColumns = new Set<DirListing.ToggleableColumn>();
 }
 
 /**
@@ -1655,6 +1684,11 @@ export namespace DirListing {
   }
 
   /**
+   * Toggleable columns.
+   */
+  export type ToggleableColumn = 'last_modified';
+
+  /**
    * A file contents model thunk.
    *
    * Note: The content of the model will be empty.
@@ -1687,7 +1721,11 @@ export namespace DirListing {
      *
      * @param node - The header node to populate.
      */
-    populateHeaderNode(node: HTMLElement, translator?: ITranslator): void;
+    populateHeaderNode(
+      node: HTMLElement,
+      translator?: ITranslator,
+      hiddenColumns?: Set<DirListing.ToggleableColumn>
+    ): void;
 
     /**
      * Handle a header click.
@@ -1705,7 +1743,9 @@ export namespace DirListing {
      *
      * @returns A new DOM node to use as a content item.
      */
-    createItemNode(): HTMLElement;
+    createItemNode(
+      hiddenColumns?: Set<DirListing.ToggleableColumn>
+    ): HTMLElement;
 
     /**
      * Update an item node to reflect the current state of a model.
@@ -1720,7 +1760,8 @@ export namespace DirListing {
       node: HTMLElement,
       model: Contents.IModel,
       fileType?: DocumentRegistry.IFileType,
-      translator?: ITranslator
+      translator?: ITranslator,
+      hiddenColumns?: Set<DirListing.ToggleableColumn>
     ): void;
 
     /**
@@ -1749,6 +1790,11 @@ export namespace DirListing {
       trans: TranslationBundle,
       fileType?: DocumentRegistry.IFileType
     ): HTMLElement;
+
+    setColumnVisibility?(
+      name: DirListing.ToggleableColumn,
+      visible: boolean
+    ): void;
   }
 
   /**
@@ -1775,7 +1821,11 @@ export namespace DirListing {
      *
      * @param node - The header node to populate.
      */
-    populateHeaderNode(node: HTMLElement, translator?: ITranslator): void {
+    populateHeaderNode(
+      node: HTMLElement,
+      translator?: ITranslator,
+      hiddenColumns?: Set<DirListing.ToggleableColumn>
+    ): void {
       translator = translator || nullTranslator;
       const trans = translator.load('jupyterlab');
       const name = this._createHeaderItemNode(trans.__('Name'));
@@ -1789,6 +1839,12 @@ export namespace DirListing {
       node.appendChild(name);
       node.appendChild(narrow);
       node.appendChild(modified);
+
+      if (hiddenColumns?.has?.('last_modified')) {
+        modified.classList.add(MODIFIED_COLUMN_HIDDEN);
+      } else {
+        modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
+      }
 
       // set the initial caret icon
       Private.updateCaret(
@@ -1873,7 +1929,9 @@ export namespace DirListing {
      *
      * @returns A new DOM node to use as a content item.
      */
-    createItemNode(): HTMLElement {
+    createItemNode(
+      hiddenColumns?: Set<DirListing.ToggleableColumn>
+    ): HTMLElement {
       const node = document.createElement('li');
       const icon = document.createElement('span');
       const text = document.createElement('span');
@@ -1884,6 +1942,12 @@ export namespace DirListing {
       node.appendChild(icon);
       node.appendChild(text);
       node.appendChild(modified);
+
+      if (hiddenColumns?.has?.('last_modified')) {
+        modified.classList.add(MODIFIED_COLUMN_HIDDEN);
+      } else {
+        modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
+      }
       return node;
     }
 
@@ -1901,9 +1965,11 @@ export namespace DirListing {
       node: HTMLElement,
       model: Contents.IModel,
       fileType?: DocumentRegistry.IFileType,
-      translator?: ITranslator
+      translator?: ITranslator,
+      hiddenColumns?: Set<DirListing.ToggleableColumn>
     ): void {
       translator = translator || nullTranslator;
+
       fileType =
         fileType || DocumentRegistry.getDefaultTextFileType(translator);
       const { icon, iconClass, name } = fileType;
@@ -1913,6 +1979,12 @@ export namespace DirListing {
       const iconContainer = DOMUtils.findElement(node, ITEM_ICON_CLASS);
       const text = DOMUtils.findElement(node, ITEM_TEXT_CLASS);
       const modified = DOMUtils.findElement(node, ITEM_MODIFIED_CLASS);
+
+      if (hiddenColumns?.has?.('last_modified')) {
+        modified.classList.add(MODIFIED_COLUMN_HIDDEN);
+      } else {
+        modified.classList.remove(MODIFIED_COLUMN_HIDDEN);
+      }
 
       // render the file item's icon
       LabIcon.resolveElement({

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1790,11 +1790,6 @@ export namespace DirListing {
       trans: TranslationBundle,
       fileType?: DocumentRegistry.IFileType
     ): HTMLElement;
-
-    setColumnVisibility?(
-      name: DirListing.ToggleableColumn,
-      visible: boolean
-    ): void;
   }
 
   /**


### PR DESCRIPTION
## References

- fixes #8860 (last modified column toggle not working when additional files are rendered), and
- fixes #10037 (allows to disable date column permanently and remembers its state between browser reloads).

## Code changes

- aligned the code with the pattern used by `navigateToCurrentDirectory` and `useFuzzyFilter`:
   - the command and setting are defined in `filebrowser-extension`, and action is performed on setting change (in a setter)
   - runtime value is also reflected on `FileBrowser`, but its use is limited to displaying the toggle check in GUI
- renderer should not hold state, so the set of `_hiddenColumns` is stored in `DirListing`
- the hidden columns state is passed to render in appropriate calls as optional for API compatibility
- only some are `ToggleableColumn`s, so we type it

## User-facing changes

- a check mark was added as we now properly track state of the column visibility and as a consequence the "Toggle Last Modified Column" command was renamed to "Show Last Modified Column".
  - I think it makes more sense now, but happy to revert if you disagree.
- new setting (`showLastModifiedColumn`) was added which allows to disable the column permanently
  - this could in fact be a list of columns to hide instead for forwards compatibility once the new browser with more columns comes in. Happy to revise.
- the annoying re-appearance of the last modified column will no longer happen

| before | after |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/5832902/114784673-797d8080-9d73-11eb-9802-34f4cb91b204.gif)  | ![after](https://user-images.githubusercontent.com/5832902/114785060-07f20200-9d74-11eb-8f1e-1123cdd70d8c.gif) |


## Backwards-incompatible changes

I put effort in to make added arguments and methods optional. There is a new setting and changes to public API:
- `FileBrowser.showLastModifiedColumn`: should be fine for compatibility, it is not that important
- `DirListing.ToggleableColumn`: exported from namespace so not relevant for compatibility
- `DirListing.setColumnVisibility`: new API member; I added a check before calling this method in case if it is absent in case if someone is hot-swapping `DirListing` with their custom implementation