### PR TITLE
Draft: Multiple terminal support

### DIFF
--- a/packages/services/src/terminal/manager.ts
+++ b/packages/services/src/terminal/manager.ts
@@ -123,11 +123,15 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
    * The manager `serverSettings` will be used.
    */
   connectTo(
-    options: Omit<Terminal.ITerminalConnection.IOptions, 'serverSettings'>
+    options: Terminal.ITerminalConnection.IOptions
   ): Terminal.ITerminalConnection {
+    const serverSettings =
+      options.serverSettings != null
+        ? options.serverSettings
+        : this.serverSettings;
     const terminalConnection = new TerminalConnection({
       ...options,
-      serverSettings: this.serverSettings
+      serverSettings
     });
     this._onStarted(terminalConnection);
     if (!this._names.includes(options.model.name)) {
@@ -172,10 +176,12 @@ export class TerminalManager extends BaseManager implements Terminal.IManager {
    * The manager `serverSettings` will be used unless overridden in the
    * options.
    */
-  async startNew(): Promise<Terminal.ITerminalConnection> {
-    const model = await startNew(this.serverSettings);
+  async startNew(
+    serverSettings: ServerConnection.ISettings = this.serverSettings
+  ): Promise<Terminal.ITerminalConnection> {
+    const model = await startNew(serverSettings);
     await this.refreshRunning();
-    return this.connectTo({ model });
+    return this.connectTo({ model, serverSettings });
   }
 
   /**

--- a/packages/services/src/terminal/restapi.ts
+++ b/packages/services/src/terminal/restapi.ts
@@ -2,6 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { URLExt, PageConfig } from '@jupyterlab/coreutils';
+
 import { ServerConnection } from '../serverconnection';
 
 /**
@@ -39,7 +40,11 @@ export async function startNew(
 ): Promise<IModel> {
   Private.errorIfNotAvailable();
   const url = URLExt.join(settings.baseUrl, TERMINAL_SERVICE_URL);
-  const init = { method: 'POST' };
+
+  const init: RequestInit = { method: 'POST' };
+  if (settings.init.body != null) {
+    init.body = settings.init.body;
+  }
 
   const response = await ServerConnection.makeRequest(url, init, settings);
   if (response.status !== 200) {

--- a/packages/services/src/terminal/terminal.ts
+++ b/packages/services/src/terminal/terminal.ts
@@ -152,9 +152,7 @@ export interface IManager extends IBaseManager {
    * #### Notes
    * The manager `serverSettings` will be always be used.
    */
-  startNew(
-    options?: ITerminalConnection.IOptions
-  ): Promise<ITerminalConnection>;
+  startNew(options?: ServerConnection.ISettings): Promise<ITerminalConnection>;
 
   /*
    * Connect to a running session.
@@ -163,9 +161,7 @@ export interface IManager extends IBaseManager {
    *
    * @returns A promise that resolves with the new session instance.
    */
-  connectTo(
-    options: Omit<ITerminalConnection.IOptions, 'serverSettings'>
-  ): ITerminalConnection;
+  connectTo(options: ITerminalConnection.IOptions): ITerminalConnection;
 
   /**
    * Shut down a terminal session by name.


### PR DESCRIPTION

![named_shell](https://user-images.githubusercontent.com/38936057/117372872-1ae18900-ae7f-11eb-93e2-842d70b8165a.gif)

A proof-of-concept first step toward supporting multiple terminals.

## References

Multiple terminal support #9789
Allow the terminal shell to be configurable in the settings #4034
jupyter/notebook#3262 Multiple Terminals

## Todo

This is still just a proof-of-concept and needs to be wrapped in an actual user experience. Ideally, the user will be able to add multiple terminals in the settings and launch them separately in the Launcher, although I believe adding items to the Launcher from within JL is unprecedented. #9789 also suggests allowing the user to configure the icon for each terminal. Thoughts?