### PR TITLE
Remove `mode` from the `JupyterFrontEnd.IShell` interface

### DIFF
--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -284,11 +284,6 @@ export namespace JupyterFrontEnd {
     readonly currentWidget: Widget | null;
 
     /**
-     * The user interface mode.
-     */
-    readonly mode: DockPanel.Mode;
-
-    /**
      * Returns an iterator for the widgets inside the application shell.
      *
      * @param area - Optional regions in the shell whose widgets are iterated.

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -17,7 +17,7 @@ import { Token } from '@lumino/coreutils';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
-import { DockPanel, Widget } from '@lumino/widgets';
+import { Widget } from '@lumino/widgets';
 
 /**
  * The type for all JupyterFrontEnd application plugins.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/10201

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

This change removes `mode` from the `JupyterFrontEnd.IShell` interface, to not force implementers of this interface to also provide a `mode`, which might not make sense in some cases.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

Undo a breaking change added in `3.1.0-alpha.12`

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
