### PR TITLE
Update labeler and add auto assign to PRs

### DIFF
--- a/.github/workflows/auto_author_assign.yml
+++ b/.github/workflows/auto_author_assign.yml
@@ -1,0 +1,15 @@
+# https://github.com/marketplace/actions/auto-author-assign
+name: 'Auto Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.3.4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,19 +1,13 @@
-name: Pull Request Labeler
-# This workflow is supposed to run every 5 minutes
+# https://github.com/marketplace/actions/labeler
+name: "Pull Request Labeler"
 on:
-  schedule:
-    - cron: '*/20 * * * *'
-permissions:
-  pull-requests:
-    write
+- pull_request_target
+
 jobs:
   triage:
     name: Update PR Labels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - if: github.repository == 'jupyterlab/jupyterlab'
-        uses: paulfantom/periodic-labeler@dffbc90404f371f76444a69221c2f7ad079e2319
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          LABEL_MAPPINGS_FILE: .github/labeler.yml
+    - uses: actions/labeler@main
+      env:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
- Updates the labeler workflow to use the latest pull_request_target so that it run on the PR right away and has the correct token to be able to set labels
- Add a PR auto assign workflow, to make triaging and filtering easier, since while someone is working on a PR it should be basically assigned to it.