### PR TITLE
Check to make sure process.argv exists before using it.

### DIFF
--- a/packages/coreutils/src/pageconfig.ts
+++ b/packages/coreutils/src/pageconfig.ts
@@ -52,7 +52,7 @@ export namespace PageConfig {
       }
     }
     // Otherwise use CLI if given.
-    if (!found && typeof process !== 'undefined') {
+    if (!found && typeof process !== 'undefined' && process.argv) {
       try {
         const cli = minimist(process.argv.slice(2));
         const path: any = require('path');


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #10506

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

In some situations, we may not have config defined on the page, and for other reasons we may have process defined, but not argv defined. This fixes the ensuing error trying to access process.argv.

## User-facing changes

None

## Backwards-incompatible changes

None
