### PR TITLE
Focus cells on split and leave cursor cel with selection when splitting

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -541,7 +541,7 @@ export namespace CodeEditor {
     readonly charWidth: number;
 
     /**
-     * Get the number of lines in the eidtor.
+     * Get the number of lines in the editor.
      */
     readonly lineCount: number;
 

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -131,7 +131,7 @@ export namespace NotebookActions {
         offsets.push(start);
       }
     }
-    
+
     offsets.push(orig.length);
 
     const clones: ICellModel[] = [];
@@ -169,7 +169,7 @@ export namespace NotebookActions {
     focusedEditor.focus();
 
     // Move to the end of the cell that now contains the cursor
-    focusedEditor.setCursorPosition({line: editor.lineCount, column: 0});
+    focusedEditor.setCursorPosition({ line: editor.lineCount, column: 0 });
 
     Private.handleState(notebook, state);
   }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -85,8 +85,12 @@ export namespace NotebookActions {
    *
    * #### Notes
    * It will preserve the existing mode.
-   * The last cell will be activated.
+   * The last cell will be activated if no selection is found.
+   * If text was selected, the cell cotaining the selection will
+     be activated.
    * The existing selection will be cleared.
+   * The activated cell will have focus and the cursor will move
+     to the end of the cell.
    * The leading whitespace in the second cell will be removed.
    * If there is no content, two empty cells will be created.
    * Both cells will have the same type as the original cell.
@@ -110,11 +114,13 @@ export namespace NotebookActions {
 
     const offsets = [0];
 
+    let start: number = -1;
+    let end: number = -1;
     for (let i = 0; i < selections.length; i++) {
       // append start and end to handle selections
       // cursors will have same start and end
-      const start = editor.getOffsetAt(selections[i].start);
-      const end = editor.getOffsetAt(selections[i].end);
+      start = editor.getOffsetAt(selections[i].start);
+      end = editor.getOffsetAt(selections[i].end);
       if (start < end) {
         offsets.push(start);
         offsets.push(end);
@@ -125,7 +131,7 @@ export namespace NotebookActions {
         offsets.push(start);
       }
     }
-
+    
     offsets.push(orig.length);
 
     const clones: ICellModel[] = [];
@@ -156,7 +162,15 @@ export namespace NotebookActions {
     }
     cells.endCompoundOperation();
 
-    notebook.activeCellIndex = index + clones.length - 1;
+    // If there is a selection the selected cell will be activated
+    const activeCellDelta = start !== end ? 2 : 1;
+    notebook.activeCellIndex = index + clones.length - activeCellDelta;
+    const focusedEditor = notebook.activeCell.editor;
+    focusedEditor.focus();
+
+    // Move to the end of the cell that now contains the cursor
+    focusedEditor.setCursorPosition({line: editor.lineCount, column: 0});
+
     Private.handleState(notebook, state);
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes https://github.com/jupyterlab/jupyterlab/issues/10210

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

The split cell behavior is now taking into account if there selections to decide what the active cell will be

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

![split](https://user-images.githubusercontent.com/3627835/119668064-72c73c00-bdfc-11eb-9c1d-047dd4bd3f10.gif)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

There are two changes with this
- Split with selections would set the cell  with the selected content to be the active one.
- It will now give focus to the active cell and move the cursor to the end