### PR TITLE
Add new widget area below the dockpanel

### DIFF
--- a/docs/source/extension/extension_points.rst
+++ b/docs/source/extension/extension_points.rst
@@ -416,6 +416,7 @@ In JupyterLab, the application shell consists of:
 -  A ``menu`` area for top-level menus, which is collapsed into the ``top`` area in multiple-document mode and put below it in single-document mode.
 -  ``left`` and ``right`` sidebar areas for collapsible content.
 -  A ``main`` work area for user activity.
+-  A ``down`` area for information content; like log console, contextual help.
 -  A ``bottom`` area for things like status bars.
 -  A ``header`` area for custom elements.
 

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -17,7 +17,7 @@ import { Token } from '@lumino/coreutils';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
-import { Widget } from '@lumino/widgets';
+import { DockPanel, Widget } from '@lumino/widgets';
 
 /**
  * The type for all JupyterFrontEnd application plugins.
@@ -282,6 +282,11 @@ export namespace JupyterFrontEnd {
      * or "focused" mean, depending on their user interface characteristics.
      */
     readonly currentWidget: Widget | null;
+
+    /**
+     * The user interface mode.
+     */
+    readonly mode: DockPanel.Mode;
 
     /**
      * Returns an iterator for the widgets inside the application shell.

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -342,7 +342,7 @@ export class LayoutRestorer implements ILayoutRestorer {
 
     const dehydrated: Private.IDownArea = {
       size: area.size
-    }
+    };
 
     if (area.currentWidget) {
       const current = Private.nameProperty.get(area.currentWidget);
@@ -356,7 +356,7 @@ export class LayoutRestorer implements ILayoutRestorer {
         .map(widget => Private.nameProperty.get(widget))
         .filter(name => !!name);
     }
-    
+
     return dehydrated;
   }
 

--- a/packages/application/src/layoutrestorer.ts
+++ b/packages/application/src/layoutrestorer.ts
@@ -165,6 +165,7 @@ export class LayoutRestorer implements ILayoutRestorer {
     const blank: ILabShell.ILayout = {
       fresh: true,
       mainArea: null,
+      downArea: null,
       leftArea: null,
       rightArea: null,
       relativeSizes: null
@@ -178,13 +179,22 @@ export class LayoutRestorer implements ILayoutRestorer {
         return blank;
       }
 
-      const { main, left, right, relativeSizes } = data as Private.ILayout;
+      const {
+        main,
+        down,
+        left,
+        right,
+        relativeSizes
+      } = data as Private.ILayout;
 
       // If any data exists, then this is not a fresh session.
       const fresh = false;
 
       // Rehydrate main area.
       const mainArea = this._rehydrateMainArea(main);
+
+      // Rehydrate down area.
+      const downArea = this._rehydrateDownArea(down);
 
       // Rehydrate left area.
       const leftArea = this._rehydrateSideArea(left);
@@ -195,6 +205,7 @@ export class LayoutRestorer implements ILayoutRestorer {
       return {
         fresh,
         mainArea,
+        downArea,
         leftArea,
         rightArea,
         relativeSizes: relativeSizes || null
@@ -316,6 +327,17 @@ export class LayoutRestorer implements ILayoutRestorer {
       return null;
     }
     return Private.deserializeMain(area, this._widgets);
+  }
+
+  private _rehydrateDownArea(
+    area?: Private.IDownArea | null
+  ): ILabShell.IDownArea | null {
+    if (!area) {
+      return null;
+    }
+
+    // TODO
+    return null;
   }
 
   /**
@@ -441,6 +463,11 @@ namespace Private {
     main?: IMainArea | null;
 
     /**
+     * The down area of the user interface
+     */
+    down?: IDownArea | null;
+
+    /**
      * The left area of the user interface.
      */
     left?: ISideArea | null;
@@ -514,6 +541,21 @@ namespace Private {
      * The index of the selected tab.
      */
     currentIndex: number;
+  }
+
+  /**
+   *
+   */
+  export interface IDownArea extends PartialJSONObject {
+    /**
+     * The current widget that has application focus.
+     */
+    current?: string | null;
+
+    /**
+     *
+     */
+    stack?: ITabArea | null;
   }
 
   /**

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -148,6 +148,11 @@ export namespace ILabShell {
     readonly mainArea: IMainArea | null;
 
     /**
+     * The down area of the user interface.
+     */
+    readonly downArea: IDownArea | null;
+
+    /**
      * The left area of the user interface.
      */
     readonly leftArea: ISideArea | null;
