### PR TITLE
Mention prebuilt extensions in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ powerful user interface.
 JupyterLab will eventually replace the classic Jupyter Notebook.
 
 JupyterLab can be extended using [npm](https://www.npmjs.com/) packages
-that use our public APIs. To find JupyterLab extensions, search for the npm keyword [jupyterlab-extension](https://www.npmjs.com/search?q=keywords:jupyterlab-extension) or the GitHub topic [jupyterlab-extension](https://github.com/topics/jupyterlab-extension). To learn more about extensions, see the [user documentation](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html).
+that use our public APIs. The _prebuilt_ extensions can be distributed
+via [PyPI](https://pypi.org/search/?q=jupyterlab&o=-created&c=Framework+%3A%3A+Jupyter),
+conda, and other package managers. The _source_ extensions can be installed
+directly from npm (search for [jupyterlab-extension](https://www.npmjs.com/search?q=keywords:jupyterlab-extension)) but require additional build step.
+You can also find JupyterLab extensions exploring GitHub topic [jupyterlab-extension](https://github.com/topics/jupyterlab-extension).
+To learn more about extensions, see the [user documentation](https://jupyterlab.readthedocs.io/en/stable/user/extensions.html).
 
 The current JupyterLab releases are suitable for general
 usage, and the extension APIs will continue to

--- a/docs/source/extension/extension_migration.rst
+++ b/docs/source/extension/extension_migration.rst
@@ -105,7 +105,7 @@ The upgrade script also updates the dependencies in ``package.json`` to the ``^3
 On the diff above, we see that additional development scripts are also added, as they are used by the new extension system workflow.
 
 The diff also shows the new ``@jupyterlab/builder`` as a ``devDependency``.
-``@jupyterlab/builder`` is a package required to build the extension as a federated extension.
+``@jupyterlab/builder`` is a package required to build the extension as a federated (prebuilt) extension.
 It hides away internal dependencies such as ``webpack``, and produces the assets that can then be distributed as part of a Python package.
 
 Extension developers do not need to interact with ``@jupyterlab/builder`` directly, but instead can use the

--- a/docs/source/user/directories.rst
+++ b/docs/source/user/directories.rst
@@ -10,7 +10,8 @@ JupyterLab manages several different locations for its data. These locations are
 
 JupyterLab also honors **LabConfig Directories** directories for configuration data from the ``labconfig`` subdirectories of the Jupyter ``config`` directories in the Jupyter path hierarchy.
 
-Additionally, JupyterLab can load dynamic federated extensions, i.e., extensions that bundle their dependencies, from the ``labextensions`` subdirectories of the Jupyter ``data`` directories. 
+Additionally, JupyterLab can load dynamic federated (prebuilt) extensions, i.e., extensions that
+bundle their dependencies, from the ``labextensions`` subdirectories of the Jupyter ``data`` directories.
 
 See the locations of these Jupyter config paths by running ``jupyter --path``.
 


### PR DESCRIPTION
## References

Small step towards #10554.

For now I only linked to PyPI for prebuilt extensions discovery as I am not sure if there is a reliable way to filter conda packages.
The link includes both `jupyterlab` keyword and `Framework :: Jupyter` trove classifier (to best filter to extensions created from cookiecutter or to a comparable standard), and sorts by most recently updated (as sorting by "relevant" gives many quite outdated extensions that do not support prebuilt system at all). Hopefully this will get better with #9538.

## Code changes

None

## User-facing changes

Updated documentation

## Backwards-incompatible changes

None