### PR TITLE
Fix focus accept button on dialog unit test

### DIFF
--- a/packages/apputils/test/dialog.spec.tsx
+++ b/packages/apputils/test/dialog.spec.tsx
@@ -240,7 +240,7 @@ describe('@jupyterlab/apputils', () => {
         it('should focus the default button when focus leaves the dialog', async () => {
           const host = document.createElement('div');
           const target = document.createElement('div');
-          target.tabIndex = 0;  // Make the div element focusable
+          target.tabIndex = 0; // Make the div element focusable
           const dialog = new TestDialog({ host });
 
           document.body.appendChild(target);

--- a/packages/apputils/test/dialog.spec.tsx
+++ b/packages/apputils/test/dialog.spec.tsx
@@ -240,6 +240,7 @@ describe('@jupyterlab/apputils', () => {
         it('should focus the default button when focus leaves the dialog', async () => {
           const host = document.createElement('div');
           const target = document.createElement('div');
+          target.tabIndex = 0;  // Make the div element focusable
           const dialog = new TestDialog({ host });
 
           document.body.appendChild(target);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #10302
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Set tabIndex on the dummy target to test the dialog is catching the focus as wanted.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A