### PR TITLE
Fix #10391 - incorrect cursor position after autocomplete

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -189,7 +189,7 @@ export class CompletionHandler implements IDisposable {
     const cursorBeforeChange = editor.getOffsetAt(editor.getCursorPosition());
     // we need to update the shared model in a single transaction so that the undo manager works as expected
     editor.model.sharedModel.updateSource(start, end, value);
-    if (cursorBeforeChange < end && cursorBeforeChange >= start) {
+    if (cursorBeforeChange <= end && cursorBeforeChange >= start) {
       editor.setCursorPosition(editor.getPositionAt(start + value.length)!);
     }
   }

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -188,6 +188,7 @@ export class CompletionHandler implements IDisposable {
     const { start, end, value } = patch;
     // we need to update the shared model in a single transaction so that the undo manager works as expected
     editor.model.sharedModel.updateSource(start, end, value);
+    editor.setCursorPosition(editor.getPositionAt(start + value.length)!);
   }
 
   /**

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -186,9 +186,12 @@ export class CompletionHandler implements IDisposable {
     }
 
     const { start, end, value } = patch;
+    const cursorBeforeChange = editor.getOffsetAt(editor.getCursorPosition());
     // we need to update the shared model in a single transaction so that the undo manager works as expected
     editor.model.sharedModel.updateSource(start, end, value);
-    editor.setCursorPosition(editor.getPositionAt(start + value.length)!);
+    if (cursorBeforeChange < end && cursorBeforeChange >= start) {
+      editor.setCursorPosition(editor.getPositionAt(start + value.length)!);
+    }
   }
 
   /**

--- a/packages/completer/test/handler.spec.ts
+++ b/packages/completer/test/handler.spec.ts
@@ -246,7 +246,7 @@ describe('@jupyterlab/completer', () => {
         const text = 'eggs\nfoo # comment\nbaz';
         const want = 'eggs\nfoobar # comment\nbaz';
         const line = 1;
-        const column = 5;
+        const column = 5; // this sets the cursor after the "#" sign - not in the mid of the replaced word
         const request: Completer.ITextState = {
           column,
           line,

--- a/packages/completer/test/handler.spec.ts
+++ b/packages/completer/test/handler.spec.ts
@@ -320,5 +320,41 @@ describe('@jupyterlab/completer', () => {
         console.warn(editor.getCursorPosition());
       });
     });
+
+    it('should update cursor position after autocomplete on empty word', () => {
+      const model = new CompleterModel();
+      const patch = 'foobar';
+      const completer = new Completer({ editor: null, model });
+      const handler = new TestCompletionHandler({ completer, connector });
+      const editor = createEditorWidget().editor;
+      const text = 'eggs\n  # comment\nbaz';
+      const want = 'eggs\n foobar # comment\nbaz';
+      const line = 1;
+      const column = 1;
+      const request: Completer.ITextState = {
+        column: column,
+        line,
+        lineHeight: 0,
+        charWidth: 0,
+        coords: null,
+        text
+      };
+
+      handler.editor = editor;
+      handler.editor.model.value.text = text;
+      handler.editor.model.sharedModel.clearUndoHistory();
+      handler.editor.setCursorPosition({ line, column });
+      model.original = request;
+      const offset = handler.editor.getOffsetAt({ line, column });
+      model.cursor = { start: offset, end: offset };
+      // Make the completion, check its value and cursor position.
+      (completer.selected as any).emit(patch);
+      expect(editor.model.value.text).toBe(want);
+      expect(editor.getCursorPosition()).toEqual({
+        line,
+        column: column + 6
+      });
+      console.warn(editor.getCursorPosition());
+    });
   });
 });

--- a/packages/completer/test/handler.spec.ts
+++ b/packages/completer/test/handler.spec.ts
@@ -354,7 +354,6 @@ describe('@jupyterlab/completer', () => {
         line,
         column: column + 6
       });
-      console.warn(editor.getCursorPosition());
     });
   });
 });


### PR DESCRIPTION

## References

This PR fixes the issue described in #10391. 

## Code changes

The auto-complete plugin now explicitly sets the cursor position after the replacement.

Previously, we relied on the behavior of modeldb to adapt the cursor position correctly. The autocomplete plugin simply replaced text and the local position would be automatically updated to the position after the replacement. This is no longer possible in all cases because y-codemirror now updates the cursor positions after each change with an algorithm that is designed to work nicely with remote changes. We instead update the position to the position before the replacement, because that will lead to fewer conflicts when multiple peers insert content at the same time. 



## User-facing changes

None

## Backwards-incompatible changes

None
