### PR TITLE
Fix closing answered issues by setting the stale-issue-message attribute

### DIFF
--- a/.github/workflows/answered.yml
+++ b/.github/workflows/answered.yml
@@ -17,4 +17,5 @@ jobs:
           days-before-stale: 30
           days-before-close: 7
           stale-issue-label: 'status:Closing as Answered'
+          stale-issue-message: ''
           only-issue-labels: 'status:Answered'


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow-up to https://github.com/jupyterlab/jupyterlab/pull/10536 after noticing that the closures are still not happening.

## Code changes

We are seeing an error that prevents issues from getting marked as closing (https://github.com/jupyterlab/jupyterlab/runs/2994705101?check_suite_focus=true#step:2:3995):

> [#5869] Skipping this issue because it should be marked as stale based on the option days-before-stale (​https://github.com/actions/stale#days-before-stale​) (30) but the option stale-issue-message (​https://github.com/actions/stale#stale-issue-message​) is not set

In the upcoming action version 4, we can omit both the skip-stale-issue-message and the stale-issue-message.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
