### PR TITLE
Restore the relative sizes of areas in split panel

### DIFF
--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -166,7 +166,8 @@ export class LayoutRestorer implements ILayoutRestorer {
       fresh: true,
       mainArea: null,
       leftArea: null,
-      rightArea: null
+      rightArea: null,
+      relativeSizes: null
     };
     const layout = this._connector.fetch(KEY);
 
@@ -177,7 +178,7 @@ export class LayoutRestorer implements ILayoutRestorer {
         return blank;
       }
 
-      const { main, left, right } = data as Private.ILayout;
+      const { main, left, right, relativeSizes } = data as Private.ILayout;
 
       // If any data exists, then this is not a fresh session.
       const fresh = false;
@@ -191,7 +192,13 @@ export class LayoutRestorer implements ILayoutRestorer {
       // Rehydrate right area.
       const rightArea = this._rehydrateSideArea(right);
 
-      return { fresh, mainArea, leftArea, rightArea };
+      return {
+        fresh,
+        mainArea,
+        leftArea,
+        rightArea,
+        relativeSizes: relativeSizes || null
+      };
     } catch (error) {
       return blank;
     }
@@ -278,6 +285,7 @@ export class LayoutRestorer implements ILayoutRestorer {
     dehydrated.main = this._dehydrateMainArea(data.mainArea);
     dehydrated.left = this._dehydrateSideArea(data.leftArea);
     dehydrated.right = this._dehydrateSideArea(data.rightArea);
+    dehydrated.relativeSizes = data.relativeSizes;
 
     return this._connector.save(KEY, dehydrated);
   }
@@ -441,6 +449,11 @@ namespace Private {
      * The right area of the user interface.
      */
     right?: ISideArea | null;
+
+    /**
+     * The relatives sizes of the areas of the user interface.
+     */
+    relativeSizes?: number[] | null;
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -153,6 +153,11 @@ export namespace ILabShell {
      * The right area of the user interface.
      */
     readonly rightArea: ISideArea | null;
+
+    /**
+     * The relatives sizes of the areas of the user interface.
+     */
+    readonly relativeSizes: number[] | null;
   }
 
   /**
@@ -218,7 +223,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     const dockPanel = (this._dockPanel = new DockPanelSvg());
     MessageLoop.installMessageHook(dockPanel, this._dockChildHook);
 
-    const hsplitPanel = new SplitPanel();
+    const hsplitPanel = (this._hsplitPanel = new Private.RestorableSplitPanel());
     const leftHandler = (this._leftHandler = new Private.SideBarHandler());
     const rightHandler = (this._rightHandler = new Private.SideBarHandler());
     const rootLayout = new BoxLayout();
@@ -288,7 +293,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     rootLayout.spacing = 0; // TODO make this configurable?
     // Use relative sizing to set the width of the side panels.
     // This will still respect the min-size of children widget in the stacked
-    // panel.
+    // panel. The default sizes will be overwritten during layout restoration.
     hsplitPanel.setRelativeSizes([1, 2.5, 1]);
 
     BoxLayout.setStretch(headerPanel, 0);
@@ -324,6 +329,9 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       this._onLayoutModified,
       this
     );
+
+    // Catch update events on the horizontal split panel
+    this._hsplitPanel.updated.connect(this._onLayoutModified, this);
 
     // Setup single-document-mode title bar
     const titleWidgetHandler = (this._titleWidgetHandler = new Private.TitleWidgetHandler(
@@ -763,7 +771,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
    * Restore the layout state for the application shell.
    */
   restoreLayout(mode: DockPanel.Mode, layout: ILabShell.ILayout): void {
-    const { mainArea, leftArea, rightArea } = layout;
+    const { mainArea, leftArea, rightArea, relativeSizes } = layout;
     // Rehydrate the main area.
     if (mainArea) {
       const { currentWidget, dock } = mainArea;
@@ -802,6 +810,11 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       }
     }
 
+    // Restore the relative sizes.
+    if (relativeSizes) {
+      this._hsplitPanel.setRelativeSizes(relativeSizes);
+    }
+
     if (!this._isRestored) {
       // Make sure all messages in the queue are finished before notifying
       // any extensions that are waiting for the promise that guarantees the
@@ -826,7 +839,8 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
             : this._dockPanel.saveLayout()
       },
       leftArea: this._leftHandler.dehydrate(),
-      rightArea: this._rightHandler.dehydrate()
+      rightArea: this._rightHandler.dehydrate(),
+      relativeSizes: this._hsplitPanel.relativeSizes()
     };
     return layout;
   }
