### PR TITLE
Fix: add lock to prevent repeating Name File dialogs

### DIFF
--- a/packages/docmanager-extension/src/index.ts
+++ b/packages/docmanager-extension/src/index.ts
@@ -805,7 +805,7 @@ function addCommands(
 
   const newFileRegex = new RegExp('^untitled', 'i');
   /**
-   * An array of activated file names used as a naive implemetation of lock for Name File
+   * An array of activated file names used as a naive implementation of lock for Name File
    */
   let activatedDocs: string[] = [];
   docManager.activateRequested.connect((sender, args) => {


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->
## References
Fix https://github.com/jupyterlab/jupyterlab/issues/10363 &  https://github.com/jupyterlab/jupyterlab/issues/10291

Edit: I am breaking https://github.com/jupyterlab/jupyterlab/pull/10294 up, hopefully that makes things easier to test 

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Added `activatedDocs` used as a naive implemetation of lock for Name File

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Repeating Name File dialogs should be removed
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
None I am aware of
