### PR TITLE
FileBrowser: Add shortcuts

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -1081,6 +1081,8 @@ function addCommands(
     });
   }
 
+  // matches the filebrowser itself
+  const selectorBrowser = '.jp-FileBrowser-listing';
   // matches anywhere on filebrowser
   const selectorContent = '.jp-DirListing-content';
   // matches all filebrowser items
@@ -1173,6 +1175,37 @@ function addCommands(
     command: CommandIDs.toggleLastModified,
     selector: '.jp-DirListing-header',
     rank: 14
+  });
+
+  app.commands.addKeyBinding({
+    command: CommandIDs.del,
+    selector: selectorBrowser,
+    keys: ['Delete']
+  });
+  app.commands.addKeyBinding({
+    command: CommandIDs.cut,
+    selector: selectorBrowser,
+    keys: ['Ctrl X']
+  });
+  app.commands.addKeyBinding({
+    command: CommandIDs.copy,
+    selector: selectorBrowser,
+    keys: ['Ctrl C']
+  });
+  app.commands.addKeyBinding({
+    command: CommandIDs.paste,
+    selector: selectorBrowser,
+    keys: ['Ctrl V']
+  });
+  app.commands.addKeyBinding({
+    command: CommandIDs.rename,
+    selector: selectorBrowser,
+    keys: ['F2']
+  });
+  app.commands.addKeyBinding({
+    command: CommandIDs.duplicate,
+    selector: selectorBrowser,
+    keys: ['Ctrl D']
   });
 }
 

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -138,6 +138,9 @@ export class FileBrowser extends Widget {
     this.layout.addWidget(this._crumbs);
     this.layout.addWidget(this._listing);
 
+    // We need to make the FileBrowser focusable so that it receives keyboard events
+    this.node.tabIndex = 0;
+
     if (options.restore !== false) {
       void model.restore(this.id);
     }


### PR DESCRIPTION
Adding keyboard shortcuts to Filebrowser, following vscode (and actually very common) shorcuts

![shortcuts](https://user-images.githubusercontent.com/21197331/117468125-aa0ca080-af54-11eb-9d32-256f68c5f740.png)
