### PR TITLE
fix: highlight tab focused buttons and Dir List

### DIFF
--- a/packages/application/style/buttons.css
+++ b/packages/application/style/buttons.css
@@ -16,6 +16,10 @@ button {
   border-radius: var(--jp-border-radius);
 }
 
+button:focus-visible {
+  border: 1px solid var(--jp-brand-color1);
+}
+
 button.jp-mod-styled.jp-mod-accept {
   background: var(--md-blue-500);
   border: 0;

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -91,6 +91,12 @@
 
 .jp-FileBrowser-toolbar.jp-Toolbar
   .jp-Toolbar-item:first-child
+  .jp-ToolbarButtonComponent:focus-visible {
+  background-color: var(--jp-brand-color0);
+}
+
+.jp-FileBrowser-toolbar.jp-Toolbar
+  .jp-Toolbar-item:first-child
   .jp-ToolbarButtonComponent
   .jp-icon3 {
   fill: white;
@@ -127,6 +133,10 @@
   display: flex;
   flex-direction: column;
   outline: 0;
+}
+
+.jp-DirListing:focus-visible {
+  border: 1px solid var(--jp-brand-color1);
 }
 
 .jp-DirListing-header {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

Fix https://github.com/jupyterlab/jupyterlab/issues/10152

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Add styles to make tab focused buttons and Dir List visible.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Load the page and press Tab, every press focuses on one element, which are highlighted in order.

(url bar) --> Dir List --> Launcher --> Toolbar --> Switcher --> (url bar)

<!-- For visual changes, include before and after screenshots here. -->
See before in https://github.com/jupyterlab/jupyterlab/issues/10152

After

https://user-images.githubusercontent.com/11983489/115981266-5909af00-a547-11eb-8ad0-b39b5a8956a8.mov

Binder https://hub-binder.mybinder.ovh/user/0618-jupyterlab-h9ww3u6q/lab-dev/lab



## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
