### PR TITLE
Fix remote-caret rendering

### DIFF
--- a/packages/codemirror/style/base.css
+++ b/packages/codemirror/style/base.css
@@ -230,8 +230,7 @@
 /* Styles for shared cursors (remote cursor locations and selected ranges) */
 .jp-CodeMirrorEditor .remote-caret {
   position: relative;
-  border-left: 1px solid black;
-  border-right: 1px solid black;
+  border-left: 2px solid black;
   margin-left: -1px;
   margin-right: -1px;
   box-sizing: border-box;
@@ -240,7 +239,7 @@
 .jp-CodeMirrorEditor .remote-caret > div {
   position: absolute;
   top: -1.05em;
-  left: -1px;
+  left: -2px;
   font-size: 0.8em;
   background-color: rgb(250, 129, 0);
   font-family: serif;


### PR DESCRIPTION

## References

When enabling collaborative editing, remote cursor-locations are often rendered as two lines, instead of one thicker line. The issue can be observed in the below picture. This is a known bug in Firefox, but now also happens in Chrome from time to time. 

![Screenshot from 2021-05-31 16-13-04](https://user-images.githubusercontent.com/5553757/120206160-22504400-c22b-11eb-8ebf-9099f4d068e9.png)

This PR fixes the issue.

## Code changes

Reworking the CSS for remote cursor carets. 

## User-facing changes

None.

## Backwards-incompatible changes

None
