### PR TITLE
Fixed event handler in debugger session test

### DIFF
--- a/packages/debugger/test/session.spec.ts
+++ b/packages/debugger/test/session.spec.ts
@@ -157,6 +157,8 @@ describe('protocol', () => {
             break;
           }
           case 'stopped':
+            const msg = event as DebugProtocol.StoppedEvent;
+            threadId = msg.body.threadId!;
             stoppedFuture.resolve();
             break;
           default:


### PR DESCRIPTION
The `threaId` stored in the `session.spec.ts` should be updated each time an event (either threadEven, or stoppedEvent) is emitted. Indeed, when there are many threads, you are not guaranteed that the id from a `ThreadEvent` is the same as that from the next `StoppedEvent`.
