### PR TITLE
Make highlighted line in debugger readable

### DIFF
--- a/packages/debugger/style/editor.css
+++ b/packages/debugger/style/editor.css
@@ -4,7 +4,18 @@
 |----------------------------------------------------------------------------*/
 
 .jp-DebuggerEditor-highlight {
-  background-color: var(--jp-warn-color0);
+  text-shadow: 0 0 1px var(--jp-layout-color0);
+  outline: 1px solid;
+}
+
+body[data-jp-theme-light='false'] .jp-DebuggerEditor-highlight {
+  background-color: var(--md-brown-800);
+  outline-color: var(--md-brown-600);
+}
+
+body[data-jp-theme-light='true'] .jp-DebuggerEditor-highlight {
+  background-color: var(--md-brown-100);
+  outline-color: var(--md-brown-300);
 }
 
 .jp-DebuggerEditor-marker {


### PR DESCRIPTION
## References

Fixes #10388.

## Code changes

Added more CSS styles for `.jp-DebuggerEditor-highlight`, conditional on light/dark theme. While @isabela-pf had great suggestions on using opacity and trying to stick with colors that we already have, I could not make it work for two reasons:
- all background colors are already used for cells, this is provide no contrast with one or more of: a) active cell editor b) blurred cell editor c) border and line numbers of the editor
- I could not work out how to add transparency without re-defining the colors; it seems that this is not currently possible if colors are defined in hex notation but it will become possible in the future once CSS 5 colors as specified in https://www.w3.org/TR/css-color-5/#relative-RGB become supported by majority of browsers

So I went with the most liked option in #10388 which was using the material brown colors + outline + very subtle text-shadow to increase contrast (which might be increased to 2px, but IMO 1px is enough).

I used body selectors rather than modifying themes as I understand that we would not want to export these new colors, but keep them as an implementation detail of debugger. However, maybe these should be exported to allow themes to customise those? In any case I think this is an improvement as-is.

## User-facing changes

### Before

![Screenshot from 2021-06-23 21-59-12](https://user-images.githubusercontent.com/5832902/123167434-6d4a2980-d46e-11eb-8b27-de595b403d0b.png)

![Screenshot from 2021-06-23 21-58-42](https://user-images.githubusercontent.com/5832902/123167465-79ce8200-d46e-11eb-9c95-d20060c5a952.png)

### After

![Screenshot from 2021-06-23 21-56-02](https://user-images.githubusercontent.com/5832902/123167520-8e127f00-d46e-11eb-931e-350b9214edcf.png)

![Screenshot from 2021-06-23 21-56-38](https://user-images.githubusercontent.com/5832902/123167488-805cf980-d46e-11eb-8c30-4988644f741e.png)

### After (editor focused)

![Screenshot from 2021-06-23 21-55-46](https://user-images.githubusercontent.com/5832902/123167630-af736b00-d46e-11eb-9d84-69ad75b5da09.png)

![Screenshot from 2021-06-23 21-56-23](https://user-images.githubusercontent.com/5832902/123167500-8521ad80-d46e-11eb-9488-345a0d9fe12e.png)

## Backwards-incompatible changes

None.