### PR TITLE
Update inspector open

### DIFF
--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -731,7 +731,8 @@ export class CodeCell extends Cell<ICodeCellModel> {
       const output = (this._output = new OutputArea({
         model: model.outputs,
         rendermime,
-        contentFactory: contentFactory
+        contentFactory: contentFactory,
+        maxNumberOutputs: options.maxNumberOutputs
       }));
       output.addClass(CELL_OUTPUT_AREA_CLASS);
       // Set a CSS if there are no outputs, and connect a signal for future

--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -60,10 +60,14 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
       namespace
     });
 
+    function isInspectorOpen() {
+      return inspector && !inspector.isDisposed;
+    }
+
     let source: IInspector.IInspectable | null = null;
     let inspector: MainAreaWidget<InspectorPanel>;
-    function openInspector(): MainAreaWidget<InspectorPanel> {
-      if (!inspector || inspector.isDisposed) {
+    function openInspector(args: string): MainAreaWidget<InspectorPanel> {
+      if (!isInspectorOpen()) {
         inspector = new MainAreaWidget({
           content: new InspectorPanel({ translator })
         });
@@ -73,6 +77,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         void tracker.add(inspector);
         source = source && !source.isDisposed ? source : null;
         inspector.content.source = source;
+        inspector.content.source?.onEditorChange(args);
       }
       if (!inspector.isAttached) {
         shell.add(inspector, 'main', { activate: false });
@@ -93,7 +98,14 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         !inspector.isVisible,
       label,
       icon: args => (args.isLauncher ? inspectorIcon : undefined),
-      execute: () => openInspector()
+      execute: args => {
+        const text = args && (args.text as string);
+        const refresh = args && (args.refresh as boolean);
+        // if inspector is open, see if we need a refresh
+        if (isInspectorOpen() && refresh)
+          inspector.content.source?.onEditorChange(text);
+        else openInspector(text);
+      }
     });
 
     // Add command to UI where possible.

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -112,7 +112,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
    * #### Notes
    * Update the hints inspector based on a text change.
    */
-  protected onEditorChange(): void {
+  onEditorChange(customText?: string): void {
     // If the handler is in standby mode, bail.
     if (this._standby) {
       return;
@@ -123,8 +123,7 @@ export class InspectionHandler implements IDisposable, IInspector.IInspectable {
     if (!editor) {
       return;
     }
-
-    const text = editor.model.value.text;
+    const text = customText ? customText : editor.model.value.text;
     const position = editor.getCursorPosition();
     const offset = Text.jsIndexToCharIndex(editor.getOffsetAt(position), text);
     const update: IInspector.IInspectorUpdate = { content: null };

--- a/packages/inspector/src/tokens.ts
+++ b/packages/inspector/src/tokens.ts
@@ -60,6 +60,13 @@ export namespace IInspector {
      * inspector is visible. It can be modified by the consumer of the source.
      */
     standby: boolean;
+    /**
+     * Handle a text changed signal from an editor.
+     *
+     * #### Notes
+     * Update the hints inspector based on a text change.
+     */
+    onEditorChange(customText?: string): void;
   }
 
   /**

--- a/packages/inspector/test/inspector.spec.ts
+++ b/packages/inspector/test/inspector.spec.ts
@@ -27,6 +27,10 @@ class TestInspectable implements IInspector.IInspectable {
   isDisposed = false;
 
   standby = false;
+
+  onEditorChange(customText?: string): void {
+    /* empty */
+  }
 }
 
 describe('inspector/index', () => {


### PR DESCRIPTION
## References

N/A

## Code changes

Issue: When opening the inspector, the inspector does not not load anything even though the user right clicks on a cell or a when a cell is active.

Fix: If a user right clicks on a cell or a user opens the inspector when a cell is active, the inspector will populate with the corresponding information. 

## User-facing changes

- before 
![inspector_before](https://user-images.githubusercontent.com/40677673/123482078-88758000-d5b9-11eb-9c3f-fd688ee53b94.gif)

- after 
![inspector_after](https://user-images.githubusercontent.com/40677673/123483347-6a108400-d5bb-11eb-9d82-d8e26658e755.gif)
 

## Backwards-incompatible changes

No changes
