### PR TITLE
Topbar menu items importance

### DIFF
--- a/packages/mainmenu-extension/package.json
+++ b/packages/mainmenu-extension/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/coreutils": "^5.1.0-alpha.5",
     "@jupyterlab/mainmenu": "^3.1.0-alpha.5",
     "@jupyterlab/services": "^6.1.0-alpha.5",
+    "@jupyterlab/settingregistry": "^3.1.0-alpha.5",
     "@jupyterlab/translation": "^3.1.0-alpha.5",
     "@lumino/algorithm": "^1.3.3",
     "@lumino/disposable": "^1.4.3",

--- a/packages/mainmenu-extension/schema/plugin.json
+++ b/packages/mainmenu-extension/schema/plugin.json
@@ -78,7 +78,21 @@
       "selector": "body"
     }
   ],
-  "properties": {},
+  "properties": {
+    "hiddenEntries": {
+      "title": "List of command IDs to hide in the main menu",
+      "description": "List of commands IDs for which the menu entry should be hidden - IDs can be found in https://github.com/jupyterlab/jupyterlab/blob/master/packages/mainmenu-extension/src/index.ts.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "examples": [
+        ["notebook:restart-and-run-to-selected", "runmenu:run-below"]
+      ]
+    }
+  },
   "additionalProperties": false,
   "type": "object"
 }

--- a/packages/mainmenu-extension/src/index.ts
+++ b/packages/mainmenu-extension/src/index.ts
@@ -149,25 +149,29 @@ const plugin: JupyterFrontEndPlugin<IMainMenu> = {
     const quitButton = PageConfig.getOption('quitButton').toLowerCase();
     menu.fileMenu.quitEntry = quitButton === 'true';
 
-    app.restored.then(async () => {
-      let settings: ISettingRegistry.ISettings | null = null;
-      try {
-        if (settingRegistry) {
-          settings = await settingRegistry.load(plugin.id);
+    app.restored
+      .then(async () => {
+        let settings: ISettingRegistry.ISettings | null = null;
+        try {
+          if (settingRegistry) {
+            settings = await settingRegistry.load(plugin.id);
+          }
+        } catch (reason) {
+          console.warn(`No setting registry for ${plugin.id}`);
+        } finally {
+          // Create the application menus.
+          createEditMenu(app, menu.editMenu, trans, settings);
+          createFileMenu(app, menu.fileMenu, router, trans, settings);
+          createKernelMenu(app, menu.kernelMenu, trans, settings);
+          createRunMenu(app, menu.runMenu, trans, settings);
+          createSettingsMenu(app, menu.settingsMenu, trans);
+          createViewMenu(app, menu.viewMenu, trans, settings);
+          createHelpMenu(app, menu.helpMenu, trans);
         }
-      } catch (reason) {
-        console.warn(`No setting registry for ${plugin.id}`);
-      } finally {
-        // Create the application menus.
-        createEditMenu(app, menu.editMenu, trans, settings);
-        createFileMenu(app, menu.fileMenu, router, trans, settings);
-        createKernelMenu(app, menu.kernelMenu, trans, settings);
-        createRunMenu(app, menu.runMenu, trans, settings);
-        createSettingsMenu(app, menu.settingsMenu, trans);
-        createViewMenu(app, menu.viewMenu, trans, settings);
-        createHelpMenu(app, menu.helpMenu, trans);
-      }
-    });
+      })
+      .catch(reason => {
+        // Ignore app.restored rejection
+      });
 
     // Set the Tabs Title so it's visible also in other shells
     const tabsMenu = menu.tabsMenu;
@@ -296,7 +300,10 @@ export function createEditMenu(
     }
   });
   menu.addGroup(
-    [{ command: CommandIDs.undo, args: {isMenu: true} }, { command: CommandIDs.redo, args: {isMenu: true} }],
+    [
+      { command: CommandIDs.undo, args: { isMenu: true } },
+      { command: CommandIDs.redo, args: { isMenu: true } }
+    ],
     0
   );
 
@@ -356,7 +363,10 @@ export function createEditMenu(
     }
   });
   menu.addGroup(
-    [{ command: CommandIDs.clearCurrent, args: {isMenu: true} }, { command: CommandIDs.clearAll, args: {isMenu: true} }],
+    [
+      { command: CommandIDs.clearCurrent, args: { isMenu: true } },
+      { command: CommandIDs.clearAll, args: { isMenu: true } }
+    ],
     10
   );
 
@@ -374,7 +384,10 @@ export function createEditMenu(
       return !hiddenEntries.includes(CommandIDs.goToLine);
     }
   });
