### PR TITLE
RTC: persist rtc user color & name in state db

### DIFF
--- a/examples/federated/md_package/index.js
+++ b/examples/federated/md_package/index.js
@@ -46,7 +46,6 @@ const plugin = {
  * Activate the markdown viewer plugin.
  */
 function activate(app, restorer, rendermime, settingRegistry, middleToken) {
-  console.log(middleToken);
   const { commands, docRegistry } = app;
   // Add the markdown renderer factory.
   rendermime.addFactory(markdownRendererFactory);

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -38,7 +38,8 @@
     "@jupyterlab/application": "^3.3.0-alpha.0",
     "@jupyterlab/coreutils": "^5.3.0-alpha.0",
     "@jupyterlab/docprovider": "^3.3.0-alpha.0",
-    "@jupyterlab/services": "^6.3.0-alpha.0"
+    "@jupyterlab/services": "^6.3.0-alpha.0",
+    "@jupyterlab/statedb": "^3.1.0-alpha.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -39,7 +39,7 @@
     "@jupyterlab/coreutils": "^5.3.0-alpha.0",
     "@jupyterlab/docprovider": "^3.3.0-alpha.0",
     "@jupyterlab/services": "^6.3.0-alpha.0",
-    "@jupyterlab/statedb": "^3.1.0-alpha.0"
+    "@jupyterlab/statedb": "^3.3.0-alpha.0"
   },
   "devDependencies": {
     "rimraf": "~3.0.0",

--- a/packages/docprovider-extension/src/index.ts
+++ b/packages/docprovider-extension/src/index.ts
@@ -17,14 +17,19 @@ import {
   WebSocketProviderWithLocks
 } from '@jupyterlab/docprovider';
 import { ServerConnection } from '@jupyterlab/services';
+import { IStateDB } from '@jupyterlab/statedb';
 
 /**
  * The default document provider plugin
  */
 const docProviderPlugin: JupyterFrontEndPlugin<IDocumentProviderFactory> = {
   id: '@jupyterlab/docprovider-extension:plugin',
+  optional: [IStateDB],
   provides: IDocumentProviderFactory,
-  activate: (app: JupyterFrontEnd): IDocumentProviderFactory => {
+  activate: (
+    app: JupyterFrontEnd,
+    state: IStateDB | null
+  ): IDocumentProviderFactory => {
     const server = ServerConnection.makeSettings();
     const url = URLExt.join(server.wsUrl, 'api/yjs');
     const collaborative =
@@ -35,7 +40,8 @@ const docProviderPlugin: JupyterFrontEndPlugin<IDocumentProviderFactory> = {
       return collaborative
         ? new WebSocketProviderWithLocks({
             ...options,
-            url
+            url,
+            state
           })
         : new ProviderMock();
     };

--- a/packages/docprovider-extension/tsconfig.json
+++ b/packages/docprovider-extension/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../services"
+    },
+    {
+      "path": "../statedb"
     }
   ]
 }

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/shared-models": "^3.3.0-alpha.0",
-    "@jupyterlab/statedb": "^3.1.0-alpha.0",
+    "@jupyterlab/statedb": "^3.3.0-alpha.0",
     "@lumino/coreutils": "^1.5.3",
     "lib0": "^0.2.42",
     "y-websocket": "^1.3.15",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@jupyterlab/shared-models": "^3.3.0-alpha.0",
+    "@jupyterlab/statedb": "^3.1.0-alpha.0",
     "@lumino/coreutils": "^1.5.3",
     "lib0": "^0.2.42",
     "y-websocket": "^1.3.15",

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-import { PromiseDelegate } from '@lumino/coreutils';
+import { JSONObject, PromiseDelegate } from '@lumino/coreutils';
 import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import { WebsocketProvider } from 'y-websocket';
@@ -11,7 +11,10 @@ import * as Y from 'yjs';
 import { IDocumentProvider, IDocumentProviderFactory } from './tokens';
 import { getAnonymousUserName, getRandomColor } from './awareness';
 import * as env from 'lib0/environment';
+import { IStateDB } from '@jupyterlab/statedb';
 
+const PREFIX = '@jupyterlab/docprovider:yprovider';
+const USER = `${PREFIX}:user`;
 /**
  * A class to provide Yjs synchronization over WebSocket.
  *
@@ -42,17 +45,11 @@ export class WebSocketProviderWithLocks
     this._path = options.path;
     this._contentType = options.contentType;
     this._serverUrl = options.url;
-    const color = '#' + env.getParam('--usercolor', getRandomColor().slice(1));
-    const name = env.getParam('--username', getAnonymousUserName());
+
     const awareness = options.ymodel.awareness;
     const currState = awareness.getLocalState();
-    // only set if this was not already set by another plugin
-    if (currState && currState.user?.name == null) {
-      options.ymodel.awareness.setLocalStateField('user', {
-        name,
-        color
-      });
-    }
+    let color = '#' + env.getParam('--usercolor', '');
+    let name = env.getParam('--username', '');
 
     // Message handler that confirms when a lock has been acquired
     this.messageHandlers[127] = (
@@ -95,6 +92,44 @@ export class WebSocketProviderWithLocks
     this._isInitialized = false;
     this._onConnectionStatus = this._onConnectionStatus.bind(this);
     this.on('status', this._onConnectionStatus);
+
+    const state = options.state;
+    if (name != '' || color != '#' || state == null) {
+      if (name == '') {
+        name = getAnonymousUserName();
+      }
+      if (color == '#') {
+        color = '#' + getRandomColor().slice(1);
+      }
+      // only set if this was not already set by another plugin
+      if (currState && currState.name == null) {
+        options.ymodel.awareness.setLocalStateField('user', {
+          name,
+          color
+        });
+      }
+      return;
+    }
+
+    const user = state.fetch(USER);
+    user.then(param => {
+      if (param === undefined) {
+        name = getAnonymousUserName();
+        color = '#' + getRandomColor().slice(1);
+        state.save(USER, { userName: name, userColor: color });
+      } else {
+        const { userName, userColor } = param as JSONObject;
+        name = userName as string;
+        color = userColor as string;
+      }
+      // only set if this was not already set by another plugin
+      if (currState && currState.name == null) {
+        options.ymodel.awareness.setLocalStateField('user', {
+          name,
+          color
+        });
+      }
+    });
   }
 
   setPath(newPath: string): void {
@@ -254,5 +289,10 @@ export namespace WebSocketProviderWithLocks {
      * The server URL
      */
     url: string;
+
+    /**
+     * The state database
+     */
+    state: IStateDB | null;
   }
 }

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -102,7 +102,7 @@ export class WebSocketProviderWithLocks
         color = '#' + getRandomColor().slice(1);
       }
       // only set if this was not already set by another plugin
