### PR TITLE
Restore maxNumberOutputs removed in #10131

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -731,7 +731,8 @@ export class CodeCell extends Cell<ICodeCellModel> {
       const output = (this._output = new OutputArea({
         model: model.outputs,
         rendermime,
-        contentFactory: contentFactory
+        contentFactory: contentFactory,
+        maxNumberOutputs: options.maxNumberOutputs
       }));
       output.addClass(CELL_OUTPUT_AREA_CLASS);
       // Set a CSS if there are no outputs, and connect a signal for future


### PR DESCRIPTION
## References

See: https://github.com/jupyterlab/jupyterlab/pull/10131/files#r652985483

## Code changes

Restore `maxNumberOutputs` removed when resolving conflicts

## User-facing changes

User-provided `maxNumberOutputs` option should now be respected.

## Backwards-incompatible changes

None