### PR TITLE
Remove tabmanager-extension from packages list

### DIFF
--- a/typedoc.js
+++ b/typedoc.js
@@ -74,7 +74,6 @@ const packages = [
   'statedb',
   'statusbar-extension',
   'statusbar',
-  'tabmanager-extension',
   'terminal-extension',
   'terminal',
   'theme-dark-extension',


### PR DESCRIPTION
### References

It looks like it might not be needed anymore after https://github.com/jupyterlab/jupyterlab/pull/8886.

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None