### PR TITLE
Disable autoclosing brackets by default in console

### DIFF
--- a/packages/console-extension/schema/tracker.json
+++ b/packages/console-extension/schema/tracker.json
@@ -176,7 +176,7 @@
       "description": "The configuration for all prompt cells.",
       "$ref": "#/definitions/editorConfig",
       "default": {
-        "autoClosingBrackets": true,
+        "autoClosingBrackets": false,
         "cursorBlinkRate": 530,
         "fontFamily": null,
         "fontSize": null,

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -393,12 +393,13 @@ async function activateConsole(
 
   commands.addCommand(CommandIDs.autoClosingBrackets, {
     execute: async args => {
-      promptCellConfig.autoClosingBrackets = !!(args['force'] ?? !promptCellConfig.autoClosingBrackets);
+      promptCellConfig.autoClosingBrackets = !!(
+        args['force'] ?? !promptCellConfig.autoClosingBrackets
+      );
       await settingRegistry.set(pluginId, 'promptCellConfig', promptCellConfig);
     },
     label: trans.__('Auto Close Brackets for Code Console Prompt'),
-    isToggled: () =>
-      promptCellConfig.autoClosingBrackets as boolean
+    isToggled: () => promptCellConfig.autoClosingBrackets as boolean
   });
 
   /**

--- a/packages/console-extension/src/index.ts
+++ b/packages/console-extension/src/index.ts
@@ -53,6 +53,8 @@ import foreign from './foreign';
  * The command IDs used by the console plugin.
  */
 namespace CommandIDs {
+  export const autoClosingBrackets = 'console:toggle-autoclosing-brackets';
+
   export const create = 'console:create';
 
   export const clear = 'console:clear';
@@ -388,6 +390,16 @@ async function activateConsole(
     }
   });
   await updateSettings();
+
+  commands.addCommand(CommandIDs.autoClosingBrackets, {
+    execute: async args => {
+      promptCellConfig.autoClosingBrackets = !!(args['force'] ?? !promptCellConfig.autoClosingBrackets);
+      await settingRegistry.set(pluginId, 'promptCellConfig', promptCellConfig);
+    },
+    label: trans.__('Auto Close Brackets for Code Console Prompt'),
+    isToggled: () =>
+      promptCellConfig.autoClosingBrackets as boolean
+  });
 
   /**
    * Whether there is an active console.

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -457,7 +457,7 @@ export namespace Commands {
       execute: () => {
         const anyToggled =
           commands.isToggled(CommandIDs.autoClosingBrackets) ||
-          commands.isToggled(autoClosingBracketsNotebook) || 
+          commands.isToggled(autoClosingBracketsNotebook) ||
           commands.isToggled(autoClosingBracketsConsole);
         // if any auto closing brackets options is toggled, toggle both off
         if (anyToggled) {

--- a/packages/fileeditor-extension/src/commands.ts
+++ b/packages/fileeditor-extension/src/commands.ts
@@ -44,7 +44,7 @@ import {
 } from '@lumino/coreutils';
 
 const autoClosingBracketsNotebook = 'notebook:toggle-autoclosing-brackets';
-
+const autoClosingBracketsConsole = 'console:toggle-autoclosing-brackets';
 /**
  * The command IDs used by the fileeditor plugin.
  */
@@ -457,25 +457,29 @@ export namespace Commands {
       execute: () => {
         const anyToggled =
           commands.isToggled(CommandIDs.autoClosingBrackets) ||
-          commands.isToggled(autoClosingBracketsNotebook);
+          commands.isToggled(autoClosingBracketsNotebook) || 
+          commands.isToggled(autoClosingBracketsConsole);
         // if any auto closing brackets options is toggled, toggle both off
         if (anyToggled) {
           void commands.execute(CommandIDs.autoClosingBrackets, {
             force: false
           });
           void commands.execute(autoClosingBracketsNotebook, { force: false });
+          void commands.execute(autoClosingBracketsConsole, { force: false });
         } else {
           // both are off, turn them on
           void commands.execute(CommandIDs.autoClosingBrackets, {
             force: true
           });
           void commands.execute(autoClosingBracketsNotebook, { force: true });
+          void commands.execute(autoClosingBracketsConsole, { force: true });
         }
       },
       label: trans.__('Auto Close Brackets'),
       isToggled: () =>
         commands.isToggled(CommandIDs.autoClosingBrackets) ||
-        commands.isToggled(autoClosingBracketsNotebook)
+        commands.isToggled(autoClosingBracketsNotebook) ||
+        commands.isToggled(autoClosingBracketsConsole)
     });
   }
 


### PR DESCRIPTION
## References

Follow-up of #9488 for code consoles (so that should be merged first)

## Code changes

Implement similar changes as in #9488 for code consoles as well, so it is easy to turn off autoclosing brackets there too.

## User-facing changes

Code consoles will default to have autoclose brackets off, and will be controlled by the global autoclosing bracket menu item in the settings menu.

## Backwards-incompatible changes

Changed the default autoclosing setting for code consoles.
