### PR TITLE
Remove installing `notebook` from the contributing guide

### DIFF
--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -137,15 +137,7 @@ To check which version of Node.js is installed:
 Installing JupyterLab
 ---------------------
 
-JupyterLab requires Jupyter Notebook version 4.3 or later.
-
-If you use ``conda``, you can install notebook using:
-
-.. code:: bash
-
-   conda install -c conda-forge notebook
-
-You may also want to install ``nb_conda_kernels`` to have a kernel
+If you use ``conda``, you may also want to install ``nb_conda_kernels`` to have a kernel
 option for different `conda
 environments <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__
 
@@ -153,17 +145,10 @@ environments <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/ma
 
    conda install -c conda-forge nb_conda_kernels
 
-If you use ``pip``, you can install notebook using:
-
-.. code:: bash
-
-   pip install notebook
-
 Fork the JupyterLab
 `repository <https://github.com/jupyterlab/jupyterlab>`__.
 
-Once you have installed the dependencies mentioned above, use the
-following steps:
+Then use the following steps:
 
 .. code:: bash
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

`notebook` is not strictly required anymore, and can be removed from the contributing guide to simplify the process a little bit.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Documentation.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
