### PR TITLE
Open inspector split to the right

### DIFF
--- a/packages/inspector-extension/src/index.ts
+++ b/packages/inspector-extension/src/index.ts
@@ -80,7 +80,7 @@ const inspector: JupyterFrontEndPlugin<IInspector> = {
         inspector.content.source?.onEditorChange(args);
       }
       if (!inspector.isAttached) {
-        shell.add(inspector, 'main', { activate: false });
+        shell.add(inspector, 'main', { activate: false, mode: 'split-right' });
       }
       shell.activateById(inspector.id);
       return inspector;


### PR DESCRIPTION
## Code changes
Issue: The inspector opens on top of everything as a new tab. Then, the user is able to click through different functions while the inspector populates. If the inspector is a new tab, the user will have to go back and forth between tabs. Alternatively, the user can create a split screen view by dragging the inspector tab. 

Fix: We can remove all of the extra steps explained above by opening the inspector split to the right instead of on top of everything. It makes sense to have the inspector open to the side because the inspector is updated as the user clicks through different functions.

## User-facing changes
- before 
![after](https://user-images.githubusercontent.com/40677673/124042733-59e31500-d9be-11eb-8d1c-2e39145b655a.gif)

- after
![before](https://user-images.githubusercontent.com/40677673/124042797-8008b500-d9be-11eb-87b5-030348d284f8.gif)


