### PR TITLE
Fix dialog windows ignoring buttons focus

### DIFF
--- a/packages/apputils/src/dialog.tsx
+++ b/packages/apputils/src/dialog.tsx
@@ -351,11 +351,20 @@ export class Dialog<T> extends Widget {
         }
         break;
       }
-      case 13: // Enter.
+      case 13: {
+        // Enter.
         event.stopPropagation();
         event.preventDefault();
-        this.resolve();
+
+        const activeEl = document.activeElement;
+        let index: number | undefined;
+
+        if (activeEl instanceof HTMLButtonElement) {
+          index = this._buttonNodes.indexOf(activeEl as HTMLElement);
+        }
+        this.resolve(index);
         break;
+      }
       default:
         break;
     }

--- a/packages/apputils/test/dialog.spec.tsx
+++ b/packages/apputils/test/dialog.spec.tsx
@@ -182,6 +182,29 @@ describe('@jupyterlab/apputils', () => {
           expect((await prompt).button.accept).toBe(true);
         });
 
+        it('should resolve with currently focused button', async () => {
+          const dialog = new TestDialog({
+            buttons: [
+              Dialog.createButton({ label: 'first' }),
+              Dialog.createButton({ label: 'second' }),
+              Dialog.createButton({ label: 'third' }),
+              Dialog.createButton({ label: 'fourth' })
+            ],
+            // focus on "first"
+            defaultButton: 0
+          });
+          const prompt = dialog.launch();
+
+          await waitForDialog();
+          // press right arrow twice (focusing on "third")
+          simulate(dialog.node, 'keydown', { keyCode: 39 });
+          simulate(dialog.node, 'keydown', { keyCode: 39 });
+          // press enter
+          simulate(dialog.node, 'keydown', { keyCode: 13 });
+          expect((await prompt).button.label).toBe('third');
+          dialog.dispose();
+        });
+
         it('should cycle to the first button on a tab key', async () => {
           const prompt = dialog.launch();
 


### PR DESCRIPTION
## References

- [x] fixes #10472
- [x] adds a unit test to prevent this in future

## Code changes

Pass the index of the focused button when confirming dialog with enter (if any button is focused, otherwise default to the default button).

## User-facing changes

Users will no longer be in danger of unknowingly invoking a destructive action by selecting a button by focusing it with keyboard and pressing enter.
 
## Backwards-incompatible changes

None