### PR TITLE
Scroll cell into view after output collapse

### DIFF
--- a/packages/cells/src/collapser.tsx
+++ b/packages/cells/src/collapser.tsx
@@ -4,6 +4,7 @@
 |----------------------------------------------------------------------------*/
 
 import { ReactWidget } from '@jupyterlab/apputils';
+import { ElementExt } from '@lumino/domutils';
 
 import * as React from 'react';
 
@@ -135,6 +136,13 @@ export class OutputCollapser extends Collapser {
     const cell = this.parent?.parent as CodeCell | undefined | null;
     if (cell) {
       cell.outputHidden = !cell.outputHidden;
+      /* Scroll cell into view after output collapse */
+      if (cell.outputHidden) {
+        let area = cell.parent?.node;
+        if (area) {
+          ElementExt.scrollIntoViewIfNeeded(area, cell.node);
+        }
+      }
     }
     /* We need this until we watch the cell state */
     this.update();


### PR DESCRIPTION
## References

[Collapse cell brings focus to the end of collapse section #8252](https://github.com/jupyterlab/jupyterlab/issues/8252#)

## Code changes

Added code to cell collapser click handler to scroll the cell back into view after hiding output. 
Using `ElementExt.scrollIntoViewIfNeeded` for this purpose.

## User-facing changes

If you scroll down a long cell output and then click on the collapse output ribbon then you are scrolled back up and the active cell is visible on screen. So you don't lose your spot in the notebook.
This is consistent with using "View > Collapse Selected Outputs" command that also scrolls back up if necessary.

## Backwards-incompatible changes

None
