### PR TITLE
Re-enable splice source tests

### DIFF
--- a/jupyterlab/tests/test_jupyterlab.py
+++ b/jupyterlab/tests/test_jupyterlab.py
@@ -448,7 +448,6 @@ class TestExtension(AppHandlerTest):
         assert self.pkg_names['extension'] in data
 
     @pytest.mark.slow
-    @pytest.mark.skip(reason="TODO temporary ci skip - enable when shared-models and docprovider packages are published")
     def test_build_splice_packages(self):
         app_options = AppOptions(splice_source=True)
         assert install_extension(self.mock_extension) is True

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -369,10 +369,8 @@ if [[ $GROUP == usage2 ]]; then
 fi
 
 
-: '
-if [[ $GROUP == splice_source ]];then
+if [[ $GROUP == splice_source ]]; then
     # Run the integrity script to link binary files
-    TODO temporary ci skip - enable when shared-models and docprovider packages are published
     jlpm integrity
 
     jupyter lab build --minimize=False --debug --dev-build=True --splice-source
@@ -399,7 +397,6 @@ if [[ $GROUP == splice_source ]];then
     cat version.txt | grep -q "spliced"
     python -m jupyterlab.browser_check
 fi
-'
 
 
 if [[ $GROUP == interop ]]; then


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyter-rtc/jupyterlab/issues/53

These tests were disabled in the rtc fork because the new `docprovider` and `shared-models` packages were not published on `npm` yet.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Enable previously skipped tests.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
