### PR TITLE
fixes doc string for toc syncCollapseState setting

### DIFF
--- a/packages/toc-extension/schema/plugin.json
+++ b/packages/toc-extension/schema/plugin.json
@@ -19,7 +19,7 @@
     "syncCollapseState": {
       "type": "boolean",
       "title": "syncCollapseState",
-      "description": "When set to true (default), when a header is collapsed in the ToC the corresponding section in the notebook is collapsed as well and vice versa.",
+      "description": "If set to true, when a header is collapsed in the ToC the corresponding section in the notebook is collapsed as well and vice versa.",
       "default": false
     }
   },


### PR DESCRIPTION
<!--
Thanks for contributing to JupyterLab!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References
[Previous PR. Docstring update in PR got lost in rebase](https://github.com/jupyterlab/jupyterlab/pull/10545#discussion_r669968684)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes
Changes in toc-extension/schema/plugin.json so syncCollapseState docstring doesn't say the default is true. 
<!-- Describe the code changes and how they address the issue. -->

## User-facing changes
Correct doc strings
<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes
None
<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->
