### PR TITLE
Update docs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,6 +8,8 @@ dependencies:
 - sphinx-copybutton
 - sphinx_rtd_theme
 - pytest
+- pytest-tornasync
+- pytest-check-links
 - pip
 - nodejs
 - jsx-lexer

--- a/docs/source/developer/contributing.rst
+++ b/docs/source/developer/contributing.rst
@@ -718,11 +718,15 @@ Writing Documentation
 Documentation is written in Markdown and reStructuredText. In
 particular, the documentation on our Read the Docs page is written in
 reStructuredText. To ensure that the Read the Docs page builds, you'll
-need to install the documentation dependencies with ``pip``:
+need to install the documentation dependencies with ``conda``:
 
 .. code:: bash
 
-   pip install -r docs/requirements.txt
+   conda env create -f docs/environment.yml
+
+.. code:: bash
+
+   conda activate jupyterlab_documentation
 
 
 To test the docs run:


### PR DESCRIPTION
Changed documentation, the section [Writing Documentation](https://jupyterlab.readthedocs.io/en/stable/developer/contributing.html#writing-documentation).

The documentation is out of date since `pip` is no longer used to install the dependencies.

## References
https://github.com/jupyterlab/jupyterlab/issues/10542

## Code changes

## User-facing changes

## Backwards-incompatible changes