@@ -176,6 +181,17 @@ export namespace ILabShell {
      * The contents of the main application dock panel.
      */
     readonly dock: DockLayout.ILayoutConfig | null;
+  }
+
+  export interface IDownArea {
+    /**
+     * The current widget that has down area focus.
+     */
+    readonly currentWidget: Widget | null;
+    /**
+     * 
+     */
+    readonly stack: DockLayout.ITabAreaConfig | null;
   }
 
   /**
@@ -870,6 +886,10 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
           this.mode === 'single-document'
             ? this._cachedLayout || this._dockPanel.saveLayout()
             : this._dockPanel.saveLayout()
+      },
+      downArea: {
+        currentWidget: this._downPanel.currentWidget,
+        stack: null // TODO
       },
       leftArea: this._leftHandler.dehydrate(),
       rightArea: this._rightHandler.dehydrate(),

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -252,7 +252,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     const bottomPanel = (this._bottomPanel = new BoxPanel());
     bottomPanel.node.setAttribute('role', 'contentinfo');
     const hboxPanel = new BoxPanel();
-    const vsplitPanel = (this._vsplitPanel = new SplitPanel());
+    const vsplitPanel = (this._vsplitPanel = new Private.RestorableSplitPanel());
     const dockPanel = (this._dockPanel = new DockPanelSvg());
     MessageLoop.installMessageHook(dockPanel, this._dockChildHook);
 
@@ -368,7 +368,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     this._dockPanel.layoutModified.connect(this._onLayoutModified, this);
 
     // Connect vsplit layout change listener
-    MessageLoop.installMessageHook(vsplitPanel, this._vsplitChangeHook);
+    this._vsplitPanel.updated.connect(this._onLayoutModified, this);
 
     // Connect down panel change listeners
     this._downPanel.currentChanged.connect(this._onLayoutModified, this);
@@ -1378,24 +1378,6 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     return true;
   };
 
-  /**
-   * A message hook for update messages on the main vertical split panel.
-   */
-  private _vsplitChangeHook = (
-    handler: IMessageHandler,
-    msg: Message
-  ): boolean => {
-    switch (msg.type) {
-      case 'update-request':
-        // Save down area size
-        this._onLayoutModified();
-        break;
-      default:
-        break;
-    }
-    return true;
-  };
-
   private _activeChanged = new Signal<this, ILabShell.IChangedArgs>(this);
   private _cachedLayout: DockLayout.ILayoutConfig | null = null;
   private _currentChanged = new Signal<this, ILabShell.IChangedArgs>(this);
@@ -1407,7 +1389,6 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   private _modeChanged = new Signal<this, DockPanel.Mode>(this);
   private _dockPanel: DockPanel;
   private _downPanel: TabPanel;
