### PR TITLE
Workaround Chromium issue with iframe reload/href

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1045,7 +1045,7 @@ namespace Private {
     renderModel(model: IRenderMime.IMimeModel): Promise<void> {
       return this._wrapped.renderModel(model).then(() => {
         const win = (this.node as HTMLIFrameElement).contentWindow;
-        if (win) {
+        if (win && win.location.href != window.location.href) {
           win.location.reload();
         }
       });

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1043,12 +1043,7 @@ namespace Private {
      * of the widget to update it if and when new data is available.
      */
     renderModel(model: IRenderMime.IMimeModel): Promise<void> {
-      return this._wrapped.renderModel(model).then(() => {
-        const win = (this.node as HTMLIFrameElement).contentWindow;
-        if (win && win.location.href != window.location.href) {
-          win.location.reload();
-        }
-      });
+      return this._wrapped.renderModel(model);
     }
 
     private _wrapped: IRenderMime.IRenderer;


### PR DESCRIPTION
## References

Fixes #10121

## Code changes

Remove reload iframe logic. For the original reason for re-loading see: https://github.com/jupyterlab/jupyterlab/pull/3399. The tests with modern browsers indicate that it is no longer necessary (and leads to issues with SVG files in Chrome).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
