### PR TITLE
Move open-with to its own plugin, so it can be disabled independently.

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -544,7 +544,7 @@ const openWithPlugin: JupyterFrontEndPlugin<void> = {
   activate: (
     app: JupyterFrontEnd,
     factory: IFileBrowserFactory,
-    translator: ITranslator,
+    translator: ITranslator
   ): void => {
     const { docRegistry: registry, commands } = app;
     const trans = translator.load('jupyterlab');

--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -532,6 +532,109 @@ const shareFile: JupyterFrontEndPlugin<void> = {
 };
 
 /**
+ * The "Open With" context menu.
+ *
+ * This is its own plugin in case you would like to disable this feature.
+ * e.g. jupyter labextension disable fort_disable_download:open-with
+ */
+const openWithPlugin: JupyterFrontEndPlugin<void> = {
+  id: '@jupyterlab/filebrowser-extension:open-with',
+  requires: [IFileBrowserFactory, ITranslator],
+  autoStart: true,
+  activate: (
+    app: JupyterFrontEnd,
+    factory: IFileBrowserFactory,
+    translator: ITranslator,
+  ): void => {
+    const { docRegistry: registry, commands } = app;
+    const trans = translator.load('jupyterlab');
+    const { tracker } = factory;
+    // matches only non-directory items
+    const selectorNotDir = '.jp-DirListing-item[data-isdir="false"]';
+
+    /**
+     * A menu widget that dynamically populates with different widget factories
+     * based on current filebrowser selection.
+     */
+    class OpenWithMenu extends Menu {
+      protected onBeforeAttach(msg: Message): void {
+        // clear the current menu items
+        this.clearItems();
+
+        // get the widget factories that could be used to open all of the items
+        // in the current filebrowser selection
+        const factories = tracker.currentWidget
+          ? OpenWithMenu._intersection(
+              map(tracker.currentWidget.selectedItems(), i => {
+                return OpenWithMenu._getFactories(i);
+              })
+            )
+          : undefined;
+
+        if (factories) {
+          // make new menu items from the widget factories
+          factories.forEach(factory => {
+            this.addItem({
+              args: { factory: factory },
+              command: CommandIDs.open
+            });
+          });
+        }
+
+        super.onBeforeAttach(msg);
+      }
+
+      static _getFactories(item: Contents.IModel): Array<string> {
+        const factories = registry
+          .preferredWidgetFactories(item.path)
+          .map(f => f.name);
+        const notebookFactory = registry.getWidgetFactory('notebook')?.name;
+        if (
+          notebookFactory &&
+          item.type === 'notebook' &&
+          factories.indexOf(notebookFactory) === -1
+        ) {
+          factories.unshift(notebookFactory);
+        }
+
+        return factories;
+      }
+
+      static _intersection<T>(iter: IIterator<Array<T>>): Set<T> | void {
+        // pop the first element of iter
+        const first = iter.next();
+        // first will be undefined if iter is empty
+        if (!first) {
+          return;
+        }
+
+        // "initialize" the intersection from first
+        const isect = new Set(first);
+        // reduce over the remaining elements of iter
+        return reduce(
+          iter,
+          (isect, subarr) => {
+            // filter out all elements not present in both isect and subarr,
+            // accumulate result in new set
+            return new Set(subarr.filter(x => isect.has(x)));
+          },
+          isect
+        );
+      }
+    }
+
+    const openWith = new OpenWithMenu({ commands });
+    openWith.title.label = trans.__('Open With');
+    app.contextMenu.addItem({
+      type: 'submenu',
+      submenu: openWith,
+      selector: selectorNotDir,
+      rank: 2
+    });
+  }
+};
+
+/**
  * A plugin providing file upload status.
  */
 export const fileUploadStatus: JupyterFrontEndPlugin<void> = {
@@ -978,77 +1081,6 @@ function addCommands(
     });
   }
 
-  /**
-   * A menu widget that dynamically populates with different widget factories
-   * based on current filebrowser selection.
-   */
-  class OpenWithMenu extends Menu {
-    protected onBeforeAttach(msg: Message): void {
-      // clear the current menu items
-      this.clearItems();
-
-      // get the widget factories that could be used to open all of the items
-      // in the current filebrowser selection
-      const factories = tracker.currentWidget
-        ? OpenWithMenu._intersection(
-            map(tracker.currentWidget.selectedItems(), i => {
-              return OpenWithMenu._getFactories(i);
-            })
-          )
-        : undefined;
-
-      if (factories) {
-        // make new menu items from the widget factories
-        factories.forEach(factory => {
-          this.addItem({
-            args: { factory: factory },
-            command: CommandIDs.open
-          });
-        });
-      }
-
-      super.onBeforeAttach(msg);
-    }
-
-    static _getFactories(item: Contents.IModel): Array<string> {
-      const factories = registry
-        .preferredWidgetFactories(item.path)
-        .map(f => f.name);
-      const notebookFactory = registry.getWidgetFactory('notebook')?.name;
-      if (
-        notebookFactory &&
-        item.type === 'notebook' &&
-        factories.indexOf(notebookFactory) === -1
-      ) {
-        factories.unshift(notebookFactory);
-      }
-
-      return factories;
-    }
-
-    static _intersection<T>(iter: IIterator<Array<T>>): Set<T> | void {
-      // pop the first element of iter
-      const first = iter.next();
-      // first will be undefined if iter is empty
-      if (!first) {
-        return;
-      }
-
-      // "initialize" the intersection from first
-      const isect = new Set(first);
-      // reduce over the remaining elements of iter
-      return reduce(
-        iter,
-        (isect, subarr) => {
-          // filter out all elements not present in both isect and subarr,
-          // accumulate result in new set
-          return new Set(subarr.filter(x => isect.has(x)));
-        },
-        isect
-      );
-    }
-  }
-
   // matches anywhere on filebrowser
   const selectorContent = '.jp-DirListing-content';
   // matches all filebrowser items
@@ -1086,15 +1118,6 @@ function addCommands(
     command: CommandIDs.open,
     selector: selectorItem,
     rank: 1
-  });
-
-  const openWith = new OpenWithMenu({ commands });
-  openWith.title.label = trans.__('Open With');
-  app.contextMenu.addItem({
-    type: 'submenu',
-    submenu: openWith,
-    selector: selectorNotDir,
-    rank: 2
   });
 
   app.contextMenu.addItem({
@@ -1295,6 +1318,7 @@ const plugins: JupyterFrontEndPlugin<any>[] = [
   fileUploadStatus,
   downloadPlugin,
   browserWidget,
-  launcherToolbarButton
+  launcherToolbarButton,
+  openWithPlugin
 ];
 export default plugins;


### PR DESCRIPTION
## References

Related to issue: [5274](https://github.com/jupyterlab/jupyterlab/issues/5274)
Related to PR: [10066](https://github.com/jupyterlab/jupyterlab/pull/10066) . 

This effectively builds on the logic proposed in issue: 5274, and introduced by Diane in PR 10066. This moves the "Open With" context menu into its own plugin, such that it can be disabled.

I've related this to the existing issue as it's using the same approach, and in our case, is used to prevent users opening a notebooks as raw text (for copy/paste).

## Code changes

Moves the open-with context menu into a plugin. No intentional changes to the logic itself.

## User-facing changes

None by default (with the extension enabled).

![Screen Shot 2021-05-04 at 8 05 16 PM](https://user-images.githubusercontent.com/49305/117093359-90314a80-ad15-11eb-9c0f-823a02c3bf7f.png)

Note the open-with context menu is present.

But if you run:

```
jupyter labextension disable @jupyterlab/filebrowser-extension:open-with
```

You'll see the context menu is now gone (as intended).

![Screen Shot 2021-05-04 at 8 06 03 PM](https://user-images.githubusercontent.com/49305/117093317-6d069b00-ad15-11eb-8a28-0862a30d48ee.png)

## Backwards-incompatible changes

None.