@@ -1211,6 +1225,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   private _rightHandler: Private.SideBarHandler;
   private _tracker = new FocusTracker<Widget>();
   private _headerPanel: Panel;
+  private _hsplitPanel: Private.RestorableSplitPanel;
   private _topHandler: Private.PanelHandler;
   private _menuHandler: Private.PanelHandler;
   private _titleWidgetHandler: Private.TitleWidgetHandler;
@@ -1681,5 +1696,22 @@ namespace Private {
     private _shell: ILabShell;
     private _isDisposed: boolean = false;
     private _selected: boolean = false;
+  }
+
+  export class RestorableSplitPanel extends SplitPanel {
+    updated: Signal<RestorableSplitPanel, void>;
+
+    constructor(options: SplitPanel.IOptions = {}) {
+      super(options);
+      this.updated = new Signal(this);
+    }
+
+    /**
+     * Emit 'updated' signal on 'update' requests.
+     */
+    protected onUpdateRequest(msg: Message): void {
+      super.onUpdateRequest(msg);
+      this.updated.emit();
+    }
   }
 }

--- a/packages/application/test/layoutrestorer.spec.ts
+++ b/packages/application/test/layoutrestorer.spec.ts
@@ -61,7 +61,8 @@ describe('apputils', () => {
         const dehydrated: ILabShell.ILayout = {
           mainArea: { currentWidget, dock: null },
           leftArea: { collapsed: true, currentWidget: null, widgets: null },
-          rightArea: { collapsed: true, currentWidget: null, widgets: null }
+          rightArea: { collapsed: true, currentWidget: null, widgets: null },
+          relativeSizes: null
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);
@@ -100,7 +101,8 @@ describe('apputils', () => {
             collapsed: true,
             widgets: [currentWidget]
           },
-          rightArea: { collapsed: true, currentWidget: null, widgets: null }
+          rightArea: { collapsed: true, currentWidget: null, widgets: null },
+          relativeSizes: null
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);
@@ -153,7 +155,8 @@ describe('apputils', () => {
         const dehydrated: ILabShell.ILayout = {
           mainArea: { currentWidget: null, dock: null },
           leftArea: { currentWidget: null, collapsed: true, widgets: null },
-          rightArea: { collapsed: true, currentWidget: null, widgets: null }
+          rightArea: { collapsed: true, currentWidget: null, widgets: null },
+          relativeSizes: null
         };
 
         await expect(restorer.save(dehydrated)).rejects.toBe(
@@ -178,7 +181,8 @@ describe('apputils', () => {
             collapsed: true,
             widgets: [currentWidget]
           },
-          rightArea: { collapsed: true, currentWidget: null, widgets: null }
+          rightArea: { collapsed: true, currentWidget: null, widgets: null },
+          relativeSizes: null
         };
         restorer.add(currentWidget, 'test-one');
         ready.resolve(void 0);


### PR DESCRIPTION
## References

Fixes #10180

## Code changes

- adds `relativeSizes` to `ILayout`
- extends `SplitPanel` to `RestorableSplitPanel` to intercept the updates so that we can save the state ech time user resizes the panels (rather than only when other widgets are moved around)

## User-facing changes

The widths of the panels are now restored after refresh/reload.

![resize-demo](https://user-images.githubusercontent.com/5832902/117177779-4dc94580-adc9-11eb-9785-194069ea4d12.gif)

## Backwards-incompatible changes

- possibly `ILabShell.ILayout`