### PR TITLE
Fix console error when closing notebook

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1440,7 +1440,10 @@ function addCommands(
   // Set up collapse signal for each header cell in a notebook
   tracker.currentChanged.connect(
     (sender: INotebookTracker, panel: NotebookPanel) => {
-      panel.content.model?.cells.changed.connect(
+      if (!panel?.content?.model?.cells) {
+        return;
+      }
+      panel.content.model.cells.changed.connect(
         (
           list: IObservableUndoableList<ICellModel>,
           args: IObservableList.IChangedArgs<ICellModel>


### PR DESCRIPTION
## References
Fixes #10383. 

## Code changes
Adds check for null value to fix an error in the console when closing a notebook editor. 

## User-facing changes
None

## Backwards-incompatible changes
None
