### PR TITLE
Handle updating dependencies without a semver range prefix

### DIFF
--- a/buildutils/src/update-dependency.ts
+++ b/buildutils/src/update-dependency.ts
@@ -55,12 +55,9 @@ async function getSpecifier(
         `Current version range is not recognized: ${currentSpecifier}`
       );
     }
-    const [, currentSigil] = match;
-    if (currentSigil) {
-      suggestedSigil = currentSigil;
-    }
+    suggestedSigil = match[1];
   }
-  return `${suggestedSigil}${suggestedTag}`;
+  return `${suggestedSigil ?? ''}${suggestedTag}`;
 }
 
 async function getVersion(pkg: string, specifier: string) {
@@ -77,7 +74,10 @@ async function getVersion(pkg: string, specifier: string) {
 
     // Look up the actual version corresponding to the tag
     const { version } = await packageJson(pkg, { version: match[2] });
-    specifier = match[1] + version;
+    specifier = `${match[1] ?? ''}${version}`;
+    if (semver.validRange(specifier) === null) {
+      throw Error(`Could not find valid version range for ${pkg}: ${specifier}`);
+    }
   }
   versionCache.set(key, specifier);
   return specifier;

--- a/buildutils/src/update-dependency.ts
+++ b/buildutils/src/update-dependency.ts
@@ -76,7 +76,9 @@ async function getVersion(pkg: string, specifier: string) {
     const { version } = await packageJson(pkg, { version: match[2] });
     specifier = `${match[1] ?? ''}${version}`;
     if (semver.validRange(specifier) === null) {
-      throw Error(`Could not find valid version range for ${pkg}: ${specifier}`);
+      throw Error(
+        `Could not find valid version range for ${pkg}: ${specifier}`
+      );
     }
   }
   versionCache.set(key, specifier);


### PR DESCRIPTION

<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

When updating a dependency that does not have a semver range prefix (^, ~, etc.), and not giving a prefix for the update so it should take any prefix from the existing version, we were running into problems with using the undefined value of the existing version.

In other words, when trying to update a dependency with version requirement 1.4.0 (note there is no semver range prefix - we just want an exact version) with arguments such as ‘update mypackage latest’, we would end up calculating a desired version of undefinedlatest, since the semver range prefix ended up being undefined from our regex matches against 1.4.0.

This change handles the case where matching for a semver range prefix returns an undefined prefix.

As an example, change the version requirement of `@lumino/widgets` in `packages/application/package.json` to `1.0.0` (note there is no semver range prefix). Then run:

    jlpm run update:dependency '@lumino/widgets' latest --dry-run

Note there is an error like:

    VersionNotFoundError: Version `undefinedlatest` for package `@lumino/widgets` could not be found


Now apply this change, and you’ll notice the dependency now updates, and correctly stays pinned to a single version:

    jupyterlab/packages/application/package.json
    @lumino/widgets 1.0.0 -> 1.23.0


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

As a bugfix, this could be backported to 3.0.x, though I probably don't need it anymore :). I discovered this while trying to update dependencies for ipywidgets.
