### PR TITLE
Fix codemirror options updating

### DIFF
--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -234,20 +234,21 @@ function activateEditorCommands(
       (settings.get('lineWiseCopyCut').composite as boolean) ?? lineWiseCopyCut;
   }
 
-  const editorOptions: any = {
-    keyMap,
-    theme,
-    scrollPastEnd,
-    styleActiveLine,
-    styleSelectedText,
-    selectionPointer,
-    lineWiseCopyCut
-  };
+
 
   /**
    * Update the settings of the current tracker instances.
    */
   function updateTracker(): void {
+    const editorOptions: any = {
+      keyMap,
+      theme,
+      scrollPastEnd,
+      styleActiveLine,
+      styleSelectedText,
+      selectionPointer,
+      lineWiseCopyCut
+    };
     tracker.forEach(widget => {
       if (widget.content.editor instanceof CodeMirrorEditor) {
         widget.content.editor.setOptions(editorOptions);
@@ -274,6 +275,15 @@ function activateEditorCommands(
    * Handle the settings of new widgets.
    */
   tracker.widgetAdded.connect((sender, widget) => {
+    const editorOptions: any = {
+      keyMap,
+      theme,
+      scrollPastEnd,
+      styleActiveLine,
+      styleSelectedText,
+      selectionPointer,
+      lineWiseCopyCut
+    };
     if (widget.content.editor instanceof CodeMirrorEditor) {
       widget.content.editor.setOptions(editorOptions);
     }

--- a/packages/codemirror-extension/src/index.ts
+++ b/packages/codemirror-extension/src/index.ts
@@ -234,8 +234,6 @@ function activateEditorCommands(
       (settings.get('lineWiseCopyCut').composite as boolean) ?? lineWiseCopyCut;
   }
 
-
-
   /**
    * Update the settings of the current tracker instances.
    */


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes an error from #10128

## Code changes

In #10128, the editor options were consolidated, but an error in the code led to them never being updated when the plugin settings were changed. In particular, https://github.com/jupyterlab/jupyterlab/pull/10128/files#diff-ab6be7bde52236b400a3794134a804439f840f5cf2a9bcb325bbe6f4f0b91823R255 used a new `editorOptions` object which never was updated.

This commit creates an `editorOptions` object when it needs it from the live global values. This means that, for example, changing the setting for `scrollPastEnd` will update existing file editors and apply to new file editors.


## User-facing changes

Codemirror plugin advanced settings will now take effect

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
