### PR TITLE
include all default*.json in @jupyterlab/testutils distributions

### DIFF
--- a/testutils/package.json
+++ b/testutils/package.json
@@ -21,7 +21,7 @@
     "lib/*.d.ts",
     "lib/*.js.map",
     "lib/*.js",
-    "default.json",
+    "default*.json",
     "tsconfigtestbase.json"
   ],
   "scripts": {


### PR DESCRIPTION
Was tinkering over on jupyterlab-lsp, and ran against some (now-lost) errors about not being able to load `default-45.json` when importing `@jupyterlab/testutils`. I pinned to `3.0.7` and my stuff started working, but this seems like a fairly easy fix. Indeed, one character!

## References

- didn't find any, maybe  not so many users in the wild

## Code changes

- includes all `default.json` files in distribution of `@jupyterlab/testutils`

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a