### PR TITLE
UI fix: clearer save message

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -815,7 +815,7 @@ function addCommands(
       if (sender.nameFileOnSave && widget === shell.currentWidget) {
         const model = doc.contentsModel;
         if (
-          state === 'completed-manual' &&
+          state === 'completed manually' &&
           model &&
           !model.renamed == true &&
           newFileRegex.test(model.name)

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -612,7 +612,7 @@ export class Context<
 
       // Emit completion.
       if (manual) {
-        this._saveState.emit('completed-manual');
+        this._saveState.emit('completed manually');
       } else {
         this._saveState.emit('completed');
       }

--- a/packages/docregistry/src/registry.ts
+++ b/packages/docregistry/src/registry.ts
@@ -977,7 +977,7 @@ export namespace DocumentRegistry {
     | 'started'
     | 'failed'
     | 'completed'
-    | 'completed-manual';
+    | 'completed manually';
 
   /**
    * A type alias for a context.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab/pull/10294
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

When manually trigger a save, 
change message from 'Save completed-manual' to 'Save completed manually'

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
