### PR TITLE
Focus on "Cancel" rather than "Delete" in delete dialog

### DIFF
--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -413,7 +413,10 @@ export class DirListing extends Widget {
       buttons: [
         Dialog.cancelButton({ label: this._trans.__('Cancel') }),
         Dialog.warnButton({ label: this._trans.__('Delete') })
-      ]
+      ],
+      // By default focus on "Cancel" to protect from accidental deletion
+      // ("delete" and "Enter" are next to each other on many keyboards).
+      defaultButton: 0
     });
 
     if (!this.isDisposed && result.button.accept) {


### PR DESCRIPTION
## References

Fixes #10399 

## Code changes

Set the default button to be the the "Cancel" button.

## User-facing changes

Before:

![image](https://user-images.githubusercontent.com/5832902/121804463-6fc2ad00-cc3e-11eb-8acf-06ded1836fcb.png)

After:

![Screenshot from 2021-06-13 11-56-58](https://user-images.githubusercontent.com/5832902/121804469-7a7d4200-cc3e-11eb-8a00-9033f987dafa.png)

## Backwards-incompatible changes

None