### PR TITLE
Export createRendermimePlugin from @jupyterlab/application

### DIFF
--- a/.github/workflows/macostests.yml
+++ b/.github/workflows/macostests.yml
@@ -10,7 +10,7 @@ jobs:
         group: [integrity, python, usage, usage2]
         python: [3.8]
       fail-fast: false
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -17,7 +17,11 @@ export { JupyterLab } from './lab';
 
 export { ILayoutRestorer, LayoutRestorer } from './layoutrestorer';
 
-export { IMimeDocumentTracker } from './mimerenderers';
+export {
+  IMimeDocumentTracker,
+  createRendermimePlugin,
+  createRendermimePlugins
+} from './mimerenderers';
 
 export { Router } from './router';
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is a proposal to export the following two utility functions:

- `createRendermimePlugin`
- `createRendermimePlugins`

from the `@jupyterlab/application` package.

This let other JupyterLab distributions be able to import them with:

```typescript
import { createRendermimePlugin, createRendermimePlugins } from '@jupyterlab/application';
```

Instead of:

```typescript
import { createRendermimePlugin, createRendermimePlugins } from '@jupyterlab/application/lib/mimerenderers';
```

Examples:

- jupyterlab-classic: https://github.com/jtpio/jupyterlab-classic/blob/3cd1de3c34b2420a5a1551e627e3c859dae3e17b/packages/application/src/app.ts#L9
- (WIP) lab-based frontend for Voila: https://github.com/voila-dashboards/voila/pull/846/files#diff-c2219559be4db114a5b7616aedb2ced9cc3ac6cdf4a82626ab6ae0f4f5d24613R7


<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Export two more functions from `@jupyterlab/application`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None.

This however brings two functions to the API surface.

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
