### PR TITLE
Set the stale message to have an actual value.

### DIFF
--- a/.github/workflows/answered.yml
+++ b/.github/workflows/answered.yml
@@ -17,5 +17,5 @@ jobs:
           days-before-stale: 30
           days-before-close: 7
           stale-issue-label: 'status:Closing as Answered'
-          stale-issue-message: ''
+          stale-issue-message: '.'
           only-issue-labels: 'status:Answered'


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Follow up from #10553 

## Code changes

According to https://github.com/DynamoDS/Dynamo/commit/8ac994c1ebc95478cf496444754c130062728581#diff-8162bb3b3d4da55f30fcbb603b5d630b21b397777a6a42eff0e0fba30bc746a1R15, we need an actual value for the stale message to be skipped.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
