### PR TITLE
Fix clean-package and correct toc extension

### DIFF
--- a/buildutils/src/clean-packages.ts
+++ b/buildutils/src/clean-packages.ts
@@ -11,7 +11,7 @@ import { readJSONFile } from './utils';
 // Get all of the packages.
 const basePath = path.resolve('.');
 const baseConfig = readJSONFile(path.join(basePath, 'package.json'));
-const packageConfig = baseConfig.workspaces;
+const packageConfig = baseConfig.workspaces.packages;
 const skipSource = process.argv.indexOf('packages') === -1;
 const skipExamples = process.argv.indexOf('examples') === -1;
 

--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -285,6 +285,7 @@
       "@jupyterlab/statedb",
       "@jupyterlab/statusbar",
       "@jupyterlab/terminal",
+      "@jupyterlab/toc",
       "@jupyterlab/tooltip",
       "@jupyterlab/translation",
       "@jupyterlab/ui-components",

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -285,6 +285,7 @@
       "@jupyterlab/statedb",
       "@jupyterlab/statusbar",
       "@jupyterlab/terminal",
+      "@jupyterlab/toc",
       "@jupyterlab/tooltip",
       "@jupyterlab/translation",
       "@jupyterlab/ui-components",

--- a/packages/toc-extension/README.md
+++ b/packages/toc-extension/README.md
@@ -1,3 +1,3 @@
-# @jupyterlab/tooltip-extension
+# @jupyterlab/toc-extension
 
 A JupyterLab extension which provides an entry-point and commands for the [@jupyterlab/toc](../toc) package.

--- a/packages/toc-extension/README.md
+++ b/packages/toc-extension/README.md
@@ -1,0 +1,3 @@
+# @jupyterlab/tooltip-extension
+
+A JupyterLab extension which provides an entry-point and commands for the [@jupyterlab/toc](../toc) package.

--- a/packages/toc-extension/package.json
+++ b/packages/toc-extension/package.json
@@ -24,6 +24,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "style": "style/index.css",
+  "directories": {
+    "lib": "lib/"
+  },
   "files": [
     "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
     "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
@@ -31,10 +34,10 @@
   ],
   "scripts": {
     "build": "tsc -b",
-    "clean": "rimraf lib",
-    "precommit": "lint-staged",
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "docs": "typedoc src",
     "prepublishOnly": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -b --watch"
   },
   "dependencies": {
     "@jupyterlab/application": "^3.1.0-alpha.11",
@@ -49,6 +52,7 @@
   },
   "devDependencies": {
     "rimraf": "~3.0.0",
+    "typedoc": "~0.20.0-beta.27",
     "typescript": "~4.1.3"
   },
   "publishConfig": {

--- a/packages/toc-extension/typedoc.json
+++ b/packages/toc-extension/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "out": "../../docs/api/toc-extension",
+  "theme": "../../typedoc-theme"
+}

--- a/packages/toc/package.json
+++ b/packages/toc/package.json
@@ -69,6 +69,7 @@
     "jest": "^26.4.2",
     "rimraf": "~3.0.0",
     "ts-jest": "^26.3.0",
+    "typedoc": "~0.20.0-beta.27",
     "typescript": "~4.1.3"
   },
   "publishConfig": {

--- a/typedoc.js
+++ b/typedoc.js
@@ -103,7 +103,7 @@ const entryPoints = packages
 const exclude =
   packages.flatMap(p => [`packages/${p}/test`]) +
   [
-    'packages/application-extension/src/index.tsx',
+    'packages/application-extension/src/index.tsx'
     //'packages/*/test/*.spec.ts',
   ];
 

--- a/typedoc.js
+++ b/typedoc.js
@@ -19,6 +19,10 @@ const packages = [
   'coreutils',
   'csvviewer-extension',
   'csvviewer',
+  'debugger-extension',
+  'debugger',
+  'docprovider-extension',
+  'docprovider',
   'docmanager-extension',
   'docmanager',
   'docregistry',
@@ -53,8 +57,6 @@ const packages = [
   // 'metapackage',
   // 'nbconvert-css',
   'nbformat',
-  'shared-models',
-  'docprovider',
   'notebook-extension',
   'notebook',
   'observables',
@@ -70,6 +72,7 @@ const packages = [
   'settingeditor-extension',
   'settingeditor',
   'settingregistry',
+  'shared-models',
   'shortcuts-extension',
   'statedb',
   'statusbar-extension',
@@ -78,8 +81,12 @@ const packages = [
   'terminal',
   'theme-dark-extension',
   'theme-light-extension',
+  'toc',
+  'toc-extension',
   'tooltip-extension',
   'tooltip',
+  'translation-extension',
+  'translation',
   'ui-components-extension',
   'ui-components',
   'vdom-extension',
@@ -96,7 +103,7 @@ const entryPoints = packages
 const exclude =
   packages.flatMap(p => [`packages/${p}/test`]) +
   [
-    'packages/application-extension/src/index.tsx'
+    'packages/application-extension/src/index.tsx',
     //'packages/*/test/*.spec.ts',
   ];
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

I realize that `jlpm run clean` was actually not cleaning the packages. Here is a fix.

But then I hit errors with `jlpm run build` due
to some configuration for the toc extension being missing.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Fix `jlpm run clean` to clean the packages.
Add documentation for the most recents packages.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A