### PR TITLE
Remove ipykernel prerelease install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,6 @@ ENV PATH="/home/micromamba/.local/bin:$PATH"
 COPY --from=build /tmp/jupyterlab-dev/dist/jupyterlab*.whl /tmp
 
 RUN pip install /tmp/jupyterlab*.whl \
-    # TODO remove when ipykernel 6 is released
-    && pip install --pre --upgrade ipykernel \
     && mkdir -p /home/micromamba/jlab_root
 
 COPY ./docker/jupyter_server_config.json /etc/jupyter/

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ ENV PATH="/home/micromamba/.local/bin:$PATH"
 COPY --from=build /tmp/jupyterlab-dev/dist/jupyterlab*.whl /tmp
 
 RUN pip install /tmp/jupyterlab*.whl \
+    && pip install --upgrade ipykernel~=6.0 \
     && mkdir -p /home/micromamba/jlab_root
 
 COPY ./docker/jupyter_server_config.json /etc/jupyter/


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Now that `ipykernel` 6 final is released, we can remove some explicit calls to install the prerelease.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

None

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
