### PR TITLE
show user dialog when attempting folder drop

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -687,6 +687,7 @@ export class DirListing extends Widget {
         this._evtScroll(event as MouseEvent);
         break;
       case 'lm-dragenter':
+        console.error('DRAGGING ENTER LM');
         this._evtDragEnter(event as IDragEvent);
         break;
       case 'lm-dragleave':
@@ -1114,6 +1115,23 @@ export class DirListing extends Widget {
     const files = event.dataTransfer?.files;
     if (!files || files.length === 0) {
       return;
+    }
+    const length = event.dataTransfer?.items.length;
+    if (!length) {
+      return;
+    }
+    for (let i = 0; i < length; i++) {
+      let entry = event.dataTransfer?.items[i].webkitGetAsEntry();
+      if (entry.isDirectory) {
+        console.log('currently not supporting drag + drop for folders');
+        void showDialog({
+          title: this._trans.__('Error Uploading Folder'),
+          body: this._trans.__(
+            'Drag and Drop is not currently supported for folders'
+          ),
+          buttons: [Dialog.cancelButton({ label: this._trans.__('Close') })]
+        });
+      }
     }
     event.preventDefault();
     for (let i = 0; i < files.length; i++) {

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -687,7 +687,6 @@ export class DirListing extends Widget {
         this._evtScroll(event as MouseEvent);
         break;
       case 'lm-dragenter':
-        console.error('DRAGGING ENTER LM');
         this._evtDragEnter(event as IDragEvent);
         break;
       case 'lm-dragleave':


### PR DESCRIPTION
## References

Initial pass at addressing folder drop issue reported in https://github.com/jupyterlab/jupyterlab/issues/9838

## Code changes

This PR adds logic to the drop event handler to check the file type, and show an error dialog if `isDirectory` is true:

<img width="1236" alt="Screen Shot 2021-05-07 at 11 58 53 AM" src="https://user-images.githubusercontent.com/14363644/117497006-b1b84f00-af2c-11eb-99e1-e544c30b34e8.png">

following pattern documented here:
https://developers.google.com/web/updates/2012/07/Drag-and-drop-a-folder-onto-Chrome-now-available

Note: `webkitGetAsEntry` may be renamed as `getAsEntry` for some browsers, so if this approach seems reasonable, I think it may make sense to add some defensive code to handle different browsers environments where this API is not exposed (https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry#browser_compatibility), as well as investigate how a similar file-type check can be made in a browser like Internet Explorer.

This initial PR does not remove the `event.preventDefault` call (I noticed while testing that the default behavior, at least in Chrome, is to launch + move focus to a second tab - it seemed a bit less disruptive for now to just silently fail and show this error message).

I also found while testing that there doesn't seem to be a way to check the file type in the `dragEnter` or `dragOver` events (methods like`webkitGetAsEntry` returns null when called in these event handlers - I believe this is WAD for security reasons, and both files + folders have the type 'Files' making them difficult to distinguish ahead of the drop event). I initially explored this approach as part of trying to disable the drop indicator altogether.

Another alternative approach is to leverage `FileReader` to attempt to read the uploaded data:
https://github.com/jupyterlab/jupyterlab/blob/master/packages/filebrowser/src/model.ts#L477
and if that fails, show an error dialog (introducing a second file read in listing.ts isn't ideal, so this might involve bubbling up + displaying a more explicit error from model.ts' `reader.readAsDataURL` call

As a follow-up to this initial error dialog, I think it should be possible, when `isDirectory` is true, to then use the browser file APIs to iterate through the files in a dropped folder (https://web.dev/read-files/), but whether this is straightforward to implement outside of Chrome/webkit-based browsers is TBD and probably a factor in whether we'd want to fully implement this `webkitGetAsEntry` based approach.

## User-facing changes

This PR introduces a user facing dialog to indicate that folder drag+drop is not supported (currently this silently fails)

## Backwards-incompatible changes

N/A
