### PR TITLE
 Add promptCellConfig to Code Console Settings

### DIFF
--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -109,6 +109,12 @@
       "description": "Whether the console defaults to showing all\nkernel activity or just kernel activity originating from itself.",
       "type": "boolean",
       "default": false
+    },
+    "autoClosingBrackets": {
+      "title": "Auto Closing Brackets",
+      "description": "Whether prompt cells in console default to having auto closing brackets.",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false,

--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -96,6 +96,67 @@
       "selector": ".jp-CodeConsole[data-jp-interaction-mode='terminal'] .jp-CodeConsole-promptCell"
     }
   ],
+  "definitions": {
+    "editorConfig": {
+      "properties": {
+        "autoClosingBrackets": {
+          "type": "boolean"
+        },
+        "cursorBlinkRate": {
+          "type": "number",
+          "title": "Cursor blinking rate",
+          "description": "Half-period in milliseconds used for cursor blinking. The default blink rate is 530ms. By setting this to zero, blinking can be disabled. A negative value hides the cursor entirely."
+        },
+        "fontFamily": {
+          "type": ["string", "null"]
+        },
+        "fontSize": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "maximum": 100
+        },
+        "lineHeight": {
+          "type": ["number", "null"]
+        },
+        "lineNumbers": {
+          "type": "boolean"
+        },
+        "lineWrap": {
+          "type": "string",
+          "enum": ["off", "on", "wordWrapColumn", "bounded"]
+        },
+        "matchBrackets": {
+          "type": "boolean"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "insertSpaces": {
+          "type": "boolean"
+        },
+        "tabSize": {
+          "type": "number"
+        },
+        "wordWrapColumn": {
+          "type": "integer"
+        },
+        "rulers": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "codeFolding": {
+          "type": "boolean"
+        },
+        "lineWiseCopyCut": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  },
   "properties": {
     "interactionMode": {
       "title": "Interaction mode",
@@ -110,11 +171,27 @@
       "type": "boolean",
       "default": false
     },
-    "autoClosingBrackets": {
-      "title": "Auto Closing Brackets",
-      "description": "Whether prompt cells in console default to having auto closing brackets.",
-      "type": "boolean",
-      "default": true
+    "promptCellConfig": {
+      "title": "Prompt Cell Configuration",
+      "description": "The configuration for all prompt cells.",
+      "$ref": "#/definitions/editorConfig",
+      "default": {
+        "autoClosingBrackets": true,
+        "cursorBlinkRate": 530,
+        "fontFamily": null,
+        "fontSize": null,
+        "lineHeight": null,
+        "lineNumbers": false,
+        "lineWrap": "off",
+        "matchBrackets": true,
+        "readOnly": false,
+        "insertSpaces": true,
+        "tabSize": 4,
+        "wordWrapColumn": 80,
+        "rulers": [],
+        "codeFolding": false,
+        "lineWiseCopyCut": true
+      }
     }
   },
   "additionalProperties": false,

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -20,7 +20,7 @@ import {
   showDialog,
   WidgetTracker
 } from '@jupyterlab/apputils';
-import { IEditorServices } from '@jupyterlab/codeeditor';
+import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
@@ -284,21 +284,102 @@ async function activateConsole(
     return panel;
   }
 
+  type lineWrap_type = 'off' | 'on' | 'wordWrapColumn' | 'bounded';
+
+  const mapOption = (
+    editor: CodeEditor.IEditor,
+    config: JSONObject,
+    option: string
+  ) => {
+    if (config[option] === undefined) {
+      return;
+    }
+    switch (option) {
+      case 'autoClosingBrackets':
+        editor.setOption(
+          'autoClosingBrackets',
+          config['autoClosingBrackets'] as boolean
+        );
+        break;
+      case 'cursorBlinkRate':
+        editor.setOption(
+          'cursorBlinkRate',
+          config['cursorBlinkRate'] as number
+        );
+        break;
+      case 'fontFamily':
+        editor.setOption('fontFamily', config['fontFamily'] as string | null);
+        break;
+      case 'fontSize':
+        editor.setOption('fontSize', config['fontSize'] as number | null);
+        break;
+      case 'lineHeight':
+        editor.setOption('lineHeight', config['lineHeight'] as number | null);
+        break;
+      case 'lineNumbers':
+        editor.setOption('lineNumbers', config['lineNumbers'] as boolean);
+        break;
+      case 'lineWrap':
+        editor.setOption('lineWrap', config['lineWrap'] as lineWrap_type);
+        break;
+      case 'matchBrackets':
+        editor.setOption('matchBrackets', config['matchBrackets'] as boolean);
+        break;
+      case 'readOnly':
+        editor.setOption('readOnly', config['readOnly'] as boolean);
+        break;
+      case 'insertSpaces':
+        editor.setOption('insertSpaces', config['insertSpaces'] as boolean);
+        break;
+      case 'tabSize':
+        editor.setOption('tabSize', config['tabSize'] as number);
+        break;
+      case 'wordWrapColumn':
+        editor.setOption('wordWrapColumn', config['wordWrapColumn'] as number);
+        break;
+      case 'rulers':
+        editor.setOption('rulers', config['rulers'] as number[]);
+        break;
+      case 'codeFolding':
+        editor.setOption('codeFolding', config['codeFolding'] as boolean);
+        break;
+    }
+  };
+
+  const setOption = (
+    editor: CodeEditor.IEditor | undefined,
+    config: JSONObject
+  ) => {
+    if (editor === undefined) {
+      return;
+    }
+    mapOption(editor, config, 'autoClosingBrackets');
+    mapOption(editor, config, 'cursorBlinkRate');
+    mapOption(editor, config, 'fontFamily');
+    mapOption(editor, config, 'fontSize');
+    mapOption(editor, config, 'lineHeight');
+    mapOption(editor, config, 'lineNumbers');
+    mapOption(editor, config, 'lineWrap');
+    mapOption(editor, config, 'matchBrackets');
+    mapOption(editor, config, 'readOnly');
+    mapOption(editor, config, 'insertSpaces');
+    mapOption(editor, config, 'tabSize');
+    mapOption(editor, config, 'wordWrapColumn');
+    mapOption(editor, config, 'rulers');
+    mapOption(editor, config, 'codeFolding');
+  };
+
   const pluginId = '@jupyterlab/console-extension:tracker';
   let interactionMode: string;
-  let autoClosingBrackets: boolean;
+  let promptCellConfig: JSONObject;
   async function updateSettings() {
     interactionMode = (await settingRegistry.get(pluginId, 'interactionMode'))
       .composite as string;
-    autoClosingBrackets = (
-      await settingRegistry.get(pluginId, 'autoClosingBrackets')
-    ).composite as boolean;
+    promptCellConfig = (await settingRegistry.get(pluginId, 'promptCellConfig'))
+      .composite as JSONObject;
     tracker.forEach(widget => {
       widget.console.node.dataset.jpInteractionMode = interactionMode;
-      widget.console.promptCell?.editor.setOption(
-        'autoClosingBrackets',
-        autoClosingBrackets
-      );
+      setOption(widget.console.promptCell?.editor, promptCellConfig);
     });
   }
   settingRegistry.pluginChanged.connect((sender, plugin) => {

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -286,11 +286,19 @@ async function activateConsole(
 
   const pluginId = '@jupyterlab/console-extension:tracker';
   let interactionMode: string;
+  let autoClosingBrackets: boolean;
   async function updateSettings() {
     interactionMode = (await settingRegistry.get(pluginId, 'interactionMode'))
       .composite as string;
+    autoClosingBrackets = (
+      await settingRegistry.get(pluginId, 'autoClosingBrackets')
+    ).composite as boolean;
     tracker.forEach(widget => {
       widget.console.node.dataset.jpInteractionMode = interactionMode;
+      widget.console.promptCell?.editor.setOption(
+        'autoClosingBrackets',
+        autoClosingBrackets
+      );
     });
   }
   settingRegistry.pluginChanged.connect((sender, plugin) => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Moving things forward from https://github.com/jupyterlab/jupyterlab/issues/6352#issuecomment-873362143
By adding promptCellConfig to Code Console Settings, this provides an interface to toggle codeMirror config settings such as `autoClosingBrackets` in Console
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
- Added `promptCellConfig` to console-extension schema
- Added `setOption` to console-extension index.ts as console settings update with `updateSettings` function
## User-facing changes
Added promptCellConfig to Code Console Settings
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
I don't think so. Please let me know if there is any!
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
