### PR TITLE
Debugger: show callstack clearer with names/ids

### DIFF
--- a/packages/debugger/src/panels/callstack/body.tsx
+++ b/packages/debugger/src/panels/callstack/body.tsx
@@ -63,15 +63,34 @@ const FramesComponent = ({
     };
   }, [model]);
 
+  const toShortLocation = (el: IDebugger.IStackFrame) => {
+    let path = el.source?.path || '';
+    const lastIndex = path.lastIndexOf('/');
+    const secondLastIndex = path.lastIndexOf('/', lastIndex - 1);
+    // If the we end up finding the leading '/', leave it in
+    path = path.substring(secondLastIndex > 0 ? secondLastIndex + 1 : 0);
+    return `${path}:${el.line}`;
+  };
+
   return (
     <ul>
       {frames.map(ele => (
         <li
           key={ele.id}
           onClick={(): void => onSelected(ele)}
-          className={selected?.id === ele.id ? 'selected' : ''}
+          className={
+            selected?.id === ele.id
+              ? 'selected jp-DebuggerCallstackFrame'
+              : 'jp-DebuggerCallstackFrame'
+          }
         >
-          {ele.name} at {ele.source?.name}:{ele.line}
+          <span className={'jp-DebuggerCallstackFrame-name'}>{ele.name}</span>
+          <span
+            className={'jp-DebuggerCallstackFrame-location'}
+            title={ele.source?.path}
+          >
+            {toShortLocation(ele)}
+          </span>
         </li>
       ))}
     </ul>

--- a/packages/debugger/src/panels/callstack/body.tsx
+++ b/packages/debugger/src/panels/callstack/body.tsx
@@ -5,6 +5,8 @@ import { ReactWidget } from '@jupyterlab/apputils';
 
 import React, { useEffect, useState } from 'react';
 
+import { PathExt } from '@jupyterlab/coreutils';
+
 import { IDebugger } from '../../tokens';
 
 /**
@@ -64,12 +66,11 @@ const FramesComponent = ({
   }, [model]);
 
   const toShortLocation = (el: IDebugger.IStackFrame) => {
-    let path = el.source?.path || '';
-    const lastIndex = path.lastIndexOf('/');
-    const secondLastIndex = path.lastIndexOf('/', lastIndex - 1);
-    // If the we end up finding the leading '/', leave it in
-    path = path.substring(secondLastIndex > 0 ? secondLastIndex + 1 : 0);
-    return `${path}:${el.line}`;
+    const path = el.source?.path || '';
+    const base = PathExt.basename(PathExt.dirname(path));
+    const filename = PathExt.basename(path);
+    const shortname = PathExt.join(base, filename);
+    return `${shortname}:${el.line}`;
   };
 
   return (

--- a/packages/debugger/style/breakpoints.css
+++ b/packages/debugger/style/breakpoints.css
@@ -39,6 +39,20 @@
   margin-left: auto;
 }
 
+.jp-DebuggerCallstackFrame {
+  display: flex;
+  align-items: center;
+}
+
+.jp-DebuggerCallstackFrame-name {
+  white-space: nowrap;
+  margin-right: 5px;
+}
+
+.jp-DebuggerCallstackFrame-location {
+  margin-left: auto;
+}
+
 [data-jp-debugger='true'] .CodeMirror-gutter-wrapper::after {
   content: '●';
   color: var(--jp-error-color1);


### PR DESCRIPTION
## References

Fixes #10139, item 8

## Code changes

## User-facing changes

Shows the callstack with shortened module name + line number with improved alignment

![image](https://user-images.githubusercontent.com/1813603/116145469-617afa80-a6ab-11eb-9273-46cf0ace09c5.png)

## Backwards-incompatible changes
N/A

CC @jtpio 