### PR TITLE
Add Yjs as a singleton package

### DIFF
--- a/builder/src/webpack.config.base.ts
+++ b/builder/src/webpack.config.base.ts
@@ -42,6 +42,10 @@ const rules = [
     }
   },
   {
+    test: /\.m?js$/,
+    type: 'javascript/auto'
+  },
+  {
     test: /\.m?js/,
     resolve: {
       fullySpecified: false

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -119,7 +119,8 @@
     "@lumino/virtualdom": "^1.8.0",
     "@lumino/widgets": "^1.19.0",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react-dom": "^17.0.1",
+    "yjs": "^13.5.6"
   },
   "dependencies": {
     "@jupyterlab/application": "~3.1.0-alpha.10",
@@ -299,7 +300,8 @@
       "@lumino/virtualdom",
       "@lumino/widgets",
       "react",
-      "react-dom"
+      "react-dom",
+      "yjs"
     ],
     "linkedPackages": {
       "@jupyterlab/application": "../packages/application",

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -57,7 +57,7 @@
     "@lumino/widgets": "^1.19.0",
     "codemirror": "~5.61.0",
     "react": "^17.0.1",
-    "y-codemirror": "^2.1.0"
+    "y-codemirror": "^2.1.1"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.10",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -41,7 +41,7 @@
     "@jupyterlab/shared-models": "^3.1.0-alpha.10",
     "@lumino/coreutils": "^1.5.3",
     "lib0": "^0.2.42",
-    "y-websocket": "^1.3.14",
+    "y-websocket": "^1.3.15",
     "yjs": "^13.5.6"
   },
   "devDependencies": {

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -40,9 +40,9 @@
   "dependencies": {
     "@jupyterlab/shared-models": "^3.1.0-alpha.10",
     "@lumino/coreutils": "^1.5.3",
-    "lib0": "^0.2.41",
-    "y-websocket": "^1.3.11",
-    "yjs": "^13.5.3"
+    "lib0": "^0.2.42",
+    "y-websocket": "^1.3.13",
+    "yjs": "^13.5.6"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.10",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -41,7 +41,7 @@
     "@jupyterlab/shared-models": "^3.1.0-alpha.10",
     "@lumino/coreutils": "^1.5.3",
     "lib0": "^0.2.42",
-    "y-websocket": "^1.3.13",
+    "y-websocket": "^1.3.14",
     "yjs": "^13.5.6"
   },
   "devDependencies": {

--- a/packages/docprovider/tsconfig.test.json
+++ b/packages/docprovider/tsconfig.test.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfigbase.test",
   "include": ["src/*", "test/*"],
-  "paths": {
-    "y-protocols/awareness.js": "y-protocols/dist/awareness.cjs"
-  },
   "references": [
     {
       "path": "../shared-models"

--- a/packages/docregistry/package.json
+++ b/packages/docregistry/package.json
@@ -60,7 +60,7 @@
     "@lumino/messaging": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
     "@lumino/widgets": "^1.19.0",
-    "yjs": "^13.5.3"
+    "yjs": "^13.5.6"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.10",

--- a/packages/shared-models/package.json
+++ b/packages/shared-models/package.json
@@ -42,8 +42,8 @@
     "@lumino/coreutils": "^1.5.3",
     "@lumino/disposable": "^1.4.3",
     "@lumino/signaling": "^1.4.3",
-    "y-protocols": "^1.0.4",
-    "yjs": "^13.5.3"
+    "y-protocols": "^1.0.5",
+    "yjs": "^13.5.6"
   },
   "devDependencies": {
     "@jupyterlab/testutils": "^3.1.0-alpha.10",

--- a/packages/shared-models/tsconfig.test.json
+++ b/packages/shared-models/tsconfig.test.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfigbase.test",
   "include": ["src/*", "test/*"],
-  "paths": {
-    "y-protocols/awareness.js": "y-protocols/dist/awareness.cjs"
-  },
   "references": [
     {
       "path": "../nbformat"

--- a/testutils/src/jest-config.ts
+++ b/testutils/src/jest-config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-const esModules = ['lib0', 'y-protocols'].join('|');
+const esModules = ['lib0', 'y\\-protocols', 'y\\-websocket', 'yjs'].join('|');
 
 module.exports = function (baseDir: string) {
   return {
@@ -26,7 +26,7 @@ module.exports = function (baseDir: string) {
       'mjs',
       'cjs'
     ],
-    transformIgnorePatterns: [`/node_modules/(?!${esModules}).+\\.js`],
+    transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`],
     reporters: ['default', 'jest-junit', 'jest-summary-reporter'],
     coverageReporters: ['json', 'lcov', 'text', 'html'],
     coverageDirectory: path.join(baseDir, 'coverage'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10584,14 +10584,7 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lib0@^0.2.31, lib0@^0.2.41:
-  version "0.2.41"
-  resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.41.tgz#57e6e9ffa2eb7c621c891946d150af50fac035bc"
-  integrity sha512-lZ0I6N81tIDgoPIlUTRhb6mNjPsG5BXIbaK/UbtjakcYnfR+O64bKtIrLXDDnfd7nAo4vpGeZ0mPzbTsNTREcg==
-  dependencies:
-    isomorphic.js "^0.2.4"
-
-lib0@^0.2.42:
+lib0@^0.2.31, lib0@^0.2.41, lib0@^0.2.42:
   version "0.2.42"
   resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.42.tgz#6d8bf1fb8205dec37a953c521c5ee403fd8769b0"
   integrity sha512-8BNM4MiokEKzMvSxTOC3gnCBisJH+jL67CnSnqzHv3jli3pUvGC8wz+0DQ2YvGr4wVQdb2R2uNNPw9LEpVvJ4Q==
@@ -16915,10 +16908,10 @@ y-protocols@^1.0.5:
   dependencies:
     lib0 "^0.2.42"
 
-y-websocket@^1.3.14:
-  version "1.3.14"
-  resolved "https://registry.yarnpkg.com/y-websocket/-/y-websocket-1.3.14.tgz#c6b1ba550aad7a3ec0d9c3dea68883e05d4cbcf0"
-  integrity sha512-F/KkUE8BOjG5cr4bxICTtQEVhPqX8RtLcDg0CldHc2r0fsx69jbWMefENmqfDD656WdJeEOk54m9sHN6vck/Bw==
+y-websocket@^1.3.15:
+  version "1.3.15"
+  resolved "https://registry.yarnpkg.com/y-websocket/-/y-websocket-1.3.15.tgz#f88d099e74d68ec6eb3e032106acf70837ed654f"
+  integrity sha512-ZASGk9jCeUM6GOMxhFZSAZoP4ItSCmGchItAMG7GSiPY3hr1X19fCflRtnw2Z/y4/d1WoRTnwyuQb8g0l285jQ==
   dependencies:
     lib0 "^0.2.42"
     lodash.debounce "^4.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9658,7 +9658,7 @@ isomorphic-fetch@^2.1.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
-isomorphic.js@^0.2.2, isomorphic.js@^0.2.4:
+isomorphic.js@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/isomorphic.js/-/isomorphic.js-0.2.4.tgz#24ca374163ae54a7ce3b86ce63b701b91aa84969"
   integrity sha512-Y4NjZceAwaPXctwsHgNsmfuPxR8lJ3f8X7QTAkhltrX4oGIv+eTlgHLXn4tWysC9zGTi929gapnPp+8F8cg7nA==
@@ -10591,12 +10591,12 @@ lib0@^0.2.31, lib0@^0.2.41:
   dependencies:
     isomorphic.js "^0.2.4"
 
-lib0@^0.2.35, lib0@^0.2.38:
-  version "0.2.40"
-  resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.40.tgz#7c89c2a7a89f9caaa0a04eaecb944d8e90a731b3"
-  integrity sha512-bKJxwll8MdwTTL3Siut6L+FjyF5sewXRE7noDTsRquEYy3Xi1UjtdEMZu46iuTvw9nQ/9p+gKkh1GxL2Kdaphw==
+lib0@^0.2.42:
+  version "0.2.42"
+  resolved "https://registry.yarnpkg.com/lib0/-/lib0-0.2.42.tgz#6d8bf1fb8205dec37a953c521c5ee403fd8769b0"
+  integrity sha512-8BNM4MiokEKzMvSxTOC3gnCBisJH+jL67CnSnqzHv3jli3pUvGC8wz+0DQ2YvGr4wVQdb2R2uNNPw9LEpVvJ4Q==
   dependencies:
-    isomorphic.js "^0.2.2"
+    isomorphic.js "^0.2.4"
 
 license-webpack-plugin@^2.3.11:
   version "2.3.11"
@@ -16893,12 +16893,12 @@ xterm@~4.8.1:
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.8.1.tgz#155a1729a43e1a89b406524e22c5634339e39ca1"
   integrity sha512-ax91ny4tI5eklqIfH79OUSGE2PUX2rGbwONmB6DfqpyhSZO8/cf++sqiaMWEVCMjACyMfnISW7C3gGMoNvNolQ==
 
-y-codemirror@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/y-codemirror/-/y-codemirror-2.1.0.tgz#905c85fececd6ffa784f9c4bcb69c22ff1ae696e"
-  integrity sha512-lwuXbZoUW1EmhSTFYR7Qkbi01ixn5/L2LpnZ/7/vSRcJL3PKnWLFJOxXdXTx6bNDGUjY8N0VjJe97fYL6ev00Q==
+y-codemirror@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/y-codemirror/-/y-codemirror-2.1.1.tgz#e841fc3001b719d7fa457dd7a9748205e2874fe9"
+  integrity sha512-QXHaOkvEJs3pB82dkW1aGfWUd4S1RA1ORtXWtprHClbqBiCOY19VKiojScSTyl8rTaOZ/zblEq+SNH2sd3Umiw==
   dependencies:
-    lib0 "^0.2.35"
+    lib0 "^0.2.41"
 
 y-leveldb@^0.1.0:
   version "0.1.0"
@@ -16908,21 +16908,21 @@ y-leveldb@^0.1.0:
     level "^6.0.1"
     lib0 "^0.2.31"
 
-y-protocols@^1.0.3, y-protocols@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/y-protocols/-/y-protocols-1.0.4.tgz#810978c6172474be87457c3bcd669e529c5ba3a1"
-  integrity sha512-5/Hd6DJ5Y2SlbqLIKq86BictdOS0iAcWJZCVop8MKqx0XWwA+BbMn4538n4Z0CGjFMUGnG1kGzagk3BKGz5SvQ==
+y-protocols@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/y-protocols/-/y-protocols-1.0.5.tgz#91d574250060b29fcac8f8eb5e276fbad594245e"
+  integrity sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==
   dependencies:
-    lib0 "^0.2.35"
+    lib0 "^0.2.42"
 
-y-websocket@^1.3.11:
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/y-websocket/-/y-websocket-1.3.11.tgz#b6e1357a2f63fe8d74ab8999991f85af88ed4221"
-  integrity sha512-Cvf85SE1mwFxrMRCokr4Rj16febCtfJziQWGn/F74h2W37SGPPpPNQjYZR9PFG7ryMAskoMF3ge7ZR1IEnL5CQ==
+y-websocket@^1.3.13:
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/y-websocket/-/y-websocket-1.3.13.tgz#5ef20f59e3b8d1660db008d1c5df71ee6a388058"
+  integrity sha512-KKz+KsCaWAFk9YblwpyNDROtvTkWq4ObHtPH9ggQB0Crw/Ad1z6SJhdnZkObCyS3vxZBy0gX9EIVmT6RnGpOpA==
   dependencies:
-    lib0 "^0.2.35"
+    lib0 "^0.2.42"
     lodash.debounce "^4.0.8"
-    y-protocols "^1.0.3"
+    y-protocols "^1.0.5"
   optionalDependencies:
     ws "^6.2.1"
     y-leveldb "^0.1.0"
@@ -17029,9 +17029,9 @@ yarn@1.21.1:
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.21.1.tgz#1d5da01a9a03492dc4a5957befc1fd12da83d89c"
   integrity sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ==
 
-yjs@^13.5.3:
-  version "13.5.3"
-  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.3.tgz#0efc5983ec287d24f4471f8f4184f9df80780835"
-  integrity sha512-LlkmCr68LCfkmoic6rBjDaD01vbdMhy07dXYo65sQ0wOYh8eylrU1b0lTo3YT/BmcyH5Jn4KewDxyJMsDwvERw==
+yjs@^13.5.6:
+  version "13.5.6"
+  resolved "https://registry.yarnpkg.com/yjs/-/yjs-13.5.6.tgz#37350d0b5ee5a7c80aa84771b4a5fb551a02c690"
+  integrity sha512-0ebPpLB/zizJbWaFUDRarWbXiXYD0OMDOCa8ZqkVVWQzeIoMRbmbNwB3suZ9YwD0bV4Su9RLn8M/bvGzIwX3hA==
   dependencies:
-    lib0 "^0.2.38"
+    lib0 "^0.2.41"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16915,10 +16915,10 @@ y-protocols@^1.0.5:
   dependencies:
     lib0 "^0.2.42"
 
-y-websocket@^1.3.13:
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/y-websocket/-/y-websocket-1.3.13.tgz#5ef20f59e3b8d1660db008d1c5df71ee6a388058"
-  integrity sha512-KKz+KsCaWAFk9YblwpyNDROtvTkWq4ObHtPH9ggQB0Crw/Ad1z6SJhdnZkObCyS3vxZBy0gX9EIVmT6RnGpOpA==
+y-websocket@^1.3.14:
+  version "1.3.14"
+  resolved "https://registry.yarnpkg.com/y-websocket/-/y-websocket-1.3.14.tgz#c6b1ba550aad7a3ec0d9c3dea68883e05d4cbcf0"
+  integrity sha512-F/KkUE8BOjG5cr4bxICTtQEVhPqX8RtLcDg0CldHc2r0fsx69jbWMefENmqfDD656WdJeEOk54m9sHN6vck/Bw==
   dependencies:
     lib0 "^0.2.42"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
## References

This addresses #10266. Extensions that define custom shared modules should share the Yjs dependency with JupyterLab. This reduces dependencies but is also needed for technical reasons as explained in the ticket.

I confirmed with @hbcarlos that this PR fixes the mentioned problem and that the yjs package is now shared with extensions.

## Code changes

This PR adds Yjs as a singleton package and updates Yjs-related dependencies. Yjs and related modules are exported as EcmaScript modules and as CommonJS modules. I made sure that from now on all packages consume the EcmaScript module version of Yjs which should result in smaller bundles.

## User-facing changes

None.

## Backwards-incompatible changes

None.