-  private _vsplitPanel: SplitPanel;
   private _isRestored = false;
   private _layoutModified = new Signal<this, void>(this);
   private _layoutDebouncer = new Debouncer(() => {
@@ -1419,6 +1400,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   private _tracker = new FocusTracker<Widget>();
   private _headerPanel: Panel;
   private _hsplitPanel: Private.RestorableSplitPanel;
+  private _vsplitPanel: Private.RestorableSplitPanel;
   private _topHandler: Private.PanelHandler;
   private _menuHandler: Private.PanelHandler;
   private _skipLinkWidgetHandler: Private.SkipLinkWidgetHandler;

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -368,8 +368,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     this._dockPanel.layoutModified.connect(this._onLayoutModified, this);
 
     // Connect vsplit layout change listener
-    // TODO needs change in lumino SplitLayout
-    // this._vsplitPanel.layoutModified.connect(this._onLayoutModified, this);
+    MessageLoop.installMessageHook(vsplitPanel, this._vsplitChangeHook);
 
     // Connect down panel change listeners
     this._downPanel.currentChanged.connect(this._onLayoutModified, this);
@@ -548,7 +547,6 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       (this.layout as BoxLayout).insertWidget(2, this._menuHandler.panel);
       this._titleWidgetHandler.show();
       this._updateTitlePanelTitle();
-
     } else {
       // Cache a reference to every widget currently in the dock panel.
       const widgets = toArray(dock.widgets());
@@ -1373,6 +1371,24 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       case 'child-removed':
         (msg as Widget.ChildMessage).child.removeClass(ACTIVITY_CLASS);
         this._tracker.remove((msg as Widget.ChildMessage).child);
+        break;
+      default:
+        break;
+    }
+    return true;
+  };
+
+  /**
+   * A message hook for update messages on the main vertical split panel.
+   */
+  private _vsplitChangeHook = (
+    handler: IMessageHandler,
+    msg: Message
+  ): boolean => {
+    switch (msg.type) {
+      case 'update-request':
+        // Save down area size
+        this._onLayoutModified();
         break;
       default:
         break;

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -618,11 +618,11 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
       return;
     }
 
-    const downWidget = this._downPanel.stackedPanel.widgets.find(
-      widget => widget.id === id
+    const tabIndex = this._downPanel.tabBar.titles.findIndex(
+      title => title.owner.id === id
     );
-    if (downWidget) {
-      downWidget.activate();
+    if (tabIndex >= 0) {
+      this._downPanel.currentIndex = tabIndex;
       return;
     }
 

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -303,7 +303,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     dockPanel.node.setAttribute('role', 'main');
 
     hboxPanel.spacing = 0;
-    vsplitPanel.spacing = 0;
+    vsplitPanel.spacing = 5;
     dockPanel.spacing = 5;
     hsplitPanel.spacing = 1;
 
@@ -373,9 +373,9 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
 
     // Connect down panel change listeners
     this._downPanel.currentChanged.connect(this._onLayoutModified, this);
-    this._downPanel.tabBar.tabMoved.connect(this._onDownPanelChanged, this);
+    this._downPanel.tabBar.tabMoved.connect(this._onTabPanelChanged, this);
     this._downPanel.stackedPanel.widgetRemoved.connect(
-      this._onDownPanelChanged,
+      this._onTabPanelChanged,
       this
     );
 
@@ -1344,7 +1344,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   /**
    * Handle a change on the down panel widgets
    */
-  private _onDownPanelChanged(): void {
+  private _onTabPanelChanged(): void {
     if (this._downPanel.stackedPanel.widgets.length === 0) {
       this._downPanel.hide();
     }

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -269,7 +269,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     topHandler.panel.id = 'jp-top-panel';
     bottomPanel.id = 'jp-bottom-panel';
     hboxPanel.id = 'jp-main-content-panel';
-    vsplitPanel.id = 'jp-main-down-panel';
+    vsplitPanel.id = 'jp-main-vsplit-panel';
     dockPanel.id = 'jp-main-dock-panel';
     hsplitPanel.id = 'jp-main-split-panel';
     downPanel.id = 'jp-down-stack';
@@ -303,7 +303,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     dockPanel.node.setAttribute('role', 'main');
 
     hboxPanel.spacing = 0;
-    vsplitPanel.spacing = 5;
+    vsplitPanel.spacing = 1;
     dockPanel.spacing = 5;
     hsplitPanel.spacing = 1;
 
@@ -316,22 +316,23 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     SplitPanel.setStretch(leftHandler.stackedPanel, 0);
     SplitPanel.setStretch(downPanel, 0);
     SplitPanel.setStretch(dockPanel, 1);
-    SplitPanel.setStretch(vsplitPanel, 1);
     SplitPanel.setStretch(rightHandler.stackedPanel, 0);
 
     BoxPanel.setStretch(leftHandler.sideBar, 0);
     BoxPanel.setStretch(hsplitPanel, 1);
     BoxPanel.setStretch(rightHandler.sideBar, 0);
 
-    vsplitPanel.addWidget(dockPanel);
-    vsplitPanel.addWidget(downPanel);
+    SplitPanel.setStretch(vsplitPanel, 1);
 
     hsplitPanel.addWidget(leftHandler.stackedPanel);
-    hsplitPanel.addWidget(vsplitPanel);
+    hsplitPanel.addWidget(dockPanel);
     hsplitPanel.addWidget(rightHandler.stackedPanel);
 
+    vsplitPanel.addWidget(hsplitPanel);
+    vsplitPanel.addWidget(downPanel);
+
     hboxPanel.addWidget(leftHandler.sideBar);
-    hboxPanel.addWidget(hsplitPanel);
+    hboxPanel.addWidget(vsplitPanel);
     hboxPanel.addWidget(rightHandler.sideBar);
 
     rootLayout.direction = 'top-to-bottom';

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -39,20 +39,26 @@ body {
   padding: 0;
 }
 
-#jp-main-dock-panel[data-mode='single-document'] .jp-MainAreaWidget{
+#jp-main-dock-panel[data-mode='single-document'] .jp-MainAreaWidget {
   border: none;
 }
 
-.jp-LabShell[data-shell-mode='single-document'] #jp-down-stack .lm-TabPanel-stackedPanel {
+.jp-LabShell[data-shell-mode='single-document']
+  #jp-down-stack
+  .lm-TabPanel-stackedPanel {
   border-left: none;
   border-right: none;
 }
 
-.jp-LabShell[data-shell-mode='single-document'] #jp-down-stack .lm-TabBar-tab:first-child {
+.jp-LabShell[data-shell-mode='single-document']
+  #jp-down-stack
+  .lm-TabBar-tab:first-child {
   border-left: none;
 }
 
-.jp-LabShell[data-shell-mode='single-document'] #jp-down-stack .lm-TabBar-tab:last-child {
+.jp-LabShell[data-shell-mode='single-document']
+  #jp-down-stack
+  .lm-TabBar-tab:last-child {
   border-right: none;
 }
 

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -35,16 +35,30 @@ body {
   padding: 5px;
 }
 
-#jp-main-dock-panel[data-mode='single-document'] {
+#jp-down-stack {
+  padding: 0px 5px 5px 5px;
+}
+
+#jp-main-dock-panel[data-mode='single-document'],
+.jp-LabShell[data-shell-mode='single-document'] #jp-down-stack {
   padding: 0;
 }
 
-#jp-main-dock-panel[data-mode='single-document'] .jp-MainAreaWidget {
+#jp-main-dock-panel[data-mode='single-document'] .jp-MainAreaWidget{
   border: none;
 }
 
-#jp-down-stack {
-  padding: 0px 5px 5px 5px;
+.jp-LabShell[data-shell-mode='single-document'] #jp-down-stack .lm-TabPanel-stackedPanel {
+  border-left: none;
+  border-right: none;
+}
+
+.jp-LabShell[data-shell-mode='single-document'] #jp-down-stack .lm-TabBar-tab:first-child {
+  border-left: none;
+}
+
+.jp-LabShell[data-shell-mode='single-document'] #jp-down-stack .lm-TabBar-tab:last-child {
+  border-right: none;
 }
 
 #jp-top-panel {

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -43,6 +43,10 @@ body {
   border: none;
 }
 
