### PR TITLE
Update skiplink implementation

### DIFF
--- a/packages/application-extension/style/base.css
+++ b/packages/application-extension/style/base.css
@@ -7,27 +7,3 @@
 #jp-MainLogo {
   width: calc(var(--jp-private-sidebar-tab-width) + var(--jp-border-width));
 }
-
-.jp-skiplink {
-  position: absolute;
-  top: -100em;
-}
-
-.jp-skiplink:focus-within {
-  position: absolute;
-  z-index: 10000;
-  top: 0;
-  left: 46%;
-  margin: 0 auto;
-  padding: 1em;
-  width: 15%;
-  box-shadow: var(--jp-elevation-z4);
-  border-radius: 4px;
-  background: var(--jp-layout-color0);
-  text-align: center;
-}
-
-.jp-skiplink:focus-within a {
-  text-decoration: underline;
-  color: var(--jp-content-link-color);
-}

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1739,12 +1739,10 @@ namespace Private {
      */
     constructor(shell: ILabShell) {
       super();
-
       this.addClass('jp-skiplink');
       this.id = 'jp-skiplink';
       this._shell = shell;
       this.createSkipLink('Skip to left side bar');
-      this.createSkipLink('Skip to main area');
     }
 
     handleEvent(event: Event): void {

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1742,7 +1742,7 @@ namespace Private {
       this.addClass('jp-skiplink');
       this.id = 'jp-skiplink';
       this._shell = shell;
-      this.private_createSkipLink('Skip to left side bar');
+      this._createSkipLink('Skip to left side bar');
     }
 
     handleEvent(event: Event): void {
@@ -1775,7 +1775,7 @@ namespace Private {
     }
     private _shell: ILabShell;
 
-    private_createSkipLink(skipLinkText: string): void {
+    private _createSkipLink(skipLinkText: string): void {
       const skipLink = document.createElement('a');
       skipLink.href = '#';
       skipLink.tabIndex = 1;

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -396,12 +396,12 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
     }
 
     // Skip Links
-    const skipLinkWidgetHandler = (this._skipLinkWidgetHandler = new Private.SkipLinkWidgetHandler(
+    const skipLinkWidget = (this._skipLinkWidget = new Private.SkipLinkWidget(
       this
     ));
 
-    this.add(skipLinkWidgetHandler.skipLinkWidget, 'top', { rank: 0 });
-    this._skipLinkWidgetHandler.show();
+    this.add(skipLinkWidget, 'top', { rank: 0 });
+    this._skipLinkWidget.show();
 
     // Wire up signals to update the title panel of the simple interface mode to
     // follow the title of this.currentWidget
@@ -1394,7 +1394,7 @@ export class LabShell extends Widget implements JupyterFrontEnd.IShell {
   private _vsplitPanel: Private.RestorableSplitPanel;
   private _topHandler: Private.PanelHandler;
   private _menuHandler: Private.PanelHandler;
-  private _skipLinkWidgetHandler: Private.SkipLinkWidgetHandler;
+  private _skipLinkWidget: Private.SkipLinkWidget;
   private _titleWidgetHandler: Private.TitleWidgetHandler;
   private _bottomPanel: Panel;
   private _mainOptionsCache = new Map<Widget, DocumentRegistry.IOpenOptions>();
@@ -1733,80 +1733,58 @@ namespace Private {
     private _lastCurrent: Widget | null;
   }
 
-  export class SkipLinkWidgetHandler {
+  export class SkipLinkWidget extends Widget {
     /**
      * Construct a new skipLink widget handler.
      */
     constructor(shell: ILabShell) {
-      const skipLinkWidget = (this._skipLinkWidget = new Widget());
-      const skipToFilterFiles = document.createElement('a');
-      skipToFilterFiles.href = '#';
-      skipToFilterFiles.tabIndex = 1;
-      skipToFilterFiles.text = 'Skip to Filter Files';
-      skipToFilterFiles.className = 'skip-link';
-      skipToFilterFiles.addEventListener('click', this);
-      skipLinkWidget.addClass('jp-skiplink');
-      skipLinkWidget.id = 'jp-skiplink';
-      skipLinkWidget.node.appendChild(skipToFilterFiles);
+      super();
+
+      this.addClass('jp-skiplink');
+      this.id = 'jp-skiplink';
+      this._shell = shell;
+      this.createSkipLink('Skip to left side bar');
+      this.createSkipLink('Skip to main area');
     }
 
     handleEvent(event: Event): void {
       switch (event.type) {
         case 'click':
-          this._focusFileSearch();
+          this._focusLeftSideBar();
           break;
       }
     }
 
-    private _focusFileSearch() {
-      const input = document.querySelector(
-        '#filename-searcher .bp3-input'
-      ) as HTMLInputElement;
-      input.focus();
+    createSkipLink(skipLinkText: string): void {
+      const skipLink = document.createElement('a');
+      skipLink.href = '#';
+      skipLink.tabIndex = 1;
+      skipLink.text = skipLinkText;
+      skipLink.className = 'skip-link';
+      this.node.appendChild(skipLink);
     }
 
     /**
-     * Get the input element managed by the handler.
+     * Handle `after-attach` messages for the widget.
      */
-    get skipLinkWidget(): Widget {
-      return this._skipLinkWidget;
+    protected onAfterAttach(msg: Message): void {
+      super.onAfterAttach(msg);
+      this.node.addEventListener('click', this);
     }
 
     /**
-     * Dispose of the handler and the resources it holds.
+     * A message handler invoked on a `'before-detach'`
+     * message
      */
-    dispose(): void {
-      if (this.isDisposed) {
-        return;
-      }
-      this._isDisposed = true;
-      this._skipLinkWidget.node.removeEventListener('click', this);
-      this._skipLinkWidget.dispose();
+    protected onBeforeDetach(msg: Message): void {
+      this.node.removeEventListener('click', this);
+      super.onBeforeDetach(msg);
     }
 
-    /**
-     * Hide the skipLink widget.
-     */
-    hide(): void {
-      this._skipLinkWidget.hide();
+    private _focusLeftSideBar() {
+      this._shell.expandLeft();
     }
-
-    /**
-     * Show the skipLink widget.
-     */
-    show(): void {
-      this._skipLinkWidget.show();
-    }
-
-    /**
-     * Test whether the handler has been disposed.
-     */
-    get isDisposed(): boolean {
-      return this._isDisposed;
-    }
-
-    private _skipLinkWidget: Widget;
-    private _isDisposed: boolean = false;
+    private _shell: ILabShell;
   }
 
   export class TitleWidgetHandler {

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1742,7 +1742,7 @@ namespace Private {
       this.addClass('jp-skiplink');
       this.id = 'jp-skiplink';
       this._shell = shell;
-      this.createSkipLink('Skip to left side bar');
+      this.private_createSkipLink('Skip to left side bar');
     }
 
     handleEvent(event: Event): void {
@@ -1751,18 +1751,6 @@ namespace Private {
           this._focusLeftSideBar();
           break;
       }
-    }
-
-    /**
-     * Create a skipLink for the widget.
-     */
-    createSkipLink(skipLinkText: string): void {
-      const skipLink = document.createElement('a');
-      skipLink.href = '#';
-      skipLink.tabIndex = 1;
-      skipLink.text = skipLinkText;
-      skipLink.className = 'skip-link';
-      this.node.appendChild(skipLink);
     }
 
     /**
@@ -1786,6 +1774,15 @@ namespace Private {
       this._shell.expandLeft();
     }
     private _shell: ILabShell;
+
+    private_createSkipLink(skipLinkText: string): void {
+      const skipLink = document.createElement('a');
+      skipLink.href = '#';
+      skipLink.tabIndex = 1;
+      skipLink.text = skipLinkText;
+      skipLink.className = 'skip-link';
+      this.node.appendChild(skipLink);
+    }
   }
 
   export class TitleWidgetHandler {

--- a/packages/application/src/shell.ts
+++ b/packages/application/src/shell.ts
@@ -1735,7 +1735,7 @@ namespace Private {
 
   export class SkipLinkWidget extends Widget {
     /**
-     * Construct a new skipLink widget handler.
+     * Construct a new skipLink widget.
      */
     constructor(shell: ILabShell) {
       super();
@@ -1753,6 +1753,9 @@ namespace Private {
       }
     }
 
+    /**
+     * Create a skipLink for the widget.
+     */
     createSkipLink(skipLinkText: string): void {
       const skipLink = document.createElement('a');
       skipLink.href = '#';

--- a/packages/application/style/base.css
+++ b/packages/application/style/base.css
@@ -95,3 +95,4 @@ body {
 @import './buttons.css';
 @import './sidepanel.css';
 @import './titlepanel.css';
+@import './skiplink.css';

--- a/packages/application/style/skiplink.css
+++ b/packages/application/style/skiplink.css
@@ -6,9 +6,7 @@
 
 .jp-skiplink {
   position: absolute;
-  top: 0em;
-  background: white;
-  z-index: 1000;
+  top: -100em;
 }
 
 .jp-skiplink:focus-within {

--- a/packages/application/style/skiplink.css
+++ b/packages/application/style/skiplink.css
@@ -1,0 +1,31 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-skiplink {
+  position: absolute;
+  top: 0em;
+  background: white;
+  z-index: 1000;
+}
+
+.jp-skiplink:focus-within {
+  position: absolute;
+  z-index: 10000;
+  top: 0;
+  left: 46%;
+  margin: 0 auto;
+  padding: 1em;
+  width: 15%;
+  box-shadow: var(--jp-elevation-z4);
+  border-radius: 4px;
+  background: var(--jp-layout-color0);
+  text-align: center;
+}
+
+.jp-skiplink:focus-within a {
+  text-decoration: underline;
+  color: var(--jp-content-link-color);
+}

--- a/packages/filebrowser/src/browser.ts
+++ b/packages/filebrowser/src/browser.ts
@@ -188,7 +188,6 @@ export class FileBrowser extends Widget {
       forceRefresh: true
     });
     this._filenameSearcher.addClass(FILTERBOX_CLASS);
-    this._filenameSearcher.id = 'filename-searcher';
 
     this.layout.removeWidget(this._filenameSearcher);
     this.layout.removeWidget(this.crumbs);


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->


I'm putting in this PR, but it's really @jasongrout's thought and exemplary patience that made this possible. This also builds directly on top of @0618's lovely skiplink work, so thanks is due there as well.

## References
#10126 is the first skiplink implementation. 
Fixes #10268
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Skiplinks are not tied to file browser but use the application regions JupyterLab will always have.
- Sets up a method to produce multiple skiplinks (the next step)
- Moves skiplink CSS to it's own file.
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Visually, this looks the same as is demonstrated in #10126. The only other change is that the skiplink now puts a user's focus in the left side bar, not in the file browser specifically.
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None that I am aware of.
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
