### PR TITLE
Add language to MarkdownCodeBlocks' "should find a block with a language" spec

### DIFF
--- a/packages/coreutils/test/markdowncodeblocks.spec.ts
+++ b/packages/coreutils/test/markdowncodeblocks.spec.ts
@@ -3,8 +3,11 @@
 
 import { MarkdownCodeBlocks } from '@jupyterlab/coreutils';
 
-const BLOCK1 = 'Here is text\n\n```\na = 10\nb = 20\n```\n\nMore text.';
-const BLOCK2 = 'Here is text\n\n```a = 10```\n\nMore text.';
+const MULTI_LINE_BLOCK =
+  'Here is text\n\n```\na = 10\nb = 20\n```\n\nMore text.';
+const SINGLE_LINE_BLOCK = 'Here is text\n\n```a = 10```\n\nMore text.';
+const MULTI_LINE_BLOCK_WITH_LANGUAGE =
+  'Here is text\n\n```python\na = 10\nb = 20\n```\n\nMore text.';
 
 describe('@jupyterlab/coreutils', () => {
   describe('MarkdownCodeBlocks', () => {
@@ -17,19 +20,25 @@ describe('@jupyterlab/coreutils', () => {
 
     describe('.findMarkdownCodeBlocks()', () => {
       it('should find a simple block', () => {
-        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK1);
+        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(
+          MULTI_LINE_BLOCK
+        );
         expect(codeblocks.length).toBe(1);
         expect(codeblocks[0].code).toBe('a = 10\nb = 20\n');
       });
 
       it('should find a single line block', () => {
-        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK2);
+        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(
+          SINGLE_LINE_BLOCK
+        );
         expect(codeblocks.length).toBe(1);
         expect(codeblocks[0].code).toBe('a = 10');
       });
 
       it('should find a block with a language', () => {
-        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(BLOCK1);
+        const codeblocks = MarkdownCodeBlocks.findMarkdownCodeBlocks(
+          MULTI_LINE_BLOCK_WITH_LANGUAGE
+        );
         expect(codeblocks.length).toBe(1);
         expect(codeblocks[0].code).toBe('a = 10\nb = 20\n');
       });


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

No issue - this is a minor spec update which doesn't seem to merit creating an issue.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

["should find a block with a language" test ](https://github.com/jupyterlab/jupyterlab/blob/91cb8d1840fc45359793af6d331650424a9ec1ca/packages/coreutils/test/markdowncodeblocks.spec.ts#L31-L35) does not do what it says it does - the code block it checks does not include a language. In fact, this test is identical to ["should find a simple block" test](https://github.com/jupyterlab/jupyterlab/blob/91cb8d1840fc45359793af6d331650424a9ec1ca/packages/coreutils/test/markdowncodeblocks.spec.ts#L19-L23) above.

The code change is to:
* Update the test to check a markdown block with a language.
*  Give more descriptive names to test blocks (I didn't want to call the new test block BLOCK3).

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

N/A - only test changes.

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

N/A