### PR TITLE
Fix CSS and avoid codemirror width and unput prompt regression

### DIFF
--- a/.github/workflows/linuxtests.yml
+++ b/.github/workflows/linuxtests.yml
@@ -8,16 +8,16 @@ jobs:
     strategy:
       matrix:
         group: [integrity, integrity2, docs, usage, python,  nonode]
-        python: [3.5, 3.8]
+        python: [3.6, 3.8]
         exclude:
           - group: integrity
-            python: 3.5
+            python: 3.6
           - group: integrity2
-            python: 3.5
+            python: 3.6
           - group: docs
-            python: 3.5
+            python: 3.6
           - group: usage
-            python: 3.5
+            python: 3.6
       fail-fast: false
     timeout-minutes: 120
     runs-on: ubuntu-latest

--- a/.github/workflows/windowstests.yml
+++ b/.github/workflows/windowstests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.5
+          python-version: 3.6
       - name: Set up Node
         uses: actions/setup-node@v1
         with:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -244,4 +244,7 @@ def setup(app):
         'enable_auto_doc_ref': False,
     }, True)
     app.add_transform(AutoStructify)
-    app.add_stylesheet('custom.css')  # may also be an URL
+    try:
+        app.add_stylesheet('custom.css')  # may also be an URL
+    except AttributeError:
+        app.add_css_file('custom.css')  # may also be an URL

--- a/packages/cells/style/collapser.css
+++ b/packages/cells/style/collapser.css
@@ -4,8 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 .jp-Collapser {
-  display: table-cell;
-  width: var(--jp-cell-collapser-width);
+  flex: 0 0 var(--jp-cell-collapser-width);
   padding: 0px;
   margin: 0px;
   border: none;

--- a/packages/cells/style/inputarea.css
+++ b/packages/cells/style/inputarea.css
@@ -9,7 +9,7 @@
 
 /* All input areas */
 .jp-InputArea {
-  display: block;
+  display: flex;
   flex-direction: row;
 }
 
@@ -25,7 +25,7 @@
 }
 
 .jp-InputPrompt {
-  width: var(--jp-cell-prompt-width);
+  flex: 0 0 var(--jp-cell-prompt-width);
   color: var(--jp-cell-inprompt-font-color);
   font-family: var(--jp-cell-prompt-font-family);
   padding: var(--jp-code-padding);

--- a/packages/cells/style/placeholder.css
+++ b/packages/cells/style/placeholder.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 .jp-Placeholder {
-  display: block;
+  display: flex;
   flex-direction: row;
   flex: 1 1 auto;
 }

--- a/packages/cells/style/widget.css
+++ b/packages/cells/style/widget.css
@@ -29,8 +29,8 @@
 
 .jp-Cell-inputWrapper,
 .jp-Cell-outputWrapper {
-  display: table;
-  width: 100%;
+  display: flex;
+  flex-direction: row;
   padding: 0px;
   margin: 0px;
   /* Added to reveal the box-shadow on the input and output collapsers. */

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -146,7 +146,7 @@
 }
 
 .jp-dragImage {
-  display: block;
+  display: flex;
   flex-direction: row;
   width: var(--jp-private-notebook-dragImage-width);
   height: var(--jp-private-notebook-dragImage-height);

--- a/packages/outputarea/style/base.css
+++ b/packages/outputarea/style/base.css
@@ -20,13 +20,12 @@
 }
 
 .jp-OutputArea-child {
-  display: block;
+  display: flex;
   flex-direction: row;
 }
 
 .jp-OutputPrompt {
-  width: var(--jp-cell-prompt-width);
-  float: left;
+  flex: 0 0 var(--jp-cell-prompt-width);
   color: var(--jp-cell-outprompt-font-color);
   font-family: var(--jp-cell-prompt-font-family);
   padding: var(--jp-code-padding);
@@ -168,7 +167,7 @@ body.lm-mod-override-cursor .jp-OutputArea-output.jp-mod-isolated:before {
 .jp-OutputArea-stdin {
   line-height: var(--jp-code-line-height);
   padding-top: var(--jp-code-padding);
-  display: block;
+  display: flex;
 }
 
 .jp-Stdin-prompt {


### PR DESCRIPTION
## Before

<img width="505" alt="Screen Shot 2021-05-10 at 10 14 12 PM" src="https://user-images.githubusercontent.com/3627835/117752848-1c8fb180-b1dd-11eb-8987-51108118a134.png">
<img width="520" alt="Screen Shot 2021-05-10 at 10 14 23 PM" src="https://user-images.githubusercontent.com/3627835/117752854-1ef20b80-b1dd-11eb-90bb-a4facab97408.png">


## After

<img width="444" alt="Screen Shot 2021-05-10 at 10 08 46 PM" src="https://user-images.githubusercontent.com/3627835/117752596-adb25880-b1dc-11eb-97ca-0a85617085b9.png">
<img width="450" alt="Screen Shot 2021-05-10 at 10 08 53 PM" src="https://user-images.githubusercontent.com/3627835/117752603-af7c1c00-b1dc-11eb-971d-aa9da814628b.png">
