### PR TITLE
Fix Permissions of Labeler Workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '*/20 * * * *'
 permissions:
-  issues:
+  pull-requests:
     write
 jobs:
   triage:


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/10136.
Use `pull-requests` permission instead of `issues` permission, since the labeler currently isn't [working](https://github.com/jupyterlab/jupyterlab/runs/2417809868?check_suite_focus=true#step:3:7).

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Update workflow permission.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
N/A
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
