### PR TITLE
Fix checkbox styling

### DIFF
--- a/packages/apputils/src/inputdialog.ts
+++ b/packages/apputils/src/inputdialog.ts
@@ -7,6 +7,8 @@ import { Styling } from './styling';
 
 const INPUT_DIALOG_CLASS = 'jp-Input-Dialog';
 
+const INPUT_BOOLEAN_DIALOG_CLASS = 'jp-Input-Boolean-Dialog';
+
 /**
  * Namespace for input dialogs
  */
@@ -225,13 +227,20 @@ class InputDialogBase<T> extends Widget implements Dialog.IBodyWidget<T> {
     super();
     this.addClass(INPUT_DIALOG_CLASS);
 
+    this._input = document.createElement('input');
+    this._input.classList.add('jp-mod-styled');
+    this._input.id = 'jp-dialog-input-id';
+
     if (label !== undefined) {
       const labelElement = document.createElement('label');
       labelElement.textContent = label;
+      labelElement.htmlFor = this._input.id;
 
       // Initialize the node
       this.node.appendChild(labelElement);
     }
+
+    this.node.appendChild(this._input);
   }
 
   /** Input HTML node */
@@ -249,14 +258,10 @@ class InputBooleanDialog extends InputDialogBase<boolean> {
    */
   constructor(options: InputDialog.IBooleanOptions) {
     super(options.label);
+    this.addClass(INPUT_BOOLEAN_DIALOG_CLASS);
 
-    this._input = document.createElement('input');
-    this._input.classList.add('jp-mod-styled');
     this._input.type = 'checkbox';
     this._input.checked = options.value ? true : false;
-
-    // Initialize the node
-    this.node.appendChild(this._input);
   }
 
   /**
@@ -279,13 +284,8 @@ class InputNumberDialog extends InputDialogBase<number> {
   constructor(options: InputDialog.INumberOptions) {
     super(options.label);
 
-    this._input = document.createElement('input', {});
-    this._input.classList.add('jp-mod-styled');
     this._input.type = 'number';
     this._input.value = options.value ? options.value.toString() : '0';
-
-    // Initialize the node
-    this.node.appendChild(this._input);
   }
 
   /**
@@ -312,16 +312,11 @@ class InputTextDialog extends InputDialogBase<string> {
   constructor(options: InputDialog.ITextOptions) {
     super(options.label);
 
-    this._input = document.createElement('input', {});
-    this._input.classList.add('jp-mod-styled');
     this._input.type = 'text';
     this._input.value = options.text ? options.text : '';
     if (options.placeholder) {
       this._input.placeholder = options.placeholder;
     }
-
-    // Initialize the node
-    this.node.appendChild(this._input);
   }
 
   /**
@@ -344,16 +339,11 @@ class InputPasswordDialog extends InputDialogBase<string> {
   constructor(options: InputDialog.ITextOptions) {
     super(options.label);
 
-    this._input = document.createElement('input', {});
-    this._input.classList.add('jp-mod-styled');
     this._input.type = 'password';
     this._input.value = options.text ? options.text : '';
     if (options.placeholder) {
       this._input.placeholder = options.placeholder;
     }
-
-    // Initialize the node
-    this.node.appendChild(this._input);
   }
 
   /**
@@ -403,18 +393,16 @@ class InputItemsDialog extends InputDialogBase<string> {
       data.id = 'input-dialog-items';
       data.appendChild(this._list);
 
-      this._input = document.createElement('input', {});
-      this._input.classList.add('jp-mod-styled');
       this._input.type = 'list';
       this._input.value = current;
       this._input.setAttribute('list', data.id);
       if (options.placeholder) {
         this._input.placeholder = options.placeholder;
       }
-      this.node.appendChild(this._input);
       this.node.appendChild(data);
     } else {
       /* Use select directly */
+      this._input.remove();
       this.node.appendChild(Styling.wrapSelect(this._list));
     }
   }

--- a/packages/apputils/style/base.css
+++ b/packages/apputils/style/base.css
@@ -9,6 +9,7 @@
 @import './dialog.css';
 @import './hoverbox.css';
 @import './iframe.css';
