### PR TITLE
Collaborative renaming & moving of files

### DIFF
--- a/packages/docprovider/src/mock.ts
+++ b/packages/docprovider/src/mock.ts
@@ -16,4 +16,7 @@ export class ProviderMock implements IDocumentProvider {
   destroy(): void {
     /* nop */
   }
+  setPath(path: string): void {
+    /* nop */
+  }
 }

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -36,6 +36,11 @@ export interface IDocumentProvider {
   releaseLock(lock: number): void;
 
   /**
+   * This should be called by the docregistry when the file has been renamed to update the websocket connection url
+   */
+  setPath(newPath: string): void;
+
+  /**
    * Destroy the provider.
    */
   destroy(): void;
@@ -59,7 +64,8 @@ export namespace IDocumentProviderFactory {
     /**
      * The name (id) of the room
      */
-    guid: string;
+    path: string;
+    contentType: string;
 
     /**
      * The YNotebook.


### PR DESCRIPTION
## References

This PR fixes #10327 by updating the session context of remote peers. 

## Code changes

A collaborative session is still identified by the path. Now we can rename that path and notify other peers that they should use a new path.

## User-facing changes

Users can now rename files and folders while in a collaborative session. Remote users will automatically update the connection url and stay in the same collaborative session.

