### PR TITLE
Fix documentation for `selectionExecuted` signal (copy-paste error)

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -99,7 +99,7 @@ export class NotebookActions {
   }
 
   /**
-   * A signal that emits whenever a cell completes execution.
+   * A signal that emits whenever a cell execution is scheduled.
    */
   static get selectionExecuted(): ISignal<
     any,


### PR DESCRIPTION
## References

Fixes a copy-paste error spotted in post-merge review: https://github.com/jupyterlab/jupyterlab/pull/10493#pullrequestreview-702260295 (interface documentation was not aligned with implementation documentation).

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None