### PR TITLE
Fix a bug since merging arrow navigation between buttons in Dialog (#10349)

### DIFF
--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -305,34 +305,40 @@ export class Dialog<T> extends Widget {
       case 37: {
         // Left arrow
         const activeEl = document.activeElement;
-        let idx = this._buttonNodes.indexOf(activeEl as HTMLElement) - 1;
 
-        // Handle a left arrows on the first button
-        if (idx < 0) {
-          idx = this._buttonNodes.length - 1;
+        if (activeEl instanceof HTMLButtonElement) {
+          let idx = this._buttonNodes.indexOf(activeEl as HTMLElement) - 1;
+
+          // Handle a left arrows on the first button
+          if (idx < 0) {
+            idx = this._buttonNodes.length - 1;
+          }
+
+          const node = this._buttonNodes[idx];
+          event.stopPropagation();
+          event.preventDefault();
+          node.focus();
         }
-
-        const node = this._buttonNodes[idx];
-        event.stopPropagation();
-        event.preventDefault();
-        node.focus();
         break;
       }
       case 39: {
         // Right arrow
         const activeEl = document.activeElement;
-        let idx = this._buttonNodes.indexOf(activeEl as HTMLElement) + 1;
 
-        // Handle a right arrows on the last button
-        if (idx == this._buttons.length) {
-          idx = 0;
+        if (activeEl instanceof HTMLButtonElement) {
+          let idx = this._buttonNodes.indexOf(activeEl as HTMLElement) + 1;
+
+          // Handle a right arrows on the last button
+          if (idx == this._buttons.length) {
+            idx = 0;
+          }
+
+          const node = this._buttonNodes[idx];
+          event.stopPropagation();
+          event.preventDefault();
+          node.focus();
+          break;
         }
-
-        const node = this._buttonNodes[idx];
-        event.stopPropagation();
-        event.preventDefault();
-        node.focus();
-        break;
       }
       case 9: {
         // Tab.

--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -337,8 +337,8 @@ export class Dialog<T> extends Widget {
           event.stopPropagation();
           event.preventDefault();
           node.focus();
-          break;
         }
+        break;
       }
       case 9: {
         // Tab.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #10394 
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
* Added a guard checking for a keydown to be handled only when the focused element is a button.

## User-facing changes
* Pressing arrow keys do not steal the focus from the input element.
<!-- Describe any visual or user interaction changes and how they address the issue. -->
![arrow_navigation](https://user-images.githubusercontent.com/15991814/121740753-6a385c00-cab2-11eb-9641-301e5c31dc94.gif)

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None