### PR TITLE
Add debugger variable renderer based on mime type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ jupyterlab/style.js
 jupyterlab/tests/**/static
 jupyterlab/tests/**/labextension
 
+ui-tests/test-output
+
 # Remove after next release
 jupyterlab/imports.css
 

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -87,6 +87,7 @@ export class MainAreaWidget<T extends Widget = Widget>
         .catch(e => {
           // Show a revealed promise error.
           const error = new Widget();
+          error.addClass('jp-MainAreaWidget-error');
           // Show the error to the user.
           const pre = document.createElement('pre');
           pre.textContent = String(e);

--- a/packages/apputils/style/mainareawidget.css
+++ b/packages/apputils/style/mainareawidget.css
@@ -7,3 +7,19 @@
 .jp-MainAreaWidget > :focus {
   outline: none;
 }
+
+.jp-MainAreaWidget .jp-MainAreaWidget-error {
+  padding: 6px;
+}
+
+.jp-MainAreaWidget .jp-MainAreaWidget-error > pre {
+  width: auto;
+  padding: 10px;
+  background: var(--jp-error-color3);
+  border: var(--jp-border-width) solid var(--jp-error-color1);
+  border-radius: var(--jp-border-radius);
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}

--- a/packages/debugger-extension/schema/main.json
+++ b/packages/debugger-extension/schema/main.json
@@ -21,6 +21,16 @@
           }
         ]
       }
