### PR TITLE
Fix a few typos, camelCase some privates

### DIFF
--- a/docs/source/developer/components.rst
+++ b/docs/source/developer/components.rst
@@ -39,7 +39,7 @@ Dissecting the 'filebrowser' example
 ------------------------------------
 
 The filebrowser example provides a stand-alone implementation of a
-filebrowser. Here's what the filebrowser's user interface looks like:
+filebrowser. Here's what the filebrowser’s user interface looks like:
 
 |filebrowser user interface|
 

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -70,7 +70,7 @@ discussion, makes others aware of work being done, and sets the stage
 for a fruitful community interaction. A pull request should reference
 the issue it is addressing. Once the pull request is merged, the issue
 related to it will also be closed. If there is additional discussion
-around implemementation the issue may be re-opened. Once 30 days have
+around implementation the issue may be re-opened. Once 30 days have
 passed with no additional discussion, the `lock
 bot <https://github.com/apps/lock>`__ will lock the issue. If additional
 discussion is desired, or if the pull request doesn't fully address the
@@ -286,7 +286,7 @@ tests.
 For tests that rely on ``@jupyterlab/services`` (starting kernels,
 interacting with files, etc.), there are two options. If a simple
 interaction is needed, the ``Mock`` namespace exposed by ``testutils``
-has a number of mock implmentations (see ``testutils/src/mock.ts``). If
+has a number of mock implementations (see ``testutils/src/mock.ts``). If
 a full server interaction is required, use the ``JupyterServer`` class.
 
 We have a helper function called ``testEmission`` to help with writing
@@ -769,7 +769,7 @@ User Interface Naming Conventions
 Documents, Files, and Activities
 """"""""""""""""""""""""""""""""
 
-Files are referrred to as either files or documents, depending on the
+Files are referred to as either files or documents, depending on the
 context.
 
 Documents are more human centered. If human viewing, interpretation,

--- a/docs/source/developer/css.rst
+++ b/docs/source/developer/css.rst
@@ -233,7 +233,7 @@ intended to be used for adding context menu items and keyboard shortcuts.
 **CSS classes that describe the state of a widget**
 
 -  ``jp-mod-current``: applied to elements on the current document only
--  ``jp-mod-completer-enabled``: applied to ediors that can host a completer
+-  ``jp-mod-completer-enabled``: applied to editors that can host a completer
 -  ``jp-mod-commandMode``: applied to a notebook in command mode
 -  ``jp-mod-editMode``: applied to a notebook in edit mode
 -  ``jp-mod-has-primary-selection``: applied to editors that have a primary selection

--- a/docs/source/extension/extension_dev.rst
+++ b/docs/source/extension/extension_dev.rst
@@ -51,7 +51,7 @@ A JupyterLab plugin is the basic unit of extensibility in JupyterLab. An extensi
 
 An extension can be published both as a source extension on NPM and as a prebuilt extension (e.g., published as a Python package). In some cases, system administrators may even choose to install a prebuilt extension by directly copying the prebuilt bundle to an appropriate directory, circumventing the need to create a Python package. If a source extension and a prebuilt extension with the same name are installed in JupyterLab, the prebuilt extension takes precedence.
 
-Because prebuilt extensions do not require a JupyterLab rebuild, they have a distinct advantage in multiuser systems where JuptyerLab is installed at the system level. On such systems, only the system administrator has permissions to rebuild JupyterLab and install source extensions. Since prebuilt extensions can be installed at the per-user level, the per-environment level, or the system level, each user can have their own separate set of prebuilt extensions that are loaded dynamically in their browser on top of the system-wide JupyterLab.
+Because prebuilt extensions do not require a JupyterLab rebuild, they have a distinct advantage in multiuser systems where JupyterLab is installed at the system level. On such systems, only the system administrator has permissions to rebuild JupyterLab and install source extensions. Since prebuilt extensions can be installed at the per-user level, the per-environment level, or the system level, each user can have their own separate set of prebuilt extensions that are loaded dynamically in their browser on top of the system-wide JupyterLab.
 
 .. tip::
    We recommend publishing prebuilt extensions in Python packages for user convenience.
@@ -626,7 +626,7 @@ If you want to test a source extension against the unreleased versions of Jupyte
     jupyter lab --watch --splice-source
 
 This command will splice the local ``packages`` directory into the application directory, allowing you to build source extension(s)
-against the current development sources.  To statically build spliced sources, use ``jupyter lab build --splice-source``.  Once a spliced build is created, any subsquent calls to `jupyter labextension build` will be in splice mode by default.  A spliced build can be forced by calling ``jupyter labextension build --splice-source``. Note that :ref:`developing a prebuilt extension <prebuilt_dev_workflow>` against a development version of JupyterLab is generally much easier than source package building.
+against the current development sources.  To statically build spliced sources, use ``jupyter lab build --splice-source``.  Once a spliced build is created, any subsequent calls to `jupyter labextension build` will be in splice mode by default.  A spliced build can be forced by calling ``jupyter labextension build --splice-source``. Note that :ref:`developing a prebuilt extension <prebuilt_dev_workflow>` against a development version of JupyterLab is generally much easier than source package building.
 
 The package should export EMCAScript 6 compatible JavaScript. It can
 import CSS using the syntax ``require('foo.css')``. The CSS files can

--- a/docs/source/extension/ui_components.rst
+++ b/docs/source/extension/ui_components.rst
@@ -166,7 +166,7 @@ Sync icon color to JupyterLab theme
    <em>Example svgs with class annotation can be found in <a href="https://github.com/jupyterlab/jupyterlab/tree/f0153e0258b32674c9aec106383ddf7b618cebab/packages/ui-components/style/icons">ui-components/style/icons</a></em>
 
 | 
-| You can ensure that the colors of your custom ``LabIcon`` sync up to the colors of the current JuptyerLab theme by adding appropriate ``class`` annotations to each colored element of your icon's svg.
+| You can ensure that the colors of your custom ``LabIcon`` sync up to the colors of the current JupyterLab theme by adding appropriate ``class`` annotations to each colored element of your icon's svg.
 | 
 | In other words, each element of your svg that a ``fill="..."`` or a ``stroke="..."`` property should also have a ``class="jp-icon<whatever>"`` property.
 
@@ -196,7 +196,7 @@ Available icon classes
 Most one-color icons in JupyterLab (including the sidebar and toolbar
 icons) are colored using the ``jp-icon3`` class.
 
-For light/dark themes, ``jp-icon0`` corresponds to the darkest/lighest
+For light/dark themes, ``jp-icon0`` corresponds to the darkest/lightest
 background color, while ``jp-icon1`` is somewhat lighter/darker, and so
 forth.
 
@@ -214,15 +214,15 @@ forth.
    </ul>
 
 For light/dark themes, ``jp-icon-accent0`` corresponds to the
