### PR TITLE
Mirror notebook's codeCellConfig in Console

### DIFF
--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -295,21 +295,21 @@ async function activateConsole(
     });
   }
   async function updateCodeCellConfig() {
-    const config = (await settingRegistry.get(notebookPluginId, 'codeCellConfig'))
-    .composite as JSONObject;
-    console.log(config);
+    const config = (
+      await settingRegistry.get(notebookPluginId, 'codeCellConfig')
+    ).composite as JSONObject;
     tracker.forEach(widget => {
-      // widget.console.node.dataset.jpInteractionMode = interactionMode;
-      // widget.console
-      console.log(widget.console.promptCell);
-      widget.console.promptCell?.editor.setOption('autoClosingBrackets', false);
+      widget.console.promptCell?.editor.setOption(
+        'autoClosingBrackets',
+        config['autoClosingBrackets'] as boolean
+      );
     });
   }
   settingRegistry.pluginChanged.connect((sender, plugin) => {
     if (plugin === pluginId) {
       void updateSettings();
     }
-    if (plugin === notebookPluginId){
+    if (plugin === notebookPluginId) {
       void updateCodeCellConfig();
     }
   });

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -285,6 +285,7 @@ async function activateConsole(
   }
 
   const pluginId = '@jupyterlab/console-extension:tracker';
+  const notebookPluginId = '@jupyterlab/notebook-extension:tracker';
   let interactionMode: string;
   async function updateSettings() {
     interactionMode = (await settingRegistry.get(pluginId, 'interactionMode'))
@@ -293,12 +294,27 @@ async function activateConsole(
       widget.console.node.dataset.jpInteractionMode = interactionMode;
     });
   }
+  async function updateCodeCellConfig() {
+    const config = (await settingRegistry.get(notebookPluginId, 'codeCellConfig'))
+    .composite as JSONObject;
+    console.log(config);
+    tracker.forEach(widget => {
+      // widget.console.node.dataset.jpInteractionMode = interactionMode;
+      // widget.console
+      console.log(widget.console.promptCell);
+      widget.console.promptCell?.editor.setOption('autoClosingBrackets', false);
+    });
+  }
   settingRegistry.pluginChanged.connect((sender, plugin) => {
     if (plugin === pluginId) {
       void updateSettings();
     }
+    if (plugin === notebookPluginId){
+      void updateCodeCellConfig();
+    }
   });
   await updateSettings();
+  await updateCodeCellConfig();
 
   /**
    * Whether there is an active console.


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
https://github.com/jupyterlab/jupyterlab/issues/6352
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Added updateCodeCellConfig function to console-extension
## User-facing changes
Prompt cells in consoles now respect the change`codeCellConfig.autoClosingBrackets` setting in notebook 
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
I don't think so, please let me know if there is any