### PR TITLE
Remove runtime dependency on `jupyter_packaging`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires=["jupyter_packaging~=0.9"]
+requires=["jupyter_packaging~=0.9,<2"]
 build-backend = "jupyter_packaging.build_api"
 
 [license]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
     packaging
     tornado>=6.1.0
     jupyter_core
-    jupyter_packaging~=0.9
     jupyterlab_server~=2.3
     jupyter_server~=1.4
     nbclassic~=0.2


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Addresses issues seen in the conda [feedstock](https://github.com/conda-forge/jupyterlab-feedstock/pull/270#issuecomment-833650804)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Removes runtime dependency on `jupyter_packaging`.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
