### PR TITLE
Refactor shared-models

### DIFF
--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -62,7 +62,9 @@ export class YDocument<T> implements models.ISharedDocument {
   /**
    * The changed signal.
    */
-  readonly changed = new Signal<this, T>(this);
+  get changed(): ISignal<this, T> {
+    return this._changed;
+  }
 
   /**
    * Perform a transaction. While the function f is called, all changes to the shared
@@ -115,6 +117,7 @@ export class YDocument<T> implements models.ISharedDocument {
   }
 
   private _isDisposed = false;
+  protected _changed = new Signal<this, T>(this);
 }
 
 export class YFile
@@ -131,7 +134,7 @@ export class YFile
   private _modelObserver = (event: Y.YTextEvent) => {
     const changes: models.FileChange = {};
     changes.sourceChange = event.changes.delta as any;
-    this.changed.emit(changes);
+    this._changed.emit(changes);
   };
 
   public static create(): YFile {
@@ -411,7 +414,7 @@ export class YNotebook
       }
     });
 
-    this.changed.emit({
+    this._changed.emit({
       cellsChange: cellsChange
     });
   };

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -85,8 +85,7 @@ export class YDocument<T> implements models.ISharedDocument {
 
   public isDisposed = false;
   public ydoc = new Y.Doc();
-  public source = this.ydoc.getText('source');
-  public undoManager = new Y.UndoManager([this.source], {
+  public undoManager = new Y.UndoManager([this.ydoc.getText('source')], {
     trackedOrigins: new Set([this])
   });
   public awareness = new Awareness(this.ydoc);


### PR DESCRIPTION
The object `source` is duplicated in `YDocument` as a `source` and in `YFile` as a `ysource`.

I removed `source` source from `YDocument` and moved `ysource` from `YFile` to `YDocument`.

I also did some refactoring to the code.

## References

## Code changes

## User-facing changes

## Backwards-incompatible changes
