### PR TITLE
Support arrow keys for button navigation

### DIFF
--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -331,7 +331,7 @@ export class Dialog<T> extends Widget {
         const activeEl = document.activeElement;
         let idx = this._buttonNodes.indexOf(activeEl as HTMLElement) + 1;
 
-        // Handle a right arros on the last button
+        // Handle a right arrows on the last button
         if (idx == this._buttons.length) {
           idx = 0;
         }

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -310,9 +310,40 @@ export class Dialog<T> extends Widget {
           this.reject();
         }
         break;
+      case 37: {
+        // Left arrow
+        const activeEl = document.activeElement;
+        let idx = this._buttonNodes.indexOf(activeEl as HTMLElement) - 1;
+
+        // Handle a left arros on the first button
+        if (idx < 0) {
+          idx = this._buttonNodes.length - 1;
+        }
+
+        const node = this._buttonNodes[idx];
+        event.stopPropagation();
+        event.preventDefault();
+        node.focus();
+        break;
+      }
+      case 39: {
+        // Right arrow
+        const activeEl = document.activeElement;
+        let idx = this._buttonNodes.indexOf(activeEl as HTMLElement) + 1;
+
+        // Handle a right arros on the last button
+        if (idx == this._buttons.length) {
+          idx = 0;
+        }
+
+        const node = this._buttonNodes[idx];
+        event.stopPropagation();
+        event.preventDefault();
+        node.focus();
+        break;
+      }
       case 9: {
         // Tab.
-
         // Handle a tab on the last button.
         const node = this._buttonNodes[this._buttons.length - 1];
         if (document.activeElement === node && !event.shiftKey) {

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -315,7 +315,7 @@ export class Dialog<T> extends Widget {
         const activeEl = document.activeElement;
         let idx = this._buttonNodes.indexOf(activeEl as HTMLElement) - 1;
 
-        // Handle a left arros on the first button
+        // Handle a left arrows on the first button
         if (idx < 0) {
           idx = this._buttonNodes.length - 1;
         }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Implements #10194 
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
* Add keydown event handler for left and right arrow keys

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
* Allow arrow navigations between buttons in dialogs
* The first button gets focused when the right arrow is pressed on the last button, and the last button gets focused when the left arrow is pressed on the first button.

<!-- For visual changes, include before and after screenshots here. -->
![arrow_navigation](https://user-images.githubusercontent.com/15991814/120846741-6beca780-c527-11eb-9fda-57c902199c3b.gif)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
