### PR TITLE
Improve error handling in labextension install

### DIFF
--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -365,11 +365,8 @@ def _get_labextension_metadata(module):
         if hasattr(m, '_jupyter_labextension_paths') :
             labexts = m._jupyter_labextension_paths()
             return m, labexts
-        else :
-            m = None
-
     except Exception:
-        m = None
+        pass
 
     # Try getting the package name from setup.py
     try:
@@ -381,7 +378,7 @@ def _get_labextension_metadata(module):
     # Make sure the package is installed
     import pkg_resources
     try:
-        dist = pkg_resources.get_distribution(package)
+        pkg_resources.get_distribution(package)
     except pkg_resources.DistributionNotFound:
         subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-e', mod_path])
         sys.path.insert(0, mod_path)
@@ -394,7 +391,7 @@ def _get_labextension_metadata(module):
         if hasattr(m, '_jupyter_labextension_paths') :
             return m, m._jupyter_labextension_paths()
     except Exception:
-        m = None
+        pass
 
     # Looking for modules in the package
     from setuptools import find_packages
@@ -407,20 +404,18 @@ def _get_labextension_metadata(module):
             if hasattr(m, '_jupyter_labextension_paths') :
                 return m, m._jupyter_labextension_paths()
         except Exception:
-            m = None
+            pass
 
-    # Looking for namespace packages
-    if m is None:
-        from setuptools import find_namespace_packages
-        packages = find_namespace_packages(mod_path)
+    from setuptools import find_namespace_packages
+    packages = find_namespace_packages(mod_path)
 
-        # Looking for the labextension metadata
-        for package in packages:
-            try:
-                m = importlib.import_module(package)
-                if hasattr(m, '_jupyter_labextension_paths') :
-                    return m, m._jupyter_labextension_paths()
-            except Exception:
-                m = None
+    # Looking for the labextension metadata
+    for package in packages:
+        try:
+            m = importlib.import_module(package)
+            if hasattr(m, '_jupyter_labextension_paths') :
+                return m, m._jupyter_labextension_paths()
+        except Exception:
+            pass
 
     raise ModuleNotFoundError('There is not a labextensions at {}'.format(module))

--- a/jupyterlab/federated_labextensions.py
+++ b/jupyterlab/federated_labextensions.py
@@ -359,14 +359,16 @@ def _get_labextension_metadata(module):
     if not osp.exists(mod_path):
         raise FileNotFoundError('The path `{}` does not exist.'.format(mod_path))
 
+    errors = []
+
     # Check if the path is a valid labextension
     try:
         m = importlib.import_module(module)
         if hasattr(m, '_jupyter_labextension_paths') :
             labexts = m._jupyter_labextension_paths()
             return m, labexts
-    except Exception:
-        pass
+    except Exception as exc:
+        errors.append(exc)
 
     # Try getting the package name from setup.py
     try:
@@ -390,8 +392,8 @@ def _get_labextension_metadata(module):
         m = importlib.import_module(package)
         if hasattr(m, '_jupyter_labextension_paths') :
             return m, m._jupyter_labextension_paths()
-    except Exception:
-        pass
+    except Exception as exc:
+        errors.append(exc)
 
     # Looking for modules in the package
     from setuptools import find_packages
@@ -403,8 +405,8 @@ def _get_labextension_metadata(module):
             m = importlib.import_module(package)
             if hasattr(m, '_jupyter_labextension_paths') :
                 return m, m._jupyter_labextension_paths()
-        except Exception:
-            pass
+        except Exception as exc:
+            errors.append(exc)
 
     from setuptools import find_namespace_packages
     packages = find_namespace_packages(mod_path)
@@ -415,7 +417,7 @@ def _get_labextension_metadata(module):
             m = importlib.import_module(package)
             if hasattr(m, '_jupyter_labextension_paths') :
                 return m, m._jupyter_labextension_paths()
-        except Exception:
-            pass
+        except Exception as exc:
+            errors.append(exc)
 
-    raise ModuleNotFoundError('There is not a labextensions at {}'.format(module))
+    raise ModuleNotFoundError('There is no labextension at {}. Errors encountered: {}'.format(module, errors))


### PR DESCRIPTION
## References

No references.

## Code changes

This PR removes some unused variable assignments from `_get_labextension_metadata()`. In addition, errors are not simply swallowed, but reported to the user, who might be able to thus debug things better.

## User-facing changes

When discovering labextensions fails, the user is no longer given a simple

```
ModuleNotFoundError: There is not a labextensions at .
```

but a more verbose error message that lists the exception(s) encountered while attempting to discover labextensions, i.e.

```
ModuleNotFoundError: There is no labextension at .  Errors encountered: [ImportError(...)]
```

## Backwards-incompatible changes

Not backwards incompatible unless someone has been parsing the `ModuleNotFoundError`'s text.