### PR TITLE
Allow NPM Registry and CDN Registry to be Configurable

### DIFF
--- a/packages/extensionmanager-extension/schema/plugin.json
+++ b/packages/extensionmanager-extension/schema/plugin.json
@@ -15,6 +15,18 @@
       "description": "Whether the user understand that extensions managed through this interface run arbitrary code that may be dangerous",
       "default": false,
       "type": "boolean"
+    },
+    "npmRegistry": {
+      "title": "NPM Registry",
+      "description": "The URI of the NPM registry to use for searching for jupyterlab extensions",
+      "default": "https://registry.npmjs.org/-/v1/",
+      "type": "string"
+    },
+    "npmCdn": {
+      "title": "NPM CDN",
+      "description": "The URI of the CDN to use for fetching full package data",
+      "default": "https://unpkg.com",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -232,9 +232,17 @@ export class ListModel extends VDomModel {
     this.serverConnectionSettings = ServerConnection.makeSettings();
     this._debouncedUpdate = new Debouncer(this.update.bind(this), 1000);
     this.lister.listingsLoaded.connect(this._listingIsLoaded, this);
+    this.searcher = new Searcher(
+      settings.composite['npmRegistry'] as string,
+      settings.composite['npmCdn'] as string
+    );
     _isDisclaimed = settings.composite['disclaimed'] === true;
     settings.changed.connect(() => {
       _isDisclaimed = settings.composite['disclaimed'] === true;
+      this.searcher = new Searcher(
+        settings.composite['npmRegistry'] as string,
+        settings.composite['npmCdn'] as string
+      );
       void this.update();
     });
   }
@@ -880,7 +888,7 @@ export class ListModel extends VDomModel {
   /**
    * A helper for performing searches of jupyterlab extensions on the NPM repository.
    */
-  protected searcher = new Searcher();
+  protected searcher: Searcher;
 
   protected lister = new Lister();
 

--- a/packages/extensionmanager/src/npm.ts
+++ b/packages/extensionmanager/src/npm.ts
@@ -220,7 +220,7 @@ export class Searcher {
    * @param cdnUri The URI of the CDN to use for fetching full package data.
    */
   constructor(
-    repoUri = 'https://registry.npmjs.org/',
+    repoUri = 'https://registry.npmjs.org/-/v1/',
     cdnUri = 'https://unpkg.com'
   ) {
     this.repoUri = repoUri;
@@ -239,7 +239,7 @@ export class Searcher {
     page = 0,
     pageination = 250
   ): Promise<ISearchResult> {
-    const uri = new URL('/-/v1/search', this.repoUri);
+    const uri = new URL('search', this.repoUri);
     // Note: Spaces are encoded to '+' signs!
     const text = `${query} keywords:"jupyterlab-extension"`;
     uri.searchParams.append('text', text);


### PR DESCRIPTION
Issue: #10109 

At the moment, the NPM Registry and the CDN used to grab metadata from a packages `package.json` are hardcoded.  In some organizations (like my own), access to the outside internet is now allowed directly from our internal compute instances which makes users unable to utilize the `ExtensionManager`. 

Thus, this change aims to allow a user to configure the NPM Registry and the CDN using the settings for this package.  A user can simply override the default values in their settings if they wish to point these references elsewhere.

**Testing** 

Internally, we use Artifactory so I tested overriding the settings with an internal URL.  I also tested the absence of the package with the default values still being used. Both worked as expected.