### PR TITLE
DirListing: Allow for no sorting when clicking on headers

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -1749,7 +1749,7 @@ export namespace DirListing {
      *
      * @returns The sort state of the header after the click event.
      */
-    handleHeaderClick(node: HTMLElement, event: MouseEvent): ISortState;
+    handleHeaderClick(node: HTMLElement, event: MouseEvent): ISortState | null;
 
     /**
      * Create a new item node for a dir listing.
@@ -1871,7 +1871,7 @@ export namespace DirListing {
      *
      * @returns The sort state of the header after the click event.
      */
-    handleHeaderClick(node: HTMLElement, event: MouseEvent): ISortState {
+    handleHeaderClick(node: HTMLElement, event: MouseEvent): ISortState | null {
       const name = DOMUtils.findElement(node, NAME_ID_CLASS);
       const modified = DOMUtils.findElement(node, MODIFIED_ID_CLASS);
       const state: ISortState = { direction: 'ascending', key: 'name' };


### PR DESCRIPTION
In the DirListing, there is already some logic that check if the sort state is defined:
```typescript
const state = this.renderer.handleHeaderClick(header, event);
if (state) {
  this.sort(state);
}
return;
```

I am merely improving the `handleHeaderClick` return type so we can explicitly request no sort from the renderer