### PR TITLE
Fix string variable in debugger tree view

### DIFF
--- a/packages/debugger/src/panels/variables/index.ts
+++ b/packages/debugger/src/panels/variables/index.ts
@@ -152,7 +152,11 @@ export const convertType = (variable: IDebugger.IVariable): string | number => {
     case 'bool':
       return value;
     case 'str':
-      return value.slice(1, value.length - 1);
+      if (variable.presentationHint?.attributes?.includes('rawString')) {
+        return value.slice(1, value.length - 1);
+      } else {
+        return value;
+      }
     default:
       return type ?? value;
   }


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #10521
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Strip the string variable only if it has a presentation hint _rawString_.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
String variable are not stripped (of left and right quote) except if we know they are quoted.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A