### PR TITLE
Switch to using a `PromiseDelegate` in `yprovider.ts`

### DIFF
--- a/packages/docprovider/src/yprovider.ts
+++ b/packages/docprovider/src/yprovider.ts
@@ -3,6 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+import { PromiseDelegate } from '@lumino/coreutils';
 import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import { WebsocketProvider } from 'y-websocket';
@@ -127,20 +128,15 @@ export class WebSocketProviderWithLocks
       return this._initialContentRequest.promise;
     }
 
-    let resolve: any, reject: any;
-    const promise: Promise<boolean> = new Promise((_resolve, _reject) => {
-      resolve = _resolve;
-      reject = _reject;
-    });
-    this._initialContentRequest = { promise, resolve, reject };
+    this._initialContentRequest = new PromiseDelegate<boolean>();
     this._sendMessage(new Uint8Array([125]));
 
     // Resolve with true if the server doesn't respond for some reason.
     // In case of a connection problem, we don't want the user to re-initialize the window.
     // Instead wait for y-websocket to connect to the server.
     // @todo maybe we should reload instead..
-    setTimeout(() => resolve(false), 1000);
-    return promise;
+    setTimeout(() => this._initialContentRequest?.resolve(false), 1000);
+    return this._initialContentRequest.promise;
   }
 
   /**
@@ -243,11 +239,7 @@ export class WebSocketProviderWithLocks
     resolve: (lock: number) => void;
     reject: () => void;
   } | null = null;
-  private _initialContentRequest: {
-    promise: Promise<boolean>;
-    resolve: (initialized: boolean) => void;
-    reject: () => void;
-  } | null = null;
+  private _initialContentRequest: PromiseDelegate<boolean> | null = null;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Switch to using a `PromiseDelegate` in the `yprovider` initial content handling.

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

The existing logic was doing pretty much what the `PromiseDelegate` does, so we might as well update to using a `PromiseDelegate` so it's consistent with the rest of the code base.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
