### PR TITLE
Add cursorBlinkRate settings for editors

### DIFF
--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -712,6 +712,13 @@ export namespace CodeEditor {
    */
   export interface IConfig {
     /**
+     * Half-period in milliseconds used for cursor blinking.
+     * By setting this to zero, blinking can be disabled.
+     * A negative value hides the cursor entirely.
+     */
+    cursorBlinkRate: number;
+
+    /**
      * User preferred font family for text editors.
      */
     fontFamily: string | null;
@@ -790,6 +797,7 @@ export namespace CodeEditor {
    * The default configuration options for an editor.
    */
   export const defaultConfig: IConfig = {
+    cursorBlinkRate: 530,
     fontFamily: null,
     fontSize: null,
     lineHeight: null,

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -1379,7 +1379,7 @@ export namespace CodeMirrorEditor {
   export function addCommand(
     name: string,
     command: (cm: CodeMirror.Editor) => void
-  ) {
+  ): void {
     (CodeMirror.commands as any)[name] = command;
   }
 }
@@ -1530,6 +1530,9 @@ namespace Private {
   ): void {
     const el = editor.getWrapperElement();
     switch (option) {
+      case 'cursorBlinkRate':
+        (editor.setOption as any)(option, value);
+        break;
       case 'lineWrap': {
         const lineWrapping = value === 'off' ? false : true;
         const lines = el.querySelector('.CodeMirror-lines') as HTMLDivElement;

--- a/packages/fileeditor-extension/schema/plugin.json
+++ b/packages/fileeditor-extension/schema/plugin.json
@@ -152,6 +152,11 @@
         "autoClosingBrackets": {
           "type": "boolean"
         },
+        "cursorBlinkRate": {
+          "type": "number",
+          "title": "Cursor blinking rate",
+          "description": "Half-period in milliseconds used for cursor blinking. The default blink rate is 530ms. By setting this to zero, blinking can be disabled. A negative value hides the cursor entirely."
+        },
         "fontFamily": {
           "type": ["string", "null"]
         },
@@ -206,6 +211,7 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": true,
+        "cursorBlinkRate": 530,
         "fontFamily": null,
         "fontSize": null,
         "lineHeight": null,

--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -584,6 +584,11 @@
         "autoClosingBrackets": {
           "type": "boolean"
         },
+        "cursorBlinkRate": {
+          "type": "number",
+          "title": "Cursor blinking rate",
+          "description": "Half-period in milliseconds used for cursor blinking. The default blink rate is 530ms. By setting this to zero, blinking can be disabled. A negative value hides the cursor entirely."
+        },
         "fontFamily": {
           "type": ["string", "null"]
         },
@@ -641,6 +646,7 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": true,
+        "cursorBlinkRate": 530,
         "fontFamily": null,
         "fontSize": null,
         "lineHeight": null,
@@ -675,6 +681,7 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": false,
+        "cursorBlinkRate": 530,
         "fontFamily": null,
         "fontSize": null,
         "lineHeight": null,
@@ -696,6 +703,7 @@
       "$ref": "#/definitions/editorConfig",
       "default": {
         "autoClosingBrackets": false,
+        "cursorBlinkRate": 530,
         "fontFamily": null,
         "fontSize": null,
         "lineHeight": null,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #10443
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Add new `cursorBlinkRate` to all cell type and to the text editor

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
User can now set the cursor blink rate
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A