### PR TITLE
Move all child cells when collapsed markdown heading is moved

### DIFF
--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -1297,6 +1297,8 @@ function addCommands(
     for (const cell of notebook.widgets) {
       if (cell instanceof MarkdownCell && cell.headingCollapsed) {
         NotebookActions.setHeadingCollapse(cell, true, notebook);
+      }
+      if (cell.model.id === notebook.activeCell?.model?.id) {
         NotebookActions.expandParent(cell, notebook);
       }
     }

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -1530,6 +1530,38 @@ export namespace NotebookActions {
   }
 
   /**
+   * Finds the next heading that isn't a child of the given markdown heading.
+   * @param cell - "Child" cell that has become the active cell
+   * @param notebook - The target notebook widget.
+   */
+  export function findNextParentHeading(
+    cell: Cell,
+    notebook: Notebook
+  ): number {
+    let index = findIndex(
+      notebook.widgets,
+      (possibleCell: Cell, index: number) => {
+        return cell.model.id === possibleCell.model.id;
+      }
+    );
+    if (index === -1) {
+      return -1;
+    }
+    let childHeaderInfo = getHeadingInfo(cell);
+    for (index = index + 1; index < notebook.widgets.length; index++) {
+      let hInfo = getHeadingInfo(notebook.widgets[index]);
+      if (
+        hInfo.isHeading &&
+        hInfo.headingLevel <= childHeaderInfo.headingLevel
+      ) {
+        return index;
+      }
+    }
+    // else no parent header found. return the index of the last cell
+    return notebook.widgets.length;
+  }
+
+  /**
    * Set the given cell and ** all "child" cells **
    * to the given collapse / expand if cell is
    * a markdown header.


### PR DESCRIPTION
## References
Fixes #10551. 

## Code changes
Adds a notebook action function to find the index of the next cell that isn't a child of a given markdown heading. Updates the function that determines which cells to move when a cell is dragged/dropped. 

## User-facing Changes
When a markdown heading is collapsed and the cell is moved, now it also moves the hidden child cells of the markdown as well as the markdown heading. The heading remains collapsed. **Note**: When the markdown heading is not collapsed, only the markdown heading cell is moved, and the child cells stay in the same place. 

## Backwards-incompatible changes
None
