### PR TITLE
Update labeler to use the `documentation` label for docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,10 @@
 Design System CSS:
   - '**/*.css'
   - '*.css'
+  
+documentation:
+  - docs/**/*
+  - docs/*
 
 tag:CSS:
   - '**/*.css'
@@ -9,10 +13,6 @@ tag:CSS:
 'tag:Design and UX':
   - design/**/*
   - design/*
-
-tag:Documentation:
-  - docs/**/*
-  - docs/*
 
 tag:Examples:
   - examples/**/*


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Update to the label used by `github-activity`.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

None

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
