### PR TITLE
Split move cell test into 2 separate tests

### DIFF
--- a/ui-tests/tests/general.test.ts
+++ b/ui-tests/tests/general.test.ts
@@ -46,7 +46,8 @@ describe('General Tests', () => {
   });
 
   test('Toggle Light theme', async () => {
-    await expect(galata.theme.setLightTheme()).resolves.toBeUndefined();
+    await galata.theme.setLightTheme();
+    await expect(galata.theme.getTheme()).resolves.toEqual('JupyterLab Light');
   });
 
   test('Move File Browser to right', async () => {

--- a/ui-tests/tests/general.test.ts
+++ b/ui-tests/tests/general.test.ts
@@ -46,7 +46,7 @@ describe('General Tests', () => {
   });
 
   test('Toggle Light theme', async () => {
-    await galata.theme.setLightTheme();
+    await expect(galata.theme.setLightTheme()).resolves.toBeUndefined();
   });
 
   test('Move File Browser to right', async () => {

--- a/ui-tests/tests/notebook-create.test.ts
+++ b/ui-tests/tests/notebook-create.test.ts
@@ -19,7 +19,7 @@ describe('Notebook Create', () => {
   });
 
   test('Create new Notebook', async () => {
-    await galata.notebook.createNew(fileName);
+    await expect(galata.notebook.createNew(fileName)).resolves.toEqual(true);
   });
 
   test('Create a Raw cell', async () => {
@@ -72,7 +72,7 @@ describe('Notebook Create', () => {
   });
 
   test('Toggle Light theme', async () => {
-    await galata.theme.setLightTheme();
+    await expect(galata.theme.setLightTheme()).resolves.toBeUndefined();
   });
 
   test('Delete Notebook', async () => {

--- a/ui-tests/tests/notebook-create.test.ts
+++ b/ui-tests/tests/notebook-create.test.ts
@@ -72,7 +72,8 @@ describe('Notebook Create', () => {
   });
 
   test('Toggle Light theme', async () => {
-    await expect(galata.theme.setLightTheme()).resolves.toBeUndefined();
+    await galata.theme.setLightTheme();
+    await expect(galata.theme.getTheme()).resolves.toEqual('JupyterLab Light');
   });
 
   test('Delete Notebook', async () => {

--- a/ui-tests/tests/notebook-edit.test.ts
+++ b/ui-tests/tests/notebook-edit.test.ts
@@ -18,7 +18,7 @@ describe('Notebook Edit', () => {
   });
 
   test('Create new Notebook', async () => {
-    await galata.notebook.createNew(fileName);
+    await expect(galata.notebook.createNew(fileName)).resolves.toEqual(true);
   });
 
   test('Create a Raw cell', async () => {
@@ -127,18 +127,20 @@ describe('Notebook Edit', () => {
     expect(await galata.capture.compareScreenshot(imageName)).toBe('same');
   });
 
-  test('Move cells', async () => {
-    let imageName = 'move-cell-up';
+  test('Move cells up', async () => {
+    const imageName = 'move-cell-up';
     await galata.notebook.selectCells(1);
     await galata.menu.clickMenuItem('Edit>Move Cells Up');
-    let nbPanel = await galata.notebook.getNotebookInPanel();
+    const nbPanel = await galata.notebook.getNotebookInPanel();
     await galata.capture.screenshot(imageName, nbPanel);
     expect(await galata.capture.compareScreenshot(imageName)).toBe('same');
+  });
 
-    imageName = 'move-cell-down';
+  test('Move cells down', async () => {
+    const imageName = 'move-cell-down';
     await galata.notebook.selectCells(0);
     await galata.menu.clickMenuItem('Edit>Move Cells Down');
-    nbPanel = await galata.notebook.getNotebookInPanel();
+    const nbPanel = await galata.notebook.getNotebookInPanel();
     await galata.capture.screenshot(imageName, nbPanel);
     expect(await galata.capture.compareScreenshot(imageName)).toBe('same');
   });

--- a/ui-tests/tests/notebook-run.test.ts
+++ b/ui-tests/tests/notebook-run.test.ts
@@ -36,7 +36,7 @@ describe('Notebook Run', () => {
   });
 
   test('Refresh File Browser', async () => {
-    await galata.filebrowser.refresh();
+    await expect(galata.filebrowser.refresh()).resolves.toBeUndefined();
   });
 
   test('Open directory uploaded', async () => {
@@ -99,14 +99,16 @@ describe('Notebook Run', () => {
   });
 
   test('Close Notebook', async () => {
-    await galata.notebook.close(true);
+    await expect(galata.notebook.close(true)).resolves.toEqual(true);
   });
 
   test('Open home directory', async () => {
-    await galata.filebrowser.openHomeDirectory();
+    await expect(galata.filebrowser.openHomeDirectory()).resolves.toEqual(true);
   });
 
   test('Delete uploaded directory', async () => {
-    await galata.contents.deleteDirectory('uploaded');
+    await expect(galata.contents.deleteDirectory('uploaded')).resolves.toEqual(
+      true
+    );
   });
 });

--- a/ui-tests/tests/notebook-toolbar.test.ts
+++ b/ui-tests/tests/notebook-toolbar.test.ts
@@ -18,7 +18,7 @@ describe('Notebook Toolbar', () => {
   });
 
   test('Create new Notebook', async () => {
-    await galata.notebook.createNew(fileName);
+    await expect(galata.notebook.createNew(fileName)).resolves.toEqual(true);
   });
 
   test('Create a Raw cell', async () => {

--- a/ui-tests/tests/toc.test.ts
+++ b/ui-tests/tests/toc.test.ts
@@ -36,7 +36,7 @@ describe('Table of Contents', () => {
   });
 
   test('Refresh File Browser', async () => {
-    await galata.filebrowser.refresh();
+    await expect(galata.filebrowser.refresh()).resolves.toBeUndefined();
   });
 
   test('Open directory uploaded', async () => {
@@ -182,16 +182,20 @@ describe('Table of Contents', () => {
   });
 
   test('Close Notebook', async () => {
-    await galata.notebook.activate(fileName);
-    await galata.notebook.close(true);
+    await expect(galata.notebook.activate(fileName)).resolves.toEqual(true);
+    await expect(galata.notebook.close(true)).resolves.toEqual(true);
   });
 
   test('Open home directory', async () => {
-    await galata.sidebar.openTab('filebrowser');
-    await galata.filebrowser.openHomeDirectory();
+    await expect(
+      galata.sidebar.openTab('filebrowser')
+    ).resolves.toBeUndefined();
+    await expect(galata.filebrowser.openHomeDirectory()).resolves.toEqual(true);
   });
 
   test('Delete uploaded directory', async () => {
-    await galata.contents.deleteDirectory('uploaded');
+    await expect(galata.contents.deleteDirectory('uploaded')).resolves.toEqual(
+      true
+    );
   });
 });

--- a/ui-tests/tests/toc.test.ts
+++ b/ui-tests/tests/toc.test.ts
@@ -187,9 +187,10 @@ describe('Table of Contents', () => {
   });
 
   test('Open home directory', async () => {
-    await expect(
-      galata.sidebar.openTab('filebrowser')
-    ).resolves.toBeUndefined();
+    await galata.sidebar.openTab('filebrowser');
+    await expect(galata.sidebar.isTabOpen('filebrowser')).resolves.toEqual(
+      true
+    );
     await expect(galata.filebrowser.openHomeDirectory()).resolves.toEqual(true);
   });
 

--- a/ui-tests/tests/util.ts
+++ b/ui-tests/tests/util.ts
@@ -29,9 +29,9 @@ const sidebarIds: galata.SidebarTabId[] = [
 ];
 
 // eslint-disable-next-line jest/no-export
-export function runMenuOpenTest() {
-  test('Open menu items', async () => {
-    for (const menuPath of menuPaths) {
+export function runMenuOpenTest(): void {
+  menuPaths.forEach(menuPath => {
+    test(`Open menu item ${menuPath}`, async () => {
       await galata.menu.open(menuPath);
       expect(await galata.menu.isOpen(menuPath)).toBeTruthy();
 
@@ -39,18 +39,18 @@ export function runMenuOpenTest() {
       const menu = await galata.menu.getOpenMenu();
       await galata.capture.screenshot(imageName, menu);
       expect(await galata.capture.compareScreenshot(imageName)).toBe('same');
-    }
+    });
   });
 
   test('Close all menus', async () => {
-    await galata.menu.closeAll();
+    await expect(galata.menu.closeAll()).resolves.toBeUndefined();
   });
 }
 
 // eslint-disable-next-line jest/no-export
-export function runSidebarOpenTest() {
-  test('Open Sidebar tabs', async () => {
-    for (const sidebarId of sidebarIds) {
+export function runSidebarOpenTest(): void {
+  sidebarIds.forEach(sidebarId => {
+    test(`Open Sidebar tab ${sidebarId}`, async () => {
       await galata.sidebar.openTab(sidebarId);
       expect(await galata.sidebar.isTabOpen(sidebarId)).toBeTruthy();
 
@@ -59,10 +59,12 @@ export function runSidebarOpenTest() {
       const sidebar = await galata.sidebar.getContentPanel(position);
       await galata.capture.screenshot(imageName, sidebar);
       expect(await galata.capture.compareScreenshot(imageName)).toBe('same');
-    }
+    });
   });
 
   test('Open file browser tab', async () => {
-    await galata.sidebar.openTab('filebrowser');
+    await expect(
+      galata.sidebar.openTab('filebrowser')
+    ).resolves.toBeUndefined();
   });
 }

--- a/ui-tests/tests/util.ts
+++ b/ui-tests/tests/util.ts
@@ -43,7 +43,8 @@ export function runMenuOpenTest(): void {
   });
 
   test('Close all menus', async () => {
-    await expect(galata.menu.closeAll()).resolves.toBeUndefined();
+    await galata.menu.closeAll();
+    await expect(galata.menu.isAnyOpen()).resolves.toEqual(false);
   });
 }
 
@@ -63,8 +64,9 @@ export function runSidebarOpenTest(): void {
   });
 
   test('Open file browser tab', async () => {
-    await expect(
-      galata.sidebar.openTab('filebrowser')
-    ).resolves.toBeUndefined();
+    await galata.sidebar.openTab('filebrowser');
+    await expect(galata.sidebar.isTabOpen('filebrowser')).resolves.toEqual(
+      true
+    );
   });
 }


### PR DESCRIPTION
## Code changes

<!-- Describe the code changes and how they address the issue. -->

Split the move cell integration test into two.
It splits also the test opening the sidebars and the menus.
At most one screenshot should be generate by test - otherwise we will likely fail seeing all errors at once.

This also changes tests to not have test without expectation (bad practice).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A