### PR TITLE
Fix autocompletion issue

### DIFF
--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -153,8 +153,10 @@ export class YFile
   public updateSource(start: number, end: number, value = ''): void {
     this.transact(() => {
       const ysource = this.ysource;
-      ysource.delete(start, end - start);
+      // insert and then delete.
+      // This ensures that the cursor position is adjusted after the replaced content.
       ysource.insert(start, value);
+      ysource.delete(start + value.length, end - start);
     });
   }
 
@@ -667,9 +669,11 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
    */
   public updateSource(start: number, end: number, value = ''): void {
     this.transact(() => {
-      const ysource = this.ymodel.get('source');
-      ysource.delete(start, end - start);
+      const ysource = this.ysource;
+      // insert and then delete.
+      // This ensures that the cursor position is adjusted after the replaced content.
       ysource.insert(start, value);
+      ysource.delete(start + value.length, end - start);
     });
   }
 


### PR DESCRIPTION

## References

This PR fixes the autocomplete issue described in https://github.com/jupyterlab/jupyterlab/pull/10118#discussion_r627932348 and https://github.com/jupyter-rtc/jupyterlab/issues/64

When a word is autocompleted (e.g. by typing Tab+Tab), the cursor position would jump to the start of the word.

## Code changes

When replacing content, we should insert first and then delete content. This ensures that the editor-binding (y-codemirror) sets the cursor location correctly. 

## Backwards-incompatible changes

None