### PR TITLE
Add the `ui-tests` folder to the labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,6 +21,8 @@ tag:Examples:
 tag:Testing:
   - tests/**/*
   - tests/*
+  - ui-tests/**/*
+  - ui-tests/*
 
 ######################
 #   Package Labels   #


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

The labeler would otherwise constantly remove a manually set `tag:Testing` label, for example in https://github.com/jupyterlab/jupyterlab/pull/10359:

![image](https://user-images.githubusercontent.com/591645/121678217-36136a00-cab7-11eb-9ddd-c58912a26266.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

None

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
