### PR TITLE
Debugger: Remove all breakpoints should confirm action first

### DIFF
--- a/packages/debugger/src/panels/breakpoints/index.ts
+++ b/packages/debugger/src/panels/breakpoints/index.ts
@@ -39,23 +39,21 @@ export class Breakpoints extends Panel {
       'closeAll',
       new ToolbarButton({
         icon: closeAllIcon,
-        onClick: (): void => {
-          if (service.model.breakpoints.breakpoints.size > 0) {
-            void showDialog({
-              title: trans.__('Remove All Breakpoints'),
-              body: trans.__(
-                'Are you sure you want to remove all breakpoints?'
-              ),
-              buttons: [
-                Dialog.okButton({ label: trans.__('Remove breakpoints') }),
-                Dialog.cancelButton({ label: trans.__('Cancel') })
-              ],
-              hasClose: true
-            }).then(result => {
-              if (result.button.accept) {
-                return service.clearBreakpoints();
-              }
-            });
+        onClick: async (): Promise<void> => {
+          if (model.breakpoints.size === 0) {
+            return;
+          }
+          const result = await showDialog({
+            title: trans.__('Remove All Breakpoints'),
+            body: trans.__('Are you sure you want to remove all breakpoints?'),
+            buttons: [
+              Dialog.okButton({ label: trans.__('Remove breakpoints') }),
+              Dialog.cancelButton({ label: trans.__('Cancel') })
+            ],
+            hasClose: true
+          });
+          if (result.button.accept) {
+            return service.clearBreakpoints();
           }
         },
         tooltip: trans.__('Remove All Breakpoints')

--- a/packages/debugger/src/panels/breakpoints/index.ts
+++ b/packages/debugger/src/panels/breakpoints/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { ToolbarButton } from '@jupyterlab/apputils';
+import { ToolbarButton, Dialog, showDialog } from '@jupyterlab/apputils';
 
 import { nullTranslator, ITranslator } from '@jupyterlab/translation';
 
@@ -40,7 +40,23 @@ export class Breakpoints extends Panel {
       new ToolbarButton({
         icon: closeAllIcon,
         onClick: (): void => {
-          void service.clearBreakpoints();
+          if (service.model.breakpoints.breakpoints.size > 0) {
+            void showDialog({
+              title: trans.__('Remove All Breakpoints'),
+              body: trans.__(
+                'Are you sure you want to remove all breakpoints?'
+              ),
+              buttons: [
+                Dialog.okButton({ label: trans.__('Remove breakpoints') }),
+                Dialog.cancelButton({ label: trans.__('Cancel') })
+              ],
+              hasClose: true
+            }).then(result => {
+              if (result.button.accept) {
+                return service.clearBreakpoints();
+              }
+            });
+          }
         },
         tooltip: trans.__('Remove All Breakpoints')
       })


### PR DESCRIPTION
## References

Fixes item 3 of #10139

## Code changes

## User-facing changes

Confirm choice before clearing breakpoints.

![image](https://user-images.githubusercontent.com/1813603/116132322-6afc6680-a69b-11eb-9a6d-58863d1ea251.png)


## Backwards-incompatible changes

None

CC @jtpio 
