### PR TITLE
Export awareness

### DIFF
--- a/packages/docprovider/src/index.ts
+++ b/packages/docprovider/src/index.ts
@@ -7,6 +7,7 @@
  * @module docprovider
  */
 
+export * from './awareness';
 export * from './mock';
 export * from './tokens';
 export * from './yprovider';


### PR DESCRIPTION
Export awareness file on the `docprovider` so other extensions can access the usernames and colors for RTC.

## References
https://github.com/davidbrochart/jupyterlab-auth/pull/1#discussion_r663744650

## Code changes
Export the awareness file in docprovider.

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
