### PR TITLE
Remove `tabIndex` taking focus away from notebook

### DIFF
--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -1118,7 +1118,6 @@ namespace Private {
      */
     constructor(options?: Panel.IOptions) {
       super(options);
-      this.node.tabIndex = 0;
     }
 
     /**


### PR DESCRIPTION
## References

Fixes #10566.

## Code changes

Remove `tabIndex` added in #10282.

## User-facing changes

Cell operations work consistently again.

## Backwards-incompatible changes

None.