### PR TITLE
Only save and use valid user settings for the editor

### DIFF
--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -99,7 +99,35 @@ export interface IFileTypeData extends ReadonlyJSONObject {
  */
 export const FACTORY = 'Editor';
 
-let config: CodeEditor.IConfig = { ...CodeEditor.defaultConfig };
+const userSettings = [
+  'autoClosingBrackets',
+  'cursorBlinkRate',
+  'fontFamily',
+  'fontSize',
+  'lineHeight',
+  'lineNumbers',
+  'lineWrap',
+  'matchBrackets',
+  'readOnly',
+  'insertSpaces',
+  'tabSize',
+  'wordWrapColumn',
+  'rulers',
+  'codeFolding'
+];
+
+function filterUserSettings(config: CodeEditor.IConfig): CodeEditor.IConfig {
+  const filteredConfig = { ...config };
+  // Delete parts of the config that are not user settings (like handlePaste).
+  for (let k of Object.keys(config)) {
+    if (!userSettings.includes(k)) {
+      delete (config as any)[k];
+    }
+  }
+  return filteredConfig;
+}
+
+let config: CodeEditor.IConfig = filterUserSettings(CodeEditor.defaultConfig);
 
 /**
  * A utility class for adding commands and menu items,
@@ -143,10 +171,10 @@ export namespace Commands {
     settings: ISettingRegistry.ISettings,
     commands: CommandRegistry
   ): void {
-    config = {
+    config = filterUserSettings({
       ...CodeEditor.defaultConfig,
       ...(settings.get('editorConfig').composite as JSONObject)
-    };
+    });
 
     // Trigger a refresh of the rendered commands
     commands.notifyCommandChanged();


### PR DESCRIPTION


<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Fixes #9411

## Code changes

The default settings included some settings that were not valid in the user settings for the text editor plugin. This explicitly filters for valid user settings when dealing with the setting system.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
