### PR TITLE
Update Maintainer List

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,28 +146,33 @@ JupyterLab's current maintainers are listed in alphabetical order, with affiliat
 - Mehmet Bektas, Splunk (general development, extensions).
 - Alex Bozarth, IBM (general development, extensions).
 - Eric Charles, Datalayer, (general development, extensions).
+- Frédéric Collonval, QuantStack (general development, extensions).
 - Martha Cryan, IBM (general development, extensions).
 - Afshin Darian, Two Sigma (co-creator, application/high-level architecture,
   prolific contributions throughout the code base).
 - Vidar T. Fauske, JPMorgan Chase (general development, extensions).
-- Tim George, Cal Poly (UI/UX design, strategy, management, user needs analysis)
 - Brian Granger, AWS (co-creator, strategy, vision, management, UI/UX design,
   architecture).
 - Jason Grout, Bloomberg (co-creator, vision, general development).
+- Michał Krassowski, University of Oxford (general development, extensions).
 - Max Klein, JPMorgan Chase (UI Package, build system, general development, extensions).
+- Gonzalo Peña-Castellanos, QuanSight  (general development, i18n, extensions).
 - Fernando Perez, UC Berkeley (co-creator, vision).
-- Ian Rose, Quansight/City of LA (general core development, extensions).
-- Andrew Schlaepfer, Bloomberg (general development, extensions).
-- Saul Shanabrook, Quansight (general development, extensions)
+- Isabela Presedo-Floyd, QuanSight Labs (design/UX).
 - Steven Silvester, Apple (co-creator, release management, packaging,
   prolific contributions throughout the code base).
+- Jeremy Tuloup, QuantStack (general development, extensions).
 
 Maintainer emeritus:
 
 - Chris Colbert, Project Jupyter (co-creator, application/low-level architecture,
   technical leadership, vision, PhosphorJS)
 - Jessica Forde, Project Jupyter (demo, documentation)
+- Tim George, Cal Poly (UI/UX design, strategy, management, user needs analysis).
 - Cameron Oelsen, Cal Poly (UI/UX design).
+- Ian Rose, Quansight/City of LA (general core development, extensions).
+- Andrew Schlaepfer, Bloomberg (general development, extensions).
+- Saul Shanabrook, Quansight (general development, extensions)
 
 This list is provided to give the reader context on who we are and how our team functions.
 To be listed, please submit a pull request with your information.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ JupyterLab's current maintainers are listed in alphabetical order, with affiliat
 - Jason Grout, Bloomberg (co-creator, vision, general development).
 - Michał Krassowski, University of Oxford (general development, extensions).
 - Max Klein, JPMorgan Chase (UI Package, build system, general development, extensions).
-- Gonzalo Peña-Castellanos, QuanSight  (general development, i18n, extensions).
+- Gonzalo Peña-Castellanos, QuanSight (general development, i18n, extensions).
 - Fernando Perez, UC Berkeley (co-creator, vision).
 - Isabela Presedo-Floyd, QuanSight Labs (design/UX).
 - Steven Silvester, Apple (co-creator, release management, packaging,


### PR DESCRIPTION

Updates maintainer list to reflect folks who have been doing maintenance work over a period of time.
I verified that all new members have 2FA enabled.

I moved @saulshanabrook, @tgeorgeux, @ian-r-rose, and @aschlaep to emeritus status, but please feel free to return to active status at any time!

@fcollonval, @krassowski, @goanpeca, @isabela-pf, @jtpio, welcome, and thanks for your service!