+#jp-down-stack {
+  padding: 0px 5px 5px 5px;
+}
+
 #jp-top-panel {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color0);
   background: var(--jp-layout-color1);

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -31,16 +31,11 @@ body {
   border-top: 4px solid red;
 }
 
-#jp-main-dock-panel {
+#jp-main-down-panel {
   padding: 5px;
 }
 
-#jp-down-stack {
-  padding: 0px 5px 5px 5px;
-}
-
-#jp-main-dock-panel[data-mode='single-document'],
-.jp-LabShell[data-shell-mode='single-document'] #jp-down-stack {
+.jp-LabShell[data-shell-mode='single-document'] #jp-main-down-panel {
   padding: 0;
 }
 

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -31,35 +31,8 @@ body {
   border-top: 4px solid red;
 }
 
-#jp-main-down-panel {
-  padding: 5px;
-}
-
-.jp-LabShell[data-shell-mode='single-document'] #jp-main-down-panel {
-  padding: 0;
-}
-
 #jp-main-dock-panel[data-mode='single-document'] .jp-MainAreaWidget {
   border: none;
-}
-
-.jp-LabShell[data-shell-mode='single-document']
-  #jp-down-stack
-  .lm-TabPanel-stackedPanel {
-  border-left: none;
-  border-right: none;
-}
-
-.jp-LabShell[data-shell-mode='single-document']
-  #jp-down-stack
-  .lm-TabBar-tab:first-child {
-  border-left: none;
-}
-
-.jp-LabShell[data-shell-mode='single-document']
-  #jp-down-stack
-  .lm-TabBar-tab:last-child {
-  border-right: none;
 }
 
 #jp-top-panel {
@@ -73,6 +46,10 @@ body {
 #jp-menu-panel {
   min-height: var(--jp-private-menu-panel-height);
   background: var(--jp-layout-color1);
+}
+
+#jp-down-stack {
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
 }
 
 .jp-LabShell[data-shell-mode='single-document'] #jp-top-panel {

--- a/packages/application/style/dockpanel.css
+++ b/packages/application/style/dockpanel.css
@@ -11,7 +11,8 @@
 | DockPanel
 |----------------------------------------------------------------------------*/
 