-  menu.addGroup([{ command: CommandIDs.goToLine, args: {isMenu: true} }], 200);
+  menu.addGroup(
+    [{ command: CommandIDs.goToLine, args: { isMenu: true } }],
+    200
+  );
 }
 
 /**
@@ -640,7 +653,11 @@ export function createKernelMenu(
       menu.kernelUsers,
       'reconnectToKernel'
     ),
-    execute: Private.delegateExecute(app, menu.kernelUsers, 'reconnectToKernel'),
+    execute: Private.delegateExecute(
+      app,
+      menu.kernelUsers,
+      'reconnectToKernel'
+    ),
     isVisible: args => {
       if (!args.isMenu) {
         return true;
@@ -771,20 +788,29 @@ export function createKernelMenu(
     CommandIDs.restartAndRunToSelected,
     CommandIDs.restartAndRunAll
   ].map(command => {
-    return { command, args: {isMenu: true} };
+    return { command, args: { isMenu: true } };
   });
 
-  menu.addGroup([{ command: CommandIDs.interruptKernel, args: {isMenu: true} }], 0);
+  menu.addGroup(
+    [{ command: CommandIDs.interruptKernel, args: { isMenu: true } }],
+    0
+  );
   menu.addGroup(restartGroup, 1);
-  menu.addGroup([{ command: CommandIDs.reconnectToKernel, args: {isMenu: true} }], 1.5);
+  menu.addGroup(
+    [{ command: CommandIDs.reconnectToKernel, args: { isMenu: true } }],
+    1.5
+  );
   menu.addGroup(
     [
-      { command: CommandIDs.shutdownKernel, args: {isMenu: true} },
-      { command: CommandIDs.shutdownAllKernels, args: {isMenu: true} }
+      { command: CommandIDs.shutdownKernel, args: { isMenu: true } },
+      { command: CommandIDs.shutdownAllKernels, args: { isMenu: true } }
     ],
     2
   );
-  menu.addGroup([{ command: CommandIDs.changeKernel, args: {isMenu: true} }], 3);
+  menu.addGroup(
+    [{ command: CommandIDs.changeKernel, args: { isMenu: true } }],
+    3
+  );
 }
 
 /**
@@ -902,7 +928,7 @@ export function createViewMenu(
     CommandIDs.matchBrackets,
     CommandIDs.wordWrap
   ].map(command => {
-    return { command, args: {isMenu: true} };
+    return { command, args: { isMenu: true } };
   });
   menu.addGroup(editorViewerGroup, 10);
 }
@@ -1007,11 +1033,11 @@ export function createRunMenu(
 
   const runAllGroup = [CommandIDs.runAll, CommandIDs.restartAndRunAll].map(
     command => {
-      return { command, args: {isMenu: true} };
+      return { command, args: { isMenu: true } };
     }
   );
 
-  menu.addGroup([{ command: CommandIDs.run, args: {isMenu: true} }], 0);
+  menu.addGroup([{ command: CommandIDs.run, args: { isMenu: true } }], 0);
   menu.addGroup(runAllGroup, 999);
 }
 

--- a/packages/mainmenu-extension/tsconfig.json
+++ b/packages/mainmenu-extension/tsconfig.json
@@ -4,9 +4,7 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": [
-    "src/*"
-  ],
+  "include": ["src/*"],
   "references": [
     {
       "path": "../application"

--- a/packages/mainmenu-extension/tsconfig.json
+++ b/packages/mainmenu-extension/tsconfig.json
@@ -4,7 +4,9 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src/*"],
+  "include": [
+    "src/*"
+  ],
   "references": [
     {
       "path": "../application"
@@ -20,6 +22,9 @@
     },
     {
       "path": "../services"
+    },
+    {
+      "path": "../settingregistry"
     },
     {
       "path": "../translation"

--- a/packages/mainmenu/src/kernel.ts
+++ b/packages/mainmenu/src/kernel.ts
@@ -86,7 +86,7 @@ export namespace IKernelMenu {
      * A function to return the label associated to the `restartKernelAndClear` action.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     restartKernelAndClearLabel?: (n: number) => string;
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

This is a first trial to fix #10091.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

I followed the suggestion of @jasongrout and define a setting in the `mainmenu-extension` package that is used to set the `isVisible` callback on command.

This is not fully satisfactory as not all commands are defined in the `mainmenu-extension` package. For example the _restart kernel and run up to selected cell_ cannot be hidden as it is define in the notebook package. I therefore wonder if it could be directly implemented in lumino by adding the ability to customize (aka hide or not) menu item independently of the `isVisible` command method. Then the `mainmenu-extension` would update the menu item visibility when the setting is changed.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

None by default

Example:
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/8435071/116986331-f1353000-accd-11eb-8e1c-34abcda7db73.png) | ![image](https://user-images.githubusercontent.com/8435071/116986260-d95dac00-accd-11eb-94a4-d5f4d4684578.png) |


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

None