### PR TITLE
Make `NotebookPanel._onSave` private

### DIFF
--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -35,6 +35,8 @@ bumped their major version (following semver convention):
 - As a result of the update to TypeScript 4.5, a couple of interfaces have had their definitions changed.
    The ``anchor`` parameter of ``HoverBox.IOptions` is now a ``DOMRect` instead of ``ClientRect``.
    The ``CodeEditor.ICoordinate`` interface now extends ``DOMRectReadOnly`` instead of ``JSONObject, ClientRect``.
+- ``@jupyterlab/notebook`` from 3.x to 4.x
+   The ``NotebookPanel._onSave`` method is now ``private``.
 
 JupyterLab 3.0 to 3.1
 ---------------------

--- a/packages/notebook/src/panel.ts
+++ b/packages/notebook/src/panel.ts
@@ -84,7 +84,13 @@ export class NotebookPanel extends DocumentWidget<Notebook, INotebookModel> {
     });
   }
 
-  _onSave(
+  /**
+   * Handle a change to the document registry save state.
+   *
+   * @param sender The document registry context
+   * @param state The document registry save state
+   */
+  private _onSave(
     sender: DocumentRegistry.Context,
     state: DocumentRegistry.SaveState
   ): void {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow up to https://github.com/jupyterlab/jupyterlab/pull/10416, as mentioned in https://github.com/jupyterlab/jupyterlab/pull/10416#pullrequestreview-684153286

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Make the `_onSave` method private.
- [x] Document the change in the migration guide

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

The `_onSave` method switches from being  public to `private`. 

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
