### PR TITLE
[HOTFIX] Render the correct index placeholder cell

### DIFF
--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -581,7 +581,7 @@ export class StaticNotebook extends Widget {
     ) {
       const index = this._renderedCellsCount;
       const cell = this._cellsArray[index];
-      this._renderPlaceholderCell(cell, index - 1);
+      this._renderPlaceholderCell(cell, index);
     }
   }
 

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -15,6 +15,7 @@ import { JupyterServer } from '@jupyterlab/testutils/lib/start_jupyter_server';
 import { Message, MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { generate, simulate } from 'simulate-event';
+import * as nbformat from '@jupyterlab/nbformat';
 import {
   INotebookModel,
   Notebook,
@@ -37,12 +38,23 @@ afterAll(async () => {
 const contentFactory = utils.createNotebookFactory();
 const editorConfig = utils.defaultEditorConfig;
 const rendermime = utils.defaultRenderMime();
+const notebookConfig = {
+  scrollPastEnd: true,
+  defaultCell: 'code' as nbformat.CellType,
+  recordTiming: false,
+  numberCellsToRenderDirectly: 2,
+  renderCellOnIdle: true,
+  observedTopMargin: '1000px',
+  observedBottomMargin: '1000px',
+  maxNumberOutputs: 50
+};
 
 const options: Notebook.IOptions = {
   rendermime,
   contentFactory,
   mimeTypeService: utils.mimeTypeService,
-  editorConfig
+  editorConfig,
+  notebookConfig
 };
 
 function createWidget(): LogStaticNotebook {
@@ -1581,6 +1593,22 @@ describe('@jupyter/notebook', () => {
         widget.activeCellIndex = 2;
         widget.model!.cells.remove(1);
         expect(widget.activeCell).toBe(widget.widgets[1]);
+      });
+    });
+
+    describe('#virtualNotebook()', () => {
+      it('should render the last cell widget', () => {
+        const model = new NotebookModel();
+        const widget = new StaticNotebook(options);
+        widget.model = model;
+        widget.model!.fromJSON(utils.DEFAULT_CONTENT);
+        const cell = widget.widgets[5];
+        expect(
+          cell.inputArea.editorWidget.model.value.text.startsWith(
+            'from IPython.display import Latex'
+          )
+        ).toBe(true);
+        console.log();
       });
     });
   });

--- a/packages/notebook/test/widget.spec.ts
+++ b/packages/notebook/test/widget.spec.ts
@@ -1596,6 +1596,7 @@ describe('@jupyter/notebook', () => {
       });
     });
 
+    // WIP See https://github.com/jupyterlab/jupyterlab/issues/10526
     describe('#virtualNotebook()', () => {
       it('should render the last cell widget', () => {
         const model = new NotebookModel();


### PR DESCRIPTION
## References

Fixes
https://github.com/jupyterlab/jupyterlab/issues/10435
https://github.com/jupyterlab/jupyterlab/issues/10488

## Code changes

Pass the correct to the private `_renderPlaceholderCell` method.

## User-facing changes

Fix the issues reported around the virtual notebook rendering (last cell not rendered, eaten cell).

## Backwards-incompatible changes

None.
