### PR TITLE
Keep overflow of CodeMirror editors

### DIFF
--- a/packages/codemirror/style/base.css
+++ b/packages/codemirror/style/base.css
@@ -264,3 +264,11 @@
   opacity: 1;
   transition-delay: 0s;
 }
+
+/* Prevent the caret names from being cut off by the editor (cell) edges */
+.CodeMirror,
+.jp-Cell-inputArea,
+.jp-InputArea-editor,
+.CodeMirror .CodeMirror-scroll {
+  overflow: visible !important;
+}


### PR DESCRIPTION
## References

A naive attempt at #10625. Likely not good enough and likely will break things. Just giving it a try.

## Code changes

Overflow CodeMirror editors.

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
