### PR TITLE
[3.0.x] Update to `codemirror~=5.58.0`

### DIFF
--- a/packages/codemirror-extension/package.json
+++ b/packages/codemirror-extension/package.json
@@ -48,7 +48,7 @@
     "@jupyterlab/statusbar": "^3.0.8",
     "@jupyterlab/translation": "^3.0.8",
     "@lumino/widgets": "^1.16.1",
-    "codemirror": "~5.57.0"
+    "codemirror": "~5.58.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -54,7 +54,7 @@
     "@lumino/polling": "^1.3.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.16.1",
-    "codemirror": "~5.57.0",
+    "codemirror": "~5.58.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -70,7 +70,7 @@
     "@lumino/disposable": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.16.1",
-    "codemirror": "~5.57.0",
+    "codemirror": "~5.58.0",
     "react": "^17.0.1",
     "vscode-debugprotocol": "^1.37.0"
   },

--- a/packages/documentsearch/package.json
+++ b/packages/documentsearch/package.json
@@ -47,7 +47,7 @@
     "@lumino/polling": "^1.3.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.16.1",
-    "codemirror": "~5.57.0",
+    "codemirror": "~5.58.0",
     "react": "^17.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5432,10 +5432,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@~5.57.0:
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.57.0.tgz#d26365b72f909f5d2dbb6b1209349ca1daeb2d50"
-  integrity sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg==
+codemirror@~5.58.0:
+  version "5.58.3"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.58.3.tgz#3f0689854ecfbed5d4479a98b96148b2c3b79796"
+  integrity sha512-KBhB+juiyOOgn0AqtRmWyAT3yoElkuvWTI6hsHa9E6GQrl6bk/fdAYcvuqW1/upO9T9rtEtapWdw4XYcNiVDEA==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Looks like third-party extensions reyling on the `3.0` packages are now getting dependabot alerts related to `codemirror` coming from transitive dependencies:

![image](https://user-images.githubusercontent.com/591645/118621367-95d36980-b7c6-11eb-9ade-192ac0ed00e5.png)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update to `codemirror~=5.58.0`
 
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
