### PR TITLE
Interface pass on the name file dialog feature

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -805,14 +805,24 @@ function addCommands(
 
   docManager.activateRequested.connect((sender, args) => {
     const widget = sender.findWidget(args);
-    if (widget && widget.shouldNameFile) {
-      widget.shouldNameFile.connect(() => {
-        if (sender.nameFileOnSave && widget == shell.currentWidget) {
+    if (!widget) {
+      return;
+    }
+
+    widget.context.saveState.connect((doc, state) => {
+      if (sender.nameFileOnSave && widget == shell.currentWidget) {
+        const model = doc.contentsModel;
+        if (
+          state === 'completed-manual' &&
+          model &&
+          !model.renamed == true &&
+          model.name.startsWith('Untitled')
+        ) {
           const context = sender.contextForWidget(widget!);
           return nameOnSaveDialog(sender, context!);
         }
-      });
-    }
+      }
+    });
   });
 
   // .jp-mod-current added so that the console-creation command is only shown

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -803,6 +803,8 @@ function addCommands(
     }
   });
 
+  const newFileRegex = new RegExp('^untitled', 'i');
+
   docManager.activateRequested.connect((sender, args) => {
     const widget = sender.findWidget(args);
     if (!widget) {
@@ -816,7 +818,7 @@ function addCommands(
           state === 'completed-manual' &&
           model &&
           !model.renamed == true &&
-          model.name.startsWith('Untitled')
+          newFileRegex.test(model.name)
         ) {
           const context = sender.contextForWidget(widget!);
           return nameOnSaveDialog(sender, context!);

--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -812,7 +812,7 @@ function addCommands(
     }
 
     widget.context.saveState.connect((doc, state) => {
-      if (sender.nameFileOnSave && widget == shell.currentWidget) {
+      if (sender.nameFileOnSave && widget === shell.currentWidget) {
         const model = doc.contentsModel;
         if (
           state === 'completed-manual' &&

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -267,20 +267,6 @@ class NameOnSaveHandler extends Widget {
   getValue(): string {
     return this.inputNode.value;
   }
-
-  /**
-   * Get the checkbox node.
-   */
-  get checkboxNode(): HTMLInputElement {
-    return this.node.getElementsByTagName('input')[1] as HTMLInputElement;
-  }
-
-  /**
-   * Get checked of the checkbox widget.
-   */
-  getChecked(): boolean {
-    return this.checkboxNode.checked;
-  }
 }
 
 /**
@@ -288,7 +274,7 @@ class NameOnSaveHandler extends Widget {
  */
 namespace Private {
   /**
-   * Create the node for a rename after launch handler.
+   * Create the node for the name file dialog handler.
    */
   export function createNameFileNode(
     manager: IDocumentManager,

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -133,7 +133,7 @@ export class DocumentManager implements IDocumentManager {
   /**
    * A signal emitted when option is changed.
    */
-  get optionChanged(): Signal<this, Object> {
+  get optionChanged(): ISignal<this, any> {
     return this._optionChanged;
   }
 

--- a/packages/docmanager/src/tokens.ts
+++ b/packages/docmanager/src/tokens.ts
@@ -5,7 +5,7 @@ import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { Contents, Kernel, ServiceManager } from '@jupyterlab/services';
 import { Token } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
-import { ISignal, Signal } from '@lumino/signaling';
+import { ISignal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 
 /* tslint:disable */
@@ -37,6 +37,11 @@ export interface IDocumentManager extends IDisposable {
   readonly activateRequested: ISignal<this, string>;
 
   /**
+   * A signal emitted when an option has changed.
+   */
+  readonly optionChanged: ISignal<this, any>;
+
+  /**
    * Whether to autosave documents.
    */
   autosave: boolean;
@@ -50,11 +55,6 @@ export interface IDocumentManager extends IDisposable {
    * Whether to prompt to name file on first save.
    */
   nameFileOnSave: boolean;
-
-  /**
-   * Singal on option changed.
-   */
-  readonly optionChanged: Signal<object, object>;
 
   /**
    * Clone a widget.

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -486,8 +486,6 @@ export class DocumentWidget<
     void this.context.ready.then(() => {
       this._handleDirtyState();
     });
-
-    this.shouldNameFile = new Signal<this, void>(this);
   }
 
   /**
@@ -531,7 +529,6 @@ export class DocumentWidget<
   }
 
   readonly context: DocumentRegistry.IContext<U>;
-  shouldNameFile: Signal<any, void>;
 }
 
 export namespace DocumentWidget {

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -1511,8 +1511,6 @@ export interface IDocumentWidget<
    * Set URI fragment identifier.
    */
   setFragment(fragment: string): void;
-
-  shouldNameFile?: Signal<this, void>;
 }
 
 /**

--- a/packages/fileeditor/src/widget.ts
+++ b/packages/fileeditor/src/widget.ts
@@ -325,20 +325,6 @@ export class FileEditorFactory extends ABCWidgetFactory<
 
     content.title.icon = textEditorIcon;
     const widget = new DocumentWidget({ content, context });
-    widget.context.saveState.connect((sender, state) => {
-      const model = sender.contentsModel;
-      /* emits shouldNameFile signal 
-         when save is completed, file is not renamed and the name starts with 'untitled'
-      */
-      if (
-        state === 'completed-manual' &&
-        model &&
-        !model.renamed == true &&
-        model.name.startsWith('untitled')
-      ) {
-        widget.shouldNameFile.emit(undefined);
-      }
-    });
     return widget;
   }
 

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -84,7 +84,10 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
     });
   }
 
-  _onSave(sender: DocumentRegistry.Context, state: DocumentRegistry.SaveState) {
+  _onSave(
+    sender: DocumentRegistry.Context,
+    state: DocumentRegistry.SaveState
+  ): void {
     if (state === 'started' && this.model) {
       // Find markdown cells
       const { cells } = this.model;
@@ -97,19 +100,6 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
           }
         }
       });
-    }
-
-    const model = sender.contentsModel;
-    /* emits shouldNameFile signal 
-       when save is completed, file is not renamed and the name starts with 'Untitled'
-    */
-    if (
-      state === 'completed-manual' &&
-      model &&
-      !model.renamed == true &&
-      model.name.startsWith('Untitled')
-    ) {
-      this.shouldNameFile.emit(undefined);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to #10043.

Quick pass on the interfaces to strip the bits that don't need to be exposed as part of the public API.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Make some parts of the public API stricter.

Remove the public `shouldNameFile` signal that was used for message passing between plugins.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes


<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
