### PR TITLE
Filebrowser ContextMenu: Use separators

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -117,7 +117,7 @@ namespace CommandIDs {
   export const rename = 'filebrowser:rename';
 
   // For main browser only.
-  export const share = 'filebrowser:share-main';
+  export const copyShareableLink = 'filebrowser:share-main';
 
   // For main browser only.
   export const copyPath = 'filebrowser:copy-path';
@@ -506,7 +506,7 @@ const shareFile: JupyterFrontEndPlugin<void> = {
     const { commands } = app;
     const { tracker } = factory;
 
-    commands.addCommand(CommandIDs.share, {
+    commands.addCommand(CommandIDs.copyShareableLink, {
       execute: () => {
         const widget = tracker.currentWidget;
         const model = widget?.selectedItems().next();
@@ -1121,6 +1121,12 @@ function addCommands(
   // If the user did not click on any file, we still want to show paste and new folder,
   // so target the content rather than an item.
   app.contextMenu.addItem({
+    type: 'separator',
+    selector: selectorContent,
+    rank: 0
+  });
+
+  app.contextMenu.addItem({
     command: CommandIDs.createNewDirectory,
     selector: selectorContent,
     rank: 1
@@ -1157,48 +1163,71 @@ function addCommands(
   });
 
   app.contextMenu.addItem({
-    command: CommandIDs.rename,
+    type: 'separator',
     selector: selectorItem,
     rank: 4
   });
+
   app.contextMenu.addItem({
-    command: CommandIDs.del,
+    command: CommandIDs.rename,
     selector: selectorItem,
     rank: 5
   });
+
   app.contextMenu.addItem({
-    command: CommandIDs.cut,
+    command: CommandIDs.del,
     selector: selectorItem,
     rank: 6
   });
 
   app.contextMenu.addItem({
+    command: CommandIDs.cut,
+    selector: selectorItem,
+    rank: 7
+  });
+
+  app.contextMenu.addItem({
     command: CommandIDs.copy,
     selector: selectorNotDir,
-    rank: 7
+    rank: 8
   });
 
   app.contextMenu.addItem({
     command: CommandIDs.duplicate,
     selector: selectorNotDir,
-    rank: 8
+    rank: 9
   });
+
   app.contextMenu.addItem({
-    command: CommandIDs.shutdown,
-    selector: selectorNotDir,
+    type: 'separator',
+    selector: selectorItem,
     rank: 10
   });
 
   app.contextMenu.addItem({
-    command: CommandIDs.share,
-    selector: selectorItem,
+    command: CommandIDs.shutdown,
+    selector: selectorNotDir,
     rank: 11
   });
+
   app.contextMenu.addItem({
-    command: CommandIDs.copyPath,
+    type: 'separator',
     selector: selectorItem,
     rank: 12
   });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.copyShareableLink,
+    selector: selectorItem,
+    rank: 15
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.copyPath,
+    selector: selectorItem,
+    rank: 14
+  });
+
   app.contextMenu.addItem({
     command: CommandIDs.toggleLastModified,
     selector: '.jp-DirListing-header',


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #10165

## Code changes

This only adds separators in the right places

## User-facing changes

When clicking on a file:

![ctx1](https://user-images.githubusercontent.com/21197331/119629287-28e75180-be0e-11eb-9f2f-632bc7094fdd.png)

When clicking on a directory:

![ctx2](https://user-images.githubusercontent.com/21197331/119629302-2dac0580-be0e-11eb-9fda-55c06d52d40c.png)

It doesn't affect other lab context menus:

![ctx3](https://user-images.githubusercontent.com/21197331/119629316-33095000-be0e-11eb-9b34-69bddf74e31b.png)

## Backwards-incompatible changes

None