+    ],
+    "context": [
+      {
+        "command": "debugger:inspect-variable",
+        "selector": ".jp-DebuggerVariables-body .jp-DebuggerVariables-grid"
+      },
+      {
+        "command": "debugger:render-mime-variable",
+        "selector": ".jp-DebuggerVariables-body"
+      }
     ]
   },
   "jupyter.lab.shortcuts": [

--- a/packages/debugger/src/debugger.ts
+++ b/packages/debugger/src/debugger.ts
@@ -3,8 +3,6 @@
 
 import { codeIcon, runIcon, stopIcon } from '@jupyterlab/ui-components';
 
-import { EditorHandler as DebuggerEditorHandler } from './handlers/editor';
-
 import { DebuggerConfig } from './config';
 
 import { DebuggerEvaluateDialog } from './dialogs/evaluate';
@@ -12,6 +10,8 @@ import { DebuggerEvaluateDialog } from './dialogs/evaluate';
 import { ReadOnlyEditorFactory as EditorFactory } from './factory';
 
 import { DebuggerHandler } from './handler';
+
+import { EditorHandler as DebuggerEditorHandler } from './handlers/editor';
 
 import {
   closeAllIcon as closeAll,
@@ -25,6 +25,8 @@ import {
 import { DebuggerModel } from './model';
 
 import { VariablesBodyGrid } from './panels/variables/grid';
+
+import { VariableMimeRenderer } from './panels/variables/mimerenderer';
 
 import { DebuggerService } from './service';
 
@@ -89,6 +91,11 @@ export namespace Debugger {
   export class VariablesGrid extends VariablesBodyGrid {}
 
   /**
+   * A widget to display data according to its mime type
+   */
+  export class VariableRenderer extends VariableMimeRenderer {}
+
+  /**
    * The command IDs used by the debugger plugin.
    */
   export namespace CommandIDs {
@@ -105,6 +112,8 @@ export namespace Debugger {
     export const stepOut = 'debugger:stepOut';
 
     export const inspectVariable = 'debugger:inspect-variable';
+
+    export const renderMimeVariable = 'debugger:render-mime-variable';
 
     export const evaluate = 'debugger:evaluate';
 

--- a/packages/debugger/src/handler.ts
+++ b/packages/debugger/src/handler.ts
@@ -78,7 +78,7 @@ function updateToggleButton(
 /**
  * A handler for debugging a widget.
  */
-export class DebuggerHandler {
+export class DebuggerHandler implements DebuggerHandler.IHandler {
   /**
    * Instantiate a new DebuggerHandler.
    *
@@ -88,6 +88,15 @@ export class DebuggerHandler {
     this._type = options.type;
     this._shell = options.shell;
     this._service = options.service;
+  }
+
+  /**
+   * Get the active widget.
+   */
+  get activeWidget():
+    | DebuggerHandler.SessionWidget[DebuggerHandler.SessionType]
+    | null {
+    return this._activeWidget;
   }
 
   /**
@@ -155,6 +164,7 @@ export class DebuggerHandler {
     }
     connection.iopubMessage.connect(iopubMessage);
     this._iopubMessageHandlers[widget.id] = iopubMessage;
+    this._activeWidget = widget;
 
     return this.updateWidget(widget, connection);
   }
@@ -373,6 +383,9 @@ export class DebuggerHandler {
   private _shell: JupyterFrontEnd.IShell;
   private _service: IDebugger;
   private _previousConnection: Session.ISessionConnection | null;
+  private _activeWidget:
+    | DebuggerHandler.SessionWidget[DebuggerHandler.SessionType]
+    | null;
   private _handlers: {
     [id: string]: DebuggerHandler.SessionHandler[DebuggerHandler.SessionType];
   } = {};
@@ -439,6 +452,42 @@ export namespace DebuggerHandler {
      * The debugger service.
      */
     service: IDebugger;
+  }
+
+  /**
+   * An interface for debugger handler.
+   */
+  export interface IHandler {
+    /**
+     * Get the active widget.
+     */
+    activeWidget:
+      | DebuggerHandler.SessionWidget[DebuggerHandler.SessionType]
+      | null;
+
+    /**
+     * Update a debug handler for the given widget, and
+     * handle kernel changed events.
+     *
+     * @param widget The widget to update.
+     * @param connection The session connection.
+     */
+    update(
+      widget: DebuggerHandler.SessionWidget[DebuggerHandler.SessionType],
+      connection: Session.ISessionConnection | null
+    ): Promise<void>;
+
+    /**
+     * Update a debug handler for the given widget, and
+     * handle connection kernel changed events.
+     *
+     * @param widget The widget to update.
+     * @param sessionContext The session context.
+     */
+    updateContext(
+      widget: DebuggerHandler.SessionWidget[DebuggerHandler.SessionType],
+      sessionContext: ISessionContext
+    ): Promise<void>;
   }
 
   /**

--- a/packages/debugger/src/index.ts
+++ b/packages/debugger/src/index.ts
@@ -11,5 +11,6 @@ export {
   IDebugger,
   IDebuggerConfig,
   IDebuggerSources,
-  IDebuggerSidebar
+  IDebuggerSidebar,
+  IDebuggerHandler
 } from './tokens';

--- a/packages/debugger/src/model.ts
+++ b/packages/debugger/src/model.ts
@@ -16,7 +16,7 @@ import { VariablesModel } from './panels/variables/model';
 /**
  * A model for a debugger.
  */
-export class DebuggerModel {
+export class DebuggerModel implements IDebugger.Model.IService {
   /**
    * Instantiate a new DebuggerModel
    */
@@ -54,6 +54,16 @@ export class DebuggerModel {
    */
   get disposed(): ISignal<this, void> {
     return this._disposed;
+  }
+
+  /**
+   * Whether the kernel support rich variable rendering based on mime type.
+   */
+  get hasRichVariableRendering(): boolean {
+    return this._hasRichVariableRendering;
+  }
+  set hasRichVariableRendering(v: boolean) {
+    this._hasRichVariableRendering = v;
   }
 
   /**
@@ -128,6 +138,7 @@ export class DebuggerModel {
 
   private _disposed = new Signal<this, void>(this);
   private _isDisposed = false;
+  private _hasRichVariableRendering = false;
   private _stoppedThreads = new Set<number>();
   private _title = '-';
   private _titleChanged = new Signal<this, string>(this);

--- a/packages/debugger/src/panels/callstack/model.ts
+++ b/packages/debugger/src/panels/callstack/model.ts
@@ -21,8 +21,10 @@ export class CallstackModel implements IDebugger.Model.ICallstack {
    */
   set frames(newFrames: IDebugger.IStackFrame[]) {
     this._state = newFrames;
+    const currentFrameId =
+      this.frame !== null ? Private.getFrameId(this.frame) : '';
     const frame = newFrames.find(
-      frame => Private.getFrameId(frame) === Private.getFrameId(this.frame)
+      frame => Private.getFrameId(frame) === currentFrameId
     );
     // Default to the first frame if the previous one can't be found.
     // Otherwise keep the current frame selected.
@@ -35,14 +37,14 @@ export class CallstackModel implements IDebugger.Model.ICallstack {
   /**
    * Get the current frame.
    */
-  get frame(): IDebugger.IStackFrame {
+  get frame(): IDebugger.IStackFrame | null {
     return this._currentFrame;
   }
 
   /**
    * Set the current frame.
    */
-  set frame(frame: IDebugger.IStackFrame) {
+  set frame(frame: IDebugger.IStackFrame | null) {
     this._currentFrame = frame;
     this._currentFrameChanged.emit(frame);
   }
@@ -57,14 +59,16 @@ export class CallstackModel implements IDebugger.Model.ICallstack {
   /**
    * Signal emitted when the current frame has changed.
    */
-  get currentFrameChanged(): ISignal<this, IDebugger.IStackFrame> {
+  get currentFrameChanged(): ISignal<this, IDebugger.IStackFrame | null> {
     return this._currentFrameChanged;
   }
 
   private _state: IDebugger.IStackFrame[] = [];
-  private _currentFrame: IDebugger.IStackFrame;
+  private _currentFrame: IDebugger.IStackFrame | null = null;
   private _framesChanged = new Signal<this, IDebugger.IStackFrame[]>(this);
-  private _currentFrameChanged = new Signal<this, IDebugger.IStackFrame>(this);
+  private _currentFrameChanged = new Signal<this, IDebugger.IStackFrame | null>(
+    this
+  );
 }
 
 /**

--- a/packages/debugger/src/panels/sources/model.ts
+++ b/packages/debugger/src/panels/sources/model.ts
@@ -23,7 +23,7 @@ export class SourcesModel implements IDebugger.Model.ISources {
    */
   readonly currentFrameChanged: ISignal<
     IDebugger.Model.ICallstack,
-    IDebugger.IStackFrame
+    IDebugger.IStackFrame | null
   >;
 
   /**
@@ -88,7 +88,7 @@ export namespace SourcesModel {
      */
     currentFrameChanged: ISignal<
       IDebugger.Model.ICallstack,
-      IDebugger.IStackFrame
+      IDebugger.IStackFrame | null
     >;
   }
 }

--- a/packages/debugger/src/panels/variables/index.ts
+++ b/packages/debugger/src/panels/variables/index.ts
@@ -19,7 +19,7 @@ import { VariablesBodyTree } from './tree';
 /**
  * A Panel to show a variable explorer.
  */
-export class Variables extends Panel {
+export class Variables extends Panel implements IDebugger.IVariablesPanel {
   /**
    * Instantiate a new Variables Panel.
    *
@@ -32,7 +32,12 @@ export class Variables extends Panel {
     const translator = options.translator || nullTranslator;
     const trans = translator.load('jupyterlab');
     this._header = new VariablesHeader(translator);
-    this._tree = new VariablesBodyTree({ model, service });
+    this._tree = new VariablesBodyTree({
+      model,
+      service,
+      commands,
+      translator
+    });
     this._table = new VariablesBodyGrid({ model, commands, themeManager });
     this._table.hide();
 
@@ -87,7 +92,7 @@ export class Variables extends Panel {
       }
     };
 
-    markViewButtonSelection(this._table.isHidden ? 'tree' : 'table');
+    markViewButtonSelection(this.viewMode);
 
     this._header.toolbar.addItem('view-VariableTreeView', treeViewButton);
 
@@ -97,6 +102,22 @@ export class Variables extends Panel {
     this.addWidget(this._tree);
     this.addWidget(this._table);
     this.addClass('jp-DebuggerVariables');
+  }
+
+  /**
+   * Latest variable selected.
+   */
+  get latestSelection(): IDebugger.IVariableSelection | null {
+    return this._table.isHidden
+      ? this._tree.latestSelection
+      : this._table.latestSelection;
+  }
+
+  /**
+   * Get the variable explorer view mode
+   */
+  get viewMode(): 'tree' | 'table' {
+    return this._table.isHidden ? 'tree' : 'table';
   }
 
   /**

--- a/packages/debugger/src/panels/variables/mimerenderer.ts
+++ b/packages/debugger/src/panels/variables/mimerenderer.ts
@@ -1,0 +1,65 @@
+import { MainAreaWidget } from '@jupyterlab/apputils';
+import { IRenderMimeRegistry, MimeModel } from '@jupyterlab/rendermime';
+import { PromiseDelegate } from '@lumino/coreutils';
+import { Panel } from '@lumino/widgets';
+import { IDebugger } from '../../tokens';
+
+/**
+ * Debugger variable mime type renderer
+ */
+export class VariableMimeRenderer extends MainAreaWidget<Panel> {
+  /**
+   * Instantiate a new VariableMimeRenderer.
+   */
+  constructor(options: VariableMimeRenderer.IOptions) {
+    const { dataLoader, rendermime } = options;
+    const content = new Panel();
+    const loaded = new PromiseDelegate<void>();
+    super({
+      content,
+      reveal: Promise.all([dataLoader, loaded.promise])
+    });
+
+    dataLoader
+      .then(async data => {
+        if (data.data) {
+          const mimeType = rendermime.preferredMimeType(data.data, 'any');
+
+          if (mimeType) {
+            const widget = rendermime.createRenderer(mimeType);
+            const model = new MimeModel(data);
+            await widget.renderModel(model);
+
+            content.addWidget(widget);
+            loaded.resolve();
+          } else {
+            loaded.reject('Unable to determine the preferred mime type.');
+          }
+        } else {
+          loaded.reject('Unable to get a view on the variable.');
+        }
+      })
+      .catch(reason => {
+        loaded.reject(reason);
+      });
+  }
+}
+
+/**
+ * Debugger variable mime type renderer namespace
+ */
+export namespace VariableMimeRenderer {
+  /**
+   * Constructor options
+   */
+  export interface IOptions {
+    /**
+     * Variable to be rendered
+     */
+    dataLoader: Promise<IDebugger.IRichVariable>;
+    /**
+     * Render mime type registry
+     */
+    rendermime: IRenderMimeRegistry;
+  }
+}

--- a/packages/debugger/src/panels/variables/tree.tsx
+++ b/packages/debugger/src/panels/variables/tree.tsx
@@ -1,19 +1,20 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { caretDownEmptyIcon, ReactWidget } from '@jupyterlab/ui-components';
-
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import {
+  caretDownEmptyIcon,
+  ReactWidget,
+  searchIcon
+} from '@jupyterlab/ui-components';
 import { ArrayExt } from '@lumino/algorithm';
-
+import { CommandRegistry } from '@lumino/commands';
 import React, { useEffect, useState } from 'react';
-
 import { DebugProtocol } from 'vscode-debugprotocol';
-
-import { IDebugger } from '../../tokens';
-
-import { VariablesModel } from './model';
-
 import { convertType } from '.';
+import { Debugger } from '../../debugger';
+import { IDebugger } from '../../tokens';
+import { VariablesModel } from './model';
 
 /**
  * The body for tree of variables.
@@ -26,7 +27,9 @@ export class VariablesBodyTree extends ReactWidget {
    */
   constructor(options: VariablesBodyTree.IOptions) {
     super();
+    this._commands = options.commands;
     this._service = options.service;
+    this._translator = options.translator;
 
     const model = options.model;
     model.changed.connect(this._updateScopes, this);
@@ -44,13 +47,25 @@ export class VariablesBodyTree extends ReactWidget {
     return scope ? (
       <VariablesComponent
         key={scope.name}
+        commands={this._commands}
         service={this._service}
         data={scope.variables}
         filter={this._filter}
+        translator={this._translator}
+        handleSelectVariable={variable => {
+          this._latestSelection = variable;
+        }}
       />
     ) : (
       <div></div>
     );
+  }
+
+  /**
+   * Get the latest hit variable
+   */
+  get latestSelection(): IDebugger.IVariableSelection | null {
+    return this._latestSelection;
   }
 
   /**
@@ -82,10 +97,31 @@ export class VariablesBodyTree extends ReactWidget {
     this.update();
   }
 
+  private _commands: CommandRegistry;
   private _scope = '';
   private _scopes: IDebugger.IScope[] = [];
   private _filter = new Set<string>();
+  private _latestSelection: IDebugger.IVariableSelection | null = null;
   private _service: IDebugger;
+  private _translator: ITranslator | undefined;
+}
+
+interface IVariablesComponentProps {
+  /**
+   * The commands registry.
+   */
+  commands: CommandRegistry;
+  data: IDebugger.IVariable[];
+  service: IDebugger;
+  filter?: Set<string>;
+  /**
+   * The application language translator
+   */
+  translator?: ITranslator;
+  /**
+   * Callback on variable selection
+   */
+  handleSelectVariable?: (variable: IDebugger.IVariable) => void;
 }
 
 /**
@@ -96,15 +132,15 @@ export class VariablesBodyTree extends ReactWidget {
  * @param props.service The debugger service.
  * @param props.filter Optional variable filter list.
  */
-const VariablesComponent = ({
-  data,
-  service,
-  filter
-}: {
-  data: IDebugger.IVariable[];
-  service: IDebugger;
-  filter?: Set<string>;
-}): JSX.Element => {
+const VariablesComponent = (props: IVariablesComponentProps): JSX.Element => {
+  const {
+    commands,
+    data,
+    service,
+    filter,
+    translator,
+    handleSelectVariable
+  } = props;
   const [variables, setVariables] = useState(data);
 
   useEffect(() => {
@@ -122,15 +158,48 @@ const VariablesComponent = ({
           return (
             <VariableComponent
               key={key}
+              commands={commands}
               data={variable}
               service={service}
               filter={filter}
+              translator={translator}
+              onSelect={handleSelectVariable}
             />
           );
         })}
     </ul>
   );
 };
+
+/**
+ * VariableComponent properties
+ */
+interface IVariableComponentProps {
+  /**
+   * The commands registry.
+   */
+  commands: CommandRegistry;
+  /**
+   * Variable description
+   */
+  data: IDebugger.IVariable;
+  /**
+   * Filter applied on the variable list
+   */
+  filter?: Set<string>;
+  /**
+   * The Debugger service
+   */
+  service: IDebugger;
+  /**
+   * The application language translator
+   */
+  translator?: ITranslator;
+  /**
+   * Callback on selection
+   */
+  onSelect?: (variable: IDebugger.IVariable) => void;
+}
 
 /**
  * A React component to display one node variable in tree.
@@ -140,15 +209,8 @@ const VariablesComponent = ({
  * @param props.service The debugger service.
  * @param props.filter Optional variable filter list.
  */
-const VariableComponent = ({
-  data,
-  service,
-  filter
-}: {
-  data: IDebugger.IVariable;
-  service: IDebugger;
-  filter?: Set<string>;
-}): JSX.Element => {
+const VariableComponent = (props: IVariableComponentProps): JSX.Element => {
+  const { commands, data, service, filter, translator, onSelect } = props;
   const [variable] = useState(data);
   const [expanded, setExpanded] = useState<boolean>();
   const [variables, setVariables] = useState<DebugProtocol.Variable[]>();
@@ -159,9 +221,12 @@ const VariableComponent = ({
   const styleType = {
     color: 'var(--jp-mirror-editor-string-color)'
   };
+  const onSelection = onSelect ?? (() => void 0);
 
   const expandable =
     variable.variablesReference !== 0 || variable.type === 'function';
+
+  const trans = (translator ?? nullTranslator).load('jupyterlab');
 
   const onVariableClicked = async (e: React.MouseEvent): Promise<void> => {
     if (!expandable) {
@@ -176,7 +241,12 @@ const VariableComponent = ({
   };
 
   return (
-    <li onClick={(e): Promise<void> => onVariableClicked(e)}>
+    <li
+      onClick={(e): Promise<void> => onVariableClicked(e)}
+      onMouseDown={() => {
+        onSelection(variable);
+      }}
+    >
       <caretDownEmptyIcon.react
         visibility={expandable ? 'visible' : 'hidden'}
         stylesheet="menuItem"
@@ -186,12 +256,45 @@ const VariableComponent = ({
       <span style={styleName}>{variable.name}</span>
       <span>: </span>
       <span style={styleType}>{convertType(variable)}</span>
+      <span className="jp-DebuggerVariables-hspacer"></span>
+      {service.model.hasRichVariableRendering && (
+        <button
+          className="jp-DebuggerVariables-renderVariable"
+          disabled={
+            !commands.isEnabled(Debugger.CommandIDs.renderMimeVariable, {
+              name: variable.name,
+              variablesReference: variable.variablesReference
+            } as any)
+          }
+          onClick={e => {
+            e.stopPropagation();
+            onSelection(variable);
+            commands
+              .execute(Debugger.CommandIDs.renderMimeVariable, {
+                name: variable.name,
+                variablesReference: variable.variablesReference
+              } as any)
+              .catch(reason => {
+                console.error(
+                  `Failed to render variable ${variable.name}`,
+                  reason
+                );
+              });
+          }}
+          title={trans.__('Render variable')}
+        >
+          <searchIcon.react stylesheet="menuItem" tag="span" />
+        </button>
+      )}
+
       {expanded && variables && (
         <VariablesComponent
           key={variable.name}
+          commands={commands}
           data={variables}
           service={service}
           filter={filter}
+          translator={translator}
         />
       )}
     </li>
@@ -214,5 +317,13 @@ namespace VariablesBodyTree {
      * The debugger service.
      */
     service: IDebugger;
+    /**
+     * The commands registry.
+     */
+    commands: CommandRegistry;
+    /**
+     * The application language translator
+     */
+    translator?: ITranslator;
   }
 }

--- a/packages/debugger/src/service.ts
+++ b/packages/debugger/src/service.ts
@@ -260,6 +260,31 @@ export class DebuggerService implements IDebugger, IDisposable {
   }
 
   /**
+   * Request rich representation of a variable.
+   *
+   * @param variableName The variable name to request
+   * @param frameId The current frame id in which to request the variable
+   * @returns The mime renderer data model
+   */
+  async inspectRichVariable(
+    variableName: string,
+    frameId?: number
+  ): Promise<IDebugger.IRichVariable> {
+    if (!this.session) {
+      throw new Error('No active debugger session');
+    }
+    const reply = await this.session.sendRequest('richInspectVariables', {
+      variableName,
+      frameId
+    });
+    if (reply.success) {
+      return reply.body;
+    } else {
+      throw new Error(reply.message);
+    }
+  }
+
+  /**
    * Request variables for a given variable reference.
    *
    * @param variablesReference The variable reference to request.
@@ -273,7 +298,11 @@ export class DebuggerService implements IDebugger, IDisposable {
     const reply = await this.session.sendRequest('variables', {
       variablesReference
     });
-    return reply.body.variables;
+    if (reply.success) {
+      return reply.body.variables;
+    } else {
+      throw new Error(reply.message);
+    }
   }
 
   /**
@@ -318,9 +347,10 @@ export class DebuggerService implements IDebugger, IDisposable {
 
     const reply = await this.session.restoreState();
     const { body } = reply;
-    const breakpoints = this._mapBreakpoints(reply.body.breakpoints);
-    const stoppedThreads = new Set(reply.body.stoppedThreads);
+    const breakpoints = this._mapBreakpoints(body.breakpoints);
+    const stoppedThreads = new Set(body.stoppedThreads);
 
+    this._model.hasRichVariableRendering = body.richRendering === true;
     this._config.setHashParams({
       kernel: this.session?.connection?.kernel?.name ?? '',
       method: body.hashMethod,

--- a/packages/debugger/src/tokens.ts
+++ b/packages/debugger/src/tokens.ts
@@ -5,7 +5,7 @@ import { CodeEditor, CodeEditorWrapper } from '@jupyterlab/codeeditor';
 
 import { KernelMessage, Session } from '@jupyterlab/services';
 
-import { Token } from '@lumino/coreutils';
+import { ReadonlyJSONObject, Token } from '@lumino/coreutils';
 
 import { IObservableDisposable } from '@lumino/disposable';
 
@@ -14,6 +14,8 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 
 import { DebugProtocol } from 'vscode-debugprotocol';
+
+import { DebuggerHandler } from './handler';
 
 /**
  * An interface describing an application's visual debugger.
@@ -86,6 +88,18 @@ export interface IDebugger {
   inspectVariable(
     variablesReference: number
   ): Promise<DebugProtocol.Variable[]>;
+
+  /**
+   * Request rich representation of a variable.
+   *
+   * @param variableName The variable name to request
+   * @param variablesReference The variable reference to request
+   * @returns The mime renderer data model
+   */
+  inspectRichVariable(
+    variableName: string,
+    variablesReference?: number
+  ): Promise<IDebugger.IRichVariable>;
 
   /**
    * Requests all the defined variables and display them in the
@@ -249,6 +263,11 @@ export namespace IDebugger {
   }
 
   /**
+   * An interface for debugger handler.
+   */
+  export interface IHandler extends DebuggerHandler.IHandler {}
+
+  /**
    * An interface for a scope.
    */
   export interface IScope {
@@ -336,6 +355,21 @@ export namespace IDebugger {
   export interface IStackFrame extends DebugProtocol.StackFrame {}
 
   /**
+   * A reply to an rich inspection request.
+   */
+  export interface IRichVariable {
+    /**
+     * The MIME bundle data returned from an rich inspection request.
+     */
+    data: ReadonlyJSONObject;
+
+    /**
+     * Any metadata that accompanies the MIME bundle returning from a rich inspection request.
+     */
+    metadata: ReadonlyJSONObject;
+  }
+
+  /**
    * An interface for a variable.
    */
   export interface IVariable extends DebugProtocol.Variable {
@@ -421,6 +455,7 @@ export namespace IDebugger {
       restart: DebugProtocol.RestartArguments;
       restartFrame: DebugProtocol.RestartFrameArguments;
       reverseContinue: DebugProtocol.ReverseContinueArguments;
+      richInspectVariables: IRichVariablesArguments;
       scopes: DebugProtocol.ScopesArguments;
       setBreakpoints: DebugProtocol.SetBreakpointsArguments;
       setExceptionBreakpoints: DebugProtocol.SetExceptionBreakpointsArguments;
@@ -464,6 +499,7 @@ export namespace IDebugger {
       restart: DebugProtocol.RestartResponse;
       restartFrame: DebugProtocol.RestartFrameResponse;
       reverseContinue: DebugProtocol.ReverseContinueResponse;
+      richInspectVariables: IRichVariablesResponse;
       scopes: DebugProtocol.ScopesResponse;
       setBreakpoints: DebugProtocol.SetBreakpointsResponse;
       setExceptionBreakpoints: DebugProtocol.SetExceptionBreakpointsResponse;
@@ -497,13 +533,17 @@ export namespace IDebugger {
      */
     export interface IDebugInfoResponse extends DebugProtocol.Response {
       body: {
-        isStarted: boolean;
+        breakpoints: IDebugInfoBreakpoints[];
         hashMethod: string;
         hashSeed: number;
-        breakpoints: IDebugInfoBreakpoints[];
+        isStarted: boolean;
+        /**
+         * Whether the kernel supports variable rich rendering or not.
+         */
+        richRendering?: boolean;
+        stoppedThreads: number[];
         tmpFilePrefix: string;
         tmpFileSuffix: string;
-        stoppedThreads: number[];
       };
     }
 
@@ -534,6 +574,36 @@ export namespace IDebugger {
     }
 
     /**
+     * Arguments for 'richVariables' request
+     *
+     * This is an addition to the Debug Adapter Protocol to support
+     * render rich variable representation.
+     */
+    export interface IRichVariablesArguments {
+      /**
+       * Variable name
+       */
+      variableName: string;
+      /**
+       * Frame Id
+       */
+      frameId?: number;
+    }
+
+    /**
+     * Arguments for 'richVariables' request
+     *
+     * This is an addition to the Debug Adapter Protocol to support
+     * rich rendering of variables.
+     */
+    export interface IRichVariablesResponse extends DebugProtocol.Response {
+      /**
+       * Variable mime type data
+       */
+      body: IRichVariable;
+    }
+
+    /**
      * Response to the 'kernel_info_request' request.
      * This interface extends the IInfoReply by adding the `debugger` key
      * that isn't part of the protocol yet.
@@ -545,9 +615,37 @@ export namespace IDebugger {
   }
 
   /**
+   * Select variable in the variables explorer.
+   */
+  export interface IVariableSelection
+    extends Pick<
+      DebugProtocol.Variable,
+      'name' | 'type' | 'variablesReference' | 'value'
+    > {}
+
+  /**
+   * Debugger variables explorer interface.
+   */
+  export interface IVariablesPanel {
+    /**
+     * Select variable in the variables explorer.
+     */
+    latestSelection: IVariableSelection | null;
+    /**
+     * Variable view mode.
+     */
+    viewMode: 'tree' | 'table';
+  }
+
+  /**
    * Debugger sidebar interface.
    */
   export interface ISidebar extends Widget {
+    /**
+     * Debugger variables explorer.
+     */
+    variables: IVariablesPanel;
+
     /**
      * Add item at the end of the sidebar.
      */
@@ -672,12 +770,12 @@ export namespace IDebugger {
       /**
        * Signal emitted when the current frame has changed.
        */
-      readonly currentFrameChanged: ISignal<this, IDebugger.IStackFrame>;
+      readonly currentFrameChanged: ISignal<this, IDebugger.IStackFrame | null>;
 
       /**
        * The current frame.
        */
-      frame: IDebugger.IStackFrame;
+      frame: IDebugger.IStackFrame | null;
 
       /**
        * The frames for the callstack.
@@ -703,6 +801,11 @@ export namespace IDebugger {
        * The callstack UI model.
        */
       readonly callstack: ICallstack;
+
+      /**
+       * Whether the kernel support rich variable rendering based on mime type.
+       */
+      hasRichVariableRendering: boolean;
 
       /**
        * The variables UI model.
@@ -744,7 +847,7 @@ export namespace IDebugger {
        */
       readonly currentFrameChanged: ISignal<
         IDebugger.Model.ICallstack,
-        IDebugger.IStackFrame
+        IDebugger.IStackFrame | null
       >;
 
       /**
@@ -827,4 +930,11 @@ export const IDebuggerSources = new Token<IDebugger.ISources>(
  */
 export const IDebuggerSidebar = new Token<IDebugger.ISidebar>(
   '@jupyterlab/debugger:IDebuggerSidebar'
+);
+
+/**
+ * The debugger handler token.
+ */
+export const IDebuggerHandler = new Token<IDebugger.IHandler>(
+  '@jupyterlab/debugger:IDebuggerHandler'
 );

--- a/packages/debugger/style/variables.css
+++ b/packages/debugger/style/variables.css
@@ -30,6 +30,38 @@
   padding: 5px 0 0 0;
   cursor: pointer;
   color: var(--jp-content-font-color1);
+  display: flex;
+  align-items: center;
+}
+
+.jp-DebuggerVariables-body ul li:hover .jp-DebuggerVariables-renderVariable {
+  display: block;
+}
+
+.jp-DebuggerVariables-body .jp-DebuggerVariables-hspacer {
+  flex: 1 1 auto;
+}
+
+.jp-DebuggerVariables-body .jp-DebuggerVariables-renderVariable {
+  flex: 0 0 auto;
+  border: none;
+  background: none;
+  cursor: pointer;
+  display: none;
+  padding: 0px 8px;
+}
+
+.jp-DebuggerVariables-body .jp-DebuggerVariables-renderVariable:active {
+  transform: scale(1.272) translateX(-4px);
+  overflow: hidden;
+}
+
+.jp-DebuggerVariables-body .jp-DebuggerVariables-renderVariable:hover {
+  background-color: var(--jp-layout-color2);
+}
+
+.jp-DebuggerVariables-body .jp-DebuggerVariables-renderVariable:disabled {
+  cursor: default;
 }
 
 .jp-DebuggerVariables-body ul li > ul {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

Status : 

~~Waiting on #10406 to ensure no visual regression~~
i won't have time to address #10406. This can be merged if approved.

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Xeus-python is providing a new debug message to get a rich variable representation:
https://github.com/jupyter-xeus/xeus-python/pull/446

Fixes #9867

This adds a command and a panel to display such rich variable.

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Add a new command to trigger the variable rich display
- Add context menu on variable explorer
  - That required to add an interface on the explorer to get the selected variable
- In the tree view an action button is displayed on hover to render the variable
- Add some styling to make the error message in MainAreaWidget appear on error background.
- the kernel capability is returned in the debugInfo request to add this feature or not.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
New context menu on the variable explorer. It has one entry on the tree view to render the variable based on mime type information. And on the grid view it has a second entry to inspect the object

The rich renderer can also be triggered from an action button displayed on hover in the tree view.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A