### PR TITLE
Upgrade CodeMirror to 5.61.0 (fixes indentation for Python type hints)

### DIFF
--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -18,7 +18,7 @@
     "es6-promise": "~4.2.8"
   },
   "devDependencies": {
-    "@types/codemirror": "^0.0.97",
+    "@types/codemirror": "^0.0.109",
     "css-loader": "^5.0.1",
     "file-loader": "~6.0.0",
     "mini-css-extract-plugin": "~1.3.2",

--- a/examples/filebrowser/package.json
+++ b/examples/filebrowser/package.json
@@ -22,7 +22,7 @@
     "es6-promise": "~4.2.8"
   },
   "devDependencies": {
-    "@types/codemirror": "^0.0.97",
+    "@types/codemirror": "^0.0.109",
     "css-loader": "^5.0.1",
     "file-loader": "~6.0.0",
     "mini-css-extract-plugin": "~1.3.2",

--- a/examples/notebook/package.json
+++ b/examples/notebook/package.json
@@ -23,7 +23,7 @@
     "es6-promise": "~4.2.8"
   },
   "devDependencies": {
-    "@types/codemirror": "^0.0.97",
+    "@types/codemirror": "^0.0.109",
     "css-loader": "^5.0.1",
     "file-loader": "~6.0.0",
     "mini-css-extract-plugin": "~1.3.2",

--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -48,7 +48,7 @@
     "@jupyterlab/statusbar": "^3.1.0-alpha.5",
     "@jupyterlab/translation": "^3.1.0-alpha.5",
     "@lumino/widgets": "^1.19.0",
-    "codemirror": "~5.57.0"
+    "codemirror": "~5.61.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -54,12 +54,12 @@
     "@lumino/polling": "^1.3.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.19.0",
-    "codemirror": "~5.57.0",
+    "codemirror": "~5.61.0",
     "react": "^17.0.1"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.5",
-    "@types/codemirror": "^0.0.97",
+    "@types/codemirror": "^0.0.109",
     "@types/jest": "^26.0.10",
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",

--- a/packages/debugger-extension/package.json
+++ b/packages/debugger-extension/package.json
@@ -68,7 +68,7 @@
     "@babel/core": "^7.10.2",
     "@babel/preset-env": "^7.10.2",
     "@jupyterlab/testutils": "^3.1.0-alpha.5",
-    "@types/codemirror": "^0.0.97",
+    "@types/codemirror": "^0.0.109",
     "@types/jest": "^26.0.10",
     "@types/react-dom": "^17.0.0",
     "jest": "^26.4.2",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -72,7 +72,7 @@
     "@lumino/messaging": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.19.0",
-    "codemirror": "~5.57.0",
+    "codemirror": "~5.61.0",
     "react": "^17.0.1",
     "vscode-debugprotocol": "^1.37.0"
   },
@@ -80,7 +80,7 @@
     "@babel/core": "^7.10.2",
     "@babel/preset-env": "^7.10.2",
     "@jupyterlab/testutils": "^3.1.0-alpha.5",
-    "@types/codemirror": "^0.0.97",
+    "@types/codemirror": "^0.0.109",
     "@types/jest": "^26.0.10",
     "@types/react-dom": "^17.0.0",
     "@types/text-encoding": "^0.0.35",

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -52,7 +52,7 @@
     "@lumino/polling": "^1.3.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.19.0",
-    "codemirror": "~5.57.0",
+    "codemirror": "~5.61.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3025,10 +3025,10 @@
   resolved "https://registry.yarnpkg.com/@types/clone/-/clone-0.1.30.tgz#e7365648c1b42136a59c7d5040637b3b5c83b614"
   integrity sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=
 
-"@types/codemirror@^0.0.97":
-  version "0.0.97"
-  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.97.tgz#6f2d8266b7f1b34aacfe8c77221fafe324c3d081"
-  integrity sha512-n5d7o9nWhC49DjfhsxANP7naWSeTzrjXASkUDQh7626sM4zK9XP2EVcHp1IcCf/IPV6c7ORzDUDF3Bkt231VKg==
+"@types/codemirror@^0.0.109":
+  version "0.0.109"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-0.0.109.tgz#89d575ff1c7b462c4c3b8654f8bb38e5622e9036"
+  integrity sha512-cSdiHeeLjvGn649lRTNeYrVCDOgDrtP+bDDSFDd1TF+i0jKGPDRozno2NOJ9lTniso+taiv4kiVS8dgM8Jm5lg==
   dependencies:
     "@types/tern" "*"
 
@@ -5445,10 +5445,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@~5.57.0:
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.57.0.tgz#d26365b72f909f5d2dbb6b1209349ca1daeb2d50"
-  integrity sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg==
+codemirror@~5.61.0:
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.61.0.tgz#318e5b034a707207948b92ffc2862195e8fdb08e"
+  integrity sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## References

Fixes issue reported https://github.com/jupyter/notebook/issues/6039 (reproduced in Lab in comments).

- [x] upgrade `codemirror` 5.57.0 → 5.61.0; see: https://github.com/codemirror/CodeMirror/compare/5.57.0...5.61.0 for list of changes
- [x] upgrade `@types/codemirror` 0.0.97 → ^0.0.109
- [x] test that everything works after upgrade
- [x] check whether if fixes other issues like those reported for f-strings

## Code changes

None

## User-facing changes

- Indentation works correctly when using type hints in Python

## Backwards-incompatible changes

May require extensions to release a new versions; I recommend targeting 3.1.