### PR TITLE
Use browser's built-in sanitizer to escape HTML in completion labels

### DIFF
--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -182,7 +182,18 @@ export class CompleterModel implements Completer.IModel {
     if (query) {
       return this._markup(query);
     }
-    return this._completionItems;
+    return this._completionItems.map(item => {
+      const newItem = Object.assign({}, item);
+      const newLabel = escapeHTML(newItem.label);
+      if (newLabel != newItem.label) {
+        // preserve the old label for insertText if not defined
+        if (typeof newItem.insertText === 'undefined') {
+          newItem.insertText = newItem.label;
+        }
+        newItem.label = newLabel;
+      }
+      return newItem;
+    });
   }
 
   /**
@@ -415,7 +426,7 @@ export class CompleterModel implements Completer.IModel {
       if (match) {
         // Highlight label text if there's a match
         let marked = StringExt.highlight(
-          item.label,
+          escapeHTML(item.label),
           match.indices,
           Private.mark
         );
@@ -455,13 +466,13 @@ export class CompleterModel implements Completer.IModel {
       }));
     }
     const results: Private.IMatch[] = [];
-    for (let option of options) {
-      option = escapeHTML(option);
+    for (const rawOption of options) {
+      const option = escapeHTML(rawOption);
       const match = StringExt.matchSumOfSquares(option, query);
       if (match) {
         const marked = StringExt.highlight(option, match.indices, Private.mark);
         results.push({
-          raw: option,
+          raw: rawOption,
           score: match.score,
           text: marked.join('')
         });

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -15,6 +15,15 @@ import { CompletionHandler } from './handler';
 import { Completer } from './widget';
 
 /**
+ * Escape HTML by native means of the browser.
+ */
+function escapeHTML(text: string) {
+  const node = document.createElement('span');
+  node.textContent = text;
+  return node.innerHTML;
+}
+
+/**
  * An implementation of a completer model.
  */
 export class CompleterModel implements Completer.IModel {
@@ -399,7 +408,8 @@ export class CompleterModel implements Completer.IModel {
       // e.g. Given label `foo(b, a, r)` and query `bar`,
       // don't count parameters, `b`, `a`, and `r` as matches.
       const index = item.label.indexOf('(');
-      const prefix = index > -1 ? item.label.substring(0, index) : item.label;
+      let prefix = index > -1 ? item.label.substring(0, index) : item.label;
+      prefix = escapeHTML(prefix);
       let match = StringExt.matchSumOfSquares(prefix, query);
       // Filter non-matching items.
       if (match) {
@@ -439,10 +449,14 @@ export class CompleterModel implements Completer.IModel {
     const options = this._options || [];
     const query = this._query;
     if (!query) {
-      return map(options, option => ({ raw: option, text: option }));
+      return map(options, option => ({
+        raw: option,
+        text: escapeHTML(option)
+      }));
     }
     const results: Private.IMatch[] = [];
-    for (const option of options) {
+    for (let option of options) {
+      option = escapeHTML(option);
       const match = StringExt.matchSumOfSquares(option, query);
       if (match) {
         const marked = StringExt.highlight(option, match.indices, Private.mark);

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { defaultSanitizer, HoverBox } from '@jupyterlab/apputils';
+import { HoverBox } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { LabIcon } from '@jupyterlab/ui-components';
 import { IIterator, IterableOrArrayLike, toArray } from '@lumino/algorithm';
@@ -949,9 +949,7 @@ export namespace Completer {
       const matchNode = document.createElement('code');
       matchNode.className = 'jp-Completer-match';
       // Use innerHTML because search results include <mark> tags.
-      matchNode.innerHTML = defaultSanitizer.sanitize(result, {
-        allowedTags: ['mark']
-      });
+      matchNode.innerHTML = result;
       return matchNode;
     }
 

--- a/packages/completer/test/model.spec.ts
+++ b/packages/completer/test/model.spec.ts
@@ -256,6 +256,31 @@ describe('completer/model', () => {
         model.reset();
         expect(model.completionItems!()).toEqual(want);
       });
+
+      it('should escape HTML markup', () => {
+        let model = new CompleterModel();
+        let want: CompletionHandler.ICompletionItems = [
+          {
+            label: '&lt;foo&gt;&lt;/foo&gt;',
+            insertText: '<foo></foo>'
+          }
+        ];
+        model.setCompletionItems!([{ label: '<foo></foo>' }]);
+        expect(model.completionItems!()).toEqual(want);
+      });
+
+      it('should escape HTML with matches markup', () => {
+        let model = new CompleterModel();
+        let want: CompletionHandler.ICompletionItems = [
+          {
+            label: '&lt;foo&gt;<mark>smi</mark>le&lt;/foo&gt;',
+            insertText: '<foo>smile</foo>'
+          }
+        ];
+        model.setCompletionItems!([{ label: '<foo>smile</foo>' }]);
+        model.query = 'smi';
+        expect(model.completionItems!()).toEqual(want);
+      });
     });
 
     describe('#items()', () => {
@@ -299,6 +324,28 @@ describe('completer/model', () => {
         ];
         model.setOptions(['foo', 'bar', 'baz', 'qux', 'quux']);
         model.query = 'qu';
+        expect(toArray(model.items())).toEqual(want);
+      });
+
+      it('should escape HTML markup', () => {
+        let model = new CompleterModel();
+        let want: Completer.IItem[] = [
+          { raw: '<foo></foo>', text: '&lt;foo&gt;&lt;/foo&gt;' }
+        ];
+        model.setOptions(['<foo></foo>']);
+        expect(toArray(model.items())).toEqual(want);
+      });
+
+      it('should escape HTML with matches markup', () => {
+        let model = new CompleterModel();
+        let want: Completer.IItem[] = [
+          {
+            raw: '<foo>smile</foo>',
+            text: '&lt;foo&gt;<mark>smi</mark>le&lt;/foo&gt;'
+          }
+        ];
+        model.setOptions(['<foo>smile</foo>']);
+        model.query = 'smi';
         expect(toArray(model.items())).toEqual(want);
       });
     });


### PR DESCRIPTION
## References

Closes #9790.

## Code changes

Replace late sanitization with early escaping.

- this has a downside that we need to be careful to always escape before passing to `_createMatchNode`
  - [x] for example`get completionItems()` does not sanitize currently if there is no query
- I could bring back the extra sanitization step as a safguard. think that it is not needed at the moment, but if we want to be on the safe side it would not hurt much (except for a reduced performance).

There is a small and insignificant performance gain for `onUpdateRequest` tested on numpy (`np.<tab>`) averages over 10 repeats:
- escape only (new): 142.62 ms, SD = 17.85
- sanitize only (old): 156.16 ms, SD = 7.47
- both (alternative): 196.21 ms, SD = 20.17

## User-facing changes

Before:

![completion-before](https://user-images.githubusercontent.com/5832902/125083893-d1046180-e0c0-11eb-8cbc-f79870d4b871.gif)

After:

![completion-after](https://user-images.githubusercontent.com/5832902/125083907-d5307f00-e0c0-11eb-9f21-d23d02918d0c.gif)

## Backwards-incompatible changes

None