-.lm-DockPanel-widget {
+.lm-DockPanel-widget,
+.lm-TabPanel-stackedPanel {
   background: var(--jp-layout-color0);
   border-left: var(--jp-border-width) solid var(--jp-border-color1);
   border-right: var(--jp-border-width) solid var(--jp-border-color1);

--- a/packages/application/style/sidepanel.css
+++ b/packages/application/style/sidepanel.css
@@ -21,17 +21,20 @@
   font-size: var(--jp-ui-font-size1);
 }
 
-.jp-SideBar.lm-TabBar {
+.jp-SideBar.lm-TabBar,
+#jp-down-stack .lm-TabBar {
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color2);
   font-size: var(--jp-ui-font-size1);
+  overflow: visible;
+}
+
+.jp-SideBar.lm-TabBar {
   min-width: calc(var(--jp-private-sidebar-tab-width) + var(--jp-border-width));
   max-width: calc(var(--jp-private-sidebar-tab-width) + var(--jp-border-width));
-  overflow: visible;
   display: block;
 }
 
-.jp-SideBar .lm-TabBar-content,
 .jp-SideBar .lm-TabBar-content {
   margin: 0;
   padding: 0;
@@ -58,7 +61,8 @@
   /* transform: translateY(var(--jp-border-width)); */
 }
 
-.jp-SideBar .lm-TabBar-tab:not(.lm-mod-current) {
+.jp-SideBar .lm-TabBar-tab:not(.lm-mod-current),
+#jp-down-stack .lm-TabBar-tab:not(.lm-mod-current) {
   background: var(--jp-layout-color2);
 }
 
@@ -76,7 +80,8 @@
   line-height: var(--jp-private-sidebar-tab-width);
 }
 
-.jp-SideBar .lm-TabBar-tab:hover:not(.lm-mod-current) {
+.jp-SideBar .lm-TabBar-tab:hover:not(.lm-mod-current),
+#jp-down-stack .lm-TabBar-tab:hover:not(.lm-mod-current) {
   background: var(--jp-layout-color1);
 }
 
@@ -182,11 +187,41 @@
     );
 }
 
+/* Down */
+
+/* Borders */
+
+#jp-down-stack > .lm-TabBar {
+  border-top: var(--jp-border-width) solid var(--jp-border-color0);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color0);
+}
+
+#jp-down-stack > .lm-TabBar .lm-TabBar-tab {
+  border-left: none;
+  border-right: none;
+}
+
+#jp-down-stack > .lm-TabBar .lm-TabBar-tab.lm-mod-current {
+  border: var(--jp-border-width) solid var(--jp-border-color1);
+  border-bottom: none;
+  transform: translateY(var(--jp-border-width));
+}
+
+#jp-down-stack > .lm-TabBar .lm-TabBar-tab.lm-mod-current:first-child {
+  border: none;
+  border-right: var(--jp-border-width) solid var(--jp-border-color1);
+}
+
 /* Stack panels */
 
 #jp-left-stack > .lm-Widget,
 #jp-right-stack > .lm-Widget {
   min-width: var(--jp-sidebar-min-width);
+}
+
+.jp-LabShell[data-shell-mode='multiple-document'] #jp-left-stack > .lm-Widget,
+.jp-LabShell[data-shell-mode='multiple-document'] #jp-right-stack > .lm-Widget {
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
 }
 
 #jp-right-stack {
@@ -195,4 +230,8 @@
 
 #jp-left-stack {
   border-right: var(--jp-border-width) solid var(--jp-border-color1);
+}
+
+#jp-down-stack > .lm-TabPanel-stackedPanel {
+  border: none;
 }

--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -83,7 +83,7 @@
 
 /* This is the main application level current tab: only 1 exists. */
 .lm-DockPanel-tabBar .lm-TabBar-tab.jp-mod-current:before,
