### PR TITLE
Make current kernel the default in kernel selector

### DIFF
--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1346,8 +1346,8 @@ namespace Private {
     populateKernelSelect(
       selector,
       options,
-      sessionContext.kernelDisplayName,
-      translator
+      translator,
+      sessionContext.kernelDisplayName
     );
     body.appendChild(selector);
     return body;
@@ -1423,8 +1423,8 @@ namespace Private {
   export function populateKernelSelect(
     node: HTMLSelectElement,
     options: SessionContext.IKernelSearch,
-    currentKernelDisplayName: string,
-    translator?: ITranslator
+    translator?: ITranslator,
+    currentKernelDisplayName?: string
   ): void {
     while (node.firstChild) {
       node.removeChild(node.firstChild);
@@ -1514,11 +1514,15 @@ namespace Private {
     if (shouldStart === false) {
       node.value = 'null';
     } else {
-      // Select current kernel by default.
-      const selectedIndex = [...node.options].findIndex(
-        option => option.text === currentKernelDisplayName
-      );
-      node.selectedIndex = Math.max(selectedIndex, 0);
+      let selectedIndex = 0;
+      if (currentKernelDisplayName) {
+        // Select current kernel by default.
+        selectedIndex = [...node.options].findIndex(
+          option => option.text === currentKernelDisplayName
+        );
+        selectedIndex = Math.max(selectedIndex, 0);
+      }
+      node.selectedIndex = selectedIndex;
     }
 
     // Bail if there are no sessions.

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1343,7 +1343,12 @@ namespace Private {
 
     const options = getKernelSearch(sessionContext);
     const selector = document.createElement('select');
-    populateKernelSelect(selector, options, translator);
+    populateKernelSelect(
+      selector,
+      options,
+      sessionContext.kernelDisplayName,
+      translator
+    );
     body.appendChild(selector);
     return body;
   }
@@ -1418,6 +1423,7 @@ namespace Private {
   export function populateKernelSelect(
     node: HTMLSelectElement,
     options: SessionContext.IKernelSearch,
+    currentKernelDisplayName: string,
     translator?: ITranslator
   ): void {
     while (node.firstChild) {
@@ -1508,7 +1514,11 @@ namespace Private {
     if (shouldStart === false) {
       node.value = 'null';
     } else {
-      node.selectedIndex = 0;
+      // Select current kernel by default.
+      const selectedIndex = [...node.options].findIndex(
+        option => option.text === currentKernelDisplayName
+      );
+      node.selectedIndex = Math.max(selectedIndex, 0);
     }
 
     // Bail if there are no sessions.


### PR DESCRIPTION
## References

[UX: Select Kernel Dropdown #7871](https://github.com/jupyterlab/jupyterlab/issues/7871)

## Code changes

Adds a parameter `currentKernelDisplayName` to `populateKernelSelect` function that creates the select options. 
Current kernel name is taken from `sessionContext.kernelDisplayName`.
The option with the same display name gets selected by default.

## User-facing changes

When clicking on kernel name a dialog appears with a dropdown to select a new kernel.
Currently the first available option is selected by default.
With this change current kernel will be the one selected.

## Backwards-incompatible changes

None.
