### PR TITLE
Fix bug in Name File dialog

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -528,7 +528,7 @@ function addCommands(
 
   commands.addCommand(CommandIDs.nameOnSave, {
     label: () =>
-      trans.__('Rename %1…', fileType(shell.currentWidget, docManager)),
+      trans.__('Name %1… on first save', fileType(shell.currentWidget, docManager)),
     isEnabled,
     execute: () => {
       if (isEnabled()) {

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -528,7 +528,10 @@ function addCommands(
 
   commands.addCommand(CommandIDs.nameOnSave, {
     label: () =>
-      trans.__('Name %1… on first save', fileType(shell.currentWidget, docManager)),
+      trans.__(
+        'Name %1… on first save',
+        fileType(shell.currentWidget, docManager)
+      ),
     isEnabled,
     execute: () => {
       if (isEnabled()) {
@@ -821,12 +824,14 @@ function addCommands(
           widget === shell.currentWidget &&
           activatedDocs.indexOf(args) == -1
         ) {
-          const model = doc.contentsModel;
+          const model = doc.model;
+          const contentsModel = doc.contentsModel;
           activatedDocs.push(args);
           if (
             model &&
+            contentsModel &&
             !model.renamed == true &&
-            newFileRegex.test(model.name)
+            newFileRegex.test(contentsModel.name)
           ) {
             const context = sender.contextForWidget(widget!);
             return nameOnSaveDialog(sender, context!).then(() => {

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -297,6 +297,11 @@ namespace Private {
     });
 
     label.textContent = trans.__("Don't ask me again");
+    label.addEventListener('click', function () {
+      checkbox.checked = !checkbox.checked;
+      manager.nameFileOnSave = !checkbox.checked;
+    });
+
     body.appendChild(name);
     div.appendChild(checkbox);
     div.appendChild(label);

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -98,10 +98,10 @@ export function nameOnSaveDialog(
     focusNodeSelector: 'input',
     buttons: [Dialog.okButton({ label: trans.__('Enter') })]
   }).then(result => {
+    context.model.renamed = true;
     context.model.dirty = false;
-    context.contentsModel!.renamed = true;
     if (!result.value) {
-      return renameFile(manager, oldPath, oldPath);
+      return null;
     }
 
     if (!isValidFileName(result.value)) {
@@ -114,7 +114,7 @@ export function nameOnSaveDialog(
           )
         )
       );
-      return renameFile(manager, oldPath, oldPath);
+      return null;
     }
     const basePath = PathExt.dirname(oldPath);
     const newPath = PathExt.join(basePath, result.value);

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -428,11 +428,7 @@ export class DocumentManager implements IDocumentManager {
    * a file.
    */
   rename(oldPath: string, newPath: string): Promise<Contents.IModel> {
-    return this.services.contents.rename(oldPath, newPath).then(model => {
-      if (model.type == 'notebook' || model.type == 'file') {
-        model.renamed = true;
-      }
-    }) as Promise<Contents.IModel>;
+    return this.services.contents.rename(oldPath, newPath);
   }
 
   /**

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -491,10 +491,9 @@ export class Context<
       const localPath = this._manager.contents.localPath(newPath);
       void this.sessionContext.session?.setName(PathExt.basename(localPath));
       this._updateContentsModel(updateModel as Contents.IModel);
+      this._model.renamed = true;
+      this._contentsModel!.renamed = true;
       this._pathChanged.emit(this._path);
-      if (this._contentsModel) {
-        this._contentsModel.renamed = true;
-      }
     }
   }
 
@@ -525,8 +524,7 @@ export class Context<
       created: model.created,
       last_modified: model.last_modified,
       mimetype: model.mimetype,
-      format: model.format,
-      renamed: model.renamed == true ? true : false
+      format: model.format
     };
     const mod = this._contentsModel ? this._contentsModel.last_modified : null;
     this._contentsModel = newModel;
@@ -583,6 +581,8 @@ export class Context<
     await this.sessionContext.session?.setPath(newPath);
     await this.sessionContext.session?.setName(newName);
 
+    this._model.renamed = true;
+    this._contentsModel!.renamed = true;
     this._pathChanged.emit(this._path);
   }
 
@@ -620,7 +620,6 @@ export class Context<
       }
 
       model.dirty = false;
-      value.renamed = this._contentsModel?.renamed;
       this._updateContentsModel(value);
 
       if (!this._isPopulated) {
@@ -872,6 +871,8 @@ or load the version on disk (revert)?`,
     await this.sessionContext.session?.setPath(newPath);
     await this.sessionContext.session?.setName(newPath.split('/').pop()!);
     await this.save();
+    this._model.renamed = true;
+    this._contentsModel!.renamed = true;
     this._pathChanged.emit(this._path);
     await this._maybeCheckpoint(true);
   }

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -61,6 +61,16 @@ export class DocumentModel
   }
 
   /**
+   * The renamed state of the document.
+   */
+  get renamed(): boolean {
+    return this._renamed;
+  }
+  set renamed(v: boolean) {
+    this._renamed = v;
+  }
+
+  /**
    * The read only state of the document.
    */
   get readOnly(): boolean {
@@ -157,6 +167,7 @@ export class DocumentModel
   readonly sharedModel: models.ISharedFile;
   private _defaultLang = '';
   private _dirty = false;
+  private _renamed = false;
   private _readOnly = false;
   private _contentChanged = new Signal<this, void>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -755,6 +755,11 @@ export namespace DocumentRegistry {
     dirty: boolean;
 
     /**
+     * The renamed state of the model.
+     */
+    renamed: boolean;
+
+    /**
      * The read-only state of the model.
      */
     readOnly: boolean;

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -138,6 +138,19 @@ export class NotebookModel implements INotebookModel {
   }
 
   /**
+   * The renamed state of the document.
+   */
+  get renamed(): boolean {
+    if (!this.metadata.has('renamed')) {
+      return false;
+    }
+    return this.metadata.get('renamed') as boolean;
+  }
+  set renamed(v: boolean) {
+    this.metadata.set('renamed', v);
+  }
+
+  /**
    * The read only state of the document.
    */
   get readOnly(): boolean {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

https://github.com/jupyterlab/jupyterlab/issues/10291

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Added 'renamed' in model
- Fixed bugs in losing track of 'renamed' state in notebook files between sessions

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
- limited 1 Name File popup per document after reloading page
- made 'Don't ask me again' text clickable in Name File popup
EDIT: 
- removed redundant Name File Dialog in notebook file if it has been previously renamed over sessions 
- removed redundant Name File Dialog after opening a saved file 


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
I don't think so, but please let me know if there is any!
