### PR TITLE
[licenses] use serverSettings from serviceManager, style tweaks

### DIFF
--- a/packages/help-extension/src/index.tsx
+++ b/packages/help-extension/src/index.tsx
@@ -508,7 +508,7 @@ const licenses: JupyterFrontEndPlugin<void> = {
     });
 
     /**
-     * Return a full report format based on a format name
+     * Return a full license report format based on a format name
      */
     function formatOrDefault(format: string): Licenses.IReportFormat {
       return (
@@ -518,10 +518,15 @@ const licenses: JupyterFrontEndPlugin<void> = {
     }
 
     /**
-     * Create a MainAreaWidget for a toolbar item
+     * Create a MainAreaWidget for a license viewer
      */
     function createLicenseWidget(args: Licenses.ICreateArgs) {
-      const licensesModel = new Licenses.Model({ licensesUrl, trans, ...args });
+      const licensesModel = new Licenses.Model({
+        ...args,
+        licensesUrl,
+        trans,
+        serverSettings: app.serviceManager.serverSettings
+      });
       const content = new Licenses({ model: licensesModel });
       content.id = `${licensesNamespace}-${++counter}`;
       content.title.label = licensesText;

--- a/packages/help-extension/style/base.css
+++ b/packages/help-extension/style/base.css
@@ -141,10 +141,18 @@
   flex: 1;
 }
 
+.jp-Licenses-Bundles .lm-TabBar-content {
+  width: 100%;
+}
+
 .jp-Licenses-Bundles .lm-TabBar-tab {
   padding: calc(var(--jp-ui-font-size1) / 2);
   background-color: var(--jp-layout-color1);
   color: var(--jp-ui-font-color1);
+}
+
+.jp-Licenses-Bundles .lm-TabBar-tabLabel {
+  text-overflow: ellipsis;
 }
 
 .jp-Licenses-Bundles .lm-TabBar-tab label {
@@ -153,7 +161,7 @@
   width: calc(2.5 * var(--jp-ui-font-size1));
   padding: 0 calc(var(--jp-ui-font-size1) / 2);
   text-align: center;
-  margin-left: var(--jp-ui-font-size1);
+  margin-left: calc(var(--jp-ui-font-size1) / 2);
 }
 
 .jp-Licenses-Bundles .lm-TabBar-tab.lm-mod-current {


### PR DESCRIPTION
## References

- follow-on to #9779 

## Code changes

- uses `serverSettings` from the serviceManager (so it can be properly overridden by e.g. jupyterlite)
  - also applies this (and the translator and licensesUrl) _after_ the spread of `args` in the command
- minor style tweaks
  - width of tab bar
  - ellipses on long package names (happens)

## User-facing changes

By inspection, fixes this tab issue:

![Screenshot from 2021-06-02 22-08-34](https://user-images.githubusercontent.com/45380/120575470-23ca6980-c3ef-11eb-8cf6-5c22b8c740a4.png)

## Backwards-incompatible changes

Previously, it would have been possible for a command executor to overload trans and licensesUrl, but this doesn't seem like a big loss.