### PR TITLE
Do not show tooltip when completer is active

### DIFF
--- a/packages/tooltip-extension/schema/notebooks.json
+++ b/packages/tooltip-extension/schema/notebooks.json
@@ -10,7 +10,7 @@
     {
       "command": "tooltip:launch-notebook",
       "keys": ["Shift Tab"],
-      "selector": ".jp-Notebook.jp-mod-editMode .jp-InputArea-editor:not(.jp-mod-has-primary-selection):not(.jp-mod-in-leading-whitespace)"
+      "selector": ".jp-Notebook.jp-mod-editMode .jp-InputArea-editor:not(.jp-mod-has-primary-selection):not(.jp-mod-in-leading-whitespace):not(.jp-mod-completer-active)"
     }
   ],
   "properties": {},


### PR DESCRIPTION
## References

Fixes #10439 (the second part, closing the issue).

## Code changes

Added condition on completer not being active to `Shift` + `Tab` tooltip selector.

## User-facing changes

Before:

![before](https://user-images.githubusercontent.com/5832902/125069809-26d00e00-e0af-11eb-9272-0eac64c289bf.gif)


After:

![now-works-shift-tab](https://user-images.githubusercontent.com/5832902/125069795-1fa90000-e0af-11eb-914c-7932f5de5d91.gif)


## Backwards-incompatible changes

None