-      if (currState && currState.name == null) {
+      if (currState && currState.user?.name == null) {
         options.ymodel.awareness.setLocalStateField('user', {
           name,
           color
@@ -123,7 +123,7 @@ export class WebSocketProviderWithLocks
         color = userColor as string;
       }
       // only set if this was not already set by another plugin
-      if (currState && currState.name == null) {
+      if (currState && currState.user?.name == null) {
         options.ymodel.awareness.setLocalStateField('user', {
           name,
           color

--- a/packages/docprovider/tsconfig.json
+++ b/packages/docprovider/tsconfig.json
@@ -8,6 +8,9 @@
   "references": [
     {
       "path": "../shared-models"
+    },
+    {
+      "path": "../statedb"
     }
   ]
 }

--- a/packages/docprovider/tsconfig.test.json
+++ b/packages/docprovider/tsconfig.test.json
@@ -6,6 +6,9 @@
       "path": "../shared-models"
     },
     {
+      "path": "../statedb"
+    },
+    {
       "path": "."
     },
     {
@@ -13,6 +16,9 @@
     },
     {
       "path": "../shared-models"
+    },
+    {
+      "path": "../statedb"
     }
   ]
 }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab/issues/10455
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Added statedb dependency to docprovider
## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->
Cursor colors and names now persist across sessions
## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
I don't think so, please let me know if there is any!
