### PR TITLE
tagging deprecated completer APIs

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -51,7 +51,8 @@ export class CompletionHandler implements IDisposable {
 
   /**
    * The data connector used to populate completion requests.
-   * @deprecated use `CompletionHandler.ICompletionItesConnector` instead of `IDataConnector`
+   * @deprecated will be removed, or will return `CompletionHandler.ICompletionItemsConnector`
+   * instead of `IDataConnector` in future versions
    *
    * #### Notes
    * The only method of this connector that will ever be called is `fetch`, so
@@ -555,6 +556,9 @@ export namespace CompletionHandler {
      * The only method of this connector that will ever be called is `fetch`, so
      * it is acceptable for the other methods to be simple functions that return
      * rejected promises.
+     *
+     * @deprecated will be removed, or will return `CompletionHandler.ICompletionItemsConnector`
+     * instead of `IDataConnector` in future versions
      */
     connector:
       | IDataConnector<IReply, void, IRequest>

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -51,6 +51,7 @@ export class CompletionHandler implements IDisposable {
 
   /**
    * The data connector used to populate completion requests.
+   * @deprecated use `CompletionHandler.ICompletionItesConnector` instead of `IDataConnector`
    *
    * #### Notes
    * The only method of this connector that will ever be called is `fetch`, so
@@ -642,6 +643,8 @@ export namespace CompletionHandler {
   export const ICompletionItemsResponseType = 'ICompletionItemsReply' as const;
 
   /**
+   * @deprecated use `ICompletionItemsReply` instead
+   *
    * A reply to a completion request.
    */
   export interface IReply {

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -557,8 +557,8 @@ export namespace CompletionHandler {
      * it is acceptable for the other methods to be simple functions that return
      * rejected promises.
      *
-     * @deprecated will be removed, or will return `CompletionHandler.ICompletionItemsConnector`
-     * instead of `IDataConnector` in future versions
+     * @deprecated passing `IDataConnector` is deprecated;
+     * pass `CompletionHandler.ICompletionItemsConnector`
      */
     connector:
       | IDataConnector<IReply, void, IRequest>

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -202,6 +202,7 @@ export class CompleterModel implements Completer.IModel {
 
   /**
    * The list of visible items in the completer menu.
+   * @deprecated use `completionItems` instead
    *
    * #### Notes
    * This is a read-only property.


### PR DESCRIPTION
## References

This PR adds deprecated tags to address https://github.com/jupyterlab/jupyterlab/issues/10276 , opening this as a draft as we determine whether additional APIs need to be flagged as deprecated for the 3.1 release.

## Code changes

This PR adds deprecation tags to the following APIs:
**Handler**
- IReply
- connector

**Model**
- items

## User-facing changes

N/A

## Backwards-incompatible changes

N/A
