### PR TITLE
Allow bumpversion to work with patch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,7 +42,7 @@ Choose and run an appropriate command to bump version numbers for this release.
 | `jlpm bumpversion release` | x.y.z.a1-> x.y.z.b0   | All a.b.c-alpha.1 -> a.b.c-beta.0  |
 | `jlpm bumpversion release` | x.y.z.a1-> x.y.z.rc0  | All a.b.c-alpha.1 -> a.b.c-rc.0    |
 | `jlpm bumpversion release` | x.y.z.rc0-> x.y.z     | All a.b.c-rc0 -> a.b.c             |
-| `jlpm patch:release`       | x.y.z -> x.y.(z+1)    | Changed a.b.c -> a.b.(c+1)         |
+| `jlpm bumpversion patch`   | x.y.z -> x.y.(z+1)    | Changed a.b.c -> a.b.(c+1)         |
 
 Note: For a minor release, we bump the JS packages by 10 versions so that
 we are not competing amongst the minor releases for version numbers.

--- a/buildutils/src/bumpversion.ts
+++ b/buildutils/src/bumpversion.ts
@@ -16,6 +16,16 @@ commander
     // Get the previous version.
     const prev = utils.getPythonVersion();
 
+    // For patch, defer to `patch:release` command
+    if (spec === 'patch') {
+      let cmd = 'jlpm run patch:release';
+      if (opts.force) {
+        cmd += ' --force';
+      }
+      utils.run(cmd);
+      process.exit(0);
+    }
+
     // Make sure we have a valid version spec.
     const options = ['major', 'minor', 'release', 'build'];
     if (options.indexOf(spec) === -1) {

--- a/scripts/ci_script.sh
+++ b/scripts/ci_script.sh
@@ -148,7 +148,7 @@ if [[ $GROUP == integrity3 ]]; then
 
     # make sure we can patch release
     jlpm bumpversion release --force  # switch to final
-    jlpm patch:release --force
+    jlpm bumpversion patch --force
 
     # make sure we can bump major JS releases
     jlpm bumpversion minor --force


### PR DESCRIPTION
## References
Partially addresses https://github.com/jupyterlab/jupyterlab/issues/10340.

## Code changes
Allow the bumpversion command to handle patch spec and defer to patch:release.


## User-facing changes
None

## Backwards-incompatible changes
None