### PR TITLE
Allow Use of CDN to be Configurable for Fetching Package Metadata

### DIFF
--- a/packages/extensionmanager-extension/schema/plugin.json
+++ b/packages/extensionmanager-extension/schema/plugin.json
@@ -27,6 +27,12 @@
       "description": "The URI of the CDN to use for fetching full package data",
       "default": "https://unpkg.com",
       "type": "string"
+    },
+    "enableCdn": {
+      "title": "Enable CDN",
+      "description": "Enables using the CDN to fetch full package data.  Otherwise, the NPM registry will be used",
+      "default": true,
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/packages/extensionmanager-extension/schema/plugin.json
+++ b/packages/extensionmanager-extension/schema/plugin.json
@@ -30,7 +30,7 @@
     },
     "enableCdn": {
       "title": "Enable CDN",
-      "description": "Enables using the CDN to fetch full package data.  Otherwise, the NPM registry will be used",
+      "description": "Enables using the CDN to fetch full package data.  Otherwise, the configured NPM registry will be used. Due to a lack of CORS support by NPM registry, only disable if supplying a custom registry",
       "default": true,
       "type": "boolean"
     }

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -234,14 +234,16 @@ export class ListModel extends VDomModel {
     this.lister.listingsLoaded.connect(this._listingIsLoaded, this);
     this.searcher = new Searcher(
       settings.composite['npmRegistry'] as string,
-      settings.composite['npmCdn'] as string
+      settings.composite['npmCdn'] as string,
+      settings.composite['enableCdn'] as boolean
     );
     _isDisclaimed = settings.composite['disclaimed'] === true;
     settings.changed.connect(() => {
       _isDisclaimed = settings.composite['disclaimed'] === true;
       this.searcher = new Searcher(
         settings.composite['npmRegistry'] as string,
-        settings.composite['npmCdn'] as string
+        settings.composite['npmCdn'] as string,
+        settings.composite['enableCdn'] as boolean
       );
       void this.update();
     });

--- a/packages/extensionmanager/src/npm.ts
+++ b/packages/extensionmanager/src/npm.ts
@@ -268,9 +268,7 @@ export class Searcher {
     const uri = this.enableCdn
       ? new URL(`/${name}@${version}/package.json`, this.cdnUri)
       : new URL(`/${name}/${version}`, this.repoUri);
-    return fetch(uri.toString(), {
-      mode: 'no-cors'
-    }).then((response: Response) => {
+    return fetch(uri.toString()).then((response: Response) => {
       if (response.ok) {
         return response.json();
       }

--- a/packages/extensionmanager/src/npm.ts
+++ b/packages/extensionmanager/src/npm.ts
@@ -221,10 +221,12 @@ export class Searcher {
    */
   constructor(
     repoUri = 'https://registry.npmjs.org/-/v1/',
-    cdnUri = 'https://unpkg.com'
+    cdnUri = 'https://unpkg.com',
+    enableCdn = true
   ) {
     this.repoUri = repoUri;
     this.cdnUri = cdnUri;
+    this.enableCdn = enableCdn;
   }
 
   /**
@@ -263,8 +265,12 @@ export class Searcher {
     name: string,
     version: string
   ): Promise<IJupyterLabPackageData | null> {
-    const uri = new URL(`/${name}@${version}/package.json`, this.cdnUri);
-    return fetch(uri.toString()).then((response: Response) => {
+    const uri = this.enableCdn
+      ? new URL(`/${name}@${version}/package.json`, this.cdnUri)
+      : new URL(`/${name}/${version}`, this.repoUri);
+    return fetch(uri.toString(), {
+      mode: 'no-cors'
+    }).then((response: Response) => {
       if (response.ok) {
         return response.json();
       }
@@ -281,6 +287,11 @@ export class Searcher {
    * The URI of the CDN to use for fetching full package data.
    */
   cdnUri: string;
+
+  /**
+   * Whether to use the CDN for fetching full package data. Otherwise, the NPM registry is used.
+   */
+  enableCdn: boolean;
 }
 
 /**


### PR DESCRIPTION
### Background

In some organizations (like my own), access to the outside internet is not allowed directly from our internal compute instances which makes users unable to utilize the ExtensionManager.

This change extends the functionality outlined in #10110 by aiming to allow a user to choose whether they want to use the CDN (by default unpkg) to fetch the _package.json_ of a package for determining if the package has a server extension or kernel companion package.  Otherwise, the NPM registry will be used.  Hence with this change, users can use their internal artifact repository (ex: Artifactory) to **both** fetch the packages for installation and fetch the package metadata. 

### Testing

I tested that the default state aligns with the current functionality (i.e. using unpkg). I tested disabling this new configuration and verified the value for the NPM registry was used.  Since NPM registry does not have CORS enabled, I provided a disclaimer in the description to warn users.
