### PR TITLE
Fix font-weight for collaborative cursor caret

### DIFF
--- a/packages/codemirror/style/base.css
+++ b/packages/codemirror/style/base.css
@@ -245,8 +245,7 @@
   font-size: 0.95em;
   background-color: rgb(250, 129, 0);
   font-family: var(--jp-ui-font-family);
-  font-style: bold;
-  font-weight: normal;
+  font-weight: bold;
   line-height: normal;
   user-select: none;
   color: white;


### PR DESCRIPTION
Follow up after #10411, fixes wrong use of font-style vs font-weight (I placed my suggestion on a wrong line). The bold font is intended to alleviate contrast issues.