### PR TITLE
Fix the `docmanager:name-on-save` command

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -527,7 +527,7 @@ function addCommands(
 
   // If inside a rich application like JupyterLab, add additional functionality.
   if (labShell) {
-    addLabCommands(app, docManager, labShell, opener, translator, palette);
+    addLabCommands(app, docManager, labShell, opener, translator);
   }
 
   commands.addCommand(CommandIDs.deleteFile, {
@@ -848,8 +848,7 @@ function addLabCommands(
   docManager: IDocumentManager,
   labShell: ILabShell,
   opener: DocumentManager.IWidgetOpener,
-  translator: ITranslator,
-  palette: ICommandPalette | null
+  translator: ITranslator
 ): void {
   const trans = translator.load('jupyterlab');
   const { commands } = app;

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -544,6 +544,18 @@ function addCommands(
     }
   });
 
+  commands.addCommand(CommandIDs.nameOnSave, {
+    label: () =>
+      trans.__('Rename %1…', fileType(shell.currentWidget, docManager)),
+    isEnabled,
+    execute: () => {
+      if (isEnabled()) {
+        const context = docManager.contextForWidget(shell.currentWidget!);
+        return nameOnSaveDialog(docManager, context!);
+      }
+    }
+  });
+
   commands.addCommand(CommandIDs.newUntitled, {
     execute: args => {
       // FIXME-TRANS: Localizing args['error']?
@@ -907,19 +919,6 @@ function addLabCommands(
       if (isEnabled()) {
         const context = docManager.contextForWidget(contextMenuWidget()!);
         return renameDialog(docManager, context!.path);
-      }
-    }
-  });
-
-  commands.addCommand(CommandIDs.nameOnSave, {
-    label: () =>
-      trans.__('Rename %1…', fileType(contextMenuWidget(), docManager)),
-    isEnabled,
-    execute: () => {
-      // Implies contextMenuWidget() !== null
-      if (isEnabled()) {
-        const context = docManager.contextForWidget(contextMenuWidget()!);
-        return nameOnSaveDialog(docManager, context!);
       }
     }
   });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

At the moment the `docmanager:name-on-save` is defined as a command for `ILabShell` here:

https://github.com/jupyterlab/jupyterlab/blob/21a57583d34e90b834d5e37e1851400c088642ee/packages/docmanager-extension/src/index.ts#L915-L926

This works in JupyterLab, but not in other distributions such as RetroLab. In such distributions that don't have an `ILabShell`, the following error is thrown:

```bash
Command 'docmanager:name-on-save' is not registered.
```

Since the following assumes such command exists (outside of the `if (labShell)` block:

https://github.com/jupyterlab/jupyterlab/blob/21a57583d34e90b834d5e37e1851400c088642ee/packages/docmanager-extension/src/index.ts#L198

This was caught when updating to the alpha 11 packages in https://github.com/jupyterlab/retrolab/pull/154.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Make the doc manager plugin more reusable.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

- None for JupyterLab users.
- Remove unused parameters

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
