### PR TITLE
Restore JupyterLabMenu missing `menu` attribute

### DIFF
--- a/packages/ui-components/src/components/menu.ts
+++ b/packages/ui-components/src/components/menu.ts
@@ -35,6 +35,14 @@ export interface IRankedMenu extends IDisposable {
   readonly items: ReadonlyArray<Menu.IItem>;
 
   /**
+   * The underlying Lumino menu.
+   *
+   * @deprecated since v3.1
+   * RankMenu inherits from Menu since v3.1
+   */
+  readonly menu: Menu;
+
+  /**
    * Menu rank
    */
   readonly rank?: number;
@@ -91,6 +99,16 @@ export class RankedMenu extends Menu implements IRankedMenu {
     super(options);
     this._rank = options.rank;
     this._includeSeparators = options.includeSeparators ?? true;
+  }
+
+  /**
+   * The underlying Lumino menu.
+   *
+   * @deprecated since v3.1
+   * RankMenu inherits from Menu since v3.1
+   */
+  get menu(): Menu {
+    return this;
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #10565
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Restore the `menu` attribute on JupyterLabMenu (API got broke in #10254)

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
N/A