+@import './inputdialog.css';
 @import './mainareawidget.css';
 @import './materialcolors.css';
 @import './spinner.css';

--- a/packages/apputils/style/inputdialog.css
+++ b/packages/apputils/style/inputdialog.css
@@ -1,0 +1,9 @@
+.jp-Input-Boolean-Dialog {
+  flex-direction: row-reverse;
+  align-items: end;
+  width: 100%;
+}
+
+.jp-Input-Boolean-Dialog > label {
+  flex: 1 1 auto;
+}

--- a/packages/apputils/style/styling.css
+++ b/packages/apputils/style/styling.css
@@ -35,63 +35,28 @@ input.jp-mod-styled {
   -moz-appearance: none;
 }
 
+input[type='checkbox'].jp-mod-styled {
+  appearance: checkbox;
+  -webkit-appearance: checkbox;
+  -moz-appearance: checkbox;
+  height: auto;
+}
+
 input.jp-mod-styled:focus {
   border: var(--jp-border-width) solid var(--md-blue-500);
   box-shadow: inset 0 0 4px var(--md-blue-300);
 }
 
-input.jp-FileDialog-Checkbox {
-  position: relative;
-  cursor: pointer;
-  background: none;
-  border: none;
-  width: 13px;
-  height: 13px;
+.jp-FileDialog-Checkbox {
   margin-top: 35px;
-  margin-right: 10px;
-  top: 5px;
-  left: 0px;
+  display: flex;
+  flex-direction: row;
+  align-items: end;
+  width: 100%;
 }
 
-input.jp-FileDialog-Checkbox:focus {
-  border: none;
-  box-shadow: none;
-}
-
-input.jp-FileDialog-Checkbox:before {
-  content: '';
-  display: block;
-  position: absolute;
-  width: 13px;
-  height: 13px;
-  top: 0;
-  left: 0;
-  background-color: #e9e9e9;
-}
-
-input.jp-FileDialog-Checkbox:checked:before {
-  content: '';
-  display: block;
-  position: absolute;
-  width: 13px;
-  height: 13px;
-  top: 0;
-  left: 0;
-  background-color: #1e80ef;
-}
-input.jp-FileDialog-Checkbox:checked:after {
-  content: '';
-  display: block;
-  width: 3px;
-  height: 7px;
-  border: solid white;
-  border-width: 0 2px 2px 0;
-  -webkit-transform: rotate(45deg);
-  -ms-transform: rotate(45deg);
-  transform: rotate(45deg);
-  position: absolute;
-  top: 1px;
-  left: 4px;
+.jp-FileDialog-Checkbox > label {
+  flex: 1 1 auto;
 }
 
 .jp-select-wrapper {

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -285,11 +285,13 @@ namespace Private {
     const body = document.createElement('div');
     const name = document.createElement('input');
     const checkbox = document.createElement('input');
+    checkbox.id = 'jp-filedialog-input-id';
     const label = document.createElement('label');
+    label.htmlFor = checkbox.id;
     const div = document.createElement('div');
+    div.classList.add(FILE_DIALOG_CHECKBOX_CLASS);
 
     checkbox.type = 'checkbox';
-    checkbox.classList.add(FILE_DIALOG_CHECKBOX_CLASS);
     checkbox.addEventListener('change', function () {
       manager.nameFileOnSave = !this.checked;
     });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #10471
Side effect fixes #10317
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
input checkbox is correctly style by default when `jp-mod-styled` class is applied.
For input dialogs and rename dialog, the label is linked to the input. So clicking on the label focuses the input element (or trigger the check status for the checkbox type).

Styling of the checkbox in the rename file dialog has been greatly simplified by using browser capability.

![inputdialog](https://user-images.githubusercontent.com/8435071/123398984-66bdce00-d5a4-11eb-8cd9-4d8734747bf2.gif)

Final style for the rename dialog

![image](https://user-images.githubusercontent.com/8435071/123399012-6d4c4580-d5a4-11eb-8f54-f8f8d45dd735.png)


## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
Checkbox is display in boolean input dialog
Label is linked to the input element. So clicking on it will react as expected.

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A