### PR TITLE
Debugger: show button shortcuts in tooltips

### DIFF
--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -670,7 +670,13 @@ namespace Private {
     if (!commands.isVisible(id, args)) {
       className += ' lm-mod-hidden';
     }
-    const tooltip = commands.caption(id, args) || label || iconLabel;
+    let tooltip = commands.caption(id, args) || label || iconLabel;
+    // Shows hot keys in tooltips
+    const binding = commands.keyBindings.find(b => b.command === id);
+    if (binding) {
+      const ks = CommandRegistry.formatKeystroke(binding.keys.join(' '));
+      tooltip = `${tooltip} (${ks})`;
+    }
     const onClick = () => {
       void commands.execute(id, args);
     };


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

Related to https://github.com/jupyterlab/jupyterlab/issues/10139

>10. Make the hotkeys for the debugger more obvious by showing them in the tooltip on the various button

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Before:
![Screen Recording 2021-05-05 at 6 55 10 PM](https://user-images.githubusercontent.com/22648112/117231470-1ad87f00-add4-11eb-8bad-035895713109.gif)

Now: 
![Screen Recording 2021-05-05 at 6 58 23 PM](https://user-images.githubusercontent.com/22648112/117231480-1dd36f80-add4-11eb-8bd7-63bf6ad44465.gif)

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
