### PR TITLE
Completer: Do not announce subset match selection if it did not change

### DIFF
--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -168,6 +168,7 @@ export class Completer extends Widget {
    */
   reset(): void {
     this._activeIndex = 0;
+    this._lastSubsetMatch = '';
     if (this._model) {
       this._model.reset(true);
     }
@@ -433,12 +434,17 @@ export class Completer extends Widget {
           return;
         }
         const populated = this._populateSubset();
-        // If there is a common subset in the options,
-        // then emit a completion signal with that subset.
-        if (model.query) {
+
+        // If the common subset was found and set on `query`,
+        // or if there is a `query` in the initialization options,
+        // then emit a completion signal with that `query` (=subset match),
+        // but only if the query has actually changed.
+        // See: https://github.com/jupyterlab/jupyterlab/issues/10439#issuecomment-875189540
+        if (model.query && model.query != this._lastSubsetMatch) {
           model.subsetMatch = true;
           this._selected.emit(model.query);
           model.subsetMatch = false;
+          this._lastSubsetMatch = model.query;
         }
         // If the query changed, update rendering of the options.
         if (populated) {
@@ -636,6 +642,7 @@ export class Completer extends Widget {
   private _selected = new Signal<this, string>(this);
   private _visibilityChanged = new Signal<this, void>(this);
   private _indexChanged = new Signal<this, number>(this);
+  private _lastSubsetMatch: string = '';
 }
 
 export namespace Completer {


### PR DESCRIPTION
## References

Fixes part 1 of #10439 (tab-cycling stuck on second item).

## Code changes

See https://github.com/jupyterlab/jupyterlab/issues/10439#issuecomment-875189540 and https://github.com/jupyterlab/jupyterlab/issues/10439#issuecomment-875195882

## User-facing changes

Before:

![before](https://user-images.githubusercontent.com/5832902/124687537-00527d00-decd-11eb-83dc-7978d5aca796.gif)

After:

![its-working](https://user-images.githubusercontent.com/5832902/124686960-ef553c00-decb-11eb-9562-8a6b36e5e336.gif)

### Subset match selection on <kbd>tab</kbd> behaviour is maintained

As mentioned in https://github.com/jupyterlab/jupyterlab/issues/10439#issuecomment-875195882 this double action (move to the item down and complete a partial match) may seem awkward but I think it is fine for now.

Before:

![test-old](https://user-images.githubusercontent.com/5832902/124687425-c4b7b300-decc-11eb-8f31-d058ecb0fc23.gif)

After:

![test-new](https://user-images.githubusercontent.com/5832902/124687461-da2cdd00-decc-11eb-9109-f3952320bebb.gif)

## Backwards-incompatible changes

None