### PR TITLE
Fix contrast issues in command palette and file browser

### DIFF
--- a/packages/apputils/src/commandpalette.ts
+++ b/packages/apputils/src/commandpalette.ts
@@ -7,6 +7,7 @@ import { Token } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { Message } from '@lumino/messaging';
 import { CommandPalette, Panel, Widget } from '@lumino/widgets';
+import { searchIcon } from '@jupyterlab/ui-components';
 
 /* tslint:disable */
 /**
@@ -47,6 +48,11 @@ export interface ICommandPalette {
 }
 
 /**
+ * Class name identifying the input group with search icon.
+ */
+const SEARCH_ICON_GROUP_CLASS = 'jp-SearchIconGroup';
+
+/**
  * Wrap the command palette in a modal to make it more usable.
  */
 export class ModalCommandPalette extends Panel {
@@ -54,14 +60,12 @@ export class ModalCommandPalette extends Panel {
     super();
     this.addClass('jp-ModalCommandPalette');
     this.id = 'modal-command-palette';
-    this._commandPalette = options.commandPalette;
-    this.addWidget(this._commandPalette);
+    this.palette = options.commandPalette;
     this._commandPalette.commands.commandExecuted.connect(() => {
       if (this.isAttached && this.isVisible) {
         this.hideAndReset();
       }
     });
-    this.hideAndReset();
   }
 
   get palette(): CommandPalette {
@@ -70,6 +74,12 @@ export class ModalCommandPalette extends Panel {
 
   set palette(value: CommandPalette) {
     this._commandPalette = value;
+    if (!this.searchIconGroup) {
+      this._commandPalette.inputNode.insertAdjacentElement(
+        'afterend',
+        this.createSearchIconGroup()
+      );
+    }
     this.addWidget(value);
     this.hideAndReset();
   }
@@ -99,7 +109,7 @@ export class ModalCommandPalette extends Panel {
       case 'keydown':
         this._evtKeydown(event as KeyboardEvent);
         break;
-      case 'focus':
+      case 'focus': {
         // if the focus shifted outside of this DOM element, hide and reset.
         const target = event.target as HTMLElement;
         if (!this.node.contains(target as HTMLElement)) {
@@ -107,6 +117,7 @@ export class ModalCommandPalette extends Panel {
           this.hideAndReset();
         }
         break;
+      }
       case 'contextmenu':
         event.preventDefault();
         event.stopPropagation();
@@ -114,6 +125,25 @@ export class ModalCommandPalette extends Panel {
       default:
         break;
     }
+  }
+
+  /**
+   * Find the element with search icon group.
+   */
+  protected get searchIconGroup(): HTMLDivElement | undefined {
+    return this._commandPalette.node.getElementsByClassName(
+      SEARCH_ICON_GROUP_CLASS
+    )[0] as HTMLDivElement;
+  }
+
+  /**
+   * Create element with search icon group.
+   */
+  protected createSearchIconGroup(): HTMLDivElement {
+    const inputGroup = document.createElement('div');
+    inputGroup.classList.add(SEARCH_ICON_GROUP_CLASS);
+    searchIcon.render(inputGroup);
+    return inputGroup;
   }
 
   /**

--- a/packages/apputils/style/commandpalette.css
+++ b/packages/apputils/style/commandpalette.css
@@ -87,20 +87,22 @@
     inset 0 0 0 3px var(--jp-input-active-box-shadow-color);
 }
 
-.lm-CommandPalette-wrapper::after {
-  content: ' ';
+.jp-SearchIconGroup {
   color: white;
   background-color: var(--jp-brand-color1);
   position: absolute;
   top: 4px;
   right: 4px;
-  height: 30px;
-  width: 10px;
-  padding: 0px 10px;
-  background-image: var(--jp-icon-search-white);
-  background-size: 20px;
-  background-repeat: no-repeat;
-  background-position: center;
+  padding: 5px 5px 1px 5px;
+}
+
+.jp-SearchIconGroup svg {
+  height: 20px;
+  width: 20px;
+}
+
+.jp-SearchIconGroup .jp-icon3[fill] {
+  fill: var(--jp-layout-color0);
 }
 
 .lm-CommandPalette-input {
@@ -167,6 +169,18 @@
 .lm-CommandPalette-item.lm-mod-active {
   color: var(--jp-ui-inverse-font-color1);
   background: var(--jp-brand-color1);
+}
+
+.lm-CommandPalette-item.lm-mod-active .lm-CommandPalette-itemLabel > mark {
+  color: var(--jp-ui-inverse-font-color0);
+}
+
+.lm-CommandPalette-item.lm-mod-active .jp-icon-selectable[fill] {
+  fill: var(--jp-layout-color0);
+}
+
+.lm-CommandPalette-item.lm-mod-active .lm-CommandPalette-itemLabel > mark {
+  color: var(--jp-ui-inverse-font-color0);
 }
 
 .lm-CommandPalette-item.lm-mod-active:hover:not(.lm-mod-disabled) {

--- a/packages/filebrowser/style/base.css
+++ b/packages/filebrowser/style/base.css
@@ -207,6 +207,10 @@
   font-weight: bold;
 }
 
+.jp-DirListing-content .jp-DirListing-item.jp-mod-selected mark {
+  color: var(--jp-ui-inverse-font-color0);
+}
+
 /* Style the directory listing content when a user drops a file to upload */
 .jp-DirListing.jp-mod-native-drop .jp-DirListing-content {
   outline: 5px dashed rgba(128, 128, 128, 0.5);
@@ -271,6 +275,11 @@
   font-size: 8px;
   position: absolute;
   left: -8px;
+}
+
+.jp-DirListing-item.jp-mod-running.jp-mod-selected
+  .jp-DirListing-itemIcon:before {
+  color: var(--jp-ui-inverse-font-color1);
 }
 
 .jp-DirListing-item.lm-mod-drag-image,

--- a/packages/ui-components/style/deprecatedExtra.css
+++ b/packages/ui-components/style/deprecatedExtra.css
@@ -7,10 +7,6 @@
  * (DEPRECATED) Support for consuming icons as CSS background images
  */
 
-:root {
-  --jp-icon-search-white: url('icons/toolbar/search.svg');
-}
-
 .jp-Icon,
 .jp-MaterialIcon {
   background-position: center;

--- a/packages/ui-components/style/icons/toolbar/check.svg
+++ b/packages/ui-components/style/icons/toolbar/check.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" viewBox="0 0 24 24">
-  <g class="jp-icon3" fill="#616161">
+  <g class="jp-icon3 jp-icon-selectable" fill="#616161">
     <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
   </g>
 </svg>


### PR DESCRIPTION
## References

Addresses issues identified in https://github.com/jupyterlab/jupyterlab/issues/8832#issuecomment-860180564

## Code changes

- [x] removed `--jp-icon-search-white` which was deprecated in 2.0 and replaced it with `searchIcon` which allows to change the fill via CSS

## User-facing changes

### File browser: selected item when filtering is active

Before light:

![Screenshot from 2021-07-02 20-58-59](https://user-images.githubusercontent.com/5832902/124323461-47610b00-db79-11eb-931d-fa0e369d3dbd.png)

After light:

![Screenshot from 2021-07-02 20-59-22](https://user-images.githubusercontent.com/5832902/124323547-6364ac80-db79-11eb-986c-080cb33217bb.png)

Before dark:

![Screenshot from 2021-07-02 20-58-10](https://user-images.githubusercontent.com/5832902/124323569-6c557e00-db79-11eb-983a-ec2ce86b27b8.png)

After dark:

![Screenshot from 2021-07-02 20-58-34](https://user-images.githubusercontent.com/5832902/124323579-72e3f580-db79-11eb-89d4-80e8d6b06e99.png)

### File browser: "kernel is running" indicator on selected items

Before, light:

![Screenshot from 2021-07-02 20-50-40](https://user-images.githubusercontent.com/5832902/124323666-9eff7680-db79-11eb-9338-15d88d434c47.png)

After, light:

![Screenshot from 2021-07-02 20-50-52](https://user-images.githubusercontent.com/5832902/124323687-a45cc100-db79-11eb-8a5b-f3b6dee36f09.png)

Before, dark:

![Screenshot from 2021-07-02 20-51-16](https://user-images.githubusercontent.com/5832902/124323641-90b15a80-db79-11eb-9fff-e6f8f10e1a7e.png)

After, dark:

![Screenshot from 2021-07-02 20-51-34](https://user-images.githubusercontent.com/5832902/124323655-97d86880-db79-11eb-854e-1028db0c2188.png)

### Command palette: search icon, tick icon, marked match fragments

Before, light:

![Screenshot from 2021-07-02 20-49-17](https://user-images.githubusercontent.com/5832902/124323738-b5a5cd80-db79-11eb-92ab-0483dcec50b7.png)

After, light:

![Screenshot from 2021-07-02 20-49-28](https://user-images.githubusercontent.com/5832902/124323748-b9d1eb00-db79-11eb-8032-09a41f20d875.png)

Before, dark:

![Screenshot from 2021-07-02 20-48-03](https://user-images.githubusercontent.com/5832902/124323823-d66e2300-db79-11eb-8583-c1299e217e57.png)

After, dark:

![Screenshot from 2021-07-02 20-48-25](https://user-images.githubusercontent.com/5832902/124323836-dbcb6d80-db79-11eb-95be-a3af3633f604.png)

Before, light, with `modal: false`:

![Screenshot from 2021-07-02 21-13-42](https://user-images.githubusercontent.com/5832902/124324290-9d827e00-db7a-11eb-972a-6dafa9781dde.png)

After, light, with `modal: false` (nothing extra, just as a check against regression when in non-modal placement):

![Screenshot from 2021-07-02 21-12-27](https://user-images.githubusercontent.com/5832902/124324268-9491ac80-db7a-11eb-877b-15af7ee0d83e.png)

## Backwards-incompatible changes

None - the removal of the deprecated CSS class was long coming (it was the last remaining CSS icon class in `deprecatedExtra.css`).