-lighest/darkest background color, while ``jp-icon-accent1`` is somewhat
+lightest/darkest background color, while ``jp-icon-accent1`` is somewhat
 darker/lighter, and so forth.
 
 Adding classes to a one-color icon
 """"""""""""""""""""""""""""""""""
 
 For most simple, one-color icons, it is desirable for the icon's color
-to strongly constrast with that of the application's background. You can
-acheive this using one of the ``jp-iconX`` classes.
+to strongly contrast with that of the application's background. You can
+achieve this using one of the ``jp-iconX`` classes.
 
 **Example: check icon**
 

--- a/docs/source/extension/virtualdom.rst
+++ b/docs/source/extension/virtualdom.rst
@@ -24,7 +24,7 @@ into a Lumino widget. Whenever the widget is mounted, the React
 element will be rendered on the page.
 
 If you need to handle other life cycle events on the Lumino widget
-or add other methods to it, you can subbclass ``ReactWidget`` and
+or add other methods to it, you can subclass ``ReactWidget`` and
 override the ``render`` method to return a React element:
 
 

--- a/docs/source/getting_started/faq.rst
+++ b/docs/source/getting_started/faq.rst
@@ -22,7 +22,7 @@ Development
 -  `How can you
    contribute? <https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md>`__
 -  :ref:`How can you extend or customize JupyterLab? <user_extensions>`
--  In the classic Notebook, `I could use custom Javascript outputed by a cell to programatically
+-  In the classic Notebook, `I could use custom Javascript outputted by a cell to programmatically
    control the Notebook <https://stackoverflow.com/a/32769976/907060>`__. Can I do the same thing in JupyterLab?
 
    JupyterLab was built to support a wide variety of extensibility, including dynamic behavior based on notebook

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -127,7 +127,7 @@ you may encounter HTTP and SSL errors due to the proxy or firewall blocking conn
 
     CondaHTTPError: HTTP 000 CONNECTION FAILED for url <https://repo.anaconda.com/pkgs/main/win-64/current_repodata.json>
 
-Here are some widely-used sites that host packages in the Python and JavaScript open-source ecosystems. Your network adminstrator may be able to allow http and https connections to these domains:
+Here are some widely-used sites that host packages in the Python and JavaScript open-source ecosystems. Your network administrator may be able to allow http and https connections to these domains:
 
 - pypi.org
 - pythonhosted.org

--- a/docs/source/user/extensions.rst
+++ b/docs/source/user/extensions.rst
@@ -144,14 +144,14 @@ You can enable a disabled extension with:
 
     jupyter labextension enable my-extension
 
-Installed extensions are enabled by default unless there is configuration explicity disabling them.
+Installed extensions are enabled by default unless there is configuration explicitly disabling them.
 Extensions can be disabled or enabled using the command line.
 Extensions or individual plugins within an extension can be disabled by another extension.
 
 The priority order for determining whether an extension is enabled or disabled is as follows:
 
 - Presence of ``<jupyter_config_path>/labconfig/pageconfig.json`` file(s) with a ``disabledExtensions`` key that is a object with package names as keys and boolean values. 
-- (deprecated) Presence of ``disabledExensions`` key in ``<lab_app_dir>/settings/pageconfig.json``.   This value is a list of extensions to disable, but is deprecated in favor of the layered configuration approach in the `labconfig` location(s).
+- (deprecated) Presence of ``disabledExtensions`` key in ``<lab_app_dir>/settings/pageconfig.json``.   This value is a list of extensions to disable, but is deprecated in favor of the layered configuration approach in the `labconfig` location(s).
 - Presence of ``disabledExtensions`` key in another JupyterLab extension's metadata that disables a given extension.  The key is ignored if that extension itself is disabled.
 
 When using the command line, you can target the ``--level`` of the config: ``user``, ``system``, or ``sys-prefix`` (default).
@@ -368,7 +368,7 @@ Blocklist mode
 Extensions can be freely downloaded without going through a vetting process.
 However, users can add malicious extensions to a blocklist. The extension manager 
 will show all extensions except for those that have 
-been explicitly added to the blocklist. Therfore, the extension manager 
+been explicitly added to the blocklist. Therefore, the extension manager
 does not allow you to install blocklisted extensions.
 
 If you, or your administrator, has enabled the blocklist mode,
@@ -399,7 +399,7 @@ will only show extensions that have been explicitly added to the allowlist.
 
 If you, or your administrator, has enabled the allowlist mode
 JupyterLab will use the allowlist and only show extensions present
-in the withelist. The other extensions will not be show in the search result.
+in the allowlist. The other extensions will not be show in the search result.
 
 If you have installed an allowlisted extension and at some point
 in time that extension is removed from the allowlist, the extension entry 

--- a/docs/source/user/terminal.rst
+++ b/docs/source/user/terminal.rst
@@ -60,5 +60,5 @@ for something else such as the vi editor.
 
 For anyone using a \*nix shell, the default ``Ctrl+Shift+C`` conflicts with the default
 shortcut for toggling the command palette (``apputils:activate-command-palette``).
-If desired, that shortcut can be changed by editing the keyboard shortcuts in setttings.
+If desired, that shortcut can be changed by editing the keyboard shortcuts in settings.
 Using ``Ctrl+Shift+V`` for paste works as usual.

--- a/docs/source/user/urls.rst
+++ b/docs/source/user/urls.rst
@@ -199,7 +199,7 @@ For example, if your workspace looks like this:
     }
   }
 
-It will run the `docmanager:open` with the `{ "path": "package.json", "factory": "JSON" }` args, because the `application-mimedocuments` tracker is registerd with the `docmanager:open` command, like this:
+It will run the `docmanager:open` with the `{ "path": "package.json", "factory": "JSON" }` args, because the `application-mimedocuments` tracker is registered with the `docmanager:open` command, like this:
 
 
 .. code-block:: typescript
@@ -216,4 +216,4 @@ It will run the `docmanager:open` with the `{ "path": "package.json", "factory":
       `${widget.context.path}:${Private.factoryNameProperty.get(widget)}`
   });
 
-Not that the part of the data key after the first `:`, `package.json:JSON` is dropped and is irrelevent.
+Not that the part of the data key after the first `:`, `package.json:JSON` is dropped and is irrelevant.

--- a/jupyterlab/debuglog.py
+++ b/jupyterlab/debuglog.py
@@ -52,9 +52,9 @@ class DebugLogFileMixin(Configurable):
             for line in msg:
                 self.log.debug(line)
             if isinstance(ex, SystemExit):
-                print('An error occured. See the log file for details: ', log_path)
+                print('An error occurred. See the log file for details: ', log_path)
                 raise
-            print('An error occured.')
+            print('An error occurred.')
             print(msg[-1].strip())
             print('See the log file for details: ', log_path)
             self.exit(1)

--- a/jupyterlab/handlers/extension_manager_handler.py
+++ b/jupyterlab/handlers/extension_manager_handler.py
@@ -262,7 +262,7 @@ class ExtensionHandler(ExtensionHandlerMixin, APIHandler):
         if (cmd not in ('install', 'uninstall', 'enable', 'disable') or
                 not name):
             raise web.HTTPError(
-                422, 'Could not process instrution %r with extension name %r' % (
+                422, 'Could not process instruction %r with extension name %r' % (
                     cmd, name))
 
         # TODO: Can we trust extension_name? Does it need sanitation?

--- a/jupyterlab/labextensions.py
+++ b/jupyterlab/labextensions.py
@@ -157,8 +157,8 @@ class InstallLabExtensionApp(BaseExtensionApp):
 
     This installs JupyterLab extensions similar to yarn add or npm install.
 
-    Pass a list of comma seperate names to the --pin-version-as flag
-    to use as alises for the packages providers. This is useful to
+    Pass a list of comma separate names to the --pin-version-as flag
+    to use as aliases for the packages providers. This is useful to
     install multiple versions of the same extension.
     These can be uninstalled with the alias you provided
     to the flag, similar to the "alias" feature of yarn add.
@@ -188,7 +188,7 @@ class InstallLabExtensionApp(BaseExtensionApp):
 
 
 class DevelopLabExtensionApp(BaseExtensionApp):
-    desciption = "Develop labextension"
+    description = "Develop labextension"
     flags = develop_flags
 
     user = Bool(False, config=True, help="Whether to do a user install")
@@ -217,7 +217,7 @@ class BuildLabExtensionApp(BaseExtensionApp):
         help="Build in development mode")
 
     source_map = Bool(False, config=True,
-        help="Generage source maps")
+        help="Generate source maps")
 
     core_path = Unicode(os.path.join(HERE, 'staging'), config=True,
         help="Directory containing core application package.json file")
@@ -242,7 +242,7 @@ class WatchLabExtensionApp(BaseExtensionApp):
         help="Build in development mode")
 
     source_map = Bool(False, config=True,
-        help="Generage source maps")
+        help="Generate source maps")
 
     core_path = Unicode(os.path.join(HERE, 'staging'), config=True,
         help="Directory containing core application package.json file")

--- a/packages/application/src/frontend.ts
+++ b/packages/application/src/frontend.ts
@@ -132,7 +132,7 @@ export abstract class JupyterFrontEnd<
 
   /**
    * Walks up the DOM hierarchy of the target of the active `contextmenu`
-   * event, testing each HTMLElement ancestor for a user-supplied funcion. This can
+   * event, testing each HTMLElement ancestor for a user-supplied function. This can
    * be used to find an HTMLElement on which to operate, given a context menu click.
    *
    * @param fn - a function that takes an `HTMLElement` and returns a
@@ -337,7 +337,7 @@ export namespace JupyterFrontEnd {
      *
      * Examples of appropriate use include displaying a help dialog for a user
      * listing the paths, or a tooltip in a filebrowser displaying the server
-     * root. Examples of inapproriate use include using one of these paths in a
+     * root. Examples of inappropriate use include using one of these paths in a
      * terminal command, generating code using these paths, or using one of
      * these paths in a request to the server (it would be better to write a
      * server extension to handle these cases).

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -449,7 +449,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   }
 
   /**
-   * A signal emitted when the shell/dock panel change modes (single/mutiple document).
+   * A signal emitted when the shell/dock panel change modes (single/multiple document).
    */
   get modeChanged(): ISignal<this, DockPanel.Mode> {
     return this._modeChanged;

--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -29,7 +29,7 @@ export class MainAreaWidget<T extends Widget = Widget>
   constructor(options: MainAreaWidget.IOptions<T>) {
     super(options);
     this.addClass('jp-MainAreaWidget');
-    // Set contain=strict to avoid many forced layout rendering while addding cells.
+    // Set contain=strict to avoid many forced layout rendering while adding cells.
     // Don't forget to remove the CSS class when your remove the spinner to allow
     // the content to be rendered.
     // @see https://github.com/jupyterlab/jupyterlab/issues/9381
@@ -113,7 +113,7 @@ export class MainAreaWidget<T extends Widget = Widget>
   }
 
   /**
-   * Print method. Defered to content.
+   * Print method. Deferred to content.
    */
   [Printing.symbol](): Printing.OptionalAsyncThunk {
     if (!this._content) {

--- a/packages/apputils/src/sanitizer.ts
+++ b/packages/apputils/src/sanitizer.ts
@@ -9,7 +9,7 @@ import { ISanitizer } from './tokens';
 /**
  * Helper class that contains regular expressions for inline CSS style validation.
  *
- * Which properties (and values) to allow is largly based on the Google Caja project:
+ * Which properties (and values) to allow is largely based on the Google Caja project:
  *   https://github.com/google/caja
  *
  * The regular expressions are largly based on the syntax definition found at
@@ -53,7 +53,7 @@ class CssProp {
   };
 
   /*
-   * Atomic (i.e. not dependant on other regular expresions) sub RegEx segments
+   * Atomic (i.e. not dependant on other regular expressions) sub RegEx segments
    */
   private static readonly A = {
     absolute_size: `xx-small|x-small|small|medium|large|x-large|xx-large`,
@@ -85,7 +85,7 @@ class CssProp {
   };
 
   /*
-   * Compound (i.e. dependant on other (sub) regular expresions) sub RegEx segments
+   * Compound (i.e. dependant on other (sub) regular expressions) sub RegEx segments
    */
   private static readonly _C = {
     alpha: `${CssProp.N.integer_zero_ff}|${CssProp.N.number_zero_one}|${CssProp.B.percentage_zero_hundred}`,

--- a/packages/apputils/src/sessioncontext.tsx
+++ b/packages/apputils/src/sessioncontext.tsx
@@ -1197,7 +1197,7 @@ export namespace SessionContext {
 }
 
 /**
- * The default implementation of the client sesison dialog provider.
+ * The default implementation of the client session dialog provider.
  */
 export const sessionContextDialogs: ISessionContext.IDialogs = {
   /**

--- a/packages/apputils/src/thememanager.ts
+++ b/packages/apputils/src/thememanager.ts
@@ -263,7 +263,7 @@ export class ThemeManager implements IThemeManager {
   }
 
   /**
-   * Toggle the `theme-scrollbbars` setting.
+   * Toggle the `theme-scrollbars` setting.
    */
   toggleThemeScrollbars(): Promise<void> {
     return this._settings.set(

--- a/packages/apputils/src/toolbar.tsx
+++ b/packages/apputils/src/toolbar.tsx
@@ -462,7 +462,7 @@ export namespace Toolbar {
  */
 export namespace ToolbarButtonComponent {
   /**
-   * Interface for ToolbarButttonComponent props.
+   * Interface for ToolbarButtonComponent props.
    */
   export interface IProps {
     className?: string;
@@ -540,7 +540,7 @@ export function ToolbarButtonComponent(props: ToolbarButtonComponent.IProps) {
         <LabIcon.resolveReact
           icon={props.icon}
           iconClass={
-            // add some extra classes for proper support of icons-as-css-backgorund
+            // add some extra classes for proper support of icons-as-css-background
             classes(props.iconClass, 'jp-Icon')
           }
           className="jp-ToolbarButtonComponent-icon"
@@ -570,7 +570,7 @@ export function addToolbarButtonClass(w: Widget): Widget {
 export class ToolbarButton extends ReactWidget {
   /**
    * Creates a toolbar button
-   * @param props props for underlying `ToolbarButton` componenent
+   * @param props props for underlying `ToolbarButton` component
    */
   constructor(private props: ToolbarButtonComponent.IProps = {}) {
     super();
@@ -632,7 +632,7 @@ export function addCommandToolbarButtonClass(w: Widget): Widget {
 export class CommandToolbarButton extends ReactWidget {
   /**
    * Creates a command toolbar button
-   * @param props props for underlying `CommandToolbarButtonComponent` componenent
+   * @param props props for underlying `CommandToolbarButtonComponent` component
    */
   constructor(private props: CommandToolbarButtonComponent.IProps) {
     super();

--- a/packages/apputils/src/vdom.ts
+++ b/packages/apputils/src/vdom.ts
@@ -167,7 +167,7 @@ export interface IUseSignalProps<SENDER, ARGS> {
    */
   initialArgs?: ARGS;
   /**
-   * Function mapping the last signal value or inital values to an element to render.
+   * Function mapping the last signal value or initial values to an element to render.
    *
    * Note: returns `React.ReactNode` as per
    * https://github.com/sw-yx/react-typescript-cheatsheet#higher-order-componentsrender-props

--- a/packages/attachments/src/model.ts
+++ b/packages/attachments/src/model.ts
@@ -342,7 +342,7 @@ export class AttachmentsModel implements IAttachmentsModel {
  */
 export namespace AttachmentsModel {
   /**
-   * The default implementation of a `IAttachemntsModel.IContentFactory`.
+   * The default implementation of a `IAttachmentsModel.IContentFactory`.
    */
   export class ContentFactory implements IAttachmentsModel.IContentFactory {
     /**
@@ -362,7 +362,7 @@ export namespace AttachmentsModel {
 }
 
 /**
- * A resolver for cell attachments 'attchment:filename'.
+ * A resolver for cell attachments 'attachment:filename'.
  *
  * Will resolve to a data: url.
  */

--- a/packages/cells/src/inputarea.ts
+++ b/packages/cells/src/inputarea.ts
@@ -190,7 +190,7 @@ export namespace InputArea {
    */
   export interface IContentFactory {
     /**
-     * The editor factory we need to include in `CodeEditorWratter.IOptions`.
+     * The editor factory we need to include in `CodeEditorWrapper.IOptions`.
      *
      * This is a separate readonly attribute rather than a factory method as we need
      * to pass it around.

--- a/packages/cells/test/widget.spec.ts
+++ b/packages/cells/test/widget.spec.ts
@@ -122,7 +122,7 @@ describe('cells/widget', () => {
         expect(widget).toBeInstanceOf(Cell);
       });
 
-      it('shoule accept a custom editorConfig', () => {
+      it('should accept a custom editorConfig', () => {
         const editorConfig: Partial<CodeEditor.IConfig> = {
           insertSpaces: false,
           matchBrackets: false

--- a/packages/codeeditor/src/editor.ts
+++ b/packages/codeeditor/src/editor.ts
@@ -276,7 +276,7 @@ export namespace CodeEditor {
     /**
      * We update the modeldb store when the shared model changes.
      * To ensure that we don't run into infinite loops, we wrap this call in a "mutex".
-     * The "mutex" ensures that the wrapped code can only be executed by either the sharedModelChanged hander
+     * The "mutex" ensures that the wrapped code can only be executed by either the sharedModelChanged handler
      * or the modelDB change handler.
      */
     protected _onSharedModelChanged(
@@ -788,7 +788,7 @@ export namespace CodeEditor {
     rulers: Array<number>;
 
     /**
-     * Wheter to allow code folding
+     * Whether to allow code folding
      */
     codeFolding: boolean;
   }

--- a/packages/codeeditor/src/mimetype.ts
+++ b/packages/codeeditor/src/mimetype.ts
@@ -15,7 +15,7 @@ export interface IEditorMimeTypeService {
    * @returns A valid mimetype.
    *
    * #### Notes
-   * If a mime type cannot be found returns the defaul mime type `text/plain`, never `null`.
+   * If a mime type cannot be found returns the default mime type `text/plain`, never `null`.
    */
   getMimeTypeByLanguage(info: nbformat.ILanguageInfoMetadata): string;
 
@@ -27,7 +27,7 @@ export interface IEditorMimeTypeService {
    * @returns A valid mimetype.
    *
    * #### Notes
-   * If a mime type cannot be found returns the defaul mime type `text/plain`, never `null`.
+   * If a mime type cannot be found returns the default mime type `text/plain`, never `null`.
    */
   getMimeTypeByFilePath(filePath: string): string;
 }

--- a/packages/codemirror/src/editor.ts
+++ b/packages/codemirror/src/editor.ts
@@ -339,7 +339,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   /**
    * Set config options for the editor.
    *
-   * This method is prefered when setting several options. The
+   * This method is preferred when setting several options. The
    * options are set within an operation, which only performs
    * the costly update at the end, and not after every option
    * is set.
@@ -510,9 +510,9 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
   getRange(
     from: CodeMirror.Position,
     to: CodeMirror.Position,
-    seperator?: string
+    separator?: string
   ): string {
-    return this._editor.getDoc().getRange(from, to, seperator);
+    return this._editor.getDoc().getRange(from, to, separator);
   }
 
   /**
@@ -957,7 +957,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
     switch (args.type) {
       case 'insert': {
         const pos = doc.posFromIndex(args.start);
-        // Replace the range, including a '+input' orign,
+        // Replace the range, including a '+input' origin,
         // which indicates that CodeMirror may merge changes
         // for undo/redo purposes.
         doc.replaceRange(args.value, pos, pos, '+input');
@@ -966,7 +966,7 @@ export class CodeMirrorEditor implements CodeEditor.IEditor {
       case 'remove': {
         const from = doc.posFromIndex(args.start);
         const to = doc.posFromIndex(args.end);
-        // Replace the range, including a '+input' orign,
+        // Replace the range, including a '+input' origin,
         // which indicates that CodeMirror may merge changes
         // for undo/redo purposes.
         doc.replaceRange('', from, to, '+input');
@@ -1463,7 +1463,7 @@ namespace Private {
   }
 
   /**
-   * Delete spaces to the previous tab stob in a codemirror editor.
+   * Delete spaces to the previous tab stop in a codemirror editor.
    */
   export function delSpaceToPrevTabStop(cm: CodeMirror.Editor): void {
     const doc = cm.getDoc();

--- a/packages/codemirror/src/mimetype.ts
+++ b/packages/codemirror/src/mimetype.ts
@@ -14,7 +14,7 @@ export class CodeMirrorMimeTypeService implements IEditorMimeTypeService {
    * Returns a mime type for the given language info.
    *
    * #### Notes
-   * If a mime type cannot be found returns the defaul mime type `text/plain`, never `null`.
+   * If a mime type cannot be found returns the default mime type `text/plain`, never `null`.
    */
   getMimeTypeByLanguage(info: nbformat.ILanguageInfoMetadata): string {
     const ext = info.file_extension || '';

--- a/packages/codemirror/test/mode.spec.ts
+++ b/packages/codemirror/test/mode.spec.ts
@@ -54,7 +54,7 @@ enum T {
  * from https://codemirror.net/demo/simplemode.html
  */
 const FAKE_SIMPLE_STATES: CodeMirror.TSimpleTopState<S, T> = {
-  // The start state contains the rules that are intially used
+  // The start state contains the rules that are initially used
   start: [
     // The regex matches the token, the token property contains the type
     { regex: /"(?:[^\\]|\\.)*?(?:"|$)/, token: T.ST },

--- a/packages/completer/src/connector.ts
+++ b/packages/completer/src/connector.ts
@@ -17,7 +17,7 @@ export class CompletionConnector extends DataConnector<
   /**
    * Create a new connector for completion requests.
    *
-   * @param options - The instatiation options for the connector.
+   * @param options - The instantiation options for the connector.
    */
   constructor(options: CompletionConnector.IOptions) {
     super();

--- a/packages/completer/src/contextconnector.ts
+++ b/packages/completer/src/contextconnector.ts
@@ -16,7 +16,7 @@ export class ContextConnector extends DataConnector<
   /**
    * Create a new context connector for completion requests.
    *
-   * @param options - The instatiation options for the context connector.
+   * @param options - The instantiation options for the context connector.
    */
   constructor(options: ContextConnector.IOptions) {
     super();
@@ -78,7 +78,7 @@ namespace Private {
     // Only choose the ones that have a non-empty type
     // field, which are likely to be of interest.
     const completionList = tokenList.filter(t => t.type).map(t => t.value);
-    // Remove duplicate completsions from the list
+    // Remove duplicate completions from the list
     const matches = Array.from(new Set<string>(completionList));
 
     return {

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -236,7 +236,7 @@ export class CompleterModel implements Completer.IModel {
    * ```
    * ['function', 'instance', 'class', 'module', 'keyword']
    * ```
-   * and then has any remaining types listed alphebetically. This will give
+   * and then has any remaining types listed alphabetically. This will give
    * reliable visual encoding for these known types, but allow kernels to
    * provide new types.
    */

--- a/packages/csvviewer-extension/src/searchprovider.ts
+++ b/packages/csvviewer-extension/src/searchprovider.ts
@@ -120,7 +120,7 @@ export class CSVSearchProvider implements ISearchProvider<CSVDocumentWidget> {
   }
 
   /**
-   * The same list of matches provided by the startQuery promise resoluton
+   * The same list of matches provided by the startQuery promise resolution
    */
   readonly matches: ISearchMatch[] = [];
 

--- a/packages/debugger/src/dialogs/evaluate.ts
+++ b/packages/debugger/src/dialogs/evaluate.ts
@@ -107,7 +107,7 @@ class EvaluateDialogBody extends Widget implements Dialog.IBodyWidget<string> {
       model
     }).initializeState();
 
-    // explicitely remove the prompt in front of the input area
+    // explicitly remove the prompt in front of the input area
     this._prompt.inputArea.promptNode.remove();
 
     this.node.appendChild(this._prompt.node);

--- a/packages/docmanager/src/dialogs.ts
+++ b/packages/docmanager/src/dialogs.ts
@@ -23,7 +23,7 @@ const FILE_DIALOG_CHECKBOX_CLASS = 'jp-FileDialog-Checkbox';
 /**
  * The class name added for the new name label in the rename dialog
  */
-const RENAME_NEWNAME_TITLE_CLASS = 'jp-new-name-title';
+const RENAME_NEW_NAME_TITLE_CLASS = 'jp-new-name-title';
 
 /**
  * A stripped-down interface for a file container.
@@ -228,7 +228,7 @@ namespace Private {
 
     const nameTitle = document.createElement('label');
     nameTitle.textContent = trans.__('New Name');
-    nameTitle.className = RENAME_NEWNAME_TITLE_CLASS;
+    nameTitle.className = RENAME_NEW_NAME_TITLE_CLASS;
     const name = document.createElement('input');
 
     body.appendChild(existingLabel);

--- a/packages/docmanager/src/manager.ts
+++ b/packages/docmanager/src/manager.ts
@@ -565,7 +565,7 @@ export class DocumentManager implements IDocumentManager {
       return undefined;
     }
 
-    // Handle the kernel pereference.
+    // Handle the kernel preference.
     const preference = this.registry.getKernelPreference(
       path,
       widgetFactory.name,
@@ -670,7 +670,7 @@ export namespace DocumentManager {
     sessionDialogs?: ISessionContext.IDialogs;
 
     /**
-     * The applicaton language translator.
+     * The application language translator.
      */
     translator?: ITranslator;
 

--- a/packages/docmanager/src/savehandler.ts
+++ b/packages/docmanager/src/savehandler.ts
@@ -159,7 +159,7 @@ export namespace SaveHandler {
    */
   export interface IOptions {
     /**
-     * The context asssociated with the file.
+     * The context associated with the file.
      */
     context: DocumentRegistry.Context;
 

--- a/packages/docmanager/src/savingstatus.tsx
+++ b/packages/docmanager/src/savingstatus.tsx
@@ -170,7 +170,7 @@ export namespace SavingStatus {
     docManager: IDocumentManager;
 
     /**
-     * The aplication language translator.
+     * The application language translator.
      */
     translator?: ITranslator;
   }

--- a/packages/docprovider/src/awareness.ts
+++ b/packages/docprovider/src/awareness.ts
@@ -83,13 +83,13 @@ export const moonsOfJupyter = [
 
 /**
  * Get a random user-name based on the moons of Jupyter.
- * This function retuns names like "Anonymous Io" or "Anonymous Metis".
+ * This function returns names like "Anonymous Io" or "Anonymous Metis".
  */
 export const getAnonymousUserName = (): string =>
   'Anonymous ' +
   moonsOfJupyter[Math.floor(Math.random() * moonsOfJupyter.length)];
 
-export const usercolors = [
+export const userColors = [
   '#12A0D3',
   '#17AB30',
   '#CC8500',
@@ -101,4 +101,4 @@ export const usercolors = [
 ];
 
 export const getRandomColor = (): string =>
-  usercolors[Math.floor(Math.random() * usercolors.length)];
+  userColors[Math.floor(Math.random() * userColors.length)];

--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -14,9 +14,9 @@ import * as env from 'lib0/environment';
 /**
  * A class to provide Yjs synchronization over WebSocket.
  *
- * The user can specify their own user-name and user-color by adding urlparameters:
+ * The user can specify their own user-name and user-color by adding url parameters:
  *   ?username=Alice&usercolor=007007
- * wher usercolor must be a six-digit hexadicimal encoded RGB value without the hash token.
+ * where usercolor must be a six-digit hexadecimal encoded RGB value without the hash token.
  *
  * We specify custom messages that the server can interpret. For reference please look in yjs_ws_server.
  *

--- a/packages/docregistry/src/context.ts
+++ b/packages/docregistry/src/context.ts
@@ -263,7 +263,7 @@ export class Context<
     const finally_ = () => {
       this._provider.releaseLock(lock);
     };
-    // if save/revert completed successfully, we set the inialized content in the rtc server.
+    // if save/revert completed successfully, we set the initialized content in the rtc server.
     promise
       .then(() => {
         this._provider.putInitializedState();
@@ -300,7 +300,7 @@ export class Context<
     } else {
       promise = this._save();
     }
-    // if save completed successfully, we set the inialized content in the rtc server.
+    // if save completed successfully, we set the initialized content in the rtc server.
     promise = promise.then(() => {
       this._provider.putInitializedState();
     });

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -379,7 +379,7 @@ export abstract class ABCWidgetFactory<
   }
 
   /**
-   * The aplication language translator.
+   * The application language translator.
    */
   get translator(): ITranslator {
     return this._translator;

--- a/packages/docregistry/src/mimedocument.ts
+++ b/packages/docregistry/src/mimedocument.ts
@@ -79,7 +79,7 @@ export class MimeContent extends Widget {
   readonly mimeType: string;
 
   /**
-   * Print method. Defered to the renderer.
+   * Print method. Deferred to the renderer.
    */
   [Printing.symbol]() {
     return Printing.getPrintFunction(this.renderer);

--- a/packages/documentsearch/src/interfaces.ts
+++ b/packages/documentsearch/src/interfaces.ts
@@ -194,7 +194,7 @@ export interface ISearchProvider<T extends Widget = Widget> {
   replaceAllMatches(newText: string): Promise<boolean>;
 
   /**
-   * The same list of matches provided by the startQuery promise resoluton
+   * The same list of matches provided by the startQuery promise resolution
    */
   readonly matches: ISearchMatch[];
 

--- a/packages/documentsearch/src/providers/notebooksearchprovider.ts
+++ b/packages/documentsearch/src/providers/notebooksearchprovider.ts
@@ -138,9 +138,9 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
       });
 
       if (cell instanceof CodeCell && this._filters.output) {
-        const outputProivder = new GenericSearchProvider();
-        outputProivder.isSubProvider = true;
-        const matchesFromOutput = await outputProivder.startQuery(
+        const outputProvider = new GenericSearchProvider();
+        outputProvider.isSubProvider = true;
+        const matchesFromOutput = await outputProvider.startQuery(
           query,
           cell.outputArea
         );
@@ -151,11 +151,11 @@ export class NotebookSearchProvider implements ISearchProvider<NotebookPanel> {
 
         allMatches.concat(matchesFromOutput);
 
-        outputProivder.changed.connect(this._onSearchProviderChanged, this);
+        outputProvider.changed.connect(this._onSearchProviderChanged, this);
 
         this._searchProviders.push({
           cell: cell,
-          provider: outputProivder
+          provider: outputProvider
         });
       }
     }

--- a/packages/documentsearch/src/searchinstance.ts
+++ b/packages/documentsearch/src/searchinstance.ts
@@ -31,7 +31,7 @@ export class SearchInstance implements IDisposable {
       overlayState: this._displayState,
       onCaseSensitiveToggled: this._onCaseSensitiveToggled.bind(this),
       onRegexToggled: this._onRegexToggled.bind(this),
-      onHightlightNext: this._highlightNext.bind(this),
+      onHighlightNext: this._highlightNext.bind(this),
       onHighlightPrevious: this._highlightPrevious.bind(this),
       onStartQuery: this._startQuery.bind(this),
       onReplaceCurrent: this._replaceCurrent.bind(this),

--- a/packages/documentsearch/src/searchoverlay.tsx
+++ b/packages/documentsearch/src/searchoverlay.tsx
@@ -213,7 +213,7 @@ class ReplaceEntry extends React.Component<IReplaceEntryProps> {
 
 interface IUpDownProps {
   onHighlightPrevious: Function;
-  onHightlightNext: Function;
+  onHighlightNext: Function;
 }
 
 function UpDownButtons(props: IUpDownProps) {
@@ -231,7 +231,7 @@ function UpDownButtons(props: IUpDownProps) {
       </button>
       <button
         className={BUTTON_WRAPPER_CLASS}
-        onClick={() => props.onHightlightNext()}
+        onClick={() => props.onHighlightNext()}
         tabIndex={0}
       >
         <caretDownEmptyThinIcon.react
@@ -352,7 +352,7 @@ interface ISearchOverlayProps {
   overlayState: IDisplayState;
   onCaseSensitiveToggled: Function;
   onRegexToggled: Function;
-  onHightlightNext: Function;
+  onHighlightNext: Function;
   onHighlightPrevious: Function;
   onStartQuery: Function;
   onEndSearch: Function;
@@ -439,7 +439,7 @@ class SearchOverlay extends React.Component<
       !filterChanged
     ) {
       if (goForward) {
-        this.props.onHightlightNext();
+        this.props.onHighlightNext();
       } else {
         this.props.onHighlightPrevious();
       }
@@ -572,7 +572,7 @@ class SearchOverlay extends React.Component<
         />
         <UpDownButtons
           onHighlightPrevious={() => this._executeSearch(false)}
-          onHightlightNext={() => this._executeSearch(true)}
+          onHighlightNext={() => this._executeSearch(true)}
         />
         {showReplace ? null : filterToggle}
         <button
@@ -642,7 +642,7 @@ export function createSearchOverlay(
     overlayState,
     onCaseSensitiveToggled,
     onRegexToggled,
-    onHightlightNext,
+    onHighlightNext,
     onHighlightPrevious,
     onStartQuery,
     onReplaceCurrent,
@@ -659,7 +659,7 @@ export function createSearchOverlay(
           <SearchOverlay
             onCaseSensitiveToggled={onCaseSensitiveToggled}
             onRegexToggled={onRegexToggled}
-            onHightlightNext={onHightlightNext}
+            onHighlightNext={onHighlightNext}
             onHighlightPrevious={onHighlightPrevious}
             onStartQuery={onStartQuery}
             onEndSearch={onEndSearch}
@@ -684,7 +684,7 @@ namespace createSearchOverlay {
     overlayState: IDisplayState;
     onCaseSensitiveToggled: Function;
     onRegexToggled: Function;
-    onHightlightNext: Function;
+    onHighlightNext: Function;
     onHighlightPrevious: Function;
     onStartQuery: Function;
     onEndSearch: Function;

--- a/packages/extensionmanager/src/model.ts
+++ b/packages/extensionmanager/src/model.ts
@@ -86,7 +86,7 @@ export interface IEntry {
  */
 export interface IInstall {
   /**
-   * The used pacakge manager (e.g. pip, conda...)
+   * The used package manager (e.g. pip, conda...)
    */
   packageManager: string | undefined;
 
@@ -162,7 +162,7 @@ export interface IInstalledEntry {
  */
 export interface IInstallEntry {
   /**
-   * The used pacakge manager (e.g. pip, conda...)
+   * The used package manager (e.g. pip, conda...)
    */
   packageManager: string | undefined;
 

--- a/packages/extensionmanager/src/widget.tsx
+++ b/packages/extensionmanager/src/widget.tsx
@@ -346,7 +346,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
                       title,
                       body: (
                         <div>
-                          {getprebuiltUninstallInstruction(entry, trans)}
+                          {getPrebuiltUninstallInstruction(entry, trans)}
                         </div>
                       ),
                       buttons: [
@@ -373,7 +373,7 @@ function ListEntry(props: ListEntry.IProperties): React.ReactElement<any> {
   );
 }
 
-function getprebuiltUninstallInstruction(
+function getPrebuiltUninstallInstruction(
   entry: IEntry,
   trans: TranslationBundle
 ): JSX.Element {
@@ -649,7 +649,7 @@ export namespace CollapsibleSection {
     headerElements?: React.ReactNode;
 
     /**
-     * If given, this will be diplayed instead of the children.
+     * If given, this will be displayed instead of the children.
      */
     errorMessage?: string | null;
 

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -59,7 +59,7 @@ export class FileBrowser extends Widget {
   /**
    * Construct a new file browser.
    *
-   * @param model - The file browser view model.
+   * @param options - The file browser options.
    */
   constructor(options: FileBrowser.IOptions) {
     super();

--- a/packages/filebrowser/src/listing.ts
+++ b/packages/filebrowser/src/listing.ts
@@ -166,7 +166,7 @@ const MULTI_SELECTED_CLASS = 'jp-mod-multiSelected';
 const RUNNING_CLASS = 'jp-mod-running';
 
 /**
- * The class name added for a decending sort.
+ * The class name added for a descending sort.
  */
 const DESCENDING_CLASS = 'jp-mod-descending';
 

--- a/packages/htmlviewer/src/index.tsx
+++ b/packages/htmlviewer/src/index.tsx
@@ -270,7 +270,7 @@ namespace Private {
   /**
    * React component for a trusted button.
    *
-   * This wraps the ToolbarButtonComponent and watches for trust chagnes.
+   * This wraps the ToolbarButtonComponent and watches for trust changes.
    */
   export function TrustButtonComponent(props: TrustButtonComponent.IProps) {
     const translator = props.translator || nullTranslator;

--- a/packages/htmlviewer/style/base.css
+++ b/packages/htmlviewer/style/base.css
@@ -22,7 +22,7 @@
 /*
 When drag events occur, `p-mod-override-cursor` is added to the body.
 Because iframes steal all cursor events, the following two rules are necessary
-to suppress pointer events while resize drags are occuring. There may be a
+to suppress pointer events while resize drags are occurring. There may be a
 better solution to this problem.
 */
 body.lm-mod-override-cursor .jp-HTMLViewer {

--- a/packages/inspector/src/inspector.ts
+++ b/packages/inspector/src/inspector.ts
@@ -159,7 +159,7 @@ export namespace InspectorPanel {
     initialContent?: Widget | string | undefined;
 
     /**
-     * The aplication language translator.
+     * The application language translator.
      */
     translator?: ITranslator;
   }

--- a/packages/inspector/src/kernelconnector.ts
+++ b/packages/inspector/src/kernelconnector.ts
@@ -17,7 +17,7 @@ export class KernelConnector extends DataConnector<
   /**
    * Create a new kernel connector for inspection requests.
    *
-   * @param options - The instatiation options for the kernel connector.
+   * @param options - The instantiation options for the kernel connector.
    */
   constructor(options: KernelConnector.IOptions) {
     super();

--- a/packages/mainmenu/src/edit.ts
+++ b/packages/mainmenu/src/edit.ts
@@ -94,7 +94,7 @@ export namespace IEditMenu {
      * A function to create the label for the `clearCurrent`action.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     clearCurrentLabel?: (n: number) => string;
 
@@ -102,7 +102,7 @@ export namespace IEditMenu {
      * A function to create the label for the `clearAll`action.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     clearAllLabel?: (n: number) => string;
 

--- a/packages/mainmenu/src/file.ts
+++ b/packages/mainmenu/src/file.ts
@@ -99,7 +99,7 @@ export namespace IFileMenu {
      * A function to create the label for the `closeAndCleanup`action.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     closeAndCleanupLabel?: (n: number) => string;
 
@@ -117,7 +117,7 @@ export namespace IFileMenu {
      * A function to create the label for the `createConsole`action.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     createConsoleLabel?: (n: number) => string;
 

--- a/packages/mainmenu/src/kernel.ts
+++ b/packages/mainmenu/src/kernel.ts
@@ -86,7 +86,7 @@ export namespace IKernelMenu {
      * A function to return the label associated to the `restartKernelAndClear` action.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     restartKernelAndClearLabel?: (n: number) => string;
   }

--- a/packages/mainmenu/src/run.ts
+++ b/packages/mainmenu/src/run.ts
@@ -60,7 +60,7 @@ export namespace IRunMenu {
      * Return the label associated to the `run` function.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     runLabel?: (n: number) => string;
 
@@ -68,7 +68,7 @@ export namespace IRunMenu {
      * Return the label associated to the `runAllLabel` function.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     runAllLabel?: (n: number) => string;
 
@@ -76,7 +76,7 @@ export namespace IRunMenu {
      * Return the label associated to the `restartAndRunAllLabel` function.
      *
      * This function receives the number of items `n` to be able to provided
-     * correct pluralized forms of tranlsations.
+     * correct pluralized forms of translations.
      */
     restartAndRunAllLabel?: (n: number) => string;
 

--- a/packages/nbformat/src/index.ts
+++ b/packages/nbformat/src/index.ts
@@ -30,7 +30,7 @@ export interface IKernelspecMetadata extends PartialJSONObject {
 }
 
 /**
- * The language info metatda
+ * The language info metadata
  */
 export interface ILanguageInfoMetadata extends PartialJSONObject {
   name: string;

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -261,7 +261,7 @@ namespace CommandIDs {
 const FACTORY = 'Notebook';
 
 /**
- * The exluded Export To ...
+ * The excluded Export To ...
  * (returned from nbconvert's export list)
  */
 const FORMAT_EXCLUDE = ['notebook', 'python', 'custom'];

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -76,7 +76,7 @@ export namespace NotebookActions {
    * #### Notes
    * It will preserve the existing mode.
    * The last cell will be activated if no selection is found.
-   * If text was selected, the cell cotaining the selection will
+   * If text was selected, the cell containing the selection will
      be activated.
    * The existing selection will be cleared.
    * The activated cell will have focus and the cursor will move
@@ -863,7 +863,7 @@ export namespace NotebookActions {
   /**
    * Deselect all of the cells of the notebook.
    *
-   * @param notebook - the targe notebook widget.
+   * @param notebook - the target notebook widget.
    */
   export function deselectAll(notebook: Notebook): void {
     if (!notebook.model || !notebook.activeCell) {
@@ -1497,11 +1497,11 @@ export namespace NotebookActions {
     if (!notebook.widgets.length) {
       return which + 1;
     }
-    let selectedheadingInfo = NotebookActions.getHeadingInfo(cell);
+    let selectedHeadingInfo = NotebookActions.getHeadingInfo(cell);
     if (
       cell.isHidden ||
       !(cell instanceof MarkdownCell) ||
-      !selectedheadingInfo.isHeading
+      !selectedHeadingInfo.isHeading
     ) {
       // otherwise collapsing and uncollapsing already hidden stuff can
       // cause some funny looking bugs.
@@ -1513,10 +1513,10 @@ export namespace NotebookActions {
     let cellNum;
     for (cellNum = which + 1; cellNum < notebook.widgets.length; cellNum++) {
       let subCell = notebook.widgets[cellNum];
-      let subCellheadingInfo = NotebookActions.getHeadingInfo(subCell);
+      let subCellHeadingInfo = NotebookActions.getHeadingInfo(subCell);
       if (
-        subCellheadingInfo.isHeading &&
-        subCellheadingInfo.headingLevel <= selectedheadingInfo.headingLevel
+        subCellHeadingInfo.isHeading &&
+        subCellHeadingInfo.headingLevel <= selectedHeadingInfo.headingLevel
       ) {
         // then reached an equivalent or higher heading level than the
         // original the end of the collapse.
@@ -1525,8 +1525,8 @@ export namespace NotebookActions {
       }
       if (
         localCollapsed &&
-        subCellheadingInfo.isHeading &&
-        subCellheadingInfo.headingLevel <= localCollapsedLevel
+        subCellHeadingInfo.isHeading &&
+        subCellHeadingInfo.headingLevel <= localCollapsedLevel
       ) {
         // then reached the end of the local collapsed, so unset NotebookActions.
         localCollapsed = false;
@@ -1539,9 +1539,9 @@ export namespace NotebookActions {
         continue;
       }
 
-      if (subCellheadingInfo.collapsed && subCellheadingInfo.isHeading) {
+      if (subCellHeadingInfo.collapsed && subCellHeadingInfo.isHeading) {
         localCollapsed = true;
-        localCollapsedLevel = subCellheadingInfo.headingLevel;
+        localCollapsedLevel = subCellHeadingInfo.headingLevel;
         // but don't collapse the locally collapsed heading, so continue to
         // expand the heading. This will get noticed in the next round.
       }
@@ -1638,7 +1638,7 @@ export namespace NotebookActions {
     const trustMessage = (
       <p>
         {trans.__(
-          'A trusted Jupyter notebook may execute hidden malicious code when you openit.'
+          'A trusted Jupyter notebook may execute hidden malicious code when you open it.'
         )}
         <br />
         {trans.__(

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -535,10 +535,10 @@ export namespace NotebookModel {
      * @param options: the cell creation options.
      *
      * #### Notes
-     * This method is intended to be a convenience method to programmaticaly
+     * This method is intended to be a convenience method to programmatically
      * call the other cell creation methods in the factory.
      */
-    createCell(type: nbformat.CellType, opts: CellModel.IOptions): ICellModel;
+    createCell(type: nbformat.CellType, options: CellModel.IOptions): ICellModel;
 
     /**
      * Create a new code cell.
@@ -607,18 +607,18 @@ export namespace NotebookModel {
      * @param options: the cell creation options.
      *
      * #### Notes
-     * This method is intended to be a convenience method to programmaticaly
+     * This method is intended to be a convenience method to programmatically
      * call the other cell creation methods in the factory.
      */
-    createCell(type: nbformat.CellType, opts: CellModel.IOptions): ICellModel {
+    createCell(type: nbformat.CellType, options: CellModel.IOptions): ICellModel {
       switch (type) {
         case 'code':
-          return this.createCodeCell(opts);
+          return this.createCodeCell(options);
         case 'markdown':
-          return this.createMarkdownCell(opts);
+          return this.createMarkdownCell(options);
         case 'raw':
         default:
-          return this.createRawCell(opts);
+          return this.createRawCell(options);
       }
     }
 

--- a/packages/notebook/src/model.ts
+++ b/packages/notebook/src/model.ts
@@ -538,7 +538,10 @@ export namespace NotebookModel {
      * This method is intended to be a convenience method to programmatically
      * call the other cell creation methods in the factory.
      */
-    createCell(type: nbformat.CellType, options: CellModel.IOptions): ICellModel;
+    createCell(
+      type: nbformat.CellType,
+      options: CellModel.IOptions
+    ): ICellModel;
 
     /**
      * Create a new code cell.
@@ -610,7 +613,10 @@ export namespace NotebookModel {
      * This method is intended to be a convenience method to programmatically
      * call the other cell creation methods in the factory.
      */
-    createCell(type: nbformat.CellType, options: CellModel.IOptions): ICellModel {
+    createCell(
+      type: nbformat.CellType,
+      options: CellModel.IOptions
+    ): ICellModel {
       switch (type) {
         case 'code':
           return this.createCodeCell(options);

--- a/packages/notebook/src/modestatus.tsx
+++ b/packages/notebook/src/modestatus.tsx
@@ -88,7 +88,7 @@ export class CommandEditStatus extends VDomRenderer<CommandEditStatus.Model> {
  */
 export namespace CommandEditStatus {
   /**
-   * A VDomModle for the CommandEdit renderer.
+   * A VDomModel for the CommandEdit renderer.
    */
   export class Model extends VDomModel {
     /**

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -545,7 +545,7 @@ export class StaticNotebook extends Widget {
     ) {
       // We have an observer and we are have been asked to push (not to insert).
       // and we are above the number of cells to render directly, then
-      // we will add a placeholder and let the instersection observer or the
+      // we will add a placeholder and let the intersection observer or the
       // idle browser render those placeholder cells.
       this._toRenderMap.set(widget.model.id, { index: index, cell: widget });
       const placeholder = this._createPlaceholderCell(
@@ -1028,7 +1028,7 @@ export namespace StaticNotebook {
   }
 
   /**
-   * A namespace for the staic notebook content factory.
+   * A namespace for the static notebook content factory.
    */
   export namespace ContentFactory {
     /**

--- a/packages/notebook/test/actions.spec.ts
+++ b/packages/notebook/test/actions.spec.ts
@@ -851,7 +851,7 @@ describe('@jupyterlab/notebook', () => {
         widget.widgets[2].model.value.text = 'a = 1';
       });
 
-      it('should run all of the cells in the notebok', async () => {
+      it('should run all of the cells in the notebook', async () => {
         const next = widget.widgets[1] as MarkdownCell;
         const cell = widget.activeCell as CodeCell;
         cell.model.outputs.clear();
@@ -1055,7 +1055,7 @@ describe('@jupyterlab/notebook', () => {
         expect(widget.isSelected(widget.widgets[1])).toBe(true);
       });
 
-      it('should extend the selection the bottomost cell', () => {
+      it('should extend the selection the bottom-most cell', () => {
         NotebookActions.extendSelectionBelow(widget, true);
         for (let i = widget.activeCellIndex; i < widget.widgets.length; i++) {
           expect(widget.isSelected(widget.widgets[i])).toBe(true);

--- a/packages/observables/src/observablemap.ts
+++ b/packages/observables/src/observablemap.ts
@@ -139,7 +139,7 @@ export namespace IObservableMap {
 }
 
 /**
- * A concrete implementation of IObservbleMap<T>.
+ * A concrete implementation of IObservableMap<T>.
  */
 export class ObservableMap<T> implements IObservableMap<T> {
   /**

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -145,7 +145,7 @@ export class OutputArea extends Widget {
   private headEndIndex: number;
 
   /**
-   * A read-only sequence of the chidren widgets in the output area.
+   * A read-only sequence of the children widgets in the output area.
    */
   get widgets(): ReadonlyArray<Widget> {
     return (this.layout as PanelLayout).widgets;

--- a/packages/rendermime/src/renderers.ts
+++ b/packages/rendermime/src/renderers.ts
@@ -398,7 +398,7 @@ export namespace renderMarkdown {
     latexTypesetter: IRenderMime.ILatexTypesetter | null;
 
     /**
-     * The application languate translator.
+     * The application language translator.
      */
     translator?: ITranslator;
   }

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -163,7 +163,7 @@ connection status, etc.
 A _kernel manager_ is an object that maintains a list of kernel models by
 regular polling. The kernel manager can instantiate a kernel connection and
 will manage its lifecycle (e.g., when the kernel is shut down, the connections
-will be disposed). The manager provides some minimal bookkeepping around
+will be disposed). The manager provides some minimal bookkeeping around
 kernels and their connections. Generally, it is easiest to interact with
 kernels on a server through a manager.
 
@@ -206,7 +206,7 @@ session model to be deleted.
 A _session manager_ is an object that maintains a list of session models by
 regular polling. The session manager can instantiate a session connection and
 will manage its lifecycle (e.g., when the session is shut down, the connections
-will be disposed). The manager provides some minimal bookkeepping around
+will be disposed). The manager provides some minimal bookkeeping around
 sessions and their connections. Generally, it is easiest to interact with
 sessions on a server through a manager.
 

--- a/packages/services/src/contents/index.ts
+++ b/packages/services/src/contents/index.ts
@@ -193,7 +193,7 @@ export namespace Contents {
   }
 
   /**
-   * Validates an ICheckpointModel, thowing an error if it does not pass.
+   * Validates an ICheckpointModel, throwing an error if it does not pass.
    */
   export function validateCheckpointModel(checkpoint: ICheckpointModel): void {
     validate.validateCheckpointModel(checkpoint);
@@ -1102,9 +1102,9 @@ export class Drive implements Contents.IDrive {
     let url = URLExt.join(baseUrl, FILES_URL, URLExt.encodeParts(localPath));
     const xsrfTokenMatch = document.cookie.match('\\b_xsrf=([^;]*)\\b');
     if (xsrfTokenMatch) {
-      const fullurl = new URL(url);
-      fullurl.searchParams.append('_xsrf', xsrfTokenMatch[1]);
-      url = fullurl.toString();
+      const fullUrl = new URL(url);
+      fullUrl.searchParams.append('_xsrf', xsrfTokenMatch[1]);
+      url = fullUrl.toString();
     }
     return Promise.resolve(url);
   }

--- a/packages/services/src/kernel/kernel.ts
+++ b/packages/services/src/kernel/kernel.ts
@@ -824,7 +824,7 @@ export interface IComm extends IDisposable {
    *
    * @param data - The data to send to the server on opening.
    *
-   * @param metadata - Additional metatada for the message.
+   * @param metadata - Additional metadata for the message.
    *
    * @returns A future for the generated message.
    *
@@ -842,7 +842,7 @@ export interface IComm extends IDisposable {
    *
    * @param data - The data to send to the server on opening.
    *
-   * @param metadata - Additional metatada for the message.
+   * @param metadata - Additional metadata for the message.
    *
    * @param buffers - Optional buffer data.
    *
@@ -865,7 +865,7 @@ export interface IComm extends IDisposable {
    *
    * @param data - The data to send to the server on opening.
    *
-   * @param metadata - Additional metatada for the message.
+   * @param metadata - Additional metadata for the message.
    *
    * @returns A future for the generated message.
    *

--- a/packages/services/src/kernel/messages.ts
+++ b/packages/services/src/kernel/messages.ts
@@ -686,7 +686,7 @@ export function isCommMsgMsg(msg: IMessage): msg is ICommMsgMsg {
 // ///////////////////////////////////////////////
 
 /**
- * Reply content indicating a sucessful request.
+ * Reply content indicating a successful request.
  */
 export interface IReplyOkContent {
   status: 'ok';
@@ -1131,7 +1131,7 @@ export interface ICommInfoReplyMsg extends IShellMessage<'comm_info_reply'> {
 // ///////////////////////////////////////////////
 
 /**
- * An experimental `'debug_request'` messsage on the `'control'` channel.
+ * An experimental `'debug_request'` message on the `'control'` channel.
  *
  * @hidden
  *
@@ -1164,7 +1164,7 @@ export function isDebugRequestMsg(msg: IMessage): msg is IDebugRequestMsg {
 }
 
 /**
- * An experimental `'debug_reply'` messsage on the `'control'` channel.
+ * An experimental `'debug_reply'` message on the `'control'` channel.
  *
  * @hidden
  *

--- a/packages/services/src/terminal/default.ts
+++ b/packages/services/src/terminal/default.ts
@@ -182,7 +182,7 @@ export class TerminalConnection implements Terminal.ITerminalConnection {
       this._updateConnectionStatus('connecting');
 
       // The first reconnect attempt should happen immediately, and subsequent
-      // attemps should pick a random number in a growing range so that we
+      // attempts should pick a random number in a growing range so that we
       // don't overload the server with synchronized reconnection attempts
       // across multiple kernels.
       const timeout = Private.getRandomIntInclusive(

--- a/packages/shared-models/src/api.ts
+++ b/packages/shared-models/src/api.ts
@@ -368,9 +368,9 @@ export interface ISharedMarkdownCell
   /**
    * Sets the cell attachments
    *
-   * @param attchments: The cell attachments.
+   * @param attachments: The cell attachments.
    */
-  setAttachments(attchments: nbformat.IAttachments | undefined): void;
+  setAttachments(attachments: nbformat.IAttachments | undefined): void;
 
   /**
    * Serialize the model to JSON.
@@ -399,9 +399,9 @@ export interface ISharedRawCell
   /**
    * Sets the cell attachments
    *
-   * @param attchments: The cell attachments.
+   * @param attachments: The cell attachments.
    */
-  setAttachments(attchments: nbformat.IAttachments | undefined): void;
+  setAttachments(attachments: nbformat.IAttachments | undefined): void;
 
   /**
    * Serialize the model to JSON.

--- a/packages/shared-models/src/ymodels.ts
+++ b/packages/shared-models/src/ymodels.ts
@@ -308,7 +308,7 @@ export class YNotebook
    * Handle a change to the list of cells.
    */
   private _onYCellsChanged = (event: Y.YArrayEvent<Y.Map<any>>) => {
-    // update the type⇔cell mapping by iterating through the addded/removed types
+    // update the type⇔cell mapping by iterating through the added/removed types
     event.changes.added.forEach(item => {
       const type = (item.content as Y.ContentType).type as Y.Map<any>;
       if (!this._ycellMapping.has(type)) {
@@ -608,12 +608,12 @@ export class YBaseCell<Metadata extends models.ISharedBaseCellMetadata>
   /**
    * Sets the cell attachments
    *
-   * @param attchments: The cell attachments.
+   * @param attachments: The cell attachments.
    */
-  public setAttachments(value: nbformat.IAttachments | undefined): void {
+  public setAttachments(attachments: nbformat.IAttachments | undefined): void {
     this.transact(() => {
-      if (value == null) {
-        this.ymodel.set('attachments', value);
+      if (attachments == null) {
+        this.ymodel.set('attachments', attachments);
       } else {
         this.ymodel.delete('attachments');
       }

--- a/packages/statusbar/src/components/group.tsx
+++ b/packages/statusbar/src/components/group.tsx
@@ -40,7 +40,7 @@ export namespace GroupItem {
    */
   export interface IProps {
     /**
-     * The spacing, in px, between the items in the goup.
+     * The spacing, in px, between the items in the group.
      */
     spacing: number;
 

--- a/packages/statusbar/src/defaults/runningSessions.tsx
+++ b/packages/statusbar/src/defaults/runningSessions.tsx
@@ -48,7 +48,7 @@ function RunningSessionsComponent(
 }
 
 /**
- * A namepsace for RunningSessionsComponents statics.
+ * A namespace for RunningSessionsComponents statics.
  */
 namespace RunningSessionsComponent {
   /**
@@ -56,7 +56,7 @@ namespace RunningSessionsComponent {
    */
   export interface IProps {
     /**
-     * A click handler for the component. By defult this is used
+     * A click handler for the component. By default this is used
      * to activate the running sessions side panel.
      */
     handleClick: () => void;
@@ -165,11 +165,11 @@ export class RunningSessions extends VDomRenderer<RunningSessions.Model> {
 }
 
 /**
- * A namespace for RunninSessions statics.
+ * A namespace for RunningSessions statics.
  */
 export namespace RunningSessions {
   /**
-   * A VDomModel for the RunninSessions status item.
+   * A VDomModel for the RunningSessions status item.
    */
   export class Model extends VDomModel {
     /**
@@ -216,7 +216,7 @@ export namespace RunningSessions {
     serviceManager: ServiceManager;
 
     /**
-     * A click handler for the item. By defult this is used
+     * A click handler for the item. By default this is used
      * to activate the running sessions side panel.
      */
     onClick: () => void;

--- a/packages/toc/src/generators/notebook/get_markdown_heading.ts
+++ b/packages/toc/src/generators/notebook/get_markdown_heading.ts
@@ -35,7 +35,7 @@ function getMarkdownHeadings(
   cellRef: Cell,
   index: number = -1
 ): INotebookHeading[] {
-  const clbk = onClick(0);
+  const callback = onClick(0);
   let headings: INotebookHeading[] = [];
   if (index === -1) {
     console.warn(
@@ -49,7 +49,7 @@ function getMarkdownHeadings(
         text: heading.text,
         level: heading.level,
         numbering: generateNumbering(dict, heading.level),
-        onClick: clbk,
+        onClick: callback,
         type: 'header',
         cellRef: cellRef,
         hasChild: false,
@@ -59,7 +59,7 @@ function getMarkdownHeadings(
       headings.push({
         text: text,
         level: lastLevel + 1,
-        onClick: clbk,
+        onClick: callback,
         type: 'markdown',
         cellRef: cellRef,
         hasChild: false,

--- a/packages/toc/src/registry.ts
+++ b/packages/toc/src/registry.ts
@@ -56,7 +56,7 @@ export class TableOfContentsRegistry {
    */
   add(generator: TableOfContentsRegistry.IGenerator): void {
     if (generator.collapseChanged) {
-      // If there is a collapseChanged for a given generator, propogate the arguments through the registry's signal
+      // If there is a collapseChanged for a given generator, propagate the arguments through the registry's signal
       generator.collapseChanged.connect(
         (
           sender: TableOfContentsRegistry.IGenerator<Widget>,

--- a/packages/translation/src/gettext.ts
+++ b/packages/translation/src/gettext.ts
@@ -130,7 +130,7 @@ class Gettext {
   constructor(options?: IOptions) {
     options = options || {};
 
-    // default values that could be overriden in Gettext() constructor
+    // default values that could be overridden in Gettext() constructor
     this._defaults = {
       domain: 'messages',
       locale: document.documentElement.getAttribute('lang') || 'en',

--- a/packages/ui-components/CONTRIBUTING.md
+++ b/packages/ui-components/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Design goals for JLIcon (already implemented):
 - reusable
   - every defined icon can be used any number of times in any set of contexts
   - where an icon is defined should not matter; all icons defined in core and extensions are reusable in any other extension
-- replacable
+- replaceable
   - all icons can be customized by replacing their svg dynamically during runtime
   - replaceability does not depend on dynamic lookup (you can assign to the `.svgstr` property of any `LabIcon` instance to trigger replacement)
   - whenever its svg is replaced, all visible copies of an icon should immediately rerender

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -174,7 +174,7 @@ hex values.
 Most one-color icons in JupyterLab (including the sidebar and toolbar
 icons) are colored using the `jp-icon3` class.
 
-For light/dark themes, `jp-icon0` corresponds to the darkest/lighest
+For light/dark themes, `jp-icon0` corresponds to the darkest/lightest
 background color, while `jp-icon1` is somewhat lighter/darker, and so
 forth.
 
@@ -189,13 +189,13 @@ forth.
 </ul>
 
 For light/dark themes, `jp-icon-accent0` corresponds to the
-lighest/darkest background color, while `jp-icon-accent1` is somewhat
+lightest/darkest background color, while `jp-icon-accent1` is somewhat
 darker/lighter, and so forth.
 
 ### Adding classes to a one-color icon
 
 For most simple, one-color icons, it is desirable for the icon's color
-to strongly constrast with that of the application's background. You can
+to strongly contrast with that of the application's background. You can
 achieve this using one of the `jp-iconX` classes.
 
 **Example: check icon**

--- a/packages/ui-components/docs/build.sh
+++ b/packages/ui-components/docs/build.sh
@@ -17,7 +17,7 @@ MONOREPO_DEVDOC=$(realpath $PKG_ROOT/../../docs/source/developer)
 # make the docs build dir
 mkdir -p $BUILD
 
-# paths in rst include directives are resovled relative to pwd
+# paths in rst include directives are resolved relative to pwd
 pushd $SOURCE > /dev/null
 
 # make a copy of labicon.rst with section levels shifted down

--- a/packages/ui-components/docs/source/labicon.rst
+++ b/packages/ui-components/docs/source/labicon.rst
@@ -139,7 +139,7 @@ Sync icon color to JupyterLab theme
    <em>Example svgs with class annotation can be found in <a href="https://github.com/jupyterlab/jupyterlab/tree/f0153e0258b32674c9aec106383ddf7b618cebab/packages/ui-components/style/icons">ui-components/style/icons</a></em>
 
 |
-| You can ensure that the colors of your custom ``LabIcon`` sync up to the colors of the current JuptyerLab theme by adding appropriate ``class`` annotations to each colored element of your icon's svg.
+| You can ensure that the colors of your custom ``LabIcon`` sync up to the colors of the current JupyterLab theme by adding appropriate ``class`` annotations to each colored element of your icon's svg.
 |
 | In other words, each element of your svg that a ``fill="..."`` or a ``stroke="..."`` property should also have a ``class="jp-icon<whatever>"`` property.
 
@@ -169,7 +169,7 @@ Available icon classes
 Most one-color icons in JupyterLab (including the sidebar and toolbar
 icons) are colored using the ``jp-icon3`` class.
 
-For light/dark themes, ``jp-icon0`` corresponds to the darkest/lighest
+For light/dark themes, ``jp-icon0`` corresponds to the darkest/lightest
 background color, while ``jp-icon1`` is somewhat lighter/darker, and so
 forth.
 
@@ -187,7 +187,7 @@ forth.
    </ul>
 
 For light/dark themes, ``jp-icon-accent0`` corresponds to the
-lighest/darkest background color, while ``jp-icon-accent1`` is somewhat
+lightest/darkest background color, while ``jp-icon-accent1`` is somewhat
 darker/lighter, and so forth.
 
 Adding classes to a one-color icon

--- a/packages/ui-components/src/style/icon.ts
+++ b/packages/ui-components/src/style/icon.ts
@@ -538,7 +538,7 @@ export namespace LabIconStyle {
   }
 
   /**
-   * Resolve a pure icon styleheet into a typestyle class
+   * Resolve a pure icon stylesheet into a typestyle class
    */
   function resolveStyleClass(stylesheet: ISheetPure): string {
     return typestyleClass({


### PR DESCRIPTION
## References

None. Noticed some typos in user-facing texts so I decided to run spellchecker on files, which picked up a few more.

## Code changes

- `ISearchOverlayProps.onHightlightNext` -> `ISearchOverlayProps.onHighlightNext`
- matched parameter `opts` name of `createCell` (etc) to the one in the docstring (`options`)
- few typos fixed in local variable names

## User-facing changes

Multiple user-facing strings (in application and in documentation) are now correct. It is important to fix them early so translations can catch up.

## Backwards-incompatible changes

- [ ] is the fix of `ISearchOverlayProps.onHightlightNext` acceptable for 3.1 or should I revert it?
   - I think this is fine, the exposed API is actually for `highlightNext()`