### PR TITLE
Added method for ToC to strip python declarations of args and…

### DIFF
--- a/packages/toc/src/generators/python/index.ts
+++ b/packages/toc/src/generators/python/index.ts
@@ -26,14 +26,14 @@ function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
     if (line.indexOf('def ') === 0) {
       processingImports = false;
       headings.push({
-        text: line.slice(0, -1),
+        text: clean_declaration_code_string(line),
         level: 2,
         onClick: onClick(i)
       });
     } else if (line.indexOf('class ') === 0) {
       processingImports = false;
       headings.push({
-        text: line.slice(0, -1),
+        text: clean_declaration_code_string(line),
         level: 1,
         onClick: onClick(i)
       });
@@ -62,6 +62,26 @@ function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
         column: 0
       });
     };
+  }
+
+  /**
+   * Clean a line of code that declares either a class or function/method
+   * keeps text until first open parenthesis or first colon
+   * i.e. strips out arguments of functions and superclass specification of classes
+   *
+   * @private
+   * @param line - line of python code to clean
+   * @returns cleaned line of code
+   */
+  function clean_declaration_code_string(line: string): string {
+    let first_paren = line.indexOf('(');
+    let first_colon = line.indexOf(':');
+    let last_char = Math.min(
+      first_paren || Infinity,
+      first_colon || Infinity,
+      line.length
+    );
+    return line.slice(0, last_char);
   }
 }
 

--- a/packages/toc/src/generators/python/index.ts
+++ b/packages/toc/src/generators/python/index.ts
@@ -74,14 +74,8 @@ function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
    * @returns cleaned line of code
    */
   function clean_declaration_code_string(line: string): string {
-    let first_paren = line.indexOf('(');
-    let first_colon = line.indexOf(':');
-    let last_char = Math.min(
-      first_paren || Infinity,
-      first_colon || Infinity,
-      line.length
-    );
-    return line.slice(0, last_char);
+    const candidates = [line.indexOf('('), line.indexOf(':'), line.length];
+    return line.slice(0, Math.min(...candidates.filter(n => n >= 0)));
   }
 }
 

--- a/packages/toc/src/generators/python/index.ts
+++ b/packages/toc/src/generators/python/index.ts
@@ -73,7 +73,7 @@ function generate(editor: IDocumentWidget<FileEditor>): IHeading[] {
    * @param line - line of python code to clean
    * @returns cleaned line of code
    */
-  function clean_declaration_code_string(line: string): string {
+  function cleanDeclarationCodeString(line: string): string {
     const candidates = [line.indexOf('('), line.indexOf(':'), line.length];
     return line.slice(0, Math.min(...candidates.filter(n => n >= 0)));
   }


### PR DESCRIPTION
…superclass spec when showing toc of .py files.  Ported from PR152 of jupyterlab-toc

## References

Fixes #10474 

I previously submitted this PR to jupyterlab-toc and was asked to resubmit here, see: https://github.com/jupyterlab/jupyterlab-toc/pull/152

## Code changes

Remove anything in parenthesis from def/class entries for ToC

## User-facing changes

In ToC, user will see entries like `def my_function` instead of `def my_function(a,b,c)`

## Backwards-incompatible changes

None