### PR TITLE
Fix completer on cell example

### DIFF
--- a/examples/cell/index.css
+++ b/examples/cell/index.css
@@ -38,3 +38,7 @@ body {
 .jp-OutputArea {
   overflow: visible;
 }
+
+.jp-Completer-Cell {
+  position: fixed;
+}

--- a/examples/cell/src/index.ts
+++ b/examples/cell/src/index.ts
@@ -10,6 +10,7 @@ import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import '@jupyterlab/application/style/index.css';
 import '@jupyterlab/cells/style/index.css';
 import '@jupyterlab/theme-light-extension/style/theme.css';
+import '@jupyterlab/completer/style/index.css';
 import '../index.css';
 
 import { SessionContext, Toolbar } from '@jupyterlab/apputils';
@@ -91,11 +92,19 @@ function main(): void {
   const connector = new KernelConnector({ session: sessionContext.session });
   const handler = new CompletionHandler({ completer, connector });
 
+  //sessionContext.session?.kernel.
+  void sessionContext.ready.then(() => {
+    handler.connector = new KernelConnector({
+      session: sessionContext.session
+    });
+  });
+
   // Set the handler's editor.
   handler.editor = editor;
 
   // Hide the widget when it first loads.
   completer.hide();
+  completer.addClass('jp-Completer-Cell');
 
   // Create a toolbar for the cell.
   const toolbar = new Toolbar();
@@ -110,7 +119,6 @@ function main(): void {
   panel.id = 'main';
   panel.direction = 'top-to-bottom';
   panel.spacing = 0;
-  panel.addWidget(completer);
   panel.addWidget(toolbar);
   panel.addWidget(cellWidget);
   BoxPanel.setStretch(toolbar, 0);
@@ -118,6 +126,7 @@ function main(): void {
 
   // Attach the panel to the DOM.
   Widget.attach(panel, document.body);
+  Widget.attach(completer, document.body);
 
   // Handle widget state.
   window.addEventListener('resize', () => {


### PR DESCRIPTION
The completer on the cell example doesn't work.
The first problem is that the `KernelConnector` is initialised before the `sessionContext` is ready, resulting in a `null` session on the `KernelConnector`.
The second problem is that Instead of adding the completer to the `BoxPanel`, we need to attach it to the document.
And the last thing is the css. Due to the order of the imports (maybe, not sure), the css class `jp-HoverBox` is picked up after `p-widget, lm-widget`, and instead of having `position: fixed`, the completer is using `position: relative`

![image](https://user-images.githubusercontent.com/26092748/121495129-a5b32780-c9d9-11eb-9b9d-fb54bbad1157.png)

## References

## Code changes

## User-facing changes

## Backwards-incompatible changes
