### PR TITLE
Move the application status check to a separate plugin

### DIFF
--- a/packages/application-extension/src/index.tsx
+++ b/packages/application-extension/src/index.tsx
@@ -561,7 +561,23 @@ const main: JupyterFrontEndPlugin<ITreePathUpdater> = {
         }).then(result => (result.button.accept ? build() : undefined));
       });
     }
+    return updateTreePath;
+  },
+  autoStart: true
+};
 
+/**
+ * Check if the application is dirty before closing the browser tab.
+ */
+const dirty: JupyterFrontEndPlugin<void> = {
+  id: '@retrolab/application-extension:dirty',
+  autoStart: true,
+  requires: [ITranslator],
+  activate: (app: JupyterFrontEnd, translator: ITranslator): void => {
+    if (!(app instanceof JupyterLab)) {
+      throw new Error(`${dirty.id} must be activated in JupyterLab.`);
+    }
+    const trans = translator.load('jupyterlab');
     const message = trans.__(
       'Are you sure you want to exit JupyterLab?\n\nAny unsaved changes will be lost.'
     );
@@ -576,9 +592,7 @@ const main: JupyterFrontEndPlugin<ITreePathUpdater> = {
         return ((event as any).returnValue = message);
       }
     });
-    return updateTreePath;
-  },
-  autoStart: true
+  }
 };
 
 /**
@@ -969,6 +983,7 @@ const JupyterLogo: JupyterFrontEndPlugin<void> = {
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
+  dirty,
   main,
   mainCommands,
   layout,


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Move the application status check to a separate plugin so it can more easily be reused in downstream distributions.

![image](https://user-images.githubusercontent.com/591645/124826201-dce30d00-df74-11eb-9bff-4a4e939709de.png)


<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Move some application functionalities to a new plugin.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
