### PR TITLE
Invoke onCellInserted when rendering a placeholder cell

### DIFF
--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -562,7 +562,9 @@ export namespace NotebookActions {
         {}
       );
 
-      model.cells.push(cell);
+      // Do not use push here, as we want an widget insertion
+      // to make sure no placeholder widget is rendered.
+      model.cells.insert(notebook.widgets.length, cell);
       notebook.activeCellIndex++;
       notebook.mode = 'edit';
     } else {

--- a/packages/notebook/src/widget.ts
+++ b/packages/notebook/src/widget.ts
@@ -542,7 +542,8 @@ export class StaticNotebook extends Widget {
     if (
       this._observer &&
       insertType === 'push' &&
-      this._renderedCellsCount > this.notebookConfig.numberCellsToRenderDirectly
+      this._renderedCellsCount >=
+        this.notebookConfig.numberCellsToRenderDirectly
     ) {
       // We have an observer and we are have been asked to push (not to insert).
       // and we are above the number of cells to render directly, then
@@ -592,6 +593,7 @@ export class StaticNotebook extends Widget {
     pl.insertWidget(index, cell);
     this._toRenderMap.delete(cell.model.id);
     this._incrementRenderedCount();
+    this.onCellInserted(index, cell);
     this._placeholderCellRendered.emit(cell);
   }
 

--- a/packages/observables/src/observablelist.ts
+++ b/packages/observables/src/observablelist.ts
@@ -465,14 +465,22 @@ export class ObservableList<T> implements IObservableList<T> {
    *
    * #### Notes
    * The `index` will be clamped to the bounds of the list.
+   *
    * By convention, the oldIndex is set to -2 to indicate
    * an insert operation.
+   *
+   * The value -2 as oldIndex can be used to distinguish from the push
+   * method which will use a value -1.
    *
    * #### Undefined Behavior
    * An `index` which is non-integral.
    */
   insert(index: number, value: T): void {
-    ArrayExt.insert(this._array, index, value);
+    if (index === this._array.length) {
+      this._array.push(value);
+    } else {
+      ArrayExt.insert(this._array, index, value);
+    }
     this._changed.emit({
       type: 'add',
       oldIndex: -2,


### PR DESCRIPTION
## References

Fixes 
- https://github.com/jupyterlab/jupyterlab/issues/10578
- https://github.com/jupyterlab/jupyterlab/issues/10434

@krassowski Happy to get user tests from you side to confirm any remaining problem.

## Code changes

The behaviour reported in the above issue find their cause in the  `onCellInserted` being not invoked when rendering a placeholder cell in the virtual notebook. The `onCellInserted` is responsible for the edge navigation between cells and fo the cell focus.

## User-facing changes

Reported issues should be fixed.

## Backwards-incompatible changes

None.
