### PR TITLE
More automated release fixes

### DIFF
--- a/buildutils/src/local-repository.ts
+++ b/buildutils/src/local-repository.ts
@@ -4,6 +4,7 @@ import * as crypto from 'crypto';
 import * as path from 'path';
 import * as os from 'os';
 import * as ps from 'process';
+import glob from 'glob';
 
 import { Command } from 'commander';
 
@@ -210,6 +211,17 @@ function fixLinks(package_dir: string) {
   fs.writeFileSync(lock_file, new_content, 'utf8');
 }
 
+/**
+ * Publish the npm tar files in a given directory
+ */
+function publishPackages(dist_dir: string) {
+  const paths = glob.sync(path.join(dist_dir, '*.tgz'));
+  paths.forEach(package_path => {
+    const name = path.basename(package_path);
+    utils.run(`npm publish ${name}`, { cwd: dist_dir });
+  });
+}
+
 const program = new Command();
 
 program
@@ -234,6 +246,13 @@ program
   .option('--path <path>', 'Path to the directory with a yarn lock')
   .action((options: any) => {
     fixLinks(options.path || process.cwd());
+  });
+
+program
+  .command('publish-dists')
+  .option('--path <path>', 'Path to the directory with npm tar balls')
+  .action((options: any) => {
+    publishPackages(options.path || process.cwd());
   });
 
 if (require.main === module) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "analyze": "jlpm run analyze:dev",
     "analyze:dev": "cd dev_mode && jlpm run build --analyze",
     "analyze:prod": "cd dev_mode && jlpm run build:prod --analyze",
-    "before:build:python": "node buildutils/lib/publish --yes --skip-tags && node buildutils/lib/update-core-mode.js",
+    "before:build:python": "node buildutils/lib/local-repository.js publish-dists --path ./dist && node buildutils/lib/update-core-mode.js",
     "build": "jlpm run build:dev",
     "build:builder": "cd builder && jlpm run build",
     "build:core": "cd jupyterlab/staging && jlpm && (jlpm deduplicate || jlpm) && jlpm run build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,5 +33,5 @@ npm-install-options = "--legacy-peer-deps"
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["git checkout .", "pip install bump2version"]
 before-build-npm = ["git commit -am 'Bump version'", "jlpm", "jlpm run build:utils", "jlpm run build:src"]
-before-build-python = ["node buildutils/lib/local-repository start", "jlpm run before:build:python", "ls -ltr jupyterlab/staging", "node buildutils/lib/local-repository stop", "node buildutils/lib/local-repository fix-links --path jupyterlab/staging"]
+before-build-python = ["node buildutils/lib/local-repository start", "jlpm run before:build:python", "node buildutils/lib/local-repository stop", "node buildutils/lib/local-repository fix-links --path jupyterlab/staging"]
 after-publish-assets = "jlpm run after:publish:assets"


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
Follow up to https://github.com/jupyterlab/jupyterlab/pull/10614
<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Use the already-packaged files from the `npm build` phase to publish to `verdaccio`, to ensure that the `shasum` of the package is the same as the one that gets published to `npm` in the `publish` workflow. The rc0 release broke because the packages that were published to `verdaccio` had a `gitHead` field in their `package.json` (added by `lerna`) while the ones published to `npm` did not, causing `yarn` to reject them based on checksum.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
None
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
