### PR TITLE
fix: typo in getting_started/faq

### DIFF
--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -29,7 +29,7 @@ Development
    outputs. To access this extensibility, you should write a custom JupyterLab extension. If you would
    like trigger some behavior in response to the user executing some code in a notebook, you can output a custom
    mimetype (:ref:`rendermime`). We currently don't allow access to the JupyterLab
-   API from the Javsacript renderer, because this would tie the kernel and the notebook output to JupyterLab
+   API from the Javascript renderer, because this would tie the kernel and the notebook output to JupyterLab
    and make it hard for other frontends to support it. 
    If you have comments or suggestions on changes here, please comment on `this issue <https://github.com/jupyterlab/jupyterlab/issues/4623>`__.
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixed the typo mentioned in #10328
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Corrected the spelling "Javascript" in the https://jupyterlab.readthedocs.io/en/stable/getting_started/faq.html 
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