-.lm-TabPanel-tabBar .lm-TabBar-tab.jp-mod-current:before {
+#jp-down-stack .lm-TabBar-tab.lm-mod-current:before {
   position: absolute;
   top: calc(-1 * var(--jp-border-width) + 1px);
   left: calc(-1 * var(--jp-border-width));

--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -18,14 +18,16 @@
 | Tabs in the dock panel
 |----------------------------------------------------------------------------*/
 
-.lm-DockPanel-tabBar {
+.lm-DockPanel-tabBar,
+.lm-TabPanel-tabBar {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
   overflow: visible;
   color: var(--jp-ui-font-color1);
   font-size: var(--jp-ui-font-size1);
 }
 
-.lm-DockPanel-tabBar[data-orientation='horizontal'] {
+.lm-DockPanel-tabBar[data-orientation='horizontal'],
+.lm-TabPanel-tabBar[data-orientation='horizontal'] {
   min-height: calc(
     var(--jp-private-horizontal-tab-height) + 2 * var(--jp-border-width)
   );
@@ -35,13 +37,15 @@
   min-width: 80px;
 }
 
-.lm-DockPanel-tabBar > .lm-TabBar-content {
+.lm-DockPanel-tabBar > .lm-TabBar-content,
+.lm-TabPanel-tabBar > .lm-TabBar-content {
   align-items: flex-end;
   min-width: 0;
   min-height: 0;
 }
 
-.lm-DockPanel-tabBar .lm-TabBar-tab {
+.lm-DockPanel-tabBar .lm-TabBar-tab,
+.lm-TabPanel-tabBar .lm-TabBar-tab {
   flex: 0 1 var(--jp-private-horizontal-tab-width);
   min-height: calc(
     var(--jp-private-horizontal-tab-height) + var(--jp-border-width)
@@ -56,16 +60,19 @@
   position: relative;
 }
 
-.lm-DockPanel-tabBar .lm-TabBar-tab:hover:not(.lm-mod-current) {
+.lm-DockPanel-tabBar .lm-TabBar-tab:hover:not(.lm-mod-current),
+.lm-TabPanel-tabBar .lm-TabBar-tab:hover:not(.lm-mod-current) {
   background: var(--jp-layout-color1);
 }
 
-.lm-DockPanel-tabBar .lm-TabBar-tab:first-child {
+.lm-DockPanel-tabBar .lm-TabBar-tab:first-child,
+.lm-TabPanel-tabBar .lm-TabBar-tab:first-child {
   margin-left: 0;
 }
 
 /* This is a current tab of a tab bar in the dock panel: each tab bar has 1. */
-.lm-DockPanel-tabBar .lm-TabBar-tab.lm-mod-current {
+.lm-DockPanel-tabBar .lm-TabBar-tab.lm-mod-current,
+.lm-TabPanel-tabBar .lm-TabBar-tab.lm-mod-current {
   background: var(--jp-layout-color1);
   color: var(--jp-ui-font-color0);
   min-height: calc(
@@ -75,7 +82,8 @@
 }
 
 /* This is the main application level current tab: only 1 exists. */
-.lm-DockPanel-tabBar .lm-TabBar-tab.jp-mod-current:before {
+.lm-DockPanel-tabBar .lm-TabBar-tab.jp-mod-current:before,
+.lm-TabPanel-tabBar .lm-TabBar-tab.jp-mod-current:before {
   position: absolute;
   top: calc(-1 * var(--jp-border-width) + 1px);
   left: calc(-1 * var(--jp-border-width));
@@ -126,7 +134,8 @@
 }
 
 .lm-DockPanel-tabBar .lm-TabBar-tab .lm-TabBar-tabIcon,
-.lm-TabBar-tab.lm-mod-drag-image .lm-TabBar-tabIcon {
+.lm-TabBar-tab.lm-mod-drag-image .lm-TabBar-tabIcon,
+.lm-TabPanel-tabBar .lm-TabBar-tab .lm-TabBar-tabIcon {
   width: 14px;
   background-position: left center;
   background-repeat: no-repeat;
@@ -134,7 +143,8 @@
   margin-right: 4px;
 }
 
-.lm-DockPanel-tabBar .lm-TabBar-tab.lm-mod-current .lm-TabBar-tabIcon {
+.lm-DockPanel-tabBar .lm-TabBar-tab.lm-mod-current .lm-TabBar-tabIcon,
+.lm-TabPanel-tabBar .lm-TabBar-tab.lm-mod-current .lm-TabBar-tabIcon {
   margin-bottom: var(--jp-border-width);
 }
 

--- a/packages/application/style/tabs.css
+++ b/packages/application/style/tabs.css
@@ -47,6 +47,7 @@
 .lm-DockPanel-tabBar .lm-TabBar-tab,
 .lm-TabPanel-tabBar .lm-TabBar-tab {
   flex: 0 1 var(--jp-private-horizontal-tab-width);
+  align-items: center;
   min-height: calc(
     var(--jp-private-horizontal-tab-height) + var(--jp-border-width)
   );
@@ -71,8 +72,7 @@
 }
 
 /* This is a current tab of a tab bar in the dock panel: each tab bar has 1. */
-.lm-DockPanel-tabBar .lm-TabBar-tab.lm-mod-current,
-.lm-TabPanel-tabBar .lm-TabBar-tab.lm-mod-current {
+.lm-DockPanel-tabBar .lm-TabBar-tab.lm-mod-current {
   background: var(--jp-layout-color1);
   color: var(--jp-ui-font-color0);
   min-height: calc(
@@ -81,9 +81,13 @@
   transform: translateY(var(--jp-border-width));
 }
 
+.lm-TabPanel-tabBar .lm-TabBar-tab.lm-mod-current {
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color0);
+}
+
 /* This is the main application level current tab: only 1 exists. */
-.lm-DockPanel-tabBar .lm-TabBar-tab.jp-mod-current:before,
-#jp-down-stack .lm-TabBar-tab.lm-mod-current:before {
+.lm-DockPanel-tabBar .lm-TabBar-tab.jp-mod-current:before {
   position: absolute;
   top: calc(-1 * var(--jp-border-width) + 1px);
   left: calc(-1 * var(--jp-border-width));

--- a/packages/application/test/layoutrestorer.spec.ts
+++ b/packages/application/test/layoutrestorer.spec.ts
@@ -50,7 +50,7 @@ describe('apputils', () => {
     });
 
     describe('#add()', () => {
-      it('should add a widget to be tracked by the restorer', async () => {
+      it('should add a widget in the main area to be tracked by the restorer', async () => {
         const ready = new PromiseDelegate<void>();
         const restorer = new LayoutRestorer({
           connector: new StateDB(),
@@ -60,6 +60,7 @@ describe('apputils', () => {
         const currentWidget = new Widget();
         const dehydrated: ILabShell.ILayout = {
           mainArea: { currentWidget, dock: null },
+          downArea: { currentWidget: null, widgets: null, size: null },
           leftArea: { collapsed: true, currentWidget: null, widgets: null },
           rightArea: { collapsed: true, currentWidget: null, widgets: null },
           relativeSizes: null
@@ -70,6 +71,29 @@ describe('apputils', () => {
         await restorer.save(dehydrated);
         const layout = await restorer.fetch();
         expect(layout.mainArea?.currentWidget).toBe(currentWidget);
+      });
+
+      it('should add a widget in the down area to be tracked by the restorer', async () => {
+        const ready = new PromiseDelegate<void>();
+        const restorer = new LayoutRestorer({
+          connector: new StateDB(),
+          first: ready.promise,
+          registry: new CommandRegistry()
+        });
+        const currentWidget = new Widget();
+        const dehydrated: ILabShell.ILayout = {
+          mainArea: { currentWidget: null, dock: null },
+          downArea: { currentWidget, widgets: null, size: null },
+          leftArea: { collapsed: true, currentWidget: null, widgets: null },
+          rightArea: { collapsed: true, currentWidget: null, widgets: null },
+          relativeSizes: null
+        };
+        restorer.add(currentWidget, 'test-one');
+        ready.resolve(void 0);
+        await restorer.restored;
+        await restorer.save(dehydrated);
+        const layout = await restorer.fetch();
+        expect(layout.downArea?.currentWidget).toBe(currentWidget);
       });
     });
 
@@ -96,6 +120,7 @@ describe('apputils', () => {
         const dehydrated: ILabShell.ILayout = {
           fresh: false,
           mainArea: { currentWidget: null, dock: null },
+          downArea: { currentWidget: null, widgets: null, size: null },
           leftArea: {
             currentWidget,
             collapsed: true,
@@ -154,6 +179,7 @@ describe('apputils', () => {
         });
         const dehydrated: ILabShell.ILayout = {
           mainArea: { currentWidget: null, dock: null },
+          downArea: { currentWidget: null, widgets: null, size: null },
           leftArea: { currentWidget: null, collapsed: true, widgets: null },
           rightArea: { collapsed: true, currentWidget: null, widgets: null },
           relativeSizes: null
@@ -176,6 +202,7 @@ describe('apputils', () => {
         const dehydrated: ILabShell.ILayout = {
           fresh: false,
           mainArea: { currentWidget: null, dock: null },
+          downArea: { currentWidget: null, widgets: null, size: null },
           leftArea: {
             currentWidget,
             collapsed: true,

--- a/packages/application/test/layoutrestorer.spec.ts
+++ b/packages/application/test/layoutrestorer.spec.ts
@@ -120,7 +120,7 @@ describe('apputils', () => {
         const dehydrated: ILabShell.ILayout = {
           fresh: false,
           mainArea: { currentWidget: null, dock: null },
-          downArea: { currentWidget: null, widgets: null, size: null },
+          downArea: { currentWidget: null, widgets: null, size: 0 },
           leftArea: {
             currentWidget,
             collapsed: true,
@@ -202,7 +202,7 @@ describe('apputils', () => {
         const dehydrated: ILabShell.ILayout = {
           fresh: false,
           mainArea: { currentWidget: null, dock: null },
-          downArea: { currentWidget: null, widgets: null, size: null },
+          downArea: { currentWidget: null, widgets: null, size: 0 },
           leftArea: {
             currentWidget,
             collapsed: true,

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -82,7 +82,11 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         inspector.content.source = source;
       }
       if (!inspector.isAttached) {
-        shell.add(inspector, 'main', { activate: false });
+        shell.add(
+          inspector,
+          shell.mode === 'multiple-document' ? 'main' : 'down',
+          { activate: shell.mode !== 'multiple-document' }
+        );
       }
       shell.activateById(inspector.id);
       return inspector;

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -82,11 +82,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         inspector.content.source = source;
       }
       if (!inspector.isAttached) {
-        shell.add(
-          inspector,
-          shell.mode === 'multiple-document' ? 'main' : 'down',
-          { activate: shell.mode !== 'multiple-document' }
-        );
+        shell.add(inspector, 'down', { activate: false });
       }
       shell.activateById(inspector.id);
       return inspector;

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -82,7 +82,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         inspector.content.source = source;
       }
       if (!inspector.isAttached) {
-        shell.add(inspector, 'down', { activate: false });
+        shell.add(inspector, 'main', { activate: false });
       }
       shell.activateById(inspector.id);
       return inspector;

--- a/packages/logconsole-extension/src/index.tsx
+++ b/packages/logconsole-extension/src/index.tsx
@@ -203,6 +203,7 @@ function activateLogConsole(
       mode: options.insertMode
     });
     void tracker.add(logConsoleWidget);
+    app.shell.activateById(logConsoleWidget.id);
 
     logConsoleWidget.update();
     app.commands.notifyCommandChanged();

--- a/packages/logconsole-extension/src/index.tsx
+++ b/packages/logconsole-extension/src/index.tsx
@@ -198,7 +198,7 @@ function activateLogConsole(
       app.commands.notifyCommandChanged();
     });
 
-    app.shell.add(logConsoleWidget, 'main', {
+    app.shell.add(logConsoleWidget, 'down', {
       ref: options.ref,
       mode: options.insertMode
     });

--- a/packages/ui-components/src/icon/widgets/tabbarsvg.ts
+++ b/packages/ui-components/src/icon/widgets/tabbarsvg.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { hpass, VirtualElement } from '@lumino/virtualdom';
-import { DockPanel, TabBar, Widget } from '@lumino/widgets';
+import { DockPanel, TabBar, TabPanel, Widget } from '@lumino/widgets';
 
 import { closeIcon } from '../iconimports';
 import { LabIconStyle } from '../../style';
@@ -92,4 +92,20 @@ export namespace DockPanelSvg {
   }
 
   export const defaultRenderer = new Renderer();
+}
+
+/**
+ * A widget which combines a `TabBar` and a `StackedPanel`.
+ * Tweaked to use an inline svg as the close icon
+ */
+export class TabPanelSvg extends TabPanel {
+  /**
+   * Construct a new tab panel.
+   *
+   * @param options - The options for initializing the tab panel.
+   */
+  constructor(options: TabPanel.IOptions = {}) {
+    options.renderer = options.renderer || TabBarSvg.defaultRenderer;
+    super(options);
+  }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
This aims to address #9735 by adding a tabpanel below the main dockpanel.
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

TODO and questions:
- [x] Add new panel to layout restorer
  - [x] SplitPanel is missing a signal when layout is changed to be stored ~~=> needs a change upstream in lumino.~~ Use message hook on the new vertical split panel.
- [x] Add focused element on the new tabpanel
- [x] doc
- [x] tests
- What about the integration in simple mode? Should that new panel be hidden?
- Quid on accessibility navigation?

## Code changes

<!-- Describe the code changes and how they address the issue. -->

The dockpanel is now wrapped in a vertical split panel to insert a tabpanel below it.

The log console opens now in that tabpanel.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

The idea is to separate the concern of documents and other kind of panels (for now log console).

The widget in the dock panel cannot be moved in the new tabpanel and vice-versa.

The tabpanel is hidden if empty.

In the demo below the [dev js console](https://github.com/QuantStack/jupyterlab-js-logs) was installed too to get two widgets in the new panel.
![downpanel](https://user-images.githubusercontent.com/8435071/117325990-86cced00-ae91-11eb-8800-379f41a24e50.gif)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

N/A