### PR TITLE
More releaser fixes

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -61,3 +61,10 @@ jobs:
           RH_VERSION_SPEC: build
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Assets
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist-files
+          path: |
+            .jupyter_releaser_checkout/dist/*.*

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "scripts": {
     "add:sibling": "node buildutils/lib/add-sibling.js",
-    "after:build:python": "node buildutils/lib/local-repository fix-links --path jupyterlab/staging",
     "after:publish:assets": "node buildutils/lib/publish --skip-publish",
     "analyze": "jlpm run analyze:dev",
     "analyze:dev": "cd dev_mode && jlpm run build --analyze",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,5 @@ npm-install-options = "--legacy-peer-deps"
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["git checkout .", "pip install bump2version"]
 before-build-npm = ["git commit -am 'Bump version'", "jlpm", "jlpm run build:utils", "jlpm run build:src"]
-before-build-python = ["node buildutils/lib/local-repository start", "jlpm run before:build:python"]
-after-build-python = ["jlpm run after:build:python", "node buildutils/lib/local-repository stop"]
+before-build-python = ["node buildutils/lib/local-repository start", "jlpm run before:build:python", "ls -ltr jupyterlab/staging", "node buildutils/lib/local-repository stop", "node buildutils/lib/local-repository fix-links --path jupyterlab/staging"]
 after-publish-assets = "jlpm run after:publish:assets"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/10608
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
- Fixes usage of `path` command line arg when fixing `yarn.lock` links.
- Ensures that we fix the `yarn.lock` before creating the python dists
- Uploads dist files after check release job so they can be inspected

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->