### PR TITLE
Added tab cycling to Completer

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -358,8 +358,8 @@ export class Completer extends Widget {
    *
    * #### Notes
    * When the user cycles all the way `down` to the last index, subsequent
-   * `down` cycles will remain on the last index. When the user cycles `up` to
-   * the first item, subsequent `up` cycles will remain on the first cycle.
+   * `down` cycles will cycle to the first index. When the user cycles `up` to
+   * the first item, subsequent `up` cycles will cycle to the last index.
    */
   private _cycle(direction: Private.scrollType): void {
     const items = this.node.querySelectorAll(`.${ITEM_CLASS}`);
@@ -368,9 +368,9 @@ export class Completer extends Widget {
     active.classList.remove(ACTIVE_CLASS);
 
     if (direction === 'up') {
-      this._activeIndex = index === 0 ? index : index - 1;
+      this._activeIndex = index === 0 ? items.length - 1 : index - 1;
     } else if (direction === 'down') {
-      this._activeIndex = index < items.length - 1 ? index + 1 : index;
+      this._activeIndex = index < items.length - 1 ? index + 1 : 0;
     } else {
       // Measure the number of items on a page.
       const boxHeight = this.node.getBoundingClientRect().height;
@@ -439,6 +439,8 @@ export class Completer extends Widget {
         if (populated) {
           this.update();
         }
+
+        this._cycle(event.shiftKey ? 'up' : 'down');
         return;
       }
       case 27: // Esc key

--- a/packages/completer/test/widget.spec.ts
+++ b/packages/completer/test/widget.spec.ts
@@ -517,7 +517,7 @@ describe('completer/widget', () => {
           anchor.dispose();
         });
 
-        it('should select the item below and not progress past last', () => {
+        it('should select the item below and wrap to top past last (arrow keys)', () => {
           const anchor = createEditorWidget();
           const model = new CompleterModel();
           const options: Completer.IOptions = {
@@ -570,6 +570,61 @@ describe('completer/widget', () => {
           );
           simulate(target, 'keydown', { keyCode: 40 }); // Down
           expect(Array.from(items[0].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          widget.dispose();
+          anchor.dispose();
+        });
+
+        it('should select the item below and wrap to top past last (tab)', () => {
+          const anchor = createEditorWidget();
+          const model = new CompleterModel();
+          const options: Completer.IOptions = {
+            editor: anchor.editor,
+            model
+          };
+          model.setOptions(['foo', 'bar', 'baz'], {
+            foo: 'instance',
+            bar: 'function'
+          });
+          Widget.attach(anchor, document.body);
+
+          const widget = new Completer(options);
+          const target = document.createElement('div');
+
+          anchor.node.appendChild(target);
+          Widget.attach(widget, document.body);
+          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+
+          const items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
+
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(target, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(target, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
             expect.not.arrayContaining([ACTIVE_CLASS])
           );
           expect(Array.from(items[1].classList)).toEqual(
@@ -578,11 +633,21 @@ describe('completer/widget', () => {
           expect(Array.from(items[2].classList)).toEqual(
             expect.arrayContaining([ACTIVE_CLASS])
           );
+          simulate(target, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should select the completion item below and not progress past last', () => {
+        it('should select the completion item below and wrap to top past last (arrow keys)', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -635,6 +700,61 @@ describe('completer/widget', () => {
           );
           simulate(target, 'keydown', { keyCode: 40 }); // Down
           expect(Array.from(items[0].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          widget.dispose();
+          anchor.dispose();
+        });
+
+        it('should select the completion item below and wrap to top past last (tab)', () => {
+          let anchor = createEditorWidget();
+          let model = new CompleterModel();
+          let options: Completer.IOptions = {
+            editor: anchor.editor,
+            model
+          };
+          model.setCompletionItems!([
+            { label: 'foo' },
+            { label: 'bar' },
+            { label: 'baz' }
+          ]);
+          Widget.attach(anchor, document.body);
+
+          let widget = new Completer(options);
+          let target = document.createElement('div');
+
+          anchor.node.appendChild(target);
+          Widget.attach(widget, document.body);
+          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+
+          let items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(target, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(target, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
             expect.not.arrayContaining([ACTIVE_CLASS])
           );
           expect(Array.from(items[1].classList)).toEqual(
@@ -643,11 +763,21 @@ describe('completer/widget', () => {
           expect(Array.from(items[2].classList)).toEqual(
             expect.arrayContaining([ACTIVE_CLASS])
           );
+          simulate(target, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should select the item above and not progress beyond first', () => {
+        it('should select the item above and wrap to bottom past first (arrow keys)', () => {
           const anchor = createEditorWidget();
           const model = new CompleterModel();
           const options: Completer.IOptions = {
@@ -718,6 +848,39 @@ describe('completer/widget', () => {
           );
           simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
           expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          widget.dispose();
+          anchor.dispose();
+        });
+
+        it('should select the item above and wrap to bottom past first (tab)', () => {
+          const anchor = createEditorWidget();
+          const model = new CompleterModel();
+          const options: Completer.IOptions = {
+            editor: anchor.editor,
+            model
+          };
+          model.setOptions(['foo', 'bar', 'baz'], {
+            foo: 'instance',
+            bar: 'function'
+          });
+          Widget.attach(anchor, document.body);
+
+          const widget = new Completer(options);
+
+          Widget.attach(widget, document.body);
+          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+
+          const items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
+
+          expect(Array.from(items[0].classList)).toEqual(
             expect.arrayContaining([ACTIVE_CLASS])
           );
           expect(Array.from(items[1].classList)).toEqual(
@@ -726,11 +889,61 @@ describe('completer/widget', () => {
           expect(Array.from(items[2].classList)).toEqual(
             expect.not.arrayContaining([ACTIVE_CLASS])
           );
+          simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
           widget.dispose();
           anchor.dispose();
         });
 
-        it('should select the completion item above and not progress beyond first', () => {
+        it('should select the completion item above and wrap to top past first (arrow keys)', () => {
           let anchor = createEditorWidget();
           let model = new CompleterModel();
           let options: Completer.IOptions = {
@@ -802,6 +1015,40 @@ describe('completer/widget', () => {
           );
           simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
           expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          widget.dispose();
+          anchor.dispose();
+        });
+
+        it('should select the completion item above and wrap to top past first (tab)', () => {
+          let anchor = createEditorWidget();
+          let model = new CompleterModel();
+          let options: Completer.IOptions = {
+            editor: anchor.editor,
+            model
+          };
+          model.setCompletionItems!([
+            { label: 'foo' },
+            { label: 'bar' },
+            { label: 'baz' }
+          ]);
+          Widget.attach(anchor, document.body);
+
+          let widget = new Completer(options);
+
+          Widget.attach(widget, document.body);
+          MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
+
+          let items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
+
+          expect(Array.from(items[0].classList)).toEqual(
             expect.arrayContaining([ACTIVE_CLASS])
           );
           expect(Array.from(items[1].classList)).toEqual(
@@ -809,6 +1056,56 @@ describe('completer/widget', () => {
           );
           expect(Array.from(items[2].classList)).toEqual(
             expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9 }); // Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          simulate(anchor.node, 'keydown', { keyCode: 9, shiftKey: true }); // Shift + Tab
+          expect(Array.from(items[0].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[1].classList)).toEqual(
+            expect.not.arrayContaining([ACTIVE_CLASS])
+          );
+          expect(Array.from(items[2].classList)).toEqual(
+            expect.arrayContaining([ACTIVE_CLASS])
           );
           widget.dispose();
           anchor.dispose();


### PR DESCRIPTION
![cycle2](https://user-images.githubusercontent.com/38936057/115947690-2c3d9500-a47e-11eb-8eb9-c76672686715.gif)

Added tab and shift + tab cycling to auto completion.

## References

[Cycle completion with tab and automatically insert parenthesis #9082](https://github.com/jupyterlab/jupyterlab/issues/9082)
[Autocomplete cycle options using <KEY> #5863](https://github.com/jupyterlab/jupyterlab/issues/5863)

## User-facing changes
Cycling through auto-complete entries with the arrow keys or the tab key wraps bottom->top and top->bottom. Not sure if this should be the behavior for arrow keys and tab cycling, just tab cycling, or neither.

Note: I had a one-time issue with the shift-tab key combination opening a tooltip in the console but haven't been able to replicate it.