### PR TITLE
Completer: expose `activeIndex` and `indexChanged`

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -57,26 +57,22 @@ export class CompletionHandler implements IDisposable {
    * it is acceptable for the other methods to be simple functions that return
    * rejected promises.
    */
-  get connector(): IDataConnector<
-    CompletionHandler.IReply,
-    void,
-    CompletionHandler.IRequest
-  > {
+  get connector():
+    | IDataConnector<CompletionHandler.IReply, void, CompletionHandler.IRequest>
+    | CompletionHandler.ICompletionItemsConnector {
     if ('responseType' in this._connector) {
       return new DummyConnector();
     }
-    return this._connector as IDataConnector<
-      CompletionHandler.IReply,
-      void,
-      CompletionHandler.IRequest
-    >;
+    return this._connector;
   }
   set connector(
-    connector: IDataConnector<
-      CompletionHandler.IReply,
-      void,
-      CompletionHandler.IRequest
-    >
+    connector:
+      | IDataConnector<
+          CompletionHandler.IReply,
+          void,
+          CompletionHandler.IRequest
+        >
+      | CompletionHandler.ICompletionItemsConnector
   ) {
     this._connector = connector;
   }

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -57,22 +57,26 @@ export class CompletionHandler implements IDisposable {
    * it is acceptable for the other methods to be simple functions that return
    * rejected promises.
    */
-  get connector():
-    | IDataConnector<CompletionHandler.IReply, void, CompletionHandler.IRequest>
-    | CompletionHandler.ICompletionItemsConnector {
+  get connector(): IDataConnector<
+    CompletionHandler.IReply,
+    void,
+    CompletionHandler.IRequest
+  > {
     if ('responseType' in this._connector) {
       return new DummyConnector();
     }
-    return this._connector;
+    return this._connector as IDataConnector<
+      CompletionHandler.IReply,
+      void,
+      CompletionHandler.IRequest
+    >;
   }
   set connector(
-    connector:
-      | IDataConnector<
-          CompletionHandler.IReply,
-          void,
-          CompletionHandler.IRequest
-        >
-      | CompletionHandler.ICompletionItemsConnector
+    connector: IDataConnector<
+      CompletionHandler.IReply,
+      void,
+      CompletionHandler.IRequest
+    >
   ) {
     this._connector = connector;
   }

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -76,6 +76,13 @@ export class Completer extends Widget {
   }
 
   /**
+   * The active index.
+   */
+  get activeIndex(): number {
+    return this._activeIndex;
+  }
+
+  /**
    * The editor used by the completion widget.
    */
   get editor(): CodeEditor.IEditor | null {
@@ -101,6 +108,13 @@ export class Completer extends Widget {
    */
   get visibilityChanged(): ISignal<this, void> {
     return this._visibilityChanged;
+  }
+
+  /**
+   * A signal emitted when the active index changes.
+   */
+  get indexChanged(): ISignal<this, number> {
+    return this._indexChanged;
   }
 
   /**
@@ -396,6 +410,7 @@ export class Completer extends Widget {
       '.jp-Completer-list'
     ) as Element;
     ElementExt.scrollIntoViewIfNeeded(completionList, active);
+    this._indexChanged.emit(this._activeIndex);
     this._updateDocPanel();
   }
 
@@ -630,6 +645,7 @@ export class Completer extends Widget {
   private _resetFlag = false;
   private _selected = new Signal<this, string>(this);
   private _visibilityChanged = new Signal<this, void>(this);
+  private _indexChanged = new Signal<this, number>(this);
 }
 
 export namespace Completer {


### PR DESCRIPTION
## References

Solves #10243

## Code changes

Adds a new signal triggered when the `_activeIndex` in the `Completer` changes.
Makes public `_activeIndex' (read-only).
Makes the `connector` in `CompletionHandler` more generic.

## User-facing changes

N/A

## Backwards-incompatible changes

Maybe changing types of `get/set connector` in `CompletionHandler`, not sure.
