### PR TITLE
PR: Add preferred-dir handling

### DIFF
--- a/packages/filebrowser-extension/src/index.ts
+++ b/packages/filebrowser-extension/src/index.ts
@@ -138,7 +138,7 @@ const browser: JupyterFrontEndPlugin<void> = {
     ICommandPalette
   ],
   autoStart: true,
-  activate: (
+  activate: async (
     app: JupyterFrontEnd,
     factory: IFileBrowserFactory,
     translator: ITranslator,
@@ -146,7 +146,7 @@ const browser: JupyterFrontEndPlugin<void> = {
     settingRegistry: ISettingRegistry | null,
     treePathUpdater: ITreePathUpdater | null,
     commandPalette: ICommandPalette | null
-  ): void => {
+  ): Promise<void> => {
     const trans = translator.load('jupyterlab');
     const browser = factory.defaultBrowser;
     browser.node.setAttribute('role', 'region');
@@ -160,6 +160,12 @@ const browser: JupyterFrontEndPlugin<void> = {
     // responsible for their own restoration behavior, if any.
     if (restorer) {
       restorer.add(browser, namespace);
+    }
+
+    // Navigate to preferred-dir trait if found
+    const preferredPath = PageConfig.getOption('preferredPath');
+    if (preferredPath) {
+      await browser.model.cd(preferredPath);
     }
 
     addCommands(app, factory, translator, settingRegistry, commandPalette);


### PR DESCRIPTION
Following on the [discussion of adding a new trait](https://github.com/jupyter-server/jupyter_server/issues/534) `preferred-dir`

And the PR on JServer -> https://github.com/jupyter-server/jupyter_server/pull/549

This PR now exposes that option on the page config added on https://github.com/jupyterlab/jupyterlab_server/pull/190/.


